### PR TITLE
chore(evals): author skill evals for review-toolkit orchestration skills

### DIFF
--- a/plugins/review-toolkit/.claude-plugin/plugin.json
+++ b/plugins/review-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review-toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review-toolkit/CHANGELOG.md
+++ b/plugins/review-toolkit/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `review-toolkit` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Added
+
+- **Skill evals for the two orchestration skills.** Rich-form `evals/evals.json` authored for
+  `quality-gate` (6 cases) and `code-review-fanout` (6 cases), each covering trigger/routing, the
+  happy path, a refusal/guardrail, and an anti-pattern the skill must not do. Additive test
+  definitions only — no behavioral change to any skill or agent.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/review-toolkit/skills/code-review-fanout/evals/evals.json
+++ b/plugins/review-toolkit/skills/code-review-fanout/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "code-review-fanout",
+  "evals": [
+    {
+      "id": 1,
+      "name": "default-tier-transparency",
+      "prompt": "Fan out a review across my branch and give me the ranked findings.",
+      "expected_output": "In default mode the skill classifies the change into a lifecycle tier (small/medium/large), emits the mandatory one-line tier-transparency statement naming surfaces run and surfaces skipped, then dispatches, normalizes, and persists the ranked findings.",
+      "files": [],
+      "expectations": [
+        "Output classifies the change into a small, medium, or large tier",
+        "Output emits a single tier-transparency line naming the tier, the surfaces run, and the surfaces skipped at that tier",
+        "Output persists the ranked findings to a findings file rather than only printing them"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "run-everything-full-sweep",
+      "prompt": "Run everything — every reviewer and orchestrator you have — on this branch.",
+      "expected_output": "The run-everything mode is selected and the skill follows the full-breadth sweep (availability gate, main-thread orchestrators, leaf fan-out, normalize, persist) rather than the lifecycle-tiered default.",
+      "files": [],
+      "expectations": [
+        "Output selects the run-everything mode, not the lifecycle-tiered default",
+        "Output performs the full-breadth sweep including main-thread orchestrator plugins and leaf agents",
+        "Output normalizes the heterogeneous surface outputs and persists a single ranked findings file"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "review-mode-report-only",
+      "prompt": "Fan out a review of my branch and clean up the issues you find.",
+      "expected_output": "The review mode reports findings and persists them but mutates nothing in the working tree; applying fixes is the separate explicit fix action, which does not auto-run after a review.",
+      "files": [],
+      "expectations": [
+        "Output produces and persists findings without modifying the working tree",
+        "Output does NOT auto-apply fixes as part of the review",
+        "Output indicates that applying fixes requires the separate explicit fix action"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "untracked-only-no-spawn",
+      "prompt": "Review my changes — I have some new files I just created but haven't staged.",
+      "expected_output": "With untracked-only changes, the dispatch gate reports that only untracked files are present and that they must be `git add`-ed to be included, and spawns no reviewers — without staging the files itself.",
+      "files": [],
+      "expectations": [
+        "Output reports that only untracked files are present and must be git add-ed to be included in the review",
+        "Output spawns no reviewer subagents for this case",
+        "Output does NOT stage (git add) the untracked files on the user's behalf"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "unknown-action-diagnostic",
+      "prompt": "/review-toolkit:code-review-fanout run-evrything",
+      "expected_output": "For an unrecognized action value the skill emits one diagnostic line naming the unknown value and the available actions, then falls back to the default review — the typo is surfaced, never silently absorbed.",
+      "files": [],
+      "expectations": [
+        "Output emits a diagnostic line naming the unknown action value and listing the available actions (run-everything, fix)",
+        "Output then falls back to running the default review",
+        "Output does not silently absorb the mistyped action as if it were a valid mode"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "pr-comment-gate-opt-in",
+      "prompt": "Fan out a full review on this branch — it has an open PR.",
+      "expected_output": "The skill withholds the code-review orchestrator's PR mode (which posts findings as a PR comment and would violate the report-only contract) unless the user explicitly opts in, skipping it and naming the skip in the surfaces list instead.",
+      "files": [],
+      "expectations": [
+        "Output does NOT dispatch the code-review orchestrator's PR-comment-posting mode without explicit user opt-in",
+        "Output names the skipped PR-mutation surface in its surfaces list rather than silently omitting it",
+        "Output keeps the review report-only, posting nothing to the open PR absent an explicit opt-in"
+      ]
+    }
+  ]
+}

--- a/plugins/review-toolkit/skills/code-review-fanout/evals/evals.json
+++ b/plugins/review-toolkit/skills/code-review-fanout/evals/evals.json
@@ -52,7 +52,7 @@
     {
       "id": 5,
       "name": "unknown-action-diagnostic",
-      "prompt": "/review-toolkit:code-review-fanout run-evrything",
+      "prompt": "/review-toolkit:code-review-fanout runall",
       "expected_output": "For an unrecognized action value the skill emits one diagnostic line naming the unknown value and the available actions, then falls back to the default review — the typo is surfaced, never silently absorbed.",
       "files": [],
       "expectations": [

--- a/plugins/review-toolkit/skills/quality-gate/evals/evals.json
+++ b/plugins/review-toolkit/skills/quality-gate/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "quality-gate",
+  "evals": [
+    {
+      "id": 1,
+      "name": "routes-security-mode",
+      "prompt": "I just finished the auth middleware that validates bearer tokens on our API endpoints. Do a security review of it.",
+      "expected_output": "The skill selects the security lens, reads the security context file before proceeding, and runs a single-lens security review rather than a broad multi-surface fan-out.",
+      "files": [],
+      "expectations": [
+        "Output selects the security review mode (one lens), not a multi-reviewer fan-out",
+        "Output indicates it reads the security context file (context/security.md) before executing the review",
+        "Output does not attempt to fan out across many reviewer surfaces at once"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "self-mode-fresh-context-dispatch",
+      "prompt": "I just finished implementing this change and I have uncommitted edits. Review my work before I move on.",
+      "expected_output": "The skill infers self mode from the just-finished-implementing signal and dispatches a fresh-context read-only subagent to run the checklist, rather than running the review on the same thread that produced the code.",
+      "files": [],
+      "expectations": [
+        "Output selects self mode",
+        "Output dispatches a fresh-context (separate) read-only subagent to perform the self-review",
+        "Output does NOT run the review checklist on the same producing thread that wrote the code"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "does-not-fix-code",
+      "prompt": "Review the code on my branch, and go ahead and fix whatever you find while you're at it.",
+      "expected_output": "The skill performs the review and identifies findings but declines to modify or fix code — it reports issues for the implementer to fix and does not write patches.",
+      "files": [],
+      "expectations": [
+        "Output performs a review that identifies findings",
+        "Output does NOT modify, patch, or fix code despite the user asking it to",
+        "Output states that fixing is the implementer's step, or otherwise defers the fix rather than applying it"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "routes-breadth-to-fanout",
+      "prompt": "Review my branch from every angle — run all the reviewers you have and give me the combined ranked findings.",
+      "expected_output": "The skill recognizes this as a breadth request (many surfaces at once, combined ranking), which is out of its single-lens scope, and routes the user to the code-review-fanout skill instead of fanning out itself.",
+      "files": [],
+      "expectations": [
+        "Output recognizes the request as a multi-surface breadth review, not a single-lens review",
+        "Output routes the user to the code-review-fanout skill for the fan-out",
+        "Output does NOT itself dispatch many reviewers in parallel and rank their combined findings"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "delegated-verify-not-substitute",
+      "prompt": "Do an architecture review of the new modules I added and report the findings.",
+      "expected_output": "The skill dispatches the architecture reviewer, then verifies each returned finding against the actual diff before presenting — treating the reviewer's report as synthesis to check, not as evidence to pass through verbatim.",
+      "files": [],
+      "expectations": [
+        "Output dispatches the architecture review lens",
+        "Output verifies each delegated finding against the actual diff before presenting it",
+        "Output does NOT present the delegated reviewer's report verbatim as confirmed evidence without checking it against the diff"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "ambiguous-mode-asks",
+      "prompt": "Can you review this?",
+      "expected_output": "With no mode selector and no disambiguating signal, the skill presents the available review modes and asks the user which lens to apply rather than silently guessing one.",
+      "files": [],
+      "expectations": [
+        "Output presents the available review modes when the intended lens is ambiguous",
+        "Output asks the user which mode to apply rather than silently committing to one",
+        "Output does not fabricate a review under an assumed mode before the user chooses"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Author rich-form `evals/evals.json` for the two `review-toolkit` orchestration skills, conforming to the bundled schema (`plugins/skill-quality/reference/evals.schema.json`):

- **quality-gate** (6 cases) — routes-security-mode, self-mode-fresh-context-dispatch, does-not-fix-code, routes-breadth-to-fanout, delegated-verify-not-substitute, ambiguous-mode-asks.
- **code-review-fanout** (6 cases) — default-tier-transparency, run-everything-full-sweep, review-mode-report-only, untracked-only-no-spawn, unknown-action-diagnostic, pr-comment-gate-opt-in.

Each skill's set covers trigger/routing, the happy path, at least one refusal/guardrail, and one anti-pattern the skill must not do.

## Warrant re-check

Both skills carry judgment-bearing behavioral contracts (mode routing, self-mode fresh-context dispatch, report-only / verify-not-substitute discipline, dispatch/PR-mutation gates) — **both warranted, no skip verdicts**.

The six reviewer *agents* shipped by review-toolkit have no `evals/` slot (agents are not skills) and are out of scope, as the issue notes.

## Delivery

- Bump `plugins/review-toolkit/.claude-plugin/plugin.json` `0.2.0` → `0.3.0` (minor; additive shipped component — matches the prior evals-authoring convention).
- Record the additive change in `plugins/review-toolkit/CHANGELOG.md`.

## Validation

- `check-jsonschema --schemafile .../evals.schema.json` → `ok -- validation done` for both files.
- `check-skill.sh quality-gate` → PASS, 0 warnings.
- `check-skill.sh code-review-fanout` → PASS (2 pre-existing SKILL.md warnings unrelated to this additive evals change).

Refs melodic-software/medley#1455

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON test fixtures and version/changelog metadata only; no production skill or agent logic changes.
> 
> **Overview**
> Adds **rich-form** `evals/evals.json` for the `quality-gate` and `code-review-fanout` orchestration skills (six cases each), aligned with the skill-quality eval schema. Cases exercise routing, happy paths, guardrails (report-only, no auto-fix, untracked-only gate, PR-comment opt-in), and anti-patterns (breadth routing, verify-not-substitute, ambiguous mode).
> 
> Bumps **review-toolkit** to **0.3.0** and documents the additive evals in **CHANGELOG** — no changes to skill or agent runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2699bc20b0e8f55386458914a5716a5b9c1b4d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->