### PR TITLE
fix(ci): drop caller concurrency that deadlocks claude-review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,13 +15,6 @@ on:
 permissions:
   contents: read
 
-# Rapid pushes to a PR supersede the in-flight review; only the newest head
-# is worth reviewing. The PR number scopes cancellation to exactly one PR
-# (head_ref would collide across same-named fork branches).
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   review:
     # Privileged review remains hosted by policy. Skip it while strict local-only


### PR DESCRIPTION
## Problem

The caller workflow is named `claude-review`, so its workflow-level concurrency group `${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}` resolves to `claude-review-<pr#>` — the exact same group the called reusable workflow ([melodic-software/ci-workflows `claude-review.yml`](https://github.com/melodic-software/ci-workflows/blob/99ac2f8c5b09dbb785d4eaf18465cbd96c30290c/.github/workflows/claude-review.yml)) hardcodes at job level (`claude-review-${{ github.event.pull_request.number || github.sha }}`). When the called job tries to enter the concurrency group its own caller already holds, GitHub fails the run instantly as a same-group deadlock.

This is the identical failure class proven in melodic-software/standards#98 (run failed in 0s) and fixed there in melodic-software/standards@f93fb81 by removing the caller-level block.

## Fix

Remove the workflow-level `concurrency:` block (and its comment) from the caller. The reusable workflow's job-level group already owns per-PR review supersession (newest head cancels the in-flight review), so no behavior is lost.

Part of melodic-software/github-iac#82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPDbXgonTuFwFwdTtHaCmw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; review cancellation behavior remains in the pinned reusable workflow.
> 
> **Overview**
> Removes the workflow-level **`concurrency`** block (and its comment) from **`.github/workflows/claude-review.yml`**.
> 
> That group used `${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}`, which resolves to **`claude-review-<pr#>`** — the same name the called **`melodic-software/ci-workflows`** reusable workflow already uses at job level. When both layers tried to enter one group, GitHub failed the run immediately as a same-group deadlock.
> 
> **Per-PR review supersession** (cancel in-flight review on newer pushes) stays owned by the reusable workflow’s job-level concurrency; nothing else in the caller workflow changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d355b146833f365f46efcb0a74f5c5e32cec3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->