### PR TITLE
feat(ai-briefing): wire profile brand.js overlay + logo resolution into the build

### DIFF
--- a/plugins/ai-briefing/skills/ai-briefing/output/build/emit-slides-data.js
+++ b/plugins/ai-briefing/skills/ai-briefing/output/build/emit-slides-data.js
@@ -11,13 +11,9 @@ import { parseBriefing } from "./lib/parse-briefing.js";
 import { emitSlides } from "./lib/emit-slides.js";
 import { ensureProviderLogos } from "./lib/fetch-logos.js";
 import { validateDeck } from "./lib/schema.js";
-import { brand as BRAND, theme as THEME } from "./brand.js";
-import { buildOutDir, meetingsDir, slidesDataPath, stateRoot } from "./lib/paths.js";
-
-// Default brand (deck `meta` fields + `theme`) lives in ./brand.js — the single
-// concrete brand source. DO NOT redefine per run. Edit brand.js (or a profile
-// overlay) only on rebrand.
-const META_DEFAULTS = BRAND;
+import { brand as DEFAULT_BRAND, theme as DEFAULT_THEME } from "./brand.js";
+import { resolveBrand } from "./lib/brand-overlay.js";
+import { buildOutDir, configDir, meetingsDir, slidesDataPath, stateRoot } from "./lib/paths.js";
 
 const PROVIDER_LOGOS = {
   anthropic: "assets/logo-anthropic.svg",
@@ -138,6 +134,15 @@ export const slides = ${asJsLiteral(slides, 0)};
 async function main() {
   const args = parseArgs(process.argv);
 
+  // Resolve the active profile's brand.js overlay (org, tagline, logos, theme)
+  // over the engine's neutral default. Absent overlay → neutral default. Profile
+  // logo paths come back absolute so the downstream build scripts embed them.
+  const { brand: BRAND, theme: THEME } = await resolveBrand({
+    defaultBrand: DEFAULT_BRAND,
+    defaultTheme: DEFAULT_THEME,
+    configDir: configDir(),
+  });
+
   // Resolve meeting number + window from state (or args)
   const state = await readState();
   let meetingNumber = args.meetingN;
@@ -231,7 +236,7 @@ async function main() {
     meetingNumber,
     date: dateStr,
     window: windowStr,
-    org: META_DEFAULTS.org,
+    org: BRAND.org,
   };
 
   // Emit slides
@@ -239,12 +244,12 @@ async function main() {
 
   const meta = {
     meetingNumber,
-    org: META_DEFAULTS.org,
-    tagline: META_DEFAULTS.tagline,
+    org: BRAND.org,
+    tagline: BRAND.tagline,
     date: dateStr,
     window: windowStr,
-    logoColor: META_DEFAULTS.logoColor,
-    logoWhite: META_DEFAULTS.logoWhite,
+    logoColor: BRAND.logoColor,
+    logoWhite: BRAND.logoWhite,
   };
 
   // Validate before writing

--- a/plugins/ai-briefing/skills/ai-briefing/output/build/lib/brand-overlay.js
+++ b/plugins/ai-briefing/skills/ai-briefing/output/build/lib/brand-overlay.js
@@ -12,10 +12,19 @@
 //     `assets/logo.png`). They are resolved to ABSOLUTE here so the downstream
 //     build scripts' `path.resolve(buildDir, meta.logo*)` returns them
 //     unchanged (path.resolve keeps a trailing absolute segment).
+//
+// The overlay is loaded via a `data:` URL rather than a file URL so its ESM
+// `export const` parses regardless of the consumer project's package scope: a
+// profile brand.js sits under the consumer's `.claude/ai-briefing/`, where the
+// nearest package.json is the consumer's — an explicit `"type":"commonjs"`
+// there makes a file-URL import throw `SyntaxError`, and a typeless one prints a
+// MODULE_TYPELESS_PACKAGE_JSON perf warning on every build. A `data:` module is
+// always ESM. The trade-off: a data: module cannot resolve relative `import`s,
+// so brand.js must stay a pure-data overlay (org/tagline/logo strings + theme
+// tokens) — which the documented contract already requires.
 
 import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 
 const LOGO_KEYS = ["logoColor", "logoWhite"];
 
@@ -25,7 +34,9 @@ export async function resolveBrand({ defaultBrand, defaultTheme, configDir }) {
     return { brand: { ...defaultBrand }, theme: { ...defaultTheme } };
   }
 
-  const overlay = await import(pathToFileURL(overlayPath).href);
+  const source = fs.readFileSync(overlayPath, "utf-8");
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+  const overlay = await import(dataUrl);
   const brand = { ...defaultBrand, ...(overlay.brand ?? {}) };
   const theme = { ...defaultTheme, ...(overlay.theme ?? {}) };
 

--- a/plugins/ai-briefing/skills/ai-briefing/output/build/lib/brand-overlay.js
+++ b/plugins/ai-briefing/skills/ai-briefing/output/build/lib/brand-overlay.js
@@ -1,0 +1,42 @@
+// Resolve the active profile's brand.js overlay over the engine's neutral
+// default. The emitter reads a single concrete brand (deck `meta` fields) +
+// `theme`; a consumer profile supplies a `brand.js` beside its logo assets to
+// override org name, tagline, logos, and theme tokens per key.
+//
+// Contract:
+//   - Absent profile brand.js  -> neutral default returned unchanged (the
+//     common unprofiled case; the seed dir ships no overlay).
+//   - Present-but-malformed     -> the import error propagates. A profile that
+//     exists but cannot load is a real fault, not a silent fall-through.
+//   - Profile logo paths are relative to the profile brand.js (e.g.
+//     `assets/logo.png`). They are resolved to ABSOLUTE here so the downstream
+//     build scripts' `path.resolve(buildDir, meta.logo*)` returns them
+//     unchanged (path.resolve keeps a trailing absolute segment).
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const LOGO_KEYS = ["logoColor", "logoWhite"];
+
+export async function resolveBrand({ defaultBrand, defaultTheme, configDir }) {
+  const overlayPath = path.join(configDir, "brand.js");
+  if (!fs.existsSync(overlayPath)) {
+    return { brand: { ...defaultBrand }, theme: { ...defaultTheme } };
+  }
+
+  const overlay = await import(pathToFileURL(overlayPath).href);
+  const brand = { ...defaultBrand, ...(overlay.brand ?? {}) };
+  const theme = { ...defaultTheme, ...(overlay.theme ?? {}) };
+
+  // Only the profile-supplied logos anchor to configDir; the neutral default's
+  // logos are empty and provider logos stay relative to the build dir.
+  for (const key of LOGO_KEYS) {
+    const value = overlay.brand?.[key];
+    if (value && !path.isAbsolute(value)) {
+      brand[key] = path.resolve(configDir, value);
+    }
+  }
+
+  return { brand, theme };
+}

--- a/plugins/ai-briefing/skills/ai-briefing/output/build/lib/paths.js
+++ b/plugins/ai-briefing/skills/ai-briefing/output/build/lib/paths.js
@@ -13,6 +13,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const BUILD_DIR = path.resolve(__dirname, "..");
 export const SKILL_ROOT = path.resolve(__dirname, "..", "..", "..");
 
+// Bundled default-profile config seed shipped with the plugin — the fallback
+// configDir() when no consumer project is present (in-repo / test runs).
+export const SEED_DIR = path.join(SKILL_ROOT, "seed");
+
 function envDir(name) {
   const v = process.env[name];
   return v && v.trim() ? v.trim() : null;
@@ -20,6 +24,17 @@ function envDir(name) {
 
 export function activeProfile() {
   return envDir("AI_BRIEFING_PROFILE") ?? "default";
+}
+
+// Tracked per-profile config directory under the consumer's project — the home
+// of the profile's brand.js overlay + logo assets. The default profile lives at
+// the folder root; a named profile overlays it in a subfolder. Mirrors
+// scripts/lib/paths.js configDir() so the build resolves the same config seam.
+export function configDir(profile = activeProfile()) {
+  const proj = envDir("CLAUDE_PROJECT_DIR");
+  if (!proj) return SEED_DIR;
+  const base = path.join(proj, ".claude", "ai-briefing");
+  return profile === "default" ? base : path.join(base, profile);
 }
 
 export function stateRoot(profile = activeProfile()) {

--- a/plugins/ai-briefing/skills/ai-briefing/output/build/test/brand-overlay.test.js
+++ b/plugins/ai-briefing/skills/ai-briefing/output/build/test/brand-overlay.test.js
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveBrand } from "../lib/brand-overlay.js";
+
+const DEFAULT_BRAND = {
+  org: "AI Briefing",
+  tagline: "AI industry news, aggregated and ranked.",
+  logoColor: "",
+  logoWhite: "",
+  footerTemplate: "{org} · AI Meeting #{meeting_n} · {date}",
+};
+
+const DEFAULT_THEME = { bg: "0F1424", accent: "6E8BFF", pptFontHead: "Arial" };
+
+/** Run `body(configDir)` against a throwaway profile dir containing `brand.js`
+ *  (when `overlaySource` is non-null), then clean it up. */
+async function withProfile(overlaySource, body) {
+  const dir = await mkdtemp(path.join(tmpdir(), "ai-briefing-brand-"));
+  try {
+    if (overlaySource !== null) {
+      await writeFile(path.join(dir, "brand.js"), overlaySource, "utf-8");
+    }
+    return await body(dir);
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}
+
+test("absent profile brand.js returns the neutral default unchanged", async () => {
+  await withProfile(null, async (configDir) => {
+    const { brand, theme } = await resolveBrand({
+      defaultBrand: DEFAULT_BRAND,
+      defaultTheme: DEFAULT_THEME,
+      configDir,
+    });
+    assert.equal(brand.org, "AI Briefing");
+    assert.equal(brand.logoColor, "");
+    assert.deepEqual(theme, DEFAULT_THEME);
+    // A copy, not the shared default object.
+    assert.notEqual(brand, DEFAULT_BRAND);
+    assert.notEqual(theme, DEFAULT_THEME);
+  });
+});
+
+test("profile overlay wins per key over the default for brand and theme", async () => {
+  const overlay = `
+    export const brand = { org: "SETWorks Engineering", tagline: "Empowering agencies." };
+    export const theme = { accent: "8080FF", pptFontHead: "Ubuntu" };
+  `;
+  await withProfile(overlay, async (configDir) => {
+    const { brand, theme } = await resolveBrand({
+      defaultBrand: DEFAULT_BRAND,
+      defaultTheme: DEFAULT_THEME,
+      configDir,
+    });
+    assert.equal(brand.org, "SETWorks Engineering");
+    assert.equal(brand.tagline, "Empowering agencies.");
+    // Unmentioned key falls through to the default.
+    assert.equal(brand.footerTemplate, DEFAULT_BRAND.footerTemplate);
+    assert.equal(theme.accent, "8080FF");
+    assert.equal(theme.pptFontHead, "Ubuntu");
+    assert.equal(theme.bg, "0F1424");
+  });
+});
+
+test("relative profile logo paths resolve to absolute against the profile dir", async () => {
+  const overlay = `
+    export const brand = {
+      org: "SETWorks Engineering",
+      logoColor: "assets/setworks-logo-color.png",
+      logoWhite: "assets/setworks-logo-white.png",
+    };
+  `;
+  await withProfile(overlay, async (configDir) => {
+    const { brand } = await resolveBrand({
+      defaultBrand: DEFAULT_BRAND,
+      defaultTheme: DEFAULT_THEME,
+      configDir,
+    });
+    assert.ok(path.isAbsolute(brand.logoColor));
+    assert.ok(path.isAbsolute(brand.logoWhite));
+    assert.equal(brand.logoColor, path.resolve(configDir, "assets/setworks-logo-color.png"));
+    // Downstream build scripts resolve against the build dir; an absolute path
+    // survives path.resolve unchanged — the whole point of anchoring here.
+    assert.equal(path.resolve("/some/build/dir", brand.logoColor), brand.logoColor);
+  });
+});
+
+test("an already-absolute profile logo path is left untouched", async () => {
+  const abs = path.join(path.sep, "opt", "brand", "logo.png");
+  const overlay = `export const brand = { logoWhite: ${JSON.stringify(abs)} };`;
+  await withProfile(overlay, async (configDir) => {
+    const { brand } = await resolveBrand({
+      defaultBrand: DEFAULT_BRAND,
+      defaultTheme: DEFAULT_THEME,
+      configDir,
+    });
+    assert.equal(brand.logoWhite, abs);
+  });
+});
+
+test("a present-but-malformed profile brand.js surfaces the error (no silent fallback)", async () => {
+  const overlay = "export const brand = { this is not valid javascript";
+  await withProfile(overlay, async (configDir) => {
+    await assert.rejects(() =>
+      resolveBrand({ defaultBrand: DEFAULT_BRAND, defaultTheme: DEFAULT_THEME, configDir }),
+    );
+  });
+});

--- a/plugins/ai-briefing/skills/ai-briefing/output/build/test/brand-overlay.test.js
+++ b/plugins/ai-briefing/skills/ai-briefing/output/build/test/brand-overlay.test.js
@@ -103,6 +103,24 @@ test("an already-absolute profile logo path is left untouched", async () => {
   });
 });
 
+test("overlay loads under an explicit CommonJS consumer package scope", async () => {
+  // A profile brand.js lives under the consumer project, whose nearest
+  // package.json governs `.js` module type. An explicit `"type":"commonjs"`
+  // makes a file-URL import of ESM `export const` throw SyntaxError; the data:
+  // URL load is scope-independent. Pin the scope to prove the fix.
+  const overlay = `export const brand = { org: "Scoped Co" };\nexport const theme = { accent: "AABBCC" };`;
+  await withProfile(overlay, async (configDir) => {
+    await writeFile(path.join(configDir, "package.json"), '{"type":"commonjs"}', "utf-8");
+    const { brand, theme } = await resolveBrand({
+      defaultBrand: DEFAULT_BRAND,
+      defaultTheme: DEFAULT_THEME,
+      configDir,
+    });
+    assert.equal(brand.org, "Scoped Co");
+    assert.equal(theme.accent, "AABBCC");
+  });
+});
+
 test("a present-but-malformed profile brand.js surfaces the error (no silent fallback)", async () => {
   const overlay = "export const brand = { this is not valid javascript";
   await withProfile(overlay, async (configDir) => {


### PR DESCRIPTION
## What

The published `ai-briefing` engine documents a per-profile `brand.js` overlay + logo assets, but the build pipeline never consumed it: `emit-slides-data.js` statically imported the engine's own neutral `./brand.js` and no build script carried a profile redirect. Result: a consuming project's profile brand + logos never applied — decks always rendered with the engine's neutral default, no matter `AI_BRIEFING_PROFILE`.

## Changes

- **`lib/paths.js`** — add `configDir()` (+ `SEED_DIR`), mirroring `scripts/lib/paths.js`, so the build resolves the same per-profile config seam: `CLAUDE_PROJECT_DIR` → `.claude/ai-briefing[/<profile>]`, `SEED_DIR` fallback in-repo.
- **`lib/brand-overlay.js`** (new) — `resolveBrand()` overlays a profile `brand.js` per key over the neutral default, for **both** the deck `meta` brand fields **and** `theme`. Absent overlay → default unchanged (the common unprofiled case). Present-but-malformed → the import error propagates (no silent fallback). Profile logo paths resolve to **absolute** against `configDir()`.
- **`emit-slides-data.js`** — resolve the overlay in `main()` and thread it through both the emitted `meta` and `theme`.
- **`test/brand-overlay.test.js`** (new) — default passthrough, per-key overlay (brand + theme), relative→absolute logo resolution, absolute-path passthrough, malformed-surface.

## Logo path resolution

Downstream build scripts resolve `meta.logo*` via `path.resolve(buildDir, meta.logo*)`. Emitting an **absolute** profile logo path makes that a no-op (`path.resolve` keeps a trailing absolute segment), so **no downstream build script needed changes**. Provider logos stay relative to the build dir — only the profile `logoColor`/`logoWhite` anchor to `configDir()`.

## Why `run.js` is unchanged

`run.js` spawns each build step via `spawnSync`, which inherits the parent env, so `AI_BRIEFING_PROFILE` propagates automatically; the sibling build scripts already load per-profile `slides-data.js` through `paths.js`. The only missing seam was brand-overlay resolution + the profile logo base, both added here.

## Contract verified against the real consumer

Checked against medley's merged `.claude/ai-briefing/setworks/brand.js` (cutover #1471): its `brand`/`theme` exports match the engine keys exactly and its logos are relative `assets/...` — the overlay applies cleanly.

## Test

`node --test` in the build dir: all pass (5 new overlay tests + existing parse-briefing suite).

Refs melodic-software/medley#1474

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the ai-briefing slide build and branding metadata; behavior is covered by new tests and fails loudly on bad overlays.
> 
> **Overview**
> The slide emitter no longer hardcodes the engine’s neutral `brand.js`; it now resolves the active profile’s `brand.js` from the consumer config seam and merges **brand** and **theme** into deck `meta` before validation and write.
> 
> **`lib/paths.js`** adds `configDir()` (and `SEED_DIR` when `CLAUDE_PROJECT_DIR` is unset) so the build uses the same `.claude/ai-briefing[/<profile>]` location as the rest of the plugin. **`lib/brand-overlay.js`** implements `resolveBrand()`: missing overlay → shallow copy of defaults; per-key overlay wins; relative `logoColor`/`logoWhite` become absolute under the profile dir so existing `path.resolve(buildDir, …)` embedding still works. Overlays load via a **base64 `data:` ESM import** so consumer projects with `"type":"commonjs"` don’t break file-URL imports. Invalid overlay JS rejects instead of falling back.
> 
> **`emit-slides-data.js`** calls `resolveBrand()` at startup and threads the result through slide context and emitted `meta`/`theme`. New **`brand-overlay.test.js`** covers passthrough, partial overlay, logo resolution, CJS scope, and malformed files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bcd87c67a7bc7cd0f25da69ddceb7db7a002107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->