### PR TITLE
feat(code-tidying): add re-runnable setup skill for the tidy-lanes seam

### DIFF
--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.1.0",
-  "description": "Structure-only codebase improvement: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps recently changed files through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract.",
+  "version": "0.2.0",
+  "description": "Structure-only codebase improvement: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps recently changed files through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/code-tidying/README.md
+++ b/plugins/code-tidying/README.md
@@ -5,7 +5,7 @@ Beck's *Tidy First?* discipline agentically: small named tidyings, separated
 from behavioral changes by commit and by PR, under a research-backed scope
 budget (≤200 LOC / ≤8 files target; ≤400 / ≤15 hard cap).
 
-Two skills, one capability:
+Three skills, one capability:
 
 - **`/code-tidying:tidy`** — proactively hunts a rotated, glob-scoped *lane* of
   the codebase for safe structural improvements (Beck's 15 tidyings + a Fowler
@@ -17,8 +17,12 @@ Two skills, one capability:
   dependency-ordered simplification waves, with per-group verification and a
   never-drop deferred-items contract. Use it when you forgot to run
   `/simplify` after each task.
+- **`/code-tidying:setup`** — interviews the repo and scaffolds tracked
+  `.claude/tidy-lanes/<lane>.md` project lane files from the bundled templates,
+  so `tidy` resolves project-specific scope globs deterministically instead of
+  falling back to the generic bundled lanes. Re-runnable to add or retune lanes.
 
-Neither skill is `/simplify` itself: `/simplify` refines the diff you just
+Neither `tidy` nor `batch-simplify` is `/simplify` itself: `/simplify` refines the diff you just
 wrote; `batch-simplify` catches up on a window of them; `tidy` hunts drift no
 one has filed yet.
 
@@ -70,7 +74,10 @@ exclusions, and verification commands.
 
 No `userConfig`. Project-specific behavior routes through
 `.claude/tidy-lanes/` lane files and your project's own `CLAUDE.md` /
-`.claude/rules` (protected paths, verification commands).
+`.claude/rules` (protected paths, verification commands). Run
+**`/code-tidying:setup`** to interview your repo and scaffold those lane files
+from the bundled templates — it is idempotent and safe to re-run to add or
+retune lanes.
 
 ## License
 

--- a/plugins/code-tidying/skills/setup/SKILL.md
+++ b/plugins/code-tidying/skills/setup/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: setup
+description: "Configure the code-tidying plugin for this repository: interview the user, infer which lane patterns fit the repo layout, and scaffold tracked .claude/tidy-lanes/<lane>.md project lane files from the bundled templates. Use when: 'set up code-tidying', 'configure tidy lanes', 'code-tidying setup', 'scaffold a tidy lane', or the tidy skill reports no project lanes for this repo. Re-runnable — safe to invoke again to add or retune lanes."
+argument-hint: "(no arguments — interactive interview)"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## Purpose
+
+Scaffold (or update) the consuming repo's tracked lane definitions at `.claude/tidy-lanes/<lane>.md`
+so `/code-tidying:tidy` resolves project-specific scope globs and watch-for patterns deterministically
+instead of falling back to the generic bundled lanes every run. A project lane at
+`${CLAUDE_PROJECT_DIR}/.claude/tidy-lanes/<lane>.md` takes precedence over the bundled lane of the
+same name — this is the plugin's seam-2 extension surface.
+
+Idempotent: re-running reads the existing lane files and proposes additions or edits against that
+baseline rather than overwriting a consumer lane blind.
+
+## Lanes vs. templates — the distinction this skill turns on
+
+- **Bundled lanes** (`${CLAUDE_PLUGIN_ROOT}/skills/tidy/lanes/*.md` — `shell-tooling`, `docs-prose`)
+  cover surfaces that look the same in most repos. They resolve automatically with **no config**;
+  a project override is worth writing only when this repo's tooling or doc directories differ from
+  the bundled defaults.
+- **Bundled templates** (`${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/*.template.md`) are `<placeholder>`
+  scaffolds for the lanes that are project-specific **by design** — code the repo has but no generic
+  lane can name. This skill's primary job is turning the fitting templates into real lane files.
+
+Never tell the user to "copy the bundled lanes." Scaffold from templates; override a bundled lane only
+when its defaults miss this repo's actual layout.
+
+## Task
+
+Apply the convention-resolution ladder — config present → use it; absent → infer from the repo and
+persist; cannot infer → ask and offer to persist; else a safe default (skip that lane, no empty file).
+
+1. **Read existing lanes first.** List `.claude/tidy-lanes/*.md`. If any exist, read each and present a
+   short summary (lane name, scope globs, watch-for count). The interview proposes changes against that
+   baseline; **never overwrite an existing consumer lane without explicit confirmation in this conversation.**
+2. **Explore the repo to draft candidate lanes.** Before asking anything, map the four bundled template
+   patterns against what actually exists, and check whether either bundled lane needs a project override:
+   - **apps** (`templates/apps-lane.template.md`) — user-facing applications + their tests: web/API/CLI
+     app roots and their sibling test projects.
+   - **dependency-root** (`templates/dependency-root-lane.template.md`) — framework/library core that
+     downstream code depends on: shared/domain/core library roots.
+   - **host-wiring** (`templates/host-wiring-lane.template.md`) — hosting infrastructure, logging,
+     registration, service defaults: composition roots, DI wiring, service-default projects.
+   - **polyglot-services** (`templates/polyglot-services-lane.template.md`) — non-primary-language
+     services, MCP servers, sidecars.
+   - **bundled-lane override** — inspect the repo's actual tooling dirs and doc dirs; a project override
+     of `shell-tooling` or `docs-prose` is warranted only when they diverge from the bundled scope globs.
+   Read the actual directory names and file extensions from the repo — do not assume a stack. Skip any
+   template pattern the repo has no surface for.
+3. **Interview, one lane at a time** (recommendation-first). Present each candidate lane with its inferred
+   scope globs and the source template, marked with a recommendation; let the user accept, edit the globs,
+   or drop the lane. Offer a custom lane last ("any other glob-scoped slice this repo should tidy on its
+   own rotation?"). Ask about the highest-blast-radius lane first.
+4. **Fill the template placeholders from real repo values.** For each accepted lane, read the closest
+   `templates/<pattern>.template.md` in full and replace every `<placeholder>` with values drawn from this
+   repo: scope globs from real directory paths, watch-for patterns tuned to the stack, lane-specific
+   exclusions for this repo's unverifiable surfaces, verification commands from the project's own
+   CLAUDE.md / rules / CI config (never invented), the Conventional Commits type, and preferred research
+   sources. Leave no `<placeholder>` behind.
+5. **Write the lane files.** Materialize each accepted lane at `.claude/tidy-lanes/<lane>.md`. Confirm the
+   directory is tracked, not gitignored. Write only lanes the user confirmed; produce no empty scaffolds.
+6. **Offer the personal overlay.** A per-developer lane override is just another `.claude/tidy-lanes/<lane>.md`;
+   a machine-local variant belongs in a gitignored path — recommend the consumer keep any `*.local.*`
+   lane files gitignored if they want personal, untracked lanes. Team lanes stay tracked.
+
+## Output
+
+Tracked `.claude/tidy-lanes/<lane>.md` file(s) in the consuming repo, plus a one-paragraph summary of which
+lanes were written, which template each came from, and how to re-run this setup to add or retune lanes.
+
+## What this skill does NOT do
+
+- Run a tidy sweep — that is `/code-tidying:tidy`.
+- Ship its own template copies — lane files scaffold from `${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/`;
+  duplicating those into this skill would drift from the source.
+- Write machine-local state — lane configuration lives in the consumer's tracked `.claude/tidy-lanes/`,
+  never in the plugin directory or a plugin data directory.

--- a/plugins/code-tidying/skills/setup/SKILL.md
+++ b/plugins/code-tidying/skills/setup/SKILL.md
@@ -56,23 +56,37 @@ persist; cannot infer → ask and offer to persist; else a safe default (skip th
    scope globs and the source template, marked with a recommendation; let the user accept, edit the globs,
    or drop the lane. Offer a custom lane last ("any other glob-scoped slice this repo should tidy on its
    own rotation?"). Ask about the highest-blast-radius lane first.
-4. **Fill the template placeholders from real repo values.** For each accepted lane, read the closest
-   `${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/<pattern>.template.md` in full and replace every
-   `<placeholder>` with values drawn from this
-   repo: scope globs from real directory paths, watch-for patterns tuned to the stack, lane-specific
-   exclusions for this repo's unverifiable surfaces, verification commands from the project's own
-   CLAUDE.md / rules / CI config (never invented), the Conventional Commits type, and preferred research
+4. **Fill the source lane from real repo values.** For each accepted lane, read its full source in full,
+   then replace every `<placeholder>` (templates) or bundled default (overrides) with values drawn from
+   this repo. The source depends on the lane's origin:
+   - **Template-pattern lanes** (apps, dependency-root, host-wiring, polyglot-services) start from the
+     exact template filename presented in step 2 — `${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/<pattern>-lane.template.md`
+     (e.g. `apps-lane.template.md`) — and every `<placeholder>` is replaced.
+   - **Bundled-lane overrides** (`shell-tooling`, `docs-prose`) have no template; start from the bundled
+     lane file `${CLAUDE_PLUGIN_ROOT}/skills/tidy/lanes/<lane>.md` and adjust its scope globs / exclusions
+     to this repo's actual layout.
+   Values to fill: scope globs from real directory paths, watch-for patterns tuned to the stack,
+   lane-specific exclusions for this repo's unverifiable surfaces, verification commands from the project's
+   own CLAUDE.md / rules / CI config (never invented), the Conventional Commits type, and preferred research
    sources. Leave no `<placeholder>` behind.
-5. **Write the lane files.** Materialize each accepted lane at `.claude/tidy-lanes/<lane>.md`. Confirm the
-   directory is tracked, not gitignored. Write only lanes the user confirmed; produce no empty scaffolds.
-6. **Offer the personal overlay.** A per-developer lane override is just another `.claude/tidy-lanes/<lane>.md`;
-   a machine-local variant belongs in a gitignored path — recommend the consumer keep any `*.local.*`
-   lane files gitignored if they want personal, untracked lanes. Team lanes stay tracked.
+5. **Write the lane files.** Materialize each accepted lane at `.claude/tidy-lanes/<lane>.md`. Write only
+   lanes the user confirmed; produce no empty scaffolds. Then verify **each written file** is actually
+   tracked, not ignored — `git check-ignore -v <file>` (or `git status --short -- <file>`) per file, since
+   a directory can be tracked while a `.gitignore` pattern still excludes an individual `.md` inside it. If
+   any lane file is ignored, surface the offending pattern and offer to fix `.gitignore` before reporting
+   success — these lanes are team-shared and must be committed to take effect.
+6. **Confirm the tracked-lane model.** `/code-tidying:tidy` resolves a lane only from
+   `.claude/tidy-lanes/<lane>.md` (then the bundled lane of that name), and its catalog lists
+   `.claude/tidy-lanes/*.md` — there is no personal/local-overlay resolution. So every scaffolded lane is a
+   tracked, team-shared file; do not point developers at a `*.local.*` variant the tidy skill would never
+   load. A developer who wants a private lane simply keeps a normal `.claude/tidy-lanes/<lane>.md` and
+   gitignores that one path, accepting it stays local-only.
 
 ## Output
 
 Tracked `.claude/tidy-lanes/<lane>.md` file(s) in the consuming repo, plus a one-paragraph summary of which
-lanes were written, which template each came from, and how to re-run this setup to add or retune lanes.
+lanes were written, which source each came from (template or bundled lane), and how to re-run this setup
+to add or retune lanes.
 
 ## What this skill does NOT do
 

--- a/plugins/code-tidying/skills/setup/SKILL.md
+++ b/plugins/code-tidying/skills/setup/SKILL.md
@@ -65,16 +65,22 @@ persist; cannot infer → ask and offer to persist; else a safe default (skip th
    - **Bundled-lane overrides** (`shell-tooling`, `docs-prose`) have no template; start from the bundled
      lane file `${CLAUDE_PLUGIN_ROOT}/skills/tidy/lanes/<lane>.md` and adjust its scope globs / exclusions
      to this repo's actual layout.
+   - **Custom lanes** (accepted from step 3's "any other slice?" offer) have no dedicated source: start
+     from whichever template pattern is closest in shape to the slice and re-fill it, or — when none fits —
+     author a new lane file from scratch using the same section structure the templates use (`## Scope`,
+     `## Watch-for patterns`, `## Lane-specific extra exclusions`, `## Verification commands`,
+     `## Conventional Commits type`, `## Preferred research sources`). Never emit an ad-hoc lane missing a section.
    Values to fill: scope globs from real directory paths, watch-for patterns tuned to the stack,
    lane-specific exclusions for this repo's unverifiable surfaces, verification commands from the project's
    own CLAUDE.md / rules / CI config (never invented), the Conventional Commits type, and preferred research
    sources. Leave no `<placeholder>` behind.
 5. **Write the lane files.** Materialize each accepted lane at `.claude/tidy-lanes/<lane>.md`. Write only
    lanes the user confirmed; produce no empty scaffolds. Then verify **each written file** is actually
-   tracked, not ignored — `git check-ignore -v <file>` (or `git status --short -- <file>`) per file, since
-   a directory can be tracked while a `.gitignore` pattern still excludes an individual `.md` inside it. If
-   any lane file is ignored, surface the offending pattern and offer to fix `.gitignore` before reporting
-   success — these lanes are team-shared and must be committed to take effect.
+   tracked, not ignored — run `git check-ignore -v <file>` per file (plain `git status` hides ignored
+   paths unless `--ignored` is passed). A non-empty `check-ignore` result means a `.gitignore` pattern
+   excludes that lane; surface the matching pattern and offer to fix `.gitignore` before reporting success,
+   since a directory can be tracked while a pattern still excludes an individual `.md` inside it — these
+   lanes are team-shared and must be committed to take effect.
 6. **Confirm the tracked-lane model.** `/code-tidying:tidy` resolves a lane only from
    `.claude/tidy-lanes/<lane>.md` (then the bundled lane of that name), and its catalog lists
    `.claude/tidy-lanes/*.md` — there is no personal/local-overlay resolution. So every scaffolded lane is a

--- a/plugins/code-tidying/skills/setup/SKILL.md
+++ b/plugins/code-tidying/skills/setup/SKILL.md
@@ -40,14 +40,14 @@ persist; cannot infer → ask and offer to persist; else a safe default (skip th
    baseline; **never overwrite an existing consumer lane without explicit confirmation in this conversation.**
 2. **Explore the repo to draft candidate lanes.** Before asking anything, map the four bundled template
    patterns against what actually exists, and check whether either bundled lane needs a project override:
-   - **apps** (`templates/apps-lane.template.md`) — user-facing applications + their tests: web/API/CLI
-     app roots and their sibling test projects.
-   - **dependency-root** (`templates/dependency-root-lane.template.md`) — framework/library core that
-     downstream code depends on: shared/domain/core library roots.
-   - **host-wiring** (`templates/host-wiring-lane.template.md`) — hosting infrastructure, logging,
-     registration, service defaults: composition roots, DI wiring, service-default projects.
-   - **polyglot-services** (`templates/polyglot-services-lane.template.md`) — non-primary-language
-     services, MCP servers, sidecars.
+   - **apps** (`${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/apps-lane.template.md`) — user-facing
+     applications + their tests: web/API/CLI app roots and their sibling test projects.
+   - **dependency-root** (`${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/dependency-root-lane.template.md`) —
+     framework/library core that downstream code depends on: shared/domain/core library roots.
+   - **host-wiring** (`${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/host-wiring-lane.template.md`) — hosting
+     infrastructure, logging, registration, service defaults: composition roots, DI wiring, service-default projects.
+   - **polyglot-services** (`${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/polyglot-services-lane.template.md`) —
+     non-primary-language services, MCP servers, sidecars.
    - **bundled-lane override** — inspect the repo's actual tooling dirs and doc dirs; a project override
      of `shell-tooling` or `docs-prose` is warranted only when they diverge from the bundled scope globs.
    Read the actual directory names and file extensions from the repo — do not assume a stack. Skip any
@@ -57,7 +57,8 @@ persist; cannot infer → ask and offer to persist; else a safe default (skip th
    or drop the lane. Offer a custom lane last ("any other glob-scoped slice this repo should tidy on its
    own rotation?"). Ask about the highest-blast-radius lane first.
 4. **Fill the template placeholders from real repo values.** For each accepted lane, read the closest
-   `templates/<pattern>.template.md` in full and replace every `<placeholder>` with values drawn from this
+   `${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/<pattern>.template.md` in full and replace every
+   `<placeholder>` with values drawn from this
    repo: scope globs from real directory paths, watch-for patterns tuned to the stack, lane-specific
    exclusions for this repo's unverifiable surfaces, verification commands from the project's own
    CLAUDE.md / rules / CI config (never invented), the Conventional Commits type, and preferred research

--- a/plugins/code-tidying/skills/setup/evals/evals.json
+++ b/plugins/code-tidying/skills/setup/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "infers-and-interviews-before-scaffolding",
+      "prompt": "/code-tidying:setup",
+      "expected_output": "Explores the repo to map the four bundled template patterns (apps, dependency-root, host-wiring, polyglot-services) against what actually exists, then interviews the user one lane at a time with a recommendation before writing anything. It does not write a lane file until the user confirms the lane and its scope globs.",
+      "files": [],
+      "expectations": [
+        "Explores the repo to draft candidate lanes from the bundled templates before asking",
+        "Interviews the user per lane with a recommendation, rather than scaffolding blind",
+        "Writes lane files only after the user confirms the lanes"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "idempotent-reads-existing-lanes",
+      "prompt": "/code-tidying:setup",
+      "expected_output": "When .claude/tidy-lanes/ already contains lane files, reads them, summarizes the current lanes, and proposes additions or edits against that baseline rather than overwriting them blind. It never overwrites an existing consumer lane without explicit confirmation.",
+      "files": [],
+      "expectations": [
+        "Detects and reads existing .claude/tidy-lanes/*.md before proposing changes",
+        "Summarizes the current lanes and proposes edits against that baseline",
+        "Does not overwrite an existing consumer lane without user confirmation"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "scaffolds-from-bundled-templates-tracked",
+      "prompt": "/code-tidying:setup\n\nJust scaffold sensible default lanes for this repo.",
+      "expected_output": "Fills placeholders from the bundled templates under ${CLAUDE_PLUGIN_ROOT}/skills/tidy/templates/ with real repo values and materializes tracked .claude/tidy-lanes/<lane>.md files. It does not ship or copy template files into the setup skill, and does not write configuration into the plugin directory or a plugin data directory.",
+      "files": [],
+      "expectations": [
+        "Scaffolds lane files by filling the bundled templates, not by shipping its own copies",
+        "Writes lane files to the consumer's tracked .claude/tidy-lanes/ directory",
+        "Does not write configuration into the plugin directory or plugin data directory"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

`code-tidying` exposed its seam-2 tracked-config folder `.claude/tidy-lanes/**` (consumer lane overrides) but shipped **no setup/configure action**, violating the extensibility contract's "every configurable plugin ships a setup action". This adds one.

## What changed

- **New skill `/code-tidying:setup`** (`plugins/code-tidying/skills/setup/`):
  - Interviews the consuming repo and infers which of the four bundled lane templates (apps, dependency-root, host-wiring, polyglot-services) fit its layout.
  - Scaffolds tracked `.claude/tidy-lanes/<lane>.md` project lane files with real scope globs, watch-for patterns, exclusions, and verification commands drawn from the repo — filling the existing `skills/tidy/templates/*.template.md` placeholders.
  - **Ships no template copies of its own** — references the bundled templates by path, avoiding a DRY/drift violation.
  - **Idempotent**: reads existing lanes first, summarizes, proposes against that baseline, never overwrites a consumer lane without confirmation. Follows the convention-resolution ladder (present → use; absent → infer & persist / ask; else safe default).
  - Interviews one lane at a time, recommendation-first.
- **`evals.json`** (3 cases) mirroring the `codebase-audit` setup exemplar: infer-then-interview, idempotent-reads-existing, scaffolds-from-templates-tracked.
- **Version bump** `0.1.0` → `0.2.0` (minor) + description parity clause naming the setup skill.
- **README**: "Two skills" → "Three skills"; Configuration section points at `/code-tidying:setup`.

## Verification

- `claude plugin validate plugins/code-tidying` → passed.
- `markdownlint-cli2` on the new SKILL.md + README → 0 errors.
- LF line endings confirmed; modeled on the shipped `codebase-audit` / `knowledge` / `machine-health` setup exemplars.

Refs melodic-software/medley#1431

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a new interactive setup skill only; no changes to tidy or batch-simplify execution paths.
> 
> **Overview**
> Adds **`/code-tidying:setup`** so repos can onboard project-specific tidy lanes without hand-copying templates. The skill explores the layout, interviews recommendation-first (one lane at a time), fills bundled `skills/tidy/templates/*.template.md` placeholders (or adjusts bundled `shell-tooling` / `docs-prose` overrides) with real globs and verification commands from the repo, and writes confirmed files under **`.claude/tidy-lanes/`**. It is **idempotent** (reads existing lanes, never overwrites without confirmation) and checks **`git check-ignore`** so scaffolded lanes are actually committable.
> 
> Ships **`skills/setup/evals/evals.json`** with three behavioral evals. **Plugin `0.2.0`** and README/manifest copy now describe three skills and point configuration at setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf49caf2c5365eb2cfc2074a8cb8d65a049486b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->