### PR TITLE
ci: route claude-review through the governed selector to the review tier

### DIFF
--- a/.github/runner-policy.json
+++ b/.github/runner-policy.json
@@ -8,10 +8,6 @@
       "reason": "hosted-control-plane",
       "justification": "The required CI gateway remains independent of selector and fleet health so route failures cannot become successful skipped checks."
     },
-    ".github/workflows/claude-review.yml#review": {
-      "reason": "privileged-control-plane",
-      "justification": "Claude review mints an OIDC credential and writes pull-request comments, so it remains isolated on GitHub-hosted compute."
-    },
     ".github/workflows/link-check.yml#link-check": {
       "reason": "privileged-control-plane",
       "justification": "The scheduled link checker can create or update repository issues and therefore remains on GitHub-hosted compute."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,15 +16,34 @@ permissions:
   contents: read
 
 jobs:
+  # Resolves the capped review tier's label (not the default fleet label) so
+  # reviews queue on the dedicated review scale set instead of competing with
+  # build capacity. Routing through the fleet also retires the old
+  # strict-policy skip guard: review no longer depends on the hosted lane.
+  select-review:
+    name: Select runner
+    permissions: {}
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    secrets:
+      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
+    with:
+      policy: ${{ vars.CI_RUNNER_POLICY }}
+      self-hosted-label: ${{ vars.CI_REVIEW_SELF_HOSTED_LABEL }}
+      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
+      scope: ${{ vars.CI_RUNNER_SCOPE }}
+      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
+      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
+
   review:
-    # Privileged review remains hosted by policy. Skip it while strict local-only
-    # emergency routing is active; prefer-self-hosted restores the hosted lane.
-    if: ${{ vars.CI_RUNNER_POLICY != 'self-hosted-only' }}
+    needs: select-review
+    if: ${{ !cancelled() }}
     permissions:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@df54d0e8c899baa7e57344c3633f033129da6632 # df54d0e 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@4dbb0dfcc1fcbaf30e1a5573bf776af54e4e7e1a # 4dbb0df 2026-07-15
+    with:
+      runner: ${{ needs.select-review.outputs.runner || 'ubuntu-24.04' }}
     # Pass only the one named secret (least privilege) rather than `secrets:
     # inherit`, which would forward every parent secret to the called workflow.
     secrets:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,10 @@ jobs:
 
   review:
     needs: select-review
-    if: ${{ !cancelled() }}
+    # !cancelled() overrides GitHub's skip propagation, so selector success must
+    # be required explicitly: a hard-failed selector emits no runner output and
+    # the hosted fallback below would otherwise run this privileged job.
+    if: ${{ !cancelled() && needs.select-review.result == 'success' }}
     permissions:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment


### PR DESCRIPTION
## What

- Add a `select-review` job resolving `${{ vars.CI_REVIEW_SELF_HOSTED_LABEL }}` through the governed selector (pinned `select-runner@cdc5917c`).
- Route the `review` job's runner from the selector output to the fleet claude-review reusable (pinned `claude-review@4dbb0dfc`), permissions exactly per the reviewed caller-perms waiver.
- Retire the `CI_RUNNER_POLICY != 'self-hosted-only'` skip guard — under strict routing it was silently skipping every review in this repo; fleet routing restores review coverage.
- Drop the `privileged-control-plane` hosted exception for `claude-review.yml#review`.

## Why

Campaign A of the zero-hosted directive (epic melodic-software/github-iac#78): automated review moves to the dedicated capped review tier. Shape matches standards' runner-policy E2E fixture; `runner-policy.mjs --root .` passes locally with zero findings.

Supersedes the closed draft #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3QehVwmWzkBLpKokNCkkt