### PR TITLE
feat(bash-lint): add shell lint/format-on-edit plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,6 +12,12 @@
       "source": "./plugins/markdown-formatter",
       "category": "formatting",
       "tags": ["markdown", "markdownlint", "formatter", "linter", "hook"]
+    },
+    {
+      "name": "bash-lint",
+      "source": "./plugins/bash-lint",
+      "category": "formatting",
+      "tags": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace
 | Plugin | Type | What it does |
 |---|---|---|
 | [`markdown-formatter`](plugins/markdown-formatter) | Hook | Auto-formats and lints Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config. |
+| [`bash-lint`](plugins/bash-lint) | Hook | Lints shell scripts on edit via ShellCheck, and formats via shfmt when the repo opts in with an `.editorconfig`, using the consuming repo's own config. |
 
-Install one: `/plugin install markdown-formatter@melodic-software`.
+Install one: `/plugin install <plugin-name>@melodic-software`.
 
 ## What's here
 

--- a/plugins/bash-lint/.claude-plugin/plugin.json
+++ b/plugins/bash-lint/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "bash-lint",
+  "version": "0.1.0",
+  "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "keywords": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"]
+}

--- a/plugins/bash-lint/README.md
+++ b/plugins/bash-lint/README.md
@@ -1,0 +1,60 @@
+# bash-lint
+
+A Claude Code plugin that lints and formats shell scripts the moment you edit
+them. On every `Write` or `Edit` of a `.sh` or `.bash` file it runs
+[ShellCheck](https://www.shellcheck.net/) and (opt-in)
+[shfmt](https://github.com/mvdan/sh), surfacing findings back to Claude as
+advisory context.
+
+It uses **your repository's own configuration** — `.shellcheckrc` for linting
+and `.editorconfig` for formatting. It ships no rules of its own.
+
+## Behavior
+
+- **Lint on edit (always).** ShellCheck (`warning` severity and above) runs on
+  every edit. It is non-mutating; it only reports.
+- **Format on edit (opt-in).** `shfmt -w` runs **only when an `.editorconfig`
+  governs the edited file** — walking up from the file to the repository root.
+  With no `.editorconfig`, the file is left untouched rather than rewritten to
+  shfmt's built-in defaults, so the plugin never imposes a style you did not
+  choose. Run with no formatting flags, so your `.editorconfig` is authoritative.
+- **Advisory, never blocking.** The hook always exits `0`. Findings are reported
+  via `additionalContext`; they never reject the edit. Make a commit hook or CI
+  your hard gate.
+- **Config from the consumer.** ShellCheck discovers `.shellcheckrc` by walking
+  up from the file's directory; shfmt reads `.editorconfig` the same way. No
+  working-directory assumptions — the tools are anchored to the edited file.
+
+## Requirements
+
+- **ShellCheck** on `PATH` for the lint pass.
+- **shfmt** on `PATH` for the format pass (and an `.editorconfig` in your repo to
+  opt in).
+
+Each pass is independent: when a tool is absent its pass is skipped and the other
+still runs. With neither present the hook is a silent no-op.
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install bash-lint@melodic-software
+```
+
+## Configuration
+
+This plugin has no `userConfig` — its only "configuration" is the `.shellcheckrc`
+and `.editorconfig` already in your repository, which it reads automatically. To
+change the rules, edit those files.
+
+### Disable without uninstalling
+
+Set the kill switch in your settings `env` block:
+
+```json
+{ "env": { "HOOK_BASH_LINT_ENABLED": "false" } }
+```
+
+## License
+
+[MIT](../../LICENSE).

--- a/plugins/bash-lint/README.md
+++ b/plugins/bash-lint/README.md
@@ -14,12 +14,16 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 - **Lint on edit (always).** ShellCheck (`warning` severity and above) runs on
   every edit. It is non-mutating; it only reports.
 - **Format on edit (opt-in).** `shfmt` runs **only when an `.editorconfig`
-  governs the edited file** — walking up from the file to the repository root.
-  With no `.editorconfig`, the file is left untouched rather than rewritten to
-  shfmt's built-in defaults, so the plugin never imposes a style you did not
-  choose. It runs with no parser/printer flags, so your `.editorconfig` is
-  authoritative, and with `--apply-ignore` so an `ignore = true` section (e.g.
-  for generated or vendored scripts) is honored even on a single edited file.
+  section governs the edited shell file** — a `[*]` catch-all or a shell glob
+  such as `[*.sh]`, `[*.bash]`, or `[*.{sh,bash}]`, found by walking up from the
+  file to the repository root. A repo whose `.editorconfig` only configures other
+  languages (or has none) leaves shell files untouched rather than rewriting them
+  to shfmt's built-in defaults, so the plugin never imposes a style you did not
+  choose. (Path-only sections like `[scripts/**]` are not treated as a shell
+  opt-in; use a shell glob or `[*]`.) It runs with no parser/printer flags, so
+  your `.editorconfig` is authoritative, and with `--apply-ignore` so an
+  `ignore = true` section (e.g. for generated or vendored scripts) is honored
+  even on a single edited file.
 - **Advisory, never blocking.** The hook always exits `0`. Findings are reported
   via `additionalContext`; they never reject the edit. Make a commit hook or CI
   your hard gate.

--- a/plugins/bash-lint/README.md
+++ b/plugins/bash-lint/README.md
@@ -13,11 +13,13 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 
 - **Lint on edit (always).** ShellCheck (`warning` severity and above) runs on
   every edit. It is non-mutating; it only reports.
-- **Format on edit (opt-in).** `shfmt -w` runs **only when an `.editorconfig`
+- **Format on edit (opt-in).** `shfmt` runs **only when an `.editorconfig`
   governs the edited file** — walking up from the file to the repository root.
   With no `.editorconfig`, the file is left untouched rather than rewritten to
   shfmt's built-in defaults, so the plugin never imposes a style you did not
-  choose. Run with no formatting flags, so your `.editorconfig` is authoritative.
+  choose. It runs with no parser/printer flags, so your `.editorconfig` is
+  authoritative, and with `--apply-ignore` so an `ignore = true` section (e.g.
+  for generated or vendored scripts) is honored even on a single edited file.
 - **Advisory, never blocking.** The hook always exits `0`. Findings are reported
   via `additionalContext`; they never reject the edit. Make a commit hook or CI
   your hard gate.
@@ -33,6 +35,10 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 
 Each pass is independent: when a tool is absent its pass is skipped and the other
 still runs. With neither present the hook is a silent no-op.
+
+The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
+(Bash 5.0+); on older bash the telemetry envelope is skipped while linting and
+formatting still run.
 
 ## Install
 

--- a/plugins/bash-lint/hooks/bash-lint.sh
+++ b/plugins/bash-lint/hooks/bash-lint.sh
@@ -108,7 +108,12 @@ ran_any=0
 # which it otherwise skips for direct-file invocations — so a repo's opt-out for
 # generated/vendored scripts is respected, not overwritten.
 if command -v shfmt >/dev/null 2>&1 && has_editorconfig; then
-  shfmt --apply-ignore -w "$FILE" 2>/dev/null
+  # --apply-ignore requires shfmt 3.8+ (2024-02). On older shfmt the flag is
+  # unknown and the call fails without formatting, so fall back to a plain
+  # in-place format — those versions cannot honor direct-file ignore rules
+  # anyway (that is exactly the capability --apply-ignore adds). On shfmt 3.8+
+  # the first call succeeds (skipping ignored files), so the fallback never runs.
+  shfmt --apply-ignore -w "$FILE" 2>/dev/null || shfmt -w "$FILE" 2>/dev/null
   ran_any=1
 fi
 

--- a/plugins/bash-lint/hooks/bash-lint.sh
+++ b/plugins/bash-lint/hooks/bash-lint.sh
@@ -80,19 +80,45 @@ build_data_json() {
     || printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"
 }
 
-# Consumer opt-in for shfmt: an .editorconfig in the edited file's directory or
-# any ancestor up to (and including) the repo root. Bare `shfmt -w` honors
-# .editorconfig only when no formatting flags are passed, so this gate is the
-# whole formatting contract — present means "format to my config", absent means
-# "leave my bytes alone".
-has_editorconfig() {
-  local dir root
+# A section header governs shell files when it is the `[*]` catch-all or names a
+# shell extension — `[*.sh]` / `[*.bash]` (incl. path prefixes like `[**/*.sh]`)
+# or a brace list naming sh or bash (`[*.{sh,bash}]`). Path-only sections such as
+# `[scripts/**]` are intentionally NOT treated as shell opt-in: matching those
+# correctly means reimplementing EditorConfig globbing, and the safe bias is to
+# leave files untouched when unsure. $1 is the text inside the brackets.
+section_applies_to_shell() {
+  local h="$1"
+  [[ "$h" == '*' ]] && return 0
+  [[ "$h" =~ \*\.(sh|bash)([^[:alnum:]]|$) ]] && return 0
+  [[ "$h" =~ [{,](sh|bash)[,}] ]] && return 0
+  return 1
+}
+
+# Consumer opt-in for shfmt: an EditorConfig SECTION that governs the edited
+# shell file (not merely the presence of any .editorconfig — a repo whose
+# .editorconfig only configures other languages must not have its shell files
+# rewritten to shfmt's built-in defaults). Walks up from the file to the repo
+# root, stopping at a `root = true` config per EditorConfig search semantics.
+# This gate is the whole formatting opt-in.
+shell_editorconfig_opt_in() {
+  local dir root cfg line is_root parent
   dir="$(cd "$(dirname "$FILE")" 2>/dev/null && pwd)" || return 1
   root="$(cd "$REPO_ROOT" 2>/dev/null && pwd)" || root=""
   while :; do
-    [[ -f "$dir/.editorconfig" ]] && return 0
+    cfg="$dir/.editorconfig"
+    if [[ -f "$cfg" ]]; then
+      is_root=0
+      while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+        if [[ "$line" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+          section_applies_to_shell "${BASH_REMATCH[1]}" && return 0
+        elif [[ "$line" =~ ^[[:space:]]*[Rr][Oo][Oo][Tt][[:space:]]*=[[:space:]]*[Tt][Rr][Uu][Ee][[:space:]]*$ ]]; then
+          is_root=1
+        fi
+      done <"$cfg"
+      [[ $is_root -eq 1 ]] && return 1 # root config, no shell section → stop
+    fi
     [[ -n "$root" && "$dir" == "$root" ]] && return 1
-    local parent
     parent="$(dirname "$dir")"
     [[ "$parent" == "$dir" ]] && return 1 # reached filesystem root
     dir="$parent"
@@ -107,7 +133,7 @@ ran_any=0
 # shfmt honor `ignore = true` editorconfig rules for this single direct file,
 # which it otherwise skips for direct-file invocations — so a repo's opt-out for
 # generated/vendored scripts is respected, not overwritten.
-if command -v shfmt >/dev/null 2>&1 && has_editorconfig; then
+if command -v shfmt >/dev/null 2>&1 && shell_editorconfig_opt_in; then
   # --apply-ignore requires shfmt 3.8+ (2024-02). On older shfmt the flag is
   # unknown and the call fails without formatting, so fall back to a plain
   # in-place format — those versions cannot honor direct-file ignore rules

--- a/plugins/bash-lint/hooks/bash-lint.sh
+++ b/plugins/bash-lint/hooks/bash-lint.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format and lint shell scripts via shfmt + ShellCheck.
+# Triggered on Write|Edit of *.sh and *.bash files.
+#
+# ADVISORY: always exits 0. ShellCheck findings (warning severity and above)
+# surface via additionalContext but never block the edit. Uses the consuming
+# repo's own .shellcheckrc and .editorconfig — ships none.
+#
+# shfmt is gated on the consumer opting in: it runs only when an .editorconfig
+# governs the edited file (walking up to the repo root). Without that opt-in the
+# file is left unformatted rather than rewritten to shfmt's built-in defaults.
+# ShellCheck (non-mutating) always runs when available.
+
+set -uo pipefail
+
+# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
+# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
+# resolve (ENOENT → silent no-op). stdin is read ONCE here and fed to both
+# hook::read_file_path (file_path) and the tool_name parse below; reading fd0
+# twice would drain the pipe on the second call.
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "BASH_LINT"
+
+# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers
+# the work below (pre-work exits do not emit telemetry).
+start=$EPOCHREALTIME
+
+INPUT=$(cat)
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+case "$FILE" in
+  *.sh | *.bash) ;;
+  *) exit 0 ;;
+esac
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Resolve repo root early — used to bound the .editorconfig opt-in walk and to
+# compute the schema-required repo-relative path in data.file.
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+# Repo-relative path: schema requires "relative to the consuming repo root".
+# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
+# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
+# (long name, forward-slash mixed form) when available so the prefix strip
+# compares the same representation. On Linux/macOS, cygpath is absent and both
+# paths are already POSIX. Falls back to raw FILE on any normalization error.
+FILE_REL="$FILE"
+if command -v cygpath >/dev/null 2>&1; then
+  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+    FILE_REL="${_file_lm#"$_root_lm"/}"
+  fi
+else
+  FILE_REL="${FILE#"$REPO_ROOT"/}"
+fi
+
+# Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
+# findings JSON array. jq is authoritative; the string fallback keeps telemetry
+# best-effort if jq fails (findings collapse to [] since they can't be re-quoted
+# safely without jq).
+build_data_json() {
+  jq -n \
+    --arg tool     "$TOOL" \
+    --arg file     "$FILE_REL" \
+    --argjson findings "$1" \
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
+    || printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"
+}
+
+# Consumer opt-in for shfmt: an .editorconfig in the edited file's directory or
+# any ancestor up to (and including) the repo root. Bare `shfmt -w` honors
+# .editorconfig only when no formatting flags are passed, so this gate is the
+# whole formatting contract — present means "format to my config", absent means
+# "leave my bytes alone".
+has_editorconfig() {
+  local dir root
+  dir="$(cd "$(dirname "$FILE")" 2>/dev/null && pwd)" || return 1
+  root="$(cd "$REPO_ROOT" 2>/dev/null && pwd)" || root=""
+  while :; do
+    [[ -f "$dir/.editorconfig" ]] && return 0
+    [[ -n "$root" && "$dir" == "$root" ]] && return 1
+    local parent
+    parent="$(dirname "$dir")"
+    [[ "$parent" == "$dir" ]] && return 1 # reached filesystem root
+    dir="$parent"
+  done
+}
+
+ran_any=0
+
+# Format pass (opt-in, mutating). No parser/printer flags — that is what keeps
+# .editorconfig in effect.
+if command -v shfmt >/dev/null 2>&1 && has_editorconfig; then
+  shfmt -w "$FILE" 2>/dev/null
+  ran_any=1
+fi
+
+# Lint pass (always-on, non-mutating). -x follows `source`/`.` directives;
+# -f gcc gives one finding per line; -S warning drops info/style noise. Config
+# (.shellcheckrc) is auto-discovered from the file's directory upward.
+if command -v shellcheck >/dev/null 2>&1; then
+  ran_any=1
+  SC_OUTPUT=$(shellcheck -x -f gcc -S warning "$FILE" 2>&1) || true
+  if [[ -n "$SC_OUTPUT" ]]; then
+    hook::ctx_reset
+    hook::ctx_append "bash-lint: $(basename "$FILE") has ShellCheck findings:"
+    findings_raw=""
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      hook::ctx_append "  $line"
+      findings_raw+="$line"$'\n'
+    done <<<"$SC_OUTPUT"
+    hook::ctx_flush PostToolUse
+
+    FINDINGS_JSON='[]'
+    if [[ -n "$findings_raw" ]]; then
+      FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
+    fi
+    data_json=$(build_data_json "$FINDINGS_JSON")
+    hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+    exit 0
+  fi
+fi
+
+# No findings. "skipped" when neither tool did anything (both absent / no opt-in);
+# "ok" when at least one pass ran cleanly.
+status="ok"
+[[ $ran_any -eq 0 ]] && status="skipped"
+data_json=$(build_data_json '[]')
+hook::emit_telemetry "bash-lint" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
+exit 0

--- a/plugins/bash-lint/hooks/bash-lint.sh
+++ b/plugins/bash-lint/hooks/bash-lint.sh
@@ -23,9 +23,19 @@ source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
 
 hook::check_enabled "BASH_LINT"
 
-# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers
-# the work below (pre-work exits do not emit telemetry).
-start=$EPOCHREALTIME
+# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers the
+# work below (pre-work exits do not emit telemetry). EPOCHREALTIME is Bash 5.0+;
+# on older bash it is unset, so default to empty — referencing it bare under
+# `set -u` would abort before the advisory exit 0, failing every edit.
+start=${EPOCHREALTIME:-}
+
+# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
+# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
+# lints and formats on older bash rather than aborting.
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::emit_telemetry "$@"
+}
 
 INPUT=$(cat)
 
@@ -91,10 +101,14 @@ has_editorconfig() {
 
 ran_any=0
 
-# Format pass (opt-in, mutating). No parser/printer flags — that is what keeps
-# .editorconfig in effect.
+# Format pass (opt-in, mutating). No parser/printer flags — that keeps
+# .editorconfig formatting in effect. --apply-ignore is a utility flag (not a
+# parser/printer flag, so it does not disable editorconfig formatting): it makes
+# shfmt honor `ignore = true` editorconfig rules for this single direct file,
+# which it otherwise skips for direct-file invocations — so a repo's opt-out for
+# generated/vendored scripts is respected, not overwritten.
 if command -v shfmt >/dev/null 2>&1 && has_editorconfig; then
-  shfmt -w "$FILE" 2>/dev/null
+  shfmt --apply-ignore -w "$FILE" 2>/dev/null
   ran_any=1
 fi
 
@@ -120,7 +134,7 @@ if command -v shellcheck >/dev/null 2>&1; then
       FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
     fi
     data_json=$(build_data_json "$FINDINGS_JSON")
-    hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+    emit_tel "bash-lint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
     exit 0
   fi
 fi
@@ -130,5 +144,5 @@ fi
 status="ok"
 [[ $ran_any -eq 0 ]] && status="skipped"
 data_json=$(build_data_json '[]')
-hook::emit_telemetry "bash-lint" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "bash-lint" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
 exit 0

--- a/plugins/bash-lint/hooks/bash-lint.test.sh
+++ b/plugins/bash-lint/hooks/bash-lint.test.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Black-box contract test for bash-lint.sh (the bash-lint plugin hook).
+#
+# Proves WIRING: the hook fires on *.sh/*.bash, skips otherwise, surfaces
+# ShellCheck findings via additionalContext (advisory, exit 0), honors the
+# kill switch, gates shfmt formatting on a consumer .editorconfig (present ->
+# format, absent -> leave bytes untouched), and emits a schema-valid telemetry
+# envelope. No medley-policy prose in the surfaced context.
+#
+# Self-contained: builds throwaway git repos with runtime-generated fixtures.
+# The hook is invoked as a subprocess from an UNRELATED cwd so any reliance on
+# the caller's working directory would surface (the tools are file-anchored, so
+# a correct hook needs no cd). shellcheck is required; without it the lint
+# branch -- which drives the findings assertions -- cannot fire, so the suite
+# skips. shfmt-gated cases skip when shfmt is absent.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/bash-lint.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "SKIP: shellcheck not on PATH -- bash-lint hook tests skipped"
+  exit 0
+fi
+HAVE_SHFMT=0
+if command -v shfmt >/dev/null 2>&1; then
+  HAVE_SHFMT=1
+fi
+
+WORK="$(mktemp -d)"
+UNRELATED="$(mktemp -d)"
+cleanup() { rm -rf "$WORK" "$UNRELATED"; }
+trap cleanup EXIT
+
+# make_sink <body> -> path to an executable single-command stub sink running
+# <body> (which reads the envelope on stdin). HOOK_TELEMETRY_SINK must be a
+# single executable path, not a command-with-args, so tests point it at a stub.
+make_sink() {
+  local s
+  s="$(mktemp -p "$WORK" sink.XXXXXX)"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$1"
+  } >"$s"
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [tries] -> block until <file> is non-empty (the
+# fire-and-forget sink flushed) or the bound elapses, polling in 20ms steps.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while ((tries-- > 0)); do
+    if [[ -s "$f" ]]; then
+      return 0
+    fi
+    sleep 0.02
+  done
+  return 1
+}
+
+new_repo() {
+  local r="$1"
+  mkdir -p "$r"
+  git -C "$r" init -q
+  git -C "$r" config user.email t@t.t
+  git -C "$r" config user.name t
+}
+
+# Invoke the hook from an unrelated cwd. CLAUDE_PROJECT_DIR is left UNSET so
+# read_file_path's membership guard is disabled (not part of the fire gate);
+# this isolates lint/format behavior from path-form mismatch in the guard.
+run_hook() {
+  local file_path="$1"
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR HOOK_BASH_LINT_ENABLED=true bash "$HOOK"
+  )
+}
+
+# Same as run_hook but with caller-supplied extra env (NAME=VALUE ...) and an
+# optional override of HOOK_BASH_LINT_ENABLED, passed through env.
+run_hook_env() {
+  local file_path="$1"
+  shift
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+  )
+}
+
+REPO="$WORK/consumer"
+new_repo "$REPO"
+
+# --- Case 1: clean .sh -> exit 0, empty stdout ------------------------------
+cat >"$REPO/clean.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "clean"
+EOF
+OUT=$(run_hook "$REPO/clean.sh")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "clean .sh -> exit 0"; else fail "clean .sh exit $RC"; fi
+if [[ -z "$OUT" ]]; then ok "clean .sh -> empty stdout"; else fail "clean .sh stdout not empty: $OUT"; fi
+
+# --- Case 2: clean .bash -> exit 0 (glob match) -----------------------------
+cat >"$REPO/clean.bash" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "clean bash"
+EOF
+OUT=$(run_hook "$REPO/clean.bash")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "clean .bash -> exit 0 (glob match)"; else fail "clean .bash exit $RC"; fi
+
+# --- Case 3: SC2154 reference to unassigned var -> advisory (exit 0) ---------
+cat >"$REPO/violation.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$undefined_var"
+EOF
+OUT=$(run_hook "$REPO/violation.sh")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "SC2154 violation -> exit 0 (advisory)"; else fail "violation exit $RC (must be advisory)"; fi
+if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext')
+  if printf '%s' "$CTX" | grep -q 'SC2154'; then
+    ok "violation -> SC2154 in additionalContext"
+  else
+    fail "violation ctx missing SC2154: $CTX"
+  fi
+  if printf '%s' "$CTX" | grep -qi 'commit/CI will block\|hard gate\|lefthook'; then
+    fail "ctx still carries medley-policy prose: $CTX"
+  else
+    ok "ctx free of medley-policy prose"
+  fi
+else
+  fail "violation -> no additionalContext JSON: $OUT"
+fi
+
+# --- Case 4: non-shell extension -> exit 0 silently -------------------------
+echo "not a script" >"$REPO/foo.txt"
+OUT=$(run_hook "$REPO/foo.txt")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-shell ext -> exit 0 silent"; else fail "non-shell not skipped (rc=$RC out=$OUT)"; fi
+
+# --- Case 5: kill switch bypasses hook --------------------------------------
+OUT=$(run_hook_env "$REPO/violation.sh" HOOK_BASH_LINT_ENABLED=false)
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent despite violation"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
+
+# --- Case 6+7: shfmt gate on .editorconfig ----------------------------------
+# Fixture body is deliberately unindented inside an if-block; shfmt would indent
+# the inner line. Gate ON (with .editorconfig) -> indented; gate OFF -> untouched.
+if [[ $HAVE_SHFMT -eq 1 ]]; then
+  # Gate ON: .editorconfig at repo root, file in a subdir (exercises the walk).
+  REPO_YES="$WORK/with-config"
+  new_repo "$REPO_YES"
+  cat >"$REPO_YES/.editorconfig" <<'EOF'
+root = true
+[*.sh]
+indent_style = space
+indent_size = 2
+EOF
+  mkdir -p "$REPO_YES/src"
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_YES/src/fmt.sh"
+  run_hook "$REPO_YES/src/fmt.sh" >/dev/null
+  if grep -q '^  echo hi$' "$REPO_YES/src/fmt.sh"; then
+    ok "shfmt gate ON (.editorconfig present) -> file formatted"
+  else
+    fail "shfmt gate ON -> not formatted: $(cat "$REPO_YES/src/fmt.sh")"
+  fi
+
+  # Gate OFF: no .editorconfig anywhere in the repo -> bytes untouched.
+  REPO_NO="$WORK/no-config"
+  new_repo "$REPO_NO"
+  mkdir -p "$REPO_NO/src"
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_NO/src/fmt.sh"
+  run_hook "$REPO_NO/src/fmt.sh" >/dev/null
+  if grep -q '^echo hi$' "$REPO_NO/src/fmt.sh"; then
+    ok "shfmt gate OFF (no .editorconfig) -> file left untouched"
+  else
+    fail "shfmt gate OFF -> file was reformatted: $(cat "$REPO_NO/src/fmt.sh")"
+  fi
+else
+  echo "  (shfmt absent -- gate cases skipped)"
+fi
+
+# ============================================================================
+# Telemetry
+# ============================================================================
+
+# --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
+OUT_NS=$(run_hook_env "$REPO/clean.sh" -u HOOK_TELEMETRY_SINK HOOK_BASH_LINT_ENABLED=true)
+RC_NS=$?
+if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
+  ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
+else
+  fail "telemetry/sink-unset: rc=$RC_NS out=$OUT_NS"
+fi
+
+# --- Stub sink + violation -> envelope status ok with findings --------------
+TEL="$(mktemp)"
+SINK="$(make_sink "cat >\"$TEL\"")"
+run_hook_env "$REPO/violation.sh" HOOK_BASH_LINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+wait_for_sink "$TEL"
+if [[ -s "$TEL" ]]; then
+  ok "telemetry/stub-sink: envelope received"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$TEL" >/dev/null 2>&1; then
+      ok "envelope: $field present"
+    else
+      fail "envelope: $field missing ($(cat "$TEL"))"
+    fi
+  done
+  if [[ "$(jq -r '.hook' "$TEL")" == "bash-lint" ]]; then ok "envelope: hook is bash-lint"; else fail "envelope: hook=$(jq -r '.hook' "$TEL")"; fi
+  if [[ "$(jq -r '.status' "$TEL")" == "ok" ]]; then ok "envelope: status ok"; else fail "envelope: status=$(jq -r '.status' "$TEL")"; fi
+  if [[ "$(jq -r '.schema_version' "$TEL")" == "1.0" ]]; then ok "envelope: schema_version 1.0"; else fail "envelope: schema_version=$(jq -r '.schema_version' "$TEL")"; fi
+  if [[ "$(jq '.data.findings | length' "$TEL")" -ge 1 ]]; then ok "envelope: findings populated"; else fail "envelope: findings empty ($(jq '.data.findings' "$TEL"))"; fi
+  if jq -e '.data.findings | any(test("SC2154"))' "$TEL" >/dev/null 2>&1; then ok "envelope: findings name SC2154"; else fail "envelope: findings missing SC2154 ($(jq '.data.findings' "$TEL"))"; fi
+  FREL=$(jq -r '.data.file' "$TEL")
+  if [[ -n "$FREL" && "$FREL" != /* && "$FREL" != ?:* ]]; then ok "envelope: data.file repo-relative ($FREL)"; else fail "envelope: data.file not repo-relative: $FREL"; fi
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL" >/dev/null 2>&1; then ok "envelope: duration_ms non-negative int"; else fail "envelope: duration_ms invalid ($(jq .duration_ms "$TEL"))"; fi
+else
+  fail "telemetry/stub-sink: no envelope written"
+fi
+rm -f "$TEL"
+
+# --- Stub sink + clean file -> status ok, findings [] -----------------------
+TELC="$(mktemp)"
+SINKC="$(make_sink "cat >\"$TELC\"")"
+run_hook_env "$REPO/clean.sh" HOOK_BASH_LINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKC" >/dev/null
+wait_for_sink "$TELC"
+if [[ -s "$TELC" ]]; then
+  if [[ "$(jq -r '.status' "$TELC")" == "ok" ]]; then ok "telemetry/clean: status ok"; else fail "telemetry/clean: status=$(jq -r '.status' "$TELC")"; fi
+  if [[ "$(jq '.data.findings | length' "$TELC")" -eq 0 ]]; then ok "telemetry/clean: findings empty array"; else fail "telemetry/clean: findings not empty ($(jq '.data.findings' "$TELC"))"; fi
+else
+  fail "telemetry/clean: no envelope written"
+fi
+rm -f "$TELC"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/bash-lint/hooks/bash-lint.test.sh
+++ b/plugins/bash-lint/hooks/bash-lint.test.sh
@@ -196,6 +196,29 @@ EOF
   else
     fail "shfmt gate OFF -> file was reformatted: $(cat "$REPO_NO/src/fmt.sh")"
   fi
+
+  # editorconfig opt-OUT: an `ignore = true` section for the edited file must be
+  # honored even on this direct-file invocation (requires --apply-ignore; shfmt
+  # skips ignore rules for direct files without it). The file is misformatted and
+  # an .editorconfig IS present (so the gate passes), but the ignore rule must
+  # leave it untouched.
+  REPO_IGN="$WORK/ignore-config"
+  new_repo "$REPO_IGN"
+  cat >"$REPO_IGN/.editorconfig" <<'EOF'
+root = true
+[*.sh]
+indent_style = space
+indent_size = 2
+[gen.sh]
+ignore = true
+EOF
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_IGN/gen.sh"
+  run_hook "$REPO_IGN/gen.sh" >/dev/null
+  if grep -q '^echo hi$' "$REPO_IGN/gen.sh"; then
+    ok "shfmt honors editorconfig ignore=true (--apply-ignore) -> file untouched"
+  else
+    fail "shfmt ignored editorconfig ignore=true -> file was reformatted: $(cat "$REPO_IGN/gen.sh")"
+  fi
 else
   echo "  (shfmt absent -- gate cases skipped)"
 fi

--- a/plugins/bash-lint/hooks/bash-lint.test.sh
+++ b/plugins/bash-lint/hooks/bash-lint.test.sh
@@ -219,6 +219,32 @@ EOF
   else
     fail "shfmt ignored editorconfig ignore=true -> file was reformatted: $(cat "$REPO_IGN/gen.sh")"
   fi
+
+  # Opt-in precision: an .editorconfig with NO shell-applicable section (only
+  # [*.md], no [*]) must NOT trigger formatting — otherwise shfmt would impose
+  # its built-in defaults on shell files the repo never opted in for.
+  REPO_NONSHELL="$WORK/nonshell-config"
+  new_repo "$REPO_NONSHELL"
+  printf '[*.md]\nindent_style = space\n' >"$REPO_NONSHELL/.editorconfig"
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_NONSHELL/x.sh"
+  run_hook "$REPO_NONSHELL/x.sh" >/dev/null
+  if grep -q '^echo hi$' "$REPO_NONSHELL/x.sh"; then
+    ok "non-shell .editorconfig ([*.md] only) -> shell file left untouched"
+  else
+    fail "non-shell .editorconfig -> shell file was reformatted: $(cat "$REPO_NONSHELL/x.sh")"
+  fi
+
+  # A [*] catch-all governs shell files, so formatting opts in.
+  REPO_STAR="$WORK/star-config"
+  new_repo "$REPO_STAR"
+  printf 'root = true\n[*]\nindent_style = space\nindent_size = 2\n' >"$REPO_STAR/.editorconfig"
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_STAR/x.sh"
+  run_hook "$REPO_STAR/x.sh" >/dev/null
+  if grep -q '^  echo hi$' "$REPO_STAR/x.sh"; then
+    ok "[*] catch-all .editorconfig -> shell file formatted"
+  else
+    fail "[*] catch-all -> shell file not formatted: $(cat "$REPO_STAR/x.sh")"
+  fi
 else
   echo "  (shfmt absent -- gate cases skipped)"
 fi

--- a/plugins/bash-lint/hooks/hook-utils.sh
+++ b/plugins/bash-lint/hooks/hook-utils.sh
@@ -1,0 +1,211 @@
+# shellcheck shell=bash
+# Minimal hook utility library for the markdown-formatter plugin.
+# Sourced (not executed). Trimmed subset of a larger shared library — only the
+# functions this plugin's hook needs: kill switch, file_path parsing + path
+# normalization, repo-root resolution, and the additionalContext accumulator.
+
+# Guard against double-sourcing.
+[[ -n "${_MDFMT_HOOK_UTILS_LOADED:-}" ]] && return 0
+readonly _MDFMT_HOOK_UTILS_LOADED=1
+
+# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
+# disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+hook::check_enabled() {
+  local var_name="HOOK_${1}_ENABLED"
+  if [[ "${!var_name:-true}" != "true" ]]; then
+    exit 0
+  fi
+}
+
+# Normalize a path for the membership comparison below: backslashes → forward
+# slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
+# fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive
+# letter + lower-cased remainder so the byte-exact comparison is effectively
+# case-insensitive. The fold is gated on the host (OSTYPE), NOT on the path
+# shape: on a case-sensitive POSIX filesystem a real single-letter top-level
+# directory such as `/c/Repo` must pass through unchanged, otherwise it would
+# collapse with `/c/repo` and the membership guard would admit a sibling
+# outside CLAUDE_PROJECT_DIR. The result is used ONLY for comparison; the
+# emitted path is always the caller's original.
+hook::normalize_path() {
+  local p="${1//\\//}"
+  case "${OSTYPE:-}" in
+    msys* | cygwin* | win32)
+      if [[ "$p" =~ ^/([a-zA-Z])/ || "$p" =~ ^([a-zA-Z]):/ ]]; then
+        local rest="${p:2}"
+        printf '%s' "${BASH_REMATCH[1]^}:${rest,,}"
+        return
+      fi
+      ;;
+    *) ;; # POSIX hosts: case-sensitive FS, no drive fold — pass through below
+  esac
+  printf '%s' "$p"
+}
+
+# Parse file_path from PostToolUse JSON on stdin; validate existence and (when
+# CLAUDE_PROJECT_DIR is set) project membership. Outputs the path on success.
+# Returns 1 to skip.
+#   FILE=$(hook::read_file_path) || exit 0
+hook::read_file_path() {
+  local file
+  file=$(jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+  [[ -n "$file" ]] || return 1
+  [[ -f "$file" ]] || return 1
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local norm_file norm_project
+    norm_file=$(hook::normalize_path "$file")
+    norm_project=$(hook::normalize_path "${CLAUDE_PROJECT_DIR}")
+    norm_project="${norm_project%/}"
+    # Anchor on a path-segment boundary: accept the project root itself or a
+    # child under it, but not a sibling whose name merely shares the prefix
+    # (e.g. /c/repo must not admit /c/repo-backup/...).
+    if [[ "$norm_file" != "$norm_project" && "$norm_file" != "$norm_project"/* ]]; then
+      return 1
+    fi
+  fi
+  printf '%s' "$file"
+}
+
+# Resolve the repository root (working-tree top) for a path inside the tree.
+# markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
+# before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
+# so it is correct for clones, linked worktrees, and bare-hub clones; falls
+# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+#   ROOT=$(hook::repo_root "$some_path")
+hook::repo_root() {
+  local hint="${1:-.}"
+  local root
+  root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+  if [[ -z "$root" ]]; then
+    root="$hint"
+    root="${root%/.claude}"
+    root="${root%\\.claude}"
+  fi
+  printf '%s' "$root"
+}
+
+# Per-hook stdout context accumulator. ctx_reset at entry, ctx_append per line,
+# ctx_flush once at exit with the hook event name.
+_HOOK_CTX_BUFFER=""
+
+hook::ctx_reset() {
+  _HOOK_CTX_BUFFER=""
+}
+
+hook::ctx_append() {
+  _HOOK_CTX_BUFFER+="$1"$'\n'
+}
+
+# Emit the accumulated context as hookSpecificOutput JSON, then clear the buffer.
+hook::ctx_flush() {
+  local event_name="$1"
+  local trimmed="${_HOOK_CTX_BUFFER%"${_HOOK_CTX_BUFFER##*[![:space:]]}"}"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  hook::emit_additional_context "$event_name" "$trimmed"
+  hook::ctx_reset
+}
+
+# Emit one telemetry envelope per hook run to the consumer-set sink.
+# Fire-and-forget: sink is dispatched in the background; the hook never waits
+# on it and its failure never affects the hook's own exit code or stdout.
+# Opt-in guard: HOOK_TELEMETRY_SINK unset or empty → return 0 immediately.
+# Fail-open: jq absent → return 0 immediately.
+#
+# Usage:
+#   hook::emit_telemetry <hook_id> <hook_event> <status> <start_epoch> <data_json> [repo_root]
+#
+# <start_epoch>  Value of $EPOCHREALTIME captured by the caller before work began.
+#               Handles both '.' and ',' as the decimal separator (LC_NUMERIC).
+# <data_json>   Pre-built JSON object for the `data` field.
+# <repo_root>   Optional consuming-repo root, used to resolve a RELATIVE
+#               HOOK_TELEMETRY_SINK. The caller passes the root it already
+#               resolved for data.file; ignored when the sink is absolute.
+#
+# Sink path resolution: HOOK_TELEMETRY_SINK may be absolute OR relative to the
+# consuming repo root. Absolute (POSIX /… or Windows X:\ / X:/) is used as-is; a
+# relative value is joined onto <repo_root> (or $CLAUDE_PROJECT_DIR when no root
+# is passed), and skipped fail-open if neither is available. Relative is the
+# portable, team-shared wiring form: CC injects settings.json env values
+# literally (no ${VAR} expansion), so a relative path tracked in settings.json is
+# the only clone-portable, worktree-safe option.
+#
+# NEVER writes to fd1 (the hook's stdout / additionalContext channel).
+hook::emit_telemetry() {
+  # Opt-in guard.
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]] || return 0
+  # Fail-open when jq is absent.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local hook_id="$1"
+  local hook_event="$2"
+  local status="$3"
+  local start_epoch="$4"
+  local data_json="$5"
+  local repo_root="${6:-}"
+
+  # Compute duration_ms from caller's $EPOCHREALTIME snapshot to now.
+  # Both '.' and ',' separators handled; 10# prefix prevents octal misreading
+  # of fractional parts with leading zeros (e.g. .045123 → 10#045123 = 45123).
+  local now=$EPOCHREALTIME
+  local s_s="${start_epoch%[.,]*}" s_f="${start_epoch#*[.,]}"
+  local e_s="${now%[.,]*}"         e_f="${now#*[.,]}"
+  local duration_ms=$(( (e_s * 1000000 + 10#$e_f - s_s * 1000000 - 10#$s_f) / 1000 ))
+
+  # True UTC timestamp (TZ= prefix overrides LC_ALL / local TZ; the Z is not a lie).
+  local timestamp
+  timestamp=$(TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' -1)
+
+  # Build the envelope. Redirect jq stderr to /dev/null; output goes to a local
+  # variable — never to fd1.
+  local envelope
+  envelope=$(jq -n \
+    --arg     schema_version "1.0" \
+    --arg     timestamp      "$timestamp" \
+    --arg     hook           "$hook_id" \
+    --arg     hook_event     "$hook_event" \
+    --arg     status         "$status" \
+    --argjson duration_ms    "$duration_ms" \
+    --argjson data           "$data_json" \
+    '{schema_version:$schema_version,timestamp:$timestamp,hook:$hook,hook_event:$hook_event,status:$status,duration_ms:$duration_ms,data:$data}' \
+    2>/dev/null) || return 0
+
+  # Resolve the sink path. A relative HOOK_TELEMETRY_SINK is joined onto the
+  # consuming repo root (portable, tracked wiring); absolute is used as-is. A
+  # relative value with no anchor is skipped fail-open — never exec a path the
+  # drifted hook CWD would resolve incorrectly.
+  local sink="$HOOK_TELEMETRY_SINK"
+  case "$sink" in
+    /* | [A-Za-z]:[/\\]*) ;;
+    *)
+      local root="${repo_root:-${CLAUDE_PROJECT_DIR:-}}"
+      [[ -n "$root" ]] || return 0
+      sink="${root%/}/$sink"
+      ;;
+  esac
+
+  # Fire-and-forget: pipe the envelope to the sink in a background subshell.
+  # The subshell's stdout AND stderr are redirected to /dev/null so the sink
+  # cannot write to the hook's fd1 (the additionalContext channel) and the
+  # backgrounded subshell does not hold a copy of the hook's fd1 open — which
+  # would block any command substitution wrapping the hook until the sink exits
+  # (the "C1 fd1-inheritance blocker"). The sink is quoted — it is a single
+  # executable path (wrap in a script to pass arguments).
+  printf '%s\n' "$envelope" | ("$sink" >/dev/null 2>&1) &
+}
+
+# Print cross-host hook JSON to stdout (exit 0). No-op when context is empty.
+# Shape: { hookSpecificOutput: { hookEventName[, additionalContext] } }.
+hook::emit_additional_context() {
+  local event_name="$1"
+  local context="$2"
+  [[ -n "$context" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -n \
+    --arg event "$event_name" \
+    --arg ctx "$context" \
+    '{hookSpecificOutput: (
+      {hookEventName: $event}
+      + (if $ctx != "" then {additionalContext: $ctx} else {} end)
+    )}'
+}

--- a/plugins/bash-lint/hooks/hook-utils.test.sh
+++ b/plugins/bash-lint/hooks/hook-utils.test.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# Unit tests for hook-utils.sh: sourced-lib tests for hook::emit_telemetry.
+#
+# Tests source hook-utils.sh directly and drive hook::emit_telemetry in
+# isolation. No subprocess invocation of bash-lint.sh — black-box
+# integration tests live in bash-lint.test.sh.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# --- Source the lib under test -----------------------------------------------
+# shellcheck source=hook-utils.sh
+source "$HOOK_DIR/hook-utils.sh"
+
+# make_sink <outfile> → prints the path to a single-executable stub sink that
+# copies its stdin to <outfile>. The contract requires HOOK_TELEMETRY_SINK to be
+# a single executable path (not a command-with-args), so tests point it at a
+# stub script rather than `tee FILE`.
+make_sink() {
+  local s
+  s="$(mktemp)"
+  cat >"$s" <<EOF
+#!/usr/bin/env bash
+cat >"$1"
+EOF
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [max_polls] → block until <file> is non-empty (the
+# fire-and-forget sink has flushed) or the bound elapses. Polls in 20ms steps so
+# the assertion fires as soon as the write lands instead of racing a fixed sleep
+# (sink dispatch is a freshly-spawned process; spawn latency varies, especially
+# on Windows Git Bash). Returns non-zero on timeout so negative cases can assert.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while (( tries-- > 0 )); do
+    [[ -s "$f" ]] && return 0
+    sleep 0.02
+  done
+  return 1
+}
+
+# --- Test 1: HOOK_TELEMETRY_SINK unset → returns 0, no output ----------------
+unset HOOK_TELEMETRY_SINK 2>/dev/null || true
+out=$(hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"foo.sh","findings":[]}' 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  ok "sink unset: returns 0"
+else
+  fail "sink unset: expected 0, got $rc"
+fi
+if [[ -z "$out" ]]; then
+  ok "sink unset: no output"
+else
+  fail "sink unset: unexpected output: $out"
+fi
+
+# --- Test 2: jq absent → fail-open (returns 0, no output) -------------------
+# Make `command -v jq` genuinely fail by running with a PATH that contains no
+# jq. A shell-function shadow does NOT exercise the guard: `command -v jq`
+# reports a defined function as present, so the absence branch is never taken.
+# emit_telemetry uses only shell builtins until its jq calls, so an empty PATH
+# is sufficient. Scoped to the command so PATH/sink never leak into the suite.
+EMPTY_BIN="$(mktemp -d)"
+# shellcheck disable=SC2030,SC2031
+out_nojq=$(
+  export HOOK_TELEMETRY_SINK="cat"
+  PATH="$EMPTY_BIN" hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"foo.sh","findings":[]}' 2>/dev/null
+)
+rc_nojq=$?
+rmdir "$EMPTY_BIN" 2>/dev/null || true
+if [[ $rc_nojq -eq 0 ]]; then
+  ok "jq absent: returns 0"
+else
+  fail "jq absent: expected 0, got $rc_nojq"
+fi
+if [[ -z "$out_nojq" ]]; then
+  ok "jq absent: no output"
+else
+  fail "jq absent: unexpected output: $out_nojq"
+fi
+
+# --- Test 3: envelope shape matches schema (7 required common fields + data) --
+SINK_FILE="$(mktemp)"
+cleanup_t3() { rm -f "$SINK_FILE"; }
+trap cleanup_t3 EXIT
+
+# Use a file-writing sink to capture the envelope.
+# shellcheck disable=SC2031  # prior subshell export is intentionally scoped there
+HOOK_TELEMETRY_SINK="$(make_sink "$SINK_FILE")"
+export HOOK_TELEMETRY_SINK
+data_json='{"tool":"Write","file":"docs/foo.sh","findings":["docs/foo.sh:12 SC2086 ..."]}'
+start=$EPOCHREALTIME
+hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$start" "$data_json" 2>/dev/null
+wait_for_sink "$SINK_FILE"
+unset HOOK_TELEMETRY_SINK
+
+if [[ -s "$SINK_FILE" ]]; then
+  ok "envelope shape: sink received data"
+  # Validate all 7 required common fields
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$SINK_FILE" >/dev/null 2>&1; then
+      ok "envelope shape: field '$field' present"
+    else
+      fail "envelope shape: field '$field' missing. envelope=$(cat "$SINK_FILE")"
+    fi
+  done
+  # Validate data sub-fields
+  for subfield in tool file findings; do
+    if jq -e ".data | has(\"$subfield\")" "$SINK_FILE" >/dev/null 2>&1; then
+      ok "envelope shape: data.$subfield present"
+    else
+      fail "envelope shape: data.$subfield missing. data=$(jq .data "$SINK_FILE")"
+    fi
+  done
+  # Validate schema_version
+  sv=$(jq -r '.schema_version' "$SINK_FILE")
+  if [[ "$sv" == "1.0" ]]; then
+    ok "envelope: schema_version is 1.0"
+  else
+    fail "envelope: schema_version expected 1.0, got $sv"
+  fi
+  # Validate hook id
+  hook_val=$(jq -r '.hook' "$SINK_FILE")
+  if [[ "$hook_val" == "bash-lint" ]]; then
+    ok "envelope: hook is bash-lint"
+  else
+    fail "envelope: hook expected bash-lint, got $hook_val"
+  fi
+  # Validate hook_event
+  he=$(jq -r '.hook_event' "$SINK_FILE")
+  if [[ "$he" == "PostToolUse" ]]; then
+    ok "envelope: hook_event is PostToolUse"
+  else
+    fail "envelope: hook_event expected PostToolUse, got $he"
+  fi
+  # Validate status
+  st=$(jq -r '.status' "$SINK_FILE")
+  if [[ "$st" == "ok" ]]; then
+    ok "envelope: status is ok"
+  else
+    fail "envelope: status expected ok, got $st"
+  fi
+else
+  fail "envelope shape: sink file empty — emit did not fire or sink did not write"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    fail "envelope shape: field '$field' not verifiable (no envelope)"
+  done
+  for subfield in tool file findings; do
+    fail "envelope shape: data.$subfield not verifiable (no envelope)"
+  done
+fi
+
+# --- Test 4: timestamp is UTC RFC3339 with Z suffix --------------------------
+if [[ -s "$SINK_FILE" ]]; then
+  ts=$(jq -r '.timestamp' "$SINK_FILE")
+  if [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    ok "timestamp: matches RFC3339 UTC pattern"
+  else
+    fail "timestamp: does not match pattern: $ts"
+  fi
+  # Verify it is genuinely UTC: timestamp hour must align with UTC hour (±1 for boundary)
+  # We verify by checking the TZ=UTC prefix actually produces UTC
+  utc_h=$(TZ=UTC date +%H)
+  ts_h="${ts:11:2}"
+  # Circular ±1h tolerance to absorb an hour-boundary straddle between the emit
+  # and this check — including the 23→00 midnight wrap, where a linear distance
+  # would read 23 and false-fail once per day. (#0 strips the leading zero so
+  # 00–09 are not misread as octal inside (( )).)
+  h_diff=$(( ( ${ts_h#0} - ${utc_h#0} + 24 ) % 24 ))
+  if [[ $h_diff -le 1 || $h_diff -ge 23 ]]; then
+    ok "timestamp: UTC hour aligns with system UTC"
+  else
+    fail "timestamp: hour drift vs UTC: ts_h=$ts_h utc_h=$utc_h diff=$h_diff"
+  fi
+else
+  fail "timestamp: no envelope to check"
+  fail "timestamp: UTC alignment not verifiable"
+fi
+
+# --- Test 5: duration_ms is a non-negative integer ---------------------------
+if [[ -s "$SINK_FILE" ]]; then
+  dur=$(jq '.duration_ms' "$SINK_FILE")
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$SINK_FILE" >/dev/null 2>&1; then
+    ok "duration_ms: is non-negative integer (value=$dur)"
+  else
+    fail "duration_ms: not a non-negative integer: $dur"
+  fi
+else
+  fail "duration_ms: no envelope to check"
+fi
+
+rm -f "$SINK_FILE"
+trap - EXIT
+
+# --- Test 6: status "skipped" passes through ---------------------------------
+SINK_FILE2="$(mktemp)"
+HOOK_TELEMETRY_SINK="$(make_sink "$SINK_FILE2")"
+export HOOK_TELEMETRY_SINK
+hook::emit_telemetry "bash-lint" "PostToolUse" "skipped" "$EPOCHREALTIME" '{"tool":"","file":"","findings":[]}' 2>/dev/null
+wait_for_sink "$SINK_FILE2"
+unset HOOK_TELEMETRY_SINK
+
+if [[ -s "$SINK_FILE2" ]]; then
+  st2=$(jq -r '.status' "$SINK_FILE2")
+  if [[ "$st2" == "skipped" ]]; then
+    ok "status skipped: correctly emitted"
+  else
+    fail "status skipped: got $st2"
+  fi
+else
+  fail "status skipped: no envelope written"
+fi
+rm -f "$SINK_FILE2"
+
+# --- Test 7: RELATIVE sink resolves against the passed repo_root (6th arg) ----
+# This is the portable/tracked-wiring path: a relative HOOK_TELEMETRY_SINK joined
+# onto the consuming repo root the caller passes.
+ROOT7="$(mktemp -d)"
+mkdir -p "$ROOT7/.claude/hooks"
+REL7=".claude/hooks/sink.sh"
+OUT7="$(mktemp)"
+cat >"$ROOT7/$REL7" <<EOF
+#!/usr/bin/env bash
+cat >"$OUT7"
+EOF
+chmod +x "$ROOT7/$REL7"
+export HOOK_TELEMETRY_SINK="$REL7"
+hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.sh","findings":[]}' "$ROOT7" 2>/dev/null
+wait_for_sink "$OUT7"
+unset HOOK_TELEMETRY_SINK
+if [[ -s "$OUT7" ]] && [[ "$(jq -r '.hook' "$OUT7")" == "bash-lint" ]]; then
+  ok "relative sink: resolved against repo_root arg, envelope delivered"
+else
+  fail "relative sink: not resolved against repo_root arg (out empty or wrong)"
+fi
+rm -rf "$ROOT7" "$OUT7"
+
+# --- Test 8: RELATIVE sink resolves against CLAUDE_PROJECT_DIR when no root arg --
+ROOT8="$(mktemp -d)"
+mkdir -p "$ROOT8/.claude/hooks"
+OUT8="$(mktemp)"
+cat >"$ROOT8/.claude/hooks/sink.sh" <<EOF
+#!/usr/bin/env bash
+cat >"$OUT8"
+EOF
+chmod +x "$ROOT8/.claude/hooks/sink.sh"
+export HOOK_TELEMETRY_SINK=".claude/hooks/sink.sh"
+CLAUDE_PROJECT_DIR="$ROOT8" hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.sh","findings":[]}' 2>/dev/null
+wait_for_sink "$OUT8"
+unset HOOK_TELEMETRY_SINK
+if [[ -s "$OUT8" ]]; then
+  ok "relative sink: resolved against CLAUDE_PROJECT_DIR fallback"
+else
+  fail "relative sink: CLAUDE_PROJECT_DIR fallback did not resolve"
+fi
+rm -rf "$ROOT8" "$OUT8"
+
+# --- Test 9: RELATIVE sink with NO anchor → fail-open skip (return 0, no write) --
+OUT9="$(mktemp)"
+rm -f "$OUT9" # ensure absent
+export HOOK_TELEMETRY_SINK="relative/no/anchor/sink.sh"
+(
+  unset CLAUDE_PROJECT_DIR 2>/dev/null || true
+  hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.sh","findings":[]}' 2>/dev/null
+)
+rc9=$?
+sleep 0.2
+unset HOOK_TELEMETRY_SINK
+if [[ $rc9 -eq 0 ]] && [[ ! -s "$OUT9" ]]; then
+  ok "relative sink, no anchor: fail-open skip (rc 0, no write)"
+else
+  fail "relative sink, no anchor: expected skip (rc=$rc9, out exists=$([[ -s "$OUT9" ]] && echo y || echo n))"
+fi
+rm -f "$OUT9"
+
+# --- Test 10: ABSOLUTE sink passes through unchanged --------------------------
+OUT10="$(mktemp)"
+ABS10="$(make_sink "$OUT10")" # mktemp path is absolute
+export HOOK_TELEMETRY_SINK="$ABS10"
+hook::emit_telemetry "bash-lint" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.sh","findings":[]}' "/some/ignored/root" 2>/dev/null
+wait_for_sink "$OUT10"
+unset HOOK_TELEMETRY_SINK
+if [[ -s "$OUT10" ]] && [[ "$(jq -r '.hook' "$OUT10")" == "bash-lint" ]]; then
+  ok "absolute sink: passes through unchanged (repo_root ignored)"
+else
+  fail "absolute sink: did not pass through"
+fi
+rm -f "$ABS10" "$OUT10"
+
+# --- Test 11: hook::normalize_path is host-gated on OSTYPE --------------------
+# The drive-letter fold is for Windows/MSYS only (case-insensitive FS). On a
+# case-sensitive POSIX host a real single-letter top dir like /c/Repo must pass
+# through unchanged, or the membership guard collapses it with /c/repo and
+# admits a sibling outside CLAUDE_PROJECT_DIR. normalize_path reads the shell's
+# OSTYPE, so override it in a subshell per case (the global stays intact).
+norm_as() { ( OSTYPE="$1"; hook::normalize_path "$2" ); }
+assert_norm() { # <ostype> <input> <expected> <desc>
+  local got
+  got="$(norm_as "$1" "$2")"
+  if [[ "$got" == "$3" ]]; then
+    ok "normalize_path[$1]: $4"
+  else
+    fail "normalize_path[$1]: $4 — expected '$3', got '$got'"
+  fi
+}
+
+# Windows/MSYS: fold both the POSIX /c/ and colon c:/ drive forms.
+assert_norm msys   "/c/Repo"        "C:/repo"        "msys folds /c/Repo → C:/repo"
+assert_norm msys   "C:/Repo"        "C:/repo"        "msys folds C:/Repo → C:/repo"
+assert_norm msys   "/c/Repo/Sub"    "C:/repo/sub"    "msys folds nested path"
+assert_norm msys   'C:\Repo\x'      "C:/repo/x"      "msys: backslashes → slashes then fold"
+assert_norm cygwin "/c/Repo"        "C:/repo"        "cygwin folds like msys"
+
+# POSIX: NO fold — single-letter top dirs stay distinct (the regression guard).
+assert_norm linux-gnu "/c/Repo"     "/c/Repo"        "linux leaves /c/Repo unchanged"
+assert_norm linux-gnu "/c/repo"     "/c/repo"        "linux leaves /c/repo unchanged"
+assert_norm linux-gnu "/opt/App/Sub" "/opt/App/Sub"  "linux leaves normal path unchanged"
+assert_norm linux-gnu 'a\b'         "a/b"            "linux still converts backslashes"
+
+# Explicit guard: on POSIX the two casings must NOT collapse to one value.
+if [[ "$(norm_as linux-gnu /c/Repo)" != "$(norm_as linux-gnu /c/repo)" ]]; then
+  ok "normalize_path[linux-gnu]: /c/Repo and /c/repo stay distinct"
+else
+  fail "normalize_path[linux-gnu]: /c/Repo and /c/repo collapsed (membership-guard regression)"
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/bash-lint/hooks/hooks.json
+++ b/plugins/bash-lint/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/bash-lint.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Ports medley's `bash-lint` hook into the marketplace as the second plugin (after `markdown-formatter`), as a repo-agnostic, plugin-form-safe capability.

**Behavior** — PostToolUse hook on `Write|Edit` of `*.sh`/`*.bash`:
- **ShellCheck lints always** (warning+), non-mutating, advisory — the hook always exits `0`.
- **shfmt formats only when the consumer opts in** with an `.editorconfig` (walking up to the repo root). With none present, the file is left untouched rather than rewritten to shfmt's defaults — the plugin never imposes a style the repo didn't choose. Run with no formatting flags so `.editorconfig` stays authoritative.
- Findings surface via `additionalContext` plus the marketplace `hook::emit_telemetry` envelope. Reads the consumer's own `.shellcheckrc`/`.editorconfig`; ships no rules. Kill switch: `HOOK_BASH_LINT_ENABLED`.

## Generalized from medley (not a byte-copy)

- Stripped medley-policy prose (lefthook/CI "hard gate" etc.) — repo-agnostic.
- Dropped the markdownlint-era `cd` — shfmt/shellcheck resolve config from the **file's** path, so no working-directory assumption is needed.
- Gated `shfmt` on `.editorconfig` opt-in vs medley's unconditional `shfmt -w`.
- Used the marketplace's `hook::emit_telemetry` envelope over medley's older `emit_timed_event`.
- `hook-utils.sh` is **byte-identical** to the `markdown-formatter` copy (git blob `6342c502…`).

## Verification (all green locally)

- `claude plugin validate --strict` — plugin manifest **and** catalog manifest
- shellcheck · editorconfig-checker · typos · markdownlint (0 errors) · comment-hygiene
- exec-bit modes (755 scripts / 644 lib) · LF endings · final newline
- Tests: `hook-utils.test.sh` **37/0**, `bash-lint.test.sh` **28/0** (includes shfmt gate ON/OFF and telemetry envelope shape)
- Runtime wiring smoke: invoked via the exact `hooks.json` command + `${CLAUDE_PLUGIN_ROOT}` with an envelope on stdin — formatted the file and surfaced `SC2154`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)