### PR TITLE
feat: add desktop-notification plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,12 @@
       "source": "./plugins/ruff-format",
       "category": "formatting",
       "tags": ["ruff", "python", "formatter", "linter", "hook"]
+    },
+    {
+      "name": "desktop-notification",
+      "source": "./plugins/desktop-notification",
+      "category": "notifications",
+      "tags": ["notification", "desktop", "toast", "bell", "osc9", "hook"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace
 | [`bash-lint`](plugins/bash-lint) | Hook | Lints shell scripts on edit via ShellCheck, and formats via shfmt when the repo opts in with an `.editorconfig`, using the consuming repo's own config. |
 | [`biome-format`](plugins/biome-format) | Hook | Formats and lints JS/TS/JSX/JSON on edit via Biome, only when the repo opts in with a `biome.json`, using the consuming repo's own Biome config. |
 | [`ruff-format`](plugins/ruff-format) | Hook | Formats and lints Python on edit via Ruff, only when the repo opts in with a Ruff config (`ruff.toml`, `.ruff.toml`, or `pyproject.toml` `[tool.ruff]`), using the consuming repo's own Ruff config. |
+| [`desktop-notification`](plugins/desktop-notification) | Hook | Alerts you when Claude Code needs input via an audible bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts. |
 
 Install one: `/plugin install <plugin-name>@melodic-software`.
 

--- a/docs/conventions/hook-telemetry/README.md
+++ b/docs/conventions/hook-telemetry/README.md
@@ -153,3 +153,4 @@ producers without coordinating with them or each other.
 | Producer | `hook` value | Data schema |
 |----------|--------------|-------------|
 | `markdown-formatter` plugin | `markdown-format` | `data/markdown-format.schema.json` |
+| `desktop-notification` plugin | `desktop-notification` | `data/desktop-notification.schema.json` |

--- a/docs/conventions/hook-telemetry/data/desktop-notification.schema.json
+++ b/docs/conventions/hook-telemetry/data/desktop-notification.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/hook-telemetry/data/desktop-notification.schema.json",
+  "title": "desktop-notification telemetry data",
+  "description": "Per-hook `data` payload for the desktop-notification hook. Discovered from the envelope `hook` value \"desktop-notification\". Evolves additive-only.",
+  "type": "object",
+  "required": ["notification_type", "channels"],
+  "additionalProperties": true,
+  "properties": {
+    "notification_type": {
+      "type": "string",
+      "description": "The Claude Code notification type that triggered the hook (permission_prompt or idle_prompt)."
+    },
+    "channels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Channels that actually fired for this notification: any of bell, terminal_notify, os_toast. Empty array = nothing fired (envelope status is then skipped)."
+    }
+  }
+}

--- a/docs/conventions/hook-telemetry/examples/desktop-notification.json
+++ b/docs/conventions/hook-telemetry/examples/desktop-notification.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "timestamp": "2026-07-09T22:37:29Z",
+  "hook": "desktop-notification",
+  "hook_event": "Notification",
+  "status": "ok",
+  "duration_ms": 6,
+  "data": {
+    "notification_type": "permission_prompt",
+    "channels": ["terminal_notify", "bell", "os_toast"]
+  }
+}

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "desktop-notification",
+  "version": "0.1.0",
+  "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "keywords": ["notification", "desktop", "toast", "bell", "osc9", "hook"]
+}

--- a/plugins/desktop-notification/README.md
+++ b/plugins/desktop-notification/README.md
@@ -1,0 +1,79 @@
+# desktop-notification
+
+A Claude Code plugin that alerts you the moment Claude needs your input. On a
+`permission_prompt` or `idle_prompt` notification it emits up to three additive,
+independently-toggleable channels: an audible terminal bell, an OSC 9 terminal
+notification, and — on macOS and Linux — an OS-native desktop toast.
+
+## Behavior
+
+- **Fires on attention prompts.** Only the `permission_prompt` and `idle_prompt`
+  notification types trigger it; every other notification is a silent no-op.
+- **Advisory, never blocking.** The hook always exits `0` (Notification hooks
+  cannot block).
+- **Three additive channels**, each default on and independently mutable:
+
+| Channel | Env toggle | What it does |
+|---|---|---|
+| `bell` | `HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED` | Audible terminal bell (bare `BEL`). |
+| `terminal_notify` | `HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED` | OSC 9 desktop notification, emitted via the hook's `terminalSequence` output (Claude Code v2.1.141+ writes it through its own terminal path). |
+| `os_toast` | `HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED` | OS-native toast (see per-OS table). |
+
+### Per-OS `os_toast` behavior
+
+| OS | Tool | Requirement |
+|---|---|---|
+| macOS | [`osascript … display notification`](https://code-maven.com/display-notification-from-the-mac-command-line) | Built-in — no dependency. First run prompts to allow notifications for the terminal app. |
+| Linux | [`notify-send`](https://man.archlinux.org/man/notify-send.1.en) (libnotify) | Install `libnotify-bin` (Debian/Ubuntu) or `libnotify` (Fedora). Absent → the `os_toast` channel is a silent no-op. |
+| Windows / other | none | No OS-toast branch: a fire-and-forget hook process leaves no live activator host for a WinRT toast to render into, so it would never reliably surface. The `terminal_notify` channel (OSC 9) carries Windows attention — [Windows Terminal handles OSC 9](https://code.claude.com/docs/en/hooks). |
+
+The OS toast body includes the current git branch when the project is a git
+repository (e.g. `Waiting for your input — feat/my-branch`); outside a repo it is
+just the message.
+
+## Requirements
+
+The hook runs on Bash 3.2+ and needs [`jq`](https://jqlang.github.io/jq/) on
+`PATH`. macOS needs nothing further; Linux needs `libnotify` only for the
+`os_toast` channel; Windows needs nothing (terminal channels only). Telemetry
+timing uses `EPOCHREALTIME` (Bash 5.0+); on older bash the telemetry envelope is
+skipped while notifications still fire.
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install desktop-notification@melodic-software
+```
+
+## Configuration
+
+This plugin has no `userConfig` — all of its variability is env-driven. Set any
+toggle in your settings `env` block (values are read literally; changes
+hot-reload):
+
+```json
+{
+  "env": {
+    "HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED": "false",
+    "HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED": "false"
+  }
+}
+```
+
+### Disable without uninstalling
+
+```json
+{ "env": { "HOOK_DESKTOP_NOTIFICATION_ENABLED": "false" } }
+```
+
+## Telemetry (opt-in)
+
+When the consumer sets `HOOK_TELEMETRY_SINK` to an executable, the hook emits one
+[telemetry envelope](../../docs/conventions/hook-telemetry/README.md) per run —
+`hook: "desktop-notification"`, `hook_event: "Notification"`, and a `data` payload
+of `notification_type` plus the `channels` that fired. Unset → exact no-op.
+
+## License
+
+[MIT](../../LICENSE).

--- a/plugins/desktop-notification/hooks/desktop-notification.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.sh
@@ -45,9 +45,15 @@ start=${EPOCHREALTIME:-}
 # parsed from the buffered value; reading fd0 twice would drain the pipe.
 INPUT=$(cat)
 
-# Extract notification details; strip CR (Git Bash pipe output).
-TYPE=$(printf '%s' "$INPUT" | jq -r '.notification_type // "unknown"' 2>/dev/null | tr -d '\r')
-MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // "Needs your attention"' 2>/dev/null | tr -d '\r')
+# Extract notification details. Strip ALL C0 control bytes (\000-\037 — includes
+# ESC, BEL, CR, LF, TAB) from the UNTRUSTED .message at parse time, before it can
+# reach ANY sink: an embedded ESC/BEL would otherwise smuggle terminal escapes
+# into the emitted OSC 9 sequence, and a newline could inject statements on the
+# osascript path. .notification_type is only matched against literal cases (a
+# control byte → no match → exit) and JSON-escaped by jq for telemetry, so it
+# needs no sanitization for safety; it is normalized here only for a clean value.
+TYPE=$(printf '%s' "$INPUT" | jq -r '.notification_type // "unknown"' 2>/dev/null | tr -d '\000-\037')
+MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // "Needs your attention"' 2>/dev/null | tr -d '\000-\037')
 [[ -n "$TYPE" ]] || TYPE="unknown"
 [[ -n "$MESSAGE" ]] || MESSAGE="Needs your attention"
 
@@ -67,6 +73,10 @@ case "$TYPE" in
 esac
 
 [[ "$MESSAGE" == "Needs your attention" ]] && MESSAGE="$DEFAULT_MSG"
+
+# HEADLINE is a fixed literal from the case above (no untrusted bytes today);
+# strip C0 defensively so a future dynamic headline can't reintroduce smuggling.
+HEADLINE=$(printf '%s' "$HEADLINE" | tr -d '\000-\037')
 
 # Consuming-repo root — used for the telemetry sink's relative-path resolution
 # and (below) the optional git branch context on the OS toast body.
@@ -100,18 +110,30 @@ fi
 # off the pipe; the hook's own terminalSequence JSON still reaches CC.
 if [[ "${HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED:-true}" == "true" ]]; then
   # Optional git branch context for the toast body (generic; empty outside a
-  # git repo → body is just the message).
-  BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null | tr -d '\r')
+  # git repo → body is just the message). Branch is also untrusted input — strip
+  # C0 bytes through the same gate as .message (a ref name can't legally carry
+  # them, but defense-in-depth so the branch can never reach a sink un-sanitized).
+  BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null | tr -d '\000-\037')
   BODY="$MESSAGE"
   [[ -n "$BRANCH" ]] && BODY="$MESSAGE — $BRANCH"
   case "$(uname -s)" in
     Darwin)
-      osascript -e "display notification \"$BODY\" with title \"$HEADLINE\"" >/dev/null 2>&1 &
+      # Pass text via argv, NEVER interpolated into the AppleScript source: a `"`
+      # in $BODY would close the string literal and a newline inject statements
+      # (→ code execution). `osascript -` reads the program from stdin (the quoted
+      # heredoc, so nothing expands); the trailing args populate `on run argv`.
+      osascript - "$HEADLINE" "$BODY" >/dev/null 2>&1 <<'OSA' &
+on run argv
+  display notification (item 2 of argv) with title (item 1 of argv)
+end run
+OSA
       CHANNELS+=("os_toast")
       ;;
     Linux)
       if command -v notify-send >/dev/null 2>&1; then
-        notify-send "$HEADLINE" "$BODY" >/dev/null 2>&1 &
+        # `--` terminates option parsing so a title/body starting with `-` is
+        # treated as a positional, never an option flag.
+        notify-send -- "$HEADLINE" "$BODY" >/dev/null 2>&1 &
         CHANNELS+=("os_toast")
       fi
       ;;

--- a/plugins/desktop-notification/hooks/desktop-notification.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Notification hook: cross-platform terminal/desktop alert when Claude Code needs input.
+# Triggered on the permission_prompt and idle_prompt notification types.
+#
+# ADVISORY: always exits 0 — Notification hooks cannot block (they return
+# terminalSequence output; exit 2 only shows stderr). Master kill switch
+# HOOK_DESKTOP_NOTIFICATION_ENABLED gates the whole hook. When on, it emits up
+# to three INDEPENDENTLY-gated channels (each default ON):
+#   BELL            — audible terminal bell (bare BEL).
+#   TERMINAL_NOTIFY — OSC 9 desktop notification (race-free, cross-platform;
+#                     honored because the hook is synchronous — CC reads the
+#                     terminalSequence field and emits the sequence on our
+#                     behalf, including on Windows Terminal, which handles OSC 9).
+#   OS_TOAST        — OS-native toast, self-backgrounded so the hook returns at
+#                     once. macOS: osascript (built-in). Linux: notify-send
+#                     (libnotify — apt install libnotify-bin / dnf install
+#                     libnotify). Windows / other: no toast branch — a
+#                     fire-and-forget process leaves no live activator host for a
+#                     WinRT toast to render into, so terminal channels carry the
+#                     attention (Windows Terminal honors the OSC 9 above).
+# Channels are additive — enabling more stacks them.
+#
+# Config from the consumer's settings `env` block (all default ON when enabled):
+#   HOOK_DESKTOP_NOTIFICATION_ENABLED=false                  disable entirely
+#   HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false             mute the bell
+#   HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false  mute OSC 9
+#   HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=false         mute the OS toast
+
+set -uo pipefail
+
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "DESKTOP_NOTIFICATION"
+
+# Capture $EPOCHREALTIME immediately after the kill switch so telemetry duration
+# covers the hook's work. EPOCHREALTIME is Bash 5.0+; on older bash it is unset,
+# so default to empty — referencing it bare under `set -u` would abort before the
+# advisory exit 0. Empty start => telemetry is skipped, the hook still notifies.
+start=${EPOCHREALTIME:-}
+
+# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
+# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
+# resolve (ENOENT → silent no-op). stdin is read ONCE here and both fields are
+# parsed from the buffered value; reading fd0 twice would drain the pipe.
+INPUT=$(cat)
+
+# Extract notification details; strip CR (Git Bash pipe output).
+TYPE=$(printf '%s' "$INPUT" | jq -r '.notification_type // "unknown"' 2>/dev/null | tr -d '\r')
+MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // "Needs your attention"' 2>/dev/null | tr -d '\r')
+[[ -n "$TYPE" ]] || TYPE="unknown"
+[[ -n "$MESSAGE" ]] || MESSAGE="Needs your attention"
+
+# Map notification type to (headline, default-message). Exit on non-actionable
+# types (no telemetry — same shape as a matcher miss). The default-message
+# override only applies when the system supplied the generic placeholder.
+case "$TYPE" in
+  permission_prompt)
+    HEADLINE="Permission Required"
+    DEFAULT_MSG="Needs your approval to continue"
+    ;;
+  idle_prompt)
+    HEADLINE="Input Needed"
+    DEFAULT_MSG="Waiting for your input"
+    ;;
+  *) exit 0 ;;
+esac
+
+[[ "$MESSAGE" == "Needs your attention" ]] && MESSAGE="$DEFAULT_MSG"
+
+# Consuming-repo root — used for the telemetry sink's relative-path resolution
+# and (below) the optional git branch context on the OS toast body.
+REPO_ROOT="$(hook::repo_root "${CLAUDE_PROJECT_DIR:-.}")"
+
+# Channels that actually fired, for the telemetry data payload.
+CHANNELS=()
+
+# Channels 1+2 — terminal-escape notification (race-free, cross-platform base).
+# Built from two INDEPENDENT appends so each channel gates alone:
+#   TERMINAL_NOTIFY → OSC 9 desktop notification. Its trailing BEL is the OSC
+#     TERMINATOR, NOT the audible bell — it must always close the OSC 9 sequence,
+#     so disabling BELL never strips it.
+#   BELL → a standalone bare BEL (audible bell for any terminal).
+# Deliberately NOT OSC 2 (window title): CC sets the terminal title to the
+# session name, and an OSC 2 here would clobber it on every prompt.
+SEQ=""
+if [[ "${HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED:-true}" == "true" ]]; then
+  SEQ+=$(printf '\033]9;%s\007' "$HEADLINE: $MESSAGE")
+  CHANNELS+=("terminal_notify")
+fi
+if [[ "${HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED:-true}" == "true" ]]; then
+  SEQ+=$(printf '\007')
+  CHANNELS+=("bell")
+fi
+
+# Channel 3 — OS-native toast (default on). Self-backgrounded so the hook
+# returns immediately. CRITICAL: redirect each child's stdout off CC's capture
+# pipe (>/dev/null 2>&1 &). A bare `&` child inherits fd1, so CC blocks for EOF
+# until the spawn's startup timeout and the hook hangs. The redirect keeps fd1
+# off the pipe; the hook's own terminalSequence JSON still reaches CC.
+if [[ "${HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED:-true}" == "true" ]]; then
+  # Optional git branch context for the toast body (generic; empty outside a
+  # git repo → body is just the message).
+  BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null | tr -d '\r')
+  BODY="$MESSAGE"
+  [[ -n "$BRANCH" ]] && BODY="$MESSAGE — $BRANCH"
+  case "$(uname -s)" in
+    Darwin)
+      osascript -e "display notification \"$BODY\" with title \"$HEADLINE\"" >/dev/null 2>&1 &
+      CHANNELS+=("os_toast")
+      ;;
+    Linux)
+      if command -v notify-send >/dev/null 2>&1; then
+        notify-send "$HEADLINE" "$BODY" >/dev/null 2>&1 &
+        CHANNELS+=("os_toast")
+      fi
+      ;;
+    *) ;; # Windows / unknown — no OS toast; terminal channels carry attention.
+  esac
+fi
+
+# Telemetry (opt-in, HOOK_TELEMETRY_SINK). Built only when a sink is wired: the
+# channels JSON + envelope cost a jq subprocess, never spent on the default path.
+if [[ -n "$start" ]] && hook::telemetry_enabled; then
+  if ((${#CHANNELS[@]})); then
+    ch_json=$(printf '%s\n' "${CHANNELS[@]}" | jq -R . | jq -s . 2>/dev/null) || ch_json='[]'
+    status="ok"
+  else
+    ch_json='[]'
+    status="skipped"
+  fi
+  data_json=$(jq -nc --arg nt "$TYPE" --argjson channels "$ch_json" \
+    '{notification_type:$nt,channels:$channels}' 2>/dev/null) \
+    || data_json='{"notification_type":"","channels":[]}'
+  hook::emit_telemetry "desktop-notification" "Notification" "$status" "$start" "$data_json" "$REPO_ROOT"
+fi
+
+# Emit terminalSequence LAST (final stdout write) and ONLY when non-empty: both
+# terminal channels off → silent stdout, exit 0 — the same shape CC tolerates
+# from the kill-switch path. jq -nc JSON-escapes the ESC/BEL control bytes; CC
+# parses the JSON and emits the raw sequence for us.
+if [[ -n "$SEQ" ]]; then
+  jq -nc --arg seq "$SEQ" '{terminalSequence: $seq}'
+fi
+exit 0

--- a/plugins/desktop-notification/hooks/desktop-notification.test.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.test.sh
@@ -226,6 +226,74 @@ wait_for_sink "$FAIL_FILE"
 if [[ $RC_FS -eq 0 ]]; then ok "telemetry/fail-sink: hook exit 0 despite sink failure"; else fail "telemetry/fail-sink: hook exit $RC_FS"; fi
 rm -f "$FAIL_FILE"
 
+# ============================================================================
+# Security: untrusted .message / branch sanitization
+# ============================================================================
+
+# A hostile .message carrying: a leading dash, a double-quote, a raw ESC + OSC 9
+# open + BEL (escape-smuggling attempt), a raw newline (statement-injection
+# attempt), and a tab. build_input JSON-encodes the control bytes via jq --arg;
+# the hook must strip them at parse time before any sink.
+EVIL="$(printf -- '-danger"q\033]9;INJECTED\007mid\tafter\nline2')"
+
+# --- Case 15: emitted terminalSequence carries only framing control bytes ----
+# BELL off → the only legitimate control bytes are ONE framing ESC (\033, opens
+# OSC 9) and ONE terminating BEL (\007). Any ESC/BEL/newline/tab from .message
+# must be gone: esc==1, bel==1, and zero other C0 bytes.
+OUT="$(run "$(build_input permission_prompt "$EVIL")" HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false)"
+RC=$?
+SEQ="$(jq -r '.terminalSequence' <<<"$OUT")"
+ESC_N="$(printf '%s' "$SEQ" | tr -cd '\033' | wc -c | tr -d ' \r')"
+BEL_N="$(printf '%s' "$SEQ" | tr -cd '\007' | wc -c | tr -d ' \r')"
+OTHER_N="$(printf '%s' "$SEQ" | tr -d '\033\007' | tr -cd '\000-\037' | wc -c | tr -d ' \r')"
+if [[ $RC -eq 0 ]]; then ok "sanitize/seq: exit 0"; else fail "sanitize/seq: exit $RC"; fi
+if [[ "$ESC_N" == "1" ]]; then ok "sanitize/seq: exactly 1 ESC (framing only, no smuggled ESC)"; else fail "sanitize/seq: ESC count $ESC_N, want 1"; fi
+if [[ "$BEL_N" == "1" ]]; then ok "sanitize/seq: exactly 1 BEL (OSC terminator only, no smuggled BEL)"; else fail "sanitize/seq: BEL count $BEL_N, want 1"; fi
+if [[ "$OTHER_N" == "0" ]]; then ok "sanitize/seq: zero other C0 bytes (newline/tab stripped)"; else fail "sanitize/seq: $OTHER_N other C0 bytes remain"; fi
+# Printable payload text survives (proves we stripped control bytes, not content).
+if printf '%s' "$SEQ" | grep -q 'INJECTED'; then ok "sanitize/seq: printable text preserved"; else fail "sanitize/seq: over-stripped printable text: $SEQ"; fi
+
+# --- Case 16: osascript receives text as argv, not interpolated program ------
+# Stub uname→Darwin (force the macOS branch cross-platform) and osascript→capture
+# argv + stdin program. Proves (a) HEADLINE/BODY arrive as argv items, (b) the
+# AppleScript source (with "display notification") comes via stdin and never
+# carries the message text, (c) the delivered BODY arg has no control bytes.
+SHIM="$WORK/osa-shim"
+mkdir -p "$SHIM"
+OSA_LOG="$WORK/osa.log"
+{ printf '#!/usr/bin/env bash\necho Darwin\n'; } >"$SHIM/uname"
+{
+  printf '#!/usr/bin/env bash\n'
+  # Single quotes are intentional: $#/$@/$a must appear LITERALLY in the emitted
+  # stub script, not expand here in the test.
+  # shellcheck disable=SC2016
+  printf '{ printf "ARGC=%%s\\n" "$#"; for a in "$@"; do printf "ARG=[%%s]\\n" "$a"; done; printf "PROG<<\\n"; cat; printf "\\n>>PROG\\n"; } >%q\n' "$OSA_LOG"
+} >"$SHIM/osascript"
+chmod +x "$SHIM/uname" "$SHIM/osascript"
+
+IN_EVIL="$(build_input permission_prompt "$EVIL")"
+(cd "$UNRELATED" && printf '%s' "$IN_EVIL" \
+  | env -u HOOK_TELEMETRY_SINK -u HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED \
+    -u HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
+    CLAUDE_PROJECT_DIR="$FAKE_REPO" HOOK_DESKTOP_NOTIFICATION_ENABLED=true \
+    HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=true PATH="$SHIM:$PATH" \
+    bash "$HOOK" >/dev/null 2>&1)
+wait_for_sink "$OSA_LOG"
+
+if grep -qx 'ARGC=3' "$OSA_LOG" 2>/dev/null; then ok "sanitize/osascript: 3 args (- + title + body)"; else fail "sanitize/osascript: ARGC wrong: $(cat "$OSA_LOG" 2>/dev/null)"; fi
+if grep -qxF 'ARG=[Permission Required]' "$OSA_LOG" 2>/dev/null; then ok "sanitize/osascript: title passed as argv item"; else fail "sanitize/osascript: title not an argv item: $(cat "$OSA_LOG" 2>/dev/null)"; fi
+# Body argv line: starts with the hostile leading dash, carries no control bytes.
+BODY_LINE="$(grep -m1 '^ARG=\[-danger' "$OSA_LOG" 2>/dev/null)"
+if [[ -n "$BODY_LINE" ]]; then ok "sanitize/osascript: body passed as argv item (leading dash intact, not an option)"; else fail "sanitize/osascript: body argv item missing: $(cat "$OSA_LOG" 2>/dev/null)"; fi
+BODY_CTL="$(printf '%s' "$BODY_LINE" | tr -cd '\000-\037' | wc -c | tr -d ' \r')"
+if [[ "$BODY_CTL" == "0" ]]; then ok "sanitize/osascript: body argv item has no control bytes"; else fail "sanitize/osascript: body argv item carries $BODY_CTL control bytes"; fi
+# The AppleScript program came via stdin, and no ARG= line carries the program.
+if grep '^ARG=' "$OSA_LOG" 2>/dev/null | grep -q 'display notification'; then fail "sanitize/osascript: program leaked into argv (interpolation!)"; else ok "sanitize/osascript: program not in argv"; fi
+# The message text must NOT appear inside the stdin program (no interpolation).
+PROG="$(sed -n '/^PROG<</,/^>>PROG/p' "$OSA_LOG" 2>/dev/null)"
+if printf '%s' "$PROG" | grep -q 'danger'; then fail "sanitize/osascript: message text interpolated into program: $PROG"; else ok "sanitize/osascript: message text absent from program (argv-only)"; fi
+if printf '%s' "$PROG" | grep -q 'display notification (item 2 of argv)'; then ok "sanitize/osascript: program reads body from argv"; else fail "sanitize/osascript: program shape unexpected: $PROG"; fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/desktop-notification/hooks/desktop-notification.test.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Black-box contract test for desktop-notification.sh (the desktop-notification plugin hook).
+#
+# Proves WIRING, not baseline parity: master kill switch, matcher detection
+# (permission_prompt + idle_prompt emit a terminalSequence), non-actionable /
+# empty stdin exit silently, the per-channel BELL + TERMINAL_NOTIFY gate matrix,
+# the OSC allowlist (OSC 9 present, OSC 2 + rejected sequences absent), and the
+# opt-in HOOK_TELEMETRY_SINK envelope contract.
+#
+# Self-contained: builds a throwaway git repo (deterministic git-branch probe)
+# and defines its own assertion helpers — installed plugins are cache-isolated
+# with no shared test lib. The OS_TOAST channel's actual toast emission is out of
+# scope (osascript / notify-send are platform-specific, self-backgrounded, and
+# stdout-redirected); os_toast is disabled by default here so terminal-channel
+# assertions stay deterministic cross-platform.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/desktop-notification.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+WORK="$(mktemp -d)"
+UNRELATED="$(mktemp -d)"
+cleanup() { rm -rf "$WORK" "$UNRELATED"; }
+trap cleanup EXIT
+
+# Fake repo so the git-branch probe is deterministic and REPO_ROOT resolves.
+FAKE_REPO="$WORK/repo"
+mkdir -p "$FAKE_REPO"
+git -C "$FAKE_REPO" init -q
+git -C "$FAKE_REPO" config user.email t@t.t
+git -C "$FAKE_REPO" config user.name t
+git -C "$FAKE_REPO" commit --allow-empty -m init -q
+
+# make_sink <body> → path to an executable single-command stub sink running
+# <body> (which reads the envelope on stdin). HOOK_TELEMETRY_SINK must be a
+# single executable path, so tests point it at a stub script under $WORK.
+make_sink() {
+  local s
+  s="$(mktemp -p "$WORK" sink.XXXXXX)"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$1"
+  } >"$s"
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# Block until <file> is non-empty (fire-and-forget sink flushed) or bound elapses.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while ((tries-- > 0)); do
+    [[ -s "$f" ]] && return 0
+    sleep 0.02
+  done
+  return 1
+}
+
+build_input() {
+  local type="$1" message="${2:-Needs your attention}"
+  MSYS_NO_PATHCONV=1 jq -n --arg t "$type" --arg m "$message" \
+    '{notification_type: $t, message: $m}'
+}
+
+# stdout-only runner. Clears ambient channel + sink vars (hermetic against a live
+# session's env), enables the master switch, defaults OS_TOAST off (keeps stdout
+# deterministic + fires no real toast), then applies caller overrides last.
+run() {
+  local input="$1"
+  shift
+  (cd "$UNRELATED" && printf '%s' "$input" \
+    | env -u HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED \
+      -u HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
+      -u HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED \
+      -u HOOK_TELEMETRY_SINK \
+      CLAUDE_PROJECT_DIR="$FAKE_REPO" \
+      HOOK_DESKTOP_NOTIFICATION_ENABLED=true \
+      HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=false \
+      "$@" \
+      bash "$HOOK" 2>/dev/null)
+}
+
+# Count BEL (\007) bytes in a terminalSequence JSON payload (raw-decoded).
+bel_count() {
+  jq -r '.terminalSequence' <<<"$1" | tr -cd '\007' | wc -c | tr -d ' \r'
+}
+
+# --- Case 1: master kill switch false → silent exit 0 -----------------------
+OUT="$(cd "$UNRELATED" && build_input permission_prompt \
+  | env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$FAKE_REPO" \
+    HOOK_DESKTOP_NOTIFICATION_ENABLED=false bash "$HOOK" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch false → silent exit 0"; else fail "kill switch (rc=$RC out=$OUT)"; fi
+
+# --- Case 2: enabled + permission_prompt → terminalSequence, OSC allowlist ---
+OUT="$(run "$(build_input permission_prompt)")"
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "permission_prompt exit 0"; else fail "permission_prompt exit $RC"; fi
+if printf '%s' "$OUT" | jq -e '.terminalSequence' >/dev/null 2>&1; then
+  ok "permission_prompt → terminalSequence, stdout parses as JSON"
+else
+  fail "permission_prompt → no terminalSequence JSON: $OUT"
+fi
+if printf '%s' "$OUT" | grep -q ']9;'; then ok "permission_prompt → OSC 9 present"; else fail "permission_prompt → OSC 9 missing: $OUT"; fi
+if printf '%s' "$OUT" | grep -q ']2;'; then fail "permission_prompt → OSC 2 present (would clobber session title)"; else ok "permission_prompt → no OSC 2 title"; fi
+if printf '%s' "$OUT" | grep -qE ']1337|]8;'; then fail "permission_prompt → rejected OSC present"; else ok "permission_prompt → no rejected OSC (1337/8)"; fi
+
+# --- Case 3: enabled + idle_prompt → terminalSequence -----------------------
+OUT="$(run "$(build_input idle_prompt)")"
+if printf '%s' "$OUT" | jq -e '.terminalSequence' >/dev/null 2>&1; then ok "idle_prompt → terminalSequence"; else fail "idle_prompt → no terminalSequence: $OUT"; fi
+
+# --- Case 4: non-actionable notification_type → silent exit 0 ---------------
+OUT="$(run "$(build_input auth_success)")"
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-actionable type → silent exit 0"; else fail "non-actionable type (rc=$RC out=$OUT)"; fi
+
+# --- Case 5: empty stdin → silent exit 0 ------------------------------------
+OUT="$(cd "$UNRELATED" && env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$FAKE_REPO" \
+  HOOK_DESKTOP_NOTIFICATION_ENABLED=true bash "$HOOK" </dev/null 2>&1)"
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "empty stdin → silent exit 0"; else fail "empty stdin (rc=$RC out=$OUT)"; fi
+
+# --- Case 6: all channel vars unset → OSC 9 + 2 BELs ------------------------
+OUT="$(run "$(build_input permission_prompt)")"
+if printf '%s' "$OUT" | grep -q ']9;'; then ok "backward-compat → OSC 9 present"; else fail "backward-compat → OSC 9 missing: $OUT"; fi
+if [[ "$(bel_count "$OUT")" == "2" ]]; then ok "backward-compat → 2 BELs (OSC terminator + standalone bell)"; else fail "backward-compat → BEL count $(bel_count "$OUT"), want 2"; fi
+
+# --- Case 7: BELL off → OSC 9 + terminator only, 1 BEL ----------------------
+OUT="$(run "$(build_input permission_prompt)" HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false)"
+if printf '%s' "$OUT" | grep -q ']9;'; then ok "BELL off → OSC 9 terminator intact"; else fail "BELL off → OSC 9 missing: $OUT"; fi
+if [[ "$(bel_count "$OUT")" == "1" ]]; then ok "BELL off → 1 BEL (OSC terminator only)"; else fail "BELL off → BEL count $(bel_count "$OUT"), want 1"; fi
+
+# --- Case 8: TERMINAL_NOTIFY off → bare BEL, no OSC 9 -----------------------
+OUT="$(run "$(build_input permission_prompt)" HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false)"
+if printf '%s' "$OUT" | grep -q ']9;'; then fail "TERMINAL_NOTIFY off → OSC 9 still present: $OUT"; else ok "TERMINAL_NOTIFY off → no OSC 9"; fi
+if printf '%s' "$OUT" | jq -e '.terminalSequence' >/dev/null 2>&1; then ok "TERMINAL_NOTIFY off → terminalSequence present"; else fail "TERMINAL_NOTIFY off → no terminalSequence: $OUT"; fi
+if [[ "$(bel_count "$OUT")" == "1" ]]; then ok "TERMINAL_NOTIFY off → 1 BEL (standalone bell only)"; else fail "TERMINAL_NOTIFY off → BEL count $(bel_count "$OUT"), want 1"; fi
+
+# --- Case 9: both terminal channels off → silent stdout ---------------------
+OUT="$(run "$(build_input permission_prompt)" \
+  HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false)"
+if [[ -z "$OUT" ]]; then ok "both terminal channels off → silent stdout"; else fail "both off → stdout not empty: $OUT"; fi
+
+# ============================================================================
+# Telemetry (HOOK_TELEMETRY_SINK) tests
+# ============================================================================
+
+# --- Case 10: sink unset → stdout parity, no envelope leak ------------------
+OUT="$(run "$(build_input permission_prompt)")"
+if printf '%s' "$OUT" | jq -e '.terminalSequence' >/dev/null 2>&1; then ok "telemetry/unset: terminalSequence parity"; else fail "telemetry/unset: no terminalSequence: $OUT"; fi
+if printf '%s' "$OUT" | jq -e '.schema_version' >/dev/null 2>&1; then fail "telemetry/unset: envelope leaked to hook stdout"; else ok "telemetry/unset: no envelope in hook stdout"; fi
+
+# --- Case 11: stub sink → schema-valid envelope, status ok, channels --------
+TEL="$(mktemp)"
+STUB="$(make_sink "cat >\"$TEL\"")"
+# Enable both terminal channels (os_toast still off) → channels = [terminal_notify, bell], status ok.
+_OUT="$(run "$(build_input permission_prompt)" HOOK_TELEMETRY_SINK="$STUB")"
+RC=$?
+wait_for_sink "$TEL"
+if [[ $RC -eq 0 ]]; then ok "telemetry/stub: hook exit 0"; else fail "telemetry/stub: hook exit $RC"; fi
+if [[ -s "$TEL" ]]; then
+  ok "telemetry/stub: envelope received"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$TEL" >/dev/null 2>&1; then ok "telemetry/envelope: $field present"; else fail "telemetry/envelope: $field missing: $(cat "$TEL")"; fi
+  done
+  if [[ "$(jq -r '.hook' "$TEL")" == "desktop-notification" ]]; then ok "telemetry/envelope: hook id"; else fail "telemetry/envelope: hook id = $(jq -r '.hook' "$TEL")"; fi
+  if [[ "$(jq -r '.hook_event' "$TEL")" == "Notification" ]]; then ok "telemetry/envelope: hook_event Notification"; else fail "telemetry/envelope: hook_event = $(jq -r '.hook_event' "$TEL")"; fi
+  if [[ "$(jq -r '.status' "$TEL")" == "ok" ]]; then ok "telemetry/envelope: status ok"; else fail "telemetry/envelope: status = $(jq -r '.status' "$TEL")"; fi
+  if [[ "$(jq -r '.schema_version' "$TEL")" == "1.0" ]]; then ok "telemetry/envelope: schema_version 1.0"; else fail "telemetry/envelope: schema_version = $(jq -r '.schema_version' "$TEL")"; fi
+  if [[ "$(jq -r '.data.notification_type' "$TEL")" == "permission_prompt" ]]; then ok "telemetry/envelope: data.notification_type"; else fail "telemetry/envelope: notification_type = $(jq -r '.data.notification_type' "$TEL")"; fi
+  if jq -e '.data.channels | index("terminal_notify") and index("bell")' "$TEL" >/dev/null 2>&1; then ok "telemetry/envelope: channels has terminal_notify + bell"; else fail "telemetry/envelope: channels = $(jq -c '.data.channels' "$TEL")"; fi
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL" >/dev/null 2>&1; then ok "telemetry/envelope: duration_ms non-negative integer"; else fail "telemetry/envelope: duration_ms = $(jq '.duration_ms' "$TEL")"; fi
+else
+  fail "telemetry/stub: no envelope written"
+fi
+rm -f "$TEL"
+
+# --- Case 12: all channels off → status skipped, channels empty -------------
+TEL="$(mktemp)"
+STUB="$(make_sink "cat >\"$TEL\"")"
+_OUT="$(run "$(build_input permission_prompt)" \
+  HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false \
+  HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false \
+  HOOK_TELEMETRY_SINK="$STUB")"
+wait_for_sink "$TEL"
+if [[ -s "$TEL" ]]; then
+  if [[ "$(jq -r '.status' "$TEL")" == "skipped" ]]; then ok "telemetry/skipped: status skipped when no channel fires"; else fail "telemetry/skipped: status = $(jq -r '.status' "$TEL")"; fi
+  if [[ "$(jq -r '.data.channels | length' "$TEL")" == "0" ]]; then ok "telemetry/skipped: channels empty"; else fail "telemetry/skipped: channels = $(jq -c '.data.channels' "$TEL")"; fi
+else
+  fail "telemetry/skipped: no envelope written"
+fi
+rm -f "$TEL"
+
+# --- Case 13: slow sink (C1 fd1-leak detector) → hook returns << 3s ---------
+SLOW="$(make_sink "cat >/dev/null; sleep 3")"
+TS_START=$EPOCHREALTIME
+# shellcheck disable=SC2034  # captured so $() blocks until fd1 closes — proves no fd1 leak
+_OUT_SLOW="$(run "$(build_input permission_prompt)" HOOK_TELEMETRY_SINK="$SLOW")"
+RC_SLOW=$?
+TS_END=$EPOCHREALTIME
+SS="${TS_START%[.,]*}" SF="${TS_START#*[.,]}"
+ES="${TS_END%[.,]*}" EF="${TS_END#*[.,]}"
+SLOW_MS=$(((ES * 1000000 + 10#$EF - SS * 1000000 - 10#$SF) / 1000))
+echo "  (C1 slow-sink elapsed: ${SLOW_MS}ms)"
+if [[ $RC_SLOW -eq 0 ]]; then ok "telemetry/slow-sink: hook exit 0"; else fail "telemetry/slow-sink: hook exit $RC_SLOW"; fi
+if [[ $SLOW_MS -lt 2000 ]]; then ok "telemetry/slow-sink: returned in ${SLOW_MS}ms (<<3000 = no fd1 leak)"; else fail "telemetry/slow-sink: ${SLOW_MS}ms — fd1 leak blocks"; fi
+
+# --- Case 14: failing sink → hook exit 0 unaffected -------------------------
+FAIL_FILE="$(mktemp)"
+FAIL_SINK="$(make_sink "cat >\"$FAIL_FILE\"; exit 1")"
+# shellcheck disable=SC2034
+_OUT_FS="$(run "$(build_input permission_prompt)" HOOK_TELEMETRY_SINK="$FAIL_SINK")"
+RC_FS=$?
+wait_for_sink "$FAIL_FILE"
+if [[ $RC_FS -eq 0 ]]; then ok "telemetry/fail-sink: hook exit 0 despite sink failure"; else fail "telemetry/fail-sink: hook exit $RC_FS"; fi
+rm -f "$FAIL_FILE"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -1,0 +1,247 @@
+# shellcheck shell=bash
+# Shared hook utility library for this marketplace's hook plugins. Sourced
+# (not executed): kill switch, file_path parsing + path normalization,
+# repo-root resolution, additionalContext accumulator, telemetry envelope.
+#
+# SINGLE SOURCE OF TRUTH: lib/hook-utils.sh at the marketplace repo root. The
+# copies at plugins/*/hooks/hook-utils.sh exist because installed plugins are
+# cache-isolated and must be self-contained — never edit a copy. Edit the
+# source and run scripts/sync-hook-utils.sh; CI rejects drifted copies.
+
+# Guard against double-sourcing.
+[[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
+readonly _HOOK_UTILS_LOADED=1
+
+# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
+# disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+hook::check_enabled() {
+  local var_name="HOOK_${1}_ENABLED"
+  if [[ "${!var_name:-true}" != "true" ]]; then
+    exit 0
+  fi
+}
+
+# Normalize a path for the membership comparison below: backslashes → forward
+# slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
+# fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive
+# letter + lower-cased remainder so the byte-exact comparison is effectively
+# case-insensitive. The fold is gated on the host (OSTYPE), NOT on the path
+# shape: on a case-sensitive POSIX filesystem a real single-letter top-level
+# directory such as `/c/Repo` must pass through unchanged, otherwise it would
+# collapse with `/c/repo` and the membership guard would admit a sibling
+# outside CLAUDE_PROJECT_DIR. The result is used ONLY for comparison; the
+# emitted path is always the caller's original.
+hook::normalize_path() {
+  local p="${1//\\//}"
+  case "${OSTYPE:-}" in
+  msys* | cygwin* | win32)
+    if [[ "$p" =~ ^/([a-zA-Z])/ || "$p" =~ ^([a-zA-Z]):/ ]]; then
+      local rest="${p:2}"
+      printf '%s' "${BASH_REMATCH[1]^}:${rest,,}"
+      return
+    fi
+    ;;
+  *) ;; # POSIX hosts: case-sensitive FS, no drive fold — pass through below
+  esac
+  printf '%s' "$p"
+}
+
+# Canonicalize to a physical path — symlinks resolved — for the membership
+# comparison below, so an in-project symlink pointing outside the project root
+# cannot defeat the guard (the lexical path would pass the prefix check while
+# the write lands elsewhere). GNU realpath ships with Git Bash and Linux
+# coreutils; readlink -f covers the BSD/macOS hosts that have no realpath.
+# When neither resolver exists the caller falls back to comparing the lexical
+# path as before — the guard is defense-in-depth scoping for a file the agent
+# already wrote via its own tools, so degrading to the historical comparison
+# beats silently disabling the hook on those hosts.
+hook::physical_path() {
+  local resolved
+  if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
+    if [[ -n "$resolved" ]]; then
+      printf '%s' "$resolved"
+      return
+    fi
+  fi
+  printf '%s' "$1"
+}
+
+# Parse file_path from PostToolUse JSON on stdin; validate existence and (when
+# CLAUDE_PROJECT_DIR is set) project membership. Both sides of the membership
+# comparison are canonicalized (symlinks resolved) first, so neither an
+# escaping symlink nor a project root reached via a symlinked path (e.g.
+# macOS /tmp) skews the verdict. Outputs the path on success. Returns 1 to skip.
+#   FILE=$(hook::read_file_path) || exit 0
+hook::read_file_path() {
+  local file
+  file=$(jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+  [[ -n "$file" ]] || return 1
+  [[ -f "$file" ]] || return 1
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local norm_file norm_project
+    norm_file=$(hook::normalize_path "$(hook::physical_path "$file")")
+    norm_project=$(hook::normalize_path "$(hook::physical_path "${CLAUDE_PROJECT_DIR}")")
+    norm_project="${norm_project%/}"
+    # Anchor on a path-segment boundary: accept the project root itself or a
+    # child under it, but not a sibling whose name merely shares the prefix
+    # (e.g. /c/repo must not admit /c/repo-backup/...).
+    if [[ "$norm_file" != "$norm_project" && "$norm_file" != "$norm_project"/* ]]; then
+      return 1
+    fi
+  fi
+  printf '%s' "$file"
+}
+
+# Resolve the repository root (working-tree top) for a path inside the tree.
+# markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
+# before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
+# so it is correct for clones, linked worktrees, and bare-hub clones; falls
+# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+#   ROOT=$(hook::repo_root "$some_path")
+hook::repo_root() {
+  local hint="${1:-.}"
+  local root
+  root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+  if [[ -z "$root" ]]; then
+    root="$hint"
+    root="${root%/.claude}"
+    root="${root%\\.claude}"
+  fi
+  printf '%s' "$root"
+}
+
+# Per-hook stdout context accumulator. ctx_reset at entry, ctx_append per line,
+# ctx_flush once at exit with the hook event name.
+_HOOK_CTX_BUFFER=""
+
+hook::ctx_reset() {
+  _HOOK_CTX_BUFFER=""
+}
+
+hook::ctx_append() {
+  _HOOK_CTX_BUFFER+="$1"$'\n'
+}
+
+# Emit the accumulated context as hookSpecificOutput JSON, then clear the buffer.
+hook::ctx_flush() {
+  local event_name="$1"
+  local trimmed="${_HOOK_CTX_BUFFER%"${_HOOK_CTX_BUFFER##*[![:space:]]}"}"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  hook::emit_additional_context "$event_name" "$trimmed"
+  hook::ctx_reset
+}
+
+# Cheap telemetry opt-in probe — true iff a consumer wired a sink. Producers
+# gate telemetry-payload construction on this (repo-relative path
+# normalization, data JSON) so the unwired default path spawns zero
+# telemetry-only subprocesses. Pure shell test, no subprocess.
+# hook::emit_telemetry re-checks the sink itself, so skipping this probe
+# costs only wasted payload work, never correctness.
+hook::telemetry_enabled() {
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]]
+}
+
+# Emit one telemetry envelope per hook run to the consumer-set sink.
+# Fire-and-forget: sink is dispatched in the background; the hook never waits
+# on it and its failure never affects the hook's own exit code or stdout.
+# Opt-in guard: HOOK_TELEMETRY_SINK unset or empty → return 0 immediately.
+# Fail-open: jq absent → return 0 immediately.
+#
+# Usage:
+#   hook::emit_telemetry <hook_id> <hook_event> <status> <start_epoch> <data_json> [repo_root]
+#
+# <start_epoch>  Value of $EPOCHREALTIME captured by the caller before work began.
+#               Handles both '.' and ',' as the decimal separator (LC_NUMERIC).
+# <data_json>   Pre-built JSON object for the `data` field.
+# <repo_root>   Optional consuming-repo root, used to resolve a RELATIVE
+#               HOOK_TELEMETRY_SINK. The caller passes the root it already
+#               resolved for data.file; ignored when the sink is absolute.
+#
+# Sink path resolution: HOOK_TELEMETRY_SINK may be absolute OR relative to the
+# consuming repo root. Absolute (POSIX /… or Windows X:\ / X:/) is used as-is; a
+# relative value is joined onto <repo_root> (or $CLAUDE_PROJECT_DIR when no root
+# is passed), and skipped fail-open if neither is available. Relative is the
+# portable, team-shared wiring form: CC injects settings.json env values
+# literally (no ${VAR} expansion), so a relative path tracked in settings.json is
+# the only clone-portable, worktree-safe option.
+#
+# NEVER writes to fd1 (the hook's stdout / additionalContext channel).
+hook::emit_telemetry() {
+  # Opt-in guard.
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]] || return 0
+  # Fail-open when jq is absent.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local hook_id="$1"
+  local hook_event="$2"
+  local status="$3"
+  local start_epoch="$4"
+  local data_json="$5"
+  local repo_root="${6:-}"
+
+  # Compute duration_ms from caller's $EPOCHREALTIME snapshot to now.
+  # Both '.' and ',' separators handled; 10# prefix prevents octal misreading
+  # of fractional parts with leading zeros (e.g. .045123 → 10#045123 = 45123).
+  local now=$EPOCHREALTIME
+  local s_s="${start_epoch%[.,]*}" s_f="${start_epoch#*[.,]}"
+  local e_s="${now%[.,]*}" e_f="${now#*[.,]}"
+  local duration_ms=$(((e_s * 1000000 + 10#$e_f - s_s * 1000000 - 10#$s_f) / 1000))
+
+  # True UTC timestamp (TZ= prefix overrides LC_ALL / local TZ; the Z is not a lie).
+  local timestamp
+  timestamp=$(TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' -1)
+
+  # Build the envelope. Redirect jq stderr to /dev/null; output goes to a local
+  # variable — never to fd1.
+  local envelope
+  envelope=$(jq -n \
+    --arg schema_version "1.0" \
+    --arg timestamp "$timestamp" \
+    --arg hook "$hook_id" \
+    --arg hook_event "$hook_event" \
+    --arg status "$status" \
+    --argjson duration_ms "$duration_ms" \
+    --argjson data "$data_json" \
+    '{schema_version:$schema_version,timestamp:$timestamp,hook:$hook,hook_event:$hook_event,status:$status,duration_ms:$duration_ms,data:$data}' \
+    2>/dev/null) || return 0
+
+  # Resolve the sink path. A relative HOOK_TELEMETRY_SINK is joined onto the
+  # consuming repo root (portable, tracked wiring); absolute is used as-is. A
+  # relative value with no anchor is skipped fail-open — never exec a path the
+  # drifted hook CWD would resolve incorrectly.
+  local sink="$HOOK_TELEMETRY_SINK"
+  case "$sink" in
+  /* | [A-Za-z]:[/\\]*) ;;
+  *)
+    local root="${repo_root:-${CLAUDE_PROJECT_DIR:-}}"
+    [[ -n "$root" ]] || return 0
+    sink="${root%/}/$sink"
+    ;;
+  esac
+
+  # Fire-and-forget: pipe the envelope to the sink in a background subshell.
+  # The subshell's stdout AND stderr are redirected to /dev/null so the sink
+  # cannot write to the hook's fd1 (the additionalContext channel) and the
+  # backgrounded subshell does not hold a copy of the hook's fd1 open — which
+  # would block any command substitution wrapping the hook until the sink exits
+  # (the "C1 fd1-inheritance blocker"). The sink is quoted — it is a single
+  # executable path (wrap in a script to pass arguments).
+  printf '%s\n' "$envelope" | ("$sink" >/dev/null 2>&1) &
+}
+
+# Print cross-host hook JSON to stdout (exit 0). No-op when context is empty.
+# Shape: { hookSpecificOutput: { hookEventName[, additionalContext] } }.
+hook::emit_additional_context() {
+  local event_name="$1"
+  local context="$2"
+  [[ -n "$context" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -n \
+    --arg event "$event_name" \
+    --arg ctx "$context" \
+    '{hookSpecificOutput: (
+      {hookEventName: $event}
+      + (if $ctx != "" then {additionalContext: $ctx} else {} end)
+    )}'
+}

--- a/plugins/desktop-notification/hooks/hooks.json
+++ b/plugins/desktop-notification/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/desktop-notification.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Migrates the desktop-notification hook into a repo-agnostic plugin. Per-OS notify paths (macOS osascript, Linux notify-send, terminal OSC 9); unsupported platform -> clean no-op; kill switch HOOK_DESKTOP_NOTIFICATION_ENABLED. Security: untrusted message text neutralized at all sinks (argv-form osascript, C0-control strip before OSC, notify-send --) after an initial injection finding. 51 tests. Clean-tier wave Phase 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches untrusted notification payloads and OS notification paths (osascript/notify-send), but the hook is non-blocking, defaults are safe, and tests cover injection and fd1-leak cases.
> 
> **Overview**
> Adds a new **`desktop-notification`** marketplace plugin that runs on Claude Code **`Notification`** events for **`permission_prompt`** and **`idle_prompt`**, so users get alerted when input is needed.
> 
> The hook is **advisory** (always exit 0) and stacks up to three **env-gated** channels: terminal **bell**, **OSC 9** via `terminalSequence` JSON, and **background OS toasts** (`osascript` on macOS, `notify-send` on Linux when present; Windows relies on terminal channels). Master and per-channel toggles use `HOOK_DESKTOP_NOTIFICATION_*`; optional **hook telemetry** documents `notification_type` and which channels fired.
> 
> **Security** treats notification text as untrusted: C0 control bytes are stripped before any sink, macOS notifications use **argv + stdin AppleScript** (no string interpolation), and Linux uses `notify-send --`. Background toast/telemetry children redirect stdout/stderr so they cannot block Claude Code on fd1.
> 
> Catalog/README and hook-telemetry convention gain the new producer schema, example envelope, and a large **contract test** suite (channels, telemetry, sanitization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d841ee34dd1b6df5f16aa6c947e22a83a1ab23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->