### PR TITLE
docs(playbook): add cross-surface caveat to Reintegration

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -651,6 +651,26 @@ out), reintegrating one plugin makes it consume one plugin while still running t
 state. Flip a repo from source to consumer deliberately, not incidentally, and ideally once the repo's
 ported plugins can move together.
 
+**Cross-surface caveat — a repo-built `stdio` MCP server declared on more than the Claude Code surface.**
+The checklist above assumes a hook plugin, whose only consumer is Claude Code. A marketplace plugin is
+Claude-Code-only, so **a marketplace-plugin cutover replaces the Claude Code surface only.** A repo-built
+`stdio` MCP server, however, is often declared on additional surfaces — Cursor (`.cursor/mcp.json`), Codex
+(`.codex/config.toml`), Claude Desktop (a `tools/desktop-mcp` installer) — none of which can consume a
+Claude Code marketplace plugin. When such a server also has **no npx/registry publish** (the playbook's
+`stdio` (repo-built), "No CLI" class), those other surfaces have no path to the plugin at all, so deleting
+the in-repo build strands the server on every non-CC surface. Compounding this, the MCP-parity CI gates
+enforce **exact equality** across `.mcp.json` / `.cursor/mcp.json` / `.codex/config.toml` — removing the
+server from only the CC surface breaks parity. So **resolve cross-surface consumption before deleting the
+in-repo server**, picking one:
+
+- **Clean-delete** — confirm (with the owner) the other surfaces do not need the server, then remove its
+  entry from **all** surfaces at once. Parity stays trivially satisfied and no new machinery is needed.
+- **Parity exemption** — keep the in-repo server for Cursor/Codex/Desktop while only the CC surface adopts
+  the plugin; this requires an exemption in the parity gates (an `.mcp.json`-only removal otherwise fails
+  them) plus a follow-up track for a genuine cross-surface distribution.
+- **Defer** — hold the cutover until the server has a cross-surface distribution path (e.g. repoint the
+  other surfaces at the plugin's on-disk bundle, or a shared build), then re-scope.
+
 ## Shared code across plugins — decision record (2026-07-04)
 
 Decided when four plugins carried byte-identical `hooks/hook-utils.sh` copies — the Rule-of-Three


### PR DESCRIPTION
## Summary

The `docs/MIGRATION-PLAYBOOK.md` "Reintegration" section is hook-plugin-oriented (kill switches, telemetry sinks, hook cutover) and silent on the case a real cutover surfaced: a **repo-built `stdio` MCP server declared on more than the Claude Code surface**.

This adds a cross-surface caveat: a marketplace-plugin cutover replaces the Claude Code surface only; a repo-built `stdio` server also declared on Cursor / Codex / Claude Desktop with no npx/registry publish has no path to the plugin, and the MCP-parity CI gates enforce exact cross-surface equality. It documents the three resolutions before in-repo deletion — **clean-delete** (confirm the other surfaces don't need it), **parity exemption** (keep the in-repo server behind a gate exemption while only CC adopts the plugin), or **defer** (until a cross-surface distribution path exists).

Surfaced by the medley miro-server reintegration cutover.

Refs melodic-software/medley#1459

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the migration playbook; no runtime, CI, or config behavior is modified in this PR.
> 
> **Overview**
> Adds a **Cross-surface caveat** to the Reintegration section of `docs/MIGRATION-PLAYBOOK.md`, right after the bootstrap-direction note.
> 
> The new text clarifies that the existing cutover checklist targets **hook plugins** (Claude Code only). A **marketplace plugin** replaces only the CC surface, while a **repo-built `stdio` MCP** is often also listed in Cursor, Codex, and Claude Desktop—surfaces that cannot use the plugin. With **no npx/registry publish**, deleting the in-repo server leaves those surfaces without the server, and **MCP-parity CI** (exact match across `.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml`) fails if the entry is removed from CC alone.
> 
> It requires resolving cross-surface use **before** deleting the in-repo server, via **clean-delete** (drop from all surfaces), **parity exemption** (keep in-repo for non-CC + gate exemption), or **defer** until a shared distribution path exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e320805fd89637294989608597719168af6ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->