### PR TITLE
feat(bug-report): add re-runnable setup skill for output_dir seam

### DIFF
--- a/plugins/bug-report/.claude-plugin/plugin.json
+++ b/plugins/bug-report/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bug-report",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Produces a structured five-field bug report — title, steps to reproduce, expected vs actual, severity with justification, and suggested fix location — from an informal defect description. Read-only by default: it emits the report and never edits code, opens a PR, or files an issue on its own.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bug-report/README.md
+++ b/plugins/bug-report/README.md
@@ -41,11 +41,14 @@ when you describe a defect). The five fields are:
 
 ## Configuration
 
-One optional `userConfig` value, prompted when you enable the plugin:
+One optional `userConfig` value, prompted at enable time (or set any time with `/bug-report:setup`):
 
 | Option | Type | Effect |
 |--------|------|--------|
 | `output_dir` | directory | Where `--file` writes reports. **Leave unset** and reports go to the plugin's own persistent data directory. Set it to a path in your repository if you want bug reports committed alongside your code. |
+
+Run `/bug-report:setup` to make this choice interactively — it reads the current value, recommends the
+uncommitted default, and (re-runnably) persists or clears `output_dir` for the team.
 
 Project-specific conventions — naming, areas, tracker choice, priority labels — are
 read from the **consuming project's own `CLAUDE.md` / rules**; the plugin imposes

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -79,10 +79,10 @@ terminal state here; do not persist a value the user did not choose.
    report skill resolves it relative to the *current* working directory, so a bare relative `.bug-reports/`
    lands under whatever subdirectory the session was started in — not reliably at the repo root. Recommend a
    form that resolves the same from any cwd: prefer `${CLAUDE_PROJECT_DIR}/.bug-reports` if the report skill
-   expands that token in `output_dir`. **Do not put a machine-absolute path in the team (project) value** —
-   `/home/alice/repo/.bug-reports` is clone-specific and breaks for every other teammate. If only an absolute
-   path works, store it in the developer's **local overlay** (step 4), not the shared project scope. Call out
-   the cwd-relative caveat when the user accepts a bare relative value.
+   expands that token in `output_dir`. **Do not put a machine-absolute path in the team (project) value** — an
+   absolute path rooted in one developer's home or checkout is clone-specific and breaks for every other
+   teammate. If only an absolute path works, store it in the developer's **local overlay** (step 4), not the
+   shared project scope. Call out the cwd-relative caveat when the user accepts a bare relative value.
 
    Present the inferred path with a recommendation and let the user accept or edit it. Keep it to this single
    knob; do not invent further options (Rule of Three).

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -45,6 +45,10 @@ terminal state here; do not persist a value the user did not choose.
    4. **Project** (`.claude/settings.json`).
    5. **User** (`~/.claude/settings.json`).
 
+   Resolve the project and local files at the **project root** (`${CLAUDE_PROJECT_DIR}`, or the git toplevel
+   when unset), not a cwd-relative `.claude/` — running setup from a subdirectory must still read and later
+   write the project-root `.claude/settings.json`, never create a stray `<subdir>/.claude/settings.json`.
+
    Report the effective value (or "unset → reports go to the plugin data directory") and which scope supplies
    it; the interview proposes a change against that baseline. Two consequences of the full ladder that a
    Local > Project > User model misses:
@@ -71,12 +75,14 @@ terminal state here; do not persist a value the user did not choose.
    - An existing reports or docs directory a bug report would naturally join (e.g. `.bug-reports/`, `docs/`).
    - If nothing is found, recommend a repo-root-anchored `.bug-reports/`.
 
-   **Anchor the path to the repo root, not the working directory.** The value is stored verbatim and the
+   **Anchor the path to the repo root, and keep a team value portable.** The value is stored verbatim and the
    report skill resolves it relative to the *current* working directory, so a bare relative `.bug-reports/`
    lands under whatever subdirectory the session was started in — not reliably at the repo root. Recommend a
    form that resolves the same from any cwd: prefer `${CLAUDE_PROJECT_DIR}/.bug-reports` if the report skill
-   expands that token in `output_dir`, otherwise an absolute path or the repo's own declared convention. Call
-   out the cwd-relative caveat when the user accepts a bare relative value.
+   expands that token in `output_dir`. **Do not put a machine-absolute path in the team (project) value** —
+   `/home/alice/repo/.bug-reports` is clone-specific and breaks for every other teammate. If only an absolute
+   path works, store it in the developer's **local overlay** (step 4), not the shared project scope. Call out
+   the cwd-relative caveat when the user accepts a bare relative value.
 
    Present the inferred path with a recommendation and let the user accept or edit it. Keep it to this single
    knob; do not invent further options (Rule of Three).

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -87,7 +87,12 @@ the concrete path `--file` will now write to.
 ## What this skill does NOT do
 
 - Produce a bug report — that is `/bug-report:bug-report`. This skill only settles where `--file` writes.
-- Write machine-local state — configuration lives in the consumer's tracked settings, never in the plugin
+- Store config in the plugin — the value lives in the consumer's Claude Code settings, never in the plugin
   directory or the plugin data directory (`${CLAUDE_PLUGIN_DATA}` is where reports themselves land when
-  `output_dir` is unset, not where config is stored).
+  `output_dir` is unset, not where config is stored). The **set** path always writes the project (tracked,
+  team) `.claude/settings.json`. The **reset** path is the one exception that may touch a machine-local scope
+  — and only to remove an inherited value the user asked to clear: it clears `.claude/settings.local.json`
+  when the local overlay supplies the effective value, or `~/.claude/settings.json` with explicit consent when
+  user scope does, because a project-scope edit cannot reach either. It never writes machine-local state the
+  plugin itself owns.
 - Persist a value the user did not choose — unset is a valid, recommended outcome.

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: setup
+description: "Configure the bug-report plugin for this repository: decide whether --file reports commit into the repo or stay in the plugin's uncommitted data directory, and persist (or clear) the output_dir userConfig option. Use when: 'set up bug-report', 'configure bug-report', 'bug-report setup', 'where do bug reports land', or you want --file reports committed alongside your code. Re-runnable — safe to invoke again to reconfigure or reset to the default."
+argument-hint: "(no arguments — interactive interview)"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## Purpose
+
+Settle the `output_dir` seam — where `/bug-report:bug-report --file` writes reports — and persist it so the
+skill resolves the location deterministically. `output_dir` is a typed `directory` `userConfig` option (seam 1
+of the extensibility contract): its value lives in
+`pluginConfigs["bug-report@melodic-software"].options.output_dir` and substitutes into skill content as
+`${user_config.output_dir}`.
+
+Unlike a plugin whose seam always wants a value, `output_dir` has **no default and unset is a legitimate,
+recommended steady state**: when it is unset, `--file` reports land in the plugin's own persistent data
+directory (`${CLAUDE_PLUGIN_DATA}/bug-reports/<project-slug>/`) — uncommitted, private to the machine.
+Setting `output_dir` is an **opt-in** for teams that want bug reports committed into the repo alongside code.
+So this skill's core decision is a yes/no, not a path hunt.
+
+Idempotent: re-running reads the current value and offers to change or clear it rather than overwriting blind.
+
+## Task
+
+Apply the convention-resolution ladder — config present → use it; the consumer wants repo-committed reports →
+infer a path and persist; the consumer wants the private default → ensure the key is absent. Absent is a valid
+terminal state here; do not persist a value the user did not choose.
+
+1. **Read the current value first, in precedence order.** Look for `output_dir` under
+   `pluginConfigs["bug-report@melodic-software"].options` in all three scopes and resolve the *effective*
+   value the way Claude Code does — **Local (`.claude/settings.local.json`) > Project
+   (`.claude/settings.json`) > User (`~/.claude/settings.json`)**, local winning. Report the effective value
+   (or "unset → reports go to the plugin data directory") and which scope supplies it; the interview proposes
+   a change against that baseline. If a local override is present, say so explicitly — step 3 writes the
+   *project* (team) value, which stays shadowed by the local override until the developer updates or removes
+   it, so a project-scope edit alone will not change what the plugin uses on that machine. Read each scope
+   **narrowly** — query only the single `pluginConfigs["bug-report@melodic-software"].options.output_dir` key
+   (e.g. with `jq`), never loading `.claude/settings.local.json` wholesale: that overlay is secret-bearing
+   (API tokens, env secrets), so do not read or echo unrelated settings content.
+2. **Interview — one decision.** Ask whether `--file` bug reports should be **committed into this repo** or
+   **kept in the plugin's private data directory (the default)**. Recommend the default (uncommitted) unless
+   the repo already commits similar working artifacts — bug reports can name unfixed defects and are often
+   better kept out of history until triaged. If the user chooses repo-committed, infer a sensible path before
+   asking a second question:
+   - A working-notes or reports convention declared in the repo's own `CLAUDE.md`, `AGENTS.md`, or
+     `.claude/rules` (that declared convention wins — surface it as the recommended value).
+   - An existing reports or docs directory a bug report would naturally join (e.g. `.bug-reports/`, `docs/`).
+   - If nothing is found, recommend `.bug-reports/` at the repo root.
+
+   Present the inferred path with a recommendation and let the user accept or edit it. Keep it to this single
+   knob; do not invent further options (Rule of Three).
+3. **Persist or clear to project scope.** Write to (or edit) the project `.claude/settings.json`:
+   - **Repo-committed chosen:** set `pluginConfigs["bug-report@melodic-software"].options.output_dir` to the
+     chosen value so it is tracked and shared with the team. Create the `pluginConfigs` / options path if
+     absent; do not disturb unrelated keys. The value is stored verbatim (Claude Code does not normalize a
+     `directory` option to absolute or validate existence), so store it exactly as it should resolve relative
+     to the working directory.
+   - **Default (uncommitted) chosen and a prior value exists:** **remove** the `output_dir` key so the plugin
+     falls back to its data directory. Removing the last option under this plugin leaves an empty `options`
+     (or `pluginConfigs` entry) — prune those empty containers too, and leave unrelated `pluginConfigs`
+     entries untouched. A set-only reconfigure would trap a stale path; clearing is part of "re-runnable".
+   - **Default chosen and no value exists:** nothing to write — confirm the effective behavior.
+4. **Offer the personal overlay.** A per-developer override goes in the local overlay
+   `.claude/settings.local.json` (same `pluginConfigs` path); recommend the consumer keep
+   `.claude/settings.local.json` gitignored if it is not already.
+
+## Output
+
+An updated (or unchanged) project `.claude/settings.json`, plus a one-line summary of the effective
+`output_dir` behavior, its scope, and how to re-run this setup to reconfigure or reset to the default. State
+the concrete path `--file` will now write to.
+
+## What this skill does NOT do
+
+- Produce a bug report — that is `/bug-report:bug-report`. This skill only settles where `--file` writes.
+- Write machine-local state — configuration lives in the consumer's tracked settings, never in the plugin
+  directory or the plugin data directory (`${CLAUDE_PLUGIN_DATA}` is where reports themselves land when
+  `output_dir` is unset, not where config is stored).
+- Persist a value the user did not choose — unset is a valid, recommended outcome.

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -28,17 +28,31 @@ Apply the convention-resolution ladder — config present → use it; the consum
 infer a path and persist; the consumer wants the private default → ensure the key is absent. Absent is a valid
 terminal state here; do not persist a value the user did not choose.
 
-1. **Read the current value first, in precedence order.** Look for `output_dir` under
-   `pluginConfigs["bug-report@melodic-software"].options` in all three scopes and resolve the *effective*
-   value the way Claude Code does — **Local (`.claude/settings.local.json`) > Project
-   (`.claude/settings.json`) > User (`~/.claude/settings.json`)**, local winning. Report the effective value
-   (or "unset → reports go to the plugin data directory") and which scope supplies it; the interview proposes
-   a change against that baseline. If a local override is present, say so explicitly — step 3 writes the
-   *project* (team) value, which stays shadowed by the local override until the developer updates or removes
-   it, so a project-scope edit alone will not change what the plugin uses on that machine. Read each scope
-   **narrowly** — query only the single `pluginConfigs["bug-report@melodic-software"].options.output_dir` key
-   (e.g. with `jq`), never loading `.claude/settings.local.json` wholesale: that overlay is secret-bearing
-   (API tokens, env secrets), so do not read or echo unrelated settings content.
+1. **Read the current value first, across every scope, in precedence order.** Look for `output_dir` under
+   `pluginConfigs["bug-report@melodic-software"].options` and resolve the *effective* value the way Claude
+   Code does — the full precedence, highest wins:
+   1. **Managed** (system `managed-settings.json`) — **read-only** to this skill.
+   2. **Command-line** (a session launched with `--settings`) — **read-only**; a transient session override.
+   3. **Local** (`.claude/settings.local.json`).
+   4. **Project** (`.claude/settings.json`).
+   5. **User** (`~/.claude/settings.json`).
+
+   Report the effective value (or "unset → reports go to the plugin data directory") and which scope supplies
+   it; the interview proposes a change against that baseline. Two consequences of the full ladder that a
+   Local > Project > User model misses:
+   - **A higher scope shadows a write.** Step 3 writes the *project* (team) value, but a Managed,
+     command-line, or Local value above it will keep winning until that scope is changed or removed. When one
+     is present, say so explicitly — a project-scope edit alone will not change what the plugin uses in that
+     session. **Managed and command-line are read-only here** (a plugin setup cannot edit system policy or a
+     session's CLI flags): if either supplies the effective value, report it as a hard blocker and do not
+     claim any write or clear will change the `--file` destination.
+   - **A lower scope can be revealed.** Because more than one scope may hold `output_dir` at once, note every
+     scope that carries a value, not just the winning one — step 3's reset needs the full set.
+
+   Read each scope **narrowly** — query only the single
+   `pluginConfigs["bug-report@melodic-software"].options.output_dir` key (e.g. with `jq`), never loading
+   `.claude/settings.local.json` (or any settings file) wholesale: that overlay is secret-bearing (API
+   tokens, env secrets), so do not read or echo unrelated settings content.
 2. **Interview — one decision.** Ask whether `--file` bug reports should be **committed into this repo** or
    **kept in the plugin's private data directory (the default)**. Recommend the default (uncommitted) unless
    the repo already commits similar working artifacts — bug reports can name unfixed defects and are often
@@ -51,28 +65,29 @@ terminal state here; do not persist a value the user did not choose.
 
    Present the inferred path with a recommendation and let the user accept or edit it. Keep it to this single
    knob; do not invent further options (Rule of Three).
-3. **Persist or clear to project scope.** Write to (or edit) the project `.claude/settings.json`:
-   - **Repo-committed chosen:** set `pluginConfigs["bug-report@melodic-software"].options.output_dir` to the
-     chosen value so it is tracked and shared with the team. Create the `pluginConfigs` / options path if
+3. **Persist or clear.** The *set* path writes the project scope; the *clear* path may span scopes:
+   - **Repo-committed chosen:** set `pluginConfigs["bug-report@melodic-software"].options.output_dir` in the
+     project `.claude/settings.json` to the chosen value so it is tracked and shared with the team. Create the
+     `pluginConfigs` / options path if
      absent; do not disturb unrelated keys. The value is stored verbatim (Claude Code does not normalize a
      `directory` option to absolute or validate existence), so store it exactly as it should resolve relative
      to the working directory.
-   - **Default (uncommitted) chosen and a prior value exists:** clear it at the scope that *supplies the
-     effective value* (identified in step 1) — removing the project key alone is not always enough:
-     - **Project scope** supplies it → remove the project `output_dir` key and the plugin falls back to its
-       data directory. Removing the last option under this plugin leaves an empty `options` (or
-       `pluginConfigs` entry) — prune those empty containers too, and leave unrelated `pluginConfigs` entries
-       untouched.
-     - **User scope** (`~/.claude/settings.json`) supplies it → a project-scope removal does **not** reset
-       this repo, because the lower-precedence user value still resolves (Local > Project > User). Either
-       update/remove the user-scope value with the developer's explicit consent (same narrow single-key
-       edit), or, if they will not touch their global config, tell them plainly that a project-scope clear
-       cannot override the inherited user value here and name the file to edit. Never silently edit a user's
-       global settings without asking.
-     - **Local overlay** (`.claude/settings.local.json`) supplies it → clear it there (same single-key edit);
-       a project-scope removal is likewise shadowed by the local override.
+   - **Default (uncommitted) chosen and a prior value exists:** reaching the plugin-data default means **no
+     scope may hold `output_dir`** — clearing only the winning scope just reveals the next value down. Using
+     the full set of value-carrying scopes from step 1:
+     - **A read-only scope (Managed or command-line) holds a value** → it cannot be cleared here. Report that
+       the private default is unreachable until the administrator changes the managed policy (or the session
+       drops the `--settings` override), and stop — do not pretend a writable-scope edit resets it.
+     - **Otherwise clear every *writable* scope that carries a value** — Local (`.claude/settings.local.json`)
+       and Project (`.claude/settings.json`) directly; User (`~/.claude/settings.json`) only with the
+       developer's **explicit consent**, since it is their global config. For each, remove the single
+       `output_dir` key and prune the emptied `options` / `pluginConfigs` containers, leaving unrelated
+       entries untouched. Only when no writable scope holds a value does the plugin fall back to its data
+       directory.
+     - **If the user declines to clear their user-scope value**, tell them plainly that the repo will keep
+       resolving that global value and name the file to edit. Never silently edit a user's global settings.
 
-     A set-only reconfigure would trap a stale path; scope-aware clearing is part of "re-runnable".
+     A set-only reconfigure would trap a stale path; scope-complete clearing is part of "re-runnable".
    - **Default chosen and no value exists:** nothing to write — confirm the effective behavior.
 4. **Offer the personal overlay.** A per-developer override goes in the local overlay
    `.claude/settings.local.json` (same `pluginConfigs` path); recommend the consumer keep
@@ -80,9 +95,10 @@ terminal state here; do not persist a value the user did not choose.
 
 ## Output
 
-An updated (or unchanged) project `.claude/settings.json`, plus a one-line summary of the effective
-`output_dir` behavior, its scope, and how to re-run this setup to reconfigure or reset to the default. State
-the concrete path `--file` will now write to.
+An updated (or unchanged) settings file in the appropriate scope(s) — project for a set, and whichever
+writable scopes carried a value for a reset — plus a one-line summary of the effective `output_dir` behavior,
+its scope, and how to re-run this setup to reconfigure or reset to the default. State the concrete path
+`--file` will now write to.
 
 ## What this skill does NOT do
 
@@ -91,8 +107,8 @@ the concrete path `--file` will now write to.
   directory or the plugin data directory (`${CLAUDE_PLUGIN_DATA}` is where reports themselves land when
   `output_dir` is unset, not where config is stored). The **set** path always writes the project (tracked,
   team) `.claude/settings.json`. The **reset** path is the one exception that may touch a machine-local scope
-  — and only to remove an inherited value the user asked to clear: it clears `.claude/settings.local.json`
-  when the local overlay supplies the effective value, or `~/.claude/settings.json` with explicit consent when
-  user scope does, because a project-scope edit cannot reach either. It never writes machine-local state the
-  plugin itself owns.
+  — and only to remove a value the user asked to clear: it clears `.claude/settings.local.json` when the local
+  overlay carries a value, or `~/.claude/settings.json` with explicit consent when user scope does, because a
+  project-scope edit cannot reach either. It never edits read-only Managed or command-line scopes, and never
+  writes machine-local state the plugin itself owns.
 - Persist a value the user did not choose — unset is a valid, recommended outcome.

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -31,7 +31,9 @@ terminal state here; do not persist a value the user did not choose.
 1. **Read the current value first, across every scope, in precedence order.** Look for `output_dir` under
    `pluginConfigs["bug-report@melodic-software"].options` and resolve the *effective* value the way Claude
    Code does — the full precedence, highest wins:
-   1. **Managed** (system `managed-settings.json`) — **read-only** to this skill.
+   1. **Managed** (enterprise policy — delivered via server-managed settings, an MDM plist/registry key, or
+      `managed-settings.d` drop-ins, not necessarily a single queryable `managed-settings.json`) — **read-only**
+      to this skill; detect best-effort and, if a managed value is present at all, treat it as a hard blocker.
    2. **Command-line** (a session launched with `--settings`) — **read-only**; a transient session override.
    3. **Local** (`.claude/settings.local.json`).
    4. **Project** (`.claude/settings.json`).
@@ -61,7 +63,14 @@ terminal state here; do not persist a value the user did not choose.
    - A working-notes or reports convention declared in the repo's own `CLAUDE.md`, `AGENTS.md`, or
      `.claude/rules` (that declared convention wins — surface it as the recommended value).
    - An existing reports or docs directory a bug report would naturally join (e.g. `.bug-reports/`, `docs/`).
-   - If nothing is found, recommend `.bug-reports/` at the repo root.
+   - If nothing is found, recommend a repo-root-anchored `.bug-reports/`.
+
+   **Anchor the path to the repo root, not the working directory.** The value is stored verbatim and the
+   report skill resolves it relative to the *current* working directory, so a bare relative `.bug-reports/`
+   lands under whatever subdirectory the session was started in — not reliably at the repo root. Recommend a
+   form that resolves the same from any cwd: prefer `${CLAUDE_PROJECT_DIR}/.bug-reports` if the report skill
+   expands that token in `output_dir`, otherwise an absolute path or the repo's own declared convention. Call
+   out the cwd-relative caveat when the user accepts a bare relative value.
 
    Present the inferred path with a recommendation and let the user accept or edit it. Keep it to this single
    knob; do not invent further options (Rule of Three).
@@ -70,8 +79,8 @@ terminal state here; do not persist a value the user did not choose.
      project `.claude/settings.json` to the chosen value so it is tracked and shared with the team. Create the
      `pluginConfigs` / options path if
      absent; do not disturb unrelated keys. The value is stored verbatim (Claude Code does not normalize a
-     `directory` option to absolute or validate existence), so store it exactly as it should resolve relative
-     to the working directory.
+     `directory` option to absolute or validate existence), so store exactly the anchored form chosen in
+     step 2 — the cwd-relative caveat there is why a bare relative value is discouraged.
    - **Default (uncommitted) chosen and a prior value exists:** reaching the plugin-data default means **no
      scope may hold `output_dir`** — clearing only the winning scope just reveals the next value down. Using
      the full set of value-carrying scopes from step 1:

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -31,9 +31,15 @@ terminal state here; do not persist a value the user did not choose.
 1. **Read the current value first, across every scope, in precedence order.** Look for `output_dir` under
    `pluginConfigs["bug-report@melodic-software"].options` and resolve the *effective* value the way Claude
    Code does — the full precedence, highest wins:
-   1. **Managed** (enterprise policy — delivered via server-managed settings, an MDM plist/registry key, or
-      `managed-settings.d` drop-ins, not necessarily a single queryable `managed-settings.json`) — **read-only**
-      to this skill; detect best-effort and, if a managed value is present at all, treat it as a hard blocker.
+   1. **Managed** (enterprise policy) — **read-only** to this skill. It is not a single file: it can arrive
+      from several sources (server-managed remote settings, MDM/OS policy such as a macOS plist or the
+      `HKLM`/`HKCU` `Policies\ClaudeCode` registry keys, and file-based `managed-settings.json` plus
+      `managed-settings.d/` drop-ins), and the cross-source resolution is a Claude Code internal detail — see
+      the managed tier under https://code.claude.com/docs/en/settings#settings-precedence. Do **not** try to
+      replicate that resolution: detect best-effort across whatever sources are queryable in this environment,
+      and because the whole tier is highest-precedence and unwritable, treat **any** detected managed
+      `output_dir` as a hard blocker. When managed sources cannot be reliably enumerated here (registry/MDM/
+      remote may not be readable), say so and have the administrator confirm rather than assuming none exists.
    2. **Command-line** (a session launched with `--settings`) — **read-only**; a transient session override.
    3. **Local** (`.claude/settings.local.json`).
    4. **Project** (`.claude/settings.json`).

--- a/plugins/bug-report/skills/setup/SKILL.md
+++ b/plugins/bug-report/skills/setup/SKILL.md
@@ -57,10 +57,22 @@ terminal state here; do not persist a value the user did not choose.
      absent; do not disturb unrelated keys. The value is stored verbatim (Claude Code does not normalize a
      `directory` option to absolute or validate existence), so store it exactly as it should resolve relative
      to the working directory.
-   - **Default (uncommitted) chosen and a prior value exists:** **remove** the `output_dir` key so the plugin
-     falls back to its data directory. Removing the last option under this plugin leaves an empty `options`
-     (or `pluginConfigs` entry) — prune those empty containers too, and leave unrelated `pluginConfigs`
-     entries untouched. A set-only reconfigure would trap a stale path; clearing is part of "re-runnable".
+   - **Default (uncommitted) chosen and a prior value exists:** clear it at the scope that *supplies the
+     effective value* (identified in step 1) — removing the project key alone is not always enough:
+     - **Project scope** supplies it → remove the project `output_dir` key and the plugin falls back to its
+       data directory. Removing the last option under this plugin leaves an empty `options` (or
+       `pluginConfigs` entry) — prune those empty containers too, and leave unrelated `pluginConfigs` entries
+       untouched.
+     - **User scope** (`~/.claude/settings.json`) supplies it → a project-scope removal does **not** reset
+       this repo, because the lower-precedence user value still resolves (Local > Project > User). Either
+       update/remove the user-scope value with the developer's explicit consent (same narrow single-key
+       edit), or, if they will not touch their global config, tell them plainly that a project-scope clear
+       cannot override the inherited user value here and name the file to edit. Never silently edit a user's
+       global settings without asking.
+     - **Local overlay** (`.claude/settings.local.json`) supplies it → clear it there (same single-key edit);
+       a project-scope removal is likewise shadowed by the local override.
+
+     A set-only reconfigure would trap a stale path; scope-aware clearing is part of "re-runnable".
    - **Default chosen and no value exists:** nothing to write — confirm the effective behavior.
 4. **Offer the personal overlay.** A per-developer override goes in the local overlay
    `.claude/settings.local.json` (same `pluginConfigs` path); recommend the consumer keep


### PR DESCRIPTION
Adds a re-runnable `setup` action to the `bug-report` plugin, closing the extensibility-contract gap where it exposed a `userConfig` `output_dir` seam but shipped no setup/configure skill.

## What changed
- **New skill** `plugins/bug-report/skills/setup/SKILL.md` — idempotent. Settles the `output_dir` seam: interviews the consumer on whether `--file` reports commit into the repo or stay in the plugin's uncommitted data directory, then persists (or clears) `pluginConfigs["bug-report@melodic-software"].options.output_dir` in project `.claude/settings.json`.
- **Version** `0.1.1` → `0.2.0` (minor). plugin.json lists no skills; skills auto-discover.
- **README** Configuration section now points at `/bug-report:setup`.

## Design notes
- Unlike the `knowledge`/`codebase-audit` exemplars whose seam always wants a value, `output_dir` has **no default and unset is a legitimate, recommended steady state** (reports land in plugin-data, uncommitted). Committing to the repo is opt-in — the interview is a yes/no, not a path hunt.
- Reconfigure handles the **clear** path (remove a stale value), not just set — a set-only skill would not be truly re-runnable.
- Reads settings scopes **narrowly** (single key via `jq`, no secret-bearing `settings.local.json` slurp), resolving effective value **Local > Project > User**, mirroring `knowledge/setup`'s safety properties.

## Verification
- `claude plugin validate ./plugins/bug-report` — ✔ passed.

Refs melodic-software/medley#1428

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plugin-only documentation and an interactive setup skill; no changes to bug-report generation logic, with explicit guards against reading secret-bearing settings wholesale.
> 
> **Overview**
> Adds **`/bug-report:setup`**, a user-invocable setup skill that closes the gap where the plugin exposed `userConfig.output_dir` but had no configure flow. The skill is **idempotent**: it resolves the effective `output_dir` across Claude Code settings precedence (managed → CLI → local → project → user), interviews whether `--file` reports should stay in the plugin data directory (recommended default) or commit into the repo, then **sets** project `.claude/settings.json` or **clears** every writable scope that holds a stale value so reset actually restores the private default.
> 
> The skill reads only the single `output_dir` key (e.g. via `jq`), warns when higher scopes shadow project writes, and documents path anchoring (`${CLAUDE_PROJECT_DIR}`) so team values stay portable.
> 
> **Docs and release:** README Configuration now points at setup at enable time or anytime; plugin version bumps **0.1.1 → 0.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1d7073b99e0d9fa28c6ea4cfa53071971630d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->