### PR TITLE
docs(playbook): codify extensibility contract v2.1 and record smoke tests

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -98,9 +98,13 @@ Design a skill so its variable parts route through the table above. "If you need
 
 ## Extensibility contract v2.1 — the four seams
 
-The table above is the raw mechanism inventory; this contract is the **adopted** policy for how a
-plugin exposes consumer variability, organizing those mechanisms into four seams. Prefer an earlier
-seam; reach for a later one only when the earlier cannot carry the need. Each seam is tagged by its
+The table above is the raw mechanism inventory ordered simplest-first; this contract is the **adopted**
+policy for how a plugin exposes consumer variability, organizing those mechanisms into four seams. Each
+seam matches a *kind* of variability — typed scalar, rich prose/rules, project convention, machine
+state — not a rung on a preference ladder: choose the seam that fits the need, and within that choice
+the table's simplest-first ordering still applies. Where the table's ordering and a seam's fit point
+differently, **fit governs** — a typed token belongs in `userConfig` (seam 1) even though the table
+lists consumer `CLAUDE.md` first. Each seam is tagged by its
 authority — **[SPEC]** (documented Claude Code behavior), **[PRECEDENT]** (an official first-party
 plugin does it, not written up as a spec), or **[PRECEDENT-EXTENSION]** (a documented shape extended
 one increment past the precedent). Behavioral gaps the docs leave open are resolved empirically in the
@@ -237,7 +241,9 @@ For each skill/hook/agent being migrated:
 7. **Idempotent, modular, extensible.** Re-running is safe; pieces compose; variability is declared.
 8. **Validate.** `claude plugin validate`; test with `--plugin-dir` in a clean repo that is NOT the
    source repo (proves repo-agnosticism).
-9. **Version.** Set an explicit semver `version` in `plugin.json`.
+9. **Version.** Set an explicit semver `version` in `plugin.json`. A later bump that changes behavior a
+   consumer depends on records the change in the plugin's changelog — see "Version pinning and update
+   delivery" above.
 10. **Publish.** Add the entry to `.claude-plugin/marketplace.json` — the plugin `source` is the
     `./`-prefixed relative path (e.g. `./plugins/<name>`). Bare names fail `claude plugin validate --strict`
     even with `metadata.pluginRoot` set, despite the marketplaces-doc example to the contrary (verified

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -7,7 +7,8 @@ vet it against best practices, then publish.
 All schema and behavior claims below were verified against the official docs on 2026-06-22 (the
 "Reintegration" section's marketplace-settings claims — `extraKnownMarketplaces` / `enabledPlugins` in a
 project's `settings.json` — on 2026-06-29, against the discover-plugins "Configure team marketplaces"
-guide). Re-verify fresh before acting — see `CLAUDE.md` "Fresh-docs mandate".
+guide; the "Extensibility contract v2.1" sections and their smoke tests on 2026-07-12 against Claude
+Code 2.1.207). Re-verify fresh before acting — see `CLAUDE.md` "Fresh-docs mandate".
 
 ## Intent
 
@@ -87,13 +88,103 @@ Prefer them in this order; the earlier ones are simplest and least surprising.
 |---|---|---|
 | Consumer `CLAUDE.md` / `.claude/rules` | The skill reads the consuming project's own context and rules | Project-specific conventions, naming, policies — the default extension surface |
 | `${CLAUDE_PROJECT_DIR}` | Path to the consumer's project root, substituted in hook/MCP/monitor commands and exported to subprocesses | Referencing project-local scripts/config |
-| `userConfig` → `${user_config.KEY}` | Values Claude Code prompts for at enable time (typed: string/number/boolean/directory/file, optional sensitive). Also exported as `CLAUDE_PLUGIN_OPTION_<KEY>`. Non-sensitive stored in `settings.json` under `pluginConfigs[<id>].options`; sensitive in the system keychain | Endpoints, toggles, tokens — consumer config without editing the plugin |
+| `userConfig` → `${user_config.KEY}` | Values Claude Code prompts for at enable time (typed: string/number/boolean/directory/file, optional sensitive). Substitutes as `${user_config.KEY}` into hook/MCP/monitor/command configs and non-sensitive values into skill/agent content; exported as `CLAUDE_PLUGIN_OPTION_<KEY>` to the plugin's own declared command subprocesses only — **not** to a Bash tool call a skill makes (see the [smoke-test record](extensibility-contract-smoke-tests.md)). Non-sensitive stored in `settings.json` under `pluginConfigs[<id>].options`; sensitive in the system keychain | Endpoints, toggles, tokens — consumer config without editing the plugin |
 | `${CLAUDE_PLUGIN_ROOT}` | Path to the plugin's own installed directory | Referencing bundled scripts/assets (mandatory under cache isolation) |
 | `${CLAUDE_PLUGIN_DATA}` | Persistent per-plugin directory that survives updates (`~/.claude/plugins/data/<id>/`) | Installed deps, caches, generated state |
 | `hooks/hooks.json` | Event handlers the plugin ships | Behavior consumers opt into by enabling the plugin |
 
 Design a skill so its variable parts route through the table above. "If you need to customize X, set
 `userConfig` Y / add it to your project rules" — never "open an issue" or "fork the skill".
+
+## Extensibility contract v2.1 — the four seams
+
+The table above is the raw mechanism inventory; this contract is the **adopted** policy for how a
+plugin exposes consumer variability, organizing those mechanisms into four seams. Prefer an earlier
+seam; reach for a later one only when the earlier cannot carry the need. Each seam is tagged by its
+authority — **[SPEC]** (documented Claude Code behavior), **[PRECEDENT]** (an official first-party
+plugin does it, not written up as a spec), or **[PRECEDENT-EXTENSION]** (a documented shape extended
+one increment past the precedent). Behavioral gaps the docs leave open are resolved empirically in the
+[smoke-test record](extensibility-contract-smoke-tests.md).
+
+1. **Typed scalars → `userConfig` → `pluginConfigs`. [SPEC]** Declare `string` / `number` /
+   `boolean` / `directory` / `file` options (a `string` may set `multiple` for an array — there is no
+   `string[]` type); mark a credential `sensitive` so it lands in the keychain, never `settings.json`.
+   Non-sensitive values store under `pluginConfigs[<id>].options`. Use for endpoints, toggles, tokens,
+   and single path knobs. The `directory` / `file` type is a UI hint, not a validator — a `--config`
+   value is stored verbatim with no existence check and no normalization to absolute (smoke-test A).
+2. **Tracked rich config under `${CLAUDE_PROJECT_DIR}`. [first-party PRECEDENT; folder form is a
+   PRECEDENT-EXTENSION]** When configuration outgrows typed scalars — prose guidance, rule lists,
+   threat models, structured rulesets — read a checked-in file instead of piling on `userConfig` knobs.
+   The proven shape is a single tracked file `.claude/<plugin>.md` (Markdown, for model-facing
+   guidance) or `.claude/<plugin>.yaml` (structured rules), each with a gitignored `*.local.*` personal
+   overlay and an optional `~/.claude/<plugin>.md` user-global. The precedent is the official
+   **security-guidance** plugin (<https://code.claude.com/docs/en/security-guidance>): it reads
+   `.claude/claude-security-guidance.md` (project), `~/.claude/claude-security-guidance.md` (user), and
+   `.claude/claude-security-guidance.local.md` (gitignored personal override), loading every location
+   that exists and concatenating them. The **folder form** `.claude/<plugin>/**` (many files, one per
+   concern) is the PRECEDENT-EXTENSION: the first-party precedent uses single files, so a plugin that
+   needs a directory of config extends the shape by one increment, keeping the same overlay and
+   resolution rules.
+   - **Resolution + override semantics.** Resolve **user-global → team (project) → local overlay**,
+     **additive-preferred**: a later layer adds to or refines earlier layers rather than silently
+     replacing them. The first-party precedent concatenates; a plugin that genuinely must override does
+     so per key, never by dropping the base layer wholesale.
+   - **Recommended consumer `.gitignore`.** Ship the overlay convention with the one line the consumer
+     adds: `.claude/*.local.*` (and `.claude/<plugin>/**/*.local.*` for the folder form) — personal
+     overlays stay out of version control, team config stays tracked.
+3. **Consumer `CLAUDE.md` / `.claude/rules` steering. [SPEC]** A plugin's skill and agent components
+   run in the model's context and already read the consuming project's own rules — the default surface
+   for project conventions, naming, and policy, requiring no plugin-side wiring. (Hook scripts do not
+   see `CLAUDE.md`; they read env vars and file-based config only.)
+4. **`${CLAUDE_PLUGIN_DATA}` for machine state only. [SPEC]** The per-plugin directory that survives
+   updates — caches, installed dependencies, generated state. Never a channel for consumer
+   *configuration* (it is machine-local and untracked); configuration flows through seams 1–3.
+
+## Convention-resolution ladder
+
+The **adopted** rule for how a plugin settles a value at runtime, applied to every seam:
+
+1. Config present → use it.
+2. Absent → explore the repo and infer, then **persist the inference** into the tracked config (seam 1
+   or 2) so the next run is deterministic.
+3. Cannot infer → ask the user, and offer to persist the answer.
+4. Otherwise → a safe generic default.
+
+No baked repo assumptions, ever. A plugin never hardcodes a consumer's layout; it reads a declared
+value, infers-and-records, or asks — never guesses silently.
+
+## Setup action — every configurable plugin ships one
+
+Every plugin that carries any `userConfig` or tracked-config seam ships a re-runnable `setup` /
+`configure` action (a skill) that interviews the consumer and writes the tracked config. It is
+idempotent — safe to re-run to reconfigure. The Thariq `config.json` first-run pattern is **rejected**
+for plugins: it is not an official mechanism, and it writes into `${CLAUDE_PLUGIN_ROOT}`, which is
+replaced on every update (the plugins-reference caching note), so its state does not survive. Setup
+writes to the consumer's tracked config or to `pluginConfigs` — both persist across updates.
+
+## Shared tools and scripts seam
+
+Separate **plugin-owned** logic from **consumer-owned** extension points:
+
+- Plugin-owned scripts ship inside the plugin and run via `${CLAUDE_PLUGIN_ROOT}/scripts/` (or `bin/`)
+  — bundled and cache-isolated, never reaching outside the plugin directory.
+- Consumer-owned extension points are **declared paths**, not assumed layout: expose them through a
+  `userConfig` `directory` option or a tracked-config key with a conventional default (e.g. `tools/`).
+  A plugin reaches the consumer's own scripts only through a path the consumer declared or the
+  convention the plugin documents — never a hardcoded repo structure.
+
+## Version pinning and update delivery
+
+- **A `version` bump in `plugin.json` is the only delivery vehicle.** A consumer receives a change only
+  after the plugin's semver `version` increases — the version is the update cache key, so an unbumped
+  plugin never delivers, even when its files changed (see "Shared code across plugins" below).
+- **Consumers update deliberately** with `/plugin marketplace update <marketplace>`, which refetches
+  the marketplace. There is no silent auto-push of plugin changes to a consumer.
+- **Breaking-change / changelog note per plugin.** A version bump that changes behavior a consumer
+  depends on — a renamed option, a moved config path, a removed action — records the change in the
+  plugin's own changelog (a `CHANGELOG.md` in the plugin), so a consumer updating deliberately sees
+  what shifted. A bump that adds a new trust surface additionally re-triggers the plugin-acceptance
+  security review below.
 
 ## Persistence, configuration & external integration
 
@@ -242,6 +333,27 @@ claude --plugin-dir ./plugins/<name>
   directories you control.
 - **Then ship.** Run `claude plugin validate` before opening a PR; after merge, consumers pull the
   change with `/plugin marketplace update melodic-software`, gated by the `version` bump in `plugin.json`.
+
+## Fresh-consumer onboarding
+
+Reintegration (below) covers a repo that already ran an in-repo copy and now switches to the plugin. A
+**brand-new** repo adopting the marketplace for the first time follows this checklist:
+
+1. **Register the marketplace.** Interactive: the trust dialog on first `/plugin` use both registers
+   and installs enabled plugins. Headless / CI: `claude plugin marketplace add <repo>` — registering
+   does not install anything on its own.
+2. **Enable at project scope** so every clone inherits it — declare `enabledPlugins` in the project's
+   checked-in `.claude/settings.json` (choose user scope instead for machine-wide, not per-repo). The
+   headless install form is `claude plugin install <plugin>@<marketplace> --scope project`.
+3. **Run each configurable plugin's setup action** to write the tracked config / `pluginConfigs`.
+   Headless, skip the interview by seeding values inline: `claude plugin install … --config KEY=VALUE`
+   (repeatable, schema-validated). Non-sensitive options land in the **user** `settings.json`
+   `pluginConfigs` regardless of the enable scope; a sensitive value passed via `--config` still routes
+   to the keychain (smoke-tests A and C).
+4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
+   option left unset does **not** block the install; it stays advisory until set via `--config` or the
+   interactive `/plugin configure` (smoke-test C). Seed every required option at install time so the
+   plugin does not run unconfigured.
 
 ## Reintegration — a consumer adopts the published plugin
 

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -345,21 +345,25 @@ claude --plugin-dir ./plugins/<name>
 Reintegration (below) covers a repo that already ran an in-repo copy and now switches to the plugin. A
 **brand-new** repo adopting the marketplace for the first time follows this checklist:
 
-1. **Register the marketplace.** Interactive: the trust dialog on first `/plugin` use both registers
-   and installs enabled plugins. Headless / CI: `claude plugin marketplace add <repo>` — registering
-   does not install anything on its own.
-2. **Enable at project scope** so every clone inherits it — declare `enabledPlugins` in the project's
-   checked-in `.claude/settings.json` (choose user scope instead for machine-wide, not per-repo). The
-   headless install form is `claude plugin install <plugin>@<marketplace> --scope project`.
-3. **Run each configurable plugin's setup action** to write the tracked config / `pluginConfigs`.
-   Headless, skip the interview by seeding values inline: `claude plugin install … --config KEY=VALUE`
-   (repeatable, schema-validated). Non-sensitive options land in the **user** `settings.json`
-   `pluginConfigs` regardless of the enable scope; a sensitive value passed via `--config` still routes
-   to the keychain (smoke-tests A and C).
+1. **Register the marketplace — checked in for clones.** Interactive: the trust dialog on first
+   `/plugin` use registers the marketplace and installs enabled plugins. For project-wide adoption,
+   declare the marketplace in the project's checked-in `.claude/settings.json` `extraKnownMarketplaces`
+   (headless: `claude plugin marketplace add <repo> --scope project`). A bare `claude plugin marketplace
+   add <repo>` writes to *user* settings, so a fresh clone or CI agent on another machine would carry the
+   enabled plugin but have no registered marketplace to resolve it from — mirror the Reintegration
+   cutover, which pairs both fields in the project settings.
+2. **Enable at project scope** so every clone inherits it — declare `enabledPlugins` in the same
+   checked-in `.claude/settings.json` (choose user scope instead for machine-wide, not per-repo).
+3. **Install and seed config on one fresh install.** `--config` is accepted only on a fresh install
+   (smoke-test C), so pass every option on the install command, never a later call: `claude plugin
+   install <plugin>@<marketplace> --scope project --config KEY=VALUE …` (repeatable, schema-validated).
+   Non-sensitive options land in the **user** `settings.json` `pluginConfigs` regardless of the enable
+   scope; a sensitive value still routes to the keychain (smoke-tests A and C). Interactively, install
+   prompts for scope, then each configurable plugin's setup action (or `/plugin configure`) writes the
+   tracked config.
 4. **Headless prompting caveat.** Install never prompts non-interactively — a required `userConfig`
-   option left unset does **not** block the install; it stays advisory until set via `--config` or the
-   interactive `/plugin configure` (smoke-test C). Seed every required option at install time so the
-   plugin does not run unconfigured.
+   option left unset does **not** block the install; it stays advisory until set (smoke-test C). Seed
+   every required option on the install command so the plugin does not run unconfigured.
 
 ## Reintegration — a consumer adopts the published plugin
 

--- a/docs/extensibility-contract-smoke-tests.md
+++ b/docs/extensibility-contract-smoke-tests.md
@@ -1,0 +1,99 @@
+# Extensibility-contract smoke tests
+
+These tests resolve behavior the official docs leave unspecified for the extensibility contract v2.1
+(the "Extensibility contract v2.1 — the four seams" section of the [migration
+playbook](MIGRATION-PLAYBOOK.md)). Each records the commands used and the observed result, so the
+contract rests on verified behavior rather than inference.
+
+Run 2026-07-12 against Claude Code 2.1.207 on Windows. Re-verify fresh before relying on a result —
+see `CLAUDE.md` "Fresh-docs mandate". The rig was a throwaway `smoketest` plugin declaring five
+`userConfig` options — a plain `string`, a `sensitive` `string`, a `directory`, a `file`, and a
+`required` `string` — published through a throwaway local marketplace and installed into a scratch
+consumer repo. All rig artifacts were removed after the run.
+
+## Test A — `directory` / `file` userConfig type behavior
+
+**Question.** Does the `directory` / `file` type drive a picker, validate the path, and what is a
+relative path resolved against?
+
+**Commands.**
+
+```shell
+# existing relative paths
+claude plugin install smoketest@<marketplace> --scope local \
+  --config req_key=hello --config some_dir=./realdir --config some_file=./realfile.txt
+# non-existent relative paths
+claude plugin install smoketest@<marketplace> --scope local \
+  --config req_key=hello --config some_dir=./does_not_exist_dir --config some_file=./does_not_exist.txt
+```
+
+**Result.**
+
+- **No existence validation on the `--config` path.** A non-existent directory and file were accepted
+  (exit 0) and stored. The `directory` / `file` type does not gate on the path resolving to anything.
+- **Values are stored verbatim, not normalized to absolute.** A relative `./realdir` is stored as
+  `./realdir`. Claude Code does not anchor it at store time; resolution is deferred to use time
+  (relative to the consumer's working directory when `${user_config.KEY}` is substituted). A plugin
+  that needs an absolute path resolves it itself.
+- **Storage scope diverges from enable scope.** Installed `--scope local` — enablement was written to
+  the consumer's `.claude/settings.local.json` — but the non-sensitive options landed in the **user**
+  `~/.claude/settings.json` under `pluginConfigs[<plugin-id>].options`. The `sensitive` option was
+  absent from settings entirely (it routes to secure storage).
+- **The picker, if any, is not observable headless.** A `--config` install never renders UI; only the
+  interactive `/plugin configure` flow would. The picker sub-question is recorded as
+  not-headless-observable rather than guessed.
+
+## Test B — does a skill-invoked Bash script inherit `CLAUDE_PLUGIN_OPTION_*`?
+
+**Question.** The plugins reference states "All values are exported to plugin subprocesses as
+`CLAUDE_PLUGIN_OPTION_<KEY>` environment variables." Does that reach a Bash command a skill tells
+Claude to run, or does only text-substitution reach a skill?
+
+**Commands.**
+
+```shell
+claude plugin install smoketest@<marketplace> --scope local \
+  --config req_key=hello --config plain_key=world_plain --config secret_key=secret_shh
+claude plugin list                                   # confirm smoketest enabled + loaded
+# headless session from the consumer repo, plugin enabled, skill visible as /smoketest:smoketest
+claude -p "run: env | grep CLAUDE_PLUGIN | sort" --allowedTools Bash
+```
+
+**Result.**
+
+- **A skill-invoked Bash-tool subprocess does NOT inherit `CLAUDE_PLUGIN_OPTION_*`.** With the plugin
+  enabled and `plain_key` set, `env | grep CLAUDE_PLUGIN_OPTION_` returned nothing. The only plugin
+  variable present was a single `CLAUDE_PLUGIN_DATA` pointing at an unrelated plugin's data directory —
+  not the invoking plugin's, so not a dependable per-plugin signal for a skill-spawned script either.
+- **"Plugin subprocesses" means the plugin's own declared command subprocesses** — hooks, MCP servers,
+  monitors, and `command`-type components — where a current plugin is defined and `${user_config.KEY}`
+  also substitutes. It does not mean arbitrary Bash tool calls the model makes while a skill runs.
+- **Authoring constraint.** A skill reads a **non-sensitive** userConfig value only through
+  `${user_config.KEY}` text-substitution into its own Markdown — never from the environment of a script
+  it spawns. A **sensitive** value is unreachable from a skill entirely: it is not substitutable into
+  skill / agent content (spec) and is not in the subprocess environment, so only a hook / MCP / monitor
+  command can consume it. Design a sensitive-value consumer as a hook or MCP server, not a skill.
+
+## Test C — does `claude plugin install` prompt for userConfig non-interactively?
+
+**Question.** On the headless / CI path, does a missing required option prompt or block?
+
+**Commands.**
+
+```shell
+# required req_key unset, no --config, stdin closed
+claude plugin install smoketest@<marketplace> --scope local </dev/null
+```
+
+**Result.**
+
+- **Headless install never prompts and never blocks.** With the required option unset it still installed
+  (exit 0) and printed an advisory: `5 userConfig options not yet set (1 required) — run /plugin
+  configure smoketest@<marketplace> in Claude Code, or pass --config KEY=VALUE.`
+- **The non-interactive configuration path is `--config KEY=VALUE`** on `claude plugin install`
+  (repeatable, schema-validated, "stored via the same path as the interactive `/plugin configure`
+  flow"). It applies **only on a fresh install** — `--config` is ignored once the plugin is already
+  installed (the command short-circuits "already installed"). Reconfiguring headless requires uninstall
+  then reinstall, or the interactive `/plugin configure`.
+- **CI implication.** Seed every required option with `--config` at install time. A bare headless
+  install leaves required options unset without failing, so the plugin would run unconfigured.

--- a/docs/extensibility-contract-smoke-tests.md
+++ b/docs/extensibility-contract-smoke-tests.md
@@ -18,13 +18,21 @@ relative path resolved against?
 
 **Commands.**
 
+`--config` is applied only on a fresh install (Test C), so uninstall before each run and read the
+stored `pluginConfigs` after each:
+
 ```shell
-# existing relative paths
+# 1) existing relative paths
+claude plugin uninstall smoketest@<marketplace> --scope local
 claude plugin install smoketest@<marketplace> --scope local \
   --config req_key=hello --config some_dir=./realdir --config some_file=./realfile.txt
-# non-existent relative paths
+# then read ~/.claude/settings.json → pluginConfigs[smoketest@<marketplace>].options
+
+# 2) non-existent relative paths (uninstall first, or --config short-circuits as a no-op)
+claude plugin uninstall smoketest@<marketplace> --scope local
 claude plugin install smoketest@<marketplace> --scope local \
   --config req_key=hello --config some_dir=./does_not_exist_dir --config some_file=./does_not_exist.txt
+# then read ~/.claude/settings.json → options now show the non-existent paths, stored verbatim
 ```
 
 **Result.**

--- a/docs/extensibility-contract-smoke-tests.md
+++ b/docs/extensibility-contract-smoke-tests.md
@@ -59,12 +59,19 @@ claude plugin list                                   # confirm smoketest enabled
 claude -p "run: env | grep CLAUDE_PLUGIN | sort" --allowedTools Bash
 ```
 
+The `claude -p … --allowedTools Bash` form asks Claude to invoke its Bash tool, so the command runs in
+Claude Code's own process environment — the same environment a skill-invoked script runs in, which is
+what makes this a valid proxy for the skill case (a skill only makes the model *decide* to run bash;
+the subprocess environment is identical).
+
 **Result.**
 
 - **A skill-invoked Bash-tool subprocess does NOT inherit `CLAUDE_PLUGIN_OPTION_*`.** With the plugin
   enabled and `plain_key` set, `env | grep CLAUDE_PLUGIN_OPTION_` returned nothing. The only plugin
-  variable present was a single `CLAUDE_PLUGIN_DATA` pointing at an unrelated plugin's data directory —
-  not the invoking plugin's, so not a dependable per-plugin signal for a skill-spawned script either.
+  variable present was a single session-level `CLAUDE_PLUGIN_DATA`, and it pointed at an unrelated
+  installed plugin's data directory, not the invoking plugin's. `${CLAUDE_PLUGIN_DATA}` resolves
+  per-plugin only inside a plugin's own declared commands; in a general Bash-tool subprocess it carries
+  one session default, so it is not a dependable per-plugin signal for a skill-spawned script either.
 - **"Plugin subprocesses" means the plugin's own declared command subprocesses** — hooks, MCP servers,
   monitors, and `command`-type components — where a current plugin is defined and `${user_config.KEY}`
   also substitutes. It does not mean arbitrary Bash tool calls the model makes while a skill runs.
@@ -93,7 +100,8 @@ claude plugin install smoketest@<marketplace> --scope local </dev/null
 - **The non-interactive configuration path is `--config KEY=VALUE`** on `claude plugin install`
   (repeatable, schema-validated, "stored via the same path as the interactive `/plugin configure`
   flow"). It applies **only on a fresh install** — `--config` is ignored once the plugin is already
-  installed (the command short-circuits "already installed"). Reconfiguring headless requires uninstall
-  then reinstall, or the interactive `/plugin configure`.
+  installed (the command short-circuits "already installed"). `claude plugin` has no `configure`
+  subcommand (verified against `claude plugin --help` on 2.1.207; `/plugin configure` is an interactive
+  slash command only), so reconfiguring headless requires uninstall then reinstall.
 - **CI implication.** Seed every required option with `--config` at install time. A bare headless
   install leaves required options unset without failing, so the plugin would run unconfigured.


### PR DESCRIPTION
## What

Amends `docs/MIGRATION-PLAYBOOK.md` with the adopted **extensibility contract v2.1** and adds
`docs/extensibility-contract-smoke-tests.md` recording the empirical runs that resolve the gaps the
official docs leave open.

Playbook additions (stable, citable headings):

- **Extensibility contract v2.1 — the four seams** — the four seams tagged by authority (userConfig
  `[SPEC]`, tracked rich config `[first-party PRECEDENT]` via the security-guidance plugin, folder form
  `[PRECEDENT-EXTENSION]`), the `.claude/<plugin>.md|yaml` convention with gitignored `*.local.*`
  overlays, the recommended consumer `.gitignore` line, and additive-preferred override semantics.
- **Convention-resolution ladder** — present → use; absent → infer + persist; can't infer → ask; else
  safe default.
- **Setup action — every configurable plugin ships one** — re-runnable interview that writes tracked
  config; the Thariq `config.json` first-run pattern rejected.
- **Shared tools and scripts seam** — plugin-owned scripts under `${CLAUDE_PLUGIN_ROOT}`;
  consumer-owned extension points as declared paths with a conventional default.
- **Version pinning and update delivery** — a `version` bump is the only delivery vehicle; consumers
  update via `/plugin marketplace update`; breaking-change/changelog note per plugin.
- **Fresh-consumer onboarding** — brand-new-repo checklist complementing the in-repo cutover
  Reintegration section.

## Why

Wave-2 needs a single tracked contract that every migration issue can cite by heading, replacing
issue-comment decisions. Three behaviors the docs do not specify are resolved by real runs against
Claude Code 2.1.207, with the commands recorded:

- **(A)** `directory`/`file` userConfig types are unvalidated UI hints — a `--config` value is stored
  verbatim (no existence check, no absolute normalization) in the **user** `settings.json`
  `pluginConfigs`, regardless of the enable scope (verified at both local and project scope).
- **(B)** a skill-invoked Bash subprocess does **not** inherit `CLAUDE_PLUGIN_OPTION_*`; skills read
  non-sensitive values only via `${user_config.KEY}` text-substitution, and sensitive values are
  reachable only from hook/MCP/monitor commands.
- **(C)** headless `claude plugin install` never prompts and never blocks on a missing required option;
  `--config KEY=VALUE` (fresh install only) is the non-interactive path.

## Verification

- `markdownlint-cli2`, `typos`, and `lychee --offline` all pass on both files.
- All smoke-test rig artifacts (throwaway plugin, marketplace, `pluginConfigs`, keychain entry) removed
  and cleanup re-verified.

Refs melodic-software/medley#1370

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code touched.
> 
> **Overview**
> Adds the adopted **extensibility contract v2.1** to `docs/MIGRATION-PLAYBOOK.md` so wave-2 migrations can cite stable headings: four seams (`userConfig`, tracked `.claude/<plugin>` config, consumer rules, `${CLAUDE_PLUGIN_DATA}` for state only), a convention-resolution ladder, mandatory re-runnable setup skills, shared script boundaries, version/changelog delivery rules, and a **fresh-consumer onboarding** checklist beside Reintegration.
> 
> The extensibility table’s `userConfig` row is tightened to match empirical behavior—`${user_config.KEY}` vs `CLAUDE_PLUGIN_OPTION_*` only in declared plugin commands, not skill-spawned Bash—and migration step 9 now points at per-plugin changelogs.
> 
> New `docs/extensibility-contract-smoke-tests.md` records Claude Code 2.1.207 runs for doc gaps: **(A)** `directory`/`file` types don’t validate paths; **(B)** skills don’t get `CLAUDE_PLUGIN_OPTION_*` in Bash subprocesses; **(C)** headless install doesn’t block on missing required options; `--config` applies only on fresh install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9fdd6332fa7c9ba21299d28b4331bb378043a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->