### PR TITLE
docs: encode GitHub branching/PR conventions citation in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,5 +57,6 @@ migration.
 
 ## Branching & PRs
 
-PRs required; squash merge; Conventional Commits branch `<type>/<description>` (enforced here by
-`.github/workflows/pr-title.yml`). Org convention home: `melodic-software/standards` `conventions/`.
+PRs required; squash merge; branch `<type>/<description>`. PR title follows Conventional Commits,
+enforced here by `.github/workflows/pr-title.yml` (squash merge sets the commit subject to the PR
+title). Org convention home: `melodic-software/standards` `conventions/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,3 +54,8 @@ The durable design rules live in [`docs/PLUGIN-PHILOSOPHY.md`](docs/PLUGIN-PHILO
 extensibility model, plugin-form caveats, per-plugin migration gate, and plugin-acceptance security
 review live in [`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md). Follow both for every
 migration.
+
+## Branching & PRs
+
+PRs required; squash merge; Conventional Commits branch `<type>/<description>` (enforced here by
+`.github/workflows/pr-title.yml`). Org convention home: `melodic-software/standards` `conventions/`.


### PR DESCRIPTION
## Summary

Closes decision #55 (`metadata-claude-md-encode-github-conventions`) for this repo. Adds a **Branching & PRs** section to `CLAUDE.md` mirroring medley's citation pattern (`AGENTS.md` "Branching & PRs": terse rule inline + one pointer to the full convention source).

- Inline rule: PRs required, squash merge, Conventional Commits branch `<type>/<description>` — already enforced here by `.github/workflows/pr-title.yml`.
- Pointer: `melodic-software/standards` `conventions/` as the org-wide convention home.

The pointer targets the `conventions/` directory rather than `conventions/engineering/naming.md` specifically: `naming.md` today covers only Clean-Code identifier naming (classes, files, variables), not branch/PR grammar. Promoting medley's branch-naming grammar into `standards` org-wide is tracked separately as decision #24 (`naming-branch-convention-org-wide`, WP-11). Once that lands, `naming.md` (or wherever it lands) becomes the sharper anchor — the directory-level pointer stays valid either way per `standards`' `conventions/engineering/reference-dont-duplicate.md` (cite a stable anchor, never a copy that can drift).

Decisions Log: https://claude.ai/code/artifact/232ecdce-8316-4880-8c0a-dc3c7dcf3a63

## Test plan

- [x] `npx markdownlint-cli2 CLAUDE.md` — 0 errors
- [x] Manual read-through against medley's `AGENTS.md` "Branching & PRs" and `.claude/rules/worktree/{branch-naming,pr-conventions}.md` for pattern fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4azyXMBuXGV2sshG7UuB