### PR TITLE
ci: onboard to the CI platform (ci-workflows + standards)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,23 +1,59 @@
 root = true
 
-# Global defaults. LF everywhere (matches .gitattributes `* text=auto eol=lf`).
+# Language/framework-agnostic base. Covers universal defaults plus the
+# languages with a presence in this repo (Markdown, shell, PowerShell) and the
+# generic Windows-native batch class. Language overlays (.NET, Python, …) extend
+# this file with their own source sections when adopted; they do not ship a
+# separate editorconfig.
+#
+# .gitattributes is the single authority for line endings (it transforms bytes
+# on checkout); end_of_line here is an editor hint only.
+
 [*]
 indent_style = space
-indent_size = 2
-end_of_line = lf
+indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 
-# Markdown — trailing whitespace is significant (hard line breaks); indent varies
-# per CommonMark. Includes .mdc (Cursor MDC: markdown + YAML frontmatter).
-[*.{md,mdc}]
+# Markdown — trailing whitespace is significant (two trailing spaces = a hard
+# line break); indentation is variable per CommonMark.
+[*.{md,markdown}]
 trim_trailing_whitespace = false
 indent_size = unset
 
-# Shell — shfmt reads these keys (it does not read .shellcheckrc).
+# Config / serialization / data
+[*.{json,jsonc,yml,yaml,toml}]
+indent_size = 2
+
+# JavaScript / TypeScript — 2-space, matching Biome's formatter (the single
+# owner of JS/TS formatting; see modules/typescript). IndentSize is disabled in
+# the checker, so this is an editor hint that keeps editors aligned with Biome.
+[*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}]
+indent_size = 2
+
+# Shell
 [*.{sh,bash}]
 indent_size = 2
-binary_next_line = true
-switch_case_indent = true
-shell_variant = bash
+
+# PowerShell — LF runs on both PowerShell 7 and Windows PowerShell 5.1 (verified
+# empirically). See the .gitattributes note before changing this to crlf.
+[*.{ps1,psm1,psd1}]
+indent_size = 4
+
+# Windows batch — cmd.exe requires CRLF.
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Git config — git writes (and idiomatically uses) tab indentation under each
+# section, so the space default does not apply. Covers the plain file, gitconfig
+# includes, and chezmoi-style source forms (dot_gitconfig, dot_gitconfig.tmpl).
+[{.gitconfig,*.gitconfig,dot_gitconfig*}]
+indent_style = tab
+
+# Lockfiles — generated; suppress formatting enforcement.
+[{package-lock.json,*.lock}]
+indent_size = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "editorconfig-checker config (keys per editorconfig-checker 3.x). Validates files against the repo-root .editorconfig. Line endings are NOT checked here — .gitattributes is the single authority for EOL, so EndOfLine is disabled to avoid double-enforcement. IndentSize and MaxLineLength are disabled because indent width and line length are owned by per-language formatters and are IDE hints, not hard rules. Exclude[] entries are regular expressions (universal, alphabetical); a consuming repo adds its own paths or excludes per-run with the -exclude flag (which combines additively with this list). Version is intentionally blank so the config adopts cleanly on any 3.x engine; a consuming repo pins its engine version in CI (this repo pins it in .github/workflows/ci.yml).",
+  "Version": "",
+  "Verbose": false,
+  "Debug": false,
+  "IgnoreDefaults": false,
+  "SpacesAfterTabs": false,
+  "NoColor": false,
+  "Exclude": [
+    "bin/",
+    "build/",
+    "\\.git/",
+    "\\.lock$",
+    "\\.min\\.",
+    "node_modules/",
+    "obj/",
+    "package-lock\\.json$",
+    "\\.venv/"
+  ],
+  "AllowedContentTypes": [],
+  "PassedFiles": [],
+  "Disable": {
+    "Charset": false,
+    "EndOfLine": true,
+    "Indentation": false,
+    "InsertFinalNewline": false,
+    "TrimTrailingWhitespace": false,
+    "IndentSize": true,
+    "MaxLineLength": true
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,60 @@
-# Normalize line endings to LF for all text files (cross-platform consistency)
+# Language/framework-agnostic base. `* text=auto eol=lf` normalizes text to LF in
+# the repository AND checks it out LF on every platform (deterministic, regardless
+# of a developer's core.autocrlf). Windows-native types below override to CRLF. A
+# later line overrides an earlier one, per attribute. This file is the single
+# authority for line endings (editorconfig end_of_line is an editor hint only).
+
 * text=auto eol=lf
 
-# Binary types Git should never normalize
-*.png binary
-*.jpg binary
-*.gif binary
-*.ico binary
-*.zip binary
+###############################################################################
+# Richer diffs (line endings inherit the LF default above).
+###############################################################################
+
+*.md    diff=markdown
+*.sh    diff=bash
+*.bash  diff=bash
+
+###############################################################################
+# PowerShell — LF is deliberate. Verified to run on both PowerShell 7 and
+# Windows PowerShell 5.1. The PowerShell repo pins .ps1 to eol=lf; the popular
+# community gitattributes template pins crlf — they target different eras. Listed
+# explicitly so it is not "corrected" to crlf without a requirement to round-trip
+# pre-existing CRLF-signed scripts unchanged.
+###############################################################################
+
+*.ps1   text eol=lf
+*.psm1  text eol=lf
+*.psd1  text eol=lf
+
+###############################################################################
+# Windows-native — cmd.exe requires CRLF (overrides the LF default above).
+###############################################################################
+
+*.cmd   text eol=crlf
+*.bat   text eol=crlf
+
+###############################################################################
+# Lockfiles — tracked, but suppress noisy diffs (regenerate to resolve).
+###############################################################################
+
+package-lock.json  -diff
+*.lock             -diff
+
+###############################################################################
+# Binary — no line-ending conversion, no diff.
+###############################################################################
+
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.webp   binary
+*.pdf    binary
+*.zip    binary
+*.gz     binary
+*.7z     binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.otf    binary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependabot keeps this repo's dependencies current with REVIEWED pull requests — GitHub-native,
+# no third-party app and no PAT. One ecosystem today: the SHA-pinned GitHub Actions in
+# .github/workflows/ (Dependabot bumps the pinned commit SHA and refreshes the trailing version
+# comment, keeping them digest-pinned). Add npm here only if this repo gains its own package.json
+# (the plugin hooks rely on the consuming repo's tooling, so there is none today). No auto-merge is
+# configured, so every bump is a PR that runs ci before a human merges.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+    # Let a brand-new release settle before proposing it (supply-chain caution); security-advisory
+    # updates bypass cooldown and still surface immediately.
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,226 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Quality lanes run the ci-workflows composite actions / reusable workflows
+# (referenced by SHA, bumped via Dependabot — never copied) against this repo's
+# own copies of the standards configs. Tool configs live at the repo root, so
+# each lane overrides the action's config input to that root path; the
+# comment-hygiene policy and lychee ruleset sit under modules/ at the actions'
+# default paths. The local ci-status gateway aggregates every lane into the
+# single required check the org ci-gate ruleset keys on.
+jobs:
+  markdown:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Lint markdown
+        uses: melodic-software/ci-workflows/.github/actions/markdown@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          config: .markdownlint-cli2.jsonc
+
+  typos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Spell-check
+        uses: melodic-software/ci-workflows/.github/actions/typos@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          config: _typos.toml
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Scan for secrets
+        uses: melodic-software/ci-workflows/.github/actions/gitleaks@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          config: .gitleaks.toml
+
+  editorconfig:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check editorconfig conformance
+        uses: melodic-software/ci-workflows/.github/actions/editorconfig@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          config: .editorconfig-checker.json
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Lint shell scripts
+        uses: melodic-software/ci-workflows/.github/actions/shellcheck@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          rcfile: .shellcheckrc
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Lint workflows
+        uses: melodic-software/ci-workflows/.github/actions/actionlint@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+
+  jsonschema:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Validate marketplace manifest
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          schemafile: https://json.schemastore.org/claude-code-marketplace.json
+          files: .claude-plugin/marketplace.json
+      - name: Validate plugin manifests
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          schemafile: https://json.schemastore.org/claude-code-plugin-manifest.json
+          files: plugins/*/.claude-plugin/plugin.json
+      - name: Validate dependabot.yml
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          builtin-schema: vendor.dependabot
+          files: .github/dependabot.yml
+      - name: Validate workflows
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          builtin-schema: vendor.github-workflows
+          files: >-
+            .github/workflows/ci.yml
+            .github/workflows/link-check.yml
+
+  exec-bit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Verify shebang files are executable
+        uses: melodic-software/ci-workflows/.github/actions/exec-bit@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+
+  machine-specific-paths:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check for machine-specific paths
+        uses: melodic-software/ci-workflows/.github/actions/machine-specific-paths@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+
+  eol-renormalize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check index-level EOL drift
+        uses: melodic-software/ci-workflows/.github/actions/eol-renormalize@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+
+  comment-hygiene:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Scan comment hygiene
+        # The vendored policy library references the literal marker tokens in its
+        # own comments, so skip the module to avoid self-matching.
+        uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        with:
+          exclude: ':(exclude)modules/comment-hygiene/**'
+
+  zizmor:
+    permissions:
+      contents: read
+    # Advisory Actions security lint; findings annotate without blocking.
+    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+    with:
+      paths: .
+
+  ci-status:
+    if: always()
+    needs:
+      - markdown
+      - typos
+      - gitleaks
+      - editorconfig
+      - shellcheck
+      - actionlint
+      - jsonschema
+      - exec-bit
+      - machine-specific-paths
+      - eol-renormalize
+      - comment-hygiene
+      - zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Aggregate lane results
+        env:
+          RESULTS: >-
+            ${{ needs.markdown.result }}
+            ${{ needs.typos.result }}
+            ${{ needs.gitleaks.result }}
+            ${{ needs.editorconfig.result }}
+            ${{ needs.shellcheck.result }}
+            ${{ needs.actionlint.result }}
+            ${{ needs.jsonschema.result }}
+            ${{ needs.exec-bit.result }}
+            ${{ needs.machine-specific-paths.result }}
+            ${{ needs.eol-renormalize.result }}
+            ${{ needs.comment-hygiene.result }}
+            ${{ needs.zizmor.result }}
+        run: |
+          for r in $RESULTS; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "A lane did not pass (result: $r)."; exit 1 ;;
+            esac
+          done
+          echo "All lanes passed or were skipped."

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,22 @@
+name: link-check
+
+# Advisory online external-link check (not part of ci-status). Runs weekly and
+# on demand; files a rolling tracking issue on failure rather than gating merges.
+# Deterministic on-disk link integrity is covered separately by the offline
+# lychee check; this lane catches dead external URLs in the docs.
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    # issues: write is scoped to this job (least privilege) — only the called
+    # workflow files the rolling tracking issue.
+    permissions:
+      contents: read
+      issues: write
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# gitleaks — https://github.com/gitleaks/gitleaks
+# Config reference: https://github.com/gitleaks/gitleaks#configuration
+#
+# Decoupled base config: inherit the upstream default ruleset and add nothing
+# repo-specific. Adopters layer their own [[allowlists]] (false positives,
+# vendored fixtures) on top. Intentional / known findings are better handled
+# per-repo with a root .gitleaksignore or an inline `gitleaks:allow` comment
+# than by editing this shared config.
+
+# Floor the engine version: silences the "no minVersion specified" debug
+# warning (v8.29.0+) and pins the feature baseline this config relies on
+# (`[extend].useDefault`, `[[allowlists]]`).
+minVersion = "v8.25.0"
+
+[extend]
+useDefault = true

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,36 @@
+{
+  // GitHub Flavored Markdown (GFM) ruleset for markdownlint-cli2.
+  // Schema pinned to markdownlint-cli2 v0.22.1 — bump together on upgrade.
+  // Rules reference: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  // All rules are enabled by default; only deviations are listed below.
+  // Globs are passed by the caller (CLI / CI), not declared here.
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/v0.22.1/schema/markdownlint-cli2-config-schema.json",
+  "ignores": [
+    // Build, dependency, and cache trees — not authored markdown.
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/bin/**",
+    "**/obj/**"
+  ],
+  "config": {
+    // --- GFM-aligned style ---
+    "MD003": { "style": "atx" }, // ATX headings (# Heading)
+    "MD004": { "style": "dash" }, // Dash unordered-list bullets
+    "MD049": { "style": "asterisk" }, // *emphasis*
+    "MD050": { "style": "asterisk" }, // **strong**
+    "MD046": { "style": "fenced" }, // Fenced (not indented) code blocks
+    "MD048": { "style": "backtick" }, // Backtick (not tilde) code fences
+    "MD024": { "siblings_only": true }, // Allow duplicate headings under different parents
+    "MD060": false, // Table column style — disabled; allows any pipe spacing (its default flags tables matching no supported style)
+
+    // --- Relaxed for GFM / prose ---
+    "MD013": false, // No hard line-length limit (tables and code exceed 80)
+    "MD025": false, // Allow multiple top-level (H1) sections
+    "MD028": false, // Allow blank lines between adjacent blockquotes
+    "MD033": false, // Allow inline HTML (<details>, <summary>, <br>, ...)
+    "MD034": false, // Allow bare URLs (GFM autolinks them)
+    "MD036": false, // Allow bold text used as a pseudo-heading
+    "MD040": false, // Fenced code need not declare a language
+    "MD041": false // First line need not be a top-level heading (frontmatter)
+  }
+}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,20 +1,64 @@
-# ShellCheck configuration. ShellCheck auto-discovers this by walking up from
-# the script's directory. Optional checks are selectively enabled — NOT
-# enable=all (the wiki warns optional checks are subjective and may conflict).
+# ShellCheck configuration — repo-agnostic shell-quality ruleset.
+# ShellCheck searches for this file from each script's directory upward; CI
+# points at this copy explicitly with --rcfile (its canonical home is
+# modules/shellcheck/).
+#
 # Ref: https://github.com/koalaman/shellcheck/wiki/Optional
+# Targets ShellCheck 0.11.0+.
+#
+# Optional checks are selectively enabled — NOT enable=all. The ShellCheck wiki
+# warns against enable=all: "optional checks are more subjective rather than
+# more comprehensive, and may conflict with each other".
 
+# Default shell dialect — scripts target bash.
 shell=bash
 
-# Allow sourcing external files; resolve them relative to the script's directory.
+# Resolve `source`d files at lint time (no remote fetch; analysis only).
 external-sources=true
+
+# Look for sourced files relative to the script's directory.
 source-path=SCRIPTDIR
 
 # --- Optional checks (selectively enabled) ---
+
+# Suggest a default *) case in case statements — catches missing fallthrough.
 enable=add-default-case
+
+# Suggest [ a -ne b ] over [ ! a -eq b ] — reduces cognitive load.
 enable=avoid-negated-conditions
+
+# Suggest explicit [ -n "$var" ] over [ "$var" ] — clarity of intent.
 enable=avoid-nullary-conditions
+
+# Notify when set -e is suppressed during function invocation in conditionals —
+# catches the bash trap where errexit silently stops working inside if/while/&&/||.
+# Ref: https://github.com/koalaman/shellcheck/wiki/SC2310
 enable=check-set-e-suppressed
+
+# Warn on unassigned uppercase variables — catches typos in UPPER_SNAKE globals.
 enable=check-unassigned-uppercase
+
+# Suggest command -v over which — POSIX standard, more reliable.
 enable=deprecate-which
+
+# Require [[ ]] over [ ] in bash. A script that intentionally uses [ ] (for
+# POSIX-style graceful degradation) opts out per-file with
+# `# shellcheck disable=require-double-brackets`.
 enable=require-double-brackets
+
+# Re-enable useless-use-of-cat — was default before 0.11.0, now optional.
 enable=useless-use-of-cat
+
+# --- NOT enabled (with rationale) ---
+
+# check-extra-masked-returns (SC2312): too noisy for pipe chains and command
+#   substitutions that intentionally capture output; deliberate `2>/dev/null ||
+#   true` patterns would fire on every `var=$(cmd)`.
+
+# quote-safe-variables (SC2248): conflicts with require-variable-braces (SC2250)
+#   — one wants "$var", the other ${var}; together they demand "${var}"
+#   everywhere. SC2086 (default, non-optional) already catches dangerous unquoted
+#   expansions.
+
+# require-variable-braces (SC2250): too verbose — $var is clear in most contexts;
+#   ${var} is only needed when concatenating adjacent characters (${var}_suffix).

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,39 @@
+# typos — https://github.com/crate-ci/typos
+# Config reference: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+# Identifiers vs words:  https://github.com/crate-ci/typos/blob/master/docs/design.md
+#
+# Decoupled base config: only repo-agnostic ignores live here. typos already
+# respects .gitignore and skips binary files, so the lists below stay minimal.
+# Adopters extend [default.extend-words], [default.extend-identifiers], and
+# [files] extend-exclude with their own domain vocabulary and vendored paths.
+
+[default]
+extend-ignore-re = [
+  # Inline ignore directives. typos has no built-in pragma, so this config
+  # blesses a convention: silence a single line, the following line, or a
+  # block, without polluting the global allow-lists. Shell / JS comment forms.
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  "(#|//)\\s*spellchecker:ignore-next-line\\n.*",
+  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+  # Markdown / HTML comment form of the block directive — invisible in render.
+  "(?s)<!--\\s*spellchecker:off\\s*-->.*?<!--\\s*spellchecker:on\\s*-->",
+  # Braced GUID / UUID literals — opaque hex segments trip the word splitter
+  # (e.g. `ba54` -> "bash"). Matches the canonical 8-4-4-4-12 brace form.
+  "\\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\}",
+]
+
+# Domain words / proper nouns (case-insensitive) and whole-token identifiers
+# (case-sensitive) are repo-specific — adopters add them, the base ships none:
+#
+#   [default.extend-words]
+#   ASO = "ASO"
+#
+#   [default.extend-identifiers]
+#   seeked = "seeked"
+
+[files]
+# typos respects .gitignore by default, so only tracked paths that should never
+# be spell-checked belong here. Minified bundles are the near-universal case.
+extend-exclude = [
+  "*.min.*",
+]

--- a/modules/comment-hygiene/comment-hygiene-patterns.sh
+++ b/modules/comment-hygiene/comment-hygiene-patterns.sh
@@ -1,0 +1,75 @@
+# shellcheck shell=bash
+# Comment-hygiene detection policy — org-wide default ruleset.
+#
+# Library, NOT executable. Pure functions: no env reads, no file I/O, no exit
+# calls. The comment-hygiene composite action sources this file and handles file
+# enumeration, path scoping, and exit-code mapping. POSIX ERE only (grep -E) for
+# cross-platform parity.
+#
+# Policy: comments in production code must not carry deferred-work markers
+# (TODO / FIXME / HACK / XXX) or issue-tracker references (issue|fixes|closes
+# #N, PR #N). Track outstanding work in the issue tracker, not in code comments,
+# so it stays visible and does not rot silently in the source.
+#
+# This file is the CONFIG artifact: to tune the policy for a repo, vendor and
+# edit it. The execution action is sourced separately and stays put.
+
+# chp::scan_text <content>
+#
+# Scan the comment lines of <content> (those starting with // or #, after
+# optional indentation) for banned markers and tracker references.
+#
+# Output (stdout): "lineno:kind:detail" per violation, lineno relative to
+# <content>. Exit: 0 = clean, 1 = one or more violations.
+chp::scan_text() {
+  local content="$1"
+  local entry lineno line violations=0
+  local nocase_was=0
+
+  # Markers match case-insensitively (Todo:, fixme, …). Save/restore the shell
+  # option so sourcing this function never leaks nocasematch to the caller.
+  if shopt -q nocasematch; then
+    nocase_was=1
+  else
+    shopt -s nocasematch
+  fi
+
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    lineno="${entry%%:*}"
+    line="${entry#*:}"
+
+    # Warning markers — FIXME/HACK/XXX share one rule; TODO is separate so the
+    # report names the exact marker.
+    if [[ "$line" =~ (^|[^[:alnum:]_])(FIXME|HACK|XXX)([^[:alnum:]_]|$) ]]; then
+      printf '%s:warning-marker:%s\n' "$lineno" "${BASH_REMATCH[2]}"
+      violations=$((violations + 1))
+      continue
+    fi
+    if [[ "$line" =~ (^|[^[:alnum:]_])TODO([^[:alnum:]_]|$) ]]; then
+      printf '%s:warning-marker:TODO\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+
+    # Issue-tracker references in comments.
+    if [[ "$line" =~ (^|[^[:alnum:]_])(issue|fixes|closes)[[:space:]]*#?[0-9]+ ]]; then
+      printf '%s:tracker-ref:issue-reference\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+    if [[ "$line" =~ (^|[^[:alnum:]_])PR[[:space:]]*#[0-9]+ ]]; then
+      printf '%s:tracker-ref:pr-reference\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+  done < <(awk '/^[[:space:]]*(\/\/|#)/ { print NR ":" $0 }' <<<"$content")
+
+  if [[ $nocase_was -eq 0 ]]; then
+    shopt -u nocasematch
+  fi
+  if [[ $violations -gt 0 ]]; then
+    return 1
+  fi
+  return 0
+}

--- a/modules/lychee/lychee.toml
+++ b/modules/lychee/lychee.toml
@@ -1,0 +1,29 @@
+# lychee ruleset — repo-agnostic link-checking config.
+# The offline CI lane runs with --offline (external URLs skipped); the online
+# advisory lane reuses this file with the network enabled.
+# Ref: https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
+
+# Verify #fragment/anchor targets resolve, not just the file path ("full"
+# checks both anchor and text fragments).
+include_fragments = "full"
+
+# Build/dependency trees — not authored content. Values are regex (single-quoted
+# TOML literals, so backslashes are not double-escaped).
+exclude_path = [
+  'node_modules',
+  '\.venv',
+  '(^|/)bin/',
+  '(^|/)obj/',
+]
+
+# URL excludes for the online lane (the offline lane skips URLs entirely):
+# auth-walled hosts that block automated checkers, loopback, and placeholders.
+exclude = [
+  '^https?://(www\.)?x\.com/',
+  '^https?://twitter\.com/',
+  '^https?://(www\.)?linkedin\.com/',
+  '^https?://bsky\.app/',
+  '^https?://localhost',
+  '^https?://127\.0\.0\.1',
+  '^https?://example\.(com|org)',
+]

--- a/plugins/markdown-formatter/hooks/hook-utils.sh
+++ b/plugins/markdown-formatter/hooks/hook-utils.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Minimal hook utility library for the markdown-formatter plugin.
 # Sourced (not executed). Trimmed subset of a larger shared library — only the
 # functions this plugin's hook needs: kill switch, file_path parsing + path


### PR DESCRIPTION
@
Stands up quality CI for `claude-code-plugins`, the next consumer in the dedup-program rollout (Phase 6 / greenfield). CI consumes the `ci-workflows` building blocks by pinned SHA behind a local `ci-status` gateway, and adopts the `standards` drop-in configs by copy (byte-identical to upstream).

## Step 0 resolution (visibility)
The rollout prompt assumed `ci-workflows` was private (which would block a public caller per architecture **D6**). **Live state: `ci-workflows` is already public**, so `uses: melodic-software/ci-workflows/...@sha` resolves from this public repo — the standard consume-by-reference model works, no architectural change needed. (Follow-ups below reconcile the IaC/doc drift this surfaced.)

## Lanes (all dogfooded green locally)
`markdown`, `typos`, `gitleaks`, `editorconfig`, `shellcheck`, `actionlint`, `check-jsonschema` (plugin manifests via schemastore + `dependabot.yml` + workflows), the four hygiene lanes (`exec-bit`, `machine-specific-paths`, `eol-renormalize`, `comment-hygiene`), and `zizmor` (advisory). `link-check.yml` is a separate **scheduled, advisory** reusable-workflow caller (`issues: write`, files a rolling tracking issue). Dependabot (`github-actions`, 7-day cooldown) keeps the SHA pins + version comments current.

### Deviations from the tracker, driven by live tracked files
- **`shellcheck` included now** (tracker said "later") — the repo already tracks shell hooks and a `.shellcheckrc`.
- **`hook-utils.sh` drops its vestigial shebang** → `# shellcheck shell=bash`, matching the standards sourced-library convention, so `exec-bit` passes (it is sourced, never executed; mode stays `100644`). This is a one-line line-1 change, disjoint from the concurrent `feat/hook-telemetry-convention` work on the same file (which adds a function lower down) — they 3-way merge cleanly.
- **`osv-scanner` omitted** — no dependency lockfiles exist to scan.
- Existing hand-rolled `.editorconfig` / `.gitattributes` / `.shellcheckrc` replaced with the canonical standards copies.

## Follow-ups (separate PRs, after this is green)
1. **github-iac**: fix the visibility drift (`Program.cs` still declares `ci-workflows` private), enable free public-repo secret scanning + push protection on this repo, and tag it `requires-ci` to arm the org `ci-gate` (sequenced so a green `ci-status` exists on `main` first).
2. **standards**: update the dedup-program rollout/plan docs to mark adoption.
@