### PR TITLE
feat(ci): adopt liveness selector with one preflight per workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,52 +22,15 @@ concurrency:
 # local ci-status gateway aggregates every lane into the
 # single required check the org ci-gate ruleset keys on.
 jobs:
-  # Give each independently scheduled workload one governed routing gate.
-  # The short hygiene checks share one checkout and one ephemeral worker to
-  # avoid runner-registration churn. A selector/configuration failure blocks
-  # the complete workload; it cannot silently redirect to paid hosted Linux.
-  select-hygiene:
-    name: Select runner for hygiene
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-hook-utils-sync:
-    name: Select runner for hook-utils-sync
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-plugin-gate:
-    name: Select runner for plugin-gate
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  select-miro-plugin:
-    name: Select runner for miro-plugin
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
+  # One governed routing gate feeds every lane in this workflow: the liveness
+  # selector makes one routing decision per workflow instead of fanning out
+  # identical preflights. The short hygiene checks still share one checkout and
+  # one ephemeral worker to avoid runner-registration churn. A
+  # selector/configuration failure blocks the complete workload; it cannot
+  # silently redirect to paid hosted Linux.
+  select-runner:
+    name: Select runner
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3415de3ff2fafee40e4d087eb6073d2f6952b595 # 3415de3 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -79,9 +42,9 @@ jobs:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
 
   hygiene:
-    needs: select-hygiene
-    if: ${{ !cancelled() && needs.select-hygiene.result == 'success' }}
-    runs-on: ${{ needs.select-hygiene.outputs.runner || 'ubuntu-24.04' }}
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -210,20 +173,20 @@ jobs:
         run: scripts/aggregate-hygiene-results.sh
 
   zizmor:
-    needs: select-hygiene
-    if: ${{ !cancelled() && needs.select-hygiene.result == 'success' }}
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
     permissions:
       contents: read
     # Advisory Actions security lint; findings annotate without blocking.
     uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-12
     with:
-      runner: ${{ needs.select-hygiene.outputs.runner || 'ubuntu-24.04' }}
+      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       paths: .
 
   hook-utils-sync:
-    needs: select-hook-utils-sync
-    if: ${{ !cancelled() && needs.select-hook-utils-sync.result == 'success' }}
-    runs-on: ${{ needs.select-hook-utils-sync.outputs.runner || 'ubuntu-24.04' }}
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -243,9 +206,9 @@ jobs:
         run: scripts/sync-hook-utils.sh --check-bump "origin/$BASE_REF"
 
   plugin-gate:
-    needs: select-plugin-gate
-    if: ${{ !cancelled() && needs.select-plugin-gate.result == 'success' }}
-    runs-on: ${{ needs.select-plugin-gate.outputs.runner || 'ubuntu-24.04' }}
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -295,9 +258,9 @@ jobs:
   # and fails on any drift, then runs the bundle over stdio so a build that
   # compiles but cannot serve MCP is caught here, not on a consumer's machine.
   miro-plugin:
-    needs: select-miro-plugin
-    if: ${{ !cancelled() && needs.select-miro-plugin.result == 'success' }}
-    runs-on: ${{ needs.select-miro-plugin.outputs.runner || 'ubuntu-24.04' }}
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -337,9 +300,9 @@ jobs:
 
   runner-policy:
     name: Runner policy
-    needs: select-hygiene
-    if: ${{ !cancelled() && needs.select-hygiene.result == 'success' }}
-    runs-on: ${{ needs.select-hygiene.outputs.runner || 'ubuntu-24.04' }}
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   select-runner:
     name: Select runner for PR title
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-13
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3415de3ff2fafee40e4d087eb6073d2f6952b595 # 3415de3 2026-07-13
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}

--- a/docs/CI-RUNNER-ROUTING.md
+++ b/docs/CI-RUNNER-ROUTING.md
@@ -35,15 +35,15 @@ but every executable pin update remains a reviewed pull request.
 
 ## Routing and failure behavior
 
-Each independently scheduled eligible job has its own selector dependency. Its
-workload requires both `!cancelled()` and a successful selector result, then
-uses the policy-required expression
-`needs.<selector>.outputs.runner || 'ubuntu-24.04'`. The success gate is
+Each workflow runs a single selector preflight shared by every eligible job it
+schedules. Each workload requires both `!cancelled()` and a successful selector
+result, then uses the policy-required expression
+`needs.select-runner.outputs.runner || 'ubuntu-24.04'`. The success gate is
 load-bearing: invalid strict configuration or selector infrastructure failure
-blocks the dependent workload instead of silently redirecting it to paid
-hosted Linux. The selector remains a separate, short GitHub-hosted job. Its
-two-minute workflow timeout does not limit the downstream workload job, which
-retains its own timeout.
+blocks the dependent workloads instead of silently redirecting them to paid
+hosted Linux. The selector remains a separate, short preflight job. Its
+two-minute workflow timeout does not limit the downstream workload jobs, which
+retain their own timeouts.
 
 For `self-hosted-only`, the selector validates the exact centrally allowlisted
 managed label and returns it without querying runner inventory or minting the
@@ -62,11 +62,14 @@ success gate, while a tiny hosted `pr-title / pr-title` control-plane job emits
 the existing required context and fails when selection or validation is not
 successful.
 
-Selectors remain one per independent workload so every required-check edge is
-explicit and policy-auditable. In strict mode they all return the same governed
-label; the fleet, not a stale inventory snapshot, enforces concurrency. Bursts
-queue on that label, one ephemeral container accepts each job, and reruns remain
-local instead of becoming a paid recovery path.
+One selector preflight per workflow makes the routing decision once instead of
+fanning out identical jobs, and every required-check edge still passes through
+the same explicit, policy-auditable selector gate. In strict mode it returns
+the same governed label for every lane; the fleet, not a stale inventory
+snapshot, enforces concurrency. Bursts queue on that label, one ephemeral
+container accepts each job, and a re-run reuses the prior attempt's successful
+selector output, so reruns remain local instead of becoming a paid recovery
+path.
 
 ## Hosted boundaries
 


### PR DESCRIPTION
## What

- **Collapse 4 selector jobs into 1**: `ci.yml` ran four identical per-lane `select-runner.yml` preflights (`select-hygiene`, `select-hook-utils-sync`, `select-plugin-gate`, `select-miro-plugin`). They are now one `select-runner` job with the exact same inputs and observer secret; every lane (`hygiene`, `zizmor`, `hook-utils-sync`, `plugin-gate`, `miro-plugin`, `runner-policy`) rewires to it with its existing `!cancelled() && result == 'success'` gate and `outputs.runner || 'ubuntu-24.04'` fallback unchanged. `ci-status` and triggers/concurrency are untouched.
- **Pin bump de50a08 → 3415de3** in `ci.yml` and `pr-title.yml`: the liveness selector routes on fleet liveness (any online managed runner keeps the workload self-hosted; GitHub queues on a busy fleet) and drops the rerun-to-hosted branch (melodic-software/ci-workflows#86). The SHA is allowlisted owner-scoped for melodic-software in the synced runner policy (melodic-software/standards#100).
- **Docs**: `docs/CI-RUNNER-ROUTING.md` now describes the one-preflight-per-workflow contract instead of one selector per workload.

## Not changed

- `zizmor.yml@de50a08` stays pinned: de50a08 is the only zizmor contract SHA approved in the standards-distributed `policy.json`; bumping it would fail the runner-policy gate.

## Verification

- `GITHUB_REPOSITORY=melodic-software/claude-code-plugins node .github/standards/runner-policy/runner-policy.mjs --root .` → `Runner policy passed.`
- `actionlint` and `markdownlint-cli2` clean on the changed files.

Part of melodic-software/github-iac#79, epic #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPDbXgonTuFwFwdTtHaCmw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every CI lane picks runners and bumps the governed selector contract; mis-routing or selector failure would block workloads, though gates and fallbacks are unchanged.
> 
> **Overview**
> **Consolidates CI runner selection** so `ci.yml` runs one shared `select-runner` preflight instead of four duplicate per-lane selector jobs; all lanes (`hygiene`, `zizmor`, `hook-utils-sync`, `plugin-gate`, `miro-plugin`, `runner-policy`) still gate on selector success and use the same `outputs.runner || 'ubuntu-24.04'` expression.
> 
> **Bumps** the pinned `select-runner.yml` reusable workflow from `de50a08` to `3415de3` in `ci.yml` and `pr-title.yml` (liveness-based routing; reruns can reuse a prior successful selector result). **`zizmor.yml` stays on `de50a08`** per runner-policy allowlisting.
> 
> **Updates** `docs/CI-RUNNER-ROUTING.md` to document one selector per workflow rather than one per workload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600d4b5210287f2f283ad0eff2ff69884c4a392e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->