### PR TITLE
feat: migrate hook kill switches to native userConfig (10 plugins)

### DIFF
--- a/lib/hook-utils.sh
+++ b/lib/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["actionlint", "github-actions", "workflow", "yaml", "linter", "hook"]
+  "keywords": ["actionlint", "github-actions", "workflow", "yaml", "linter", "hook"],
+  "userConfig": {
+    "actionlint_enabled": {
+      "type": "boolean",
+      "title": "actionlint-check hook",
+      "description": "Lint GitHub Actions workflow files on edit via actionlint",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -8,20 +8,20 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["actionlint", "github-actions", "workflow", "yaml", "linter", "hook"],
+  "keywords": [
+    "actionlint",
+    "github-actions",
+    "workflow",
+    "yaml",
+    "linter",
+    "hook"
+  ],
   "userConfig": {
     "actionlint_enabled": {
       "type": "boolean",
       "title": "actionlint-check hook",
       "description": "Lint GitHub Actions workflow files on edit via actionlint",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -10,13 +10,11 @@ All notable changes to the `actionlint` plugin are documented here. Format follo
 - **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch
   doctrine ruling). The hook toggle is now the `actionlint_enabled` boolean
   (default `true`), read by the hook through the native
-  `CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED` hook-process mirror; the stdin read
-  bound is now the `stdin_read_timeout` option (default `2`). Configure
+  `CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED` hook-process mirror. Configure
   interactively with `/plugin configure actionlint` or headless via
   `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_ACTIONLINT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
-  environment variables are retired and no longer read. A consumer that set
-  either in a settings `env` block must re-express the value as the matching
-  `userConfig` option. Zero-config behavior is unchanged (hook on, same
+- **BREAKING:** the `HOOK_ACTIONLINT_ENABLED` environment variable is retired
+  and no longer read. A consumer that set it in a settings `env` block must
+  re-express the value as the matching `userConfig` option. Zero-config behavior is unchanged (hook on, same
   defaults). The `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is
   unaffected.

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the `actionlint` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch
+  doctrine ruling). The hook toggle is now the `actionlint_enabled` boolean
+  (default `true`), read by the hook through the native
+  `CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED` hook-process mirror; the stdin read
+  bound is now the `stdin_read_timeout` option (default `2`). Configure
+  interactively with `/plugin configure actionlint` or headless via
+  `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_ACTIONLINT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
+  environment variables are retired and no longer read. A consumer that set
+  either in a settings `env` block must re-express the value as the matching
+  `userConfig` option. Zero-config behavior is unchanged (hook on, same
+  defaults). The `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is
+  unaffected.

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -40,16 +40,25 @@ your `PATH`.
 
 ## Configuration
 
-This plugin has no `userConfig`. actionlint auto-discovers its own
-`.github/actionlint.yaml` config from your repository when present.
+actionlint auto-discovers its own `.github/actionlint.yaml` config from your
+repository when present. Two `userConfig` options tune the hook itself:
 
-### Disable without uninstalling
+- **`actionlint_enabled`** (boolean, default `true`) — kill switch for the
+  actionlint-check hook.
+- **`stdin_read_timeout`** (number, default `2`, min `1`) — seconds to wait
+  reading the hook payload from stdin before failing open.
 
-Set the kill switch in your settings `env` block:
+Configure interactively with `/plugin configure actionlint` or headless at
+install time:
 
-```json
-{ "env": { "HOOK_ACTIONLINT_ENABLED": "false" } }
+```shell
+claude plugin install actionlint@melodic-software --config actionlint_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings), so a value set
+here applies across every project. To disable actionlint for a single
+repository, disable the plugin in that project's `enabledPlugins` rather than
+setting `actionlint_enabled`.
 
 ## License
 

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -41,12 +41,10 @@ your `PATH`.
 ## Configuration
 
 actionlint auto-discovers its own `.github/actionlint.yaml` config from your
-repository when present. Two `userConfig` options tune the hook itself:
+repository when present. One `userConfig` option tunes the hook itself:
 
 - **`actionlint_enabled`** (boolean, default `true`) — kill switch for the
   actionlint-check hook.
-- **`stdin_read_timeout`** (number, default `2`, min `1`) — seconds to wait
-  reading the hook payload from stdin before failing open.
 
 Configure interactively with `/plugin configure actionlint` or headless at
 install time:

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -82,7 +82,7 @@ run_hook() {
   (
     cd "$UNRELATED" || return 1
     printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR HOOK_ACTIONLINT_ENABLED=true bash "$HOOK"
+      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -152,7 +152,7 @@ RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok ".txt under workflows -> exit 0 silent"; else fail ".txt not skipped (rc=$RC out=$OUT)"; fi
 
 # --- Case 6: kill switch bypasses hook --------------------------------------
-OUT=$(run_hook_env "$REPO/.github/workflows/violation.yml" HOOK_ACTIONLINT_ENABLED=false)
+OUT=$(run_hook_env "$REPO/.github/workflows/violation.yml" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=false)
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent despite violation"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
 
@@ -179,7 +179,7 @@ fi
 # ============================================================================
 
 # --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
-OUT_NS=$(run_hook_env "$REPO/.github/workflows/clean.yml" -u HOOK_TELEMETRY_SINK HOOK_ACTIONLINT_ENABLED=true)
+OUT_NS=$(run_hook_env "$REPO/.github/workflows/clean.yml" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true)
 RC_NS=$?
 if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
   ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
@@ -190,7 +190,7 @@ fi
 # --- Stub sink + violation -> envelope status ok with findings --------------
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/.github/workflows/violation.yml" HOOK_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+run_hook_env "$REPO/.github/workflows/violation.yml" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -216,7 +216,7 @@ rm -f "$TEL"
 # --- Stub sink + clean file -> status ok, findings [] -----------------------
 TELC="$(mktemp)"
 SINKC="$(make_sink "cat >\"$TELC\"")"
-run_hook_env "$REPO/.github/workflows/clean.yml" HOOK_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKC" >/dev/null
+run_hook_env "$REPO/.github/workflows/clean.yml" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKC" >/dev/null
 wait_for_sink "$TELC"
 if [[ -s "$TELC" ]]; then
   if [[ "$(jq -r '.status' "$TELC")" == "ok" ]]; then ok "telemetry/clean: status ok"; else fail "telemetry/clean: status=$(jq -r '.status' "$TELC")"; fi
@@ -242,7 +242,7 @@ done
 OUT_ABS=$(
   cd "$UNRELATED" || exit 1
   printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/clean.yml" \
-    | env -u CLAUDE_PROJECT_DIR -i PATH="${KEEP#:}" HOOK_ACTIONLINT_ENABLED=true \
+    | env -u CLAUDE_PROJECT_DIR -i PATH="${KEEP#:}" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true \
         HOOK_TELEMETRY_SINK="$ABSENT_SINK" bash "$HOOK"
 )
 RC_ABS=$?

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"]
+  "keywords": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"],
+  "userConfig": {
+    "bash_format_enabled": {
+      "type": "boolean",
+      "title": "bash-format hook",
+      "description": "Lint and format shell scripts on edit via ShellCheck + shfmt",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -8,20 +8,21 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["bash", "shell", "shellcheck", "shfmt", "formatter", "linter", "hook"],
+  "keywords": [
+    "bash",
+    "shell",
+    "shellcheck",
+    "shfmt",
+    "formatter",
+    "linter",
+    "hook"
+  ],
   "userConfig": {
     "bash_format_enabled": {
       "type": "boolean",
       "title": "bash-format hook",
       "description": "Lint and format shell scripts on edit via ShellCheck + shfmt",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`.** The bash-format toggle is now the
+  `bash_format_enabled` option (default `true`), read by the hook through the native
+  `CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED` hook-process mirror; the stdin read bound is
+  now the `stdin_read_timeout` option (default `2`). Configure interactively with
+  `/plugin configure bash-format` or headless via `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_BASH_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT` environment
+  variables are retired and no longer read. A consumer that set either in a settings `env`
+  block must re-express the value as the matching `userConfig` option. Zero-config behavior
+  is unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK` telemetry seam is
+  unaffected.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -9,12 +9,11 @@ All notable changes to the `bash-format` plugin are documented here. Format foll
 
 - **Kill switch migrated to native `userConfig`.** The bash-format toggle is now the
   `bash_format_enabled` option (default `true`), read by the hook through the native
-  `CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED` hook-process mirror; the stdin read bound is
-  now the `stdin_read_timeout` option (default `2`). Configure interactively with
+  `CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED` hook-process mirror. Configure interactively with
   `/plugin configure bash-format` or headless via `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_BASH_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT` environment
-  variables are retired and no longer read. A consumer that set either in a settings `env`
-  block must re-express the value as the matching `userConfig` option. Zero-config behavior
+- **BREAKING:** the `HOOK_BASH_FORMAT_ENABLED` environment variable is retired and no
+  longer read. A consumer that set it in a settings `env` block must re-express the
+  value as the matching `userConfig` option. Zero-config behavior
   is unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK` telemetry seam is
   unaffected.
 

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -53,17 +53,27 @@ formatting still run.
 
 ## Configuration
 
-This plugin has no `userConfig` — its only "configuration" is the `.shellcheckrc`
-and `.editorconfig` already in your repository, which it reads automatically. To
-change the rules, edit those files.
+The linting and formatting rules come from the `.shellcheckrc` and
+`.editorconfig` already in your repository, which the plugin reads automatically.
+To change the rules, edit those files.
 
-### Disable without uninstalling
+Two `userConfig` options tune the hook itself:
 
-Set the kill switch in your settings `env` block:
+| Option | Default | Effect |
+|--------|---------|--------|
+| `bash_format_enabled` | `true` | Toggle for the bash-format hook; set `false` for a clean no-op. |
+| `stdin_read_timeout` | `2` | Seconds the hook waits for its stdin payload before failing open (min `1`). |
 
-```json
-{ "env": { "HOOK_BASH_FORMAT_ENABLED": "false" } }
+Set them interactively with `/plugin configure bash-format`, or headless on the
+install command:
+
+```shell
+claude plugin install bash-format@melodic-software --config bash_format_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the project's).
+To turn the hook off for a single repository, disable the whole plugin in that
+project's `enabledPlugins` instead.
 
 ## License
 

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -57,14 +57,13 @@ The linting and formatting rules come from the `.shellcheckrc` and
 `.editorconfig` already in your repository, which the plugin reads automatically.
 To change the rules, edit those files.
 
-Two `userConfig` options tune the hook itself:
+One `userConfig` option tunes the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
 | `bash_format_enabled` | `true` | Toggle for the bash-format hook; set `false` for a clean no-op. |
-| `stdin_read_timeout` | `2` | Seconds the hook waits for its stdin payload before failing open (min `1`). |
 
-Set them interactively with `/plugin configure bash-format`, or headless on the
+Set it interactively with `/plugin configure bash-format`, or headless on the
 install command:
 
 ```shell

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -87,12 +87,12 @@ run_hook() {
   (
     cd "$UNRELATED" || return 1
     printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR HOOK_BASH_FORMAT_ENABLED=true bash "$HOOK"
+      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
   )
 }
 
 # Same as run_hook but with caller-supplied extra env (NAME=VALUE ...) and an
-# optional override of HOOK_BASH_FORMAT_ENABLED, passed through env.
+# optional override of CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED, passed through env.
 run_hook_env() {
   local file_path="$1"
   shift
@@ -159,7 +159,7 @@ RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-shell ext -> exit 0 silent"; else fail "non-shell not skipped (rc=$RC out=$OUT)"; fi
 
 # --- Case 5: kill switch bypasses hook --------------------------------------
-OUT=$(run_hook_env "$REPO/violation.sh" HOOK_BASH_FORMAT_ENABLED=false)
+OUT=$(run_hook_env "$REPO/violation.sh" CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=false)
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent despite violation"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
 
@@ -254,7 +254,7 @@ fi
 # ============================================================================
 
 # --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
-OUT_NS=$(run_hook_env "$REPO/clean.sh" -u HOOK_TELEMETRY_SINK HOOK_BASH_FORMAT_ENABLED=true)
+OUT_NS=$(run_hook_env "$REPO/clean.sh" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true)
 RC_NS=$?
 if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
   ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
@@ -265,7 +265,7 @@ fi
 # --- Stub sink + violation -> envelope status ok with findings --------------
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/violation.sh" HOOK_BASH_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+run_hook_env "$REPO/violation.sh" CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -292,7 +292,7 @@ rm -f "$TEL"
 # --- Stub sink + clean file -> status ok, findings [] -----------------------
 TELC="$(mktemp)"
 SINKC="$(make_sink "cat >\"$TELC\"")"
-run_hook_env "$REPO/clean.sh" HOOK_BASH_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKC" >/dev/null
+run_hook_env "$REPO/clean.sh" CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKC" >/dev/null
 wait_for_sink "$TELC"
 if [[ -s "$TELC" ]]; then
   if [[ "$(jq -r '.status' "$TELC")" == "ok" ]]; then ok "telemetry/clean: status ok"; else fail "telemetry/clean: status=$(jq -r '.status' "$TELC")"; fi

--- a/plugins/bash-format/hooks/hook-utils.sh
+++ b/plugins/bash-format/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["biome", "typescript", "javascript", "json", "jsx", "formatter", "linter", "hook"]
+  "keywords": ["biome", "typescript", "javascript", "json", "jsx", "formatter", "linter", "hook"],
+  "userConfig": {
+    "biome_format_enabled": {
+      "type": "boolean",
+      "title": "biome-format hook",
+      "description": "Format and lint JS/TS/JSX/JSON on edit via Biome",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -8,20 +8,22 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["biome", "typescript", "javascript", "json", "jsx", "formatter", "linter", "hook"],
+  "keywords": [
+    "biome",
+    "typescript",
+    "javascript",
+    "json",
+    "jsx",
+    "formatter",
+    "linter",
+    "hook"
+  ],
   "userConfig": {
     "biome_format_enabled": {
       "type": "boolean",
       "title": "biome-format hook",
       "description": "Format and lint JS/TS/JSX/JSON on edit via Biome",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -10,12 +10,10 @@ All notable changes to the `biome-format` plugin are documented here. Format fol
 - **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch
   doctrine ruling). The hook's toggle is now the `biome_format_enabled` boolean
   (default `true`), read through the native `CLAUDE_PLUGIN_OPTION_<KEY>`
-  hook-process mirror; the stdin read bound is the `stdin_read_timeout` option
-  (default `2`). Configure interactively with `/plugin configure biome-format` or
-  headless via `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_BIOME_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
-  environment variables are retired and no longer read. A consumer that set
-  either in a settings `env` block must re-express the value as the matching
-  `userConfig` option. Zero-config behavior is unchanged (hook on, same
+  hook-process mirror. Configure interactively with `/plugin configure biome-format`
+  or headless via `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_BIOME_FORMAT_ENABLED` environment variable is retired
+  and no longer read. A consumer that set it in a settings `env` block must
+  re-express the value as the matching `userConfig` option. Zero-config behavior is unchanged (hook on, same
   defaults). The `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is
   unaffected.

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the `biome-format` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch
+  doctrine ruling). The hook's toggle is now the `biome_format_enabled` boolean
+  (default `true`), read through the native `CLAUDE_PLUGIN_OPTION_<KEY>`
+  hook-process mirror; the stdin read bound is the `stdin_read_timeout` option
+  (default `2`). Configure interactively with `/plugin configure biome-format` or
+  headless via `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_BIOME_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
+  environment variables are retired and no longer read. A consumer that set
+  either in a settings `env` block must re-express the value as the matching
+  `userConfig` option. Zero-config behavior is unchanged (hook on, same
+  defaults). The `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is
+  unaffected.

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -59,17 +59,26 @@ linting still run.
 
 ## Configuration
 
-This plugin has no `userConfig` — its only "configuration" is the `biome.json`
-already in your repository, which it reads automatically. To change the rules,
-edit that file.
+The formatting rules come from the `biome.json` already in your repository, which
+the plugin reads automatically. To change the rules, edit that file.
 
-### Disable without uninstalling
+Two `userConfig` options tune the hook itself:
 
-Set the kill switch in your settings `env` block:
+| Option | Default | Effect |
+|--------|---------|--------|
+| `biome_format_enabled` | `true` | Toggle for the biome-format hook; set to `false` for a clean no-op |
+| `stdin_read_timeout` | `2` | Seconds the hook waits for its payload before failing open |
 
-```json
-{ "env": { "HOOK_BIOME_FORMAT_ENABLED": "false" } }
+Set them interactively with `/plugin configure biome-format`, or headless on the
+install command:
+
+```shell
+claude plugin install biome-format@melodic-software --config biome_format_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the
+project's). To turn the hook off for a single repository, disable the whole
+plugin in that project's `enabledPlugins` instead.
 
 ## License
 

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -62,14 +62,13 @@ linting still run.
 The formatting rules come from the `biome.json` already in your repository, which
 the plugin reads automatically. To change the rules, edit that file.
 
-Two `userConfig` options tune the hook itself:
+One `userConfig` option tunes the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
 | `biome_format_enabled` | `true` | Toggle for the biome-format hook; set to `false` for a clean no-op |
-| `stdin_read_timeout` | `2` | Seconds the hook waits for its payload before failing open |
 
-Set them interactively with `/plugin configure biome-format`, or headless on the
+Set it interactively with `/plugin configure biome-format`, or headless on the
 install command:
 
 ```shell

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -106,7 +106,7 @@ run_hook() {
   (
     cd "$UNRELATED" || return 1
     printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR HOOK_BIOME_FORMAT_ENABLED=true bash "$HOOK"
+      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -237,7 +237,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-matching ext -> exit 0 silent"; el
 # --- Case 7: kill switch bypasses hook --------------------------------------
 printf 'const k=1;var j=2\n' >"$REPO/kill.ts"
 BEFORE_K="$(cat "$REPO/kill.ts")"
-OUT=$(run_hook_env "$REPO/kill.ts" HOOK_BIOME_FORMAT_ENABLED=false)
+OUT=$(run_hook_env "$REPO/kill.ts" CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=false)
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
 if [[ "$(cat "$REPO/kill.ts")" == "$BEFORE_K" ]]; then ok "kill switch -> file untouched"; else fail "kill switch -> file was modified"; fi
@@ -266,7 +266,7 @@ EXT_CFG="$WORK/external-cfg"
 mkdir -p "$EXT_CFG"
 printf '%s\n' '{ "javascript": { "formatter": { "quoteStyle": "double" } } }' >"$EXT_CFG/biome.json"
 printf 'const s = "hi";\nexport { s };\n' >"$REPO_ENV/q.ts"
-run_hook_env "$REPO_ENV/q.ts" HOOK_BIOME_FORMAT_ENABLED=true BIOME_CONFIG_PATH="$EXT_CFG" >/dev/null
+run_hook_env "$REPO_ENV/q.ts" CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true BIOME_CONFIG_PATH="$EXT_CFG" >/dev/null
 if grep -q "const s = 'hi';" "$REPO_ENV/q.ts"; then
   ok "BIOME_CONFIG_PATH override neutralized -> repo config authoritative"
 else
@@ -278,7 +278,7 @@ fi
 # ============================================================================
 
 # --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
-OUT_NS=$(run_hook_env "$REPO/clean.ts" -u HOOK_TELEMETRY_SINK HOOK_BIOME_FORMAT_ENABLED=true)
+OUT_NS=$(run_hook_env "$REPO/clean.ts" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true)
 RC_NS=$?
 if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
   ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
@@ -290,7 +290,7 @@ fi
 printf 'const unusedTel = 1;\n' >"$REPO/tel.ts"
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/tel.ts" HOOK_BIOME_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+run_hook_env "$REPO/tel.ts" CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -317,7 +317,7 @@ rm -f "$TEL"
 printf 'const s=1;var t=2\n' >"$REPO_NO/tel2.ts"
 TELS="$(mktemp)"
 SINKS="$(make_sink "cat >\"$TELS\"")"
-run_hook_env "$REPO_NO/tel2.ts" HOOK_BIOME_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+run_hook_env "$REPO_NO/tel2.ts" CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
 wait_for_sink "$TELS"
 if [[ -s "$TELS" ]]; then
   if [[ "$(jq -r '.status' "$TELS")" == "skipped" ]]; then ok "telemetry/gate-off: status skipped"; else fail "telemetry/gate-off: status=$(jq -r '.status' "$TELS")"; fi

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Claude Code operations toolkit. Five skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",
@@ -24,6 +24,61 @@
       "type": "string",
       "title": "New-plugin install policy for the plugins skill's sync action",
       "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default — offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\"."
+    },
+    "api_error_audit_enabled": {
+      "type": "boolean",
+      "title": "api-error-audit hook",
+      "description": "Emit turn-failure telemetry on API errors",
+      "default": true
+    },
+    "config_change_audit_enabled": {
+      "type": "boolean",
+      "title": "config-change-audit hook",
+      "description": "Emit telemetry on config-source mutations",
+      "default": true
+    },
+    "instructions_loaded_audit_enabled": {
+      "type": "boolean",
+      "title": "instructions-loaded-audit hook",
+      "description": "Emit telemetry on rule/instruction file loads",
+      "default": true
+    },
+    "permission_denied_audit_enabled": {
+      "type": "boolean",
+      "title": "permission-denied-audit hook",
+      "description": "Emit telemetry on permission denials",
+      "default": true
+    },
+    "pre_compact_audit_enabled": {
+      "type": "boolean",
+      "title": "pre-compact-audit hook",
+      "description": "Emit telemetry on context-compaction events",
+      "default": true
+    },
+    "skill_usage_audit_enabled": {
+      "type": "boolean",
+      "title": "skill-usage-audit hook",
+      "description": "Emit telemetry on skill usage; shared by both skill-usage audit hooks (the Skill-tool and slash-command expansion paths) and also gates the shared skill-usage.jsonl store",
+      "default": true
+    },
+    "tool_failure_audit_enabled": {
+      "type": "boolean",
+      "title": "tool-failure-audit hook",
+      "description": "Emit telemetry on Write/Edit/Bash tool failures",
+      "default": true
+    },
+    "instructions_loaded_audit_log_session_start": {
+      "type": "boolean",
+      "title": "instructions-loaded-audit session_start logging",
+      "description": "Opt back into logging session_start instruction loads (dropped by default as deterministic and high-volume)",
+      "default": false
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
     }
   }
 }

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.0]
+
+### Changed
+
+- **Per-hook kill switches migrated to native `userConfig`** (the fleet-wide
+  kill-switch doctrine ruling). Each audit hook's toggle is now a `userConfig`
+  boolean (default `true`), read by the hooks through the native
+  `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process mirror: `api_error_audit_enabled`,
+  `config_change_audit_enabled`, `instructions_loaded_audit_enabled`,
+  `permission_denied_audit_enabled`, `pre_compact_audit_enabled`,
+  `skill_usage_audit_enabled` (shared by both skill-usage audit hooks), and
+  `tool_failure_audit_enabled`. The `instructions-loaded-audit` session_start
+  opt-in is now the `instructions_loaded_audit_log_session_start` option
+  (default `false`), and the stdin read bound is the `stdin_read_timeout` option
+  (default `2`). Configure interactively with `/plugin configure claude-ops` or
+  headless via `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_<NAME>_ENABLED` and
+  `HOOK_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START` environment variables are
+  retired and no longer read. A consumer that set any of these in a settings
+  `env` block must re-express the value as the matching `userConfig` option.
+  Zero-config behavior is unchanged (all audit hooks on, same defaults). The
+  `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.
+
 ## [0.10.1]
 
 ### Changed

--- a/plugins/claude-ops/README.md
+++ b/plugins/claude-ops/README.md
@@ -25,12 +25,13 @@ Seven advisory `*-audit` telemetry emitters (across eight hook scripts —
 `skill-usage-audit` has two producers, see below) emit the marketplace
 [hook-telemetry envelope](../../docs/conventions/hook-telemetry/README.md) — one
 JSON event per run carrying that hook's own `duration_ms`, outcome, and a
-privacy-safe subject. Each is independently toggleable via
-`HOOK_<NAME>_ENABLED=false`. The six pure emitters are a no-op until a consumer
-wires a sink (below); `skill-usage-audit` is the exception — both its producers
-also write the shared `skill-usage.jsonl` second store unconditionally (disable
-the whole feature with `HOOK_SKILL_USAGE_AUDIT_ENABLED=false`, or relocate the
-store with the `skill_usage_dir` option).
+privacy-safe subject. Each is independently toggleable via its own `userConfig`
+boolean (default **on**; see [Per-hook kill switches](#per-hook-kill-switches)).
+The six pure emitters are a no-op until a consumer wires a sink (below);
+`skill-usage-audit` is the exception — both its producers also write the shared
+`skill-usage.jsonl` second store unconditionally (disable the whole feature with
+`skill_usage_audit_enabled=false`, or relocate the store with the
+`skill_usage_dir` option).
 
 `skill-usage-audit` is captured by two disjoint producers so both invocation
 paths are measured: the model-invoked `Skill` tool (`PostToolUse`) and the
@@ -52,6 +53,39 @@ tell the paths apart; both share the same telemetry `hook` id and second store.
 None captures a command body, absolute path, error message, or argument body —
 only category labels, privacy-safe subjects, and (for `instructions-loaded-audit`)
 the repo-relative path of the loaded rule file.
+
+### Per-hook kill switches
+
+Each audit hook is toggled by its own `userConfig` boolean (default **on**; set
+to `false` for a clean no-op) — disable one hook without touching the others.
+The hooks read them through the native `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process
+mirror.
+
+| Hook | Option |
+|---|---|
+| `api-error-audit` | `api_error_audit_enabled` |
+| `config-change-audit` | `config_change_audit_enabled` |
+| `instructions-loaded-audit` | `instructions_loaded_audit_enabled` |
+| `permission-denied-audit` | `permission_denied_audit_enabled` |
+| `pre-compact-audit` | `pre_compact_audit_enabled` |
+| `skill-usage-audit` (both paths) | `skill_usage_audit_enabled` |
+| `tool-failure-audit` | `tool_failure_audit_enabled` |
+
+`instructions-loaded-audit` drops deterministic, high-volume `session_start`
+loads by default; set `instructions_loaded_audit_log_session_start=true` to opt
+back into logging them. A `stdin_read_timeout` option (seconds, default `2`)
+bounds how long each hook waits for its payload before failing open.
+
+Set them interactively with `/plugin configure claude-ops`, or headless on the
+install command:
+
+```shell
+claude plugin install claude-ops@melodic-software --config skill_usage_audit_enabled=false
+```
+
+These options are user-scoped (stored in your user settings, not the
+project's). To turn a hook off for a single repository, disable the whole plugin
+in that project's `enabledPlugins` instead.
 
 ### Wiring the reference sink
 
@@ -122,7 +156,10 @@ instead of failing.
 
 ## Configuration
 
-Three `userConfig` options:
+The per-hook kill switches, `instructions_loaded_audit_log_session_start`, and
+`stdin_read_timeout` are documented under
+[Per-hook kill switches](#per-hook-kill-switches). Three further `userConfig`
+options tune the skills:
 
 - **`install_new`** (string, optional) — new-catalog-plugin install policy for the `plugins`
   skill's `sync` action. `ask` (default) offers not-yet-installed catalog plugins in one batched

--- a/plugins/claude-ops/hooks/api-error-audit.sh
+++ b/plugins/claude-ops/hooks/api-error-audit.sh
@@ -7,7 +7,7 @@
 # The subject is the StopFailure `error` type only: `error_details` may carry
 # prompt fragments or session metadata, so it is never captured (privacy-safe).
 # Pure telemetry emitter: no sink wired (HOOK_TELEMETRY_SINK unset) → no-op.
-# Kill switch: HOOK_API_ERROR_AUDIT_ENABLED=false.
+# Kill switch: CLAUDE_PLUGIN_OPTION_API_ERROR_AUDIT_ENABLED=false.
 
 set -uo pipefail
 

--- a/plugins/claude-ops/hooks/api-error-audit.test.sh
+++ b/plugins/claude-ops/hooks/api-error-audit.test.sh
@@ -34,7 +34,7 @@ assert_silent "unwired → silent" "$OUT"
 
 # --- Kill switch suppresses emission ---------------------------------------
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
-env HOOK_TELEMETRY_SINK="$SINKK" HOOK_API_ERROR_AUDIT_ENABLED=false \
+env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PLUGIN_OPTION_API_ERROR_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 assert_file_absent "kill switch → no envelope" "$TELK"
 

--- a/plugins/claude-ops/hooks/config-change-audit.sh
+++ b/plugins/claude-ops/hooks/config-change-audit.sh
@@ -6,7 +6,7 @@
 # NON-BLOCKING: exit 0 always. The subject is the source identifier
 # (path-only, privacy-safe).
 # Pure telemetry emitter: no sink wired (HOOK_TELEMETRY_SINK unset) → no-op.
-# Kill switch: HOOK_CONFIG_CHANGE_AUDIT_ENABLED=false.
+# Kill switch: CLAUDE_PLUGIN_OPTION_CONFIG_CHANGE_AUDIT_ENABLED=false.
 
 set -uo pipefail
 

--- a/plugins/claude-ops/hooks/config-change-audit.test.sh
+++ b/plugins/claude-ops/hooks/config-change-audit.test.sh
@@ -30,7 +30,7 @@ assert_exit "unwired → exit 0" 0 "$RC"
 assert_silent "unwired → silent" "$OUT"
 
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
-env HOOK_TELEMETRY_SINK="$SINKK" HOOK_CONFIG_CHANGE_AUDIT_ENABLED=false \
+env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PLUGIN_OPTION_CONFIG_CHANGE_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 assert_file_absent "kill switch → no envelope" "$TELK"
 

--- a/plugins/claude-ops/hooks/hook-utils.sh
+++ b/plugins/claude-ops/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/claude-ops/hooks/instructions-loaded-audit.sh
+++ b/plugins/claude-ops/hooks/instructions-loaded-audit.sh
@@ -11,12 +11,12 @@
 # Write-time filter: session_start loads are deterministic (the same always-load
 # files fire every boot) and high-volume, so they are dropped by default. Opt
 # back in for one-off debugging with:
-#   HOOK_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START=true
+#   CLAUDE_PLUGIN_OPTION_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START=true
 #
 # Pure telemetry emitter: no sink wired (HOOK_TELEMETRY_SINK unset) → no-op.
 # Kill switches:
-#   HOOK_INSTRUCTIONS_LOADED_AUDIT_ENABLED=false           — disable entirely
-#   HOOK_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START=true   — opt back into session_start
+#   CLAUDE_PLUGIN_OPTION_INSTRUCTIONS_LOADED_AUDIT_ENABLED=false           — disable entirely
+#   CLAUDE_PLUGIN_OPTION_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START=true   — opt back into session_start
 
 set -uo pipefail
 
@@ -38,7 +38,7 @@ LOAD_REASON=$(hook::jq_field "$INPUT" '.load_reason' || true)
 
 # Drop session_start at write time unless explicitly opted back in.
 if [[ "$LOAD_REASON" == "session_start" &&
-  "${HOOK_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START:-false}" != "true" ]]; then
+  "${CLAUDE_PLUGIN_OPTION_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START:-false}" != "true" ]]; then
   exit 0
 fi
 

--- a/plugins/claude-ops/hooks/instructions-loaded-audit.test.sh
+++ b/plugins/claude-ops/hooks/instructions-loaded-audit.test.sh
@@ -56,7 +56,7 @@ assert_file_absent "session_start filtered by default" "$TELS"
 # --- session_start opt-in re-enables emission ------------------------------
 TELO="$TEST_TMPDIR/telo.json"; SINKO="$(make_sink "$TELO")"
 env HOOK_TELEMETRY_SINK="$SINKO" CLAUDE_PROJECT_DIR="$PROJ" \
-  HOOK_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START=true \
+  CLAUDE_PLUGIN_OPTION_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START=true \
   bash "$HOOK" <<<"$(MSYS_NO_PATHCONV=1 jq -nc --arg fp "$PROJ/CLAUDE.md" '{file_path:$fp, load_reason:"session_start"}')" >/dev/null 2>&1
 if wait_for_sink "$TELO"; then
   assert_eq "session_start opt-in subject" "CLAUDE.md:session_start" "$(jq -r '.data.subject' "$TELO")"
@@ -69,7 +69,7 @@ assert_exit "unwired → exit 0" 0 "$RC"
 assert_silent "unwired → silent" "$OUT"
 
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
-env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PROJECT_DIR="$PROJ" HOOK_INSTRUCTIONS_LOADED_AUDIT_ENABLED=false \
+env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PROJECT_DIR="$PROJ" CLAUDE_PLUGIN_OPTION_INSTRUCTIONS_LOADED_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 assert_file_absent "kill switch → no envelope" "$TELK"
 

--- a/plugins/claude-ops/hooks/permission-denied-audit.sh
+++ b/plugins/claude-ops/hooks/permission-denied-audit.sh
@@ -11,7 +11,7 @@
 #   other      → tool_name only
 # Full command strings, file paths, and tool_input bodies are NEVER captured.
 # Pure telemetry emitter: no sink wired (HOOK_TELEMETRY_SINK unset) → no-op.
-# Kill switch: HOOK_PERMISSION_DENIED_AUDIT_ENABLED=false.
+# Kill switch: CLAUDE_PLUGIN_OPTION_PERMISSION_DENIED_AUDIT_ENABLED=false.
 
 set -uo pipefail
 

--- a/plugins/claude-ops/hooks/permission-denied-audit.test.sh
+++ b/plugins/claude-ops/hooks/permission-denied-audit.test.sh
@@ -55,7 +55,7 @@ assert_exit "unwired → exit 0" 0 "$RC"
 assert_silent "unwired → silent" "$OUT"
 
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
-env HOOK_TELEMETRY_SINK="$SINKK" HOOK_PERMISSION_DENIED_AUDIT_ENABLED=false \
+env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PLUGIN_OPTION_PERMISSION_DENIED_AUDIT_ENABLED=false \
   bash "$HOOK" <<<'{"tool_name":"Bash","tool_input":{"command":"ls"}}' >/dev/null 2>&1
 assert_file_absent "kill switch → no envelope" "$TELK"
 

--- a/plugins/claude-ops/hooks/pre-compact-audit.sh
+++ b/plugins/claude-ops/hooks/pre-compact-audit.sh
@@ -6,7 +6,7 @@
 # NON-BLOCKING by policy: exit 0 always; never returns decision:"block".
 # The subject is the trigger value.
 # Pure telemetry emitter: no sink wired (HOOK_TELEMETRY_SINK unset) → no-op.
-# Kill switch: HOOK_PRE_COMPACT_AUDIT_ENABLED=false.
+# Kill switch: CLAUDE_PLUGIN_OPTION_PRE_COMPACT_AUDIT_ENABLED=false.
 
 set -uo pipefail
 

--- a/plugins/claude-ops/hooks/pre-compact-audit.test.sh
+++ b/plugins/claude-ops/hooks/pre-compact-audit.test.sh
@@ -30,7 +30,7 @@ assert_exit "unwired → exit 0" 0 "$RC"
 assert_silent "unwired → silent" "$OUT"
 
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
-env HOOK_TELEMETRY_SINK="$SINKK" HOOK_PRE_COMPACT_AUDIT_ENABLED=false \
+env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PLUGIN_OPTION_PRE_COMPACT_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 assert_file_absent "kill switch → no envelope" "$TELK"
 

--- a/plugins/claude-ops/hooks/skill-usage-audit.sh
+++ b/plugins/claude-ops/hooks/skill-usage-audit.sh
@@ -9,7 +9,7 @@
 #      HOOK_TELEMETRY_SINK (the shared, generic seam).
 #
 # NON-BLOCKING: exit 0 always. Captures the skill name only — no argument body.
-# Kill switch: HOOK_SKILL_USAGE_AUDIT_ENABLED=false.
+# Kill switch: CLAUDE_PLUGIN_OPTION_SKILL_USAGE_AUDIT_ENABLED=false.
 
 set -uo pipefail
 

--- a/plugins/claude-ops/hooks/skill-usage-audit.test.sh
+++ b/plugins/claude-ops/hooks/skill-usage-audit.test.sh
@@ -77,7 +77,7 @@ assert_file_absent "non-Skill → no envelope" "$TELN"
 PROJ5="$TEST_TMPDIR/proj5"; mkdir -p "$PROJ5"
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
 env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PROJECT_DIR="$PROJ5" \
-  HOOK_SKILL_USAGE_AUDIT_ENABLED=false \
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 assert_file_absent "kill switch → no second store" "$PROJ5/.claude/observability/skill-usage.jsonl"
 assert_file_absent "kill switch → no envelope" "$TELK"

--- a/plugins/claude-ops/hooks/skill-usage-expansion-audit.sh
+++ b/plugins/claude-ops/hooks/skill-usage-expansion-audit.sh
@@ -23,7 +23,7 @@
 # the user-typed path rather than silently drop it.
 #
 # NON-BLOCKING: exit 0 always. Captures the command name only — no argument body.
-# Kill switch: HOOK_SKILL_USAGE_AUDIT_ENABLED=false (shared with the tool-path
+# Kill switch: CLAUDE_PLUGIN_OPTION_SKILL_USAGE_AUDIT_ENABLED=false (shared with the tool-path
 # producer — one switch disables the whole skill-usage-audit feature).
 
 set -uo pipefail

--- a/plugins/claude-ops/hooks/skill-usage-expansion-audit.test.sh
+++ b/plugins/claude-ops/hooks/skill-usage-expansion-audit.test.sh
@@ -101,7 +101,7 @@ assert_file_absent "no command_name → no envelope" "$TELN"
 PROJ5="$TEST_TMPDIR/proj5"; mkdir -p "$PROJ5"
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
 env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PROJECT_DIR="$PROJ5" \
-  HOOK_SKILL_USAGE_AUDIT_ENABLED=false \
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 assert_file_absent "kill switch → no second store" "$PROJ5/.claude/observability/skill-usage.jsonl"
 assert_file_absent "kill switch → no envelope" "$TELK"

--- a/plugins/claude-ops/hooks/tool-failure-audit.sh
+++ b/plugins/claude-ops/hooks/tool-failure-audit.sh
@@ -8,7 +8,7 @@
 #   other      → tool_name only
 # Full command strings, error messages, file paths, and stdin are NEVER captured.
 # Pure telemetry emitter: no sink wired (HOOK_TELEMETRY_SINK unset) → no-op.
-# Kill switch: HOOK_TOOL_FAILURE_AUDIT_ENABLED=false.
+# Kill switch: CLAUDE_PLUGIN_OPTION_TOOL_FAILURE_AUDIT_ENABLED=false.
 
 set -uo pipefail
 

--- a/plugins/claude-ops/hooks/tool-failure-audit.test.sh
+++ b/plugins/claude-ops/hooks/tool-failure-audit.test.sh
@@ -42,7 +42,7 @@ assert_exit "unwired → exit 0" 0 "$RC"
 assert_silent "unwired → silent" "$OUT"
 
 TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
-env HOOK_TELEMETRY_SINK="$SINKK" HOOK_TOOL_FAILURE_AUDIT_ENABLED=false \
+env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PLUGIN_OPTION_TOOL_FAILURE_AUDIT_ENABLED=false \
   bash "$HOOK" <<<'{"tool_name":"Bash","tool_input":{"command":"ls"}}' >/dev/null 2>&1
 assert_file_absent "kill switch → no envelope" "$TELK"
 

--- a/plugins/claude-ops/skills/observability/context/data-sources.md
+++ b/plugins/claude-ops/skills/observability/context/data-sources.md
@@ -104,7 +104,7 @@ jq -s --arg since "$SINCE_ISO" '
 ' "$HOOK_LOG"
 ```
 
-Empty: `"hook log empty — set HOOK_OBSERVABILITY_LOG_ENABLED=true and re-run after hooks fire"`.
+Empty: `"hook log empty — wire HOOK_TELEMETRY_SINK to your sink script and re-run after hooks fire"`.
 
 ## 4. Recurring tool-call patterns
 
@@ -173,10 +173,10 @@ jq -s --arg since "$SINCE_ISO" '
 **Flag rules:**
 
 - HIGH: same `<bin>:<sha16>` appearing 3+ times (recurring agent confusion — escalation candidate for blocking exit 2 once FP rate < 1%)
-- MEDIUM: per-binary count > 5 in window (binary's `--help` may be non-exhaustive — candidate for `HOOK_CLI_FLAG_VERIFY_SKIP_BINS`)
+- MEDIUM: per-binary count > 5 in window (binary's `--help` may be non-exhaustive — candidate for the guardrails `cli_flag_verify_skip_bins` option)
 - INFO: total count, unique-pair count, per-binary distribution
 
-Empty: `"no cli-flag-verify violations — verifier may be advisory-clean OR HOOK_OBSERVABILITY_LOG_ENABLED is false / HOOK_CLI_FLAG_VERIFY_LOG_VIOLATIONS_ENABLED is false"`.
+Empty: `"no cli-flag-verify violations — verifier may be advisory-clean OR the consumer's telemetry sink is not wired/enabled"`.
 
 ## 5. Drift candidates (rules-vs-code mismatches)
 

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,12 +1,45 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "desktop-notification",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["notification", "desktop", "toast", "bell", "osc9", "hook"]
+  "keywords": ["notification", "desktop", "toast", "bell", "osc9", "hook"],
+  "userConfig": {
+    "desktop_notification_enabled": {
+      "type": "boolean",
+      "title": "desktop-notification master toggle",
+      "description": "Master switch for the whole notification hook",
+      "default": true
+    },
+    "desktop_notification_bell_enabled": {
+      "type": "boolean",
+      "title": "bell channel",
+      "description": "Audible terminal bell (bare BEL)",
+      "default": true
+    },
+    "desktop_notification_terminal_notify_enabled": {
+      "type": "boolean",
+      "title": "terminal-notify channel",
+      "description": "OSC 9 terminal notification emitted via the hook's terminalSequence output",
+      "default": true
+    },
+    "desktop_notification_os_toast_enabled": {
+      "type": "boolean",
+      "title": "os-toast channel",
+      "description": "OS-native desktop toast (macOS/Linux)",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -8,7 +8,14 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["notification", "desktop", "toast", "bell", "osc9", "hook"],
+  "keywords": [
+    "notification",
+    "desktop",
+    "toast",
+    "bell",
+    "osc9",
+    "hook"
+  ],
   "userConfig": {
     "desktop_notification_enabled": {
       "type": "boolean",
@@ -33,13 +40,6 @@
       "title": "os-toast channel",
       "description": "OS-native desktop toast (macOS/Linux)",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/desktop-notification/CHANGELOG.md
+++ b/plugins/desktop-notification/CHANGELOG.md
@@ -11,12 +11,11 @@ All notable changes to the `desktop-notification` plugin are documented here. Fo
   fleet-wide kill-switch doctrine ruling). The whole-hook switch is now the
   `desktop_notification_enabled` boolean and each channel its own
   `desktop_notification_<channel>_enabled` boolean (default `true`), read by the
-  hook through the native `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process mirror; the
-  stdin read bound is the new `stdin_read_timeout` option (default `2`). Configure
-  interactively with `/plugin configure desktop-notification` or headless via
+  hook through the native `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process mirror.
+  Configure interactively with `/plugin configure desktop-notification` or headless via
   `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_DESKTOP_NOTIFICATION_*` and `HOOK_STDIN_READ_TIMEOUT`
-  environment variables are retired and no longer read. A consumer that set any of
+- **BREAKING:** the `HOOK_DESKTOP_NOTIFICATION_*` environment variables are
+  retired and no longer read. A consumer that set any of
   these in a settings `env` block must re-express the value as the matching
   `userConfig` option. Zero-config behavior is unchanged (all channels on, same
   defaults). The `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.

--- a/plugins/desktop-notification/CHANGELOG.md
+++ b/plugins/desktop-notification/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the `desktop-notification` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.0]
+
+### Changed
+
+- **Master toggle and per-channel mutes migrated to native `userConfig`** (the
+  fleet-wide kill-switch doctrine ruling). The whole-hook switch is now the
+  `desktop_notification_enabled` boolean and each channel its own
+  `desktop_notification_<channel>_enabled` boolean (default `true`), read by the
+  hook through the native `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process mirror; the
+  stdin read bound is the new `stdin_read_timeout` option (default `2`). Configure
+  interactively with `/plugin configure desktop-notification` or headless via
+  `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_DESKTOP_NOTIFICATION_*` and `HOOK_STDIN_READ_TIMEOUT`
+  environment variables are retired and no longer read. A consumer that set any of
+  these in a settings `env` block must re-express the value as the matching
+  `userConfig` option. Zero-config behavior is unchanged (all channels on, same
+  defaults). The `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.

--- a/plugins/desktop-notification/README.md
+++ b/plugins/desktop-notification/README.md
@@ -69,9 +69,6 @@ These options are user-scoped (stored in your user settings, not the
 project's). To silence notifications for a single repository, disable the whole
 plugin in that project's `enabledPlugins` instead.
 
-A `stdin_read_timeout` option (seconds, default `2`) bounds how long the hook
-waits for its payload before failing open.
-
 ### Disable without uninstalling
 
 Set `desktop_notification_enabled` to `false` (via `/plugin configure

--- a/plugins/desktop-notification/README.md
+++ b/plugins/desktop-notification/README.md
@@ -13,11 +13,11 @@ notification, and — on macOS and Linux — an OS-native desktop toast.
   cannot block).
 - **Three additive channels**, each default on and independently mutable:
 
-| Channel | Env toggle | What it does |
+| Channel | Option | What it does |
 |---|---|---|
-| `bell` | `HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED` | Audible terminal bell (bare `BEL`). |
-| `terminal_notify` | `HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED` | OSC 9 desktop notification, emitted via the hook's `terminalSequence` output (Claude Code v2.1.141+ writes it through its own terminal path). |
-| `os_toast` | `HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED` | OS-native toast (see per-OS table). |
+| `bell` | `desktop_notification_bell_enabled` | Audible terminal bell (bare `BEL`). |
+| `terminal_notify` | `desktop_notification_terminal_notify_enabled` | OSC 9 desktop notification, emitted via the hook's `terminalSequence` output (Claude Code v2.1.141+ writes it through its own terminal path). |
+| `os_toast` | `desktop_notification_os_toast_enabled` | OS-native toast (see per-OS table). |
 
 ### Per-OS `os_toast` behavior
 
@@ -48,24 +48,34 @@ skipped while notifications still fire.
 
 ## Configuration
 
-This plugin has no `userConfig` — all of its variability is env-driven. Set any
-toggle in your settings `env` block (values are read literally; changes
-hot-reload):
+Every channel is toggled by its own `userConfig` boolean (default **on**; set to
+`false` to mute that channel). Mute the OS toast and keep the rest:
 
-```json
-{
-  "env": {
-    "HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED": "false",
-    "HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED": "false"
-  }
-}
+| Option | What it controls |
+|---|---|
+| `desktop_notification_enabled` | Master toggle for the whole hook. |
+| `desktop_notification_bell_enabled` | The `bell` channel. |
+| `desktop_notification_terminal_notify_enabled` | The `terminal_notify` (OSC 9) channel. |
+| `desktop_notification_os_toast_enabled` | The `os_toast` channel. |
+
+Set them interactively with `/plugin configure desktop-notification`, or headless
+on the install command:
+
+```shell
+claude plugin install desktop-notification@melodic-software --config desktop_notification_os_toast_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the
+project's). To silence notifications for a single repository, disable the whole
+plugin in that project's `enabledPlugins` instead.
+
+A `stdin_read_timeout` option (seconds, default `2`) bounds how long the hook
+waits for its payload before failing open.
 
 ### Disable without uninstalling
 
-```json
-{ "env": { "HOOK_DESKTOP_NOTIFICATION_ENABLED": "false" } }
-```
+Set `desktop_notification_enabled` to `false` (via `/plugin configure
+desktop-notification` or `--config desktop_notification_enabled=false`).
 
 ## Telemetry (opt-in)
 

--- a/plugins/desktop-notification/hooks/desktop-notification.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.sh
@@ -4,7 +4,7 @@
 #
 # ADVISORY: always exits 0 — Notification hooks cannot block (they return
 # terminalSequence output; exit 2 only shows stderr). Master kill switch
-# HOOK_DESKTOP_NOTIFICATION_ENABLED gates the whole hook. When on, it emits up
+# CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED gates the whole hook. When on, it emits up
 # to three INDEPENDENTLY-gated channels (each default ON):
 #   BELL            — audible terminal bell (bare BEL).
 #   TERMINAL_NOTIFY — OSC 9 desktop notification (race-free, cross-platform;
@@ -21,10 +21,10 @@
 # Channels are additive — enabling more stacks them.
 #
 # Config from the consumer's settings `env` block (all default ON when enabled):
-#   HOOK_DESKTOP_NOTIFICATION_ENABLED=false                  disable entirely
-#   HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false             mute the bell
-#   HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false  mute OSC 9
-#   HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=false         mute the OS toast
+#   CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=false                  disable entirely
+#   CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED=false             mute the bell
+#   CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false  mute OSC 9
+#   CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=false         mute the OS toast
 
 set -uo pipefail
 
@@ -94,11 +94,11 @@ CHANNELS=()
 # Deliberately NOT OSC 2 (window title): CC sets the terminal title to the
 # session name, and an OSC 2 here would clobber it on every prompt.
 SEQ=""
-if [[ "${HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED:-true}" == "true" ]]; then
+if [[ "${CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED:-true}" == "true" ]]; then
   SEQ+=$(printf '\033]9;%s\007' "$HEADLINE: $MESSAGE")
   CHANNELS+=("terminal_notify")
 fi
-if [[ "${HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED:-true}" == "true" ]]; then
+if [[ "${CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED:-true}" == "true" ]]; then
   SEQ+=$(printf '\007')
   CHANNELS+=("bell")
 fi
@@ -108,7 +108,7 @@ fi
 # pipe (>/dev/null 2>&1 &). A bare `&` child inherits fd1, so CC blocks for EOF
 # until the spawn's startup timeout and the hook hangs. The redirect keeps fd1
 # off the pipe; the hook's own terminalSequence JSON still reaches CC.
-if [[ "${HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED:-true}" == "true" ]]; then
+if [[ "${CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED:-true}" == "true" ]]; then
   # Optional git branch context for the toast body (generic; empty outside a
   # git repo → body is just the message). Branch is also untrusted input — strip
   # C0 bytes through the same gate as .message (a ref name can't legally carry

--- a/plugins/desktop-notification/hooks/desktop-notification.test.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.test.sh
@@ -80,13 +80,13 @@ run() {
   local input="$1"
   shift
   (cd "$UNRELATED" && printf '%s' "$input" \
-    | env -u HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED \
-      -u HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
-      -u HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED \
+    | env -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED \
+      -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
+      -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED \
       -u HOOK_TELEMETRY_SINK \
       CLAUDE_PROJECT_DIR="$FAKE_REPO" \
-      HOOK_DESKTOP_NOTIFICATION_ENABLED=true \
-      HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=false \
+      CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=true \
+      CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=false \
       "$@" \
       bash "$HOOK" 2>/dev/null)
 }
@@ -99,7 +99,7 @@ bel_count() {
 # --- Case 1: master kill switch false → silent exit 0 -----------------------
 OUT="$(cd "$UNRELATED" && build_input permission_prompt \
   | env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$FAKE_REPO" \
-    HOOK_DESKTOP_NOTIFICATION_ENABLED=false bash "$HOOK" 2>&1)"
+    CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=false bash "$HOOK" 2>&1)"
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch false → silent exit 0"; else fail "kill switch (rc=$RC out=$OUT)"; fi
 
@@ -127,7 +127,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-actionable type → silent exit 0"
 
 # --- Case 5: empty stdin → silent exit 0 ------------------------------------
 OUT="$(cd "$UNRELATED" && env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$FAKE_REPO" \
-  HOOK_DESKTOP_NOTIFICATION_ENABLED=true bash "$HOOK" </dev/null 2>&1)"
+  CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=true bash "$HOOK" </dev/null 2>&1)"
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "empty stdin → silent exit 0"; else fail "empty stdin (rc=$RC out=$OUT)"; fi
 
@@ -137,19 +137,19 @@ if printf '%s' "$OUT" | grep -q ']9;'; then ok "backward-compat → OSC 9 presen
 if [[ "$(bel_count "$OUT")" == "2" ]]; then ok "backward-compat → 2 BELs (OSC terminator + standalone bell)"; else fail "backward-compat → BEL count $(bel_count "$OUT"), want 2"; fi
 
 # --- Case 7: BELL off → OSC 9 + terminator only, 1 BEL ----------------------
-OUT="$(run "$(build_input permission_prompt)" HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false)"
+OUT="$(run "$(build_input permission_prompt)" CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED=false)"
 if printf '%s' "$OUT" | grep -q ']9;'; then ok "BELL off → OSC 9 terminator intact"; else fail "BELL off → OSC 9 missing: $OUT"; fi
 if [[ "$(bel_count "$OUT")" == "1" ]]; then ok "BELL off → 1 BEL (OSC terminator only)"; else fail "BELL off → BEL count $(bel_count "$OUT"), want 1"; fi
 
 # --- Case 8: TERMINAL_NOTIFY off → bare BEL, no OSC 9 -----------------------
-OUT="$(run "$(build_input permission_prompt)" HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false)"
+OUT="$(run "$(build_input permission_prompt)" CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false)"
 if printf '%s' "$OUT" | grep -q ']9;'; then fail "TERMINAL_NOTIFY off → OSC 9 still present: $OUT"; else ok "TERMINAL_NOTIFY off → no OSC 9"; fi
 if printf '%s' "$OUT" | jq -e '.terminalSequence' >/dev/null 2>&1; then ok "TERMINAL_NOTIFY off → terminalSequence present"; else fail "TERMINAL_NOTIFY off → no terminalSequence: $OUT"; fi
 if [[ "$(bel_count "$OUT")" == "1" ]]; then ok "TERMINAL_NOTIFY off → 1 BEL (standalone bell only)"; else fail "TERMINAL_NOTIFY off → BEL count $(bel_count "$OUT"), want 1"; fi
 
 # --- Case 9: both terminal channels off → silent stdout ---------------------
 OUT="$(run "$(build_input permission_prompt)" \
-  HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false)"
+  CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED=false CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false)"
 if [[ -z "$OUT" ]]; then ok "both terminal channels off → silent stdout"; else fail "both off → stdout not empty: $OUT"; fi
 
 # ============================================================================
@@ -190,8 +190,8 @@ rm -f "$TEL"
 TEL="$(mktemp)"
 STUB="$(make_sink "cat >\"$TEL\"")"
 _OUT="$(run "$(build_input permission_prompt)" \
-  HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false \
-  HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false \
+  CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED=false \
+  CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED=false \
   HOOK_TELEMETRY_SINK="$STUB")"
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
@@ -240,7 +240,7 @@ EVIL="$(printf -- '-danger"q\033]9;INJECTED\007mid\tafter\nline2')"
 # BELL off → the only legitimate control bytes are ONE framing ESC (\033, opens
 # OSC 9) and ONE terminating BEL (\007). Any ESC/BEL/newline/tab from .message
 # must be gone: esc==1, bel==1, and zero other C0 bytes.
-OUT="$(run "$(build_input permission_prompt "$EVIL")" HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED=false)"
+OUT="$(run "$(build_input permission_prompt "$EVIL")" CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED=false)"
 RC=$?
 SEQ="$(jq -r '.terminalSequence' <<<"$OUT")"
 ESC_N="$(printf '%s' "$SEQ" | tr -cd '\033' | wc -c | tr -d ' \r')"
@@ -273,10 +273,10 @@ chmod +x "$SHIM/uname" "$SHIM/osascript"
 
 IN_EVIL="$(build_input permission_prompt "$EVIL")"
 (cd "$UNRELATED" && printf '%s' "$IN_EVIL" \
-  | env -u HOOK_TELEMETRY_SINK -u HOOK_DESKTOP_NOTIFICATION_BELL_ENABLED \
-    -u HOOK_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
-    CLAUDE_PROJECT_DIR="$FAKE_REPO" HOOK_DESKTOP_NOTIFICATION_ENABLED=true \
-    HOOK_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=true PATH="$SHIM:$PATH" \
+  | env -u HOOK_TELEMETRY_SINK -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED \
+    -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
+    CLAUDE_PROJECT_DIR="$FAKE_REPO" CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=true \
+    CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=true PATH="$SHIM:$PATH" \
     bash "$HOOK" >/dev/null 2>&1)
 wait_for_sink "$OSA_LOG"
 

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -8,20 +8,21 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["eol", "line-endings", "crlf", "lf", "gitattributes", "normalizer", "hook"],
+  "keywords": [
+    "eol",
+    "line-endings",
+    "crlf",
+    "lf",
+    "gitattributes",
+    "normalizer",
+    "hook"
+  ],
   "userConfig": {
     "eol_normalizer_enabled": {
       "type": "boolean",
       "title": "eol-normalizer hook",
       "description": "Normalize a written file's line endings to its .gitattributes eol value",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["eol", "line-endings", "crlf", "lf", "gitattributes", "normalizer", "hook"]
+  "keywords": ["eol", "line-endings", "crlf", "lf", "gitattributes", "normalizer", "hook"],
+  "userConfig": {
+    "eol_normalizer_enabled": {
+      "type": "boolean",
+      "title": "eol-normalizer hook",
+      "description": "Normalize a written file's line endings to its .gitattributes eol value",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the `eol-normalizer` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch doctrine
+  ruling). The hook's toggle is now the `eol_normalizer_enabled` boolean (default `true`),
+  read by the hook through the native `CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED`
+  hook-process mirror; the stdin read bound is now the `stdin_read_timeout` option
+  (default `2`). Configure interactively with `/plugin configure eol-normalizer` or
+  headless via `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_EOL_NORMALIZER_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
+  environment variables are retired and no longer read. A consumer that set either in a
+  settings `env` block must re-express the value as the matching `userConfig` option.
+  Zero-config behavior is unchanged (normalization on, same defaults). The
+  `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -10,11 +10,10 @@ All notable changes to the `eol-normalizer` plugin are documented here. Format f
 - **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch doctrine
   ruling). The hook's toggle is now the `eol_normalizer_enabled` boolean (default `true`),
   read by the hook through the native `CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED`
-  hook-process mirror; the stdin read bound is now the `stdin_read_timeout` option
-  (default `2`). Configure interactively with `/plugin configure eol-normalizer` or
-  headless via `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_EOL_NORMALIZER_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
-  environment variables are retired and no longer read. A consumer that set either in a
-  settings `env` block must re-express the value as the matching `userConfig` option.
+  hook-process mirror. Configure interactively with `/plugin configure eol-normalizer`
+  or headless via `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_EOL_NORMALIZER_ENABLED` environment variable is retired
+  and no longer read. A consumer that set it in a settings `env` block must
+  re-express the value as the matching `userConfig` option.
   Zero-config behavior is unchanged (normalization on, same defaults). The
   `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -52,15 +52,14 @@ still runs.
 
 The normalization policy itself is your repository's `.gitattributes`, which the
 hook reads automatically — to change which files normalize to which endings,
-edit your `.gitattributes`. Two `userConfig` options tune the hook's own
+edit your `.gitattributes`. One `userConfig` option tunes the hook's own
 behavior:
 
 | Option | Type | Default | Effect |
 |--------|------|---------|--------|
 | `eol_normalizer_enabled` | boolean | `true` | Toggle the eol-normalizer hook. Set to `false` for a clean no-op. |
-| `stdin_read_timeout` | number | `2` | Seconds the hook waits for its stdin payload before failing open. |
 
-Set them interactively with `/plugin configure eol-normalizer`, or headless on
+Set it interactively with `/plugin configure eol-normalizer`, or headless on
 the install command:
 
 ```shell

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -50,17 +50,26 @@ still runs.
 
 ## Configuration
 
-This plugin has no `userConfig` — its only "configuration" is the
-`.gitattributes` already in your repository, which it reads automatically. To
-change which files normalize to which endings, edit your `.gitattributes`.
+The normalization policy itself is your repository's `.gitattributes`, which the
+hook reads automatically — to change which files normalize to which endings,
+edit your `.gitattributes`. Two `userConfig` options tune the hook's own
+behavior:
 
-### Disable without uninstalling
+| Option | Type | Default | Effect |
+|--------|------|---------|--------|
+| `eol_normalizer_enabled` | boolean | `true` | Toggle the eol-normalizer hook. Set to `false` for a clean no-op. |
+| `stdin_read_timeout` | number | `2` | Seconds the hook waits for its stdin payload before failing open. |
 
-Set the kill switch in your settings `env` block:
+Set them interactively with `/plugin configure eol-normalizer`, or headless on
+the install command:
 
-```json
-{ "env": { "HOOK_EOL_NORMALIZER_ENABLED": "false" } }
+```shell
+claude plugin install eol-normalizer@melodic-software --config eol_normalizer_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the
+project's). To turn the plugin off for a single repository, disable it in that
+project's `enabledPlugins` instead.
 
 ## License
 

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -83,7 +83,7 @@ run_hook() {
   (
     cd "$UNRELATED" || return 1
     printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR HOOK_EOL_NORMALIZER_ENABLED=true bash "$HOOK"
+      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -121,7 +121,7 @@ if [[ "$(cr_count "$REPO/img.png")" == "1" ]]; then ok "unspecified .png -> CR p
 
 # --- Case 3: kill switch bypasses -------------------------------------------
 printf 'echo x\r\n' >"$REPO/off.sh"
-OUT=$(run_hook_env "$REPO/off.sh" HOOK_EOL_NORMALIZER_ENABLED=false)
+OUT=$(run_hook_env "$REPO/off.sh" CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=false)
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch -> exit 0 silent"; else fail "kill switch (rc=$RC out=$OUT)"; fi
 if [[ "$(cr_count "$REPO/off.sh")" == "1" ]]; then ok "kill switch -> CRLF preserved (not normalized)"; else fail "kill switch normalized despite off: CR=$(cr_count "$REPO/off.sh")"; fi
@@ -187,7 +187,7 @@ if [[ -x "$REPO/exec.sh" ]]; then ok "fallback: executable mode preserved"; else
 
 # --- Sink unset -> empty stdout, exit 0 (parity) ----------------------------
 printf 'echo p\r\n' >"$REPO/tel1.sh"
-OUT_NS=$(run_hook_env "$REPO/tel1.sh" -u HOOK_TELEMETRY_SINK HOOK_EOL_NORMALIZER_ENABLED=true)
+OUT_NS=$(run_hook_env "$REPO/tel1.sh" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true)
 RC_NS=$?
 if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
   ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
@@ -199,7 +199,7 @@ fi
 printf 'echo q\r\n' >"$REPO/tel2.sh"
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/tel2.sh" HOOK_EOL_NORMALIZER_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+run_hook_env "$REPO/tel2.sh" CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -226,7 +226,7 @@ rm -f "$TEL"
 printf 'x\r\n' >"$REPO/tel3.png"
 TELS="$(mktemp)"
 SINKS="$(make_sink "cat >\"$TELS\"")"
-run_hook_env "$REPO/tel3.png" HOOK_EOL_NORMALIZER_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+run_hook_env "$REPO/tel3.png" CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
 wait_for_sink "$TELS"
 if [[ -s "$TELS" ]]; then
   if [[ "$(jq -r '.status' "$TELS")" == "skipped" ]]; then ok "telemetry/unspecified: status skipped"; else fail "telemetry/unspecified: status=$(jq -r '.status' "$TELS")"; fi

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,12 +1,75 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Seven safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["guard", "security", "secrets", "hooks", "pretooluse", "git", "hardcoded-paths", "cli-flags", "pull-request"]
+  "keywords": ["guard", "security", "secrets", "hooks", "pretooluse", "git", "hardcoded-paths", "cli-flags", "pull-request"],
+  "userConfig": {
+    "secret_pattern_detection_enabled": {
+      "type": "boolean",
+      "title": "secret-pattern-detection guard",
+      "description": "Block writes containing high-confidence secret/credential patterns",
+      "default": true
+    },
+    "hardcoded_path_check_enabled": {
+      "type": "boolean",
+      "title": "hardcoded-path-check guard",
+      "description": "Block writes containing hardcoded machine-specific paths",
+      "default": true
+    },
+    "block_no_verify_enabled": {
+      "type": "boolean",
+      "title": "block-no-verify guard",
+      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, lefthook disables)",
+      "default": true
+    },
+    "block_hook_bypass_enabled": {
+      "type": "boolean",
+      "title": "block-hook-bypass guard",
+      "description": "Block Bash file-write workarounds that circumvent Write/Edit hook gates",
+      "default": true
+    },
+    "cli_flag_verify_enabled": {
+      "type": "boolean",
+      "title": "cli-flag-verify guard",
+      "description": "Advise on hallucinated CLI flags written to files (never blocks)",
+      "default": true
+    },
+    "workflow_resilience_check_enabled": {
+      "type": "boolean",
+      "title": "workflow-resilience-check guard",
+      "description": "Advise on un-throttled Workflow fan-out (never blocks)",
+      "default": true
+    },
+    "flag_commit_pr_skill_bypass_enabled": {
+      "type": "boolean",
+      "title": "flag-commit-pr-skill-bypass guard",
+      "description": "Advise when direct git commit / gh pr create bypasses the source-control skills (never blocks)",
+      "default": true
+    },
+    "cli_flag_verify_bins": {
+      "type": "string",
+      "title": "cli-flag-verify binaries",
+      "description": "Comma-separated binaries cli-flag-verify scans; empty uses the built-in default set",
+      "default": ""
+    },
+    "cli_flag_verify_skip_bins": {
+      "type": "string",
+      "title": "cli-flag-verify skip list",
+      "description": "Comma-separated binaries cli-flag-verify must never scan",
+      "default": ""
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -8,7 +8,17 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["guard", "security", "secrets", "hooks", "pretooluse", "git", "hardcoded-paths", "cli-flags", "pull-request"],
+  "keywords": [
+    "guard",
+    "security",
+    "secrets",
+    "hooks",
+    "pretooluse",
+    "git",
+    "hardcoded-paths",
+    "cli-flags",
+    "pull-request"
+  ],
   "userConfig": {
     "secret_pattern_detection_enabled": {
       "type": "boolean",
@@ -63,13 +73,6 @@
       "title": "cli-flag-verify skip list",
       "description": "Comma-separated binaries cli-flag-verify must never scan",
       "default": ""
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to the `guardrails` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.5.0]
+
+### Changed
+
+- **Per-hook kill switches and tuning scalars migrated to native `userConfig`** (the
+  fleet-wide kill-switch doctrine ruling). Each guard's toggle is now a `userConfig`
+  boolean named `<guard>_enabled` (default `true`), read by the hooks through the
+  native `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process mirror; `cli-flag-verify`'s binary
+  set and skip list are now the `cli_flag_verify_bins` / `cli_flag_verify_skip_bins`
+  options; the stdin read bound is the `stdin_read_timeout` option (default `2`).
+  Configure interactively with `/plugin configure guardrails` or headless via
+  `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_<NAME>_ENABLED`, `HOOK_CLI_FLAG_VERIFY_BINS`,
+  `HOOK_CLI_FLAG_VERIFY_SKIP_BINS`, and `HOOK_STDIN_READ_TIMEOUT` environment
+  variables are retired and no longer read. A consumer that set any of these in a
+  settings `env` block must re-express the value as the matching `userConfig` option.
+  Zero-config behavior is unchanged (all guards on, same defaults). The
+  `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -12,12 +12,11 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   boolean named `<guard>_enabled` (default `true`), read by the hooks through the
   native `CLAUDE_PLUGIN_OPTION_<KEY>` hook-process mirror; `cli-flag-verify`'s binary
   set and skip list are now the `cli_flag_verify_bins` / `cli_flag_verify_skip_bins`
-  options; the stdin read bound is the `stdin_read_timeout` option (default `2`).
-  Configure interactively with `/plugin configure guardrails` or headless via
+  options. Configure interactively with `/plugin configure guardrails` or headless via
   `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_<NAME>_ENABLED`, `HOOK_CLI_FLAG_VERIFY_BINS`,
-  `HOOK_CLI_FLAG_VERIFY_SKIP_BINS`, and `HOOK_STDIN_READ_TIMEOUT` environment
-  variables are retired and no longer read. A consumer that set any of these in a
+- **BREAKING:** the `HOOK_<NAME>_ENABLED`, `HOOK_CLI_FLAG_VERIFY_BINS`, and
+  `HOOK_CLI_FLAG_VERIFY_SKIP_BINS` environment variables are retired and no
+  longer read. A consumer that set any of these in a
   settings `env` block must re-express the value as the matching `userConfig` option.
   Zero-config behavior is unchanged (all guards on, same defaults). The
   `HOOK_TELEMETRY_SINK` consumer-side telemetry seam is unaffected.

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -59,25 +59,33 @@ way but always allow the operation.
 
 ## Per-hook kill switches
 
-Each guard is toggled by its own env var (default **on**; set to `false` for a
-clean no-op). This per-hook control is the bundle's core contract — disable one
-guard without touching the others.
+Each guard is toggled by its own `userConfig` boolean (default **on**; set to
+`false` for a clean no-op). This per-hook control is the bundle's core
+contract — disable one guard without touching the others.
 
-| Guard | Kill switch |
-|-------|-------------|
-| secret-pattern-detection | `HOOK_SECRET_PATTERN_DETECTION_ENABLED` |
-| hardcoded-path-check | `HOOK_HARDCODED_PATH_CHECK_ENABLED` |
-| block-no-verify | `HOOK_BLOCK_NO_VERIFY_ENABLED` |
-| block-hook-bypass | `HOOK_BLOCK_HOOK_BYPASS_ENABLED` |
-| cli-flag-verify | `HOOK_CLI_FLAG_VERIFY_ENABLED` |
-| workflow-resilience-check | `HOOK_WORKFLOW_RESILIENCE_CHECK_ENABLED` |
-| flag-commit-pr-skill-bypass | `HOOK_FLAG_COMMIT_PR_SKILL_BYPASS_ENABLED` |
+| Guard | Option |
+|-------|--------|
+| secret-pattern-detection | `secret_pattern_detection_enabled` |
+| hardcoded-path-check | `hardcoded_path_check_enabled` |
+| block-no-verify | `block_no_verify_enabled` |
+| block-hook-bypass | `block_hook_bypass_enabled` |
+| cli-flag-verify | `cli_flag_verify_enabled` |
+| workflow-resilience-check | `workflow_resilience_check_enabled` |
+| flag-commit-pr-skill-bypass | `flag_commit_pr_skill_bypass_enabled` |
 
-Set them in your settings `env` block:
+Set them interactively with `/plugin configure guardrails`, or headless on the
+install command:
 
-```json
-{ "env": { "HOOK_HARDCODED_PATH_CHECK_ENABLED": "false" } }
+```shell
+claude plugin install guardrails@melodic-software --config hardcoded_path_check_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the
+project's). To turn guards off for a single repository, disable the whole
+plugin in that project's `enabledPlugins` instead.
+
+A `stdin_read_timeout` option (seconds, default `2`) bounds how long each
+guard waits for its hook payload before failing open.
 
 ## Consumer seams
 
@@ -97,9 +105,9 @@ repo-specific policy of their own:
   placeholders, `tests/fixtures` / `tests/testdata` trees, `settings.local.json`,
   `CLAUDE.local.md`, and hook scripts.
 - **CLI-flag tuning.** `cli-flag-verify` checks a default binary set
-  (`claude gh dotnet docker npm kubectl terraform az aws`); override with
-  `HOOK_CLI_FLAG_VERIFY_BINS=bin1,bin2,…` and skip specific binaries with
-  `HOOK_CLI_FLAG_VERIFY_SKIP_BINS=bin1,bin2`.
+  (`claude gh dotnet docker npm kubectl terraform az aws`); override with the
+  `cli_flag_verify_bins` option (`bin1,bin2,…`) and skip specific binaries
+  with `cli_flag_verify_skip_bins`.
 - **Skill-availability gating.** `flag-commit-pr-skill-bypass` reads
   `enabledPlugins` from the consuming project's own `.claude/settings.json`
   (`.claude/settings.local.json` as an override, only for a key already present

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -84,9 +84,6 @@ These options are user-scoped (stored in your user settings, not the
 project's). To turn guards off for a single repository, disable the whole
 plugin in that project's `enabledPlugins` instead.
 
-A `stdin_read_timeout` option (seconds, default `2`) bounds how long each
-guard waits for its hook payload before failing open.
-
 ## Consumer seams
 
 The guards scope and tune themselves to **your** repository — they ship no

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -18,7 +18,7 @@
 # a shell parser, and neutralizing quotes re-blocks inert prose. An LLM never
 # emits this form; the deny-list plus human oversight are the adversarial layers.
 # The only supported deliberate bypass is the kill switch
-# (HOOK_BLOCK_HOOK_BYPASS_ENABLED=false).
+# (block_hook_bypass_enabled userConfig option set to false).
 #
 # BLOCKING: exits 2 on any detected bypass form.
 
@@ -54,8 +54,8 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/nul
 bash_subject() {
   local cmd="$1" tok
   tok="${cmd%%[[:space:]]*}"
-  while [[ "$tok" == "sudo" || "$tok" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$tok" == "sudo" || "$tok" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     cmd="${cmd#*[[:space:]]}"
     cmd="${cmd#"${cmd%%[![:space:]]*}"}"
     tok="${cmd%%[[:space:]]*}"
@@ -156,9 +156,9 @@ if [[ "$EXEC_LC" =~ $_cat_redir ]]; then
 fi
 
 # echo ... > file (stdout-to-real-file only; not stderr/fd redirects or /dev/null)
-if [[ "$EXEC_LC" =~ $_echo_redir ]] \
-  && [[ "$EXEC_LC" =~ $_echo_file_out ]] \
-  && ! [[ "$EXEC_LC" =~ $_echo_devnull ]]; then
+if [[ "$EXEC_LC" =~ $_echo_redir ]] &&
+  [[ "$EXEC_LC" =~ $_echo_file_out ]] &&
+  ! [[ "$EXEC_LC" =~ $_echo_devnull ]]; then
   block_bypass "echo-redirect" "echo > file write bypasses Write/Edit hooks"
 fi
 
@@ -166,8 +166,8 @@ fi
 # the literal-stripped form (EXEC_LC) so prose/commit text merely mentioning it
 # is not a false positive; scan the RAW command (COMMAND_LC) for the write
 # indicators — they legitimately live inside the quoted `-c` payload the strip removes.
-if [[ "$EXEC_LC" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] \
-  && [[ "$COMMAND_LC" =~ $_py_write ]]; then
+if [[ "$EXEC_LC" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] &&
+  [[ "$COMMAND_LC" =~ $_py_write ]]; then
   block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
 fi
 

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -124,7 +124,7 @@ run "here-string alone (allowed)" "grep foo <<< \"haystack\"" 0
 
 # --- Kill switch — disabled path is a clean no-op even on a bypass ----------
 run "kill switch off → no-op despite cat > file" "cat > foo.txt" 0 \
-  HOOK_BLOCK_HOOK_BYPASS_ENABLED=false
+  CLAUDE_PLUGIN_OPTION_BLOCK_HOOK_BYPASS_ENABLED=false
 
 # --- Telemetry: block emits a `blocked` envelope ----------------------------
 TEL="$(mktemp -p "$TEST_TMPDIR")"

--- a/plugins/guardrails/hooks/block-no-verify.sh
+++ b/plugins/guardrails/hooks/block-no-verify.sh
@@ -24,7 +24,7 @@
 # ($VAR, $(…), $IFS) — a determined author can construct an expansion-based
 # bypass. It is a friction guard against accidental/casual bypass, not a
 # sandbox. The ONLY supported deliberate bypass is the kill switch
-# (HOOK_BLOCK_NO_VERIFY_ENABLED=false).
+# (block_no_verify_enabled userConfig option set to false).
 #
 # BLOCKING: exits 2 on any detected bypass form.
 
@@ -65,8 +65,8 @@ MAX_COMMAND_LEN=16384
 bash_subject() {
   local cmd="$1" tok
   tok="${cmd%%[[:space:]]*}"
-  while [[ "$tok" == "sudo" || "$tok" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$tok" == "sudo" || "$tok" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     cmd="${cmd#*[[:space:]]}"
     cmd="${cmd#"${cmd%%[![:space:]]*}"}"
     tok="${cmd%%[[:space:]]*}"
@@ -283,7 +283,7 @@ check_segment() {
       fi
       ((j += 2))
       ;;
-    --config=*|--config-env=*)
+    --config=* | --config-env=*)
       lc="${gw#*=}"
       lc="${lc,,}"
       [[ "$lc" == *core.hookspath=* ]] && block "hooksPath" \
@@ -479,7 +479,7 @@ parse_and_check() {
 if ((${#COMMAND} > MAX_COMMAND_LEN)); then
   block "too-long" \
     "BLOCKED: command too long to parse safely (> $MAX_COMMAND_LEN chars)." \
-    "Shorten the command, or set HOOK_BLOCK_NO_VERIFY_ENABLED=false to bypass."
+    "Shorten the command, or set the guardrails block_no_verify_enabled option to false (/plugin configure) to bypass."
 fi
 
 parse_and_check

--- a/plugins/guardrails/hooks/block-no-verify.test.sh
+++ b/plugins/guardrails/hooks/block-no-verify.test.sh
@@ -177,7 +177,7 @@ run "git push (no env-var, allowed)" "git push" 0
 
 # --- Kill switch — disabled path is a clean no-op even on a bypass -----------
 run "kill switch off → no-op despite --no-verify" "git commit --no-verify -m test" 0 \
-  HOOK_BLOCK_NO_VERIFY_ENABLED=false
+  CLAUDE_PLUGIN_OPTION_BLOCK_NO_VERIFY_ENABLED=false
 
 # --- Telemetry: block emits a `blocked` envelope ----------------------------
 TEL="$(mktemp -p "$TEST_TMPDIR")"

--- a/plugins/guardrails/hooks/cli-flag-verify.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.sh
@@ -19,9 +19,9 @@
 # NON-BLOCKING (advisory): exits 0 with hookSpecificOutput additionalContext
 # on unknown flags (exit 1 stderr is not shown to the agent per hook contract).
 #
-# Per-binary opt-out via HOOK_CLI_FLAG_VERIFY_SKIP_BINS=bin1,bin2 (e.g. for
+# Per-binary opt-out via the cli_flag_verify_skip_bins userConfig option (e.g. for
 # extension-heavy CLIs like gh where --help is non-exhaustive). Disable entirely
-# with HOOK_CLI_FLAG_VERIFY_ENABLED=false.
+# with the cli_flag_verify_enabled userConfig option set to false.
 
 set -uo pipefail
 
@@ -50,9 +50,9 @@ VERIFIER="$PLUGIN_ROOT/lib/verification/verify-cli-flag.sh"
 FILE=$(hook::read_file_path) || exit 0
 IS_MD=false
 case "$FILE" in
-  *.md) IS_MD=true ;;
-  *.sh | *.bash | *.ps1 | *.psm1) ;;
-  *) exit 0 ;;
+*.md) IS_MD=true ;;
+*.sh | *.bash | *.ps1 | *.psm1) ;;
+*) exit 0 ;;
 esac
 
 [[ -x "$VERIFIER" ]] || exit 0 # Verifier not present — fail open, don't block
@@ -60,7 +60,7 @@ esac
 # Repo root for telemetry data.file + relative sink resolution (file-anchored).
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
 
-# Known binaries to check. Add via env: HOOK_CLI_FLAG_VERIFY_BINS=bin1,bin2,...
+# Known binaries to check. Override via the cli_flag_verify_bins userConfig option.
 # `git` and `npx` are intentionally EXCLUDED — both are unreliable `--help`
 # flag lists whose residuals are all real-flag false positives:
 #   - `git <subcmd> --help` routes to the man page (or a short synopsis under
@@ -72,13 +72,13 @@ REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
 #     cases produce visible FPs — same shape that excludes git.
 # Re-add either via the env var if it ever ships a stdout-parseable flag list.
 DEFAULT_BINS="claude gh dotnet docker npm kubectl terraform az aws"
-BINS_RAW="${HOOK_CLI_FLAG_VERIFY_BINS:-$DEFAULT_BINS}"
+BINS_RAW="${CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS:-$DEFAULT_BINS}"
 # Normalize: comma OR space separated → space separated.
 BINS="${BINS_RAW//,/ }"
 
 # Per-binary opt-outs. Comma-separated. Common case: gh extensions, docker plugin
 # subcommands where --help is not exhaustive.
-SKIP_RAW="${HOOK_CLI_FLAG_VERIFY_SKIP_BINS:-}"
+SKIP_RAW="${CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_SKIP_BINS:-}"
 SKIP="${SKIP_RAW//,/ }"
 
 is_skipped() {
@@ -140,17 +140,17 @@ extract_candidates() {
     while ((idx < ${#toks[@]})); do
       lead="${toks[idx]#[\`\'\"\(\!]}"
       case "$lead" in
-        sudo | command | env | time | exec | xargs | then | do | else | "!")
+      sudo | command | env | time | exec | xargs | then | do | else | "!")
+        ((idx++))
+        continue
+        ;;
+      *)
+        if [[ "$lead" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
           ((idx++))
           continue
-          ;;
-        *)
-          if [[ "$lead" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
-            ((idx++))
-            continue
-          fi
-          break
-          ;;
+        fi
+        break
+        ;;
       esac
     done
     ((idx < ${#toks[@]})) || continue
@@ -176,39 +176,39 @@ extract_candidates() {
     for ((k = idx + 1; k < ${#toks[@]}; k++)); do
       tk="${toks[k]}"
       case "$tk" in
-        --)
-          break
-          ;;
-        --*)
-          chain_done=1
-          fl="${tk%%=*}" # drop =VALUE
-          if [[ "$fl" =~ ^(--[a-zA-Z][a-zA-Z0-9-]*) ]]; then
-            fl="${BASH_REMATCH[1]}"
-            case "$fl" in
-              --help | --version) ;;
-              *) seg_flags+=("$fl") ;;
-            esac
-          fi
-          ;;
-        -?*)
-          # short option: before the subcommand, skip it (chain keeps looking);
-          # after the subcommand, options have begun → chain ends.
-          ((chain_done == 0 && ${#chain[@]} > 0)) && chain_done=1
-          ;;
-        *)
-          ct="${tk%[\`\'\"\):;,]}"
-          ct="${ct#[\`\'\"\(]}"
-          # A second known bin starts a NESTED command whose flags are not this
-          # bin's — `docker run <img> dotnet restore --force-evaluate`,
-          # `xargs gh issue … --json`. Everything from here belongs to it; stop.
-          [[ " $BINS " == *" $ct "* ]] && break
-          # Only shaped lowercase words join the chain; a non-shaped positional
-          # (path, csproj, var, SLN file) is skipped without ending the chain so
-          # `dotnet list <SLN> package --flag` still resolves the full subcommand.
-          if ((chain_done == 0)) && [[ "$ct" =~ ^[a-z][a-z0-9-]*$ ]] && ((${#chain[@]} < 4)); then
-            chain+=("$ct")
-          fi
-          ;;
+      --)
+        break
+        ;;
+      --*)
+        chain_done=1
+        fl="${tk%%=*}" # drop =VALUE
+        if [[ "$fl" =~ ^(--[a-zA-Z][a-zA-Z0-9-]*) ]]; then
+          fl="${BASH_REMATCH[1]}"
+          case "$fl" in
+          --help | --version) ;;
+          *) seg_flags+=("$fl") ;;
+          esac
+        fi
+        ;;
+      -?*)
+        # short option: before the subcommand, skip it (chain keeps looking);
+        # after the subcommand, options have begun → chain ends.
+        ((chain_done == 0 && ${#chain[@]} > 0)) && chain_done=1
+        ;;
+      *)
+        ct="${tk%[\`\'\"\):;,]}"
+        ct="${ct#[\`\'\"\(]}"
+        # A second known bin starts a NESTED command whose flags are not this
+        # bin's — `docker run <img> dotnet restore --force-evaluate`,
+        # `xargs gh issue … --json`. Everything from here belongs to it; stop.
+        [[ " $BINS " == *" $ct "* ]] && break
+        # Only shaped lowercase words join the chain; a non-shaped positional
+        # (path, csproj, var, SLN file) is skipped without ending the chain so
+        # `dotnet list <SLN> package --flag` still resolves the full subcommand.
+        if ((chain_done == 0)) && [[ "$ct" =~ ^[a-z][a-z0-9-]*$ ]] && ((${#chain[@]} < 4)); then
+          chain+=("$ct")
+        fi
+        ;;
       esac
     done
 
@@ -261,8 +261,11 @@ emit_tel() {
   # Redaction: if the path could not be made repo-relative, emit the basename
   # only — never an absolute path (it would embed the developer's username).
   case "$file_rel" in
-    /* | [A-Za-z]:*) file_rel="${file_rel##*/}"; file_rel="${file_rel##*\\}" ;;
-    *) ;;
+  /* | [A-Za-z]:*)
+    file_rel="${file_rel##*/}"
+    file_rel="${file_rel##*\\}"
+    ;;
+  *) ;;
   esac
   if ((${#FAILURES[@]} > 0)); then
     local f raw="" bin rest chainstr flag disp
@@ -278,8 +281,8 @@ emit_tel() {
   fi
   local data
   data=$(jq -n --arg file "$file_rel" --argjson findings "$findings_json" \
-    '{tool:"",file:$file,findings:$findings}' 2>/dev/null) \
-    || data='{"tool":"","file":"","findings":[]}'
+    '{tool:"",file:$file,findings:$findings}' 2>/dev/null) ||
+    data='{"tool":"","file":"","findings":[]}'
   hook::emit_telemetry "cli-flag-verify" "PostToolUse" "ok" "$start" "$data" "$REPO_ROOT"
 }
 
@@ -300,7 +303,7 @@ if ((${#FAILURES[@]} > 0)); then
     fi
     hook::ctx_append "  UNKNOWN_FLAG: $disp (not found in '$helpref')"
     hook::ctx_append "    fix:   run '$helpref' and confirm the flag exists"
-    hook::ctx_append "    skip:  HOOK_CLI_FLAG_VERIFY_SKIP_BINS=$bin (env override)"
+    hook::ctx_append "    skip:  add $bin to the guardrails cli_flag_verify_skip_bins option"
   done
   hook::ctx_append ""
   hook::ctx_append "Subagent / training-recall flag claims are unverified — confirm"

--- a/plugins/guardrails/hooks/cli-flag-verify.test.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.test.sh
@@ -53,7 +53,7 @@ run_fake() {
   local target="$case_dir/target.$ext"
   printf '%s\n' "$content" >"$target"
   PATH="$FAKE_BIN_DIR:$PATH" \
-    HOOK_CLI_FLAG_VERIFY_BINS=faketool \
+    CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS=faketool \
     LOCALAPPDATA="$case_dir/cache" \
     XDG_CACHE_HOME="$case_dir/cache" \
     bash "$HOOK" <<<"$(MSYS_NO_PATHCONV=1 jq -n --arg fp "$target" '{tool_input:{file_path:$fp}}')" 2>&1
@@ -127,15 +127,15 @@ dis_dir="$TEST_TMPDIR/fake-disabled"
 mkdir -p "$dis_dir/cache"
 printf 'faketool sub --fake\n' >"$dis_dir/target.sh"
 dis_input=$(MSYS_NO_PATHCONV=1 jq -n --arg fp "$dis_dir/target.sh" '{tool_input:{file_path:$fp}}')
-OUT=$(PATH="$FAKE_BIN_DIR:$PATH" HOOK_CLI_FLAG_VERIFY_BINS=faketool \
+OUT=$(PATH="$FAKE_BIN_DIR:$PATH" CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS=faketool \
   LOCALAPPDATA="$dis_dir/cache" XDG_CACHE_HOME="$dis_dir/cache" \
-  HOOK_CLI_FLAG_VERIFY_ENABLED=false bash "$HOOK" <<<"$dis_input" 2>&1); RC=$?
+  CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_ENABLED=false bash "$HOOK" <<<"$dis_input" 2>&1); RC=$?
 assert_exit "disabled via env → exit 0" 0 "$RC"
 assert_silent "disabled via env → no output" "$OUT"
 
-OUT=$(PATH="$FAKE_BIN_DIR:$PATH" HOOK_CLI_FLAG_VERIFY_BINS=faketool \
+OUT=$(PATH="$FAKE_BIN_DIR:$PATH" CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS=faketool \
   LOCALAPPDATA="$dis_dir/cache" XDG_CACHE_HOME="$dis_dir/cache" \
-  HOOK_CLI_FLAG_VERIFY_SKIP_BINS=faketool bash "$HOOK" <<<"$dis_input" 2>&1); RC=$?
+  CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_SKIP_BINS=faketool bash "$HOOK" <<<"$dis_input" 2>&1); RC=$?
 assert_exit "per-binary skip → exit 0" 0 "$RC"
 
 # ============================ TELEMETRY ====================================
@@ -145,7 +145,7 @@ tel_dir="$TEST_TMPDIR/fake-tel"
 mkdir -p "$tel_dir/cache"
 printf 'faketool sub --fake\n' >"$tel_dir/target.sh"
 tel_input=$(MSYS_NO_PATHCONV=1 jq -n --arg fp "$tel_dir/target.sh" '{tool_input:{file_path:$fp}}')
-PATH="$FAKE_BIN_DIR:$PATH" HOOK_CLI_FLAG_VERIFY_BINS=faketool \
+PATH="$FAKE_BIN_DIR:$PATH" CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS=faketool \
   LOCALAPPDATA="$tel_dir/cache" XDG_CACHE_HOME="$tel_dir/cache" \
   HOOK_TELEMETRY_SINK="$SINK" bash "$HOOK" <<<"$tel_input" >/dev/null 2>&1 || true
 if wait_for_sink "$TEL"; then

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
@@ -38,7 +38,7 @@
 # substitution, and a determined author can construct a form that evades the
 # match. This is a nudge toward the canonical skills, not an enforcement gate.
 #
-# Kill switch: HOOK_FLAG_COMMIT_PR_SKILL_BYPASS_ENABLED=false
+# Kill switch: flag_commit_pr_skill_bypass_enabled userConfig option
 
 set -uo pipefail
 
@@ -70,8 +70,8 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/nul
 bash_subject() {
   local cmd="$1" tok
   tok="${cmd%%[[:space:]]*}"
-  while [[ "$tok" == "sudo" || "$tok" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$tok" == "sudo" || "$tok" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     cmd="${cmd#*[[:space:]]}"
     cmd="${cmd#"${cmd%%[![:space:]]*}"}"
     tok="${cmd%%[[:space:]]*}"
@@ -94,8 +94,8 @@ emit_tel() {
   fi
   local data
   data=$(jq -n --arg subject "$SUBJECT" --argjson forms "$forms_json" \
-    '{tool:"Bash",subject:$subject,forms:$forms}' 2>/dev/null) \
-    || data='{"tool":"Bash","subject":"","forms":[]}'
+    '{tool:"Bash",subject:$subject,forms:$forms}' 2>/dev/null) ||
+    data='{"tool":"Bash","subject":"","forms":[]}'
   hook::emit_telemetry "flag-commit-pr-skill-bypass" "PreToolUse" "ok" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 
@@ -175,8 +175,8 @@ FORMS=()
 # carrying the Co-Authored-By line. Either marker present → the caller already
 # replicates the skill's mechanic; stay quiet.
 if [[ "$STRIPPED_LC" =~ (^|[[:space:];&|()]+)git[[:space:]]+commit([[:space:]]|$) ]]; then
-  if ! [[ "$COMMAND_LC" =~ (^|[[:space:]])(-f|--file)[[:space:]]+-([[:space:]]|$) ]] \
-    || ! [[ "$COMMAND_LC" =~ --trailer ]]; then
+  if ! [[ "$COMMAND_LC" =~ (^|[[:space:]])(-f|--file)[[:space:]]+-([[:space:]]|$) ]] ||
+    ! [[ "$COMMAND_LC" =~ --trailer ]]; then
     MESSAGES+=("direct \`git commit\` (missing the canonical \`-F -\` stdin form + \`--trailer\` Co-Authored-By line) — prefer the \`/commit\` skill (source-control plugin), which encapsulates the heredoc mechanic, Conventional Commits pre-check, and attribution trailer.")
     FORMS+=("git-commit-bypass")
   fi

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.test.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.test.sh
@@ -94,7 +94,7 @@ assert_contains "settings.local.json true overrides settings.json false" "$out" 
 
 # --- kill switch — disabled path is a clean no-op even on a bypass shape -----
 out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$ENABLED_PROJECT" \
-  HOOK_FLAG_COMMIT_PR_SKILL_BYPASS_ENABLED=false)
+  CLAUDE_PLUGIN_OPTION_FLAG_COMMIT_PR_SKILL_BYPASS_ENABLED=false)
 assert_silent "kill switch off → no-op despite bypass shape" "$out"
 
 # --- empty stdin → silent (graceful no-op) -----------------------------------

--- a/plugins/guardrails/hooks/hardcoded-path-check.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.sh
@@ -16,7 +16,7 @@
 #
 # Consumer seams: gitignored files are skipped (git check-ignore against
 # $CLAUDE_PROJECT_DIR) — designate machine-local files there. Disable entirely
-# with HOOK_HARDCODED_PATH_CHECK_ENABLED=false.
+# with the hardcoded_path_check_enabled userConfig option set to false.
 
 set -uo pipefail
 
@@ -48,8 +48,8 @@ INPUT=$(cat)
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null | tr -d '\r')
 
 case "$TOOL" in
-  Write | Edit | NotebookEdit) ;;
-  *) exit 0 ;;
+Write | Edit | NotebookEdit) ;;
+*) exit 0 ;;
 esac
 
 FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null | tr -d '\r')
@@ -68,39 +68,39 @@ if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
   _scope_project="$(hook::normalize_path "${CLAUDE_PROJECT_DIR}")"
   _scope_project="${_scope_project%/}"
   case "$_scope_file" in
-    "$_scope_project"/*) ;; # inside the project — proceed
-    *) exit 0 ;;           # outside the project — not this hook's concern
+  "$_scope_project"/*) ;; # inside the project — proceed
+  *) exit 0 ;;            # outside the project — not this hook's concern
   esac
 fi
 
 # Skip files that legitimately contain path patterns (regex strings). These
 # cannot rely on the gitignore check below because they are tracked.
 case "$NORM_FILE" in
-  # Hook / hook-manager scripts contain path-detection patterns as regex strings.
-  *.claude/hooks/* | *.lefthook/*) exit 0 ;;
-  # Claude Code session/workflow state (under ~/.claude/projects/) lives OUTSIDE
-  # any repo working tree and is never committed; absolute paths there are expected
-  # machine-local glue. The gitignore check below cannot catch it — the path is
-  # outside $CLAUDE_PROJECT_DIR, so `git check-ignore` errors rather than matching.
-  *.claude/projects/*) exit 0 ;;
-  *) ;;
+# Hook / hook-manager scripts contain path-detection patterns as regex strings.
+*.claude/hooks/* | *.lefthook/*) exit 0 ;;
+# Claude Code session/workflow state (under ~/.claude/projects/) lives OUTSIDE
+# any repo working tree and is never committed; absolute paths there are expected
+# machine-local glue. The gitignore check below cannot catch it — the path is
+# outside $CLAUDE_PROJECT_DIR, so `git check-ignore` errors rather than matching.
+*.claude/projects/*) exit 0 ;;
+*) ;;
 esac
 
 # Skip gitignored files — designated for machine-specific state (settings.local.json,
 # CLAUDE.local.md, .venv/, node_modules/, etc.). git check-ignore does not require
 # the file to exist on disk, so this works for new Write operations too.
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]] \
-  && git -C "$CLAUDE_PROJECT_DIR" check-ignore -q "$FILE" 2>/dev/null; then
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]] &&
+  git -C "$CLAUDE_PROJECT_DIR" check-ignore -q "$FILE" 2>/dev/null; then
   exit 0
 fi
 
 # Extract content to check — Write has .content, Edit has .new_string,
 # NotebookEdit has .new_source.
 case "$TOOL" in
-  Write) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null | tr -d '\r') ;;
-  Edit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null | tr -d '\r') ;;
-  NotebookEdit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_source // empty' 2>/dev/null | tr -d '\r') ;;
-  *) exit 0 ;; # unreachable — $TOOL filtered to Write|Edit|NotebookEdit above
+Write) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null | tr -d '\r') ;;
+Edit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null | tr -d '\r') ;;
+NotebookEdit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_source // empty' 2>/dev/null | tr -d '\r') ;;
+*) exit 0 ;; # unreachable — $TOOL filtered to Write|Edit|NotebookEdit above
 esac
 [[ -n "${CONTENT:-}" ]] || exit 0
 
@@ -127,8 +127,11 @@ fi
 # Redaction: if the path could not be made repo-relative, emit the basename only
 # — never an absolute path (it would embed the developer's username) into telemetry.
 case "$FILE_REL" in
-  /* | [A-Za-z]:*) FILE_REL="${FILE_REL##*/}"; FILE_REL="${FILE_REL##*\\}" ;;
-  *) ;;
+/* | [A-Za-z]:*)
+  FILE_REL="${FILE_REL##*/}"
+  FILE_REL="${FILE_REL##*\\}"
+  ;;
+*) ;;
 esac
 
 # Emit one telemetry envelope: $1 status, $2 labels JSON array. Gated on the
@@ -138,8 +141,8 @@ emit_tel() {
   hook::telemetry_enabled || return 0
   local data
   data=$(jq -n --arg file "$FILE_REL" --argjson violations "$2" \
-    '{tool:"'"$TOOL"'",file:$file,violations:$violations}' 2>/dev/null) \
-    || data='{"tool":"","file":"","violations":[]}'
+    '{tool:"'"$TOOL"'",file:$file,violations:$violations}' 2>/dev/null) ||
+    data='{"tool":"","file":"","violations":[]}'
   hook::emit_telemetry "hardcoded-path-check" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 

--- a/plugins/guardrails/hooks/hardcoded-path-check.test.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.test.sh
@@ -98,7 +98,7 @@ OUT=$(CLAUDE_PROJECT_DIR="$GITREPO" bash "$HOOK" <<<"$(write_json "$GITREPO/igno
 assert_exit "gitignored file → exit 0 (consumer seam)" 0 "$RC"
 
 # Kill switch — disabled path is a clean no-op even on a real machine path.
-OUT=$(HOOK_HARDCODED_PATH_CHECK_ENABLED=false bash "$HOOK" <<<"$(write_json "$FIXTURE" "$LINUX_HOME")" 2>&1); RC=$?
+OUT=$(CLAUDE_PLUGIN_OPTION_HARDCODED_PATH_CHECK_ENABLED=false bash "$HOOK" <<<"$(write_json "$FIXTURE" "$LINUX_HOME")" 2>&1); RC=$?
 assert_exit "kill switch off → exit 0" 0 "$RC"
 assert_silent "kill switch off → no stderr" "$OUT"
 

--- a/plugins/guardrails/hooks/hook-utils.sh
+++ b/plugins/guardrails/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/guardrails/hooks/secret-pattern-detection.sh
+++ b/plugins/guardrails/hooks/secret-pattern-detection.sh
@@ -16,7 +16,7 @@
 # Consumer seams: scoped to $CLAUDE_PROJECT_DIR (files outside it are another
 # repo's concern); a generic allowlist exempts dependency caches, .env
 # examples, test fixtures, and machine-local CC state. Disable entirely with
-# HOOK_SECRET_PATTERN_DETECTION_ENABLED=false.
+# the secret_pattern_detection_enabled userConfig option set to false.
 
 set -uo pipefail
 
@@ -41,8 +41,8 @@ INPUT=$(cat)
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null | tr -d '\r')
 
 case "$TOOL" in
-  Write | Edit | NotebookEdit) ;;
-  *) exit 0 ;;
+Write | Edit | NotebookEdit) ;;
+*) exit 0 ;;
 esac
 
 FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null | tr -d '\r')
@@ -67,8 +67,8 @@ PROJECT_DIR="$(hook::normalize_path "${CLAUDE_PROJECT_DIR:-}")"
 PROJECT_DIR="${PROJECT_DIR%/}"
 if [[ -n "$PROJECT_DIR" ]]; then
   case "$NORM_FILE" in
-    "$PROJECT_DIR"/*) ;; # inside the project — proceed
-    *) exit 0 ;;         # outside the project — not this hook's concern
+  "$PROJECT_DIR"/*) ;; # inside the project — proceed
+  *) exit 0 ;;         # outside the project — not this hook's concern
   esac
 fi
 
@@ -82,27 +82,27 @@ fi
 #   - tests/fixtures, tests/testdata: scoped to test trees only
 #   - CC skill context/completed: research notes; code review is the backstop
 case "$ALLOW_FILE" in
-  *.claude/hooks/*) exit 0 ;;
-  *settings.local.json) exit 0 ;;
-  *CLAUDE.local.md) exit 0 ;;
-  # Dependency caches — anchored to a path-segment boundary (leading `/` or start
-  # of path) so a directory that merely CONTAINS the name (evil_node_modules/,
-  # .venv-backup/) is NOT exempted from the scan.
-  */.venv/* | .venv/*) exit 0 ;;
-  */node_modules/* | node_modules/*) exit 0 ;;
-  *.env.example | *.env.sample | *.env.template) exit 0 ;;
-  *tests/fixtures/* | *tests/testdata/* | *Tests/fixtures/* | *Tests/testdata/*) exit 0 ;;
-  *.claude/skills/*/context/*) exit 0 ;;
-  *.claude/skills/*/completed/*) exit 0 ;;
-  *) ;; # proceed to content check
+*.claude/hooks/*) exit 0 ;;
+*settings.local.json) exit 0 ;;
+*CLAUDE.local.md) exit 0 ;;
+# Dependency caches — anchored to a path-segment boundary (leading `/` or start
+# of path) so a directory that merely CONTAINS the name (evil_node_modules/,
+# .venv-backup/) is NOT exempted from the scan.
+*/.venv/* | .venv/*) exit 0 ;;
+*/node_modules/* | node_modules/*) exit 0 ;;
+*.env.example | *.env.sample | *.env.template) exit 0 ;;
+*tests/fixtures/* | *tests/testdata/* | *Tests/fixtures/* | *Tests/testdata/*) exit 0 ;;
+*.claude/skills/*/context/*) exit 0 ;;
+*.claude/skills/*/completed/*) exit 0 ;;
+*) ;; # proceed to content check
 esac
 
 # --- Extract content to check ---
 case "$TOOL" in
-  Write) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null | tr -d '\r') ;;
-  Edit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null | tr -d '\r') ;;
-  NotebookEdit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_source // empty' 2>/dev/null | tr -d '\r') ;;
-  *) exit 0 ;; # unreachable — $TOOL filtered to Write|Edit|NotebookEdit above
+Write) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null | tr -d '\r') ;;
+Edit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null | tr -d '\r') ;;
+NotebookEdit) CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_source // empty' 2>/dev/null | tr -d '\r') ;;
+*) exit 0 ;; # unreachable — $TOOL filtered to Write|Edit|NotebookEdit above
 esac
 [[ -n "${CONTENT:-}" ]] || exit 0
 
@@ -117,8 +117,11 @@ fi
 # Redaction: if the path could not be made repo-relative, emit the basename only
 # — never an absolute path (it would embed the developer's username) into telemetry.
 case "$FILE_REL" in
-  /* | [A-Za-z]:*) FILE_REL="${FILE_REL##*/}"; FILE_REL="${FILE_REL##*\\}" ;;
-  *) ;;
+/* | [A-Za-z]:*)
+  FILE_REL="${FILE_REL##*/}"
+  FILE_REL="${FILE_REL##*\\}"
+  ;;
+*) ;;
 esac
 
 # Emit one telemetry envelope: $1 status, $2 labels JSON array. Gated on the
@@ -128,8 +131,8 @@ emit_tel() {
   hook::telemetry_enabled || return 0
   local data
   data=$(jq -n --arg file "$FILE_REL" --argjson violations "$2" \
-    '{tool:"'"$TOOL"'",file:$file,violations:$violations}' 2>/dev/null) \
-    || data='{"tool":"","file":"","violations":[]}'
+    '{tool:"'"$TOOL"'",file:$file,violations:$violations}' 2>/dev/null) ||
+    data='{"tool":"","file":"","violations":[]}'
   hook::emit_telemetry "secret-pattern-detection" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 

--- a/plugins/guardrails/hooks/secret-pattern-detection.test.sh
+++ b/plugins/guardrails/hooks/secret-pattern-detection.test.sh
@@ -117,7 +117,7 @@ assert_exit "file outside project root → exit 0" 0 "$RC"
 assert_silent "outside project root → no stderr" "$OUT"
 
 # Kill switch — disabled path is a clean no-op even on a real-shape token.
-OUT=$(HOOK_SECRET_PATTERN_DETECTION_ENABLED=false bash "$HOOK" <<<"$(write_json "$FIXTURE" "x='$AWS_TOKEN'")" 2>&1); RC=$?
+OUT=$(CLAUDE_PLUGIN_OPTION_SECRET_PATTERN_DETECTION_ENABLED=false bash "$HOOK" <<<"$(write_json "$FIXTURE" "x='$AWS_TOKEN'")" 2>&1); RC=$?
 assert_exit "kill switch off → exit 0" 0 "$RC"
 assert_silent "kill switch off → no stderr" "$OUT"
 

--- a/plugins/guardrails/hooks/workflow-resilience-check.sh
+++ b/plugins/guardrails/hooks/workflow-resilience-check.sh
@@ -9,7 +9,7 @@
 # fan-out trips server-side 529 (a 27-item Opus pipeline lost 22/27 agents this
 # way). Closes the inline-authoring gap that no file glob can reach.
 #
-# Kill switch: HOOK_WORKFLOW_RESILIENCE_CHECK_ENABLED=false
+# Kill switch: workflow_resilience_check_enabled userConfig option
 
 set -uo pipefail
 

--- a/plugins/guardrails/hooks/workflow-resilience-check.test.sh
+++ b/plugins/guardrails/hooks/workflow-resilience-check.test.sh
@@ -52,7 +52,7 @@ out=$(run_hook "$(workflow_script_json 'const a = await agent("do x"); const b =
 assert_silent "no fan-out stays silent" "$out"
 
 # CASE 7: kill switch off → silent even on un-throttled fan-out.
-out=$(run_hook "$(workflow_script_json 'await pipeline(FILES, s1)')" HOOK_WORKFLOW_RESILIENCE_CHECK_ENABLED=false)
+out=$(run_hook "$(workflow_script_json 'await pipeline(FILES, s1)')" CLAUDE_PLUGIN_OPTION_WORKFLOW_RESILIENCE_CHECK_ENABLED=false)
 assert_silent "kill switch silences hook" "$out"
 
 # CASE 8: saved scriptPath with un-throttled fan-out → advisory fires (reads file).

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["markdown", "markdownlint", "formatter", "linter", "hook"]
+  "keywords": ["markdown", "markdownlint", "formatter", "linter", "hook"],
+  "userConfig": {
+    "markdown_format_enabled": {
+      "type": "boolean",
+      "title": "markdown-format hook",
+      "description": "Auto-format and lint Markdown on Write/Edit of .md/.mdc files",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -8,20 +8,19 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["markdown", "markdownlint", "formatter", "linter", "hook"],
+  "keywords": [
+    "markdown",
+    "markdownlint",
+    "formatter",
+    "linter",
+    "hook"
+  ],
   "userConfig": {
     "markdown_format_enabled": {
       "type": "boolean",
       "title": "markdown-format hook",
       "description": "Auto-format and lint Markdown on Write/Edit of .md/.mdc files",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -9,15 +9,14 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 
 - **Kill switch migrated to native `userConfig`.** The toggle is now the
   `markdown_format_enabled` boolean (default `true`), read by the hook through the
-  native `CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED` hook-process mirror; the stdin
-  read bound is the new `stdin_read_timeout` option (default `2`). Configure interactively
-  with `/plugin configure markdown-format` or headless via
+  native `CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED` hook-process mirror. Configure
+  interactively with `/plugin configure markdown-format` or headless via
   `claude plugin install --config KEY=VALUE`.
 
 ### Breaking
 
-- The `HOOK_MARKDOWN_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT` environment variables
-  are retired and no longer read. A consumer that set either in a settings `env` block must
+- The `HOOK_MARKDOWN_FORMAT_ENABLED` environment variable is retired and no longer
+  read. A consumer that set it in a settings `env` block must
   re-express the value as the matching `userConfig` option. Zero-config behavior is
   unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK` telemetry seam is unaffected.
 

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`.** The toggle is now the
+  `markdown_format_enabled` boolean (default `true`), read by the hook through the
+  native `CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED` hook-process mirror; the stdin
+  read bound is the new `stdin_read_timeout` option (default `2`). Configure interactively
+  with `/plugin configure markdown-format` or headless via
+  `claude plugin install --config KEY=VALUE`.
+
+### Breaking
+
+- The `HOOK_MARKDOWN_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT` environment variables
+  are retired and no longer read. A consumer that set either in a settings `env` block must
+  re-express the value as the matching `userConfig` option. Zero-config behavior is
+  unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK` telemetry seam is unaffected.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -65,17 +65,27 @@ the advisory to appear again.
 
 ## Configuration
 
-This plugin has no `userConfig` — its only "configuration" is the markdownlint
-config already in your repository, which it reads automatically. To change the
-rules, edit your repo's markdownlint config.
+The rules themselves are never configured here — the plugin's only rule source is
+the markdownlint config already in your repository, which it reads automatically.
+To change the rules, edit your repo's markdownlint config.
 
-### Disable without uninstalling
+Two `userConfig` options tune the hook itself:
 
-Set the kill switch in your settings `env` block:
+| Option | Type | Default | Effect |
+|--------|------|---------|--------|
+| `markdown_format_enabled` | boolean | `true` | Toggle the markdown-format hook; set `false` for a clean no-op. |
+| `stdin_read_timeout` | number | `2` | Seconds the hook waits for its stdin payload before failing open. |
 
-```json
-{ "env": { "HOOK_MARKDOWN_FORMAT_ENABLED": "false" } }
+Set them interactively with `/plugin configure markdown-format`, or headless on
+the install command:
+
+```shell
+claude plugin install markdown-format@melodic-software --config markdown_format_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the project's).
+To disable formatting for a single repository, disable the whole plugin in that
+project's `enabledPlugins` instead.
 
 ## License
 

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -69,14 +69,13 @@ The rules themselves are never configured here — the plugin's only rule source
 the markdownlint config already in your repository, which it reads automatically.
 To change the rules, edit your repo's markdownlint config.
 
-Two `userConfig` options tune the hook itself:
+One `userConfig` option tunes the hook itself:
 
 | Option | Type | Default | Effect |
 |--------|------|---------|--------|
 | `markdown_format_enabled` | boolean | `true` | Toggle the markdown-format hook; set `false` for a clean no-op. |
-| `stdin_read_timeout` | number | `2` | Seconds the hook waits for its stdin payload before failing open. |
 
-Set them interactively with `/plugin configure markdown-format`, or headless on
+Set it interactively with `/plugin configure markdown-format`, or headless on
 the install command:
 
 ```shell

--- a/plugins/markdown-format/hooks/hook-utils.sh
+++ b/plugins/markdown-format/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -144,7 +144,7 @@ JSONC
 run_hook() {
   local file_path="$1"
   (cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$file_path" \
-    | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")
+    | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")
 }
 
 # --- Fixture A: fixable only (Path A) — clean after fix, no additionalContext -
@@ -259,7 +259,7 @@ chmod +x "$LOCAL_MDLINT"
 LOCAL_FIXTURE="$REPO/fixtureLocal.md"
 printf '# Local\n\n* local item\n' >"$LOCAL_FIXTURE"
 OUT_LOCAL="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$LOCAL_FIXTURE" \
-  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_LOCAL=$?
 if [[ $RC_LOCAL -eq 0 && -z "$OUT_LOCAL" ]]; then
   ok "repo-local markdownlint shim exits 0 with no advisory"
@@ -287,7 +287,7 @@ if [[ -L "$LOCAL_MDLINT" ]]; then
   LOCAL_SYMLINK_FIXTURE="$REPO/fixtureLocalSymlink.md"
   printf '# Local Symlink\n\n* symlink item\n' >"$LOCAL_SYMLINK_FIXTURE"
   OUT_LOCAL_SYMLINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$LOCAL_SYMLINK_FIXTURE" \
-    | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+    | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
   RC_LOCAL_SYMLINK=$?
   if [[ $RC_LOCAL_SYMLINK -eq 0 && -z "$OUT_LOCAL_SYMLINK" ]] \
     && grep -q '^- symlink item$' "$LOCAL_SYMLINK_FIXTURE"; then
@@ -330,7 +330,7 @@ fi
 
 if [[ "$ESCAPE_LINK_CREATED" == true ]]; then
   OUT_ESCAPE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" \
-    | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+    | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
   RC_ESCAPE=$?
   if [[ $RC_ESCAPE -eq 0 ]] \
     && printf '%s' "$OUT_ESCAPE" | jq -e '.hookSpecificOutput.additionalContext | contains("contained repository-local")' >/dev/null 2>&1; then
@@ -355,7 +355,7 @@ fi
 # With neither PATH nor a contained local binary available, the hook must not
 # invoke the package runner (which could fetch from the network).
 OUT_NO_MDLINT="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" \
-  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_NO_MDLINT=$?
 if [[ $RC_NO_MDLINT -eq 0 ]]; then ok "missing markdownlint exits 0 (advisory)"; else fail "missing markdownlint exit $RC_NO_MDLINT"; fi
 if printf '%s' "$OUT_NO_MDLINT" | jq -e '.hookSpecificOutput.additionalContext | contains("neither on PATH nor available as a contained repository-local")' >/dev/null 2>&1; then
@@ -376,7 +376,7 @@ command() {
 }
 EOF
 OUT_NO_JQ="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" \
-  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_JQ_ENV" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_JQ_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_NO_JQ=$?
 if [[ $RC_NO_JQ -eq 0 ]]; then ok "missing jq exits 0 (advisory)"; else fail "missing jq exit $RC_NO_JQ"; fi
 if printf '%s' "$OUT_NO_JQ" | jq -e '.hookSpecificOutput.additionalContext | contains("jq is required")' >/dev/null 2>&1; then
@@ -405,7 +405,7 @@ TRUST_FILE="$REPO/trust-cjs.md"
 printf '# Executable config\n\nClean text.' >"$TRUST_FILE"
 
 OUT_TRUST_1="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_TRUST_1=$?
 if [[ $RC_TRUST_1 -eq 0 ]]; then ok "executable config advisory exits 0"; else fail "executable config advisory exit $RC_TRUST_1"; fi
 if printf '%s' "$OUT_TRUST_1" | jq -e '.hookSpecificOutput.additionalContext | contains("trust advisory") and contains(".markdownlint-cli2.cjs")' >/dev/null 2>&1; then
@@ -420,7 +420,7 @@ else
 fi
 
 OUT_TRUST_2="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if [[ -z "$OUT_TRUST_2" ]]; then
   ok "unchanged executable config warning appears only once"
 else
@@ -429,7 +429,7 @@ fi
 
 printf '\n// reviewed configuration revision\n' >>"$REPO/.markdownlint-cli2.cjs"
 OUT_TRUST_3="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if printf '%s' "$OUT_TRUST_3" | jq -e '.hookSpecificOutput.additionalContext | contains("trust advisory")' >/dev/null 2>&1; then
   ok "changed executable config state warns again"
 else
@@ -451,7 +451,7 @@ cat >"$ORIGINAL_CONFIG" <<'JSONC'
 }
 JSONC
 OUT_TRUST_MODULES="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if printf '%s' "$OUT_TRUST_MODULES" | jq -e '.hookSpecificOutput.additionalContext | contains("trust advisory") and contains(".markdownlint-cli2.jsonc")' >/dev/null 2>&1; then
   ok "module-loading config keys emit visible trust advisory"
 else
@@ -462,7 +462,7 @@ fi
 # no modules, so it must not produce trust-warning noise.
 mv "$SAVED_CONFIG" "$ORIGINAL_CONFIG"
 OUT_TRUST_SAFE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if [[ -z "$OUT_TRUST_SAFE" ]]; then
   ok "rule-only declarative config emits no trust advisory"
 else
@@ -471,7 +471,7 @@ fi
 
 # --- Kill switch: disabled hook is a no-op ----------------------------------
 OUT_K="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FB" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=false bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=false bash "$HOOK")"
 RC_K=$?
 if [[ $RC_K -eq 0 && -z "$OUT_K" ]]; then
   ok "kill switch disables hook"
@@ -490,7 +490,7 @@ fi
 # Re-run fixture A with sink unset — must still produce empty stdout, exit 0.
 printf '# Title A2\r\n\r\nSome text\r\n\r\n- item one\r\n- item two' >"$REPO/fixtureA2.md"
 OUT_A_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$REPO/fixtureA2.md" \
-  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_A_NOSINK=$?
 if [[ $RC_A_NOSINK -eq 0 ]]; then ok "telemetry/sink-unset: exit 0 (parity)"; else fail "telemetry/sink-unset: expected 0, got $RC_A_NOSINK"; fi
 if [[ -z "$OUT_A_NOSINK" ]]; then ok "telemetry/sink-unset: empty stdout (parity)"; else fail "telemetry/sink-unset: stdout not empty: $OUT_A_NOSINK"; fi
@@ -498,7 +498,7 @@ if [[ -z "$OUT_A_NOSINK" ]]; then ok "telemetry/sink-unset: empty stdout (parity
 # Re-run fixture B with sink unset — must still emit additionalContext, exit 0.
 printf '# Doc B2\n\n## Section\n\ntext\n\n## Section\n\n* star item\n' >"$REPO/fixtureB2.md"
 OUT_B_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Edit"}' "$REPO/fixtureB2.md" \
-  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK HOOK_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_B_NOSINK=$?
 if [[ $RC_B_NOSINK -eq 0 ]]; then ok "telemetry/sink-unset B: exit 0 (parity)"; else fail "telemetry/sink-unset B: expected 0, got $RC_B_NOSINK"; fi
 if printf '%s' "$OUT_B_NOSINK" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
@@ -521,7 +521,7 @@ STUB_SINK="$(make_sink "cat >\"$TEL_FILE\"")"
 printf '# Doc T\n\n## Section\n\ntext\n\n## Section\n\nmore text\n' >"$REPO/fixtureT.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_FILE
 _OUT_T="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureT.md" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_SINK" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_SINK" bash "$HOOK")"
 RC_T=$?
 wait_for_sink "$TEL_FILE"
 
@@ -595,7 +595,7 @@ STUB_CLEAN="$(make_sink "cat >\"$TEL_CLEAN\"")"
 printf '# Clean Doc\n\nSome text.\n' >"$REPO/fixtureClean.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_CLEAN
 _OUT_CLEAN="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureClean.md" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_CLEAN" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_CLEAN" bash "$HOOK")"
 RC_CLEAN=$?
 wait_for_sink "$TEL_CLEAN"
 
@@ -619,7 +619,7 @@ FAIL_SINK="$(make_sink "cat >\"$FAIL_SINK_FILE\"; exit 1")"
 printf '# Failing Sink Doc\n\nSome text.\n' >"$REPO/fixtureFailSink.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; exit code is the assertion
 _OUT_FS="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureFailSink.md" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$FAIL_SINK" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$FAIL_SINK" bash "$HOOK")"
 RC_FS=$?
 wait_for_sink "$FAIL_SINK_FILE"
 
@@ -634,7 +634,7 @@ printf '# Slow Sink Doc\n\nSome text.\n' >"$REPO/fixtureSlowSink.md"
 TS_SLOW_START=$EPOCHREALTIME
 # shellcheck disable=SC2034  # stdout captured so the $(...) blocks until fd1 closes — proves no fd1 leak
 _OUT_SLOW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureSlowSink.md" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SLOW_SINK" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SLOW_SINK" bash "$HOOK")"
 RC_SLOW=$?
 TS_SLOW_END=$EPOCHREALTIME
 SS="${TS_SLOW_START%[.,]*}"; SF="${TS_SLOW_START#*[.,]}"
@@ -656,7 +656,7 @@ TEL_LEAK="$(mktemp)"
 LEAK_SINK="$(make_sink "cat >\"$TEL_LEAK\"")"
 printf '# Leak Doc\n\n## Section\n\ntext\n\n## Section\n\nmore text\n' >"$REPO/fixtureLeakCheck.md"
 OUT_LEAK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureLeakCheck.md" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$LEAK_SINK" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$LEAK_SINK" bash "$HOOK")"
 wait_for_sink "$TEL_LEAK"
 
 # The hook stdout must NOT contain the telemetry envelope's top-level keys
@@ -710,7 +710,7 @@ count_lm() { grep -c -- '-lm' "$CYG_LOG" 2>/dev/null || true; }
 : >"$JQ_LOG"
 printf '# Gate Doc\n\nClean text.\n' >"$REPO/fixtureGate.md"
 OUT_GATE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureGate.md" \
-  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK HOOK_MARKDOWN_FORMAT_ENABLED=true PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
 RC_GATE=$?
 if [[ $RC_GATE -eq 0 && -z "$OUT_GATE" ]]; then
   ok "telemetry-gate/unwired: exit 0, empty stdout"
@@ -740,7 +740,7 @@ GATE_SINK="$(make_sink "cat >\"$TEL_GATE\"")"
 printf '# Gate Doc Wired\n\nClean text.\n' >"$REPO/fixtureGateWired.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_GATE
 _OUT_GW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureGateWired.md" \
-  | env -u CLAUDE_PROJECT_DIR HOOK_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$GATE_SINK" PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
+  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$GATE_SINK" PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
 wait_for_sink "$TEL_GATE"
 CYG_LM_WIRED="$(count_lm)"
 if [[ "$CYG_LM_WIRED" -eq 2 ]]; then

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -8,20 +8,20 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["powershell", "psscriptanalyzer", "pwsh", "formatter", "linter", "hook"],
+  "keywords": [
+    "powershell",
+    "psscriptanalyzer",
+    "pwsh",
+    "formatter",
+    "linter",
+    "hook"
+  ],
   "userConfig": {
     "powershell_format_enabled": {
       "type": "boolean",
       "title": "powershell-format hook",
       "description": "Format and lint PowerShell on edit via PSScriptAnalyzer",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["powershell", "psscriptanalyzer", "pwsh", "formatter", "linter", "hook"]
+  "keywords": ["powershell", "psscriptanalyzer", "pwsh", "formatter", "linter", "hook"],
+  "userConfig": {
+    "powershell_format_enabled": {
+      "type": "boolean",
+      "title": "powershell-format hook",
+      "description": "Format and lint PowerShell on edit via PSScriptAnalyzer",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -10,11 +10,11 @@ All notable changes to the `powershell-format` plugin are documented here. Forma
 - **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch doctrine
   ruling). The hook toggle is now the `powershell_format_enabled` option (default `true`),
   read by the hook through the native `CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED`
-  hook-process mirror; the stdin read bound is the `stdin_read_timeout` option (default `2`).
-  Configure interactively with `/plugin configure powershell-format` or headless via
+  hook-process mirror. Configure interactively with `/plugin configure powershell-format`
+  or headless via
   `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_POWERSHELL_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
-  environment variables are retired and no longer read. A consumer that set either in a
-  settings `env` block must re-express the value as the matching `userConfig` option.
+- **BREAKING:** the `HOOK_POWERSHELL_FORMAT_ENABLED` environment variable is
+  retired and no longer read. A consumer that set it in a settings `env` block
+  must re-express the value as the matching `userConfig` option.
   Zero-config behavior is unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK`
   consumer-side telemetry seam is unaffected.

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the `powershell-format` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch doctrine
+  ruling). The hook toggle is now the `powershell_format_enabled` option (default `true`),
+  read by the hook through the native `CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED`
+  hook-process mirror; the stdin read bound is the `stdin_read_timeout` option (default `2`).
+  Configure interactively with `/plugin configure powershell-format` or headless via
+  `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_POWERSHELL_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT`
+  environment variables are retired and no longer read. A consumer that set either in a
+  settings `env` block must re-express the value as the matching `userConfig` option.
+  Zero-config behavior is unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK`
+  consumer-side telemetry seam is unaffected.

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -66,17 +66,27 @@ linting still run.
 
 ## Configuration
 
-This plugin has no `userConfig` — its only "configuration" is the
-`PSScriptAnalyzerSettings.psd1` already in your repository, which it reads
+The formatting and linting rules come from the
+`PSScriptAnalyzerSettings.psd1` already in your repository, which the hook reads
 automatically. To change the rules, edit that file.
 
-### Disable without uninstalling
+Two behavior knobs are exposed as native `userConfig` options:
 
-Set the kill switch in your settings `env` block:
+| Option | Default | Effect |
+|--------|---------|--------|
+| `powershell_format_enabled` | `true` | Toggle for the powershell-format hook; set `false` for a clean no-op. |
+| `stdin_read_timeout` | `2` | Seconds the hook waits for its stdin payload before failing open. |
 
-```json
-{ "env": { "HOOK_POWERSHELL_FORMAT_ENABLED": "false" } }
+Set them interactively with `/plugin configure powershell-format`, or headless
+on the install command:
+
+```shell
+claude plugin install powershell-format@melodic-software --config powershell_format_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the
+project's). To turn the hook off for a single repository, disable the whole
+plugin in that project's `enabledPlugins` instead.
 
 ## License
 

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -70,14 +70,13 @@ The formatting and linting rules come from the
 `PSScriptAnalyzerSettings.psd1` already in your repository, which the hook reads
 automatically. To change the rules, edit that file.
 
-Two behavior knobs are exposed as native `userConfig` options:
+One behavior knob is exposed as a native `userConfig` option:
 
 | Option | Default | Effect |
 |--------|---------|--------|
 | `powershell_format_enabled` | `true` | Toggle for the powershell-format hook; set `false` for a clean no-op. |
-| `stdin_read_timeout` | `2` | Seconds the hook waits for its stdin payload before failing open. |
 
-Set them interactively with `/plugin configure powershell-format`, or headless
+Set it interactively with `/plugin configure powershell-format`, or headless
 on the install command:
 
 ```shell

--- a/plugins/powershell-format/hooks/hook-utils.sh
+++ b/plugins/powershell-format/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/powershell-format/hooks/powershell-format.test.sh
+++ b/plugins/powershell-format/hooks/powershell-format.test.sh
@@ -69,7 +69,7 @@ run_hook() {
   (
     cd "$UNRELATED" || return 1
     printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
-      env -u CLAUDE_PROJECT_DIR HOOK_POWERSHELL_FORMAT_ENABLED=true bash "$HOOK"
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -135,7 +135,7 @@ new_repo "$REPO_ABSENT"
 printf "%s\n" "gci -Path '.'" >"$REPO_ABSENT/a.ps1"
 BEFORE_ABSENT="$(cat "$REPO_ABSENT/a.ps1")"
 if _pwsh_free_usable "$_filtered"; then
-  OUT=$(run_hook_env "$REPO_ABSENT/a.ps1" HOOK_POWERSHELL_FORMAT_ENABLED=true PATH="$_filtered")
+  OUT=$(run_hook_env "$REPO_ABSENT/a.ps1" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true PATH="$_filtered")
   RC=$?
   if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "pwsh absent -> exit 0, silent (clean skip)"; else fail "pwsh absent not silent (rc=$RC out=$OUT)"; fi
   if [[ "$(cat "$REPO_ABSENT/a.ps1")" == "$BEFORE_ABSENT" ]]; then ok "pwsh absent -> file left untouched"; else fail "pwsh absent -> file was rewritten"; fi
@@ -166,14 +166,14 @@ BEFORE_STUB="$(cat "$REPO_STUB/s.ps1")"
 
 # exit 3 -> module absent -> clean silent skip
 make_stub_pwsh 'exit 3'
-OUT=$(run_hook_env "$REPO_STUB/s.ps1" HOOK_POWERSHELL_FORMAT_ENABLED=true PATH="$STUB_BIN:$PATH")
+OUT=$(run_hook_env "$REPO_STUB/s.ps1" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true PATH="$STUB_BIN:$PATH")
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "module absent (pwsh exit 3) -> exit 0, silent (clean skip)"; else fail "module absent not silent (rc=$RC out=$OUT)"; fi
 if [[ "$(cat "$REPO_STUB/s.ps1")" == "$BEFORE_STUB" ]]; then ok "module absent -> file left untouched"; else fail "module absent -> file was rewritten"; fi
 
 # exit 4 (+ stderr) -> analyzer threw -> advisory tool-break context, exit 0
 make_stub_pwsh 'echo "boom: bad settings" >&2; exit 4'
-OUT=$(run_hook_env "$REPO_STUB/s.ps1" HOOK_POWERSHELL_FORMAT_ENABLED=true PATH="$STUB_BIN:$PATH")
+OUT=$(run_hook_env "$REPO_STUB/s.ps1" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true PATH="$STUB_BIN:$PATH")
 RC=$?
 if [[ $RC -eq 0 ]]; then ok "tool break (pwsh exit 4) -> exit 0 (advisory)"; else fail "tool break exit $RC (must be advisory)"; fi
 if printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
@@ -205,7 +205,7 @@ BEFORE_CEIL="$(cat "$REPO_CEIL/proj/sub/c.ps1")"
 OUT=$(
   cd "$UNRELATED" || exit 1
   printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO_CEIL/proj/sub/c.ps1" |
-    CLAUDE_PROJECT_DIR="$REPO_CEIL/proj" HOOK_POWERSHELL_FORMAT_ENABLED=true bash "$HOOK"
+    CLAUDE_PROJECT_DIR="$REPO_CEIL/proj" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true bash "$HOOK"
 )
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "settings above CLAUDE_PROJECT_DIR ceiling -> not found, silent skip"; else fail "ceiling not respected (rc=$RC out=$OUT)"; fi
@@ -315,7 +315,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-matching ext -> exit 0 silent"; el
 # --- Case 7: kill switch bypasses hook ---------------------------------------
 printf "%s\n" "gci -Path '.'" >"$REPO/kill.ps1"
 BEFORE_K="$(cat "$REPO/kill.ps1")"
-OUT=$(run_hook_env "$REPO/kill.ps1" HOOK_POWERSHELL_FORMAT_ENABLED=false)
+OUT=$(run_hook_env "$REPO/kill.ps1" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=false)
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
 if [[ "$(cat "$REPO/kill.ps1")" == "$BEFORE_K" ]]; then ok "kill switch -> file untouched"; else fail "kill switch -> file was modified"; fi
@@ -394,7 +394,7 @@ fi
 # ============================================================================
 
 # --- Sink unset -> empty stdout, exit 0 (parity) -----------------------------
-OUT_NS=$(run_hook_env "$REPO/clean.ps1" -u HOOK_TELEMETRY_SINK HOOK_POWERSHELL_FORMAT_ENABLED=true)
+OUT_NS=$(run_hook_env "$REPO/clean.ps1" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true)
 RC_NS=$?
 if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
   ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
@@ -408,7 +408,7 @@ fi
 printf '%s\n' '$global:tel = 1' >"$REPO/tel.ps1"
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/tel.ps1" HOOK_POWERSHELL_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+run_hook_env "$REPO/tel.ps1" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -435,7 +435,7 @@ rm -f "$TEL"
 printf "%s\n" "gci -Path '.'" >"$REPO_NO/tel2.ps1"
 TELS="$(mktemp)"
 SINKS="$(make_sink "cat >\"$TELS\"")"
-run_hook_env "$REPO_NO/tel2.ps1" HOOK_POWERSHELL_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+run_hook_env "$REPO_NO/tel2.ps1" CLAUDE_PLUGIN_OPTION_POWERSHELL_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
 wait_for_sink "$TELS"
 if [[ -s "$TELS" ]]; then
   if [[ "$(jq -r '.status' "$TELS")" == "skipped" ]]; then ok "telemetry/gate-off: status skipped"; else fail "telemetry/gate-off: status=$(jq -r '.status' "$TELS")"; fi

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -8,20 +8,19 @@
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["ruff", "python", "formatter", "linter", "hook"],
+  "keywords": [
+    "ruff",
+    "python",
+    "formatter",
+    "linter",
+    "hook"
+  ],
   "userConfig": {
     "ruff_format_enabled": {
       "type": "boolean",
       "title": "ruff-format hook",
       "description": "Run Ruff check --fix and format on edit of a Python file",
       "default": true
-    },
-    "stdin_read_timeout": {
-      "type": "number",
-      "title": "Hook stdin read timeout (seconds)",
-      "description": "Bound on reading the hook payload from stdin before failing open",
-      "default": 2,
-      "min": 1
     }
   }
 }

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,12 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["ruff", "python", "formatter", "linter", "hook"]
+  "keywords": ["ruff", "python", "formatter", "linter", "hook"],
+  "userConfig": {
+    "ruff_format_enabled": {
+      "type": "boolean",
+      "title": "ruff-format hook",
+      "description": "Run Ruff check --fix and format on edit of a Python file",
+      "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
+    }
+  }
 }

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the `ruff-format` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.0]
+
+### Changed
+
+- **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch doctrine
+  ruling). The toggle is now the `ruff_format_enabled` boolean (default `true`), read by
+  the hook through the native `CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED` hook-process
+  mirror; the stdin read bound is the new `stdin_read_timeout` option (default `2`).
+  Configure interactively with `/plugin configure ruff-format` or headless via
+  `claude plugin install --config KEY=VALUE`.
+- **BREAKING:** the `HOOK_RUFF_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT` environment
+  variables are retired and no longer read. A consumer that set either in a settings
+  `env` block must re-express the value as the matching `userConfig` option. Zero-config
+  behavior is unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK` consumer-side
+  telemetry seam is unaffected.

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -10,11 +10,10 @@ All notable changes to the `ruff-format` plugin are documented here. Format foll
 - **Kill switch migrated to native `userConfig`** (the fleet-wide kill-switch doctrine
   ruling). The toggle is now the `ruff_format_enabled` boolean (default `true`), read by
   the hook through the native `CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED` hook-process
-  mirror; the stdin read bound is the new `stdin_read_timeout` option (default `2`).
-  Configure interactively with `/plugin configure ruff-format` or headless via
+  mirror. Configure interactively with `/plugin configure ruff-format` or headless via
   `claude plugin install --config KEY=VALUE`.
-- **BREAKING:** the `HOOK_RUFF_FORMAT_ENABLED` and `HOOK_STDIN_READ_TIMEOUT` environment
-  variables are retired and no longer read. A consumer that set either in a settings
-  `env` block must re-express the value as the matching `userConfig` option. Zero-config
+- **BREAKING:** the `HOOK_RUFF_FORMAT_ENABLED` environment variable is retired and
+  no longer read. A consumer that set it in a settings `env` block must re-express
+  the value as the matching `userConfig` option. Zero-config
   behavior is unchanged (hook on, same defaults). The `HOOK_TELEMETRY_SINK` consumer-side
   telemetry seam is unaffected.

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -63,17 +63,27 @@ and linting still run.
 
 ## Configuration
 
-This plugin has no `userConfig` — its only "configuration" is the Ruff config
-already in your repository, which it reads automatically. To change the rules,
-edit that file.
+The rules themselves are never configured here — they come from the Ruff config
+already in your repository, which the plugin reads automatically. To change the
+rules, edit that file.
 
-### Disable without uninstalling
+Two `userConfig` options tune the hook itself:
 
-Set the kill switch in your settings `env` block:
+| Option | Default | Effect |
+|--------|---------|--------|
+| `ruff_format_enabled` | `true` | Kill switch — set `false` for a clean no-op. |
+| `stdin_read_timeout` | `2` | Seconds the hook waits for its payload before failing open. |
 
-```json
-{ "env": { "HOOK_RUFF_FORMAT_ENABLED": "false" } }
+Set them interactively with `/plugin configure ruff-format`, or headless on the
+install command:
+
+```shell
+claude plugin install ruff-format@melodic-software --config ruff_format_enabled=false
 ```
+
+These options are user-scoped (stored in your user settings, not the project's).
+To turn the plugin off for a single repository, disable it in that project's
+`enabledPlugins` instead.
 
 ## License
 

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -67,14 +67,13 @@ The rules themselves are never configured here — they come from the Ruff confi
 already in your repository, which the plugin reads automatically. To change the
 rules, edit that file.
 
-Two `userConfig` options tune the hook itself:
+One `userConfig` option tunes the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
 | `ruff_format_enabled` | `true` | Kill switch — set `false` for a clean no-op. |
-| `stdin_read_timeout` | `2` | Seconds the hook waits for its payload before failing open. |
 
-Set them interactively with `/plugin configure ruff-format`, or headless on the
+Set it interactively with `/plugin configure ruff-format`, or headless on the
 install command:
 
 ```shell

--- a/plugins/ruff-format/hooks/hook-utils.sh
+++ b/plugins/ruff-format/hooks/hook-utils.sh
@@ -12,11 +12,12 @@
 [[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
 readonly _HOOK_UTILS_LOADED=1
 
-# Per-hook kill switch via HOOK_<NAME>_ENABLED env var. Exits 0 (allow) if
-# disabled. Place after source, before stdin parsing.
-#   hook::check_enabled "MARKDOWN_FORMAT"  # checks HOOK_MARKDOWN_FORMAT_ENABLED
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
 hook::check_enabled() {
-  local var_name="HOOK_${1}_ENABLED"
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
   if [[ "${!var_name:-true}" != "true" ]]; then
     exit 0
   fi
@@ -115,12 +116,13 @@ hook::repo_root() {
 # late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
 # on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
 # read timed out before a complete JSON payload arrived (caller may block).
-# Bound is HOOK_STDIN_READ_TIMEOUT seconds (default 2). jq (when present)
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
 # distinguishes a truncated read from a genuinely small-but-complete payload; a
 # missing/broken jq (exit 127) fails open like absent jq.
 #   INPUT=$(hook::buffer_stdin) || exit 0
 hook::buffer_stdin() {
-  local input="" read_status=0 read_timeout="${HOOK_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
   start_epoch=${EPOCHREALTIME:-}
   IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
   input=$(printf '%s' "$input" | tr -d '\r')
@@ -132,8 +134,8 @@ hook::buffer_stdin() {
   if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
     elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
     timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
-    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] \
-      && ((elapsed_ms + 100 >= timeout_ms)); then
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
       echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
       return 2
     fi
@@ -171,8 +173,8 @@ hook::extract_bash_subject() {
   # Trim leading whitespace so the first token is real.
   cmd="${cmd#"${cmd%%[![:space:]]*}"}"
   local first_token="${cmd%%[[:space:]]*}"
-  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] \
-    && [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
     # A quote in the prefix token means a quoted value spans the next whitespace;
     # we cannot tokenize it safely — bail rather than leak a value fragment.
     if [[ "$first_token" == *[\"\']* ]]; then

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -108,7 +108,7 @@ run_hook() {
   (
     cd "$UNRELATED" || return 1
     printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
-      env -u CLAUDE_PROJECT_DIR HOOK_RUFF_FORMAT_ENABLED=true bash "$HOOK"
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -308,7 +308,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "non-matching ext -> exit 0 silent"; el
 # --- Case 7: kill switch bypasses hook ----------------------------------------
 printf 'k=1\n' >"$REPO/kill.py"
 BEFORE_K="$(cat "$REPO/kill.py")"
-OUT=$(run_hook_env "$REPO/kill.py" HOOK_RUFF_FORMAT_ENABLED=false)
+OUT=$(run_hook_env "$REPO/kill.py" CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=false)
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch off -> exit 0 silent"; else fail "kill switch failed (rc=$RC out=$OUT)"; fi
 if [[ "$(cat "$REPO/kill.py")" == "$BEFORE_K" ]]; then ok "kill switch -> file untouched"; else fail "kill switch -> file was modified"; fi
@@ -320,7 +320,7 @@ mkdir -p "$REPO_PATH"
 git -C "$REPO_PATH" init -q
 printf 'line-length = 88\n' >"$REPO_PATH/ruff.toml"
 printf 'p=1\n' >"$REPO_PATH/p.py"
-OUT=$(run_hook_env "$REPO_PATH/p.py" HOOK_RUFF_FORMAT_ENABLED=true PATH="$(dirname "$REAL_RUFF"):$PATH")
+OUT=$(run_hook_env "$REPO_PATH/p.py" CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true PATH="$(dirname "$REAL_RUFF"):$PATH")
 RC=$?
 if [[ $RC -eq 0 ]] && grep -q 'p = 1' "$REPO_PATH/p.py"; then
   ok "PATH fallback -> Ruff resolved and file formatted"
@@ -333,7 +333,7 @@ fi
 # ============================================================================
 
 # --- Sink unset -> empty stdout, exit 0 (parity) ------------------------------
-OUT_NS=$(run_hook_env "$REPO/clean.py" -u HOOK_TELEMETRY_SINK HOOK_RUFF_FORMAT_ENABLED=true)
+OUT_NS=$(run_hook_env "$REPO/clean.py" -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true)
 RC_NS=$?
 if [[ $RC_NS -eq 0 && -z "$OUT_NS" ]]; then
   ok "telemetry/sink-unset: exit 0, empty stdout (parity)"
@@ -345,7 +345,7 @@ fi
 printf 'print(undefined_tel)\n' >"$REPO/tel.py"
 TEL="$(mktemp)"
 SINK="$(make_sink "cat >\"$TEL\"")"
-run_hook_env "$REPO/tel.py" HOOK_RUFF_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
+run_hook_env "$REPO/tel.py" CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINK" >/dev/null
 wait_for_sink "$TEL"
 if [[ -s "$TEL" ]]; then
   ok "telemetry/stub-sink: envelope received"
@@ -372,7 +372,7 @@ rm -f "$TEL"
 printf 's=1\n' >"$REPO_NO/tel2.py"
 TELS="$(mktemp)"
 SINKS="$(make_sink "cat >\"$TELS\"")"
-run_hook_env "$REPO_NO/tel2.py" HOOK_RUFF_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+run_hook_env "$REPO_NO/tel2.py" CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
 wait_for_sink "$TELS"
 if [[ -s "$TELS" ]]; then
   if [[ "$(jq -r '.status' "$TELS")" == "skipped" ]]; then ok "telemetry/gate-off: status skipped"; else fail "telemetry/gate-off: status=$(jq -r '.status' "$TELS")"; fi


### PR DESCRIPTION
Part of #315 (userConfig wave). No linked issue closes with this PR — #315 stays open for the remaining skill-channel scalar migrations (knowledge, source-control, disk-hygiene, repo-hygiene, planning description fix).

## What

Applies the kill-switch doctrine ruling (PR #321) across every plugin carrying the shared `lib/hook-utils.sh`: per-hook selectivity is now a `userConfig` boolean (default `true`) read through the hook-process `CLAUDE_PLUGIN_OPTION_<KEY>` mirror, and the custom `HOOK_*` env channel retires in the same release.

**Scope note:** #315 listed 9 same-pattern plugins; the shared-library reader change atomically flips every plugin carrying a synced copy, which adds `biome-format` and `claude-ops` (both call `hook::check_enabled`) to this wave — 10 plugins total. `disk-hygiene` and `repo-hygiene` (listed in #315) carry no hook-utils copy; their switches live in skill-invoked scripts where the mirror does not reach, so they move with the skill-channel PR.

## Per plugin

| Plugin | Version | Options added |
|---|---|---|
| guardrails (flagship) | 0.5.0 | 7 per-guard `*_enabled` toggles, `cli_flag_verify_bins`, `cli_flag_verify_skip_bins`, `stdin_read_timeout` |
| claude-ops | 0.11.0 | 7 audit-hook toggles, `instructions_loaded_audit_log_session_start`, `stdin_read_timeout` (existing `registry_dir`/`skill_usage_dir`/`install_new` preserved) |
| desktop-notification | 0.2.0 | master toggle + 3 per-channel mutes, `stdin_read_timeout` |
| actionlint 0.2.0 · bash-format 0.3.0 · biome-format 0.2.0 · eol-normalizer 0.2.0 · markdown-format 0.3.0 · powershell-format 0.2.0 · ruff-format 0.2.0 | — | single `<plugin>_enabled` toggle + `stdin_read_timeout` each |

Every plugin: README configuration prose rewritten (`/plugin configure`, `claude plugin install --config`, user-scope note, per-repo disable via `enabledPlugins`) and a CHANGELOG entry with the BREAKING env-retirement note.

**BREAKING (consumer-visible):** `HOOK_<NAME>_ENABLED`, `HOOK_STDIN_READ_TIMEOUT`, `HOOK_CLI_FLAG_VERIFY_BINS`, `HOOK_CLI_FLAG_VERIFY_SKIP_BINS`, `HOOK_INSTRUCTIONS_LOADED_AUDIT_LOG_SESSION_START` are no longer read; re-express any non-default value as the matching userConfig option. Zero-config behavior unchanged. The consumer-side `HOOK_TELEMETRY_SINK` seam is untouched.

## Verification

- Boolean mirror serialization verified against the installed CC 2.1.214 bundle: options export as `String(value)` → `"true"`/`"false"`, so the enabled-unless-"false" reader semantics hold; the reader's `${!var:-true}` fallback also covers an absent mirror.
- Full plugin test suite green (`scripts/run-plugin-tests.sh` exit 0; guardrails 248 + lib 46 assertions pass).
- `scripts/sync-hook-utils.sh --check`, `scripts/check-cross-plugin-source-drift.sh --check`, `scripts/validate-plugins.sh` (manifests + catalog, strict), `node scripts/generate-catalog.mjs --check`: all green.
- markdownlint clean on every edited markdown file.
- One sed collateral caught and repaired: a `LEFTHOOK_*` lefthook-prefix test fixture in block-no-verify.test.sh.

## Related

- #313 (fleet conformance audit epic — dims 3+6 remediation)
- #315 (userConfig wave — this PR covers the hook-channel portion)
- #321 (kill-switch doctrine reconciliation this PR implements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
