### PR TITLE
feat(session-flow): add --bg background-agent launch option to handoff

### DIFF
--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.1.0",
-  "description": "Session-lifecycle toolkit of four skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear), retro (structured session retrospective with transcript metrics and learning codification), and orchestration-brief (arm a session or worker with proactive-orchestration imperatives).",
+  "version": "0.2.0",
+  "description": "Session-lifecycle toolkit of four skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), retro (structured session retrospective with transcript metrics and learning codification), and orchestration-brief (arm a session or worker with proactive-orchestration imperatives).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/session-flow/README.md
+++ b/plugins/session-flow/README.md
@@ -35,12 +35,16 @@ Writes a mid-session save-point for the `/clear`-and-resume pattern: a durable h
 progress, decisions, files modified, tried-and-ruled-out, next steps, TaskList snapshot) plus a
 copy-paste resume prompt — or prompt-only when follow-ups are small. Handoff files chain via
 `session_id` / `previous_handoff` frontmatter so `retro` can analyze the whole session chain. The
-skill always STOPS after emitting the save-point — continuing would defeat the purpose.
+skill always STOPS after emitting the save-point — continuing would defeat the purpose. With
+`--bg` it additionally launches a fresh background agent seeded with the resume prompt (via
+`claude --bg`, managed with `claude agents`), so the work resumes without a manual
+`/clear`-and-paste.
 
 ```shell
 /session-flow:handoff                 # auto-detect full vs prompt-only
 /session-flow:handoff prompt          # force prompt-only
 /session-flow:handoff file phase-3    # force full handoff, topic "phase-3"
+/session-flow:handoff --bg            # hand the resume prompt to a background agent
 ```
 
 ### retro

--- a/plugins/session-flow/skills/handoff/SKILL.md
+++ b/plugins/session-flow/skills/handoff/SKILL.md
@@ -166,17 +166,22 @@ handoff file; prompt-only: the remaining-work bullets travel inline).
 Sequence — the rails prompt from "Final step" is still emitted FIRST (transparency + manual
 fallback), then:
 
-1. Launch from the consuming project's root, passing the rails prompt verbatim as one argument:
+1. Launch from the consuming project's root, passing the rails prompt verbatim as one argument.
+   `<topic>` = the resolved topic slug (argument or inferred); when none resolves, use `resume`:
 
    ```bash
-   claude --bg --name "handoff-<topic>" "$(cat <<'EOF'
+   cd "${CLAUDE_PROJECT_DIR}" && claude --bg --name "handoff-<topic>" "$(cat <<'HANDOFF_RESUME_PROMPT_END'
    <resume prompt exactly as emitted between the rails>
-   EOF
+   HANDOFF_RESUME_PROMPT_END
    )"
    ```
 
    `claude --bg` starts the session as a background agent and returns immediately; the user
-   manages it with `claude agents`.
+   manages it with `claude agents`. The sentinel is deliberately unique — a bare `EOF` line
+   inside a freeform resume prompt would terminate a plain `<<'EOF'` heredoc early and silently
+   truncate the prompt. Awareness note: the prompt travels in the process argument list, so it is
+   briefly visible to other local processes (`ps`) — inherent to `claude --bg "<prompt>"`; keep
+   secrets out of resume prompts (they don't belong there on ANY path).
 
 2. Report the launch result: the command's output, the agent name, and the `claude agents`
    management hint. Swap the `/clear`-then-paste instruction for this report — the user no longer

--- a/plugins/session-flow/skills/handoff/SKILL.md
+++ b/plugins/session-flow/skills/handoff/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: handoff
-description: "Write a mid-session save-point for /clear-and-resume — a durable handoff file (default) or a copy-paste resume prompt when follow-ups are small. Use when: 'handoff', 'save state', 'checkpoint this', 'pause', 'come back later', context is heavy, or quality is degrading."
-argument-hint: "[file|prompt] [topic] (e.g., /handoff, /handoff prompt, /handoff file phase-3)"
+description: "Write a mid-session save-point for /clear-and-resume — a durable handoff file (default) or a copy-paste resume prompt when follow-ups are small. Pass --bg to hand the resume prompt to a fresh background agent instead of pasting it yourself. Use when: 'handoff', 'save state', 'checkpoint this', 'pause', 'come back later', 'continue in the background', context is heavy, or quality is degrading."
+argument-hint: "[file|prompt] [topic] [--bg] (e.g., /handoff, /handoff prompt, /handoff file phase-3, /handoff --bg)"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -35,13 +35,17 @@ session or machine can resume from them.
 
 ## Arguments
 
-`$ARGUMENTS` carries `[file|prompt] [topic]` — both optional, positional:
+`$ARGUMENTS` carries `[file|prompt] [topic] [--bg]` — all optional; method and topic positional:
 
 - **Method** (`file` | `prompt`) — recognized ONLY as the first token. `file` forces the full
   durable handoff; `prompt` forces prompt-only. Omitted → auto-detect (see "Choosing the path").
 - **Topic** — short kebab slug for the filename. When the first token is not a method keyword it IS
   the topic (`/handoff phase-3`); with a method present it is the second token. Omitted → inferred
   from context.
+- **`--bg`** — flag, recognized anywhere in the argument string; strip it before reading the
+  positionals. After the save-point is produced, launch a fresh background agent seeded with the
+  resume prompt instead of relying on the user to `/clear`-and-paste. See "Background-agent launch
+  (`--bg`)".
 
 ## Hard rule — handoff ALWAYS terminates current execution
 
@@ -54,9 +58,11 @@ having listed multiple steps, nor by the remaining work being "small".
 
 - [ ] Path chosen (full vs prompt-only) per "Choosing the path"
 - [ ] Copy/paste resume prompt emitted between two dashed rails (see "Final step")
-- [ ] `/clear`-then-paste instruction surfaced to the user
+- [ ] `/clear`-then-paste instruction surfaced to the user — with `--bg`, replaced by the launch
+  report per "Background-agent launch (`--bg`)"
 - [ ] **STOP.** No further work items, no next phase, no follow-on skill, no commit/push. The
-  session ends as far as the task is concerned
+  session ends as far as the task is concerned — `--bg` does not relax this: the background agent
+  is the continuation, and this session neither monitors nor babysits it
 
 **NOT authorization to continue (these all STOP):**
 
@@ -74,6 +80,7 @@ specifically (e.g. "don't `/clear` between phases, keep going").
 - Mid-task, context heavy (check `/context` output or user report)
 - Quality degrading (context rot) — responses drifting, repeating, or looping
 - About to pause for hours/overnight; want a clean resume
+- Going AFK but the work should keep moving — pass `--bg` so a background agent resumes it
 - About to switch to a different task; this one isn't done
 - Last turn had an unexpected compaction
 - Sharing state with another session or machine
@@ -149,6 +156,37 @@ bullets inline between the rails instead.
 `<UUID>` = this session's `$CLAUDE_CODE_SESSION_ID` (the frontmatter `session_id`) — it lets a
 fresh session or `/retro` chain-walker locate the transcript later.
 
+## Background-agent launch (`--bg`)
+
+Honored ONLY when the user explicitly passed `--bg` — never self-elected, including when this
+skill is model-invoked. Composes with BOTH paths: the launched agent receives exactly the resume
+prompt that sits between the rails (full path: it follows the prompt's Read directive to the
+handoff file; prompt-only: the remaining-work bullets travel inline).
+
+Sequence — the rails prompt from "Final step" is still emitted FIRST (transparency + manual
+fallback), then:
+
+1. Launch from the consuming project's root, passing the rails prompt verbatim as one argument:
+
+   ```bash
+   claude --bg --name "handoff-<topic>" "$(cat <<'EOF'
+   <resume prompt exactly as emitted between the rails>
+   EOF
+   )"
+   ```
+
+   `claude --bg` starts the session as a background agent and returns immediately; the user
+   manages it with `claude agents`.
+
+2. Report the launch result: the command's output, the agent name, and the `claude agents`
+   management hint. Swap the `/clear`-then-paste instruction for this report — the user no longer
+   needs to paste anything.
+3. **Launch failure → fall back, never block.** Non-zero exit (e.g. the installed Claude Code
+   predates `--bg`) → report the error and fall back to the standard `/clear`-then-paste
+   instruction. The save-point already exists; nothing is lost.
+4. **STOP is unchanged.** The background agent is the continuation; this session still terminates
+   the task per the hard rule. Do not monitor, poll, or babysit the launched agent.
+
 ## Post-write enforcement checklist
 
 Tick each item in the response so the user can verify the exit shape. Missing any tick = handoff
@@ -175,12 +213,19 @@ incomplete.
 - [ ] **EXECUTION STOPS HERE** — "small enough" means the prompt captures the work, NOT "small
   enough to skip `/clear` and finish in-session"
 
+**Either path with `--bg` (additional):**
+
+- [ ] Background agent launched with the rails prompt (`claude --bg --name …`) and the launch
+  result reported — OR the non-zero exit reported with fallback to `/clear`-then-paste
+
 ## What this skill does NOT do
 
 - **Does not commit** — handoff docs are durable task state, not source code. Commit ready code
   changes separately; describe uncommitted work in "Progress"
 - **Does not invoke `/clear`** — the user types `/clear`. The skill produces the save-point, emits
   the resume prompt, and stops
+- **Does not launch a background agent unprompted** — the `--bg` launch happens only when the user
+  passed the flag; the default exit is always the copy/paste prompt
 - **Does not continue executing the underlying task** — per the hard rule above. Prompt-only does
   NOT relax this
 - **Does not replace a contract or plan** — it captures in-flight state at any point

--- a/plugins/session-flow/skills/handoff/SKILL.md
+++ b/plugins/session-flow/skills/handoff/SKILL.md
@@ -166,17 +166,20 @@ handoff file; prompt-only: the remaining-work bullets travel inline).
 Sequence — the rails prompt from "Final step" is still emitted FIRST (transparency + manual
 fallback), then:
 
-1. **Dirty-tree gate.** Run `git status --porcelain` in the consuming project and IGNORE the
-   save-point file this handoff just wrote — the save-point is part of the launch, never
-   disqualifying dirty state (the background session starts in this working directory, so it
-   reads the handoff file before any edit moves it into a worktree). Background sessions move
-   into an isolated git worktree (a fresh checkout) before editing files
-   (<https://code.claude.com/docs/en/agent-view>), so OTHER uncommitted changes in this checkout
-   would NOT carry into the launched agent's edits. Any such changes → do NOT launch: report why
-   and fall back to the standard `/clear`-then-paste instruction (same checkout, dirty state
-   intact), noting the user can commit or stash and re-run `/handoff --bg`. Exception: launch
-   anyway when the current session already runs inside a linked git worktree — isolation is
-   skipped there per the same page.
+1. **Dirty-tree gate.** Run `git status --porcelain -uall` in the consuming project (`-uall`
+   lists files inside untracked directories individually; the default collapses a brand-new
+   handoff directory into one directory entry, which both defeats the exemption below and can
+   hide other dirt behind it) and IGNORE save-point files under the handoff location — the
+   just-written one AND any prior sessions' (this skill never commits them; they are
+   session-chain artifacts, part of the launch rather than disqualifying dirty state; the
+   background session starts in this working directory, so it reads the handoff file before any
+   edit moves it into a worktree). Background sessions move into an isolated git worktree (a
+   fresh checkout) before editing files (<https://code.claude.com/docs/en/agent-view>), so OTHER
+   uncommitted changes in this checkout would NOT carry into the launched agent's edits. Any
+   such changes → do NOT launch: report why and fall back to the standard `/clear`-then-paste
+   instruction (same checkout, dirty state intact), noting the user can commit or stash and
+   re-run `/handoff --bg`. Exception: launch anyway when the current session already runs inside
+   a linked git worktree — isolation is skipped there per the same page.
 2. Launch from the consuming project's root, passing the rails prompt verbatim as one argument.
    `<topic>` = the resolved topic slug (argument or inferred); when none resolves, use `resume`:
 
@@ -188,7 +191,10 @@ fallback), then:
    ```
 
    `claude --bg` starts the session as a background agent and returns immediately; the user
-   manages it with `claude agents`. `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` is required
+   manages it with `claude agents`. The launched agent is a NEW session: it inherits none of the
+   current session's CLI configuration (e.g. `--mcp-config`, `--settings`, `--add-dir`,
+   `--plugin-dir`) — mirror onto the launch command any such flags the resumed work depends on,
+   and say so in the launch report. `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` is required
    because this launch runs from a Bash-tool subprocess, which carries
    `CLAUDE_CODE_CHILD_SESSION=1` — nested sessions are otherwise excluded from the
    `claude agents` list (<https://code.claude.com/docs/en/env-vars>). The heredoc sentinel is
@@ -235,9 +241,9 @@ incomplete.
 
 **Either path with `--bg` (additional):**
 
-- [ ] Dirty-tree gate evaluated (`git status --porcelain` this turn, ignoring the just-written
-  save-point); other uncommitted changes without the linked-worktree exception → no launch,
-  reason reported, fallback to `/clear`-then-paste
+- [ ] Dirty-tree gate evaluated (`git status --porcelain -uall` this turn, ignoring save-point
+  files under the handoff location); other uncommitted changes without the linked-worktree
+  exception → no launch, reason reported, fallback to `/clear`-then-paste
 - [ ] Background agent launched with the rails prompt (`claude --bg --name …`) and the launch
   result reported — OR the non-zero exit reported with fallback to `/clear`-then-paste
 

--- a/plugins/session-flow/skills/handoff/SKILL.md
+++ b/plugins/session-flow/skills/handoff/SKILL.md
@@ -166,30 +166,42 @@ handoff file; prompt-only: the remaining-work bullets travel inline).
 Sequence — the rails prompt from "Final step" is still emitted FIRST (transparency + manual
 fallback), then:
 
-1. Launch from the consuming project's root, passing the rails prompt verbatim as one argument.
+1. **Dirty-tree gate.** Run `git status --porcelain` in the consuming project. Background
+   sessions move into an isolated git worktree (a fresh checkout) before editing files
+   (<https://code.claude.com/docs/en/agent-view>), so uncommitted changes in this checkout would
+   NOT carry into the launched agent's edits. Dirty tree → do NOT launch: report why and fall
+   back to the standard `/clear`-then-paste instruction (same checkout, dirty state intact),
+   noting the user can commit or stash and re-run `/handoff --bg`. Exception: launch anyway when
+   the current session already runs inside a linked git worktree — isolation is skipped there per
+   the same page.
+2. Launch from the consuming project's root, passing the rails prompt verbatim as one argument.
    `<topic>` = the resolved topic slug (argument or inferred); when none resolves, use `resume`:
 
    ```bash
-   cd "${CLAUDE_PROJECT_DIR}" && claude --bg --name "handoff-<topic>" "$(cat <<'HANDOFF_RESUME_PROMPT_END'
+   cd "${CLAUDE_PROJECT_DIR}" && CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 claude --bg --name "handoff-<topic>" "$(cat <<'HANDOFF_RESUME_PROMPT_END'
    <resume prompt exactly as emitted between the rails>
    HANDOFF_RESUME_PROMPT_END
    )"
    ```
 
    `claude --bg` starts the session as a background agent and returns immediately; the user
-   manages it with `claude agents`. The sentinel is deliberately unique — a bare `EOF` line
-   inside a freeform resume prompt would terminate a plain `<<'EOF'` heredoc early and silently
-   truncate the prompt. Awareness note: the prompt travels in the process argument list, so it is
-   briefly visible to other local processes (`ps`) — inherent to `claude --bg "<prompt>"`; keep
-   secrets out of resume prompts (they don't belong there on ANY path).
+   manages it with `claude agents`. `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` is required
+   because this launch runs from a Bash-tool subprocess, which carries
+   `CLAUDE_CODE_CHILD_SESSION=1` — nested sessions are otherwise excluded from the
+   `claude agents` list (<https://code.claude.com/docs/en/env-vars>). The heredoc sentinel is
+   deliberately unique — a bare `EOF` line inside a freeform resume prompt would terminate a
+   plain `<<'EOF'` heredoc early and silently truncate the prompt. Awareness note: the prompt
+   travels in the process argument list, so it is briefly visible to other local processes
+   (`ps`) — inherent to `claude --bg "<prompt>"`; keep secrets out of resume prompts (they don't
+   belong there on ANY path).
 
-2. Report the launch result: the command's output, the agent name, and the `claude agents`
+3. Report the launch result: the command's output, the agent name, and the `claude agents`
    management hint. Swap the `/clear`-then-paste instruction for this report — the user no longer
    needs to paste anything.
-3. **Launch failure → fall back, never block.** Non-zero exit (e.g. the installed Claude Code
+4. **Launch failure → fall back, never block.** Non-zero exit (e.g. the installed Claude Code
    predates `--bg`) → report the error and fall back to the standard `/clear`-then-paste
    instruction. The save-point already exists; nothing is lost.
-4. **STOP is unchanged.** The background agent is the continuation; this session still terminates
+5. **STOP is unchanged.** The background agent is the continuation; this session still terminates
    the task per the hard rule. Do not monitor, poll, or babysit the launched agent.
 
 ## Post-write enforcement checklist
@@ -220,6 +232,8 @@ incomplete.
 
 **Either path with `--bg` (additional):**
 
+- [ ] Dirty-tree gate evaluated (`git status --porcelain` this turn); dirty tree without the
+  linked-worktree exception → no launch, reason reported, fallback to `/clear`-then-paste
 - [ ] Background agent launched with the rails prompt (`claude --bg --name …`) and the launch
   result reported — OR the non-zero exit reported with fallback to `/clear`-then-paste
 

--- a/plugins/session-flow/skills/handoff/SKILL.md
+++ b/plugins/session-flow/skills/handoff/SKILL.md
@@ -166,14 +166,17 @@ handoff file; prompt-only: the remaining-work bullets travel inline).
 Sequence — the rails prompt from "Final step" is still emitted FIRST (transparency + manual
 fallback), then:
 
-1. **Dirty-tree gate.** Run `git status --porcelain` in the consuming project. Background
-   sessions move into an isolated git worktree (a fresh checkout) before editing files
-   (<https://code.claude.com/docs/en/agent-view>), so uncommitted changes in this checkout would
-   NOT carry into the launched agent's edits. Dirty tree → do NOT launch: report why and fall
-   back to the standard `/clear`-then-paste instruction (same checkout, dirty state intact),
-   noting the user can commit or stash and re-run `/handoff --bg`. Exception: launch anyway when
-   the current session already runs inside a linked git worktree — isolation is skipped there per
-   the same page.
+1. **Dirty-tree gate.** Run `git status --porcelain` in the consuming project and IGNORE the
+   save-point file this handoff just wrote — the save-point is part of the launch, never
+   disqualifying dirty state (the background session starts in this working directory, so it
+   reads the handoff file before any edit moves it into a worktree). Background sessions move
+   into an isolated git worktree (a fresh checkout) before editing files
+   (<https://code.claude.com/docs/en/agent-view>), so OTHER uncommitted changes in this checkout
+   would NOT carry into the launched agent's edits. Any such changes → do NOT launch: report why
+   and fall back to the standard `/clear`-then-paste instruction (same checkout, dirty state
+   intact), noting the user can commit or stash and re-run `/handoff --bg`. Exception: launch
+   anyway when the current session already runs inside a linked git worktree — isolation is
+   skipped there per the same page.
 2. Launch from the consuming project's root, passing the rails prompt verbatim as one argument.
    `<topic>` = the resolved topic slug (argument or inferred); when none resolves, use `resume`:
 
@@ -232,8 +235,9 @@ incomplete.
 
 **Either path with `--bg` (additional):**
 
-- [ ] Dirty-tree gate evaluated (`git status --porcelain` this turn); dirty tree without the
-  linked-worktree exception → no launch, reason reported, fallback to `/clear`-then-paste
+- [ ] Dirty-tree gate evaluated (`git status --porcelain` this turn, ignoring the just-written
+  save-point); other uncommitted changes without the linked-worktree exception → no launch,
+  reason reported, fallback to `/clear`-then-paste
 - [ ] Background agent launched with the rails prompt (`claude --bg --name …`) and the launch
   result reported — OR the non-zero exit reported with fallback to `/clear`-then-paste
 


### PR DESCRIPTION
Adds a `--bg` flag to the session-flow plugin's `handoff` skill: after producing the save-point, the skill launches a fresh background agent seeded with the resume prompt (`claude --bg --name …`, managed via `claude agents`) instead of relying on the user to `/clear`-and-paste.

Refs melodic-software/medley#1341

## What changed

- `skills/handoff/SKILL.md` — `--bg` flag documented in frontmatter (`description`, `argument-hint`) and Arguments; new "Background-agent launch (`--bg`)" section (emit rails prompt first, launch, report result, fall back to copy/paste on non-zero exit, STOP unchanged); STOP-gate and post-write checklists extended; "What this skill does NOT do" gains a never-unprompted guarantee.
- `.claude-plugin/plugin.json` — version 0.1.0 → 0.2.0 (MINOR: new feature) so consumers receive the update; description mentions the option.
- `README.md` — handoff section + usage example updated.

## Decisions (pre-baked upstream)

- `--bg` is an OPTION on the existing handoff skill, no new skill (interview ledger lock, medley pocock-v11 slice).
- `claude --bg` / `--name` Tier-0 re-verified locally this session (`claude --help`): "Start the session as a background agent and return immediately (manage with `claude agents`)".
- Fresh-docs mandate: skills + plugins-reference pages fetched this session (frontmatter fields, `$ARGUMENTS`, explicit-version update semantics confirmed).

## Verification

- `scripts/validate-plugins.sh` — all manifests + catalog PASS
- `markdownlint-cli2` on changed .md — 0 errors
- `typos` on `plugins/session-flow/` — clean
- session-flow plugin tests: `parse-transcript.test.sh` SKIPs locally (pytest not installed for python3 on this machine — install gap noted per protocol; the test is unrelated to this docs/manifest-only diff and runs in CI)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and manifest-only change; no executable code paths, with behavior gated on explicit user flag and git dirty-tree checks described in the skill.
> 
> **Overview**
> Adds an optional **`--bg`** flag to the **`handoff`** skill so that, after the usual save-point and dashed-rails resume prompt, the skill can launch a fresh background agent via **`claude --bg`** (managed with **`claude agents`**) instead of only instructing manual **`/clear`**-and-paste.
> 
> **`SKILL.md`** documents the flag in frontmatter and arguments, a full **Background-agent launch** flow (dirty-tree gate with handoff-file exemptions, launch command with persistence env and heredoc, CLI flag mirroring, failure fallback), and updates STOP gates, checklists, and “does not” rules so **`--bg`** never relaxes session termination or unprompted launch. **`plugin.json`** bumps **0.1.0 → 0.2.0** and mentions the option; **`README.md`** adds usage and narrative for **`/session-flow:handoff --bg`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b31ca32dbd73769b5cb52b6530e385b06bfeec3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->