### PR TITLE
feat(planning): enforce fresh-eyes separation in the plan stress-test

### DIFF
--- a/plugins/fable-5-playbook/skills/fable-5-playbook/context/orchestration.md
+++ b/plugins/fable-5-playbook/skills/fable-5-playbook/context/orchestration.md
@@ -62,6 +62,8 @@ A worker's return is recall-grade knowledge per the calibration chapter, section
 
 In-context adversarial self-review — the verification chapter, section "Adversarial self-review" — is the floor at every effort level; self-review is a floor, never the final gate for multi-file work, because the context that produced the changes contains the exact assumptions that produced the error and converges on approval rather than detection.
 
+The independence gradient runs further than fresh context alone: self-review (floor) < a fresh **same-vendor** context (strips the producer's rationale) < a **different-vendor** model (strips the producer's training priors too — its errors are uncorrelated with yours, so it catches failure classes a same-family reviewer shares). Reach for the strongest independent critic the work warrants; a high-blast-radius verification is the natural place to spend a cross-vendor reviewer when one is installed.
+
 **TRIGGER — a fresh-context verifier is required in addition to the floor:** after any multi-file edit batch, and before declaring any multi-part task complete. Outside these triggers, the in-context floor suffices.
 
 Hand the verifier two things only: the artifact, and binary criteria checkable against the artifact by reading, searching, or counting — a holistic quality question invites a rubber stamp; a criterion with a yes/no answer does not. Withhold your rationale for the changes: a verifier that reads your justification inherits your blind spots and audits your story instead of your artifact.

--- a/plugins/planning/skills/architect/SKILL.md
+++ b/plugins/planning/skills/architect/SKILL.md
@@ -139,7 +139,7 @@ If MEDIUM or higher, or any trigger matches: proceed to Step 4 (Formal Stress-Te
 
 This step runs only when the blast-radius assessment triggers it. Note: Step 3 (plan stress-test sub-agent) already ran — this is the deeper, formal version.
 
-1. **Invoke `/devils-advocate`** — pass the plan for systematic adversarial review. The stress-test skill runs its own multi-round process (assumption identification, evidence check, failure scenarios, operational gotchas)
+1. **Dispatch `/devils-advocate` to a fresh-context sub-agent** — hand it the plan (plus the Brief and any design artifacts), not your rationale for it. The producing main thread MUST NOT run the stress-test inline, for the same reason Step 3 dispatches: the context that wrote the plan carries the assumptions that produced its blind spots and converges on approval rather than detection. The stress-test skill runs its own multi-round process (assumption identification, evidence check, failure scenarios, operational gotchas) in that clean context; the main thread then verifies its findings against the actual code/files before acting on them — sub-agent findings are synthesis, not ground truth
 
 2. **Evaluate findings** — if `/devils-advocate` produces CRITICAL or HIGH findings:
    - Run targeted research to resolve the specific issues surfaced (`/discovery:research` if installed, or the strongest research capability available)

--- a/plugins/planning/skills/architect/context/research-iterate.md
+++ b/plugins/planning/skills/architect/context/research-iterate.md
@@ -52,7 +52,7 @@ Based on research results:
 
 ### 4. Re-assess
 
-Run `/devils-advocate` on the updated plan. Only the changed sections need deep review — unchanged sections carry forward their previous assessment.
+Dispatch `/devils-advocate` to a fresh-context sub-agent on the updated plan — never re-run it inline in the producing context, the same fresh-eyes discipline as the first pass (Step 4). Only the changed sections need deep review — unchanged sections carry forward their previous assessment.
 
 ## Guardrails
 

--- a/plugins/planning/skills/devils-advocate/SKILL.md
+++ b/plugins/planning/skills/devils-advocate/SKILL.md
@@ -21,6 +21,10 @@ Plans fail for predictable reasons: unchecked assumptions, undiscovered bugs in 
 
 Not a rubber stamp. Find real issues that would cause rework, not generic warnings. Every finding must be backed by evidence — a specific bug number, doc reference, code path, or logical argument. "This might break" without evidence is not a finding.
 
+## Fresh-context requirement
+
+If the plan or proposal under review was produced in THIS context/session, dispatch this stress-test to a fresh-context sub-agent rather than running it inline — the producing context shares the assumptions that created the plan's blind spots and drifts toward approving its own work. When you were invoked on an artifact this context did not author (a file, a plan from another session, a diff), you are already the fresh pair of eyes — proceed directly.
+
 ## When to Use
 
 **Proactively (autonomous invocation):**


### PR DESCRIPTION
## Problem

The `architect` skill already enforces the fresh-eyes principle for its **Step 3** plan stress-test — it dispatches a fresh-context `plan-reviewer` sub-agent and says so explicitly (*"The producing main thread MUST NOT self-attack the plan inline — fresh-context verifiers outperform self-critique; the model that just wrote the plan rubber-stamps it"*).

But **Step 4** (the deeper, formal stress-test) invoked `/devils-advocate` **inline**, and the `research-iterate` re-assess loop re-ran it inline too. So the *more consequential* adversarial review ran in the very context that authored the plan — the context that shares the plan's assumptions and converges on approval rather than detection. The lighter review got clean context; the deeper one didn't. Backwards.

## Fix

- **`architect` Step 4 + `research-iterate` loop** now dispatch `/devils-advocate` to a **fresh-context sub-agent** (handing it the plan + Brief, not the rationale), then verify its findings against the code — mirroring the discipline Step 3 already codifies.
- **`devils-advocate` self-guard**: a new "Fresh-context requirement" section — if the artifact under review was produced in the same context, dispatch to fresh context rather than run inline. Makes the principle enforceable regardless of caller, and future-proofs against the same inline-chaining elsewhere.
- **`fable-5-playbook` doctrine**: the "Fresh-context verification" chapter gains the full independence gradient — self-review (floor) < fresh **same-vendor** context < **different-vendor** model (uncorrelated errors). Stated tool-agnostically, so plugin *discovery* supplies the cross-vendor reviewer rather than a hardcoded reference.

## Origin & scope

From a fresh-eyes audit of the plugin suite (prompted by OpenAI's Codex plugin becoming available as a cross-vendor reviewer). The review path (`review-toolkit`, `quality-gate`) and Step 3 are already exemplary — this PR fixes the one real inline-self-review violation plus the doctrine gap.

**Follow-ups (separate PRs):** the fixer==verifier couplings in `implementation` (`implement`/`test-write`/`verify-changes`), `diagnose`, and `code-tidying` (generalize `implement-dispatch`'s autonomous-only fresh-context verifier to all paths); the `code-review-fanout` orchestrator seam for adding a cross-vendor review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to skill markdown and playbook guidance; no runtime, auth, or data paths affected.
> 
> **Overview**
> **Formal plan stress-testing** no longer runs in the thread that wrote the plan. **`architect` Step 4** and the **`research-iterate` re-assess** step now **dispatch `/devils-advocate` to a fresh-context sub-agent**, passing the plan, Brief, and design artifacts—not the author’s rationale—and the main thread **verifies findings against the repo** before acting, matching the discipline already required for Step 3’s plan-reviewer.
> 
> **`/devils-advocate`** gains a **Fresh-context requirement**: if the artifact under review was produced in the same session, stress-test via sub-agent; if reviewing an external file or another session’s work, run inline as the fresh pair of eyes.
> 
> The **fable-5 orchestration** chapter documents an **independence gradient** for verification: in-context self-review (floor) → fresh same-vendor context → cross-vendor reviewer when available for high-blast-radius checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56502f210f672e8dc0b4734ad5b68c5e287a16b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->