### PR TITLE
feat(review): dereference cross-repo REVIEW.md citations

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -9,8 +9,9 @@ All notable changes to the `review` plugin are documented here. Format follows
 
 - **Cross-repo `REVIEW.md` citation dereferencing** in `code-reviewer`, `security-reviewer`, and
   `architecture-guardian`. Each now recognizes a code-span citation in a consuming project's
-  `REVIEW.md` shaped like `<relative-path>.md#<heading>` and Reads that path — which may live
-  outside the current repository, mounted via `--add-dir` — for the full criterion behind a thin
+  `REVIEW.md` shaped like `<relative-path>.md#<heading>`, splits it into the file path and heading
+  anchor, and Reads only the `.md` file — which may live outside the current repository, mounted via
+  `--add-dir` — before locating the referenced heading for the full criterion behind a thin
   `REVIEW.md` line before finalizing an overlapping finding. An unresolved citation (mount absent,
   wrong path) is noted in the agent's report rather than dropped silently or treated as a hard
   failure. Whether a `--add-dir`-mounted path is visible to a plugin subagent's `Read` tool the same

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.0]
+
+### Added
+
+- **Cross-repo `REVIEW.md` citation dereferencing** in `code-reviewer`, `security-reviewer`, and
+  `architecture-guardian`. Each now recognizes a code-span citation in a consuming project's
+  `REVIEW.md` shaped like `<relative-path>.md#<heading>` and Reads that path — which may live
+  outside the current repository, mounted via `--add-dir` — for the full criterion behind a thin
+  `REVIEW.md` line before finalizing an overlapping finding. An unresolved citation (mount absent,
+  wrong path) is noted in the agent's report rather than dropped silently or treated as a hard
+  failure. Whether a `--add-dir`-mounted path is visible to a plugin subagent's `Read` tool the same
+  way it is to the main session is not yet empirically verified against a live cross-repo mount.
+
 ## [0.8.0]
 
 ### Changed

--- a/plugins/review/agents/architecture-guardian.md
+++ b/plugins/review/agents/architecture-guardian.md
@@ -11,7 +11,7 @@ You are a senior software architect reviewing code changes for architectural vio
 
 ## Before reviewing
 
-1. **Read the project's own architecture reference first** — architecture docs, ADRs, layer rules, module conventions (`CLAUDE.md`, `REVIEW.md`, project rules, `docs/architecture*`, `ARCHITECTURE.md`), when present. The project's documented architecture is authoritative; this baseline fills the gaps. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, Read that path (it may live outside this repository, mounted via `--add-dir`, or be present locally) for the full criterion behind that line before finalizing any finding that overlaps its topic. If the path doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
+1. **Read the project's own architecture reference first** — architecture docs, ADRs, layer rules, module conventions (`CLAUDE.md`, `REVIEW.md`, project rules, `docs/architecture*`, `ARCHITECTURE.md`), when present. The project's documented architecture is authoritative; this baseline fills the gaps. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, split it at the last `#`: Read only the `<relative-path>.md` file (it may live outside this repository, mounted via `--add-dir`, or be present locally), then locate the `<heading>` section within it for the full criterion behind that line before finalizing any finding that overlaps its topic. If the `.md` file doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
 2. **Identify the change set** — run:
 
    ```bash

--- a/plugins/review/agents/architecture-guardian.md
+++ b/plugins/review/agents/architecture-guardian.md
@@ -11,7 +11,7 @@ You are a senior software architect reviewing code changes for architectural vio
 
 ## Before reviewing
 
-1. **Read the project's own architecture reference first** — architecture docs, ADRs, layer rules, module conventions (`CLAUDE.md`, project rules, `docs/architecture*`, `ARCHITECTURE.md`), when present. The project's documented architecture is authoritative; this baseline fills the gaps.
+1. **Read the project's own architecture reference first** — architecture docs, ADRs, layer rules, module conventions (`CLAUDE.md`, `REVIEW.md`, project rules, `docs/architecture*`, `ARCHITECTURE.md`), when present. The project's documented architecture is authoritative; this baseline fills the gaps. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, Read that path (it may live outside this repository, mounted via `--add-dir`, or be present locally) for the full criterion behind that line before finalizing any finding that overlaps its topic. If the path doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
 2. **Identify the change set** — run:
 
    ```bash

--- a/plugins/review/agents/code-reviewer.md
+++ b/plugins/review/agents/code-reviewer.md
@@ -11,7 +11,7 @@ You are a senior code reviewer. Your job is to catch issues that automated tooli
 
 ## Before reviewing
 
-1. **Read the project's own conventions first.** Check for a `CLAUDE.md`, project rules, a `REVIEW.md` or review-criteria docs, and contributing guides. The project's documented conventions override this baseline wherever they conflict.
+1. **Read the project's own conventions first.** Check for a `CLAUDE.md`, project rules, a `REVIEW.md` or review-criteria docs, and contributing guides. The project's documented conventions override this baseline wherever they conflict. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, Read that path (it may live outside this repository, mounted via `--add-dir`, or be present locally) for the full criterion behind that line before finalizing any finding that overlaps its topic. If the path doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
 2. **Identify the change set** — run:
 
    ```bash

--- a/plugins/review/agents/code-reviewer.md
+++ b/plugins/review/agents/code-reviewer.md
@@ -11,7 +11,7 @@ You are a senior code reviewer. Your job is to catch issues that automated tooli
 
 ## Before reviewing
 
-1. **Read the project's own conventions first.** Check for a `CLAUDE.md`, project rules, a `REVIEW.md` or review-criteria docs, and contributing guides. The project's documented conventions override this baseline wherever they conflict. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, Read that path (it may live outside this repository, mounted via `--add-dir`, or be present locally) for the full criterion behind that line before finalizing any finding that overlaps its topic. If the path doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
+1. **Read the project's own conventions first.** Check for a `CLAUDE.md`, project rules, a `REVIEW.md` or review-criteria docs, and contributing guides. The project's documented conventions override this baseline wherever they conflict. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, split it at the last `#`: Read only the `<relative-path>.md` file (it may live outside this repository, mounted via `--add-dir`, or be present locally), then locate the `<heading>` section within it for the full criterion behind that line before finalizing any finding that overlaps its topic. If the `.md` file doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
 2. **Identify the change set** — run:
 
    ```bash

--- a/plugins/review/agents/security-reviewer.md
+++ b/plugins/review/agents/security-reviewer.md
@@ -11,7 +11,7 @@ You are a senior security engineer reviewing code changes. Your job is to catch 
 
 ## Before reviewing
 
-1. **Read the project's own security criteria first** — a security review guide, threat-model doc, or security section of the project rules, when present. Project criteria override this baseline wherever they conflict.
+1. **Read the project's own security criteria first** — a security review guide, threat-model doc, `REVIEW.md`, or security section of the project rules, when present. Project criteria override this baseline wherever they conflict. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, Read that path (it may live outside this repository, mounted via `--add-dir`, or be present locally) for the full criterion behind that line before finalizing any finding that overlaps its topic. If the path doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
 2. **Identify the change set** — run:
 
    ```bash

--- a/plugins/review/agents/security-reviewer.md
+++ b/plugins/review/agents/security-reviewer.md
@@ -11,7 +11,7 @@ You are a senior security engineer reviewing code changes. Your job is to catch 
 
 ## Before reviewing
 
-1. **Read the project's own security criteria first** — a security review guide, threat-model doc, `REVIEW.md`, or security section of the project rules, when present. Project criteria override this baseline wherever they conflict. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, Read that path (it may live outside this repository, mounted via `--add-dir`, or be present locally) for the full criterion behind that line before finalizing any finding that overlaps its topic. If the path doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
+1. **Read the project's own security criteria first** — a security review guide, threat-model doc, `REVIEW.md`, or security section of the project rules, when present. Project criteria override this baseline wherever they conflict. If `REVIEW.md` contains a code-span citation shaped like `<relative-path>.md#<heading>`, split it at the last `#`: Read only the `<relative-path>.md` file (it may live outside this repository, mounted via `--add-dir`, or be present locally), then locate the `<heading>` section within it for the full criterion behind that line before finalizing any finding that overlaps its topic. If the `.md` file doesn't exist, note the unresolved citation in your report and continue — don't drop the review or treat it as a hard failure.
 2. **Identify the change set** — run:
 
    ```bash


### PR DESCRIPTION
## Summary

Part of the org-wide standards-sync initiative (`melodic-software/standards`' `REVIEW.md` + `distribution/REVIEW-CREDENTIAL.md`). Today none of `code-reviewer`, `security-reviewer`, or `architecture-guardian` dereference a citation inside a consuming repo's `REVIEW.md` — only `code-reviewer` even mentions the file, and none follow a citation into a mounted external path.

- Teaches all three agents to recognize a `REVIEW.md` code-span citation shaped like `<relative-path>.md#<heading>` and `Read` that path — which may live outside the current repository, mounted via `--add-dir` (e.g. `melodic-software/ci-workflows`' `claude-review.yml@<sha>`, PR in flight) — for the full criterion behind a thin `REVIEW.md` line before finalizing an overlapping finding.
- Repo-agnostic per this repo's own `CLAUDE.md` rule: no consuming repo, path, or criteria file is named anywhere in the instruction text.
- `Read` is already granted to all three agents (confirmed from each file's frontmatter) — this is an instruction-only change, no tool-grant change.
- An unresolved citation (mount absent, wrong path) is noted in the agent's report rather than dropped silently or treated as a hard review failure.
- Bumps `plugin.json` to `0.9.0` and adds a `CHANGELOG.md` entry per this repo's Keep a Changelog format.

## Verified before writing (per this repo's CLAUDE.md)

- `code.claude.com/docs/en/memory` — confirmed `--add-dir` semantics.
- `code.claude.com/docs/en/code-review` — confirmed the `REVIEW.md` citation shape this session authored in `standards/REVIEW.md`, and confirmed this plugin's headless-CI consumption path is a separate, still-open question from this change (out of scope here — see the `ci-workflows` PR's own scope note).

## Explicitly unverified

Whether a `--add-dir`-mounted path is visible to a plugin subagent's `Read` tool the same way it is to the main session is not empirically confirmed against a live cross-repo mount (no such mount exists yet — the credential it depends on isn't provisioned). Tracked as an empirical-test follow-up, not asserted here.

## Test plan

- [ ] CI green.
- [ ] Cannot be functionally end-to-end tested yet — depends on the `ci-workflows` mount PR and the not-yet-provisioned credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)