### PR TITLE
fix(link-check): ignore runtime and fixture URLs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -5,3 +5,11 @@
 # upstream sibling files that are deliberately not vendored — do not check
 # links that resolve into a vendor directory.
 /plugins/[^/]+/skills/[^/]+/vendor/
+
+# Claude Code expands these runtime variables after loading an installed
+# plugin. In source Markdown they are intentionally not filesystem paths.
+CLAUDE_(PLUGIN_ROOT|PLUGIN_DATA|PROJECT_DIR|SKILL_DIR)
+
+# Synthetic ai-briefing eval fixtures use a fictional release feed. The URLs
+# are test data for ranking/deduplication behavior, not external dependencies.
+github\.com/meridian-labs/agent-cli/releases/tag/


### PR DESCRIPTION
Closes #18

Depends on melodic-software/standards#135 and its generated standards-sync PR.

## Summary

- ignore Claude Code runtime-variable links that are valid only after plugin installation expands the variable
- ignore fictional release URLs embedded in ai-briefing eval fixtures
- keep real local links and external dependency URLs checked

## Why

The original `--accept-timeouts` compatibility failure is already fixed and the reusable workflow pin on `main` contains Lychee 0.24.2. Re-running the current full Markdown corpus exposed two consumer-owned false-positive classes: runtime-substituted plugin paths and fictional fixture URLs.

The remaining shared exclusions belong to the standards-managed `lychee.toml`: exact private raw-content inventory plus five exact public bot-blocked paths. They are implemented and boundary-tested upstream in melodic-software/standards#135 rather than copied downstream; unrelated URLs on those public hosts remain checked.

Lychee's current official documentation distinguishes URL regex exclusions (including `.lycheeignore`) from source-path exclusions:

- https://lychee.cli.rs/recipes/excluding-links/
- https://lychee.cli.rs/recipes/excluding-paths/
- https://lychee.cli.rs/guides/config/#excluding-links

## Validation

Using this branch's `.lycheeignore` with the proposed standards config:

- online: 1,655 links scanned, 0 errors
- offline: 1,655 links scanned, 0 errors
- `git diff --check`

The scheduled hosted lane remains intentionally skipped while `CI_RUNNER_POLICY=self-hosted-only`; no policy change is included.