### PR TITLE
docs(evals): eval-warrant policy, coverage snapshot, consumer-verify recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Install one: `/plugin install <plugin-name>@melodic-software`.
 - `docs/extensibility-contract-smoke-tests.md` — verified behavior for gaps the official docs leave open.
 - `docs/extensibility-contract-grading.md` — point-in-time grade of every shipped plugin against the contract.
 - `docs/hook-migration-audit.md` — point-in-time audit of medley's general-purpose hooks for extraction into `guardrails`/`claude-ops`.
+- `docs/evals-coverage.md` — point-in-time skill-eval coverage snapshot: which skills warrant evals, which are owed backfill, and the explicit skips.
 - `docs/ai-briefing-design.md` — engine/profile/personal split design record for the `ai-briefing` migration (reference adopter of the profiled-folder convention).
 - `docs/CI-RUNNER-ROUTING.md` — local-runner selection, hosted boundaries, and failure recovery.
 - `CLAUDE.md` — operating rules for AI agents working in this repo (fresh-docs mandate + canonical links).

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -223,9 +223,13 @@ skills under `${user_config.skills_root}` → `${CLAUDE_PROJECT_DIR}/.claude/ski
 against the plugin's **source tree**, not against a bare `/plugin install`; the exercise step is the
 part that runs against the plugin as you actually enabled it.
 
-First locate the plugin's source skills directory `<root>` — either a checkout of this marketplace
-(`plugins/<plugin>/skills`) or the installed copy under
-`~/.claude/plugins/marketplaces/<marketplace>/plugins/<plugin>/skills`. Then:
+Steps 1-2 are **source-tree verification**: run them against a checkout of this marketplace with
+`<root>` = `plugins/<plugin>/skills`. This is the source, not necessarily the version you have
+*enabled* — installed plugins are copied to a version-keyed cache under `~/.claude/plugins/cache`
+(cache isolation; see "Cache isolation" and "Local development loop" below and the official plugins
+reference "plugin caching and file resolution"), so after a marketplace update the source `evals.json`
+can differ from the enabled copy. Step 3 (exercise) is the definitive as-enabled check because it runs
+against the plugin you actually invoked. Then:
 
 1. **Presence** — confirm the file `<root>/<skill>/evals/evals.json` exists. The static gate is only a
    partial signal: `/skill-quality:skill-quality check <skill>` (`check` is an action argument to the

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -217,23 +217,31 @@ must not do.
 
 **Consumer-verify recipe — "verify this plugin in MY repo".** There is **no first-party command that
 executes model-graded evals today** — automated eval *running* is a deferred surface (owned by
-`melodic-software/medley#1418`); `skill-quality` only checks presence and schema. So a consumer
-verifies a plugin against its evals in three grounded steps:
+`melodic-software/medley#1418`); `skill-quality` only checks presence and schema, and it resolves
+skills under `${user_config.skills_root}` → `${CLAUDE_PROJECT_DIR}/.claude/skills` only — it does
+**not** discover an installed marketplace plugin's skills by plugin name. So the static checks below run
+against the plugin's **source tree**, not against a bare `/plugin install`; the exercise step is the
+part that runs against the plugin as you actually enabled it.
 
-1. **Presence** — confirm the file `plugins/<plugin>/skills/<skill>/evals/evals.json` exists. Note the
-   limit of the static gate: `/skill-quality:skill-quality check <skill>` (`check` is an action argument
-   to the `skill-quality` skill) flags a *missing* eval file only for action-router-shaped skills — its
-   check fires on a `## Actions` heading — so a warranted non-router skill (e.g. `diagnose`) passes
-   `check` without flagging the gap. Rely on the direct file check or the coverage snapshot, not a green
-   `check`, to confirm a non-router skill's evals are present.
-2. **Schema** — `/skill-quality:skill-quality validate-evals <skill>` validates `evals/evals.json`
-   against the bundled schema (structure only — it does not run the cases, and it treats an absent file
-   as "not a failure", so it is a schema gate, not a presence gate).
-3. **Exercise (manual)** — for each case, paste its `prompt` into a fresh session with the plugin
-   enabled in your repo and read the result against that case's `expected_output` / `expectations`.
-   Cases with a `files` list need those fixtures present relative to the skill directory. This is a
-   human judgment pass, not an automated pass/fail, until the deferred runner lands — at which point
-   this step becomes a single command and this recipe is revised.
+First locate the plugin's source skills directory `<root>` — either a checkout of this marketplace
+(`plugins/<plugin>/skills`) or the installed copy under
+`~/.claude/plugins/marketplaces/<marketplace>/plugins/<plugin>/skills`. Then:
+
+1. **Presence** — confirm the file `<root>/<skill>/evals/evals.json` exists. The static gate is only a
+   partial signal: `/skill-quality:skill-quality check <skill>` (`check` is an action argument to the
+   `skill-quality` skill, run with `skills_root` pointed at `<root>` via `/skill-quality:setup`) flags a
+   *missing* eval file only for action-router-shaped skills — its check fires on a `## Actions` heading —
+   so a warranted non-router skill (e.g. `diagnose`) passes `check` without flagging the gap. Rely on the
+   direct file check or the coverage snapshot, not a green `check`, to confirm presence.
+2. **Schema** — `/skill-quality:skill-quality validate-evals <skill>` (same `skills_root`) validates
+   `evals/evals.json` against the bundled schema (structure only — it does not run the cases, and it
+   treats an absent file as "not a failure", so it is a schema gate, not a presence gate).
+3. **Exercise (manual) — the real consumer check** — enable the plugin in your repo (`/plugin install
+   <plugin>@<marketplace>`), then for each case in `<root>/<skill>/evals/evals.json` paste its `prompt`
+   into a fresh session and read the result against that case's `expected_output` / `expectations`. Cases
+   with a `files` list need those fixtures present relative to the skill directory. This is a human
+   judgment pass, not an automated pass/fail, until the deferred runner lands — at which point it becomes
+   a single command and this recipe is revised.
 
 ## Shared tools and scripts seam
 

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -220,10 +220,10 @@ executes model-graded evals today** — automated eval *running* is a deferred s
 `melodic-software/medley#1418`); `skill-quality` only checks presence and schema. So a consumer
 verifies a plugin against its evals in three grounded steps:
 
-1. **Presence** — `/skill-quality:check <skill>` (the seventeen-check static gate flags a warranted
-   skill that ships no evals).
-2. **Schema** — `/skill-quality:validate-evals <skill>` validates `evals/evals.json` against the
-   bundled schema (structure only — it does not run the cases).
+1. **Presence** — `/skill-quality:skill-quality check <skill>` (the seventeen-check static gate flags
+   a warranted skill that ships no evals; `check` is an action argument to the `skill-quality` skill).
+2. **Schema** — `/skill-quality:skill-quality validate-evals <skill>` validates `evals/evals.json`
+   against the bundled schema (structure only — it does not run the cases).
 3. **Exercise (manual)** — for each case, paste its `prompt` into a fresh session with the plugin
    enabled in your repo and read the result against that case's `expected_output` / `expectations`.
    Cases with a `files` list need those fixtures present relative to the skill directory. This is a

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -199,7 +199,7 @@ a skill ships them only when they earn their keep.
 **Warrant rule.** A skill **warrants** evals when it carries a judgment-bearing behavioral contract
 that could silently regress — how it triggers, how it routes an ambiguous request, when it refuses,
 or the shape of what it emits. A skill is an explicit **skip** when it is pure-reference (answers
-from a knowledge corpus with no decision contract — `boris`, `tdd`, …) or lives in a **hook** plugin
+from a knowledge corpus with no decision contract — `fable-5-playbook`, `tdd`, …) or lives in a **hook** plugin
 (deterministic, silent-always-on, guarded by `.test.sh`, no model-invoked skill). A `setup` /
 `configure` skill *is* warrantable — it makes interview and write-config decisions (the
 `codebase-audit/setup` eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -190,6 +190,46 @@ for plugins: it is not an official mechanism, and it writes into `${CLAUDE_PLUGI
 replaced on every update (the plugins-reference caching note), so its state does not survive. Setup
 writes to the consumer's tracked config or to `pluginConfigs` — both persist across updates.
 
+## Evals — warrant policy and consumer-verify recipe
+
+Evals are model-graded behavior fixtures at `plugins/<plugin>/skills/<skill>/evals/evals.json`,
+schema `plugins/skill-quality/reference/evals.schema.json`. They are **warranted, not mandatory** —
+a skill ships them only when they earn their keep.
+
+**Warrant rule.** A skill **warrants** evals when it carries a judgment-bearing behavioral contract
+that could silently regress — how it triggers, how it routes an ambiguous request, when it refuses,
+or the shape of what it emits. A skill is an explicit **skip** when it is pure-reference (answers
+from a knowledge corpus with no decision contract — `boris`, `tdd`, …) or lives in a **hook** plugin
+(deterministic, silent-always-on, guarded by `.test.sh`, no model-invoked skill). A `setup` /
+`configure` skill *is* warrantable — it makes interview and write-config decisions (the
+`codebase-audit/setup` eval is the model). Gray-zone skills (thin mechanical wrappers, reference-ish
+routers) are **author-confirm**: re-check the warrant against the live `SKILL.md` at authoring time
+and record an explicit skip verdict if it dissolves — a satisfied "looks covered" is not a warrant.
+Coverage against this rule is snapshotted per audit in
+[`evals-coverage.md`](evals-coverage.md); that doc is the point-in-time record, this section is the
+policy.
+
+**Rich form.** Each case carries `id`, a kebab-case `name`, a `prompt`, an `expected_output`
+description, optional `files` fixtures, and an `expectations` array of objectively-verifiable checks
+(the field may equivalently be named `assertions` — skill-creator upstream uses that name). Aim to
+cover trigger/routing, the happy path, at least one refusal/guardrail, and one anti-pattern the skill
+must not do.
+
+**Consumer-verify recipe — "verify this plugin in MY repo".** There is **no first-party command that
+executes model-graded evals today** — automated eval *running* is a deferred surface (owned by
+`melodic-software/medley#1418`); `skill-quality` only checks presence and schema. So a consumer
+verifies a plugin against its evals in three grounded steps:
+
+1. **Presence** — `/skill-quality:check <skill>` (the seventeen-check static gate flags a warranted
+   skill that ships no evals).
+2. **Schema** — `/skill-quality:validate-evals <skill>` validates `evals/evals.json` against the
+   bundled schema (structure only — it does not run the cases).
+3. **Exercise (manual)** — for each case, paste its `prompt` into a fresh session with the plugin
+   enabled in your repo and read the result against that case's `expected_output` / `expectations`.
+   Cases with a `files` list need those fixtures present relative to the skill directory. This is a
+   human judgment pass, not an automated pass/fail, until the deferred runner lands — at which point
+   this step becomes a single command and this recipe is revised.
+
 ## Shared tools and scripts seam
 
 Separate **plugin-owned** logic from **consumer-owned** extension points:

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -241,11 +241,16 @@ against the plugin you actually invoked. Then:
    `evals/evals.json` against the bundled schema (structure only — it does not run the cases, and it
    treats an absent file as "not a failure", so it is a schema gate, not a presence gate).
 3. **Exercise (manual) — the real consumer check** — enable the plugin in your repo (`/plugin install
-   <plugin>@<marketplace>`), then for each case in `<root>/<skill>/evals/evals.json` paste its `prompt`
-   into a fresh session and read the result against that case's `expected_output` / `expectations`. Cases
-   with a `files` list need those fixtures present relative to the skill directory. This is a human
-   judgment pass, not an automated pass/fail, until the deferred runner lands — at which point it becomes
-   a single command and this recipe is revised.
+   <plugin>@<marketplace>`), then read the eval cases **from the copy you actually enabled**, not from
+   `<root>`: the enabled version lives in the version-keyed cache under `~/.claude/plugins/cache`, and
+   reading cases from a source checkout that has drifted from it would exercise the installed plugin
+   against a different version's prompts/fixtures. To use the source evals *as* the enabled plugin
+   instead, load that source directory with `--plugin-dir` (the local copy then takes session precedence
+   — see "Local development loop" below). For each case paste its `prompt` into a fresh session and read
+   the result against that case's `expected_output` / `expectations`; cases with a `files` list need
+   those fixtures present relative to the skill directory. This is a human judgment pass, not an
+   automated pass/fail, until the deferred runner lands — at which point it becomes a single command and
+   this recipe is revised.
 
 ## Shared tools and scripts seam
 

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -220,10 +220,15 @@ executes model-graded evals today** — automated eval *running* is a deferred s
 `melodic-software/medley#1418`); `skill-quality` only checks presence and schema. So a consumer
 verifies a plugin against its evals in three grounded steps:
 
-1. **Presence** — `/skill-quality:skill-quality check <skill>` (the seventeen-check static gate flags
-   a warranted skill that ships no evals; `check` is an action argument to the `skill-quality` skill).
+1. **Presence** — confirm the file `plugins/<plugin>/skills/<skill>/evals/evals.json` exists. Note the
+   limit of the static gate: `/skill-quality:skill-quality check <skill>` (`check` is an action argument
+   to the `skill-quality` skill) flags a *missing* eval file only for action-router-shaped skills — its
+   check fires on a `## Actions` heading — so a warranted non-router skill (e.g. `diagnose`) passes
+   `check` without flagging the gap. Rely on the direct file check or the coverage snapshot, not a green
+   `check`, to confirm a non-router skill's evals are present.
 2. **Schema** — `/skill-quality:skill-quality validate-evals <skill>` validates `evals/evals.json`
-   against the bundled schema (structure only — it does not run the cases).
+   against the bundled schema (structure only — it does not run the cases, and it treats an absent file
+   as "not a failure", so it is a schema gate, not a presence gate).
 3. **Exercise (manual)** — for each case, paste its `prompt` into a fresh session with the plugin
    enabled in your repo and read the result against that case's `expected_output` / `expectations`.
    Cases with a `files` list need those fixtures present relative to the skill directory. This is a

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -1,0 +1,99 @@
+# Skill-eval coverage — warrant snapshot
+
+Point-in-time record of which shipped skills carry model-graded evals, which *warrant* them and are
+owed backfill, and which are explicit **skips**. This is an **audit snapshot**, not durable policy —
+the warrant rule and the consumer-verify recipe are policy and live in the
+[migration playbook](MIGRATION-PLAYBOOK.md) ("Evals — warrant policy and consumer-verify recipe").
+This table records where each plugin stood on the stamp date and which backfill issue owns each gap.
+Empirical claims decay: a row is only true as of the stamp below.
+
+Stamped 2026-07-12, built from the per-skill eval presence read this session against the 41 plugins
+in `.claude-plugin/marketplace.json` and the class column of
+[`extensibility-contract-grading.md`](extensibility-contract-grading.md) (retrofit-audit
+`melodic-software/medley#1388`). Facts are Tier-0 — presence read from each `plugins/<p>/skills/<s>/evals/evals.json`.
+Emitter: evals-backfill `melodic-software/medley#1396`.
+
+## Warrant rule (summary)
+
+Full rule + rationale: playbook "Evals — warrant policy and consumer-verify recipe". In brief a skill
+**warrants** evals when it carries a judgment-bearing behavioral contract — triggering, routing,
+refusal, or output shape that could silently regress. A skill is an explicit **skip** when it is
+pure-reference (answers from a corpus, no decision contract) or a **hook** (deterministic, guarded by
+`.test.sh`, no model-invoked skill). Gray-zone skills are marked **author-confirm**: the backfill
+session re-checks the warrant against the live `SKILL.md` and records a skip verdict if it dissolves.
+
+## Verdict summary
+
+- **Covered (fully): 7 plugins** — every behavior skill already ships evals: `bug-report`,
+  `code-tidying`, `codebase-audit`, `work-items`, `mcp-tool-audit`, `improve-architecture`,
+  `repo-hygiene`.
+- **Covered (partial) → backfill owed: 2 plugins** — `claude-config-audit` (2/3;
+  `memory-health` uncovered) and `implementation` (6/11; `implement`, `implement-dispatch`, `build`,
+  `lint`, `setup` uncovered).
+- **Warranted, uncovered → backfill owed: 15 more plugins** — see the batch table.
+- **Deferred (do not backfill in this repo now): 2 plugins** — `songwriting` and `knowledge`, each
+  slated to move out of the marketplace under an open decision gate; author evals in the destination
+  once separation lands.
+- **Skip (explicit): 13 plugins** — 4 pure-reference + 9 hooks.
+- Total warranted skills owed backfill this wave: **46**, grouped into **8 one-session batches**
+  (`melodic-software/medley#1447`–`#1454`).
+
+## Backfill batches emitted
+
+One issue per batch, each sized to one agent-session, sub-issue-linked under wave-2 map
+`melodic-software/medley#1369`, `agent-ready`. Each batch issue carries the authoring recipe, the
+schema path, and the per-skill warrant re-check instruction.
+
+| Batch issue | Skills | Notes |
+|---|---|---|
+| `melodic-software/medley#1447` | planning: architect, brainstorm, design, design-handoff, devils-advocate, interview, prd (7) | — |
+| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep; claude-config-audit: memory-health (5) | closes the claude-config-audit partial gap |
+| `melodic-software/medley#1449` | implementation: implement, implement-dispatch, build, lint, setup (5) | #1420 (ecosystem-commands + setup) CLOSED → stable; build/lint/setup author-confirm |
+| `melodic-software/medley#1450` | docs-hygiene: compress, declutter, encapsulation-audit, extract-ssot, rename-references (5) | — |
+| `melodic-software/medley#1451` | session-flow: handoff, orchestration-brief, retro, workflow; source-control: commit, pull-request, worktree (7) | — |
+| `melodic-software/medley#1452` | claude-ops: claude-code-changelog, claude-observability, claude-troubleshooting; prototype: logic, ui (5) | coordinate w/ claude-ops setup #1432 + hook migration #1391 (no file conflict) |
+| `melodic-software/medley#1453` | context7, firecrawl, playwright, diagnose, teach, kindle-dedrm (6) | thin single-skill plugins; proportional case counts |
+| `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | author vs current shipped behavior; owning retrofits update their eval on behavior change — simulation #1405, machine-health #1419, skill-quality #1418 |
+
+## Deferred — author in the destination repo once separation lands
+
+Recorded as decisions, not silent omissions, each with a revisit trigger (playbook defer-record pattern):
+
+- **`songwriting` (9 skills: co-write, daily-practice, diagnosis, meter-prosody, object-writing,
+  rhyme, song-form, suno, workflow)** — wave map `melodic-software/medley#1369` slates songwriting for a
+  dedicated personal repo, and its corpus/home is under an open decision gate
+  (`melodic-software/medley#1402`, needs-human). Authoring 9 skills of evals in the marketplace now
+  risks migrated/wasted work. **Revisit trigger:** #1402 resolves songwriting's home → author the
+  evals in whichever repo the plugin lands (evals travel with the skill dir).
+- **`knowledge` (2 shipped skills: book-distill, setup; + youtube/course-digest pending)** — the
+  knowledge artifacts move to a dedicated repo (`repo(knowledge-artifacts)`
+  `melodic-software/medley#1393`, needs-human) and the skill set is still growing (youtube #1408 /
+  course-digest #1409, needs-decision). Both the home and the skill set are unsettled. **Revisit
+  trigger:** #1393 fixes the plugin's home AND #1408/#1409 land the new skills → author evals for the
+  full stable skill set in the destination.
+
+## Future coverage — net-new skills not yet shipped
+
+The seven setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1433`, `#1435`) each add a
+net-new `setup`/`configure` skill that does not exist yet. When each setup skill lands, add a setup
+eval for it (the `codebase-audit/setup` eval is the model — a config-writer skill is warrantable).
+This is a per-retrofit follow-on, not part of the backfill batches above.
+
+## Skip — pure-reference plugins (4)
+
+Knowledge-only single-skill plugins; no decision/routing/refusal contract to guard. Explicit skip.
+
+| Plugin / skill | Verdict |
+|---|---|
+| boris/boris | skip — pure-reference |
+| fable-5-playbook/fable-5-playbook | skip — pure-reference |
+| thariq-skills/thariq-skills | skip — pure-reference |
+| tdd/tdd | skip — pure-reference |
+
+## Skip — hook plugins (9)
+
+Silent-always-on components; no model-invoked skill (no `SKILL.md`). Contract tests are `.test.sh`,
+not model-graded evals. Explicit skip.
+
+`actionlint`, `bash-lint`, `biome-format`, `eol-normalizer`, `markdown-formatter`,
+`powershell-format`, `ruff-format`, `desktop-notification`, `guardrails`.

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -7,10 +7,11 @@ the warrant rule and the consumer-verify recipe are policy and live in the
 This table records where each plugin stood on the stamp date and which backfill issue owns each gap.
 Empirical claims decay: a row is only true as of the stamp below.
 
-Stamped 2026-07-12, built from the per-skill eval presence read this session against the 41 plugins
+Stamped 2026-07-12, built from the per-skill eval presence read this session against the 42 plugins
 in `.claude-plugin/marketplace.json` and the class column of
 [`extensibility-contract-grading.md`](extensibility-contract-grading.md) (retrofit-audit
-`melodic-software/medley#1388`). Facts are Tier-0 — presence read from each `plugins/<p>/skills/<s>/evals/evals.json`.
+`melodic-software/medley#1388`, which graded 41 — the `miro` MCP-server plugin landed after that audit
+and is classified below). Facts are Tier-0 — presence read from each `plugins/<p>/skills/<s>/evals/evals.json`.
 Emitter: evals-backfill `melodic-software/medley#1396`.
 
 ## Warrant rule (summary)
@@ -34,7 +35,7 @@ session re-checks the warrant against the live `SKILL.md` and records a skip ver
 - **Deferred (do not backfill in this repo now): 2 plugins** — `songwriting` and `knowledge`, each
   slated to move out of the marketplace under an open decision gate; author evals in the destination
   once separation lands.
-- **Skip (explicit): 11 plugins** — 2 pure-reference + 9 hooks.
+- **Skip (explicit): 12 plugins** — 2 pure-reference + 9 hooks + 1 MCP-server (`miro`).
 - Total warranted skills owed backfill this wave: **51**, grouped into **10 one-session batches**
   (`melodic-software/medley#1447`–`#1455`, `#1458`).
 
@@ -107,3 +108,13 @@ not model-graded evals. Explicit skip.
 
 `actionlint`, `bash-lint`, `biome-format`, `eol-normalizer`, `markdown-formatter`,
 `powershell-format`, `ruff-format`, `desktop-notification`, `guardrails`.
+
+## Skip — MCP-server plugins (1)
+
+Bundle a stdio MCP server (`.mcp.json` + a TypeScript/Node package), not model-invoked skills — no
+`SKILL.md`, so there is no per-skill behavioral contract for a model-graded eval. Server behavior is
+guarded by the plugin's own package tests (`vitest`), not evals. Explicit skip.
+
+| Plugin | Verdict |
+|---|---|
+| miro | skip — MCP-server plugin, no skills (tests are `vitest`, not evals) |

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -35,7 +35,7 @@ session re-checks the warrant against the live `SKILL.md` and records a skip ver
   slated to move out of the marketplace under an open decision gate; author evals in the destination
   once separation lands.
 - **Skip (explicit): 11 plugins** — 2 pure-reference + 9 hooks.
-- Total warranted skills owed backfill this wave: **50**, grouped into **10 one-session batches**
+- Total warranted skills owed backfill this wave: **51**, grouped into **10 one-session batches**
   (`melodic-software/medley#1447`–`#1455`, `#1458`).
 
 ## Backfill batches emitted
@@ -47,7 +47,7 @@ schema path, and the per-skill warrant re-check instruction.
 | Batch issue | Skills | Notes |
 |---|---|---|
 | `melodic-software/medley#1447` | planning: architect, brainstorm, design, design-handoff, devils-advocate, interview, prd (7) | — |
-| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep; claude-config-audit: memory-health (5) | closes the claude-config-audit partial gap |
+| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep, setup; claude-config-audit: memory-health (6) | closes the claude-config-audit partial gap; discovery `setup` shipped via #1429 without an eval |
 | `melodic-software/medley#1449` | implementation: implement, implement-dispatch, build, lint, setup (5) | #1420 (ecosystem-commands + setup) CLOSED → stable; build/lint/setup author-confirm |
 | `melodic-software/medley#1450` | docs-hygiene: compress, declutter, encapsulation-audit, extract-ssot, rename-references (5) | — |
 | `melodic-software/medley#1451` | session-flow: handoff, orchestration-brief, retro, workflow; source-control: commit, pull-request, worktree (7) | — |
@@ -83,8 +83,10 @@ Several open setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `
 batches above**: the natural home for a new skill's eval is the retrofit PR that ships the skill —
 `code-tidying` #1431 already did exactly this (its `setup` shipped with an eval), and that is the
 pattern to follow. A config-writer skill is warrantable (the `codebase-audit/setup` eval is the model).
-Because concurrent retrofits land continuously, treat any "not yet shipped" wording here as
-stamp-relative — re-read the tree, not this line, before acting.
+When a retrofit ships its setup skill *without* an eval (as `discovery` #1429 did — that skill is now
+folded into batch #1448), the gap falls back to this backfill program. Because concurrent retrofits
+land continuously, this snapshot's per-skill lists are stamp-relative: re-scan the live tree for any
+warranted skill lacking `evals/evals.json` before treating the batch set as complete.
 
 ## Skip — pure-reference plugins (2)
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -11,7 +11,9 @@ Stamped 2026-07-12, built from the per-skill eval presence read this session aga
 in `.claude-plugin/marketplace.json` and the class column of
 [`extensibility-contract-grading.md`](extensibility-contract-grading.md) (retrofit-audit
 `melodic-software/medley#1388`, which graded 41 — the `miro` MCP-server plugin landed after that audit
-and is classified below). Facts are Tier-0 — presence read from each `plugins/<p>/skills/<s>/evals/evals.json`.
+and is classified below). Presence was read per-skill from each `plugins/<p>/skills/<s>/evals/evals.json`;
+because sibling workers backfill concurrently, that read is accurate only at its instant — the batch
+table's Status column carries the reconciliation and the live tree is the source of truth.
 Emitter: evals-backfill `melodic-software/medley#1396`.
 
 > **Live-ledger caveat.** This is a stamp-time plan in a concurrently-backfilled marketplace, not a
@@ -33,19 +35,24 @@ session re-checks the warrant against the live `SKILL.md` and records a skip ver
 
 ## Verdict summary
 
-- **Covered (fully): 7 plugins** — every behavior skill already ships evals: `bug-report`,
+Counts below are **at stamp**; concurrent backfill has since covered many of the "owed" skills — the
+batch table's Status column carries the current reconciliation, and the live tree is authoritative.
+
+- **Covered (fully) at stamp: 7 plugins** — every behavior skill already shipped evals: `bug-report`,
   `code-tidying`, `codebase-audit`, `work-items`, `mcp-tool-audit`, `improve-architecture`,
   `repo-hygiene`.
-- **Covered (partial) → backfill owed: 2 plugins** — `claude-config-audit` (2/3;
-  `memory-health` uncovered) and `implementation` (6/11; `implement`, `implement-dispatch`, `build`,
-  `lint`, `setup` uncovered).
-- **Warranted, uncovered → backfill owed: 19 more plugins** — see the batch table.
+- **Covered (partial) at stamp: 2 plugins** — `claude-config-audit` (`memory-health` was the gap, now
+  backfilled) and `implementation` (`implement`, `implement-dispatch`, `build`, `lint`, `setup`
+  uncovered).
+- **Warranted, uncovered at stamp: 19 more plugins** — see the batch table + Status column.
 - **Deferred (do not backfill in this repo now): 2 plugins** — `songwriting` and `knowledge`, each
   slated to move out of the marketplace under an open decision gate; author evals in the destination
   once separation lands.
 - **Skip (explicit): 12 plugins** — 2 pure-reference + 9 hooks + 1 MCP-server (`miro`).
-- Total warranted skills owed backfill this wave: **51**, grouped into **10 one-session batches**
-  (`melodic-software/medley#1447`–`#1455`, `#1458`).
+- **51 warranted skills were identified as uncovered at stamp**, grouped into **10 one-session
+  batches** (`melodic-software/medley#1447`–`#1455`, `#1458`). Concurrent sibling backfill has since
+  covered many; **as of the latest reconciliation ~26 remain uncovered** (see the Status column below).
+  The precise number keeps falling as batches land — the live tree, not this line, is authoritative.
 
 ## Backfill batches emitted
 
@@ -53,18 +60,22 @@ One issue per batch, each sized to one agent-session, sub-issue-linked under wav
 `melodic-software/medley#1369`, `agent-ready`. Each batch issue carries the authoring recipe, the
 schema path, and the per-skill warrant re-check instruction.
 
-| Batch issue | Skills | Notes |
+The **Status** column is the reconciliation as of the latest re-scan — `DONE` = all listed skills were
+covered by concurrent sibling backfill (the issue is a no-op, close it); `PARTIAL` = some remain;
+`OPEN` = none covered yet. Status decays; re-scan the tree before acting.
+
+| Batch issue | Skills | Status (reconciled) |
 |---|---|---|
-| `melodic-software/medley#1447` | planning: architect, brainstorm, design, design-handoff, devils-advocate, interview, prd (7) | — |
-| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep, setup; claude-config-audit: memory-health (6) | closes the claude-config-audit partial gap; per the live-ledger caveat above, several of these were backfilled concurrently — the issue tracks only what still lacks evals |
-| `melodic-software/medley#1449` | implementation: implement, implement-dispatch, build, lint, setup (5) | #1420 (ecosystem-commands + setup) CLOSED → stable; build/lint/setup author-confirm |
-| `melodic-software/medley#1450` | docs-hygiene: compress, declutter, encapsulation-audit, extract-ssot, rename-references (5) | — |
-| `melodic-software/medley#1451` | session-flow: handoff, orchestration-brief, retro, workflow; source-control: commit, pull-request, worktree (7) | — |
-| `melodic-software/medley#1452` | claude-ops: claude-code-changelog, claude-observability, claude-troubleshooting; prototype: logic, ui (5) | coordinate w/ claude-ops setup #1432 + hook migration #1391 (no file conflict) |
-| `melodic-software/medley#1453` | context7, firecrawl, playwright, diagnose, teach, kindle-dedrm (6) | thin single-skill plugins; proportional case counts |
-| `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | author vs current shipped behavior; owning retrofits update their eval on behavior change — simulation #1405, machine-health #1419, skill-quality #1418 |
-| `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | ecosystem-commands retrofit #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
-| `melodic-software/medley#1458` | boris, thariq-skills (2) | reclassified from pure-reference: each ships an `update`/`update --apply` action (routing + mutation-safety contract); scope evals to that contract, not the knowledge content |
+| `melodic-software/medley#1447` | planning: architect, brainstorm, design, design-handoff, devils-advocate, interview, prd (7) | **DONE** — all 7 backfilled concurrently |
+| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep, setup; claude-config-audit: memory-health (6) | **PARTIAL** — only `discovery/setup` remains; the other 5 backfilled concurrently |
+| `melodic-software/medley#1449` | implementation: implement, implement-dispatch, build, lint, setup (5) | **OPEN** — #1420 (ecosystem-commands + setup) CLOSED → stable; build/lint/setup author-confirm |
+| `melodic-software/medley#1450` | docs-hygiene: compress, declutter, encapsulation-audit, extract-ssot, rename-references (5) | **OPEN** |
+| `melodic-software/medley#1451` | session-flow: handoff, orchestration-brief, retro, workflow; source-control: commit, pull-request, worktree (7) | **OPEN** |
+| `melodic-software/medley#1452` | claude-ops: claude-code-changelog, claude-observability, claude-troubleshooting; prototype: logic, ui (5) | **DONE** — all 5 backfilled concurrently |
+| `melodic-software/medley#1453` | context7, firecrawl, playwright, diagnose, teach, kindle-dedrm (6) | **DONE** — all 6 backfilled concurrently |
+| `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | **OPEN** — author vs current shipped behavior; owning retrofits update their eval on behavior change (simulation #1405, machine-health #1419, skill-quality #1418) |
+| `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | **OPEN** — #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
+| `melodic-software/medley#1458` | boris, thariq-skills (2) | **DONE** — both backfilled concurrently; reclassified from pure-reference for their `update`/`update --apply` routing + mutation-safety contract |
 
 ## Deferred — author in the destination repo once separation lands
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -49,10 +49,11 @@ batch table's Status column carries the current reconciliation, and the live tre
   slated to move out of the marketplace under an open decision gate; author evals in the destination
   once separation lands.
 - **Skip (explicit): 12 plugins** — 2 pure-reference + 9 hooks + 1 MCP-server (`miro`).
-- **51 warranted skills were identified as uncovered at stamp**, grouped into **10 one-session
-  batches** (`melodic-software/medley#1447`–`#1455`, `#1458`). Concurrent sibling backfill has since
-  covered many; **as of the latest reconciliation ~26 remain uncovered** (see the Status column below).
-  The precise number keeps falling as batches land — the live tree, not this line, is authoritative.
+- **~54 warranted skills identified as uncovered** (51 at stamp + 3 setup skills that shipped uncovered
+  since), grouped into **11 one-session batches** (`melodic-software/medley#1447`–`#1455`, `#1458`,
+  `#1462`). Concurrent sibling backfill has since covered many; **as of the latest reconciliation ~29
+  remain uncovered** (see the Status column below). The precise number keeps moving as batches land and
+  new setup skills ship — the live tree, not this line, is authoritative.
 
 ## Backfill batches emitted
 
@@ -76,6 +77,7 @@ covered by concurrent sibling backfill (the issue is a no-op, close it); `PARTIA
 | `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | **OPEN** — author vs current shipped behavior; owning retrofits update their eval on behavior change (simulation #1405, machine-health #1419, skill-quality #1418) |
 | `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | **OPEN** — #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
 | `melodic-software/medley#1458` | boris, thariq-skills (2) | **DONE** — both backfilled concurrently; reclassified from pure-reference for their `update`/`update --apply` routing + mutation-safety contract |
+| `melodic-software/medley#1462` | setup-action skills self-scan: bug-report/setup, claude-ops/setup, work-items/setup + future landings (3) | **OPEN** — self-scanning catch-all for setup skills that shipped without evals and aren't in a family batch/deferral |
 
 ## Deferred — author in the destination repo once separation lands
 
@@ -96,17 +98,17 @@ Recorded as decisions, not silent omissions, each with a revisit trigger (playbo
   which individual skills already carry evals (`youtube` ships one). **Revisit trigger:** #1393 fixes
   the plugin's home → author evals for whatever skills still lack them, in the destination repo.
 
-## Future coverage — net-new skills from open retrofits
+## Future coverage — setup-action skills (self-scanning batch)
 
-Several open setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1435`) add a net-new
-`setup`/`configure` skill. Evals for those are a **per-retrofit follow-on, not part of the backfill
-batches above**: the natural home for a new skill's eval is the retrofit PR that ships the skill —
-`code-tidying` #1431 already did exactly this (its `setup` shipped with an eval), and that is the
-pattern to follow. A config-writer skill is warrantable (the `codebase-audit/setup` eval is the model).
-When a retrofit ships its setup skill *without* an eval (as `discovery` #1429 did — that skill is now
-folded into batch #1448), the gap falls back to this backfill program. Because concurrent retrofits
-land continuously, this snapshot's per-skill lists are stamp-relative: re-scan the live tree for any
-warranted skill lacking `evals/evals.json` before treating the batch set as complete.
+The setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1435`) ship net-new
+`setup`/`configure` skills over time, and several have landed *without* evals. The ideal home for a new
+skill's eval is the retrofit PR that ships it — `code-tidying` #1431 did exactly this (its `setup`
+shipped with an eval) — but when a retrofit ships a setup skill uncovered, the gap falls to this
+program. To stop chasing each landing individually, **`melodic-software/medley#1462` is a self-scanning
+catch-all**: it scans `plugins/*/skills/setup/` for any setup skill lacking `evals/evals.json` and
+backfills those not already owned by a plugin-family batch (`discovery/setup` #1448,
+`implementation/setup` #1449, `machine-health`/`skill-quality` setup #1454) or deferred (`knowledge`,
+`songwriting`). A config-writer skill is warrantable (the `codebase-audit/setup` eval is the model).
 
 ## Skip — pure-reference plugins (2)
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -69,20 +69,22 @@ Recorded as decisions, not silent omissions, each with a revisit trigger (playbo
   risks migrated/wasted work. **Revisit trigger:** #1402 resolves songwriting's home → author the
   evals for all 10 skills (including `setup`) in whichever repo the plugin lands (evals travel with the
   skill dir).
-- **`knowledge` (2 shipped skills: book-distill, setup; + youtube/course-digest pending)** — the
-  knowledge artifacts move to a dedicated repo (`repo(knowledge-artifacts)`
-  `melodic-software/medley#1393`, needs-human) and the skill set is still growing (youtube #1408 /
-  course-digest #1409, needs-decision). Both the home and the skill set are unsettled. **Revisit
-  trigger:** #1393 fixes the plugin's home AND #1408/#1409 land the new skills → author evals for the
-  full stable skill set in the destination.
+- **`knowledge` (book-distill, setup, and the now-shipped youtube; course-digest pending
+  `melodic-software/medley#1409`)** — the knowledge artifacts move to a dedicated repo
+  (`repo(knowledge-artifacts)` `melodic-software/medley#1393`, needs-human) and the skill set is still
+  growing. Both the home and the skill set are unsettled, so the whole plugin is deferred regardless of
+  which individual skills already carry evals (`youtube` ships one). **Revisit trigger:** #1393 fixes
+  the plugin's home → author evals for whatever skills still lack them, in the destination repo.
 
-## Future coverage — net-new skills not yet shipped
+## Future coverage — net-new skills from open retrofits
 
-The setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1435`) each add a net-new
-`setup`/`configure` skill that does not exist yet. When each setup skill lands, add a setup eval for it
-(the `codebase-audit/setup` eval is the model — a config-writer skill is warrantable). This is a
-per-retrofit follow-on, not part of the backfill batches above. (`songwriting`'s setup skill has
-already shipped and is covered by the songwriting deferral above, not here.)
+Several open setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1435`) add a net-new
+`setup`/`configure` skill. Evals for those are a **per-retrofit follow-on, not part of the backfill
+batches above**: the natural home for a new skill's eval is the retrofit PR that ships the skill —
+`code-tidying` #1431 already did exactly this (its `setup` shipped with an eval), and that is the
+pattern to follow. A config-writer skill is warrantable (the `codebase-audit/setup` eval is the model).
+Because concurrent retrofits land continuously, treat any "not yet shipped" wording here as
+stamp-relative — re-read the tree, not this line, before acting.
 
 ## Skip — pure-reference plugins (2)
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -60,12 +60,14 @@ schema path, and the per-skill warrant re-check instruction.
 
 Recorded as decisions, not silent omissions, each with a revisit trigger (playbook defer-record pattern):
 
-- **`songwriting` (9 skills: co-write, daily-practice, diagnosis, meter-prosody, object-writing,
-  rhyme, song-form, suno, workflow)** — wave map `melodic-software/medley#1369` slates songwriting for a
+- **`songwriting` (10 skills: co-write, daily-practice, diagnosis, meter-prosody, object-writing,
+  rhyme, song-form, suno, workflow, and the now-shipped `setup`)** — wave map
+  `melodic-software/medley#1369` slates songwriting for a
   dedicated personal repo, and its corpus/home is under an open decision gate
-  (`melodic-software/medley#1402`, needs-human). Authoring 9 skills of evals in the marketplace now
+  (`melodic-software/medley#1402`, needs-human). Authoring 10 skills of evals in the marketplace now
   risks migrated/wasted work. **Revisit trigger:** #1402 resolves songwriting's home → author the
-  evals in whichever repo the plugin lands (evals travel with the skill dir).
+  evals for all 10 skills (including `setup`) in whichever repo the plugin lands (evals travel with the
+  skill dir).
 - **`knowledge` (2 shipped skills: book-distill, setup; + youtube/course-digest pending)** — the
   knowledge artifacts move to a dedicated repo (`repo(knowledge-artifacts)`
   `melodic-software/medley#1393`, needs-human) and the skill set is still growing (youtube #1408 /
@@ -75,10 +77,11 @@ Recorded as decisions, not silent omissions, each with a revisit trigger (playbo
 
 ## Future coverage — net-new skills not yet shipped
 
-The seven setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1433`, `#1435`) each add a
-net-new `setup`/`configure` skill that does not exist yet. When each setup skill lands, add a setup
-eval for it (the `codebase-audit/setup` eval is the model — a config-writer skill is warrantable).
-This is a per-retrofit follow-on, not part of the backfill batches above.
+The setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1435`) each add a net-new
+`setup`/`configure` skill that does not exist yet. When each setup skill lands, add a setup eval for it
+(the `codebase-audit/setup` eval is the model — a config-writer skill is warrantable). This is a
+per-retrofit follow-on, not part of the backfill batches above. (`songwriting`'s setup skill has
+already shipped and is covered by the songwriting deferral above, not here.)
 
 ## Skip — pure-reference plugins (4)
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -30,13 +30,13 @@ session re-checks the warrant against the live `SKILL.md` and records a skip ver
 - **Covered (partial) → backfill owed: 2 plugins** — `claude-config-audit` (2/3;
   `memory-health` uncovered) and `implementation` (6/11; `implement`, `implement-dispatch`, `build`,
   `lint`, `setup` uncovered).
-- **Warranted, uncovered → backfill owed: 15 more plugins** — see the batch table.
+- **Warranted, uncovered → backfill owed: 17 more plugins** — see the batch table.
 - **Deferred (do not backfill in this repo now): 2 plugins** — `songwriting` and `knowledge`, each
   slated to move out of the marketplace under an open decision gate; author evals in the destination
   once separation lands.
 - **Skip (explicit): 13 plugins** — 4 pure-reference + 9 hooks.
-- Total warranted skills owed backfill this wave: **46**, grouped into **8 one-session batches**
-  (`melodic-software/medley#1447`–`#1454`).
+- Total warranted skills owed backfill this wave: **48**, grouped into **9 one-session batches**
+  (`melodic-software/medley#1447`–`#1455`).
 
 ## Backfill batches emitted
 
@@ -54,6 +54,7 @@ schema path, and the per-skill warrant re-check instruction.
 | `melodic-software/medley#1452` | claude-ops: claude-code-changelog, claude-observability, claude-troubleshooting; prototype: logic, ui (5) | coordinate w/ claude-ops setup #1432 + hook migration #1391 (no file conflict) |
 | `melodic-software/medley#1453` | context7, firecrawl, playwright, diagnose, teach, kindle-dedrm (6) | thin single-skill plugins; proportional case counts |
 | `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | author vs current shipped behavior; owning retrofits update their eval on behavior change — simulation #1405, machine-health #1419, skill-quality #1418 |
+| `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | ecosystem-commands retrofit #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
 
 ## Deferred — author in the destination repo once separation lands
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -56,7 +56,7 @@ schema path, and the per-skill warrant re-check instruction.
 | Batch issue | Skills | Notes |
 |---|---|---|
 | `melodic-software/medley#1447` | planning: architect, brainstorm, design, design-handoff, devils-advocate, interview, prd (7) | — |
-| `melodic-software/medley#1448` | discovery: setup (the other 4 discovery skills + `claude-config-audit/memory-health` were backfilled concurrently — re-verify and author only what still lacks evals) | discovery `setup` shipped via #1429 without an eval |
+| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep, setup; claude-config-audit: memory-health (6) | closes the claude-config-audit partial gap; per the live-ledger caveat above, several of these were backfilled concurrently — the issue tracks only what still lacks evals |
 | `melodic-software/medley#1449` | implementation: implement, implement-dispatch, build, lint, setup (5) | #1420 (ecosystem-commands + setup) CLOSED → stable; build/lint/setup author-confirm |
 | `melodic-software/medley#1450` | docs-hygiene: compress, declutter, encapsulation-audit, extract-ssot, rename-references (5) | — |
 | `melodic-software/medley#1451` | session-flow: handoff, orchestration-brief, retro, workflow; source-control: commit, pull-request, worktree (7) | — |

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -14,6 +14,14 @@ in `.claude-plugin/marketplace.json` and the class column of
 and is classified below). Facts are Tier-0 — presence read from each `plugins/<p>/skills/<s>/evals/evals.json`.
 Emitter: evals-backfill `melodic-software/medley#1396`.
 
+> **Live-ledger caveat.** This is a stamp-time plan in a concurrently-backfilled marketplace, not a
+> live ledger. Between the stamp and any read, other workers land evals — during this document's own
+> authoring, `discovery`'s `explore`/`explore-deep`/`research`/`research-deep` skills and
+> `claude-config-audit/memory-health` were backfilled by sibling work. The batch issues below therefore
+> instruct each author to re-check every listed skill against the live tree and **skip any that already
+> ship `evals/evals.json`**. Treat the per-skill lists and counts as stamp-time identification; re-scan
+> before acting.
+
 ## Warrant rule (summary)
 
 Full rule + rationale: playbook "Evals — warrant policy and consumer-verify recipe". In brief a skill
@@ -48,7 +56,7 @@ schema path, and the per-skill warrant re-check instruction.
 | Batch issue | Skills | Notes |
 |---|---|---|
 | `melodic-software/medley#1447` | planning: architect, brainstorm, design, design-handoff, devils-advocate, interview, prd (7) | — |
-| `melodic-software/medley#1448` | discovery: explore, explore-deep, research, research-deep, setup; claude-config-audit: memory-health (6) | closes the claude-config-audit partial gap; discovery `setup` shipped via #1429 without an eval |
+| `melodic-software/medley#1448` | discovery: setup (the other 4 discovery skills + `claude-config-audit/memory-health` were backfilled concurrently — re-verify and author only what still lacks evals) | discovery `setup` shipped via #1429 without an eval |
 | `melodic-software/medley#1449` | implementation: implement, implement-dispatch, build, lint, setup (5) | #1420 (ecosystem-commands + setup) CLOSED → stable; build/lint/setup author-confirm |
 | `melodic-software/medley#1450` | docs-hygiene: compress, declutter, encapsulation-audit, extract-ssot, rename-references (5) | — |
 | `melodic-software/medley#1451` | session-flow: handoff, orchestration-brief, retro, workflow; source-control: commit, pull-request, worktree (7) | — |

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -30,13 +30,13 @@ session re-checks the warrant against the live `SKILL.md` and records a skip ver
 - **Covered (partial) → backfill owed: 2 plugins** — `claude-config-audit` (2/3;
   `memory-health` uncovered) and `implementation` (6/11; `implement`, `implement-dispatch`, `build`,
   `lint`, `setup` uncovered).
-- **Warranted, uncovered → backfill owed: 17 more plugins** — see the batch table.
+- **Warranted, uncovered → backfill owed: 19 more plugins** — see the batch table.
 - **Deferred (do not backfill in this repo now): 2 plugins** — `songwriting` and `knowledge`, each
   slated to move out of the marketplace under an open decision gate; author evals in the destination
   once separation lands.
-- **Skip (explicit): 13 plugins** — 4 pure-reference + 9 hooks.
-- Total warranted skills owed backfill this wave: **48**, grouped into **9 one-session batches**
-  (`melodic-software/medley#1447`–`#1455`).
+- **Skip (explicit): 11 plugins** — 2 pure-reference + 9 hooks.
+- Total warranted skills owed backfill this wave: **50**, grouped into **10 one-session batches**
+  (`melodic-software/medley#1447`–`#1455`, `#1458`).
 
 ## Backfill batches emitted
 
@@ -55,6 +55,7 @@ schema path, and the per-skill warrant re-check instruction.
 | `melodic-software/medley#1453` | context7, firecrawl, playwright, diagnose, teach, kindle-dedrm (6) | thin single-skill plugins; proportional case counts |
 | `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | author vs current shipped behavior; owning retrofits update their eval on behavior change — simulation #1405, machine-health #1419, skill-quality #1418 |
 | `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | ecosystem-commands retrofit #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
+| `melodic-software/medley#1458` | boris, thariq-skills (2) | reclassified from pure-reference: each ships an `update`/`update --apply` action (routing + mutation-safety contract); scope evals to that contract, not the knowledge content |
 
 ## Deferred — author in the destination repo once separation lands
 
@@ -83,16 +84,17 @@ The setup-action retrofits (`melodic-software/medley#1428`–`#1432`, `#1435`) e
 per-retrofit follow-on, not part of the backfill batches above. (`songwriting`'s setup skill has
 already shipped and is covered by the songwriting deferral above, not here.)
 
-## Skip — pure-reference plugins (4)
+## Skip — pure-reference plugins (2)
 
-Knowledge-only single-skill plugins; no decision/routing/refusal contract to guard. Explicit skip.
+Knowledge-only single-skill plugins; the only argument is knowledge navigation or a query, with no
+mutation, refusal, or external side-effect contract to guard. Explicit skip. (`boris` and
+`thariq-skills` were graded pure-reference too, but each additionally ships a mutating `update` action
+and is therefore warranted — batch #1458 above.)
 
 | Plugin / skill | Verdict |
 |---|---|
-| boris/boris | skip — pure-reference |
-| fable-5-playbook/fable-5-playbook | skip — pure-reference |
-| thariq-skills/thariq-skills | skip — pure-reference |
-| tdd/tdd | skip — pure-reference |
+| fable-5-playbook/fable-5-playbook | skip — pure-reference (`[full \| <chapter>]` is knowledge navigation, no mutation) |
+| tdd/tdd | skip — pure-reference (`[question or concept]` Q&A, no mutation) |
 
 ## Skip — hook plugins (9)
 


### PR DESCRIPTION
Codifies the eval-backfill triage output for the plugin-migration wave-2 program.

## What lands

- **`docs/MIGRATION-PLAYBOOK.md`** — new "Evals — warrant policy and consumer-verify recipe" section:
  the durable warrant rule (behavior skills warrant evals; pure-reference and hook plugins skip; a
  `setup` skill is warrantable; gray-zone skills are author-confirm) and the consumer-verify recipe.
  The recipe is grounded in tooling that exists **today** — `/skill-quality:check` (presence) +
  `/skill-quality:validate-evals` (schema), then a manual exercise pass. There is no first-party
  model-graded eval *runner* yet (deferred, owned by `melodic-software/medley#1418`), so the recipe
  says so instead of describing a command that does not exist.
- **`docs/evals-coverage.md`** (new) — point-in-time coverage snapshot: per-plugin verdicts, the
  eight one-session backfill batches, the `songwriting` / `knowledge` deferrals (both slated to leave
  the marketplace under open decision gates), and the explicit pure-reference (4) + hook (9) skips.
- **`README.md`** — indexes the new snapshot doc.

## Batches emitted (in the medley tracker, linked under wave-2 map #1369)

46 warranted, uncovered skills grouped into eight `agent-ready` one-session batches:
`melodic-software/medley#1447`–`#1454`. No evals authored inline — this issue is triage/emit only.

Refs melodic-software/medley#1396

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to policy and triage records; no runtime, hooks, or skill behavior changes.
> 
> **Overview**
> Documents the wave-2 **skill-eval** program: durable policy in the migration playbook and a stamped coverage ledger, without adding any `evals.json` files in this PR.
> 
> **`docs/MIGRATION-PLAYBOOK.md`** gains **"Evals — warrant policy and consumer-verify recipe"**, defining when skills **warrant** model-graded evals (judgment-bearing contracts, including `setup`), explicit **skips** (pure-reference and hook plugins), and **author-confirm** gray zones. It also describes the eval case shape and a **consumer-verify** flow grounded in today’s tooling: direct presence checks, `/skill-quality:validate-evals` (schema only), and a manual exercise pass—calling out that there is **no** automated eval runner yet (`melodic-software/medley#1418`) and that `skill-quality check` only flags missing evals for action-router skills with `## Actions`.
> 
> **`docs/evals-coverage.md`** (new) is a **2026-07-12** snapshot: covered vs owed skills, **11** medley backfill batches with reconciled **DONE/PARTIAL/OPEN** status, deferrals for `songwriting` and `knowledge`, and explicit skip lists (pure-reference, hooks, `miro` MCP).
> 
> **`README.md`** indexes the new snapshot doc under "What's here".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714ada8f0167aa7a0ec65a89306a813ba205b7eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->