### PR TITLE
chore(skill-quality): harden static checker + record terminal retrofit scope

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -828,3 +828,32 @@ accepted).
   need for custom subagent-row data during orchestration, not a presentation preference. Upstream:
   <https://code.claude.com/docs/en/statusline#subagent-status-lines>,
   <https://code.claude.com/docs/en/plugins-reference#standard-plugin-layout>.
+
+## `skill-quality` retrofit scope — decision record (2026-07-13)
+
+The `skill-quality` plugin shipped only the generic static contract checker (`check-skill.sh`, seventeen
+model-free checks) plus the `evals.schema.json` validation asset. Its held-back scope is resolved here as
+**terminal exclusions** — decided out of the plugin for good, each with a permanent home, **not** deferrals
+with a revisit trigger. (Contrast the "Deferred surfaces" record above, where the medley surface is held
+*pending* a trigger; these are held *out*.)
+
+- **A/B eval runner** (`tools/evals/run-skill-comparison.sh`): a headless `claude -p` skill-body A/B
+  comparison driver — spins throwaway worktrees, runs fixture trials per arm, scrubs transcripts. **Not a
+  plugin component; stays medley-owned in `tools/evals/`.** It is a *dynamic authoring experiment* harness,
+  a distinct concern from this plugin's *static QA gate* (one cohesive capability per plugin — see the
+  design charter), with a single consumer and ~29 KB of worktree / hub-safety / platform path-scrub
+  surface that would be marketplace upkeep for that one consumer. **No revisit trigger:** a genuine
+  second-consumer demand is a fresh publish issue, not standing debt.
+- **Contract libs** (`tools/skill-contract/`: portability, encapsulation, script-contract, dispatcher):
+  enforce medley-**invented** regimes — the skill public-surface / encapsulation contract, BEHAVIOR.md
+  symmetry, unit-anatomy, the cleanliness-regime script contract, and a medley-specific identifier
+  deny-list. **Permanent home is medley** (a de-couple-from-source-repo gate they cannot pass — every scan
+  scope, exemption, and identifier is this repo's). The narrow genuinely-generic seams (machine-path /
+  escape-path scanning, an encapsulation deep-cite regex, a "new script ships `--help` + a sibling test"
+  assertion, a deny-list scan *mechanism* whose data is per-consumer) are net-new versus the shipped
+  checks but have **no second consumer**; extracting them now is speculative generality / a pre-Rule-of-
+  Three abstraction (`melodic-software/standards` `conventions/engineering/simpler-code.md`). The plugin
+  can grow a machine-path check the day a real consumer needs one — as its own issue.
+- **Checker hardening** (block-scalar description unfolding, an unquoted-`Use when:` warning, a
+  `CHECK_SKILL_BASE_REF` post-commit audit ref for the git-backed checks, and a line-1 frontmatter-fence
+  requirement): the one worker-executable slice — **landed** with this record.

--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Skill-authoring QA tooling: a static contract checker that runs seventeen deterministic checks over a Claude Code skill (frontmatter, listing-budget cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence) and a bundled evals.json schema for validation. Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the `skill-quality` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.3.0]
+
+### Added
+
+- **Post-commit audit ref.** `CHECK_SKILL_BASE_REF` (default `HEAD`) selects the ref the git-backed
+  checks (3 trigger-preservation, 8 vendor byte-identity, 9 stale-tracking metadata) diff the working
+  tree against. The default still catches an uncommitted rewrite; pointing it before a change (e.g.
+  `HEAD^` or a merge-base) and running on a clean tree catches an already-committed change that the
+  `HEAD` == working-tree comparison would miss.
+
+### Changed
+
+- **Block-scalar descriptions are unfolded.** A `description: |` / `>-` block scalar is now expanded to
+  its text before the length (2), trigger-preservation (3), and phrasing (12) checks, which previously
+  operated on the `|` / `>` marker instead of the content.
+- **Frontmatter must open on line 1.** The YAML frontmatter fence is required at line 1; content before
+  it is no longer treated as frontmatter, closing a path where a stray `---` further down could satisfy
+  check 1.
+- **Unquoted `Use when:` triggers warn (check 12).** Trigger-drop protection (check 3) tracks only
+  single-quoted `'phrase'` triggers; an unquoted `Use when:` list now raises a warning so those phrases
+  get quoted and covered, rather than silently going unprotected.

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -17,10 +17,17 @@
 #   2. ${CLAUDE_PROJECT_DIR}/.claude/skills (plugin runtime)
 #   3. <git-root>/.claude/skills (default)
 #
+# Base ref for the git-backed diff checks (3, 8, 9):
+#   CHECK_SKILL_BASE_REF (default HEAD). These checks diff the WORKING TREE
+#   against this ref, so the default catches an uncommitted rewrite. For a
+#   post-commit audit (where HEAD == tree hides an already-committed change),
+#   run on a clean tree with CHECK_SKILL_BASE_REF pointing before the change
+#   (e.g. HEAD^ or a merge-base).
+#
 # Checks:
 #   1. Frontmatter parses; name + description present
 #   2. description + when_to_use <= 1536 chars (listing-truncation guard)
-#   3. Trigger-keyword preservation vs `git show HEAD:` (skipped for new skills)
+#   3. Trigger-keyword preservation vs the base ref (skipped for new skills)
 #   4. SKILL.md < 500 lines (hard cap)
 #   5. Backtick-cited skill-internal supporting files resolve
 #   6. markdownlint clean (markdownlint-cli2; WARN-skip if npx absent)
@@ -29,22 +36,25 @@
 #   9. Stale-tracking metadata keys preserved vs HEAD (upstream-version/synced/upstream-sha)
 #  10. SKILL.md <= 200 lines soft target (WARN; progressive disclosure)
 #  11. Gotchas surface present (WARN; inline `## Gotchas` or context|reference/gotchas.md)
-#  12. description carries "Use when" trigger phrasing (WARN)
+#  12. description carries "Use when" trigger phrasing, single-quoted (WARN)
 #  13. No committed cache/build artifacts (__pycache__, *.pyc, node_modules) (FAIL)
 #  14. Action-router-shaped skill ships evals/evals.json (WARN)
 #  15. Companion spoke dirs referenced from SKILL.md (WARN; orphan-spoke direction)
 #  16. metadata.category present (INFO only)
 #  17. Vendor-backed: metadata.synced not older than 180 days (WARN)
 #
-# Known limitations (static, git-diff-based design):
-#   - Checks 3/8 compare the working tree against HEAD, so a trigger-phrase or
-#     vendor change that is ALREADY committed is invisible (HEAD == tree). The
-#     gate is authored for the pre-commit / uncommitted-rewrite case; a
-#     post-commit audit needs an explicit base ref.
-#   - Frontmatter is located at the first `---` fence, not strictly line 1.
-#   - A block-scalar `description: |` / `>-` is not unfolded, so checks 2/3/12
-#     see the marker rather than the text. Prefer a single-line quoted
-#     description (the listing budget encourages this anyway).
+# Notes (static, git-diff-based design):
+#   - Checks 3/8/9 diff the working tree against CHECK_SKILL_BASE_REF (default
+#     HEAD). The default catches an uncommitted rewrite; a post-commit audit
+#     sets the base ref before the change and runs on a clean tree (see above).
+#   - Frontmatter must open with `---` on line 1; content before the fence is
+#     not treated as frontmatter.
+#   - A block-scalar `description: |` / `>-` is unfolded before checks 2/3/12,
+#     so they see the text rather than the marker. A single-line quoted
+#     description is still preferred (the listing budget encourages this).
+#   - Trigger-drop protection (check 3) tracks single-quoted 'phrase' triggers.
+#     An unquoted `Use when:` list is not tracked; check 12 warns so those
+#     triggers get quoted and covered.
 
 set -uo pipefail
 
@@ -67,6 +77,15 @@ fi
 
 # shellcheck source=./skill-frontmatter.sh
 source "$SCRIPT_DIR/skill-frontmatter.sh"
+
+# Base ref for the git-backed diff checks (3, 8, 9) — see the header. Default
+# HEAD (uncommitted-rewrite case); an explicit ref enables a post-commit audit.
+BASE_REF="${CHECK_SKILL_BASE_REF:-HEAD}"
+if [[ "$BASE_REF" != "HEAD" ]] \
+  && ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$BASE_REF^{commit}" >/dev/null 2>&1; then
+  printf 'Error: CHECK_SKILL_BASE_REF=%s is not a valid commit\n' "$BASE_REF" >&2
+  exit 2
+fi
 
 SKILL_NAME="${1:?Usage: check-skill.sh <skill-name>}"
 
@@ -160,22 +179,22 @@ fi
 
 # --- Check 3: trigger-keyword preservation vs HEAD -------------------------
 
-if git -C "$REPO_ROOT" cat-file -e "HEAD:$SKILL_REL/SKILL.md" 2>/dev/null; then
-  HEAD_FM_3="$(git -C "$REPO_ROOT" show "HEAD:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
-  HEAD_DESC="$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field description <<<"$HEAD_FM_3")")"
-  HEAD_WTU="$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field when_to_use <<<"$HEAD_FM_3")")"
-  HEAD_TRIG="$(printf '%s\n%s\n' "$HEAD_DESC" "$HEAD_WTU" | skill_frontmatter::extract_triggers)"
+if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
+  BASE_FM_3="$(git -C "$REPO_ROOT" show "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
+  BASE_DESC="$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field description <<<"$BASE_FM_3")")"
+  BASE_WTU="$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field when_to_use <<<"$BASE_FM_3")")"
+  BASE_TRIG="$(printf '%s\n%s\n' "$BASE_DESC" "$BASE_WTU" | skill_frontmatter::extract_triggers)"
   CUR_TRIG="$(printf '%s\n%s\n' "$CUR_DESC" "$CUR_WTU" | skill_frontmatter::extract_triggers)"
-  if [[ -n "$HEAD_TRIG" ]]; then
-    MISSING="$(comm -23 <(printf '%s\n' "$HEAD_TRIG") <(printf '%s\n' "$CUR_TRIG"))"
+  if [[ -n "$BASE_TRIG" ]]; then
+    MISSING="$(comm -23 <(printf '%s\n' "$BASE_TRIG") <(printf '%s\n' "$CUR_TRIG"))"
     if [[ -n "$MISSING" ]]; then
-      err "dropped trigger keyword(s) vs HEAD (auto-invocation regression): $(printf '%s' "$MISSING" | tr '\n' ' ')"
+      err "dropped trigger keyword(s) vs $BASE_REF (auto-invocation regression): $(printf '%s' "$MISSING" | tr '\n' ' ')"
     else
-      note "all $(printf '%s\n' "$HEAD_TRIG" | grep -c .) HEAD trigger phrase(s) preserved"
+      note "all $(printf '%s\n' "$BASE_TRIG" | grep -c .) base-ref trigger phrase(s) preserved"
     fi
   fi
 else
-  note "no HEAD version (new skill) — keyword-preservation check skipped"
+  note "no $BASE_REF version (new skill) — keyword-preservation check skipped"
 fi
 
 # --- Check 4: SKILL.md < LINE_HARD_CAP lines -------------------------------
@@ -264,22 +283,22 @@ fi
 # Only meaningful when the skill has a HEAD baseline: a brand-new vendored skill
 # staged before a pre-commit run has no prior vendor/ to preserve, so its staged
 # files must not read as "changed vs HEAD".
-if [[ -d "$SKILL_DIR/vendor" ]] && git -C "$REPO_ROOT" cat-file -e "HEAD:$SKILL_REL/SKILL.md" 2>/dev/null; then
-  if git -C "$REPO_ROOT" diff --quiet HEAD -- "$SKILL_REL/vendor/" 2>/dev/null; then
-    note "vendor/ unchanged vs HEAD"
+if [[ -d "$SKILL_DIR/vendor" ]] && git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
+  if git -C "$REPO_ROOT" diff --quiet "$BASE_REF" -- "$SKILL_REL/vendor/" 2>/dev/null; then
+    note "vendor/ unchanged vs $BASE_REF"
   else
-    err "vendor/ changed vs HEAD — vendored content carries a byte-identical guarantee; rewrites must not touch vendor/"
+    err "vendor/ changed vs $BASE_REF — vendored content carries a byte-identical guarantee; rewrites must not touch vendor/"
   fi
 fi
 
 # --- Check 9: stale-tracking metadata keys preserved vs HEAD ---------------
 
-if git -C "$REPO_ROOT" cat-file -e "HEAD:$SKILL_REL/SKILL.md" 2>/dev/null; then
-  HEAD_FM="$(git -C "$REPO_ROOT" show "HEAD:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
+if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
+  BASE_FM="$(git -C "$REPO_ROOT" show "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
   for key in upstream-version synced upstream-sha; do
-    if grep -qE "^[[:space:]]*$key:" <<<"$HEAD_FM"; then
+    if grep -qE "^[[:space:]]*$key:" <<<"$BASE_FM"; then
       grep -qE "^[[:space:]]*$key:" <<<"$FRONTMATTER" \
-        || err "metadata key '$key' present at HEAD but dropped (stale-tracking metadata for a vendored skill)"
+        || err "metadata key '$key' present at $BASE_REF but dropped (stale-tracking metadata for a vendored skill)"
     fi
   done
 fi
@@ -301,8 +320,12 @@ fi
 
 # --- Check 12: description carries trigger phrasing --------------------------
 
-if [[ -n "$CUR_DESC" ]] && ! grep -qi 'use when' <<<"$CUR_DESC$CUR_WTU"; then
-  warn "description has no 'Use when:' trigger phrasing — a description is a trigger spec, not a summary"
+if [[ -n "$CUR_DESC" ]]; then
+  if ! grep -qi 'use when' <<<"$CUR_DESC$CUR_WTU"; then
+    warn "description has no 'Use when:' trigger phrasing — a description is a trigger spec, not a summary"
+  elif [[ -z "$(printf '%s\n%s\n' "$CUR_DESC" "$CUR_WTU" | skill_frontmatter::extract_triggers)" ]]; then
+    warn "'Use when:' triggers are not single-quoted — drop-regression protection (check 3) tracks only 'quoted' phrases; single-quote each trigger phrase to cover it"
+  fi
 fi
 
 # --- Check 13: no committed cache/build artifacts ----------------------------

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -249,6 +249,38 @@ else
   fail "base-ref audit should catch a committed drop HEAD misses (rc_head=$rc_head rc_base=$rc_base): $out_base"
 fi
 
+# 11. A block header with the chomp indicator BEFORE the indent indicator
+#     (`|-2`, a legal YAML order) is still recognized and unfolded.
+make_skill blkord-skill '---
+name: blkord-skill
+description: |-2
+  Do the thing. Use when: '"'"'order alpha'"'"', '"'"'order beta'"'"'.
+---
+
+## Purpose
+
+Committed baseline with a sign-first block header carrying two triggers.
+'
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm 'add blkord-skill'
+make_skill blkord-skill '---
+name: blkord-skill
+description: |-2
+  Do the thing. Use when: '"'"'order alpha'"'"'.
+---
+
+## Purpose
+
+Working tree drops order beta.
+'
+out="$(run blkord-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'order beta' <<<"$out"; then
+  pass "sign-first block header (|-2) is recognized and unfolded"
+else
+  fail "sign-first block header should be unfolded (rc=$rc): $out"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -313,6 +313,40 @@ else
   fail "commented block header should be unfolded (rc=$rc): $out"
 fi
 
+# 13. A block whose first content line is MORE indented than a later line
+#     (e.g. under an explicit `|2`) still captures the later line's triggers —
+#     the column-0 boundary is used, not the first line's indent.
+make_skill blkindent-skill '---
+name: blkindent-skill
+description: |2
+    Deeply indented first line. Use when: '"'"'indent alpha'"'"'.
+  Shallower valid line. Use when: '"'"'indent beta'"'"'.
+---
+
+## Purpose
+
+Baseline with triggers on lines of differing indent under an explicit indicator.
+'
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm 'add blkindent-skill'
+make_skill blkindent-skill '---
+name: blkindent-skill
+description: |2
+    Deeply indented first line. Use when: '"'"'indent alpha'"'"'.
+---
+
+## Purpose
+
+Working tree drops the shallower line carrying indent beta.
+'
+out="$(run blkindent-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'indent beta' <<<"$out"; then
+  pass "block content past a more-indented first line is captured (indent indicator honored)"
+else
+  fail "trigger on a less-indented block line should be tracked (rc=$rc): $out"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -37,7 +37,7 @@ make_skill() {
 
 good_body='---
 name: good-skill
-description: "Do a thing. Use when: you need a thing done."
+description: "Do a thing. Use when: '"'"'a thing'"'"' is needed."
 ---
 
 ## Purpose
@@ -138,6 +138,115 @@ if [[ $rc -eq 0 ]] && grep -q 'PASS' <<<"$out"; then
   pass "relative skills root resolves via CLAUDE_PROJECT_DIR from a subdir"
 else
   fail "relative skills root should resolve via CLAUDE_PROJECT_DIR (rc=$rc): $out"
+fi
+
+# 7. Content before the opening `---` fence is not frontmatter (check 1 fails).
+make_skill preamble-skill 'Stray preamble before the fence.
+---
+name: preamble-skill
+description: "Thing. Use when: '"'"'x trigger'"'"'."
+---
+
+## Purpose
+
+Frontmatter does not open on line 1.
+'
+out="$(run preamble-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'no YAML frontmatter' <<<"$out"; then
+  pass "content before the --- fence is not treated as frontmatter"
+else
+  fail "preamble before fence should fail check 1 (rc=$rc): $out"
+fi
+
+# 8. A block-scalar `description: |` is unfolded, so a trigger phrase dropped
+#    from inside the block is still caught by check 3.
+make_skill blk-skill '---
+name: blk-skill
+description: |
+  Do the thing. Use when: '"'"'block alpha'"'"', '"'"'block beta'"'"'.
+---
+
+## Purpose
+
+Committed baseline with a block-scalar description carrying two triggers.
+'
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm 'add blk-skill'
+make_skill blk-skill '---
+name: blk-skill
+description: |
+  Do the thing. Use when: '"'"'block alpha'"'"'.
+---
+
+## Purpose
+
+Working tree drops the block beta trigger.
+'
+out="$(run blk-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'block beta' <<<"$out"; then
+  pass "block-scalar description is unfolded (trigger drop caught inside |)"
+else
+  fail "block-scalar trigger drop should be caught (rc=$rc): $out"
+fi
+
+# 9. An unquoted `Use when:` list warns (drop-protection gap surfaced) but passes.
+make_skill unq-skill '---
+name: unq-skill
+description: "Do the thing. Use when: you need it, or someone asks."
+---
+
+## Purpose
+
+Unquoted Use-when triggers.
+
+## Gotchas
+
+None known.
+'
+out="$(run unq-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]] && grep -q 'not single-quoted' <<<"$out"; then
+  pass "unquoted Use-when triggers warn (drop-protection gap surfaced)"
+else
+  fail "unquoted triggers should warn without failing (rc=$rc): $out"
+fi
+
+# 10. CHECK_SKILL_BASE_REF catches an ALREADY-COMMITTED trigger drop that the
+#     default working-tree-vs-HEAD comparison misses (HEAD == tree).
+make_skill baseref-skill '---
+name: baseref-skill
+description: "Thing. Use when: '"'"'ref alpha'"'"', '"'"'ref beta'"'"'."
+---
+
+## Purpose
+
+First commit carries two triggers.
+'
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm 'baseref v1'
+make_skill baseref-skill '---
+name: baseref-skill
+description: "Thing. Use when: '"'"'ref alpha'"'"'."
+---
+
+## Purpose
+
+Second commit drops ref beta — now committed, so HEAD == tree.
+'
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm 'baseref v2 drops beta'
+run baseref-skill >/dev/null 2>&1
+rc_head=$?
+out_base="$(cd "$TMP" \
+  && CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 CHECK_SKILL_BASE_REF=HEAD^ \
+    bash "$SUT" baseref-skill 2>&1)"
+rc_base=$?
+if [[ $rc_head -eq 0 ]] && [[ $rc_base -eq 1 ]] && grep -q 'ref beta' <<<"$out_base"; then
+  pass "post-commit base ref catches a committed trigger drop that HEAD misses"
+else
+  fail "base-ref audit should catch a committed drop HEAD misses (rc_head=$rc_head rc_base=$rc_base): $out_base"
 fi
 
 if [[ $fails -ne 0 ]]; then

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -281,6 +281,38 @@ else
   fail "sign-first block header should be unfolded (rc=$rc): $out"
 fi
 
+# 12. A block header with a trailing `# comment` (legal YAML) is still
+#     recognized and unfolded.
+make_skill blkcmt-skill '---
+name: blkcmt-skill
+description: | # trigger notes
+  Do the thing. Use when: '"'"'comment alpha'"'"', '"'"'comment beta'"'"'.
+---
+
+## Purpose
+
+Committed baseline with a commented block header carrying two triggers.
+'
+git -C "$TMP" add -A
+git -C "$TMP" commit -qm 'add blkcmt-skill'
+make_skill blkcmt-skill '---
+name: blkcmt-skill
+description: | # trigger notes
+  Do the thing. Use when: '"'"'comment alpha'"'"'.
+---
+
+## Purpose
+
+Working tree drops comment beta.
+'
+out="$(run blkcmt-skill 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] && grep -q 'comment beta' <<<"$out"; then
+  pass "commented block header (| # ...) is recognized and unfolded"
+else
+  fail "commented block header should be unfolded (rc=$rc): $out"
+fi
+
 if [[ $fails -ne 0 ]]; then
   printf '%d assertion(s) failed\n' "$fails" >&2
   exit 1

--- a/plugins/skill-quality/scripts/skill-frontmatter.sh
+++ b/plugins/skill-quality/scripts/skill-frontmatter.sh
@@ -20,8 +20,9 @@ skill_frontmatter::extract() {
 }
 
 # Extract a frontmatter scalar by key (quotes stripped) from stdin. A block
-# scalar (`key: |` / `key: >`, with optional chomp/indent indicator) is unfolded
-# to its text so downstream length / trigger / phrasing checks see the content
+# scalar header (`key: |` / `key: >`, with an optional indent and/or chomp
+# indicator in either order and an optional trailing `# comment`) is unfolded to
+# its text so downstream length / trigger / phrasing checks see the content
 # rather than the `|` / `>` marker: literal (`|`) joins lines with newlines,
 # folded (`>`) with spaces.
 skill_frontmatter::field() {
@@ -30,7 +31,7 @@ skill_frontmatter::field() {
     $0 ~ "^" k ":[[:space:]]*" {
       val = $0
       sub("^" k ":[[:space:]]*", "", val)
-      if (val ~ /^[|>]([0-9][+-]?|[+-][0-9]?)?[[:space:]]*$/) {
+      if (val ~ /^[|>]([0-9][+-]?|[+-][0-9]?)?[[:space:]]*(#.*)?$/) {
         fold = (val ~ /^>/)
         out = ""; started = 0; base = -1
         while ((getline line) > 0) {

--- a/plugins/skill-quality/scripts/skill-frontmatter.sh
+++ b/plugins/skill-quality/scripts/skill-frontmatter.sh
@@ -30,7 +30,7 @@ skill_frontmatter::field() {
     $0 ~ "^" k ":[[:space:]]*" {
       val = $0
       sub("^" k ":[[:space:]]*", "", val)
-      if (val ~ /^[|>][0-9]*[+-]?[[:space:]]*$/) {
+      if (val ~ /^[|>]([0-9][+-]?|[+-][0-9]?)?[[:space:]]*$/) {
         fold = (val ~ /^>/)
         out = ""; started = 0; base = -1
         while ((getline line) > 0) {

--- a/plugins/skill-quality/scripts/skill-frontmatter.sh
+++ b/plugins/skill-quality/scripts/skill-frontmatter.sh
@@ -32,15 +32,20 @@ skill_frontmatter::field() {
       val = $0
       sub("^" k ":[[:space:]]*", "", val)
       if (val ~ /^[|>]([0-9][+-]?|[+-][0-9]?)?[[:space:]]*(#.*)?$/) {
+        # Text capture for the checks (not a full YAML parser): a frontmatter
+        # key sits at column 0, so every indented line is block content and the
+        # first column-0 line is the next key. Collecting on that boundary
+        # ignores the indent indicator entirely, so an explicit indent smaller
+        # than the first content line cannot drop later lines. Leading indent is
+        # stripped per line (irrelevant to length / trigger / phrasing checks).
         fold = (val ~ /^>/)
-        out = ""; started = 0; base = -1
+        out = ""; started = 0
         while ((getline line) > 0) {
           if (line ~ /^[[:space:]]*$/) { if (started) out = out (fold ? " " : "\n"); continue }
-          match(line, /^[[:space:]]*/); ind = RLENGTH
-          if (base < 0) base = ind
-          if (ind < base) break
+          if (line !~ /^[[:space:]]/) break
+          sub(/^[[:space:]]+/, "", line)
           if (started) out = out (fold ? " " : "\n")
-          out = out substr(line, base + 1)
+          out = out line
           started = 1
         }
         print out

--- a/plugins/skill-quality/scripts/skill-frontmatter.sh
+++ b/plugins/skill-quality/scripts/skill-frontmatter.sh
@@ -9,20 +9,43 @@ fi
 SKILL_FRONTMATTER_LIB_LOADED=1
 
 # Extract YAML frontmatter (between first two --- fences) from stdin.
+# The opening fence MUST be line 1 — content before it is not frontmatter, so a
+# stray `---` further down cannot be mistaken for the block's start.
 skill_frontmatter::extract() {
   awk '
+    NR == 1 && $0 !~ /^---[[:space:]]*$/ { exit }
     /^---[[:space:]]*$/ { fence++; if (fence == 1) next; if (fence >= 2) exit }
     fence == 1 { print }
   '
 }
 
-# Extract a single-line frontmatter scalar by key (quotes stripped) from stdin.
+# Extract a frontmatter scalar by key (quotes stripped) from stdin. A block
+# scalar (`key: |` / `key: >`, with optional chomp/indent indicator) is unfolded
+# to its text so downstream length / trigger / phrasing checks see the content
+# rather than the `|` / `>` marker: literal (`|`) joins lines with newlines,
+# folded (`>`) with spaces.
 skill_frontmatter::field() {
   local key="$1"
   awk -v k="$key" '
     $0 ~ "^" k ":[[:space:]]*" {
-      sub("^" k ":[[:space:]]*", "")
-      print
+      val = $0
+      sub("^" k ":[[:space:]]*", "", val)
+      if (val ~ /^[|>][0-9]*[+-]?[[:space:]]*$/) {
+        fold = (val ~ /^>/)
+        out = ""; started = 0; base = -1
+        while ((getline line) > 0) {
+          if (line ~ /^[[:space:]]*$/) { if (started) out = out (fold ? " " : "\n"); continue }
+          match(line, /^[[:space:]]*/); ind = RLENGTH
+          if (base < 0) base = ind
+          if (ind < base) break
+          if (started) out = out (fold ? " " : "\n")
+          out = out substr(line, base + 1)
+          started = 1
+        }
+        print out
+        exit
+      }
+      print val
       exit
     }
   '

--- a/plugins/skill-quality/skills/skill-quality/SKILL.md
+++ b/plugins/skill-quality/skills/skill-quality/SKILL.md
@@ -85,5 +85,9 @@ that line before editing, since it may be an illustrative example path rather th
   exits 2 (env error).
 - `check-skill.sh` runs `npx markdownlint-cli2` for check 6; when `npx` is absent that check downgrades
   to a WARN rather than failing, so a run on a machine without Node still gates on the other sixteen.
-- Trigger-keyword preservation compares against `HEAD`, so a brand-new skill (no committed version)
-  skips check 3 — that is expected, not a silent pass.
+- Trigger-keyword preservation compares the working tree against `HEAD` by default, so a brand-new skill
+  (no committed version) skips check 3 — that is expected, not a silent pass. For a post-commit audit
+  (where `HEAD` == the working tree hides an already-committed change), set `CHECK_SKILL_BASE_REF` to a
+  ref before the change (e.g. `HEAD^` or a merge-base) and run on a clean tree; it reroutes checks 3/8/9.
+- Trigger-drop protection tracks single-quoted `'phrase'` triggers. An unquoted `Use when:` list is not
+  tracked by check 3; check 12 warns so those phrases get quoted and covered.


### PR DESCRIPTION
Lands the worker-executable slice of the `skill-quality` retrofit and codifies the two resolved scope decisions.

## Checker hardening

Four verified bot-review findings on the shipped `check-skill.sh`, each with a test:

- **Block-scalar descriptions unfolded.** `description: |` / `>-` is expanded to its text before the length (2), trigger-preservation (3), and phrasing (12) checks, which previously operated on the `|` / `>` marker.
- **Frontmatter fence required on line 1.** Content before the opening `---` is no longer treated as frontmatter, closing a path where a stray `---` further down satisfied check 1.
- **Post-commit audit ref.** `CHECK_SKILL_BASE_REF` (default `HEAD`) selects the ref the git-backed checks (3/8/9) diff the working tree against. The default still catches an uncommitted rewrite; pointing it before a change (e.g. `HEAD^` / merge-base) on a clean tree catches an already-committed change that `HEAD` == tree would miss.
- **Unquoted `Use when:` warning (check 12).** Trigger-drop protection tracks only single-quoted `'phrase'` triggers; an unquoted `Use when:` list now warns so those phrases get quoted and covered. Deterministic warning rather than fuzzy prose-diffing, which would inject false regressions into check 3.

## Decision record

`docs/MIGRATION-PLAYBOOK.md` gains a `skill-quality` retrofit-scope record: the A/B eval runner (`tools/evals/run-skill-comparison.sh`) and the medley-regime contract libs (`tools/skill-contract/`) are **terminal exclusions** — permanent medley homes, no revisit trigger — distinct from the deferral section. Basis: one cohesive capability per plugin (the runner is a dynamic authoring experiment, not the static QA gate; single consumer, ~29 KB upkeep) and no-speculative-generality (`melodic-software/standards` `simpler-code.md`) for the narrow generic contract-lib seams that lack a second consumer.

## Verification

- `check-skill.test.sh` — 10 assertions pass (4 new: frontmatter-position, block-scalar unfold, unquoted-trigger warn, base-ref post-commit audit)
- `shellcheck -x` clean on all three scripts
- Dogfooded against the plugin's own shipped skills (both PASS)
- `claude plugin validate plugins/skill-quality` and `claude plugin validate --strict .` pass
- markdownlint clean; version `0.2.0` -> `0.3.0` + `CHANGELOG.md`

Refs melodic-software/medley#1418

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect a local skill QA script and documentation only; default behavior stays HEAD-based, with stricter frontmatter and new warnings that may surface on existing skills.
> 
> **Overview**
> **`skill-quality` 0.3.0** tightens the static `check-skill.sh` gate and documents what stays out of the plugin.
> 
> The checker now **unfolds block-scalar `description` values** in `skill-frontmatter.sh` so length, trigger-preservation, and phrasing checks run on real text (including `|-2`, trailing `#` comments, and mixed-indent block lines). **Frontmatter must start with `---` on line 1**; preamble before the fence no longer satisfies check 1. Git-backed checks **3 / 8 / 9** compare the working tree to **`CHECK_SKILL_BASE_REF`** (default `HEAD`, validated commit) so a clean-tree audit with e.g. `HEAD^` can catch already-committed trigger or vendor regressions. **Check 12** adds a **WARN** when `Use when:` phrases are not single-quoted, since check 3 only tracks `'quoted'` triggers.
> 
> Tests in `check-skill.test.sh` cover these paths; **`CHANGELOG.md`** and **`plugin.json`** bump to **0.3.0**; the **`skill-quality` skill** Gotchas note the base ref and quoting behavior.
> 
> **`docs/MIGRATION-PLAYBOOK.md`** adds a **`skill-quality` retrofit-scope** decision: the medley A/B eval runner and medley-specific contract libs are **terminal exclusions** (permanent medley homes, no revisit trigger); the hardening slice is recorded as landed with that record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a094f9d3dadf4ca0256a1846766761c11c1c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->