### PR TITLE
chore: initialize marketplace scaffold

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "melodic-software",
+  "owner": {
+    "name": "Melodic Software",
+    "url": "https://github.com/melodic-software"
+  },
+  "description": "Reusable, repo-agnostic Claude Code plugins — skills, hooks, and agents.",
+  "metadata": {
+    "pluginRoot": "./plugins"
+  },
+  "plugins": []
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize line endings to LF for all text files (cross-platform consistency)
+* text=auto eol=lf
+
+# Binary types Git should never normalize
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Dependencies
+node_modules/
+__pycache__/
+.venv/
+venv/
+
+# OS / editor cruft
+.DS_Store
+Thumbs.db
+*.swp
+
+# Local-only Claude Code state
+.claude/settings.local.json
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# Operating rules — AI agents working in this repo
+
+This repository is a public Claude Code plugin marketplace. Plugins here must be reusable,
+repo-agnostic, configurable by consumers, and safe in plugin form.
+
+## Fresh-docs mandate (non-negotiable)
+
+Operate only off current official documentation — never training-data recall, never a stale summary.
+Before ANY change to this repo (a new plugin, a manifest edit, a structure change), WebFetch the
+relevant page(s) below for current schema and behavior, and cite the URL. If a fact is not confirmed
+from a fetched page this session, treat it as unverified and say so.
+
+| Topic | Canonical URL |
+|---|---|
+| Create plugins | https://code.claude.com/docs/en/plugins |
+| Plugins reference (schemas, variables, CLI) | https://code.claude.com/docs/en/plugins-reference |
+| Create & distribute a marketplace | https://code.claude.com/docs/en/plugin-marketplaces |
+| Discover & install plugins | https://code.claude.com/docs/en/discover-plugins |
+| Skills | https://code.claude.com/docs/en/skills |
+| Hooks reference | https://code.claude.com/docs/en/hooks |
+| Subagents | https://code.claude.com/docs/en/sub-agents |
+| Settings | https://code.claude.com/docs/en/settings |
+| MCP | https://code.claude.com/docs/en/mcp |
+| Docs index (discover any other page) | https://code.claude.com/docs/llms.txt |
+
+## Design rules for plugins added here
+
+- **Repo-agnostic.** No hardcoded paths, repo names, or project-specific values. Read the consumer's
+  context via `${CLAUDE_PROJECT_DIR}` and the consumer's own `CLAUDE.md` / `.claude/rules`.
+- **Configurable without editing the plugin.** Expose consumer choices through `userConfig`
+  (`${user_config.KEY}`), never by requiring a fork or a hand-edit of the skill.
+- **Plugin-form-safe.** Installed plugins run from an isolated cache — reference only files inside the
+  plugin via `${CLAUDE_PLUGIN_ROOT}`; persist state in `${CLAUDE_PLUGIN_DATA}`. No `../` reach-outs.
+- **No PII / secrets.** Public repo + permanent git history: scrub before the first commit, not after.
+- **Versioned.** Set an explicit semver `version` in each `plugin.json` so consumers update on bumps.
+
+## Process
+
+The full design charter, extensibility model, plugin-form caveats, and per-plugin migration gate live
+in [`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md). Follow it for every migration.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# claude-code-plugins
-Melodic Software — public Claude Code plugin marketplace: reusable, repo-agnostic skills, hooks, and agents.
+# Melodic Software — Claude Code plugins
+
+A public [Claude Code](https://code.claude.com/docs) plugin marketplace of reusable, repo-agnostic
+skills, hooks, and agents. Each plugin is designed to work in any repository and to be customized by
+consumers without editing the plugin itself.
+
+> Status: initialized. Plugins are migrated in one at a time; the catalog below grows as each is
+> vetted and validated. See [`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md).
+
+## Use this marketplace
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install <plugin-name>@melodic-software
+```
+
+Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace update melodic-software`.
+
+## What's here
+
+- `.claude-plugin/marketplace.json` — the marketplace catalog.
+- `plugins/` — one directory per plugin.
+- `docs/MIGRATION-PLAYBOOK.md` — design charter, extensibility model, and the per-plugin migration gate.
+- `CLAUDE.md` — operating rules for AI agents working in this repo (fresh-docs mandate + canonical links).
+
+## Official documentation
+
+This repo tracks policy and wiring only; authoritative behavior lives in the official docs, which must
+be read fresh rather than recalled. Start at the
+[Claude Code plugins guide](https://code.claude.com/docs/en/plugins).
+
+## License
+
+[MIT](LICENSE).

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1,0 +1,85 @@
+# Migration playbook
+
+How skills, hooks, and agents become reusable plugins in this marketplace. One plugin is migrated at a
+time: lift it out, make it work in plugin form and in any repo, build in configuration and extensibility,
+vet it against best practices, then publish.
+
+All schema and behavior claims below were verified against the official docs on 2026-06-22. Re-verify
+fresh before acting — see `CLAUDE.md` "Fresh-docs mandate".
+
+## Intent
+
+The point of moving a skill/hook out of a private repo and into a plugin is **reuse and developer
+experience**: it should drop into any repository and work, and a consumer should be able to customize
+behavior without filing an issue or editing the plugin. If a consumer needs to change a workflow, add an
+action, or adapt to their repo, that is an **extensibility point** the plugin must expose by design.
+
+## Design charter
+
+Every plugin is designed to these principles (named here as the bar; apply, don't recite):
+
+- Low coupling, high cohesion
+- Vertical slice architecture
+- SOLID
+- Clean code
+- DRY / single source of truth / no duplication
+
+Concretely for plugins: a plugin owns one cohesive capability, depends on nothing repo-specific, and
+exposes its variability through declared configuration rather than internal forks.
+
+## Extensibility model — what works today
+
+These are the proven, documented mechanisms for consumer customization that do not confuse the agent.
+Prefer them in this order; the earlier ones are simplest and least surprising.
+
+| Mechanism | What it does | Use for |
+|---|---|---|
+| Consumer `CLAUDE.md` / `.claude/rules` | The skill reads the consuming project's own context and rules | Project-specific conventions, naming, policies — the default extension surface |
+| `${CLAUDE_PROJECT_DIR}` | Path to the consumer's project root, substituted in hook/MCP/monitor commands and exported to subprocesses | Referencing project-local scripts/config |
+| `userConfig` → `${user_config.KEY}` | Values Claude Code prompts for at enable time (typed: string/number/boolean, optional sensitive). Also exported as `CLAUDE_PLUGIN_OPTION_<KEY>`. Non-sensitive stored in `settings.json` `pluginConfigs`; sensitive in keychain | Endpoints, toggles, tokens — consumer config without editing the plugin |
+| `${CLAUDE_PLUGIN_ROOT}` | Path to the plugin's own installed directory | Referencing bundled scripts/assets (mandatory under cache isolation) |
+| `${CLAUDE_PLUGIN_DATA}` | Persistent per-plugin directory that survives updates (`~/.claude/plugins/data/<id>/`) | Installed deps, caches, generated state |
+| `hooks/hooks.json` | Event handlers the plugin ships | Behavior consumers opt into by enabling the plugin |
+
+Design a skill so its variable parts route through the table above. "If you need to customize X, set
+`userConfig` Y / add it to your project rules" — never "open an issue" or "fork the skill".
+
+## Plugin-form caveats (works in-repo, breaks as a plugin)
+
+Catalog these per migration; they are the usual failures when an in-repo skill becomes a plugin.
+
+- **Cache isolation.** Installed plugins are copied to `~/.claude/plugins/cache`. Any reference to files
+  outside the plugin directory (`../../tools/...`, `.claude/rules/...`) breaks. Fix: bundle dependencies
+  inside the plugin and reference them via `${CLAUDE_PLUGIN_ROOT}`; persist state via `${CLAUDE_PLUGIN_DATA}`.
+- **Namespacing.** An in-repo `/foo` becomes `/melodic-software:foo` (plugin-namespaced). Internal
+  cross-references to the bare name break — update them.
+- **Agent shadowing.** Project/user `.claude/agents/` override same-named plugin agents. A leftover
+  in-repo copy masks the plugin version until removed from the source repo.
+- **Headless registration.** `extraKnownMarketplaces` auto-registration requires the interactive trust
+  dialog; CI/headless/cloud must run `claude plugin marketplace add` explicitly or pre-seed via
+  `CLAUDE_CODE_PLUGIN_SEED_DIR`.
+
+## Per-plugin migration gate
+
+For each skill/hook/agent being migrated:
+
+1. **Research fresh.** WebFetch the official docs for every component involved (see `CLAUDE.md`).
+2. **Scope one capability.** One cohesive plugin; no grab-bags.
+3. **De-couple from the source repo.** Remove hardcoded paths/names; route project-specifics to the
+   consumer's context.
+4. **Bundle + isolate.** Move required assets inside the plugin; reference via `${CLAUDE_PLUGIN_ROOT}`.
+5. **Expose extensibility.** Declare `userConfig` for consumer choices; document each option.
+6. **Strip PII / secrets.** Hard gate — before the first commit.
+7. **Idempotent, modular, extensible.** Re-running is safe; pieces compose; variability is declared.
+8. **Validate.** `claude plugin validate`; test with `--plugin-dir` in a clean repo that is NOT the
+   source repo (proves repo-agnosticism).
+9. **Version.** Set an explicit semver `version` in `plugin.json`.
+10. **Publish.** Add the entry to `.claude-plugin/marketplace.json` and document it in the README.
+
+## What to wait on / avoid for now
+
+- Don't pre-build cross-plugin `dependencies` graphs until two plugins genuinely share a need.
+- Don't abstract a shared library before a second consumer exists (Rule of Three).
+- Don't rely on any mechanism not confirmed from current docs this session — if a customization need has
+  no proven native path yet, record it here as a gap and keep the workaround in the consumer's repo until
+  the native mechanism is verified.


### PR DESCRIPTION
Initialize the fresh public marketplace.

- marketplace.json catalog (name: melodic-software, empty plugins, pluginRoot ./plugins)
- README (consumer add/install)
- CLAUDE.md fresh-docs mandate + canonical doc links
- docs/MIGRATION-PLAYBOOK.md (design charter, extensibility model, caveats, per-plugin gate)
- .gitignore, .gitattributes (LF)

Scaffold only; plugins migrated one at a time.