### PR TITLE
chore(evals): backfill setup-action skill evals (5 setup skills)

### DIFF
--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -77,7 +77,7 @@ covered by concurrent sibling backfill (the issue is a no-op, close it); `PARTIA
 | `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | **OPEN** — author vs current shipped behavior; owning retrofits update their eval on behavior change (simulation #1405, machine-health #1419, skill-quality #1418) |
 | `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | **OPEN** — #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
 | `melodic-software/medley#1458` | boris, thariq-skills (2) | **DONE** — both backfilled concurrently; reclassified from pure-reference for their `update`/`update --apply` routing + mutation-safety contract |
-| `melodic-software/medley#1462` | setup-action skills self-scan: bug-report/setup, claude-ops/setup, work-items/setup + future landings (3) | **OPEN** — self-scanning catch-all for setup skills that shipped without evals and aren't in a family batch/deferral |
+| `melodic-software/medley#1462` | setup-action skills self-scan: bug-report/setup, claude-ops/setup, work-items/setup, ai-briefing/setup + future landings (4) | **DONE** — all four backfilled; `ai-briefing/setup` caught by the scan as a post-filing landing (uncovered, no family-batch/retrofit owner — #1457 covers behavior fixes, not its eval — not deferred) |
 
 ## Deferred — author in the destination repo once separation lands
 
@@ -109,6 +109,8 @@ catch-all**: it scans `plugins/*/skills/setup/` for any setup skill lacking `eva
 backfills those not already owned by a plugin-family batch (`discovery/setup` #1448,
 `implementation/setup` #1449, `machine-health`/`skill-quality` setup #1454) or deferred (`knowledge`,
 `songwriting`). A config-writer skill is warrantable (the `codebase-audit/setup` eval is the model).
+Its first pass covered `bug-report/setup`, `claude-ops/setup`, `work-items/setup`, and `ai-briefing/setup`
+(the last caught as a post-filing landing — a scaffold/dep-install setup with no other eval owner).
 
 ## Skip — pure-reference plugins (2)
 

--- a/docs/evals-coverage.md
+++ b/docs/evals-coverage.md
@@ -77,7 +77,7 @@ covered by concurrent sibling backfill (the issue is a no-op, close it); `PARTIA
 | `melodic-software/medley#1454` | event-storming: methodology, simulation; machine-health: machine-health, setup; skill-quality: skill-quality, setup (6) | **OPEN** — author vs current shipped behavior; owning retrofits update their eval on behavior change (simulation #1405, machine-health #1419, skill-quality #1418) |
 | `melodic-software/medley#1455` | review-toolkit: quality-gate, code-review-fanout (2) | **OPEN** — #1421 CLOSED → stable; the six reviewer agents are not skills and carry no `evals/` slot |
 | `melodic-software/medley#1458` | boris, thariq-skills (2) | **DONE** — both backfilled concurrently; reclassified from pure-reference for their `update`/`update --apply` routing + mutation-safety contract |
-| `melodic-software/medley#1462` | setup-action skills self-scan: bug-report/setup, claude-ops/setup, work-items/setup, ai-briefing/setup + future landings (4) | **DONE** — all four backfilled; `ai-briefing/setup` caught by the scan as a post-filing landing (uncovered, no family-batch/retrofit owner — #1457 covers behavior fixes, not its eval — not deferred) |
+| `melodic-software/medley#1462` | setup-action skills self-scan: bug-report/setup, claude-ops/setup, work-items/setup, ai-briefing/setup, planning/setup + future landings (5) | **DONE** — all five backfilled; `ai-briefing/setup` and `planning/setup` caught by the scan as post-filing landings (uncovered, no family-batch owner — #1447 covers planning's seven behavior skills but not `setup`, #1457 covers ai-briefing behavior fixes not its eval — neither deferred) |
 
 ## Deferred — author in the destination repo once separation lands
 
@@ -109,8 +109,9 @@ catch-all**: it scans `plugins/*/skills/setup/` for any setup skill lacking `eva
 backfills those not already owned by a plugin-family batch (`discovery/setup` #1448,
 `implementation/setup` #1449, `machine-health`/`skill-quality` setup #1454) or deferred (`knowledge`,
 `songwriting`). A config-writer skill is warrantable (the `codebase-audit/setup` eval is the model).
-Its first pass covered `bug-report/setup`, `claude-ops/setup`, `work-items/setup`, and `ai-briefing/setup`
-(the last caught as a post-filing landing — a scaffold/dep-install setup with no other eval owner).
+Its first pass covered `bug-report/setup`, `claude-ops/setup`, `work-items/setup`, `ai-briefing/setup`, and
+`planning/setup` (the last two caught as post-filing landings — a scaffold/dep-install setup and a
+`notes_dir` config-writer, each with no other eval owner).
 
 ## Skip — pure-reference plugins (2)
 

--- a/plugins/ai-briefing/.claude-plugin/plugin.json
+++ b/plugins/ai-briefing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-briefing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Aggregate AI-industry news via multi-wave collection (Chrome/X, Grok, Perplexity, RSS, GitHub releases), dedup, rank, and present as markdown, HTML, or PPTX decks. Ships retro/search/drift actions, a per-profile runner and build pipeline with a neutral default brand, and a named-profile seam so each audience/deployment supplies its own curated follow-list, branding, and ranking lens. Machine state (seen-items, runs, generated decks) persists per profile in the plugin data directory.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ai-briefing/skills/setup/evals/evals.json
+++ b/plugins/ai-briefing/skills/setup/evals/evals.json
@@ -1,0 +1,43 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "scaffolds-profile-and-seeds-follow-list-idempotently",
+      "prompt": "/ai-briefing:setup",
+      "expected_output": "Resolves the profile name from --profile or asks, defaulting to the root default profile, and scaffolds the profiled folder under the consumer's .claude/ai-briefing/ (or .../<name>/ for a named profile). It copies the bundled seed following-list.json only when one is absent and leaves an existing follow-list intact (offering a refresh instead), and recommends gitignoring the .claude/ai-briefing/**/*.local.* personal overlays while keeping team config tracked.",
+      "files": [],
+      "expectations": [
+        "Resolves the profile name (from --profile or by asking) defaulting to the root default profile",
+        "Scaffolds the profile under the consumer's .claude/ai-briefing/ rather than any machine-local location",
+        "Copies the seed following-list.json only when absent and leaves an existing follow-list intact",
+        "Recommends gitignoring the .claude/ai-briefing/**/*.local.* personal overlays while keeping team config tracked"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "optional-branding-and-lens-skipped-cleanly",
+      "prompt": "/ai-briefing:setup",
+      "expected_output": "Offers the optional brand.js branding overlay and the audience.md stack-lens as choices, scaffolding each into the profile directory only when the consumer wants it and skipping cleanly when declined (leaving the neutral default brand and no impact tag). Neither optional overlay is written into the plugin data directory.",
+      "files": [],
+      "expectations": [
+        "Offers brand.js and audience.md as optional overlays rather than forcing them",
+        "Scaffolds an accepted overlay into the profile directory, not the plugin data directory",
+        "Skips a declined overlay cleanly, leaving the neutral default brand and no impact tag"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "stages-runtime-deps-version-gated-not-curated-config",
+      "prompt": "/ai-briefing:setup",
+      "expected_output": "Stages the runnable script tree and installs node_modules as a sibling under ${CLAUDE_PLUGIN_DATA}/runtime, gated on the plugin version so a re-run re-stages only when the version changed (installing the heavier build tree only when slides/html output is needed). It never writes curated profile config into ${CLAUDE_PLUGIN_DATA} — that directory holds machine-local run state (seen-items, generated decks) only.",
+      "files": [],
+      "expectations": [
+        "Stages the runnable tree and installs node_modules under ${CLAUDE_PLUGIN_DATA}/runtime so ESM resolution finds the deps",
+        "Gates re-staging on the plugin version so an unchanged re-run does not reinstall",
+        "Installs the heavier build tree only when slides/html output is required",
+        "Never writes curated profile config into ${CLAUDE_PLUGIN_DATA} (machine run-state only)"
+      ]
+    }
+  ]
+}

--- a/plugins/bug-report/.claude-plugin/plugin.json
+++ b/plugins/bug-report/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bug-report",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Produces a structured five-field bug report — title, steps to reproduce, expected vs actual, severity with justification, and suggested fix location — from an informal defect description. Read-only by default: it emits the report and never edits code, opens a PR, or files an issue on its own.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bug-report/skills/setup/evals/evals.json
+++ b/plugins/bug-report/skills/setup/evals/evals.json
@@ -1,0 +1,44 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "interviews-the-binary-before-writing",
+      "prompt": "/bug-report:setup",
+      "expected_output": "Reads the current effective output_dir across settings scopes (querying only that single key, not whole settings files), reports the effective value or that it is unset (reports land in the plugin data directory), then interviews the single yes/no decision — commit --file reports into the repo, or keep them in the plugin's private data directory — recommending the uncommitted default. It writes nothing until the user chooses, and only when repo-committed is chosen does it infer a repo-root-anchored path.",
+      "files": [],
+      "expectations": [
+        "Reads the effective output_dir narrowly (only the pluginConfigs output_dir key), never loading a settings file wholesale",
+        "Presents the commit-vs-private-default choice as a single decision with the uncommitted default recommended",
+        "Writes no configuration until the user has chosen",
+        "Infers a repo-root-anchored path only when the user opts into repo-committed reports, with no baked repo assumptions"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "idempotent-reset-clears-every-writable-scope",
+      "prompt": "/bug-report:setup",
+      "expected_output": "When output_dir already carries a value, re-running reads the current value and its scope and proposes changes against that baseline rather than overwriting blind. Choosing the private (uncommitted) default clears output_dir from every writable scope that carries it — not just the winning one — pruning emptied options/pluginConfigs containers, touching the user global scope only with explicit consent, and never editing read-only Managed or command-line scopes.",
+      "files": [],
+      "expectations": [
+        "Detects and reports the existing effective value and its scope before proposing changes",
+        "Clears output_dir from every writable scope that carries it when resetting to the default, not only the winning scope",
+        "Edits the user global scope only with explicit consent and never edits read-only Managed or command-line scopes",
+        "Does not overwrite or drop the existing value without user confirmation"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "writes-portable-value-to-tracked-project-scope",
+      "prompt": "/bug-report:setup\n\nCommit --file bug reports into this repo.",
+      "expected_output": "Writes output_dir to the consumer's tracked project .claude/settings.json as a portable repo-root-anchored value (e.g. ${CLAUDE_PROJECT_DIR}/.bug-reports), never a machine-absolute path in the shared team scope, creating the pluginConfigs/options path without disturbing unrelated keys. It offers the .claude/settings.local.json personal overlay plus gitignore convention and never writes configuration into the plugin directory or plugin data directory.",
+      "files": [],
+      "expectations": [
+        "Writes output_dir to the consumer's tracked project .claude/settings.json",
+        "Stores a portable repo-root-anchored value, never a machine-absolute path in the shared team scope",
+        "Offers the .claude/settings.local.json personal overlay and gitignore convention",
+        "Does not write configuration into the plugin directory or plugin data directory"
+      ]
+    }
+  ]
+}

--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Claude Code operations toolkit. Four skills: claude-observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), claude-troubleshooting (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), claude-code-changelog (ingest Claude Code changelog entries and integrate them into the current repo), and a re-runnable setup action that settles where the troubleshooting registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/skills/setup/evals/evals.json
+++ b/plugins/claude-ops/skills/setup/evals/evals.json
@@ -1,0 +1,44 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "interviews-binary-then-path-only-if-needed",
+      "prompt": "/claude-ops:setup",
+      "expected_output": "Reads the current effective registry_dir across scopes (querying only that single key, not whole settings files), reports the effective value or that it is unset (registry lives in the per-machine plugin data directory), then presents the binary — per-machine (unset, recommended default) versus in-repo git-tracked — and asks for a directory only when the consumer chooses in-repo, inferring a .claude/-rooted tracked path. No baked repo assumptions.",
+      "files": [],
+      "expectations": [
+        "Reads the effective registry_dir narrowly (only the pluginConfigs registry_dir key), never loading a settings file wholesale",
+        "Presents the per-machine-vs-in-repo binary with the per-machine default recommended",
+        "Asks for a directory only when in-repo is chosen and infers a .claude/-rooted tracked path",
+        "Makes no baked repo assumptions and writes nothing until the user chooses"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "idempotent-reports-scope-and-shadowing",
+      "prompt": "/claude-ops:setup",
+      "expected_output": "When registry_dir already carries a value, re-running reports the effective value and which scope (Local > Project > User) supplies it, and proposes changes against that baseline rather than overwriting blind. When a local override shadows the project value, it says so explicitly — a project-scope write will not change what the plugin uses until the developer updates or removes the local override.",
+      "files": [],
+      "expectations": [
+        "Reports the existing effective registry_dir and its supplying scope before proposing changes",
+        "Resolves precedence as Local > Project > User",
+        "Warns when a higher-precedence local override will shadow a project-scope write",
+        "Does not overwrite the existing value blind"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "persists-to-tracked-project-not-plugin",
+      "prompt": "/claude-ops:setup\n\nKeep the troubleshooting registry in this repo, git-tracked.",
+      "expected_output": "Writes registry_dir to the consumer's project .claude/settings.json as a value relative to the project root, storing it verbatim and creating the pluginConfigs/options path without disturbing unrelated keys. It offers the .claude/settings.local.json personal overlay plus gitignore convention and never stores configuration in the plugin install directory or its data directory.",
+      "files": [],
+      "expectations": [
+        "Writes registry_dir to the consumer's tracked project .claude/settings.json relative to the project root",
+        "Creates the pluginConfigs/options path without disturbing unrelated keys",
+        "Offers the .claude/settings.local.json personal overlay and gitignore convention",
+        "Does not store configuration in the plugin install directory or plugin data directory"
+      ]
+    }
+  ]
+}

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pre-implementation planning pipeline: diverge on candidate approaches, lock product intent and the engineering contract, explore the design space, stress-test adversarially, and produce a structured implementation plan with an approval gate — persisting PRD.md / PLAN.md / design artifacts for fresh-session handoff.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/planning/skills/setup/evals/evals.json
+++ b/plugins/planning/skills/setup/evals/evals.json
@@ -1,0 +1,44 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "infers-notes-dir-and-interviews-before-writing",
+      "prompt": "/planning:setup",
+      "expected_output": "Reads the current effective notes_dir across scopes (querying only that single key, not whole settings files) and reports the effective value and its scope. When none is set, it infers a landing location from the repo — a working-notes convention declared in CLAUDE.md/AGENTS.md/.claude/rules, else an existing notes/working-artifacts directory, else the documented .claude/notes default — and presents that single knob with a recommendation, writing nothing until the user accepts.",
+      "files": [],
+      "expectations": [
+        "Reads the effective notes_dir narrowly (only the pluginConfigs notes_dir key), never loading a settings file wholesale",
+        "Infers the value from the repo (declared working-notes convention, existing notes directory, else the .claude/notes default) rather than guessing",
+        "Presents the single notes_dir knob with a recommendation and invents no further options",
+        "Writes nothing until the user accepts the value"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "surfaces-convention-shadowing-and-idempotent",
+      "prompt": "/planning:setup",
+      "expected_output": "When notes_dir already carries a value, re-running reports it and its scope and proposes changes against that baseline rather than overwriting blind. Even with a value set, it inspects the repo for a declared working-notes convention and, when one conflicts with the effective value, surfaces the shadowing explicitly — the declared convention wins at write time — and offers to reconcile. It also flags when a higher-precedence Managed or Local layer will shadow the project value it writes.",
+      "files": [],
+      "expectations": [
+        "Reports the existing effective notes_dir and its scope before proposing changes",
+        "Inspects for a declared working-notes convention even when a value is set, and surfaces the shadowing when it conflicts (convention wins at write time)",
+        "Warns when a higher-precedence Managed or Local layer will shadow the project-scope write",
+        "Does not overwrite the existing value blind"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "persists-portable-value-to-tracked-project-not-plugin",
+      "prompt": "/planning:setup\n\nLand planning artifacts in docs/planning for the whole team.",
+      "expected_output": "Writes a portable, project-relative notes_dir to the consumer's tracked project .claude/settings.json, creating the pluginConfigs/options path without disturbing unrelated keys. It never propagates a machine-absolute or personal value into the shared team scope — routing a personal-only override to .claude/settings.local.json instead — offers the local overlay plus gitignore convention, and never writes into the plugin directory or plugin data directory.",
+      "files": [],
+      "expectations": [
+        "Writes a portable, project-relative notes_dir to the consumer's tracked project .claude/settings.json",
+        "Never propagates a machine-absolute or personal value into the shared team scope, routing a personal-only override to .claude/settings.local.json",
+        "Offers the .claude/settings.local.json personal overlay and gitignore convention",
+        "Does not write into the plugin directory or plugin data directory"
+      ]
+    }
+  ]
+}

--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Manages development work items through a provider-neutral tracker seam (GitHub the bound adapter today): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and structured triage. The recurring-schedule seam (.github/recurring-schedule.json) is seeded and reshaped by the re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/skills/setup/evals/evals.json
+++ b/plugins/work-items/skills/setup/evals/evals.json
@@ -1,0 +1,57 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "infers-candidates-and-interviews-per-item",
+      "prompt": "/work-items:setup",
+      "expected_output": "Reads any existing .github/recurring-schedule.json and summarizes it, then infers candidate recurring items from what the repo actually contains (dependency manifests, lint/formatter config, CI workflows, security-sensitive surfaces) each with a recommended cadence, and interviews one item at a time with recommended field values marked before moving on. It does not invent items the repo gives no signal for, and writes only what the user accepts.",
+      "files": [],
+      "expectations": [
+        "Reads and summarizes an existing .github/recurring-schedule.json before proposing changes",
+        "Infers candidate items from concrete repo signals (manifests, lint config, CI workflows, security surfaces) with recommended cadences",
+        "Interviews one item at a time with recommended values, rather than writing blind",
+        "Does not invent items for which the repo gives no signal"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "idempotent-preserves-existing-item-dates",
+      "prompt": "/work-items:setup",
+      "expected_output": "Re-running against an existing schedule preserves each existing item's last_checked and next_due as-is — setup seeds but performs no maintenance, so it never advances the cadence clock — recomputing next_due only when the user explicitly reschedules or changes cadence, and never resetting last_checked to today. New items seed last_checked to today and next_due to today plus the cadence's day count. Blindly resetting an overdue item's dates (which would drop it from the due/work tiers) is avoided.",
+      "files": [],
+      "expectations": [
+        "Preserves existing items' last_checked and next_due unchanged (never advances the clock during setup)",
+        "Recomputes next_due only on an explicit reschedule or cadence change, and never sets last_checked to today for an existing item",
+        "Seeds a new item's last_checked to today and next_due to today plus the cadence duration",
+        "Does not drop an already-overdue item out of the due/work tiers by resetting its dates"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "writes-tracked-config-ensures-label-unique-keys",
+      "prompt": "/work-items:setup\n\nSeed a sensible recurring schedule for this repo.",
+      "expected_output": "Writes the accepted items to the consumer's tracked .github/recurring-schedule.json (project-root anchored, {\"items\": [ ... ]} root), verifying every final id AND every final title is unique across the array and stopping to prompt on any collision rather than writing a duplicate. It ensures the load-bearing recurring label exists via the bound provider (recommending creation, not treating it as optional) and never writes into the plugin directory or plugin data directory.",
+      "files": [],
+      "expectations": [
+        "Writes the schedule to the consumer's tracked project-root .github/recurring-schedule.json with the {\"items\": []} root",
+        "Verifies every final id and every final title is unique and stops on a collision rather than writing duplicates",
+        "Ensures the load-bearing recurring label exists via the bound provider rather than treating it as optional",
+        "Does not write into the plugin directory or plugin data directory"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "reconciles-renamed-or-dropped-row-open-item",
+      "prompt": "/work-items:setup",
+      "expected_output": "When an existing schedule row is renamed or dropped, it looks up that row's open [Maintenance] item under the OLD title, filtering provider search results to an exact [Maintenance] {old title} match (never a mere prefix/substring). A renamed row's item is retitled to the new title (or closed if retiring); a dropped row's item is closed with a note. A rename or drop with no exact-match open item needs no reconciliation.",
+      "files": [],
+      "expectations": [
+        "Looks up the stranded open item under the row's OLD title when a row is renamed or dropped",
+        "Filters provider search to an exact [Maintenance] {old title} match, never a prefix or substring match",
+        "Retitles the item for a renamed row and closes it (with a note) for a dropped row",
+        "Performs no reconciliation when no exact-match open item exists"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Rich-form `evals/evals.json` for five `setup`-action skills that shipped without eval coverage:

- `ai-briefing/setup` (3 cases) — profile scaffold + seed idempotency, optional overlays skipped cleanly, version-gated runtime staging (no curated config in plugin data).
- `bug-report/setup` (3 cases) — binary interview before writing, idempotent reset clears every writable scope, portable value to tracked project scope.
- `claude-ops/setup` (3 cases) — binary-then-path interview, effective-scope + shadowing report, tracked-project persistence.
- `planning/setup` (3 cases) — infer notes_dir + interview, working-notes-convention shadowing on re-run, portable persist to tracked project (or local overlay).
- `work-items/setup` (4 cases) — candidate inference + per-item interview, existing-date preservation, tracked config with unique keys + `recurring` label, renamed/dropped-row reconciliation.

Each set is scoped to the skill's setup contract (interview → convention resolution → tracked-consumer-scope persist), mirrors the `codebase-audit/setup` model, and conforms to `plugins/skill-quality/reference/evals.schema.json`.

## Scope note — ai-briefing + planning included

The issue names three skills "as of filing" plus "+ future landings," and is an explicit self-scanning catch-all. A live re-scan surfaced two post-filing landings meeting the catch-all criterion (uncovered, not owned by any plugin-family batch, not deferred): `ai-briefing/setup` (#1457 addresses its behavior fixes, not its eval) and `planning/setup` (#1447 covers planning's seven behavior skills but not `setup`). Both authored against current shipped behavior. `docs/evals-coverage.md` updated; the #1462 row is now `(5)`.

## Verification

- `check-jsonschema` against the bundled schema — all five PASS.
- `check-skill.sh setup` (skills_root per plugin) — all five PASS (0 errors; sole WARN is a pre-existing "no Gotchas surface", unrelated to evals).
- Each touched `plugin.json` bumped one minor version (repo eval-backfill convention).

Refs melodic-software/medley#1462