### PR TITLE
feat: add eol-normalizer plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,12 @@
       "source": "./plugins/ruff-format",
       "category": "formatting",
       "tags": ["ruff", "python", "formatter", "linter", "hook"]
+    },
+    {
+      "name": "eol-normalizer",
+      "source": "./plugins/eol-normalizer",
+      "category": "formatting",
+      "tags": ["eol", "line-endings", "crlf", "lf", "gitattributes", "hook"]
     }
   ]
 }

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "eol-normalizer",
+  "version": "0.1.0",
+  "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "keywords": ["eol", "line-endings", "crlf", "lf", "gitattributes", "normalizer", "hook"]
+}

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -1,0 +1,64 @@
+# eol-normalizer
+
+A Claude Code plugin that normalizes a file's working-tree line endings the
+moment you edit it. On every `Write` or `Edit` it resolves the file's
+`.gitattributes` `eol=` value via
+[`git check-attr`](https://git-scm.com/docs/git-check-attr) and rewrites the
+file's line endings to match — symmetric CRLF↔LF, idempotent, best-effort.
+
+It uses **your repository's own `.gitattributes`** — it ships no policy and
+imposes no rules of its own.
+
+## Behavior
+
+- **LF arm (every OS).** A file resolving to `eol=lf` is normalized CRLF→LF
+  unconditionally. LF is correct on every platform — a CRLF-contaminated `.sh`
+  or `requirements.txt` breaks shebangs and parsing everywhere — so this arm is
+  never OS-gated.
+- **CRLF arm (Windows only).** A file resolving to `eol=crlf` is normalized
+  LF→CRLF only on Windows. On Linux/macOS, git's checkout smudge already yields
+  CRLF for those paths; the only way such a file lands as LF on disk is a Windows
+  write that bypasses smudge, so the arm self-gates to Windows.
+- **Unspecified → no-op.** A path with no `eol=` attribute is left untouched.
+  There is no hardcoded extension list — resolution is entirely
+  `.gitattributes`-driven, so narrow rules (a single `eol=lf` path) correctly
+  win over broad ones (`*.txt eol=crlf`).
+- **Advisory, never blocking.** The hook always exits `0`. Make a commit hook or
+  CI (`git add --renormalize`, an EditorConfig check) your hard gate.
+
+## Requirements
+
+- **git** on `PATH` — the attribute resolution (`git check-attr`) and repo-root
+  detection depend on it. Without a git repository the hook is a silent no-op.
+
+Rewriting uses `perl` when present, falling back to `tr`/`awk` otherwise, so no
+extra tooling is required.
+
+The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
+(Bash 5.0+); on older bash the telemetry envelope is skipped while normalization
+still runs.
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install eol-normalizer@melodic-software
+```
+
+## Configuration
+
+This plugin has no `userConfig` — its only "configuration" is the
+`.gitattributes` already in your repository, which it reads automatically. To
+change which files normalize to which endings, edit your `.gitattributes`.
+
+### Disable without uninstalling
+
+Set the kill switch in your settings `env` block:
+
+```json
+{ "env": { "HOOK_EOL_NORMALIZER_ENABLED": "false" } }
+```
+
+## License
+
+[MIT](../../LICENSE).

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -11,14 +11,17 @@ imposes no rules of its own.
 
 ## Behavior
 
-- **LF arm (every OS).** A file resolving to `eol=lf` is normalized CRLF→LF
-  unconditionally. LF is correct on every platform — a CRLF-contaminated `.sh`
-  or `requirements.txt` breaks shebangs and parsing everywhere — so this arm is
-  never OS-gated.
-- **CRLF arm (Windows only).** A file resolving to `eol=crlf` is normalized
-  LF→CRLF only on Windows. On Linux/macOS, git's checkout smudge already yields
-  CRLF for those paths; the only way such a file lands as LF on disk is a Windows
-  write that bypasses smudge, so the arm self-gates to Windows.
+- **LF arm (every OS).** A file resolving to `eol=lf` is normalized CRLF→LF.
+- **CRLF arm (every OS).** A file resolving to `eol=crlf` is normalized
+  LF→CRLF. The hook compensates for tool writes that bypass git's checkout
+  smudge, and such writes happen on any platform — an LF write to an
+  `eol=crlf` path violates the repo's policy on Linux/macOS just as much as on
+  Windows.
+- **Binary guard.** `eol` alone is not proof of text: under a broad
+  `* text=auto eol=lf` rule, the `eol` attribute resolves to `lf` for binaries
+  too. The hook mirrors gitattributes semantics — explicit `text` is trusted,
+  `-text` skips, and `text=auto` content-sniffs (NUL scan of the first 8000
+  bytes, git's own detection window) — so binary files are never rewritten.
 - **Unspecified → no-op.** A path with no `eol=` attribute is left untouched.
   There is no hardcoded extension list — resolution is entirely
   `.gitattributes`-driven, so narrow rules (a single `eol=lf` path) correctly

--- a/plugins/eol-normalizer/hooks/eol-normalizer.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# PostToolUse hook: normalize a written file's working-tree line endings to its
+# .gitattributes `eol=` value (symmetric, git check-attr-driven).
+# Triggered on Write|Edit of any file in the consuming repo.
+#
+# ADVISORY / NON-BLOCKING: always exits 0. The normalization is best-effort;
+# the consuming repo's commit hook / CI (editorconfig, git renormalize) remains
+# the authoritative gate.
+#
+# CROSS-PLATFORM: the LF arm (CRLF->LF) runs on every OS; the CRLF arm
+# (LF->CRLF) is Windows-only. That OS gate lives inside the lib's crlf arm
+# (normalize_eol_platform_crlf), NOT here — a top-level uname short-circuit
+# would silence the always-on LF arm on Linux/macOS.
+#
+# Uses the consuming repo's own .gitattributes — it ships no policy of its own.
+
+set -uo pipefail
+
+# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
+# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
+# resolve (ENOENT -> silent no-op). stdin is read ONCE here and reused for both
+# hook::read_file_path (file_path) and the tool_name parse; reading fd0 twice
+# would drain the pipe on the second call.
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "EOL_NORMALIZER"
+
+# Capture $EPOCHREALTIME immediately after the kill switch so duration_ms covers
+# the work below. EPOCHREALTIME is Bash 5.0+; on older bash it is unset, so
+# default to empty — referencing it bare under `set -u` would abort before the
+# advisory exit 0, failing every edit.
+start=${EPOCHREALTIME:-}
+
+# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
+# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
+# normalizes on older bash rather than aborting.
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::emit_telemetry "$@"
+}
+
+# The bundled EOL library (normalize_eol_file / normalize_eol_platform_crlf).
+# Sourced from the plugin's own hooks dir so it is self-contained on install.
+# shellcheck source=normalize-eol.sh
+source "$(dirname "${BASH_SOURCE[0]}")/normalize-eol.sh"
+
+INPUT=$(cat)
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Resolve the repo root that anchors `git check-attr` (CWD-independent — the hook
+# process CWD is not guaranteed to be the repo root). File-anchored so it is
+# correct for clones, linked worktrees, and bare-hub clones.
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+
+# Repo-relative path for the telemetry data.file. On Windows Git Bash,
+# git rev-parse --show-toplevel returns a drive-letter path while FILE may be in
+# POSIX mount form; normalize both through cygpath -lm (long, forward-slash mixed
+# form) when available so the prefix strip compares the same representation. On
+# Linux/macOS cygpath is absent and both paths are already POSIX. Falls back to
+# raw FILE on any normalization error.
+FILE_REL="$FILE"
+if command -v cygpath >/dev/null 2>&1; then
+  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+    FILE_REL="${_file_lm#"$_root_lm"/}"
+  fi
+else
+  FILE_REL="${FILE#"$REPO_ROOT"/}"
+fi
+
+# Build the telemetry data object. jq is authoritative; the fallback is a fixed
+# empty-shape object (never an interpolation of TOOL/FILE_REL, which could inject
+# quotes or backslashes from a path and corrupt the envelope).
+build_data_json() {
+  jq -n \
+    --arg tool "$TOOL" \
+    --arg file "$FILE_REL" \
+    --arg action "$1" \
+    '{tool:$tool,file:$file,action:$action}' 2>/dev/null \
+    || printf '{"tool":"","file":"","action":""}'
+}
+
+# The lib mutates the file in place (side effect persists past the subshell) and
+# echoes the action taken: lf | crlf | skip.
+ACTION=$(normalize_eol_file "$REPO_ROOT" "$FILE")
+
+# status "ok" when the file was actually normalized (lf/crlf); "skipped" when the
+# attr was unspecified or the crlf arm self-gated off on a non-Windows host.
+case "$ACTION" in
+  lf | crlf) status="ok" ;;
+  *) status="skipped" ;;
+esac
+
+data_json=$(build_data_json "$ACTION")
+emit_tel "eol-normalizer" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
+exit 0

--- a/plugins/eol-normalizer/hooks/eol-normalizer.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.sh
@@ -7,10 +7,9 @@
 # the consuming repo's commit hook / CI (editorconfig, git renormalize) remains
 # the authoritative gate.
 #
-# CROSS-PLATFORM: the LF arm (CRLF->LF) runs on every OS; the CRLF arm
-# (LF->CRLF) is Windows-only. That OS gate lives inside the lib's crlf arm
-# (normalize_eol_platform_crlf), NOT here — a top-level uname short-circuit
-# would silence the always-on LF arm on Linux/macOS.
+# CROSS-PLATFORM: both arms (CRLF->LF and LF->CRLF) run on every OS — the hook
+# compensates for tool writes that bypass git's checkout smudge, and such
+# writes happen on any platform.
 #
 # Uses the consuming repo's own .gitattributes — it ships no policy of its own.
 
@@ -40,7 +39,7 @@ emit_tel() {
   hook::emit_telemetry "$@"
 }
 
-# The bundled EOL library (normalize_eol_file / normalize_eol_platform_crlf).
+# The bundled EOL library (normalize_eol_file).
 # Sourced from the plugin's own hooks dir so it is self-contained on install.
 # shellcheck source=normalize-eol.sh
 source "$(dirname "${BASH_SOURCE[0]}")/normalize-eol.sh"
@@ -89,7 +88,7 @@ build_data_json() {
 ACTION=$(normalize_eol_file "$REPO_ROOT" "$FILE")
 
 # status "ok" when the file was actually normalized (lf/crlf); "skipped" when the
-# attr was unspecified or the crlf arm self-gated off on a non-Windows host.
+# attr was unspecified, the path is -text, or content sniffed binary.
 case "$ACTION" in
   lf | crlf) status="ok" ;;
   *) status="skipped" ;;

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Black-box contract test for eol-normalizer.sh (the eol-normalizer plugin hook).
+#
+# Proves BEHAVIOR + WIRING: the hook fires on Write|Edit, resolves each file's
+# eol from the consuming repo's own .gitattributes via git check-attr, normalizes
+# CRLF->LF (every OS) and LF->CRLF (Windows only), no-ops on unspecified paths,
+# honors the kill switch, keeps stdout empty (advisory, exit 0), and emits a
+# schema-valid telemetry envelope. No policy of its own — the fixture repo's
+# .gitattributes is the sole authority.
+#
+# Self-contained: builds throwaway git repos with runtime-generated fixtures and
+# .gitattributes. The hook is invoked as a subprocess from an UNRELATED cwd so
+# any reliance on the caller's working directory would surface (the tools are
+# file-anchored, so a correct hook needs no cd). git is required; without it the
+# hook is a no-op and these assertions cannot fire, so the suite skips.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/eol-normalizer.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: git not on PATH -- eol-normalizer hook tests skipped"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+UNRELATED="$(mktemp -d)"
+cleanup() { rm -rf "$WORK" "$UNRELATED"; }
+trap cleanup EXIT
+
+is_windows() {
+  case "$(uname -s)" in
+    MINGW* | MSYS*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+cr_count() { tr -cd '\r' <"$1" | wc -c | tr -d ' '; }
+
+# make_sink <body> -> path to an executable single-command stub sink running
+# <body> (which reads the envelope on stdin). HOOK_TELEMETRY_SINK must be a
+# single executable path, not a command-with-args, so tests point it at a stub.
+make_sink() {
+  local s
+  s="$(mktemp -p "$WORK" sink.XXXXXX)"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$1"
+  } >"$s"
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [tries] -> block until <file> is non-empty (the
+# fire-and-forget sink flushed) or the bound elapses, polling in 20ms steps.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while ((tries-- > 0)); do
+    [[ -s "$f" ]] && return 0
+    sleep 0.02
+  done
+  return 1
+}
+
+new_repo() {
+  local r="$1"
+  mkdir -p "$r"
+  git -C "$r" init -q
+  git -C "$r" config user.email t@t.t
+  git -C "$r" config user.name t
+}
+
+# Invoke the hook from an unrelated cwd. CLAUDE_PROJECT_DIR is left UNSET so
+# read_file_path's membership guard is disabled (not part of the fire gate);
+# this isolates normalization behavior from path-form mismatch in the guard.
+run_hook() {
+  local file_path="$1"
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR HOOK_EOL_NORMALIZER_ENABLED=true bash "$HOOK"
+  )
+}
+
+# Same as run_hook but with caller-supplied extra env (NAME=VALUE / -u NAME ...).
+run_hook_env() {
+  local file_path="$1"
+  shift
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+  )
+}
+
+REPO="$WORK/consumer"
+new_repo "$REPO"
+# The consuming repo's authority: .sh -> LF, .txt -> CRLF, .png unspecified.
+printf '*.sh eol=lf\n*.txt eol=crlf\n' >"$REPO/.gitattributes"
+
+# --- Case 1: LF arm (every OS) — CRLF .sh -> LF, exit 0, empty stdout --------
+printf 'echo a\r\necho b\r\n' >"$REPO/seed.sh"
+if [[ "$(cr_count "$REPO/seed.sh")" == "2" ]]; then ok "pre: seed.sh seeded with 2 CR"; else fail "pre: seed.sh CR=$(cr_count "$REPO/seed.sh")"; fi
+OUT=$(run_hook "$REPO/seed.sh")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "LF arm .sh -> exit 0"; else fail "LF arm .sh exit $RC"; fi
+if [[ -z "$OUT" ]]; then ok "LF arm .sh -> empty stdout (advisory)"; else fail "LF arm stdout not empty: $OUT"; fi
+if [[ "$(cr_count "$REPO/seed.sh")" == "0" ]]; then ok "LF arm CRLF .sh -> 0 CR (every OS)"; else fail "LF arm .sh CR=$(cr_count "$REPO/seed.sh")"; fi
+
+# --- Case 2: unspecified (.png) -> no-op, every OS ---------------------------
+printf 'not really binary\r\n' >"$REPO/img.png"
+OUT=$(run_hook "$REPO/img.png")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "unspecified .png -> exit 0 silent"; else fail "unspecified .png (rc=$RC out=$OUT)"; fi
+if [[ "$(cr_count "$REPO/img.png")" == "1" ]]; then ok "unspecified .png -> CR preserved (no-op)"; else fail "unspecified .png normalized: CR=$(cr_count "$REPO/img.png")"; fi
+
+# --- Case 3: kill switch bypasses -------------------------------------------
+printf 'echo x\r\n' >"$REPO/off.sh"
+OUT=$(run_hook_env "$REPO/off.sh" HOOK_EOL_NORMALIZER_ENABLED=false)
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch -> exit 0 silent"; else fail "kill switch (rc=$RC out=$OUT)"; fi
+if [[ "$(cr_count "$REPO/off.sh")" == "1" ]]; then ok "kill switch -> CRLF preserved (not normalized)"; else fail "kill switch normalized despite off: CR=$(cr_count "$REPO/off.sh")"; fi
+
+# --- Case 4: CRLF arm (Windows only) — LF .txt -> CRLF, OS-gated -------------
+printf 'line one\nline two\n' >"$REPO/gap.txt"
+OUT=$(run_hook "$REPO/gap.txt")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "CRLF arm .txt -> exit 0"; else fail "CRLF arm .txt exit $RC"; fi
+if is_windows; then
+  if [[ "$(cr_count "$REPO/gap.txt")" == "2" ]]; then ok "CRLF arm LF .txt -> 2 CR (Windows)"; else fail "CRLF arm .txt CR=$(cr_count "$REPO/gap.txt") (expected 2 on Windows)"; fi
+else
+  if [[ "$(cr_count "$REPO/gap.txt")" == "0" ]]; then ok "CRLF arm .txt -> unchanged 0 CR (non-Windows, self-gated off)"; else fail "CRLF arm .txt CR=$(cr_count "$REPO/gap.txt") (expected 0 off-Windows)"; fi
+fi
+
+# ============================================================================
+# Telemetry
+# ============================================================================
+
+# --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
+printf 'echo p\r\n' >"$REPO/tel1.sh"
+OUT_NS=$(run_hook_env "$REPO/tel1.sh" -u HOOK_TELEMETRY_SINK HOOK_EOL_NORMALIZER_ENABLED=true)
+RC_NS=$?
+if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
+  ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
+else
+  fail "telemetry/sink-unset: rc=$RC_NS out=$OUT_NS"
+fi
+
+# --- Stub sink + normalized .sh -> envelope status ok, action lf ------------
+printf 'echo q\r\n' >"$REPO/tel2.sh"
+TEL="$(mktemp)"
+SINK="$(make_sink "cat >\"$TEL\"")"
+run_hook_env "$REPO/tel2.sh" HOOK_EOL_NORMALIZER_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+wait_for_sink "$TEL"
+if [[ -s "$TEL" ]]; then
+  ok "telemetry/stub-sink: envelope received"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$TEL" >/dev/null 2>&1; then
+      ok "envelope: $field present"
+    else
+      fail "envelope: $field missing ($(cat "$TEL"))"
+    fi
+  done
+  if [[ "$(jq -r '.hook' "$TEL")" == "eol-normalizer" ]]; then ok "envelope: hook is eol-normalizer"; else fail "envelope: hook=$(jq -r '.hook' "$TEL")"; fi
+  if [[ "$(jq -r '.status' "$TEL")" == "ok" ]]; then ok "envelope: status ok"; else fail "envelope: status=$(jq -r '.status' "$TEL")"; fi
+  if [[ "$(jq -r '.schema_version' "$TEL")" == "1.0" ]]; then ok "envelope: schema_version 1.0"; else fail "envelope: schema_version=$(jq -r '.schema_version' "$TEL")"; fi
+  if [[ "$(jq -r '.data.action' "$TEL")" == "lf" ]]; then ok "envelope: data.action lf"; else fail "envelope: data.action=$(jq -r '.data.action' "$TEL")"; fi
+  FREL=$(jq -r '.data.file' "$TEL")
+  if [[ -n "$FREL" && "$FREL" != /* && "$FREL" != ?:* ]]; then ok "envelope: data.file repo-relative ($FREL)"; else fail "envelope: data.file not repo-relative: $FREL"; fi
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL" >/dev/null 2>&1; then ok "envelope: duration_ms non-negative int"; else fail "envelope: duration_ms invalid ($(jq .duration_ms "$TEL"))"; fi
+else
+  fail "telemetry/stub-sink: no envelope written"
+fi
+rm -f "$TEL"
+
+# --- Stub sink + unspecified .png -> status skipped, action skip ------------
+printf 'x\r\n' >"$REPO/tel3.png"
+TELS="$(mktemp)"
+SINKS="$(make_sink "cat >\"$TELS\"")"
+run_hook_env "$REPO/tel3.png" HOOK_EOL_NORMALIZER_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+wait_for_sink "$TELS"
+if [[ -s "$TELS" ]]; then
+  if [[ "$(jq -r '.status' "$TELS")" == "skipped" ]]; then ok "telemetry/unspecified: status skipped"; else fail "telemetry/unspecified: status=$(jq -r '.status' "$TELS")"; fi
+  if [[ "$(jq -r '.data.action' "$TELS")" == "skip" ]]; then ok "telemetry/unspecified: action skip"; else fail "telemetry/unspecified: action=$(jq -r '.data.action' "$TELS")"; fi
+else
+  fail "telemetry/unspecified: no envelope written"
+fi
+rm -f "$TELS"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -3,9 +3,9 @@
 #
 # Proves BEHAVIOR + WIRING: the hook fires on Write|Edit, resolves each file's
 # eol from the consuming repo's own .gitattributes via git check-attr, normalizes
-# CRLF->LF (every OS) and LF->CRLF (Windows only), no-ops on unspecified paths,
-# honors the kill switch, keeps stdout empty (advisory, exit 0), and emits a
-# schema-valid telemetry envelope. No policy of its own — the fixture repo's
+# CRLF->LF and LF->CRLF (both on every OS), no-ops on unspecified paths, skips
+# binary content under text=auto, honors the kill switch, keeps stdout empty
+# (advisory, exit 0), and emits a schema-valid telemetry envelope. No policy of its own — the fixture repo's
 # .gitattributes is the sole authority.
 #
 # Self-contained: builds throwaway git repos with runtime-generated fixtures and
@@ -39,13 +39,6 @@ WORK="$(mktemp -d)"
 UNRELATED="$(mktemp -d)"
 cleanup() { rm -rf "$WORK" "$UNRELATED"; }
 trap cleanup EXIT
-
-is_windows() {
-  case "$(uname -s)" in
-    MINGW* | MSYS*) return 0 ;;
-    *) return 1 ;;
-  esac
-}
 
 cr_count() { tr -cd '\r' <"$1" | wc -c | tr -d ' '; }
 
@@ -133,16 +126,60 @@ RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch -> exit 0 silent"; else fail "kill switch (rc=$RC out=$OUT)"; fi
 if [[ "$(cr_count "$REPO/off.sh")" == "1" ]]; then ok "kill switch -> CRLF preserved (not normalized)"; else fail "kill switch normalized despite off: CR=$(cr_count "$REPO/off.sh")"; fi
 
-# --- Case 4: CRLF arm (Windows only) — LF .txt -> CRLF, OS-gated -------------
+# --- Case 4: CRLF arm (every OS) — LF .txt -> CRLF ---------------------------
 printf 'line one\nline two\n' >"$REPO/gap.txt"
 OUT=$(run_hook "$REPO/gap.txt")
 RC=$?
 if [[ $RC -eq 0 ]]; then ok "CRLF arm .txt -> exit 0"; else fail "CRLF arm .txt exit $RC"; fi
-if is_windows; then
-  if [[ "$(cr_count "$REPO/gap.txt")" == "2" ]]; then ok "CRLF arm LF .txt -> 2 CR (Windows)"; else fail "CRLF arm .txt CR=$(cr_count "$REPO/gap.txt") (expected 2 on Windows)"; fi
+if [[ "$(cr_count "$REPO/gap.txt")" == "2" ]]; then ok "CRLF arm LF .txt -> 2 CR (every OS)"; else fail "CRLF arm .txt CR=$(cr_count "$REPO/gap.txt") (expected 2)"; fi
+
+# --- Case 5: text=auto binary guard — NUL content never rewritten ------------
+# Under a broad `* text=auto eol=lf` rule, check-attr resolves eol=lf for
+# binaries too; the hook must content-sniff and skip instead of corrupting.
+AUTOREPO="$WORK/autorepo"
+new_repo "$AUTOREPO"
+printf '* text=auto eol=lf\n' >"$AUTOREPO/.gitattributes"
+printf 'BIN\r\n\x00\x01\x02\r\ndata' >"$AUTOREPO/blob.bin"
+BIN_BYTES_BEFORE=$(wc -c <"$AUTOREPO/blob.bin" | tr -d ' ')
+OUT=$(run_hook "$AUTOREPO/blob.bin")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "binary guard -> exit 0 silent"; else fail "binary guard (rc=$RC out=$OUT)"; fi
+if [[ "$(wc -c <"$AUTOREPO/blob.bin" | tr -d ' ')" == "$BIN_BYTES_BEFORE" && "$(cr_count "$AUTOREPO/blob.bin")" == "2" ]]; then
+  ok "binary guard: NUL file under text=auto eol=lf left byte-identical"
 else
-  if [[ "$(cr_count "$REPO/gap.txt")" == "0" ]]; then ok "CRLF arm .txt -> unchanged 0 CR (non-Windows, self-gated off)"; else fail "CRLF arm .txt CR=$(cr_count "$REPO/gap.txt") (expected 0 off-Windows)"; fi
+  fail "binary guard: binary file was rewritten (bytes $(wc -c <"$AUTOREPO/blob.bin" | tr -d ' ')/$BIN_BYTES_BEFORE CR=$(cr_count "$AUTOREPO/blob.bin"))"
 fi
+# Text sibling in the same repo still normalizes (the sniff passes text through).
+printf 'echo t\r\n' >"$AUTOREPO/auto.sh"
+run_hook "$AUTOREPO/auto.sh" >/dev/null
+if [[ "$(cr_count "$AUTOREPO/auto.sh")" == "0" ]]; then ok "binary guard: text file under text=auto still normalized"; else fail "binary guard: text file not normalized CR=$(cr_count "$AUTOREPO/auto.sh")"; fi
+
+# --- Case 6: -text is never rewritten even with eol set ----------------------
+printf '*.dat -text eol=lf\n' >>"$AUTOREPO/.gitattributes"
+printf 'a\r\nb\r\n' >"$AUTOREPO/keep.dat"
+run_hook "$AUTOREPO/keep.dat" >/dev/null
+if [[ "$(cr_count "$AUTOREPO/keep.dat")" == "2" ]]; then ok "-text guard: CR preserved despite eol=lf"; else fail "-text guard: rewritten CR=$(cr_count "$AUTOREPO/keep.dat")"; fi
+
+# --- Case 7: no-perl fallback preserves file mode (white-box) -----------------
+# The mktemp fallback stages into a fresh temp file; without mode preservation
+# a 755 script would come back non-executable. Shadow `command` so the lib's
+# perl probe fails, forcing the fallback arm.
+printf '#!/bin/sh\r\necho hi\r\n' >"$REPO/exec.sh"
+chmod 755 "$REPO/exec.sh"
+(
+  # shellcheck disable=SC2329  # invoked indirectly: the sourced lib's `command -v perl` probe hits this shadow
+  command() { if [[ "${1:-}" == "-v" && "${2:-}" == "perl" ]]; then return 1; fi; builtin command "$@"; }
+  # Prove the shim actually hides perl before relying on it.
+  if command -v perl >/dev/null 2>&1; then
+    echo "FAIL: test shim: perl shadow ineffective" >&2
+    exit 1
+  fi
+  # shellcheck source=normalize-eol.sh
+  source "$HOOK_DIR/normalize-eol.sh"
+  normalize_eol_to_lf "$REPO/exec.sh"
+) || fail "fallback: subshell failed"
+if [[ "$(cr_count "$REPO/exec.sh")" == "0" ]]; then ok "fallback: CRLF stripped without perl"; else fail "fallback: CR=$(cr_count "$REPO/exec.sh")"; fi
+if [[ -x "$REPO/exec.sh" ]]; then ok "fallback: executable mode preserved"; else fail "fallback: exec bit lost"; fi
 
 # ============================================================================
 # Telemetry

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -1,0 +1,247 @@
+# shellcheck shell=bash
+# Shared hook utility library for this marketplace's hook plugins. Sourced
+# (not executed): kill switch, file_path parsing + path normalization,
+# repo-root resolution, additionalContext accumulator, telemetry envelope.
+#
+# SINGLE SOURCE OF TRUTH: lib/hook-utils.sh at the marketplace repo root. The
+# copies at plugins/*/hooks/hook-utils.sh exist because installed plugins are
+# cache-isolated and must be self-contained — never edit a copy. Edit the
+# source and run scripts/sync-hook-utils.sh; CI rejects drifted copies.
+
+# Guard against double-sourcing.
+[[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
+readonly _HOOK_UTILS_LOADED=1
+
+# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
+# disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+hook::check_enabled() {
+  local var_name="HOOK_${1}_ENABLED"
+  if [[ "${!var_name:-true}" != "true" ]]; then
+    exit 0
+  fi
+}
+
+# Normalize a path for the membership comparison below: backslashes → forward
+# slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
+# fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive
+# letter + lower-cased remainder so the byte-exact comparison is effectively
+# case-insensitive. The fold is gated on the host (OSTYPE), NOT on the path
+# shape: on a case-sensitive POSIX filesystem a real single-letter top-level
+# directory such as `/c/Repo` must pass through unchanged, otherwise it would
+# collapse with `/c/repo` and the membership guard would admit a sibling
+# outside CLAUDE_PROJECT_DIR. The result is used ONLY for comparison; the
+# emitted path is always the caller's original.
+hook::normalize_path() {
+  local p="${1//\\//}"
+  case "${OSTYPE:-}" in
+  msys* | cygwin* | win32)
+    if [[ "$p" =~ ^/([a-zA-Z])/ || "$p" =~ ^([a-zA-Z]):/ ]]; then
+      local rest="${p:2}"
+      printf '%s' "${BASH_REMATCH[1]^}:${rest,,}"
+      return
+    fi
+    ;;
+  *) ;; # POSIX hosts: case-sensitive FS, no drive fold — pass through below
+  esac
+  printf '%s' "$p"
+}
+
+# Canonicalize to a physical path — symlinks resolved — for the membership
+# comparison below, so an in-project symlink pointing outside the project root
+# cannot defeat the guard (the lexical path would pass the prefix check while
+# the write lands elsewhere). GNU realpath ships with Git Bash and Linux
+# coreutils; readlink -f covers the BSD/macOS hosts that have no realpath.
+# When neither resolver exists the caller falls back to comparing the lexical
+# path as before — the guard is defense-in-depth scoping for a file the agent
+# already wrote via its own tools, so degrading to the historical comparison
+# beats silently disabling the hook on those hosts.
+hook::physical_path() {
+  local resolved
+  if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
+    if [[ -n "$resolved" ]]; then
+      printf '%s' "$resolved"
+      return
+    fi
+  fi
+  printf '%s' "$1"
+}
+
+# Parse file_path from PostToolUse JSON on stdin; validate existence and (when
+# CLAUDE_PROJECT_DIR is set) project membership. Both sides of the membership
+# comparison are canonicalized (symlinks resolved) first, so neither an
+# escaping symlink nor a project root reached via a symlinked path (e.g.
+# macOS /tmp) skews the verdict. Outputs the path on success. Returns 1 to skip.
+#   FILE=$(hook::read_file_path) || exit 0
+hook::read_file_path() {
+  local file
+  file=$(jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+  [[ -n "$file" ]] || return 1
+  [[ -f "$file" ]] || return 1
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local norm_file norm_project
+    norm_file=$(hook::normalize_path "$(hook::physical_path "$file")")
+    norm_project=$(hook::normalize_path "$(hook::physical_path "${CLAUDE_PROJECT_DIR}")")
+    norm_project="${norm_project%/}"
+    # Anchor on a path-segment boundary: accept the project root itself or a
+    # child under it, but not a sibling whose name merely shares the prefix
+    # (e.g. /c/repo must not admit /c/repo-backup/...).
+    if [[ "$norm_file" != "$norm_project" && "$norm_file" != "$norm_project"/* ]]; then
+      return 1
+    fi
+  fi
+  printf '%s' "$file"
+}
+
+# Resolve the repository root (working-tree top) for a path inside the tree.
+# markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
+# before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
+# so it is correct for clones, linked worktrees, and bare-hub clones; falls
+# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+#   ROOT=$(hook::repo_root "$some_path")
+hook::repo_root() {
+  local hint="${1:-.}"
+  local root
+  root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+  if [[ -z "$root" ]]; then
+    root="$hint"
+    root="${root%/.claude}"
+    root="${root%\\.claude}"
+  fi
+  printf '%s' "$root"
+}
+
+# Per-hook stdout context accumulator. ctx_reset at entry, ctx_append per line,
+# ctx_flush once at exit with the hook event name.
+_HOOK_CTX_BUFFER=""
+
+hook::ctx_reset() {
+  _HOOK_CTX_BUFFER=""
+}
+
+hook::ctx_append() {
+  _HOOK_CTX_BUFFER+="$1"$'\n'
+}
+
+# Emit the accumulated context as hookSpecificOutput JSON, then clear the buffer.
+hook::ctx_flush() {
+  local event_name="$1"
+  local trimmed="${_HOOK_CTX_BUFFER%"${_HOOK_CTX_BUFFER##*[![:space:]]}"}"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  hook::emit_additional_context "$event_name" "$trimmed"
+  hook::ctx_reset
+}
+
+# Cheap telemetry opt-in probe — true iff a consumer wired a sink. Producers
+# gate telemetry-payload construction on this (repo-relative path
+# normalization, data JSON) so the unwired default path spawns zero
+# telemetry-only subprocesses. Pure shell test, no subprocess.
+# hook::emit_telemetry re-checks the sink itself, so skipping this probe
+# costs only wasted payload work, never correctness.
+hook::telemetry_enabled() {
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]]
+}
+
+# Emit one telemetry envelope per hook run to the consumer-set sink.
+# Fire-and-forget: sink is dispatched in the background; the hook never waits
+# on it and its failure never affects the hook's own exit code or stdout.
+# Opt-in guard: HOOK_TELEMETRY_SINK unset or empty → return 0 immediately.
+# Fail-open: jq absent → return 0 immediately.
+#
+# Usage:
+#   hook::emit_telemetry <hook_id> <hook_event> <status> <start_epoch> <data_json> [repo_root]
+#
+# <start_epoch>  Value of $EPOCHREALTIME captured by the caller before work began.
+#               Handles both '.' and ',' as the decimal separator (LC_NUMERIC).
+# <data_json>   Pre-built JSON object for the `data` field.
+# <repo_root>   Optional consuming-repo root, used to resolve a RELATIVE
+#               HOOK_TELEMETRY_SINK. The caller passes the root it already
+#               resolved for data.file; ignored when the sink is absolute.
+#
+# Sink path resolution: HOOK_TELEMETRY_SINK may be absolute OR relative to the
+# consuming repo root. Absolute (POSIX /… or Windows X:\ / X:/) is used as-is; a
+# relative value is joined onto <repo_root> (or $CLAUDE_PROJECT_DIR when no root
+# is passed), and skipped fail-open if neither is available. Relative is the
+# portable, team-shared wiring form: CC injects settings.json env values
+# literally (no ${VAR} expansion), so a relative path tracked in settings.json is
+# the only clone-portable, worktree-safe option.
+#
+# NEVER writes to fd1 (the hook's stdout / additionalContext channel).
+hook::emit_telemetry() {
+  # Opt-in guard.
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]] || return 0
+  # Fail-open when jq is absent.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local hook_id="$1"
+  local hook_event="$2"
+  local status="$3"
+  local start_epoch="$4"
+  local data_json="$5"
+  local repo_root="${6:-}"
+
+  # Compute duration_ms from caller's $EPOCHREALTIME snapshot to now.
+  # Both '.' and ',' separators handled; 10# prefix prevents octal misreading
+  # of fractional parts with leading zeros (e.g. .045123 → 10#045123 = 45123).
+  local now=$EPOCHREALTIME
+  local s_s="${start_epoch%[.,]*}" s_f="${start_epoch#*[.,]}"
+  local e_s="${now%[.,]*}" e_f="${now#*[.,]}"
+  local duration_ms=$(((e_s * 1000000 + 10#$e_f - s_s * 1000000 - 10#$s_f) / 1000))
+
+  # True UTC timestamp (TZ= prefix overrides LC_ALL / local TZ; the Z is not a lie).
+  local timestamp
+  timestamp=$(TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' -1)
+
+  # Build the envelope. Redirect jq stderr to /dev/null; output goes to a local
+  # variable — never to fd1.
+  local envelope
+  envelope=$(jq -n \
+    --arg schema_version "1.0" \
+    --arg timestamp "$timestamp" \
+    --arg hook "$hook_id" \
+    --arg hook_event "$hook_event" \
+    --arg status "$status" \
+    --argjson duration_ms "$duration_ms" \
+    --argjson data "$data_json" \
+    '{schema_version:$schema_version,timestamp:$timestamp,hook:$hook,hook_event:$hook_event,status:$status,duration_ms:$duration_ms,data:$data}' \
+    2>/dev/null) || return 0
+
+  # Resolve the sink path. A relative HOOK_TELEMETRY_SINK is joined onto the
+  # consuming repo root (portable, tracked wiring); absolute is used as-is. A
+  # relative value with no anchor is skipped fail-open — never exec a path the
+  # drifted hook CWD would resolve incorrectly.
+  local sink="$HOOK_TELEMETRY_SINK"
+  case "$sink" in
+  /* | [A-Za-z]:[/\\]*) ;;
+  *)
+    local root="${repo_root:-${CLAUDE_PROJECT_DIR:-}}"
+    [[ -n "$root" ]] || return 0
+    sink="${root%/}/$sink"
+    ;;
+  esac
+
+  # Fire-and-forget: pipe the envelope to the sink in a background subshell.
+  # The subshell's stdout AND stderr are redirected to /dev/null so the sink
+  # cannot write to the hook's fd1 (the additionalContext channel) and the
+  # backgrounded subshell does not hold a copy of the hook's fd1 open — which
+  # would block any command substitution wrapping the hook until the sink exits
+  # (the "C1 fd1-inheritance blocker"). The sink is quoted — it is a single
+  # executable path (wrap in a script to pass arguments).
+  printf '%s\n' "$envelope" | ("$sink" >/dev/null 2>&1) &
+}
+
+# Print cross-host hook JSON to stdout (exit 0). No-op when context is empty.
+# Shape: { hookSpecificOutput: { hookEventName[, additionalContext] } }.
+hook::emit_additional_context() {
+  local event_name="$1"
+  local context="$2"
+  [[ -n "$context" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -n \
+    --arg event "$event_name" \
+    --arg ctx "$context" \
+    '{hookSpecificOutput: (
+      {hookEventName: $event}
+      + (if $ctx != "" then {additionalContext: $ctx} else {} end)
+    )}'
+}

--- a/plugins/eol-normalizer/hooks/hooks.json
+++ b/plugins/eol-normalizer/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/eol-normalizer.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/eol-normalizer/hooks/normalize-eol.sh
+++ b/plugins/eol-normalizer/hooks/normalize-eol.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Symmetric working-tree EOL normalization driven by .gitattributes `eol=`.
+# Sourced (never executed) by the plugin's PostToolUse hook (eol-normalizer.sh).
+#
+# Resolution is `git check-attr eol` — the single authoritative source that
+# honors the consuming repo's .gitattributes precedence (a narrow `eol=lf`
+# rule wins over a broader `*.txt eol=crlf`). NO fast-path extension list:
+# a hardcoded list re-introduces the very bug this lib removes.
+#
+# Dispatch:
+#   lf          -> CRLF->LF, unconditional + idempotent. LF is correct on every
+#                  platform; a CRLF-contaminated .sh / requirements.txt breaks
+#                  shebangs / pip parsing everywhere, so this arm is NOT gated.
+#   crlf        -> LF->CRLF, Windows-only. git smudge already yields CRLF on a
+#                  Linux/macOS checkout for eol=crlf paths; the only way such a
+#                  file lands as LF on disk is a Windows Write that bypasses
+#                  smudge, so the arm gates on normalize_eol_platform_crlf.
+#   unspecified -> no-op.
+
+# Returns 0 when this platform should enforce CRLF on disk (Windows Git Bash).
+normalize_eol_platform_crlf() {
+  case "$(uname -s)" in
+    MINGW* | MSYS*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Normalize <file>'s working-tree EOL to its .gitattributes `eol=` value.
+# <root> anchors `git -C <root> check-attr` so resolution is CWD-independent
+# (hook process CWD is not guaranteed to be the repo root — hooks/quirks.md).
+# Echoes the action performed (lf | crlf | skip); ALWAYS returns 0 — best-effort,
+# and safe under `set -e` in the pre-commit consumer's staged-file loop.
+normalize_eol_file() {
+  local root="$1" file="$2"
+  [[ -f "$file" ]] || {
+    printf 'skip'
+    return 0
+  }
+
+  local eol
+  eol=$(git -C "$root" check-attr eol -- "$file" 2>/dev/null | tr -d '\r')
+  # Output is `<path>: eol: <value>`; the path may contain ':' (Windows drive)
+  # or spaces, so take the last whitespace token, never a ':' split.
+  eol="${eol##* }"
+
+  case "$eol" in
+    lf)
+      normalize_eol_to_lf "$file"
+      printf 'lf'
+      ;;
+    crlf)
+      if normalize_eol_platform_crlf; then
+        normalize_eol_to_crlf "$file"
+        printf 'crlf'
+      else
+        printf 'skip'
+      fi
+      ;;
+    *)
+      printf 'skip'
+      ;;
+  esac
+  return 0
+}
+
+# CRLF -> LF (unconditional, idempotent on already-LF input).
+normalize_eol_to_lf() {
+  local file="$1"
+  if command -v perl >/dev/null 2>&1; then
+    perl -pi -e 's/\r\n/\n/g' "$file"
+  else
+    # Portable fallback: strip all CR (text files carry no lone CR).
+    if tr -d '\r' <"$file" >"${file}.lf.tmp"; then
+      mv "${file}.lf.tmp" "$file"
+    else
+      rm -f "${file}.lf.tmp"
+    fi
+  fi
+}
+
+# LF -> CRLF (idempotent; bare LF only, never turns CRLF into CRCRLF).
+normalize_eol_to_crlf() {
+  local file="$1"
+  if command -v perl >/dev/null 2>&1; then
+    perl -pi -e 's/(?<!\r)\n/\r\n/g' "$file"
+  else
+    if awk 'BEGIN{RS="\r?\n"; ORS="\r\n"} {print}' "$file" >"${file}.crlf.tmp"; then
+      mv "${file}.crlf.tmp" "$file"
+    else
+      rm -f "${file}.crlf.tmp"
+    fi
+  fi
+}

--- a/plugins/eol-normalizer/hooks/normalize-eol.sh
+++ b/plugins/eol-normalizer/hooks/normalize-eol.sh
@@ -67,13 +67,16 @@ normalize_eol_file() {
 normalize_eol_to_lf() {
   local file="$1"
   if command -v perl >/dev/null 2>&1; then
-    perl -pi -e 's/\r\n/\n/g' "$file"
+    perl -pi -e 's/\r\n/\n/g' -- "$file"
   else
-    # Portable fallback: strip all CR (text files carry no lone CR).
-    if tr -d '\r' <"$file" >"${file}.lf.tmp"; then
-      mv "${file}.lf.tmp" "$file"
+    # Portable fallback: strip all CR (text files carry no lone CR). Stage into a
+    # same-dir mktemp file (unpredictable name — CWE-377) then atomically mv.
+    local tmp
+    tmp=$(mktemp "${file}.XXXXXX") || return 0
+    if tr -d '\r' <"$file" >"$tmp"; then
+      mv -- "$tmp" "$file"
     else
-      rm -f "${file}.lf.tmp"
+      rm -f -- "$tmp"
     fi
   fi
 }
@@ -82,12 +85,15 @@ normalize_eol_to_lf() {
 normalize_eol_to_crlf() {
   local file="$1"
   if command -v perl >/dev/null 2>&1; then
-    perl -pi -e 's/(?<!\r)\n/\r\n/g' "$file"
+    perl -pi -e 's/(?<!\r)\n/\r\n/g' -- "$file"
   else
-    if awk 'BEGIN{RS="\r?\n"; ORS="\r\n"} {print}' "$file" >"${file}.crlf.tmp"; then
-      mv "${file}.crlf.tmp" "$file"
+    # Stage into a same-dir mktemp file (unpredictable name — CWE-377) then mv.
+    local tmp
+    tmp=$(mktemp "${file}.XXXXXX") || return 0
+    if awk 'BEGIN{RS="\r?\n"; ORS="\r\n"} {print}' "$file" >"$tmp"; then
+      mv -- "$tmp" "$file"
     else
-      rm -f "${file}.crlf.tmp"
+      rm -f -- "$tmp"
     fi
   fi
 }

--- a/plugins/eol-normalizer/hooks/normalize-eol.sh
+++ b/plugins/eol-normalizer/hooks/normalize-eol.sh
@@ -7,22 +7,25 @@
 # rule wins over a broader `*.txt eol=crlf`). NO fast-path extension list:
 # a hardcoded list re-introduces the very bug this lib removes.
 #
-# Dispatch:
-#   lf          -> CRLF->LF, unconditional + idempotent. LF is correct on every
-#                  platform; a CRLF-contaminated .sh / requirements.txt breaks
-#                  shebangs / pip parsing everywhere, so this arm is NOT gated.
-#   crlf        -> LF->CRLF, Windows-only. git smudge already yields CRLF on a
-#                  Linux/macOS checkout for eol=crlf paths; the only way such a
-#                  file lands as LF on disk is a Windows Write that bypasses
-#                  smudge, so the arm gates on normalize_eol_platform_crlf.
+# Dispatch (both arms run on every OS — the hook compensates for tool writes
+# that bypass git's checkout smudge, and such writes happen on any platform):
+#   lf          -> CRLF->LF, idempotent.
+#   crlf        -> LF->CRLF, idempotent.
 #   unspecified -> no-op.
+#
+# Binary guard: `eol` alone is not proof of text. Under `* text=auto eol=lf`,
+# check-attr reports `eol: lf` for binaries too, while git's own conversion
+# stays guarded by content detection. The guard mirrors gitattributes
+# semantics: explicit `text` is trusted, `-text` skips, `text=auto` content-
+# sniffs; `eol` with `text` unspecified sets text implicitly (per the
+# gitattributes doc), so it converts like explicit `text`.
 
-# Returns 0 when this platform should enforce CRLF on disk (Windows Git Bash).
-normalize_eol_platform_crlf() {
-  case "$(uname -s)" in
-    MINGW* | MSYS*) return 0 ;;
-    *) return 1 ;;
-  esac
+# Returns 0 when <file> looks binary: any NUL byte in the first 8000 bytes —
+# the same window git's buffer_is_binary() uses for text=auto detection.
+normalize_eol_is_binary() {
+  local file="$1" nul_count
+  nul_count=$(head -c 8000 <"$file" | LC_ALL=C tr -dc '\0' | wc -c) || return 1
+  [[ "$nul_count" -gt 0 ]]
 }
 
 # Normalize <file>'s working-tree EOL to its .gitattributes `eol=` value.
@@ -44,19 +47,43 @@ normalize_eol_file() {
   eol="${eol##* }"
 
   case "$eol" in
+    lf | crlf) ;;
+    *)
+      printf 'skip'
+      return 0
+      ;;
+  esac
+
+  # Binary guard (see header). `unspecified` falls to the `set` arm: eol on a
+  # path with no text attr implicitly sets text, so git itself would convert.
+  local text
+  text=$(git -C "$root" check-attr text -- "$file" 2>/dev/null | tr -d '\r')
+  text="${text##* }"
+  case "$text" in
+    unset)
+      printf 'skip'
+      return 0
+      ;;
+    auto)
+      if normalize_eol_is_binary "$file"; then
+        printf 'skip'
+        return 0
+      fi
+      ;;
+    *) ;;
+  esac
+
+  case "$eol" in
     lf)
       normalize_eol_to_lf "$file"
       printf 'lf'
       ;;
     crlf)
-      if normalize_eol_platform_crlf; then
-        normalize_eol_to_crlf "$file"
-        printf 'crlf'
-      else
-        printf 'skip'
-      fi
+      normalize_eol_to_crlf "$file"
+      printf 'crlf'
       ;;
     *)
+      # Unreachable — eol was vetted lf|crlf above.
       printf 'skip'
       ;;
   esac
@@ -71,8 +98,11 @@ normalize_eol_to_lf() {
   else
     # Portable fallback: strip all CR (text files carry no lone CR). Stage into a
     # same-dir mktemp file (unpredictable name — CWE-377) then atomically mv.
+    # `cp -p` first so the staged file carries the original's mode (chmod
+    # --reference is GNU-only); the redirect then replaces its content.
     local tmp
     tmp=$(mktemp "${file}.XXXXXX") || return 0
+    cp -p -- "$file" "$tmp" 2>/dev/null || true
     if tr -d '\r' <"$file" >"$tmp"; then
       mv -- "$tmp" "$file"
     else
@@ -88,8 +118,11 @@ normalize_eol_to_crlf() {
     perl -pi -e 's/(?<!\r)\n/\r\n/g' -- "$file"
   else
     # Stage into a same-dir mktemp file (unpredictable name — CWE-377) then mv.
+    # `cp -p` first so the staged file carries the original's mode (chmod
+    # --reference is GNU-only); the redirect then replaces its content.
     local tmp
     tmp=$(mktemp "${file}.XXXXXX") || return 0
+    cp -p -- "$file" "$tmp" 2>/dev/null || true
     if awk 'BEGIN{RS="\r?\n"; ORS="\r\n"} {print}' "$file" >"$tmp"; then
       mv -- "$tmp" "$file"
     else


### PR DESCRIPTION
Migrates the EOL-normalization PostToolUse hook into a repo-agnostic plugin. Bundles normalize-eol.sh via ${CLAUDE_PLUGIN_ROOT}; consumer conventions from .gitattributes/.editorconfig; kill switch HOOK_EOL_NORMALIZER_ENABLED; opt-in telemetry. Security-hardened (-- arg terminators + mktemp staging). 27 contract tests; plugin validate clean. Clean-tier wave Phase 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The hook mutates files on disk immediately after agent edits; guards and best-effort behavior limit damage, but wrong attribute resolution could still rewrite content outside intent.
> 
> **Overview**
> Introduces a new **eol-normalizer** formatting plugin and lists it in the marketplace catalog.
> 
> On **PostToolUse** for `Write|Edit`, the hook reads the edited path from stdin (with Windows Git Bash–safe single read), resolves the consuming repo root, and runs **`normalize_eol_file`** so working-tree endings match **`.gitattributes`** (`eol=lf` → CRLF→LF, `eol=crlf` → LF→CRLF on all platforms). Paths without `eol=`, `-text`, or **text=auto** binaries (NUL sniff) are left alone. The hook is **advisory** (always exit 0), disable via **`HOOK_EOL_NORMALIZER_ENABLED`**, and optionally emits telemetry through the shared **`hook-utils`** copy bundled in the plugin.
> 
> The plugin ships **`normalize-eol.sh`** (perl with `tr`/`awk` + `mktemp` fallbacks that preserve file mode), **`hooks.json`** wiring, README, and a black-box **`eol-normalizer.test.sh`** suite covering LF/CRLF arms, kill switch, binary/`-text` guards, and telemetry envelopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb3e295b06387fd5bb16201c427659ea7113045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->