### PR TITLE
chore: collapse Dependabot labels to just dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    # Only the `dependencies` label (already in the governed taxonomy). This overrides
+    # Dependabot's defaults, suppressing the auto-created snake_case `github_actions`
+    # ecosystem label — the label every downstream tool ignores anyway (release notes
+    # group on `dependencies`; auto-merge, unused here, keys on fetch-metadata outputs).
+    labels:
+      - dependencies
     schedule:
       interval: weekly
     commit-message:


### PR DESCRIPTION
Overrides Dependabot's default labels with the single `dependencies` label (already in the governed taxonomy), suppressing the auto-created snake_case `github_actions` ecosystem label.

**Why:** `github_actions` (underscore — a [known Dependabot inconsistency](https://github.com/dependabot/dependabot-core/issues/12814)) is the only label breaking the lower-kebab-case taxonomy, and nothing consumes the ecosystem label — release-notes/changelog grouping keys on `dependencies`; auto-merge (unused here) keys on fetch-metadata outputs, not labels. The ecosystem stays visible in every PR title.

Part of a fleet-wide sweep; `github_actions` is dropped from `Labels.cs` in the github-iac repos separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot PR labels; no runtime or CI workflow behavior changes.
> 
> **Overview**
> Dependabot’s **github-actions** update entry now sets an explicit **`labels: [dependencies]`** list, replacing Dependabot’s default label set (including the auto-added **`github_actions`** ecosystem tag).
> 
> Inline comments document that this aligns with the repo’s governed label taxonomy and that nothing in this repo keys off the ecosystem label anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d60a738c15f5a9e4353db17468733c10be1ef44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->