### PR TITLE
ci(actions): scoped concurrency + dependabot batching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependencies
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: build
     # Let a brand-new release settle before proposing it (supply-chain caution); security-advisory
@@ -37,8 +38,17 @@ updates:
       - dependencies
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    # Batch minor + patch bumps into one reviewed PR; majors stay individual.
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   # The standards-distributed runner policy has its own package manifest and
   # lockfile. Keep this as an independent dependency root so policy parser
   # updates are reviewed and cannot drift behind the materialized component.
@@ -48,8 +58,16 @@ updates:
       - dependencies
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   # The miro plugin bundles a Node MCP server; its runtime + build dependencies
   # are pinned by plugins/miro/package-lock.json and rebuilt into the committed
   # bundle by CI, so bumps are reviewed here like any other locked manifest.
@@ -59,8 +77,16 @@ updates:
       - dependencies
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   # Ruff is a CI-only executable pinned to the Ubuntu x64 wheel and its PyPI
   # digest. Dependabot must update both the version and reviewed hash.
   - package-ecosystem: pip
@@ -69,5 +95,6 @@ updates:
       - dependencies
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     cooldown:
       default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 permissions:
   contents: read
 
-# head_ref scopes cancellation to the PR branch; push runs fall back to the
-# unique run_id, so default-branch runs are never cancelled.
+# The PR number scopes cancellation to exactly one PR (head_ref would collide
+# across same-named fork branches); push runs fall back to the unique run_id,
+# so default-branch runs are never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 # Quality lanes run the ci-workflows composite actions / reusable workflows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
-  merge_group:
-    types: [checks_requested]
 
 permissions:
   contents: read
 
+# head_ref scopes cancellation to the PR branch; push runs fall back to the
+# unique run_id, so default-branch runs are never cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Quality lanes run the ci-workflows composite actions / reusable workflows

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,9 +16,10 @@ permissions:
   contents: read
 
 # Rapid pushes to a PR supersede the in-flight review; only the newest head
-# is worth reviewing. head_ref scopes cancellation to the PR branch.
+# is worth reviewing. The PR number scopes cancellation to exactly one PR
+# (head_ref would collide across same-named fork branches).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
 
+# Rapid pushes to a PR supersede the in-flight review; only the newest head
+# is worth reviewing. head_ref scopes cancellation to the PR branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   review:
     # Privileged review remains hosted by policy. Skip it while strict local-only

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,10 +12,11 @@ on:
 permissions:
   pull-requests: read # Allows the called validator to read the PR title.
 
-# head_ref scopes cancellation to the PR branch (this workflow only runs on
-# pull_request events; run_id is a safety fallback that never cancels).
+# The PR number scopes cancellation to exactly one PR — head_ref would collide
+# across same-named fork branches (this workflow only runs on pull_request
+# events; run_id is a safety fallback that never cancels).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,14 +8,14 @@ name: pr-title
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
 
 permissions:
   pull-requests: read # Allows the called validator to read the PR title.
 
+# head_ref scopes cancellation to the PR branch (this workflow only runs on
+# pull_request events; run_id is a safety fallback that never cancels).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Applies GitHub Actions volume controls to this repo (Epic W4).

## What / why

- **Concurrency scoped to `head_ref || run_id`** in `ci`, `pr-title`, and (newly added) `claude-review`: superseded PR runs are cancelled to save runner minutes, while push/default-branch runs get a unique `run_id` group and are never cancelled. The previous `github.ref`-keyed groups could cancel in-flight default-branch pushes.
- **Dead `merge_group` triggers removed** from `ci` and `pr-title`: merge queue is Enterprise-only and the org is on the Team plan, so these triggers can never fire.
- **Dependabot batching**: explicit `open-pull-requests-limit: 5` on every update entry, and an `npm-minor-patch` group per npm dependency root so minor+patch bumps land as one reviewed PR while majors stay individual. Weekly schedule, 7-day cooldown, and github-actions `patterns: ["*"]` grouping were already configured and are unchanged.

Not applicable here: no matrix strategies exist (no `max-parallel` needed) and all `setup-node` steps already use built-in npm caching. The pip entry covers a single pinned executable (ruff), so a group would be a no-op.

Validated locally with `actionlint` and `check-jsonschema` (vendor.dependabot + vendor.github-workflows).

Part of melodic-software/github-iac#82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPDbXgonTuFwFwdTtHaCmw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Dependabot configuration only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Tightens **GitHub Actions** and **Dependabot** volume controls for Epic W4.
> 
> **Workflow concurrency** is keyed by `pull_request.number` (with `run_id` on push) instead of `github.ref`, so stale PR runs cancel without colliding across fork branches with the same branch name, and **main pushes** each get a unique group and are not cancelled. **`cancel-in-progress: true`** is added to **`claude-review`** so rapid pushes only review the latest head. **`merge_group`** triggers are removed from **`ci`** and **`pr-title`** (unused on Team plan).
> 
> **Dependabot** sets **`open-pull-requests-limit: 5`** on every update entry and adds **`npm-minor-patch`** groups on each npm root so minor/patch bumps batch into one PR; majors stay separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa8a51671c77c939614edd9cfed51aacfb914f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->