### PR TITLE
fix(knowledge): harden youtube extraction pipeline (recovery, throttle, path safety)

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), and a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## 0.5.2
+
+### Fixed
+
+- **YouTube extraction — crash/incorrect-output paths on normal use.** Recovery
+  (`--recover`/`resume`) now accepts an auto-caption-only `*-orig.vtt` instead of
+  throwing `Missing mp4/vtt/info.json`; `watch.json` + tempSession are persisted
+  before the long extraction phase so an interrupt there stays recoverable;
+  exact cue/densification anchor timestamps survive the second dedup pass instead
+  of being replaced by fabricated ordinals; harvested GitHub deep links are cloned
+  from the canonical `https://github.com/<owner>/<repo>` URL rather than the
+  un-cloneable deep link; the documented `companion` Phase 0b marker is accepted;
+  recovery is no longer advertised when the acquisition `workDir` is gone;
+  `--skip-research` is persisted so resume doesn't re-route into research;
+  marking the terminal `synthesis` phase sets `watch.status` to `complete` so the
+  blocking checklist is enforced; `resume` advertises the on-disk continuation-prompt
+  path; the research gate requires a `research-agenda.md`; and contact-sheet snapshots
+  write a local `.gitignore` so the JPG binaries can't be committed.
+- **YouTube extraction — hardening.** Deck/attachment fetches stream to disk under a
+  500 MB cap (byte-counted, not just `content-length`) instead of buffering the whole
+  attacker-controlled response; the acquire throttle gained an optional overall
+  `timeoutMs` and heartbeats a held slot's mtime so a long download isn't misclassified
+  as stale and reclaimed; clone paths sanitize Windows-reserved characters; acquisition
+  forces `--no-playlist`; and a passing key-frame quality-audit row now requires a
+  substantive evidence note (an omitted note no longer bypasses the gate).
+
 ## 0.5.1
 
 ### Changed

--- a/plugins/knowledge/skills/youtube/extraction/acquisition/acquire-throttle.js
+++ b/plugins/knowledge/skills/youtube/extraction/acquisition/acquire-throttle.js
@@ -12,6 +12,9 @@ const DEFAULT_MAX_CONCURRENT = 1;
 const ABSOLUTE_MAX_CONCURRENT = 3;
 const LOCK_STALE_MS = 15 * 60 * 1000;
 const LOCK_POLL_MS = 250;
+// Refresh a held slot's mtime well inside the stale TTL so a long-running
+// acquisition is never misclassified as stale and reclaimed by a peer.
+const SLOT_HEARTBEAT_MS = 5 * 60 * 1000;
 
 /**
  * @returns {number}
@@ -70,6 +73,46 @@ async function isStaleSlot(slotPath) {
 }
 
 /**
+ * Bump a held slot's modification time to "now" so peers see it as live.
+ *
+ * @param {string} slotPath
+ * @returns {Promise<boolean>} true when the mtime was refreshed
+ */
+export async function refreshSlot(slotPath) {
+  const now = new Date();
+  try {
+    await fs.utimes(slotPath, now, now);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start an interval that heartbeats a held slot's mtime until stopped.
+ *
+ * @param {string} slotPath
+ * @param {number} intervalMs
+ * @returns {{ stop: () => void }}
+ */
+function startSlotHeartbeat(slotPath, intervalMs) {
+  if (!intervalMs || intervalMs <= 0) {
+    return { stop() {} };
+  }
+  const timer = setInterval(() => {
+    void refreshSlot(slotPath);
+  }, intervalMs);
+  if (typeof timer.unref === "function") {
+    timer.unref();
+  }
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+  };
+}
+
+/**
  * Run `fn` while holding one of `maxSlots` file-based acquire slots.
  *
  * @template T
@@ -77,13 +120,21 @@ async function isStaleSlot(slotPath) {
  * @param {object} [options]
  * @param {number} [options.maxSlots]
  * @param {typeof sleepMs} [options.sleep]
+ * @param {number|null} [options.timeoutMs] - throw if total slot-wait exceeds this; null = wait forever
+ * @param {number} [options.heartbeatMs] - interval to refresh the held slot's mtime
+ * @param {string} [options.baseDir] - lock directory (seam for tests)
  * @returns {Promise<T>}
  */
 export async function withAcquireThrottle(
   fn,
-  { maxSlots = resolveMaxConcurrentAcquires(), sleep = sleepMs } = {},
+  {
+    maxSlots = resolveMaxConcurrentAcquires(),
+    sleep = sleepMs,
+    timeoutMs = null,
+    heartbeatMs = SLOT_HEARTBEAT_MS,
+    baseDir = lockDirPath(),
+  } = {},
 ) {
-  const baseDir = lockDirPath();
   await fs.mkdir(baseDir, { recursive: true });
 
   /** @type {string[]} */
@@ -91,13 +142,17 @@ export async function withAcquireThrottle(
     path.join(baseDir, `slot-${index}`),
   );
 
+  let waitedMs = 0;
+
   // biome-ignore lint/suspicious/noUnnecessaryConditions: intentional lock poll loop
   while (true) {
     for (const slotPath of slotPaths) {
       if (await tryAcquireSlot(slotPath)) {
+        const heartbeat = startSlotHeartbeat(slotPath, heartbeatMs);
         try {
           return await fn();
         } finally {
+          heartbeat.stop();
           await releaseSlot(slotPath);
         }
       }
@@ -107,6 +162,13 @@ export async function withAcquireThrottle(
       }
     }
 
+    if (timeoutMs != null && waitedMs >= timeoutMs) {
+      throw new Error(
+        `withAcquireThrottle: timed out after ${waitedMs}ms waiting for an acquire slot (maxSlots=${maxSlots})`,
+      );
+    }
+
     await sleep(LOCK_POLL_MS);
+    waitedMs += LOCK_POLL_MS;
   }
 }

--- a/plugins/knowledge/skills/youtube/extraction/acquisition/acquire-throttle.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/acquisition/acquire-throttle.test.js
@@ -1,0 +1,84 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { refreshSlot, withAcquireThrottle } from "./acquire-throttle.js";
+
+/** @type {string} */
+let baseDir;
+
+beforeEach(async () => {
+  baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "acquire-throttle-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(baseDir, { recursive: true, force: true });
+});
+
+describe("withAcquireThrottle", () => {
+  it("runs fn while holding a slot, then releases it", async () => {
+    const result = await withAcquireThrottle(async () => "done", {
+      maxSlots: 1,
+      heartbeatMs: 0,
+      baseDir,
+    });
+
+    expect(result).toBe("done");
+    expect(fsSync.existsSync(path.join(baseDir, "slot-0"))).toBe(false);
+  });
+
+  it("reclaims a stale slot and proceeds", async () => {
+    const stale = path.join(baseDir, "slot-0");
+    await fs.mkdir(stale);
+    const longAgo = new Date(Date.now() - 20 * 60 * 1000); // older than the 15-min TTL
+    await fs.utimes(stale, longAgo, longAgo);
+
+    const fn = vi.fn(async () => "reclaimed");
+    const result = await withAcquireThrottle(fn, {
+      maxSlots: 1,
+      heartbeatMs: 0,
+      baseDir,
+      sleep: async () => {},
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result).toBe("reclaimed");
+  });
+
+  it("throws a descriptive timeout when a fresh slot stays held", async () => {
+    const held = path.join(baseDir, "slot-0");
+    await fs.mkdir(held); // fresh mtime — never stale during the test
+
+    await expect(
+      withAcquireThrottle(async () => "never", {
+        maxSlots: 1,
+        heartbeatMs: 0,
+        baseDir,
+        timeoutMs: 1000,
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/timed out after \d+ms/);
+  });
+});
+
+describe("refreshSlot", () => {
+  it("bumps a slot's mtime toward now", async () => {
+    const slot = path.join(baseDir, "slot-0");
+    await fs.mkdir(slot);
+    const longAgo = new Date(Date.now() - 20 * 60 * 1000);
+    await fs.utimes(slot, longAgo, longAgo);
+    const before = (await fs.stat(slot)).mtimeMs;
+
+    const ok = await refreshSlot(slot);
+
+    expect(ok).toBe(true);
+    expect((await fs.stat(slot)).mtimeMs).toBeGreaterThan(before);
+  });
+
+  it("returns false for a missing slot", async () => {
+    expect(await refreshSlot(path.join(baseDir, "nope"))).toBe(false);
+  });
+});

--- a/plugins/knowledge/skills/youtube/extraction/acquisition/build-yt-dlp-args.js
+++ b/plugins/knowledge/skills/youtube/extraction/acquisition/build-yt-dlp-args.js
@@ -92,6 +92,10 @@ export function buildYtDlpArgs(
   /** @type {string[]} */
   const args = [
     "--no-progress",
+    // A watch URL copied from a playlist carries `&list=…`; without this,
+    // yt-dlp would fetch every playlist entry into the same workDir and
+    // resolve artifacts for the wrong video (preflight already forces it).
+    "--no-playlist",
     "--paths",
     `temp:${workDir}`,
     "-o",

--- a/plugins/knowledge/skills/youtube/extraction/acquisition/build-yt-dlp-args.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/acquisition/build-yt-dlp-args.test.js
@@ -42,6 +42,15 @@ describe("buildYtDlpArgs", () => {
     expect(args.at(-1)).toBe(URL);
   });
 
+  it("forces --no-playlist so a playlist watch URL fetches only the one video", () => {
+    const args = buildYtDlpArgs("https://www.youtube.com/watch?v=abc&list=PL123", {
+      mode: "full",
+      outputTemplate: OUTPUT,
+      workDir: WORK_DIR,
+    });
+    expect(args).toContain("--no-playlist");
+  });
+
   it("omits caption flags in video-only mode", () => {
     const args = buildYtDlpArgs(URL, {
       mode: "video-only",

--- a/plugins/knowledge/skills/youtube/extraction/evals/check-research-complete.js
+++ b/plugins/knowledge/skills/youtube/extraction/evals/check-research-complete.js
@@ -7,6 +7,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { writeStderr } from "@melodic/video-digestion/shared/terminal";
 
@@ -37,44 +38,51 @@ export function checkResearchComplete(sliceDir) {
     return 1;
   }
 
-  if (fs.existsSync(agendaPath)) {
-    const agenda = fs.readFileSync(agendaPath, "utf8");
-    const pendingRows = (agenda.match(/\|\s*pending\s*\|/gi) ?? []).length;
-    if (pendingRows > 0) {
-      writeStderr(`FAIL: ${pendingRows} research-agenda rows still pending`);
-      return 1;
-    }
+  // The agenda is required, not optional: without it the gate previously fell
+  // through to success with no auditable claim-resolution plan.
+  if (!fs.existsSync(agendaPath)) {
+    writeStderr(`FAIL: missing ${agendaPath}`);
+    return 1;
+  }
 
-    const openClaims = (agenda.match(/\|\s*T2\s*\|\s*$/gm) ?? []).length;
-    if (openClaims > 0) {
-      writeStderr(`WARN: ${openClaims} agenda rows may still be T2-only — verify promotion`);
-    }
+  const agenda = fs.readFileSync(agendaPath, "utf8");
+  const pendingRows = (agenda.match(/\|\s*pending\s*\|/gi) ?? []).length;
+  if (pendingRows > 0) {
+    writeStderr(`FAIL: ${pendingRows} research-agenda rows still pending`);
+    return 1;
+  }
 
-    const doneRows = (agenda.match(/\|\s*done\s*\|/gi) ?? []).length;
-    const deferredRows = (agenda.match(/\|\s*deferred\s*\|/gi) ?? []).length;
-    const findingsDir = lanePath(sliceDir, LANES.research, "findings");
-    const findingCount = fs.existsSync(findingsDir)
-      ? fs.readdirSync(findingsDir).filter((name) => name.endsWith(".md")).length
-      : 0;
-    if (doneRows > 0 && findingCount < doneRows) {
-      writeStderr(
-        `FAIL: research-findings count (${findingCount}) < done agenda rows (${doneRows})`,
-      );
-      return 1;
-    }
-    if (doneRows + deferredRows === 0) {
-      writeStderr("FAIL: research-agenda has no done or deferred rows");
-      return 1;
-    }
+  const openClaims = (agenda.match(/\|\s*T2\s*\|\s*$/gm) ?? []).length;
+  if (openClaims > 0) {
+    writeStderr(`WARN: ${openClaims} agenda rows may still be T2-only — verify promotion`);
+  }
+
+  const doneRows = (agenda.match(/\|\s*done\s*\|/gi) ?? []).length;
+  const deferredRows = (agenda.match(/\|\s*deferred\s*\|/gi) ?? []).length;
+  const findingsDir = lanePath(sliceDir, LANES.research, "findings");
+  const findingCount = fs.existsSync(findingsDir)
+    ? fs.readdirSync(findingsDir).filter((name) => name.endsWith(".md")).length
+    : 0;
+  if (doneRows > 0 && findingCount < doneRows) {
+    writeStderr(`FAIL: research-findings count (${findingCount}) < done agenda rows (${doneRows})`);
+    return 1;
+  }
+  if (doneRows + deferredRows === 0) {
+    writeStderr("FAIL: research-agenda has no done or deferred rows");
+    return 1;
   }
 
   return 0;
 }
 
-const sliceDir = process.argv[2];
-if (!sliceDir) {
-  writeStderr("Usage: node evals/check-research-complete.js <slice-dir>");
-  process.exit(2);
-}
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
 
-process.exitCode = checkResearchComplete(sliceDir);
+if (isMain) {
+  const sliceDir = process.argv[2];
+  if (!sliceDir) {
+    writeStderr("Usage: node evals/check-research-complete.js <slice-dir>");
+    process.exit(2);
+  }
+  process.exitCode = checkResearchComplete(sliceDir);
+}

--- a/plugins/knowledge/skills/youtube/extraction/evals/check-research-complete.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/evals/check-research-complete.test.js
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { checkResearchComplete } from "./check-research-complete.js";
+
+describe("checkResearchComplete agenda gate", () => {
+  /** @type {string} */
+  let sliceDir;
+
+  beforeEach(() => {
+    sliceDir = fs.mkdtempSync(path.join(os.tmpdir(), "check-research-"));
+    fs.mkdirSync(path.join(sliceDir, "research"), { recursive: true });
+    fs.writeFileSync(path.join(sliceDir, "RESEARCH.md"), "R".repeat(250));
+    fs.writeFileSync(path.join(sliceDir, "research", "claim-inventory.md"), "# claims\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(sliceDir, { recursive: true, force: true });
+  });
+
+  /** @param {string} body */
+  function writeAgenda(body) {
+    fs.writeFileSync(path.join(sliceDir, "research", "research-agenda.md"), body);
+  }
+
+  /** @param {number} count */
+  function writeFindings(count) {
+    const dir = path.join(sliceDir, "research", "findings");
+    fs.mkdirSync(dir, { recursive: true });
+    for (let i = 0; i < count; i++) {
+      fs.writeFileSync(path.join(dir, `finding-${i}.md`), "# finding\n");
+    }
+  }
+
+  it("fails when the agenda file is missing", () => {
+    expect(checkResearchComplete(sliceDir)).toBe(1);
+  });
+
+  it("fails when an agenda row is still pending", () => {
+    writeAgenda("| claim | T1 | pending |\n");
+    expect(checkResearchComplete(sliceDir)).toBe(1);
+  });
+
+  it("passes with a resolved agenda backed by a finding", () => {
+    writeAgenda("| claim | T1 | done |\n");
+    writeFindings(1);
+    expect(checkResearchComplete(sliceDir)).toBe(0);
+  });
+});

--- a/plugins/knowledge/skills/youtube/extraction/harvesting/analyze-harvested-repos.js
+++ b/plugins/knowledge/skills/youtube/extraction/harvesting/analyze-harvested-repos.js
@@ -38,6 +38,18 @@ export async function shallowCloneGitHubRepo(url, destDir, spawnFn = spawn) {
 }
 
 /**
+ * Sanitize an owner/repo segment for use as a filesystem path component.
+ * GitHub disallows Windows-reserved chars (`: * ? " < > |`), but a crafted
+ * deep link could smuggle them in and break `path.join`/`fs` on Windows.
+ *
+ * @param {string} segment
+ * @returns {string}
+ */
+export function sanitizePathSegment(segment) {
+  return segment.replace(/[^\w.-]/g, "_");
+}
+
+/**
  * @param {Array<{ url: string }>} links
  * @returns {string[]}
  */
@@ -81,8 +93,14 @@ export async function analyzeHarvestedRepos(
       const parsed = parseGitHubUrl(url);
       if (!parsed) continue;
 
-      const cloneDir = path.join(tempRoot, `${parsed.owner}-${parsed.repo}`);
-      const cloned = await clone(url, cloneDir);
+      const cloneDir = path.join(
+        tempRoot,
+        `${sanitizePathSegment(parsed.owner)}-${sanitizePathSegment(parsed.repo)}`,
+      );
+      // Clone the canonical repo URL, not the harvested deep link (e.g.
+      // `.../blob/main/README.md`), which git cannot clone.
+      const cloneUrl = `https://github.com/${parsed.owner}/${parsed.repo}`;
+      const cloned = await clone(cloneUrl, cloneDir);
       if (!cloned) continue;
 
       analyses.push({

--- a/plugins/knowledge/skills/youtube/extraction/harvesting/analyze-harvested-repos.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/harvesting/analyze-harvested-repos.test.js
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { filterGitHubUrls } from "./analyze-harvested-repos.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  analyzeHarvestedRepos,
+  filterGitHubUrls,
+  sanitizePathSegment,
+} from "./analyze-harvested-repos.js";
 
 describe("filterGitHubUrls", () => {
   it("should keep unique GitHub URLs only", () => {
@@ -13,5 +21,47 @@ describe("filterGitHubUrls", () => {
       "https://github.com/org/repo",
       "https://github.com/org/repo.git",
     ]);
+  });
+});
+
+describe("sanitizePathSegment", () => {
+  it("replaces Windows-reserved and path-breaking chars with underscores", () => {
+    expect(sanitizePathSegment('a:b*c?d"e<f>g|h')).toBe("a_b_c_d_e_f_g_h");
+  });
+
+  it("preserves word chars, dots, and hyphens", () => {
+    expect(sanitizePathSegment("Org-Name.v2")).toBe("Org-Name.v2");
+  });
+});
+
+describe("analyzeHarvestedRepos clone target", () => {
+  /** @type {string} */
+  let sliceDir;
+
+  beforeEach(() => {
+    sliceDir = fs.mkdtempSync(path.join(os.tmpdir(), "harvested-repos-test-"));
+    fs.mkdirSync(path.join(sliceDir, "source"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(sliceDir, { recursive: true, force: true });
+  });
+
+  it("clones the canonical repo URL built from parsed parts, not the harvested deep link", async () => {
+    fs.writeFileSync(
+      path.join(sliceDir, "source", "harvested-links.json"),
+      JSON.stringify([{ url: "https://github.com/melodic-software/medley/blob/main/README.md" }]),
+    );
+
+    /** @type {string[]} */
+    const clonedUrls = [];
+    await analyzeHarvestedRepos(sliceDir, {
+      clone: async (url) => {
+        clonedUrls.push(url);
+        return false; // skip structure detection; only the clone target matters here
+      },
+    });
+
+    expect(clonedUrls).toEqual(["https://github.com/melodic-software/medley"]);
   });
 });

--- a/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.js
+++ b/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.js
@@ -21,8 +21,10 @@ export const MAX_ATTACHMENT_BYTES = 500 * 1024 * 1024;
 /**
  * Stream a WHATWG response body to disk, aborting past `maxBytes`. Enforces the
  * cap on the actual byte count (a missing/lying `content-length` cannot bypass
- * it) and removes the partial file on failure so a truncated download never
- * masquerades as a complete attachment.
+ * it). Writes to a `.partial` sidecar and renames on success, so a mid-stream
+ * failure (including the cap firing after headers passed) removes only the
+ * partial — a previously-fetched attachment at `destPath` survives a failed
+ * retry, preserving the old buffered implementation's idempotency.
  *
  * @param {ReadableStream} webStream
  * @param {string} destPath
@@ -41,10 +43,12 @@ async function streamToFileWithCap(webStream, destPath, maxBytes) {
       callback(null, chunk);
     },
   });
+  const partialPath = `${destPath}.partial`;
   try {
-    await pipeline(Readable.fromWeb(webStream), cap, fs.createWriteStream(destPath));
+    await pipeline(Readable.fromWeb(webStream), cap, fs.createWriteStream(partialPath));
+    fs.renameSync(partialPath, destPath);
   } catch (error) {
-    fs.rmSync(destPath, { force: true });
+    fs.rmSync(partialPath, { force: true });
     throw error;
   }
 }

--- a/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.js
+++ b/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.js
@@ -7,11 +7,47 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 
 import { writeStderr, writeStdout } from "@melodic/video-digestion/shared/terminal";
 
 import { LANES, lanePath } from "../lib/slice-lanes.js";
+
+/** Default cap on a single fetched attachment; links come from attacker-controlled video descriptions. */
+export const MAX_ATTACHMENT_BYTES = 500 * 1024 * 1024;
+
+/**
+ * Stream a WHATWG response body to disk, aborting past `maxBytes`. Enforces the
+ * cap on the actual byte count (a missing/lying `content-length` cannot bypass
+ * it) and removes the partial file on failure so a truncated download never
+ * masquerades as a complete attachment.
+ *
+ * @param {ReadableStream} webStream
+ * @param {string} destPath
+ * @param {number} maxBytes
+ * @returns {Promise<void>}
+ */
+async function streamToFileWithCap(webStream, destPath, maxBytes) {
+  let bytes = 0;
+  const cap = new Transform({
+    transform(chunk, _encoding, callback) {
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        callback(new Error(`response exceeded ${maxBytes} bytes`));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+  try {
+    await pipeline(Readable.fromWeb(webStream), cap, fs.createWriteStream(destPath));
+  } catch (error) {
+    fs.rmSync(destPath, { force: true });
+    throw error;
+  }
+}
 
 /**
  * @param {string} url
@@ -29,10 +65,13 @@ function slugFromUrl(url) {
 
 /**
  * @param {string} sliceDir
- * @param {{ dryRun?: boolean }} [options]
+ * @param {{ dryRun?: boolean, maxBytes?: number }} [options]
  * @returns {Promise<{ fetched: string[], skipped: string[] }>}
  */
-export async function fetchDeckAttachments(sliceDir, { dryRun = false } = {}) {
+export async function fetchDeckAttachments(
+  sliceDir,
+  { dryRun = false, maxBytes = MAX_ATTACHMENT_BYTES } = {},
+) {
   const absSlice = path.resolve(sliceDir);
   const linksPath = lanePath(absSlice, LANES.source, "harvested-links.json");
   if (!fs.existsSync(linksPath)) {
@@ -75,8 +114,16 @@ export async function fetchDeckAttachments(sliceDir, { dryRun = false } = {}) {
         skipped.push(`${url}: HTTP ${response.status}`);
         continue;
       }
-      const buffer = Buffer.from(await response.arrayBuffer());
-      fs.writeFileSync(destPath, buffer);
+      const declaredLen = Number(response.headers.get("content-length") ?? 0);
+      if (declaredLen > maxBytes) {
+        skipped.push(`${url}: too large (content-length ${declaredLen} > ${maxBytes})`);
+        continue;
+      }
+      if (!response.body) {
+        skipped.push(`${url}: empty response body`);
+        continue;
+      }
+      await streamToFileWithCap(response.body, destPath, maxBytes);
       fetched.push(destPath);
     } catch (error) {
       skipped.push(`${url}: ${error instanceof Error ? error.message : String(error)}`);

--- a/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.test.js
@@ -92,6 +92,30 @@ describe("fetchDeckAttachments", () => {
     expect(leftovers).toEqual([]);
   });
 
+  it("preserves a previously-fetched attachment when a retry stream fails", async () => {
+    writeLinks([{ type: "attachment", url: "https://example.com/spec.pdf" }]);
+    const destPath = path.join(
+      sliceDir,
+      "source",
+      "attachments",
+      "attachment",
+      "spec.pdf",
+    );
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.writeFileSync(destPath, "previously-good-content");
+
+    // Retry that overruns the cap mid-stream — must not clobber the good file.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(Buffer.from("x".repeat(100)))),
+    );
+
+    const result = await fetchDeckAttachments(sliceDir, { maxBytes: 10 });
+
+    expect(result.fetched).toHaveLength(0);
+    expect(fs.readFileSync(destPath, "utf8")).toBe("previously-good-content");
+  });
+
   it("skips a non-ok HTTP response", async () => {
     writeLinks([{ type: "attachment", url: "https://example.com/missing.pdf" }]);
     vi.stubGlobal(

--- a/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/harvesting/fetch-deck-attachments.test.js
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Readable } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchDeckAttachments } from "./fetch-deck-attachments.js";
+
+/**
+ * @param {Buffer} buffer
+ * @param {{ ok?: boolean, status?: number, contentLength?: string | null }} [meta]
+ */
+function fakeResponse(buffer, { ok = true, status = 200, contentLength } = {}) {
+  const headers = new Headers();
+  if (contentLength !== undefined && contentLength !== null) {
+    headers.set("content-length", contentLength);
+  }
+  return {
+    ok,
+    status,
+    headers,
+    body: ok ? Readable.toWeb(Readable.from(buffer)) : null,
+  };
+}
+
+describe("fetchDeckAttachments", () => {
+  /** @type {string} */
+  let sliceDir;
+
+  beforeEach(() => {
+    sliceDir = fs.mkdtempSync(path.join(os.tmpdir(), "fetch-deck-test-"));
+    fs.mkdirSync(path.join(sliceDir, "source"), { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fs.rmSync(sliceDir, { recursive: true, force: true });
+  });
+
+  /**
+   * @param {Array<Record<string, unknown>>} links
+   */
+  function writeLinks(links) {
+    fs.writeFileSync(
+      path.join(sliceDir, "source", "harvested-links.json"),
+      JSON.stringify(links),
+    );
+  }
+
+  it("streams a normal attachment to disk", async () => {
+    writeLinks([{ type: "attachment", url: "https://example.com/spec.pdf" }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(Buffer.from("hello world"), { contentLength: "11" })),
+    );
+
+    const result = await fetchDeckAttachments(sliceDir);
+
+    expect(result.fetched).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+    expect(fs.readFileSync(result.fetched[0], "utf8")).toBe("hello world");
+  });
+
+  it("skips when content-length exceeds the cap without downloading", async () => {
+    writeLinks([{ type: "attachment", url: "https://example.com/huge.zip" }]);
+    const fetchMock = vi.fn(async () =>
+      fakeResponse(Buffer.from("x".repeat(50)), { contentLength: "9999999" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchDeckAttachments(sliceDir, { maxBytes: 10 });
+
+    expect(result.fetched).toHaveLength(0);
+    expect(result.skipped[0]).toMatch(/too large/);
+  });
+
+  it("aborts and removes the partial file when the streamed body exceeds the cap", async () => {
+    writeLinks([{ type: "attachment", url: "https://example.com/lying.bin" }]);
+    // No content-length header — the byte-counting cap must catch it mid-stream.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(Buffer.from("x".repeat(100)))),
+    );
+
+    const result = await fetchDeckAttachments(sliceDir, { maxBytes: 10 });
+
+    expect(result.fetched).toHaveLength(0);
+    expect(result.skipped[0]).toMatch(/exceeded 10 bytes/);
+    const attachmentsDir = path.join(sliceDir, "source", "attachments", "attachment");
+    const leftovers = fs.existsSync(attachmentsDir) ? fs.readdirSync(attachmentsDir) : [];
+    expect(leftovers).toEqual([]);
+  });
+
+  it("skips a non-ok HTTP response", async () => {
+    writeLinks([{ type: "attachment", url: "https://example.com/missing.pdf" }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse(Buffer.from(""), { ok: false, status: 404 })),
+    );
+
+    const result = await fetchDeckAttachments(sliceDir);
+
+    expect(result.fetched).toHaveLength(0);
+    expect(result.skipped[0]).toMatch(/HTTP 404/);
+  });
+
+  it("skips when fetch itself rejects", async () => {
+    writeLinks([{ type: "attachment", url: "https://example.com/boom.pdf" }]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+
+    const result = await fetchDeckAttachments(sliceDir);
+
+    expect(result.fetched).toHaveLength(0);
+    expect(result.skipped[0]).toMatch(/network down/);
+  });
+});

--- a/plugins/knowledge/skills/youtube/extraction/lib/watch-vision-validation.js
+++ b/plugins/knowledge/skills/youtube/extraction/lib/watch-vision-validation.js
@@ -303,7 +303,10 @@ export function validateQualityAudit(doc) {
     if (typeof f.pass !== "boolean") {
       errors.push(`files[${i}].pass must be boolean`);
     }
-    if (f.pass === true && typeof f.note === "string" && isStubQualityAuditNote(f.note)) {
+    // A passing row must carry a substantive note: an omitted note (not a
+    // string) or a stub/short one both fail — this is the evidence the gate
+    // exists to enforce exactly when pass=true claims review happened.
+    if (f.pass === true && (typeof f.note !== "string" || isStubQualityAuditNote(f.note))) {
       errors.push(`files[${i}].note must be substantive (min 20 chars, not stub token)`);
     }
   }

--- a/plugins/knowledge/skills/youtube/extraction/lib/watch-vision-validation.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/lib/watch-vision-validation.test.js
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { forbiddenSynthesisFileNameReason } from "./synthesis-filename.js";
 import {
   validatePromotionDecisions,
+  validateQualityAudit,
   validateTriageBatchFiles,
   validateTriageSheet,
 } from "./watch-vision-validation.js";
@@ -85,6 +86,42 @@ describe("validatePromotionDecisions", () => {
           session: "opening",
         },
       ],
+    });
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("validateQualityAudit note enforcement", () => {
+  const reviewedAt = "2026-01-01T00:00:00.000Z";
+
+  it("rejects a passing row with the note omitted", () => {
+    const errors = validateQualityAudit({
+      reviewedAt,
+      files: [{ name: "demo.png", pass: true }],
+    });
+    expect(errors).toContain("files[0].note must be substantive (min 20 chars, not stub token)");
+  });
+
+  it("rejects a passing row with a stub note", () => {
+    const errors = validateQualityAudit({
+      reviewedAt,
+      files: [{ name: "demo.png", pass: true, note: "ok" }],
+    });
+    expect(errors).toContain("files[0].note must be substantive (min 20 chars, not stub token)");
+  });
+
+  it("accepts a passing row with a substantive note", () => {
+    const errors = validateQualityAudit({
+      reviewedAt,
+      files: [{ name: "demo.png", pass: true, note: "Sharp architecture diagram with legible labels" }],
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("does not require a note on a failing row", () => {
+    const errors = validateQualityAudit({
+      reviewedAt,
+      files: [{ name: "demo.png", pass: false }],
     });
     expect(errors).toEqual([]);
   });

--- a/plugins/knowledge/skills/youtube/extraction/watch/detect-recoverable-bootstrap.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/detect-recoverable-bootstrap.js
@@ -22,9 +22,11 @@ import { watchStatePath } from "./watch-state.js";
 function workDirComplete(workDir) {
   if (!workDir || !fs.existsSync(workDir)) return false;
   const entries = fs.readdirSync(workDir);
+  // Any `.vtt` (including the `*-orig.vtt` auto-caption) counts — recovery
+  // rebuilds transcript from it, matching resolveWorkArtifacts' fallback.
   return (
     entries.some((n) => n.endsWith(".mp4")) &&
-    entries.some((n) => n.endsWith(".vtt") && !n.includes("-orig")) &&
+    entries.some((n) => n.endsWith(".vtt")) &&
     entries.some((n) => n.endsWith(".info.json"))
   );
 }
@@ -78,16 +80,14 @@ export function detectRecoverableBootstrap(sliceDir) {
 
   const hasFrames = frameCount > 0;
   const hasSheets = sheetCount > 0;
-  const recoverable = hasFrames && hasSheets;
+  // recover-watch-bootstrap.js reads mp4/vtt/info.json from workDir and throws
+  // when they are gone, so a slice is only recoverable when workDir survives
+  // too — advertising recovery without it hands the user a command that fails.
+  const recoverable = hasFrames && hasSheets && hasWork;
 
-  let reason;
-  if (recoverable && hasWork) {
-    reason = "temp dirs have video, frames, and contact sheets";
-  } else if (recoverable) {
-    reason = "temp dirs have frames and contact sheets (transcript may exist in slice)";
-  } else {
-    reason = `insufficient temp artifacts (frames=${frameCount}, sheets=${sheetCount}, work=${hasWork})`;
-  }
+  const reason = recoverable
+    ? "temp dirs have video, frames, and contact sheets"
+    : `insufficient temp artifacts (frames=${frameCount}, sheets=${sheetCount}, work=${hasWork})`;
 
   return {
     recoverable,

--- a/plugins/knowledge/skills/youtube/extraction/watch/detect-recoverable-bootstrap.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/detect-recoverable-bootstrap.test.js
@@ -8,6 +8,7 @@ import {
   detectRecoverableBootstrap,
   formatRecoverCommand,
 } from "./detect-recoverable-bootstrap.js";
+import { resolveWorkArtifacts } from "./recover-watch-bootstrap.js";
 
 describe("detectRecoverableBootstrap", () => {
   it("returns not recoverable when watching complete", () => {
@@ -51,5 +52,77 @@ describe("detectRecoverableBootstrap", () => {
     const result = detectRecoverableBootstrap(tmp);
     expect(result.recoverable).toBe(true);
     expect(formatRecoverCommand(tmp)).toContain("recover-watch-bootstrap.js");
+  });
+
+  it("accepts an auto-caption-only workDir (*-orig.vtt)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "detect-recover-"));
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-extraction-"));
+    const framesDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-frames-"));
+    const sheetsDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-sheets-"));
+
+    fs.writeFileSync(path.join(workDir, "video.mp4"), "x");
+    fs.writeFileSync(path.join(workDir, "captions.en-orig.vtt"), "WEBVTT\n");
+    fs.writeFileSync(path.join(workDir, "meta.info.json"), "{}");
+    fs.writeFileSync(path.join(framesDir, "anchor_00010000_0001.png"), "x");
+    fs.writeFileSync(path.join(sheetsDir, "sheet_001.jpg"), "x");
+
+    fs.mkdirSync(path.join(tmp, "run-state"));
+    fs.writeFileSync(
+      path.join(tmp, "run-state", "watch.json"),
+      JSON.stringify({
+        phases: {},
+        tempSession: { workDir, framesDir, contactSheetsDir: sheetsDir },
+      }),
+    );
+
+    expect(detectRecoverableBootstrap(tmp).recoverable).toBe(true);
+  });
+
+  it("is not recoverable when workDir is gone even if frames+sheets survive", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "detect-recover-"));
+    const framesDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-frames-"));
+    const sheetsDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-sheets-"));
+
+    fs.writeFileSync(path.join(framesDir, "anchor_00010000_0001.png"), "x");
+    fs.writeFileSync(path.join(sheetsDir, "sheet_001.jpg"), "x");
+
+    fs.mkdirSync(path.join(tmp, "run-state"));
+    fs.writeFileSync(
+      path.join(tmp, "run-state", "watch.json"),
+      JSON.stringify({
+        phases: {},
+        tempSession: {
+          workDir: path.join(os.tmpdir(), "youtube-extraction-gone-9999"),
+          framesDir,
+          contactSheetsDir: sheetsDir,
+        },
+      }),
+    );
+
+    const result = detectRecoverableBootstrap(tmp);
+    expect(result.recoverable).toBe(false);
+    expect(formatRecoverCommand(tmp)).toBe("");
+  });
+});
+
+describe("resolveWorkArtifacts", () => {
+  it("resolves an auto-caption-only workDir via the *-orig.vtt fallback", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-extraction-"));
+    fs.writeFileSync(path.join(workDir, "video.mp4"), "x");
+    fs.writeFileSync(path.join(workDir, "captions.en-orig.vtt"), "WEBVTT\n");
+    fs.writeFileSync(path.join(workDir, "meta.info.json"), "{}");
+
+    const artifacts = resolveWorkArtifacts(workDir);
+    expect(artifacts.vttPath.endsWith("captions.en-orig.vtt")).toBe(true);
+  });
+
+  it("prefers a cleaned .vtt over the -orig auto-caption when both exist", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "youtube-extraction-"));
+    fs.writeFileSync(path.join(workDir, "video.mp4"), "x");
+    fs.writeFileSync(path.join(workDir, "captions.en-orig.vtt"), "WEBVTT\n");
+    fs.writeFileSync(path.join(workDir, "captions.en.vtt"), "WEBVTT\n");
+    fs.writeFileSync(path.join(workDir, "meta.info.json"), "{}");
+
+    expect(resolveWorkArtifacts(workDir).vttPath.endsWith("captions.en.vtt")).toBe(true);
   });
 });

--- a/plugins/knowledge/skills/youtube/extraction/watch/recover-watch-bootstrap.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/recover-watch-bootstrap.js
@@ -88,10 +88,15 @@ function loadExistingContactSheets(contactSheetsDir, batches) {
  * @param {string} workDir
  * @returns {{ videoPath: string, vttPath: string, infoPath: string }}
  */
-function resolveWorkArtifacts(workDir) {
+export function resolveWorkArtifacts(workDir) {
   const entries = fs.readdirSync(workDir);
   const videoPath = entries.find((name) => name.endsWith(".mp4"));
-  const vttPath = entries.find((name) => name.endsWith(".vtt") && !name.includes("-orig"));
+  // Prefer a manual/cleaned caption, but fall back to the `*-orig.vtt` the
+  // caption ladder keeps for auto-caption-only videos — the original
+  // acquisition used it, so recovery must accept it too.
+  const vttPath =
+    entries.find((name) => name.endsWith(".vtt") && !name.includes("-orig")) ??
+    entries.find((name) => name.endsWith(".vtt"));
   const infoPath = entries.find((name) => name.endsWith(".info.json"));
   if (!videoPath || !vttPath || !infoPath) {
     throw new Error(`Missing mp4/vtt/info.json in ${workDir}`);

--- a/plugins/knowledge/skills/youtube/extraction/watch/run-resume.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/run-resume.js
@@ -18,6 +18,7 @@ import {
 } from "./detect-recoverable-bootstrap.js";
 import {
   buildContinuationPrompt,
+  continuationPromptPath,
   findNextPhase,
   readWatchState,
   writeContinuationPrompt,
@@ -54,7 +55,7 @@ export async function runResumeCli(argv) {
         status: state.status,
         nextPhase,
         frameSelection: state.frameSelection ?? null,
-        continuationPromptPath: path.join(sliceDir, "continuation-prompt.md"),
+        continuationPromptPath: continuationPromptPath(sliceDir),
         continuationPrompt,
         recoverableBootstrap: recovery.recoverable,
         recoverCommand: recovery.recoverable ? formatRecoverCommand(sliceDir) : null,

--- a/plugins/knowledge/skills/youtube/extraction/watch/run-watch.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/run-watch.js
@@ -104,6 +104,7 @@ export async function runWatchCli(argv) {
     });
     state.tempSession = tempSession;
     state.status = "acquiring";
+    state.skipResearch = skipResearch;
     state = markPhaseComplete(state, "acquire", {
       videoDownloaded: Boolean(artifacts.videoPath),
       captionRung: caption.rung,
@@ -129,6 +130,12 @@ export async function runWatchCli(argv) {
       endSec: cue.endSec,
       text: cue.text,
     }));
+
+    // Persist state + tempSession before the long extraction phase so an
+    // interrupt during ffmpeg/contact-sheet work leaves a watch.json that
+    // detectRecoverableBootstrap can discover (it requires the file to exist).
+    state.status = "watching";
+    await writeWatchState(sliceDir, state);
 
     const watching = await orchestrateWatching({
       videoPath: artifacts.videoPath,
@@ -167,6 +174,12 @@ export async function runWatchCli(argv) {
     const harvestPath = lanePath(sliceDir, LANES.source, "harvested-links.json");
     await fs.writeFile(harvestPath, `${JSON.stringify(harvestedLinks, null, 2)}\n`, "utf8");
     state = markPhaseComplete(state, "harvest", { linkCount: harvestedLinks.length });
+
+    // Record the skip in the phase map so resume (which derives nextPhase from
+    // watch.json alone) advances past research instead of re-routing into it.
+    if (skipResearch) {
+      state = markPhaseComplete(state, "research", { skipped: true });
+    }
 
     await writeWatchState(sliceDir, state);
     const continuationPrompt = await writeContinuationPrompt(sliceDir, state);

--- a/plugins/knowledge/skills/youtube/extraction/watch/snapshot-bootstrap.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/snapshot-bootstrap.js
@@ -34,6 +34,11 @@ export function snapshotBootstrapContactSheets(sliceDir) {
   const destDir = lanePath(absSlice, LANES.keyFrames, "contact-sheets");
   fs.mkdirSync(destDir, { recursive: true });
 
+  // These contact-sheet JPGs are local-only disaster-recovery snapshots and
+  // must never enter git — write a local ignore in case the consuming repo
+  // doesn't already ignore .work, so staging slice artifacts can't commit them.
+  fs.writeFileSync(path.join(destDir, ".gitignore"), "*.jpg\n", "utf8");
+
   const sheets = fs
     .readdirSync(contactSheetsDir)
     .filter((name) => /^sheet_\d+\.jpg$/i.test(name))

--- a/plugins/knowledge/skills/youtube/extraction/watch/snapshot-bootstrap.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/snapshot-bootstrap.test.js
@@ -38,4 +38,21 @@ describe("snapshotBootstrapContactSheets", () => {
     expect(meta.sourceDir).toMatch(/^\{tmp\}\//);
     expect(meta.sourceDir).not.toMatch(/AppData|[/\\]Temp[/\\]/);
   });
+
+  it("writes a local .gitignore excluding the snapshot JPG binaries", () => {
+    mkdirSync(join(sliceDir, "run-state"), { recursive: true });
+    writeFileSync(
+      join(sliceDir, "run-state", "watch.json"),
+      `${JSON.stringify({ tempSession: { contactSheetsDir: sheetsDir } }, null, 2)}\n`,
+      "utf8",
+    );
+
+    snapshotBootstrapContactSheets(sliceDir);
+
+    const ignore = readFileSync(
+      join(sliceDir, "key-frames", "contact-sheets", ".gitignore"),
+      "utf8",
+    );
+    expect(ignore).toContain("*.jpg");
+  });
 });

--- a/plugins/knowledge/skills/youtube/extraction/watch/watch-state.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/watch-state.js
@@ -28,6 +28,7 @@ import { YOUTUBE_WATCH_EPIC_DIR } from "../transcript/derive-video-slug.js";
  * @property {PhaseRecord|null} watching
  * @property {PhaseRecord|null} vision
  * @property {PhaseRecord|null} harvest
+ * @property {PhaseRecord|null} companion - optional Phase 0b digest of source/companion-sources.md
  * @property {PhaseRecord|null} research
  * @property {PhaseRecord|null} synthesis
  */
@@ -40,6 +41,7 @@ import { YOUTUBE_WATCH_EPIC_DIR } from "../transcript/derive-video-slug.js";
  * @property {string} title
  * @property {'pending'|'acquiring'|'watching'|'vision'|'researching'|'synthesizing'|'complete'} status
  * @property {WatchPhases} phases
+ * @property {boolean} [skipResearch] - user passed --skip-research; research phase is recorded as skipped
  * @property {object} [frameSelection]
  * @property {number} [frameSelection.selectedCount]
  * @property {number} [frameSelection.softCap]
@@ -81,6 +83,7 @@ export function createWatchState({ videoId, videoSlug, sourceUrl, title }) {
       watching: null,
       vision: null,
       harvest: null,
+      companion: null,
       research: null,
       synthesis: null,
     },
@@ -141,7 +144,9 @@ export function buildContinuationPrompt(state) {
   const next = findNextPhase(state.phases);
   const completed = Object.entries(state.phases)
     .filter(([, value]) => value !== null)
-    .map(([name]) => name);
+    .map(([name, value]) =>
+      /** @type {PhaseRecord} */ (value)?.metrics?.skipped ? `${name} (skipped)` : name,
+    );
 
   return `# Continue /youtube watch — ${state.title}
 
@@ -242,13 +247,19 @@ export async function writeContinuationPrompt(
   return prompt;
 }
 
-/** Phases that may be marked via the CLI — guards against typo'd phase keys. */
+/**
+ * Phases that may be marked via the CLI — guards against typo'd phase keys.
+ * `companion` is an optional Phase 0b side-marker (not in the sequential
+ * {@link findNextPhase} order): markable when `source/companion-sources.md`
+ * exists, absent from the next-phase walk so a no-companion watch is unaffected.
+ */
 const MARKABLE_PHASES = /** @type {(keyof WatchPhases)[]} */ ([
   "acquire",
   "transcript",
   "watching",
   "vision",
   "harvest",
+  "companion",
   "research",
   "synthesis",
 ]);
@@ -284,7 +295,13 @@ export async function runMarkPhase(sliceDir, phase, { readFile, writeFile, mkdir
     return 0;
   }
 
-  const next = markPhaseComplete(state, phase);
+  let next = markPhaseComplete(state, phase);
+  // Marking the terminal phase closes the slice: flip status to "complete" so
+  // validateWatchChecklistForCompleteSlice enforces the blocking checklist
+  // (it skips unless status === "complete").
+  if (phase === "synthesis") {
+    next = { ...next, status: "complete" };
+  }
   await writeWatchState(sliceDir, next, writeFile, mkdir);
   writeStdout(`mark-phase: ${phase} marked complete\n`);
   return 0;

--- a/plugins/knowledge/skills/youtube/extraction/watch/watch-state.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/watch/watch-state.test.js
@@ -253,6 +253,81 @@ describe("mark-phase CLI (idempotent)", () => {
   });
 });
 
+describe("companion phase (optional side-marker)", () => {
+  function seededStore() {
+    const sliceDir = "/tmp/slice";
+    const state = sampleTalk();
+    const store = new Map([[watchStatePath(sliceDir), `${JSON.stringify(state, null, 2)}\n`]]);
+    const readFile = vi.fn(async (p) => {
+      const value = store.get(p);
+      if (value === undefined) throw new Error("ENOENT");
+      return value;
+    });
+    const writeFile = vi.fn(async (p, data) => {
+      store.set(p, data);
+    });
+    const mkdir = vi.fn(async () => {});
+    return { sliceDir, store, readFile, writeFile, mkdir };
+  }
+
+  it("accepts mark-phase companion", async () => {
+    const { sliceDir, store, readFile, writeFile, mkdir } = seededStore();
+    const code = await runMarkPhase(sliceDir, "companion", { readFile, writeFile, mkdir });
+    expect(code).toBe(0);
+    const persisted = JSON.parse(store.get(watchStatePath(sliceDir)));
+    expect(persisted.phases.companion).not.toBeNull();
+  });
+
+  it("does not appear in the sequential next-phase walk", () => {
+    let state = sampleTalk();
+    // A no-companion watch that completed acquire..harvest must advance to research,
+    // never stall on an unmarked optional companion slot.
+    for (const phase of ["acquire", "transcript", "watching", "vision", "harvest"]) {
+      state = markPhaseComplete(state, phase);
+    }
+    expect(state.phases.companion).toBeNull();
+    expect(findNextPhase(state.phases)).toBe("research");
+  });
+});
+
+describe("terminal phase completes the slice", () => {
+  it("flips status to complete when synthesis is marked", async () => {
+    const sliceDir = "/tmp/slice";
+    let state = sampleTalk();
+    for (const phase of ["acquire", "transcript", "watching", "vision", "harvest", "research"]) {
+      state = markPhaseComplete(state, phase);
+    }
+    const store = new Map([[watchStatePath(sliceDir), `${JSON.stringify(state, null, 2)}\n`]]);
+    const readFile = vi.fn(async (p) => store.get(p));
+    const writeFile = vi.fn(async (p, data) => store.set(p, data));
+    const mkdir = vi.fn(async () => {});
+
+    await runMarkPhase(sliceDir, "synthesis", { readFile, writeFile, mkdir });
+
+    expect(JSON.parse(store.get(watchStatePath(sliceDir))).status).toBe("complete");
+  });
+});
+
+describe("skip-research phase map (resume routing)", () => {
+  it("advances past research to synthesis when research is marked skipped", () => {
+    let state = sampleTalk();
+    for (const phase of ["acquire", "transcript", "watching", "vision", "harvest"]) {
+      state = markPhaseComplete(state, phase);
+    }
+    state = markPhaseComplete(state, "research", { skipped: true });
+    expect(findNextPhase(state.phases)).toBe("synthesis");
+  });
+
+  it("annotates a skipped research phase in the continuation prompt", () => {
+    let state = { ...sampleTalk(), skipResearch: true };
+    for (const phase of ["acquire", "transcript", "watching", "vision", "harvest"]) {
+      state = markPhaseComplete(state, phase);
+    }
+    state = markPhaseComplete(state, "research", { skipped: true });
+    expect(buildContinuationPrompt(state)).toContain("research (skipped)");
+  });
+});
+
 describe("watch state persistence (real filesystem)", () => {
   it("creates the run-state lane dir when writing into a fresh slice", async () => {
     // Regression: a fresh slice has no run-state/ subdir; the live watch ENOENT'd on

--- a/plugins/knowledge/skills/youtube/extraction/watching/orchestrate-watching.js
+++ b/plugins/knowledge/skills/youtube/extraction/watching/orchestrate-watching.js
@@ -110,6 +110,20 @@ export async function orchestrateWatching(
   const mergedPaths = mergedCandidates.map((frame) => frame.path);
   const dedupResult = await runDedup(mergedPaths, {}, { log });
 
+  // The deduplicator reconstructs frames from bare paths with timestampSec=null,
+  // dropping the exact cue/densification anchor times. Re-attach them by path so
+  // assignFrameTimestamps only fabricates ordinals for the truly-unknown frames.
+  const knownTimestampByPath = new Map(
+    mergedCandidates
+      .filter((frame) => frame.timestampSec != null)
+      .map((frame) => [frame.path, frame.timestampSec]),
+  );
+  for (const frame of dedupResult.unique) {
+    if (frame.timestampSec == null && knownTimestampByPath.has(frame.path)) {
+      frame.timestampSec = knownTimestampByPath.get(frame.path);
+    }
+  }
+
   assignFrameTimestamps(dedupResult.unique, durationSec);
 
   const scored = dedupResult.unique.map((frame, index) => {

--- a/plugins/knowledge/skills/youtube/extraction/watching/orchestrate-watching.test.js
+++ b/plugins/knowledge/skills/youtube/extraction/watching/orchestrate-watching.test.js
@@ -64,4 +64,61 @@ describe("orchestrateWatching", () => {
     expect(state.contactSheets).toHaveLength(1);
     expect(state.overCap).toBe(false);
   });
+
+  it("preserves exact anchor timestamps through the second dedup pass", async () => {
+    const extractSceneFrames = vi.fn(async () => ({
+      method: "scene-detection",
+      count: 2,
+      sceneCount: 2,
+      frames: [
+        { path: "/tmp/scene_0001.png", file: "scene_0001.png", timestampSec: null },
+        { path: "/tmp/scene_0002.png", file: "scene_0002.png", timestampSec: null },
+      ],
+    }));
+
+    // Mirrors the real deduplicator: rebuilds frames from bare paths with
+    // timestampSec=null, discarding any anchor time the caller had attached.
+    const deduplicateFrames = vi.fn(async (paths) => ({
+      frames: paths,
+      unique: paths.map((framePath) => ({
+        path: framePath,
+        file: framePath.split("/").pop(),
+        timestampSec: null,
+      })),
+      total: paths.length,
+      duplicates: 0,
+    }));
+
+    const createContactSheet = vi.fn(async (paths, outputPath) => ({
+      outputPath,
+      inputPaths: paths,
+      frameCount: paths.length,
+    }));
+    const probeVideoDuration = vi.fn(async () => ({ durationSec: 120, formatName: "mp4" }));
+    // 73s is deliberately off the ordinal grid (duration/frameCount) so a
+    // fabricated timestamp could never coincidentally equal it.
+    const extractAnchorFrames = vi.fn(async () => [
+      { path: "/tmp/anchor_0073.png", file: "anchor_0073.png", timestampSec: 73, isInterval: false },
+    ]);
+
+    const state = await orchestrateWatching(
+      {
+        videoPath: "/tmp/video.mp4",
+        framesDir: "/tmp/frames",
+        contactSheetsDir: "/tmp/sheets",
+        cues: [{ startSec: 10, endSec: 20, text: "Let me show you this code demo" }],
+      },
+      {
+        extractSceneFrames,
+        deduplicateFrames,
+        createContactSheet,
+        probeVideoDuration,
+        extractAnchorFrames,
+        log: { info: vi.fn(), warn: vi.fn() },
+      },
+    );
+
+    const anchor = state.uniqueFrames.find((frame) => frame.path === "/tmp/anchor_0073.png");
+    expect(anchor?.timestampSec).toBe(73);
+  });
 });


### PR DESCRIPTION
## What

Fixes latent behavior gaps in the `knowledge` plugin's youtube extraction pipeline (`plugins/knowledge/skills/youtube/extraction/`), surfaced by the Claude + Codex bot reviews on #102 and deferred from the youtube retrofit — a migration changes location, not behavior, so these were held out of that PR and fixed here where the plugin is canonical.

## Higher priority — crash / incorrect output on normal-use paths

- **A** — recovery accepts an auto-caption-only `*-orig.vtt` (both the recover and detect predicates) instead of throwing `Missing mp4/vtt/info.json` on resume.
- **B** — `watch.json` + tempSession are persisted **before** the long ffmpeg/contact-sheet phase, so an interrupt there leaves a slice `detectRecoverableBootstrap` can discover.
- **C** — exact cue/densification anchor timestamps are re-attached by path after the second dedup pass, instead of being replaced by fabricated ordinals.
- **D** — harvested GitHub deep links are cloned from the canonical `https://github.com/<owner>/<repo>` URL, not the un-cloneable deep link.
- **L** — the documented `companion` Phase 0b marker is accepted (added to the phase map + `mark-phase` allow-list; deliberately **not** in the sequential next-phase walk, so a no-companion watch is unaffected).
- **M** — recovery is gated on a surviving `workDir` (`hasWork` in the predicate), so `resume` no longer advertises a recovery command that immediately fails.
- **N** — acquisition forces `--no-playlist` so a `watch?v=…&list=…` URL fetches only the one video.
- **O** — `--skip-research` is recorded in the phase map (research marked skipped) so `resume` advances past research instead of re-routing into it.
- **P** — marking the terminal `synthesis` phase sets `watch.status = "complete"`, so `validateWatchChecklistForCompleteSlice` enforces the blocking checklist.
- **Q** — `resume` advertises the on-disk `run-state/continuation-prompt.md` path via the same helper `run-watch` writes with.
- **R** — the research gate requires `research-agenda.md` (previously it fell through to success when the agenda was absent).
- **S** — snapshot contact sheets write a local `.gitignore` so the JPG binaries can't be committed.

## Hardening

- **F** — deck/attachment fetches stream to disk under a **byte-counted** 500 MB cap (a missing/lying `content-length` can't bypass it; partial file removed on abort), instead of buffering the whole attacker-controlled response.
- **G/H** — the acquire throttle gained an optional overall `timeoutMs` and heartbeats a held slot's mtime, so a long download isn't misclassified as stale and reclaimed by a peer.
- **J** — clone paths sanitize Windows-reserved characters.
- **K** — a passing key-frame quality-audit row now requires a substantive evidence note (an **omitted** note no longer bypasses the gate).

**E** (non-default `library_dir` → `--work-root` wiring) was already fully implemented on `main` — verified both the code (`run.mjs`, `work-root.js`, `run-args`) and the `SKILL.md` doc side (every `run.mjs` site documents the leading `--work-root`). No change needed.

## Out of scope

- **I** (the hidden 500-frame ceiling in the vendored `video-digestion/frames/scene-detect.js`) is **not** in this PR. Its SSOT lives in medley `tools/shared/video-digestion` and PR #149 established that the plugin's `vendor/` copy has **no automated re-vendor path** from medley. Fixing it here would mean editing the plugin copy as source (violating SSOT-first) or hand-transcribing across repos. It is carved to a dedicated follow-up requiring a medley-SSOT edit + re-vendor.

## Tests

Every fix has coverage — new suites for `fetch-deck-attachments`, `acquire-throttle`, and `check-research-complete`, plus regression cases added to the existing suites. Full extraction suite: **253 passing**; `tsc --noEmit` clean; `claude plugin validate` passes.

Delivery: `knowledge` **0.5.1 → 0.5.2** with a CHANGELOG entry (behavior fixes reach consumers only via a version bump).

Refs melodic-software/medley#1439

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recovery, resume routing, and untrusted URL fetch paths across the YouTube pipeline; changes are well-tested but affect long-running watch workflows and concurrent acquisition behavior.
> 
> **Overview**
> Bumps the **knowledge** plugin to **0.5.2** with a broad fix pass on the YouTube extraction pipeline—recovery/resume correctness, watch phase state, and defensive limits on untrusted inputs.
> 
> **Recovery and resume** now treat auto-caption-only `*-orig.vtt` like a full caption set, require a surviving acquisition `workDir` before advertising bootstrap recovery, and persist `watch.json` + `tempSession` before the long ffmpeg/contact-sheet phase. Anchor/cue timestamps are reattached after the second dedup pass so they are not replaced by ordinal guesses. `--skip-research` is stored on state and recorded as a skipped research phase so resume skips research; marking **synthesis** sets `watch.status` to `complete` so the blocking checklist gate runs. `resume` reports the real `continuation-prompt.md` path; optional **companion** is markable without blocking the main phase order.
> 
> **Acquisition and harvest** add `--no-playlist` on yt-dlp, acquire-slot heartbeats plus optional wait `timeoutMs`, canonical GitHub clone URLs (not deep links) with sanitized path segments, and streamed deck/attachment downloads with a 500 MB byte cap.
> 
> **Gates and hygiene** require `research-agenda.md` for research completion, enforce substantive notes on passing quality-audit rows, and write `*.jpg` into a local `.gitignore` when snapshotting contact sheets.
> 
> New/expanded Vitest coverage backs the throttle, attachment fetch, research gate, recovery, watch-state, and orchestration changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a9329610a54e239bf5419d1a0c7466261cb03b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->