### PR TITLE
chore(work-items,wayfind): align plugins to reconciled label taxonomy

### DIFF
--- a/plugins/planning/skills/wayfind/SKILL.md
+++ b/plugins/planning/skills/wayfind/SKILL.md
@@ -72,9 +72,11 @@ an interactive session — do not fabricate a map.
 1. **Survey + fog test.** Ground in the effort (read any existing `.work/<slug>/`, recent
    commits, the topic). Sort every uncertainty through the fog test: sharp → candidate
    decision item; foggy → *Not-yet-specified* prose.
-2. **Create or extend the map issue.** On first use in a repo, bootstrap the wayfind label
-   taxonomy (`work-map`, `wayfind:*`, `needs-human`) create-if-missing — a fresh repo won't have
-   them and an unknown `--label` fails the create. Then create one issue labelled bare `work-map`
+2. **Create or extend the map issue.** On first use in a repo, **verify** the wayfind label
+   taxonomy (`work-map`, `wayfind:*`, `needs-human`) is present — an unknown `--label` fails the
+   create. Labels are provisioned by the label-as-code SSOT (github-iac, the sole writer), never
+   created ad hoc: if any are missing, STOP and report them for a github-iac PR (or the repo's
+   own provisioning for an opt-out repo). Then create one issue labelled bare `work-map`
    (+ any repo program labels). Body carries the five sections — **Destination** (where this is going once the
    fog clears) / **Notes** (pointers to `.work/` artifacts, research, prior context) /
    **Decisions-so-far** (a *pointer index* — each resolved decision's home is its own item's

--- a/plugins/planning/skills/wayfind/SKILL.md
+++ b/plugins/planning/skills/wayfind/SKILL.md
@@ -100,8 +100,8 @@ an interactive session — do not fabricate a map.
    non-interactive session, further filter OUT `needs-human` items; if that empties the
    frontier, STOP with a truthful "all remaining decisions need a human" — never resolve a
    HITL item by standing in for the human.
-3. **Pick one and claim it** (sibling claim model — `status:claimed` label + `@me` assignee +
-   comment-ID collision check; see [`context/tracker-mechanics.md`](context/tracker-mechanics.md)).
+3. **Pick one and claim it** (sibling claim model — `@me` assignee + claim-comment lease with
+   comment-order collision check, no claim label; see [`context/tracker-mechanics.md`](context/tracker-mechanics.md)).
 4. **Route by type** — invoke the target skill directly; its own Q&A supplies the HITL loop:
 
    | Type label | Mode | Routes to |

--- a/plugins/planning/skills/wayfind/context/tracker-mechanics.md
+++ b/plugins/planning/skills/wayfind/context/tracker-mechanics.md
@@ -109,8 +109,10 @@ gh issue edit <item#> --add-assignee "@me"
 # 3. Collision check via claim-comment ORDER (not assignees). The EARLIEST claim comment wins.
 gh issue view <item#> --json comments \
   --jq '[.comments[] | select(.body | startswith("🔒 claim:"))] | sort_by(.createdAt) | .[0].body' | tr -d '\r'
-#    If the earliest claim comment is NOT yours (marker mismatch): back off — remove ONLY your own
-#    assignee, delete your claim comment, and pick the next frontier item.
+#    If the earliest claim comment is NOT yours (marker mismatch): back off — delete your claim
+#    comment and pick the next frontier item. Do NOT clear the assignee: a same-identity `@me`
+#    collision means the assignee slot is shared with the winner, so removing it would also
+#    un-claim their item and let it re-enter the frontier out from under them.
 ```
 
 Session-start `reclaim` is idempotent: clear your own assignee (and claim comment) on items you

--- a/plugins/planning/skills/wayfind/context/tracker-mechanics.md
+++ b/plugins/planning/skills/wayfind/context/tracker-mechanics.md
@@ -110,9 +110,11 @@ gh issue edit <item#> --add-assignee "@me"
 gh issue view <item#> --json comments \
   --jq '[.comments[] | select(.body | startswith("🔒 claim:"))] | sort_by(.createdAt) | .[0].body' | tr -d '\r'
 #    If the earliest claim comment is NOT yours (marker mismatch): back off — delete your claim
-#    comment and pick the next frontier item. Do NOT clear the assignee: a same-identity `@me`
-#    collision means the assignee slot is shared with the winner, so removing it would also
-#    un-claim their item and let it re-enter the frontier out from under them.
+#    comment. Re-read assignees (step 1's command): if another login besides your own is present
+#    (a foreign race — the winner assigned under a different identity), remove ONLY your own
+#    assignee. If you are the item's sole assignee, leave it: a same-identity `@me` collision
+#    means that slot is shared with the winner, so removing it would also un-claim their item and
+#    let it re-enter the frontier out from under them. Either way, pick the next frontier item.
 ```
 
 Session-start `reclaim` is idempotent: clear your own assignee (and claim comment) on items you

--- a/plugins/planning/skills/wayfind/context/tracker-mechanics.md
+++ b/plugins/planning/skills/wayfind/context/tracker-mechanics.md
@@ -19,14 +19,18 @@ or every item whose blocker ever closed is stranded off the frontier forever.
 
 ## Bootstrap labels (first use in a repo)
 
-`/wayfind` introduces its own taxonomy — `work-map`, `wayfind:research|interview|design|prototype|task`,
-`needs-human` — which a fresh consumer repo will NOT already have (unlike the type/status labels
-`/work-items` reuses). Create-if-missing them once at chart-mode entry, before the first `gh issue
-create --label` (an unknown `--label` fails the create):
+`/wayfind` uses its own taxonomy — `work-map`, `wayfind:research|interview|design|prototype|task`,
+`needs-human`. These labels are provisioned by the label-as-code SSOT (`melodic-software/github-iac`,
+the **sole writer**), never created ad hoc — an out-of-band `gh label create` is pruned on the next
+`pulumi up`. At chart-mode entry, **verify** the taxonomy is present (an unknown `--label` fails the
+`gh issue create`); if any are missing, stop and have them added via a github-iac PR (or, for a
+`ManagedLabels: false` opt-out repo, the repo's own provisioning) — do not create them locally:
 
 ```shell
+# Presence check only — never create. Report any missing labels for github-iac to provision.
+have=$(gh label list --json name --jq '.[].name')
 for L in work-map wayfind:research wayfind:interview wayfind:design wayfind:prototype wayfind:task needs-human; do
-  gh label list --json name --jq '.[].name' | grep -qxF "$L" || gh label create "$L" --description "wayfind decision-map taxonomy"
+  grep -qxF "$L" <<<"$have" || echo "MISSING (provision via github-iac): $L"
 done
 ```
 
@@ -92,25 +96,24 @@ neither can tell who won. The discriminator is the claim comment — GitHub time
 the earliest wins. Embed a per-session marker in the comment so you can recognize your own.
 
 ```shell
-# 1. Pre-check (read): not already claimed/assigned by someone else.
-gh issue view <item#> --json assignees,labels \
-  --jq '{assignees:[.assignees[].login], claimed:([.labels[].name]|any(.=="status:claimed"))}' | tr -d '\r'
+# 1. Pre-check (read): not already assigned by someone else. The claim is assignee + lease —
+#    there is NO claim label.
+gh issue view <item#> --json assignees \
+  --jq '{assignees:[.assignees[].login]}' | tr -d '\r'
 
-# 2. Ensure the claim label exists, post a claim marker comment (embed a per-session marker),
-#    then assign self + label. @me MUST be the session identity so the timeline is honest.
-gh label list --json name --jq '.[].name' | grep -qxF status:claimed || gh label create status:claimed --description "Claimed by a work session"
+# 2. Post a claim marker comment (the lease — embed a per-session marker), then assign self.
+#    @me MUST be the session identity so the timeline is honest.
 gh issue comment <item#> --body "🔒 claim: <session-marker>"
-gh issue edit <item#> --add-label status:claimed --add-assignee "@me"
+gh issue edit <item#> --add-assignee "@me"
 
 # 3. Collision check via claim-comment ORDER (not assignees). The EARLIEST claim comment wins.
 gh issue view <item#> --json comments \
   --jq '[.comments[] | select(.body | startswith("🔒 claim:"))] | sort_by(.createdAt) | .[0].body' | tr -d '\r'
 #    If the earliest claim comment is NOT yours (marker mismatch): back off — remove ONLY your own
-#    assignee (never the shared status:claimed label the winner holds), delete your claim comment,
-#    and pick the next frontier item.
+#    assignee, delete your claim comment, and pick the next frontier item.
 ```
 
-Session-start `reclaim` is idempotent: clear your own `status:claimed` + assignee on items you
+Session-start `reclaim` is idempotent: clear your own assignee (and claim comment) on items you
 hold that have no in-progress signal (open PR / branch pushes / recent comments), noting the
 release in a comment.
 
@@ -120,8 +123,7 @@ release in a comment.
 # 1. Resolution comment on the item (the decision's durable home).
 gh issue comment <item#> --body "Resolved: <decision> — <one-line basis>"
 # 2. Add the one-line pointer to the map's Decisions-so-far index (edit the map body).
-# 3. Close the item.
-gh issue edit <item#> --remove-label status:claimed
+# 3. Close the item (closing removes it from the frontier — the claim is assignee + lease, no label to clear).
 gh issue close <item#> --reason completed
 ```
 

--- a/plugins/work-items/skills/setup/SKILL.md
+++ b/plugins/work-items/skills/setup/SKILL.md
@@ -74,17 +74,19 @@ empty `{"items": []}` skeleton so the recurring actions stop degrading.
      `last_checked` to today (setup did no maintenance). Blindly resetting the dates would drop an
      already-overdue item out of the `due` / `work` recurring tiers, which both select on
      `next_due <= today`.
-4. **Ensure the `recurring` label exists — it is load-bearing, not optional.** `due` / `work`
+4. **Check the `recurring` label is present — it is load-bearing, not optional.** `due` / `work`
    enumerate open maintenance items by the `recurring` label (adapter: "List items", `--label
    recurring`), and the create path filters out labels the repo lacks — so if you write a schedule while
    the `recurring` label is absent, the first `[Maintenance]` item created (by the recurring automation
    or the `work` due-recurring tier) lands without that label, is invisible to the next `due` / `work`
-   pass, and gets duplicated or reported as orphaned. When the label is missing, create it once through
-   the bound provider (a provider label op — for the GitHub adapter, `gh label create recurring`; see
-   the adapter's operations reference) — recommend this and default to it. If the user declines, tell
-   them plainly that the schedule cannot be reconciled until the label exists, and do not silently treat
-   it as optional. The `cadence:{cadence}` labels are taxonomy niceties (not required for
-   reconciliation) — offer to create the missing ones, or note their absence. This step files no items;
+   pass, and gets duplicated or reported as orphaned. Verify presence via the adapter's label listing
+   (for the GitHub adapter, `gh label list`). **Labels are provisioned by the label-as-code SSOT
+   (`melodic-software/github-iac`), the sole writer — never `gh label create` them ad hoc** (an
+   out-of-band label is pruned on the next `pulumi up`). When `recurring` is missing, tell the user
+   plainly that the schedule cannot be reconciled until the label is added via a github-iac PR (or, for
+   a `ManagedLabels: false` opt-out repo, through the repo's own provisioning); do not silently treat it
+   as optional. The `cadence:{cadence}` labels are taxonomy niceties (not required for reconciliation) —
+   note their absence the same way if they are missing. This step files no items;
    for a row now in the schedule, its `[Maintenance]` item is created — item only, no extra schedule
    row — by the consuming repo's recurring automation or the `work` due-recurring tier when `next_due`
    arrives. Do **not** point users at `add --recurring` to create it: that per-item path appends another

--- a/plugins/work-items/skills/work-items/SKILL.md
+++ b/plugins/work-items/skills/work-items/SKILL.md
@@ -18,18 +18,18 @@ This skill manages **development work items** — maintenance tasks, feature req
 
 **Default = fix, not file.** Do NOT reflexively suggest `/work-items:work-items add` or `/work-items:work-items scan` for small / medium drift discovered while working. Boy Scout scope (cosmetic, stale counts, broken links, single-line corrections, one-paragraph clarifications) belongs in the current change, not the tracker. File NEW items only when the work is genuinely orthogonal to the current session, large enough to need its own `/architect` plan, or needs research the current session isn't positioned to do. Auto-suggesting `add` for fixable scope is the failure mode this rule prevents. When in doubt, fix in-place and surface what was fixed in the commit message / PR description.
 
-**Label taxonomy.** Work items use an 8-group label prefix structure — UNIVERSAL groups (work in any repo) plus REPO-SPECIFIC groups carrying this repo's concrete values. The full member list (including this repo's populated `area:` / `category:` / `ecosystem:` / `cadence:` values) lives in [`reference/label-taxonomy.md`](reference/label-taxonomy.md).
+**Label taxonomy.** Work items are classified along a prefix-axis grammar — UNIVERSAL axes (work in any repo) plus REPO-SPECIFIC axes carrying this repo's concrete values. Members are **not** snapshotted here: on org repos the universal axes are owned by the label-as-code SSOT (`melodic-software/github-iac`, the sole writer) and discovered live (`gh label list`); the **type axis is a native GitHub Issue Type** (`Bug`/`Feature`/`Task`), not a label, on org repos. The grammar and citations live in [`reference/label-taxonomy.md`](reference/label-taxonomy.md).
 
-| Group | Prefix | Scope | Examples |
-|-------|--------|-------|----------|
-| Type | `type:` | universal | `type:feat`, `type:fix`, `type:chore`, `type:docs`, `type:refactor`, `type:test`, `type:build`, `type:perf` (Conventional Commits) |
-| Priority | `priority:` | universal | `priority:p0-critical` through `priority:p3-low` |
-| Status | `status:` | universal | `status:needs-triage`, `status:considering`, `status:claimed`, `status:blocked`, `status:needs-info` |
+| Axis | Mechanism | Scope | What it encodes |
+|------|-----------|-------|-----------------|
+| Type | native Issue Type (org) · `type:` label (personal) | universal | `Bug` / `Feature` / `Task` — the kind of issue; commit-type granularity stays at the commit layer |
+| Priority | `priority:` | universal | urgency — members from the live set / github-iac |
+| Status | `status:` | universal | exception + gate flags only (`needs-info`, `needs-decision`, `ready`, `needs-triage`); claim = assignee + lease, blocked = native edge (neither is a label) |
 | Meta | (none) | universal | `automated`, `recurring`, `agent-ready`, `needs-human`, `good-first-issue`, `migrated`, `stale` |
 | Area | `area:` | repo-specific | the consuming repo's architecture surface — see `reference/label-taxonomy.md` |
 | Category | `category:` | repo-specific | the consuming repo's domain categorization — see `reference/label-taxonomy.md` |
 | Ecosystem | `ecosystem:` | repo-specific | the consuming repo's language/toolchain mix — see `reference/label-taxonomy.md` |
-| Cadence | `cadence:` | repo-specific | e.g. `cadence:weekly`, `cadence:monthly` — full set in `reference/label-taxonomy.md` |
+| Cadence | `cadence:` | repo-specific | e.g. `cadence:weekly`, `cadence:monthly` — members from the live set |
 
 **Recurring schedule.** Recurring items are defined in `.github/recurring-schedule.json` and created as items by the consuming repo's recurring-issues automation when they come due. The `/work-items:work-items recheck` action updates this schedule after completing a periodic check.
 

--- a/plugins/work-items/skills/work-items/actions/add.md
+++ b/plugins/work-items/skills/work-items/actions/add.md
@@ -17,7 +17,7 @@ Create a new work item with labels from the taxonomy.
 ## Flags
 
 - `--category <name>` -- Category label. Valid values are the consuming repo's `category:` labels (see [`../reference/label-taxonomy.md`](../reference/label-taxonomy.md)); default `general` only when the repo actually defines a `category:general` label, otherwise omit the category label
-- `--type <type>` -- Type label (default: `chore`). Valid: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `perf`
+- `--type <type>` -- The issue's type (default: `task`). Accepts the commit-style inputs `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `perf` and maps them to the coarse issue type: `fix` → **Bug**, `feat` → **Feature**, everything else → **Task**. On **org repos** the type is a **native GitHub Issue Type** set through the seam (not a `type:` label); on **personal / non-org repos** (no native Issue Types) it becomes a coarse `type: bug`/`type: feature`/`type: task` label instead
 - `--area <area>` -- Area label — the consuming repo's `area:` labels (see [`../reference/label-taxonomy.md`](../reference/label-taxonomy.md))
 - `--ecosystem <eco>` -- Ecosystem label — the consuming repo's `ecosystem:` labels (see [`../reference/label-taxonomy.md`](../reference/label-taxonomy.md))
 - `--priority <p>` -- Priority label (e.g., `p0-critical`, `p1-high`, `p2-medium`, `p3-low`)
@@ -35,7 +35,9 @@ Create a new work item with labels from the taxonomy.
 
 1. **Duplicate check** (skip if `--force`) — the search-before-create pre-flight (adapter: "Search items", `--state all`, bare read). If a potential duplicate is found (similar title), present it: "Similar item found: **#N {title}** ({state}). Add anyway, merge, or skip?"
 
-1. **Build labels list** `{labels}` (comma-separated for the seam) from the flags. Start from the group defaults `type:chore,priority:p3-low,category:general` and replace each group's default with any supplied `--type`/`--priority`/`--category` value (one label per group); append `--area`/`--ecosystem` labels when provided. When `--agent-ready` is set, also append the `agent-ready` meta label so the item is eligible for autonomous pickup. A default that the consuming repo doesn't define is omitted rather than passed.
+1. **Resolve the issue type** `{type}` from `--type` (default `task`), mapping the input to the coarse type: `fix` → `Bug`, `feat` → `Feature`, everything else → `Task`. **Org repos** (native Issue Types available): the type is applied through the seam as a native Issue Type, **not** a label — it is not part of `{labels}`. **Personal / non-org repos** (native-type mechanism unavailable): the type rides as a coarse long-form label instead — append `type: bug` / `type: feature` / `type: task` (colon-space, matching the reconciled naming) to `{labels}`. Determine which path applies from the bound adapter's capabilities (for the GitHub adapter, native Issue Types are an org-only feature).
+
+1. **Build labels list** `{labels}` (comma-separated for the seam) from the remaining flags. Start from the group defaults `priority:p3-low,category:general` and replace each group's default with any supplied `--priority`/`--category` value (one label per group); append `--area`/`--ecosystem` labels when provided. When `--agent-ready` is set, also append the `agent-ready` meta label so the item is eligible for autonomous pickup. A default that the consuming repo doesn't define is omitted rather than passed.
 
 1. **Build body.** If `--agent-ready`, use the agent-brief template from [`reference/agent-brief.md`](../reference/agent-brief.md) (Category, Summary, Current behavior, Desired behavior, Key interfaces, Acceptance criteria, Out of scope). Otherwise use the default template:
 
@@ -67,7 +69,7 @@ Create a new work item with labels from the taxonomy.
 {if --recurring: ## Recurring\n\nCadence: {cadence}\nTriggers: {triggers or "none configured"}}
 ```
 
-1. **Create the item** via the seam (`create-item` routes the write through the adapter's identity policy). **When `--recurring` targets a repo with no `.github/recurring-schedule.json` yet, resolve the schedule bootstrap FIRST** (the ask-first path in the next step) — if the user declines the new schedule or it cannot be written, create the item **non-recurring** (drop the `[Maintenance]` prefix and the `recurring`/`cadence:` labels) or abort; never create a `[Maintenance]` item that `due`/`recheck` can never reconcile because no schedule row backs it. If `--recurring` and the schedule is in place, prefix the title with `[Maintenance]` to match the convention used by the recurring-issues automation (enables dedup and `recheck` matching). Write the composed body to a temp file with the Write tool and pass it argv-safe — **never** inline the generated body, which can contain quotes, backticks, or `$()` the shell would interpret before the seam sees it:
+1. **Create the item** via the seam (`create-item` routes the write through the adapter's identity policy). On org repos pass the resolved native Issue Type via the seam's `--type` passthrough (the adapter maps `Bug`/`Feature`/`Task` to the native GitHub Issue Type); on personal / non-org repos the type instead rode into `{labels}` in the resolve step, so omit `--type`. **When `--recurring` targets a repo with no `.github/recurring-schedule.json` yet, resolve the schedule bootstrap FIRST** (the ask-first path in the next step) — if the user declines the new schedule or it cannot be written, create the item **non-recurring** (drop the `[Maintenance]` prefix and the `recurring`/`cadence:` labels) or abort; never create a `[Maintenance]` item that `due`/`recheck` can never reconcile because no schedule row backs it. If `--recurring` and the schedule is in place, prefix the title with `[Maintenance]` to match the convention used by the recurring-issues automation (enables dedup and `recheck` matching). Write the composed body to a temp file with the Write tool and pass it argv-safe — **never** inline the generated body, which can contain quotes, backticks, or `$()` the shell would interpret before the seam sees it:
 
 ```bash
 BODY_FILE=$(mktemp)
@@ -77,7 +79,8 @@ BODY_FILE=$(mktemp)
 "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/tools/work-item-tracker/work-item-tracker.sh" create-item \
   --title "[Maintenance] {title}" \
   --body "$(cat "$BODY_FILE")" \
-  --labels "{labels}"
+  --type "{type}" \
+  --labels "{labels}"   # --type: org repos only (native Issue Type); on personal/non-org repos drop it — the type is already a type: label in {labels}
 rm -f "$BODY_FILE"
 ```
 
@@ -102,7 +105,7 @@ For non-recurring items, omit the `[Maintenance]` prefix. The emitted item objec
 
 Read the current file, append the new item to the `items` array, write it back. Compute `next_due` from today + cadence duration. Also add the `recurring` and `cadence:{cadence}` labels to the item.
 
-1. Confirm: "Created **#{number}**: {title} (labels: {labels})"
+1. Confirm: "Created **#{number}**: {title} (type: {type}, labels: {labels})"
 
 ## Cadence Duration Table
 

--- a/plugins/work-items/skills/work-items/actions/audit.md
+++ b/plugins/work-items/skills/work-items/actions/audit.md
@@ -36,7 +36,7 @@ List open recurring items (adapter: "List items", `--label recurring`, `--state 
 
 ### 3. Unlabeled items + label conflicts
 
-Items missing expected labels (no `type:*`, no `category:*`) and items with conflicting labels (e.g. two `priority:*`) surface via the hygiene projections in the bound adapter's operations reference (GitHub: `tools/work-item-tracker/adapters/github/README.md` "Aggregate / count (dashboard + hygiene)" — bare reads).
+Items missing their **type** classification (org repos: no native Issue Type set; personal / non-org repos: no `type:*` label), missing an expected `category:*` label, or carrying conflicting labels (e.g. two `priority:*`) surface via the hygiene projections in the bound adapter's operations reference (GitHub: `tools/work-item-tracker/adapters/github/README.md` "Aggregate / count (dashboard + hygiene)" — bare reads). On org repos the type axis is a native Issue Type, so absence of a `type:*` label is **not** a defect — read the native type field for the presence check.
 
 ## Output
 
@@ -53,10 +53,10 @@ Items missing expected labels (no `type:*`, no `category:*`) and items with conf
 |---|--------------|--------|
 | 1 | Review biome.json | No matching item |
 
-### Unlabeled Items
+### Unclassified Items
 | # | Item | Missing |
 |---|------|---------|
-| 1 | #55 Something | No type:* label |
+| 1 | #55 Something | No issue type set |
 
 ### Label Conflicts
 (none found)

--- a/plugins/work-items/skills/work-items/actions/decompose.md
+++ b/plugins/work-items/skills/work-items/actions/decompose.md
@@ -98,7 +98,8 @@ BODY_FILE=$(mktemp)
 # not via shell interpolation. plan/PRD text can contain backticks or $() the shell would
 # interpret; "$(cat "$BODY_FILE")" passes it as one literal argument, never re-parsed.
 "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/tools/work-item-tracker/work-item-tracker.sh" create-item --title "<slice title>" --body "$(cat "$BODY_FILE")" \
-  --labels "type:<t>,area:<a>,$META_LABEL" \
+  --type "<Bug|Feature|Task>" \
+  --labels "area:<a>,$META_LABEL" \    # --type: org repos only (native Issue Type); on personal/non-org repos drop --type and prepend a coarse type: bug|feature|task label to --labels instead
   --blocked-by "<blocker-id>[,<blocker-id>]"
 rm -f "$BODY_FILE"
 ```
@@ -128,7 +129,7 @@ Concise description of this vertical slice. Describe end-to-end behavior, not la
 Or "None — can start immediately" if no blockers.
 ```
 
-Apply labels per taxonomy: `type:` from slice nature, `area:` from affected module, `agent-ready` for AFK slices, `needs-human` for HITL + investigation slices. The seam records `--blocked-by` as a native dependency edge; the human-readable "Blocked by" body section mirrors it for readers.
+Classify per taxonomy: the **issue type** from the slice nature — `Bug` (fixing broken behavior), `Feature` (new capability), `Task` (everything else) — set through the seam's `--type` on org repos (native Issue Type), or a `type:` label on personal / non-org repos; `area:` from the affected module; `agent-ready` for AFK slices, `needs-human` for HITL + investigation slices. The seam records `--blocked-by` as a native dependency edge; the human-readable "Blocked by" body section mirrors it for readers.
 
 **Do NOT close or modify any parent item** — decomposition creates children, doesn't replace the parent.
 

--- a/plugins/work-items/skills/work-items/actions/decompose.md
+++ b/plugins/work-items/skills/work-items/actions/decompose.md
@@ -97,9 +97,10 @@ BODY_FILE=$(mktemp)
 # Write the composed slice body to "$BODY_FILE" with the Write tool NOW — before create-item —
 # not via shell interpolation. plan/PRD text can contain backticks or $() the shell would
 # interpret; "$(cat "$BODY_FILE")" passes it as one literal argument, never re-parsed.
+# --type: org repos only (native Issue Type); on personal/non-org repos drop --type and prepend a coarse type: bug|feature|task label to --labels instead
 "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/tools/work-item-tracker/work-item-tracker.sh" create-item --title "<slice title>" --body "$(cat "$BODY_FILE")" \
   --type "<Bug|Feature|Task>" \
-  --labels "area:<a>,$META_LABEL" \    # --type: org repos only (native Issue Type); on personal/non-org repos drop --type and prepend a coarse type: bug|feature|task label to --labels instead
+  --labels "area:<a>,$META_LABEL" \
   --blocked-by "<blocker-id>[,<blocker-id>]"
 rm -f "$BODY_FILE"
 ```

--- a/plugins/work-items/skills/work-items/actions/decompose.md
+++ b/plugins/work-items/skills/work-items/actions/decompose.md
@@ -100,7 +100,7 @@ BODY_FILE=$(mktemp)
 # --type: org repos only (native Issue Type); on personal/non-org repos drop --type and prepend a coarse type: bug|feature|task label to --labels instead
 "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/tools/work-item-tracker/work-item-tracker.sh" create-item --title "<slice title>" --body "$(cat "$BODY_FILE")" \
   --type "<Bug|Feature|Task>" \
-  --labels "area:<a>,$META_LABEL" \
+  --labels "area: <a>,$META_LABEL" \
   --blocked-by "<blocker-id>[,<blocker-id>]"
 rm -f "$BODY_FILE"
 ```

--- a/plugins/work-items/skills/work-items/actions/list.md
+++ b/plugins/work-items/skills/work-items/actions/list.md
@@ -26,8 +26,8 @@ List work items with optional filtering.
 ```markdown
 | # | Item | Type | Labels | Assignee | Updated |
 |---|------|------|--------|----------|---------|
-| 1 | #42 Fix <thing> | Bug | area:<your-area>, priority:p1-high | @user | 2d ago |
-| 2 | #38 Review <config> | Task | area:<your-area> | -- | 5d ago |
+| 1 | #42 Fix <thing> | Bug | area: <your-area>, priority:p1-high | @user | 2d ago |
+| 2 | #38 Review <config> | Task | area: <your-area> | -- | 5d ago |
 ```
 
 The `#` column is a sequential index for this listing. When the user references an item by `#`, match it to the item in the most recent listing.

--- a/plugins/work-items/skills/work-items/actions/list.md
+++ b/plugins/work-items/skills/work-items/actions/list.md
@@ -24,10 +24,10 @@ List work items with optional filtering.
 1. Parse the result and present as a condensed table:
 
 ```markdown
-| # | Item | Labels | Assignee | Updated |
-|---|------|--------|----------|---------|
-| 1 | #42 Fix <thing> | type:fix, area:<your-area> | @user | 2d ago |
-| 2 | #38 Review <config> | type:chore, category:<your-category> | -- | 5d ago |
+| # | Item | Type | Labels | Assignee | Updated |
+|---|------|------|--------|----------|---------|
+| 1 | #42 Fix <thing> | Bug | area:<your-area>, priority:p1-high | @user | 2d ago |
+| 2 | #38 Review <config> | Task | area:<your-area> | -- | 5d ago |
 ```
 
 The `#` column is a sequential index for this listing. When the user references an item by `#`, match it to the item in the most recent listing.

--- a/plugins/work-items/skills/work-items/actions/search.md
+++ b/plugins/work-items/skills/work-items/actions/search.md
@@ -35,7 +35,7 @@ SCHEDULE="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/.github/recurr
 
 | # | Item | Type | Labels | Assignee |
 |---|------|------|--------|----------|
-| 1 | #42 Fix analyzer false positive | Bug | area:analyzers | @agent1 |
+| 1 | #42 Fix analyzer false positive | Bug | area: analyzers | @agent1 |
 
 ### Closed Items (X matches)
 

--- a/plugins/work-items/skills/work-items/actions/search.md
+++ b/plugins/work-items/skills/work-items/actions/search.md
@@ -33,9 +33,9 @@ SCHEDULE="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/.github/recurr
 
 ### Open Items (X matches)
 
-| # | Item | Labels | Assignee |
-|---|------|--------|----------|
-| 1 | #42 Fix analyzer false positive | type:fix | @agent1 |
+| # | Item | Type | Labels | Assignee |
+|---|------|------|--------|----------|
+| 1 | #42 Fix analyzer false positive | Bug | area:analyzers | @agent1 |
 
 ### Closed Items (X matches)
 

--- a/plugins/work-items/skills/work-items/actions/start.md
+++ b/plugins/work-items/skills/work-items/actions/start.md
@@ -37,7 +37,7 @@ Claim a work item through the seam (assignee + lease record).
 
 1. **Suggest branch name.** Signal the closing-keyword link upstream so `/pull-request create` can auto-inject `Closes #N` from the branch parse. The agent NEVER runs `git checkout` itself; it emits the command for the user.
 
-   **Derive the branch `<type>` vocabulary** (the commit-layer prefix — `feat`/`fix`/`chore`/…) from the item's **issue type**. Prefer the native GitHub Issue Type when present: `Bug` → `fix`, `Feature` → `feat`, `Task` → `chore`. Fall back to a `type:*` label (personal / non-org repos, or a not-yet-migrated org item) by Conventional Commits priority — `feat > fix > refactor > docs > chore > test > build > perf`, first match wins, strip the `type:` prefix. Default to `chore` when neither is present.
+   **Derive the branch `<type>` vocabulary** (the commit-layer prefix — `feat`/`fix`/`chore`/…) from the item's **issue type**. Prefer the native GitHub Issue Type when present: `Bug` → `fix`, `Feature` → `feat`, `Task` → `chore`. Fall back to a `type:` label (personal / non-org repos, or a not-yet-migrated org item): the coarse long-form labels map like the native types — `type: bug` → `fix`, `type: feature` → `feat`, `type: task` → `chore`; a legacy commit-style label maps by Conventional Commits priority — `feat > fix > refactor > docs > chore > test > build > perf`, first match wins, strip the `type:` prefix. Default to `chore` when neither is present.
 
    **Derive `<slug>`** from the item title: lowercase, replace non-alphanumeric runs with `-`, trim leading/trailing `-`, cap 40 chars.
 

--- a/plugins/work-items/skills/work-items/actions/start.md
+++ b/plugins/work-items/skills/work-items/actions/start.md
@@ -37,7 +37,7 @@ Claim a work item through the seam (assignee + lease record).
 
 1. **Suggest branch name.** Signal the closing-keyword link upstream so `/pull-request create` can auto-inject `Closes #N` from the branch parse. The agent NEVER runs `git checkout` itself; it emits the command for the user.
 
-   **Derive `<type>`** from item labels by Conventional Commits priority — `feat > fix > refactor > docs > chore > test > build > perf`. First match wins; strip `type:` prefix. Default to `chore` if no `type:*` label present.
+   **Derive the branch `<type>` vocabulary** (the commit-layer prefix — `feat`/`fix`/`chore`/…) from the item's **issue type**. Prefer the native GitHub Issue Type when present: `Bug` → `fix`, `Feature` → `feat`, `Task` → `chore`. Fall back to a `type:*` label (personal / non-org repos, or a not-yet-migrated org item) by Conventional Commits priority — `feat > fix > refactor > docs > chore > test > build > perf`, first match wins, strip the `type:` prefix. Default to `chore` when neither is present.
 
    **Derive `<slug>`** from the item title: lowercase, replace non-alphanumeric runs with `-`, trim leading/trailing `-`, cap 40 chars.
 

--- a/plugins/work-items/skills/work-items/actions/triage.md
+++ b/plugins/work-items/skills/work-items/actions/triage.md
@@ -29,13 +29,13 @@ Read the item body, comments, and any linked PRs (adapter: "View item", bare rea
 
 Based on content, recommend:
 
-- **Type label** (`type:feat`, `type:fix`, `type:chore`, etc.)
+- **Type** — the native GitHub Issue Type (`Bug` / `Feature` / `Task`) on org repos, set through the seam; on personal / non-org repos, a `type:` label instead
 - **Priority label** (`priority:p0-critical` through `priority:p3-low`)
-- **State label** — initial recommendation from: `status:needs-info`, `status:considering`, or agent-ready (`agent-ready` meta label)
+- **State label** — initial recommendation from: `status:needs-info`, `status:ready`, or agent-ready (`agent-ready` meta label)
 
 ### 3. Reproduce (bugs only)
 
-For `type:fix` items, attempt reproduction before interviewing:
+For **Bug** items, attempt reproduction before interviewing:
 
 - Run the described steps
 - Confirm the failure mode matches the report
@@ -63,11 +63,13 @@ Valid state label transitions:
 
 ```text
 (unlabeled) → status:needs-triage
-status:needs-triage → status:needs-info | status:considering | agent-ready | wontfix (close)
+status:needs-triage → status:needs-info | status:ready | agent-ready | wontfix (close)
 status:needs-info → status:needs-triage (on reporter reply)
-status:considering → status:claimed | agent-ready | wontfix (close)
-status:claimed → (close on completion)
+status:ready → claimed (assignee + lease via the seam — not a label) | agent-ready | wontfix (close)
+claimed (assignee + lease) → (close on completion)
 ```
+
+Claiming is coordination state, not a label — it is the seam's assignee + lease (`start` action, `tools/work-item-tracker/CONTRACT.md` "Lease protocol"); `blocked` is a native `blocked-by` edge, not a `status:` label.
 
 ## Needs-info template
 

--- a/plugins/work-items/skills/work-items/actions/work.md
+++ b/plugins/work-items/skills/work-items/actions/work.md
@@ -22,7 +22,7 @@ Before selecting, clear stale claims left by crashed or abandoned sessions (an i
 
 1. **Due recurring items** — `recurring-schedule`, where `next_due <= today`, sorted by `next_due`. Schedule commitments take precedence over category flags; picking a recurring item early shifts its subsequent cadence and undermines the recurrence guarantee.
 
-2. **Non-recurring guardrails items** — the frontier (open ∧ unblocked ∧ unassigned) filtered to `category:guardrails` (when the repo uses that category), non-recurring. Force multipliers — each one completed makes ALL future autonomous work more reliable. Within this tier, prefer: enforcement mechanisms (CI/CD gates, architecture tests, hooks) > tool validation > research/planning.
+2. **Non-recurring guardrails items** — the frontier (open ∧ unblocked ∧ unassigned) filtered to `area: guardrails` (when the repo defines that area), non-recurring. Force multipliers — each one completed makes ALL future autonomous work more reliable. Within this tier, prefer: enforcement mechanisms (CI/CD gates, architecture tests, hooks) > tool validation > research/planning.
 
 3. **Highest-impact non-recurring unassigned items** — the remaining frontier, non-recurring, oldest-first. Select based on: items that unblock others, items in smaller categories, shorter well-scoped items over sprawling research epics.
 
@@ -52,7 +52,7 @@ For each tier, emit the corresponding query:
   "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}/tools/work-item-tracker/work-item-tracker.sh" list-frontier --autonomous
   ```
 
-  `--autonomous` additionally excludes `needs-human` items. Tier 2 keeps only `category:guardrails` non-recurring; tier 3 keeps the rest. The normalized frontier model omits `createdAt`, so apply tier 3's **oldest-first** ordering by sorting the candidates on `createdAt` from the adapter "List items" projection (over the frontier numbers) before picking the top one — pass an explicit `--limit` covering the whole frontier on that projection so the default truncation can't hide an older candidate outside the first page and defeat the oldest-first pick (page per the adapter "List items" note if the frontier exceeds the max page size). Provider search syntax never leaves the adapter — the label filter runs over the labels `list-frontier` already returns.
+  `--autonomous` additionally excludes `needs-human` items. Tier 2 keeps only `area: guardrails` non-recurring; tier 3 keeps the rest. The normalized frontier model omits `createdAt`, so apply tier 3's **oldest-first** ordering by sorting the candidates on `createdAt` from the adapter "List items" projection (over the frontier numbers) before picking the top one — pass an explicit `--limit` covering the whole frontier on that projection so the default truncation can't hide an older candidate outside the first page and defeat the oldest-first pick (page per the adapter "List items" note if the frontier exceeds the max page size). Provider search syntax never leaves the adapter — the label filter runs over the labels `list-frontier` already returns.
 
 Tiers flagged `last-resort: true` are skipped if any prior tier yielded a candidate.
 
@@ -70,7 +70,7 @@ Because the frontier is already unassigned + unblocked, present the top candidat
 
 ```
 **Auto-selected (<tier-name>):** #42 Fix <thing>
-Labels: type:fix, category:<your-category>, area:<your-area>
+Type: Bug · Labels: area:<your-area>, priority:<your-priority>
 
 Proceed with this item? (yes / pick different / skip)
 ```
@@ -95,7 +95,7 @@ On user confirmation ("yes"):
 
    `<id>` MUST be fully-qualified (`claim` rejects a bare number): frontier candidates (tiers 2/3) already carry it from `list-frontier`; a recurring candidate matched to an open item by `number` (Step 2) is first qualified via adapter "Resolve item ID". Exit `0` → claim held. Exit `7` → another session won: advance to the next candidate (do NOT retry the same item). Claim identity is the authenticated session user, never the bot.
 
-1. **Suggest branch name.** Propose `<type>/<N>-<slug>` so `/pull-request create` can auto-inject `Closes #N` from the branch parse. Same protocol as `start.md` "Workflow" final step — type derivation by Conventional Commits priority, slug from title (kebab-case, 40-char cap), existing-branch detection, multi-claim 3-option (switch / stay+cover-both / skip). Agent emits `git checkout -b ...` for the user; never executes itself.
+1. **Suggest branch name.** Propose `<type>/<N>-<slug>` so `/pull-request create` can auto-inject `Closes #N` from the branch parse. Same protocol as `start.md` "Workflow" final step — branch `<type>` vocabulary derived from the item's issue type (native Issue Type preferred, `type:*` label fallback), slug from title (kebab-case, 40-char cap), existing-branch detection, multi-claim 3-option (switch / stay+cover-both / skip). Agent emits `git checkout -b ...` for the user; never executes itself.
 
 1. **Execute the project's development workflow:** the agent MUST follow every step — no shortcuts, no skipping research, no surface-level execution. When the consuming project defines a workflow (a workflow skill, a CLAUDE.md workflow section, or team convention), follow every step of it and read the project's rules for the item's domain first; otherwise follow the generic sequence: explore → plan → implement → test → review → PR.
 

--- a/plugins/work-items/skills/work-items/actions/work.md
+++ b/plugins/work-items/skills/work-items/actions/work.md
@@ -70,7 +70,7 @@ Because the frontier is already unassigned + unblocked, present the top candidat
 
 ```
 **Auto-selected (<tier-name>):** #42 Fix <thing>
-Type: Bug · Labels: area:<your-area>, priority:<your-priority>
+Type: Bug · Labels: area: <your-area>, priority:<your-priority>
 
 Proceed with this item? (yes / pick different / skip)
 ```

--- a/plugins/work-items/skills/work-items/reference/agent-brief.md
+++ b/plugins/work-items/skills/work-items/reference/agent-brief.md
@@ -39,7 +39,7 @@ State what is out of scope. Prevents gold-plating or assumptions about adjacent 
 ```markdown
 ## Agent Brief
 
-**Type:** bug / feat / chore / refactor (per `type:` label taxonomy)
+**Type:** Bug / Feature / Task (the issue's type — native Issue Type on org repos, `type:` label on personal / non-org repos)
 **Summary:** one-line description of what needs to happen
 
 **Current behavior:**

--- a/plugins/work-items/skills/work-items/reference/label-taxonomy.md
+++ b/plugins/work-items/skills/work-items/reference/label-taxonomy.md
@@ -1,29 +1,34 @@
 # Label taxonomy
 
-The label prefix structure consumed by every action that creates, queries, or filters work items. UNIVERSAL groups work in any repo; PROJECT-SPECIFIC groups carry the consuming repo's concrete values.
+The label prefix structure consumed by every action that creates, queries, or filters work items. This document describes the **grammar** (which axes exist and what each encodes); it does **not** enumerate the members of each axis. Members are owned elsewhere and discovered live, so this file can never drift from the deployed set:
 
-When no taxonomy enforcement is desired, actions accept any label without a prefix check. By default, actions validate labels against the groups below.
+- **Org repos** — the universal axes are declared and deployed by the label-as-code SSOT (`melodic-software/github-iac`), the sole writer. Discover the live members with the bound adapter's label listing (for the GitHub adapter, `gh label list`).
+- **Type axis is not a label on org repos** — it is a **native GitHub Issue Type** (`Bug` / `Feature` / `Task`, single-select, org-managed). Actions set it through the seam, never as a `type:` label. Personal / non-org repos (no native Issue Types) keep `type:` labels as the fallback.
 
-## Universal groups
+UNIVERSAL axes work in any repo; PROJECT-SPECIFIC axes carry the consuming repo's concrete values. When no taxonomy enforcement is desired, actions accept any label without a prefix check; by default, actions validate labels against the axes below.
 
-These groups work in any repo and don't change per team.
+## Universal axes
 
-| Group | Prefix | Members |
-|-------|--------|---------|
-| Type | `type:` | `type:feat`, `type:fix`, `type:chore`, `type:docs`, `type:refactor`, `type:test`, `type:build`, `type:perf` (Conventional Commits) |
-| Priority | `priority:` | `priority:p0-critical`, `priority:p1-high`, `priority:p2-medium`, `priority:p3-low` |
-| Status | `status:` | `status:needs-triage`, `status:considering`, `status:claimed`, `status:blocked`, `status:needs-info` |
-| Meta | (none) | `automated`, `recurring`, `agent-ready`, `needs-human`, `good-first-issue`, `migrated`, `stale` |
-| Cadence | `cadence:` | `cadence:weekly`, `cadence:biweekly`, `cadence:monthly`, `cadence:quarterly`, `cadence:semi-annual`, `cadence:annual` |
+These axes work in any repo and don't change per team. Do not snapshot their members here — read them from the SSOT / live set.
 
-## Project-specific groups
+| Axis | Mechanism | What it encodes |
+|------|-----------|-----------------|
+| Type | native Issue Type (org) · `type:` label (personal/non-org) | The kind of issue: `Bug` (broken vs. intent), `Feature` (new capability), `Task` (any other tracked work — maintenance, refactor, tests, docs, audits, chores). Commit-type granularity (`fix`/`feat`/`chore`/`docs`/`refactor`/`test`/`build`/`perf`) stays at the commit layer, not the issue axis. |
+| Priority | `priority:` | Urgency. Members from the live set / github-iac. |
+| Status | `status:` | Exception and gate flags only (e.g. `needs-info`, `needs-decision`, `ready`, `needs-triage`). Members from the live set. **Claim is not a status label** — it is assignee + lease (see the seam claim protocol). **Blocked is not a status label** — it is a native `blocked-by` dependency edge. |
+| Meta | (none) | Tool-owned flat markers the automation sets: `automated`, `recurring`, `agent-ready`, `needs-human`, `good-first-issue`, `migrated`, `stale`. |
+| Cadence | `cadence:` | Recurrence period for maintenance items. Members from the live set. |
 
-The consuming repo defines the members of these groups to match its own architecture surface, domain categorization, and language/toolchain mix. Discover the live set from the bound adapter's label listing (for the GitHub adapter, `tools/work-item-tracker/adapters/github/README.md` — e.g. `gh label list`).
+## Project-specific axes
 
-| Group | Prefix | What it encodes |
-|-------|--------|-----------------|
-| Area | `area:` | The repo's architecture surface (modules, apps, infrastructure lanes) |
-| Category | `category:` | Domain categorization of the work (e.g. guardrails, testing, general) |
+The consuming repo defines the members of these axes to match its own architecture surface, domain categorization, and language/toolchain mix. Discover the live set from the bound adapter's label listing (for the GitHub adapter, `tools/work-item-tracker/adapters/github/README.md` — e.g. `gh label list`).
+
+| Axis | Prefix | What it encodes |
+|------|--------|-----------------|
+| Area | `area:` | The repo's architecture surface (modules, apps, infrastructure lanes, cross-cutting concerns) |
+| Category | `category:` | Domain categorization of the work (e.g. testing, general) |
 | Ecosystem | `ecosystem:` | Language/toolchain (e.g. dotnet, python, typescript, bash) |
 
-When a project-specific group has no labels in the consuming repo, actions simply omit that group — no validation error. To adopt a group, create its labels once through the bound adapter and list the members in the consuming project's own rules if agents should prefer specific values.
+When a project-specific axis has no labels in the consuming repo, actions simply omit that axis — no validation error.
+
+**New labels are never created ad hoc.** The SSOT (github-iac) is the sole writer of org-repo labels; a needed label is added via a github-iac PR, not `gh label create`. Actions only read and validate against the live set (they create labels only for a `ManagedLabels: false` opt-out repo that has no IaC-managed set).


### PR DESCRIPTION
Part of EPIC melodic-software/medley#1491 · Wave 1 · slice S6. Aligns the shipped `work-items` and `wayfind` plugins to the reconciled label/status/type taxonomy so they consume the `github-iac` label-as-code SSOT instead of a divergent, plugin-private one — closing the two-writer and contradicting-source-of-truth defects.

Refs melodic-software/medley#1497

## What changed

**work-items** (`plugins/work-items/`)
- `reference/label-taxonomy.md` + `SKILL.md`: no longer restate a member set — describe the axis grammar and cite the live set / github-iac. Type axis = **native GitHub Issue Types** (`Bug`/`Feature`/`Task`) on org repos, `type:` labels only on personal/non-org repos. Dropped the Conventional-Commit `type:feat/fix/chore/...` set and the retired `status: considering/claimed/blocked` enums (claim = assignee + lease; blocked = native `blocked-by` edge).
- `actions/add.md`, `actions/triage.md`, `actions/decompose.md`: type flow is native-Issue-Type-aware — the type routes through the seam (`--type` passthrough) for org repos, with a coarse `type:` label kept only for personal repos. Triage's status state machine migrated off `status:considering/claimed`.
- `actions/start.md`, `actions/work.md`, `actions/audit.md`: branch-vocabulary derivation and the type-presence hygiene check now prefer the native Issue Type (falling back to a `type:` label), so they stay coherent across the transition.
- `actions/work.md`: guardrails tier retargeted `category:guardrails` → `area: guardrails`.
- `skills/setup/SKILL.md`: ad-hoc `gh label create recurring` replaced with a presence check — labels are provisioned via github-iac (the sole writer).
- Display examples (`list.md`, `search.md`) updated to show the native type, not a `type:` label.

**wayfind** (`plugins/planning/skills/wayfind/`)
- `context/tracker-mechanics.md` + `SKILL.md`: claim protocol migrated off the `status:claimed` label to **assignee + claim-comment lease** (mirrors work-items); the bootstrap `gh label create` loop replaced with a presence check (labels come from github-iac).

## Acceptance
- `grep -rn "gh label create" plugins/` → only prohibition prose remains (no invocations).
- No `status:claimed`/`status:considering` in claim logic — only retirement-documentation references remain (CHANGELOG, done/start notes, evals).
- Taxonomy doc no longer restates a `type:`-label set; it cites the SSOT.
- `claude plugin validate` (all manifests + strict catalog), `typos`, and offline link check all pass.

## Deliberately deferred
- **medley seam (`tools/work-item-tracker/`, not in this repo):** `create-item` needs a `--type` passthrough, and the adapter's normalized/list projection must surface the native Issue Type — both are consumed by the doc changes here. One coherent medley-side dependency.
- Priority slug reconciliation (`p0-p3` → `critical/high/medium/low`), full `category:` → `area:` retirement, and `cadence:` reconciliation — not in #1497's change list; premature before the github-iac live apply (S10). `status: needs-triage` reconciliation (it becomes `priority: needs-triage` in the SSOT) rides with the deferred priority work.

## Post-merge
- Plugins now consume the reconciled taxonomy; no ad-hoc label creation remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeckVXBre3L8oKqKqytkSk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral contract changes for agents creating, triaging, and claiming issues depend on github-iac labels being present and on medley seam support for `--type`; misalignment could cause failed creates or wrong tier selection until those land.
> 
> **Overview**
> Aligns **work-items** and **wayfind** plugin docs with the **github-iac** label-as-code SSOT so agents stop maintaining a second, divergent taxonomy.
> 
> **work-items** stops snapshotting label members in `label-taxonomy.md` and instead documents axis grammar plus live discovery (`gh label list`). On org repos, **type** is a native GitHub Issue Type (`Bug` / `Feature` / `Task`) passed through the seam as `create-item --type`; commit-style `--type` flags map to those coarse types, with `type: bug|feature|task` labels only on personal/non-org repos. Retired **status** semantics are removed from workflows: no `status:claimed` / `status:considering` / `status:blocked` — claiming is **assignee + lease**, blocking is a **native edge**, and triage moves toward `status:ready`. **add**, **decompose**, **triage**, **audit**, **start**, and **work** are updated for native-type-aware creation, hygiene checks, branch-prefix derivation, and listings that show a **Type** column. The autonomous **work** guardrails tier filters `area: guardrails` instead of `category:guardrails`. **setup** verifies the `recurring` label exists and blocks on github-iac provisioning instead of `gh label create`.
> 
> **wayfind** mirrors the same claim model (no `status:claimed` or claim-label bootstrap) and replaces create-if-missing wayfind labels with a **presence check** that reports missing labels for github-iac.
> 
> **Note:** These docs assume a medley-side seam change (`create-item --type` and list projections exposing native Issue Type) that is not in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f3c0259ac583219e502a3bd025dff39503f0f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->