### PR TITLE
chore: declare MIT license across plugin manifests and READMEs

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["actionlint", "github-actions", "workflow", "yaml", "linter", "hook"]
 }

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -53,4 +53,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/bash-lint/.claude-plugin/plugin.json
+++ b/plugins/bash-lint/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"]
 }

--- a/plugins/bash-lint/.claude-plugin/plugin.json
+++ b/plugins/bash-lint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-lint",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-lint/README.md
+++ b/plugins/bash-lint/README.md
@@ -67,4 +67,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["biome", "typescript", "javascript", "json", "jsx", "formatter", "linter", "hook"]
 }

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -73,4 +73,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/book-distill/.claude-plugin/plugin.json
+++ b/plugins/book-distill/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "book-distill",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Distills a technical book (PDF or EPUB) into concept-organized, author-attributed skill reference files through a structured multi-session read-write pipeline.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/book-distill/.claude-plugin/plugin.json
+++ b/plugins/book-distill/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["book", "distill", "pdf", "epub", "skill", "knowledge", "reference", "documentation"]
 }

--- a/plugins/bug-report/.claude-plugin/plugin.json
+++ b/plugins/bug-report/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bug-report",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Produces a structured five-field bug report — title, steps to reproduce, expected vs actual, severity with justification, and suggested fix location — from an informal defect description. Read-only by default: it emits the report and never edits code, opens a PR, or files an issue on its own.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bug-report/.claude-plugin/plugin.json
+++ b/plugins/bug-report/.claude-plugin/plugin.json
@@ -7,6 +7,7 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["bug", "bug-report", "defect", "triage", "issue", "workflow", "skill"],
   "userConfig": {
     "output_dir": {

--- a/plugins/bug-report/README.md
+++ b/plugins/bug-report/README.md
@@ -77,4 +77,5 @@ Otherwise the emitted report is the deliverable — copy it into your tracker.
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "desktop-notification",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["notification", "desktop", "toast", "bell", "osc9", "hook"]
 }

--- a/plugins/desktop-notification/README.md
+++ b/plugins/desktop-notification/README.md
@@ -76,4 +76,5 @@ of `notification_type` plus the `channels` that fired. Unset → exact no-op.
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/diagnose/.claude-plugin/plugin.json
+++ b/plugins/diagnose/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "diagnose",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Debug observed failures via a disciplined six-phase loop: build a fast deterministic reproduction signal, reproduce, rank falsifiable hypotheses, instrument, fix with a regression test, then clean up and post-mortem.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/diagnose/.claude-plugin/plugin.json
+++ b/plugins/diagnose/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["debug", "diagnose", "debugging", "troubleshooting", "root-cause", "regression", "skill"]
 }

--- a/plugins/diagnose/README.md
+++ b/plugins/diagnose/README.md
@@ -34,8 +34,8 @@ when you describe broken behavior with no pre-existing reproduction.
   **optional**: if your environment provides it, the skill uses it; otherwise it
   proceeds with self-contained inline guidance. No phase blocks on a missing tool.
 - **Reads your conventions, assumes none.** Test naming, module layout, banned APIs,
-  and where working notes live come from your own project's `CLAUDE.md` and tool
-  config.
+  and where working notes live come from your own project's `CLAUDE.md`, its
+  `.claude/rules/` project rules, and tool config.
 
 ## Install
 

--- a/plugins/diagnose/README.md
+++ b/plugins/diagnose/README.md
@@ -34,8 +34,8 @@ when you describe broken behavior with no pre-existing reproduction.
   **optional**: if your environment provides it, the skill uses it; otherwise it
   proceeds with self-contained inline guidance. No phase blocks on a missing tool.
 - **Reads your conventions, assumes none.** Test naming, module layout, banned APIs,
-  and where working notes live come from your own project's `CLAUDE.md` /
-  `.claude/rules` and tool config.
+  and where working notes live come from your own project's `CLAUDE.md` and tool
+  config.
 
 ## Install
 

--- a/plugins/diagnose/skills/diagnose/reference/ecosystem-debugging.md
+++ b/plugins/diagnose/skills/diagnose/reference/ecosystem-debugging.md
@@ -2,7 +2,7 @@
 
 Referenced from `/diagnose` Phase 1 ("Iterate on the loop itself" — `timing-injection`) and Phase 4 ("Instrument" — `logging` + `banned-output`; "Performance branch" — `perf-tooling`). Find your stack below; the universal principle is to wrap I/O and time sources at their seam and tag every probe with a unique `[DEBUG-<hex>]` prefix so cleanup is a single grep.
 
-The rows below are idiomatic defaults, not policy. Where your project defines its own conventions — a mandated logger, a banned-symbols analyzer, a preferred benchmark harness — those win; read your project's `CLAUDE.md` and tool config and honor them.
+The rows below are idiomatic defaults, not policy. Where your project defines its own conventions — a mandated logger, a banned-symbols analyzer, a preferred benchmark harness — those win; read your project's `CLAUDE.md`, its `.claude/rules/` project rules, and tool config, and honor them.
 
 ## .NET (`dotnet`)
 

--- a/plugins/diagnose/skills/diagnose/reference/ecosystem-debugging.md
+++ b/plugins/diagnose/skills/diagnose/reference/ecosystem-debugging.md
@@ -2,7 +2,7 @@
 
 Referenced from `/diagnose` Phase 1 ("Iterate on the loop itself" — `timing-injection`) and Phase 4 ("Instrument" — `logging` + `banned-output`; "Performance branch" — `perf-tooling`). Find your stack below; the universal principle is to wrap I/O and time sources at their seam and tag every probe with a unique `[DEBUG-<hex>]` prefix so cleanup is a single grep.
 
-The rows below are idiomatic defaults, not policy. Where your project defines its own conventions — a mandated logger, a banned-symbols analyzer, a preferred benchmark harness — those win; read your project's `CLAUDE.md` / `.claude/rules` and tool config and honor them.
+The rows below are idiomatic defaults, not policy. Where your project defines its own conventions — a mandated logger, a banned-symbols analyzer, a preferred benchmark harness — those win; read your project's `CLAUDE.md` and tool config and honor them.
 
 ## .NET (`dotnet`)
 

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["eol", "line-endings", "crlf", "lf", "gitattributes", "normalizer", "hook"]
 }

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -64,4 +64,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Four PreToolUse safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, and (advisory) hallucinated CLI flags — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["guard", "security", "secrets", "hooks", "pretooluse", "git", "hardcoded-paths", "cli-flags"]
 }

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -106,4 +106,5 @@ as before.
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/improve-architecture/.claude-plugin/plugin.json
+++ b/plugins/improve-architecture/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["architecture", "refactoring", "deep-modules", "ousterhout", "module-design", "testability", "skill"]
 }

--- a/plugins/improve-architecture/.claude-plugin/plugin.json
+++ b/plugins/improve-architecture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "improve-architecture",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scans an existing codebase for module-level architecture friction — shallow modules, seam leaks, and locality gaps — using Ousterhout's deep-module lens, presents candidates as a self-contained HTML report, and runs an interview loop on the selected candidate before handing off for planning.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-formatter/.claude-plugin/plugin.json
+++ b/plugins/markdown-formatter/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-formatter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-formatter/.claude-plugin/plugin.json
+++ b/plugins/markdown-formatter/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["markdown", "markdownlint", "formatter", "linter", "hook"]
 }

--- a/plugins/markdown-formatter/README.md
+++ b/plugins/markdown-formatter/README.md
@@ -54,4 +54,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/mcp-tool-audit/.claude-plugin/plugin.json
+++ b/plugins/mcp-tool-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mcp-tool-audit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Audits MCP server tool definitions against MCP-specification and Anthropic tool-design criteria and reports a per-tool PASS/WARN/FAIL scorecard covering description, parameters, naming, and annotations. Language-agnostic — Python (FastMCP), TypeScript, and .NET.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/mcp-tool-audit/.claude-plugin/plugin.json
+++ b/plugins/mcp-tool-audit/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["mcp", "tools", "audit", "quality", "scorecard", "skill"]
 }

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["powershell", "psscriptanalyzer", "pwsh", "formatter", "linter", "hook"]
 }

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -80,4 +80,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.

--- a/plugins/prototype/.claude-plugin/plugin.json
+++ b/plugins/prototype/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["prototype", "spike", "throwaway", "design", "ui", "state-machine", "skill"]
 }

--- a/plugins/prototype/.claude-plugin/plugin.json
+++ b/plugins/prototype/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "prototype",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Builds throwaway code to answer a design question before committing to architecture — a logic facet (an interactive terminal app over a portable state model) and a UI facet (radically different visual variants on one route).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -7,5 +7,6 @@
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
+  "license": "MIT",
   "keywords": ["ruff", "python", "formatter", "linter", "hook"]
 }

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -77,4 +77,5 @@ Set the kill switch in your settings `env` block:
 
 ## License
 
-[MIT](../../LICENSE).
+MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
+melodic-software/claude-code-plugins repository.


### PR DESCRIPTION
## Summary

- Adds the documented `license` field (`"MIT"`) to all 15 `plugin.json` manifests — closes the provenance gap the plugin-acceptance security review flagged; the policy is marketplace-wide (all-or-none).
- Replaces the relative `[MIT](../../LICENSE)` link in 10 plugin READMEs with the self-contained SPDX prose form the newer plugins already ship — the relative link breaks post-install under plugin cache isolation.
- diagnose: drops the two remaining `.claude/rules` mentions (README + ecosystem-debugging reference) left mid-edit at unit close; consumer guidance keeps `CLAUDE.md` + tool config.

## Verification

- `jq` asserts `license == "MIT"` in all 15 manifests
- `claude plugin validate --strict .` → pass
- `typos` + `markdownlint-cli2` on touched files → clean
- `grep -rn '.claude/rules' plugins/diagnose/` → empty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation only; no hook, skill, or runtime behavior changes.
> 
> **Overview**
> Adds **`"license": "MIT"`** to every plugin **`plugin.json`** and bumps each plugin’s **patch version** so marketplace manifests declare provenance consistently.
> 
> On **10 plugin READMEs**, the **License** section no longer uses the relative `[MIT](../../LICENSE)` link (which breaks after install in the plugin cache). It now uses self-contained **SPDX MIT** text pointing readers to the repo-root **`LICENSE`**.
> 
> **diagnose** docs only tweak how consumer conventions are described: **`CLAUDE.md`**, **`.claude/rules/`** project rules, and tool config are named explicitly in the README and **`ecosystem-debugging.md`** reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa772ac84f932abc2284d75436760263bbdb06dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->