### PR TITLE
fix(ci): route compatible checks to local fleet

### DIFF
--- a/.github/runner-policy.json
+++ b/.github/runner-policy.json
@@ -1,23 +1,12 @@
 {
   "schemaVersion": 1,
+  "repositoryOwner": "melodic-software",
   "visibility": "private",
   "selfHostedCi": true,
   "exceptions": {
-    ".github/workflows/ci.yml#zizmor": {
-      "reason": "docker-socket",
-      "justification": "The reviewed zizmor reusable workflow invokes a container action, while local workers deliberately receive no Docker socket."
-    },
-    ".github/workflows/ci.yml#runner-policy": {
-      "reason": "hosted-control-plane",
-      "justification": "The policy enforcement path must remain independent of the fleet and able to report invalid local routing."
-    },
     ".github/workflows/ci.yml#ci-status": {
       "reason": "hosted-control-plane",
-      "justification": "The required-check aggregator stays hosted and gates actual workload outcomes; strict selector failures block their dependent workloads instead of redirecting them to paid hosted Linux."
-    },
-    ".github/workflows/pr-title.yml#pr-title": {
-      "reason": "hosted-control-plane",
-      "justification": "The tiny required-check gateway must emit a failed pr-title context when strict routing or semantic validation fails; the semantic workload remains governed separately."
+      "justification": "The required CI gateway remains independent of selector and fleet health so route failures cannot become successful skipped checks."
     },
     ".github/workflows/claude-review.yml#review": {
       "reason": "privileged-control-plane",
@@ -26,6 +15,10 @@
     ".github/workflows/link-check.yml#link-check": {
       "reason": "privileged-control-plane",
       "justification": "The scheduled link checker can create or update repository issues and therefore remains on GitHub-hosted compute."
+    },
+    ".github/workflows/pr-title.yml#pr-title": {
+      "reason": "hosted-control-plane",
+      "justification": "The required PR-title gateway remains independent of selector and fleet health so route failures cannot become successful skipped checks."
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   # the complete workload; it cannot silently redirect to paid hosted Linux.
   select-hygiene:
     name: Select runner for hygiene
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -40,7 +40,7 @@ jobs:
 
   select-hook-utils-sync:
     name: Select runner for hook-utils-sync
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -53,7 +53,7 @@ jobs:
 
   select-plugin-gate:
     name: Select runner for plugin-gate
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -66,7 +66,7 @@ jobs:
 
   select-miro-plugin:
     name: Select runner for miro-plugin
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -209,11 +209,14 @@ jobs:
         run: scripts/aggregate-hygiene-results.sh
 
   zizmor:
+    needs: select-hygiene
+    if: ${{ !cancelled() && needs.select-hygiene.result == 'success' }}
     permissions:
       contents: read
     # Advisory Actions security lint; findings annotate without blocking.
-    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
+    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-12
     with:
+      runner: ${{ needs.select-hygiene.outputs.runner || 'ubuntu-24.04' }}
       paths: .
 
   hook-utils-sync:
@@ -333,9 +336,9 @@ jobs:
 
   runner-policy:
     name: Runner policy
-    # The independent enforcement path stays hosted and audits the selector
-    # wiring rather than depending on the fleet it is responsible for policing.
-    runs-on: ubuntu-24.04
+    needs: select-hygiene
+    if: ${{ !cancelled() && needs.select-hygiene.result == 'success' }}
+    runs-on: ${{ needs.select-hygiene.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -366,8 +369,9 @@ jobs:
       - miro-plugin
       - runner-policy
       - zizmor
-    # The required gateway stays hosted so a fleet outage cannot prevent it
-    # from reporting required workload failures.
+    # The required gateway remains independent of selector/fleet health so a
+    # failed route materializes as a failing required check, never a skipped
+    # check that GitHub could treat as successful.
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,6 +17,9 @@ permissions:
 
 jobs:
   review:
+    # Privileged review remains hosted by policy. Skip it while strict local-only
+    # emergency routing is active; prefer-self-hosted restores the hosted lane.
+    if: ${{ vars.CI_RUNNER_POLICY != 'self-hosted-only' }}
     permissions:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   link-check:
+    # This issue-writing advisory lane remains hosted by policy and is paused
+    # while strict local-only emergency routing is active.
+    if: ${{ vars.CI_RUNNER_POLICY != 'self-hosted-only' }}
     # issues: write is scoped to this job (least privilege) — only the called
     # workflow files the rolling tracking issue.
     permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   select-runner:
     name: Select runner for PR title
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3cb83c9502da0b210c335785e250023508c4b8e3 # 3cb83c9 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -48,6 +48,8 @@ jobs:
     name: pr-title / pr-title
     needs: [select-runner, validate-pr-title]
     if: ${{ always() && !cancelled() }}
+    # This fail-closed required gateway must report selector failure even when
+    # the local fleet cannot accept the validation workload.
     runs-on: ubuntu-24.04
     permissions: {}
     steps:


### PR DESCRIPTION
## What changed

- pin all local-compatible selector callers to the owner-scoped immutable `de50a08b…` revision
- route native Zizmor and runner-policy enforcement through the selected local runner
- keep the required `ci-status` and `pr-title / pr-title` gateways hosted and fail-closed so selector/fleet failures cannot become successful skipped checks
- skip privileged Claude review and link-check jobs only during emergency `self-hosted-only` mode; both remain enabled for adaptive/hosted policies
- declare the reviewed `melodic-software` repository owner for the scoped selector contract

## Why

The former strict policy still required GitHub-hosted compute for ordinary compatible Linux lanes, and billing lockout made selector/control jobs go red. This change moves compatible work to the local fleet while preserving tiny independent required gateways that must materialize even when selector or fleet health fails.

## Validation

- independent review: PASS, including fail-closed required-gateway re-review
- synced Standards owner-scoped analyzer: zero findings
- Actionlint: PASS
- `git diff --check`: PASS
- signed commit directly based on Standards sync main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI control-plane routing and required-check behavior during fleet outages; misconfiguration could block merges or run security tooling on self-hosted runners without Docker where zizmor expects it.
> 
> **Overview**
> Moves **compatible Linux CI lanes** onto the governed self-hosted fleet by pinning `select-runner` (and `zizmor`) to immutable owner-scoped revision `de50a08`, and wiring **`zizmor`** and **`runner-policy`** through `select-hygiene` with `runs-on` / `runner` from the selector instead of fixed GitHub-hosted runners.
> 
> **`.github/runner-policy.json`** now declares `repositoryOwner: melodic-software` and drops hosted exceptions for `zizmor` and `runner-policy`; required **`ci-status`** and **`pr-title / pr-title`** stay explicitly hosted with updated fail-closed wording so selector or fleet failures surface as failing required checks, not benign skips.
> 
> **`claude-review`** and **`link-check`** gain `if: vars.CI_RUNNER_POLICY != 'self-hosted-only'` so privileged hosted lanes pause only during strict local-only emergency mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3861854952f66dcc5a1763444fdac97d39441f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->