### PR TITLE
ci: consolidate self-hosted hygiene lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,9 +184,13 @@ jobs:
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
 
+      - name: Test hygiene result aggregation
+        run: scripts/aggregate-hygiene-results.sh --self-test
+
       - name: Aggregate hygiene results
         if: always()
         env:
+          # Display names (left) are annotations; step ids (right) use underscores.
           CHECK_RESULTS: |
             markdown=${{ steps.markdown.outcome }}
             typos=${{ steps.typos.outcome }}
@@ -202,15 +206,7 @@ jobs:
             machine-specific-paths=${{ steps.machine_paths.outcome }}
             eol-renormalize=${{ steps.eol.outcome }}
             comment-hygiene=${{ steps.comment_hygiene.outcome }}
-        run: |
-          failed=0
-          while IFS='=' read -r check result; do
-            if [[ "$result" != success ]]; then
-              echo "::error title=$check failed::Hygiene check finished with outcome: $result"
-              failed=1
-            fi
-          done <<< "$CHECK_RESULTS"
-          exit "$failed"
+        run: scripts/aggregate-hygiene-results.sh
 
   zizmor:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,143 +21,12 @@ concurrency:
 # local ci-status gateway aggregates every lane into the
 # single required check the org ci-gate ruleset keys on.
 jobs:
-  # Give every independently scheduled workload its own governed routing gate.
-  # In self-hosted-only mode each trusted private workload receives the exact
-  # centrally allowlisted label and queues until fleet capacity is available.
-  # A selector/configuration failure blocks its workload; it cannot silently
-  # redirect that workload to paid hosted Linux.
-  select-markdown:
-    name: Select runner for markdown
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-typos:
-    name: Select runner for typos
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-gitleaks:
-    name: Select runner for gitleaks
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-editorconfig:
-    name: Select runner for editorconfig
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-shellcheck:
-    name: Select runner for shellcheck
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-actionlint:
-    name: Select runner for actionlint
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-jsonschema:
-    name: Select runner for jsonschema
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-exec-bit:
-    name: Select runner for exec-bit
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-machine-specific-paths:
-    name: Select runner for machine-specific-paths
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-eol-renormalize:
-    name: Select runner for eol-renormalize
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-comment-hygiene:
-    name: Select runner for comment-hygiene
+  # Give each independently scheduled workload one governed routing gate.
+  # The short hygiene checks share one checkout and one ephemeral worker to
+  # avoid runner-registration churn. A selector/configuration failure blocks
+  # the complete workload; it cannot silently redirect to paid hosted Linux.
+  select-hygiene:
+    name: Select runner for hygiene
     uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
@@ -208,10 +77,10 @@ jobs:
     secrets:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
 
-  markdown:
-    needs: select-markdown
-    if: ${{ !cancelled() && needs.select-markdown.result == 'success' }}
-    runs-on: ${{ needs.select-markdown.outputs.runner || 'ubuntu-24.04' }}
+  hygiene:
+    needs: select-hygiene
+    if: ${{ !cancelled() && needs.select-hygiene.result == 'success' }}
+    runs-on: ${{ needs.select-hygiene.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -219,109 +88,69 @@ jobs:
         with:
           persist-credentials: false
       - name: Lint markdown
+        id: markdown
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/markdown@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           config: .markdownlint-cli2.jsonc
 
-  typos:
-    needs: select-typos
-    if: ${{ !cancelled() && needs.select-typos.result == 'success' }}
-    runs-on: ${{ needs.select-typos.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Spell-check
+        id: typos
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/typos@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           config: _typos.toml
 
-  gitleaks:
-    needs: select-gitleaks
-    if: ${{ !cancelled() && needs.select-gitleaks.result == 'success' }}
-    runs-on: ${{ needs.select-gitleaks.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Scan for secrets
+        id: gitleaks
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/gitleaks@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           config: .gitleaks.toml
 
-  editorconfig:
-    needs: select-editorconfig
-    if: ${{ !cancelled() && needs.select-editorconfig.result == 'success' }}
-    runs-on: ${{ needs.select-editorconfig.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Check editorconfig conformance
+        id: editorconfig
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/editorconfig@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           config: .editorconfig-checker.json
 
-  shellcheck:
-    needs: select-shellcheck
-    if: ${{ !cancelled() && needs.select-shellcheck.result == 'success' }}
-    runs-on: ${{ needs.select-shellcheck.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Lint shell scripts
+        id: shellcheck
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/shellcheck@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           rcfile: .shellcheckrc
 
-  actionlint:
-    needs: select-actionlint
-    if: ${{ !cancelled() && needs.select-actionlint.result == 'success' }}
-    runs-on: ${{ needs.select-actionlint.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Lint workflows
+        id: actionlint
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/actionlint@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
 
-  jsonschema:
-    needs: select-jsonschema
-    if: ${{ !cancelled() && needs.select-jsonschema.result == 'success' }}
-    runs-on: ${{ needs.select-jsonschema.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Validate marketplace manifest
+        id: marketplace_schema
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           schemafile: https://json.schemastore.org/claude-code-marketplace.json
           files: .claude-plugin/marketplace.json
       - name: Validate plugin manifests
+        id: plugin_schema
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           schemafile: https://json.schemastore.org/claude-code-plugin-manifest.json
           files: plugins/*/.claude-plugin/plugin.json
       - name: Validate dependabot.yml
+        id: dependabot_schema
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           builtin-schema: vendor.dependabot
           files: .github/dependabot.yml
       - name: Validate workflows
+        id: workflow_schema
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           builtin-schema: vendor.github-workflows
@@ -331,61 +160,57 @@ jobs:
             .github/workflows/link-check.yml
             .github/workflows/pr-title.yml
 
-  exec-bit:
-    needs: select-exec-bit
-    if: ${{ !cancelled() && needs.select-exec-bit.result == 'success' }}
-    runs-on: ${{ needs.select-exec-bit.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Verify shebang files are executable
+        id: exec_bit
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/exec-bit@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
 
-  machine-specific-paths:
-    needs: select-machine-specific-paths
-    if: ${{ !cancelled() && needs.select-machine-specific-paths.result == 'success' }}
-    runs-on: ${{ needs.select-machine-specific-paths.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Check for machine-specific paths
+        id: machine_paths
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/machine-specific-paths@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
         with:
           # The guardrails plugin bundles a path-detection pattern lib whose
           # regex bodies self-match this lane's own detector.
           exclude: ':(exclude)plugins/guardrails/lib/path-detection/**'
 
-  eol-renormalize:
-    needs: select-eol-renormalize
-    if: ${{ !cancelled() && needs.select-eol-renormalize.result == 'success' }}
-    runs-on: ${{ needs.select-eol-renormalize.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Check index-level EOL drift
+        id: eol
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/eol-renormalize@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
 
-  comment-hygiene:
-    needs: select-comment-hygiene
-    if: ${{ !cancelled() && needs.select-comment-hygiene.result == 'success' }}
-    runs-on: ${{ needs.select-comment-hygiene.outputs.runner || 'ubuntu-24.04' }}
-    timeout-minutes: 15
-    steps:
-      - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
       - name: Scan comment hygiene
+        id: comment_hygiene
+        continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/comment-hygiene@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
+
+      - name: Aggregate hygiene results
+        if: always()
+        env:
+          CHECK_RESULTS: |
+            markdown=${{ steps.markdown.outcome }}
+            typos=${{ steps.typos.outcome }}
+            gitleaks=${{ steps.gitleaks.outcome }}
+            editorconfig=${{ steps.editorconfig.outcome }}
+            shellcheck=${{ steps.shellcheck.outcome }}
+            actionlint=${{ steps.actionlint.outcome }}
+            marketplace-schema=${{ steps.marketplace_schema.outcome }}
+            plugin-schema=${{ steps.plugin_schema.outcome }}
+            dependabot-schema=${{ steps.dependabot_schema.outcome }}
+            workflow-schema=${{ steps.workflow_schema.outcome }}
+            exec-bit=${{ steps.exec_bit.outcome }}
+            machine-specific-paths=${{ steps.machine_paths.outcome }}
+            eol-renormalize=${{ steps.eol.outcome }}
+            comment-hygiene=${{ steps.comment_hygiene.outcome }}
+        run: |
+          failed=0
+          while IFS='=' read -r check result; do
+            if [[ "$result" != success ]]; then
+              echo "::error title=$check failed::Hygiene check finished with outcome: $result"
+              failed=1
+            fi
+          done <<< "$CHECK_RESULTS"
+          exit "$failed"
 
   zizmor:
     permissions:
@@ -539,17 +364,7 @@ jobs:
   ci-status:
     if: always()
     needs:
-      - markdown
-      - typos
-      - gitleaks
-      - editorconfig
-      - shellcheck
-      - actionlint
-      - jsonschema
-      - exec-bit
-      - machine-specific-paths
-      - eol-renormalize
-      - comment-hygiene
+      - hygiene
       - hook-utils-sync
       - plugin-gate
       - miro-plugin

--- a/scripts/aggregate-hygiene-results.sh
+++ b/scripts/aggregate-hygiene-results.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Aggregate the hygiene step outcomes without treating trailing blank records
+# as checks. This remains a script so its parser contract can be regression
+# tested independently of GitHub expression evaluation.
+set -u
+
+aggregate_results() {
+  local input=$1
+  local annotate=${2:-true}
+  local failed=0
+  local check
+  local result
+
+  while IFS='=' read -r check result; do
+    # YAML block scalars and Bash here-strings can each contribute a trailing
+    # newline. Ignore only a fully blank record; a named empty outcome fails.
+    if [[ -z "$check" && -z "$result" ]]; then
+      continue
+    fi
+
+    if [[ "$result" != success ]]; then
+      if [[ "$annotate" == true ]]; then
+        printf '::error title=%s failed::Hygiene check finished with outcome: %s\n' \
+          "$check" "$result"
+      fi
+      failed=1
+    fi
+  done <<< "$input"
+
+  return "$failed"
+}
+
+self_test() {
+  local failed=0
+
+  if ! aggregate_results $'markdown=success\ncomment-hygiene=success\n' false; then
+    echo 'all-success records with a trailing newline must pass' >&2
+    failed=1
+  fi
+  if aggregate_results $'markdown=\n' false; then
+    echo 'a named empty outcome must fail' >&2
+    failed=1
+  fi
+  if aggregate_results $'markdown=failure\n' false; then
+    echo 'a named non-success outcome must fail' >&2
+    failed=1
+  fi
+
+  if [[ "$failed" -eq 0 ]]; then
+    echo 'Hygiene result aggregation contract passed.'
+  fi
+  return "$failed"
+}
+
+case "${1:-}" in
+  '') aggregate_results "${CHECK_RESULTS:-}" ;;
+  --self-test) self_test ;;
+  *) echo "usage: $0 [--self-test]" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

- consolidate the 11 short hygiene lanes behind one governed runner selector and one checkout
- keep every hygiene check visible, continue after individual failures, and fail closed in a final outcome aggregator
- retain hook-utils, plugin-gate, and Miro as independent self-hosted workloads; keep runner-policy, zizmor, and the required `ci-status` gateway hosted

## Impact

- self-hosted CI dispatches per run drop from 14 to 4 (71% fewer)
- including the unchanged PR-title workload, self-hosted dispatches per PR drop from 15 to 5 (67% fewer)
- selector invocations and ephemeral worker registrations also drop by 10 per CI run
- the most recent successful pre-change run spent 137 seconds total across the 11 hygiene jobs, so their additive runtime remains well inside the existing 15-minute timeout even before eliminating repeated checkout and action setup

## Validation

- `actionlint` on every workflow
- all marketplace, plugin-manifest, Dependabot, and GitHub-workflow schemas
- standards-managed runner policy with private-repository evidence
- `zizmor` (no findings; 6 existing suppressions)
- hook-utils sync and bump gates; shared library tests (46 passed)
- Miro typecheck, lint, tests (23 passed), and committed-bundle verification
- signed commit verification

The full plugin contract runner did not terminate under Windows Git Bash in the memory-health orphan-rule test; its exact process tree was stopped and cleaned. The required Linux `plugin-gate` check on this PR is the authoritative full-suite result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how required hygiene checks are scheduled and how failures surface (aggregator vs per-job failure), so a bug in aggregation or `continue-on-error` wiring could mask or misreport failures despite unchanged individual check actions.
> 
> **Overview**
> **Consolidates eleven short hygiene CI jobs** (markdown, typos, gitleaks, editorconfig, shellcheck, actionlint, jsonschema, exec-bit, machine-specific-paths, eol-renormalize, comment-hygiene) into a single **`hygiene`** job behind one **`select-hygiene`** runner gate and **one checkout**, cutting self-hosted dispatches and selector/worker churn.
> 
> Each hygiene step now uses **`continue-on-error: true`** with stable step ids; a new **`scripts/aggregate-hygiene-results.sh`** parses `CHECK_RESULTS`, emits per-check `::error` annotations, and **fails the job** if any outcome is not `success` (with a **`--self-test`** step in CI). **`ci-status`** now depends on **`hygiene`** instead of the eleven separate jobs.
> 
> Heavier lanes (hook-utils-sync, plugin-gate, miro-plugin) and hosted **`runner-policy`**, **`zizmor`**, and **`ci-status`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79656f49d8521a5a7dba54d4e67f0d4e5070d001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->