### PR TITLE
fix(planning): align wayfind label taxonomy with colon-space axis grammar

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Pre-implementation planning pipeline: chart a too-big, foggy effort as a decision map, diverge on candidate approaches, lock product intent and the engineering contract, actively maintain resolved domain language, explore the design space, stress-test adversarially, and produce a structured implementation plan with an approval gate.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Pre-implementation planning pipeline: chart a too-big, foggy effort as a decision map, diverge on candidate approaches, lock product intent and the engineering contract, actively maintain resolved domain language, explore the design space, stress-test adversarially, and produce a structured implementation plan with an approval gate.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.2]
+
+### Changed
+
+- **`/planning:wayfind` label taxonomy follows the colon-space axis grammar**: the typed decision-item
+  labels are now `wayfind: research|interview|design|prototype|task` (previously `wayfind:research`
+  etc.), so label-as-code owners with a `prefix: value` naming grammar can declare the taxonomy
+  verbatim instead of carrying a grammar exception. `work-map` and `needs-human` stay flat
+  (grammar-exempt). Frontier queries and the bootstrap presence check match the new names. Maps
+  charted under the old names need a one-time label rename before `work` mode can route them.
+
 ## [0.11.1]
 
 ### Fixed

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.11.2]
+## [0.12.0]
 
 ### Changed
 

--- a/plugins/planning/skills/wayfind/SKILL.md
+++ b/plugins/planning/skills/wayfind/SKILL.md
@@ -76,7 +76,7 @@ an interactive session — do not fabricate a map.
    commits, the topic). Sort every uncertainty through the fog test: sharp → candidate
    decision item; foggy → *Not-yet-specified* prose.
 2. **Create or extend the map issue.** On first use in a repo, **verify** the wayfind label
-   taxonomy (`work-map`, `wayfind:*`, `needs-human`) is present — an unknown `--label` fails the
+   taxonomy (`work-map`, `wayfind: *`, `needs-human`) is present — an unknown `--label` fails the
    create. Honor the consuming repository's declared label ownership. If it names a label-as-code
    source of truth, STOP and report the exact missing set to that owner; otherwise report the set and
    ask the user how labels are provisioned. Never create labels ad hoc from this skill. Then create one issue labelled bare `work-map`
@@ -111,11 +111,11 @@ an interactive session — do not fabricate a map.
 
    | Type label | Mode | Routes to |
    |---|---|---|
-   | `wayfind:research` | autonomous-capable | `/discovery:research` (falls back to inline research if not installed) |
-   | `wayfind:interview` | HITL | `/planning:interview` |
-   | `wayfind:design` | HITL | `/planning:design` — or `/event-storming:methodology` / `/event-storming:simulation` when the item is domain/event-model work |
-   | `wayfind:prototype` | HITL | `/prototype:logic` (behaviour/feasibility) or `/prototype:ui` (design/UX) — the item body says which |
-   | `wayfind:task` | per-item | Direct decision-unblocking work — no feature code, no PR tie |
+   | `wayfind: research` | autonomous-capable | `/discovery:research` (falls back to inline research if not installed) |
+   | `wayfind: interview` | HITL | `/planning:interview` |
+   | `wayfind: design` | HITL | `/planning:design` — or `/event-storming:methodology` / `/event-storming:simulation` when the item is domain/event-model work |
+   | `wayfind: prototype` | HITL | `/prototype:logic` (behaviour/feasibility) or `/prototype:ui` (design/UX) — the item body says which |
+   | `wayfind: task` | per-item | Direct decision-unblocking work — no feature code, no PR tie |
 
 5. **Graduate on every resolution.** When the decision resolves: post the resolution as a
    comment on the item, add its one-line pointer to the map's *Decisions-so-far* index, then

--- a/plugins/planning/skills/wayfind/context/map-anatomy.md
+++ b/plugins/planning/skills/wayfind/context/map-anatomy.md
@@ -39,7 +39,7 @@ an exclusion here is itself a decision; note why.>
 
 ## Typed decision items
 
-Each sub-issue is one **sharp** question. The `wayfind:<type>` label sets both the routing
+Each sub-issue is one **sharp** question. The `wayfind: <type>` label sets both the routing
 target (which skill resolves it) and the default mode:
 
 | Type | Default mode | Meaning |
@@ -51,7 +51,7 @@ target (which skill resolves it) and the default mode:
 | `task` | per-item | Decision-unblocking do-work — no feature code, no PR tie |
 
 Mode is materialized as the `needs-human` label (present = HITL). Extension policy: a new
-`wayfind:<type>` value requires an existing routing target — never a type with nowhere to go.
+`wayfind: <type>` value requires an existing routing target — never a type with nowhere to go.
 
 ## Invariants (checked at every `work` session start)
 

--- a/plugins/planning/skills/wayfind/context/tracker-mechanics.md
+++ b/plugins/planning/skills/wayfind/context/tracker-mechanics.md
@@ -19,8 +19,9 @@ or every item whose blocker ever closed is stranded off the frontier forever.
 
 ## Bootstrap labels (first use in a repo)
 
-`/wayfind` uses its own taxonomy — `work-map`, `wayfind:research|interview|design|prototype|task`,
-`needs-human`. At chart-mode entry, **verify** the taxonomy is present because an unknown `--label`
+`/wayfind` uses its own taxonomy — `work-map`, `wayfind: research|interview|design|prototype|task`
+(axis labels follow the colon-space grammar so label-as-code owners with a `prefix: value` convention
+can declare them verbatim), `needs-human`. At chart-mode entry, **verify** the taxonomy is present because an unknown `--label`
 fails `gh issue create`. Read the consuming repository's instructions and configuration for label
 ownership. If they declare a label-as-code source of truth, treat that declared system as the writer,
 report the exact missing set to its owner, and stop. If no ownership policy is declared, report the
@@ -30,7 +31,7 @@ provisioning repository and never creates labels ad hoc:
 ```shell
 # Presence check only — never create. Route missing labels to the repository-declared owner.
 have=$(gh label list --json name --jq '.[].name')
-for L in work-map wayfind:research wayfind:interview wayfind:design wayfind:prototype wayfind:task needs-human; do
+for L in work-map 'wayfind: research' 'wayfind: interview' 'wayfind: design' 'wayfind: prototype' 'wayfind: task' needs-human; do
   grep -qxF "$L" <<<"$have" || echo "MISSING (route to repository label owner): $L"
 done
 ```
@@ -50,7 +51,7 @@ A map is never assigned and never carries a claim label — it is a container, n
 # Type label routes + sets default mode. HITL types add `needs-human`; research omits it.
 gh issue create --parent <map#> \
   --title "<sharp question>" \
-  --label "wayfind:<research|interview|design|prototype|task>" \
+  --label "wayfind: <research|interview|design|prototype|task>" \
   --body "<what must be decided, options if known, the item body picks logic/ui for prototype>"
 
 # HITL item — materialize the mode:
@@ -82,7 +83,7 @@ gh issue view "$MAP" --json subIssues --jq '.subIssues.nodes[].number' | tr -d '
     select(.state == "OPEN")
     | select(([.blockedBy.nodes[] | select(.state == "OPEN")] | length) == 0)
     | select((.assignees | length) == 0)
-    | "#\(.number) \(.title) [\([.labels[].name] | map(select(startswith("wayfind:")))[])]"' | tr -d '\r'
+    | "#\(.number) \(.title) [\([.labels[].name] | map(select(startswith("wayfind: ")))[])]"' | tr -d '\r'
 done
 # Non-interactive: also drop needs-human items — add
 #   | select((.labels | map(.name) | index("needs-human")) | not)

--- a/plugins/planning/skills/wayfind/evals/evals.json
+++ b/plugins/planning/skills/wayfind/evals/evals.json
@@ -16,11 +16,11 @@
     {
       "id": 2,
       "name": "work-mode-routes-decision-item-to-target-skill",
-      "prompt": "/planning:wayfind work — on our decision map (#142), the next open, unblocked, unassigned item is #145, labeled wayfind:design, asking us to choose the aggregate boundaries for the new billing domain. Resolve it.",
+      "prompt": "/planning:wayfind work — on our decision map (#142), the next open, unblocked, unassigned item is #145, labeled 'wayfind: design', asking us to choose the aggregate boundaries for the new billing domain. Resolve it.",
       "expected_output": "Work mode picks #145 as the frontier item, claims it (assignee plus a claim-comment lease), and routes the decision by invoking /planning:design directly — since design-typed items route there — rather than deciding the aggregate boundaries itself inline.",
       "files": [],
       "expectations": [
-        "Output identifies #145 (wayfind:design) as the frontier item being resolved",
+        "Output identifies #145 ('wayfind: design') as the frontier item being resolved",
         "Output routes the decision to /planning:design, the routing target for design-typed items, rather than resolving the aggregate-boundary question itself inline",
         "Output claims the item (assignee plus claim comment) before starting resolution rather than working it unclaimed"
       ]


### PR DESCRIPTION
## What

`/planning:wayfind` typed decision-item labels become `wayfind: <type>` (colon-space): SKILL.md routing table, tracker-mechanics bootstrap check + frontier jq (`startswith("wayfind: ")`), map-anatomy, evals. Planning plugin v0.11.1 → v0.11.2 + CHANGELOG.

## Why

Label-as-code owners enforcing the `prefix: value` axis grammar (github-iac `LabelsGrammarTests`) reject bare-colon names, forcing a permanent grammar exception for a taxonomy we own. Verified in the wild: colon-space is one of the two dominant OSS axis styles (React `Component: …`, Angular `action: …`, Flutter `a: …`); bare-colon is the rare one (TensorFlow). `work-map` / `needs-human` stay flat, grammar-exempt.

## Migration

Maps charted under old names need a one-time label rename before `work` mode routes them. None exist yet — this lands before the first map (ai-adoption-ladder, blocked on the companion github-iac label PR melodic-software/github-iac#150).

## Deferred

Label-name config seam for orgs with a different grammar (e.g. slash style) — deferred with trigger, tracked on the ai-adoption-ladder map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)