### PR TITLE
fix(markdown-formatter): guard EPOCHREALTIME for Bash < 5 portability

### DIFF
--- a/plugins/markdown-formatter/.claude-plugin/plugin.json
+++ b/plugins/markdown-formatter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-formatter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-formatter/README.md
+++ b/plugins/markdown-formatter/README.md
@@ -27,6 +27,10 @@ imposes no rules of its own.
 `npx` (the hook falls back to `npx markdownlint-cli2`). When neither is present
 the hook is a silent no-op.
 
+The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
+(Bash 5.0+); on older bash the telemetry envelope is skipped while formatting
+still runs.
+
 ## Install
 
 ```shell

--- a/plugins/markdown-formatter/hooks/markdown-format.sh
+++ b/plugins/markdown-formatter/hooks/markdown-format.sh
@@ -18,9 +18,19 @@ source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
 
 hook::check_enabled "MARKDOWN_FORMAT"
 
-# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers
-# the formatting work (pre-format exits below do not emit telemetry).
-start=$EPOCHREALTIME
+# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers the
+# formatting work (pre-format exits below do not emit telemetry). EPOCHREALTIME is
+# Bash 5.0+; on older bash it is unset, so default to empty — referencing it bare
+# under `set -u` would abort before the advisory exit 0, failing every edit.
+start=${EPOCHREALTIME:-}
+
+# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
+# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
+# formats on older bash rather than aborting.
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::emit_telemetry "$@"
+}
 
 INPUT=$(cat)
 
@@ -73,14 +83,14 @@ elif command -v npx >/dev/null 2>&1; then
 else
   # markdownlint unavailable — emit skipped telemetry then exit cleanly.
   data_json=$(build_data_json '[]')
-  hook::emit_telemetry "markdown-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "markdown-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
   exit 0
 fi
 
 if FIX_OUTPUT=$(cd "$REPO_ROOT" && "${MDLINT[@]}" --fix "$FILE" 2>&1); then
   # Clean after fix — emit ok with empty findings.
   data_json=$(build_data_json '[]')
-  hook::emit_telemetry "markdown-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "markdown-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
   exit 0
 fi
 
@@ -108,5 +118,5 @@ if [[ -n "$findings_raw" ]]; then
 fi
 
 data_json=$(build_data_json "$FINDINGS_JSON")
-hook::emit_telemetry "markdown-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "markdown-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
 exit 0


### PR DESCRIPTION
## Summary

Propagation follow-up from #16's Codex review: `markdown-formatter` carried the identical latent bug.

`EPOCHREALTIME` is Bash 5.0+. The hook's `start=$EPOCHREALTIME` under `set -u` aborts on Bash 3.2/4.x (e.g. stock macOS) **before** the advisory `exit 0` — failing every `Write`/`Edit`, not just markdown ones (the capture runs before the file-type filter).

## Fix

- Default the stamp: `start=${EPOCHREALTIME:-}` (no `set -u` abort).
- `emit_tel` wrapper skips telemetry when the stamp is empty, so the hook still formats on older bash; the high-res envelope is simply omitted there.
- `hook-utils.sh` stays **byte-identical** to the bash-lint copy (the guard lives in the hook, not the lib).
- **Version 0.1.0 → 0.1.1** so already-installed consumers receive the fix.

## Verification (all green locally)

- shellcheck · editorconfig · typos · markdownlint (0 errors) · comment-hygiene
- `claude plugin validate --strict` passed
- Tests: `markdown-format.test.sh` **41/0**, `hook-utils.test.sh` **37/0**
- Confirmed `hook-utils.sh` byte-identical to `plugins/bash-lint/hooks/hook-utils.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)