### PR TITLE
ci: bump claude-review pin to df54d0e

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@4dbb0dfcc1fcbaf30e1a5573bf776af54e4e7e1a # 4dbb0df 2026-07-15
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@df54d0e8c899baa7e57344c3633f033129da6632 # df54d0e 2026-07-16
     with:
       runner: ${{ needs.select-review.outputs.runner || 'ubuntu-24.04' }}
     # Pass only the one named secret (least privilege) rather than `secrets:


### PR DESCRIPTION
No related issue: step 3 of melodic-software/standards#159 (six-consumer claude-review pin bump); that issue closes only when all six consumers land.

## Related

- melodic-software/standards#159
- melodic-software/ci-workflows@df54d0e (`fix(claude-review): surface real review failures instead of a silent green`)

## What

Bump the `claude-review.yml` reusable-workflow pin `4dbb0dfc` → `df54d0e8c899baa7e57344c3633f033129da6632`.

- Restores failure-comment visibility (a failed review now surfaces instead of a silent green).
- The upstream diff is otherwise additive-only: an optional `standards-ref` input plus two optional App secrets for the private depth tier — unused by this caller, no shape change.
- The `df54d0e` runner-input contract is already present in this repo's synced `.github/standards/runner-policy/policy.json` (or the local component, for standards itself), so the Runner policy lane validates it as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3QehVwmWzkBLpKokNCkkt
