### PR TITLE
chore(event-storming): reconcile simulation skill to the shipped miro plugin

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -432,6 +432,27 @@ over stdio — no npm/registry publish, no consumer token wall, no `npx` (#58510
   never `settings.json`); the consumer supplies and scopes it. The server exits at startup if unset.
 - **Opt-in.** `defaultEnabled: false` — installs disabled; the consumer enables it deliberately.
 
+**Consuming a sibling plugin's MCP tools (first instance: `event-storming` → `miro`).** When plugin A's
+skill drives plugin B's bundled MCP server, three rules hold:
+
+- **Namespaced tool names.** A plugin-bundled server's tools are callable as
+  `mcp__plugin_<plugin>_<server>__<tool>` — for `miro`, `mcp__plugin_miro_miro__miro_create_board`
+  ([mcp reference](https://code.claude.com/docs/en/mcp)). A bare `miro_*` name, or a bare-server-key
+  `mcp__miro__…`, does **not** resolve for a plugin-bundled server. Any *declarative* reference
+  (a skill's `allowed-tools`, a permission rule, a subagent `tools` field, a hook matcher) MUST use the
+  full prefixed form; a matcher against the bare server key never fires. In model-facing prose the
+  runtime resolves the tool the model actually calls, so a skill may name tools by their bare
+  conceptual `<tool>` **provided it states once** that those names denote the provider's tools under
+  the `mcp__plugin_<plugin>_<server>__` prefix (`simulation` does this in its availability gate).
+- **Availability gate probes the prefixed form.** The consumer detects the capability by checking a
+  prefixed tool (`mcp__plugin_miro_miro__miro_list_boards`), not a bare name — otherwise the gate can
+  never fire and the consumer silently stays in its degraded default forever.
+- **Soft dependency, never bundle-or-fork.** The consumer does not bundle the provider's server nor
+  hard-depend on it: it keeps its no-server default (here structured-markdown), documents that the
+  enhanced path requires the separately-enabled provider plugin, and degrades gracefully when the
+  provider's tools are absent. This is the cross-plugin form of the "swap the MCP server, not a
+  pluggable abstraction; declare the dependency, don't fork" rule above.
+
 ## Plugin-form caveats (works in-repo, breaks as a plugin)
 
 Catalog these per migration; they are the usual failures when an in-repo skill becomes a plugin.

--- a/plugins/event-storming/.claude-plugin/plugin.json
+++ b/plugins/event-storming/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "event-storming",
   "version": "0.2.0",
-  "description": "EventStorming for domain discovery — a methodology skill (Big Picture / Process Modeling / Design-Level facilitation reference, notation, patterns) and a simulation skill (agentic multi-persona workshops that produce a structured-markdown model by default; a live Miro-board rendering path is available when connected to a Miro MCP server exposing miro_* tools, a fast-follow to reconcile with Miro's official tool surface).",
+  "description": "EventStorming for domain discovery — a methodology skill (Big Picture / Process Modeling / Design-Level facilitation reference, notation, patterns) and a simulation skill (agentic multi-persona workshops that produce a structured-markdown model by default; a live Miro-board rendering path is available when the first-party miro plugin is enabled).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"

--- a/plugins/event-storming/README.md
+++ b/plugins/event-storming/README.md
@@ -10,7 +10,7 @@ agentic workshop:
 | Skill | Invoke | Does |
 |---|---|---|
 | `methodology` | `/event-storming:methodology [--big-picture\|--process\|--design-level\|--patterns\|--glossary\|--notation\|--remote]` | Facilitation knowledge and reference across the three formats — notation, building blocks, patterns/anti-patterns, remote adaptations. No args runs an interactive discovery flow. |
-| `simulation` | `/event-storming:simulation [--simulate\|--process-model\|--design-level\|--evaluate\|--retrospective\|--induction\|--value\|--crc\|--ux\|--discover-bcs] [domain]` | An agentic, multi-persona EventStorming workshop that produces a structured-markdown model by default, plus per-run scoring and bounded-context discovery. A live Miro-board rendering path is available when a compatible Miro MCP server is connected (see Requirements). |
+| `simulation` | `/event-storming:simulation [--simulate\|--process-model\|--design-level\|--evaluate\|--retrospective\|--induction\|--value\|--crc\|--ux\|--discover-bcs] [domain]` | An agentic, multi-persona EventStorming workshop that produces a structured-markdown model by default, plus per-run scoring and bounded-context discovery. A live Miro-board rendering path is available when the first-party `miro` plugin is enabled (see Requirements). |
 
 ## When to use which
 
@@ -19,7 +19,7 @@ agentic workshop:
 - **simulation** *runs* the workshop for you: it spins up 4–7 siloed personas, plays every Big
   Picture phase in order, discovers bounded contexts, and lets you drill into Process Modeling and
   Design-Level per context. By default it emits the model as structured markdown (event timeline,
-  persona roster, bounded-context tables); with a compatible Miro MCP server connected it renders
+  persona roster, bounded-context tables); with the first-party `miro` plugin enabled it renders
   the same model onto a live Miro board instead.
 
 Each skill auto-invokes on its own trigger phrases, or you can call it directly.
@@ -37,20 +37,18 @@ Each skill auto-invokes on its own trigger phrases, or you can call it directly.
 - **simulation** — no hard dependency. It runs out of the box in **structured-markdown mode** (the
   agentic workshop, emitting the model as an event timeline, persona roster, and bounded-context
   tables). Two optional surfaces enhance it, neither bundled:
-  - A **Miro MCP server** for the live-board rendering path.
+  - The first-party **`miro` plugin** for the live-board rendering path.
   - A **web-research surface** for domain context.
 
 Both optional surfaces degrade gracefully:
 
-- **Miro** — the live-board path currently expects a Miro MCP server exposing `miro_*` tool names
-  (`miro_list_boards`, `miro_create_board`, `miro_bulk_create_sticky_notes`, …). Miro's official
-  hosted server (`mcp.miro.com`) uses a **different** tool surface (`board_create` /
-  `board_search_boards` / `layout_create`, OAuth 2.1), so the board path does **not** work against
-  it yet — reconciling the skill to Miro's official tools (and recording the remote-MCP trust
-  decision that entails) is a tracked **fast-follow**. Against any server whose tool names differ,
-  `simulation` detects the mismatch at preflight and runs in structured-markdown mode instead of
-  failing. Miro's own setup docs: <https://developers.miro.com/docs/mcp-intro> and
-  <https://developers.miro.com/docs/connecting-miro-mcp-to-ai-coding-tools>.
+- **Miro** — the live-board path uses the first-party **`miro` plugin**: a bundled local-stdio MCP
+  server, enabled separately (`claude plugin enable miro`) with a Miro API token stored in the
+  keychain. Its tools are namespaced `mcp__plugin_miro_miro__*`. With the plugin absent (or its
+  tools unavailable), `simulation` detects it at preflight and runs in structured-markdown mode
+  instead of failing. Miro's official hosted server (`mcp.miro.com`) was evaluated and **rejected**
+  as the target (no board-delete tool for teardown; third-party remote egress) — trust record in the
+  marketplace repo's MCP decision table (`docs/MIGRATION-PLAYBOOK.md`).
 - **Web research absent** — the skills use the Perplexity MCP tools if present, otherwise Claude
   Code's built-in `WebSearch` / `WebFetch`; with no research surface at all they ask you for the
   domain context rather than guessing.

--- a/plugins/event-storming/README.md
+++ b/plugins/event-storming/README.md
@@ -43,8 +43,9 @@ Each skill auto-invokes on its own trigger phrases, or you can call it directly.
 Both optional surfaces degrade gracefully:
 
 - **Miro** — the live-board path uses the first-party **`miro` plugin**: a bundled local-stdio MCP
-  server, enabled separately (`claude plugin enable miro`) with a Miro API token stored in the
-  keychain. Its tools are namespaced `mcp__plugin_miro_miro__*`. With the plugin absent (or its
+  server that a fresh consumer must **install from this marketplace and then enable**
+  (`claude plugin install miro@melodic-software`, then `claude plugin enable miro`) with a Miro API
+  token stored in the keychain. Its tools are namespaced `mcp__plugin_miro_miro__*`. With the plugin absent (or its
   tools unavailable), `simulation` detects it at preflight and runs in structured-markdown mode
   instead of failing. Miro's official hosted server (`mcp.miro.com`) was evaluated and **rejected**
   as the target (no board-delete tool for teardown; third-party remote egress) — trust record in the

--- a/plugins/event-storming/skills/simulation/SKILL.md
+++ b/plugins/event-storming/skills/simulation/SKILL.md
@@ -49,9 +49,10 @@ plugin's tool under the `mcp__plugin_miro_miro__` prefix.
      Every phase that would place stickies instead appends to the markdown artifact. The
      facilitation logic, personas, phase ordering, and rubric scoring are identical; only the
      rendering surface changes. Persist the artifact under `${CLAUDE_PLUGIN_DATA}/sessions/`.
-  2. **Enable the `miro` plugin, then retry:** point the user at the `miro` plugin — enable it
-     (`claude plugin enable miro` or the `/plugin` interface) and supply a Miro API token (stored in
-     the keychain) — and stop until its tools are available. See the README.
+  2. **Install + enable the `miro` plugin, then retry:** a fresh user has only `event-storming` — the
+     `miro` plugin must be installed from the marketplace first (`claude plugin install miro@melodic-software`),
+     then enabled (`claude plugin enable miro` or the `/plugin` interface) with a Miro API token
+     (stored in the keychain). Stop until its tools are available. Full setup: `reference/miro-integration.md`.
 
 Modes that read an *existing* board (`--process-model`, `--design-level`, `--evaluate`, `--crc`,
 `--discover-bcs` with a board URL) require Miro — if it's absent, say so and offer path 2, since

--- a/plugins/event-storming/skills/simulation/SKILL.md
+++ b/plugins/event-storming/skills/simulation/SKILL.md
@@ -32,21 +32,26 @@ For facilitation knowledge, format guidance, notation, and the no-args interacti
 
 ## Miro availability & graceful degradation
 
-This skill drives an EventStorming model onto a **Miro board** via a Miro MCP server. Before any
-mode runs, check whether Miro tools are available in the session (e.g. `miro_list_boards` /
-`miro_create_board` are callable).
+This skill drives an EventStorming model onto a **Miro board** via the first-party **`miro` plugin**
+— a bundled local-stdio MCP server, enabled separately (`event-storming` does not bundle it). The
+plugin exposes its tools under the **`mcp__plugin_miro_miro__`** prefix, so before any mode runs
+check whether e.g. `mcp__plugin_miro_miro__miro_list_boards` / `mcp__plugin_miro_miro__miro_create_board`
+are callable. A bare `miro_*` name does not resolve for a plugin-bundled server, so the gate must
+probe the prefixed form. Every `miro_*` tool named in this skill and its reference docs denotes that
+plugin's tool under the `mcp__plugin_miro_miro__` prefix.
 
 - **Miro available** → run normally: create boards, place stickies, screenshot-verify each phase.
-- **Miro absent** → do NOT fail. Tell the user Miro isn't connected, then offer two paths and let
-  them choose:
+- **Miro absent** → do NOT fail. Tell the user the `miro` plugin isn't enabled, then offer two paths
+  and let them choose:
   1. **Structured-markdown mode (default, recommended):** run the same agentic multi-persona
      workshop, but emit the model as structured markdown instead of board stickies — an ordered
      event timeline, a persona roster, bounded-context tables, and hot-spot / opportunity lists.
      Every phase that would place stickies instead appends to the markdown artifact. The
      facilitation logic, personas, phase ordering, and rubric scoring are identical; only the
      rendering surface changes. Persist the artifact under `${CLAUDE_PLUGIN_DATA}/sessions/`.
-  2. **Connect Miro, then retry:** point the user at their Miro MCP server setup (the plugin does
-     not ship one — see the README) and stop until it's connected.
+  2. **Enable the `miro` plugin, then retry:** point the user at the `miro` plugin — enable it
+     (`claude plugin enable miro` or the `/plugin` interface) and supply a Miro API token (stored in
+     the keychain) — and stop until its tools are available. See the README.
 
 Modes that read an *existing* board (`--process-model`, `--design-level`, `--evaluate`, `--crc`,
 `--discover-bcs` with a board URL) require Miro — if it's absent, say so and offer path 2, since

--- a/plugins/event-storming/skills/simulation/reference/miro-integration.md
+++ b/plugins/event-storming/skills/simulation/reference/miro-integration.md
@@ -4,106 +4,39 @@ This reference covers how to use Miro as a digital canvas for EventStorming work
 
 ---
 
-## MCP Server Options
+## Miro board access via the `miro` plugin
 
-Two Miro MCP servers exist with different capabilities:
+The live-board path uses the first-party **`miro` plugin** — a bundled local-stdio MCP server that
+exposes the full board lifecycle (create → populate → delete-teardown) plus connectors, frames,
+tags, and overlap detection. It is a **separate plugin from `event-storming`**: markdown is the
+default output, and the board capability is opt-in, so enabling `event-storming` does not start a
+Miro MCP server.
 
-| Feature | Official Miro MCP | Community `mcp-miro` |
-|---------|-------------------|---------------------|
-| **URL/Package** | `https://mcp.miro.com` | `@llmindset/mcp-miro` (npm) |
-| **Transport** | HTTP (streamable) | stdio (Node.js) |
-| **Auth** | OAuth 2.1 (browser flow) | Miro REST API token (env var) |
-| **Sticky notes** | No | **Yes** — create, bulk create |
-| **Shapes** | No | **Yes** |
-| **Diagrams** | Yes — flowchart, UML, ERD | No |
-| **Tables** | Yes — CRUD | No |
-| **Documents** | Yes — markdown docs | No |
-| **Board reading** | Yes — list items, explore | Yes — read board/frame |
-| **Bulk ops** | No | Yes (max 20/batch) |
+> **Remote-MCP trust (resolved).** Miro's official hosted server (`mcp.miro.com`, remote HTTP,
+> OAuth 2.1) was **rejected** as the live-board target: it has no board-delete tool (the skill's
+> teardown cannot be expressed on it) and would delegate board/workshop content egress to a
+> third-party remote MCP. The live-board path targets the first-party bundled server instead
+> (owner's own code, local stdio, no third-party remote egress). Durable accept record + rationale:
+> the marketplace repo's MCP decision table in `docs/MIGRATION-PLAYBOOK.md` — not restated here.
 
-**For EventStorming: a server exposing sticky-note creation is the core requirement.**
+### Tool namespace
 
-> **Tool-surface caveat (read before setup).** The simulation skill's live board path calls
-> `miro_*`-style tool names (`miro_list_boards`, `miro_create_board`, `miro_bulk_create_sticky_notes`,
-> `miro_list_board_items`, `miro_delete_board`). Those names match a Miro MCP server built to expose
-> them; they do **not** match Miro's official hosted server (`mcp.miro.com`), whose tools are named
-> `board_create` / `board_search_boards` / `layout_create` and which authenticates via OAuth 2.1
-> rather than a token env var. Reconciling the skill to Miro's official tool surface (and recording
-> the remote-MCP trust decision that entails) is a tracked fast-follow — until then, the board path
-> works only against a `miro_*`-exposing server, and the skill **degrades to structured-markdown
-> output** (per the availability gate) against any server whose tool names differ. Verify the exact
-> tool names and token/auth env var your chosen server actually exposes before relying on the board
-> path; the specifics below are a starting point, not a guaranteed-current contract.
+Because the server is plugin-bundled, its tools are namespaced at runtime as
+**`mcp__plugin_miro_miro__<tool>`** (e.g. `mcp__plugin_miro_miro__miro_create_board`). A bare
+`miro_*` name — or a bare-server-key `mcp__miro__…` — does **not** resolve for a plugin-bundled
+server. Every `miro_*` tool named in this skill and its reference docs denotes that plugin's tool
+under the `mcp__plugin_miro_miro__` prefix; the availability gate (SKILL.md "Miro availability &
+graceful degradation") probes the prefixed form.
 
-The official Miro MCP (`mcp.miro.com`) can be added as a complement for diagram generation (e.g., creating UML or ERD diagrams from EventStorming output).
+### Setup
 
----
-
-## Setup: Community `mcp-miro` Server
-
-### Prerequisites
-
-- Node.js installed
-- A Miro account with a board to target
-- A Miro REST API token (from Miro Developer Portal)
-
-### Step 1: Get Miro API Token
-
-1. Go to https://miro.com/app/settings/user-profile/apps
-2. Create a new app (or use existing)
-3. Generate an OAuth token with scopes: `boards:read`, `boards:write`
-4. Copy the token
-
-### Step 2: Add to `.mcp.json`
-
-**Never hardcode a token in `.mcp.json` — it gets committed.** Reference it through an environment
-variable (or `settings.local.json`) so the secret stays out of tracked files. Use this form:
-
-```json
-{
-  "mcpServers": {
-    "miro": {
-      "command": "npx",
-      "args": ["-y", "@llmindset/mcp-miro"],
-      "env": {
-        "MIRO_API_TOKEN": "${MIRO_API_TOKEN}"
-      }
-    }
-  }
-}
-```
-
-Then set `MIRO_API_TOKEN` in your shell environment or `settings.local.json` (never commit the
-literal token). Confirm the exact env-var name your chosen server reads — it varies by package (some
-community servers read `MIRO_OAUTH_TOKEN`) — per the tool-surface caveat above.
-
-### Step 3: Restart Claude Code
-
-MCP servers are loaded at session start. After adding `.mcp.json`, open a new terminal session.
-
-### Step 4: Verify
-
-In the new session, the Miro tools should appear in the tool list. Test with:
-
-```
-List my Miro boards
-```
-
----
-
-## Setup: Official Miro MCP (Optional Complement)
-
-```bash
-claude mcp add --transport http miro-official https://mcp.miro.com
-```
-
-Then authenticate:
-
-```
-/mcp auth
-```
-
-This adds diagram creation, table management, and document capabilities alongside the community server's sticky note support.
+1. **Enable the plugin:** `claude plugin enable miro` (or the `/plugin` interface). It installs
+   disabled by design.
+2. **Supply a Miro API token:** Claude Code prompts for it at enable time (masked input) and stores
+   it in the system keychain — never in `settings.json`. Get a token from
+   https://miro.com/app/settings/user-profile/apps with `boards:read` + `boards:write` scopes.
+3. **Verify:** in a session with the plugin enabled, `mcp__plugin_miro_miro__*` tools are callable —
+   test with "List my Miro boards".
 
 ---
 
@@ -307,7 +240,7 @@ When running simulated EventStorming sessions (see `agentic-simulation.md`), age
 
 ### Bulk Creation Pattern
 
-The community MCP server supports bulk creation (up to 20 items per batch). For a simulated Chaotic Exploration phase:
+The `miro` plugin's server supports bulk creation (up to 20 items per batch) via `miro_bulk_create_sticky_notes`. For a simulated Chaotic Exploration phase:
 
 1. Ask each persona agent to generate their events as structured data
 2. Batch-create all stickies on the board
@@ -340,7 +273,5 @@ The community MCP server supports bulk creation (up to 20 items per batch). For 
 - [Miro MCP Server Overview](https://help.miro.com/hc/en-us/articles/31624028247058)
 - [Miro Developer Docs — MCP Intro](https://developers.miro.com/docs/mcp-intro)
 - [Miro Developer Docs — Connecting to Claude Code](https://developers.miro.com/docs/connecting-miro-mcp-to-ai-coding-tools)
-- [Community mcp-miro (evalstate)](https://github.com/evalstate/mcp-miro)
-- [npm @llmindset/mcp-miro](https://www.npmjs.com/package/@llmindset/mcp-miro)
 - [Miro REST API — Sticky Note Style](https://miroapp.github.io/api-clients/python/miro_api/models/sticky_note_style.html)
 - [Miro REST API — Create Sticky Note](https://developers.miro.com/reference/create-sticky-note-item)

--- a/plugins/event-storming/skills/simulation/reference/miro-integration.md
+++ b/plugins/event-storming/skills/simulation/reference/miro-integration.md
@@ -30,12 +30,17 @@ graceful degradation") probes the prefixed form.
 
 ### Setup
 
-1. **Enable the plugin:** `claude plugin enable miro` (or the `/plugin` interface). It installs
-   disabled by design.
-2. **Supply a Miro API token:** Claude Code prompts for it at enable time (masked input) and stores
-   it in the system keychain — never in `settings.json`. Get a token from
+A fresh consumer has only `event-storming` installed — the `miro` plugin must be **installed from the
+marketplace first, then enabled** (enabling alone does not install it).
+
+1. **Add the marketplace** (if not already added): `claude plugin marketplace add melodic-software/claude-code-plugins`.
+2. **Install the plugin:** `claude plugin install miro@melodic-software`. It installs **disabled**
+   (`defaultEnabled: false` by design).
+3. **Enable it and supply a token:** `claude plugin enable miro` (or the `/plugin` interface). Claude
+   Code prompts for the Miro API token at enable time (masked input) and stores it in the system
+   keychain — never in `settings.json`. Get a token from
    https://miro.com/app/settings/user-profile/apps with `boards:read` + `boards:write` scopes.
-3. **Verify:** in a session with the plugin enabled, `mcp__plugin_miro_miro__*` tools are callable —
+4. **Verify:** in a session with the plugin enabled, `mcp__plugin_miro_miro__*` tools are callable —
    test with "List my Miro boards".
 
 ---


### PR DESCRIPTION
## What

Reconciles the `event-storming` `simulation` skill to the now-shipped first-party **`miro` plugin** (bundled local-stdio MCP), and codifies the cross-plugin MCP-consumption convention it establishes.

## Why

The Miro board capability shipped as the dedicated `miro` plugin. A plugin-bundled MCP server's tools are namespaced at runtime as `mcp__plugin_<plugin>_<server>__<tool>` — for this plugin `mcp__plugin_miro_miro__miro_create_board` — and a bare `miro_*` name (or bare-server-key `mcp__miro__…`) **never resolves** for a plugin-bundled server ([mcp reference](https://code.claude.com/docs/en/mcp)). The skill's availability gate + docs referenced bare `miro_*` and still documented the superseded community `@llmindset/mcp-miro` setup and an unresolved trust "fast-follow".

## Changes

- **`SKILL.md`** — availability gate probes the `mcp__plugin_miro_miro__*` prefixed form; states once that the skill's `miro_*` names denote that plugin's tools under the prefix; the "connect Miro" path now enables the `miro` plugin.
- **`reference/miro-integration.md`** — replaces the stale community `@llmindset/mcp-miro` `npx` setup and the "open trust fast-follow" caveat with the `miro`-plugin enable/token setup, a tool-namespace note, and a pointer to the resolved remote-MCP-trust record (cites the playbook decision table — no duplicate SSOT).
- **`README.md` / `plugin.json`** — the live-board path works via the enabled `miro` plugin; structured-markdown stays the default.
- **`docs/MIGRATION-PLAYBOOK.md`** — codifies the sibling-plugin-MCP-consumption convention (event-storming → miro, the first instance): namespaced references, prefixed availability gate, soft dependency (never bundle-or-fork).

## Scope notes

- **Teardown gating (PR #86 finding)** — verified already handled: the markdown-fallback branch skips `miro_delete_board` and all board ops, and deletions require user confirmation. No change needed.
- **Coordinate/frame reconciliation** — split to a follow-up issue as one holistic, live-board-verified pass (the three reference files carry two conflicting layout schemes that cannot be safely reconciled statically). Not in this PR.

## Verification

markdownlint (0 errors), `scripts/validate-plugins.sh` (plugin + marketplace manifests pass), `typos` (clean), `plugin.json` valid JSON.

Refs melodic-software/medley#1405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill-behavior guidance only; no runtime code or credential handling changes. Main operational risk is agents following the new prefixed gate correctly so Miro mode is not silently skipped.
> 
> **Overview**
> Realigns **`event-storming`**’s `simulation` skill and docs with the first-party **`miro`** plugin instead of generic/community MCP setup. The live-board path now documents install → enable → keychain token, rejects `mcp.miro.com` with a pointer to the playbook trust record, and treats structured markdown as the default when `miro` is off.
> 
> **`SKILL.md`** changes the Miro availability gate to probe **`mcp__plugin_miro_miro__*`** (bare `miro_*` does not resolve for plugin-bundled servers) and updates the “connect Miro” path to marketplace install/enable of the `miro` plugin.
> 
> **`reference/miro-integration.md`** drops the `@llmindset/mcp-miro` / `.mcp.json` instructions in favor of plugin setup, tool-namespace rules, and bulk-create wording for the bundled server.
> 
> **`docs/MIGRATION-PLAYBOOK.md`** adds the cross-plugin MCP convention (`event-storming` → `miro`): prefixed tool names for declarative matchers, prefixed availability probes, and soft dependency without bundle-or-fork.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4951336087230076bd7bfda6f6f8defb7fa2f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->