### PR TITLE
feat(session-flow): add keep-going skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -161,7 +161,7 @@
       "name": "session-flow",
       "source": "./plugins/session-flow",
       "category": "workflow",
-      "tags": ["workflow", "handoff", "retro", "retrospective", "session", "orchestration", "skill"]
+      "tags": ["workflow", "handoff", "keep-going", "resume", "recover", "retro", "retrospective", "session", "orchestration", "skill"]
     },
     {
       "name": "tdd",

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Browse and manage with `/plugin`. To refresh after updates: `/plugin marketplace
 
 ### Workflow
 
-- [`session-flow`](plugins/session-flow) — Session-lifecycle toolkit of four skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), retro (structured session retrospective with transcript metrics and learning codification), and orchestrate (arm a session or worker with proactive-orchestration imperatives).
+- [`session-flow`](plugins/session-flow) — Session-lifecycle toolkit of five skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), and orchestrate (arm a session or worker with proactive-orchestration imperatives).
 
 ### Project Management
 

--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.6.0",
-  "description": "Session-lifecycle toolkit of four skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), retro (structured session retrospective with transcript metrics and learning codification), and orchestrate (arm a session or worker with proactive-orchestration imperatives).",
+  "version": "0.7.0",
+  "description": "Session-lifecycle toolkit of five skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), and orchestrate (arm a session or worker with proactive-orchestration imperatives).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["workflow", "handoff", "retrospective", "session", "checkpoint", "orchestration", "skill"]
+  "keywords": ["workflow", "handoff", "keep-going", "resume", "recover", "retrospective", "session", "checkpoint", "orchestration", "skill"]
 }

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — session-flow plugin
 
+## 0.7.0 — 2026-07-17
+
+Added:
+
+- keep-going: new skill. Recovers and continues a session after any
+  interruption (rate limit, crash, disconnect, gap) — inventory off-thread
+  work, inspect each item's real state from its artifact rather than
+  assuming, resume the resumable / restart the dead / surface the
+  unrecoverable, then reconcile the main thread from a fresh read of its
+  backing plan or handoff file and continue. Safe/idempotent work
+  auto-resumes; re-running side-effectful work (push, PR comment, deploy) is
+  gated against double-firing. It is the resume counterpart to handoff, and
+  the interruption cause is deliberately not diagnosed (recovery is
+  identical regardless). The plugin now bundles five skills.
+
 ## 0.6.0 — 2026-07-16
 
 Changed:

--- a/plugins/session-flow/README.md
+++ b/plugins/session-flow/README.md
@@ -1,13 +1,14 @@
 # session-flow
 
-A Claude Code plugin bundling four skills for one cohesive capability: managing the lifecycle of a
-working session — where you are in the work, how to pause and resume it, what to learn from it, and
-how to arm it for delegation-heavy tasks.
+A Claude Code plugin bundling five skills for one cohesive capability: managing the lifecycle of a
+working session — where you are in the work, how to pause and resume it, how to recover it after an
+interruption, what to learn from it, and how to arm it for delegation-heavy tasks.
 
 | Skill | Question it answers |
 |---|---|
 | `/session-flow:workflow` | Where am I in the staged dev workflow, and what comes next? |
 | `/session-flow:handoff` | How do I save this session's state so a fresh `/clear` session resumes without rediscovery? |
+| `/session-flow:keep-going` | We were interrupted — what was running, what survived, and where does the main task continue? |
 | `/session-flow:retro` | What happened this session, what did we learn, and how do we codify it? |
 | `/session-flow:orchestrate` | How do I arm this session (or a spawned worker) with proactive-orchestration imperatives? |
 
@@ -45,6 +46,20 @@ skill always STOPS after emitting the save-point — continuing would defeat the
 /session-flow:handoff prompt          # force prompt-only
 /session-flow:handoff file phase-3    # force full handoff, topic "phase-3"
 /session-flow:handoff --bg            # hand the resume prompt to a background agent
+```
+
+### keep-going
+
+The resume counterpart to `handoff`: recovers a session after any interruption — a rate limit, a
+crash, a disconnect, or a long gap. Inventories the off-thread work (background tasks, shells,
+monitors, scheduled tasks, workflows, subagents — whatever the current harness exposes), inspects
+each item's real state from its own artifact rather than assuming it finished or died, resumes the
+resumable and restarts the dead, then reconciles the main thread from a fresh read of its backing
+plan or handoff file and continues. Safe, idempotent work auto-resumes; re-running anything with
+external side effects (a push, a PR comment, a deploy) is gated so a re-fire cannot double-apply.
+
+```shell
+/session-flow:keep-going              # inventory → inspect → recover → reconcile → report
 ```
 
 ### retro

--- a/plugins/session-flow/skills/keep-going/SKILL.md
+++ b/plugins/session-flow/skills/keep-going/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: keep-going
+description: "Recover and continue after any interruption — rate limit, crash, disconnect, or a gap. Inventory off-thread work, inspect its real state, resume or restart it, then continue the main task where it stood. Use when: 'keep going', 'continue', 'pick up where you left off', 'resume', 'you got cut off', 'we got interrupted', 'carry on', 'what were you doing'. Auto-resumes safe work; gates re-running anything with side effects."
+user-invocable: true
+disable-model-invocation: true
+---
+
+# Keep going
+
+## Purpose
+
+After an interruption — a rate limit, a crash, a disconnect, or just a
+long gap — work started off the main thread may be paused, dead, or
+silently finished, and the main task's position is easy to misremember.
+This skill recovers the off-thread work, reconciles the main thread from
+its real state rather than assumption, and continues. Scope is general:
+the recovery is the same whatever caused the interruption, so the cause
+is not diagnosed here.
+
+Where `/session-flow:handoff` deliberately pauses a session, keep-going is
+the resume counterpart — it picks the work back up after any pause, planned
+or not.
+
+## Steps
+
+1. **Inventory off-thread work.** Enumerate everything that was running
+   outside this thread. On the current harness that includes background
+   tasks, background shell commands, monitors, scheduled / cron tasks,
+   dynamic workflows, and spawned subagents — treat that list as
+   examples of the *kinds* of off-thread work to find, not a fixed
+   catalogue; the tool surface evolves, so inventory whatever mechanisms
+   exist now.
+2. **Inspect real state — never assume.** For each item, read its actual
+   state from the source of truth: task output, journals, transcripts,
+   shell logs, monitor status. Do not infer "it probably finished" or
+   "it probably died" — check. An interruption can leave work completed,
+   mid-flight, or dead, and only the artifact tells you which.
+3. **Recover per item.** Classify and act:
+   - **Resumable** → resume it. Prefer a real resume over a restart when
+     the mechanism supports one (e.g. a workflow resume reuses the cached
+     prefix instead of redoing work).
+   - **Dead but safe to redo** → restart it (subject to the autonomy
+     policy below).
+   - **Unrecoverable** → surface it plainly; do not fake a recovery.
+4. **Reconcile the main thread.** Restate where the primary task actually
+   stood — grounded in a fresh read of any plan / checklist / task
+   artifact backing it, not a prior turn's claim — then continue it. When
+   the interruption followed a `/session-flow:handoff`, the handoff file is
+   that artifact; read it rather than trusting memory.
+5. **Report.** One list: recovered, restarted, still-running, and lost /
+   unrecoverable.
+
+## Autonomy policy — resume freely, gate re-fires
+
+- **Auto-resume** safe, idempotent, read-only, or clearly incomplete
+  work without asking. That is the default; recovery should not stall on
+  confirmation for work that cannot double-fire.
+- **GATE** before RE-RUNNING anything with external side effects — a
+  push, a PR comment, a sent message, a deploy, a mutation — where a
+  re-fire could duplicate the effect. When the inspection in step 2
+  cannot prove the action did NOT already land, stop and ask before
+  repeating it. Double-firing a side effect is worse than pausing.
+
+## Nothing-off-thread case
+
+If the inventory finds no off-thread work, say so and go straight to
+step 4: reconcile the main thread from its real state and continue. The
+interruption may have hit mid-turn on the main thread alone — recovering
+that is still the job.
+
+## What this skill does NOT do
+
+- **Does not diagnose the interruption type.** Whether it was a short
+  limit, a weekly limit, or a crash does not change the recovery, so it
+  is not classified here.
+- **Does not blindly restart side-effectful work.** Re-firing is gated
+  by the autonomy policy, not automatic.
+- **Does not trust remembered state.** Every status claim is grounded in
+  a fresh read of the real artifact.
+
+## Gotchas
+
+- The specific tools that hold off-thread work change over time; the
+  duty is to inventory whatever off-thread mechanisms the current
+  harness exposes, not to look only for the ones named above.
+- "Probably done" is the failure mode. A resumable job that looks
+  finished may have died at 90%; a side-effect that looks unsent may
+  have landed just before the cutoff. Read the artifact both ways.

--- a/plugins/session-flow/skills/keep-going/SKILL.md
+++ b/plugins/session-flow/skills/keep-going/SKILL.md
@@ -2,7 +2,7 @@
 name: keep-going
 description: "Recover and continue after any interruption — rate limit, crash, disconnect, or a gap. Inventory off-thread work, inspect its real state, resume or restart it, then continue the main task where it stood. Use when: 'keep going', 'continue', 'pick up where you left off', 'resume', 'you got cut off', 'we got interrupted', 'carry on', 'what were you doing'. Auto-resumes safe work; gates re-running anything with side effects."
 user-invocable: true
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Keep going

--- a/plugins/session-flow/skills/keep-going/evals/evals.json
+++ b/plugins/session-flow/skills/keep-going/evals/evals.json
@@ -1,0 +1,55 @@
+{
+  "skill_name": "keep-going",
+  "evals": [
+    {
+      "id": 1,
+      "name": "inspect-real-state-not-assume",
+      "prompt": "keep going — we got cut off. You had a couple of background jobs running before the disconnect.",
+      "expected_output": "The skill inventories the off-thread work, then inspects each item's ACTUAL state from its source of truth (task output / logs / transcript) rather than assuming it finished or died, resumes the resumable ones, reconciles the main thread from a fresh read of its backing artifact, and reports a recovered / restarted / still-running / lost list.",
+      "files": [],
+      "expectations": [
+        "Inventories the off-thread work rather than only continuing the main thread",
+        "Inspects each item's real state from its artifact — does not assume 'probably done' or 'probably died'",
+        "Reconciles the main thread from a fresh read of its plan/checklist/task artifact, not a remembered claim",
+        "Ends with a recovered / restarted / still-running / lost report"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "gate-side-effectful-refire",
+      "prompt": "keep going. Before the crash you were about to push a commit and post a PR comment — I'm not sure whether either went through.",
+      "expected_output": "The skill auto-resumes safe/idempotent work but GATES the push and the PR comment: because step-2 inspection cannot prove they did not already land, it stops and asks before re-running them rather than double-firing the side effects.",
+      "files": [],
+      "expectations": [
+        "Does NOT blindly re-run the push or the PR comment",
+        "Attempts to inspect whether each side effect already landed",
+        "When it cannot prove a side effect did not land, stops and asks before repeating it",
+        "Still auto-resumes safe, idempotent, read-only work without gating"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "nothing-off-thread-still-reconciles",
+      "prompt": "keep going — I think we just got interrupted mid-task, nothing was running in the background.",
+      "expected_output": "The inventory finds no off-thread work, the skill says so, and it goes straight to reconciling the main thread from its real state and continuing — recovering a mid-turn interruption on the main thread alone is still the job.",
+      "files": [],
+      "expectations": [
+        "Reports that no off-thread work was found rather than inventing recovery items",
+        "Proceeds to reconcile the main thread from its real state and continue",
+        "Does not stall just because there was nothing off-thread to recover"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "does-not-diagnose-limit-type",
+      "prompt": "keep going — was that a 5-hour limit or the weekly one that cut us off?",
+      "expected_output": "The skill does not try to classify the interruption type (short vs weekly limit vs crash) — the recovery is identical regardless — and instead runs the inventory / inspect / recover / reconcile flow.",
+      "files": [],
+      "expectations": [
+        "Does not attempt to diagnose or classify the interruption/limit type",
+        "Proceeds with the recovery flow that is the same regardless of cause",
+        "Focuses on real-state inspection and continuation, not the interruption's origin"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a fifth skill to **`session-flow`**: `/session-flow:keep-going` —
recover and continue after any interruption (rate limit, crash, disconnect,
gap). It is the resume counterpart to `handoff`: handoff deliberately pauses
a session, keep-going picks it back up.

Flow: **inventory** off-thread work → **inspect** each item's real state
from its own artifact (never assume "probably done" / "probably died") →
**recover** (resume the resumable, restart the dead, surface the
unrecoverable) → **reconcile** the main thread from a fresh read of its
backing plan or handoff file → **report** recovered / restarted /
still-running / lost.

**Autonomy policy:** safe, idempotent, read-only work auto-resumes;
re-running anything with external side effects (a push, a PR comment, a
deploy) is gated when inspection cannot prove it did not already land —
double-firing a side effect is worse than pausing.

## Design decisions

- **Cause not diagnosed.** Short-limit vs weekly-limit vs crash does not
  change the recovery, so it is deliberately not classified.
- **No capability enumeration.** Harness mechanisms (background tasks,
  shells, monitors, scheduled tasks, workflows, subagents) are named only as
  marked examples of the *kinds* of off-thread work — the duty is to
  inventory whatever the current harness exposes, so the skill survives tool
  evolution.
- **Follows the plugin's conventions.** Version bump 0.6.0 → 0.7.0,
  `## X.Y.Z — DATE` changelog format, README skill-table + section, keywords,
  and root catalog entry all updated in the plugin's existing style.

## Coordination note

This PR bumps `session-flow` to **0.7.0** and edits the shared plugin
files (plugin.json version/description, README, CHANGELOG, root
marketplace + catalog row). If a concurrent `session-flow` PR (e.g. a
further orchestrate change) lands first, these shared-file edits are the
expected conflict resolved by serializing the merge — this branch rebases
onto the new base and re-bumps the version. The `keep-going/` skill files
themselves are conflict-free.

## Gates

- markdownlint-cli2 (MD013=80): clean.
- `/skill-quality:check`: PASS, 0 errors / 0 warnings.
- Evals present and schema-valid (4 warranted cases: real-state inspection,
  side-effect re-fire gating, nothing-off-thread, does-not-diagnose-cause).
- `claude plugin validate` (plugin) and `--strict` (catalog): pass.

Part of the round-2 personal-skill graduation, alongside `re-anchor`
(#249) and `naming` (#250). Raw `~/.claude/skills/` copies are removed only
after these merge and verify.

## Related

- Sibling round-2 graduation PRs: #249 (re-anchor), #250 (naming), #251 (keep-going session-flow skill).
- Upstream issues filed from this work: #252 (extract-ssot threshold), #253 (docs-hygiene proactive detection).

No linked issue — round-2 personal-skill graduation is driven by the planning brief, not a tracked GitHub issue.
