### PR TITLE
chore(knowledge/setup): retrofit library_dir precedence + portability hardening

### DIFF
--- a/plugins/codebase-audit/.claude-plugin/plugin.json
+++ b/plugins/codebase-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codebase-audit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Repo-wide drift audit between docs, config, code, and architecture: verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings, and fixes or presents for review. Audit dimensions are configurable through a tracked .claude/codebase-audit.md config file written by the setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/codebase-audit/skills/setup/SKILL.md
+++ b/plugins/codebase-audit/skills/setup/SKILL.md
@@ -21,12 +21,16 @@ Idempotent: re-running reads the existing config and offers updates rather than 
    empty source lists is an explicit opt-out that *removes* that inherited dimension (step 6). Load every layer
    you can access and present a short summary of the *effective merged* result (dimensions present, glob counts,
    example-claim counts) — honoring those opt-outs, so a dimension a higher layer deliberately zeroed out is
-   reported as removed, not as still present — and report which layer contributes what. When a local or user-global layer adds to the team file, **say so
-   explicitly** — step 5 writes the *team* file, so a team-scope edit alone will not account for what a local
-   or user-global overlay contributes to what the audit actually runs on that machine. When a higher layer
-   cannot be read (a user-global base is often outside the repo and OS-specific), **warn that it was not
-   considered** rather than presenting the team file alone as the effective config. The interview then
-   proposes changes against that baseline; nothing is dropped without the user confirming.
+   reported as removed, not as still present — and report which layer contributes what. When a local or
+   user-global layer changes the team file's effect — whether it *adds* globs or *opts a dimension out* with
+   empty source lists — **say so explicitly**, because step 5 writes only the *team* file. A team-scope edit
+   alone will not account for what a higher overlay contributes; in particular, when a local (or user-global)
+   opt-out zeroes a dimension, accepting a team-scope *re-enable* here will not restore that dimension on this
+   machine — the overlay keeps removing it — so prompt the user to also remove or update the opt-out in that
+   overlay, not just re-enable it in the team file. When a higher layer cannot be read (a user-global base is
+   often outside the repo and OS-specific), **warn that it was not considered** rather than presenting the team
+   file alone as the effective config. The interview then proposes changes against that baseline; nothing is
+   dropped without the user confirming.
 2. **Explore the repo to draft defaults.** Before asking anything, infer candidates:
    - **documentation** primary-sources: doc directories (`docs/`, `README.md`), agent-instruction
      files (`AGENTS.md`, `CLAUDE.md`), ADR directories, convention docs.

--- a/plugins/codebase-audit/skills/setup/SKILL.md
+++ b/plugins/codebase-audit/skills/setup/SKILL.md
@@ -17,9 +17,11 @@ Idempotent: re-running reads the existing config and offers updates rather than 
 1. **Read the effective config first, across all layers.** The audit config resolves as an additive merge
    of the documented layers — user-global (`~/.claude/codebase-audit.md`) → team (`.claude/codebase-audit.md`)
    → local overlay (`.claude/codebase-audit.local.md`) — where a later layer's globs union with (not replace)
-   the earlier layer's and example-claims concatenate (step 6). Load every layer you can access and present a
-   short summary of the *effective merged* result (dimensions present, glob counts, example-claim counts),
-   reporting which layer contributes what. When a local or user-global layer adds to the team file, **say so
+   the earlier layer's and example-claims concatenate, **except** that a later layer declaring a dimension with
+   empty source lists is an explicit opt-out that *removes* that inherited dimension (step 6). Load every layer
+   you can access and present a short summary of the *effective merged* result (dimensions present, glob counts,
+   example-claim counts) — honoring those opt-outs, so a dimension a higher layer deliberately zeroed out is
+   reported as removed, not as still present — and report which layer contributes what. When a local or user-global layer adds to the team file, **say so
    explicitly** — step 5 writes the *team* file, so a team-scope edit alone will not account for what a local
    or user-global overlay contributes to what the audit actually runs on that machine. When a higher layer
    cannot be read (a user-global base is often outside the repo and OS-specific), **warn that it was not

--- a/plugins/codebase-audit/skills/setup/SKILL.md
+++ b/plugins/codebase-audit/skills/setup/SKILL.md
@@ -14,8 +14,16 @@ Idempotent: re-running reads the existing config and offers updates rather than 
 
 ## Task
 
-1. **Read existing config first.** If `.claude/codebase-audit.md` exists, load it and present a
-   short summary (dimensions present, glob counts, example-claim counts). The interview then
+1. **Read the effective config first, across all layers.** The audit config resolves as an additive merge
+   of the documented layers — user-global (`~/.claude/codebase-audit.md`) → team (`.claude/codebase-audit.md`)
+   → local overlay (`.claude/codebase-audit.local.md`) — where a later layer's globs union with (not replace)
+   the earlier layer's and example-claims concatenate (step 6). Load every layer you can access and present a
+   short summary of the *effective merged* result (dimensions present, glob counts, example-claim counts),
+   reporting which layer contributes what. When a local or user-global layer adds to the team file, **say so
+   explicitly** — step 5 writes the *team* file, so a team-scope edit alone will not account for what a local
+   or user-global overlay contributes to what the audit actually runs on that machine. When a higher layer
+   cannot be read (a user-global base is often outside the repo and OS-specific), **warn that it was not
+   considered** rather than presenting the team file alone as the effective config. The interview then
    proposes changes against that baseline; nothing is dropped without the user confirming.
 2. **Explore the repo to draft defaults.** Before asking anything, infer candidates:
    - **documentation** primary-sources: doc directories (`docs/`, `README.md`), agent-instruction

--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files) and a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/skills/setup/SKILL.md
+++ b/plugins/knowledge/skills/setup/SKILL.md
@@ -87,10 +87,10 @@ cannot infer → ask and offer to persist; otherwise a safe generic default (rep
 An updated `library_dir` in the consumer's settings — the project `.claude/settings.json` by default, or the
 local overlay `.claude/settings.local.json` for a personal-only override (step 5) — plus a one-line summary
 of the value written, its scope, and how to re-run this setup to reconfigure. Note in the summary that
-`library_dir` governs where the plugin's ingestion pipelines land synthesized artifacts — `/knowledge:book-distill`
-is unaffected, since it always writes to the target skill you name at invocation — and that `library_dir` is
-meant to track any working-notes/artifacts convention the consuming project declares in its own `CLAUDE.md` or
-rules (setup keeps the two aligned; the pipelines themselves resolve `library_dir` directly at write time).
+`library_dir` is the persisted seam for where the plugin's ingestion pipelines are configured to land
+synthesized artifacts, and that it is meant to track any working-notes/artifacts convention the consuming
+project declares in its own `CLAUDE.md` or rules — setup keeps the two aligned. `/knowledge:book-distill` is
+unaffected either way, since it always writes to the target skill you name at invocation.
 
 ## What this skill does NOT do
 

--- a/plugins/knowledge/skills/setup/SKILL.md
+++ b/plugins/knowledge/skills/setup/SKILL.md
@@ -98,7 +98,7 @@ recorded for when the pipelines consume it — not as currently relocating artif
 ## What this skill does NOT do
 
 - Run a distillation or ingestion — that is the plugin's pipeline skills (e.g. `/knowledge:book-distill`).
-- Write machine-local state — configuration lives in the consumer's tracked settings (project
-  `.claude/settings.json`, or `.claude/settings.local.json` for a personal-only override per step 5), never
-  in the plugin directory or the plugin data directory (`${CLAUDE_PLUGIN_DATA}` is for caches and generated
-  state only).
+- Write anything into the plugin directory or the plugin data directory — configuration lives in the
+  consumer's settings (tracked project `.claude/settings.json`, or the personal `.claude/settings.local.json`
+  overlay for a personal-only override per step 5), never in the plugin install path (`${CLAUDE_PLUGIN_DATA}`
+  is for caches and generated state only).

--- a/plugins/knowledge/skills/setup/SKILL.md
+++ b/plugins/knowledge/skills/setup/SKILL.md
@@ -21,45 +21,81 @@ Apply the convention-resolution ladder — config present → use it; absent →
 cannot infer → ask and offer to persist; otherwise a safe generic default (repo root `.`).
 
 1. **Read the current value first, in precedence order.** Look for `library_dir` under
-   `pluginConfigs["knowledge@melodic-software"].options` in all three scopes and resolve the *effective*
-   value the way Claude Code does — **Local (`.claude/settings.local.json`) > Project
-   (`.claude/settings.json`) > User (`~/.claude/settings.json`)**, local winning. Report the effective
-   value and which scope supplies it; the interview proposes a change against that baseline. If a local
-   override is present, say so explicitly — step 4 writes the *project* (team) value, which stays shadowed
-   by the local override until the developer updates or removes it, so a project-scope edit alone will not
-   change what the plugin actually uses on that machine. Read each scope **narrowly** — query only the
-   single `pluginConfigs["knowledge@melodic-software"].options.library_dir` key (e.g. with `jq`), never
-   loading `.claude/settings.local.json` wholesale: that overlay is secret-bearing (API tokens, env
-   secrets), so do not read or echo unrelated settings content.
-2. **Infer a default before asking.** If no value is set, explore the consuming repo for an existing
+   `pluginConfigs["knowledge@melodic-software"].options` and resolve the *effective* value the way Claude
+   Code does — the documented order, highest first, is **Managed (system-level `managed-settings.json`
+   policy) > command-line `--settings` session override > Local (`.claude/settings.local.json`) > Project
+   (`.claude/settings.json`) > User (`~/.claude/settings.json`)** (see the official precedence in the
+   [Claude Code settings docs](https://code.claude.com/docs/en/settings)). Inspect each layer you can
+   access; a Managed policy or a session launched with `--settings` sits **above** Local and, if it supplies
+   `library_dir`, wins and cannot be overridden by the project value step 5 writes — when you cannot read
+   those higher layers (managed policy is often outside the repo and OS-specific), **explicitly warn that
+   they were not considered** rather than declaring the lower value authoritative. Report the effective
+   value and which scope supplies it; the interview proposes a change against that baseline. If a Managed
+   layer or a Local override is present, say so explicitly — step 5 writes the *project* (team) value, which
+   stays shadowed by any higher-precedence layer until it is updated or removed, so a project-scope edit
+   alone will not change what the plugin actually uses on that machine. Read each scope **narrowly** —
+   query only the single `pluginConfigs["knowledge@melodic-software"].options.library_dir` key (e.g. with
+   `jq`), never loading `.claude/settings.local.json` wholesale: that overlay is secret-bearing (API tokens,
+   env secrets), so do not read or echo unrelated settings content.
+2. **Always check for a declared convention — even when a value is set.** `library_dir` is authoritative at
+   the pipelines' write time (they resolve the persisted seam directly), so unlike a runtime-override design
+   there is no silent write-to-a-different-path trap here. The risk is a different one: the plugin's intent is
+   that `library_dir` *tracks* the consuming repo's own working-notes/artifacts convention (declared in its
+   `CLAUDE.md`, `AGENTS.md`, or `.claude/rules`), so a stored `library_dir` that disagrees with a declared
+   convention is likely a stale or accidental value — setup would carry that divergence forward as the team
+   destination. So whenever a value is present, still inspect the repo for a declared convention and, if it
+   conflicts with the effective value, **surface the divergence explicitly** and offer to reconcile (align
+   `library_dir` to the convention, or record that the divergence is intentional). Only skip this inspection
+   when the effective value already matches the declared convention (or no convention is declared).
+3. **Infer a default before asking.** If no value is set, explore the consuming repo for an existing
    artifact/notes convention rather than guessing:
    - A working-notes or artifacts directory declared in the repo's own `CLAUDE.md`, `AGENTS.md`, or
-     `.claude/rules` (that declared convention wins — surface it as the recommended value).
+     `.claude/rules` (surface that declared convention as the recommended value, so the persisted
+     `library_dir` tracks it).
    - An existing docs or knowledge directory (`docs/`, `knowledge/`, `.claude/notes/`) that synthesized
      artifacts would naturally join.
    - If nothing is found, the safe default is the repo root `.` (the plugin's declared `userConfig`
      default), meaning artifacts land at the top of the consuming repo unless a skill is told otherwise.
-3. **Interview — one decision.** Present the inferred value with a recommendation and let the user accept
+4. **Interview — one decision.** Present the inferred value with a recommendation and let the user accept
    or edit it. Keep it to the single `library_dir` knob; do not invent further options (Rule of Three — add
    a knob only when a real repeated repo-specific need surfaces).
-4. **Persist to project scope.** Write the chosen value to the project `.claude/settings.json` at
-   `pluginConfigs["knowledge@melodic-software"].options.library_dir` so it is tracked and shared with the
-   team. Create the `pluginConfigs` / options path if absent; do not disturb unrelated keys. The value is
-   stored verbatim (Claude Code does not normalize a `directory` option to absolute or validate existence),
-   so store it exactly as the user intends it to resolve relative to their working directory.
-5. **Offer the personal overlay.** A per-developer override goes in the local overlay
+5. **Persist — but only a portable value, and to the scope the user intends.** The default target is the
+   project `.claude/settings.json` at `pluginConfigs["knowledge@melodic-software"].options.library_dir`, so
+   it is tracked and shared with the team. Two guards before writing there:
+   - **Never copy a personal/session value into team settings unexamined.** If the effective baseline from
+     step 1 came from a higher-precedence *personal* layer (`.claude/settings.local.json` or a `--settings`
+     session file), it may be machine-specific (e.g. an absolute path under one developer's home). Do not
+     propagate that verbatim into tracked `.claude/settings.json` — teammates would inherit an unusable
+     path while the original machine keeps its local override. Confirm the value is **portable**
+     (project-relative, no user-specific absolute segment) before a project write; if it is not, ask for a
+     portable form.
+   - **Match the scope to intent.** If the user only wants a personal override (not a team default), write
+     to the local overlay `.claude/settings.local.json` instead and skip the project write entirely. The
+     portability requirement above applies **only to the shared project write** — a local-only override is
+     machine-specific by nature, so store the user's value as given there (an absolute home-directory path is
+     legitimate) without rewriting it toward portability.
+   Create the `pluginConfigs` / options path if absent; do not disturb unrelated keys. The value is stored
+   verbatim (Claude Code does not normalize a `directory` option to absolute or validate existence), so store
+   it exactly as it should resolve — the portable form for a project write, the user's given value for a
+   local-only override.
+6. **Confirm the overlay convention.** A per-developer override lives in the local overlay
    `.claude/settings.local.json` (same `pluginConfigs` path); recommend the consumer keep
    `.claude/settings.local.json` gitignored if it is not already.
 
 ## Output
 
-An updated project `.claude/settings.json` carrying `library_dir`, plus a one-line summary of the value
-written, its scope, and how to re-run this setup to reconfigure. Note in the summary that `library_dir`
-governs where the plugin's ingestion pipelines land synthesized artifacts — `/knowledge:book-distill`
-is unaffected, since it always writes to the target skill you name at invocation.
+An updated `library_dir` in the consumer's settings — the project `.claude/settings.json` by default, or the
+local overlay `.claude/settings.local.json` for a personal-only override (step 5) — plus a one-line summary
+of the value written, its scope, and how to re-run this setup to reconfigure. Note in the summary that
+`library_dir` governs where the plugin's ingestion pipelines land synthesized artifacts — `/knowledge:book-distill`
+is unaffected, since it always writes to the target skill you name at invocation — and that `library_dir` is
+meant to track any working-notes/artifacts convention the consuming project declares in its own `CLAUDE.md` or
+rules (setup keeps the two aligned; the pipelines themselves resolve `library_dir` directly at write time).
 
 ## What this skill does NOT do
 
 - Run a distillation or ingestion — that is the plugin's pipeline skills (e.g. `/knowledge:book-distill`).
-- Write machine-local state — configuration lives in the consumer's tracked settings, never in the plugin
-  directory or the plugin data directory (`${CLAUDE_PLUGIN_DATA}` is for caches and generated state only).
+- Write machine-local state — configuration lives in the consumer's tracked settings (project
+  `.claude/settings.json`, or `.claude/settings.local.json` for a personal-only override per step 5), never
+  in the plugin directory or the plugin data directory (`${CLAUDE_PLUGIN_DATA}` is for caches and generated
+  state only).

--- a/plugins/knowledge/skills/setup/SKILL.md
+++ b/plugins/knowledge/skills/setup/SKILL.md
@@ -87,10 +87,13 @@ cannot infer → ask and offer to persist; otherwise a safe generic default (rep
 An updated `library_dir` in the consumer's settings — the project `.claude/settings.json` by default, or the
 local overlay `.claude/settings.local.json` for a personal-only override (step 5) — plus a one-line summary
 of the value written, its scope, and how to re-run this setup to reconfigure. Note in the summary that
-`library_dir` is the persisted seam for where the plugin's ingestion pipelines are configured to land
-synthesized artifacts, and that it is meant to track any working-notes/artifacts convention the consuming
-project declares in its own `CLAUDE.md` or rules — setup keeps the two aligned. `/knowledge:book-distill` is
-unaffected either way, since it always writes to the target skill you name at invocation.
+`library_dir` is the destination seam the knowledge plugin declares for where synthesized artifacts should
+land, and that it is meant to track any working-notes/artifacts convention the consuming project declares in
+its own `CLAUDE.md` or rules — setup keeps the two aligned. Be accurate about current reach so the user is not
+misled: `/knowledge:book-distill` ignores `library_dir` (it writes to the target skill you name at
+invocation), and the `/knowledge:youtube` pipeline does not yet honor a non-default `library_dir` (its work
+root falls back to the consuming project root), so when a non-default value is persisted, report it as
+recorded for when the pipelines consume it — not as currently relocating artifacts.
 
 ## What this skill does NOT do
 


### PR DESCRIPTION
Applies the resolved `planning/setup` hardening to `knowledge/setup`'s `library_dir` seam (same single-directory `userConfig` shape, same latent issues).

## Changes

**`plugins/knowledge/skills/setup/SKILL.md`**
- **Precedence** — step 1 now resolves the full documented order (Managed > `--settings` > Local > Project > User), warns when higher layers are unreadable instead of declaring a lower value authoritative, and surfaces layer shadowing before the project write.
- **Portability** — step 5 guards the tracked project write: never propagate a machine-specific personal-layer value into team settings; route personal-only overrides to `.claude/settings.local.json` (portability required only for the shared project write).
- **Declared-convention alignment** — inspect the repo's declared working-notes/artifacts convention even when a value is set; surface divergence and offer to reconcile.

**`plugins/codebase-audit/skills/setup/SKILL.md`** (partial match — writes a tracked `.md`, not settings)
- Applied only the precedence/shadowing subset: step 1 reports the *effective additively-merged* config across user-global → team → local layers (and warns on unreadable layers), instead of summarizing the team file alone. Settings-write portability specifics do not apply.

## Deviations (own-flagged)

1. **Fix #3 premise softened for knowledge.** The issue's fix #3 parenthetical assumed knowledge "honors that convention over the config at write time" (true for planning). Verified via `skills/youtube/extraction/lib/work-root.js` and the youtube pipeline that **knowledge resolves `library_dir` directly at write time — no skill overrides it with a repo convention at runtime.** Documenting that behavior would be false, so I softened the imported write-time-override claim: `library_dir` is runtime-authoritative, and setup's job is to keep it *aligned* with any declared convention. Fixes #1 and #2 are unaffected.
2. **`codebase-audit` version bump not in issue scope.** Patch-bumped `0.1.0 → 0.1.1` because its SKILL behavior changed; the issue only specified the `knowledge` minor bump.

## Verification
- `knowledge` `plugin.json` minor bump `0.2.0 → 0.3.0`; `codebase-audit` `0.1.0 → 0.1.1`.
- `claude plugin validate` clean on both plugins.
- markdownlint clean on both edited files.

Refs melodic-software/medley#1463

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to plugin skill documentation and version metadata; no application runtime or security-sensitive code paths are modified.
> 
> **Overview**
> **Hardens setup skills** for the `knowledge` and `codebase-audit` plugins so interactive setup reflects layered config reality instead of treating a single team file as authoritative.
> 
> For **`knowledge/setup`**, step 1 now follows the full Claude Code precedence chain (Managed → `--settings` → Local → Project → User), warns when higher layers are unreadable, and calls out when a project write would stay shadowed. A new step reconciles `library_dir` with repo-declared working-notes conventions even when a value is already set. Persistence (step 5) blocks copying machine-specific personal paths into tracked project settings, routes personal-only overrides to `.claude/settings.local.json`, and the output section documents honest pipeline behavior (`book-distill` ignores `library_dir`; YouTube does not yet honor it). **`knowledge`** bumps **0.2.0 → 0.3.0**.
> 
> For **`codebase-audit/setup`**, step 1 is expanded to summarize the **effective merged** config across user-global → team → local layers (including dimension opt-outs via empty source lists), explain that only the team file is written, and warn when overlays block re-enabling dimensions. **`codebase-audit`** patch-bumps **0.1.0 → 0.1.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13139aaaa46a5883c3ffe9781845190dc9f228e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->