### PR TITLE
docs(event-storming): reconcile PM/DL coordinate refs in simulation docs

### DIFF
--- a/plugins/event-storming/skills/simulation/reference/agentic-simulation.md
+++ b/plugins/event-storming/skills/simulation/reference/agentic-simulation.md
@@ -836,7 +836,9 @@ Create a NEW Miro board. This is a different workshop with different participant
 **Round 2: Alternative Paths + Unfulfilled Expectations**
 
 - For each command: "What if it fails? What if it's rejected? What if it partially succeeds?"
-- Place happy path events on top (y=0), alternatives below (y=+250)
+- Place happy path events on the Main Flow row; route failure/rejection alternatives to the
+  Exception flows row and additional/secondary alternatives to the Secondary alternatives row
+  (see the Process Modeling Y-Coordinate Table in `miro-integration.md`)
 - **Events that are NOT happening** (Ch. 14): Model unfulfilled expectations via time-triggered events. "End of day happened before Greeting Received" models a forgotten birthday. Prompt agents: "What SHOULD happen but doesn't? What deadlines expire? What expectations go unfulfilled?" Making the time-frame explicit leads to interesting insights
 - Continue until all paths reach a stable state (System Happy + User Happy)
 

--- a/plugins/event-storming/skills/simulation/reference/simulation-evaluation.md
+++ b/plugins/event-storming/skills/simulation/reference/simulation-evaluation.md
@@ -156,9 +156,9 @@ Run these checks BEFORE starting any simulation:
 | Criterion | Source Reference | Expected | How to Check | Weight |
 |-----------|----------------|----------|--------------|--------|
 | Color grammar strict | Ch. 13-14 | Policy (violet) between every Event→Command | Visual audit of flow | Critical |
-| Three passes completed | Ch. 14-15 | Rush to Goal → Speak Out Loud → Magic Words | Check for corrected policies (violet at y=200) | Critical |
+| Three passes completed | Ch. 14-15 | Rush to Goal → Speak Out Loud → Magic Words | Check for corrected policies on the Pass 2 corrections row (see the Process Modeling Y-Coordinate Table in `miro-integration.md`) | Critical |
 | "Always/Immediately" applied | Ch. 14 | Magic Words challenge breaks 50%+ of policies | Count corrected vs original policies | High |
-| Alternative paths modeled | Ch. 15 | Failure events at y=250 for each command | Count failure events | High |
+| Alternative paths modeled | Ch. 15 | Failure events on the Exception flows / Secondary alternatives rows for each command (see the Process Modeling Y-Coordinate Table in `miro-integration.md`) | Count failure events | High |
 | Read models present | Ch. 14 | light_green stickies showing info needed for decisions | Board check | High |
 | Win conditions met (4/4) | Ch. 13 | All paths complete, grammar preserved, hot spots addressed, stakeholders happy | Explicit win condition assessment | Critical |
 | Legend complete | Ch. 14 | Full color grammar shown | Count legend entries | Medium |


### PR DESCRIPTION
## What

Reconciles the two Process Modeling coordinate conflicts flagged across the `event-storming`
`simulation` skill's three reference docs onto the existing per-phase canonical scheme (mirroring
#1473's Big Picture reconciliation), for the PM/DL phases left unchanged by that prior work.

## Why

`simulation-evaluation.md` and `agentic-simulation.md` carried compact literal PM y-values that
drifted from the **Process Modeling Y-Coordinate Table** in `miro-integration.md`:

| Item | Compact literal (removed) | Canonical table row |
|---|---|---|
| Corrected policies | `y=200` | Pass 2 corrections = `300` |
| Alternative/failure events | `y=+250` / `y=250` | Exception flows = `600`, Secondary alternatives = `900` |

## Resolution — per-phase canonical (per the issue, mirroring #1473)

The Process Modeling and Design-Level Y-Coordinate Tables in `miro-integration.md` are the single
source of truth for their phases. Replaced the drifting literals in `agentic-simulation.md`
(PM Round 2: Alternative Paths) and `simulation-evaluation.md` (PM Rubric: Three passes completed,
Alternative paths modeled) with references to the canonical table rows instead of restating
values — same treatment PR #159 gave the Big Picture phase.

Swept every `y=`/`x=`/frame/tool coordinate reference in both files: no other PM/DL drift found.
Design-Level sections in `agentic-simulation.md` contain no numeric coordinate literals to begin
with (mechanical step descriptions only), so nothing there needed changing.

## Verification (geometric, x-aware — no live Miro board)

Per the issue: PM/DL layouts are x-localized per flow-segment (not full-width bands like Big
Picture), so the overlap check must be x-aware — two elements overlap only when their x-ranges
intersect AND `|Δy| < ~199px`.

- **Deterministic overlap check** over the Process Modeling Y-Coordinate Table (the table this PR
  aligns to): built a representative 3-segment flow (x = 0, 400, 800 — the documented 400px
  horizontal spacing) with every table row placed at each segment. **0 overlaps** across 30
  elements — confirms the table is a geometrically safe alignment target.
- **To-scale render** of the table for one flow segment confirms clean layering: every adjacent
  row gap is ≥200px (header stack) or 300px (below Main Flow), all clear of the 199px overlap
  threshold.

## Out of scope (follow-up — same bug class as #1473's "spotted but not fixed here")

The same verification pass surfaced two issues in `miro-integration.md` itself, outside this
issue's scope (which only covers the two flagged PM literals in the other two files):

1. **Design-Level Y-Coordinate Table has a genuine internal overlap.** Actors (`-200`), Commands
   (`-100`), Aggregates (`0`) are packed into 100px gaps — under the `|Δy| < 199px` threshold.
   Deterministic check confirms: `OVERLAP: Actors <-> Commands |dy|=100px`,
   `OVERLAP: Commands <-> Aggregates |dy|=100px`.
2. **An orphaned duplicate coordinate scheme** sits in `miro-integration.md` right after the
   Design-Level table (`**Main flow (y=0 baseline)**` / `**Above the flow**` / `**Below the
   flow**` / `**Example: one complete flow segment**` blocks) restating its own values (Actors
   `-250`, Read Models `-450`, Hot Spots `-250`, Alternative outcomes `+250`) that match neither
   the PM nor the DL table. Per `git blame`, this block and both per-format tables were introduced
   in the same original authoring commit — it's the literal source the compact values removed by
   this PR trace back to, never cleaned up when the two tables were added. Same shape as the
   leaked-compact-scheme bug #1473/PR #159 fixed for Big Picture.

Fixing #1 requires choosing new DL spacing (multiple valid options, no single correct answer
dictated by existing evidence) — a decision, not a mechanical literal-swap like this PR, so it
wasn't forced here. Filing a follow-up issue for a human decision was attempted but blocked by
this session's own write-permission guard (unrequested tracker write); flagging here instead so
it isn't lost.

Closes melodic-software/medley#1490