### PR TITLE
fix(comment-hygiene): exclude '.' from the owner/repo#N leading boundary

### DIFF
--- a/modules/comment-hygiene/comment-hygiene-patterns.sh
+++ b/modules/comment-hygiene/comment-hygiene-patterns.sh
@@ -77,8 +77,10 @@ chp::scan_text() {
       continue
     fi
 
-    # owner/repo#N — same- or cross-repo issue reference (e.g. org/app#123).
-    if [[ "$line" =~ (^|[^[:alnum:]_/])[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+ ]]; then
+    # owner/repo#N — same- or cross-repo issue reference (e.g. org/app#123). The
+    # leading boundary excludes '.' so a dotted URL host (e.g. example.com/page#2)
+    # is not misread as an owner/repo segment.
+    if [[ "$line" =~ (^|[^[:alnum:]_/.])[A-Za-z0-9._-]+/[A-Za-z0-9._-]+#[0-9]+ ]]; then
       printf '%s:tracker-ref:repo-issue\n' "$lineno"
       violations=$((violations + 1))
       continue


### PR DESCRIPTION
## What

Propagates the canonical comment-hygiene fix — **melodic-software/standards#47** — to this repo's vendored copy of `comment-hygiene-patterns.sh`, keeping all copies byte-identical.

## Why

The repo-issue (`owner/repo#N`) rule's leading boundary `[^[:alnum:]_/]` allowed a dotted URL host to satisfy it, so an ordinary comment linking a URL with a numeric fragment was wrongly flagged:

```sh
// see https://example.com/page#2 for details   # was: tracker-ref:repo-issue
```

## Fix

Add `.` to the negated boundary class (`[^[:alnum:]_/]` → `[^[:alnum:]_/.]`). A dotted host is no longer misread as an owner segment; genuine `owner/repo#N` references still match. See standards#47 for the full rationale, regression test, and validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01KPusuNL65RexZQQQ4SqL7t
