### PR TITLE
feat: make missing hook prerequisites skip visibly (10 plugins)

### DIFF
--- a/lib/hook-utils.sh
+++ b/lib/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/lib/hook-utils.sh
+++ b/lib/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -554,6 +554,28 @@ else
 fi
 rm -rf "$DATA16"
 
+# --- Test 16b: hook::raw_file_path — jq-free extraction -----------------------
+if got=$(hook::raw_file_path '{"session_id":"s","tool_input":{"file_path":"src/app.py"},"tool_name":"Write"}') && [[ "$got" == "src/app.py" ]]; then
+  ok "raw_file_path: plain path extracted"
+else
+  fail "raw_file_path: plain path (got '$got')"
+fi
+if got=$(hook::raw_file_path '{"tool_input":{"file_path":"C:\\repo\\a.yml"}}') && [[ "$got" == 'C:\\repo\\a.yml' ]]; then
+  ok "raw_file_path: JSON-escaped Windows path returned escaped"
+else
+  fail "raw_file_path: escaped path (got '$got')"
+fi
+if got=$(hook::raw_file_path '{"tool_input":{"file_path":"a \"quoted\" name.md"}}') && [[ "$got" == 'a \"quoted\" name.md' ]]; then
+  ok "raw_file_path: escaped quotes inside value survive"
+else
+  fail "raw_file_path: quoted value (got '$got')"
+fi
+if hook::raw_file_path '{"tool_name":"Bash","tool_input":{"command":"ls"}}' >/dev/null; then
+  fail "raw_file_path: no file_path should return 1"
+else
+  ok "raw_file_path: absent file_path returns 1"
+fi
+
 # --- Test 17: hook::require_jq — gate behavior --------------------------------
 # jq present → returns 0, no output, no exit.
 out17=$( (

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -460,6 +460,147 @@ else
 fi
 unset HOOK_TELEMETRY_SINK
 
+# --- Test 14: hook::json_escape ----------------------------------------------
+# Input via a variable: on Cygwin/MSYS bash a $'...' literal containing \r
+# passed as a direct argument inside $(...) loses the CR at parse time.
+in14=$'he said "hi" \\ path\nline2\ttab\rcr'
+esc=$(hook::json_escape "$in14")
+if [[ "$esc" == 'he said \"hi\" \\ path\nline2\ttab\rcr' ]]; then
+  ok "json_escape: quote/backslash/newline/tab/cr escaped"
+else
+  fail "json_escape: got '$esc'"
+fi
+esc2=$(hook::json_escape $'a\001b\033c')
+if [[ "$esc2" == "abc" ]]; then
+  ok "json_escape: residual C0 bytes dropped, other bytes kept"
+else
+  fail "json_escape: wrong residual-C0 handling: $(printf '%q' "$esc2")"
+fi
+
+# --- Test 15: hook::emit_skip_notice — valid JSON, both channels, jq-free -----
+notice=$(hook::emit_skip_notice PostToolUse 'my-plugin: tool "x" missing — skipped')
+if jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"
+  and (.hookSpecificOutput.additionalContext | contains("missing"))
+  and (.systemMessage | contains("missing"))' <<<"$notice" >/dev/null 2>&1; then
+  ok "emit_skip_notice: valid JSON with both channels"
+else
+  fail "emit_skip_notice: bad JSON or missing fields: $notice"
+fi
+# jq-free path: PATH stripped of everything (tr fallback keeps the message).
+EMPTY15="$(mktemp -d)"
+notice_nojq=$(PATH="$EMPTY15" hook::emit_skip_notice PostToolUse "p: jq missing")
+rmdir "$EMPTY15" 2>/dev/null || true
+if [[ "$notice_nojq" == *'"systemMessage":"p: jq missing"'* ]]; then
+  ok "emit_skip_notice: emits without any external binaries"
+else
+  fail "emit_skip_notice: empty-PATH emission broken: $notice_nojq"
+fi
+# Combined: distinct agent context + user message in ONE document.
+combined=$(hook::emit_channels PostToolUse $'finding line 1\nfinding line 2' 'tool missing — skipped')
+if jq -e '(.hookSpecificOutput.additionalContext | contains("finding line 2"))
+  and .systemMessage == "tool missing — skipped"' <<<"$combined" >/dev/null 2>&1; then
+  ok "emit_channels: combined ctx + sysmsg in one document"
+else
+  fail "emit_channels: combined shape wrong: $combined"
+fi
+if [[ -z "$(hook::emit_channels PostToolUse "" "")" ]]; then
+  ok "emit_channels: both empty → no output"
+else
+  fail "emit_channels: emitted with both channels empty"
+fi
+sysmsg=$(hook::emit_system_message 'notify: jq missing')
+if jq -e '.systemMessage == "notify: jq missing" and (has("hookSpecificOutput") | not)' <<<"$sysmsg" >/dev/null 2>&1; then
+  ok "emit_system_message: systemMessage-only shape"
+else
+  fail "emit_system_message: wrong shape: $sysmsg"
+fi
+
+# --- Test 16: hook::notice_once — per-session dedup via CLAUDE_PLUGIN_DATA ----
+DATA16="$(mktemp -d)"
+INPUT_S1='{"session_id":"aaaa-1111","hook_event_name":"PostToolUse"}'
+INPUT_S2='{"session_id":"bbbb-2222","hook_event_name":"PostToolUse"}'
+if (CLAUDE_PLUGIN_DATA="$DATA16" hook::notice_once "k1" "$INPUT_S1"); then
+  ok "notice_once: first call emits"
+else
+  fail "notice_once: first call suppressed"
+fi
+if (CLAUDE_PLUGIN_DATA="$DATA16" hook::notice_once "k1" "$INPUT_S1"); then
+  fail "notice_once: repeat call in same session emitted again"
+else
+  ok "notice_once: repeat call suppressed"
+fi
+if (CLAUDE_PLUGIN_DATA="$DATA16" hook::notice_once "k1" "$INPUT_S2"); then
+  ok "notice_once: new session emits again"
+else
+  fail "notice_once: new session suppressed"
+fi
+if (CLAUDE_PLUGIN_DATA="$DATA16" hook::notice_once "k2" "$INPUT_S1"); then
+  ok "notice_once: distinct key emits"
+else
+  fail "notice_once: distinct key suppressed"
+fi
+# No CLAUDE_PLUGIN_DATA → fail open toward visibility (emit every time).
+if (
+  unset CLAUDE_PLUGIN_DATA 2>/dev/null
+  hook::notice_once "k1" "$INPUT_S1"
+) &&
+  (
+    unset CLAUDE_PLUGIN_DATA 2>/dev/null
+    hook::notice_once "k1" "$INPUT_S1"
+  ); then
+  ok "notice_once: no data dir → fail-open emit"
+else
+  fail "notice_once: no data dir suppressed a notice"
+fi
+rm -rf "$DATA16"
+
+# --- Test 17: hook::require_jq — gate behavior --------------------------------
+# jq present → returns 0, no output, no exit.
+out17=$( (
+  hook::require_jq PostToolUse tp '{"session_id":"s"}'
+  echo "alive"
+) 2>/dev/null)
+if [[ "$out17" == "alive" ]]; then
+  ok "require_jq: jq present → pass-through"
+else
+  fail "require_jq: jq present misbehaved: $out17"
+fi
+# jq absent → notice on first run, exit 0; suppressed on second. Simulate the
+# REAL missing-jq shape (Git Bash without jq): a stub PATH that still carries
+# the coreutils notice_once needs (mkdir/find/tr) but no jq — an empty PATH
+# would also hide mkdir, making the dedup marker untrackable and the notice
+# fail-open on every run. bash is resolved via $BASH since the stub PATH has none.
+DATA17="$(mktemp -d)"
+FAKEBIN17="$(mktemp -d)"
+for t in mkdir find tr; do
+  real_t=$(command -v "$t")
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN17/$t"
+  chmod +x "$FAKEBIN17/$t"
+done
+run17() {
+  CLAUDE_PLUGIN_DATA="$DATA17" "$BASH" -c '
+    PATH="'"$FAKEBIN17"'"
+    source "'"$HOOK_DIR"'/hook-utils.sh"
+    hook::require_jq PostToolUse tp "{\"session_id\":\"cccc-3333\"}"
+    echo "unreachable"
+  ' 2>/dev/null
+}
+first17=$(run17)
+rc_first=$?
+second17=$(run17)
+rc_second=$?
+if [[ $rc_first -eq 0 && "$first17" == *'"systemMessage"'* && "$first17" != *unreachable* ]]; then
+  ok "require_jq: jq absent → visible notice + exit 0"
+else
+  fail "require_jq: first run rc=$rc_first out=$first17"
+fi
+if [[ $rc_second -eq 0 && "$second17" != *'"systemMessage"'* && "$second17" != *unreachable* ]]; then
+  ok "require_jq: second run same session → silent exit 0"
+else
+  fail "require_jq: second run rc=$rc_second out=$second17"
+fi
+rm -rf "$DATA17" "$FAKEBIN17"
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Missing prerequisites now skip visibly** (prerequisite-visibility wave;
+  doctrine: a silently skipped feature is a defect). When `actionlint` or `jq`
+  is absent, the hook emits a once-per-session notice to both Claude
+  (`additionalContext`) and the user (`systemMessage`) instead of a silent
+  no-op, then still exits `0` (advisory, never blocking). Notice dedup state
+  lives under `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+- README now declares the full hook runtime: Bash (Git Bash on native Windows),
+  `jq`, and `actionlint`, each with its absence behavior.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -23,12 +23,19 @@ your `PATH`.
   ShellCheck deadlocks on large blocks under the Windows subprocess IPC path in
   actionlint 1.7.x, and either adds latency unsuited to an edit-time hook.
   Native workflow diagnostics are unaffected; run the full integrations in CI.
-- **Graceful degrade.** When `actionlint` is not on `PATH` the hook is a silent
-  no-op.
+- **Graceful degrade.** When `actionlint` (or `jq`) is not on `PATH` the hook
+  skips and says so — a once-per-session notice to both Claude
+  (`additionalContext`) and you (`systemMessage`), never a silent no-op.
 
 ## Requirements
 
-- **actionlint** on `PATH`. See the
+- **Bash** — the hook is a Bash script. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run it under Git Bash.
+- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+  visible once-per-session notice. [Install jq](https://jqlang.org/download/).
+- **actionlint** on `PATH` — the linter itself. Absent: workflow lint skips
+  with a visible once-per-session notice. See the
   [actionlint install guide](https://github.com/rhysd/actionlint/blob/main/docs/install.md).
 
 ## Install

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -37,6 +37,16 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq-free applicability pre-filter: never emit the jq notice for an edit this
+# hook would not lint anyway (the Write|Edit matcher is broader than the
+# workflow-file filter). Slashes normalized from JSON-escaped backslashes;
+# loose on separators, tight on location + extension.
+RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+case "${RAW_FILE//\\//}" in
+*/.github/*workflows/*.yml | */.github/*workflows/*.yaml) ;;
+*) exit 0 ;;
+esac
+
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of a silent no-op (dim-9 doctrine).
 hook::require_jq PostToolUse actionlint "$INPUT"

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -5,8 +5,9 @@
 # ADVISORY: always exits 0. actionlint findings surface via additionalContext
 # but never block the edit. Make a commit hook or CI your hard gate.
 #
-# Graceful degrade: when actionlint is not on PATH the hook is a silent no-op
-# (exit 0) — the plugin ships no binary of its own.
+# Graceful degrade: when actionlint (or jq) is not on PATH the hook skips
+# (exit 0) with a visible once-per-session notice on both the agent and user
+# channels — the plugin ships no binary of its own.
 
 set -uo pipefail
 
@@ -36,13 +37,17 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq is load-bearing for input parsing; absent → visible once-per-session skip
+# notice instead of a silent no-op (dim-9 doctrine).
+hook::require_jq PostToolUse actionlint "$INPUT"
+
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 # Only GitHub Actions workflow files. actionlint recognizes both .yml and .yaml
 # under .github/workflows/; other YAML is not a workflow and must be skipped.
 FILE_NORM="$(hook::normalize_path "$FILE")"
 case "$FILE_NORM" in
-  */.github/workflows/*.yml | */.github/workflows/*.yaml) ;;
-  *) exit 0 ;;
+*/.github/workflows/*.yml | */.github/workflows/*.yaml) ;;
+*) exit 0 ;;
 esac
 
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
@@ -78,15 +83,19 @@ build_data_json() {
     --arg tool "$TOOL" \
     --arg file "$FILE_REL" \
     --argjson findings "$1" \
-    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
-    || printf '{"tool":"","file":"","findings":[]}'
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null ||
+    printf '{"tool":"","file":"","findings":[]}'
 }
 
-# Graceful degrade: actionlint absent -> silent no-op. Telemetry (opt-in) records
-# a "skipped" status so a consumer sink can observe the coverage gap.
+# Graceful degrade: actionlint absent -> skip, made VISIBLE once per session on
+# both channels (agent + user). Telemetry (opt-in) also records a "skipped"
+# status so a consumer sink can observe the coverage gap.
 if ! command -v actionlint >/dev/null 2>&1; then
   data_json=$(build_data_json '[]')
   emit_tel "actionlint" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  if hook::notice_once "actionlint-missing" "$INPUT"; then
+    hook::emit_skip_notice PostToolUse "actionlint: 'actionlint' not found on PATH — workflow lint skipped for this session. Install: https://github.com/rhysd/actionlint/blob/main/docs/install.md"
+  fi
   exit 0
 fi
 

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -299,6 +299,21 @@ if [[ -z "$OUT_NOJQ2" ]]; then
 else
   fail "jq-absent second run not silent: $OUT_NOJQ2"
 fi
+# Out-of-scope edit (README, not a workflow file) with jq absent -> fully
+# silent: the jq-free applicability pre-filter must run before the jq gate.
+JQ_DATA2="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+OUT_OOS=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"test-oos-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/README.md" |
+    env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA2" \
+      CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
+)
+RC_OOS=$?
+if [[ $RC_OOS -eq 0 && -z "$OUT_OOS" ]]; then
+  ok "jq-absent + out-of-scope edit -> fully silent (pre-filter before gate)"
+else
+  fail "jq-absent out-of-scope edit (rc=$RC_OOS out=$OUT_OOS)"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -81,8 +81,8 @@ run_hook() {
   local file_path="$1"
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -93,8 +93,8 @@ run_hook_env() {
   shift
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
   )
 }
 
@@ -226,34 +226,79 @@ else
 fi
 rm -f "$TELC"
 
-# --- actionlint-absent graceful degrade -> exit 0 silent, status skipped ----
-# Shadow actionlint with an empty PATH dir containing only the tools the hook
-# needs (bash/jq/git/dirname...), proving the `command -v actionlint` guard
-# yields a silent no-op. Build a PATH that resolves core tools but not actionlint.
+# --- actionlint-absent -> exit 0, VISIBLE once-per-session notice, skipped ---
+# Shadow actionlint via a fake-bin dir of exec wrappers for every tool the hook
+# needs (jq may share a real dir with actionlint, so keeping whole dirs cannot
+# isolate the shadow). First run must emit the skip notice on both channels;
+# a second run in the same session (same CLAUDE_PLUGIN_DATA + session_id) must
+# be silent; telemetry still records status "skipped".
 ABSENT_TEL="$(mktemp)"
 ABSENT_SINK="$(make_sink "cat >\"$ABSENT_TEL\"")"
-# Resolve the real dirs of the tools we must keep, minus any dir holding actionlint.
-AL_DIR="$(dirname "$(command -v actionlint)")"
-KEEP=""
-for t in bash jq git dirname basename cat env printf mktemp; do
-  d="$(dirname "$(command -v "$t" 2>/dev/null)")"
-  [[ -n "$d" && "$d" != "$AL_DIR" ]] && KEEP="$KEEP:$d"
+FAKEBIN="$(mktemp -d -p "$WORK" fakebin.XXXXXX)"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN/$t"
+  chmod +x "$FAKEBIN/$t"
 done
-OUT_ABS=$(
-  cd "$UNRELATED" || exit 1
-  printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/clean.yml" \
-    | env -u CLAUDE_PROJECT_DIR -i PATH="${KEEP#:}" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true \
-        HOOK_TELEMETRY_SINK="$ABSENT_SINK" bash "$HOOK"
-)
+ABSENT_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+run_absent() {
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"test-absent-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/clean.yml" |
+      env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$ABSENT_DATA" \
+        CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true HOOK_TELEMETRY_SINK="$ABSENT_SINK" bash "$HOOK"
+  )
+}
+OUT_ABS=$(run_absent)
 RC_ABS=$?
-if [[ $RC_ABS -eq 0 && -z "$OUT_ABS" ]]; then ok "actionlint-absent -> exit 0 silent"; else fail "actionlint-absent (rc=$RC_ABS out=$OUT_ABS)"; fi
+if [[ $RC_ABS -eq 0 ]]; then ok "actionlint-absent -> exit 0"; else fail "actionlint-absent exit $RC_ABS"; fi
+if jq -e '(.systemMessage | contains("actionlint")) and (.hookSpecificOutput.additionalContext | contains("actionlint"))' <<<"$OUT_ABS" >/dev/null 2>&1; then
+  ok "actionlint-absent -> visible notice on both channels"
+else
+  fail "actionlint-absent: notice missing or malformed: $OUT_ABS"
+fi
 wait_for_sink "$ABSENT_TEL"
 if [[ -s "$ABSENT_TEL" ]]; then
   if [[ "$(jq -r '.status' "$ABSENT_TEL")" == "skipped" ]]; then ok "actionlint-absent -> telemetry status skipped"; else fail "actionlint-absent status=$(jq -r '.status' "$ABSENT_TEL")"; fi
 else
-  echo "  (actionlint-absent: no envelope -- PATH shadow could not resolve jq; skipping status assert)"
+  fail "actionlint-absent: no telemetry envelope written"
+fi
+OUT_ABS2=$(run_absent)
+RC_ABS2=$?
+if [[ $RC_ABS2 -eq 0 && -z "$OUT_ABS2" ]]; then
+  ok "actionlint-absent -> second run same session is silent (once-per-session)"
+else
+  fail "actionlint-absent second run (rc=$RC_ABS2 out=$OUT_ABS2)"
 fi
 rm -f "$ABSENT_TEL"
+
+# --- jq-absent -> exit 0, VISIBLE once-per-session notice --------------------
+# Same fake-bin, minus jq: the hook cannot parse its input at all, so the gate
+# must surface the skip instead of silently no-opping on every edit.
+rm -f "$FAKEBIN/jq"
+JQ_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+run_nojq() {
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"test-nojq-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/clean.yml" |
+      env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA" \
+        CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
+  )
+}
+OUT_NOJQ=$(run_nojq)
+RC_NOJQ=$?
+if [[ $RC_NOJQ -eq 0 && "$OUT_NOJQ" == *'"systemMessage"'* && "$OUT_NOJQ" == *jq* ]]; then
+  ok "jq-absent -> exit 0 with visible notice"
+else
+  fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
+fi
+OUT_NOJQ2=$(run_nojq)
+if [[ -z "$OUT_NOJQ2" ]]; then
+  ok "jq-absent -> second run same session is silent (once-per-session)"
+else
+  fail "jq-absent second run not silent: $OUT_NOJQ2"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/actionlint/hooks/hook-utils.sh
+++ b/plugins/actionlint/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.0]
+
+### Changed
+
+- **Missing prerequisites now skip visibly** (prerequisite-visibility wave;
+  doctrine: a silently skipped feature is a defect). ShellCheck absent → the
+  lint pass skips with a once-per-session notice to both Claude
+  (`additionalContext`) and the user (`systemMessage`). shfmt absent while an
+  `.editorconfig` opts the repo into formatting → same visible skip for the
+  format pass (no opt-in stays quiet — the repo chose not to format). `jq`
+  absent → the whole hook skips visibly. Findings and a pending notice compose
+  into a single JSON document. Notice dedup state lives under
+  `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+- README now declares the full hook runtime: Bash (Git Bash on native Windows),
+  `jq`, ShellCheck, and shfmt, each with its absence behavior.
+
 ## [0.3.0]
 
 ### Changed

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -33,12 +33,20 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 
 ## Requirements
 
-- **ShellCheck** on `PATH` for the lint pass.
-- **shfmt** on `PATH` for the format pass (and an `.editorconfig` in your repo to
-  opt in).
+- **Bash** — the hook is a Bash script. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run it under Git Bash.
+- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+  visible once-per-session notice. [Install jq](https://jqlang.org/download/).
+- **ShellCheck** on `PATH` for the lint pass. Absent: the lint pass skips with
+  a visible once-per-session notice.
+- **shfmt** on `PATH` for the format pass (and an `.editorconfig` in your repo
+  to opt in). Absent while the repo opts in: the format pass skips with a
+  visible once-per-session notice. Without the `.editorconfig` opt-in the
+  format pass stays quiet — the repo chose not to format.
 
-Each pass is independent: when a tool is absent its pass is skipped and the other
-still runs. With neither present the hook is a silent no-op.
+Each pass is independent: when a tool is absent its pass is skipped (visibly)
+and the other still runs.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`
 (Bash 5.0+); on older bash the telemetry envelope is skipped while linting and

--- a/plugins/bash-format/hooks/bash-format.sh
+++ b/plugins/bash-format/hooks/bash-format.sh
@@ -39,6 +39,15 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq-free applicability pre-filter: never emit the jq notice for an edit this
+# hook would not process anyway (the Write|Edit matcher is broader than the
+# shell-file filter).
+RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+case "$RAW_FILE" in
+*.sh | *.bash) ;;
+*) exit 0 ;;
+esac
+
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of a silent no-op (dim-9 doctrine).
 hook::require_jq PostToolUse bash-format "$INPUT"

--- a/plugins/bash-format/hooks/bash-format.sh
+++ b/plugins/bash-format/hooks/bash-format.sh
@@ -39,6 +39,10 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq is load-bearing for input parsing; absent → visible once-per-session skip
+# notice instead of a silent no-op (dim-9 doctrine).
+hook::require_jq PostToolUse bash-format "$INPUT"
+
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 case "$FILE" in
 *.sh | *.bash) ;;
@@ -130,53 +134,77 @@ shell_editorconfig_opt_in() {
 
 ran_any=0
 
+# Missing-tool notice accumulator: a run can lack shfmt AND shellcheck, and can
+# carry ShellCheck findings alongside a pending shfmt notice — everything must
+# compose into the single JSON document emitted at the end (hook::emit_channels).
+NOTICE=""
+append_notice() {
+  [[ -n "$NOTICE" ]] && NOTICE+=" "
+  NOTICE+="$1"
+}
+
 # Format pass (opt-in, mutating). No parser/printer flags — that keeps
 # .editorconfig formatting in effect. --apply-ignore is a utility flag (not a
 # parser/printer flag, so it does not disable editorconfig formatting): it makes
 # shfmt honor `ignore = true` editorconfig rules for this single direct file,
 # which it otherwise skips for direct-file invocations — so a repo's opt-out for
 # generated/vendored scripts is respected, not overwritten.
-if command -v shfmt >/dev/null 2>&1 && shell_editorconfig_opt_in; then
-  # --apply-ignore requires shfmt 3.8+ (2024-02). On older shfmt the flag is
-  # unknown and the call fails without formatting, so fall back to a plain
-  # in-place format — those versions cannot honor direct-file ignore rules
-  # anyway (that is exactly the capability --apply-ignore adds). On shfmt 3.8+
-  # the first call succeeds (skipping ignored files), so the fallback never runs.
-  shfmt --apply-ignore -w "$FILE" 2>/dev/null || shfmt -w "$FILE" 2>/dev/null
-  ran_any=1
+# The consumer opted in via .editorconfig but shfmt is absent → visible
+# once-per-session skip notice, not a silent gap (dim-9 doctrine). No opt-in →
+# quiet (N/A, the repo chose not to format).
+if shell_editorconfig_opt_in; then
+  if command -v shfmt >/dev/null 2>&1; then
+    # --apply-ignore requires shfmt 3.8+ (2024-02). On older shfmt the flag is
+    # unknown and the call fails without formatting, so fall back to a plain
+    # in-place format — those versions cannot honor direct-file ignore rules
+    # anyway (that is exactly the capability --apply-ignore adds). On shfmt 3.8+
+    # the first call succeeds (skipping ignored files), so the fallback never runs.
+    shfmt --apply-ignore -w "$FILE" 2>/dev/null || shfmt -w "$FILE" 2>/dev/null
+    ran_any=1
+  elif hook::notice_once "bash-format-shfmt" "$INPUT"; then
+    append_notice "bash-format: .editorconfig opts this repo into shell formatting but 'shfmt' is not on PATH — formatting skipped for this session. Install: https://github.com/mvdan/sh#shfmt"
+  fi
 fi
 
 # Lint pass (always-on, non-mutating). -x follows `source`/`.` directives;
 # -f gcc gives one finding per line; -S warning drops info/style noise. Config
 # (.shellcheckrc) is auto-discovered from the file's directory upward.
+# ShellCheck absent → visible once-per-session skip notice (dim-9 doctrine).
+CTX=""
+FINDINGS_JSON='[]'
 if command -v shellcheck >/dev/null 2>&1; then
   ran_any=1
   SC_OUTPUT=$(shellcheck -x -f gcc -S warning "$FILE" 2>&1) || true
   if [[ -n "$SC_OUTPUT" ]]; then
-    hook::ctx_reset
-    hook::ctx_append "bash-format: $(basename "$FILE") has ShellCheck findings:"
+    CTX="bash-format: $(basename "$FILE") has ShellCheck findings:"$'\n'
     findings_raw=""
     while IFS= read -r line; do
       [[ -n "$line" ]] || continue
-      hook::ctx_append "  $line"
+      CTX+="  $line"$'\n'
       findings_raw+="$line"$'\n'
     done <<<"$SC_OUTPUT"
-    hook::ctx_flush PostToolUse
-
-    FINDINGS_JSON='[]'
     if [[ -n "$findings_raw" ]]; then
       FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
     fi
-    data_json=$(build_data_json "$FINDINGS_JSON")
-    emit_tel "bash-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
-    exit 0
   fi
+elif hook::notice_once "bash-format-shellcheck" "$INPUT"; then
+  append_notice "bash-format: 'shellcheck' not found on PATH — shell lint skipped for this session. Install: https://github.com/koalaman/shellcheck#installing"
 fi
 
-# No findings. "skipped" when neither tool did anything (both absent / no opt-in);
-# "ok" when at least one pass ran cleanly.
+# Single emission point: findings on the agent channel, missing-tool notice on
+# both channels, composed into one JSON document.
+CTX="${CTX%$'\n'}"
+if [[ -n "$NOTICE" ]]; then
+  AGENT_CTX="$CTX"
+  [[ -n "$AGENT_CTX" ]] && AGENT_CTX+=$'\n'
+  AGENT_CTX+="$NOTICE"
+  hook::emit_channels PostToolUse "$AGENT_CTX" "$NOTICE"
+else
+  hook::emit_channels PostToolUse "$CTX" ""
+fi
+
 status="ok"
 [[ $ran_any -eq 0 ]] && status="skipped"
-data_json=$(build_data_json '[]')
+data_json=$(build_data_json "$FINDINGS_JSON")
 emit_tel "bash-format" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
 exit 0

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -393,6 +393,21 @@ if [[ $RC_NOJQ -eq 0 && "$OUT_NOJQ" == *'"systemMessage"'* && "$OUT_NOJQ" == *jq
 else
   fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
 fi
+# Out-of-scope edit (a .md file) with jq absent -> fully silent: the jq-free
+# applicability pre-filter must run before the jq gate.
+JQ_DATA2="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+OUT_OOS=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"test-oos-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/README.md" |
+    env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA2" \
+      CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
+)
+RC_OOS=$?
+if [[ $RC_OOS -eq 0 && -z "$OUT_OOS" ]]; then
+  ok "jq-absent + out-of-scope edit -> fully silent (pre-filter before gate)"
+else
+  fail "jq-absent out-of-scope edit (rc=$RC_OOS out=$OUT_OOS)"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -86,8 +86,8 @@ run_hook() {
   local file_path="$1"
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -98,8 +98,8 @@ run_hook_env() {
   shift
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
   )
 }
 
@@ -301,6 +301,98 @@ else
   fail "telemetry/clean: no envelope written"
 fi
 rm -f "$TELC"
+
+# --- Missing-tool visibility (dim-9 doctrine) --------------------------------
+# Fake-bin dir of exec wrappers so individual tools can be removed from PATH
+# without losing the coreutils the hook and the notice dedup need.
+FAKEBIN="$(mktemp -d -p "$WORK" fakebin.XXXXXX)"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink shellcheck shfmt; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN/$t"
+  chmod +x "$FAKEBIN/$t"
+done
+
+# ShellCheck absent -> visible once-per-session notice on both channels.
+rm -f "$FAKEBIN/shellcheck" "$FAKEBIN/shfmt"
+SC_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+run_no_tools() {
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"test-sc-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$1" |
+      env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$SC_DATA" \
+        CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
+  )
+}
+OUT_SC=$(run_no_tools "$REPO/clean.sh")
+RC_SC=$?
+if [[ $RC_SC -eq 0 ]]; then ok "shellcheck-absent -> exit 0"; else fail "shellcheck-absent exit $RC_SC"; fi
+if jq -e '(.systemMessage | contains("shellcheck")) and (.hookSpecificOutput.additionalContext | contains("shellcheck"))' <<<"$OUT_SC" >/dev/null 2>&1; then
+  ok "shellcheck-absent -> visible notice on both channels"
+else
+  fail "shellcheck-absent: notice missing or malformed: $OUT_SC"
+fi
+OUT_SC2=$(run_no_tools "$REPO/clean.sh")
+if [[ -z "$OUT_SC2" ]]; then
+  ok "shellcheck-absent -> second run same session is silent (once-per-session)"
+else
+  fail "shellcheck-absent second run not silent: $OUT_SC2"
+fi
+
+# shfmt-absent WITH .editorconfig opt-in + shellcheck PRESENT with findings ->
+# ONE JSON document: findings in additionalContext, shfmt notice on both
+# channels (composition contract: a hook's stdout is a single JSON doc).
+printf '#!/bin/sh\nexec "%s" "$@"\n' "$(command -v shellcheck)" >"$FAKEBIN/shellcheck"
+chmod +x "$FAKEBIN/shellcheck"
+REPO_MIX="$WORK/mixrepo"
+new_repo "$REPO_MIX"
+cat >"$REPO_MIX/.editorconfig" <<'EOF'
+root = true
+
+[*.sh]
+indent_style = space
+indent_size = 2
+EOF
+printf '#!/bin/bash\ncd /tmp\necho done\n' >"$REPO_MIX/finding.sh"
+MIX_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+OUT_MIX=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"test-mix-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO_MIX/finding.sh" |
+    env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$MIX_DATA" \
+      CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
+)
+RC_MIX=$?
+if [[ $RC_MIX -eq 0 ]]; then ok "shfmt-absent+findings -> exit 0"; else fail "shfmt-absent+findings exit $RC_MIX"; fi
+DOCS=$(jq -s 'length' <<<"$OUT_MIX" 2>/dev/null)
+if [[ "$DOCS" == "1" ]]; then
+  ok "shfmt-absent+findings -> single JSON document on stdout"
+else
+  fail "shfmt-absent+findings: stdout is not one JSON doc (docs=$DOCS): $OUT_MIX"
+fi
+if jq -e '(.hookSpecificOutput.additionalContext | contains("SC2164"))
+  and (.hookSpecificOutput.additionalContext | contains("shfmt"))
+  and (.systemMessage | contains("shfmt"))
+  and (.systemMessage | contains("SC2164") | not)' <<<"$OUT_MIX" >/dev/null 2>&1; then
+  ok "shfmt-absent+findings -> findings on agent channel, notice on both, findings not in systemMessage"
+else
+  fail "shfmt-absent+findings: composition wrong: $OUT_MIX"
+fi
+
+# jq-absent -> visible once-per-session notice (input parsing gate).
+rm -f "$FAKEBIN/jq"
+JQ_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+OUT_NOJQ=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"test-nojq-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/clean.sh" |
+    env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA" \
+      CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK"
+)
+RC_NOJQ=$?
+if [[ $RC_NOJQ -eq 0 && "$OUT_NOJQ" == *'"systemMessage"'* && "$OUT_NOJQ" == *jq* ]]; then
+  ok "jq-absent -> exit 0 with visible notice"
+else
+  fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/plugins/bash-format/hooks/hook-utils.sh
+++ b/plugins/bash-format/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/bash-format/hooks/hook-utils.sh
+++ b/plugins/bash-format/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Missing prerequisites now skip visibly** (prerequisite-visibility wave;
+  doctrine: a silently skipped feature is a defect). A repo governed by a Biome
+  config with no `biome` binary available (node_modules/.bin or PATH) → the
+  hook skips with a once-per-session notice to both Claude
+  (`additionalContext`) and the user (`systemMessage`); a repo without a Biome
+  config stays quiet (the opt-out). `jq` absent → the whole hook skips visibly.
+  Notice dedup state lives under `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+- README now declares the full hook runtime: Bash (Git Bash on native Windows),
+  `jq`, and Biome, each with its absence behavior.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/biome-format/README.md
+++ b/plugins/biome-format/README.md
@@ -37,9 +37,15 @@ runs only when your repo has opted into Biome.
 
 ## Requirements
 
+- **Bash** — the hook is a Bash script. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run it under Git Bash.
+- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+  visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **Biome** available to the repo — installed in the repo's `node_modules`
   (the hook runs `node_modules/.bin/biome`) or on `PATH`. Biome is never
-  downloaded on the fly; if it is not present, the hook is a silent no-op.
+  downloaded on the fly; if it is not present while a Biome config governs the
+  repo, the hook skips with a visible once-per-session notice.
   **Biome 2.x is recommended** (tested against 2.5.1): the hook invokes
   `check --write --error-on-warnings --reporter=github`, and on much older
   releases those flags may be absent, in which case the run is reported as a

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -43,6 +43,15 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq-free applicability pre-filter: never emit the jq notice for an edit this
+# hook would not process anyway (the Write|Edit matcher is broader than the
+# JS/TS/JSON filter).
+RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+case "$RAW_FILE" in
+*.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs | *.mts | *.cts | *.json | *.jsonc) ;;
+*) exit 0 ;;
+esac
+
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of a silent no-op (dim-9 doctrine).
 hook::require_jq PostToolUse biome-format "$INPUT"

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -43,10 +43,14 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq is load-bearing for input parsing; absent → visible once-per-session skip
+# notice instead of a silent no-op (dim-9 doctrine).
+hook::require_jq PostToolUse biome-format "$INPUT"
+
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 case "$FILE" in
-  *.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs | *.mts | *.cts | *.json | *.jsonc) ;;
-  *) exit 0 ;;
+*.ts | *.tsx | *.js | *.jsx | *.mjs | *.cjs | *.mts | *.cts | *.json | *.jsonc) ;;
+*) exit 0 ;;
 esac
 
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
@@ -83,8 +87,8 @@ build_data_json() {
     --arg tool "$TOOL" \
     --arg file "$FILE_REL" \
     --argjson findings "$1" \
-    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
-    || printf '{"tool":"","file":"","findings":[]}'
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null ||
+    printf '{"tool":"","file":"","findings":[]}'
 }
 
 emit_skipped() {
@@ -148,7 +152,14 @@ if [[ -z "$BIOME_BIN" ]]; then
   BIOME_BIN="$(command -v biome 2>/dev/null)" || BIOME_BIN=""
 fi
 
-[[ -n "$BIOME_BIN" ]] || emit_skipped
+# The repo opted in via a Biome config but no binary is available → visible
+# once-per-session skip notice, not a silent gap (dim-9 doctrine).
+if [[ -z "$BIOME_BIN" ]]; then
+  if hook::notice_once "biome-format-biome" "$INPUT"; then
+    hook::emit_skip_notice PostToolUse "biome-format: a Biome config governs this repo but no 'biome' binary was found (node_modules/.bin or PATH) — format/lint skipped for this session. Install: npm install --save-dev @biomejs/biome"
+  fi
+  emit_skipped
+fi
 
 # Pass the file as a path relative to CONFIG_DIR (the CWD Biome runs in) so the
 # github reporter echoes a clean repo-relative path (e.g. src/app.ts) instead of

--- a/plugins/biome-format/hooks/biome-format.test.sh
+++ b/plugins/biome-format/hooks/biome-format.test.sh
@@ -33,6 +33,47 @@ ok() {
   PASS=$((PASS + 1))
 }
 
+# --- Missing-binary visibility (dim-9 doctrine) ------------------------------
+# Needs NO real Biome, so it runs even when the rest of the suite skips: a repo
+# with a governing biome.json but no binary anywhere must produce a visible
+# once-per-session skip notice on both channels, silent on the second run.
+NB_WORK="$(mktemp -d)"
+NB_FAKEBIN="$NB_WORK/fakebin"
+mkdir -p "$NB_FAKEBIN"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$NB_FAKEBIN/$t"
+  chmod +x "$NB_FAKEBIN/$t"
+done
+NB_REPO="$NB_WORK/repo"
+mkdir -p "$NB_REPO"
+git -C "$NB_REPO" init -q
+printf '{}\n' >"$NB_REPO/biome.json"
+printf 'const x = 1\n' >"$NB_REPO/app.js"
+NB_DATA="$NB_WORK/plugdata"
+mkdir -p "$NB_DATA"
+run_nb() {
+  printf '{"session_id":"test-nobiome-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$NB_REPO/app.js" |
+    env -u CLAUDE_PROJECT_DIR PATH="$NB_FAKEBIN" CLAUDE_PLUGIN_DATA="$NB_DATA" \
+      CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true bash "$HOOK"
+}
+OUT_NB=$(run_nb)
+RC_NB=$?
+if [[ $RC_NB -eq 0 ]]; then ok "biome-absent -> exit 0"; else fail "biome-absent exit $RC_NB"; fi
+if jq -e '(.systemMessage | contains("biome")) and (.hookSpecificOutput.additionalContext | contains("Biome config"))' <<<"$OUT_NB" >/dev/null 2>&1; then
+  ok "biome-absent with governing config -> visible notice on both channels"
+else
+  fail "biome-absent: notice missing or malformed: $OUT_NB"
+fi
+OUT_NB2=$(run_nb)
+if [[ -z "$OUT_NB2" ]]; then
+  ok "biome-absent -> second run same session is silent (once-per-session)"
+else
+  fail "biome-absent second run not silent: $OUT_NB2"
+fi
+rm -rf "$NB_WORK"
+
 # Resolve a real Biome binary. node_modules/.bin/biome shims in each fixture
 # forward to this. Skip the suite when none is available.
 if [[ -n "${BIOME_TEST_BIN:-}" && -x "${BIOME_TEST_BIN}" ]]; then
@@ -40,8 +81,10 @@ if [[ -n "${BIOME_TEST_BIN:-}" && -x "${BIOME_TEST_BIN}" ]]; then
 elif command -v biome >/dev/null 2>&1; then
   REAL_BIOME="$(command -v biome)"
 else
-  echo "SKIP: no Biome binary (set BIOME_TEST_BIN or put biome on PATH) -- biome-format hook tests skipped"
-  exit 0
+  echo "SKIP: no Biome binary (set BIOME_TEST_BIN or put biome on PATH) -- remaining biome-format hook tests skipped"
+  echo "PASS=$PASS FAIL=$FAIL"
+  [[ $FAIL -eq 0 ]]
+  exit
 fi
 
 WORK="$(mktemp -d)"
@@ -105,8 +148,8 @@ run_hook() {
   local file_path="$1"
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_BIOME_FORMAT_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -116,8 +159,8 @@ run_hook_env() {
   shift
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
   )
 }
 

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/biome-format/hooks/hook-utils.sh
+++ b/plugins/biome-format/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,14 +1,27 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Claude Code operations toolkit. Five skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["claude-code", "operations", "observability", "otel", "troubleshooting", "changelog", "monitoring", "hooks", "telemetry", "audit", "plugins", "marketplace"],
+  "keywords": [
+    "claude-code",
+    "operations",
+    "observability",
+    "otel",
+    "troubleshooting",
+    "changelog",
+    "monitoring",
+    "hooks",
+    "telemetry",
+    "audit",
+    "plugins",
+    "marketplace"
+  ],
   "userConfig": {
     "registry_dir": {
       "type": "string",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.1]
+
+### Changed
+
+- Shared `hook-utils.sh` resynced with the fleet's new prerequisite-visibility
+  helpers (jq-free notice emitters, once-per-session gate, jq gate). No
+  behavior change for this plugin's audit hooks. README now states the hook
+  runtime (Bash via Git Bash on native Windows, jq) and the jq fail-open
+  behavior.
+
 ## [0.11.0]
 
 ### Changed

--- a/plugins/claude-ops/README.md
+++ b/plugins/claude-ops/README.md
@@ -148,6 +148,10 @@ your own repository's context:
 
 ## Requirements
 
+The audit hooks are Bash scripts (Git Bash on native Windows — install
+[Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)) and
+use `jq`; without jq they fail open (no audit line is written).
+
 Core flows need only `git`, `jq`, `gh` (authenticated), and `python3`.
 Optional: `duckdb` for OTEL store queries and `npx` for ccusage. The machine-level
 `otelcol-contrib` service and Aspire dashboard Compose stack are provisioned separately; the

--- a/plugins/claude-ops/hooks/hook-utils.sh
+++ b/plugins/claude-ops/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/claude-ops/hooks/hook-utils.sh
+++ b/plugins/claude-ops/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "desktop-notification",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/desktop-notification/CHANGELOG.md
+++ b/plugins/desktop-notification/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `desktop-notification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Missing jq now skips visibly** (prerequisite-visibility wave; doctrine: a
+  silently skipped feature is a defect). Without `jq` the hook can neither
+  classify the notification nor emit its terminal sequence, so it now surfaces
+  a once-per-session `systemMessage` notice (the Notification event has no
+  `additionalContext` channel) instead of silently dropping every
+  notification. Notice dedup state lives under
+  `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+- README now states the jq absence behavior and the Bash (Git Bash on native
+  Windows) hook runtime.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/desktop-notification/README.md
+++ b/plugins/desktop-notification/README.md
@@ -33,9 +33,12 @@ just the message.
 
 ## Requirements
 
-The hook runs on Bash 3.2+ and needs [`jq`](https://jqlang.github.io/jq/) on
-`PATH`. macOS needs nothing further; Linux needs `libnotify` only for the
-`os_toast` channel; Windows needs nothing (terminal channels only). Telemetry
+The hook runs on Bash 3.2+ (Git Bash on native Windows — install
+[Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)) and
+needs [`jq`](https://jqlang.github.io/jq/) on `PATH`; without jq, notifications
+are disabled with a visible once-per-session notice. macOS needs nothing
+further; Linux needs `libnotify` only for the `os_toast` channel; Windows needs
+nothing (terminal channels only). Telemetry
 timing uses `EPOCHREALTIME` (Bash 5.0+); on older bash the telemetry envelope is
 skipped while notifications still fire.
 

--- a/plugins/desktop-notification/hooks/desktop-notification.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.sh
@@ -45,6 +45,17 @@ start=${EPOCHREALTIME:-}
 # parsed from the buffered value; reading fd0 twice would drain the pipe.
 INPUT=$(cat)
 
+# jq is load-bearing for parsing and for the terminalSequence emission; absent →
+# visible once-per-session notice instead of silently dropping every
+# notification (dim-9 doctrine). systemMessage-only: the Notification event has
+# no additionalContext channel.
+if ! command -v jq >/dev/null 2>&1; then
+  if hook::notice_once "desktop-notification-jq" "$INPUT"; then
+    hook::emit_system_message "desktop-notification: jq not found on PATH — desktop notifications disabled for this session. Install jq (https://jqlang.org/download/) to enable them."
+  fi
+  exit 0
+fi
+
 # Extract notification details. Strip ALL C0 control bytes (\000-\037 — includes
 # ESC, BEL, CR, LF, TAB) from the UNTRUSTED .message at parse time, before it can
 # reach ANY sink: an embedded ESC/BEL would otherwise smuggle terminal escapes
@@ -61,15 +72,15 @@ MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // "Needs your attention"' 2>/d
 # types (no telemetry — same shape as a matcher miss). The default-message
 # override only applies when the system supplied the generic placeholder.
 case "$TYPE" in
-  permission_prompt)
-    HEADLINE="Permission Required"
-    DEFAULT_MSG="Needs your approval to continue"
-    ;;
-  idle_prompt)
-    HEADLINE="Input Needed"
-    DEFAULT_MSG="Waiting for your input"
-    ;;
-  *) exit 0 ;;
+permission_prompt)
+  HEADLINE="Permission Required"
+  DEFAULT_MSG="Needs your approval to continue"
+  ;;
+idle_prompt)
+  HEADLINE="Input Needed"
+  DEFAULT_MSG="Waiting for your input"
+  ;;
+*) exit 0 ;;
 esac
 
 [[ "$MESSAGE" == "Needs your attention" ]] && MESSAGE="$DEFAULT_MSG"
@@ -117,27 +128,27 @@ if [[ "${CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED:-true}" == "
   BODY="$MESSAGE"
   [[ -n "$BRANCH" ]] && BODY="$MESSAGE — $BRANCH"
   case "$(uname -s)" in
-    Darwin)
-      # Pass text via argv, NEVER interpolated into the AppleScript source: a `"`
-      # in $BODY would close the string literal and a newline inject statements
-      # (→ code execution). `osascript -` reads the program from stdin (the quoted
-      # heredoc, so nothing expands); the trailing args populate `on run argv`.
-      osascript - "$HEADLINE" "$BODY" >/dev/null 2>&1 <<'OSA' &
+  Darwin)
+    # Pass text via argv, NEVER interpolated into the AppleScript source: a `"`
+    # in $BODY would close the string literal and a newline inject statements
+    # (→ code execution). `osascript -` reads the program from stdin (the quoted
+    # heredoc, so nothing expands); the trailing args populate `on run argv`.
+    osascript - "$HEADLINE" "$BODY" >/dev/null 2>&1 <<'OSA' &
 on run argv
   display notification (item 2 of argv) with title (item 1 of argv)
 end run
 OSA
+    CHANNELS+=("os_toast")
+    ;;
+  Linux)
+    if command -v notify-send >/dev/null 2>&1; then
+      # `--` terminates option parsing so a title/body starting with `-` is
+      # treated as a positional, never an option flag.
+      notify-send -- "$HEADLINE" "$BODY" >/dev/null 2>&1 &
       CHANNELS+=("os_toast")
-      ;;
-    Linux)
-      if command -v notify-send >/dev/null 2>&1; then
-        # `--` terminates option parsing so a title/body starting with `-` is
-        # treated as a positional, never an option flag.
-        notify-send -- "$HEADLINE" "$BODY" >/dev/null 2>&1 &
-        CHANNELS+=("os_toast")
-      fi
-      ;;
-    *) ;; # Windows / unknown — no OS toast; terminal channels carry attention.
+    fi
+    ;;
+  *) ;; # Windows / unknown — no OS toast; terminal channels carry attention.
   esac
 fi
 
@@ -152,8 +163,8 @@ if [[ -n "$start" ]] && hook::telemetry_enabled; then
     status="skipped"
   fi
   data_json=$(jq -nc --arg nt "$TYPE" --argjson channels "$ch_json" \
-    '{notification_type:$nt,channels:$channels}' 2>/dev/null) \
-    || data_json='{"notification_type":"","channels":[]}'
+    '{notification_type:$nt,channels:$channels}' 2>/dev/null) ||
+    data_json='{"notification_type":"","channels":[]}'
   hook::emit_telemetry "desktop-notification" "Notification" "$status" "$start" "$data_json" "$REPO_ROOT"
 fi
 

--- a/plugins/desktop-notification/hooks/desktop-notification.test.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.test.sh
@@ -79,8 +79,8 @@ build_input() {
 run() {
   local input="$1"
   shift
-  (cd "$UNRELATED" && printf '%s' "$input" \
-    | env -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED \
+  (cd "$UNRELATED" && printf '%s' "$input" |
+    env -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED \
       -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
       -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED \
       -u HOOK_TELEMETRY_SINK \
@@ -97,8 +97,8 @@ bel_count() {
 }
 
 # --- Case 1: master kill switch false → silent exit 0 -----------------------
-OUT="$(cd "$UNRELATED" && build_input permission_prompt \
-  | env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$FAKE_REPO" \
+OUT="$(cd "$UNRELATED" && build_input permission_prompt |
+  env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$FAKE_REPO" \
     CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=false bash "$HOOK" 2>&1)"
 RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "kill switch false → silent exit 0"; else fail "kill switch (rc=$RC out=$OUT)"; fi
@@ -272,8 +272,8 @@ OSA_LOG="$WORK/osa.log"
 chmod +x "$SHIM/uname" "$SHIM/osascript"
 
 IN_EVIL="$(build_input permission_prompt "$EVIL")"
-(cd "$UNRELATED" && printf '%s' "$IN_EVIL" \
-  | env -u HOOK_TELEMETRY_SINK -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED \
+(cd "$UNRELATED" && printf '%s' "$IN_EVIL" |
+  env -u HOOK_TELEMETRY_SINK -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_BELL_ENABLED \
     -u CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_TERMINAL_NOTIFY_ENABLED \
     CLAUDE_PROJECT_DIR="$FAKE_REPO" CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=true \
     CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_OS_TOAST_ENABLED=true PATH="$SHIM:$PATH" \
@@ -293,6 +293,40 @@ if grep '^ARG=' "$OSA_LOG" 2>/dev/null | grep -q 'display notification'; then fa
 PROG="$(sed -n '/^PROG<</,/^>>PROG/p' "$OSA_LOG" 2>/dev/null)"
 if printf '%s' "$PROG" | grep -q 'danger'; then fail "sanitize/osascript: message text interpolated into program: $PROG"; else ok "sanitize/osascript: message text absent from program (argv-only)"; fi
 if printf '%s' "$PROG" | grep -q 'display notification (item 2 of argv)'; then ok "sanitize/osascript: program reads body from argv"; else fail "sanitize/osascript: program shape unexpected: $PROG"; fi
+
+# --- jq-absent -> visible once-per-session notice (dim-9 doctrine) -----------
+# Without jq the hook can neither classify the notification nor emit its
+# terminalSequence; the skip must surface via systemMessage (the Notification
+# event has no additionalContext channel) once per session.
+FAKEBIN="$(mktemp -d -p "$WORK" fakebin.XXXXXX)"
+for t in bash git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN/$t"
+  chmod +x "$FAKEBIN/$t"
+done
+JQ_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+run_nojq() {
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"test-nojq-1","notification_type":"permission_prompt","message":"Needs your attention"}' |
+      env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA" \
+        CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATION_ENABLED=true bash "$HOOK"
+  )
+}
+OUT_NOJQ=$(run_nojq)
+RC_NOJQ=$?
+if [[ $RC_NOJQ -eq 0 && "$OUT_NOJQ" == *'"systemMessage"'* && "$OUT_NOJQ" == *jq* && "$OUT_NOJQ" != *hookSpecificOutput* ]]; then
+  ok "jq-absent -> exit 0 with systemMessage-only notice"
+else
+  fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
+fi
+OUT_NOJQ2=$(run_nojq)
+if [[ -z "$OUT_NOJQ2" ]]; then
+  ok "jq-absent -> second run same session is silent (once-per-session)"
+else
+  fail "jq-absent second run not silent: $OUT_NOJQ2"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/desktop-notification/hooks/hook-utils.sh
+++ b/plugins/desktop-notification/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Missing jq now skips visibly** (prerequisite-visibility wave; doctrine: a
+  silently skipped feature is a defect). Without `jq` the hook cannot parse its
+  input, so it now surfaces a once-per-session notice to both Claude
+  (`additionalContext`) and the user (`systemMessage`) instead of silently
+  disabling normalization. Notice dedup state lives under
+  `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+- README now declares the full hook runtime: Bash (Git Bash on native Windows),
+  `jq`, and git, with the no-git-repo case classified as a quiet not-applicable
+  rather than a missing prerequisite.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -31,8 +31,14 @@ imposes no rules of its own.
 
 ## Requirements
 
+- **Bash** — the hook is a Bash script. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run it under Git Bash.
+- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+  visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **git** on `PATH` — the attribute resolution (`git check-attr`) and repo-root
-  detection depend on it. Without a git repository the hook is a silent no-op.
+  detection depend on it. Without a git repository the hook is a quiet no-op
+  (nothing to normalize against — not a missing prerequisite).
 
 Rewriting uses `perl` when present, falling back to `tr`/`awk` otherwise, so no
 extra tooling is required.

--- a/plugins/eol-normalizer/hooks/eol-normalizer.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.sh
@@ -46,6 +46,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/normalize-eol.sh"
 
 INPUT=$(cat)
 
+# jq is load-bearing for input parsing; absent → visible once-per-session skip
+# notice instead of silently disabling the whole hook (dim-9 doctrine).
+hook::require_jq PostToolUse eol-normalizer "$INPUT"
+
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 
@@ -79,8 +83,8 @@ build_data_json() {
     --arg tool "$TOOL" \
     --arg file "$FILE_REL" \
     --arg action "$1" \
-    '{tool:$tool,file:$file,action:$action}' 2>/dev/null \
-    || printf '{"tool":"","file":"","action":""}'
+    '{tool:$tool,file:$file,action:$action}' 2>/dev/null ||
+    printf '{"tool":"","file":"","action":""}'
 }
 
 # The lib mutates the file in place (side effect persists past the subshell) and
@@ -90,8 +94,8 @@ ACTION=$(normalize_eol_file "$REPO_ROOT" "$FILE")
 # status "ok" when the file was actually normalized (lf/crlf); "skipped" when the
 # attr was unspecified, the path is -text, or content sniffed binary.
 case "$ACTION" in
-  lf | crlf) status="ok" ;;
-  *) status="skipped" ;;
+lf | crlf) status="ok" ;;
+*) status="skipped" ;;
 esac
 
 data_json=$(build_data_json "$ACTION")

--- a/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.test.sh
@@ -82,8 +82,8 @@ run_hook() {
   local file_path="$1"
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true bash "$HOOK"
   )
 }
 
@@ -93,8 +93,8 @@ run_hook_env() {
   shift
   (
     cd "$UNRELATED" || return 1
-    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" \
-      | env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
   )
 }
 
@@ -168,7 +168,10 @@ printf '#!/bin/sh\r\necho hi\r\n' >"$REPO/exec.sh"
 chmod 755 "$REPO/exec.sh"
 (
   # shellcheck disable=SC2329  # invoked indirectly: the sourced lib's `command -v perl` probe hits this shadow
-  command() { if [[ "${1:-}" == "-v" && "${2:-}" == "perl" ]]; then return 1; fi; builtin command "$@"; }
+  command() {
+    if [[ "${1:-}" == "-v" && "${2:-}" == "perl" ]]; then return 1; fi
+    builtin command "$@"
+  }
   # Prove the shim actually hides perl before relying on it.
   if command -v perl >/dev/null 2>&1; then
     echo "FAIL: test shim: perl shadow ineffective" >&2
@@ -235,6 +238,41 @@ else
   fail "telemetry/unspecified: no envelope written"
 fi
 rm -f "$TELS"
+
+# --- jq-absent -> visible once-per-session notice (dim-9 doctrine) -----------
+# Without jq the hook cannot parse its input at all; the skip must surface on
+# both channels once per session instead of silently disabling normalization.
+FAKEBIN="$(mktemp -d -p "$WORK" fakebin.XXXXXX)"
+for t in bash git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN/$t"
+  chmod +x "$FAKEBIN/$t"
+done
+JQ_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+run_nojq() {
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"test-nojq-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$1" |
+      env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA" \
+        CLAUDE_PLUGIN_OPTION_EOL_NORMALIZER_ENABLED=true bash "$HOOK"
+  )
+}
+NOJQ_FILE="$WORK/nojq.txt"
+printf 'x\n' >"$NOJQ_FILE"
+OUT_NOJQ=$(run_nojq "$NOJQ_FILE")
+RC_NOJQ=$?
+if [[ $RC_NOJQ -eq 0 && "$OUT_NOJQ" == *'"systemMessage"'* && "$OUT_NOJQ" == *jq* ]]; then
+  ok "jq-absent -> exit 0 with visible notice"
+else
+  fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
+fi
+OUT_NOJQ2=$(run_nojq "$NOJQ_FILE")
+if [[ -z "$OUT_NOJQ2" ]]; then
+  ok "jq-absent -> second run same session is silent (once-per-session)"
+else
+  fail "jq-absent second run not silent: $OUT_NOJQ2"
+fi
 
 echo
 echo "PASS=$PASS FAIL=$FAIL"

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/eol-normalizer/hooks/hook-utils.sh
+++ b/plugins/eol-normalizer/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Seven safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Changed
+
+- Shared `hook-utils.sh` resynced with the fleet's new prerequisite-visibility
+  helpers (jq-free notice emitters, once-per-session gate, jq gate). No
+  behavior change for this plugin's guards: their documented jq fail-open with
+  a stderr notice is unchanged.
+
 ## [0.5.0]
 
 ### Changed

--- a/plugins/guardrails/hooks/hook-utils.sh
+++ b/plugins/guardrails/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/guardrails/hooks/hook-utils.sh
+++ b/plugins/guardrails/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.0]
+
+### Changed
+
+- **Missing-prerequisite notices now reach the user too, once per session**
+  (prerequisite-visibility wave). The jq and markdownlint-cli2 absence
+  warnings — previously an `additionalContext`-only message repeated on every
+  edit — now use the shared visible-skip mechanism: one notice per session on
+  both channels (`additionalContext` for Claude, `systemMessage` for the
+  user). Notice dedup state lives under `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+
 ## [0.3.0]
 
 ### Changed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -38,9 +38,9 @@ The hook requires the following tools:
 
 Missing prerequisites do not block an edit. Following Claude Code's
 [PostToolUse contract](https://code.claude.com/docs/en/hooks#posttooluse-decision-control),
-the hook exits `0` and reports a visible `additionalContext` warning. It never
-falls back to `npx`, installs a package, or performs a network request during a
-hook run.
+the hook exits `0` and reports a once-per-session notice to both Claude
+(`additionalContext`) and you (`systemMessage`). It never falls back to `npx`,
+installs a package, or performs a network request during a hook run.
 
 Telemetry timing uses `EPOCHREALTIME` (Bash 5.0+); on older Bash the telemetry
 envelope is skipped while formatting still runs.

--- a/plugins/markdown-format/hooks/hook-utils.sh
+++ b/plugins/markdown-format/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/markdown-format/hooks/hook-utils.sh
+++ b/plugins/markdown-format/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -38,17 +38,14 @@ emit_tel() {
 INPUT=$(cat)
 
 # jq is required to parse Claude Code's hook payload and to emit structured
-# PostToolUse context. Keep this advisory and visible: exit 0 with a static JSON
-# message rather than turning every edit into a hook error or failing silently.
-if ! command -v jq >/dev/null 2>&1; then
-  printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"markdown-format skipped: jq is required on PATH. Install jq, then retry the Markdown edit."}}'
-  exit 0
-fi
+# PostToolUse context. Absent → visible once-per-session skip notice on both
+# the agent and user channels (dim-9 doctrine), exit 0.
+hook::require_jq PostToolUse markdown-format "$INPUT"
 
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 case "$FILE" in
-  *.md | *.mdc) ;;
-  *) exit 0 ;;
+*.md | *.mdc) ;;
+*) exit 0 ;;
 esac
 
 # Resolve repo root early — needed for CWD-anchored config discovery and for
@@ -91,11 +88,11 @@ fi
 # harmless and strictly safer than emitting malformed JSON.
 build_data_json() {
   jq -n \
-    --arg tool     "$TOOL" \
-    --arg file     "$FILE_REL" \
+    --arg tool "$TOOL" \
+    --arg file "$FILE_REL" \
     --argjson findings "$1" \
-    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null \
-    || printf '{"tool":"","file":"","findings":[]}'
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null ||
+    printf '{"tool":"","file":"","findings":[]}'
 }
 
 # Resolve the consuming repository's pinned npm binary without invoking a
@@ -144,9 +141,12 @@ elif REPO_MDLINT="$(resolve_repo_markdownlint)"; then
   MDLINT=("$REPO_MDLINT")
 else
   # Never invoke a package runner here: hooks must not download or execute an
-  # unpinned package as a side effect of editing a file. Degrade visibly.
-  hook::emit_additional_context PostToolUse \
-    "markdown-format skipped: markdownlint-cli2 is neither on PATH nor available as a contained repository-local node_modules/.bin executable. Install it explicitly; this hook does not invoke npx or download tools."
+  # unpinned package as a side effect of editing a file. Degrade visibly on
+  # both channels, once per session (dim-9 doctrine).
+  if hook::notice_once "markdown-format-markdownlint" "$INPUT"; then
+    hook::emit_skip_notice PostToolUse \
+      "markdown-format: markdownlint-cli2 is neither on PATH nor available as a contained repository-local node_modules/.bin executable — Markdown lint skipped for this session. Install it explicitly; this hook does not invoke npx or download tools."
+  fi
   emit_tel "skipped" '[]'
   exit 0
 fi
@@ -160,8 +160,8 @@ fi
 # create a false warning.
 RISK_CONFIGS=()
 CONFIG_ROOT="$(cd "$REPO_ROOT" 2>/dev/null && pwd -P)" || CONFIG_ROOT="$REPO_ROOT"
-CONFIG_TARGET_DIR="$(cd "$(dirname "$FILE")" 2>/dev/null && pwd -P)" \
-  || CONFIG_TARGET_DIR="$(dirname "$FILE")"
+CONFIG_TARGET_DIR="$(cd "$(dirname "$FILE")" 2>/dev/null && pwd -P)" ||
+  CONFIG_TARGET_DIR="$(dirname "$FILE")"
 collect_risky_configs() {
   local cursor dir candidate config
   local dirs=()

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -37,6 +37,15 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq-free applicability pre-filter: never emit the jq notice for an edit this
+# hook would not process anyway (the Write|Edit matcher is broader than the
+# Markdown filter).
+RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+case "$RAW_FILE" in
+*.md | *.mdc) ;;
+*) exit 0 ;;
+esac
+
 # jq is required to parse Claude Code's hook payload and to emit structured
 # PostToolUse context. Absent → visible once-per-session skip notice on both
 # the agent and user channels (dim-9 doctrine), exit 0.

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -110,7 +110,7 @@ make_sink() {
 # instead of racing variable process-spawn latency (notably on Windows Git Bash).
 wait_for_sink() {
   local f="$1" tries="${2:-150}"
-  while (( tries-- > 0 )); do
+  while ((tries-- > 0)); do
     [[ -s "$f" ]] && return 0
     sleep 0.02
   done
@@ -143,8 +143,8 @@ JSONC
 # POSIX-vs-Windows path-form mismatch in the guard.
 run_hook() {
   local file_path="$1"
-  (cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$file_path" \
-    | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")
+  (cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$file_path" |
+    env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")
 }
 
 # --- Fixture A: fixable only (Path A) — clean after fix, no additionalContext -
@@ -258,8 +258,8 @@ cp "$TEST_BIN/markdownlint-cli2" "$LOCAL_MDLINT"
 chmod +x "$LOCAL_MDLINT"
 LOCAL_FIXTURE="$REPO/fixtureLocal.md"
 printf '# Local\n\n* local item\n' >"$LOCAL_FIXTURE"
-OUT_LOCAL="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$LOCAL_FIXTURE" \
-  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_LOCAL="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$LOCAL_FIXTURE" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_LOCAL=$?
 if [[ $RC_LOCAL -eq 0 && -z "$OUT_LOCAL" ]]; then
   ok "repo-local markdownlint shim exits 0 with no advisory"
@@ -286,11 +286,11 @@ ln -s ../markdownlint-cli2/markdownlint-cli2 "$LOCAL_MDLINT"
 if [[ -L "$LOCAL_MDLINT" ]]; then
   LOCAL_SYMLINK_FIXTURE="$REPO/fixtureLocalSymlink.md"
   printf '# Local Symlink\n\n* symlink item\n' >"$LOCAL_SYMLINK_FIXTURE"
-  OUT_LOCAL_SYMLINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$LOCAL_SYMLINK_FIXTURE" \
-    | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  OUT_LOCAL_SYMLINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$LOCAL_SYMLINK_FIXTURE" |
+    env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
   RC_LOCAL_SYMLINK=$?
-  if [[ $RC_LOCAL_SYMLINK -eq 0 && -z "$OUT_LOCAL_SYMLINK" ]] \
-    && grep -q '^- symlink item$' "$LOCAL_SYMLINK_FIXTURE"; then
+  if [[ $RC_LOCAL_SYMLINK -eq 0 && -z "$OUT_LOCAL_SYMLINK" ]] &&
+    grep -q '^- symlink item$' "$LOCAL_SYMLINK_FIXTURE"; then
     ok "contained relative POSIX .bin symlink applied --fix"
   else
     fail "contained relative POSIX .bin symlink failed (rc=$RC_LOCAL_SYMLINK out=$OUT_LOCAL_SYMLINK)"
@@ -317,23 +317,26 @@ ESCAPE_WINDOWS_JUNCTION=false
 if command -v powershell.exe >/dev/null 2>&1 && command -v cygpath >/dev/null 2>&1; then
   # shellcheck disable=SC2016 # $env variables expand in PowerShell, not Bash.
   LINK_PATH="$(cygpath -aw "$REPO/node_modules")" \
-    TARGET_PATH="$(cygpath -aw "$ESCAPE_DIR")" \
+  TARGET_PATH="$(cygpath -aw "$ESCAPE_DIR")" \
     powershell.exe -NoLogo -NoProfile -NonInteractive -Command \
-      'New-Item -ItemType Junction -Path $env:LINK_PATH -Target $env:TARGET_PATH | Out-Null' \
-      >/dev/null 2>&1 \
-    && ESCAPE_LINK_CREATED=true \
-    && ESCAPE_WINDOWS_JUNCTION=true
+    'New-Item -ItemType Junction -Path $env:LINK_PATH -Target $env:TARGET_PATH | Out-Null' \
+    >/dev/null 2>&1 &&
+    ESCAPE_LINK_CREATED=true &&
+    ESCAPE_WINDOWS_JUNCTION=true
 else
   mkdir -p "$REPO/node_modules/.bin"
   ln -s "$ESCAPE_TARGET" "$LOCAL_MDLINT" && ESCAPE_LINK_CREATED=true
 fi
 
 if [[ "$ESCAPE_LINK_CREATED" == true ]]; then
-  OUT_ESCAPE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" \
-    | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+  # Fresh CLAUDE_PLUGIN_DATA: the skip notice is once-per-session, so an
+  # inherited data dir with a prior marker would suppress it and fail the assert.
+  PD_ESCAPE="$(mktemp -d -p "$WORK" pd.XXXXXX)"
+  OUT_ESCAPE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" |
+    env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_DATA="$PD_ESCAPE" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
   RC_ESCAPE=$?
-  if [[ $RC_ESCAPE -eq 0 ]] \
-    && printf '%s' "$OUT_ESCAPE" | jq -e '.hookSpecificOutput.additionalContext | contains("contained repository-local")' >/dev/null 2>&1; then
+  if [[ $RC_ESCAPE -eq 0 ]] &&
+    printf '%s' "$OUT_ESCAPE" | jq -e '.hookSpecificOutput.additionalContext | contains("contained repository-local")' >/dev/null 2>&1; then
     ok "escaping repo-local markdownlint emits advisory"
   else
     fail "escaping repo-local markdownlint was not rejected (rc=$RC_ESCAPE out=$OUT_ESCAPE)"
@@ -346,7 +349,7 @@ if [[ "$ESCAPE_WINDOWS_JUNCTION" == true ]]; then
   # shellcheck disable=SC2016 # $env variables expand in PowerShell, not Bash.
   LINK_PATH="$(cygpath -aw "$REPO/node_modules")" \
     powershell.exe -NoLogo -NoProfile -NonInteractive -Command \
-      'Remove-Item -LiteralPath $env:LINK_PATH -Force' >/dev/null 2>&1
+    'Remove-Item -LiteralPath $env:LINK_PATH -Force' >/dev/null 2>&1
 else
   rm -rf "$REPO/node_modules"
 fi
@@ -354,8 +357,9 @@ fi
 # --- Missing markdownlint: visible advisory, never npx ----------------------
 # With neither PATH nor a contained local binary available, the hook must not
 # invoke the package runner (which could fetch from the network).
-OUT_NO_MDLINT="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" \
-  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+PD_NO_MDLINT="$(mktemp -d -p "$WORK" pd.XXXXXX)"
+OUT_NO_MDLINT="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_MDLINT_ENV" CLAUDE_PLUGIN_DATA="$PD_NO_MDLINT" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_NO_MDLINT=$?
 if [[ $RC_NO_MDLINT -eq 0 ]]; then ok "missing markdownlint exits 0 (advisory)"; else fail "missing markdownlint exit $RC_NO_MDLINT"; fi
 if printf '%s' "$OUT_NO_MDLINT" | jq -e '.hookSpecificOutput.additionalContext | contains("neither on PATH nor available as a contained repository-local")' >/dev/null 2>&1; then
@@ -375,12 +379,13 @@ command() {
   builtin command "$@"
 }
 EOF
-OUT_NO_JQ="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" \
-  | env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_JQ_ENV" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+PD_NO_JQ="$(mktemp -d -p "$WORK" pd.XXXXXX)"
+OUT_NO_JQ="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_JQ_ENV" CLAUDE_PLUGIN_DATA="$PD_NO_JQ" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_NO_JQ=$?
 if [[ $RC_NO_JQ -eq 0 ]]; then ok "missing jq exits 0 (advisory)"; else fail "missing jq exit $RC_NO_JQ"; fi
-if printf '%s' "$OUT_NO_JQ" | jq -e '.hookSpecificOutput.additionalContext | contains("jq is required")' >/dev/null 2>&1; then
-  ok "missing jq emits visible additionalContext"
+if printf '%s' "$OUT_NO_JQ" | jq -e '(.hookSpecificOutput.additionalContext | contains("jq not found on PATH")) and (.systemMessage | contains("jq not found on PATH"))' >/dev/null 2>&1; then
+  ok "missing jq emits visible notice on both channels"
 else
   fail "missing jq warning absent: $OUT_NO_JQ"
 fi
@@ -404,8 +409,8 @@ CJS
 TRUST_FILE="$REPO/trust-cjs.md"
 printf '# Executable config\n\nClean text.' >"$TRUST_FILE"
 
-OUT_TRUST_1="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_TRUST_1="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_TRUST_1=$?
 if [[ $RC_TRUST_1 -eq 0 ]]; then ok "executable config advisory exits 0"; else fail "executable config advisory exit $RC_TRUST_1"; fi
 if printf '%s' "$OUT_TRUST_1" | jq -e '.hookSpecificOutput.additionalContext | contains("trust advisory") and contains(".markdownlint-cli2.cjs")' >/dev/null 2>&1; then
@@ -419,8 +424,8 @@ else
   fail "trust advisory blocked markdownlint --fix"
 fi
 
-OUT_TRUST_2="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_TRUST_2="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if [[ -z "$OUT_TRUST_2" ]]; then
   ok "unchanged executable config warning appears only once"
 else
@@ -428,8 +433,8 @@ else
 fi
 
 printf '\n// reviewed configuration revision\n' >>"$REPO/.markdownlint-cli2.cjs"
-OUT_TRUST_3="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_TRUST_3="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if printf '%s' "$OUT_TRUST_3" | jq -e '.hookSpecificOutput.additionalContext | contains("trust advisory")' >/dev/null 2>&1; then
   ok "changed executable config state warns again"
 else
@@ -450,8 +455,8 @@ cat >"$ORIGINAL_CONFIG" <<'JSONC'
   "noProgress": true
 }
 JSONC
-OUT_TRUST_MODULES="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_TRUST_MODULES="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if printf '%s' "$OUT_TRUST_MODULES" | jq -e '.hookSpecificOutput.additionalContext | contains("trust advisory") and contains(".markdownlint-cli2.jsonc")' >/dev/null 2>&1; then
   ok "module-loading config keys emit visible trust advisory"
 else
@@ -461,8 +466,8 @@ fi
 # Negative control: a declarative rule-only config is not executable and loads
 # no modules, so it must not produce trust-warning noise.
 mv "$SAVED_CONFIG" "$ORIGINAL_CONFIG"
-OUT_TRUST_SAFE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_TRUST_SAFE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$TRUST_FILE" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_DATA="$TRUST_DATA" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 if [[ -z "$OUT_TRUST_SAFE" ]]; then
   ok "rule-only declarative config emits no trust advisory"
 else
@@ -470,8 +475,8 @@ else
 fi
 
 # --- Kill switch: disabled hook is a no-op ----------------------------------
-OUT_K="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FB" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=false bash "$HOOK")"
+OUT_K="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FB" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=false bash "$HOOK")"
 RC_K=$?
 if [[ $RC_K -eq 0 && -z "$OUT_K" ]]; then
   ok "kill switch disables hook"
@@ -489,16 +494,16 @@ fi
 
 # Re-run fixture A with sink unset — must still produce empty stdout, exit 0.
 printf '# Title A2\r\n\r\nSome text\r\n\r\n- item one\r\n- item two' >"$REPO/fixtureA2.md"
-OUT_A_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$REPO/fixtureA2.md" \
-  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_A_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$REPO/fixtureA2.md" |
+  env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_A_NOSINK=$?
 if [[ $RC_A_NOSINK -eq 0 ]]; then ok "telemetry/sink-unset: exit 0 (parity)"; else fail "telemetry/sink-unset: expected 0, got $RC_A_NOSINK"; fi
 if [[ -z "$OUT_A_NOSINK" ]]; then ok "telemetry/sink-unset: empty stdout (parity)"; else fail "telemetry/sink-unset: stdout not empty: $OUT_A_NOSINK"; fi
 
 # Re-run fixture B with sink unset — must still emit additionalContext, exit 0.
 printf '# Doc B2\n\n## Section\n\ntext\n\n## Section\n\n* star item\n' >"$REPO/fixtureB2.md"
-OUT_B_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Edit"}' "$REPO/fixtureB2.md" \
-  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
+OUT_B_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Edit"}' "$REPO/fixtureB2.md" |
+  env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true bash "$HOOK")"
 RC_B_NOSINK=$?
 if [[ $RC_B_NOSINK -eq 0 ]]; then ok "telemetry/sink-unset B: exit 0 (parity)"; else fail "telemetry/sink-unset B: expected 0, got $RC_B_NOSINK"; fi
 if printf '%s' "$OUT_B_NOSINK" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
@@ -520,8 +525,8 @@ STUB_SINK="$(make_sink "cat >\"$TEL_FILE\"")"
 # Fixture with unfixable finding (MD024 duplicate heading): status ok + findings populated.
 printf '# Doc T\n\n## Section\n\ntext\n\n## Section\n\nmore text\n' >"$REPO/fixtureT.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_FILE
-_OUT_T="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureT.md" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_SINK" bash "$HOOK")"
+_OUT_T="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureT.md" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_SINK" bash "$HOOK")"
 RC_T=$?
 wait_for_sink "$TEL_FILE"
 
@@ -594,8 +599,8 @@ TEL_CLEAN="$(mktemp)"
 STUB_CLEAN="$(make_sink "cat >\"$TEL_CLEAN\"")"
 printf '# Clean Doc\n\nSome text.\n' >"$REPO/fixtureClean.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_CLEAN
-_OUT_CLEAN="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureClean.md" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_CLEAN" bash "$HOOK")"
+_OUT_CLEAN="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureClean.md" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_CLEAN" bash "$HOOK")"
 RC_CLEAN=$?
 wait_for_sink "$TEL_CLEAN"
 
@@ -618,8 +623,8 @@ FAIL_SINK_FILE="$(mktemp)"
 FAIL_SINK="$(make_sink "cat >\"$FAIL_SINK_FILE\"; exit 1")"
 printf '# Failing Sink Doc\n\nSome text.\n' >"$REPO/fixtureFailSink.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; exit code is the assertion
-_OUT_FS="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureFailSink.md" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$FAIL_SINK" bash "$HOOK")"
+_OUT_FS="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureFailSink.md" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$FAIL_SINK" bash "$HOOK")"
 RC_FS=$?
 wait_for_sink "$FAIL_SINK_FILE"
 
@@ -633,13 +638,15 @@ printf '# Slow Sink Doc\n\nSome text.\n' >"$REPO/fixtureSlowSink.md"
 
 TS_SLOW_START=$EPOCHREALTIME
 # shellcheck disable=SC2034  # stdout captured so the $(...) blocks until fd1 closes — proves no fd1 leak
-_OUT_SLOW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureSlowSink.md" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SLOW_SINK" bash "$HOOK")"
+_OUT_SLOW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureSlowSink.md" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SLOW_SINK" bash "$HOOK")"
 RC_SLOW=$?
 TS_SLOW_END=$EPOCHREALTIME
-SS="${TS_SLOW_START%[.,]*}"; SF="${TS_SLOW_START#*[.,]}"
-ES="${TS_SLOW_END%[.,]*}"; EF="${TS_SLOW_END#*[.,]}"
-SLOW_MS=$(( (ES * 1000000 + 10#$EF - SS * 1000000 - 10#$SF) / 1000 ))
+SS="${TS_SLOW_START%[.,]*}"
+SF="${TS_SLOW_START#*[.,]}"
+ES="${TS_SLOW_END%[.,]*}"
+EF="${TS_SLOW_END#*[.,]}"
+SLOW_MS=$(((ES * 1000000 + 10#$EF - SS * 1000000 - 10#$SF) / 1000))
 
 echo "  (C1 slow-sink elapsed: ${SLOW_MS}ms)"
 if [[ $RC_SLOW -eq 0 ]]; then ok "telemetry/slow-sink: hook exit 0"; else fail "telemetry/slow-sink: hook exit $RC_SLOW"; fi
@@ -655,8 +662,8 @@ fi
 TEL_LEAK="$(mktemp)"
 LEAK_SINK="$(make_sink "cat >\"$TEL_LEAK\"")"
 printf '# Leak Doc\n\n## Section\n\ntext\n\n## Section\n\nmore text\n' >"$REPO/fixtureLeakCheck.md"
-OUT_LEAK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureLeakCheck.md" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$LEAK_SINK" bash "$HOOK")"
+OUT_LEAK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureLeakCheck.md" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$LEAK_SINK" bash "$HOOK")"
 wait_for_sink "$TEL_LEAK"
 
 # The hook stdout must NOT contain the telemetry envelope's top-level keys
@@ -709,8 +716,8 @@ count_lm() { grep -c -- '-lm' "$CYG_LOG" 2>/dev/null || true; }
 : >"$CYG_LOG"
 : >"$JQ_LOG"
 printf '# Gate Doc\n\nClean text.\n' >"$REPO/fixtureGate.md"
-OUT_GATE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureGate.md" \
-  | env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
+OUT_GATE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureGate.md" |
+  env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
 RC_GATE=$?
 if [[ $RC_GATE -eq 0 && -z "$OUT_GATE" ]]; then
   ok "telemetry-gate/unwired: exit 0, empty stdout"
@@ -739,8 +746,8 @@ TEL_GATE="$(mktemp)"
 GATE_SINK="$(make_sink "cat >\"$TEL_GATE\"")"
 printf '# Gate Doc Wired\n\nClean text.\n' >"$REPO/fixtureGateWired.md"
 # shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_GATE
-_OUT_GW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureGateWired.md" \
-  | env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$GATE_SINK" PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
+_OUT_GW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/fixtureGateWired.md" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$GATE_SINK" PATH="$SHIM_DIR:$PATH" bash "$HOOK")"
 wait_for_sink "$TEL_GATE"
 CYG_LM_WIRED="$(count_lm)"
 if [[ "$CYG_LM_WIRED" -eq 2 ]]; then

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Missing jq now skips visibly** (prerequisite-visibility wave; doctrine: a
+  silently skipped feature is a defect). Without `jq` the hook cannot parse its
+  input, so it now surfaces a once-per-session notice to both Claude
+  (`additionalContext`) and the user (`systemMessage`) instead of a silent
+  no-op. `pwsh`/PSScriptAnalyzer absence deliberately stays quiet — a machine
+  without PowerShell is classified as not-applicable, and the README now says
+  so. Notice dedup state lives under `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -46,11 +46,18 @@ Do not enable this plugin against an untrusted working tree.
 
 ## Requirements
 
+- **Bash** — the hook is a Bash script. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run it under Git Bash.
+- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+  visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **PowerShell 7+** (`pwsh`) on `PATH` — the hook probes `pwsh` only; legacy
-  Windows PowerShell 5.1 (`powershell.exe`) is not used. If absent, the hook is
-  a silent no-op.
+  Windows PowerShell 5.1 (`powershell.exe`) is not used. If absent, the hook
+  stays quiet by design: a machine without PowerShell is treated as
+  not-applicable, not as a missing prerequisite.
 - The **PSScriptAnalyzer** module installed
-  (`Install-Module PSScriptAnalyzer`). If absent, the hook is a silent no-op.
+  (`Install-Module PSScriptAnalyzer`). If absent, the hook stays quiet (same
+  not-applicable classification).
 - A **`PSScriptAnalyzerSettings.psd1`** in your repo — the opt-in.
 
 The hook itself runs on Bash 3.2+. Telemetry timing uses `EPOCHREALTIME`

--- a/plugins/powershell-format/hooks/hook-utils.sh
+++ b/plugins/powershell-format/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/powershell-format/hooks/hook-utils.sh
+++ b/plugins/powershell-format/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -47,6 +47,11 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq is load-bearing for input parsing; absent → visible once-per-session skip
+# notice instead of a silent no-op (dim-9 doctrine). pwsh absence below stays
+# QUIET by design: a machine without PowerShell is a platform N/A, not a gap.
+hook::require_jq PostToolUse powershell-format "$INPUT"
+
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 case "$FILE" in
 *.ps1 | *.psm1 | *.psd1) ;;

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -47,6 +47,15 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq-free applicability pre-filter: never emit the jq notice for an edit this
+# hook would not process anyway (the Write|Edit matcher is broader than the
+# PowerShell-file filter).
+RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+case "$RAW_FILE" in
+*.ps1 | *.psm1 | *.psd1) ;;
+*) exit 0 ;;
+esac
+
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of a silent no-op (dim-9 doctrine). pwsh absence below stays
 # QUIET by design: a machine without PowerShell is a platform N/A, not a gap.

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Changed
+
+- **Missing prerequisites now skip visibly** (prerequisite-visibility wave;
+  doctrine: a silently skipped feature is a defect). A repo governed by a Ruff
+  config with no `ruff` binary available (.venv or PATH) → the hook skips with
+  a once-per-session notice to both Claude (`additionalContext`) and the user
+  (`systemMessage`); a repo without a Ruff config stays quiet (the opt-out).
+  `jq` absent → the whole hook skips visibly. Notice dedup state lives under
+  `${CLAUDE_PLUGIN_DATA}/skip-notices`.
+- Shared `hook-utils.sh` resynced with the new prerequisite-visibility helpers
+  (jq-free notice emitters, once-per-session gate, jq gate).
+- README now declares the full hook runtime: Bash (Git Bash on native Windows),
+  `jq`, and Ruff, each with its absence behavior.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -39,10 +39,16 @@ own and runs only when your repo has opted into Ruff.
 
 ## Requirements
 
+- **Bash** — the hook is a Bash script. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run it under Git Bash.
+- **jq** on `PATH` — parses the hook payload. Absent: the hook skips with a
+  visible once-per-session notice. [Install jq](https://jqlang.org/download/).
 - **Ruff** available to the repo — installed in the repo's `.venv` (the hook
   resolves `.venv/bin/ruff`, or `.venv/Scripts/ruff.exe` on Windows, walking up
   from the edited file) or on `PATH`. Ruff is never downloaded on the fly; if
-  it is not present, the hook is a silent no-op. **Ruff 0.12+ is recommended**
+  it is not present while a Ruff config governs the repo, the hook skips with a
+  visible once-per-session notice. **Ruff 0.12+ is recommended**
   (tested against 0.15.20): earlier releases lack stabilized version-aware
   syntax errors, and on much older releases the flags the hook passes may be
   absent, in which case the run is reported as a tool break rather than a

--- a/plugins/ruff-format/hooks/hook-utils.sh
+++ b/plugins/ruff-format/hooks/hook-utils.sh
@@ -23,6 +23,106 @@ hook::check_enabled() {
   fi
 }
 
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled, passing the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
 # Normalize a path for the membership comparison below: backslashes → forward
 # slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
 # fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive

--- a/plugins/ruff-format/hooks/hook-utils.sh
+++ b/plugins/ruff-format/hooks/hook-utils.sh
@@ -108,10 +108,26 @@ hook::notice_once() {
   return 0
 }
 
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
 # jq gate for hooks whose input parsing cannot proceed without it. When jq is
 # absent: one visible skip notice per session, then exit 0 — an advisory hook
 # never blocks the tool over a missing prerequisite. Place after
-# hook::check_enabled, passing the buffered stdin for session scoping.
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
 #   hook::require_jq PostToolUse my-plugin "$INPUT"
 hook::require_jq() {
   command -v jq >/dev/null 2>&1 && return 0

--- a/plugins/ruff-format/hooks/ruff-format.sh
+++ b/plugins/ruff-format/hooks/ruff-format.sh
@@ -51,6 +51,10 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq is load-bearing for input parsing; absent → visible once-per-session skip
+# notice instead of a silent no-op (dim-9 doctrine).
+hook::require_jq PostToolUse ruff-format "$INPUT"
+
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 case "$FILE" in
 *.py | *.pyi) ;;
@@ -157,7 +161,14 @@ if [[ -z "$RUFF_BIN" ]]; then
   RUFF_BIN="$(command -v ruff 2>/dev/null)" || RUFF_BIN=""
 fi
 
-[[ -n "$RUFF_BIN" ]] || emit_skipped
+# The repo opted in via a Ruff config but no binary is available → visible
+# once-per-session skip notice, not a silent gap (dim-9 doctrine).
+if [[ -z "$RUFF_BIN" ]]; then
+  if hook::notice_once "ruff-format-ruff" "$INPUT"; then
+    hook::emit_skip_notice PostToolUse "ruff-format: a Ruff config governs this repo but no 'ruff' binary was found (.venv or PATH) — format/lint skipped for this session. Install: https://docs.astral.sh/ruff/installation/"
+  fi
+  emit_skipped
+fi
 
 # Pass the file as a path relative to the repo root (the CWD Ruff runs in) so
 # concise diagnostics echo a clean repo-relative path (e.g. src/app.py) instead

--- a/plugins/ruff-format/hooks/ruff-format.sh
+++ b/plugins/ruff-format/hooks/ruff-format.sh
@@ -51,6 +51,15 @@ emit_tel() {
 
 INPUT=$(cat)
 
+# jq-free applicability pre-filter: never emit the jq notice for an edit this
+# hook would not process anyway (the Write|Edit matcher is broader than the
+# Python-file filter).
+RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+case "$RAW_FILE" in
+*.py | *.pyi) ;;
+*) exit 0 ;;
+esac
+
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of a silent no-op (dim-9 doctrine).
 hook::require_jq PostToolUse ruff-format "$INPUT"

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -382,6 +382,62 @@ else
 fi
 rm -f "$TELS"
 
+# --- Missing-tool visibility (dim-9 doctrine) --------------------------------
+# Fake-bin dir of exec wrappers (no ruff): a repo with a governing Ruff config
+# but no binary must produce a visible once-per-session skip notice on both
+# channels, silent on the second run. jq removal then exercises the input gate.
+FAKEBIN="$(mktemp -d -p "$WORK" fakebin.XXXXXX)"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN/$t"
+  chmod +x "$FAKEBIN/$t"
+done
+REPO_NR="$WORK/no-ruff"
+mkdir -p "$REPO_NR"
+git -C "$REPO_NR" init -q
+printf 'line-length = 88\n' >"$REPO_NR/.ruff.toml"
+printf 'x=1\n' >"$REPO_NR/app.py"
+NR_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+run_nr() {
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"test-noruff-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO_NR/app.py" |
+      env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$NR_DATA" \
+        CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true bash "$HOOK"
+  )
+}
+OUT_NR=$(run_nr)
+RC_NR=$?
+if [[ $RC_NR -eq 0 ]]; then ok "ruff-absent -> exit 0"; else fail "ruff-absent exit $RC_NR"; fi
+if jq -e '(.systemMessage | contains("ruff")) and (.hookSpecificOutput.additionalContext | contains("Ruff config"))' <<<"$OUT_NR" >/dev/null 2>&1; then
+  ok "ruff-absent with governing config -> visible notice on both channels"
+else
+  fail "ruff-absent: notice missing or malformed: $OUT_NR"
+fi
+OUT_NR2=$(run_nr)
+if [[ -z "$OUT_NR2" ]]; then
+  ok "ruff-absent -> second run same session is silent (once-per-session)"
+else
+  fail "ruff-absent second run not silent: $OUT_NR2"
+fi
+
+# jq-absent -> visible once-per-session notice (input parsing gate).
+rm -f "$FAKEBIN/jq"
+JQ_DATA="$(mktemp -d -p "$WORK" plugdata.XXXXXX)"
+OUT_NOJQ=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"session_id":"test-nojq-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO_NR/app.py" |
+    env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$JQ_DATA" \
+      CLAUDE_PLUGIN_OPTION_RUFF_FORMAT_ENABLED=true bash "$HOOK"
+)
+RC_NOJQ=$?
+if [[ $RC_NOJQ -eq 0 && "$OUT_NOJQ" == *'"systemMessage"'* && "$OUT_NOJQ" == *jq* ]]; then
+  ok "jq-absent -> exit 0 with visible notice"
+else
+  fail "jq-absent (rc=$RC_NOJQ out=$OUT_NOJQ)"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Tranche A of the prerequisite-visibility wave: land the shared visible-skip mechanism in `lib/hook-utils.sh`, resync all 10 carrying plugins, and convert every silent missing-prerequisite skip in the hook fleet into a once-per-session notice on both channels.

## Shared mechanism (`lib/hook-utils.sh`)

Doctrine (PLUGIN-PHILOSOPHY § Prerequisites and failure behavior): absence must be surfaced to BOTH the agent and the user; a silently skipped feature is a defect. New helpers, all jq-free by design (the most common missing prerequisite is jq itself):

- `hook::json_escape` — pure-bash JSON string escaper (backslash/quote/`\n\r\t` named, residual C0 dropped via `tr` with a no-`tr` fallback).
- `hook::emit_channels <event> <ctx> <sysmsg>` — composes `additionalContext` (agent) and `systemMessage` (user, verified against the current hooks doc as the user-visible universal field) into ONE JSON document — a hook's stdout is parsed as a single doc, so a run with lint findings AND a pending notice must not print twice.
- `hook::emit_skip_notice` / `hook::emit_system_message` — thin wrappers (same message both channels; systemMessage-only for events without an additionalContext channel, e.g. Notification).
- `hook::notice_once <key> <input>` — once-per-session dedup via a marker under `${CLAUDE_PLUGIN_DATA}/skip-notices` (session_id regex-extracted from the raw input, no jq; 7-day marker prune; fails open toward visibility when no data dir is available).
- `hook::require_jq <event> <plugin> <input>` — jq gate: visible once-per-session skip + exit 0.

## Per-plugin behavior changes

| Plugin | Version | Change |
|---|---|---|
| actionlint | 0.3.0 | actionlint-absent and jq-absent now notice visibly (were silent no-ops) |
| bash-format | 0.4.0 | shellcheck-absent notices; shfmt-absent-with-`.editorconfig`-opt-in notices (no opt-in stays quiet); jq gate; findings + notice compose into one JSON doc |
| biome-format | 0.3.0 | biome-absent while a Biome config governs the repo notices (opt-out stays quiet); jq gate |
| ruff-format | 0.3.0 | ruff-absent while a Ruff config governs the repo notices (opt-out stays quiet); jq gate |
| eol-normalizer | 0.3.0 | jq-absent notices (previously silently disabled the whole hook) |
| desktop-notification | 0.3.0 | jq-absent notices via systemMessage only (Notification event has no additionalContext channel); previously every notification was silently dropped |
| markdown-format | 0.4.0 | existing jq/markdownlint-cli2 warnings migrated onto the shared mechanism — gain the user channel and once-per-session dedup (were agent-only, every edit) |
| powershell-format | 0.3.0 | jq gate added; pwsh/PSScriptAnalyzer absence deliberately stays quiet — classified not-applicable (machine without PowerShell), now stated in the README |
| guardrails | 0.5.1 | lib resync only — guards' documented jq fail-open + stderr notice unchanged |
| claude-ops | 0.11.1 | lib resync only — audit hooks unchanged; README states hook runtime + jq fail-open |

All 10 READMEs now declare the full hook runtime (Bash via Git Bash on native Windows, jq, plugin CLI) with each prerequisite's absence classification — the fleet-wide dim-10 README gap flagged on actionlint.

## Verification

- `lib/hook-utils.test.sh`: 61 passing (new: escaper, emitters incl. empty-PATH emission, combined-channel composition, notice_once dedup across sessions/keys/fail-open, require_jq gate with a coreutils-but-no-jq stub PATH — the real missing-jq shape).
- Per-plugin suites extended with missing-tool cases (notice on both channels, once-per-session dedup, single-JSON-doc composition, telemetry `skipped` still emitted): actionlint 34, bash-format 38, biome-format 3 (binary-independent, runs even where Biome is absent), ruff-format 50, eol-normalizer 35, desktop-notification 54, markdown-format 65 — all green locally, plus full `scripts/run-plugin-tests.sh`.
- `scripts/sync-hook-utils.sh --check` and `--check-bump origin/main` green; `scripts/validate-plugins.sh` green; ShellCheck clean on all changed shell files.
- Platform facts re-verified this session from https://code.claude.com/docs/en/hooks (`systemMessage` = user-visible universal output field; `session_id` in every hook input) and https://code.claude.com/docs/en/plugins-reference (`CLAUDE_PLUGIN_DATA` exported to hook processes, survives updates).

## Deliberately out of scope

- Migrating the bare-`cat` stdin readers onto `hook::buffer_stdin` (deferred hardening noted in the #323 review) — orthogonal stdin-semantics change; keeping this PR single-purpose.
- Guardrails/claude-ops hook behavior (dim 9 PASS in the audit; PreToolUse/audit semantics deserve their own change if ever revisited).
- Tranche B (skill-channel prereq declarations: docs-hygiene, kindle-dedrm, source-control, work-items, review) and tranche C (dim-10 cross-platform declarations) follow as separate PRs.

## Related

Part of #317. No linked issue is closed by this PR (tranches B and C remain before #317 can close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
