### PR TITLE
feat: add actionlint plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,12 @@
       "source": "./plugins/ruff-format",
       "category": "formatting",
       "tags": ["ruff", "python", "formatter", "linter", "hook"]
+    },
+    {
+      "name": "actionlint",
+      "source": "./plugins/actionlint",
+      "category": "formatting",
+      "tags": ["actionlint", "github-actions", "workflow", "yaml", "linter", "hook"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace
 | [`eol-normalizer`](plugins/eol-normalizer) | Hook | Normalizes a file's working-tree line endings on edit to its `.gitattributes` `eol=` value via `git check-attr` — symmetric CRLF↔LF, binary-safe, using the consuming repo's own attributes. |
 | [`desktop-notification`](plugins/desktop-notification) | Hook | Alerts you when Claude Code needs input via an audible bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts. |
 | [`powershell-format`](plugins/powershell-format) | Hook | Formats and lints PowerShell on edit via PSScriptAnalyzer, only when the repo opts in with a `PSScriptAnalyzerSettings.psd1`, using the consuming repo's own analyzer settings. |
+| [`actionlint`](plugins/actionlint) | Hook | Lints GitHub Actions workflow files (`.github/workflows/*.yml`/`.yaml`) on edit via the `actionlint` already on your `PATH` — advisory findings, never blocking. |
 
 Install one: `/plugin install <plugin-name>@melodic-software`.
 

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "actionlint",
+  "version": "0.1.0",
+  "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "keywords": ["actionlint", "github-actions", "workflow", "yaml", "linter", "hook"]
+}

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -17,11 +17,12 @@ your `PATH`.
   your hard gate.
 - **Scoped to workflows.** Only files matching `.github/workflows/*.yml` and
   `.github/workflows/*.yaml` are linted. Other YAML is left alone.
-- **Embedded ShellCheck disabled (`-shellcheck=`).** actionlint's embedded-bash
-  ShellCheck integration is turned off. It spawns a ShellCheck subprocess per
-  `run:` block — which deadlocks on large blocks under the Windows subprocess IPC
-  path in actionlint 1.7.x and adds latency unsuited to an edit-time hook. Native
-  workflow diagnostics are unaffected; run the full integration in CI.
+- **External run-block linters disabled (`-shellcheck= -pyflakes=`).**
+  actionlint's embedded-bash ShellCheck and `shell: python` pyflakes
+  integrations are turned off. Each spawns a subprocess per `run:` block —
+  ShellCheck deadlocks on large blocks under the Windows subprocess IPC path in
+  actionlint 1.7.x, and either adds latency unsuited to an edit-time hook.
+  Native workflow diagnostics are unaffected; run the full integrations in CI.
 - **Graceful degrade.** When `actionlint` is not on `PATH` the hook is a silent
   no-op.
 

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -1,0 +1,55 @@
+# actionlint
+
+A Claude Code plugin that lints GitHub Actions workflow files the moment you
+edit them. On every `Write` or `Edit` of a file under `.github/workflows/`
+(`*.yml` or `*.yaml`) it runs [actionlint](https://github.com/rhysd/actionlint)
+and surfaces any findings back to Claude as advisory context.
+
+It ships no rules of its own and no binary — it runs the `actionlint` already on
+your `PATH`.
+
+## Behavior
+
+- **Lint on edit.** actionlint runs on every edit of a workflow file. It is
+  non-mutating; it only reports.
+- **Advisory, never blocking.** The hook always exits `0`. Findings are reported
+  via `additionalContext`; they never reject the edit. Make a commit hook or CI
+  your hard gate.
+- **Scoped to workflows.** Only files matching `.github/workflows/*.yml` and
+  `.github/workflows/*.yaml` are linted. Other YAML is left alone.
+- **Embedded ShellCheck disabled (`-shellcheck=`).** actionlint's embedded-bash
+  ShellCheck integration is turned off. It spawns a ShellCheck subprocess per
+  `run:` block — which deadlocks on large blocks under the Windows subprocess IPC
+  path in actionlint 1.7.x and adds latency unsuited to an edit-time hook. Native
+  workflow diagnostics are unaffected; run the full integration in CI.
+- **Graceful degrade.** When `actionlint` is not on `PATH` the hook is a silent
+  no-op.
+
+## Requirements
+
+- **actionlint** on `PATH`. See the
+  [actionlint install guide](https://github.com/rhysd/actionlint/blob/main/docs/install.md).
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install actionlint@melodic-software
+```
+
+## Configuration
+
+This plugin has no `userConfig`. actionlint auto-discovers its own
+`.github/actionlint.yaml` config from your repository when present.
+
+### Disable without uninstalling
+
+Set the kill switch in your settings `env` block:
+
+```json
+{ "env": { "HOOK_ACTIONLINT_ENABLED": "false" } }
+```
+
+## License
+
+[MIT](../../LICENSE).

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -95,7 +95,7 @@ fi
 # (2) adds latency unsuited to an edit-time advisory hook. Native workflow
 # diagnostics (the value of this hook) are unaffected; deep embedded-bash linting
 # belongs in a commit hook or CI, not here.
-AL_OUTPUT=$(actionlint -shellcheck= "$FILE" 2>&1) || true
+AL_OUTPUT=$(actionlint -shellcheck= -- "$FILE" 2>&1) || true
 
 if [[ -n "$AL_OUTPUT" ]]; then
   hook::ctx_reset

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -90,13 +90,13 @@ if ! command -v actionlint >/dev/null 2>&1; then
   exit 0
 fi
 
-# -shellcheck= disables actionlint's embedded-bash ShellCheck integration. That
-# integration spawns a ShellCheck subprocess per `run:` block, which (1) deadlocks
-# on large blocks under the Windows subprocess IPC path in actionlint 1.7.x and
-# (2) adds latency unsuited to an edit-time advisory hook. Native workflow
-# diagnostics (the value of this hook) are unaffected; deep embedded-bash linting
-# belongs in a commit hook or CI, not here.
-AL_OUTPUT=$(cd "$REPO_ROOT" && actionlint -shellcheck= -- "$FILE_REL" 2>&1) || true
+# -shellcheck= and -pyflakes= disable actionlint's external run-block linters
+# (embedded-bash ShellCheck, `shell: python` pyflakes). Both spawn a subprocess
+# per `run:` block — ShellCheck deadlocks on large blocks under the Windows
+# subprocess IPC path in actionlint 1.7.x, and either adds latency unsuited to
+# an edit-time advisory hook. Native workflow diagnostics (the value of this
+# hook) are unaffected; deep run-block linting belongs in a commit hook or CI.
+AL_OUTPUT=$(cd "$REPO_ROOT" && actionlint -shellcheck= -pyflakes= -- "$FILE_REL" 2>&1) || true
 
 if [[ -n "$AL_OUTPUT" ]]; then
   hook::ctx_reset

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# PostToolUse hook: lint GitHub Actions workflow files via actionlint.
+# Triggered on Write|Edit of .github/workflows/*.yml and *.yaml files.
+#
+# ADVISORY: always exits 0. actionlint findings surface via additionalContext
+# but never block the edit. Make a commit hook or CI your hard gate.
+#
+# Graceful degrade: when actionlint is not on PATH the hook is a silent no-op
+# (exit 0) — the plugin ships no binary of its own.
+
+set -uo pipefail
+
+# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
+# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
+# resolve (ENOENT -> silent no-op). stdin is read ONCE here and fed to both
+# hook::read_file_path (file_path) and the tool_name parse below; reading fd0
+# twice would drain the pipe on the second call.
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "ACTIONLINT"
+
+# Capture $EPOCHREALTIME immediately after the kill-switch so duration_ms covers
+# the work below (pre-work exits do not emit telemetry). EPOCHREALTIME is Bash
+# 5.0+; on older bash it is unset, so default to empty — referencing it bare
+# under `set -u` would abort before the advisory exit 0.
+start=${EPOCHREALTIME:-}
+
+# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
+# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
+# lints on older bash rather than aborting.
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::emit_telemetry "$@"
+}
+
+INPUT=$(cat)
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+# Only GitHub Actions workflow files. actionlint recognizes both .yml and .yaml
+# under .github/workflows/; other YAML is not a workflow and must be skipped.
+case "$FILE" in
+  */.github/workflows/*.yml | */.github/workflows/*.yaml) ;;
+  *) exit 0 ;;
+esac
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Resolve repo root early — used to compute the schema-required repo-relative
+# path in data.file.
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+# Repo-relative path: schema requires "relative to the consuming repo root".
+# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
+# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
+# (long name, forward-slash mixed form) when available so the prefix strip
+# compares the same representation. On Linux/macOS, cygpath is absent and both
+# paths are already POSIX. Falls back to raw FILE on any normalization error.
+FILE_REL="$FILE"
+if command -v cygpath >/dev/null 2>&1; then
+  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+    FILE_REL="${_file_lm#"$_root_lm"/}"
+  fi
+else
+  FILE_REL="${FILE#"$REPO_ROOT"/}"
+fi
+
+# Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
+# findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
+# object — NOT an interpolation of TOOL/FILE_REL, which could inject quotes or
+# backslashes from a path and corrupt the envelope. The fallback is essentially
+# unreachable in practice (it fires only if `jq -n` fails, and when jq is absent
+# hook::emit_telemetry drops the envelope anyway).
+build_data_json() {
+  jq -n \
+    --arg tool "$TOOL" \
+    --arg file "$FILE_REL" \
+    --argjson findings "$1" \
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
+    || printf '{"tool":"","file":"","findings":[]}'
+}
+
+# Graceful degrade: actionlint absent -> silent no-op. Telemetry (opt-in) records
+# a "skipped" status so a consumer sink can observe the coverage gap.
+if ! command -v actionlint >/dev/null 2>&1; then
+  data_json=$(build_data_json '[]')
+  emit_tel "actionlint" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+fi
+
+# -shellcheck= disables actionlint's embedded-bash ShellCheck integration. That
+# integration spawns a ShellCheck subprocess per `run:` block, which (1) deadlocks
+# on large blocks under the Windows subprocess IPC path in actionlint 1.7.x and
+# (2) adds latency unsuited to an edit-time advisory hook. Native workflow
+# diagnostics (the value of this hook) are unaffected; deep embedded-bash linting
+# belongs in a commit hook or CI, not here.
+AL_OUTPUT=$(actionlint -shellcheck= "$FILE" 2>&1) || true
+
+if [[ -n "$AL_OUTPUT" ]]; then
+  hook::ctx_reset
+  hook::ctx_append "actionlint: $(basename "$FILE") has findings:"
+  findings_raw=""
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    hook::ctx_append "  $line"
+    findings_raw+="$line"$'\n'
+  done <<<"$AL_OUTPUT"
+  hook::ctx_flush PostToolUse
+
+  FINDINGS_JSON='[]'
+  if [[ -n "$findings_raw" ]]; then
+    FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
+  fi
+  data_json=$(build_data_json "$FINDINGS_JSON")
+  emit_tel "actionlint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+fi
+
+# Clean workflow.
+data_json=$(build_data_json '[]')
+emit_tel "actionlint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+exit 0

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Black-box contract test for actionlint-check.sh (the actionlint plugin hook).
+#
+# Proves WIRING: the hook fires on .github/workflows/*.yml and *.yaml, skips
+# other paths, surfaces actionlint findings via additionalContext (advisory,
+# exit 0), honors the kill switch, disables the embedded-bash ShellCheck
+# integration (-shellcheck=), and emits a schema-valid telemetry envelope. No
+# consumer-specific policy prose in the surfaced context.
+#
+# Self-contained: builds throwaway git repos with runtime-generated fixtures.
+# The hook is invoked as a subprocess from an UNRELATED cwd so any reliance on
+# the caller's working directory would surface (the tool is file-anchored, so a
+# correct hook needs no cd). actionlint is required to drive the violation
+# assertions; without it the suite skips (the hook itself no-ops silently).
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/actionlint-check.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "SKIP: actionlint not on PATH -- actionlint hook tests skipped"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+UNRELATED="$(mktemp -d)"
+cleanup() { rm -rf "$WORK" "$UNRELATED"; }
+trap cleanup EXIT
+
+# make_sink <body> -> path to an executable single-command stub sink running
+# <body> (which reads the envelope on stdin). HOOK_TELEMETRY_SINK must be a
+# single executable path, not a command-with-args, so tests point it at a stub.
+make_sink() {
+  local s
+  s="$(mktemp -p "$WORK" sink.XXXXXX)"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$1"
+  } >"$s"
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [tries] -> block until <file> is non-empty (the
+# fire-and-forget sink flushed) or the bound elapses, polling in 20ms steps.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while ((tries-- > 0)); do
+    if [[ -s "$f" ]]; then
+      return 0
+    fi
+    sleep 0.02
+  done
+  return 1
+}
+
+new_repo() {
+  local r="$1"
+  mkdir -p "$r/.github/workflows"
+  git -C "$r" init -q
+  git -C "$r" config user.email t@t.t
+  git -C "$r" config user.name t
+}
+
+# Invoke the hook from an unrelated cwd. CLAUDE_PROJECT_DIR is left UNSET so
+# read_file_path's membership guard is disabled (not part of the fire gate);
+# this isolates lint behavior from path-form mismatch in the guard.
+run_hook() {
+  local file_path="$1"
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR HOOK_ACTIONLINT_ENABLED=true bash "$HOOK"
+  )
+}
+
+# Same as run_hook but with caller-supplied extra env (NAME=VALUE ...) passed
+# through env.
+run_hook_env() {
+  local file_path="$1"
+  shift
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
+      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+  )
+}
+
+REPO="$WORK/consumer"
+new_repo "$REPO"
+
+# --- Case 1: clean .yml -> exit 0, empty stdout -----------------------------
+printf 'name: clean\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "ok"\n' \
+  >"$REPO/.github/workflows/clean.yml"
+OUT=$(run_hook "$REPO/.github/workflows/clean.yml")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "clean .yml -> exit 0"; else fail "clean .yml exit $RC"; fi
+if [[ -z "$OUT" ]]; then ok "clean .yml -> empty stdout"; else fail "clean .yml stdout not empty: $OUT"; fi
+
+# --- Case 2: clean .yaml -> exit 0 (extension coverage) ---------------------
+printf 'name: clean2\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "ok"\n' \
+  >"$REPO/.github/workflows/clean.yaml"
+OUT=$(run_hook "$REPO/.github/workflows/clean.yaml")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "clean .yaml -> exit 0 empty (glob covers .yaml)"; else fail "clean .yaml (rc=$RC out=$OUT)"; fi
+
+# --- Case 3: violation -> advisory (exit 0) + finding in additionalContext ---
+printf 'name: bad\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ steps.missing.outputs.x }}"\n' \
+  >"$REPO/.github/workflows/violation.yml"
+OUT=$(run_hook "$REPO/.github/workflows/violation.yml")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "violation -> exit 0 (advisory)"; else fail "violation exit $RC (must be advisory)"; fi
+if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  CTX=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext')
+  if printf '%s' "$CTX" | grep -q 'missing'; then
+    ok "violation -> diagnostic in additionalContext"
+  else
+    fail "violation ctx missing diagnostic: $CTX"
+  fi
+  if printf '%s' "$CTX" | grep -qiE 'commit/CI will block|hard gate|lefthook'; then
+    fail "ctx carries consumer-specific policy prose: $CTX"
+  else
+    ok "ctx free of consumer-specific policy prose"
+  fi
+else
+  fail "violation -> no additionalContext JSON: $OUT"
+fi
+
+# --- Case 4: workflow-shaped name OUTSIDE .github/workflows -> exit 0 silent -
+printf 'name: anything\n' >"$REPO/foo.yml"
+OUT=$(run_hook "$REPO/foo.yml")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-workflow .yml -> exit 0 silent"; else fail "non-workflow .yml not skipped (rc=$RC out=$OUT)"; fi
+
+# --- Case 5: non-yaml extension under workflows -> exit 0 silent -------------
+printf 'not yaml\n' >"$REPO/.github/workflows/foo.txt"
+OUT=$(run_hook "$REPO/.github/workflows/foo.txt")
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok ".txt under workflows -> exit 0 silent"; else fail ".txt not skipped (rc=$RC out=$OUT)"; fi
+
+# --- Case 6: kill switch bypasses hook --------------------------------------
+OUT=$(run_hook_env "$REPO/.github/workflows/violation.yml" HOOK_ACTIONLINT_ENABLED=false)
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent despite violation"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
+
+# --- Case 7: large run: block, -shellcheck= disabled -> exit 0 (no SC) -------
+# `echo $UNQUOTED` is a ShellCheck-only finding (SC2086) with no native
+# actionlint diagnostic. With the embedded ShellCheck integration off, the hook
+# exits 0 with no finding. If -shellcheck= regressed AND ShellCheck is present,
+# an SC2086 line would surface. When ShellCheck is absent actionlint skips the
+# integration regardless, so this never false-fails.
+printf 'name: bigrun\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          FOO=bar\n          echo $FOO\n          for i in 1 2 3; do echo "line $i"; done\n' \
+  >"$REPO/.github/workflows/bigrun.yml"
+OUT=$(run_hook "$REPO/.github/workflows/bigrun.yml")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "large run: block -> exit 0 (no hang)"; else fail "bigrun exit $RC"; fi
+if printf '%s' "$OUT" | grep -q 'SC2086'; then
+  fail "shellcheck finding surfaced (SC2086) -- -shellcheck= regressed: $OUT"
+else
+  ok "no shellcheck finding surfaced (SC2086)"
+fi
+
+# ============================================================================
+# Telemetry
+# ============================================================================
+
+# --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
+OUT_NS=$(run_hook_env "$REPO/.github/workflows/clean.yml" -u HOOK_TELEMETRY_SINK HOOK_ACTIONLINT_ENABLED=true)
+RC_NS=$?
+if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
+  ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
+else
+  fail "telemetry/sink-unset: rc=$RC_NS out=$OUT_NS"
+fi
+
+# --- Stub sink + violation -> envelope status ok with findings --------------
+TEL="$(mktemp)"
+SINK="$(make_sink "cat >\"$TEL\"")"
+run_hook_env "$REPO/.github/workflows/violation.yml" HOOK_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+wait_for_sink "$TEL"
+if [[ -s "$TEL" ]]; then
+  ok "telemetry/stub-sink: envelope received"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$TEL" >/dev/null 2>&1; then
+      ok "envelope: $field present"
+    else
+      fail "envelope: $field missing ($(cat "$TEL"))"
+    fi
+  done
+  if [[ "$(jq -r '.hook' "$TEL")" == "actionlint" ]]; then ok "envelope: hook is actionlint"; else fail "envelope: hook=$(jq -r '.hook' "$TEL")"; fi
+  if [[ "$(jq -r '.status' "$TEL")" == "ok" ]]; then ok "envelope: status ok"; else fail "envelope: status=$(jq -r '.status' "$TEL")"; fi
+  if [[ "$(jq -r '.schema_version' "$TEL")" == "1.0" ]]; then ok "envelope: schema_version 1.0"; else fail "envelope: schema_version=$(jq -r '.schema_version' "$TEL")"; fi
+  if [[ "$(jq '.data.findings | length' "$TEL")" -ge 1 ]]; then ok "envelope: findings populated"; else fail "envelope: findings empty ($(jq '.data.findings' "$TEL"))"; fi
+  FREL=$(jq -r '.data.file' "$TEL")
+  if [[ -n "$FREL" && "$FREL" != /* && "$FREL" != ?:* ]]; then ok "envelope: data.file repo-relative ($FREL)"; else fail "envelope: data.file not repo-relative: $FREL"; fi
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL" >/dev/null 2>&1; then ok "envelope: duration_ms non-negative int"; else fail "envelope: duration_ms invalid ($(jq .duration_ms "$TEL"))"; fi
+else
+  fail "telemetry/stub-sink: no envelope written"
+fi
+rm -f "$TEL"
+
+# --- Stub sink + clean file -> status ok, findings [] -----------------------
+TELC="$(mktemp)"
+SINKC="$(make_sink "cat >\"$TELC\"")"
+run_hook_env "$REPO/.github/workflows/clean.yml" HOOK_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKC" >/dev/null
+wait_for_sink "$TELC"
+if [[ -s "$TELC" ]]; then
+  if [[ "$(jq -r '.status' "$TELC")" == "ok" ]]; then ok "telemetry/clean: status ok"; else fail "telemetry/clean: status=$(jq -r '.status' "$TELC")"; fi
+  if [[ "$(jq '.data.findings | length' "$TELC")" -eq 0 ]]; then ok "telemetry/clean: findings empty array"; else fail "telemetry/clean: findings not empty ($(jq '.data.findings' "$TELC"))"; fi
+else
+  fail "telemetry/clean: no envelope written"
+fi
+rm -f "$TELC"
+
+# --- actionlint-absent graceful degrade -> exit 0 silent, status skipped ----
+# Shadow actionlint with an empty PATH dir containing only the tools the hook
+# needs (bash/jq/git/dirname...), proving the `command -v actionlint` guard
+# yields a silent no-op. Build a PATH that resolves core tools but not actionlint.
+ABSENT_TEL="$(mktemp)"
+ABSENT_SINK="$(make_sink "cat >\"$ABSENT_TEL\"")"
+# Resolve the real dirs of the tools we must keep, minus any dir holding actionlint.
+AL_DIR="$(dirname "$(command -v actionlint)")"
+KEEP=""
+for t in bash jq git dirname basename cat env printf mktemp; do
+  d="$(dirname "$(command -v "$t" 2>/dev/null)")"
+  [[ -n "$d" && "$d" != "$AL_DIR" ]] && KEEP="$KEEP:$d"
+done
+OUT_ABS=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/clean.yml" \
+    | env -u CLAUDE_PROJECT_DIR -i PATH="${KEEP#:}" HOOK_ACTIONLINT_ENABLED=true \
+        HOOK_TELEMETRY_SINK="$ABSENT_SINK" bash "$HOOK"
+)
+RC_ABS=$?
+if [[ $RC_ABS -eq 0 && -z "$OUT_ABS" ]]; then ok "actionlint-absent -> exit 0 silent"; else fail "actionlint-absent (rc=$RC_ABS out=$OUT_ABS)"; fi
+wait_for_sink "$ABSENT_TEL"
+if [[ -s "$ABSENT_TEL" ]]; then
+  if [[ "$(jq -r '.status' "$ABSENT_TEL")" == "skipped" ]]; then ok "actionlint-absent -> telemetry status skipped"; else fail "actionlint-absent status=$(jq -r '.status' "$ABSENT_TEL")"; fi
+else
+  echo "  (actionlint-absent: no envelope -- PATH shadow could not resolve jq; skipping status assert)"
+fi
+rm -f "$ABSENT_TEL"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -117,6 +117,7 @@ RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "clean .yaml -> exit 0 empty (glob covers .yaml)"; else fail "clean .yaml (rc=$RC out=$OUT)"; fi
 
 # --- Case 3: violation -> advisory (exit 0) + finding in additionalContext ---
+# shellcheck disable=SC2016  # literal workflow YAML fixture: ${{ }} must stay unexpanded
 printf 'name: bad\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo "${{ steps.missing.outputs.x }}"\n' \
   >"$REPO/.github/workflows/violation.yml"
 OUT=$(run_hook "$REPO/.github/workflows/violation.yml")
@@ -161,6 +162,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent despi
 # exits 0 with no finding. If -shellcheck= regressed AND ShellCheck is present,
 # an SC2086 line would surface. When ShellCheck is absent actionlint skips the
 # integration regardless, so this never false-fails.
+# shellcheck disable=SC2016  # literal workflow YAML fixture: $FOO must stay unexpanded
 printf 'name: bigrun\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: |\n          FOO=bar\n          echo $FOO\n          for i in 1 2 3; do echo "line $i"; done\n' \
   >"$REPO/.github/workflows/bigrun.yml"
 OUT=$(run_hook "$REPO/.github/workflows/bigrun.yml")

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -1,0 +1,247 @@
+# shellcheck shell=bash
+# Shared hook utility library for this marketplace's hook plugins. Sourced
+# (not executed): kill switch, file_path parsing + path normalization,
+# repo-root resolution, additionalContext accumulator, telemetry envelope.
+#
+# SINGLE SOURCE OF TRUTH: lib/hook-utils.sh at the marketplace repo root. The
+# copies at plugins/*/hooks/hook-utils.sh exist because installed plugins are
+# cache-isolated and must be self-contained — never edit a copy. Edit the
+# source and run scripts/sync-hook-utils.sh; CI rejects drifted copies.
+
+# Guard against double-sourcing.
+[[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
+readonly _HOOK_UTILS_LOADED=1
+
+# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
+# disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+hook::check_enabled() {
+  local var_name="HOOK_${1}_ENABLED"
+  if [[ "${!var_name:-true}" != "true" ]]; then
+    exit 0
+  fi
+}
+
+# Normalize a path for the membership comparison below: backslashes → forward
+# slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
+# fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive
+# letter + lower-cased remainder so the byte-exact comparison is effectively
+# case-insensitive. The fold is gated on the host (OSTYPE), NOT on the path
+# shape: on a case-sensitive POSIX filesystem a real single-letter top-level
+# directory such as `/c/Repo` must pass through unchanged, otherwise it would
+# collapse with `/c/repo` and the membership guard would admit a sibling
+# outside CLAUDE_PROJECT_DIR. The result is used ONLY for comparison; the
+# emitted path is always the caller's original.
+hook::normalize_path() {
+  local p="${1//\\//}"
+  case "${OSTYPE:-}" in
+  msys* | cygwin* | win32)
+    if [[ "$p" =~ ^/([a-zA-Z])/ || "$p" =~ ^([a-zA-Z]):/ ]]; then
+      local rest="${p:2}"
+      printf '%s' "${BASH_REMATCH[1]^}:${rest,,}"
+      return
+    fi
+    ;;
+  *) ;; # POSIX hosts: case-sensitive FS, no drive fold — pass through below
+  esac
+  printf '%s' "$p"
+}
+
+# Canonicalize to a physical path — symlinks resolved — for the membership
+# comparison below, so an in-project symlink pointing outside the project root
+# cannot defeat the guard (the lexical path would pass the prefix check while
+# the write lands elsewhere). GNU realpath ships with Git Bash and Linux
+# coreutils; readlink -f covers the BSD/macOS hosts that have no realpath.
+# When neither resolver exists the caller falls back to comparing the lexical
+# path as before — the guard is defense-in-depth scoping for a file the agent
+# already wrote via its own tools, so degrading to the historical comparison
+# beats silently disabling the hook on those hosts.
+hook::physical_path() {
+  local resolved
+  if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
+    if [[ -n "$resolved" ]]; then
+      printf '%s' "$resolved"
+      return
+    fi
+  fi
+  printf '%s' "$1"
+}
+
+# Parse file_path from PostToolUse JSON on stdin; validate existence and (when
+# CLAUDE_PROJECT_DIR is set) project membership. Both sides of the membership
+# comparison are canonicalized (symlinks resolved) first, so neither an
+# escaping symlink nor a project root reached via a symlinked path (e.g.
+# macOS /tmp) skews the verdict. Outputs the path on success. Returns 1 to skip.
+#   FILE=$(hook::read_file_path) || exit 0
+hook::read_file_path() {
+  local file
+  file=$(jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+  [[ -n "$file" ]] || return 1
+  [[ -f "$file" ]] || return 1
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local norm_file norm_project
+    norm_file=$(hook::normalize_path "$(hook::physical_path "$file")")
+    norm_project=$(hook::normalize_path "$(hook::physical_path "${CLAUDE_PROJECT_DIR}")")
+    norm_project="${norm_project%/}"
+    # Anchor on a path-segment boundary: accept the project root itself or a
+    # child under it, but not a sibling whose name merely shares the prefix
+    # (e.g. /c/repo must not admit /c/repo-backup/...).
+    if [[ "$norm_file" != "$norm_project" && "$norm_file" != "$norm_project"/* ]]; then
+      return 1
+    fi
+  fi
+  printf '%s' "$file"
+}
+
+# Resolve the repository root (working-tree top) for a path inside the tree.
+# markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
+# before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
+# so it is correct for clones, linked worktrees, and bare-hub clones; falls
+# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+#   ROOT=$(hook::repo_root "$some_path")
+hook::repo_root() {
+  local hint="${1:-.}"
+  local root
+  root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+  if [[ -z "$root" ]]; then
+    root="$hint"
+    root="${root%/.claude}"
+    root="${root%\\.claude}"
+  fi
+  printf '%s' "$root"
+}
+
+# Per-hook stdout context accumulator. ctx_reset at entry, ctx_append per line,
+# ctx_flush once at exit with the hook event name.
+_HOOK_CTX_BUFFER=""
+
+hook::ctx_reset() {
+  _HOOK_CTX_BUFFER=""
+}
+
+hook::ctx_append() {
+  _HOOK_CTX_BUFFER+="$1"$'\n'
+}
+
+# Emit the accumulated context as hookSpecificOutput JSON, then clear the buffer.
+hook::ctx_flush() {
+  local event_name="$1"
+  local trimmed="${_HOOK_CTX_BUFFER%"${_HOOK_CTX_BUFFER##*[![:space:]]}"}"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  hook::emit_additional_context "$event_name" "$trimmed"
+  hook::ctx_reset
+}
+
+# Cheap telemetry opt-in probe — true iff a consumer wired a sink. Producers
+# gate telemetry-payload construction on this (repo-relative path
+# normalization, data JSON) so the unwired default path spawns zero
+# telemetry-only subprocesses. Pure shell test, no subprocess.
+# hook::emit_telemetry re-checks the sink itself, so skipping this probe
+# costs only wasted payload work, never correctness.
+hook::telemetry_enabled() {
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]]
+}
+
+# Emit one telemetry envelope per hook run to the consumer-set sink.
+# Fire-and-forget: sink is dispatched in the background; the hook never waits
+# on it and its failure never affects the hook's own exit code or stdout.
+# Opt-in guard: HOOK_TELEMETRY_SINK unset or empty → return 0 immediately.
+# Fail-open: jq absent → return 0 immediately.
+#
+# Usage:
+#   hook::emit_telemetry <hook_id> <hook_event> <status> <start_epoch> <data_json> [repo_root]
+#
+# <start_epoch>  Value of $EPOCHREALTIME captured by the caller before work began.
+#               Handles both '.' and ',' as the decimal separator (LC_NUMERIC).
+# <data_json>   Pre-built JSON object for the `data` field.
+# <repo_root>   Optional consuming-repo root, used to resolve a RELATIVE
+#               HOOK_TELEMETRY_SINK. The caller passes the root it already
+#               resolved for data.file; ignored when the sink is absolute.
+#
+# Sink path resolution: HOOK_TELEMETRY_SINK may be absolute OR relative to the
+# consuming repo root. Absolute (POSIX /… or Windows X:\ / X:/) is used as-is; a
+# relative value is joined onto <repo_root> (or $CLAUDE_PROJECT_DIR when no root
+# is passed), and skipped fail-open if neither is available. Relative is the
+# portable, team-shared wiring form: CC injects settings.json env values
+# literally (no ${VAR} expansion), so a relative path tracked in settings.json is
+# the only clone-portable, worktree-safe option.
+#
+# NEVER writes to fd1 (the hook's stdout / additionalContext channel).
+hook::emit_telemetry() {
+  # Opt-in guard.
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]] || return 0
+  # Fail-open when jq is absent.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local hook_id="$1"
+  local hook_event="$2"
+  local status="$3"
+  local start_epoch="$4"
+  local data_json="$5"
+  local repo_root="${6:-}"
+
+  # Compute duration_ms from caller's $EPOCHREALTIME snapshot to now.
+  # Both '.' and ',' separators handled; 10# prefix prevents octal misreading
+  # of fractional parts with leading zeros (e.g. .045123 → 10#045123 = 45123).
+  local now=$EPOCHREALTIME
+  local s_s="${start_epoch%[.,]*}" s_f="${start_epoch#*[.,]}"
+  local e_s="${now%[.,]*}" e_f="${now#*[.,]}"
+  local duration_ms=$(((e_s * 1000000 + 10#$e_f - s_s * 1000000 - 10#$s_f) / 1000))
+
+  # True UTC timestamp (TZ= prefix overrides LC_ALL / local TZ; the Z is not a lie).
+  local timestamp
+  timestamp=$(TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' -1)
+
+  # Build the envelope. Redirect jq stderr to /dev/null; output goes to a local
+  # variable — never to fd1.
+  local envelope
+  envelope=$(jq -n \
+    --arg schema_version "1.0" \
+    --arg timestamp "$timestamp" \
+    --arg hook "$hook_id" \
+    --arg hook_event "$hook_event" \
+    --arg status "$status" \
+    --argjson duration_ms "$duration_ms" \
+    --argjson data "$data_json" \
+    '{schema_version:$schema_version,timestamp:$timestamp,hook:$hook,hook_event:$hook_event,status:$status,duration_ms:$duration_ms,data:$data}' \
+    2>/dev/null) || return 0
+
+  # Resolve the sink path. A relative HOOK_TELEMETRY_SINK is joined onto the
+  # consuming repo root (portable, tracked wiring); absolute is used as-is. A
+  # relative value with no anchor is skipped fail-open — never exec a path the
+  # drifted hook CWD would resolve incorrectly.
+  local sink="$HOOK_TELEMETRY_SINK"
+  case "$sink" in
+  /* | [A-Za-z]:[/\\]*) ;;
+  *)
+    local root="${repo_root:-${CLAUDE_PROJECT_DIR:-}}"
+    [[ -n "$root" ]] || return 0
+    sink="${root%/}/$sink"
+    ;;
+  esac
+
+  # Fire-and-forget: pipe the envelope to the sink in a background subshell.
+  # The subshell's stdout AND stderr are redirected to /dev/null so the sink
+  # cannot write to the hook's fd1 (the additionalContext channel) and the
+  # backgrounded subshell does not hold a copy of the hook's fd1 open — which
+  # would block any command substitution wrapping the hook until the sink exits
+  # (the "C1 fd1-inheritance blocker"). The sink is quoted — it is a single
+  # executable path (wrap in a script to pass arguments).
+  printf '%s\n' "$envelope" | ("$sink" >/dev/null 2>&1) &
+}
+
+# Print cross-host hook JSON to stdout (exit 0). No-op when context is empty.
+# Shape: { hookSpecificOutput: { hookEventName[, additionalContext] } }.
+hook::emit_additional_context() {
+  local event_name="$1"
+  local context="$2"
+  [[ -n "$context" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -n \
+    --arg event "$event_name" \
+    --arg ctx "$context" \
+    '{hookSpecificOutput: (
+      {hookEventName: $event}
+      + (if $ctx != "" then {additionalContext: $ctx} else {} end)
+    )}'
+}

--- a/plugins/actionlint/hooks/hooks.json
+++ b/plugins/actionlint/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/actionlint-check.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Migrates the actionlint workflow-lint hook into a repo-agnostic plugin (renamed from actionlint-check; -check noise suffix dropped). Advisory PostToolUse on .github/workflows/*.ya?ml; actionlint absent -> clean no-op; kill switch HOOK_ACTIONLINT_ENABLED; -- operand terminator. 29 tests; validate clean. Clean-tier wave Phase 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, non-blocking hook plugin with no auth or data-path changes; behavior matches existing marketplace hook patterns.
> 
> **Overview**
> Adds a new **`actionlint`** marketplace plugin that runs **actionlint** from the consumer’s `PATH` on **PostToolUse** `Write|Edit` for `.github/workflows/*.yml` and `*.yaml`.
> 
> Findings are **advisory only** (hook always exits 0) and appear in `additionalContext`; edits are never blocked. The hook skips non-workflow paths, no-ops when actionlint is missing, and can be turned off with `HOOK_ACTIONLINT_ENABLED=false`. For edit-time speed and Windows stability it invokes actionlint with **`-shellcheck=`** and **`-pyflakes=`**, leaving full run-block linting to CI.
> 
> Catalog and **README** are updated; the plugin ships manifest, docs, `hooks.json`, shared **`hook-utils.sh`**, the hook script (repo-relative paths, optional telemetry), and a black-box **contract test** suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c305341fd6779528e41d11904320229e449f36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->