### PR TITLE
chore(evals): author skill evals for docs-hygiene (5 skills)

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Documentation-hygiene toolkit of five skills: compress (flavor-trim markdown with a semantic-diff safety net), declutter (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), encapsulation-audit (detect citations into skill-private surfaces), and rename-references (sweep stale references after renames).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/skills/compress/evals/evals.json
+++ b/plugins/docs-hygiene/skills/compress/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "compress",
+  "evals": [
+    {
+      "id": 1,
+      "name": "default-compress-preserves-content",
+      "prompt": "Compress this doc: read evals/fixtures/verbose-onboarding-snippet.md relative to the skill directory and tighten it. Drop the flavor but keep everything load-bearing.",
+      "expected_output": "Runs the default action: snapshot, mechanical compression backend (caveman or in-session Edit), a separate semantic-diff pass, revert of any semantic loss, then markdownlint. Filler ('basically', 'really', 'just', 'honestly', 'perhaps') is cut; the zero-warnings directive, the `MAX_UPLOAD_MB=25` value, and the 25 MB rejection threshold are preserved verbatim.",
+      "files": ["evals/fixtures/verbose-onboarding-snippet.md"],
+      "expectations": [
+        "Output removes filler/hedging words (e.g. 'basically', 'really', 'just', 'honestly', 'perhaps')",
+        "The literal `MAX_UPLOAD_MB=25` and the 25 MB rejection threshold are preserved, not dropped or altered",
+        "The 'warnings are treated as errors / block the merge' directive is preserved as content, not cut as flavor",
+        "The run includes a semantic-diff verification step and a markdownlint check, not just a raw edit"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "audit-is-read-only",
+      "prompt": "/compress audit docs/",
+      "expected_output": "Runs the audit action only: a read-only dry-run that classifies each target SKIP / COMPRESS / UNCERTAIN with an expected-yield estimate. No file is edited and no semantic-diff subagent is dispatched.",
+      "files": [],
+      "expectations": [
+        "The run classifies targets as SKIP / COMPRESS / UNCERTAIN rather than editing them",
+        "No file is modified (audit is read-only)",
+        "No semantic-diff subagent is dispatched (dispatch is default-action only, not audit)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "semantic-diff-is-separate-not-self-audit",
+      "prompt": "Compress the prose in docs/architecture/overview.md. It's long and wordy.",
+      "expected_output": "After producing the condensed edits, a SEPARATE fresh-context semantic-diff pass compares original vs condensed and reverts every SEMANTIC LOSS and AMBIGUITY finding. The model that produced the edits does not grade its own output, and the verifier does not re-add words to 'preserve clarity'.",
+      "files": [],
+      "expectations": [
+        "The semantic-diff verification is described as a separate fresh-context pass, not a self-review by the editing model",
+        "SEMANTIC LOSS and AMBIGUITY findings are reverted, not merely noted",
+        "The verifier is not used to re-expand or re-add removed words"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "sub-3-percent-reverts-without-force",
+      "prompt": "Compress CLAUDE.md — it's already pretty tight but see if there's anything to cut.",
+      "expected_output": "An already-disciplined always-loaded instruction file yields under 3% with zero semantic loss, so the default `<3% AND 0 semantic-loss -> REVERT` rule trips and the change is reverted. The run notes that `--force` would be required to keep a sub-3% diff.",
+      "files": [],
+      "expectations": [
+        "A sub-3%, zero-semantic-loss result is reverted rather than shipped under the default rule",
+        "Output states that `--force` is the way to keep an intentional sub-3% diff",
+        "Output does not silently ship a below-threshold change as if it were a normal compression"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "refuse-code-file-target",
+      "prompt": "Compress apps/billing/src/fees.ts — trim the verbose comments and dead code.",
+      "expected_output": "Declines: the methodology is markdown-specific and code / code-comment compression is out of scope. It does not run the compression pipeline on the TypeScript file and points to code-focused tooling instead.",
+      "files": [],
+      "expectations": [
+        "Output declines to compress the code file, citing markdown-only scope",
+        "Output does NOT run the flavor-vs-content compression pipeline on the `.ts` source",
+        "Output does not treat code-comment trimming as in scope"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "ssot-relocation-not-flavor",
+      "prompt": "Compress docs/guide.md. One paragraph restates the full label taxonomy that already lives in .claude/rules/labels.md — collapse it down to a citation while you're compressing.",
+      "expected_output": "Recognizes that collapsing a passage which recaps a cited single source of truth is content RELOCATION, not flavor removal — the semantic-diff net would see the words gone from THIS file and revert them as semantic loss, blind to the SSOT. It treats the relocation as a manual editorial pass (verifying the SSOT actually holds the detail first), or routes multi-file duplication to /extract-ssot, rather than silently deleting the paragraph as flavor.",
+      "files": [],
+      "expectations": [
+        "Output distinguishes content relocation (recap of a cited SSOT) from flavor removal",
+        "Output does NOT silently delete the recap paragraph as if it were flavor that the semantic-diff pass would allow",
+        "Output routes the dedup to a manual editorial pass or to /extract-ssot rather than handling it as ordinary compression"
+      ]
+    }
+  ]
+}

--- a/plugins/docs-hygiene/skills/compress/evals/fixtures/verbose-onboarding-snippet.md
+++ b/plugins/docs-hygiene/skills/compress/evals/fixtures/verbose-onboarding-snippet.md
@@ -1,0 +1,12 @@
+# Onboarding: local build
+
+Basically, before you really get started, you should just make sure that you have
+the required toolchain installed. Honestly, this is perhaps the single most common
+thing that trips new contributors up, so it is really worth double-checking.
+
+Run the build. The build MUST complete with zero warnings — warnings are treated as
+errors and will block the merge. If you happen to see any warnings at all, you will
+want to fix the root cause rather than suppressing them.
+
+Set `MAX_UPLOAD_MB=25` before starting the dev server; uploads above 25 MB are
+rejected by the gateway.

--- a/plugins/docs-hygiene/skills/declutter/evals/evals.json
+++ b/plugins/docs-hygiene/skills/declutter/evals/evals.json
@@ -1,0 +1,74 @@
+{
+  "skill_name": "declutter",
+  "evals": [
+    {
+      "id": 1,
+      "name": "classify-noise-shapes-with-tiers",
+      "prompt": "Declutter this file: read evals/fixtures/noisy-rule-snippet.md relative to the skill directory and audit it for noise.",
+      "expected_output": "Emits a per-file tier table classifying the noise: the dated 'Empirically observed 2026-03-14' line as a citation, the `.work/net-hardening-slice/PLAN.md` reference as a ghost-ref (Tier 2), the 'Path-scoped to ... loads on Read' clause as scope-meta, and the hardcoded 'following three skills' roster as an enum-list. Each finding carries treatment guidance. No edits are applied.",
+      "files": ["evals/fixtures/noisy-rule-snippet.md"],
+      "expectations": [
+        "Output classifies findings by the skill's shape vocabulary (citation, ghost-ref, preamble, enum-list, scope-meta)",
+        "The `.work/net-hardening-slice/PLAN.md` reference is flagged as a ghost-ref",
+        "The hardcoded 'following three skills' list is flagged as an enum-list with a runtime-derivation / category-citation treatment",
+        "The output is a classification report with tiers and treatments; no file is edited"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "read-only-even-when-asked-to-fix",
+      "prompt": "Declutter .claude/rules/foo.md and just go ahead and strip the noise you find — remove it for me.",
+      "expected_output": "Stays read-only despite the request to edit: surfaces the findings with treatment guidance and does NOT apply Edit/Write. It explains the author applies each treatment, or points to the sibling edit-capable skills for the actual removal.",
+      "files": [],
+      "expectations": [
+        "Output does NOT edit or write the file despite the explicit request to strip noise",
+        "Output surfaces findings with treatment guidance for the author to apply",
+        "The read-only contract is honored or explicitly stated"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "slot-variable-not-flagged-as-ghost-ref",
+      "prompt": "Declutter a rule file whose body contains the schema placeholder path `.work/<slug>/PLAN.md` used to describe the working-notes convention (not a literal directory name). Classify it.",
+      "expected_output": "Recognizes `<slug>` as a slot-variable / schema placeholder and does NOT flag it as a ghost-ref. Only concrete literal paths into ephemeral directories are ghost-refs.",
+      "files": [],
+      "expectations": [
+        "The `<slug>` placeholder path is NOT flagged as a ghost-ref",
+        "Output states that slot-variable / schema-placeholder tokens are exempt from the ghost-ref shape"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "exempt-sections-never-flagged",
+      "prompt": "Declutter a rule file that ends with a `## Cross-references` section listing sibling rules and a `## Sources` footer with dated citations. Audit the whole file.",
+      "expected_output": "Treats `## Cross-references` and `## Sources` / `## History` footers as exempt sections and does NOT flag their contents (including the dated citations that live in the Sources footer, which is exactly where the citation treatment relocates them).",
+      "files": [],
+      "expectations": [
+        "Content under `## Cross-references` is not flagged as noise",
+        "Dated citations inside a `## Sources` / `## History` footer are not flagged (the footer is the citation shape's relocation target, not noise)"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "flavor-is-compress-not-declutter",
+      "prompt": "Declutter docs/wordy.md — it's full of filler like 'basically', 'really', and 'just', plus a lot of hedging. Flag all of that.",
+      "expected_output": "Does NOT classify filler / hedging / articles as any of the five declutter noise shapes — that FLAVOR is the sibling /compress's territory. It reports no noise-shape findings for the filler and routes flavor removal to /compress.",
+      "files": [],
+      "expectations": [
+        "Filler / hedging words are NOT classified under any of declutter's five noise shapes",
+        "Output routes flavor removal to /compress rather than handling it as declutter noise"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "preamble-diataxis-classification",
+      "prompt": "Declutter a data-registry reference file (a table of label slugs) that opens with a multi-paragraph 'Why this file exists' section explaining the history and motivation. How do you treat the preamble?",
+      "expected_output": "Applies the Diataxis classifier: on a Reference-quadrant file (a data table / registry) the 'Why this file exists' preamble is Tier 2 with a STRIP treatment, replacing it with a one-sentence orientation — as opposed to KEEP on an Explanation-quadrant file (rule body, ADR, convention rationale).",
+      "files": [],
+      "expectations": [
+        "Output flags the preamble on the Reference-quadrant file with a STRIP / replace-with-one-sentence treatment",
+        "Output distinguishes the Reference-quadrant STRIP from the Explanation-quadrant KEEP case"
+      ]
+    }
+  ]
+}

--- a/plugins/docs-hygiene/skills/declutter/evals/fixtures/noisy-rule-snippet.md
+++ b/plugins/docs-hygiene/skills/declutter/evals/fixtures/noisy-rule-snippet.md
@@ -1,0 +1,22 @@
+# Retry policy
+
+## Why this file exists
+
+This file exists to document the retry policy. It was created because we kept
+re-litigating retry behavior in review, so we wrote it down here to settle it.
+
+Path-scoped to `src/net/**`; loads on Read of any file under that tree.
+
+## Policy
+
+Empirically observed 2026-03-14: three retries with exponential backoff clears the
+transient socket resets we saw in the incident. Cap total wait at 30s.
+
+For per-slice overrides, see `.work/net-hardening-slice/PLAN.md` for the worked
+example the author drafted.
+
+The following three skills consume this rule: `/net-audit`, `/net-lint`, `/net-verify`.
+
+## Cross-references
+
+- `src/net/backoff.md` — backoff curve derivation

--- a/plugins/docs-hygiene/skills/encapsulation-audit/evals/evals.json
+++ b/plugins/docs-hygiene/skills/encapsulation-audit/evals/evals.json
@@ -1,0 +1,75 @@
+{
+  "skill_name": "encapsulation-audit",
+  "evals": [
+    {
+      "id": 1,
+      "name": "detect-routes-and-tables-violations",
+      "prompt": "Audit encapsulation across the repo — who is reaching into skill internals?",
+      "expected_output": "Runs the detect action: executes the detection grep, classifies each raw hit legal-vs-illegal via the filter taxonomy, and emits a violations table (File / Line / Cite / Suggested path A|B) plus a summary count. One action per response.",
+      "files": [],
+      "expectations": [
+        "Output runs the detect action and produces a violations table with a suggested remediation path (A or B) per hit",
+        "Raw hits are classified through the filter taxonomy rather than every grep hit being reported as illegal",
+        "Output is scoped to detect only, not fix or file-issues in the same response"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "single-violation-still-flagged",
+      "prompt": "The detector found exactly one external citation reaching into a skill's private subdirectory. It's only one place — is that worth flagging?",
+      "expected_output": "Flags the single violation. Encapsulation violations are single-instance matters — the Rule of Three does NOT gate them, and 'it's only one place' is the single-violation-tolerance anti-pattern the skill guards against. Each cite is a binary contract break.",
+      "files": [],
+      "expectations": [
+        "Output flags the single violation rather than dismissing it as below a threshold",
+        "Output states that the Rule of Three does not gate encapsulation (single-instance matter)",
+        "Output does not treat 'only one place' as a reason to tolerate the violation"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "filter-taxonomy-legal-hits",
+      "prompt": "The detect grep returned two hits: (a) `.claude/skills/compress/SKILL.md` citing `.claude/skills/compress/context/flavor-vs-content-matrix.md`, and (b) a path under `~/.claude/plugins/cache/docs-hygiene/...`. Classify them.",
+      "expected_output": "Classifies both as legal, not violations: (a) is self-citation (intra-skill progressive disclosure) and (b) is plugin-cache (upstream territory / foreign contract). Neither survives the filter taxonomy as illegal.",
+      "files": [],
+      "expectations": [
+        "The self-citation (skill citing its own private path) is classified legal, not a violation",
+        "The `~/.claude/plugins/cache/...` hit is classified legal (plugin-cache filter)",
+        "Neither hit is reported as an illegal violation"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "path-b-missing-action-files-and-stops",
+      "prompt": "A rule file reaches into a skill's private body because it wants the skill's behavior, but the skill has no public action that covers the use case. Remediate it.",
+      "expected_output": "Chooses Path B (route via /skill invocation) but, finding the needed public action does NOT exist, surfaces the gap as a side note, files a tracking work item for the missing action, and leaves a `# TODO(encapsulation-audit): missing /<skill> <action>` marker — it does NOT silently inline a workaround that hides the violation from future audits.",
+      "files": [],
+      "expectations": [
+        "Output identifies this as a Path B (wants behavior) case, not Path A (wants data)",
+        "On the missing action it files a tracking work item and leaves a TODO(encapsulation-audit) marker rather than fixing it silently",
+        "Output does NOT inline a workaround that would hide the violation from later audits"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "scripts-entry-surface-is-legal",
+      "prompt": "A CI workflow path-cites `.claude/skills/extract-ssot/scripts/detect.sh` directly. Is that an encapsulation violation?",
+      "expected_output": "No — a skill's `scripts/` is its declared entry surface, so harness / CI / hooks may path-cite entry scripts directly. The inbound audit treats `<X>/scripts/...` cites as legal (like data files and a bare SKILL.md path) and does not flag it.",
+      "files": [],
+      "expectations": [
+        "Output classifies the `scripts/` entry-script cite as legal, not a violation",
+        "Output cites the scripts/ entry-surface carve-out as the reason"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "duplication-routes-to-extract-ssot",
+      "prompt": "I found the same paragraph of content duplicated across three skill bodies. Can encapsulation-audit consolidate it?",
+      "expected_output": "Routes away: content duplication / Rule-of-Three clusters are the sibling /extract-ssot's concern, not encapsulation-audit's. This skill detects citations into private surfaces, not repeated content.",
+      "files": [],
+      "expectations": [
+        "Output routes content-duplication consolidation to /extract-ssot",
+        "Output does NOT treat cross-file duplication as an encapsulation violation"
+      ]
+    }
+  ]
+}

--- a/plugins/docs-hygiene/skills/extract-ssot/evals/evals.json
+++ b/plugins/docs-hygiene/skills/extract-ssot/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "extract-ssot",
+  "evals": [
+    {
+      "id": 1,
+      "name": "identify-on-duplication-smell",
+      "prompt": "The same 'always run the build before opening a PR' guardrail is reworded across five rule and skill files. I want a single source of truth for it.",
+      "expected_output": "Routes to the identify action (or a targeted single-cluster identify), grounding the cluster in Tier 0 grep evidence, and — because 5 instances clear the Rule of Three — proceeds toward planning an extraction into a single named home cited by exact heading.",
+      "files": [],
+      "expectations": [
+        "Output routes to the extract-ssot workflow (identify / verify / plan) rather than editing files ad hoc",
+        "Output confirms the instance count via direct (Tier 0) grep evidence, not recall",
+        "Output treats 5 instances as clearing the Rule of Three"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "refuse-below-rule-of-three",
+      "prompt": "This constraint appears in exactly two files. Extract it into a shared SSOT rule so it's DRY.",
+      "expected_output": "Refuses extraction: with only 2 instances the Rule of Three is not met, and premature abstraction is the dominant failure mode. It recommends leaving the content inline until a third instance appears.",
+      "files": [],
+      "expectations": [
+        "Output REFUSES the extraction at 2 instances (below the Rule of Three)",
+        "Output recommends keeping the content inline for now",
+        "Output frames premature extraction as the risk, not a benefit"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "tier0-evidence-not-recall",
+      "prompt": "I'm pretty sure the timeout guidance is duplicated all over the rules — I remember seeing it in a bunch of places. Just extract it into one rule.",
+      "expected_output": "Does not act on recall or a subagent summary as if it were proof. It promotes the claim to Tier 0 by running its own grep to confirm the actual instances and locations before planning or editing — a remembered roster is a lead list, never evidence.",
+      "files": [],
+      "expectations": [
+        "Output runs its own grep / file reads to confirm the duplication before extracting (Tier 0)",
+        "Output does NOT extract based solely on the user's recall / 'I remember seeing it'",
+        "Output treats the recalled claim as an unverified lead until grounded"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "code-cluster-out-of-scope",
+      "prompt": "The same magic string literal is repeated in four .cs source files. Use extract-ssot to DRY it up.",
+      "expected_output": "Flags the cluster but declines to apply its markdown citation contract to code: repeated code literals are extracted with language-idiomatic tooling (a constants file / shared module, IDE-rename / Roslyn), where compiler and lint catch missed call sites. The skill's HOW is markdown-specific.",
+      "files": [],
+      "expectations": [
+        "Output identifies the .cs cluster as code, out of scope for the skill's markdown citation contract",
+        "Output refers the caller to language-idiomatic extraction (constants/shared module, IDE rename / Roslyn)",
+        "Output does NOT apply a markdown 'cite by heading' contract to the code duplication"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "describe-use-expose-classification",
+      "prompt": "The install command `npm ci && npm run build` appears verbatim in the README's Getting Started section and is also referenced by a build rule. Should both cite one SSOT, or can they restate it?",
+      "expected_output": "Classifies roles: the build rule is a USE consumer and must cite the SSOT rather than recap body content, while the README is an EXPOSE surface that MAY restate the command for onboarding clarity when adjacent prose cross-references the SSOT. Contract identifiers themselves (the literal command tokens) stay inline.",
+      "files": [],
+      "expectations": [
+        "Output classifies the consumers by role (USE must cite; EXPOSE may restate)",
+        "Output allows the README (EXPOSE) to restate for onboarding clarity with a cross-reference, rather than forcing a bare citation",
+        "Output does not treat naming the literal command tokens as duplication"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "one-level-deep-no-citation-chains",
+      "prompt": "Plan an extraction where rule A.md would cite B.md, and B.md already cites C.md for the same concept. Is that fine?",
+      "expected_output": "Rejects the transitive chain: citations stay one level deep — never A -> B -> C. It consolidates so consumers cite the single canonical home directly, and notes a heading rename triggers a /rename-references sweep.",
+      "files": [],
+      "expectations": [
+        "Output rejects the multi-hop A -> B -> C citation chain (one level deep)",
+        "Output has consumers cite the single canonical SSOT directly",
+        "Output notes that a heading/identifier change requires a /rename-references sweep"
+      ]
+    }
+  ]
+}

--- a/plugins/docs-hygiene/skills/rename-references/evals/evals.json
+++ b/plugins/docs-hygiene/skills/rename-references/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "rename-references",
+  "evals": [
+    {
+      "id": 1,
+      "name": "audit-sweep-on-rename",
+      "prompt": "I renamed the skill /verify to /verify-changes. Find every stale reference.",
+      "expected_output": "Runs an audit sweep with the full pattern library (not a single token grep), triages hits into Certain / Chain-context / Ambiguous buckets, and reports them read-only. Old=`/verify`, new=`/verify-changes` parsed from the prose.",
+      "files": [],
+      "expectations": [
+        "Output runs the full pattern-library sweep, not a single `/verify` token grep",
+        "Hits are triaged into the Certain / Chain-context / Ambiguous buckets",
+        "The audit is read-only (no edits applied in this audit invocation)"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "never-trust-single-pattern-clean",
+      "prompt": "I ran `grep -r '/verify' .` and it came back with zero matches after my rename. That means the rename is clean, right?",
+      "expected_output": "Warns that a single-pattern grep returning clean is exactly the bug this skill exists to prevent — references survive in chain prose, comma-lists, numbered table rows, and frontmatter forms that token-only grep misses. It runs the full pattern library / audit rather than trusting the clean single-grep.",
+      "files": [],
+      "expectations": [
+        "Output does NOT accept the zero-match single grep as proof the rename is clean",
+        "Output names syntactic forms (chain prose, comma-lists, numbered rows, frontmatter) that a token grep misses",
+        "Output recommends running the full pattern library / audit"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "english-verb-forces-ambiguous-confirm",
+      "prompt": "Apply a rename of the skill `test` to `test e2e` across the repo.",
+      "expected_output": "Forces the bare `test` token into the Ambiguous bucket (English-verb blocklist) regardless of regex position and confirms each match with surrounding context rather than auto-applying — bare 'test' collides with ordinary English usage. It applies the most-specific match first to avoid double-editing the substring expansion.",
+      "files": [],
+      "expectations": [
+        "The bare `test` token is routed to the Ambiguous bucket and confirmed per-match, not auto-applied",
+        "Output cites the English-verb collision as the reason for mandatory confirmation",
+        "Output does not blindly replace every `test` occurrence in prose"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "re-sweep-until-zero-new-form-learned",
+      "prompt": "You applied the /verify to /verify-changes rename. The re-sweep still finds one match in a frontmatter glob form the pattern library didn't have. What now?",
+      "expected_output": "Does not declare done: re-sweep must reach count == 0. The new syntactic form is a pattern-library gap — it adds the form to the pattern registry, re-iterates the sweep, and does NOT silently apply or ignore the straggler.",
+      "files": [],
+      "expectations": [
+        "Output does NOT declare the rename complete while the re-sweep count is non-zero",
+        "Output treats the new form as a pattern-library gap to add, then re-sweeps",
+        "Output does not silently apply or drop the remaining match"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "refuse-framework-migration",
+      "prompt": "Use rename-references to migrate our test project from xUnit v2 to xUnit v3 — update all the APIs.",
+      "expected_output": "Declines: framework version migrations are a behavioral upgrade, not a text rename, and are out of scope. It points to dedicated migration tooling and clarifies the skill handles documentation / config / identifier-string renames, not AST-level or API migrations.",
+      "files": [],
+      "expectations": [
+        "Output declines the framework migration as out of scope",
+        "Output distinguishes a behavioral/API migration from a text-string rename",
+        "Output points to dedicated migration tooling instead of running its sweep"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "plan-doc-auto-excluded",
+      "prompt": "Apply the /verify to /verify-changes rename. Note the active plan doc PLAN.md documents this very rename and mentions both names on purpose.",
+      "expected_output": "Auto-excludes the rename-documenting plan doc from the sweep — both old and new names appear there by design, and editing it would break the migration narrative. Apply mode rejects `--include-plan-docs`; the plan doc is left untouched.",
+      "files": [],
+      "expectations": [
+        "The active rename-documenting plan doc is auto-excluded and left unedited",
+        "Output explains both names appear in the plan doc by design (self-reference)",
+        "Output does not rewrite the plan doc's occurrences of the old name"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds rich-form `evals/evals.json` for all five `docs-hygiene` skills and bumps the plugin's `plugin.json` version so marketplace consumers pick up the new shipped eval component.

| Skill | Cases | Focus |
|---|---|---|
| `compress` | 6 | default-vs-audit routing, content preserved over flavor, separate semantic-diff pass, sub-3% revert, refuse code file, SSOT-relocation-not-flavor |
| `declutter` | 6 | shape/tier classification, read-only when asked to fix, slot-variable not ghost-ref, exempt sections, flavor is `/compress`, Diataxis preamble |
| `encapsulation-audit` | 6 | detect routing, single-violation not gated by Rule of Three, filter-taxonomy legal hits, Path B missing-action files+stops, `scripts/` entry-surface legal, dedup routes to `/extract-ssot` |
| `extract-ssot` | 6 | identify on duplication smell, refuse below Rule of Three, Tier 0 over recall, code cluster out of scope, DESCRIBE/USE/EXPOSE, one-level-deep citations |
| `rename-references` | 6 | audit sweep, never trust single-pattern grep, English-verb ambiguous confirm, re-sweep until zero, refuse framework migration, plan-doc auto-excluded |

Two markdown fixtures back the `compress` and `declutter` happy-path cases. Each case carries `id`, kebab-case `name`, `prompt`, `expected_output`, optional `files`, and an `expectations` array of objectively-verifiable checks — modeled on the `bug-report` rich-form exemplar.

## Warrant

All five skills carry judgment-bearing behavioral contracts (action routing + guardrail/refusal rules + guarded anti-patterns) — none is pure-reference, so **no skip verdicts**.

## Decision called out

Version-bump level was unspecified by the issue. `docs-hygiene` is a single multi-skill plugin, so one manifest bump covers all five: chose a **minor** bump (`0.1.0` -> `0.2.0`) — evals are an additive, backward-compatible shipped component. Matches the sibling evals PR precedent; reversible to patch if a maintainer prefers.

## Validation

- `check-jsonschema` against the bundled `plugins/skill-quality/reference/evals.schema.json` — all 5 conform
- `check-skill.sh` presence gate — all 5 PASS, 0 errors (remaining WARNs are pre-existing skill-body Gotchas-surface items, out of scope for an evals-only PR)
- `scripts/validate-plugins.sh` (manifests + catalog, `--strict`) — pass
- LF endings, final newline, `typos` clean

## Doc drift noted

The issue cites `docs/MIGRATION-PLAYBOOK.md` "Evals — warrant policy and consumer-verify recipe" and `docs/evals-coverage.md`; neither exists on current `main` (they live on the unmerged evals-backfill branch). Did not block this work; the coverage doc is now stale re docs-hygiene and will need reconciling when that branch lands.

Refs melodic-software/medley#1450

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive eval JSON and fixtures only; no skill runtime or application logic changes. Version bump is backward-compatible packaging.
> 
> **Overview**
> Ships **rich-form** `evals/evals.json` for all five `docs-hygiene` skills (`compress`, `declutter`, `encapsulation-audit`, `extract-ssot`, `rename-references`), with six cases each covering action routing, guardrails, refusals, and sibling-skill boundaries. Cases use `prompt`, `expected_output`, and verifiable `expectations` (plus optional `files`).
> 
> Adds markdown fixtures for the `compress` and `declutter` fixture-driven cases (`verbose-onboarding-snippet.md`, `noisy-rule-snippet.md`).
> 
> Bumps **`docs-hygiene`** plugin manifest version **`0.1.0` → `0.2.0`** so marketplace installs pick up the new eval component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0ab0b900540c122ef7f76d53b8e3d08875059c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->