### PR TITLE
ci: route control-plane lanes through the governed selector

### DIFF
--- a/.github/runner-policy.json
+++ b/.github/runner-policy.json
@@ -3,18 +3,5 @@
   "repositoryOwner": "melodic-software",
   "visibility": "private",
   "selfHostedCi": true,
-  "exceptions": {
-    ".github/workflows/ci.yml#ci-status": {
-      "reason": "hosted-control-plane",
-      "justification": "The required CI gateway remains independent of selector and fleet health so route failures cannot become successful skipped checks."
-    },
-    ".github/workflows/link-check.yml#link-check": {
-      "reason": "privileged-control-plane",
-      "justification": "The scheduled link checker can create or update repository issues and therefore remains on GitHub-hosted compute."
-    },
-    ".github/workflows/pr-title.yml#pr-title": {
-      "reason": "hosted-control-plane",
-      "justification": "The required PR-title gateway remains independent of selector and fleet health so route failures cannot become successful skipped checks."
-    }
-  }
+  "exceptions": {}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,9 @@ jobs:
           files: >-
             .github/workflows/ci.yml
             .github/workflows/claude-review.yml
+            .github/workflows/do-not-merge.yml
             .github/workflows/link-check.yml
+            .github/workflows/pr-issue-linkage.yml
             .github/workflows/pr-title.yml
 
       - name: Verify shebang files are executable
@@ -352,8 +354,8 @@ jobs:
           CI_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
 
   ci-status:
-    if: always()
     needs:
+      - select-runner
       - hygiene
       - hook-utils-sync
       - cross-plugin-source-drift
@@ -361,10 +363,13 @@ jobs:
       - miro-plugin
       - runner-policy
       - zizmor
-    # The required gateway remains independent of selector/fleet health so a
-    # failed route materializes as a failing required check, never a skipped
-    # check that GitHub could treat as successful.
-    runs-on: ubuntu-24.04
+    # Fail-closed through execution: !cancelled() (never a success-guard) so a
+    # selector/fleet failure still runs this required aggregate on the hosted
+    # fallback and the result join below turns it red. A success-guard would skip
+    # the job, and a skipped required check reports success to branch protection.
+    # Happy path routes to the fleet (github-iac#78).
+    if: ${{ !cancelled() }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 15
     steps:
       - name: Aggregate lane results

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,54 @@
+name: do-not-merge
+
+# Blocks merging while the PR carries the `do-not-merge` label, via the shared
+# do-not-merge-gate reusable from ci-workflows. Runs on pull_request_target so
+# the base-branch definition evaluates (a head edit cannot neuter the gate);
+# safe because the reusable reads PR label metadata via the API and runs no head
+# code. `labeled`/`unlabeled` are required so applying or removing the label
+# re-evaluates the gate — a status check binds to a SHA, so without them a check
+# that passed before the label was applied stays green and the merge is never
+# blocked. `merge_group` re-checks the label in the queue (inert without a
+# queue). The emitted required-check context is `do-not-merge / do-not-merge`.
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+
+permissions:
+  pull-requests: read
+
+# pull_request_target runs the base-branch definition, so github.ref is the base
+# branch: the PR number scopes cancellation and github.ref covers merge_group
+# (which carries no pull_request object); the fallback is inert without a queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  select-runner:
+    name: Select runner
+    permissions: {}
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    secrets:
+      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
+    with:
+      policy: ${{ vars.CI_RUNNER_POLICY }}
+      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
+      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
+      scope: ${{ vars.CI_RUNNER_SCOPE }}
+      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
+      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
+
+  do-not-merge:
+    needs: select-runner
+    # Fail-closed selector-result reporter: always() so every routing outcome
+    # materializes the required check. The reusable receives the selector result
+    # and fail-closes on any non-success before evaluating the label, so a
+    # routing failure never dispatches this gate to paid hosted Linux.
+    if: ${{ always() }}
+    permissions:
+      pull-requests: read
+    uses: melodic-software/ci-workflows/.github/workflows/do-not-merge-gate.yml@885302176345486ca6c2c392d83131f9b5389251 # 8853021 2026-07-16
+    with:
+      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+      prerequisite-result: ${{ needs.select-runner.result }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,17 +13,34 @@ permissions:
   contents: read
 
 jobs:
+  select-runner:
+    name: Select runner
+    permissions: {}
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    secrets:
+      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
+    with:
+      policy: ${{ vars.CI_RUNNER_POLICY }}
+      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
+      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
+      scope: ${{ vars.CI_RUNNER_SCOPE }}
+      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
+      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
+
   link-check:
-    # This issue-writing advisory lane remains hosted by policy and is paused
-    # while strict local-only emergency routing is active.
-    if: ${{ vars.CI_RUNNER_POLICY != 'self-hosted-only' }}
+    # Routes through the governed selector to the fleet; the old strict-policy
+    # pause is retired now that this issue-writing lane no longer depends on
+    # hosted compute.
+    needs: select-runner
+    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
     # issues: write is scoped to this job (least privilege) — only the called
     # workflow files the rolling tracking issue.
     permissions:
       contents: read
       issues: write
-    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@3dfb18452a8c6059a22e62456390d84feb10b42f # 3dfb184 2026-07-16
     with:
+      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       args: >-
         --cache
         --max-cache-age 7d

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,0 +1,53 @@
+name: pr-issue-linkage
+
+# Validates the PR body carries a native closing keyword (Closes/Fixes/Resolves
+# #N, including owner/repo#N, or the literal "No linked issue" when the PR closes
+# nothing) and a non-empty `## Related` section, via the shared
+# pr-issue-linkage reusable from ci-workflows. `pull_request_target` runs the
+# base-branch definition, so a head-branch edit cannot bypass the gate — safe
+# here because the reusable reads PR body metadata from the event payload only
+# and runs no head code. `edited` re-validates on a body edit. `merge_group`
+# reports the check green in the queue (the body was validated at PR time; inert
+# without a queue). The emitted required-check context is
+# `pr-issue-linkage / pr-issue-linkage`.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+  merge_group:
+
+permissions: {}
+
+# pull_request_target runs the base-branch definition, so github.ref is the base
+# branch: the PR number scopes cancellation and github.ref covers merge_group
+# (which carries no pull_request object); the fallback is inert without a queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  select-runner:
+    name: Select runner
+    permissions: {}
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    secrets:
+      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
+    with:
+      policy: ${{ vars.CI_RUNNER_POLICY }}
+      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
+      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
+      scope: ${{ vars.CI_RUNNER_SCOPE }}
+      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
+      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
+
+  pr-issue-linkage:
+    needs: select-runner
+    # Fail-closed selector-result reporter: always() so every routing outcome
+    # materializes the required check. The reusable receives the selector result
+    # and fail-closes on any non-success before validating the body, so a
+    # routing failure never dispatches this gate to paid hosted Linux.
+    if: ${{ always() }}
+    permissions: {}
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@f7e94a80254fdca0aa85a600a07d784753b090e3 # f7e94a8 2026-07-16
+    with:
+      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+      prerequisite-result: ${{ needs.select-runner.result }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -34,24 +34,29 @@ jobs:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
 
   validate-pr-title:
-    # Run semantic validation only after a successful routing decision. A
-    # strict selector/configuration failure never dispatches this workload to
-    # paid hosted Linux.
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
+    # Fail-closed selector-result reporter: always() so every routing outcome
+    # materializes the required check. The reusable receives the selector result
+    # and fail-closes on any non-success, reporting the check as failed rather
+    # than dispatching validation to paid hosted Linux.
+    if: ${{ always() }}
     needs: select-runner
     permissions:
       pull-requests: read # Reads the pull-request title for validation.
-    uses: melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c # 99ac2f8 2026-07-11
+    uses: melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@51012e2c7b8bf74bc26e08c6446b488254a8770f # 51012e2 2026-07-12
     with:
       runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+      prerequisite-result: ${{ needs.select-runner.result }}
 
   pr-title:
     name: pr-title / pr-title
     needs: [select-runner, validate-pr-title]
-    if: ${{ always() && !cancelled() }}
-    # This fail-closed required gateway must report selector failure even when
-    # the local fleet cannot accept the validation workload.
-    runs-on: ubuntu-24.04
+    # Fail-closed through execution: !cancelled() (never a success-guard) so a
+    # selector failure still runs this required wrapper on the hosted fallback
+    # and the step below turns it red. A success-guard would skip the job, and a
+    # skipped required check reports success to branch protection. Happy path
+    # routes to the fleet (github-iac#78).
+    if: ${{ !cancelled() }}
+    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
     permissions: {}
     steps:
       - name: Enforce routing and semantic validation results


### PR DESCRIPTION
Wave 3 per-repo floor conversion (melodic-software/github-iac#78, 2026-07-16 owner override): converts every remaining hosted control-plane lane to governed selector routing — claude-code-plugins ends with ZERO runner-policy exceptions.

No linked issue.

## What

- `ci.yml`: ci-status aggregate routes with `if: ${{ !cancelled() }}` (fails closed through execution on the hosted fallback, never by skipping); the workflow-schema `files:` list gains the two new callers.
- `pr-title.yml`: the required-check status wrapper routes to the fleet; semantic-pr pin bumped to `51012e2` with `prerequisite-result` (`if: ${{ always() }}` per the validator's fail-closed reporter contract).
- `link-check.yml`: select-runner added; pin bumped to the `3dfb184` runner-input variant; retired the `CI_RUNNER_POLICY != self-hosted-only` pause guard.
- New `do-not-merge` + `pr-issue-linkage` callers (melodic-software/ci-workflows#120 / #121 rollout): `pull_request_target` + `merge_group`; execute on the hosted fallback until melodic-software/ci-workflows#130 admits those events.
- `runner-policy.json`: all 3 exceptions dropped → `"exceptions": {}`.

## Verification

- Local `runner-policy.mjs` run (CI env parity): clean; the two new callers' contracts landed via the standards sync (#236) already merged to main.
- actionlint clean; every converted `runs-on` keeps the `|| 'ubuntu-24.04'` fallback (epic decision 4).

## Related

- melodic-software/github-iac#78 (epic — Wave 3)
- melodic-software/ci-workflows#120, melodic-software/ci-workflows#121, melodic-software/ci-workflows#130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3QehVwmWzkBLpKokNCkkt