### PR TITLE
docs: reconcile kill-switch doctrine — per-hook toggles are userConfig

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -759,11 +759,14 @@ surface to a published plugin for a single consumer's low-value nicety.
    `enabledPlugins` (project `settings.json`, so clones inherit it on trust — the interactive trust prompt
    both registers and installs the enabled plugin). Headless/CI has no such prompt, and registering a
    marketplace does not install its plugins, so do both explicitly: `claude plugin marketplace add <repo>`
-   then `claude plugin install <plugin>@<marketplace> --scope project` — otherwise the marketplace is known
-   but the plugin is absent, and step 3's verify edit would run with no plugin hook.
-2. Set any non-default plugin `userConfig` toggles (on the install command via `--config`, or
-   `/plugin configure`); keep the `HOOK_TELEMETRY_SINK` wiring and the sink script (the bridge),
-   adapting the sink for any observability-contract divergence.
+   then `claude plugin install <plugin>@<marketplace> --scope project --config KEY=VALUE …`, seeding every
+   non-default `userConfig` toggle on that install command — `--config` applies only on a fresh install and
+   is ignored once the plugin is already installed (smoke-test C), so a headless reconfiguration later
+   means uninstall/reinstall. Otherwise the marketplace is known but the plugin is absent, and step 3's
+   verify edit would run with no plugin hook.
+2. Interactively, `/plugin configure` adjusts `userConfig` toggles at any time; keep the
+   `HOOK_TELEMETRY_SINK` wiring and the sink script (the bridge), adapting the sink for any
+   observability-contract divergence.
 3. **Verify before retiring** the old hook (blue-green — keep it recoverable, but never run both on the
    same edit). Matching `PostToolUse` hooks run concurrently, so leaving both registered would race two
    formatters on the just-edited file (last-writer-wins clobbering, plus doubled telemetry and context) —

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -33,9 +33,9 @@ plugin per hook.
   ([skills](https://code.claude.com/docs/en/skills), fetched 2026-07-15) — every extra skill is an
   always-paid context line. The standing exception is the `setup` lane, always its own skill with
   `disable-model-invocation: true` — see the philosophy's "Setup is explicit and repeatable".
-- **Hooks group by concern.** Per-hook selectivity comes from an env kill-switch
-  (`HOOK_<PLUGIN>_ENABLED`), a `matcher`, or an `if` guard — author-managed control inside the bundle,
-  the ecosystem norm.
+- **Hooks group by concern.** Per-hook selectivity comes from a `userConfig` toggle (read through
+  the hook-process `CLAUDE_PLUGIN_OPTION_<KEY>` mirror), a `matcher`, or an `if` guard —
+  author-managed control inside the bundle.
 - **Whole-product / vendor-brand bundles** driven by distribution are a separate, allowed shape.
 
 ### Decompose an oversized skill before packaging it
@@ -78,9 +78,9 @@ skill still has one discovery intent.
 `skillOverrides` setting explicitly *excludes* plugin skills (those are managed through `/plugin`), so
 there is no clean per-skill à-la-carte toggle. Bundling several skills is therefore acceptable only
 *within* one cohesive capability you would never split — it forbids lumping *distinct* capabilities into
-a single plugin. Hooks differ: the env kill-switch gives clean per-hook control inside a bundle. The
-discriminating axis is **silent-always-on** components (hooks — keep atomic, or toggle via env) versus
-**opt-in-per-invocation** components (skills — group by capability).
+a single plugin. Hooks differ: a per-hook `userConfig` toggle gives clean per-hook control inside a
+bundle. The discriminating axis is **silent-always-on** components (hooks — keep atomic, or toggle via
+`userConfig`) versus **opt-in-per-invocation** components (skills — group by capability).
 
 **Buckets are catalog metadata, never structure.** Category grouping lives in `marketplace.json`
 `category` / `tags` and catalog docs only: the disk layout stays flat (`plugins/<name>`, no
@@ -631,7 +631,7 @@ plugins-reference, and hooks pages 2026-07-17; re-verify per the `CLAUDE.md` fre
    Check: which binaries it spawns; whether it mutates files in place and is
    **advisory** (exits 0, never blocks) vs gating; no `eval` / `curl … | sh` / outbound network; untrusted
    input (file contents, tool args, PR/issue text) never flows unquoted into a shell; a kill switch
-   (`HOOK_<PLUGIN>_ENABLED`) exists.
+   (a per-hook `userConfig` boolean with a `default` of `true`) exists.
 2. **MCP servers — `.mcp.json` / inline in `plugin.json`.** `miro` is the **only** plugin that ships one
    (local `stdio`, bundled — see its §2 trust accept above); no plugin ships a **remote** MCP server, which
    remains the higher-scrutiny case. A plugin's MCP server **starts automatically when the plugin is enabled**
@@ -731,8 +731,10 @@ extension points, never by teaching the plugin a consumer's specifics.
 **The plugin is generic; the consumer's own seams restore its specifics.** Map each behavior the
 in-repo hook had that the generalized plugin dropped to one of these, in order:
 
-- **Kill switch / toggles** → the plugin's own env var, set in the consumer's `settings.json` `env`
-  (the name changes from the in-repo `HOOK_<OLD>_ENABLED` to the plugin's `HOOK_<PLUGIN>_ENABLED`).
+- **Kill switch / toggles** → the plugin's own `userConfig` toggles (`/plugin configure`
+  interactively, `claude plugin install --config` headless) — user-scoped, replacing the in-repo
+  `HOOK_<OLD>_ENABLED` env var. Per-repo control is the plugin's `enabledPlugins` entry; a genuinely
+  project-scoped per-hook need is a plugin gap (below), not an env var.
 - **Project conventions** → for a hook plugin, the consumer's own tool config files that the hook already
   reads (`biome.json`, `.shellcheckrc`, `.editorconfig`, …) — that is where these plugins pick up project
   conventions, **not** `CLAUDE.md`. (`CLAUDE.md` / `.claude/rules` reach only a plugin's *skill/agent*
@@ -747,7 +749,7 @@ in-repo hook had that the generalized plugin dropped to one of these, in order:
   so the remap preserves the real contract rather than a guessed one.
 
 If a genuine specific has **no** seam, that is a real plugin gap → add a declared extension
-(`userConfig`, or a new env var consistent with the plugin's existing ones) — but only when it carries
+(`userConfig`, or a tracked consumer-project config key) — but only when it carries
 real behavior, not cosmetic prose a consumer's `CLAUDE.md` already establishes. Resist adding config
 surface to a published plugin for a single consumer's low-value nicety.
 
@@ -759,8 +761,9 @@ surface to a published plugin for a single consumer's low-value nicety.
    marketplace does not install its plugins, so do both explicitly: `claude plugin marketplace add <repo>`
    then `claude plugin install <plugin>@<marketplace> --scope project` — otherwise the marketplace is known
    but the plugin is absent, and step 3's verify edit would run with no plugin hook.
-2. Rewire the kill-switch env var to the plugin's name; keep the `HOOK_TELEMETRY_SINK` wiring and the
-   sink script (the bridge), adapting the sink for any observability-contract divergence.
+2. Set any non-default plugin `userConfig` toggles (on the install command via `--config`, or
+   `/plugin configure`); keep the `HOOK_TELEMETRY_SINK` wiring and the sink script (the bridge),
+   adapting the sink for any observability-contract divergence.
 3. **Verify before retiring** the old hook (blue-green — keep it recoverable, but never run both on the
    same edit). Matching `PostToolUse` hooks run concurrently, so leaving both registered would race two
    formatters on the just-edited file (last-writer-wins clobbering, plus doubled telemetry and context) —

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -139,6 +139,11 @@ a skill-invoked shell script) takes the value through non-sensitive `${user_conf
 in skill or agent content, an explicit argument, or a component field that substitutes it. The
 custom environment variable is retired when the migration lands.
 
+A hook kill switch is such a scalar: per-hook selectivity ships as a `userConfig` boolean with a
+`default` of `true`, read through the hook mirror. Per-project control stays whole-plugin via
+scope-level `enabledPlugins`; a genuinely project-scoped per-hook behavior graduates to the tracked
+consumer-project file on demonstrated need — never a custom env channel.
+
 `version` lives in `plugin.json` only, never in a marketplace entry. The platform resolves
 plugin.json first, but a marketplace-entry copy is dead metadata that silently becomes live if the
 manifest field is ever removed — one home, no shadow.


### PR DESCRIPTION
Resolves doctrine finding 1 of epic #313 (the finding, not the epic). No linked issue closes with this PR.

## What

The philosophy doc mandated migrating personal env toggles to `userConfig` (env channel retires), while the migration playbook endorsed `HOOK_<PLUGIN>_ENABLED` as the ecosystem norm and its plugin-acceptance security review required that env var to exist. This PR reconciles: **migration wins, with a scope carve-out.**

The reconciliation line (added to PLUGIN-PHILOSOPHY § Configuration ownership and scope): a hook kill switch is a personal scalar — per-hook selectivity ships as a `userConfig` boolean with `default: true`, read through the hook-process `CLAUDE_PLUGIN_OPTION_<KEY>` mirror. Per-project control stays whole-plugin via scope-level `enabledPlugins`; a genuinely project-scoped per-hook behavior graduates to the tracked consumer-project file on demonstrated need — never a custom env channel.

## Playbook sites updated to match

- Bundling rationale ('Hooks group by concern' + 'Why capability, not grab-bag'): per-hook control now cites the userConfig toggle, not the env kill-switch.
- Security review item 1: the kill-switch existence check now requires a per-hook userConfig boolean (default true).
- Reintegration seam map: toggles route through `/plugin configure` / `claude plugin install --config`; per-repo control is the `enabledPlugins` entry; the no-seam plugin-gap escape now names a tracked consumer-project config key instead of a new env var.
- Cutover checklist step 2: set non-default userConfig toggles instead of rewiring an env var.

Deliberately unchanged: the consumer-side `HOOK_TELEMETRY_SINK` seam (project-scoped observability wiring, not a personal toggle — classified in the flagship migration), legacy in-repo hook toggles in the cutover procedure, and `docs/hook-migration-audit.md` (a historical audit record).

## Verification

- Facts re-verified this session against https://code.claude.com/docs/en/plugins-reference and https://code.claude.com/docs/en/hooks: all userConfig values export to hook processes as `CLAUDE_PLUGIN_OPTION_<KEY>`; `pluginConfigs` is read from user settings, `--settings`, and managed settings only (v2.1.207+); no native per-hook disable exists (only `disableAllHooks`, `if`, or whole-plugin disable — `enabledPlugins` is scope-level).
- markdownlint-cli2: 0 errors on both files.
- Grep confirms no stale `HOOK_*_ENABLED` doctrine text remains in either doctrine doc.

Unblocks the #315 plugin migrations (guardrails flagship + 9 single-switch hook plugins + knowledge/source-control scalars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Related

- Epic #313 (fleet conformance audit — doctrine-update finding 1)
- #315 (userConfig wave — this reconciliation is its gating first task)
