### PR TITLE
fix(improve-architecture): re-enable model invocation

### DIFF
--- a/plugins/improve-architecture/.claude-plugin/plugin.json
+++ b/plugins/improve-architecture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "improve-architecture",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Scans an existing codebase for module-level architecture friction — shallow modules, seam leaks, and locality gaps — using Ousterhout's deep-module lens, presents candidates as a self-contained HTML report, and runs an interview loop on the selected candidate before handing off for planning.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/improve-architecture/CHANGELOG.md
+++ b/plugins/improve-architecture/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the `improve-architecture` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.1.3]
+
+### Fixed
+
+- **Model invocation re-enabled.** `disable-model-invocation` in the `improve-architecture` skill's
+  frontmatter is flipped back to `false`. The migration flipped it to `true`, silently disabling the
+  automatic triggering the skill's description advertises ("Use when: 'improve architecture', 'find
+  deepening opportunities', …") — the pre-migration original set `false`, and no rationale for the flip
+  exists anywhere. With this fix the skill again triggers automatically when a request matches its
+  description, in addition to explicit `/improve-architecture` invocation.

--- a/plugins/improve-architecture/skills/improve-architecture/SKILL.md
+++ b/plugins/improve-architecture/skills/improve-architecture/SKILL.md
@@ -3,7 +3,7 @@ name: improve-architecture
 description: "Scan an existing codebase for module-level friction and architecture improvement opportunities. Explores for shallow modules (interface nearly as complex as implementation), seam leaks, and locality gaps; presents candidates as a self-contained HTML report; runs an interview loop on the selected candidate; hands off an agreed candidate shape for planning. Use when: 'improve architecture', 'find deepening opportunities', 'shallow modules', 'architecture improvement', 'Ousterhout deepening', 'make code more testable', 'make code more AI-navigable', 'find refactoring opportunities', 'what should we improve', 'architecture scan', 'codebase friction', 'module seams', 'locality'. Skip when: applying mechanical code-level tidyings (this operates at module level), reviewing a diff before merge, enforcing architecture rules on a change, or root-cause debugging a specific failure."
 argument-hint: "[action] (e.g., deepening)"
 user-invocable: true
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 ## Pre-computed context


### PR DESCRIPTION
## Summary

Restores `disable-model-invocation: false` in the `improve-architecture` skill frontmatter. The medley→plugin migration flipped it to `true`, silently disabling the automatic (model-invoked) triggering the skill's unchanged description still advertises. The pre-migration original set `false`, this is the only skill in the repo (besides the deliberately-manual `teach`) carrying `true`, and no rationale for the flip is recorded anywhere — a migration regression, not a design decision.

- `disable-model-invocation: true` → `false` (matches the 80 other skills in this marketplace that set `false` explicitly; semantics verified against https://code.claude.com/docs/en/skills — default `false`, `true` prevents automatic loading)
- Version bump `0.1.2` → `0.1.3`
- New `CHANGELOG.md` recording the fix

## Consumer impact

After `/plugin marketplace update melodic-software` + plugin update, `improve-architecture` again triggers automatically when a request matches its description, in addition to explicit `/improve-architecture` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xHkkNc7CR98L8Xz9Mu7ZA