### PR TITLE
docs: record deferred medley surfaces in the migration playbook

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -363,8 +363,7 @@ convention), so a contributor who touches a deferred surface finds the trigger w
   has no native slot to ship one, so these may be removed entirely rather than migrated. **Revisit
   trigger:** the engines survive the next usage review (still earning their keep) → package as a plugin
   skill that dispatches the engine through the `Workflow` tool's `scriptPath`, resolved under
-  `${CLAUDE_PLUGIN_ROOT}`; the smoke test for that path is specced in the extensibility-contract v2.1
-  playbook amendment.
+  `${CLAUDE_PLUGIN_ROOT}`, with a smoke test specced for that dispatch path before packaging.
 - **`onboard` skill:** repo-specific today — its phase gates encode this repo's exact runtime, linter, and
   tooling pins. **Revisit trigger:** a second repo needs environment-prerequisite auditing → extract a
   generic core through the extensibility-contract seams (the convention-resolution ladder infers or asks

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -348,3 +348,28 @@ testing the source covers them. Plugins keep only their own black-box hook contr
 - Don't rely on any mechanism not confirmed from current docs this session — if a customization need has
   no proven native path yet, record it here as a gap and keep the workaround in the consumer's repo until
   the native mechanism is verified.
+
+## Deferred surfaces — decision record (2026-07-12)
+
+Three general-purpose surfaces in the harvest-source repo (`melodic-software/medley`) are held out of this
+wave's plugin migration deliberately, each with an explicit revisit trigger — recorded here so the deferral
+is a decision, not a silent omission. The medley side carries a thin pointer back to this record at each
+surface (the workflow-engine authoring rule, the `onboard` skill, and the `gh-bot.sh` bot-identity
+convention), so a contributor who touches a deferred surface finds the trigger without leaving that repo.
+
+- **Workflow engines** (`code-review.js`, `codebase-review.js`, `deep-research.js`,
+  `research-deep-fanout.js`, `skills-audit.js`, `skills-evals.js`, `skills-remediate.js`): not a plugin
+  component per current docs — the `Workflow` tool loads an engine script from disk and a plugin manifest
+  has no native slot to ship one, so these may be removed entirely rather than migrated. **Revisit
+  trigger:** the engines survive the next usage review (still earning their keep) → package as a plugin
+  skill that dispatches the engine through the `Workflow` tool's `scriptPath`, resolved under
+  `${CLAUDE_PLUGIN_ROOT}`; the smoke test for that path is specced in the extensibility-contract v2.1
+  playbook amendment.
+- **`onboard` skill:** repo-specific today — its phase gates encode this repo's exact runtime, linter, and
+  tooling pins. **Revisit trigger:** a second repo needs environment-prerequisite auditing → extract a
+  generic core through the extensibility-contract seams (the convention-resolution ladder infers or asks
+  for the per-repo pins), leaving repo specifics in tracked config rather than baked into the skill.
+- **`tools/github-auth` (`gh-bot.sh`):** hardcodes the org's bot App / installation identity. **Revisit
+  trigger:** a second repo needs bot-actor GitHub operations → parameterize org / App / installation
+  through the seams (`userConfig` scalars, `sensitive` for the key) instead of standing up a second
+  hardcoded wrapper.


### PR DESCRIPTION
## What

Add a dated "Deferred surfaces — decision record (2026-07-12)" section to `docs/MIGRATION-PLAYBOOK.md` recording the three wave-2 deferrals, each with an explicit revisit trigger:

- **Workflow engines** — not a plugin component per current docs; may be removed. Trigger: survive the next usage review → package as a plugin skill dispatched via `Workflow` `scriptPath` under `${CLAUDE_PLUGIN_ROOT}`.
- **`onboard` skill** — repo-specific today. Trigger: a second repo needs env-prerequisite auditing → extract a generic core through the contract seams.
- **`tools/github-auth` (`gh-bot.sh`)** — hardcodes org bot identity. Trigger: a second repo needs bot-actor GitHub ops → parameterize org/App through the seams.

## Why

Nothing is excluded from the plugin migration silently — each deferred general-purpose surface is a decision with a stated trigger, not an omission. Companion PR in `melodic-software/medley` adds a thin pointer back to this record at each surface.

Refs melodic-software/medley#1397

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or migration behavior changes.
> 
> **Overview**
> Adds a dated **Deferred surfaces — decision record (2026-07-12)** section to `docs/MIGRATION-PLAYBOOK.md` so three harvest-source (`melodic-software/medley`) items stay out of the current plugin wave **on purpose**, each with a **revisit trigger** instead of a silent skip.
> 
> It documents deferral for **workflow engines** (no plugin slot today; may be removed unless a usage review keeps them → then ship via `Workflow` `scriptPath` under `${CLAUDE_PLUGIN_ROOT}`), the repo-specific **`onboard` skill** (generalize only when a second repo needs env-prerequisite auditing), and **`gh-bot.sh`** (parameterize bot identity via `userConfig` when a second consumer appears). The section also notes companion pointers in medley back to this record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f1da3a80c46fda47cdb562142a0c67469b2d4af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->