### PR TITLE
fix(ai-briefing): correct reversed ok() args in grok-capture-agent.test.js

### DIFF
--- a/plugins/ai-briefing/skills/ai-briefing/scripts/grok-capture-agent.test.js
+++ b/plugins/ai-briefing/skills/ai-briefing/scripts/grok-capture-agent.test.js
@@ -8,7 +8,8 @@ import { captureProfileViaGrok } from "./lib/grok-capture-agent.js";
 import { createTestReporter } from "./lib/terminal.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const { ok, printResults } = createTestReporter();
+const reporter = createTestReporter();
+const { ok } = reporter;
 
 async function testDryRun() {
   const r = await captureProfileViaGrok({
@@ -56,5 +57,5 @@ async function testGrokCheck() {
 await testDryRun();
 await testRunnerSubcommandDryRun();
 await testGrokCheck();
-const failCount = printResults("grok-capture-agent.test.js");
-process.exit(failCount > 0 ? 1 : 0);
+reporter.printResults();
+process.exit(reporter.fail > 0 ? 1 : 0);

--- a/plugins/ai-briefing/skills/ai-briefing/scripts/grok-capture-agent.test.js
+++ b/plugins/ai-briefing/skills/ai-briefing/scripts/grok-capture-agent.test.js
@@ -16,8 +16,8 @@ async function testDryRun() {
     cutoffIso: "2026-06-01T00:00:00.000Z",
     dryRun: true,
   });
-  ok(r.posts.n === 0, "dry-run returns empty posts");
-  ok(r.slug === "xai", "slugifies handle");
+  ok("dry-run returns empty posts", r.posts.n === 0);
+  ok("slugifies handle", r.slug === "xai");
 }
 
 async function testRunnerSubcommandDryRun() {
@@ -35,10 +35,10 @@ async function testRunnerSubcommandDryRun() {
     ],
     { encoding: "utf-8", cwd: __dirname },
   );
-  ok(r.status === 0, `init exit 0 (got ${r.status})`);
+  ok(`init exit 0 (got ${r.status})`, r.status === 0);
   const json = JSON.parse(r.stdout.trim().split("\n").pop());
-  ok(typeof json.config.grok_preload === "boolean", "grok_preload boolean in config");
-  ok(json.config.grok_preload_requested === true, "grok_preload_requested tracked");
+  ok("grok_preload boolean in config", typeof json.config.grok_preload === "boolean");
+  ok("grok_preload_requested tracked", json.config.grok_preload_requested === true);
 }
 
 async function testGrokCheck() {
@@ -47,10 +47,10 @@ async function testGrokCheck() {
     encoding: "utf-8",
     cwd: __dirname,
   });
-  ok(r.status === 0, "grok-check exit 0");
+  ok("grok-check exit 0", r.status === 0);
   const json = JSON.parse(r.stdout.trim());
-  ok(typeof json.ready === "boolean", "grok-check has ready");
-  ok(json.required_for_briefing === false, "grok not required for briefing");
+  ok("grok-check has ready", typeof json.ready === "boolean");
+  ok("grok not required for briefing", json.required_for_briefing === false);
 }
 
 await testDryRun();

--- a/plugins/ai-briefing/skills/ai-briefing/scripts/package.json
+++ b/plugins/ai-briefing/skills/ai-briefing/scripts/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "run": "node per-profile-runner.js",
     "dry-run": "node per-profile-runner.js init --dry-run --scope=test --force",
-    "test": "node chrome-extraction.test.js && node chunked-retrieval.test.js && node synthesize-categorize-contracts.test.js && node stage-cli-orchestration.test.js && node mid-run-resume.test.js && node anti-bot-pause.test.js && node retry-failed-audit.test.js && node grok-wave0-orchestration.test.js"
+    "test": "node chrome-extraction.test.js && node chunked-retrieval.test.js && node synthesize-categorize-contracts.test.js && node stage-cli-orchestration.test.js && node mid-run-resume.test.js && node anti-bot-pause.test.js && node retry-failed-audit.test.js && node grok-wave0-orchestration.test.js && node grok-capture-agent.test.js"
   },
   "dependencies": {
     "zod": "^4.0.0"


### PR DESCRIPTION
## What

`grok-capture-agent.test.js` called the reporter as `ok(cond, label)` in all nine assertions, but the signature is `ok(label, cond, detail)` (`lib/terminal.js`). The boolean landed in the `label` slot and the non-empty description string landed in `cond` (always truthy) — every assertion fake-passed regardless of the real condition.

## Change

- Swap all nine `ok()` calls to `(label, cond)`.
- Add `grok-capture-agent.test.js` to the `scripts` npm `test` script so the corrected assertions run in the per-plugin migration gate.

## Verification

`npm test` in `plugins/ai-briefing/skills/ai-briefing/scripts` (with `CLAUDE_PLUGIN_DATA` / `CLAUDE_PROJECT_DIR` unset) — full suite green; the new file reports 8 pass / 0 fail with conditions now actually evaluated.

Refs melodic-software/medley#1480

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production runtime impact; improves CI signal for Grok capture contracts.
> 
> **Overview**
> Fixes **silent test failures** in `grok-capture-agent.test.js` by aligning all nine `ok()` calls with `createTestReporter()`’s `ok(label, cond, detail)` contract in `lib/terminal.js`. Previously `ok(cond, label)` treated the description string as the condition (always truthy), so assertions never failed.
> 
> Also switches teardown to `reporter.printResults()` and `process.exit(reporter.fail > 0 ? 1 : 0)`, and **appends** `grok-capture-agent.test.js` to the `scripts` package `npm test` chain so these checks run in the migration gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 964591c14751a06aedd166c0a17a989513fff15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->