### PR TITLE
feat: add cross-plugin source-drift discovery check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,21 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/sync-hook-utils.sh --check-bump "origin/$BASE_REF"
 
+  cross-plugin-source-drift:
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check for unregistered or drifted cross-plugin source clusters
+        run: scripts/check-cross-plugin-source-drift.sh --check
+      - name: Run cross-plugin-source-drift tests
+        run: bash scripts/check-cross-plugin-source-drift.test.sh
+
   plugin-gate:
     needs: select-runner
     if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
@@ -341,6 +356,7 @@ jobs:
     needs:
       - hygiene
       - hook-utils-sync
+      - cross-plugin-source-drift
       - plugin-gate
       - miro-plugin
       - runner-policy

--- a/scripts/check-cross-plugin-source-drift.sh
+++ b/scripts/check-cross-plugin-source-drift.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Discover and check cross-plugin shared-source-file drift: files that live
+# at the same path-within-plugin (e.g. hooks/hook-utils.sh) in 2+ plugins.
+#
+#   scripts/check-cross-plugin-source-drift.sh          discover: list every
+#                                                        current cross-plugin
+#                                                        file cluster and
+#                                                        whether its copies
+#                                                        are identical
+#   scripts/check-cross-plugin-source-drift.sh --check  fail if a registered
+#                                                        cluster has drifted,
+#                                                        or an unregistered
+#                                                        cluster is now fully
+#                                                        identical
+#
+# This does not replace a cluster's own dedicated drift check --
+# scripts/sync-hook-utils.sh stays authoritative for hooks/hook-utils.sh,
+# scripts/validate-plugin-contracts.mjs for reference/artifact-protocol.md.
+# This script's job is the one neither of those can do: notice when a NEW
+# shared-copy pattern appears with no dedicated check yet, the same way the
+# babysit-prs / source-control:pull-request policy split drifted apart
+# silently until a manual audit caught it. Register a cluster in
+# cross-plugin-source-registry.txt once it has a dedicated check (or is
+# accepted as low-stakes coincidence); an unregistered identical cluster is
+# a decision waiting to be made, not yet a violation of anything.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+registry="scripts/cross-plugin-source-registry.txt"
+
+# Filenames that are *expected* to differ per plugin by design -- excluded
+# from clustering entirely so they never produce noise.
+skip_basenames=(SKILL.md plugin.json README.md CHANGELOG.md evals.json hooks.json .gitignore)
+
+is_skipped() {
+  local base="$1" skip
+  for skip in "${skip_basenames[@]}"; do
+    [[ "$base" == "$skip" ]] && return 0
+  done
+  return 1
+}
+
+# rel path within a plugin -> space-separated "plugin:fullpath" entries
+declare -A cluster_entries
+# rel path -> IDENTICAL | DIFFERS (only set for clusters with 2+ entries)
+declare -A cluster_status
+
+for plugin_dir in plugins/*/; do
+  plugin="${plugin_dir%/}"
+  plugin="${plugin##*/}"
+  while IFS= read -r -d '' full; do
+    base="${full##*/}"
+    # shellcheck disable=SC2310  # is_skipped only compares strings; nothing inside it can fail
+    if is_skipped "$base"; then
+      continue
+    fi
+    rel="${full#"$plugin_dir"}"
+    cluster_entries["$rel"]+="${plugin}:${full} "
+  done < <(find "$plugin_dir" -type f -print0)
+done
+
+for rel in "${!cluster_entries[@]}"; do
+  # shellcheck disable=SC2206
+  entries=(${cluster_entries[$rel]})
+  ((${#entries[@]} >= 2)) || continue
+
+  first_hash=""
+  identical=1
+  for entry in "${entries[@]}"; do
+    read -r h _ < <(sha256sum "${entry#*:}")
+    if [[ -z "$first_hash" ]]; then
+      first_hash="$h"
+    elif [[ "$h" != "$first_hash" ]]; then
+      identical=0
+    fi
+  done
+  if ((identical)); then
+    cluster_status["$rel"]="IDENTICAL"
+  else
+    cluster_status["$rel"]="DIFFERS"
+  fi
+done
+
+declare -A registered
+if [[ -f "$registry" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    registered["$line"]=1
+  done <"$registry"
+fi
+
+mode="${1:-discover}"
+case "$mode" in
+discover | --check) ;;
+*)
+  echo "usage: $(basename "$0") [--check]" >&2
+  exit 2
+  ;;
+esac
+
+if [[ "$mode" == "discover" ]]; then
+  for rel in $(printf '%s\n' "${!cluster_status[@]}" | sort); do
+    # shellcheck disable=SC2206
+    entries=(${cluster_entries[$rel]})
+    plugins_list=()
+    for entry in "${entries[@]}"; do
+      plugins_list+=("${entry%%:*}")
+    done
+    reg=""
+    [[ -n "${registered[$rel]:-}" ]] && reg=" [registered]"
+    printf '%-10s %s  (plugins: %s)%s\n' "${cluster_status[$rel]}" "$rel" "${plugins_list[*]}" "$reg"
+  done
+  exit 0
+fi
+
+# --check mode
+errors=0
+
+for rel in "${!cluster_status[@]}"; do
+  if [[ "${cluster_status[$rel]}" == "IDENTICAL" && -z "${registered[$rel]:-}" ]]; then
+    # shellcheck disable=SC2206
+    entries=(${cluster_entries[$rel]})
+    plugins_list=()
+    for entry in "${entries[@]}"; do
+      plugins_list+=("${entry%%:*}")
+    done
+    echo "UNREGISTERED: $rel is byte-identical across ${#entries[@]} plugins (${plugins_list[*]}) with no entry in $registry." >&2
+    echo "  Either give it a dedicated drift check and register it, or add it to $registry as accepted." >&2
+    errors=$((errors + 1))
+  fi
+done
+
+for rel in "${!registered[@]}"; do
+  status="${cluster_status[$rel]:-}"
+  if [[ -z "$status" ]]; then
+    echo "REGISTRY STALE: $rel is registered but no longer appears in 2+ plugins." >&2
+    errors=$((errors + 1))
+  elif [[ "$status" != "IDENTICAL" ]]; then
+    echo "DRIFTED: $rel is registered as a shared-copy cluster but its copies no longer match." >&2
+    errors=$((errors + 1))
+  fi
+done
+
+if ((errors > 0)); then
+  exit 1
+fi
+echo "No unregistered or drifted cross-plugin source clusters found."

--- a/scripts/check-cross-plugin-source-drift.test.sh
+++ b/scripts/check-cross-plugin-source-drift.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Unit tests for check-cross-plugin-source-drift.sh. Builds a tiny synthetic
+# plugins/ tree per scenario in a temp dir (not the real repo tree, which is
+# large and would make these tests slow and coupled to live content) and
+# invokes the script against it directly -- the script's own
+# `cd "$(dirname "$0")/.."` makes this work unmodified: copy it to
+# <fixture>/scripts/ and it operates on <fixture>/plugins and
+# <fixture>/scripts/cross-plugin-source-registry.txt.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SELF_DIR/check-cross-plugin-source-drift.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# new_fixture → prints the path to a fresh <tmp>/scripts + <tmp>/plugins tree
+# with the script copied in, ready for callers to populate.
+new_fixture() {
+  local dir
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/scripts" "$dir/plugins"
+  cp "$SCRIPT" "$dir/scripts/check-cross-plugin-source-drift.sh"
+  chmod +x "$dir/scripts/check-cross-plugin-source-drift.sh"
+  printf '%s' "$dir"
+}
+
+# plugin_file <fixture> <plugin> <relpath> <content>
+plugin_file() {
+  local fixture="$1" plugin="$2" rel="$3" content="$4"
+  mkdir -p "$(dirname "$fixture/plugins/$plugin/$rel")"
+  printf '%s' "$content" >"$fixture/plugins/$plugin/$rel"
+}
+
+registry() {
+  local fixture="$1"
+  shift
+  printf '%s\n' "$@" >"$fixture/scripts/cross-plugin-source-registry.txt"
+}
+
+run_check() (
+  cd "$1" && bash scripts/check-cross-plugin-source-drift.sh --check
+)
+
+run_discover() (
+  cd "$1" && bash scripts/check-cross-plugin-source-drift.sh
+)
+
+# --- an identical cluster that's registered passes -------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/shared.sh "same content"
+plugin_file "$f" beta hooks/shared.sh "same content"
+registry "$f" "hooks/shared.sh"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "registered identical cluster passes --check"
+else
+  fail "registered identical cluster should pass --check, got: $out"
+fi
+rm -rf "$f"
+
+# --- an identical cluster with NO registry entry fails ----------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/new-shared.sh "same content"
+plugin_file "$f" beta hooks/new-shared.sh "same content"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "unregistered identical cluster should fail --check, got success: $out"
+else
+  if echo "$out" | grep -q "UNREGISTERED"; then
+    ok "unregistered identical cluster fails --check with UNREGISTERED"
+  else
+    fail "expected UNREGISTERED in output, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- a registered cluster that has drifted (copies no longer match) fails --
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/shared.sh "version one"
+plugin_file "$f" beta hooks/shared.sh "version two -- drifted"
+registry "$f" "hooks/shared.sh"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "drifted registered cluster should fail --check, got success: $out"
+else
+  if echo "$out" | grep -q "DRIFTED"; then
+    ok "drifted registered cluster fails --check with DRIFTED"
+  else
+    fail "expected DRIFTED in output, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- a registered cluster that dropped below 2 copies fails as stale -------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/shared.sh "only one copy left"
+registry "$f" "hooks/shared.sh"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "registry entry with <2 copies should fail --check, got success: $out"
+else
+  if echo "$out" | grep -q "REGISTRY STALE"; then
+    ok "registry entry with <2 copies fails --check with REGISTRY STALE"
+  else
+    fail "expected REGISTRY STALE in output, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- files that legitimately differ per plugin are never flagged -----------
+f="$(new_fixture)"
+plugin_file "$f" alpha SKILL.md "alpha's own content"
+plugin_file "$f" beta SKILL.md "beta's own, totally different"
+plugin_file "$f" alpha README.md "alpha readme"
+plugin_file "$f" beta README.md "beta readme"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "per-plugin-by-design files (SKILL.md, README.md) never flagged"
+else
+  fail "expected --check to pass with no shared-copy candidates, got: $out"
+fi
+rm -rf "$f"
+
+# --- discover mode lists both IDENTICAL and DIFFERS clusters, with [registered] tag
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/shared.sh "same"
+plugin_file "$f" beta hooks/shared.sh "same"
+plugin_file "$f" alpha reference/per-plugin.md "alpha version"
+plugin_file "$f" beta reference/per-plugin.md "beta version"
+registry "$f" "hooks/shared.sh"
+out="$(run_discover "$f" 2>&1)"
+if echo "$out" | grep -q "IDENTICAL.*hooks/shared.sh.*\[registered\]"; then
+  ok "discover tags a registered identical cluster"
+else
+  fail "expected discover to tag hooks/shared.sh as IDENTICAL + [registered], got: $out"
+fi
+if echo "$out" | grep -q "DIFFERS.*reference/per-plugin.md"; then
+  ok "discover lists a differing cluster without failing"
+else
+  fail "expected discover to list reference/per-plugin.md as DIFFERS, got: $out"
+fi
+rm -rf "$f"
+
+# --- a single plugin carrying a file is not a cluster (no 2+ occurrence) ---
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/only-here.sh "content"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "a file carried by only one plugin is never treated as a cluster"
+else
+  fail "single-plugin file should not trigger --check failure, got: $out"
+fi
+rm -rf "$f"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/cross-plugin-source-registry.txt
+++ b/scripts/cross-plugin-source-registry.txt
@@ -1,0 +1,14 @@
+# Cross-plugin shared-source-file clusters that are expected to stay
+# byte-identical across every plugin that carries them, and already have a
+# dedicated drift check elsewhere. Read by check-cross-plugin-source-drift.sh
+# --check: an identical cluster not listed here fails as "unregistered" (a
+# new shared-copy pattern needing a decision); a listed cluster whose copies
+# no longer match fails as "drifted".
+#
+# One path-within-plugin per line, relative to each plugin's own root.
+
+# Dedicated check: scripts/sync-hook-utils.sh --check (CI: hook-utils-sync)
+hooks/hook-utils.sh
+
+# Dedicated check: scripts/validate-plugin-contracts.mjs (lifecycleProtocolCopies)
+reference/artifact-protocol.md


### PR DESCRIPTION
## Summary

Closes decision #37 (Decisions Log: https://claude.ai/code/artifact/232ecdce-8316-4880-8c0a-dc3c7dcf3a63).

**Redirected implementation** (per the Decisions Log's corrected premise): this is a `claude-code-plugins` repo internal dev-time concern, not a `claude-config-audit` plugin addition — that plugin has no scope over this marketplace repo's own `plugins/` tree.

## Why

`scripts/sync-hook-utils.sh` and `scripts/validate-plugin-contracts.mjs` each already enforce byte-identical copies for one specific shared file (`hooks/hook-utils.sh`, `reference/artifact-protocol.md`) — both hardcoded to the one cluster they were built for. Neither would notice a **third** shared-copy pattern appearing tomorrow; someone has to remember to hand-write a new check every time. That's the same shape of gap that let the `babysit-prs` / `source-control:pull-request` policy split drift apart uncaught until a manual audit found it.

## What

`scripts/check-cross-plugin-source-drift.sh` discovers every file that lives at the same path-within-plugin in 2+ plugins today, and `--check` fails if:

- a currently byte-identical cluster has no entry in `scripts/cross-plugin-source-registry.txt` (a new pattern needs a decision: give it a dedicated check, or register it as accepted), or
- a registered cluster's copies no longer match, or a registered path dropped below 2 plugin copies.

Seeded the registry with the two known clusters (both already governed by their own dedicated check — this is defense-in-depth for them, not a replacement). Confirmed empirically against the live tree: exactly these two clusters are identical today; everything else that shares a basename (`topic-docs.md`, `checklist.md`, `audit-checklist.md`) differs by design and is correctly ignored.

New CI lane `cross-plugin-source-drift`, wired into `ci-status`'s `needs:`, mirroring the `hook-utils-sync` lane's CI-lane precedent.

## Verification

- `scripts/check-cross-plugin-source-drift.test.sh`: 8/8 pass (synthetic fixtures — isolated from the live tree so tests stay fast and deterministic).
- `scripts/check-cross-plugin-source-drift.sh` (discover + `--check`) run against the real tree: correctly finds the 2 known identical clusters (both registered → passes) and correctly ignores the 3 known differs-by-design clusters.
- `shellcheck --rcfile=.shellcheckrc`: clean on both new scripts.
- `shfmt -d`: clean.
- `actionlint`: clean on the updated `ci.yml`.

Opened as draft — leaving merge-ready work queued for review rather than merging autonomously.