### PR TITLE
fix(knowledge): preserve literal less-than cue text

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), and a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## 0.5.5
+
+### Fixed
+
+- **Lossless WebVTT transcript extraction.** Cue cleanup still strips complete WebVTT tags in one
+  linear pass, but now preserves an unmatched literal less-than tail instead of truncating the rest
+  of programming, mathematics, or other tolerant transcript text.
+
 ## 0.5.4
 
 ### Fixed

--- a/plugins/knowledge/vendor/video-digestion/transcript/vtt-parser.js
+++ b/plugins/knowledge/vendor/video-digestion/transcript/vtt-parser.js
@@ -64,18 +64,30 @@ export function formatTimestamp(seconds) {
  * @returns {string}
  */
 export function stripVttInlineTags(text) {
-  let result = "";
-  let inTag = false;
-  for (const character of text) {
-    if (character === "<") {
-      inTag = true;
-    } else if (character === ">" && inTag) {
-      inTag = false;
-    } else if (!inTag) {
-      result += character;
+  const result = [];
+  let copyStart = 0;
+  let tagStart = -1;
+
+  for (let index = 0; index < text.length; index++) {
+    const character = text[index];
+    if (tagStart === -1) {
+      if (character === "<") {
+        if (copyStart < index) {
+          result.push(text.slice(copyStart, index));
+        }
+        tagStart = index;
+      }
+    } else if (character === ">") {
+      tagStart = -1;
+      copyStart = index + 1;
     }
   }
-  return result;
+
+  const tailStart = tagStart === -1 ? copyStart : tagStart;
+  if (tailStart < text.length) {
+    result.push(text.slice(tailStart));
+  }
+  return result.join("");
 }
 
 /**

--- a/plugins/knowledge/vendor/video-digestion/transcript/vtt-parser.test.js
+++ b/plugins/knowledge/vendor/video-digestion/transcript/vtt-parser.test.js
@@ -13,8 +13,20 @@ describe("stripVttInlineTags", () => {
     );
   });
 
-  it("handles a long unterminated tag in linear traversal", () => {
-    expect(stripVttInlineTags(`<${"<".repeat(100_000)}payload`)).toBe("");
+  it.each(["if (x < y)", "count < limit"])(
+    "preserves an unmatched less-than tail: %s",
+    (caption) => {
+      expect(stripVttInlineTags(caption)).toBe(caption);
+    },
+  );
+
+  it("preserves an unmatched less-than tail after a complete tag", () => {
+    expect(stripVttInlineTags("<c>count</c> < limit")).toBe("count < limit");
+  });
+
+  it("preserves a long unterminated candidate in linear traversal", () => {
+    const caption = `<${"<".repeat(100_000)}payload`;
+    expect(stripVttInlineTags(caption)).toBe(caption);
   });
 });
 
@@ -26,5 +38,14 @@ describe("parseVttSegment", () => {
 <c>Hello</c> <b>world</b>`);
     expect(cues).toHaveLength(1);
     expect(cues[0].text).toBe("Hello world");
+  });
+
+  it("preserves literal less-than text in a parsed cue", () => {
+    const cues = parseVttSegment(`WEBVTT
+
+00:00:01.000 --> 00:00:03.000
+if (x < y)`);
+    expect(cues).toHaveLength(1);
+    expect(cues[0].text).toBe("if (x < y)");
   });
 });


### PR DESCRIPTION
## Summary

- preserve an unmatched literal `<` tail during tolerant WebVTT transcript extraction
- keep complete-tag stripping and nested-malformed behavior unchanged in one linear pass
- add direct, long-input, and `parseVttSegment` regressions
- bump the `knowledge` plugin to `0.5.5` and document the fix

## Root cause

The single-pass tag stripper introduced in #183 entered tag state on any `<` and discarded the buffered tail at end of input. Programming and mathematics captions such as `if (x < y)` were therefore truncated even though no complete tag existed.

The W3C tokenizer treats raw `<` as tag syntax, so this is an intentional tolerant/lossless extraction fallback for nonconforming caption input; complete `<...>` spans retain the previous stripping behavior. See the [WebVTT cue text contract](https://www.w3.org/TR/2026/CRD-webvtt1-20260520/#webvtt-caption-or-subtitle-cue-text) and [cue text parsing rules](https://www.w3.org/TR/2026/CRD-webvtt1-20260520/#webvtt-cue-text-parsing-rules).

The patch version is required because Claude Code uses an explicit plugin version as its delivery/cache key. See [plugin version management](https://code.claude.com/docs/en/plugins-reference#version-management).

## Validation

- focused vendored Vitest: 8/8
- course-digest extraction: 91/91 tests; TypeScript build passed
- YouTube extraction: 255/255 tests; TypeScript build passed
- all shell plugin contract tests passed or skipped by their documented optional-tool rules
- `scripts/validate-plugins.sh`: 14 setup skills and 1,285 plugin files checked; all manifests and catalog valid
- Markdownlint and `git diff --check` passed
- independent exhaustive/randomized review matched a buffered reference and found no remaining CRITICAL/IMPORTANT issue

Follow-up for unresolved review thread `PRRT_kwDOTCGFQM6Q-DO4` on #183.
