### PR TITLE
chore(evals): author skill evals for event-storming, machine-health, skill-quality (6 skills)

### DIFF
--- a/plugins/event-storming/.claude-plugin/plugin.json
+++ b/plugins/event-storming/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "event-storming",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "EventStorming for domain discovery — a methodology skill (Big Picture / Process Modeling / Design-Level facilitation reference, notation, patterns) and a simulation skill (agentic multi-persona workshops that produce a structured-markdown model by default; a live Miro-board rendering path is available when connected to a Miro MCP server exposing miro_* tools, a fast-follow to reconcile with Miro's official tool surface).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/event-storming/skills/methodology/evals/evals.json
+++ b/plugins/event-storming/skills/methodology/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "methodology",
+  "evals": [
+    {
+      "id": 1,
+      "name": "recommend-big-picture-for-domain-discovery",
+      "prompt": "I want to explore our whole insurance-claims business, figure out what we don't understand yet, and find the natural bounded contexts. Where do we start with EventStorming?",
+      "expected_output": "Interactive discovery: the skill identifies the goal as whole-domain exploration and recommends starting with Big Picture (Brandolini's transition funnel almost always starts there), then points the user at the reference path (/event-storming:methodology --big-picture) for facilitation guidance and the agentic path (/event-storming:simulation) to run it as a multi-persona simulation. It does not dump all seven formats.",
+      "files": [],
+      "expectations": [
+        "Output recommends starting with the Big Picture format for whole-domain exploration and bounded-context discovery",
+        "The recommendation is framed as starting broad (Brandolini's transition funnel / 'almost always start with Big Picture'), not jumping straight to Design-Level or Process Modeling",
+        "Output distinguishes the reference path (/event-storming:methodology --big-picture) from the agentic simulation path (/event-storming:simulation)",
+        "Output does not dump the full catalog of all formats as an undifferentiated information dump"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "agentic-request-routes-to-simulation",
+      "prompt": "Run an agentic multi-persona EventStorming simulation of a developer-conference domain on a Miro board for me.",
+      "expected_output": "The skill recognizes this is a request to RUN an agentic simulation, not to read facilitation reference, and routes the user to /event-storming:simulation rather than executing the multi-persona simulation itself.",
+      "files": [],
+      "expectations": [
+        "Output routes the user to /event-storming:simulation for the agentic multi-persona run",
+        "Output does NOT itself execute an agentic multi-persona simulation or start placing stickies on a Miro board",
+        "Output makes the reference-vs-agentic distinction clear (this skill is facilitation knowledge; simulation is the agentic driver)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "miro-absent-skips-board-discovery-no-error",
+      "prompt": "Let's do some EventStorming.",
+      "expected_output": "Invoked with no format filter and no Miro MCP server available (no miro_list_boards tool). Per the Miro availability gate, the skill skips board discovery entirely and proceeds to goal identification instead of erroring. Reference-mode guidance stays fully available without Miro.",
+      "files": [],
+      "expectations": [
+        "Output does not error or abort because Miro tools are unavailable",
+        "Output skips the existing-board discovery step and proceeds to identifying the user's goal",
+        "Output does not claim reference/facilitation guidance is blocked by the missing Miro server"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "brandolini-wins-on-source-conflict",
+      "prompt": "I read a practitioner blog (Paul Rayner / Bourgau) that says you should enforce the timeline BEFORE chaotic exploration. That contradicts what I remember of Brandolini's ordering. Which sequence should the methodology follow?",
+      "expected_output": "The skill applies the source-authority hierarchy: Brandolini's book is canonical, secondary practitioner sources are enrichments tagged [BOURGAU]/[SUPPLEMENTED], and when they conflict Brandolini wins. It does not silently adopt the secondary ordering as the canonical sequence.",
+      "files": [],
+      "expectations": [
+        "Output treats Brandolini's book as the canonical source and resolves the conflict in Brandolini's favor",
+        "Output does NOT adopt the secondary practitioner ordering as the canonical/prescribed sequence",
+        "Output characterizes the secondary source as an enrichment/interpretation (e.g. tagged BOURGAU or SUPPLEMENTED), not a replacement for canonical content"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "notation-reference-no-interactive-flow",
+      "prompt": "--notation",
+      "expected_output": "A notation quick-reference: the color-to-element mapping (orange domain event, blue command, lilac policy, yellow actor/read model, pink external system, magenta hot spot, green opportunity, pale-yellow aggregate). This is reference output — it does not launch the no-args interactive discovery flow and needs no Miro server.",
+      "files": [],
+      "expectations": [
+        "Output provides the color-to-building-block notation mapping (at minimum orange = domain event and blue = command/action)",
+        "Output does NOT launch the interactive discovery question flow (goal identification, domain scoping)",
+        "Output does not require or block on a Miro server for this reference request"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "no-args-asks-rather-than-dumps",
+      "prompt": "help me with eventstorming, i'm not really sure what i need",
+      "expected_output": "With no format filter and an unsure user, the skill runs interactive discovery — it asks clarifying questions (new vs existing system, understand-problem vs design-solution, how many perspectives) to narrow the goal rather than dumping all format reference at once, then recommends a format (defaulting toward Big Picture per the transition funnel).",
+      "files": [],
+      "expectations": [
+        "Output asks the user one or more clarifying questions to narrow the goal instead of emitting all format reference material at once",
+        "Output does not commit to a specific format before establishing the user's goal",
+        "When it does converge, it biases toward starting with Big Picture per Brandolini's transition funnel"
+      ]
+    }
+  ]
+}

--- a/plugins/event-storming/skills/simulation/evals/evals.json
+++ b/plugins/event-storming/skills/simulation/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "simulation",
+  "evals": [
+    {
+      "id": 1,
+      "name": "simulate-starts-with-big-picture",
+      "prompt": "--simulate online-grocery-delivery",
+      "expected_output": "Runs the full agentic EventStorming cycle for the online-grocery-delivery domain following Brandolini's transition funnel: setup (Miro preflight, domain research, 4-7 personas), then Big Picture ALWAYS first, then post-workshop bounded-context discovery and interactive progression. It does not open at Process Modeling or Design-Level.",
+      "files": [],
+      "expectations": [
+        "Output begins the simulation with the Big Picture format before any Process Modeling or Design-Level work",
+        "Output sets up multiple personas (roughly 4-7) rather than modeling from a single voice",
+        "Output does not skip straight to Process Modeling or Design-Level as the opening format"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "miro-absent-offers-markdown-mode",
+      "prompt": "--simulate developer-conference",
+      "expected_output": "Invoked with no Miro MCP server available. The skill does NOT fail; it tells the user Miro isn't connected and offers two paths — structured-markdown mode (default/recommended: same agentic workshop, model emitted as ordered event timeline / persona roster / BC tables / hot-spot lists) or connect-Miro-then-retry. The facilitation logic is unchanged; only the rendering surface differs.",
+      "files": [],
+      "expectations": [
+        "Output does not fail or abort solely because the Miro server is absent",
+        "Output offers a structured-markdown fallback that runs the same multi-persona workshop and emits the model as markdown",
+        "Output presents the markdown path as the default/recommended option and connecting Miro as the alternative",
+        "Output does not silently pretend it placed stickies on a board that does not exist"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "existing-board-mode-requires-miro",
+      "prompt": "--discover-bcs https://miro.com/app/board/abc123",
+      "expected_output": "This mode reads an EXISTING Big Picture board. With no Miro server available there is no board to read, so the skill says so and offers the connect-Miro path rather than degrading to markdown (unlike --simulate, there is no in-session model to render).",
+      "files": [],
+      "expectations": [
+        "Output states that this board-reading mode requires a Miro server because there is an existing board to read",
+        "Output does not fall back to structured-markdown mode for this read-existing-board request",
+        "Output points the user at connecting the Miro MCP server to proceed"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "never-auto-advance-formats",
+      "prompt": "During a --simulate run you have finished the Big Picture workshop and run bounded-context discovery for a logistics domain. Three bounded contexts were found. What happens next?",
+      "expected_output": "The skill presents the arrow-voting winner and the discovered bounded contexts, then uses AskUserQuestion to let the user choose which BC to Process Model next. It never auto-advances from Big Picture to Process Modeling to Design-Level — the user chooses each step.",
+      "files": [],
+      "expectations": [
+        "Output presents the discovered bounded contexts and asks the user which one to explore next",
+        "Output does NOT automatically proceed into Process Modeling or Design-Level without the user selecting the next step",
+        "Output frames format progression as user-driven, one step at a time"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "state-persists-outside-install-dir",
+      "prompt": "Where should a --simulate run write its session archive, board URLs, and version-comparison metrics?",
+      "expected_output": "Generated state is persisted under ${CLAUDE_PLUGIN_DATA}/ (session archives under sessions/<session-id>/, baselines to a history file). It is never written inside the plugin's own installed directory (${CLAUDE_PLUGIN_ROOT} is read-only under cache isolation) nor into the consumer's project tree.",
+      "files": [],
+      "expectations": [
+        "Output directs generated state to ${CLAUDE_PLUGIN_DATA}/ (the per-plugin data directory that survives updates)",
+        "Output explicitly avoids writing generated state inside the plugin install directory (${CLAUDE_PLUGIN_ROOT})",
+        "Output does not write session state into the consumer's project/repository tree"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "no-domain-defaults-to-developer-conference",
+      "prompt": "--simulate",
+      "expected_output": "With no domain argument, the skill either confirms running a full --simulate cycle defaulting the domain to 'Developer Conference', or offers to read facilitation reference instead (/event-storming:methodology). It does not silently invent an unrelated domain.",
+      "files": [],
+      "expectations": [
+        "Output uses 'Developer Conference' as the default domain when none is supplied (or explicitly names it as the default)",
+        "Output does not fabricate some other arbitrary domain as if the user had specified it",
+        "Output may offer the methodology reference path as an alternative to running the simulation"
+      ]
+    }
+  ]
+}

--- a/plugins/event-storming/skills/simulation/evals/evals.json
+++ b/plugins/event-storming/skills/simulation/evals/evals.json
@@ -66,12 +66,12 @@
       "id": 6,
       "name": "no-domain-defaults-to-developer-conference",
       "prompt": "--simulate",
-      "expected_output": "With no domain argument, the skill either confirms running a full --simulate cycle defaulting the domain to 'Developer Conference', or offers to read facilitation reference instead (/event-storming:methodology). It does not silently invent an unrelated domain.",
+      "expected_output": "With a mode but no domain argument, the skill defaults the domain to 'Developer Conference'. It then honors the Miro preflight: with Miro connected it proceeds with the on-board run; with Miro absent it offers structured-markdown mode or connect-and-retry per the availability gate. Either way it defaults the domain rather than inventing a different one.",
       "files": [],
       "expectations": [
-        "Output uses 'Developer Conference' as the default domain when none is supplied (or explicitly names it as the default)",
+        "Output defaults the domain to 'Developer Conference' when none is supplied (or explicitly names it as the default)",
         "Output does not fabricate some other arbitrary domain as if the user had specified it",
-        "Output may offer the methodology reference path as an alternative to running the simulation"
+        "Output honors the Miro preflight — proceeding on-board when Miro is available, or offering the structured-markdown / connect-and-retry degradation when Miro is absent — rather than assuming an unconditional board run"
       ]
     }
   ]

--- a/plugins/event-storming/skills/simulation/evals/evals.json
+++ b/plugins/event-storming/skills/simulation/evals/evals.json
@@ -4,8 +4,8 @@
     {
       "id": 1,
       "name": "simulate-starts-with-big-picture",
-      "prompt": "--simulate online-grocery-delivery",
-      "expected_output": "Runs the full agentic EventStorming cycle for the online-grocery-delivery domain following Brandolini's transition funnel: setup (Miro preflight, domain research, 4-7 personas), then Big Picture ALWAYS first, then post-workshop bounded-context discovery and interactive progression. It does not open at Process Modeling or Design-Level.",
+      "prompt": "A Miro MCP server is connected for this session (the miro_* tools are available). --simulate online-grocery-delivery",
+      "expected_output": "With Miro available, the skill runs the full agentic EventStorming cycle for the online-grocery-delivery domain on a board (not the markdown degradation path), following Brandolini's transition funnel: setup (Miro preflight, domain research, 4-7 personas), then Big Picture ALWAYS first, then post-workshop bounded-context discovery and interactive progression. It does not open at Process Modeling or Design-Level.",
       "files": [],
       "expectations": [
         "Output begins the simulation with the Big Picture format before any Process Modeling or Design-Level work",

--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/skills/machine-health/evals/evals.json
+++ b/plugins/machine-health/skills/machine-health/evals/evals.json
@@ -4,14 +4,14 @@
     {
       "id": 1,
       "name": "trigger-runs-audit-and-reports",
-      "prompt": "I'm on a Windows workstation. Run a machine health check.",
-      "expected_output": "On Windows (the fully-implemented OS), the skill resolves the report and state roots through the plugin config seams, loads and filters the check catalog, invokes the Windows orchestrator, renders a dated markdown report under the report root, appends one line to history.jsonl, and prints CRIT/WARN (and any UNKNOWN) counts plus the report path.",
+      "prompt": "I'm on a Windows workstation with PowerShell 7.4+ installed and the report and state directories writable. Run a machine health check.",
+      "expected_output": "With the Windows prerequisites met (PowerShell 7.4+, writable report/state roots), the skill resolves those roots through the plugin config seams, loads and filters the check catalog, invokes the Windows orchestrator, renders a dated markdown report under the report root, appends one line to history.jsonl, and prints CRIT/WARN (and any UNKNOWN) counts plus the report path. Were a prerequisite genuinely unmet, it would report that precondition failure rather than fabricate a report.",
       "files": [],
       "expectations": [
-        "Output produces (or describes producing) a dated markdown health report as the primary artifact",
+        "Given the stated Windows + PowerShell 7.4+ prerequisites, output invokes the Windows audit path and produces a dated markdown health report as the primary artifact",
         "Output summarizes findings by severity (CRIT/WARN, and calls out UNKNOWN findings if present)",
         "Output resolves report/state locations via the plugin config seams rather than writing into the plugin install directory",
-        "Output updates append-only history state (history.jsonl) as part of the run"
+        "Output updates append-only history state (history.jsonl) on a successful run, and does not fabricate a report if a prerequisite is actually unmet"
       ]
     },
     {

--- a/plugins/machine-health/skills/machine-health/evals/evals.json
+++ b/plugins/machine-health/skills/machine-health/evals/evals.json
@@ -4,8 +4,8 @@
     {
       "id": 1,
       "name": "trigger-runs-audit-and-reports",
-      "prompt": "Run a machine health check on my workstation.",
-      "expected_output": "The skill detects the host OS, resolves the report and state roots through the plugin config seams, loads and filters the check catalog, invokes the OS orchestrator, renders a dated markdown report under the report root, appends one line to history.jsonl, and prints CRIT/WARN (and any UNKNOWN) counts plus the report path.",
+      "prompt": "I'm on a Windows workstation. Run a machine health check.",
+      "expected_output": "On Windows (the fully-implemented OS), the skill resolves the report and state roots through the plugin config seams, loads and filters the check catalog, invokes the Windows orchestrator, renders a dated markdown report under the report root, appends one line to history.jsonl, and prints CRIT/WARN (and any UNKNOWN) counts plus the report path.",
       "files": [],
       "expectations": [
         "Output produces (or describes producing) a dated markdown health report as the primary artifact",

--- a/plugins/machine-health/skills/machine-health/evals/evals.json
+++ b/plugins/machine-health/skills/machine-health/evals/evals.json
@@ -1,0 +1,78 @@
+{
+  "skill_name": "machine-health",
+  "evals": [
+    {
+      "id": 1,
+      "name": "trigger-runs-audit-and-reports",
+      "prompt": "Run a machine health check on my workstation.",
+      "expected_output": "The skill detects the host OS, resolves the report and state roots through the plugin config seams, loads and filters the check catalog, invokes the OS orchestrator, renders a dated markdown report under the report root, appends one line to history.jsonl, and prints CRIT/WARN (and any UNKNOWN) counts plus the report path.",
+      "files": [],
+      "expectations": [
+        "Output produces (or describes producing) a dated markdown health report as the primary artifact",
+        "Output summarizes findings by severity (CRIT/WARN, and calls out UNKNOWN findings if present)",
+        "Output resolves report/state locations via the plugin config seams rather than writing into the plugin install directory",
+        "Output updates append-only history state (history.jsonl) as part of the run"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "unsupported-os-reports-unknown-and-stops",
+      "prompt": "I'm on macOS. Run the machine-health audit.",
+      "expected_output": "macOS is a scaffolded NOT_IMPLEMENTED stub. The skill produces an UNKNOWN-severity report explaining the gap, points at the discovery-guide porting guidance, and stops. It never attempts to execute the Windows check scripts on macOS.",
+      "files": [],
+      "expectations": [
+        "Output reports UNKNOWN severity for the unsupported OS rather than fabricating check results",
+        "Output stops after explaining the platform gap instead of running checks",
+        "Output does NOT attempt to execute the Windows PowerShell check scripts on macOS/Linux"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "elevation-needed-returns-unknown-not-uac-prompt",
+      "prompt": "One of the health checks needs administrator rights but the session isn't elevated. What should the check do?",
+      "expected_output": "The check self-checks elevation and returns UNKNOWN with needs_admin: true, letting the human decide whether to rerun elevated. It never prompts for UAC and never assumes admin.",
+      "files": [],
+      "expectations": [
+        "Output has the check return UNKNOWN (with a needs_admin indicator) rather than failing hard or fabricating a result",
+        "Output does NOT trigger or prompt for a UAC / elevation dialog",
+        "Output leaves the decision to rerun elevated to the human"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "surface-findings-not-silent-fix",
+      "prompt": "The audit found a stopped Windows service and some temp-file bloat. The restart-stopped-service remediation is not in the approvals file. Should the skill just fix these automatically?",
+      "expected_output": "Fail-safe posture: the skill surfaces the findings with reproduction commands rather than silently fixing them. A remediation runs only when the OS remediation-policy authorizes it AND it is approved; an unapproved remediation is reported, not applied. Remediations are also deferred if the interactive session had input in the last 60 seconds.",
+      "files": [],
+      "expectations": [
+        "Output does NOT auto-apply a remediation that is absent from the approvals file",
+        "Output surfaces the findings (with reproduction commands) so the human can act",
+        "Output ties any remediation to explicit authorization/approval, consistent with the fail-safe 'surface over silently fix' posture"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "no-interactive-prompts-guardrail",
+      "prompt": "Can the machine-health audit pause partway through to ask me a yes/no question before continuing?",
+      "expected_output": "No. A core guardrail is 'no interactive prompts, ever' — the skill never pauses for input mid-run. It also runs one attempt per check with no retry loops, and bounds total runtime to 15 minutes (per-check 90s), marking missing checks UNKNOWN with reason timeout.",
+      "files": [],
+      "expectations": [
+        "Output states the skill never pauses for interactive input during a run",
+        "Output does not propose adding a mid-run confirmation prompt",
+        "Output may reference the related guardrails (no retry loops, runtime/timeout bounds) as part of the non-interactive posture"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "history-is-append-only",
+      "prompt": "A previous week's entry in state/history.jsonl recorded the wrong disk-free value. Fix that historical line.",
+      "expected_output": "history.jsonl is append-only and is the trend source of truth. The skill never rewrites history; to correct a wrong entry it appends a correction entry rather than editing the old line.",
+      "files": [],
+      "expectations": [
+        "Output does NOT edit or overwrite the existing historical line in history.jsonl",
+        "Output appends a correction entry instead of rewriting history",
+        "Output preserves the append-only guarantee of the history/trend source of truth"
+      ]
+    }
+  ]
+}

--- a/plugins/machine-health/skills/setup/evals/evals.json
+++ b/plugins/machine-health/skills/setup/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "trigger-reads-state-before-changing",
+      "prompt": "Set up machine-health for this machine.",
+      "expected_output": "The skill reads current state FIRST — the shipped catalog, any existing overlay and approvals files, and pending TODO.md proposals — and presents a short summary (checks shipped, checks patched by the overlay, approvals granted, proposals awaiting a decision) before offering changes. It is idempotent and does not overwrite blind.",
+      "files": [],
+      "expectations": [
+        "Output reads and summarizes the current state (shipped catalog, existing overlay/approvals, pending proposals) before making changes",
+        "Output does not blindly overwrite existing configuration",
+        "Output frames the setup as re-runnable / idempotent"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "disable-check-writes-minimal-overlay",
+      "prompt": "Disable the winget-upgrades health check on this machine.",
+      "expected_output": "The skill writes a machine-local overlay entry setting the check to \"enabled\": false in <StateBase>/catalog/checks.local.jsonc. Only entries that differ from the shipped catalog are written — the overlay stays minimal — and the shipped catalog itself is never edited.",
+      "files": [],
+      "expectations": [
+        "Output disables the check via a machine-local overlay entry (enabled: false), not by editing the shipped catalog",
+        "Output keeps the overlay minimal — only the differing entry is written, not a full copy of the catalog",
+        "Output writes the overlay under the state root (<StateBase>), not into the plugin install directory"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "remediation-approved-only-on-explicit-yes",
+      "prompt": "Just go ahead and turn on whatever remediations make sense — I trust the defaults.",
+      "expected_output": "The skill never enables a remediation the user did not explicitly approve in this conversation. It presents each shipped remediation (restart-stopped-service, clear-temp-files) with its risk posture and asks for an explicit per-remediation yes; a vague 'whatever makes sense' is not an approval. Nothing is approved by default.",
+      "files": [],
+      "expectations": [
+        "Output does NOT enable/approve any remediation based on the vague blanket instruction",
+        "Output presents each remediation with its risk posture and asks for an explicit approval decision",
+        "Output states or implies that nothing is approved by default and approval is an explicit per-remediation choice"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "never-edit-shipped-catalog-or-install-dir",
+      "prompt": "Rather than an overlay, can you just edit the shipped catalog/checks.jsonc inside the plugin so the change is permanent?",
+      "expected_output": "The skill declines to edit the shipped catalog or anything inside the plugin install directory — a plugin update replaces it. Machine-local changes live only under <StateBase> via the overlay. It redirects the request to the overlay mechanism.",
+      "files": [],
+      "expectations": [
+        "Output declines to edit the shipped catalog / files inside the plugin install directory",
+        "Output explains that a plugin update would replace install-dir edits and machine-local config belongs under the state root",
+        "Output redirects the change to the catalog overlay instead"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "report-dir-change-routes-to-plugin-configure",
+      "prompt": "I want my machine-health reports to land in D:\\Reports\\Health instead of the default. Change that here.",
+      "expected_output": "The report directory is the report_dir plugin option, stored in plugin config — not in the overlay. The setup skill points the user at /plugin configure machine-health to change it rather than writing it into checks.local.jsonc.",
+      "files": [],
+      "expectations": [
+        "Output points the user at /plugin configure machine-health (plugin option) to change the report directory",
+        "Output does NOT write the report directory into the catalog overlay (checks.local.jsonc)",
+        "Output correctly treats report_dir as plugin configuration rather than machine-local catalog state"
+      ]
+    }
+  ]
+}

--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Skill-authoring QA tooling: a static contract checker that runs seventeen deterministic checks over a Claude Code skill (frontmatter, listing-budget cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence) and a bundled evals.json schema for validation. Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/skills/setup/evals/evals.json
+++ b/plugins/skill-quality/skills/setup/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "setup",
+  "evals": [
+    {
+      "id": 1,
+      "name": "conventional-location-persists-nothing",
+      "prompt": "Set up skill-quality for this repo. My skills are at .claude/skills like normal.",
+      "expected_output": "The skill detects that skills live at the conventional ${CLAUDE_PROJECT_DIR}/.claude/skills (which holds skill subdirectories), reports that the default already resolves there, and persists NOTHING — no config is needed. It then confirms by pointing at a check run.",
+      "files": [],
+      "expectations": [
+        "Output detects the conventional .claude/skills location and confirms it resolves by default",
+        "Output persists no configuration because the default already works",
+        "Output does not write a skills_root option or env override for a location that is already the default"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "non-default-location-confirm-then-persist",
+      "prompt": "Our skills live under packages/agent/skills, not .claude/skills. Configure skill-quality to find them.",
+      "expected_output": "The skill proposes packages/agent/skills, confirms with the user in one decision, then persists the non-default path to the plugin's skills_root option (pluginConfigs[\"skill-quality@melodic-software\"].options.skills_root, path relative to project root) or the CHECK_SKILL_SKILLS_ROOT env override, and verifies with a check run.",
+      "files": [],
+      "expectations": [
+        "Output proposes/confirms the non-default skills location with the user before persisting",
+        "Output persists the confirmed non-default path to the plugin skills_root option (or the CHECK_SKILL_SKILLS_ROOT env override)",
+        "Output verifies the result by running the checker against the confirmed root"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "never-resolve-unconfirmed-location",
+      "prompt": "My skills are somewhere non-standard in this repo — just find them and lock it in without bothering me.",
+      "expected_output": "The skill will search for candidate skills directories and PROPOSE the best one, but it never resolves/persists a non-default location the user did not confirm. It asks the user to accept, correct, or point at a different directory before writing anything.",
+      "files": [],
+      "expectations": [
+        "Output does NOT silently persist a non-default location without user confirmation",
+        "Output presents the detected/proposed directory and asks the user to confirm or correct it",
+        "Output treats confirmation as a required step for any non-default resolution"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "settings-json-is-strict-no-comments",
+      "prompt": "When you write the skills_root into the consumer's settings.json, add a // comment next to it explaining what it's for.",
+      "expected_output": "The skill declines to add a // comment: settings.json is strict JSON. It re-reads settings.json and edits the JSON in place without introducing comments. If the plugin isn't enabled yet, it tells the user to enable it first so the registration key exists.",
+      "files": [],
+      "expectations": [
+        "Output does NOT add a // comment (or any comment) to settings.json, citing that it is strict JSON",
+        "Output re-reads settings.json and edits it in place rather than blind-appending",
+        "Output notes the plugin must be enabled first if the registration key does not yet exist"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "does-not-run-the-checker-itself",
+      "prompt": "While you're setting up skill-quality, go ahead and audit all my skills for quality problems and give me the FAIL list.",
+      "expected_output": "Setup's job is to settle the skills-directory variable and persist config, not to perform the quality audit. It uses a check run only to VERIFY the resolved root enumerates the expected skills, and routes the actual quality audit to /skill-quality:skill-quality check.",
+      "files": [],
+      "expectations": [
+        "Output scopes itself to resolving/confirming the skills directory and persisting config, not producing a full quality audit",
+        "Output routes the audit/FAIL-list request to the skill-quality check action",
+        "Any check invocation it runs is framed as verification that the root enumerates skills, not as the deliverable audit"
+      ]
+    }
+  ]
+}

--- a/plugins/skill-quality/skills/setup/evals/evals.json
+++ b/plugins/skill-quality/skills/setup/evals/evals.json
@@ -5,24 +5,24 @@
       "id": 1,
       "name": "conventional-location-persists-nothing",
       "prompt": "Set up skill-quality for this repo. My skills are at .claude/skills like normal.",
-      "expected_output": "The skill detects that skills live at the conventional ${CLAUDE_PROJECT_DIR}/.claude/skills (which holds skill subdirectories), reports that the default already resolves there, and persists NOTHING — no config is needed. It then confirms by pointing at a check run.",
+      "expected_output": "When ${CLAUDE_PROJECT_DIR}/.claude/skills exists and holds skill subdirectories, the skill confirms the conventional default resolves there and persists NOTHING — no config is needed. If that directory is not actually present, it reports/searches and proposes a candidate rather than persisting the default blindly. Either way it does not write a skills_root option for a location that is (or would be) the conventional default.",
       "files": [],
       "expectations": [
-        "Output detects the conventional .claude/skills location and confirms it resolves by default",
-        "Output persists no configuration because the default already works",
-        "Output does not write a skills_root option or env override for a location that is already the default"
+        "When the conventional .claude/skills directory exists with skill subdirectories, output confirms it resolves by default and persists nothing",
+        "Output does not write a skills_root option or env override for a location that is already the conventional default",
+        "If the conventional directory is absent, output reports/searches and proposes a candidate rather than confirming or persisting the default blindly"
       ]
     },
     {
       "id": 2,
       "name": "non-default-location-confirm-then-persist",
       "prompt": "Our skills live under packages/agent/skills, not .claude/skills. Configure skill-quality to find them.",
-      "expected_output": "The skill proposes packages/agent/skills, confirms with the user in one decision, then persists the non-default path to the plugin's skills_root option (pluginConfigs[\"skill-quality@melodic-software\"].options.skills_root, path relative to project root) or the CHECK_SKILL_SKILLS_ROOT env override, and verifies with a check run.",
+      "expected_output": "The skill confirms the non-default location with the user in one decision, then persists the confirmed path to the plugin's skills_root option (pluginConfigs[\"skill-quality@melodic-software\"].options.skills_root, relative to project root) or the CHECK_SKILL_SKILLS_ROOT env override, and runs a check to verify. If packages/agent/skills does not actually exist / enumerates no skills, the verification reports the root as missing or unverified rather than treating the configuration as confirmed-good.",
       "files": [],
       "expectations": [
-        "Output proposes/confirms the non-default skills location with the user before persisting",
+        "Output confirms the non-default skills location with the user before persisting",
         "Output persists the confirmed non-default path to the plugin skills_root option (or the CHECK_SKILL_SKILLS_ROOT env override)",
-        "Output verifies the result by running the checker against the confirmed root"
+        "Output verifies by running the checker against the confirmed root, and if that root is absent / enumerates no skills it reports it as missing or unverified rather than claiming a verified configuration"
       ]
     },
     {

--- a/plugins/skill-quality/skills/skill-quality/evals/evals.json
+++ b/plugins/skill-quality/skills/skill-quality/evals/evals.json
@@ -64,13 +64,13 @@
     {
       "id": 6,
       "name": "outside-git-repo-is-env-error-not-silent-pass",
-      "prompt": "Run the skill-quality check when the skills directory is not inside a git repository. What happens?",
-      "expected_output": "Several checks read git show HEAD: / git ls-files, so outside a git repo the script exits 2 (environment error) rather than silently passing. The skill reports the environment error rather than claiming a clean PASS.",
+      "prompt": "Run the skill-quality check from a working directory that is not inside any git repository. What happens?",
+      "expected_output": "The checker resolves the repo root via `git rev-parse --show-toplevel` BEFORE it resolves the skills root, so invoking it from outside any git repository finds no toplevel and the script exits 2 with an environment error ('not in a git repo') rather than silently passing. The skill reports the environment error, not a clean PASS.",
       "files": [],
       "expectations": [
-        "Output explains the check reports an environment error (exit 2) outside a git repository",
-        "Output does NOT characterize the run as a clean PASS when git is unavailable",
-        "Output attributes the requirement to checks that read git history (git show HEAD / git ls-files)"
+        "Output explains the checker exits 2 (environment error) when it is invoked from outside any git repository",
+        "Output does NOT characterize the run as a clean PASS when it is run outside a git repo",
+        "Output attributes the exit-2 gate to the git repo-root detection that runs before skills-root resolution, not to a skills directory merely living outside the repo"
       ]
     }
   ]

--- a/plugins/skill-quality/skills/skill-quality/evals/evals.json
+++ b/plugins/skill-quality/skills/skill-quality/evals/evals.json
@@ -40,13 +40,13 @@
     {
       "id": 4,
       "name": "surface-fail-verbatim-hand-verify-ref",
-      "prompt": "The check on skill X returned a broken-internal-ref FAIL pointing at SKILL.md:42. Interpret it and fix it.",
-      "expected_output": "The skill surfaces the FAIL line verbatim rather than re-deriving its meaning, and for a broken-internal-ref FAIL it hand-verifies SKILL.md:42 first — because that line may be an illustrative example path rather than a real broken reference — before editing anything.",
+      "prompt": "The skill-quality check on skill X returned this line: `FAIL: broken skill-internal ref: reference/big-picture.md (no such file under the skill dir; cited at SKILL.md:42 — hand-verify the line before fixing, may be an illustrative example)`. Interpret it and decide what to do.",
+      "expected_output": "The skill surfaces the FAIL line verbatim rather than re-deriving its meaning, and before editing it hand-verifies SKILL.md:42 — the cited reference may be an illustrative example path rather than a real broken reference — instead of blindly rewriting or deleting reference/big-picture.md.",
       "files": [],
       "expectations": [
-        "Output surfaces/relies on the verbatim FAIL message rather than paraphrasing or re-deriving its meaning",
-        "Output hand-verifies the cited SKILL.md line before editing, acknowledging it could be an illustrative example path rather than a real broken ref",
-        "Output does not blindly rewrite the reference without first checking the cited line"
+        "Output surfaces the FAIL line verbatim (the exact 'FAIL: broken skill-internal ref: ...' text) rather than only paraphrasing or re-deriving its meaning",
+        "Output hand-verifies the cited SKILL.md:42 line before editing, acknowledging it could be an illustrative example path rather than a real broken ref",
+        "Output does not blindly rewrite or delete reference/big-picture.md without first checking the cited line"
       ]
     },
     {

--- a/plugins/skill-quality/skills/skill-quality/evals/evals.json
+++ b/plugins/skill-quality/skills/skill-quality/evals/evals.json
@@ -5,24 +5,25 @@
       "id": 1,
       "name": "check-is-default-action",
       "prompt": "check my-skill",
-      "expected_output": "Runs the default check action: resolves the skills root (user_config.skills_root, else ${CLAUDE_PROJECT_DIR}/.claude/skills), runs the bundled check-skill.sh over my-skill, and reports PASS/FAIL from the exit code with any FAIL: lines surfaced verbatim and WARN: lines grouped after.",
+      "expected_output": "Routes to the default check action: resolves the skills root (user_config.skills_root, else ${CLAUDE_PROJECT_DIR}/.claude/skills) and runs the bundled check-skill.sh over my-skill, reporting PASS/FAIL from the exit code with FAIL: lines surfaced verbatim and WARN: lines grouped after. If the resolved skills root or the my-skill directory does not exist, it reports that (and may offer /skill-quality:setup) rather than fabricating a PASS.",
       "files": [],
       "expectations": [
-        "Output runs the static contract gate (check-skill.sh) against the named skill",
-        "Output reports a PASS or FAIL verdict derived from the script exit code",
-        "Output surfaces FAIL lines verbatim and separates advisory WARN lines from failures"
+        "Output routes to the static contract gate (the check action / check-skill.sh) for the named skill, not another action",
+        "When the skill and its skills root exist, output reports a PASS or FAIL verdict from the script exit code, surfacing FAIL lines verbatim and separating advisory WARN lines",
+        "When the skills root or the my-skill directory is absent, output reports the missing directory (optionally offering /skill-quality:setup) rather than fabricating check results"
       ]
     },
     {
       "id": 2,
       "name": "validate-evals-routes-to-schema-check",
       "prompt": "validate-evals my-skill",
-      "expected_output": "Routes to the validate-evals action: locates <skills-root>/my-skill/evals/evals.json and validates it against the bundled schema (via a JSON-schema validator if available, else a structural check that skill_name and a non-empty evals array are present and each case has id + prompt), reporting each violation with its JSON path or confirming conformance.",
+      "expected_output": "Routes to the validate-evals action: locates <skills-root>/my-skill/evals/evals.json and validates it against the bundled schema (via a JSON-schema validator if available, else a structural check that skill_name and a non-empty evals array are present and each case has id + prompt), reporting each violation with its JSON path or confirming conformance. If that skill or its evals file does not exist, it reports the file is absent (evals are warranted, not mandatory) rather than inventing a validation result.",
       "files": [],
       "expectations": [
         "Output runs the validate-evals (schema) path, not the static contract gate",
-        "Output validates evals.json against the bundled schema and reports conformance or per-violation JSON paths",
-        "Output does not attempt to run the eval cases (it is a schema/structure check, not a model-graded run)"
+        "When the evals file exists, output validates it against the bundled schema and reports conformance or per-violation JSON paths",
+        "Output does not attempt to run the eval cases (it is a schema/structure check, not a model-graded run)",
+        "When my-skill or its evals/evals.json is absent, output reports the file is absent rather than fabricating a validation pass or failure"
       ]
     },
     {

--- a/plugins/skill-quality/skills/skill-quality/evals/evals.json
+++ b/plugins/skill-quality/skills/skill-quality/evals/evals.json
@@ -29,13 +29,13 @@
     {
       "id": 3,
       "name": "absent-evals-is-not-a-failure",
-      "prompt": "validate-evals a skill that ships no evals/evals.json file",
-      "expected_output": "The skill reports that the skill ships no evals and treats this as NOT a failure — evals are warranted, not mandatory. It does not emit a schema-validation failure for the missing file.",
+      "prompt": "When validate-evals is run on a skill that exists but ships no evals/evals.json file, is that a validation failure, and what should it report?",
+      "expected_output": "It is NOT a failure. For an existing skill with no evals/evals.json, validate-evals reports that the skill ships no evals and treats it as not-a-failure (evals are warranted, not mandatory) rather than emitting a schema-validation error.",
       "files": [],
       "expectations": [
-        "Output reports the absence of an evals file as 'ships no evals', explicitly not a failure",
-        "Output does NOT report a schema validation failure or error for the missing file",
-        "Output reflects the warranted-not-mandatory policy for evals"
+        "Output states that an existing skill without an evals/evals.json file is NOT a validation failure",
+        "Output does NOT characterize the missing evals file as a schema validation failure or error",
+        "Output reflects the warranted-not-mandatory policy (validate-evals reports 'ships no evals' rather than failing)"
       ]
     },
     {

--- a/plugins/skill-quality/skills/skill-quality/evals/evals.json
+++ b/plugins/skill-quality/skills/skill-quality/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill_name": "skill-quality",
+  "evals": [
+    {
+      "id": 1,
+      "name": "check-is-default-action",
+      "prompt": "check my-skill",
+      "expected_output": "Runs the default check action: resolves the skills root (user_config.skills_root, else ${CLAUDE_PROJECT_DIR}/.claude/skills), runs the bundled check-skill.sh over my-skill, and reports PASS/FAIL from the exit code with any FAIL: lines surfaced verbatim and WARN: lines grouped after.",
+      "files": [],
+      "expectations": [
+        "Output runs the static contract gate (check-skill.sh) against the named skill",
+        "Output reports a PASS or FAIL verdict derived from the script exit code",
+        "Output surfaces FAIL lines verbatim and separates advisory WARN lines from failures"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "validate-evals-routes-to-schema-check",
+      "prompt": "validate-evals my-skill",
+      "expected_output": "Routes to the validate-evals action: locates <skills-root>/my-skill/evals/evals.json and validates it against the bundled schema (via a JSON-schema validator if available, else a structural check that skill_name and a non-empty evals array are present and each case has id + prompt), reporting each violation with its JSON path or confirming conformance.",
+      "files": [],
+      "expectations": [
+        "Output runs the validate-evals (schema) path, not the static contract gate",
+        "Output validates evals.json against the bundled schema and reports conformance or per-violation JSON paths",
+        "Output does not attempt to run the eval cases (it is a schema/structure check, not a model-graded run)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "absent-evals-is-not-a-failure",
+      "prompt": "validate-evals a skill that ships no evals/evals.json file",
+      "expected_output": "The skill reports that the skill ships no evals and treats this as NOT a failure — evals are warranted, not mandatory. It does not emit a schema-validation failure for the missing file.",
+      "files": [],
+      "expectations": [
+        "Output reports the absence of an evals file as 'ships no evals', explicitly not a failure",
+        "Output does NOT report a schema validation failure or error for the missing file",
+        "Output reflects the warranted-not-mandatory policy for evals"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "surface-fail-verbatim-hand-verify-ref",
+      "prompt": "The check on skill X returned a broken-internal-ref FAIL pointing at SKILL.md:42. Interpret it and fix it.",
+      "expected_output": "The skill surfaces the FAIL line verbatim rather than re-deriving its meaning, and for a broken-internal-ref FAIL it hand-verifies SKILL.md:42 first — because that line may be an illustrative example path rather than a real broken reference — before editing anything.",
+      "files": [],
+      "expectations": [
+        "Output surfaces/relies on the verbatim FAIL message rather than paraphrasing or re-deriving its meaning",
+        "Output hand-verifies the cited SKILL.md line before editing, acknowledging it could be an illustrative example path rather than a real broken ref",
+        "Output does not blindly rewrite the reference without first checking the cited line"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "not-for-authoring-new-skills",
+      "prompt": "Use skill-quality to write me a brand-new skill for parsing CSV files.",
+      "expected_output": "The skill declines: it is a static QA gate (check / validate-evals), not a skill-authoring tool. It routes the user to skill authoring (e.g. skill-creator) rather than generating a new SKILL.md.",
+      "files": [],
+      "expectations": [
+        "Output does NOT author a new skill / SKILL.md",
+        "Output states that skill-quality is a QA/validation gate, not an authoring tool",
+        "Output redirects the user to an appropriate skill-authoring path"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "outside-git-repo-is-env-error-not-silent-pass",
+      "prompt": "Run the skill-quality check when the skills directory is not inside a git repository. What happens?",
+      "expected_output": "Several checks read git show HEAD: / git ls-files, so outside a git repo the script exits 2 (environment error) rather than silently passing. The skill reports the environment error rather than claiming a clean PASS.",
+      "files": [],
+      "expectations": [
+        "Output explains the check reports an environment error (exit 2) outside a git repository",
+        "Output does NOT characterize the run as a clean PASS when git is unavailable",
+        "Output attributes the requirement to checks that read git history (git show HEAD / git ls-files)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Authors rich-form `evals/evals.json` for six skills across three plugins — one file per skill under `plugins/<plugin>/skills/<skill>/evals/evals.json` — conforming to the bundled schema `plugins/skill-quality/reference/evals.schema.json` and modeled on the `bug-report` rich-form example.

Each set targets trigger/routing, the happy path, at least one refusal/guardrail, and one anti-pattern (4-6 cases each).

## Per-skill warrant re-check

Re-checked against the **current shipped `SKILL.md`** on `origin/main`. **All six warrant evals — no skips.**

| Skill | Warrant (judgment-bearing contract exercised) |
|---|---|
| `event-storming/methodology` | format-recommendation routing, Miro-availability gate (skip, don't error), Brandolini source-authority precedence, methodology↔simulation boundary |
| `event-storming/simulation` | simulate↔methodology routing, Miro-absent structured-markdown degradation, existing-board modes require Miro, never-auto-advance-formats, state under `CLAUDE_PLUGIN_DATA` |
| `machine-health/machine-health` | OS routing (UNKNOWN+stop on macOS/Linux), elevation → UNKNOWN not a UAC prompt, surface-over-silently-fix, no-interactive-prompts, append-only history |
| `machine-health/setup` | read-state-first idempotency, minimal overlay, explicit-approval-only remediations, never edit shipped catalog/install dir, `report_dir` → plugin config |
| `skill-quality/skill-quality` | check↔validate-evals routing, absent-evals is not a failure, surface FAIL verbatim / hand-verify refs, not-for-authoring, outside-git-repo env error |
| `skill-quality/setup` | conventional-location persists nothing, non-default confirm-then-persist, never resolve an unconfirmed location, strict-JSON (no comments), scoped to config not audit |

## Version bumps

Evals ship as a plugin component, so each touched plugin is version-bumped (minor, matching prior evals-PR precedent):

- `event-storming` 0.1.0 → 0.2.0
- `machine-health` 0.2.0 → 0.3.0
- `skill-quality` 0.1.0 → 0.2.0

## Validation

All six validated against the bundled schema with `check-jsonschema` (`ok -- validation done` for each). Authored against current shipped behavior; the owning retrofits (simulation miro-reconcile, machine-health behavior/cadence, skill-quality runner/contract) update their own skill's eval if they change behavior.

Refs melodic-software/medley#1454

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive eval JSON and manifest version bumps only; no production logic or security-sensitive behavior changes.
> 
> **Overview**
> Adds **rich-form** `evals/evals.json` under six skills in **event-storming** (`methodology`, `simulation`), **machine-health** (`machine-health`, `setup`), and **skill-quality** (`skill-quality`, `setup`). Each file has 4–6 cases with prompts, `expected_output`, and `expectations`, encoding routing, happy paths, guardrails, and anti-patterns (e.g. Miro gates, Brandolini precedence, fail-safe audit posture, setup overlay vs plugin config).
> 
> **Minor version bumps** in each touched plugin manifest: `event-storming` 0.1.0→0.2.0, `machine-health` 0.2.0→0.3.0, `skill-quality` 0.1.0→0.2.0, matching prior evals-only releases. No skill runtime or checker script changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 118abe6640940f959d288dfdb5d6d4ac552faee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->