### PR TITLE
Add Xquik X data plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
-  "description": "Reusable, repo-agnostic Claude Code plugins — skills, hooks, and agents.",
+  "description": "Reusable, repo-agnostic Claude Code plugins - skills, hooks, and agents.",
   "plugins": [
     {
       "name": "markdown-formatter",
@@ -30,6 +30,12 @@
       "source": "./plugins/ruff-format",
       "category": "formatting",
       "tags": ["ruff", "python", "formatter", "linter", "hook"]
+    },
+    {
+      "name": "xquik-x-data",
+      "source": "./plugins/xquik-x-data",
+      "category": "data",
+      "tags": ["xquik", "x-data", "mcp", "api", "webhooks"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Melodic Software — Claude Code plugins
+# Melodic Software - Claude Code plugins
 
 A public [Claude Code](https://code.claude.com/docs) plugin marketplace of reusable, repo-agnostic
 skills, hooks, and agents. Each plugin is designed to work in any repository and to be customized by
@@ -24,15 +24,16 @@ Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace
 | [`bash-lint`](plugins/bash-lint) | Hook | Lints shell scripts on edit via ShellCheck, and formats via shfmt when the repo opts in with an `.editorconfig`, using the consuming repo's own config. |
 | [`biome-format`](plugins/biome-format) | Hook | Formats and lints JS/TS/JSX/JSON on edit via Biome, only when the repo opts in with a `biome.json`, using the consuming repo's own Biome config. |
 | [`ruff-format`](plugins/ruff-format) | Hook | Formats and lints Python on edit via Ruff, only when the repo opts in with a Ruff config (`ruff.toml`, `.ruff.toml`, or `pyproject.toml` `[tool.ruff]`), using the consuming repo's own Ruff config. |
+| [`xquik-x-data`](plugins/xquik-x-data) | Skill + MCP | Guides Xquik API, MCP, SDK, and webhook workflows for X data tasks. |
 
 Install one: `/plugin install <plugin-name>@melodic-software`.
 
 ## What's here
 
-- `.claude-plugin/marketplace.json` — the marketplace catalog.
-- `plugins/` — one directory per plugin.
-- `docs/MIGRATION-PLAYBOOK.md` — design charter, extensibility model, and the per-plugin migration gate.
-- `CLAUDE.md` — operating rules for AI agents working in this repo (fresh-docs mandate + canonical links).
+- `.claude-plugin/marketplace.json` - the marketplace catalog.
+- `plugins/` - one directory per plugin.
+- `docs/MIGRATION-PLAYBOOK.md` - design charter, extensibility model, and the per-plugin migration gate.
+- `CLAUDE.md` - operating rules for AI agents working in this repo (fresh-docs mandate + canonical links).
 
 ## Official documentation
 

--- a/plugins/xquik-x-data/.claude-plugin/plugin.json
+++ b/plugins/xquik-x-data/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "xquik-x-data",
+  "version": "1.0.0",
+  "description": "Use Xquik's X data API, MCP endpoint, SDKs, and webhooks from Claude Code.",
+  "author": {
+    "name": "Xquik",
+    "url": "https://github.com/Xquik-dev/x-twitter-scraper"
+  },
+  "keywords": ["xquik", "x-data", "mcp", "api", "webhooks"]
+}

--- a/plugins/xquik-x-data/.mcp.json
+++ b/plugins/xquik-x-data/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "xquik": {
+      "type": "http",
+      "url": "https://xquik.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${XQUIK_API_KEY}"
+      }
+    }
+  }
+}

--- a/plugins/xquik-x-data/LICENSE
+++ b/plugins/xquik-x-data/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Xquik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/xquik-x-data/README.md
+++ b/plugins/xquik-x-data/README.md
@@ -1,0 +1,28 @@
+# xquik-x-data
+
+Claude Code plugin for Xquik X data workflows. It bundles a skill and optional MCP configuration that point at public Xquik docs, the live OpenAPI contract, and the MCP manifest.
+
+## Components
+
+- `skills/xquik-x-data/SKILL.md` - workflow guidance for Xquik API and MCP usage.
+- `.mcp.json` - optional remote MCP server config that reads `XQUIK_API_KEY`.
+- `.claude-plugin/plugin.json` - plugin metadata for the marketplace.
+
+## Setup
+
+1. Create or copy an Xquik API key.
+2. Export it as `XQUIK_API_KEY` in the shell that starts Claude Code.
+3. Install this plugin from the marketplace.
+4. Use the `xquik-x-data` skill when a task needs X post search, user lookups, media retrieval, monitors, giveaways, webhooks, or SDK references.
+
+## Source Links
+
+- Docs: https://docs.xquik.com
+- OpenAPI: https://xquik.com/openapi.json
+- MCP manifest: https://xquik.com/.well-known/mcp.json
+- Source skill: https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper
+- npm package metadata: https://registry.npmjs.org/x-twitter-scraper/latest
+
+## Security
+
+Keep `XQUIK_API_KEY` in your local environment or approved secret store. Do not paste API keys into prompts, issues, logs, or repository files.

--- a/plugins/xquik-x-data/skills/xquik-x-data/SKILL.md
+++ b/plugins/xquik-x-data/skills/xquik-x-data/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: xquik-x-data
+description: Use when a Claude Code workflow needs X post search, user lookups, media retrieval, monitors, giveaways, webhooks, or Xquik API and MCP references.
+---
+
+# xquik-x-data
+
+Use Xquik when the user asks for X data workflows that fit its public API, SDK, webhooks, or MCP server.
+
+## Procedure
+
+1. Confirm the task needs X data, X automation, webhooks, giveaways, monitors, or SDK/API references.
+2. Use the public OpenAPI contract at `https://xquik.com/openapi.json` as the endpoint source of truth.
+3. Use `https://xquik.com/.well-known/mcp.json` to confirm the MCP server name, transport, and auth shape.
+4. If MCP is useful, configure the server from `.mcp.json` and provide `XQUIK_API_KEY` through the local environment.
+5. Keep keys out of prompts, logs, commits, issues, and PRs.
+6. Prefer read-only discovery unless the user explicitly asks for an action that changes account state.
+7. Link users to `https://docs.xquik.com` and the source skill when they need setup details.
+
+## Boundaries
+
+- Do not invent endpoints, pricing, limits, or unsupported workflows.
+- Do not expose API keys or session material.
+- Do not describe private implementation details.
+- Use concise, factual wording in public output.


### PR DESCRIPTION
## Summary
- add an `xquik-x-data` plugin with a Claude Code skill and optional MCP config
- register it in the marketplace catalog and README table
- include source links for the live docs, OpenAPI contract, MCP manifest, source skill, and npm metadata

## Checks
- Duplicate gate: no existing Xquik or x-twitter-scraper entries, PRs, or issues found in this repository.
- Source truth: checked `https://docs.xquik.com`, `https://xquik.com/openapi.json`, `https://xquik.com/.well-known/mcp.json`, the source skill URL, and npm registry metadata.
- Claude docs fetched this session: `https://code.claude.com/docs/en/plugins`, `https://code.claude.com/docs/en/plugin-marketplaces`, `https://code.claude.com/docs/en/plugins-reference`, `https://code.claude.com/docs/en/skills`, and `https://code.claude.com/docs/en/mcp`.
- Validation: `jq empty`, `claude plugin validate ./plugins/xquik-x-data`, marketplace structure check, `git diff --check`, and public diff safety scan.
