### PR TITLE
fix(code-tidying): route tidy's PR creation through the canonical gate

### DIFF
--- a/plugins/code-tidying/skills/tidy/SKILL.md
+++ b/plugins/code-tidying/skills/tidy/SKILL.md
@@ -132,7 +132,11 @@ Self-review by the producing context is enough here — a fresh-context verifier
 
 ### Phase H — Ship
 
-Create the PR (`gh pr create`) with title:
+Never call `git commit` or `gh pr create` directly — Phase E already committed the tidyings, so what's left is PR creation, and that has a canonical gate (issue-linkage resolution, injection-safe body assembly, a pre-create check for a valid closing keyword or explicit opt-out) that a bare `gh pr create` skips entirely.
+
+If the `source-control` plugin is installed, invoke `/pull-request create`. Its stage-and-commit step is a no-op here (tree is already clean from Phase E), so it goes straight to rebase-check, issue-linkage resolution, and gated PR creation. Supply it this PR's title and body content:
+
+Title:
 
 ```text
 <lane-default-type>(<lane-area>): <what was tidied>
@@ -144,12 +148,14 @@ Examples:
 - `docs(skills): repair stale cross-references`
 - `chore(tools): apply shellcheck/shfmt drift across tools/*.sh`
 
-PR body sections:
+Body sections:
 
 - **Summary** — 1-3 bullets: which lane, which tidyings, anchor commit.
 - **Tidyings applied** — table: tidying type → file → line range → LOC delta.
 - **Deferred items** — if the scope budget capped the run, link filed issue numbers.
 - **Test plan** — verification commands run + results.
+
+If `source-control` isn't installed, apply the same invariants inline: resolve issue-linkage before writing a closing keyword (`Closes #N` only after confirming issue #N exists in this repo — e.g. `gh issue view N`; otherwise state `No related issue: <reason>`), assemble the body via a quoted heredoc (`<<'EOF'`) plus parameter-expansion concat rather than an unquoted `<<EOF` (which would execute any `$(...)` embedded in prompt-derived text), and refuse to call `gh pr create` until the assembled body contains a valid closing keyword or the opt-out marker.
 
 Then monitor checks (`gh pr checks <n> --watch`) until green. Address review-bot findings: verify each against the current code — fix the correct ones, rebut the incorrect ones with evidence. **Manual merge by a human** — this skill does NOT auto-merge.
 

--- a/plugins/code-tidying/skills/tidy/SKILL.md
+++ b/plugins/code-tidying/skills/tidy/SKILL.md
@@ -134,7 +134,7 @@ Self-review by the producing context is enough here — a fresh-context verifier
 
 Never call `git commit` or `gh pr create` directly — Phase E already committed the tidyings, so what's left is PR creation, and that has a canonical gate (issue-linkage resolution, injection-safe body assembly, a pre-create check for a valid closing keyword or explicit opt-out) that a bare `gh pr create` skips entirely.
 
-If the `source-control` plugin is installed, invoke `/pull-request create`. Its stage-and-commit step is a no-op here (tree is already clean from Phase E), so it goes straight to rebase-check, issue-linkage resolution, and gated PR creation. Supply it this PR's title and body content:
+If the `source-control` plugin is installed, invoke `/pull-request create`. Its stage-and-commit step is a no-op here (tree is already clean from Phase E), so it goes straight to rebase-check, issue-linkage resolution, and gated PR creation. Supply it this PR's title and body content — the canonical flow's body template is fixed to Summary + Test plan (`plugins/source-control/skills/pull-request/reference/create.md` §2.4.1), so give it only those two sections; tidy's own audit-trail content goes in a follow-up comment (below), not the PR body:
 
 Title:
 
@@ -151,11 +151,25 @@ Examples:
 Body sections:
 
 - **Summary** — 1-3 bullets: which lane, which tidyings, anchor commit.
-- **Tidyings applied** — table: tidying type → file → line range → LOC delta.
-- **Deferred items** — if the scope budget capped the run, link filed issue numbers.
 - **Test plan** — verification commands run + results.
 
-If `source-control` isn't installed, apply the same invariants inline: resolve issue-linkage before writing a closing keyword (`Closes #N` only after confirming issue #N exists in this repo — e.g. `gh issue view N`; otherwise state `No related issue: <reason>`), assemble the body via a quoted heredoc (`<<'EOF'`) plus parameter-expansion concat rather than an unquoted `<<EOF` (which would execute any `$(...)` embedded in prompt-derived text), and refuse to call `gh pr create` until the assembled body contains a valid closing keyword or the opt-out marker.
+`/pull-request create` reports the created `<pr_number>` back on completion (its own §2.6 "Report and stop"). Immediately post one follow-up comment on that PR with `tidy`'s own audit trail — content the canonical body template has no slot for:
+
+```bash
+gh pr comment <pr_number> --body-file - <<'EOF'
+## Tidyings applied
+
+<table: tidying type → file → line range → LOC delta>
+
+## Deferred items
+
+<links to filed issue numbers, if the scope budget capped the run>
+EOF
+```
+
+Omit the "Deferred items" section entirely when nothing was deferred — don't post an empty table either; skip the whole comment if Phase D found nothing to report beyond what's already in the PR body.
+
+If `source-control` isn't installed, apply the same invariants inline: resolve issue-linkage before writing a closing keyword (`Closes #N` only after confirming issue #N exists in this repo — e.g. `gh issue view N`; otherwise state `No related issue: <reason>`), assemble the body via a quoted heredoc (`<<'EOF'`) plus parameter-expansion concat rather than an unquoted `<<EOF` (which would execute any `$(...)` embedded in prompt-derived text), and refuse to call `gh pr create` until the assembled body contains a valid closing keyword or the opt-out marker. In this fallback path only, the Tidyings-applied/Deferred-items sections stay in the PR body itself (there is no canonical gate to conflict with).
 
 Then monitor checks (`gh pr checks <n> --watch`) until green. Address review-bot findings: verify each against the current code — fix the correct ones, rebut the incorrect ones with evidence. **Manual merge by a human** — this skill does NOT auto-merge.
 
@@ -191,7 +205,7 @@ Full template: [reference/scope-budget.md](reference/scope-budget.md). Summary:
 - Every item the scope budget cuts becomes one filed work item.
 - Title format: `<conv-type>(<area>): <what>`.
 - Body must include: rationale, file list, scope estimate (LOC + files), and a link to the parent tidy PR.
-- The PR body's "Deferred items" section links every filed item by number.
+- Phase H's "Deferred items" follow-up comment (or, when `source-control` isn't installed, the PR body's own "Deferred items" section) links every filed item by number.
 
 ## Gotchas
 

--- a/plugins/code-tidying/skills/tidy/SKILL.md
+++ b/plugins/code-tidying/skills/tidy/SKILL.md
@@ -167,7 +167,7 @@ gh pr comment <pr_number> --body-file - <<'EOF'
 EOF
 ```
 
-Omit the "Deferred items" section entirely when nothing was deferred — don't post an empty table either; skip the whole comment if Phase D found nothing to report beyond what's already in the PR body.
+The comment itself is never optional when a PR was created — "Tidyings applied" is never empty at that point (Phase D's empty-PR-avoidance rule means no PR gets created when there's nothing to tidy), and it's the only place this content appears now that the canonical body template has no slot for it. Only the "Deferred items" subsection is conditional: omit it when nothing was deferred, and never post it as an empty table.
 
 If `source-control` isn't installed, apply the same invariants inline: resolve issue-linkage before writing a closing keyword (`Closes #N` only after confirming issue #N exists in this repo — e.g. `gh issue view N`; otherwise state `No related issue: <reason>`), assemble the body via a quoted heredoc (`<<'EOF'`) plus parameter-expansion concat rather than an unquoted `<<EOF` (which would execute any `$(...)` embedded in prompt-derived text), and refuse to call `gh pr create` until the assembled body contains a valid closing keyword or the opt-out marker. In this fallback path only, the Tidyings-applied/Deferred-items sections stay in the PR body itself (there is no canonical gate to conflict with).
 

--- a/plugins/code-tidying/skills/tidy/reference/scope-budget.md
+++ b/plugins/code-tidying/skills/tidy/reference/scope-budget.md
@@ -51,7 +51,7 @@ When the hunt phase produces more candidates than fit in the budget:
 
 3. **Defer the rest.** For each unselected candidate above a "would-be-worth-doing" threshold (i.e., not trivial micro-tidyings — those just go away), file a work item using the deferred-items template below: via `/work-items:track add` when that plugin is installed, else `gh issue create`, else present the list to the user.
 
-4. **Record the deferred issue numbers in the PR body** under a `## Deferred items` section. This makes the PR's review obvious-by-default: "here's what I did, here's what I parked for next time, here are the issue numbers to hold me accountable."
+4. **Record the deferred issue numbers** under a `## Deferred items` section — in Phase H's follow-up PR comment when `source-control` is installed, otherwise directly in the PR body. This makes the PR's review obvious-by-default: "here's what I did, here's what I parked for next time, here are the issue numbers to hold me accountable."
 
 ### Greedy vs. optimal selection
 
@@ -128,6 +128,6 @@ No upper bound on deferred issues per run. If a single run defers >10 items, tha
 
 1. **Phase D (Hunt + prioritize + scope-budget enforce)** — after building the prioritized findings table, sum the LOC deltas. Apply the greedy selection.
 2. **Phase E (Implement)** — periodically check actual LOC delta against the running estimate (`git diff --stat origin/<default-branch>...HEAD`). This measures the full branch diff — all commits since the branch point, not just uncommitted changes relative to HEAD. If actual exceeds estimated by >25%, stop the current tidying mid-flight and re-budget.
-3. **Phase H (Ship)** — the PR body's `## Deferred items` section comes directly from this protocol's filed-issue list.
+3. **Phase H (Ship)** — the `## Deferred items` section (follow-up comment, or PR body when `source-control` isn't installed) comes directly from this protocol's filed-issue list.
 
 If the cap numbers themselves need to change, that's a research-driven update — not a tidy. See the SELF-UPDATE EXTRA HARD list in `reference/exclusions.md`.


### PR DESCRIPTION
## Summary

`code-tidying:tidy`'s Phase H ("Ship") told the agent to create the PR by calling `gh pr create` directly — a bare bypass of `source-control:pull-request`'s canonical create flow, which resolves issue-linkage (with an issue-existence check before shipping a `Closes #N` keyword), assembles the PR body injection-safely (quoted heredoc + parameter-expansion concat, a defense against shell injection through prompt-derived text), and gates PR creation on a valid closing keyword or explicit opt-out before calling `gh pr create` itself.

Closes decisions **#3** and **#42** of the melodic-software issue/PR consistency initiative's Decisions Log (`https://claude.ai/code/artifact/232ecdce-8316-4880-8c0a-dc3c7dcf3a63`):

- **#3 (formatting-tidy-canonical-pr-gate-bypass)** — "YES, fix — but not via direct skill-to-skill coupling... minimize coupling between `code-tidying:tidy` and `source-control:pull-request`... Likely shape: a shared script/check both skills call, or a convention-level requirement enforced by a common gate." This PR fixes the bypass without a hard cross-plugin dependency (below).
- **#42 (crosscut-skill-content-sync-mechanism)** — "Single shared reference doc, all authoring skills import it." Applied here for its first concrete instance (see Design rationale).

## What changed

Phase H now applies the same optional-plugin graceful-degrade pattern `tidy` already uses elsewhere in its own SKILL.md (Phase C for `discovery`, Phase D for `work-items`):

- **If `source-control` is installed:** invoke `/pull-request create`, supplying tidy's own title/body-section content. Its stage-and-commit step (§2.3) is a no-op here since Phase E already committed the tidyings atomically — the call goes straight to rebase-check, issue-linkage resolution, and gated PR creation.
- **If `source-control` isn't installed:** the same invariants apply inline — verify an issue exists before writing `Closes #N`, assemble the body via quoted heredoc + concat (never an unquoted `<<EOF`), and refuse `gh pr create` until the body carries a valid closing keyword or an explicit `Refs #N` / `No related issue:` opt-out.

## Design rationale (decision #42, recorded as an assumption — no user available to confirm interactively this session)

Considered extracting the safety invariants into a new shared reference doc (mirroring the `docs/PLUGIN-ARTIFACT-PROTOCOL.md` → per-plugin `reference/artifact-protocol.md` precedent, drift-checked by `validate-plugin-contracts.mjs` and this session's new `scripts/check-cross-plugin-source-drift.sh`). Rejected for now: every invariant worth stating is already authoritative in `pull-request/reference/create.md`, so a copied doc would be pure duplication with drift risk — and with exactly one non-`source-control` consumer today, it wouldn't even register as a cluster for the new drift checker (which requires 2+ plugin copies). A prose convention pointer is lighter, carries no duplication to drift, and degrades gracefully if `source-control` is absent — which a hard-copied doc wouldn't buy any safety over.

This is decision #42's design choice for its *first application*, not a retrofit of every authoring skill in the marketplace — no other skill is touched by this PR. Rolling the same pattern out to other PR-creating skills (if any surface a similar bypass) is deferred, unscoped follow-up work, tracked in the Decisions Log rather than guessed at here.

## Test plan

- `bash scripts/validate-plugins.sh` — all plugin manifests + strict catalog validation pass.
- `node scripts/validate-plugin-contracts.mjs` — 16 setup skills + 1342 plugin files checked, clean.
- `npx markdownlint-cli2 plugins/code-tidying/skills/tidy/SKILL.md` — 0 errors.
- Confirmed no other stale bare-`gh pr create` references remain under `plugins/code-tidying/`.
- No existing test file exercises `tidy`'s `SKILL.md` prose directly (only `open-pr-count.test.sh`, unrelated to Phase H) — nothing to update there.