### PR TITLE
docs(playbook): document the local plugin development loop

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -81,6 +81,30 @@ For each skill/hook/agent being migrated:
     2026-06-23). Then run `claude plugin validate --strict <repo-root>` to validate the **catalog manifest
     itself** — a bad entry surfaces only there, not in per-plugin validation. Document the plugin in the README.
 
+## Local development loop
+
+For a plugin that already ships here, iterate against your local clone without re-publishing and
+without changing any consumer's marketplace registration. `--plugin-dir` loads a plugin straight from
+a directory; when its `name` matches an installed marketplace plugin, **the local copy takes
+precedence for that session**, so you exercise working-tree edits against the installed copy without
+uninstalling it (verified 2026-06-24).
+
+```shell
+# from this repo root — point at the plugin directory, not the marketplace root
+claude --plugin-dir ./plugins/<name>
+```
+
+- **Edit, then `/reload-plugins`** to pick up changes without restarting — it reloads skills, agents,
+  hooks, and plugin MCP/LSP servers, reading the files on disk, so no commit or reinstall is needed.
+- **Session-scoped and non-destructive.** The override lasts only for that session and never edits a
+  consumer's `extraKnownMarketplaces`; the published registration stays on its GitHub remote. The lone
+  exception: `--plugin-dir` cannot override a plugin that *managed* settings force-enable or
+  force-disable.
+- **Trust.** A locally loaded plugin carries the same trust considerations as any source — only load
+  directories you control.
+- **Then ship.** Run `claude plugin validate` before opening a PR; after merge, consumers pull the
+  change with `/plugin marketplace update melodic-software`, gated by the `version` bump in `plugin.json`.
+
 ## What to wait on / avoid for now
 
 - Don't pre-build cross-plugin `dependencies` graphs until two plugins genuinely share a need.


### PR DESCRIPTION
## Summary

Adds a **Local development loop** section to `docs/MIGRATION-PLAYBOOK.md`. The playbook covered first-publish validation (the migration gate's `--plugin-dir` step) but had no guidance for *iterating on an already-shipped plugin* against a local clone — the gap surfaced while finalizing how a consumer (dotfiles) keeps its tracked marketplace registration stable.

The new section documents the doc-verified loop:
- `claude --plugin-dir ./plugins/<name>` loads the working copy; when the name matches an installed marketplace plugin, the local copy takes **session precedence** (no uninstall needed).
- Edit → `/reload-plugins` picks up on-disk changes without a restart (reloads skills, agents, hooks, MCP/LSP).
- The override is session-scoped and never edits a consumer's `extraKnownMarketplaces` — the published remote registration stays put. Exception: cannot override a plugin force-enabled/disabled by *managed* settings.
- Trust considerations apply; validate before PR; consumers pull via `/plugin marketplace update`.

## Verification

Verified 2026-06-24 firsthand against the official [Create plugins](https://code.claude.com/docs/en/plugins) guide ("Test your plugins locally" / quickstart), per this repo's fresh-docs mandate. No new external links introduced (link-checker safe); MD013 is disabled so prose wraps freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)