### PR TITLE
fix(guardrails): block heredoc-opener stdout redirect in block-hook-bypass

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Six safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, and (advisory) un-throttled Workflow fan-out that risks burst 529s — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -85,9 +85,12 @@ strip_literals() {
   local cmd="$1" line result="" in_heredoc=0 delim="" trimmed
   # `(^|[^<])` before `<<` excludes a here-string `<<<` — matching `<<` inside
   # `<<<` would capture a bogus delimiter and strand the stripper in-heredoc,
-  # swallowing every later line (a here-string bypass). The delimiter's first
-  # char is `[^[:space:]<]` for the same reason.
-  local heredoc_start_re='(^|[^<])<<-?[[:space:]]*([^[:space:]<][^[:space:]]*)'
+  # swallowing every later line (a here-string bypass). The delimiter body
+  # excludes `<` for the same reason, and `>` so a redirect glued to the
+  # delimiter (`cat <<EOF>file`) terminates the token — bash ends the delimiter
+  # word at `>`, so the `>file` is a real redirect that must reach the scan
+  # instead of being swallowed into a bogus `EOF>file` delimiter.
+  local heredoc_start_re='(^|[^<])<<-?[[:space:]]*([^[:space:]<>]+)'
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     if ((in_heredoc)); then

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -109,7 +109,11 @@ strip_literals() {
       delim="${delim%\'}"
       delim="${delim#\"}"
       delim="${delim%\"}"
-      line="${line%%<<*}"
+      # Drop only the heredoc operator + delimiter token, keeping the text before
+      # `<<` AND any text after the delimiter on the opener line — a trailing
+      # stdout redirect (`cat <<EOF > file`) must still reach the redirect scan
+      # rather than being truncated away with the body.
+      line="${line%%<<*}${line#*"${BASH_REMATCH[0]}"}"
       in_heredoc=1
     fi
     line=$(printf '%s' "$line" | sed "s/'[^']*'//g" | sed -E 's/"([^"\\]|\\.)*"//g')

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -102,6 +102,18 @@ run "heredoc opener stdout redirect (blocked)" "$HEREDOC_OPENER_REDIR" 2
 # A plain heredoc with NO redirect on the opener stays allowed.
 HEREDOC_NO_REDIR=$(printf 'cat <<EOF | cat\ncontent line\nEOF')
 run "heredoc opener, no redirect (allowed)" "$HEREDOC_NO_REDIR" 0
+# Redirect GLUED to the delimiter (no space): bash ends the delimiter word at
+# `>`, so `cat <<EOF>real.txt` is a real stdout redirect. The delimiter capture
+# must stop at `>` (not greedily swallow `EOF>real.txt`) so the `>` survives.
+HEREDOC_GLUED_REDIR=$(printf 'cat <<EOF>real.txt\ncontent line\nEOF')
+run "heredoc opener redirect glued to delimiter (blocked)" "$HEREDOC_GLUED_REDIR" 2
+# Tab-stripping opener form (`<<-EOF`): the `<<-?` regex + fix cover it.
+HEREDOC_TAB_STRIP=$(printf 'cat <<-EOF > real.txt\ncontent line\nEOF')
+run "heredoc tab-strip opener redirect (blocked)" "$HEREDOC_TAB_STRIP" 2
+# Quoted delimiter (`<<'EOF'`): BASH_REMATCH[0] is `<<'EOF'`; the suffix scan
+# still preserves the trailing redirect.
+HEREDOC_QUOTED_DELIM=$(printf "cat <<'EOF' > real.txt\ncontent line\nEOF")
+run "heredoc quoted-delimiter opener redirect (blocked)" "$HEREDOC_QUOTED_DELIM" 2
 
 # A here-string (<<<) has no terminator — it must NOT be mistaken for a heredoc,
 # which would strand the stripper and swallow the trailing bypass.

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -93,6 +93,16 @@ run "heredoc metachar delim, trailing cat > bypass (blocked)" "$HEREDOC_METACHAR
 HEREDOC_BACKSLASH=$(printf 'cat <<\\EOF\ncontent line\nEOF\ncat > real.txt')
 run "heredoc backslash delim, trailing cat > bypass (blocked)" "$HEREDOC_BACKSLASH" 2
 
+# A stdout redirect ON the heredoc opener line (`cat <<EOF > file`) is a real
+# file-write bypass. The strip must drop only the heredoc operator + delimiter,
+# keeping the trailing `> file` so the redirect scan still fires — truncating
+# everything after `<<` would leak this form (exit 0).
+HEREDOC_OPENER_REDIR=$(printf 'cat <<EOF > real.txt\ncontent line\nEOF')
+run "heredoc opener stdout redirect (blocked)" "$HEREDOC_OPENER_REDIR" 2
+# A plain heredoc with NO redirect on the opener stays allowed.
+HEREDOC_NO_REDIR=$(printf 'cat <<EOF | cat\ncontent line\nEOF')
+run "heredoc opener, no redirect (allowed)" "$HEREDOC_NO_REDIR" 0
+
 # A here-string (<<<) has no terminator — it must NOT be mistaken for a heredoc,
 # which would strand the stripper and swallow the trailing bypass.
 HERESTRING=$(printf 'read x <<< %sok%s\ncat > real.txt' '"' '"')


### PR DESCRIPTION
## What

`block-hook-bypass`'s `strip_literals` truncated the heredoc opener line at `<<` (`line="${line%%<<*}"`), so a stdout redirect carried on the same line — `cat <<EOF > generated.txt` — was dropped **before** the redirect scan, letting a real file-write bypass through (hook exited 0).

Fix: drop only the heredoc operator + delimiter token, preserving the text before `<<` **and** any text after the delimiter, so a trailing `> file` still reaches `_cat_redir` / `_echo_redir`.

## Tests

Added two contract cases:
- `cat <<EOF > real.txt` (+ body + terminator) → exit 2 (blocked)
- `cat <<EOF | cat` (heredoc, no redirect) → exit 0 (allowed)

Full suite green (34/34); `shellcheck` clean; `claude plugin validate plugins/guardrails` passes. Patched guardrails `0.3.1` → `0.3.2`.

## Scope

Only the redirect-after-heredoc-operator opener form. The documented friction-guard floor (explicit-fd redirects, combined `&>`, args-before-redirect, etc.) stays accepted per the issue.

Refs melodic-software/medley#1461

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive PreToolUse hook logic changed to close a real bypass; scope is narrow with new contract tests, but incorrect stripping could still miss or over-block Bash commands.
> 
> **Overview**
> Closes a **Bash hook-bypass** hole in `strip_literals`: truncating the heredoc opener at `<<` dropped same-line stdout redirects (`cat <<EOF > file`), so `cat`-redirect detection never ran.
> 
> **`strip_literals`** now removes only the `<<` operator and delimiter token and keeps any suffix on that line (e.g. `> file`). The heredoc delimiter regex stops at `>` so forms like `cat <<EOF>file` still expose the redirect to the scan. Guardrails plugin version **0.3.1 → 0.3.2**.
> 
> Contract tests cover opener redirects (spaced, glued, tab-strip, quoted delimiter) and confirm plain heredocs without redirects stay allowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d871a8b20dee0c7432f7e0829fb1b286bdd5d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->