### PR TITLE
feat(knowledge/youtube): honor library_dir — wire resolved work root into the pipeline

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files) and a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## 0.4.0
+
+### Changed
+
+- **`youtube` skill now honors the `library_dir` seam.** The invoking skill wires a
+  non-default `library_dir` into the extraction pipeline by passing
+  `run.mjs --work-root <dir>`, which the launcher translates into the
+  `YOUTUBE_WORK_ROOT` environment variable the scripts already read — so watch,
+  transcript, and queue artifacts land under the configured directory instead of
+  always at the consuming repo root. The default (`.`) path is unchanged: no flag,
+  `resolveWorkRoot()` keeps its `CLAUDE_PROJECT_DIR` → `process.cwd()` fallback. A
+  double-quoted CLI arg was chosen over an inline `YOUTUBE_WORK_ROOT=… node` prefix
+  because the latter is bash-only and fails under PowerShell.
+- **`setup` Output** now states that `library_dir` governs where youtube artifacts
+  land, restoring the stronger wording softened while the seam was unwired
+  (`book-distill` remains the documented exception).
+
 ## 0.2.0
 
 ### Added

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -13,7 +13,9 @@ only after that version increases.
   `run.mjs --work-root <dir>`, which the launcher translates into the
   `YOUTUBE_WORK_ROOT` environment variable the scripts already read — so watch,
   transcript, and queue artifacts land under the configured directory instead of
-  always at the consuming repo root. The default (`.`) path is unchanged: no flag,
+  always at the consuming repo root. Agent-written slice artifacts (the queue table,
+  its claim stubs, and every Output-contract deliverable) anchor to the same resolved
+  root, so a non-default `library_dir` never splits a slice across two directories. The default (`.`) path is unchanged: no flag,
   `resolveWorkRoot()` keeps its `CLAUDE_PROJECT_DIR` → `process.cwd()` fallback. A
   double-quoted CLI arg was chosen over an inline `YOUTUBE_WORK_ROOT=… node` prefix
   because the latter is bash-only and fails under PowerShell.

--- a/plugins/knowledge/skills/setup/SKILL.md
+++ b/plugins/knowledge/skills/setup/SKILL.md
@@ -89,11 +89,11 @@ local overlay `.claude/settings.local.json` for a personal-only override (step 5
 of the value written, its scope, and how to re-run this setup to reconfigure. Note in the summary that
 `library_dir` is the destination seam the knowledge plugin declares for where synthesized artifacts should
 land, and that it is meant to track any working-notes/artifacts convention the consuming project declares in
-its own `CLAUDE.md` or rules — setup keeps the two aligned. Be accurate about current reach so the user is not
-misled: `/knowledge:book-distill` ignores `library_dir` (it writes to the target skill you name at
-invocation), and the `/knowledge:youtube` pipeline does not yet honor a non-default `library_dir` (its work
-root falls back to the consuming project root), so when a non-default value is persisted, report it as
-recorded for when the pipelines consume it — not as currently relocating artifacts.
+its own `CLAUDE.md` or rules — setup keeps the two aligned. Be accurate about reach so the user is not
+misled: `library_dir` governs where `/knowledge:youtube` artifacts land — its watch, transcript, and queue
+output lands under the configured directory (the skill wires the resolved value in as the pipeline's work
+root before writing). `/knowledge:book-distill` is the exception: it ignores `library_dir` and writes to the
+target skill you name at invocation, so a non-default value does not relocate distilled book output.
 
 ## What this skill does NOT do
 

--- a/plugins/knowledge/skills/youtube/SKILL.md
+++ b/plugins/knowledge/skills/youtube/SKILL.md
@@ -47,6 +47,8 @@ Every extraction command in this skill runs through `run.mjs`, and each writes i
 
 - **Default / unset** — when `${user_config.library_dir}` is `.`, empty, or still an unexpanded token, invoke `run.mjs` **without** `--work-root`. `resolveWorkRoot()` falls back to `${CLAUDE_PROJECT_DIR}` (then `process.cwd()`), landing artifacts at the consuming repo root.
 
+**Agent-written artifacts share the same root — do not split the slice.** Every `.work/<watch-epic>/…` path in this skill and its `context/` files is relative to this same resolved work root, not always the repo root. That includes the paths you materialize by hand — the `mkdir -p .work/<watch-epic>/claims` and `QUEUE.md` copy/append steps under **Queue action**, the `claims/*.json` stubs, and every agent-authored slice artifact in the **Output contract**. When `${user_config.library_dir}` is non-default, write them all under `${CLAUDE_PROJECT_DIR}/${user_config.library_dir}/.work/<watch-epic>/…` so the queue table, its concurrency claims, and the `--work-root` script output share one root; a split root would let `queue list` / `watch` read claims from a different directory than the table being edited. Default / unset → repo-root `.work/<watch-epic>/…` as written.
+
 The `setup-deps.mjs` install step is exempt — it installs node dependencies into `${CLAUDE_PLUGIN_DATA}`, not the work root.
 
 ## Action router

--- a/plugins/knowledge/skills/youtube/SKILL.md
+++ b/plugins/knowledge/skills/youtube/SKILL.md
@@ -33,6 +33,22 @@ Derive `.work/<watch-epic>/<video-slug>/` from metadata title + video id:
 
 Implementation: `${CLAUDE_PLUGIN_ROOT}/skills/youtube/extraction/transcript/derive-video-slug.js`
 
+## Artifact landing (work root)
+
+Every extraction command in this skill runs through `run.mjs`, and each writes its `.work/<watch-epic>/…` artifacts under a work root resolved by `resolveWorkRoot()`. That root honors the knowledge plugin's `library_dir` seam (`pluginConfigs["knowledge@melodic-software"].options.library_dir`, substituted into this skill's content as `${user_config.library_dir}`):
+
+- **Non-default** — when `${user_config.library_dir}` is a non-empty value other than the repo-root default `.` (and not an unexpanded `${user_config.library_dir}` token), pass it as a **leading** `--work-root` flag on **every** `run.mjs` invocation in this skill:
+
+  ```bash
+  node "${CLAUDE_PLUGIN_ROOT}/skills/youtube/extraction/run.mjs" --work-root "${CLAUDE_PROJECT_DIR}/${user_config.library_dir}" <script.js> [args…]
+  ```
+
+  `run.mjs` forwards it to the extraction child as `YOUTUBE_WORK_ROOT` (a double-quoted CLI arg is cross-platform; an inline `YOUTUBE_WORK_ROOT=… node` prefix is bash-only and fails under PowerShell). When `library_dir` is already absolute, pass it directly and drop the `${CLAUDE_PROJECT_DIR}/` prefix. This applies to **all** the run-script sites below — `run-transcript.js`, `preflight-metadata.js`, `queue-claim.js`, `run-watch.js`, `watch-state.js`, `vision-gated-promote.js`, `init-watch-checklist.js`, `analyze-harvested-repos.js`, `check-research-complete.js`, `check-watch-outcomes.js`, and `run-resume.js` — not only the first.
+
+- **Default / unset** — when `${user_config.library_dir}` is `.`, empty, or still an unexpanded token, invoke `run.mjs` **without** `--work-root`. `resolveWorkRoot()` falls back to `${CLAUDE_PROJECT_DIR}` (then `process.cwd()`), landing artifacts at the consuming repo root.
+
+The `setup-deps.mjs` install step is exempt — it installs node dependencies into `${CLAUDE_PLUGIN_DATA}`, not the work root.
+
 ## Action router
 
 | Action | Status | Behavior |

--- a/plugins/knowledge/skills/youtube/extraction/lib/run-args.js
+++ b/plugins/knowledge/skills/youtube/extraction/lib/run-args.js
@@ -1,0 +1,53 @@
+/**
+ * Argument + environment helpers for the youtube extraction launcher (`run.mjs`).
+ *
+ * The launcher accepts an OPTIONAL leading `--work-root <dir>` flag ahead of the
+ * target script. It exists so the invoking skill can wire the knowledge plugin's
+ * `library_dir` seam into the pipeline WITHOUT a shell-specific env prefix:
+ * `YOUTUBE_WORK_ROOT=… node …` is bash-only (it fails under PowerShell), so a
+ * cross-platform double-quoted CLI arg is passed instead and translated here into
+ * the `YOUTUBE_WORK_ROOT` environment variable `resolveWorkRoot()` reads.
+ *
+ * Both helpers are pure so the launcher's contract is unit-testable without
+ * spawning a child process.
+ */
+
+/**
+ * Split the launcher's argv (already sliced past `node run.mjs`) into an optional
+ * work root, the target script, and its remaining arguments.
+ *
+ * @param {string[]} argv
+ * @returns {{ workRoot: string | undefined, script: string | undefined, rest: string[] }}
+ */
+export function parseRunArgs(argv) {
+  const args = [...argv];
+  let workRoot;
+  if (args[0] === "--work-root") {
+    // A bare `--work-root` with no following value is a caller bug — surface it
+    // rather than silently swallowing the next token as an empty root.
+    if (args.length < 2) {
+      throw new Error("`--work-root` requires a directory value");
+    }
+    workRoot = args[1];
+    args.splice(0, 2);
+  }
+  const [script, ...rest] = args;
+  return { workRoot, script, rest };
+}
+
+/**
+ * Build the child process environment, layering `YOUTUBE_WORK_ROOT` on top of the
+ * inherited environment only when a non-empty work root was supplied. An empty or
+ * missing work root leaves the environment untouched so `resolveWorkRoot()` keeps
+ * its `CLAUDE_PROJECT_DIR` → `process.cwd()` fallback.
+ *
+ * @param {NodeJS.ProcessEnv} baseEnv
+ * @param {string | undefined} workRoot
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function buildChildEnv(baseEnv, workRoot) {
+  if (!workRoot) {
+    return baseEnv;
+  }
+  return { ...baseEnv, YOUTUBE_WORK_ROOT: workRoot };
+}

--- a/plugins/knowledge/skills/youtube/extraction/lib/run-args.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/lib/run-args.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChildEnv, parseRunArgs } from "./run-args.js";
+
+describe("parseRunArgs", () => {
+  it("returns no work root when the flag is absent", () => {
+    expect(parseRunArgs(["watch/run-watch.js", "https://x"])).toEqual({
+      workRoot: undefined,
+      script: "watch/run-watch.js",
+      rest: ["https://x"],
+    });
+  });
+
+  it("extracts a leading --work-root and strips it from the script args", () => {
+    expect(parseRunArgs(["--work-root", "/proj/docs/knowledge", "transcript/run-transcript.js", "https://x"])).toEqual({
+      workRoot: "/proj/docs/knowledge",
+      script: "transcript/run-transcript.js",
+      rest: ["https://x"],
+    });
+  });
+
+  it("only honors --work-root in the leading position", () => {
+    // A `--work-root` after the script is a script argument, not the launcher flag.
+    const parsed = parseRunArgs(["watch/queue-claim.js", "--work-root", "list"]);
+    expect(parsed.workRoot).toBeUndefined();
+    expect(parsed.script).toBe("watch/queue-claim.js");
+    expect(parsed.rest).toEqual(["--work-root", "list"]);
+  });
+
+  it("throws when --work-root has no value", () => {
+    expect(() => parseRunArgs(["--work-root"])).toThrow(/requires a directory value/);
+  });
+
+  it("does not mutate the caller's argv", () => {
+    const argv = ["--work-root", "/proj", "watch/run-watch.js"];
+    parseRunArgs(argv);
+    expect(argv).toEqual(["--work-root", "/proj", "watch/run-watch.js"]);
+  });
+});
+
+describe("buildChildEnv", () => {
+  it("layers YOUTUBE_WORK_ROOT on top of the inherited env when a root is given", () => {
+    const base = { PATH: "/usr/bin", CLAUDE_PROJECT_DIR: "/proj" };
+    expect(buildChildEnv(base, "/proj/docs/knowledge")).toEqual({
+      PATH: "/usr/bin",
+      CLAUDE_PROJECT_DIR: "/proj",
+      YOUTUBE_WORK_ROOT: "/proj/docs/knowledge",
+    });
+  });
+
+  it("returns the base env untouched when no work root is given", () => {
+    const base = { PATH: "/usr/bin" };
+    expect(buildChildEnv(base, undefined)).toBe(base);
+    expect(buildChildEnv(base, "")).toBe(base);
+  });
+
+  it("does not mutate the base env", () => {
+    const base = { PATH: "/usr/bin" };
+    buildChildEnv(base, "/proj");
+    expect(base).toEqual({ PATH: "/usr/bin" });
+  });
+});

--- a/plugins/knowledge/skills/youtube/extraction/lib/work-root.js
+++ b/plugins/knowledge/skills/youtube/extraction/lib/work-root.js
@@ -7,8 +7,9 @@
  * repo. The base is resolved from the environment instead, honoring the
  * knowledge plugin's `library_dir` seam:
  *
- * 1. `YOUTUBE_WORK_ROOT` — explicit override the invoking skill exports from the
- *    resolved `library_dir` (when it is not the repo-root default).
+ * 1. `YOUTUBE_WORK_ROOT` — explicit override the invoking skill wires in from the
+ *    resolved `library_dir` (when it is not the repo-root default) by passing
+ *    `run.mjs --work-root <dir>`, which sets this var for the extraction child.
  * 2. `CLAUDE_PROJECT_DIR` — the consuming project root the harness provides.
  * 3. `process.cwd()` — fallback when invoked directly from the project root.
  *

--- a/plugins/knowledge/skills/youtube/extraction/run.mjs
+++ b/plugins/knowledge/skills/youtube/extraction/run.mjs
@@ -11,17 +11,33 @@
  * bash-only — it fails under PowerShell — and ignored by the ESM loader, which
  * does not honor NODE_PATH at all.)
  *
- * Usage: node run.mjs <relative-script.js> [args…]
+ * An OPTIONAL leading `--work-root <dir>` flag lets the invoking skill wire the
+ * knowledge plugin's `library_dir` seam into the pipeline the same cross-platform
+ * way: a double-quoted CLI arg (safe in bash and PowerShell) is translated here
+ * into the `YOUTUBE_WORK_ROOT` env var the extraction scripts' `resolveWorkRoot()`
+ * reads. Omit it for the repo-root default; the fallback chain then applies.
+ *
+ * Usage: node run.mjs [--work-root <dir>] <relative-script.js> [args…]
  */
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { buildChildEnv, parseRunArgs } from "./lib/run-args.js";
+
 const here = path.dirname(fileURLToPath(import.meta.url));
-const [script, ...rest] = process.argv.slice(2);
+
+let parsed;
+try {
+  parsed = parseRunArgs(process.argv.slice(2));
+} catch (error) {
+  process.stderr.write(`${error.message}\nUsage: node run.mjs [--work-root <dir>] <relative-script.js> [args…]\n`);
+  process.exit(2);
+}
+const { workRoot, script, rest } = parsed;
 
 if (!script) {
-  process.stderr.write("Usage: node run.mjs <relative-script.js> [args…]\n");
+  process.stderr.write("Usage: node run.mjs [--work-root <dir>] <relative-script.js> [args…]\n");
   process.exit(2);
 }
 
@@ -36,6 +52,6 @@ const registerHook = path.join(here, "register-hook.mjs");
 const result = spawnSync(
   process.execPath,
   ["--import", pathToFileURL(registerHook).href, target, ...rest],
-  { stdio: "inherit" },
+  { stdio: "inherit", env: buildChildEnv(process.env, workRoot) },
 );
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## What

Wire the knowledge plugin's `library_dir` `userConfig` seam into the youtube pipeline at runtime. Before this, `library_dir` was configurable and persisted by `setup`, but the youtube pipeline never consumed it — a non-default value (e.g. `docs/knowledge`) did **not** redirect watch/transcript/queue artifacts; they still landed at the consuming repo root via `resolveWorkRoot()`'s `CLAUDE_PROJECT_DIR` fallback.

## How

- **`run.mjs`** learns an optional leading `--work-root <dir>` flag and translates it into the `YOUTUBE_WORK_ROOT` env var the extraction scripts' `resolveWorkRoot()` already reads (forwarded to the spawned child). Arg parsing + child-env layering extracted to **`lib/run-args.js`** (pure, unit-tested in `lib/run-args.test.js`).
- **`youtube/SKILL.md`** — new "Artifact landing (work root)" section: when `${user_config.library_dir}` is non-default, pass `--work-root "${CLAUDE_PROJECT_DIR}/${user_config.library_dir}"` on **every** `run.mjs` invocation (call sites enumerated). Default/empty/unexpanded → no flag; `resolveWorkRoot()` fallback intact.
- **`setup/SKILL.md`** Output — restores the stronger "`library_dir` governs where youtube artifacts land" wording that was softened while the seam was unwired; `book-distill` remains the documented exception.
- **`plugin.json`** `0.3.0` → `0.4.0` + CHANGELOG entry.

## Decision (unbriefed, called out)

| Decision | What it changes | Basis (evidence) |
| --- | --- | --- |
| Cross-platform CLI arg (`run.mjs --work-root`) instead of the issue's literal "export `YOUTUBE_WORK_ROOT` before invoking" as a shell env prefix | Adds a small optional flag to `run.mjs` (issue framed the change as SKILL.md-only) | An inline `YOUTUBE_WORK_ROOT=… node` prefix is bash-only and fails under PowerShell — `run.mjs`'s own docstring already avoids `NODE_PATH=… node` for exactly this reason (Cross-Platform-by-Default). The in-repo idiom for wiring a `${user_config.X}` seam into a command is a double-quoted CLI arg (`claude-troubleshooting` passes `--data-dir "…"`). `resolveWorkRoot()` is left untouched per the issue. |

## Verification

- `vitest run` — 221/221 pass (incl. new `lib/run-args.test.js`)
- `tsc --noEmit` — clean
- `claude plugin validate` + `scripts/validate-plugins.sh` — pass
- `scripts/run-plugin-tests.sh` — 18 checks + all plugin tests pass
- e2e smoke: `run.mjs --work-root X <probe>` → child sees `YOUTUBE_WORK_ROOT=X`; no flag → falls back to `CLAUDE_PROJECT_DIR`; bad flag → clean usage exit 2

Refs melodic-software/medley#1466

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive launcher flag and skill documentation; default artifact paths unchanged when library_dir is `.`.
> 
> **Overview**
> **`/knowledge:youtube` now respects `library_dir`.** Non-default values redirect watch, transcript, and queue `.work/…` output under the configured directory instead of always using the repo root.
> 
> The skill passes a leading **`run.mjs --work-root <dir>`** on every extraction invocation; **`lib/run-args.js`** parses that flag and sets **`YOUTUBE_WORK_ROOT`** for the child so existing **`resolveWorkRoot()`** behavior applies. Default `.` omits the flag (unchanged fallback). Skill docs require agent-written queue/claim/output paths to use the same root so scripts and hand-edited artifacts stay aligned.
> 
> **`setup`** output again states that `library_dir` governs YouTube artifact landing (`book-distill` still documented as the exception). Plugin version **0.4.0** + CHANGELOG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2138dbfce43e4a487409f7669b7b60e42d7be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->