### PR TITLE
build(dependabot): fast-track first-party melodic-software/* actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     # updates bypass cooldown and still surface immediately.
     cooldown:
       default-days: 7
+      # First-party melodic-software/* actions skip the supply-chain wait so our
+      # own ci-workflows fixes propagate without the cooldown delay.
+      exclude:
+        - "melodic-software/*"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Exclude melodic-software/* from the github-actions cooldown so our own
ci-workflows fixes propagate without the 7-day supply-chain wait (third-party
actions keep the cooldown; security-advisory updates already bypass it).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>