### PR TITLE
chore(planning): add design-handoff skill (design→plan gate)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -197,7 +197,7 @@
       "name": "planning",
       "source": "./plugins/planning",
       "category": "development",
-      "tags": ["planning", "brainstorm", "prd", "interview", "design", "devils-advocate", "architect", "stress-test", "skill"]
+      "tags": ["planning", "brainstorm", "prd", "interview", "design", "design-handoff", "devils-advocate", "architect", "stress-test", "skill"]
     },
     {
       "name": "review-toolkit",

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pre-implementation planning pipeline: diverge on candidate approaches, lock product intent and the engineering contract, explore the design space, stress-test adversarially, and produce a structured implementation plan with an approval gate — persisting PRD.md / PLAN.md / design artifacts for fresh-session handoff.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["planning", "brainstorm", "prd", "interview", "design", "devils-advocate", "architect", "stress-test", "implementation-plan", "skill"],
+  "keywords": ["planning", "brainstorm", "prd", "interview", "design", "design-handoff", "devils-advocate", "architect", "stress-test", "implementation-plan", "skill"],
   "userConfig": {
     "notes_dir": {
       "type": "string",

--- a/plugins/planning/README.md
+++ b/plugins/planning/README.md
@@ -1,9 +1,9 @@
 # planning
 
 A Claude Code plugin for the **pre-implementation planning pipeline** — everything
-between a rough idea and approved, executable work. Six skills covering divergence,
-product intent, the engineering contract, design exploration, adversarial review,
-and the implementation plan itself.
+between a rough idea and approved, executable work. Seven skills covering divergence,
+product intent, the engineering contract, design exploration, the design→plan gate,
+adversarial review, and the implementation plan itself.
 
 | Skill | Stage | What it does |
 |---|---|---|
@@ -11,12 +11,13 @@ and the implementation plan itself.
 | `/planning:prd` | Product intent | Produces a Product Requirements Document (problem, users, success metrics) in three tiers — one-pager, consumer-feature, B2B-internal — with a synthesize path and a review mode. |
 | `/planning:interview` | Engineering contract | Locks a task contract (goal, constraints, acceptance criteria, named assumptions) into a PLAN.md Brief — synthesizing when intent is clear, running depth-first Q&A when it isn't, or interviewing relentlessly on request. |
 | `/planning:design` | Design space | Explores types, contracts, module boundaries, and package topology through collaborative discussion rounds, producing capability-matrix / type-inventory / design-threads / topology artifacts plus a binary handoff gate. |
+| `/planning:design-handoff` | Design→plan gate | Gates a finished design for `/planning:architect` — a binary check that every `design-threads.md` thread is RESOLVED, directional, or TAGGED-DEFERRED — then packages the architect-ready summary and resume prompt, or FAILs and routes back to `/planning:design`. |
 | `/planning:devils-advocate` | Adversarial review | Stress-tests plans via assumption extraction, evidence checks, failure scenarios, and operational-gotcha sweeps — every finding evidence-backed, never generic warnings. |
 | `/planning:architect` | Implementation plan | Produces a structured plan (goal, approach, test strategy, blast radius, parallelism analysis, tagged unilateral decisions) with a mandatory fresh-context stress-test and a user approval gate, persisted to PLAN.md. |
 
 The pipeline composes end-to-end — `brainstorm → prd → interview → design →
-architect` with `devils-advocate` attacking the plan before approval — but every
-skill also works standalone.
+design-handoff → architect` with `devils-advocate` attacking the plan before
+approval — but every skill also works standalone.
 
 ## Works in any repo
 

--- a/plugins/planning/skills/design-handoff/SKILL.md
+++ b/plugins/planning/skills/design-handoff/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: design-handoff
+description: "Gate and package a finished design for /planning:architect: binary check that every thread in design-threads.md is RESOLVED, directional, or TAGGED-DEFERRED, then emit the architect-ready summary and resume prompt. Use when: 'design handoff', 'hand off the design', 'is the design ready', 'architect-ready summary', 'design gate', /planning:design discussion rounds stop surfacing gaps, or entering /planning:architect from a completed design session. FAILs on any thread that is unresolved AND untagged — names it and routes back to /planning:design. Skip when: still exploring the design space — use /planning:design; mid-session save-point to clear and resume later — use a session-handoff capability."
+argument-hint: "(no args — reads the design-threads artifact in your notes directory)"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## Pre-computed context
+
+Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
+
+## Purpose
+
+The seam between design and planning. `/planning:architect`'s prerequisite check blocks on design-gate evidence; this skill produces that evidence honestly — a binary check read off the artifact, then a handoff summary sourced from the artifacts rather than recalled from conversation memory.
+
+Design artifacts live in `${user_config.notes_dir}/<topic-slug>/design/` — derive `<topic-slug>` from the task or branch name (kebab-case, ≤40 chars; shared with `/planning:design` and `/planning:architect`). If the consuming project declares its own working-notes convention, that convention wins.
+
+## Binary gate — check the artifact, not your memory
+
+Read `${user_config.notes_dir}/<topic-slug>/design/design-threads.md` and confirm, thread by thread, that **every** design thread is one of:
+
+- **RESOLVED** — the deciding rationale is recorded in the artifact (not merely "decided"), or
+- **directional** — direction agreed AND the remaining detail carries a research tag, or
+- **TAGGED-DEFERRED** — an explicit research tag naming the external investigation needed.
+
+A thread that is unresolved AND untagged is a silent gap → **FAIL**: list the offending thread(s), route back to `/planning:design` (its design-threads and discussion rounds) to resolve or tag, and do NOT hand off. This is a binary check read off `design-threads.md`, not a "did we cover enough?" recap — a producing model rubber-stamps its own recap, so the gate must be read off the file rather than judged from memory.
+
+If `design-threads.md` does not exist, check for `design-resolution.md` at the same path (the `/planning:design` early-exit artifact) — early-exit slices hand off on that artifact alone. Neither present → FAIL: no design evidence; route to `/planning:design`.
+
+## Handoff summary (gate passed)
+
+Hand off to `/planning:architect` — sourced from the artifacts, not recalled from memory:
+
+- Resolved decisions with their recorded rationale (from `design-threads.md`)
+- Deferred research items with tags
+- Design artifacts produced
+- Dependency order for implementation (which decisions block others)
+- Extension / config / observability threads **RESOLVED** or **TAGGED-DEFERRED** — `/planning:architect` next walks its design-default checklist against the plan
+- **Review-routing notes** — when the consuming project declares review checklists (architecture, code-design, security, multi-tenancy, messaging, and the like), list which apply to this slice so `/planning:architect` and the implementation stage inherit proactive review targets
+- **Mechanization notes** (optional) — when the project distinguishes deterministic mechanization from human judgment, mark per capability whether a sub-step is script-, hook-, agent-, or human-owned; a trivial early-exit records "no deterministic sub-steps"
+
+Emit a resume prompt so a fresh cleared session can pick up at `/planning:architect` reading only the persisted artifacts.
+
+## What this skill does NOT do
+
+- **Design exploration or thread resolution** — that's `/planning:design` (a FAILed gate routes there; this skill never resolves threads itself)
+- **Implementation planning** — that's `/planning:architect` (this skill packages its input)
+- **Mid-session save-point** — that's a session-handoff capability (a journal entry plus status for a later clear-and-resume). This skill is the design→plan stage seam, not a pause-point
+
+## Gotchas
+
+- A thread marked "decided" without recorded rationale is NOT RESOLVED — the rationale must be in the artifact, or `/planning:architect` inherits an unexplainable decision. FAIL it back to `/planning:design` to record the why
+- Do not soften a FAIL into a warning because the offending thread "feels minor" — silent gaps are exactly what the binary gate exists to catch
+- `/planning:design` also exposes a lightweight `handoff` action for the in-session shortcut; this standalone skill is the richer gate for entering `/planning:architect` from a completed design session — both apply the same RESOLVED / directional / TAGGED-DEFERRED criteria


### PR DESCRIPTION
## What

Adds the standalone `design-handoff` skill to the `planning` plugin — the design→plan gate the initial planning cutover skipped. Ports the medley skill and decouples every medley coupling behind the plugin's existing contract seams.

## Decoupling (medley → plugin seams)

- **Artifact path:** reads `${user_config.notes_dir}/<topic-slug>/design/design-threads.md` (was `.work/<slug>/research/design-threads.md`); falls back to `design-resolution.md` at the same path.
- **Slug:** derived inline from task/branch like `/planning:design` — no dependency on medley's `tools/work-artifacts/derive-slug.sh` preamble; `allowed-tools` grant dropped.
- **Outcome-gate principle** inlined (no `.claude/rules/agent-trust.md` citation).
- **Review-routing** and **mechanization** notes generalized to "when the consuming project declares X"; medley doc citations (`docs/conventions/*`, `docs/work-artifacts/*`) dropped.
- **Skill refs** namespaced (`/planning:design`, `/planning:architect`); session-handoff described generically.
- Gate criteria **unchanged**: every `design-threads.md` thread must be RESOLVED / directional / TAGGED-DEFERRED.

## Scope

Additive only. `/planning:design` (with its inline `handoff` action) and `/planning:architect` are **unchanged** — architect's Step 1 gate is artifact-location-based, so this skill writing/validating `design-threads.md` at the `notes_dir` path satisfies it with no edits to those skills.

- `plugin.json` version `0.1.0` → `0.2.0` (additive skill, no new trust surface).
- README: Six → Seven skills, new table row, pipeline line extended.
- `marketplace.json` + `plugin.json` keywords: `design-handoff` tag added.

## Verification

- `scripts/validate-plugins.sh` — all manifests + catalog pass.
- `markdownlint-cli2` (repo config) — 0 errors; `typos` — clean.
- No residual medley-path couplings in the ported skill; trailing newlines correct.

## Note (follow-up)

`/planning:design` keeps a lightweight inline `handoff` action that overlaps this standalone skill (both apply the same RESOLVED / directional / TAGGED-DEFERRED criteria). Left intentionally to keep this PR additive; a follow-up can decide whether the inline action should delegate to `/planning:design-handoff`.

Refs melodic-software/medley#1389

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive skill markdown and manifest/README metadata only; no runtime code, hooks, or changes to architect’s existing artifact-based gate.
> 
> **Overview**
> Adds **`/planning:design-handoff`** as a standalone skill in the planning plugin: it reads `design-threads.md` (or `design-resolution.md` for early-exit) under `${user_config.notes_dir}/<topic-slug>/design/`, applies a **binary** RESOLVED / directional / TAGGED-DEFERRED gate, and on pass packages an architect-ready summary plus a fresh-session resume prompt; on fail it names blocking threads and routes back to `/planning:design`.
> 
> Catalog and docs are updated only: planning plugin **0.1.0 → 0.2.0**, README pipeline extended (`design-handoff` step, seven skills), and `design-handoff` added to marketplace/plugin keywords. **`/planning:design` and `/planning:architect` are not modified** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e30fc20334a341f9bc407e79b0ff4fbfde11580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->