### PR TITLE
fix: harden telemetry data fallback in bash-lint and markdown-formatter

### DIFF
--- a/plugins/bash-lint/.claude-plugin/plugin.json
+++ b/plugins/bash-lint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-lint",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-lint/hooks/bash-lint.sh
+++ b/plugins/bash-lint/hooks/bash-lint.sh
@@ -68,16 +68,19 @@ else
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
-# findings JSON array. jq is authoritative; the string fallback keeps telemetry
-# best-effort if jq fails (findings collapse to [] since they can't be re-quoted
-# safely without jq).
+# findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
+# object — NOT an interpolation of TOOL/FILE_REL, which could inject quotes or
+# backslashes from a path and corrupt the envelope. The fallback is essentially
+# unreachable in practice (it fires only if `jq -n` fails, and when jq is absent
+# hook::emit_telemetry drops the envelope anyway), so losing the values here is
+# harmless and strictly safer than emitting malformed JSON.
 build_data_json() {
   jq -n \
     --arg tool     "$TOOL" \
     --arg file     "$FILE_REL" \
     --argjson findings "$1" \
     '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
-    || printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"
+    || printf '{"tool":"","file":"","findings":[]}'
 }
 
 # A section header governs shell files when it is the `[*]` catch-all or names a

--- a/plugins/markdown-formatter/.claude-plugin/plugin.json
+++ b/plugins/markdown-formatter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-formatter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-formatter/hooks/markdown-format.sh
+++ b/plugins/markdown-formatter/hooks/markdown-format.sh
@@ -63,16 +63,19 @@ else
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
-# findings JSON array. jq is authoritative; the string fallback keeps telemetry
-# best-effort if jq fails (findings collapse to [] since they can't be re-quoted
-# safely without jq).
+# findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
+# object — NOT an interpolation of TOOL/FILE_REL, which could inject quotes or
+# backslashes from a path and corrupt the envelope. The fallback is essentially
+# unreachable in practice (it fires only if `jq -n` fails, and when jq is absent
+# hook::emit_telemetry drops the envelope anyway), so losing the values here is
+# harmless and strictly safer than emitting malformed JSON.
 build_data_json() {
   jq -n \
     --arg tool     "$TOOL" \
     --arg file     "$FILE_REL" \
     --argjson findings "$1" \
     '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
-    || printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"
+    || printf '{"tool":"","file":"","findings":[]}'
 }
 
 MDLINT=()


### PR DESCRIPTION
## What

Follow-up to #19. Propagates two cross-plugin items I flagged when shipping `biome-format`:

**1. Telemetry fallback hardening (the real change).** `bash-lint` and `markdown-formatter` carried the same `build_data_json` jq-failure fallback that `biome-format` had before review hardened it: `printf '{"tool":"%s","file":"%s","findings":[]}' "$TOOL" "$FILE_REL"`. A path containing a quote or backslash could corrupt the telemetry envelope. Both now emit a fixed empty-shape object instead. The path is near-unreachable (fires only if `jq -n` fails, and `hook::emit_telemetry` already drops the envelope when `jq` is absent), so dropping the values is harmless and strictly safer than risking malformed JSON. All three plugins' `build_data_json` are now consistent.

Patch-bumped so consumers pull the change via `claude plugin update`: `bash-lint` 0.1.0 → 0.1.1, `markdown-formatter` 0.1.1 → 0.1.2.

**2. `MultiEdit` matcher — investigated, no change (moot).** Codex flagged that `Write|Edit` omits `MultiEdit`. Verified against the current [tools reference](https://code.claude.com/docs/en/tools-reference): the only file-modification tools are **`Edit`, `Write`, `NotebookEdit`** — `MultiEdit` is gone (merged into `Edit`), and the permission-format table confirms `Edit(...)` applies to "Edit, Write, NotebookEdit". So `Write|Edit` is already complete; `NotebookEdit` only touches `.ipynb`, which none of these plugins' extensions match. No matcher change warranted.

## Verification

`shellcheck`, `typos`, `editorconfig-checker`, `comment-hygiene` all pass on the changed files. Both test suites green against real tools (`bash-lint` 31, `markdown-formatter` 41). `claude plugin validate --strict` passes for both plugins and the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)