### PR TITLE
chore: adopt widened comment-hygiene policy and re-pin ci-workflows @9567b8b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Lint markdown
-        uses: melodic-software/ci-workflows/.github/actions/markdown@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/markdown@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           config: .markdownlint-cli2.jsonc
 
@@ -42,7 +42,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Spell-check
-        uses: melodic-software/ci-workflows/.github/actions/typos@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/typos@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           config: _typos.toml
 
@@ -55,7 +55,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Scan for secrets
-        uses: melodic-software/ci-workflows/.github/actions/gitleaks@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/gitleaks@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           config: .gitleaks.toml
 
@@ -68,7 +68,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check editorconfig conformance
-        uses: melodic-software/ci-workflows/.github/actions/editorconfig@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/editorconfig@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           config: .editorconfig-checker.json
 
@@ -81,7 +81,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Lint shell scripts
-        uses: melodic-software/ci-workflows/.github/actions/shellcheck@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/shellcheck@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           rcfile: .shellcheckrc
 
@@ -94,7 +94,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Lint workflows
-        uses: melodic-software/ci-workflows/.github/actions/actionlint@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/actionlint@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
 
   jsonschema:
     runs-on: ubuntu-latest
@@ -105,22 +105,22 @@ jobs:
         with:
           persist-credentials: false
       - name: Validate marketplace manifest
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           schemafile: https://json.schemastore.org/claude-code-marketplace.json
           files: .claude-plugin/marketplace.json
       - name: Validate plugin manifests
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           schemafile: https://json.schemastore.org/claude-code-plugin-manifest.json
           files: plugins/*/.claude-plugin/plugin.json
       - name: Validate dependabot.yml
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           builtin-schema: vendor.dependabot
           files: .github/dependabot.yml
       - name: Validate workflows
-        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           builtin-schema: vendor.github-workflows
           files: >-
@@ -136,7 +136,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Verify shebang files are executable
-        uses: melodic-software/ci-workflows/.github/actions/exec-bit@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/exec-bit@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
 
   machine-specific-paths:
     runs-on: ubuntu-latest
@@ -147,7 +147,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check for machine-specific paths
-        uses: melodic-software/ci-workflows/.github/actions/machine-specific-paths@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/machine-specific-paths@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
 
   eol-renormalize:
     runs-on: ubuntu-latest
@@ -158,7 +158,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check index-level EOL drift
-        uses: melodic-software/ci-workflows/.github/actions/eol-renormalize@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/eol-renormalize@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
 
   comment-hygiene:
     runs-on: ubuntu-latest
@@ -171,7 +171,7 @@ jobs:
       - name: Scan comment hygiene
         # The vendored policy library references the literal marker tokens in its
         # own comments, so skip the module to avoid self-matching.
-        uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+        uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
         with:
           exclude: ':(exclude)modules/comment-hygiene/**'
 
@@ -179,7 +179,7 @@ jobs:
     permissions:
       contents: read
     # Advisory Actions security lint; findings annotate without blocking.
-    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24
     with:
       paths: .
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,4 +19,4 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@08a9343ba6c3ebc2355f140d381c5ac6de9bbb06 # 08a9343 2026-06-23
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@9567b8b58f33fcfd1ece6bffc4564a74264cd421 # 9567b8b 2026-06-24

--- a/modules/comment-hygiene/comment-hygiene-patterns.sh
+++ b/modules/comment-hygiene/comment-hygiene-patterns.sh
@@ -7,17 +7,19 @@
 # cross-platform parity.
 #
 # Policy: comments in production code must not carry deferred-work markers
-# (TODO / FIXME / HACK / XXX) or issue-tracker references (issue|fixes|closes
-# #N, PR #N). Track outstanding work in the issue tracker, not in code comments,
-# so it stays visible and does not rot silently in the source.
+# (TODO / FIXME / HACK / XXX) or issue-tracker references: cc-issue, GitHub
+# closing keywords with a number (fix(es|ed)/close[sd]/resolve[sd] #N), issue /
+# issues / tracked #N, owner/repo#N, GH-N, and PR #N. Track outstanding work in
+# the issue tracker, not in code comments, so it stays visible and does not rot
+# silently in the source.
 #
 # This file is the CONFIG artifact: to tune the policy for a repo, vendor and
 # edit it. The execution action is sourced separately and stays put.
 
 # chp::scan_text <content>
 #
-# Scan the comment lines of <content> (those starting with // or #, after
-# optional indentation) for banned markers and tracker references.
+# Scan the comment lines of <content> (those starting with //, #, /*, *, or
+# <!--, after optional indentation) for banned markers and tracker references.
 #
 # Output (stdout): "lineno:kind:detail" per violation, lineno relative to
 # <content>. Exit: 0 = clean, 1 = one or more violations.
@@ -52,18 +54,53 @@ chp::scan_text() {
       continue
     fi
 
-    # Issue-tracker references in comments.
-    if [[ "$line" =~ (^|[^[:alnum:]_])(issue|fixes|closes)[[:space:]]*#?[0-9]+ ]]; then
+    # Internal continuous-collaboration issue marker.
+    if [[ "$line" =~ cc-issue ]]; then
+      printf '%s:tracker-ref:cc-issue\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+
+    # GitHub closing keywords only close an issue when paired with a #number, so
+    # require the # — that keeps prose like "fix 3 bugs" or "close the handle"
+    # clean while catching "fixes #12" / "resolves #42" / "closed #7".
+    if [[ "$line" =~ (^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+ ]]; then
+      printf '%s:tracker-ref:closing-keyword\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+
+    # issue / issues / tracked references (the # is optional here).
+    if [[ "$line" =~ (^|[^[:alnum:]_])(issues?|tracked)[[:space:]]*:?[[:space:]]*#?[0-9]+ ]]; then
       printf '%s:tracker-ref:issue-reference\n' "$lineno"
       violations=$((violations + 1))
       continue
     fi
+
+    # owner/repo#N — same- or cross-repo issue reference (e.g. org/app#123).
+    if [[ "$line" =~ (^|[^[:alnum:]_/])[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+ ]]; then
+      printf '%s:tracker-ref:repo-issue\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+
+    # GH-N shorthand.
+    if [[ "$line" =~ (^|[^[:alnum:]_])GH-[0-9]+ ]]; then
+      printf '%s:tracker-ref:gh-reference\n' "$lineno"
+      violations=$((violations + 1))
+      continue
+    fi
+
     if [[ "$line" =~ (^|[^[:alnum:]_])PR[[:space:]]*#[0-9]+ ]]; then
       printf '%s:tracker-ref:pr-reference\n' "$lineno"
       violations=$((violations + 1))
       continue
     fi
-  done < <(awk '/^[[:space:]]*(\/\/|#)/ { print NR ":" $0 }' <<<"$content")
+    # Jira-style keys (PROJ-123) are intentionally NOT matched: the bare
+    # LETTERS-NUMBER shape collides with technical tokens (UTF-8, SHA-256,
+    # ISO-8601, RFC-2119, CVE-2025-…, P-256) and POSIX ERE cannot exclude them.
+    # Deferred until a Jira-using consumer supplies an explicit project-key list.
+  done < <(awk '/^[[:space:]]*(\/\/|#|\/\*|\*|<!--)/ { print NR ":" $0 }' <<<"$content")
 
   if [[ $nocase_was -eq 0 ]]; then
     shopt -u nocasematch


### PR DESCRIPTION
## What

- **Re-sync** `modules/comment-hygiene/comment-hygiene-patterns.sh` to the `standards` SSOT (blob `7ebe897`). The widened policy now also flags `cc-issue`, GitHub closing-keyword+`#N`, `issue`/`issues`/`tracked` refs, `owner/repo#N` and `GH-N`, and scans block (`/* *`) and HTML (`<!--`) comment lines.
- **Re-pin** every `melodic-software/ci-workflows` action and reusable-workflow ref (`ci.yml`, `link-check.yml`) to current `main` (`9567b8b`, 2026-06-24).

## Why

No Dependabot exists for vendored configs, so the patterns re-sync is manual. Re-pinning to current ci-workflows main activates the matching coarse prefilter, git-tracked file walks, and inline PR annotations alongside the widened policy. Dependabot would later bump the SHA pins on its own cycle; this brings them current now.

## Verification

- Vendored blob byte-identical to SSOT (`git rev-parse :…` == `7ebe897`, `i/lf`).
- All ci-workflows refs at `9567b8b`.
- Comment-hygiene scan clean under the widened policy.
