### PR TITLE
feat(disk-hygiene): standing policy layers, leak-signature hints, OS auto-clean advisory

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -67,7 +67,7 @@ at preview. Backups remain the recovery boundary for user data.
 The skill stores snapshots, plans, and reports under `${CLAUDE_PLUGIN_DATA}`. It never writes generated
 state into the installed plugin directory or the audited target.
 
-The optional policy file has this shape:
+Policy files all share one shape:
 
 ```json
 {
@@ -78,17 +78,29 @@ The optional policy file has this shape:
       "id": "my-tool-staging",
       "os": ["all"],
       "kind": "name_glob",
-      "pattern": "temp_git_*",
+      "pattern": "my-tool-stage-*",
       "confidence_ceiling": "medium",
-      "reason": "My tool's documented clone-staging convention"
+      "reason": "My tool's documented staging-directory convention"
     }
   ],
   "additional_protected_path_globs": ["client-deliverables/**"]
 }
 ```
 
+Without `--policy`, standing policy files layer over the baseline when present:
+`~/.claude/disk-hygiene.json` (user-global) first, then the consumer project's
+`.claude/disk-hygiene.json`. An explicit `--policy` file is the invocation-specific choice and
+replaces both standing layers. The scan output records which sources applied.
+
 Candidate hints can be disabled or extended. Consumer protection globs are additive. Hard safety
-predicates and the baseline protected-name/root rules are non-overridable.
+predicates and the baseline protected-name/root rules are non-overridable by any layer: a policy
+file can only add protections, add hints, or disable discovery hints (which can only cause junk to
+be missed, never removed).
+
+When the audited zone overlaps the user temp directory, the scan also reports an `os_autoclean`
+advisory naming the OS mechanism that should own it (Windows Storage Sense, systemd-tmpfiles) and,
+when that mechanism is off or set to fire only on low disk space, recommends enabling it rather than
+hand-cleaning the zone.
 
 ## Relationship to other tools
 
@@ -109,8 +121,11 @@ predicates and the baseline protected-name/root rules are non-overridable.
   construction, or downloads are used. Paths cross the process boundary as JSON or individually
   quoted CLI arguments.
 - **MCP / external trust:** no MCP server, agent, dependency, or third-party service is shipped.
-- **Configuration:** no `userConfig` and no credentials. Optional policy is an explicit invocation
-  argument and contains patterns only.
+- **Configuration:** no `userConfig` and no credentials. Policy comes from an explicit invocation
+  argument or standing `disk-hygiene.json` files under `~/.claude/` and the consumer project's
+  `.claude/`. All policy input is pattern-only and additive: it can add protections and discovery
+  hints or disable hints, and cannot weaken hard guards or authorize removal, so ambient config
+  cannot widen the destructive surface.
 - **Isolation:** bundled assets resolve from `${CLAUDE_PLUGIN_ROOT}`; generated state belongs under
   `${CLAUDE_PLUGIN_DATA}`. The audited target is read, then mutated only through the gated lane.
 - **Egress:** none. `git` and `lsof` are local read-only subprocesses.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -49,7 +49,8 @@ stay there, never in the target or `${CLAUDE_PLUGIN_ROOT}`. Run:
 
 ```text
 "<hook-python>" "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py" scan \
-  --target "<target>" --output "<run-dir>/snapshot.json" [--policy "<policy.json>"]
+  --target "<target>" --output "<run-dir>/snapshot.json" [--policy "<policy.json>"] \
+  --project-dir "${CLAUDE_PROJECT_DIR}"
 ```
 
 For a large root, first map its immediate children and fan out read-only analysis by subtree. Each
@@ -57,8 +58,17 @@ worker receives a bounded subtree and returns evidence only. The parent owns cla
 report, every approval, preview, and all execution. Do not let workers delete or prepare approvals.
 
 The bundled [baseline policy](reference/baseline-policy.json) contains cross-platform candidate hints
-and protected names. An optional policy can disable/add hints and add protected globs; it cannot weaken
-hard guards. Treat scan errors and unvisited protected roots as coverage gaps, not clean results.
+and protected names. Without `--policy`, the engine also layers standing policy files when present:
+`~/.claude/disk-hygiene.json` (user-global), then `<project>/.claude/disk-hygiene.json` via
+`--project-dir`. An explicit `--policy` is the invocation-specific choice and replaces both standing
+layers. Every overlay can only disable/add hints and add protected globs; none can weaken hard guards.
+The scan output names its `policy_sources`. Treat scan errors and unvisited protected roots as
+coverage gaps, not clean results.
+
+The scan output may also carry an `os_autoclean` advisory when the target overlaps a zone an OS
+mechanism (Windows Storage Sense, systemd-tmpfiles) should own. Surface its recommendation in the
+report; prefer enabling the OS mechanism over hand-cleaning that zone, mirroring the managed-state
+rule below.
 
 ## 2. Establish evidence and ownership
 

--- a/plugins/disk-hygiene/skills/clean/evals/evals.json
+++ b/plugins/disk-hygiene/skills/clean/evals/evals.json
@@ -96,6 +96,30 @@
         "Does not run hygiene.py apply",
         "Returns the tiered audit and states that interactive confirmation is required"
       ]
+    },
+    {
+      "id": 9,
+      "name": "standing-policy-files-layer-additively",
+      "prompt": "/disk-hygiene:clean ~/scratch — my user-global ~/.claude/disk-hygiene.json protects 'client-deliverables/**' and this project's .claude/disk-hygiene.json adds a staging hint.",
+      "expected_output": "The scan without --policy layers the user-global then project standing policy files over the baseline, reports which policy sources applied, and honors the added protections; no layer can weaken hard guards.",
+      "files": [],
+      "expectations": [
+        "Runs scan without --policy and the output's policy_sources lists baseline plus both standing files",
+        "Treats standing policy input as additive: added protections and hints only",
+        "An explicit --policy file replaces the standing layers instead of stacking on them"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "os-managed-temp-zone-recommends-the-os-mechanism",
+      "prompt": "/disk-hygiene:clean --execute my user temp directory, it has gigabytes of stale files.",
+      "expected_output": "The audit surfaces the os_autoclean advisory: the OS ships an auto-clean mechanism for this zone (e.g. Windows Storage Sense), so the report recommends enabling/tuning it rather than hand-deleting, mirroring the managed-state handoff rule.",
+      "files": [],
+      "expectations": [
+        "Surfaces the scan's os_autoclean recommendation in the report",
+        "Prefers enabling the OS mechanism over manual cleanup of the OS-owned zone",
+        "Still performs the read-only audit and never treats the advisory as deletion authority"
+      ]
     }
   ]
 }

--- a/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
+++ b/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
@@ -79,6 +79,30 @@
       "pattern": "*.crdownload",
       "confidence_ceiling": "low",
       "reason": "Browser partial download; browser process and resume state must be checked"
+    },
+    {
+      "id": "claude-json-failed-atomic-write",
+      "os": ["all"],
+      "kind": "name_glob",
+      "pattern": ".claude.json.tmp.*",
+      "confidence_ceiling": "medium",
+      "reason": "Claude Code atomic-write staging remnant (.claude.json.tmp.<pid>.<hash>); confirm no live Claude Code process owns it"
+    },
+    {
+      "id": "agent-temp-git-scratch",
+      "os": ["all"],
+      "kind": "name_glob",
+      "pattern": "temp_git_*",
+      "confidence_ceiling": "medium",
+      "reason": "AI-agent Git scratch/staging directory leaked outside a worktree; confirm no session or clone still references it"
+    },
+    {
+      "id": "pulumi-writability-probe",
+      "os": ["all"],
+      "kind": "name_glob",
+      "pattern": ".pulumi-write-test-*",
+      "confidence_ceiling": "medium",
+      "reason": "Pulumi orphaned writability probe; a completed or crashed run leaves it behind, but verify no engine process is active"
     }
   ]
 }

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -115,15 +115,28 @@ def classify_exact_engine_command(command: str) -> str | None:
         return None
 
     if tokens[2] == "scan":
-        valid = (
-            len(tokens) in {7, 9}
-            and tokens[3] == "--target"
-            and _argument(tokens[4])
-            and tokens[5] == "--output"
-            and _argument(tokens[6])
-            and (len(tokens) == 7 or (tokens[7] == "--policy" and _argument(tokens[8])))
-        )
-        return "scan" if valid else None
+        if (
+            len(tokens) not in {7, 9, 11}
+            or tokens[3] != "--target"
+            or not _argument(tokens[4])
+            or tokens[5] != "--output"
+            or not _argument(tokens[6])
+        ):
+            return None
+        optional = tokens[7:]
+        seen: list[str] = []
+        while optional:
+            flag = optional[0]
+            if (
+                flag not in {"--policy", "--project-dir"}
+                or flag in seen
+                or len(optional) < 2
+                or not _argument(optional[1])
+            ):
+                return None
+            seen.append(flag)
+            optional = optional[2:]
+        return "scan"
     if tokens[2] == "preview":
         valid = (
             len(tokens) == 7

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -280,19 +280,30 @@ def standing_policy_paths(project_dir: Path | None) -> list[Path]:
     return [path for path in layers if path.is_file()]
 
 
-def load_policy(
-    overlay_path: Path | None, project_dir: Path | None = None
-) -> dict[str, Any]:
+def baseline_policy() -> dict[str, Any]:
     baseline = load_json(BASELINE_POLICY)
     if baseline.get("version") != SCHEMA_VERSION:
         raise HygieneError("unsupported baseline policy version")
-    result = {
+    return {
         "version": SCHEMA_VERSION,
         "protected_exact_names": list(baseline.get("protected_exact_names", [])),
         "hints": list(baseline.get("hints", [])),
         "additional_protected_path_globs": [],
         "policy_sources": ["baseline"],
     }
+
+
+def baseline_protected_names() -> set[str]:
+    """Bundled protected names only — validation paths must never depend on
+    ambient standing policy; an approved snapshot stays previewable even if a
+    standing file is later edited or malformed."""
+    return set(baseline_policy()["protected_exact_names"])
+
+
+def load_policy(
+    overlay_path: Path | None, project_dir: Path | None = None
+) -> dict[str, Any]:
+    result = baseline_policy()
     # An explicit --policy is the invocation-specific choice and wins outright;
     # otherwise standing user-global and project files layer additively.
     overlays = (
@@ -1065,7 +1076,7 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         or snapshot.get("engine") != "disk-hygiene-python-1"
     ):
         raise HygieneError("unsupported snapshot version")
-    baseline_exact_names = set(load_policy(None)["protected_exact_names"])
+    baseline_exact_names = baseline_protected_names()
     target_input = Path(snapshot.get("target", "")).absolute()
     if has_linkish_component(target_input):
         raise HygieneError("snapshot target now traverses a link or reparse point")
@@ -1316,7 +1327,7 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
         candidate_blockers = hard_protection(
             candidate_path,
             target,
-            set(load_policy(None)["protected_exact_names"])
+            baseline_protected_names()
             | set(snapshot.get("policy", {}).get("protected_exact_names", [])),
             known_mounts,
         )
@@ -1354,7 +1365,7 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
             fresh_protections = hard_protection(
                 path,
                 target,
-                set(load_policy(None)["protected_exact_names"]),
+                baseline_protected_names(),
                 fresh_mounts,
             )
             if any(

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -16,6 +16,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -272,7 +273,16 @@ def hard_protection(
     return sorted(set(reasons))
 
 
-def load_policy(overlay_path: Path | None) -> dict[str, Any]:
+def standing_policy_paths(project_dir: Path | None) -> list[Path]:
+    layers = [Path.home() / ".claude" / "disk-hygiene.json"]
+    if project_dir is not None:
+        layers.append(project_dir / ".claude" / "disk-hygiene.json")
+    return [path for path in layers if path.is_file()]
+
+
+def load_policy(
+    overlay_path: Path | None, project_dir: Path | None = None
+) -> dict[str, Any]:
     baseline = load_json(BASELINE_POLICY)
     if baseline.get("version") != SCHEMA_VERSION:
         raise HygieneError("unsupported baseline policy version")
@@ -281,9 +291,21 @@ def load_policy(overlay_path: Path | None) -> dict[str, Any]:
         "protected_exact_names": list(baseline.get("protected_exact_names", [])),
         "hints": list(baseline.get("hints", [])),
         "additional_protected_path_globs": [],
+        "policy_sources": ["baseline"],
     }
-    if overlay_path is None:
-        return result
+    # An explicit --policy is the invocation-specific choice and wins outright;
+    # otherwise standing user-global and project files layer additively.
+    overlays = (
+        [overlay_path]
+        if overlay_path is not None
+        else standing_policy_paths(project_dir)
+    )
+    for path in overlays:
+        apply_policy_overlay(result, path)
+    return result
+
+
+def apply_policy_overlay(result: dict[str, Any], overlay_path: Path) -> None:
     overlay = load_json(overlay_path)
     allowed = {
         "version",
@@ -293,9 +315,11 @@ def load_policy(overlay_path: Path | None) -> dict[str, Any]:
     }
     unknown = sorted(set(overlay) - allowed)
     if unknown:
-        raise HygieneError(f"unknown policy fields: {', '.join(unknown)}")
+        raise HygieneError(
+            f"unknown policy fields in {overlay_path}: {', '.join(unknown)}"
+        )
     if overlay.get("version") != SCHEMA_VERSION:
-        raise HygieneError("policy version must be 1")
+        raise HygieneError(f"policy version must be 1: {overlay_path}")
     disabled = overlay.get("disabled_hint_ids", [])
     additions = overlay.get("additional_hints", [])
     protections = overlay.get("additional_protected_path_globs", [])
@@ -309,15 +333,17 @@ def load_policy(overlay_path: Path | None) -> dict[str, Any]:
     for hint in additions:
         validate_hint(hint)
         if hint["id"] in known_ids:
-            raise HygieneError(f"additional hint ID already exists: {hint['id']}")
+            raise HygieneError(
+                f"additional hint ID already exists ({overlay_path}): {hint['id']}"
+            )
         known_ids.add(hint["id"])
     disabled_set = set(disabled)
     result["hints"] = [
         hint for hint in result["hints"] if hint.get("id") not in disabled_set
     ]
     result["hints"].extend(additions)
-    result["additional_protected_path_globs"] = protections
-    return result
+    result["additional_protected_path_globs"].extend(protections)
+    result["policy_sources"].append(str(overlay_path))
 
 
 def validate_hint(hint: Any) -> None:
@@ -405,6 +431,95 @@ def discover_enclosing_git(target: Path) -> tuple[list[Path], list[str]]:
     if marker_root is not None:
         return [marker_root.resolve()], [f"{marker_root}: git-state-unverified"]
     return [], []
+
+
+def windows_storage_sense_state() -> dict[str, Any]:
+    import winreg
+
+    key_path = (
+        r"Software\Microsoft\Windows\CurrentVersion"
+        r"\StorageSense\Parameters\StoragePolicy"
+    )
+    state: dict[str, Any] = {
+        "enabled": None,
+        "temporary_files_cleanup": None,
+        "cadence_days": None,
+    }
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+            for name, field in (
+                ("01", "enabled"),
+                ("04", "temporary_files_cleanup"),
+            ):
+                try:
+                    state[field] = bool(winreg.QueryValueEx(key, name)[0])
+                except OSError:
+                    pass
+            try:
+                state["cadence_days"] = int(winreg.QueryValueEx(key, "2048")[0])
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return state
+
+
+def os_autoclean_advisory(target: Path) -> dict[str, Any] | None:
+    """Report-only: name the OS auto-clean mechanism that should own this zone.
+
+    Mirrors the managed-state rule for products: when the OS already ships a
+    garbage collector for a zone, recommend enabling/tuning it instead of
+    hand-cleaning. Never authorizes or blocks anything.
+    """
+    try:
+        temp_root = Path(tempfile.gettempdir()).resolve()
+    except OSError:
+        return None
+    resolved = target.resolve()
+    covers_target = is_within(resolved, temp_root) or is_within(temp_root, resolved)
+    if not covers_target:
+        return None
+    if sys.platform == "win32":
+        state = windows_storage_sense_state()
+        effective = (
+            state["enabled"] is True
+            and state["temporary_files_cleanup"] is True
+            # Cadence 0 = "during low free disk space", which may never fire.
+            and (state["cadence_days"] or 0) > 0
+        )
+        return {
+            "mechanism": "windows-storage-sense",
+            "state": state,
+            "recommendation": None
+            if effective
+            else (
+                "This zone includes the user temp directory, which Windows "
+                "Storage Sense can clean automatically. Recommend enabling "
+                "temporary-file cleanup on a scheduled cadence (Settings > "
+                "System > Storage) instead of hand-cleaning it here."
+            ),
+        }
+    if sys.platform.startswith("linux"):
+        configured = any(
+            Path(root).is_dir()
+            for root in ("/etc/tmpfiles.d", "/run/tmpfiles.d", "/usr/lib/tmpfiles.d")
+        )
+        return {
+            "mechanism": "systemd-tmpfiles",
+            "state": {"config_present": configured},
+            "recommendation": None
+            if configured
+            else (
+                "This zone includes the temp directory, which systemd-tmpfiles "
+                "normally ages out. Recommend configuring tmpfiles.d instead of "
+                "hand-cleaning it here."
+            ),
+        }
+    return {
+        "mechanism": "not-detected",
+        "state": {},
+        "recommendation": None,
+    }
 
 
 def scan_tree(target: Path, policy: dict[str, Any]) -> dict[str, Any]:
@@ -625,6 +740,10 @@ def validate_plan(
                 f"candidate owner must be named or unmanaged: {relative}"
             )
         if owner != "unmanaged":
+            # Managed candidates are permanently report-only (preview and apply
+            # block them unconditionally). This gate exists so the report can
+            # name a proven-runnable native-GC command, and so managed state
+            # whose native GC is not even eligible is never proposed at all.
             native = candidate.get("native_gc_evidence")
             if (
                 not isinstance(native, dict)
@@ -1309,6 +1428,7 @@ def build_parser() -> argparse.ArgumentParser:
     scan.add_argument("--target", required=True)
     scan.add_argument("--output", required=True)
     scan.add_argument("--policy")
+    scan.add_argument("--project-dir")
     for name in ("preview", "apply"):
         command = subparsers.add_parser(name)
         command.add_argument("--snapshot", required=True)
@@ -1350,7 +1470,10 @@ def main(argv: list[str] | None = None) -> int:
                     "filesystem and OS-managed roots are not valid audit targets"
                 )
             policy = load_policy(
-                Path(args.policy).expanduser().absolute() if args.policy else None
+                Path(args.policy).expanduser().absolute() if args.policy else None,
+                Path(args.project_dir).expanduser().absolute()
+                if args.project_dir
+                else None,
             )
             if has_protected_path_component(
                 target, set(policy["protected_exact_names"])
@@ -1370,6 +1493,8 @@ def main(argv: list[str] | None = None) -> int:
                     "entries": len(snapshot["entries"]),
                     "hinted_entries": hinted,
                     "errors": snapshot["errors"],
+                    "policy_sources": policy["policy_sources"],
+                    "os_autoclean": os_autoclean_advisory(target),
                     "note": "Hints are discovery signals, never cleanup verdicts.",
                 }
             )

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -769,6 +769,16 @@ class StandingPolicyTests(unittest.TestCase):
             self.assertIn("NTUSER.DAT", policy["protected_exact_names"])
             self.assertIn("extra-keep/**", policy["additional_protected_path_globs"])
 
+    def test_validation_names_never_read_standing_policy(self) -> None:
+        def explode(_project_dir):
+            raise AssertionError("validation must not touch standing policy")
+
+        with mock.patch.object(
+            hygiene, "standing_policy_paths", side_effect=explode
+        ):
+            names = hygiene.baseline_protected_names()
+        self.assertIn("NTUSER.DAT", names)
+
     def test_baseline_ships_agent_leak_signatures(self) -> None:
         with mock.patch.object(
             hygiene, "standing_policy_paths", return_value=[]

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -43,6 +43,15 @@ def candidate(path: str, tier: str = "high") -> dict[str, object]:
 
 
 class HygieneTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Keep every load_policy(None) call independent of the developer
+        # machine's real standing policy files.
+        patcher = mock.patch.object(
+            hygiene, "standing_policy_paths", return_value=[]
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
     def test_scan_is_read_only_and_hints_are_not_verdicts(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "target"
@@ -659,6 +668,168 @@ class HygieneTests(unittest.TestCase):
             self.assertEqual("work product", untouched.read_text(encoding="utf-8"))
 
 
+class StandingPolicyTests(unittest.TestCase):
+    @staticmethod
+    def write_policy(root: Path, body: dict[str, object]) -> Path:
+        path = root / ".claude" / "disk-hygiene.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"version": 1, **body}), encoding="utf-8")
+        return path
+
+    @staticmethod
+    def hint(hint_id: str, pattern: str) -> dict[str, object]:
+        return {
+            "id": hint_id,
+            "os": ["all"],
+            "kind": "name_glob",
+            "pattern": pattern,
+            "confidence_ceiling": "medium",
+            "reason": "fixture standing-policy hint",
+        }
+
+    def test_standing_layers_apply_user_global_then_project(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary) / "home"
+            project = Path(temporary) / "project"
+            user_path = self.write_policy(
+                home,
+                {
+                    "additional_hints": [self.hint("user-hint", "user-*")],
+                    "additional_protected_path_globs": ["user-keep/**"],
+                },
+            )
+            project_path = self.write_policy(
+                project,
+                {
+                    "additional_hints": [self.hint("project-hint", "proj-*")],
+                    "additional_protected_path_globs": ["proj-keep/**"],
+                },
+            )
+            with mock.patch.object(hygiene.Path, "home", return_value=home):
+                policy = hygiene.load_policy(None, project)
+            ids = {hint["id"] for hint in policy["hints"]}
+            self.assertIn("user-hint", ids)
+            self.assertIn("project-hint", ids)
+            self.assertEqual(
+                ["user-keep/**", "proj-keep/**"],
+                policy["additional_protected_path_globs"],
+            )
+            self.assertEqual(
+                ["baseline", str(user_path), str(project_path)],
+                policy["policy_sources"],
+            )
+
+    def test_explicit_policy_replaces_standing_layers(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary) / "home"
+            self.write_policy(
+                home, {"additional_hints": [self.hint("user-hint", "user-*")]}
+            )
+            explicit = Path(temporary) / "explicit.json"
+            explicit.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "additional_hints": [self.hint("explicit-hint", "exp-*")],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(hygiene.Path, "home", return_value=home):
+                policy = hygiene.load_policy(explicit, Path(temporary) / "project")
+            ids = {hint["id"] for hint in policy["hints"]}
+            self.assertIn("explicit-hint", ids)
+            self.assertNotIn("user-hint", ids)
+            self.assertEqual(["baseline", str(explicit)], policy["policy_sources"])
+
+    def test_cross_layer_duplicate_hint_id_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary) / "home"
+            project = Path(temporary) / "project"
+            self.write_policy(
+                home, {"additional_hints": [self.hint("shared-id", "user-*")]}
+            )
+            self.write_policy(
+                project, {"additional_hints": [self.hint("shared-id", "proj-*")]}
+            )
+            with mock.patch.object(hygiene.Path, "home", return_value=home):
+                with self.assertRaisesRegex(
+                    hygiene.HygieneError, "already exists"
+                ):
+                    hygiene.load_policy(None, project)
+
+    def test_standing_layers_cannot_weaken_protections(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            home = Path(temporary) / "home"
+            self.write_policy(
+                home, {"additional_protected_path_globs": ["extra-keep/**"]}
+            )
+            with mock.patch.object(hygiene.Path, "home", return_value=home):
+                policy = hygiene.load_policy(None, None)
+            self.assertIn("NTUSER.DAT", policy["protected_exact_names"])
+            self.assertIn("extra-keep/**", policy["additional_protected_path_globs"])
+
+    def test_baseline_ships_agent_leak_signatures(self) -> None:
+        with mock.patch.object(
+            hygiene, "standing_policy_paths", return_value=[]
+        ):
+            policy = hygiene.load_policy(None)
+        matched = {
+            name: [
+                hint["id"]
+                for hint in hygiene.matching_hints(name, name, policy)
+            ]
+            for name in (
+                ".claude.json.tmp.25020.a926d229fa70",
+                "temp_git_clone_1234",
+                ".pulumi-write-test-42",
+            )
+        }
+        self.assertIn(
+            "claude-json-failed-atomic-write",
+            matched[".claude.json.tmp.25020.a926d229fa70"],
+        )
+        self.assertIn("agent-temp-git-scratch", matched["temp_git_clone_1234"])
+        self.assertIn(
+            "pulumi-writability-probe", matched[".pulumi-write-test-42"]
+        )
+
+
+class OsAutocleanAdvisoryTests(unittest.TestCase):
+    def test_zone_outside_temp_has_no_advisory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            unrelated = Path(temporary) / "unrelated"
+            unrelated.mkdir()
+            with mock.patch.object(
+                hygiene.tempfile,
+                "gettempdir",
+                return_value=os.fspath(Path(temporary) / "temp-root"),
+            ):
+                (Path(temporary) / "temp-root").mkdir()
+                self.assertIsNone(hygiene.os_autoclean_advisory(unrelated))
+
+    def test_temp_zone_reports_platform_mechanism(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            temp_root = Path(temporary) / "temp-root"
+            temp_root.mkdir()
+            with mock.patch.object(
+                hygiene.tempfile, "gettempdir", return_value=os.fspath(temp_root)
+            ):
+                advisory = hygiene.os_autoclean_advisory(temp_root)
+        self.assertIsNotNone(advisory)
+        assert advisory is not None
+        expected = {
+            "win32": "windows-storage-sense",
+            "linux": "systemd-tmpfiles",
+        }.get(
+            "win32"
+            if hygiene.sys.platform == "win32"
+            else ("linux" if hygiene.sys.platform.startswith("linux") else "other"),
+            "not-detected",
+        )
+        self.assertEqual(expected, advisory["mechanism"])
+
+
 class GuardTests(unittest.TestCase):
     @staticmethod
     def python_command() -> str:
@@ -834,6 +1005,35 @@ class GuardTests(unittest.TestCase):
             "deny",
             self.run_guard(malformed)["hookSpecificOutput"]["permissionDecision"],
         )
+
+    def test_guard_scan_accepts_optional_policy_and_project_dir(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        base = f'"{self.python_command()}" "{script}" scan --target t --output s'
+        allowed = (
+            f"{base} --policy p",
+            f"{base} --project-dir d",
+            f"{base} --policy p --project-dir d",
+            f"{base} --project-dir d --policy p",
+        )
+        denied = (
+            f"{base} --policy p --policy q",
+            f"{base} --project-dir d --project-dir e",
+            f"{base} --unknown v",
+            f"{base} --policy",
+            f"{base} --policy p --project-dir",
+        )
+        for command in allowed:
+            self.assertEqual(
+                "allow",
+                self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+        for command in denied:
+            self.assertEqual(
+                "deny",
+                self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #228 — post-ship follow-ups for `disk-hygiene` from a verified gap analysis of the shipped source against issue #160, `docs/PLUGIN-PHILOSOPHY.md`, and `docs/MIGRATION-PLAYBOOK.md`.

## Changes

1. **Leak-signature hints shipped in the baseline** — `.claude.json.tmp.*` (failed atomic write), `temp_git_*` (agent Git scratch leaked outside a worktree), `.pulumi-write-test-*` (orphaned writability probe). These are the families #160 named as the plugin's reason to exist; all hint-only, discovery never authorizes removal. The README policy example no longer duplicates a baseline pattern.
2. **Standing policy auto-discovery** — without `--policy`, the engine layers `~/.claude/disk-hygiene.json` (user-global) then `<project>/.claude/disk-hygiene.json` (passed as the new `--project-dir` scan argument, substituted from `${CLAUDE_PROJECT_DIR}` in the skill body). Explicit `--policy` stays the invocation-specific choice and replaces both standing layers, per PLUGIN-PHILOSOPHY's configuration-ownership seam. Safe by construction: overlay application is additive-only (add protections, add hints, disable discovery hints), so ambient config cannot widen the destructive surface. Scan output records `policy_sources`; cross-layer duplicate hint IDs fail closed with the offending file named.
3. **`os_autoclean` advisory (report-only)** — extends the defer-to-the-owning-GC rule from products to the OS: when the audited zone overlaps the user temp directory, the scan reports the owning mechanism (Windows Storage Sense read from `HKCU\...\StoragePolicy` incl. the cadence=0 "low disk only" trap, `systemd-tmpfiles` on Linux) and recommends enabling it instead of hand-cleaning. Never blocks or authorizes anything.
4. **Guard** — exact scan shape extended for the optional `--policy` / `--project-dir` pair set; duplicates, unknown flags, and dangling values still fail closed.
5. **Intent comment** on `validate_plan`'s native-GC eligibility gate: managed candidates are permanently report-only; the evidence exists so the report names a proven-runnable native command and ineligible managed state is never proposed.

Deliberately deferred (tracked in #228 with triggers): reversible Recycle-Bin/XDG-trash disposal (TOCTOU vs descriptor-anchored unlink), RELOCATE disposition, Windows/macOS execution lanes.

## Verification

- `test_hygiene.py`: 50 passed, 4 platform skips (run on Windows). New coverage: standing-layer ordering and sources, explicit-policy replacement, cross-layer ID collision, non-weakening invariant, baseline leak signatures matching real leaked names, advisory zone logic, guard shape matrix.
- Existing tests isolated from developer machines' real standing policy files via a `setUp` patch.
- `ruff check` clean; whole-file `ruff format` deliberately not applied (baseline files are unformatted — formatting churn kept out of this PR). markdownlint clean on changed docs.
- Two new evals (standing-policy layering, OS-mechanism handoff).
- `plugin.json` bumped 0.1.0 → 0.2.0.

Fresh-docs mandate: verified this session against [skills](https://code.claude.com/docs/en/skills) (`${CLAUDE_PROJECT_DIR}` substitution in skill body, v2.1.196+) and [plugins reference](https://code.claude.com/docs/en/plugins-reference) (manifest schema, path substitutions), plus [Configure Storage Sense](https://learn.microsoft.com/windows/configuration/storage/storage-sense) and [Policy CSP - Storage](https://learn.microsoft.com/windows/client-management/mdm/policy-csp-storage) for cadence value semantics (0/1/7/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
