### PR TITLE
ci: pin ci-workflows reusables and selector at v0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   # silently redirect to paid hosted Linux.
   select-runner:
     name: Select runner
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3415de3ff2fafee40e4d087eb6073d2f6952b595 # 3415de3 2026-07-13
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -192,7 +192,7 @@ jobs:
     permissions:
       contents: read
     # Advisory Actions security lint; findings annotate without blocking.
-    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@de50a08b6093d231519ee7a4c9371db76c0a7e1e # de50a08 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       paths: .

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,7 +23,7 @@ jobs:
   select-review:
     name: Select runner
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     secrets:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
     with:
@@ -44,7 +44,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@df54d0e8c899baa7e57344c3633f033129da6632 # df54d0e 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-review.outputs.runner || 'ubuntu-24.04' }}
     # Pass only the one named secret (least privilege) rather than `secrets:

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -28,7 +28,7 @@ jobs:
   select-runner:
     name: Select runner
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     secrets:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
     with:
@@ -48,7 +48,7 @@ jobs:
     if: ${{ always() }}
     permissions:
       pull-requests: read
-    uses: melodic-software/ci-workflows/.github/workflows/do-not-merge-gate.yml@885302176345486ca6c2c392d83131f9b5389251 # 8853021 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/do-not-merge-gate.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       prerequisite-result: ${{ needs.select-runner.result }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -16,7 +16,7 @@ jobs:
   select-runner:
     name: Select runner
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     secrets:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
     with:
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@3dfb18452a8c6059a22e62456390d84feb10b42f # 3dfb184 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       args: >-

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -28,7 +28,7 @@ jobs:
   select-runner:
     name: Select runner
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52 # cdc5917 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     secrets:
       observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
     with:
@@ -47,7 +47,7 @@ jobs:
     # routing failure never dispatches this gate to paid hosted Linux.
     if: ${{ always() }}
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@f7e94a80254fdca0aa85a600a07d784753b090e3 # f7e94a8 2026-07-16
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       prerequisite-result: ${{ needs.select-runner.result }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   select-runner:
     name: Select runner for PR title
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@3415de3ff2fafee40e4d087eb6073d2f6952b595 # 3415de3 2026-07-13
+    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       policy: ${{ vars.CI_RUNNER_POLICY }}
       self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
@@ -42,7 +42,7 @@ jobs:
     needs: select-runner
     permissions:
       pull-requests: read # Reads the pull-request title for validation.
-    uses: melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@51012e2c7b8bf74bc26e08c6446b488254a8770f # 51012e2 2026-07-12
+    uses: melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
       prerequisite-result: ${{ needs.select-runner.result }}


### PR DESCRIPTION
No linked issue.

Repins every ci-workflows selector and reusable-workflow reference to `ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5` (v0.6.0), registered in the runner policy by melodic-software/standards#175 and distributed by the just-merged standards-sync PR. Gate callers gain `merge_group` / same-repo `pull_request_target` selector routing; the claude-review lane picks up per-head concurrency and the superseded-head guard.

## Verification

- Local dogfood: `GITHUB_REPOSITORY=melodic-software/claude-code-plugins node .github/standards/runner-policy/runner-policy.mjs --root .` passes against the #175 policy.
- No residual pre-v0.6.0 ci-workflows workflow pins (grep-verified).

## Related

- melodic-software/standards#175 (policy registration)
- melodic-software/github-iac#78 (epic — Campaign A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)