### PR TITLE
docs(ai-briefing): disambiguate profiled-folder selection rule

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -145,9 +145,9 @@ one increment past the precedent). Behavioral gaps the docs leave open are resol
      refines the root, absent keys fall through). A single-config consumer never nests: its files sit at
      the root, which *is* the default profile, so growing a profile later is additive (drop a sibling
      subfolder), never a reorg — and there is no reserved `default/`/`team/` name to collide with. Pick
-     the active profile by the convention-resolution ladder: exactly one profile folder present → use it;
-     several → an `active_profile` `userConfig` scalar (seam 1) or a per-invocation `--profile <name>`
-     argument selects; none → the root default. This is a one-increment PRECEDENT-EXTENSION of the folder
+     the active profile by the convention-resolution ladder: exactly one named profile subfolder present
+     → use it; several → an `active_profile` `userConfig` scalar (seam 1) or a per-invocation
+     `--profile <name>` argument selects; none → the root default. This is a one-increment PRECEDENT-EXTENSION of the folder
      form, for a plugin that could ever profile — ship the **folder** form, since the single-file form
      cannot grow a profile without a file→folder reorg. Distinct from the concern-named folder above: that
      splits config across *plugins* (concern axis); this splits it across *audiences* within one plugin


### PR DESCRIPTION
Follow-up to #105. The profiled-folder selection rule read "exactly one profile **folder** present → use it," but the `.claude/<plugin>/` root is itself a folder, so a skimming reader could misread it. Tightened to "exactly one named profile **subfolder** present." One-word clarity fix; no semantic change.

Addresses the review note on #105.

Refs melodic-software/medley#1392

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime or config semantics change.
> 
> **Overview**
> Clarifies the **profiled folder** convention in `MIGRATION-PLAYBOOK.md` so the auto-selection step is not misread: the ladder now says **exactly one named profile subfolder** present → use it, instead of “exactly one profile folder,” which could be confused with the `.claude/<plugin>/` root directory (also a folder).
> 
> The rest of the resolution ladder (`active_profile`, `--profile`, root default) is unchanged; this is wording only, not a behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95502df69a629d67ea1fbec0c9e4b434efd03e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->