### PR TITLE
build(dependabot): stop proposing governed reusable-workflow bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,14 @@ updates:
       github-actions:
         patterns:
           - "*"
+    # The runner-policy allowlist pins ci-workflows reusable-workflow refs to
+    # independently reviewed SHAs, so a Dependabot bump to an unreviewed main
+    # commit can only fail the Runner policy lane. Those pins move through
+    # deliberate reviewed PRs after a standards allowlist update; composite
+    # actions (melodic-software/ci-workflows/.github/actions/*) are not
+    # SHA-allowlisted and stay Dependabot-managed.
+    ignore:
+      - dependency-name: "melodic-software/ci-workflows/.github/workflows/*"
   # Biome and Claude Code are executable CI dependencies locked at the root.
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Same fix as melodic-software/standards#102: Dependabot's rebased github-actions group (#167) proposes governed ci-workflows reusable-workflow refs at an unreviewed commit the runner-policy allowlist rejects — permanently red by design. Ignore `melodic-software/ci-workflows/.github/workflows/*` (reusables only; composite actions stay Dependabot-managed). After merge: `@dependabot recreate` on #167.

Part of melodic-software/github-iac#78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPDbXgonTuFwFwdTtHaCmw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to Dependabot ignore rules; no runtime or CI workflow behavior changes beyond stopping noisy failing bump PRs.
> 
> **Overview**
> **Dependabot** no longer proposes version bumps for **`melodic-software/ci-workflows/.github/workflows/*`** reusable workflow references in the **github-actions** ecosystem.
> 
> Runner policy pins those refs to **reviewed SHAs**; automated bumps to unreviewed commits only fail the Runner policy lane and leave PRs permanently red. Workflow pins are expected to move via deliberate reviewed PRs after standards allowlist updates. **Composite actions** under `ci-workflows/.github/actions/*` are **not** ignored and remain Dependabot-managed.
> 
> Comments in **`.github/dependabot.yml`** document that split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ab9c9d38783cca59d6a949e57f0bc773b8b7105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->