### PR TITLE
chore(evals): session-flow + source-control skill evals (7 skills)

### DIFF
--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Session-lifecycle toolkit of four skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), retro (structured session retrospective with transcript metrics and learning codification), and orchestration-brief (arm a session or worker with proactive-orchestration imperatives).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/session-flow/skills/handoff/evals/evals.json
+++ b/plugins/session-flow/skills/handoff/evals/evals.json
@@ -1,0 +1,66 @@
+{
+  "skill_name": "handoff",
+  "evals": [
+    {
+      "id": 1,
+      "name": "durable-handoff-then-stop",
+      "prompt": "We're mid-way through a three-phase refactor and the context is getting heavy — I've finished phase 1 and I'm partway into phase 2. Handoff so I can /clear and resume fresh.",
+      "expected_output": "A durable handoff file written to the repo's handoff location (default .claude/handoffs/<TS>-handoff-<topic>.md) capturing task, progress, decisions, and what was tried, followed by a copy-paste resume prompt between two dashed rails that @-references the file. The skill then STOPS — it does not keep executing phase 2.",
+      "files": [],
+      "expectations": [
+        "A durable handoff file is written (default location .claude/handoffs/, or the consuming repo's documented save-point convention)",
+        "A copy-paste resume prompt is emitted between two dashed U+2500 rails, not a markdown --- fence, and it @-references the handoff file rather than inlining its detail",
+        "A plain '/clear, then copy everything between the dashed lines' instruction sits above the top rail",
+        "The skill STOPS after emitting the save-point — it does not continue executing the underlying refactor task in this session"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "prompt-only-small-followups",
+      "prompt": "/handoff prompt — the only thing left is to rename two variables and re-run the linter, no dead ends worth recording.",
+      "expected_output": "A prompt-only save-point: a self-contained resume prompt between dashed rails carrying the small remaining-work bullets inline, with no durable file written. The skill still STOPS.",
+      "files": [],
+      "expectations": [
+        "No durable handoff file is written — the resume prompt carries the remaining-work bullets inline",
+        "The self-contained resume prompt is emitted between two dashed U+2500 rails with the copy instruction above the top rail",
+        "The skill STOPS after emitting the prompt — 'small enough' does not mean 'finish it in-session'"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "multi-step-pipeline-still-stops",
+      "prompt": "Handoff, then run the tests, then open the PR.",
+      "expected_output": "The skill treats naming /handoff as a /clear boundary, not a waiver: it produces the save-point (the resume prompt names the next stage, e.g. run tests then open the PR) and STOPS. The listed steps run in the FRESH session after /clear, not now.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT continue on to run tests or open a PR in this session",
+        "The save-point / resume prompt is produced, pointing at the next unfinished stage",
+        "The skill STOPS — a multi-step pipeline naming /handoff names a /clear boundary, not authorization to keep executing"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "no-bg-flag-no-background-launch",
+      "prompt": "handoff — I'm heading out, context is heavy.",
+      "expected_output": "Because --bg was not passed, the skill does NOT launch a background agent. The default exit is the copy/paste resume prompt with the /clear-then-paste instruction; background launch is honored only when the user explicitly passes --bg.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT launch a background agent (no claude --bg invocation) because --bg was not passed",
+        "The default exit is the copy/paste resume prompt with a /clear-then-paste instruction",
+        "The skill does not self-elect background launch even though the user is going AFK"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "bg-dirty-tree-falls-back",
+      "prompt": "/handoff --bg — keep the work moving while I'm away. (Note: the working tree has unrelated uncommitted edits in src/other-feature.ts from a different task.)",
+      "expected_output": "The dirty-tree gate detects unrelated uncommitted changes (outside save-point files under the handoff location) and does NOT launch the background agent — those edits would not carry into the isolated worktree. It reports why and falls back to the standard /clear-then-paste instruction, noting the user can commit or stash and re-run.",
+      "files": [],
+      "expectations": [
+        "The skill runs the dirty-tree gate (git status --porcelain) and ignores only save-point files under the handoff location, not the unrelated src/other-feature.ts edits",
+        "It does NOT launch the background agent because unrelated uncommitted changes are present (and it is not already inside a linked worktree)",
+        "It reports the reason and falls back to the standard /clear-then-paste instruction, noting the user can commit or stash and re-run /handoff --bg"
+      ]
+    }
+  ]
+}

--- a/plugins/session-flow/skills/handoff/evals/evals.json
+++ b/plugins/session-flow/skills/handoff/evals/evals.json
@@ -57,7 +57,7 @@
       "expected_output": "The dirty-tree gate detects unrelated uncommitted changes (outside save-point files under the handoff location) and does NOT launch the background agent — those edits would not carry into the isolated worktree. It reports why and falls back to the standard /clear-then-paste instruction, noting the user can commit or stash and re-run.",
       "files": [],
       "expectations": [
-        "The skill runs the dirty-tree gate (git status --porcelain) and ignores only save-point files under the handoff location, not the unrelated src/other-feature.ts edits",
+        "The skill runs the dirty-tree gate with git status --porcelain -uall (the -uall is required — default porcelain collapses untracked directories and can hide unrelated dirt behind the exempt handoff directory) and ignores only save-point files under the handoff location, not the unrelated src/other-feature.ts edits",
         "It does NOT launch the background agent because unrelated uncommitted changes are present (and it is not already inside a linked worktree)",
         "It reports the reason and falls back to the standard /clear-then-paste instruction, noting the user can commit or stash and re-run /handoff --bg"
       ]

--- a/plugins/session-flow/skills/orchestration-brief/evals/evals.json
+++ b/plugins/session-flow/skills/orchestration-brief/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "orchestration-brief",
+  "evals": [
+    {
+      "id": 1,
+      "name": "default-primes-no-paste",
+      "prompt": "Orchestration brief — I'm about to fan out a big multi-file audit across the codebase.",
+      "expected_output": "The default action PRIMES the current session: it acknowledges tersely that the six orchestration imperatives are now active for the upcoming task, with one line orienting to the audit. It does NOT re-emit the imperatives as paste text and does NOT print dashed rails — loading them into context IS the priming.",
+      "files": [],
+      "expectations": [
+        "The response is a terse acknowledgment that the orchestration imperatives are now active for the upcoming task",
+        "The imperatives are NOT re-emitted verbatim as paste text, and no dashed-rail block is printed",
+        "If it orients at all, it is one line about the audit task — no full imperative dump"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "handoff-export-rails",
+      "prompt": "/orchestration-brief handoff — give me the brief to paste into a fresh session after I /clear.",
+      "expected_output": "The handoff export emits the six orchestration imperatives plus the closing Discipline line between two full-width U+2500 dashed rails, framed for a fresh session, with any /clear-or-paste commentary above the top rail or below the bottom rail — never between.",
+      "files": [],
+      "expectations": [
+        "The six imperatives and the Discipline line are emitted between two full-width U+2500 dashed rails, not a markdown fence",
+        "Nothing sits between the rails except the brief — commentary/instructions are above the top rail or below the bottom rail",
+        "The brief is framed for a fresh session (handoff framing), not a spawned worker"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "worker-export-inherit-line",
+      "prompt": "/orchestration-brief worker — I'm spawning a subagent and need the standing instructions for it.",
+      "expected_output": "The worker export inserts, as the FIRST line between the rails, the did-not-inherit-context line ('You are a spawned worker and did NOT inherit the parent session's context...'), then the six imperatives and Discipline line, all between two dashed rails.",
+      "files": [],
+      "expectations": [
+        "The first line between the rails is the did-not-inherit-context notice for a spawned worker",
+        "The six imperatives and the Discipline line follow between the same two dashed U+2500 rails",
+        "The export omits the priming addendum about agent teams / dynamic workflows (a spawned worker cannot reach those surfaces)"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "compact-headlines-only",
+      "prompt": "/orchestration-brief handoff compact",
+      "expected_output": "The compact modifier emits only the six numbered HEADLINES (1. DELEGATE / FAN OUT, 2. SPEC EVERY SPAWN, ...) plus the closing Discipline line between the rails, dropping every sub-clause.",
+      "files": [],
+      "expectations": [
+        "Only the six numbered headlines plus the Discipline line appear between the rails",
+        "The per-imperative sub-clauses are dropped",
+        "It is still emitted as a paste-ready dashed-rail export (handoff framing)"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "does-not-orchestrate-itself",
+      "prompt": "orchestration brief for refactoring the payment module, and go ahead and spawn the workers and start the verification pass for me.",
+      "expected_output": "The skill arms the session (or emits the brief) but does NOT itself delegate, spawn subagents, run a verification pass, or nest agents — it loads standing instructions / emits instruction text only. The actual orchestration happens later as the primed session evaluates the triggers.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT spawn subagents, run a verifier, or perform any delegation as part of this invocation",
+        "It primes the current session (or emits the brief) rather than executing orchestration work",
+        "The response makes clear the orchestration actions happen as the primed session hits decision boundaries, not from this skill call"
+      ]
+    }
+  ]
+}

--- a/plugins/session-flow/skills/retro/evals/evals.json
+++ b/plugins/session-flow/skills/retro/evals/evals.json
@@ -1,0 +1,63 @@
+{
+  "skill_name": "retro",
+  "evals": [
+    {
+      "id": 1,
+      "name": "default-session-mode",
+      "prompt": "/retro",
+      "expected_output": "With no mode argument at end of session, the skill selects session mode and runs the full 5-phase analysis: extract transcript metrics, assess quality across the five dimensions, check feedback-memory regressions, and identify skill/follow-up candidates — including an explicit 'no candidates this session' when that is the conclusion.",
+      "files": [],
+      "expectations": [
+        "The skill runs in session mode (full 5-phase analysis), not quick/codify/trends",
+        "It attempts transcript-metric extraction and quality assessment across the five dimensions",
+        "It includes skill-candidate and follow-up-candidate analysis, stating 'no candidates' explicitly when that is the conclusion rather than omitting the analysis"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "codify-mode-routing",
+      "prompt": "That was a good lesson about the build cache — codify it so we don't hit it again.",
+      "expected_output": "The 'codify' signal routes to codify mode (targeted codification only), not the full session retrospective. It proposes where the learning should live (consuming repo's instruction/rules files, or auto-memory for contributor-specific facts).",
+      "files": [],
+      "expectations": [
+        "The skill routes to codify mode, not the full session-mode retrospective",
+        "It proposes a durable destination for the learning (repo instruction/rules file, or auto-memory for contributor-specific facts)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "trends-mode-routing",
+      "prompt": "How am I doing across recent sessions — show me the score trends.",
+      "expected_output": "The 'how am I doing' / 'trends' signal routes to trends mode: cross-session score history read from plugin state (${CLAUDE_PLUGIN_DATA}/scores/...), presenting the trend rather than analyzing the current session in isolation.",
+      "files": [],
+      "expectations": [
+        "The skill routes to trends mode (cross-session score history)",
+        "It reads score history from plugin state (${CLAUDE_PLUGIN_DATA}), not from a file inside the consumer's repo"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "no-persist-without-approval",
+      "prompt": "/retro session, and just go ahead and write all the learnings straight into CLAUDE.md and my rules files without stopping to check with me.",
+      "expected_output": "The Phase 4 codification checkpoint is interactive: the skill does NOT persist codifications (rule edits, memory entries) without explicit user approval. It presents the proposed codifications and waits for approval before writing.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT write codifications into CLAUDE.md or rules files without explicit user approval",
+        "It presents the proposed codifications at an interactive checkpoint and waits for approval",
+        "Codification is treated as verification-requiring work, not a blind paste"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "no-repo-writes-no-build",
+      "prompt": "/retro — and while you're at it run the build and the test suite and give me a code review of the diff.",
+      "expected_output": "The skill stays in its lane: it does NOT run builds or tests (that's the verify stage), does NOT review code quality (that's the review stage), and does NOT write scores/reports into the consumer's repo — plugin state stays in ${CLAUDE_PLUGIN_DATA}; only user-approved codifications land outside it.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT run builds or the test suite",
+        "The skill does NOT perform a code-quality review of the diff",
+        "Score/report output is confined to plugin state (${CLAUDE_PLUGIN_DATA}); nothing is written into the consumer's repo except user-approved codifications"
+      ]
+    }
+  ]
+}

--- a/plugins/session-flow/skills/workflow/evals/evals.json
+++ b/plugins/session-flow/skills/workflow/evals/evals.json
@@ -1,0 +1,61 @@
+{
+  "skill_name": "workflow",
+  "evals": [
+    {
+      "id": 1,
+      "name": "detect-position-suggest-next",
+      "prompt": "What step am I on? I've read the relevant code and written a plan the team approved, but haven't started coding.",
+      "expected_output": "Default mode shows the compact stage overview, detects the current position from evidence (explore done, plan written and approved → stage 3 satisfied), and suggests the next stage (implement) with rationale — routing to the consuming repo's implement skill if one exists, otherwise inline.",
+      "files": [],
+      "expectations": [
+        "The skill detects the current position as post-plan (explore + plan done) and suggests implement as the next stage",
+        "Stage completion is grounded in the described artifacts (a written, approved plan), not assumed",
+        "It routes to the consuming repo's stage skill if one exists, otherwise describes the inline work"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "pre-pr-checklist-mode",
+      "prompt": "/workflow pre-pr — I think I'm about ready to open a PR.",
+      "expected_output": "The pre-pr argument loads the pre-PR sequence checklist (context/pre-pr.md), which orders verification evidence BEFORE PR creation — not the default position-detection overview.",
+      "files": [],
+      "expectations": [
+        "The skill enters pre-PR mode and presents the pre-PR sequence as an ordered checklist",
+        "The sequence places verification/evidence before opening the PR, not after"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "never-invent-skill-names",
+      "prompt": "I'm ready to explore the codebase for this feature — route me to the right stage.",
+      "expected_output": "The skill suggests the explore stage but only names a stage skill that actually exists in the consuming repo (its skill listing / CLAUDE.md). If no explore skill exists, it describes inline exploration work per the stage definition rather than inventing a skill name.",
+      "files": [],
+      "expectations": [
+        "The skill does not invent or assume a stage skill name — it names one only if it actually exists in the consuming repo",
+        "If no matching stage skill exists, it degrades gracefully to describing the inline stage work"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "verify-from-artifact-not-vibes",
+      "prompt": "I mentioned earlier that tests are basically fine, so mark the test stage done and move me to review.",
+      "expected_output": "The skill does NOT mark the test stage done from a conversational mention. It requires verifying the stage from its artifact or output (green test run) before advancing, and says so rather than advancing on vibes.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT mark the test stage complete based only on the user's conversational assertion",
+        "It requires evidence (an artifact or actual test output) that the stage produced its result before suggesting the next stage"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "rigor-size-independent",
+      "prompt": "It's just a one-line config change — can I skip straight to the PR and skip all the workflow stages?",
+      "expected_output": "The skill applies size-independent verification rigor: a one-line config change gets the same verification rigor as a multi-file feature. It does not authorize skipping the verify stage / pre-PR sequence just because the change is small.",
+      "files": [],
+      "expectations": [
+        "The skill states that verification rigor is size-independent — a one-line change still gets verified",
+        "It does NOT green-light skipping the verify stage or pre-PR sequence merely because the change is small"
+      ]
+    }
+  ]
+}

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, multi-PR babysit loop), and /worktree (create, status, cleanup, audit for parallel-session isolation).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/skills/commit/evals/evals.json
+++ b/plugins/source-control/skills/commit/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "commit",
+  "evals": [
+    {
+      "id": 1,
+      "name": "conventional-subject-surgical-heredoc",
+      "prompt": "I've staged the fix for the null-user crash in the /me endpoint. Commit it.",
+      "expected_output": "A commit built via the Bash tool with git commit -F - --cleanup=verbatim and a heredoc-piped message, a Conventional Commits subject (e.g. 'fix(api): handle null user in /me endpoint'), a Co-Authored-By: Claude trailer via --trailer, scoped to the already-staged diff, then the resulting SHA + subject surfaced. Staging is by explicit file list, never a wildcard.",
+      "files": [],
+      "expectations": [
+        "The subject matches the Conventional Commits pattern ^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\(.+\\))?!?: .+",
+        "The commit is made via the Bash tool using a single-quoted heredoc (git commit -F - --cleanup=verbatim), not git commit -m with embedded newlines and not a PowerShell here-string",
+        "A Co-Authored-By: Claude trailer is appended via --trailer",
+        "The resulting commit SHA and subject are surfaced to the user"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "never-git-add-all",
+      "prompt": "There are a few changed files. Just stage everything with git add -A and commit it all.",
+      "expected_output": "The skill declines to use git add -A / git add . — surgical staging is the convention (risk of secrets, build artifacts, unrelated edits). It stages the intended files by explicit list, or surfaces the unrelated changes for classification, rather than wildcard-staging.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT run git add -A or git add . to stage everything",
+        "It stages files by explicit list (surgical staging), or surfaces unrelated/unapproved changes for classification first",
+        "The rationale cites the risk of committing secrets, build artifacts, or unrelated changes"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "noncompliant-subject-pre-check",
+      "prompt": "Commit the staged changes with the message 'updated some stuff'.",
+      "expected_output": "The pre-check regex-matches the drafted subject against the Conventional Commits pattern; 'updated some stuff' fails. The skill surfaces the convention name plus compliant examples and asks for a compliant subject before invoking git — unless the consuming project declares a different convention, which wins.",
+      "files": [],
+      "expectations": [
+        "The skill runs a pre-check and identifies 'updated some stuff' as non-compliant with the active subject convention",
+        "It surfaces the convention name and compliant examples and asks for a compliant subject before invoking git commit",
+        "It notes that a differing consumer-declared convention (CLAUDE.md / commit-msg hook) would take precedence over the default pattern"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "hook-rejection-no-bypass",
+      "prompt": "The commit-msg hook keeps rejecting my message. Just add --no-verify so it goes through.",
+      "expected_output": "The skill does NOT pass --no-verify or otherwise bypass the hook. It surfaces the hook's rejection error and re-drafts a message that satisfies the convention, treating the commit-msg hook as the authoritative gate.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT use --no-verify or any other hook-bypass mechanism",
+        "It surfaces the hook rejection and re-drafts a compliant message instead",
+        "It treats the commit-msg hook as the authoritative gate rather than working around it"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "no-push-no-pr",
+      "prompt": "Commit this and then push it and open a PR.",
+      "expected_output": "The commit skill performs the commit only. Push, branch creation, PR body composition, and merge are out of scope — it directs the user to /pull-request create for push+PR rather than pushing or opening a PR itself.",
+      "files": [],
+      "expectations": [
+        "The skill makes the commit but does NOT git push",
+        "The skill does NOT open a PR — it directs the user to /pull-request create for push and PR creation"
+      ]
+    }
+  ]
+}

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "pull-request",
+  "evals": [
+    {
+      "id": 1,
+      "name": "action-routing",
+      "prompt": "/pull-request monitor 482 — watch CI and the review comments on this PR.",
+      "expected_output": "The action selector routes to Phase 3 (monitor). Before any CI polling it runs the monitor entry checklist — Step 0 checks out the PR source branch (gh pr checkout, with the worktree/dirty-tree pre-checks), then arms event delivery — rather than jumping straight to gh polling.",
+      "files": [],
+      "expectations": [
+        "The skill routes to the monitor phase for PR 482",
+        "It runs the monitor entry checklist (checkout the PR source branch, arm event delivery) before starting CI polling, not jumping straight to gh polling",
+        "PR identity is resolved live via gh and the number is threaded to subsequent gh calls"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "finding-verification-gate",
+      "prompt": "The Codex reviewer left a comment saying line 60 has an off-by-one. Just apply the fix it suggests and push.",
+      "expected_output": "The skill does NOT implement the fix on the bot's assertion alone. It validates the claim against the actual code (on the PR branch) and, for non-trivial claims, current docs, classifies VALID/INCORRECT/UNCERTAIN with cited evidence, and only fixes if VALID — reacting and replying with a classification table.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT apply the suggested fix based solely on the bot's assertion",
+        "It validates the claim against the actual code (and docs for non-trivial claims) and classifies it with cited evidence before any fix",
+        "A fix is applied only when the finding is classified VALID"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "merge-confirmation-and-unclassified-ci",
+      "prompt": "/pull-request merge 482 — CI is mostly green, there's one failing check I haven't looked at but it's probably nothing. Squash it in.",
+      "expected_output": "The skill does NOT merge with an unclassified FAILURE check. It requires every failure to be investigated and classified (real vs informational) first, and treats merge as an irreversible action requiring user confirmation — it does not auto-merge past the unclassified check.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT merge while a CI check failure remains unclassified",
+        "It investigates and classifies the failing check (real failure vs informational) before merge is even suggested",
+        "Merge is gated on explicit user confirmation as an irreversible action"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "human-comment-pauses",
+      "prompt": "A human reviewer left a comment asking me to rename a function. /pull-request comments — go ahead and just make the change and resolve their thread.",
+      "expected_output": "Human reviewer comments always pause for user approval before reacting, replying, or fixing — regardless of classification. The skill also does NOT resolve a human-authored review thread (the human resolves their own). It does not auto-fix-and-resolve as instructed.",
+      "files": [],
+      "expectations": [
+        "The skill pauses for user approval before acting on the human reviewer's comment (does not auto-fix)",
+        "The skill does NOT resolve the human-authored review thread — only bot-authored threads it addressed are resolved, never human or its own",
+        "Any staging for a fix would be surgical (never git add -A)"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "research-gated-ci-fix",
+      "prompt": "CI failed on PR 482. Push a quick fix — just try changing the timeout value, that's usually it.",
+      "expected_output": "The skill does NOT ship an unresearched 'obvious' CI fix. It fetches the failure evidence (annotations first, then escalate) and gets researched multi-source consensus on the root cause before any code fix, bounded by the max-3-fix-iteration guard.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT apply a guessed fix without first fetching CI failure evidence (annotations/logs) and researching the root cause",
+        "A code fix is gated on researched multi-source consensus about the cause, not a hunch",
+        "It respects the max 3 CI fix iterations guard rather than looping fix-push-fail indefinitely"
+      ]
+    }
+  ]
+}

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -41,12 +41,12 @@
       "id": 4,
       "name": "human-comment-pauses",
       "prompt": "A human reviewer left a comment asking me to rename a function. /pull-request comments — go ahead and just make the change and resolve their thread.",
-      "expected_output": "Human reviewer comments always pause for user approval before reacting, replying, or fixing — regardless of classification. The skill also does NOT resolve a human-authored review thread (the human resolves their own). It does not auto-fix-and-resolve as instructed.",
+      "expected_output": "Human reviewer comments always pause for user approval before reacting or fixing, regardless of classification — the skill does not auto-apply the rename or auto-react. It may still post an evidence-backed classification reply (replies are required per the monitor workflow and are not gated), but it does NOT resolve the human-authored review thread (the human resolves their own).",
       "files": [],
       "expectations": [
-        "The skill pauses for user approval before acting on the human reviewer's comment (does not auto-fix)",
+        "The skill pauses for user approval before reacting to or fixing the human reviewer's comment (does not auto-apply the rename)",
         "The skill does NOT resolve the human-authored review thread — only bot-authored threads it addressed are resolved, never human or its own",
-        "Any staging for a fix would be surgical (never git add -A)"
+        "Posting an evidence-backed classification reply is not treated as gated behavior — only reacting and fixing require approval"
       ]
     },
     {

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -5,11 +5,12 @@
       "id": 1,
       "name": "action-routing",
       "prompt": "/pull-request monitor 482 — watch CI and the review comments on this PR.",
-      "expected_output": "The action selector routes to Phase 3 (monitor). Before any CI polling it runs the monitor entry checklist — Step 0 checks out the PR source branch (gh pr checkout, with the worktree/dirty-tree pre-checks), then arms event delivery — rather than jumping straight to gh polling.",
+      "expected_output": "The action selector routes to Phase 3 (monitor). Before any CI polling it runs the monitor entry checklist — Step 0 checks out the PR source branch (gh pr checkout, with the worktree/dirty-tree pre-checks) and, in an interactive session not already on the PR branch, confirms the target branch with the user before the mechanical switch even though PR 482 was named — then arms event delivery, rather than jumping straight to gh polling.",
       "files": [],
       "expectations": [
         "The skill routes to the monitor phase for PR 482",
         "It runs the monitor entry checklist (checkout the PR source branch, arm event delivery) before starting CI polling, not jumping straight to gh polling",
+        "In an interactive session not already on the PR branch, it confirms the target branch with the user before re-pointing the worktree — naming PR 482 does not waive the target-branch confirmation gate",
         "PR identity is resolved live via gh and the number is threaded to subsequent gh calls"
       ]
     },

--- a/plugins/source-control/skills/worktree/evals/evals.json
+++ b/plugins/source-control/skills/worktree/evals/evals.json
@@ -17,7 +17,7 @@
       "id": 2,
       "name": "cleanup-emits-branch-delete-not-inline",
       "prompt": "/worktree cleanup — remove the stale worktrees and delete their branches.",
-      "expected_output": "Cleanup removes stale/orphaned worktrees but does NOT run the branch deletion inline: it emits the git branch -D commands (and the self-worktree removal) for the USER to run — a worktree can't delete itself, branch deletion is destructive, and the project's hooks may block it mid-session. -D (not -d) is used because squash-merge changes the SHA.",
+      "expected_output": "Cleanup removes stale/orphaned worktrees but does NOT run the branch deletion inline: it emits the git branch -D commands for the USER to run — branch deletion is destructive and the project's hooks may block it mid-session. If the active worktree is itself a cleanup candidate, its removal is emitted too (a worktree can't delete itself), but not when the current checkout is not a target. -D (not -d) is used because squash-merge changes the SHA.",
       "files": [],
       "expectations": [
         "The skill does NOT run git branch -D inline — it emits the branch-deletion command(s) for the user to run",

--- a/plugins/source-control/skills/worktree/evals/evals.json
+++ b/plugins/source-control/skills/worktree/evals/evals.json
@@ -1,0 +1,64 @@
+{
+  "skill_name": "worktree",
+  "evals": [
+    {
+      "id": 1,
+      "name": "create-routing-enterworktree-last",
+      "prompt": "/worktree create feat/payment-retry — set me up an isolated worktree for this feature.",
+      "expected_output": "The create action validates the name against the EnterWorktree schema constraints, explains the setup, and calls EnterWorktree(name: ...) as its FINAL action — nothing executes after that call because the working directory and session state transition on it.",
+      "files": [],
+      "expectations": [
+        "The skill validates the worktree/branch name before creating",
+        "EnterWorktree is called as the final action of the invocation — no steps are scheduled to run after it",
+        "It does not attempt post-EnterWorktree work in the same turn"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "cleanup-emits-branch-delete-not-inline",
+      "prompt": "/worktree cleanup — remove the stale worktrees and delete their branches.",
+      "expected_output": "Cleanup removes stale/orphaned worktrees but does NOT run the branch deletion inline: it emits the git branch -D commands (and the self-worktree removal) for the USER to run — a worktree can't delete itself, branch deletion is destructive, and the project's hooks may block it mid-session. -D (not -d) is used because squash-merge changes the SHA.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT run git branch -D inline — it emits the branch-deletion command(s) for the user to run",
+        "It emits (rather than executes inline) the removal of the worktree the session currently occupies, since a worktree cannot delete itself",
+        "Branch deletion uses -D (not -d), and the reasoning cites squash-merge changing the SHA / destructiveness / hooks"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "cleanup-file-lock-and-stderr-safety",
+      "prompt": "/worktree cleanup on Windows — one of the stale worktrees has a build server running against it.",
+      "expected_output": "Before git worktree remove --force, the skill releases OS file locks (stops the build server / worktree-rooted daemons for THAT worktree only, never another live worktree's processes). It does not swallow removal stderr (no 2>/dev/null) so a failed removal surfaces as an honest husk report rather than a false success.",
+      "files": [],
+      "expectations": [
+        "The skill releases OS file locks (stops the build server / worktree-rooted daemons) before git worktree remove --force, scoped to the target worktree only",
+        "It does NOT suppress removal stderr (no 2>/dev/null) so failed removals surface honestly",
+        "It never stops another live worktree's processes"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "not-pr-lifecycle",
+      "prompt": "/worktree — this branch is done, push it and open and merge the PR for me.",
+      "expected_output": "The worktree skill does NOT push, create, merge, or close PRs, and does NOT commit or stage code. It directs the user to /pull-request for the PR back-half (and /commit for the commit mechanic) rather than performing those actions.",
+      "files": [],
+      "expectations": [
+        "The skill does NOT push, create, merge, or close a PR",
+        "The skill does NOT commit or stage code",
+        "It routes the PR lifecycle work to /pull-request (and commit work to /commit)"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "default-on-main-guides-isolation",
+      "prompt": "/worktree — (currently checked out on the default branch, about to start a new feature)",
+      "expected_output": "The smart-default action detects it is on the default branch and guides the user to create a branch (git checkout -b <type>/<description>) or /worktree create for parallel-session isolation — surfacing the project's branch-naming convention rather than enforcing one.",
+      "files": [],
+      "expectations": [
+        "The skill detects it is on the default branch and guides toward creating a branch or worktree before writing code",
+        "It suggests the project's branch-naming convention (default <type>/<kebab-description>) as guidance, not a hard-enforced gate"
+      ]
+    }
+  ]
+}

--- a/plugins/source-control/skills/worktree/evals/evals.json
+++ b/plugins/source-control/skills/worktree/evals/evals.json
@@ -21,7 +21,7 @@
       "files": [],
       "expectations": [
         "The skill does NOT run git branch -D inline — it emits the branch-deletion command(s) for the user to run",
-        "It emits (rather than executes inline) the removal of the worktree the session currently occupies, since a worktree cannot delete itself",
+        "If the active worktree is itself one of the cleanup candidates, its removal is emitted for the user to run (a worktree cannot delete itself) rather than executed inline; self-removal is not emitted when the current checkout is not a target",
         "Branch deletion uses -D (not -d), and the reasoning cites squash-merge changing the SHA / destructiveness / hooks"
       ]
     },


### PR DESCRIPTION
Author rich-form `evals/evals.json` for the 7 skills in the session-flow + source-control batch.

## Warrant re-check (per-skill, against live SKILL.md)

All 7 warrant evals — each carries a judgment-bearing behavioral contract that could silently regress (routing, refusals, emitted-shape). **No skips.**

| Skill | Warrant |
|---|---|
| session-flow/handoff | file-vs-prompt routing; hard STOP-doesn't-continue rule; `--bg` dirty-tree gate |
| session-flow/orchestration-brief | default-primes-no-paste vs handoff/worker export; `--bg`/self-spawn refusal |
| session-flow/retro | mode detection; Phase-4 no-persist-without-approval; no repo writes / no build |
| session-flow/workflow | position detection; never-invent-skill-names; verify-from-artifact; size-independent rigor |
| source-control/commit | Conventional Commits pre-check; surgical staging (no `git add -A`); no `--no-verify` bypass |
| source-control/pull-request | finding-verification gate; research-gated CI fix; merge/human-comment gates |
| source-control/worktree | EnterWorktree-last; `git branch -D` emitted-not-run; file-lock/stderr safety; not-PR-lifecycle |

## Cases

5 per skill (35 total), each covering trigger/routing, happy path, ≥1 refusal/guardrail, and ≥1 anti-pattern the skill must not do. Modeled on the rich-form example (`plugins/bug-report/.../evals.json`): `id`, kebab `name`, `prompt`, `expected_output`, `files: []`, `expectations[]`. No fixtures needed (these are routing/behavior contracts, not code-inspection).

## Validation

Each file validated against the bundled schema (`plugins/skill-quality/reference/evals.schema.json`) — all pass. The repo's `python jsonschema`/`ajv` were unavailable and `skill-quality:validate-evals` is a model-driven action (no standalone script), so validation ran via a comprehensive `jq` check enforcing every schema constraint: both-level `additionalProperties`, required `id`+`prompt`, `id` type, `name` kebab pattern `^[a-z0-9]+(-[a-z0-9]+)*$`, non-empty `evals`/`prompt`/`skill_name`.

## Delivery

Both plugin versions bumped (evals are a shipped component; the version bump is the only delivery vehicle) — session-flow `0.2.0 → 0.2.1`, source-control `0.1.0 → 0.1.1`. Additive-only, no behavior change → no changelog note required.

Refs melodic-software/medley#1451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JSON eval fixtures and manifest version bumps only; no changes to skill execution logic or delivery code paths.
> 
> **Overview**
> Adds **shipped eval suites** for seven **session-flow** and **source-control** skills: new `evals/evals.json` under each skill with five rich-form cases (prompt, expected output, expectations) that lock routing, guardrails, and refusal behavior—e.g. handoff stop-after-save-point and `--bg` dirty-tree gate, orchestration-brief prime vs export modes, retro mode routing and no-persist-without-approval, workflow artifact-based stage verification, commit surgical staging and hook non-bypass, PR monitor/merge/CI/human-comment gates, worktree EnterWorktree-last and cleanup safety.
> 
> Bumps plugin patch versions only (**session-flow** `0.2.1`, **source-control** `0.1.1**) so the eval artifacts ship with the plugins. **No skill runtime or SKILL.md changes** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1dc26753b6bcaf6f6eab9ef4897dac3cc73b37e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->