### PR TITLE
fix(source-control): harden PR lifecycle guards

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, multi-PR babysit loop), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (interview the repo and write the tracked commit-subject / PR-title convention config), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable per repo via a tracked .claude/source-control.md config written by a re-runnable setup skill; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Fixed
+
+- Require a branch-derived issue to be open before adding `Closes #N`, preserve
+  merge-commit branch history when integrating the default branch during PR
+  babysitting, and stash a dirty worktree before reusing it for the next task.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -89,6 +89,42 @@
         "Posts an evidence-backed classification reply to the human reviewer's comment (replies are not gated), but pauses for explicit user approval before reacting to or acting on it, even though the bot finding in the same turn was handled autonomously",
         "Does not auto-resolve the human-authored review thread"
       ]
+    },
+    {
+      "id": 8,
+      "name": "closed-branch-issue-does-not-autoclose",
+      "prompt": "/pull-request create from branch fix/321-stale-link. GitHub reports issue #321 exists but its state is CLOSED.",
+      "expected_output": "The skill does not emit `Closes #321`. A branch-derived number is accepted only when `gh issue view --json state` returns `OPEN`; a closed issue falls through to the orphan-PR prompt for an explicit Closes, Refs, or no-related-issue choice.",
+      "files": [],
+      "expectations": [
+        "It checks the live issue state rather than treating a successful gh issue view as sufficient",
+        "It does not add Closes #321 for a CLOSED issue",
+        "It runs the orphan-PR prompt instead of silently creating an unlinked PR"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "babysit-preserves-merge-workflow",
+      "prompt": "/pull-request babysit PR #482. The checked-out branch is behind main and `git log --merges origin/main..HEAD` returns a merge commit.",
+      "expected_output": "The skill integrates `origin/main` with `git merge`, preserving the branch's merge workflow, and uses a plain `git push`. It does not rebase or force-push the merge-commit branch.",
+      "files": [],
+      "expectations": [
+        "It checks for merge commits before choosing an integration mode",
+        "It uses git merge origin/main for a merge-commit branch",
+        "It uses a plain push, not a force-with-lease push, after the merge"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "worktree-reuse-protects-dirty-tree",
+      "prompt": "/pull-request merge 482 completed. Reuse this worktree for the next task, but `git status --porcelain` shows tracked edits and an untracked file.",
+      "expected_output": "Before `git checkout -b` changes branches, the skill stashes the dirty tree with `git stash push -u` and reports how to inspect and restore the stash. The edits do not silently carry onto the next task branch.",
+      "files": [],
+      "expectations": [
+        "It runs the dirty-tree guard before creating the next branch",
+        "It stashes tracked and untracked changes with git stash push -u",
+        "It reports the stash and restoration command to the user"
+      ]
     }
   ]
 }

--- a/plugins/source-control/skills/pull-request/reference/babysit.md
+++ b/plugins/source-control/skills/pull-request/reference/babysit.md
@@ -221,7 +221,7 @@ if [ "$CHECKOUT_MODE" = "full" ]; then
     if git log --merges --format='%H' "origin/$DEFAULT_BRANCH..HEAD" | grep -q .; then
       INTEGRATION_MODE="merge"
       echo "Branch $BRANCH uses merge commits — merging origin/$DEFAULT_BRANCH"
-      git merge "origin/$DEFAULT_BRANCH"
+      git merge --no-edit "origin/$DEFAULT_BRANCH"
       INTEGRATION_EXIT=$?
     else
       INTEGRATION_MODE="rebase"

--- a/plugins/source-control/skills/pull-request/reference/babysit.md
+++ b/plugins/source-control/skills/pull-request/reference/babysit.md
@@ -215,27 +215,46 @@ else
   CHECKOUT_MODE="full"
 fi
 
-# Branch freshness — rebase if behind the default branch (full mode only)
+# Branch freshness — preserve the branch's integration workflow (full mode only)
 if [ "$CHECKOUT_MODE" = "full" ]; then
   if ! git merge-base --is-ancestor "origin/$DEFAULT_BRANCH" HEAD; then
-    echo "Branch $BRANCH is behind origin/$DEFAULT_BRANCH — rebasing"
-    if git rebase "origin/$DEFAULT_BRANCH"; then
-      REBASE_STATUS="rebased"
-      # Bare push — the branch's upstream was configured by `gh pr checkout`
-      # (fork PRs push to the HEAD repository, not the base repo's origin).
-      git push --force-with-lease
+    if git log --merges --format='%H' "origin/$DEFAULT_BRANCH..HEAD" | grep -q .; then
+      INTEGRATION_MODE="merge"
+      echo "Branch $BRANCH uses merge commits — merging origin/$DEFAULT_BRANCH"
+      git merge "origin/$DEFAULT_BRANCH"
+      INTEGRATION_EXIT=$?
+    else
+      INTEGRATION_MODE="rebase"
+      echo "Branch $BRANCH is behind origin/$DEFAULT_BRANCH — rebasing"
+      git rebase "origin/$DEFAULT_BRANCH"
+      INTEGRATION_EXIT=$?
+    fi
+
+    if [ "$INTEGRATION_EXIT" -eq 0 ]; then
+      REBASE_STATUS="integrated"
+      # A merge preserves existing commits and pushes normally. A rebase
+      # rewrites them and therefore needs a lease-protected force push.
+      if [ "$INTEGRATION_MODE" = "merge" ]; then
+        git push
+      else
+        git push --force-with-lease
+      fi
     else
       # Graduated conflict handling — attempt simple, abort complex.
-      # conflict-attempting is a TRANSIENT state: resolve it (rebase
-      # --continue) or abort BEFORE any further processing — never leave a
-      # rebase in progress (unmerged paths break later checkouts + parking).
+      # conflict-attempting is a TRANSIENT state: resolve it (merge/rebase
+      # --continue) or abort BEFORE any further processing — never leave an
+      # integration in progress (unmerged paths break later checkouts + parking).
       CONFLICT_COUNT=$(git diff --name-only --diff-filter=U | grep -c . || true)
       if [ "$CONFLICT_COUNT" -le 3 ]; then
         echo "Simple conflict ($CONFLICT_COUNT files) — attempting resolution"
         REBASE_STATUS="conflict-attempting"
       else
-        echo "Complex conflict ($CONFLICT_COUNT files) — aborting rebase"
-        git rebase --abort
+        echo "Complex conflict ($CONFLICT_COUNT files) — aborting $INTEGRATION_MODE"
+        if [ "$INTEGRATION_MODE" = "merge" ]; then
+          git merge --abort
+        else
+          git rebase --abort
+        fi
         REBASE_STATUS="conflict-aborted"
       fi
     fi
@@ -244,25 +263,26 @@ if [ "$CHECKOUT_MODE" = "full" ]; then
   fi
 
   # conflict-attempting: resolve NOW — per file, take the mechanical
-  # resolution; if ANY file needs intent judgment, `git rebase --abort` and
-  # set REBASE_STATUS="conflict-aborted". On success: `git add <files>` +
-  # `git rebase --continue` + a bare `git push --force-with-lease` (upstream
-  # set by gh pr checkout), then REBASE_STATUS="rebased". Only terminal states pass this point.
+  # resolution; if ANY file needs intent judgment, abort the active merge or
+  # rebase and set REBASE_STATUS="conflict-aborted". On success: `git add
+  # <files>` + the matching `git merge --continue` / `git rebase --continue`,
+  # then plain `git push` for a merge or `git push --force-with-lease` for a
+  # rebase. Set REBASE_STATUS="integrated". Only terminal states pass this point.
 
   # Safe fallback: ONLY the terminal success states keep full mode. A
   # lingering conflict-attempting (resolution skipped) degrades to read-only
   # rather than granting write access mid-rebase.
-  if [ "$REBASE_STATUS" != "rebased" ] && [ "$REBASE_STATUS" != "current" ]; then
+  if [ "$REBASE_STATUS" != "integrated" ] && [ "$REBASE_STATUS" != "current" ]; then
     CHECKOUT_MODE="read-only"
   fi
 fi
 ```
 
-**Rebase conflict handling (graduated).** Check for merge commits first (`git log --merges origin/$DEFAULT_BRANCH..HEAD`) — a branch that previously merged the default branch integrates via `git merge origin/$DEFAULT_BRANCH`, not rebase. Then:
+**Integration conflict handling (graduated).** Check for merge commits first (`git log --merges origin/$DEFAULT_BRANCH..HEAD`) — a branch that previously merged the default branch integrates via `git merge origin/$DEFAULT_BRANCH` plus a plain push; other branches rebase and force-push with lease. Then:
 
-- **Zero conflicts** (`REBASE_STATUS=rebased`) — rebase succeeded, force-push with lease, continue normally
-- **Simple conflicts** (≤3 files, `REBASE_STATUS=conflict-attempting`) — TRANSIENT: attempt resolution immediately; on success `git rebase --continue` + bare `git push --force-with-lease` → `rebased`; if ANY file requires intent judgment, `git rebase --abort` → `conflict-aborted`. Never proceed to comment processing, parking, or the next PR with a rebase in progress
-- **Complex conflicts** (>3 files, `REBASE_STATUS=conflict-aborted`) — abort the rebase, post a PR comment: `"⚠️ Branch is behind main with merge conflicts ({N} files). Manual rebase required before CI will trigger."`. If an interactive terminal, also surface to the user directly. Process comments read-only (classification + reply, no fixes — the code may be stale)
+- **Zero conflicts** (`REBASE_STATUS=integrated`) — merge or rebase succeeded, push with the mode-appropriate command, continue normally
+- **Simple conflicts** (≤3 files, `REBASE_STATUS=conflict-attempting`) — TRANSIENT: attempt resolution immediately; on success continue the active merge/rebase and push with the mode-appropriate command → `integrated`; if ANY file requires intent judgment, abort the active integration → `conflict-aborted`. Never proceed to comment processing, parking, or the next PR with an integration in progress
+- **Complex conflicts** (>3 files, `REBASE_STATUS=conflict-aborted`) — abort the merge/rebase, post a PR comment: `"⚠️ Branch is behind main with integration conflicts ({N} files). Manual resolution is required before CI will trigger."`. If an interactive terminal, also surface to the user directly. Process comments read-only (classification + reply, no fixes — the code may be stale)
 - **Already current** (`REBASE_STATUS=current`) — no action needed
 
 **Why mandatory:** exploration and research read files from the working tree. Without checkout, findings are validated against the wrong code. Branch freshness prevents CI failures from stale code and ensures conflict detection happens proactively.
@@ -404,7 +424,7 @@ Every iteration MUST output a completed checklist with evidence per step. Free-f
 
 #### PR #<N> — <title> (<branch>)
 - [ ] **Branch:** checked out <branch> (mode: full/read-only)
-- [ ] **Branch freshness:** <current/rebased/conflict-aborted> — evidence: `git merge-base` output
+- [ ] **Branch freshness:** <current/integrated/conflict-aborted> — evidence: `git merge-base` output
 - [ ] **CI:** <pass/fail/pending> — evidence: `gh pr checks <N>` output
 - [ ] **Comments fetched:** <N> total from all 3 API surfaces (<M> self-replies filtered)
 - [ ] **Findings extracted:** <M> individual findings from <K> comments

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -106,17 +106,18 @@ if [[ -n "$ISSUE_NUM" ]]; then
   # GitHub auto-close only fires when the issue exists, lives in this repo,
   # and is open at merge time. A typo'd branch like
   # `feat/99999-foo` would otherwise ship a misleading `Closes #99999` line.
-  if gh issue view "$ISSUE_NUM" --json state,number >/dev/null 2>&1; then
+  ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null || true)
+  if [[ "$ISSUE_STATE" == "OPEN" ]]; then
     CLOSES_LINE="Closes #${ISSUE_NUM}"
   else
-    echo "⚠ Branch suggests Closes #${ISSUE_NUM} but no such issue in this repo. Falling back to interactive prompt." >&2
+    echo "⚠ Branch suggests Closes #${ISSUE_NUM}, but that issue is missing or not open in this repo. Falling back to interactive prompt." >&2
     ISSUE_NUM=""   # fall through to orphan-PR 3-option prompt below
   fi
 fi
 # If still empty, the orphan-PR prompt populates CLOSES_LINE below.
 ```
 
-**Single-issue branch:** parser returns `N` from `<type>/<N>-<slug>` (and `chore/routine-issue-<N>-<slug>` for cloud routines). When `gh issue view` confirms issue exists, `${CLOSES_LINE}` becomes `Closes #N`. If issue doesn't exist (typo / wrong repo / closed-and-deleted), flow falls through to orphan-PR prompt — never ship an unverified keyword.
+**Single-issue branch:** parser returns `N` from `<type>/<N>-<slug>` (and `chore/routine-issue-<N>-<slug>` for cloud routines). When `gh issue view` confirms the issue exists and its state is `OPEN`, `${CLOSES_LINE}` becomes `Closes #N`. If the issue is missing, closed, or otherwise not open, the flow falls through to the orphan-PR prompt — never ship a stale or unverified keyword.
 
 **Multi-issue PR (same branch closes 2+ issues):** after primary line is set, ask user inline:
 

--- a/plugins/source-control/skills/pull-request/reference/merge.md
+++ b/plugins/source-control/skills/pull-request/reference/merge.md
@@ -54,17 +54,24 @@ Reuse the worktree for next task by creating a new branch from the latest defaul
 # 0. Resolve the repo's default branch (repo-agnostic — not every repo uses main)
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 
-# 1. Get the latest default branch
+# 1. Preserve unrelated local work before changing branches. Non-conflicting
+# edits otherwise carry silently onto the next task branch.
+if [ -n "$(git status --porcelain)" ]; then
+  git stash push -u -m "pre-merge-cleanup: <old-branch>"
+  echo "Stashed uncommitted changes before worktree reuse."
+fi
+
+# 2. Get the latest default branch
 git fetch origin "$DEFAULT_BRANCH"
 
-# 2. Create new branch from it (NOT checkout of the default branch — that's blocked in a worktree)
+# 3. Create new branch from it (NOT checkout of the default branch — that's blocked in a worktree)
 git checkout -b <new-type>/<new-desc> "origin/$DEFAULT_BRANCH"
 
-# 3. Delete old merged branch (squash merge needs -D not -d)
+# 4. Delete old merged branch (squash merge needs -D not -d)
 git branch -D <old-branch>
 ```
 
-Then report the transition and suggest `/clear` for fresh conversation context (`/clear` fires any SessionStart hooks the project registers). Use `-D` not `-d` because squash merge changes the commit SHA.
+If a stash was created, report it and tell the user to inspect it with `git stash list` and restore it on an appropriate branch with `git stash pop`. Then report the transition and suggest `/clear` for fresh conversation context (`/clear` fires any SessionStart hooks the project registers). Use `-D` not `-d` because squash merge changes the commit SHA.
 
 Worktree reuse (new branch from latest default branch in the same directory) is faster than remove+recreate and preserves gitignored files; the alternative is `ExitWorktree` + a fresh `EnterWorktree` for a clean slate.
 


### PR DESCRIPTION
Closes #73

## Summary

- require a branch-derived issue to be `OPEN` before emitting `Closes #N`
- preserve merge-commit branch history during babysit integration and use a plain push after merges
- stash dirty worktrees before reusing them for a new task branch
- add focused evals for all three deferred review findings and bump source-control to 0.4.1

## Why

The previous issue lookup treated any successful `gh issue view` as closable, the babysit snippet always rebased despite its merge-workflow rule, and worktree reuse could silently carry unrelated edits onto a new branch.

Current behavior was verified against the official GitHub CLI issue JSON reference and Git's current log, merge, rebase, status, and checkout documentation:

- https://cli.github.com/manual/gh_issue_view
- https://git-scm.com/docs/git-log
- https://git-scm.com/docs/git-merge
- https://git-scm.com/docs/git-rebase
- https://git-scm.com/docs/git-status
- https://git-scm.com/docs/git-checkout
- https://code.claude.com/docs/en/skills

## Validation

- `node scripts/validate-plugin-contracts.mjs`
- `node scripts/generate-catalog.mjs --check`
- `claude plugin validate plugins/source-control`
- `git diff --check`

The repository-wide shell-test runner was attempted, but its pre-existing babysit readiness suite exceeds the local 30-second per-test diagnostic timeout; no shell implementation changed in this PR.