### PR TITLE
fix: correct plugin-system inaccuracies and harden references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,9 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "melodic-software",
   "owner": {
     "name": "Melodic Software",
-    "url": "https://github.com/melodic-software"
+    "email": "info@melodicsoftware.com"
   },
   "description": "Reusable, repo-agnostic Claude Code plugins — skills, hooks, and agents.",
   "metadata": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,24 @@ from a fetched page this session, treat it as unverified and say so.
 |---|---|
 | Create plugins | https://code.claude.com/docs/en/plugins |
 | Plugins reference (schemas, variables, CLI) | https://code.claude.com/docs/en/plugins-reference |
+| Plugin dependencies (version constraints) | https://code.claude.com/docs/en/plugin-dependencies |
 | Create & distribute a marketplace | https://code.claude.com/docs/en/plugin-marketplaces |
 | Discover & install plugins | https://code.claude.com/docs/en/discover-plugins |
 | Skills | https://code.claude.com/docs/en/skills |
+| Slash commands | https://code.claude.com/docs/en/commands |
 | Hooks reference | https://code.claude.com/docs/en/hooks |
 | Subagents | https://code.claude.com/docs/en/sub-agents |
 | Settings | https://code.claude.com/docs/en/settings |
+| Memory — CLAUDE.md, `.claude/rules/`, auto memory | https://code.claude.com/docs/en/memory |
+| The `.claude` directory | https://code.claude.com/docs/en/claude-directory |
 | MCP | https://code.claude.com/docs/en/mcp |
+| Tools reference (monitors) | https://code.claude.com/docs/en/tools-reference |
 | Docs index (discover any other page) | https://code.claude.com/docs/llms.txt |
+
+Machine-readable JSON Schemas (editor validation for the JSON in this repo; Claude Code ignores the
+`$schema` field at load time): `marketplace.json` →
+`https://json.schemastore.org/claude-code-marketplace.json`, `plugin.json` →
+`https://json.schemastore.org/claude-code-plugin-manifest.json` (published on SchemaStore).
 
 ## Design rules for plugins added here
 

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -36,7 +36,7 @@ Prefer them in this order; the earlier ones are simplest and least surprising.
 |---|---|---|
 | Consumer `CLAUDE.md` / `.claude/rules` | The skill reads the consuming project's own context and rules | Project-specific conventions, naming, policies — the default extension surface |
 | `${CLAUDE_PROJECT_DIR}` | Path to the consumer's project root, substituted in hook/MCP/monitor commands and exported to subprocesses | Referencing project-local scripts/config |
-| `userConfig` → `${user_config.KEY}` | Values Claude Code prompts for at enable time (typed: string/number/boolean, optional sensitive). Also exported as `CLAUDE_PLUGIN_OPTION_<KEY>`. Non-sensitive stored in `settings.json` `pluginConfigs`; sensitive in keychain | Endpoints, toggles, tokens — consumer config without editing the plugin |
+| `userConfig` → `${user_config.KEY}` | Values Claude Code prompts for at enable time (typed: string/number/boolean/directory/file, optional sensitive). Also exported as `CLAUDE_PLUGIN_OPTION_<KEY>`. Non-sensitive stored in `settings.json` under `pluginConfigs[<id>].options`; sensitive in the system keychain | Endpoints, toggles, tokens — consumer config without editing the plugin |
 | `${CLAUDE_PLUGIN_ROOT}` | Path to the plugin's own installed directory | Referencing bundled scripts/assets (mandatory under cache isolation) |
 | `${CLAUDE_PLUGIN_DATA}` | Persistent per-plugin directory that survives updates (`~/.claude/plugins/data/<id>/`) | Installed deps, caches, generated state |
 | `hooks/hooks.json` | Event handlers the plugin ships | Behavior consumers opt into by enabling the plugin |
@@ -51,8 +51,9 @@ Catalog these per migration; they are the usual failures when an in-repo skill b
 - **Cache isolation.** Installed plugins are copied to `~/.claude/plugins/cache`. Any reference to files
   outside the plugin directory (`../../tools/...`, `.claude/rules/...`) breaks. Fix: bundle dependencies
   inside the plugin and reference them via `${CLAUDE_PLUGIN_ROOT}`; persist state via `${CLAUDE_PLUGIN_DATA}`.
-- **Namespacing.** An in-repo `/foo` becomes `/melodic-software:foo` (plugin-namespaced). Internal
-  cross-references to the bare name break — update them.
+- **Namespacing.** Components are namespaced by the plugin's own `name`, not the marketplace name —
+  an in-repo `/foo` becomes `/<plugin-name>:foo`. Internal cross-references to the bare name break —
+  update them.
 - **Agent shadowing.** Project/user `.claude/agents/` override same-named plugin agents. A leftover
   in-repo copy masks the plugin version until removed from the source repo.
 - **Headless registration.** `extraKnownMarketplaces` auto-registration requires the interactive trust


### PR DESCRIPTION
## Summary

Full per-file audit of the repo against **current official Claude Code docs** (re-verified this session per the repo''s fresh-docs mandate). The vast majority of existing content was confirmed accurate; this PR fixes the real inaccuracies found and strengthens references. No code, only manifest/docs.

## Real defects fixed

- **`marketplace.json` — off-schema `owner.url`.** The documented `owner` object supports only `name` (required) + `email` (optional) — `url` is not a valid owner field. Replaced with the documented contact field using the `info@melodicsoftware.com` shared inbox (matches the docs'' `DevTools Team` / `devtools@example.com` team-alias example; no personal PII). Source: plugin-marketplaces "Owner fields".
- **`MIGRATION-PLAYBOOK.md` — wrong namespacing.** Components are namespaced by the **plugin''s own `name`**, not the marketplace name. Corrected `/melodic-software:foo` → `/<plugin-name>:foo`. Source: plugins-reference (`plugin-dev:agent-creator` example).

## Polish / accuracy

- **`marketplace.json`** — added `$schema` → published SchemaStore marketplace schema (editor validation; Claude Code ignores it at load time).
- **`MIGRATION-PLAYBOOK.md`** — `userConfig` types also include `directory`/`file`; non-sensitive values stored under `pluginConfigs[<id>].options`.
- **`CLAUDE.md`** — canonical-docs table made comprehensive (plugin dependencies, slash commands, memory, `.claude` directory, tools reference) + cited the two SchemaStore JSON Schemas.

## Verified-correct (no change needed)

All plugin env vars/paths (`CLAUDE_PLUGIN_ROOT`/`DATA`/`PROJECT_DIR`, cache/data paths), `userConfig`→keychain storage, `hooks/hooks.json`, agent shadowing precedence, `extraKnownMarketplaces` + `CLAUDE_CODE_PLUGIN_SEED_DIR` headless guidance, `claude plugin validate` / `--plugin-dir`, all README commands, and `.gitignore` (`CLAUDE.local.md` and `.claude/rules/` are both current, documented features).

## Validation

`claude plugin validate .` → passes (exit 0; only the expected "no plugins defined" warning). JSON parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)