### PR TITLE
feat(biome-format): add Biome format/lint-on-edit plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,12 @@
       "source": "./plugins/bash-lint",
       "category": "formatting",
       "tags": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"]
+    },
+    {
+      "name": "biome-format",
+      "source": "./plugins/biome-format",
+      "category": "formatting",
+      "tags": ["biome", "typescript", "javascript", "json", "jsx", "formatter", "linter", "hook"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace
 |---|---|---|
 | [`markdown-formatter`](plugins/markdown-formatter) | Hook | Auto-formats and lints Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config. |
 | [`bash-lint`](plugins/bash-lint) | Hook | Lints shell scripts on edit via ShellCheck, and formats via shfmt when the repo opts in with an `.editorconfig`, using the consuming repo's own config. |
+| [`biome-format`](plugins/biome-format) | Hook | Formats and lints JS/TS/JSX/JSON on edit via Biome, only when the repo opts in with a `biome.json`, using the consuming repo's own Biome config. |
 
 Install one: `/plugin install <plugin-name>@melodic-software`.
 

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "biome-format",
+  "version": "0.1.0",
+  "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "keywords": ["biome", "typescript", "javascript", "json", "jsx", "formatter", "linter", "hook"]
+}

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -1,0 +1,69 @@
+# biome-format
+
+A Claude Code plugin that formats and lints JavaScript, TypeScript, JSX, and
+JSON the moment you edit them. On every `Write` or `Edit` of a `.ts`, `.tsx`,
+`.js`, `.jsx`, `.mjs`, `.cjs`, `.mts`, `.cts`, `.json`, or `.jsonc` file it runs
+[Biome](https://biomejs.dev/)'s `check --write` — applying safe fixes,
+formatting, and import sorting — then surfaces any residual findings back to
+Claude as advisory context.
+
+It uses **your repository's own `biome.json`**. It ships no rules of its own and
+runs only when your repo has opted into Biome.
+
+## Behavior
+
+- **Opt-in on `biome.json`.** Biome runs **only when a Biome configuration
+  governs the edited file** — `biome.json`, `biome.jsonc`, `.biome.json`, or
+  `.biome.jsonc`, found by walking up from the file to the repository root. A
+  repo without a Biome config is left untouched rather than rewritten to Biome's
+  built-in defaults, so the plugin never imposes a style you did not choose.
+- **Format + lint on edit.** `biome check --write` applies safe fixes,
+  formatting, and import sorting in place. Residual diagnostics — errors and,
+  because the hook passes `--error-on-warnings`, warnings — are reported but not
+  auto-applied (unsafe fixes are never forced).
+- **Respects your ignores.** Biome honors your config's `files.includes` ignore
+  rules even for the single edited file. A path your config excludes (for
+  generated or vendored code) is left untouched, with no advisory noise.
+- **Advisory, never blocking.** The hook always exits `0`. Findings are reported
+  via `additionalContext`; they never reject the edit. Make a commit hook or CI
+  your hard gate.
+- **Config discovery from your repo.** The hook finds the governing `biome.json`
+  by walking up from the edited file and runs Biome from that config's directory,
+  so a single repo-root (or subtree) config governs files in subdirectories
+  beneath it.
+
+## Requirements
+
+- **Biome** available to the repo — installed in the repo's `node_modules`
+  (the hook runs `node_modules/.bin/biome`) or on `PATH`. Biome is never
+  downloaded on the fly; if it is not present, the hook is a silent no-op.
+- A **`biome.json`** (or `.jsonc` / dotted variant) in the repo — the opt-in.
+
+The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
+(Bash 5.0+); on older bash the telemetry envelope is skipped while formatting and
+linting still run.
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install biome-format@melodic-software
+```
+
+## Configuration
+
+This plugin has no `userConfig` — its only "configuration" is the `biome.json`
+already in your repository, which it reads automatically. To change the rules,
+edit that file.
+
+### Disable without uninstalling
+
+Set the kill switch in your settings `env` block:
+
+```json
+{ "env": { "HOOK_BIOME_FORMAT_ENABLED": "false" } }
+```
+
+## License
+
+[MIT](../../LICENSE).

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -12,11 +12,14 @@ runs only when your repo has opted into Biome.
 
 ## Behavior
 
-- **Opt-in on `biome.json`.** Biome runs **only when a Biome configuration
-  governs the edited file** — `biome.json`, `biome.jsonc`, `.biome.json`, or
-  `.biome.jsonc`, found by walking up from the file to the repository root. A
-  repo without a Biome config is left untouched rather than rewritten to Biome's
-  built-in defaults, so the plugin never imposes a style you did not choose.
+- **Opt-in on `biome.json`.** Biome runs **only when a `biome.json` or
+  `biome.jsonc` governs the edited file**, found by walking up from the file to
+  the repository root. A repo without a Biome config is left untouched rather
+  than rewritten to Biome's built-in defaults, so the plugin never imposes a
+  style you did not choose. (The hidden `.biome.json` / `.biome.jsonc` names are
+  intentionally not treated as the opt-in: Biome only loads them from 2.4
+  onward, so honoring them here would risk reformatting with built-in defaults on
+  an older Biome. Use a canonical `biome.json` / `biome.jsonc`.)
 - **Format + lint on edit.** `biome check --write` applies safe fixes,
   formatting, and import sorting in place. Residual diagnostics — errors and,
   because the hook passes `--error-on-warnings`, warnings — are reported but not
@@ -41,7 +44,7 @@ runs only when your repo has opted into Biome.
   `check --write --error-on-warnings --reporter=github`, and on much older
   releases those flags may be absent, in which case the run is reported as a
   tool break rather than a finding.
-- A **`biome.json`** (or `.jsonc` / dotted variant) in the repo — the opt-in.
+- A **`biome.json`** or **`biome.jsonc`** in the repo — the opt-in.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while formatting and

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -37,6 +37,10 @@ runs only when your repo has opted into Biome.
 - **Biome** available to the repo — installed in the repo's `node_modules`
   (the hook runs `node_modules/.bin/biome`) or on `PATH`. Biome is never
   downloaded on the fly; if it is not present, the hook is a silent no-op.
+  **Biome 2.x is recommended** (tested against 2.5.1): the hook invokes
+  `check --write --error-on-warnings --reporter=github`, and on much older
+  releases those flags may be absent, in which case the run is reported as a
+  tool break rather than a finding.
 - A **`biome.json`** (or `.jsonc` / dotted variant) in the repo — the opt-in.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format and lint JS/TS/JSX/JSON files via Biome.
+# Triggered on Write|Edit of *.ts, *.tsx, *.js, *.jsx, *.mjs, *.cjs, *.mts,
+# *.cts, *.json, *.jsonc files.
+#
+# ADVISORY: always exits 0. `biome check --write` applies safe fixes, formatting,
+# and import sorting; residual Biome diagnostics (errors and, via
+# --error-on-warnings, warnings) surface via additionalContext but never block
+# the edit. A commit hook or CI is the hard gate.
+#
+# Opt-in: Biome runs ONLY when a biome.json (or .jsonc / dotted) config governs
+# the edited file — found by walking up from the file to the repo root. A repo
+# that has not adopted a Biome config is left untouched rather than rewritten to
+# Biome's built-in defaults, so the plugin never imposes a style it did not
+# choose. The Biome binary is resolved from the repo's own node_modules (or PATH)
+# — never downloaded.
+
+set -uo pipefail
+
+# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
+# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
+# resolve (ENOENT -> silent no-op). stdin is read ONCE here and fed to both
+# hook::read_file_path (file_path) and the tool_name parse below; reading fd0
+# twice would drain the pipe on the second call.
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "BIOME_FORMAT"
+
+# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers the
+# work below (pre-work exits do not emit telemetry). EPOCHREALTIME is Bash 5.0+;
+# on older bash it is unset, so default to empty — referencing it bare under
+# `set -u` would abort before the advisory exit 0, failing every edit.
+start=${EPOCHREALTIME:-}
+
+# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
+# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
+# formats and lints on older bash rather than aborting.
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::emit_telemetry "$@"
+}
+
+INPUT=$(cat)
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+case "$FILE" in
+  *.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs | *.mts | *.cts | *.json | *.jsonc) ;;
+  *) exit 0 ;;
+esac
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Resolve repo root early — used to bound the biome-config opt-in walk and to
+# compute the schema-required repo-relative path in data.file.
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+# Repo-relative path: schema requires "relative to the consuming repo root".
+# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
+# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
+# (long name, forward-slash mixed form) when available so the prefix strip
+# compares the same representation. On Linux/macOS, cygpath is absent and both
+# paths are already POSIX. Falls back to raw FILE on any normalization error.
+FILE_REL="$FILE"
+if command -v cygpath >/dev/null 2>&1; then
+  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+    FILE_REL="${_file_lm#"$_root_lm"/}"
+  fi
+else
+  FILE_REL="${FILE#"$REPO_ROOT"/}"
+fi
+
+# Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
+# findings JSON array. jq is authoritative; the string fallback keeps telemetry
+# best-effort if jq fails (findings collapse to [] since they can't be re-quoted
+# safely without jq).
+build_data_json() {
+  jq -n \
+    --arg tool "$TOOL" \
+    --arg file "$FILE_REL" \
+    --argjson findings "$1" \
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
+    || printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"
+}
+
+emit_skipped() {
+  local data_json
+  data_json=$(build_data_json '[]')
+  emit_tel "biome-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+}
+
+# Resolve the file's directory in `pwd` form once. Both walks below start here,
+# and it anchors the CONFIG_DIR-relative path passed to Biome.
+FILE_DIR_POSIX="$(cd "$(dirname "$FILE")" 2>/dev/null && pwd)" || FILE_DIR_POSIX=""
+root="$(cd "$REPO_ROOT" 2>/dev/null && pwd)" || root=""
+
+# Consumer opt-in: a Biome configuration that governs the edited file. Walk up
+# from the file's directory to the repo root, recording the TOPMOST config dir
+# (closest to the repo root). Biome discovers its configuration from the CWD
+# upward — not from the target file — and a "root" config orchestrates any nested
+# (`"root": false`) configs beneath it, so running from the topmost config's
+# directory is the correct, monorepo-safe CWD. Absence of any config is the
+# opt-out: the file is left untouched.
+CONFIG_DIR=""
+dir="$FILE_DIR_POSIX"
+while [[ -n "$dir" ]]; do
+  for name in biome.json biome.jsonc .biome.json .biome.jsonc; do
+    [[ -f "$dir/$name" ]] && CONFIG_DIR="$dir" && break
+  done
+  [[ -n "$root" && "$dir" == "$root" ]] && break
+  parent="$(dirname "$dir")"
+  [[ "$parent" == "$dir" ]] && break # reached filesystem root
+  dir="$parent"
+done
+
+[[ -n "$CONFIG_DIR" ]] || emit_skipped
+
+# Resolve the Biome binary from the repo's own install (node_modules/.bin/biome,
+# walking up from the file) or PATH — never `npx`, which would download Biome on
+# a per-edit hook. Absent -> skip (the repo opted into config but Biome is not
+# installed; nothing to run).
+BIOME_BIN=""
+dir="$FILE_DIR_POSIX"
+while [[ -n "$dir" ]]; do
+  if [[ -f "$dir/node_modules/.bin/biome" ]]; then
+    BIOME_BIN="$dir/node_modules/.bin/biome"
+    break
+  fi
+  [[ -n "$root" && "$dir" == "$root" ]] && break
+  parent="$(dirname "$dir")"
+  [[ "$parent" == "$dir" ]] && break
+  dir="$parent"
+done
+if [[ -z "$BIOME_BIN" ]]; then
+  BIOME_BIN="$(command -v biome 2>/dev/null)" || BIOME_BIN=""
+fi
+
+[[ -n "$BIOME_BIN" ]] || emit_skipped
+
+# Pass the file as a path relative to CONFIG_DIR (the CWD Biome runs in) so the
+# github reporter echoes a clean repo-relative path (e.g. src/app.ts) instead of
+# an absolute, URL-encoded one. CONFIG_DIR and FILE_DIR_POSIX both come from
+# `pwd`, so the prefix strip compares the same form; CONFIG_DIR is an ancestor of
+# the file, so it always matches. Falls back to the absolute path if it does not.
+BIOME_ARG="$FILE"
+if [[ -n "$FILE_DIR_POSIX" ]]; then
+  _file_posix="$FILE_DIR_POSIX/$(basename "$FILE")"
+  _rel="${_file_posix#"$CONFIG_DIR"/}"
+  [[ "$_rel" != "$_file_posix" ]] && BIOME_ARG="$_rel"
+fi
+
+# Run Biome from the governing config's directory (CWD-anchored discovery).
+# `check` = format + lint + import sorting; --write applies safe fixes;
+# --error-on-warnings makes residual warnings (not just errors) exit non-zero so
+# they surface as advisory context. --reporter=github emits one compact
+# workflow-command line per diagnostic (::warning/::error/::notice with rule,
+# file, line, and message) instead of the verbose default boxes — the analog of
+# ShellCheck's gcc format: actionable findings without the decorative noise.
+if OUTPUT=$(cd "$CONFIG_DIR" && "$BIOME_BIN" check --write --error-on-warnings --reporter=github "$BIOME_ARG" 2>&1); then
+  data_json=$(build_data_json '[]')
+  emit_tel "biome-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+fi
+
+# Non-zero exit. The github reporter emits one `::warning`/`::error`/`::notice`
+# line per diagnostic; their presence is the unambiguous signal that Biome made a
+# lint/format judgment with residual findings. Surface just those lines (not the
+# decorative footer). Status "ok" — the linter RAN and produced a judgment
+# (findings live in data.findings), mirroring the bash-lint model where status
+# reflects whether the tool ran, not whether it was clean.
+FINDINGS=$(grep -E '^::(warning|error|notice)' <<<"$OUTPUT" || true)
+if [[ -n "$FINDINGS" ]]; then
+  hook::ctx_reset
+  hook::ctx_append "biome-format: $(basename "$FILE") has Biome findings (advisory):"
+  findings_raw=""
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    hook::ctx_append "  $line"
+    findings_raw+="$line"$'\n'
+  done <<<"$FINDINGS"
+  hook::ctx_flush PostToolUse
+
+  FINDINGS_JSON='[]'
+  if [[ -n "$findings_raw" ]]; then
+    FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
+  fi
+  data_json=$(build_data_json "$FINDINGS_JSON")
+  emit_tel "biome-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+fi
+
+# No findings, but the file was deliberately ignored by the consumer's Biome
+# config (or a built-in default ignore such as node_modules). Biome exits 1 with
+# "No files were processed in the specified paths." — this is the repo's opt-out,
+# not a finding and not a break, so skip silently without nagging via context.
+# (Biome 2.x respects files.includes ignores even for explicitly-passed paths.)
+if grep -qE 'No files were processed|provided but ignored' <<<"$OUTPUT"; then
+  emit_skipped
+fi
+
+# Biome broke for non-lint reasons (config parse error, panic, ENOENT) — no
+# judgment was made. Surface the diagnostic via additionalContext (NOT stderr —
+# an advisory hook's exit-0 stderr can trip a false "Hook Error" label). Record
+# as "skipped" (the linter never ran), the same status as the no-config /
+# no-binary paths.
+hook::ctx_reset
+hook::ctx_append "biome-format: biome failed for $(basename "$FILE") (no diagnostics; tool break, not a finding):"
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  hook::ctx_append "  $line"
+done <<<"$OUTPUT"
+hook::ctx_flush PostToolUse
+data_json=$(build_data_json '[]')
+emit_tel "biome-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+exit 0

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -72,16 +72,19 @@ else
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
-# findings JSON array. jq is authoritative; the string fallback keeps telemetry
-# best-effort if jq fails (findings collapse to [] since they can't be re-quoted
-# safely without jq).
+# findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
+# object — NOT an interpolation of TOOL/FILE_REL, which could inject quotes or
+# backslashes from a path and corrupt the envelope. The fallback is essentially
+# unreachable in practice (it fires only if `jq -n` fails, and when jq is absent
+# hook::emit_telemetry drops the envelope anyway), so losing the values here is
+# harmless and strictly safer than emitting malformed JSON.
 build_data_json() {
   jq -n \
     --arg tool "$TOOL" \
     --arg file "$FILE_REL" \
     --argjson findings "$1" \
     '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
-    || printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"
+    || printf '{"tool":"","file":"","findings":[]}'
 }
 
 emit_skipped() {

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -8,9 +8,9 @@
 # --error-on-warnings, warnings) surface via additionalContext but never block
 # the edit. A commit hook or CI is the hard gate.
 #
-# Opt-in: Biome runs ONLY when a biome.json (or .jsonc / dotted) config governs
-# the edited file — found by walking up from the file to the repo root. A repo
-# that has not adopted a Biome config is left untouched rather than rewritten to
+# Opt-in: Biome runs ONLY when a biome.json or biome.jsonc config governs the
+# edited file — found by walking up from the file to the repo root. A repo that
+# has not adopted a Biome config is left untouched rather than rewritten to
 # Biome's built-in defaults, so the plugin never imposes a style it did not
 # choose. The Biome binary is resolved from the repo's own node_modules (or PATH)
 # — never downloaded.
@@ -106,10 +106,18 @@ root="$(cd "$REPO_ROOT" 2>/dev/null && pwd)" || root=""
 # (`"root": false`) configs beneath it, so running from the topmost config's
 # directory is the correct, monorepo-safe CWD. Absence of any config is the
 # opt-out: the file is left untouched.
+#
+# Only the canonical names are accepted, NOT the hidden .biome.json/.biome.jsonc
+# variants: hidden-config loading was added in Biome 2.4, so on an older Biome
+# this gate would fire while Biome's own discovery ignored the dotted file and
+# reformatted with built-in defaults — the exact silent wrong-config reformat the
+# opt-in exists to prevent. Gating on the names every supported Biome discovers keeps
+# the gate in lockstep with discovery across versions. Dotted-config support is
+# deferred behind a Biome>=2.4 probe.
 CONFIG_DIR=""
 dir="$FILE_DIR_POSIX"
 while [[ -n "$dir" ]]; do
-  for name in biome.json biome.jsonc .biome.json .biome.jsonc; do
+  for name in biome.json biome.jsonc; do
     [[ -f "$dir/$name" ]] && CONFIG_DIR="$dir" && break
   done
   [[ -n "$root" && "$dir" == "$root" ]] && break

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -169,7 +169,14 @@ fi
 # workflow-command line per diagnostic (::warning/::error/::notice with rule,
 # file, line, and message) instead of the verbose default boxes — the analog of
 # ShellCheck's gcc format: actionable findings without the decorative noise.
-if OUTPUT=$(cd "$CONFIG_DIR" && "$BIOME_BIN" check --write --error-on-warnings --reporter=github "$BIOME_ARG" 2>&1); then
+#
+# BIOME_CONFIG_PATH is unset for this command: Biome reads it as a config-path
+# override, so a stray user- or project-level export would make Biome format the
+# edit with an unrelated config even though the gate keyed on the repo's own
+# biome.json (verified empirically). Unsetting it keeps the discovered CONFIG_DIR
+# config authoritative — consistent with the in-tree opt-in this plugin is built
+# on (an out-of-tree config has no in-tree biome.json, so the gate skips anyway).
+if OUTPUT=$(cd "$CONFIG_DIR" && env -u BIOME_CONFIG_PATH "$BIOME_BIN" check --write --error-on-warnings --reporter=github "$BIOME_ARG" 2>&1); then
   data_json=$(build_data_json '[]')
   emit_tel "biome-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
   exit 0

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -255,6 +255,24 @@ RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "ignored file -> exit 0, silent (no nag)"; else fail "ignored file not silent (rc=$RC out=$OUT)"; fi
 if [[ "$(cat "$REPO_IGN/generated/gen.ts")" == "$BEFORE_IGN" ]]; then ok "ignored file -> left untouched (respects config ignore)"; else fail "ignored file -> was rewritten"; fi
 
+# --- Case 9: BIOME_CONFIG_PATH override does not hijack the repo config -------
+# Biome reads BIOME_CONFIG_PATH as a config-path override; the hook unsets it so
+# the gated repo config stays authoritative. Repo config formats single-quoted;
+# an external config formats double-quoted. With BIOME_CONFIG_PATH pointing at
+# the external config, the result must still be single-quoted (repo config wins).
+REPO_ENV="$WORK/env-override"
+new_biome_repo "$REPO_ENV" '{ "javascript": { "formatter": { "quoteStyle": "single" } } }'
+EXT_CFG="$WORK/external-cfg"
+mkdir -p "$EXT_CFG"
+printf '%s\n' '{ "javascript": { "formatter": { "quoteStyle": "double" } } }' >"$EXT_CFG/biome.json"
+printf 'const s = "hi";\nexport { s };\n' >"$REPO_ENV/q.ts"
+run_hook_env "$REPO_ENV/q.ts" HOOK_BIOME_FORMAT_ENABLED=true BIOME_CONFIG_PATH="$EXT_CFG" >/dev/null
+if grep -q "const s = 'hi';" "$REPO_ENV/q.ts"; then
+  ok "BIOME_CONFIG_PATH override neutralized -> repo config authoritative"
+else
+  fail "BIOME_CONFIG_PATH hijacked the config: $(cat "$REPO_ENV/q.ts")"
+fi
+
 # ============================================================================
 # Telemetry
 # ============================================================================

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -133,6 +133,19 @@ RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "gate OFF (no biome.json) -> exit 0, silent"; else fail "gate OFF not silent (rc=$RC out=$OUT)"; fi
 if [[ "$(cat "$REPO_NO/nofmt.ts")" == "$BEFORE_NO" ]]; then ok "gate OFF -> file left untouched"; else fail "gate OFF -> file was rewritten"; fi
 
+# --- Case 1b: hidden .biome.json alone does NOT opt in ----------------------
+# .biome.json/.biome.jsonc are only loaded by Biome >= 2.4, so the gate must not
+# fire on them — otherwise an older Biome would reformat with built-in defaults.
+REPO_DOT="$WORK/dotted-only"
+new_biome_repo "$REPO_DOT" NO_CONFIG
+printf '{}\n' >"$REPO_DOT/.biome.json"
+printf 'const x=1;var y=2\n' >"$REPO_DOT/dot.ts"
+BEFORE_DOT="$(cat "$REPO_DOT/dot.ts")"
+OUT=$(run_hook "$REPO_DOT/dot.ts")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "hidden .biome.json only -> exit 0, silent (no opt-in)"; else fail "hidden config opted in (rc=$RC out=$OUT)"; fi
+if [[ "$(cat "$REPO_DOT/dot.ts")" == "$BEFORE_DOT" ]]; then ok "hidden .biome.json only -> file left untouched"; else fail "hidden config -> file was rewritten"; fi
+
 # --- Case 2: gate ON + clean file -> exit 0, empty stdout -------------------
 REPO="$WORK/consumer"
 new_biome_repo "$REPO"

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# Black-box contract test for biome-format.sh (the biome-format plugin hook).
+#
+# Proves WIRING: the hook fires on JS/TS/JSX/JSON, skips otherwise, applies
+# Biome's --write fixes, surfaces residual findings via additionalContext
+# (advisory, exit 0), honors the kill switch, gates on a consumer biome.json
+# (present -> run, absent -> leave bytes untouched), respects the config's own
+# ignore rules for an explicitly-edited file (no nag), and emits a schema-valid
+# telemetry envelope. No medley-policy prose in the surfaced context.
+#
+# Self-contained: builds throwaway git repos with runtime-generated fixtures.
+# Each repo gets a node_modules/.bin/biome shim that forwards to a real Biome,
+# so the hook's node_modules resolution path is exercised. The hook is invoked
+# from an UNRELATED cwd so any reliance on the caller's working directory would
+# surface (Biome discovers config from the cwd the hook cd's to, not the caller).
+#
+# Requires a real Biome binary: $BIOME_TEST_BIN if set, else `biome` on PATH.
+# Without one the behavioral assertions cannot run, so the suite skips.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/biome-format.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# Resolve a real Biome binary. node_modules/.bin/biome shims in each fixture
+# forward to this. Skip the suite when none is available.
+if [[ -n "${BIOME_TEST_BIN:-}" && -x "${BIOME_TEST_BIN}" ]]; then
+  REAL_BIOME="${BIOME_TEST_BIN}"
+elif command -v biome >/dev/null 2>&1; then
+  REAL_BIOME="$(command -v biome)"
+else
+  echo "SKIP: no Biome binary (set BIOME_TEST_BIN or put biome on PATH) -- biome-format hook tests skipped"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+UNRELATED="$(mktemp -d)"
+cleanup() { rm -rf "$WORK" "$UNRELATED"; }
+trap cleanup EXIT
+
+# make_sink <body> -> path to an executable single-command stub sink running
+# <body> (which reads the envelope on stdin). HOOK_TELEMETRY_SINK must be a
+# single executable path, not a command-with-args, so tests point it at a stub.
+make_sink() {
+  local s
+  s="$(mktemp -p "$WORK" sink.XXXXXX)"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$1"
+  } >"$s"
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [tries] -> block until <file> is non-empty (the
+# fire-and-forget sink flushed) or the bound elapses, polling in 20ms steps.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while ((tries-- > 0)); do
+    if [[ -s "$f" ]]; then
+      return 0
+    fi
+    sleep 0.02
+  done
+  return 1
+}
+
+# new_biome_repo <dir> [config_body] -> init a git repo with a node_modules
+# biome shim and (unless config_body is the literal NO_CONFIG) a biome.json.
+new_biome_repo() {
+  local r="$1" cfg="${2:-}"
+  mkdir -p "$r/node_modules/.bin"
+  git -C "$r" init -q
+  git -C "$r" config user.email t@t.t
+  git -C "$r" config user.name t
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'exec "%s" "$@"\n' "$REAL_BIOME"
+  } >"$r/node_modules/.bin/biome"
+  chmod +x "$r/node_modules/.bin/biome"
+  if [[ "$cfg" != "NO_CONFIG" ]]; then
+    if [[ -n "$cfg" ]]; then
+      printf '%s\n' "$cfg" >"$r/biome.json"
+    else
+      printf '{}\n' >"$r/biome.json"
+    fi
+  fi
+}
+
+# Invoke the hook from an unrelated cwd. CLAUDE_PROJECT_DIR is left UNSET so
+# read_file_path's membership guard is disabled (not part of the fire gate);
+# this isolates lint/format behavior from path-form mismatch in the guard.
+run_hook() {
+  local file_path="$1"
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR HOOK_BIOME_FORMAT_ENABLED=true bash "$HOOK"
+  )
+}
+
+# Same as run_hook but with caller-supplied extra env (NAME=VALUE ...).
+run_hook_env() {
+  local file_path="$1"
+  shift
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+  )
+}
+
+# --- Case 1: opt-in gate OFF (no biome.json) -> file left untouched ----------
+# The whole conservative opt-in: a repo with Biome installed but NO config must
+# not have its files rewritten to Biome's built-in defaults.
+REPO_NO="$WORK/no-config"
+new_biome_repo "$REPO_NO" NO_CONFIG
+printf 'const x=1;var y=2\n' >"$REPO_NO/nofmt.ts"
+BEFORE_NO="$(cat "$REPO_NO/nofmt.ts")"
+OUT=$(run_hook "$REPO_NO/nofmt.ts")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "gate OFF (no biome.json) -> exit 0, silent"; else fail "gate OFF not silent (rc=$RC out=$OUT)"; fi
+if [[ "$(cat "$REPO_NO/nofmt.ts")" == "$BEFORE_NO" ]]; then ok "gate OFF -> file left untouched"; else fail "gate OFF -> file was rewritten"; fi
+
+# --- Case 2: gate ON + clean file -> exit 0, empty stdout -------------------
+REPO="$WORK/consumer"
+new_biome_repo "$REPO"
+printf 'const x = 1;\nexport { x };\n' >"$REPO/clean.ts"
+OUT=$(run_hook "$REPO/clean.ts")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "clean .ts -> exit 0"; else fail "clean .ts exit $RC"; fi
+if [[ -z "$OUT" ]]; then ok "clean .ts -> empty stdout"; else fail "clean .ts stdout not empty: $OUT"; fi
+
+# --- Case 3: gate ON + bad formatting (no lint error) -> file formatted ------
+mkdir -p "$REPO/src"
+printf 'const a = 1;export {a}\n' >"$REPO/src/fmt.ts"
+OUT=$(run_hook "$REPO/src/fmt.ts")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "format case -> exit 0 (advisory)"; else fail "format case exit $RC"; fi
+if grep -q 'export { a };' "$REPO/src/fmt.ts"; then
+  ok "gate ON (subdir file) -> Biome reformatted the file"
+else
+  fail "gate ON -> file not formatted: $(cat "$REPO/src/fmt.ts")"
+fi
+
+# --- Case 4: gate ON + lint finding (unused var) -> advisory context ---------
+# File in a subdir (config at repo root) exercises both the walk and the
+# CONFIG_DIR-relative path passed to Biome.
+mkdir -p "$REPO/lib"
+printf 'const unusedVar = 1;\n' >"$REPO/lib/lint.ts"
+OUT=$(run_hook "$REPO/lib/lint.ts")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "lint finding -> exit 0 (advisory)"; else fail "lint finding exit $RC (must be advisory)"; fi
+if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext')
+  if printf '%s' "$CTX" | grep -qi 'noUnusedVariables\|unused'; then
+    ok "lint finding -> surfaced in additionalContext"
+  else
+    fail "lint ctx missing the finding: $CTX"
+  fi
+  # Path is repo-relative (lib/lint.ts or lib\lint.ts), not an absolute,
+  # URL-encoded one (C%3A...). Accept either separator for cross-platform parity.
+  if printf '%s' "$CTX" | grep -qiE 'lib[/\\]lint\.ts' && ! printf '%s' "$CTX" | grep -qi 'C%3A\|%3A'; then
+    ok "lint finding -> path is clean and repo-relative"
+  else
+    fail "lint finding -> path not clean/relative: $CTX"
+  fi
+  if printf '%s' "$CTX" | grep -qi 'commit/CI will block\|hard gate\|lefthook'; then
+    fail "ctx still carries medley-policy prose: $CTX"
+  else
+    ok "ctx free of medley-policy prose"
+  fi
+else
+  fail "lint finding -> no additionalContext JSON: $OUT"
+fi
+
+# --- Case 4b: mid-edit syntax error -> surfaced as a finding, not a break ----
+# The dominant on-edit trigger: the file does not parse yet. Biome's github
+# reporter emits ::error title=parse lines, so it must land in the findings
+# branch (advisory, exit 0), not be mislabeled as a tool break.
+printf 'const = ;\n' >"$REPO/syntax.ts"
+OUT=$(run_hook "$REPO/syntax.ts")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "syntax error -> exit 0 (advisory)"; else fail "syntax error exit $RC"; fi
+if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext')
+  if printf '%s' "$CTX" | grep -qi 'has Biome findings' && printf '%s' "$CTX" | grep -qi 'parse\|expected'; then
+    ok "syntax error -> surfaced as a finding (not a tool break)"
+  else
+    fail "syntax error -> not in findings branch: $CTX"
+  fi
+else
+  fail "syntax error -> no additionalContext JSON: $OUT"
+fi
+
+# --- Case 5: gate ON + JSON needing format -> file formatted (in-scope) ------
+printf '{"b":2,"a":1}\n' >"$REPO/data.json"
+OUT=$(run_hook "$REPO/data.json")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "JSON case -> exit 0"; else fail "JSON case exit $RC"; fi
+if grep -q '"b": 2' "$REPO/data.json"; then
+  ok "JSON file formatted by Biome"
+else
+  fail "JSON not formatted: $(cat "$REPO/data.json")"
+fi
+
+# --- Case 6: non-matching extension -> exit 0 silently ----------------------
+echo "plain text" >"$REPO/notes.txt"
+OUT=$(run_hook "$REPO/notes.txt")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-matching ext -> exit 0 silent"; else fail "non-matching ext not skipped (rc=$RC out=$OUT)"; fi
+
+# --- Case 7: kill switch bypasses hook --------------------------------------
+printf 'const k=1;var j=2\n' >"$REPO/kill.ts"
+BEFORE_K="$(cat "$REPO/kill.ts")"
+OUT=$(run_hook_env "$REPO/kill.ts" HOOK_BIOME_FORMAT_ENABLED=false)
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
+if [[ "$(cat "$REPO/kill.ts")" == "$BEFORE_K" ]]; then ok "kill switch -> file untouched"; else fail "kill switch -> file was modified"; fi
+
+# --- Case 8: config ignores the edited file -> untouched, no nag ------------
+# Biome 2.x respects files.includes ignores even for an explicitly-passed path.
+# The hook must treat "provided but ignored" as a silent skip, not a tool break.
+REPO_IGN="$WORK/ignore-config"
+new_biome_repo "$REPO_IGN" '{ "files": { "includes": ["**", "!**/generated/**"] } }'
+mkdir -p "$REPO_IGN/generated"
+printf 'const z=1;var w=2\n' >"$REPO_IGN/generated/gen.ts"
+BEFORE_IGN="$(cat "$REPO_IGN/generated/gen.ts")"
+OUT=$(run_hook "$REPO_IGN/generated/gen.ts")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "ignored file -> exit 0, silent (no nag)"; else fail "ignored file not silent (rc=$RC out=$OUT)"; fi
+if [[ "$(cat "$REPO_IGN/generated/gen.ts")" == "$BEFORE_IGN" ]]; then ok "ignored file -> left untouched (respects config ignore)"; else fail "ignored file -> was rewritten"; fi
+
+# ============================================================================
+# Telemetry
+# ============================================================================
+
+# --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
+OUT_NS=$(run_hook_env "$REPO/clean.ts" -u HOOK_TELEMETRY_SINK HOOK_BIOME_FORMAT_ENABLED=true)
+RC_NS=$?
+if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
+  ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
+else
+  fail "telemetry/sink-unset: rc=$RC_NS out=$OUT_NS"
+fi
+
+# --- Stub sink + lint finding -> envelope status ok with findings -----------
+printf 'const unusedTel = 1;\n' >"$REPO/tel.ts"
+TEL="$(mktemp)"
+SINK="$(make_sink "cat >\"$TEL\"")"
+run_hook_env "$REPO/tel.ts" HOOK_BIOME_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+wait_for_sink "$TEL"
+if [[ -s "$TEL" ]]; then
+  ok "telemetry/stub-sink: envelope received"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$TEL" >/dev/null 2>&1; then
+      ok "envelope: $field present"
+    else
+      fail "envelope: $field missing ($(cat "$TEL"))"
+    fi
+  done
+  if [[ "$(jq -r '.hook' "$TEL")" == "biome-format" ]]; then ok "envelope: hook is biome-format"; else fail "envelope: hook=$(jq -r '.hook' "$TEL")"; fi
+  if [[ "$(jq -r '.status' "$TEL")" == "ok" ]]; then ok "envelope: status ok"; else fail "envelope: status=$(jq -r '.status' "$TEL")"; fi
+  if [[ "$(jq -r '.schema_version' "$TEL")" == "1.0" ]]; then ok "envelope: schema_version 1.0"; else fail "envelope: schema_version=$(jq -r '.schema_version' "$TEL")"; fi
+  if [[ "$(jq '.data.findings | length' "$TEL")" -ge 1 ]]; then ok "envelope: findings populated"; else fail "envelope: findings empty ($(jq '.data.findings' "$TEL"))"; fi
+  FREL=$(jq -r '.data.file' "$TEL")
+  if [[ -n "$FREL" && "$FREL" != /* && "$FREL" != ?:* ]]; then ok "envelope: data.file repo-relative ($FREL)"; else fail "envelope: data.file not repo-relative: $FREL"; fi
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL" >/dev/null 2>&1; then ok "envelope: duration_ms non-negative int"; else fail "envelope: duration_ms invalid ($(jq .duration_ms "$TEL"))"; fi
+else
+  fail "telemetry/stub-sink: no envelope written"
+fi
+rm -f "$TEL"
+
+# --- Stub sink + gate OFF -> status skipped ---------------------------------
+printf 'const s=1;var t=2\n' >"$REPO_NO/tel2.ts"
+TELS="$(mktemp)"
+SINKS="$(make_sink "cat >\"$TELS\"")"
+run_hook_env "$REPO_NO/tel2.ts" HOOK_BIOME_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+wait_for_sink "$TELS"
+if [[ -s "$TELS" ]]; then
+  if [[ "$(jq -r '.status' "$TELS")" == "skipped" ]]; then ok "telemetry/gate-off: status skipped"; else fail "telemetry/gate-off: status=$(jq -r '.status' "$TELS")"; fi
+  if [[ "$(jq '.data.findings | length' "$TELS")" -eq 0 ]]; then ok "telemetry/gate-off: findings empty array"; else fail "telemetry/gate-off: findings not empty"; fi
+else
+  fail "telemetry/gate-off: no envelope written"
+fi
+rm -f "$TELS"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -1,0 +1,211 @@
+# shellcheck shell=bash
+# Minimal hook utility library for the markdown-formatter plugin.
+# Sourced (not executed). Trimmed subset of a larger shared library — only the
+# functions this plugin's hook needs: kill switch, file_path parsing + path
+# normalization, repo-root resolution, and the additionalContext accumulator.
+
+# Guard against double-sourcing.
+[[ -n "${_MDFMT_HOOK_UTILS_LOADED:-}" ]] && return 0
+readonly _MDFMT_HOOK_UTILS_LOADED=1
+
+# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
+# disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+hook::check_enabled() {
+  local var_name="HOOK_${1}_ENABLED"
+  if [[ "${!var_name:-true}" != "true" ]]; then
+    exit 0
+  fi
+}
+
+# Normalize a path for the membership comparison below: backslashes → forward
+# slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
+# fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive
+# letter + lower-cased remainder so the byte-exact comparison is effectively
+# case-insensitive. The fold is gated on the host (OSTYPE), NOT on the path
+# shape: on a case-sensitive POSIX filesystem a real single-letter top-level
+# directory such as `/c/Repo` must pass through unchanged, otherwise it would
+# collapse with `/c/repo` and the membership guard would admit a sibling
+# outside CLAUDE_PROJECT_DIR. The result is used ONLY for comparison; the
+# emitted path is always the caller's original.
+hook::normalize_path() {
+  local p="${1//\\//}"
+  case "${OSTYPE:-}" in
+    msys* | cygwin* | win32)
+      if [[ "$p" =~ ^/([a-zA-Z])/ || "$p" =~ ^([a-zA-Z]):/ ]]; then
+        local rest="${p:2}"
+        printf '%s' "${BASH_REMATCH[1]^}:${rest,,}"
+        return
+      fi
+      ;;
+    *) ;; # POSIX hosts: case-sensitive FS, no drive fold — pass through below
+  esac
+  printf '%s' "$p"
+}
+
+# Parse file_path from PostToolUse JSON on stdin; validate existence and (when
+# CLAUDE_PROJECT_DIR is set) project membership. Outputs the path on success.
+# Returns 1 to skip.
+#   FILE=$(hook::read_file_path) || exit 0
+hook::read_file_path() {
+  local file
+  file=$(jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+  [[ -n "$file" ]] || return 1
+  [[ -f "$file" ]] || return 1
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local norm_file norm_project
+    norm_file=$(hook::normalize_path "$file")
+    norm_project=$(hook::normalize_path "${CLAUDE_PROJECT_DIR}")
+    norm_project="${norm_project%/}"
+    # Anchor on a path-segment boundary: accept the project root itself or a
+    # child under it, but not a sibling whose name merely shares the prefix
+    # (e.g. /c/repo must not admit /c/repo-backup/...).
+    if [[ "$norm_file" != "$norm_project" && "$norm_file" != "$norm_project"/* ]]; then
+      return 1
+    fi
+  fi
+  printf '%s' "$file"
+}
+
+# Resolve the repository root (working-tree top) for a path inside the tree.
+# markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
+# before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
+# so it is correct for clones, linked worktrees, and bare-hub clones; falls
+# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+#   ROOT=$(hook::repo_root "$some_path")
+hook::repo_root() {
+  local hint="${1:-.}"
+  local root
+  root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+  if [[ -z "$root" ]]; then
+    root="$hint"
+    root="${root%/.claude}"
+    root="${root%\\.claude}"
+  fi
+  printf '%s' "$root"
+}
+
+# Per-hook stdout context accumulator. ctx_reset at entry, ctx_append per line,
+# ctx_flush once at exit with the hook event name.
+_HOOK_CTX_BUFFER=""
+
+hook::ctx_reset() {
+  _HOOK_CTX_BUFFER=""
+}
+
+hook::ctx_append() {
+  _HOOK_CTX_BUFFER+="$1"$'\n'
+}
+
+# Emit the accumulated context as hookSpecificOutput JSON, then clear the buffer.
+hook::ctx_flush() {
+  local event_name="$1"
+  local trimmed="${_HOOK_CTX_BUFFER%"${_HOOK_CTX_BUFFER##*[![:space:]]}"}"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  hook::emit_additional_context "$event_name" "$trimmed"
+  hook::ctx_reset
+}
+
+# Emit one telemetry envelope per hook run to the consumer-set sink.
+# Fire-and-forget: sink is dispatched in the background; the hook never waits
+# on it and its failure never affects the hook's own exit code or stdout.
+# Opt-in guard: HOOK_TELEMETRY_SINK unset or empty → return 0 immediately.
+# Fail-open: jq absent → return 0 immediately.
+#
+# Usage:
+#   hook::emit_telemetry <hook_id> <hook_event> <status> <start_epoch> <data_json> [repo_root]
+#
+# <start_epoch>  Value of $EPOCHREALTIME captured by the caller before work began.
+#               Handles both '.' and ',' as the decimal separator (LC_NUMERIC).
+# <data_json>   Pre-built JSON object for the `data` field.
+# <repo_root>   Optional consuming-repo root, used to resolve a RELATIVE
+#               HOOK_TELEMETRY_SINK. The caller passes the root it already
+#               resolved for data.file; ignored when the sink is absolute.
+#
+# Sink path resolution: HOOK_TELEMETRY_SINK may be absolute OR relative to the
+# consuming repo root. Absolute (POSIX /… or Windows X:\ / X:/) is used as-is; a
+# relative value is joined onto <repo_root> (or $CLAUDE_PROJECT_DIR when no root
+# is passed), and skipped fail-open if neither is available. Relative is the
+# portable, team-shared wiring form: CC injects settings.json env values
+# literally (no ${VAR} expansion), so a relative path tracked in settings.json is
+# the only clone-portable, worktree-safe option.
+#
+# NEVER writes to fd1 (the hook's stdout / additionalContext channel).
+hook::emit_telemetry() {
+  # Opt-in guard.
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]] || return 0
+  # Fail-open when jq is absent.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local hook_id="$1"
+  local hook_event="$2"
+  local status="$3"
+  local start_epoch="$4"
+  local data_json="$5"
+  local repo_root="${6:-}"
+
+  # Compute duration_ms from caller's $EPOCHREALTIME snapshot to now.
+  # Both '.' and ',' separators handled; 10# prefix prevents octal misreading
+  # of fractional parts with leading zeros (e.g. .045123 → 10#045123 = 45123).
+  local now=$EPOCHREALTIME
+  local s_s="${start_epoch%[.,]*}" s_f="${start_epoch#*[.,]}"
+  local e_s="${now%[.,]*}"         e_f="${now#*[.,]}"
+  local duration_ms=$(( (e_s * 1000000 + 10#$e_f - s_s * 1000000 - 10#$s_f) / 1000 ))
+
+  # True UTC timestamp (TZ= prefix overrides LC_ALL / local TZ; the Z is not a lie).
+  local timestamp
+  timestamp=$(TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' -1)
+
+  # Build the envelope. Redirect jq stderr to /dev/null; output goes to a local
+  # variable — never to fd1.
+  local envelope
+  envelope=$(jq -n \
+    --arg     schema_version "1.0" \
+    --arg     timestamp      "$timestamp" \
+    --arg     hook           "$hook_id" \
+    --arg     hook_event     "$hook_event" \
+    --arg     status         "$status" \
+    --argjson duration_ms    "$duration_ms" \
+    --argjson data           "$data_json" \
+    '{schema_version:$schema_version,timestamp:$timestamp,hook:$hook,hook_event:$hook_event,status:$status,duration_ms:$duration_ms,data:$data}' \
+    2>/dev/null) || return 0
+
+  # Resolve the sink path. A relative HOOK_TELEMETRY_SINK is joined onto the
+  # consuming repo root (portable, tracked wiring); absolute is used as-is. A
+  # relative value with no anchor is skipped fail-open — never exec a path the
+  # drifted hook CWD would resolve incorrectly.
+  local sink="$HOOK_TELEMETRY_SINK"
+  case "$sink" in
+    /* | [A-Za-z]:[/\\]*) ;;
+    *)
+      local root="${repo_root:-${CLAUDE_PROJECT_DIR:-}}"
+      [[ -n "$root" ]] || return 0
+      sink="${root%/}/$sink"
+      ;;
+  esac
+
+  # Fire-and-forget: pipe the envelope to the sink in a background subshell.
+  # The subshell's stdout AND stderr are redirected to /dev/null so the sink
+  # cannot write to the hook's fd1 (the additionalContext channel) and the
+  # backgrounded subshell does not hold a copy of the hook's fd1 open — which
+  # would block any command substitution wrapping the hook until the sink exits
+  # (the "C1 fd1-inheritance blocker"). The sink is quoted — it is a single
+  # executable path (wrap in a script to pass arguments).
+  printf '%s\n' "$envelope" | ("$sink" >/dev/null 2>&1) &
+}
+
+# Print cross-host hook JSON to stdout (exit 0). No-op when context is empty.
+# Shape: { hookSpecificOutput: { hookEventName[, additionalContext] } }.
+hook::emit_additional_context() {
+  local event_name="$1"
+  local context="$2"
+  [[ -n "$context" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -n \
+    --arg event "$event_name" \
+    --arg ctx "$context" \
+    '{hookSpecificOutput: (
+      {hookEventName: $event}
+      + (if $ctx != "" then {additionalContext: $ctx} else {} end)
+    )}'
+}

--- a/plugins/biome-format/hooks/hook-utils.test.sh
+++ b/plugins/biome-format/hooks/hook-utils.test.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# Unit tests for hook-utils.sh: sourced-lib tests for hook::emit_telemetry.
+#
+# Tests source hook-utils.sh directly and drive hook::emit_telemetry in
+# isolation. No subprocess invocation of biome-format.sh — black-box
+# integration tests live in biome-format.test.sh.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# --- Source the lib under test -----------------------------------------------
+# shellcheck source=hook-utils.sh
+source "$HOOK_DIR/hook-utils.sh"
+
+# make_sink <outfile> → prints the path to a single-executable stub sink that
+# copies its stdin to <outfile>. The contract requires HOOK_TELEMETRY_SINK to be
+# a single executable path (not a command-with-args), so tests point it at a
+# stub script rather than `tee FILE`.
+make_sink() {
+  local s
+  s="$(mktemp)"
+  cat >"$s" <<EOF
+#!/usr/bin/env bash
+cat >"$1"
+EOF
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [max_polls] → block until <file> is non-empty (the
+# fire-and-forget sink has flushed) or the bound elapses. Polls in 20ms steps so
+# the assertion fires as soon as the write lands instead of racing a fixed sleep
+# (sink dispatch is a freshly-spawned process; spawn latency varies, especially
+# on Windows Git Bash). Returns non-zero on timeout so negative cases can assert.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while (( tries-- > 0 )); do
+    [[ -s "$f" ]] && return 0
+    sleep 0.02
+  done
+  return 1
+}
+
+# --- Test 1: HOOK_TELEMETRY_SINK unset → returns 0, no output ----------------
+unset HOOK_TELEMETRY_SINK 2>/dev/null || true
+out=$(hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"foo.ts","findings":[]}' 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  ok "sink unset: returns 0"
+else
+  fail "sink unset: expected 0, got $rc"
+fi
+if [[ -z "$out" ]]; then
+  ok "sink unset: no output"
+else
+  fail "sink unset: unexpected output: $out"
+fi
+
+# --- Test 2: jq absent → fail-open (returns 0, no output) -------------------
+# Make `command -v jq` genuinely fail by running with a PATH that contains no
+# jq. A shell-function shadow does NOT exercise the guard: `command -v jq`
+# reports a defined function as present, so the absence branch is never taken.
+# emit_telemetry uses only shell builtins until its jq calls, so an empty PATH
+# is sufficient. Scoped to the command so PATH/sink never leak into the suite.
+EMPTY_BIN="$(mktemp -d)"
+# shellcheck disable=SC2030,SC2031
+out_nojq=$(
+  export HOOK_TELEMETRY_SINK="cat"
+  PATH="$EMPTY_BIN" hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"foo.ts","findings":[]}' 2>/dev/null
+)
+rc_nojq=$?
+rmdir "$EMPTY_BIN" 2>/dev/null || true
+if [[ $rc_nojq -eq 0 ]]; then
+  ok "jq absent: returns 0"
+else
+  fail "jq absent: expected 0, got $rc_nojq"
+fi
+if [[ -z "$out_nojq" ]]; then
+  ok "jq absent: no output"
+else
+  fail "jq absent: unexpected output: $out_nojq"
+fi
+
+# --- Test 3: envelope shape matches schema (7 required common fields + data) --
+SINK_FILE="$(mktemp)"
+cleanup_t3() { rm -f "$SINK_FILE"; }
+trap cleanup_t3 EXIT
+
+# Use a file-writing sink to capture the envelope.
+# shellcheck disable=SC2031  # prior subshell export is intentionally scoped there
+HOOK_TELEMETRY_SINK="$(make_sink "$SINK_FILE")"
+export HOOK_TELEMETRY_SINK
+data_json='{"tool":"Write","file":"docs/foo.ts","findings":["docs/foo.ts:1 lint/correctness/noUnusedVariables"]}'
+start=$EPOCHREALTIME
+hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$start" "$data_json" 2>/dev/null
+wait_for_sink "$SINK_FILE"
+unset HOOK_TELEMETRY_SINK
+
+if [[ -s "$SINK_FILE" ]]; then
+  ok "envelope shape: sink received data"
+  # Validate all 7 required common fields
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$SINK_FILE" >/dev/null 2>&1; then
+      ok "envelope shape: field '$field' present"
+    else
+      fail "envelope shape: field '$field' missing. envelope=$(cat "$SINK_FILE")"
+    fi
+  done
+  # Validate data sub-fields
+  for subfield in tool file findings; do
+    if jq -e ".data | has(\"$subfield\")" "$SINK_FILE" >/dev/null 2>&1; then
+      ok "envelope shape: data.$subfield present"
+    else
+      fail "envelope shape: data.$subfield missing. data=$(jq .data "$SINK_FILE")"
+    fi
+  done
+  # Validate schema_version
+  sv=$(jq -r '.schema_version' "$SINK_FILE")
+  if [[ "$sv" == "1.0" ]]; then
+    ok "envelope: schema_version is 1.0"
+  else
+    fail "envelope: schema_version expected 1.0, got $sv"
+  fi
+  # Validate hook id
+  hook_val=$(jq -r '.hook' "$SINK_FILE")
+  if [[ "$hook_val" == "biome-format" ]]; then
+    ok "envelope: hook is biome-format"
+  else
+    fail "envelope: hook expected biome-format, got $hook_val"
+  fi
+  # Validate hook_event
+  he=$(jq -r '.hook_event' "$SINK_FILE")
+  if [[ "$he" == "PostToolUse" ]]; then
+    ok "envelope: hook_event is PostToolUse"
+  else
+    fail "envelope: hook_event expected PostToolUse, got $he"
+  fi
+  # Validate status
+  st=$(jq -r '.status' "$SINK_FILE")
+  if [[ "$st" == "ok" ]]; then
+    ok "envelope: status is ok"
+  else
+    fail "envelope: status expected ok, got $st"
+  fi
+else
+  fail "envelope shape: sink file empty — emit did not fire or sink did not write"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    fail "envelope shape: field '$field' not verifiable (no envelope)"
+  done
+  for subfield in tool file findings; do
+    fail "envelope shape: data.$subfield not verifiable (no envelope)"
+  done
+fi
+
+# --- Test 4: timestamp is UTC RFC3339 with Z suffix --------------------------
+if [[ -s "$SINK_FILE" ]]; then
+  ts=$(jq -r '.timestamp' "$SINK_FILE")
+  if [[ "$ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    ok "timestamp: matches RFC3339 UTC pattern"
+  else
+    fail "timestamp: does not match pattern: $ts"
+  fi
+  # Verify it is genuinely UTC: timestamp hour must align with UTC hour (±1 for boundary)
+  # We verify by checking the TZ=UTC prefix actually produces UTC
+  utc_h=$(TZ=UTC date +%H)
+  ts_h="${ts:11:2}"
+  # Circular ±1h tolerance to absorb an hour-boundary straddle between the emit
+  # and this check — including the 23→00 midnight wrap, where a linear distance
+  # would read 23 and false-fail once per day. (#0 strips the leading zero so
+  # 00–09 are not misread as octal inside (( )).)
+  h_diff=$(( ( ${ts_h#0} - ${utc_h#0} + 24 ) % 24 ))
+  if [[ $h_diff -le 1 || $h_diff -ge 23 ]]; then
+    ok "timestamp: UTC hour aligns with system UTC"
+  else
+    fail "timestamp: hour drift vs UTC: ts_h=$ts_h utc_h=$utc_h diff=$h_diff"
+  fi
+else
+  fail "timestamp: no envelope to check"
+  fail "timestamp: UTC alignment not verifiable"
+fi
+
+# --- Test 5: duration_ms is a non-negative integer ---------------------------
+if [[ -s "$SINK_FILE" ]]; then
+  dur=$(jq '.duration_ms' "$SINK_FILE")
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$SINK_FILE" >/dev/null 2>&1; then
+    ok "duration_ms: is non-negative integer (value=$dur)"
+  else
+    fail "duration_ms: not a non-negative integer: $dur"
+  fi
+else
+  fail "duration_ms: no envelope to check"
+fi
+
+rm -f "$SINK_FILE"
+trap - EXIT
+
+# --- Test 6: status "skipped" passes through ---------------------------------
+SINK_FILE2="$(mktemp)"
+HOOK_TELEMETRY_SINK="$(make_sink "$SINK_FILE2")"
+export HOOK_TELEMETRY_SINK
+hook::emit_telemetry "biome-format" "PostToolUse" "skipped" "$EPOCHREALTIME" '{"tool":"","file":"","findings":[]}' 2>/dev/null
+wait_for_sink "$SINK_FILE2"
+unset HOOK_TELEMETRY_SINK
+
+if [[ -s "$SINK_FILE2" ]]; then
+  st2=$(jq -r '.status' "$SINK_FILE2")
+  if [[ "$st2" == "skipped" ]]; then
+    ok "status skipped: correctly emitted"
+  else
+    fail "status skipped: got $st2"
+  fi
+else
+  fail "status skipped: no envelope written"
+fi
+rm -f "$SINK_FILE2"
+
+# --- Test 7: RELATIVE sink resolves against the passed repo_root (6th arg) ----
+# This is the portable/tracked-wiring path: a relative HOOK_TELEMETRY_SINK joined
+# onto the consuming repo root the caller passes.
+ROOT7="$(mktemp -d)"
+mkdir -p "$ROOT7/.claude/hooks"
+REL7=".claude/hooks/sink.sh"
+OUT7="$(mktemp)"
+cat >"$ROOT7/$REL7" <<EOF
+#!/usr/bin/env bash
+cat >"$OUT7"
+EOF
+chmod +x "$ROOT7/$REL7"
+export HOOK_TELEMETRY_SINK="$REL7"
+hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.ts","findings":[]}' "$ROOT7" 2>/dev/null
+wait_for_sink "$OUT7"
+unset HOOK_TELEMETRY_SINK
+if [[ -s "$OUT7" ]] && [[ "$(jq -r '.hook' "$OUT7")" == "biome-format" ]]; then
+  ok "relative sink: resolved against repo_root arg, envelope delivered"
+else
+  fail "relative sink: not resolved against repo_root arg (out empty or wrong)"
+fi
+rm -rf "$ROOT7" "$OUT7"
+
+# --- Test 8: RELATIVE sink resolves against CLAUDE_PROJECT_DIR when no root arg --
+ROOT8="$(mktemp -d)"
+mkdir -p "$ROOT8/.claude/hooks"
+OUT8="$(mktemp)"
+cat >"$ROOT8/.claude/hooks/sink.sh" <<EOF
+#!/usr/bin/env bash
+cat >"$OUT8"
+EOF
+chmod +x "$ROOT8/.claude/hooks/sink.sh"
+export HOOK_TELEMETRY_SINK=".claude/hooks/sink.sh"
+CLAUDE_PROJECT_DIR="$ROOT8" hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.ts","findings":[]}' 2>/dev/null
+wait_for_sink "$OUT8"
+unset HOOK_TELEMETRY_SINK
+if [[ -s "$OUT8" ]]; then
+  ok "relative sink: resolved against CLAUDE_PROJECT_DIR fallback"
+else
+  fail "relative sink: CLAUDE_PROJECT_DIR fallback did not resolve"
+fi
+rm -rf "$ROOT8" "$OUT8"
+
+# --- Test 9: RELATIVE sink with NO anchor → fail-open skip (return 0, no write) --
+OUT9="$(mktemp)"
+rm -f "$OUT9" # ensure absent
+export HOOK_TELEMETRY_SINK="relative/no/anchor/sink.sh"
+(
+  unset CLAUDE_PROJECT_DIR 2>/dev/null || true
+  hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.ts","findings":[]}' 2>/dev/null
+)
+rc9=$?
+sleep 0.2
+unset HOOK_TELEMETRY_SINK
+if [[ $rc9 -eq 0 ]] && [[ ! -s "$OUT9" ]]; then
+  ok "relative sink, no anchor: fail-open skip (rc 0, no write)"
+else
+  fail "relative sink, no anchor: expected skip (rc=$rc9, out exists=$([[ -s "$OUT9" ]] && echo y || echo n))"
+fi
+rm -f "$OUT9"
+
+# --- Test 10: ABSOLUTE sink passes through unchanged --------------------------
+OUT10="$(mktemp)"
+ABS10="$(make_sink "$OUT10")" # mktemp path is absolute
+export HOOK_TELEMETRY_SINK="$ABS10"
+hook::emit_telemetry "biome-format" "PostToolUse" "ok" "$EPOCHREALTIME" '{"tool":"Write","file":"x.ts","findings":[]}' "/some/ignored/root" 2>/dev/null
+wait_for_sink "$OUT10"
+unset HOOK_TELEMETRY_SINK
+if [[ -s "$OUT10" ]] && [[ "$(jq -r '.hook' "$OUT10")" == "biome-format" ]]; then
+  ok "absolute sink: passes through unchanged (repo_root ignored)"
+else
+  fail "absolute sink: did not pass through"
+fi
+rm -f "$ABS10" "$OUT10"
+
+# --- Test 11: hook::normalize_path is host-gated on OSTYPE --------------------
+# The drive-letter fold is for Windows/MSYS only (case-insensitive FS). On a
+# case-sensitive POSIX host a real single-letter top dir like /c/Repo must pass
+# through unchanged, or the membership guard collapses it with /c/repo and
+# admits a sibling outside CLAUDE_PROJECT_DIR. normalize_path reads the shell's
+# OSTYPE, so override it in a subshell per case (the global stays intact).
+norm_as() { ( OSTYPE="$1"; hook::normalize_path "$2" ); }
+assert_norm() { # <ostype> <input> <expected> <desc>
+  local got
+  got="$(norm_as "$1" "$2")"
+  if [[ "$got" == "$3" ]]; then
+    ok "normalize_path[$1]: $4"
+  else
+    fail "normalize_path[$1]: $4 — expected '$3', got '$got'"
+  fi
+}
+
+# Windows/MSYS: fold both the POSIX /c/ and colon c:/ drive forms.
+assert_norm msys   "/c/Repo"        "C:/repo"        "msys folds /c/Repo → C:/repo"
+assert_norm msys   "C:/Repo"        "C:/repo"        "msys folds C:/Repo → C:/repo"
+assert_norm msys   "/c/Repo/Sub"    "C:/repo/sub"    "msys folds nested path"
+assert_norm msys   'C:\Repo\x'      "C:/repo/x"      "msys: backslashes → slashes then fold"
+assert_norm cygwin "/c/Repo"        "C:/repo"        "cygwin folds like msys"
+
+# POSIX: NO fold — single-letter top dirs stay distinct (the regression guard).
+assert_norm linux-gnu "/c/Repo"     "/c/Repo"        "linux leaves /c/Repo unchanged"
+assert_norm linux-gnu "/c/repo"     "/c/repo"        "linux leaves /c/repo unchanged"
+assert_norm linux-gnu "/opt/App/Sub" "/opt/App/Sub"  "linux leaves normal path unchanged"
+assert_norm linux-gnu 'a\b'         "a/b"            "linux still converts backslashes"
+
+# Explicit guard: on POSIX the two casings must NOT collapse to one value.
+if [[ "$(norm_as linux-gnu /c/Repo)" != "$(norm_as linux-gnu /c/repo)" ]]; then
+  ok "normalize_path[linux-gnu]: /c/Repo and /c/repo stay distinct"
+else
+  fail "normalize_path[linux-gnu]: /c/Repo and /c/repo collapsed (membership-guard regression)"
+fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/biome-format/hooks/hooks.json
+++ b/plugins/biome-format/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/biome-format.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

Adds **biome-format**, the third plugin in this marketplace — a PostToolUse hook that runs Biome's `check --write` on edits to JS/TS/JSX/JSON files, auto-applying safe fixes + formatting + import sorting and surfacing residual findings to Claude as advisory context. It uses the **consuming repo's own `biome.json`** and ships no rules.

Built to the bash-lint structural template: `.claude-plugin/plugin.json`, `hooks/hooks.json`, `hooks/biome-format.sh`, byte-identical `hooks/hook-utils.sh`, self-contained `*.test.sh`, and a `README.md`.

## Key design decisions

- **Opt-in gate.** Biome runs only when a `biome.json` (or `.jsonc`/dotted) governs the edited file — the conservative opt-in mirroring bash-lint's `.editorconfig` gate. A repo without Biome config is left untouched rather than rewritten to Biome's built-in defaults.
- **CWD-anchored discovery.** Verified against current Biome docs that config discovery walks up from the **CWD** (not the target file) with a nested-config scanner — so the hook `cd`s to the topmost governing config dir (the root config's directory).
- **No `npx`.** The Biome binary is resolved from the repo's `node_modules/.bin/biome` or `PATH`; never downloaded on a per-edit hook.
- **Compact findings.** `--reporter=github` yields one-line-per-diagnostic output (the gcc-format analog) with a clean repo-relative path. Residual findings surface via `additionalContext`; the hook always exits 0.
- **Respects ignores.** Biome 2.x honors the config's `files.includes` ignores even for an explicitly-edited path — verified empirically; the hook treats that as a silent skip (no nagging).

## Verification

All local CI lanes pass: shellcheck, typos, editorconfig-checker, markdownlint, comment-hygiene, exec-bit (3 scripts `100755`, `hook-utils.sh` `100644`), LF + final newline, `hook-utils.sh` byte-identical to the existing copies. `claude plugin validate --strict` passes for both the plugin and the catalog. Both test suites green (hook-utils 37, black-box 36) against **real Biome 2.5.1**, plus a runtime wiring smoke invoking the exact `hooks.json` command with `${CLAUDE_PLUGIN_ROOT}` set and a real envelope on stdin.

Registered in `.claude-plugin/marketplace.json` and the root README catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)