### PR TITLE
fix: state shell requirements with a Windows path across 8 plugins

### DIFF
--- a/plugins/ai-briefing/.claude-plugin/plugin.json
+++ b/plugins/ai-briefing/.claude-plugin/plugin.json
@@ -1,14 +1,23 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ai-briefing",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Build source-backed AI-industry briefings from official vendor publications, configured RSS/Atom feeds, GitHub releases, reputable secondary reporting, and user-supplied URLs. Deduplicate, rank, and present results as markdown or optional HTML/PPTX decks, with repository-owned profile, audience, and brand configuration. Automated X/Twitter collection is disabled; Playwright is used only for deterministic local rendering.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["ai-briefing", "ai-news", "aggregation", "briefing", "slides", "presentation", "rss", "skill"],
+  "keywords": [
+    "ai-briefing",
+    "ai-news",
+    "aggregation",
+    "briefing",
+    "slides",
+    "presentation",
+    "rss",
+    "skill"
+  ],
   "userConfig": {
     "active_profile": {
       "type": "string",

--- a/plugins/ai-briefing/CHANGELOG.md
+++ b/plugins/ai-briefing/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `ai-briefing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Changed
+
+- README states the POSIX-shell requirement of the `setup --with-build-deps`
+  install step with its Windows path (Git Bash; the script's platform gate
+  already accepts MINGW/MSYS/CYGWIN) — cross-platform declaration wave. The
+  Node build pipeline is unchanged and remains shell-free.
+
 ## [0.5.0]
 
 ### Changed

--- a/plugins/ai-briefing/README.md
+++ b/plugins/ai-briefing/README.md
@@ -35,6 +35,12 @@ Setup preflights Node, npm, and the OS family. On Linux, Playwright's documented
 Unsupported or missing prerequisites are reported before the existing runtime is changed.
 See [Playwright system requirements](https://playwright.dev/docs/intro#system-requirements).
 
+The `setup --with-build-deps` install step is a POSIX-shell script: it requires
+Bash — on native Windows that is Git Bash (its platform gate accepts
+`MINGW*`/`MSYS*`/`CYGWIN*`; install
+[Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)).
+The build pipeline itself is portable Node and has no shell requirement.
+
 ## Source access policy
 
 Automated X/Twitter collection is disabled. The plugin does not scrape profiles, timelines,

--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,12 +1,21 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps recently changed files through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract; /code-tidying:comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["tidy", "refactoring", "simplify", "boy-scout", "tidy-first", "maintenance", "comments", "skill"]
+  "keywords": [
+    "tidy",
+    "refactoring",
+    "simplify",
+    "boy-scout",
+    "tidy-first",
+    "maintenance",
+    "comments",
+    "skill"
+  ]
 }

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Changed
+
+- README declares the Bash 4+ requirement of the bundled scripts (`mapfile`,
+  case-conversion expansions) with its Windows path (Git Bash) — cross-platform
+  declaration wave. Script behavior unchanged (CRLF and drive-letter handling
+  already present).
+
 ## [0.4.2]
 
 ### Changed

--- a/plugins/code-tidying/README.md
+++ b/plugins/code-tidying/README.md
@@ -53,7 +53,11 @@ exclusions, and verification commands.
 
 - Self-contained: taxonomy, scope-budget research, exclusion lists, lane
   templates, and the throttle script all ship inside the plugin under
-  `${CLAUDE_PLUGIN_ROOT}`.
+  `${CLAUDE_PLUGIN_ROOT}`. The bundled scripts require **Bash 4+** (they use
+  `mapfile` and case-conversion expansions) — on native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)
+  so they run under Git Bash; the scripts already handle CRLF and
+  drive-letter paths.
 - Graceful degrade: if the `discovery` plugin is installed, explore/research
   phases use `/discovery:explore` + `/discovery:research`; if `work-items` is
   installed, deferrals file through `/work-items:track add`; if

--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,12 +1,22 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["teach", "learn", "learning", "coach", "tutor", "pedagogy", "primer", "onboarding", "skill"]
+  "keywords": [
+    "teach",
+    "learn",
+    "learning",
+    "coach",
+    "tutor",
+    "pedagogy",
+    "primer",
+    "onboarding",
+    "skill"
+  ]
 }

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to the `education` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.3.1]
+
+### Changed
+
+- README Requirements now declare the skill's Bash + coreutils mechanics
+  (`sha256sum`/`shasum`, `realpath`, `tr`, `sed`) with their Windows path
+  (Git Bash bundles all of them), replacing the inaccurate "none beyond
+  Claude Code" — cross-platform declaration wave.
+
+## [0.3.0]
+
+First versioned release covered by this changelog; see the git history of
+`plugins/education/` for earlier changes.

--- a/plugins/education/README.md
+++ b/plugins/education/README.md
@@ -37,8 +37,12 @@ before they're taught. See the skill body for the full pedagogy.
 
 ## Requirements
 
-- None beyond Claude Code. For `codebase` mode, launch it from the repository you
-  want to learn — the plugin reads that repo's own docs and source.
+- **Bash + coreutils** (`sha256sum`/`shasum`, `realpath`, `tr`, `sed`) for the
+  skill's inline mechanics — on native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  they run under Git Bash, which bundles all of them.
+- For `codebase` mode, launch it from the repository you want to learn — the
+  plugin reads that repo's own docs and source.
 - `topic` mode fetches documentation URLs to ground explanations in primary
   sources; if your setup restricts `WebFetch`, allow it or seed `RESOURCES.md`
   manually.

--- a/plugins/event-storming/.claude-plugin/plugin.json
+++ b/plugins/event-storming/.claude-plugin/plugin.json
@@ -1,12 +1,21 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "event-storming",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "EventStorming for domain discovery — a methodology skill (Big Picture / Process Modeling / Design-Level facilitation reference, notation, patterns) and a simulation skill (agentic multi-persona workshops that produce a structured-markdown model by default; a live Miro-board rendering path is available when the first-party miro plugin is enabled).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["event-storming", "ddd", "domain-modeling", "bounded-contexts", "miro", "facilitation", "simulation", "skill"]
+  "keywords": [
+    "event-storming",
+    "ddd",
+    "domain-modeling",
+    "bounded-contexts",
+    "miro",
+    "facilitation",
+    "simulation",
+    "skill"
+  ]
 }

--- a/plugins/event-storming/CHANGELOG.md
+++ b/plugins/event-storming/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `event-storming` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.3]
+
+### Changed
+
+- Simulation session teardown is phrased shell-agnostically at both sites
+  (`rm -rf` on POSIX/Git Bash, `Remove-Item -Recurse -Force` on PowerShell)
+  instead of an unconditional `rm -rf` with no Windows path — cross-platform
+  declaration wave.
+
 ## [0.5.2]
 
 ### Changed

--- a/plugins/event-storming/skills/simulation/reference/agentic-simulation.md
+++ b/plugins/event-storming/skills/simulation/reference/agentic-simulation.md
@@ -335,7 +335,7 @@ Use `{domain}-{date}-{random4}` format, e.g., `devconf-20260321-a7f2`, where `{r
 **Cleanup protocol:**
 At session end, ask user: "Delete persona temp files? (They can be archived for session replay.)"
 
-- If yes: `rm -rf {session_dir}/` (deletes the session directory itself — `{session_dir}` already resolves to `{system_temp}/eventstorming-session-{session_id}`)
+- If yes: delete the session directory recursively with the host shell's remover — `rm -rf {session_dir}/` on POSIX/Git Bash, `Remove-Item -Recurse -Force {session_dir}` on PowerShell (`{session_dir}` already resolves to `{system_temp}/eventstorming-session-{session_id}`)
 - If no: archive to `${CLAUDE_PLUGIN_DATA}/sessions/{session_id}/` (the per-plugin data directory that survives updates). Session archives are per-run state, not skill source; never write them into the plugin's own installed directory (`${CLAUDE_PLUGIN_ROOT}`, read-only under cache isolation) or into the consumer's project tree
 
 ---
@@ -649,7 +649,7 @@ Every simulation session follows this lifecycle. The protocol ensures clean stat
 
 - Update the plugin data store with version metrics, board URLs, and findings (`${CLAUDE_PLUGIN_DATA}/history.jsonl`)
 - Ask user about persona temp files: "Delete persona profiles? (Can be archived for session replay)"
-  - Delete: `rm -rf {session_dir}/`
+  - Delete the session directory recursively (`rm -rf {session_dir}/` on POSIX/Git Bash; `Remove-Item -Recurse -Force {session_dir}` on PowerShell)
   - Archive: copy to `${CLAUDE_PLUGIN_DATA}/sessions/{session_id}/` (see "Cleanup protocol" above)
 - Clean up test/smoke-test boards (with user confirmation via `miro_delete_board`)
 - Optionally clean up old version boards (keep only latest, with user approval)

--- a/plugins/event-storming/skills/simulation/reference/agentic-simulation.md
+++ b/plugins/event-storming/skills/simulation/reference/agentic-simulation.md
@@ -335,7 +335,7 @@ Use `{domain}-{date}-{random4}` format, e.g., `devconf-20260321-a7f2`, where `{r
 **Cleanup protocol:**
 At session end, ask user: "Delete persona temp files? (They can be archived for session replay.)"
 
-- If yes: delete the session directory recursively with the host shell's remover — `rm -rf {session_dir}/` on POSIX/Git Bash, `Remove-Item -Recurse -Force {session_dir}` on PowerShell (`{session_dir}` already resolves to `{system_temp}/eventstorming-session-{session_id}`)
+- If yes: delete the session directory recursively with the host shell's remover — `rm -rf "{session_dir}/"` on POSIX/Git Bash, `Remove-Item -LiteralPath "{session_dir}" -Recurse -Force` on PowerShell; keep the path quoted, it may contain spaces (`{session_dir}` already resolves to `{system_temp}/eventstorming-session-{session_id}`)
 - If no: archive to `${CLAUDE_PLUGIN_DATA}/sessions/{session_id}/` (the per-plugin data directory that survives updates). Session archives are per-run state, not skill source; never write them into the plugin's own installed directory (`${CLAUDE_PLUGIN_ROOT}`, read-only under cache isolation) or into the consumer's project tree
 
 ---
@@ -649,7 +649,7 @@ Every simulation session follows this lifecycle. The protocol ensures clean stat
 
 - Update the plugin data store with version metrics, board URLs, and findings (`${CLAUDE_PLUGIN_DATA}/history.jsonl`)
 - Ask user about persona temp files: "Delete persona profiles? (Can be archived for session replay)"
-  - Delete the session directory recursively (`rm -rf {session_dir}/` on POSIX/Git Bash; `Remove-Item -Recurse -Force {session_dir}` on PowerShell)
+  - Delete the session directory recursively, path quoted (`rm -rf "{session_dir}/"` on POSIX/Git Bash; `Remove-Item -LiteralPath "{session_dir}" -Recurse -Force` on PowerShell)
   - Archive: copy to `${CLAUDE_PLUGIN_DATA}/sessions/{session_id}/` (see "Cleanup protocol" above)
 - Clean up test/smoke-test boards (with user confirmation via `miro_delete_board`)
 - Optionally clean up old version boards (keep only latest, with user approval)

--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,14 +1,31 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), and a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["knowledge", "distill", "book", "pdf", "epub", "youtube", "video", "transcript", "course", "dometrain", "teachable", "playwright", "skill", "reference", "synthesis", "ingest"],
+  "keywords": [
+    "knowledge",
+    "distill",
+    "book",
+    "pdf",
+    "epub",
+    "youtube",
+    "video",
+    "transcript",
+    "course",
+    "dometrain",
+    "teachable",
+    "playwright",
+    "skill",
+    "reference",
+    "synthesis",
+    "ingest"
+  ],
   "userConfig": {
     "library_dir": {
       "type": "directory",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## 0.7.1
+
+### Changed
+
+- README declares the shell mechanics with their Windows path (Git Bash
+  bundles the `sha256sum` that `book-distill` runs on every distillation) and
+  the EPUB branch's `unzip` requirement (not bundled with Git Bash) —
+  cross-platform declaration wave. PDF-only use needs neither extra install.
+
 ## 0.7.0
 
 ### Changed

--- a/plugins/knowledge/README.md
+++ b/plugins/knowledge/README.md
@@ -60,6 +60,14 @@ needs video without the rest of the knowledge stack.
 
 - A PDF or EPUB you have the right to read. PDF works natively with Claude
   Code's Read tool; EPUB requires unzipping and text extraction first.
+- **Bash + coreutils** for the skills' inline mechanics (`book-distill`
+  hashes its progress-file slug with `sha256sum`/`shasum` on every run) — on
+  native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)
+  so they run under Git Bash, which bundles `sha256sum`.
+- **`unzip` on `PATH` for the EPUB branch** — not bundled with Git Bash;
+  install it or extract the EPUB with another archive tool first. PDF-only
+  use does not need it.
 
 ## Install
 

--- a/plugins/mcp-tools/.claude-plugin/plugin.json
+++ b/plugins/mcp-tools/.claude-plugin/plugin.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mcp-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Audits MCP server tool definitions against MCP-specification and Anthropic tool-design criteria and reports a per-tool PASS/WARN/FAIL scorecard covering description, parameters, naming, and annotations. Language-agnostic — Python (FastMCP), TypeScript, and .NET.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["mcp", "tools", "audit", "quality", "scorecard", "skill"]
+  "keywords": [
+    "mcp",
+    "tools",
+    "audit",
+    "quality",
+    "scorecard",
+    "skill"
+  ]
 }

--- a/plugins/mcp-tools/CHANGELOG.md
+++ b/plugins/mcp-tools/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to the `mcp-tools` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.2.1]
+
+### Changed
+
+- README gains a Requirements section declaring the audit's Bash + coreutils
+  and `jq` mechanics with their Windows path (Git Bash; `jq` is a separate
+  install there) — cross-platform declaration wave.
+
+## [0.2.0]
+
+First versioned release covered by this changelog; see the git history of
+`plugins/mcp-tools/` for earlier changes.

--- a/plugins/mcp-tools/README.md
+++ b/plugins/mcp-tools/README.md
@@ -38,6 +38,15 @@ Claude can also invoke it automatically when you ask to "audit MCP tools" or "ch
 - Does not test tool functionality — use the MCP Inspector for that.
 - Does not evaluate MCP resources — only tools.
 
+## Requirements
+
+- **Bash + coreutils** for the audit's inline mechanics — on native Windows,
+  install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows)
+  so they run under Git Bash.
+- **jq** on `PATH` for JSON handling
+  ([install](https://jqlang.org/download/); a separate install in Git Bash).
+
 ## Install
 
 ```shell

--- a/plugins/prototype/.claude-plugin/plugin.json
+++ b/plugins/prototype/.claude-plugin/plugin.json
@@ -1,12 +1,20 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "prototype",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Builds throwaway code to answer a design question before committing to architecture — a logic facet (an interactive terminal app over a portable state model) and a UI facet (radically different visual variants on one route).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["prototype", "spike", "throwaway", "design", "ui", "state-machine", "skill"]
+  "keywords": [
+    "prototype",
+    "spike",
+    "throwaway",
+    "design",
+    "ui",
+    "state-machine",
+    "skill"
+  ]
 }

--- a/plugins/prototype/CHANGELOG.md
+++ b/plugins/prototype/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `prototype` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.4]
+
+### Changed
+
+- README declares the Bash requirement of the bundled ecosystem-detection
+  script with its Windows path (Git Bash) and documents the no-Bash degrade
+  (detection reports "none detected"; the skills read the host project
+  directly) — cross-platform declaration wave.
+
 ## [0.2.3]
 
 ### Changed

--- a/plugins/prototype/README.md
+++ b/plugins/prototype/README.md
@@ -43,8 +43,14 @@ production code lives.
 
 ## Requirements
 
-None beyond Claude Code. Prototypes are built in whatever language and task runner your host
-project already uses; the plugin adds no runtime of its own.
+- **Bash** for the bundled ecosystem-detection script — on native Windows,
+  install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  it runs under Git Bash. Without Bash, detection reports "none detected" and
+  the skills read the host project directly to pick the stack.
+
+Prototypes are built in whatever language and task runner your host project
+already uses; the plugin adds no runtime of its own.
 
 ## License
 

--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.1]
+
+### Fixed
+
+- The `clean` skill's PreToolUse destructive-guard hook now uses the
+  interpreter-named exec form (`command: "bash"`,
+  `args: [".../destructive-guard.sh"]`) instead of naming the bare `.sh` as
+  the command — the doctrine-prescribed Windows-safe spawn shape
+  (cross-platform declaration wave).
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -10,7 +10,8 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "\"${CLAUDE_PLUGIN_ROOT}\"/skills/clean/scripts/destructive-guard.sh"
+          command: "bash"
+          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive-guard.sh"]
 ---
 
 ## Pre-computed context


### PR DESCRIPTION
Tranche C of the prerequisite-visibility wave: every dim-10 cross-platform FAIL from the conformance audit — undeclared shell/coreutils assumptions get a stated requirement with the Git Bash Windows path, and the two structural Windows hazards get real fixes.

## Per-plugin changes

| Plugin | Version | Change |
|---|---|---|
| mcp-tools | 0.2.1 | README Requirements section added (Bash + coreutils, jq, Git Bash path). CHANGELOG created. |
| ai-briefing | 0.5.1 | README states the POSIX-shell requirement of `setup --with-build-deps` (script's platform gate already accepts MINGW/MSYS/CYGWIN — the doc prong was the gap). |
| education | 0.3.1 | README corrected from "none beyond Claude Code": declares `sha256sum`/`shasum`, `realpath`, `tr`, `sed` with the Git Bash path (bundles all of them). CHANGELOG created. |
| prototype | 0.2.4 | README declares the detection-script Bash requirement and documents the no-Bash degrade honestly (pre-computed context echoes "none detected"; the skills read the host project directly — verified against `skills/logic/SKILL.md`, which never branches on the detection output). |
| code-tidying | 0.4.3 | README declares Bash 4+ (`mapfile`, case-conversion expansions) with the Git Bash path; notes the scripts' existing CRLF/drive-letter handling. |
| knowledge | 0.7.1 | README declares the Git Bash shell mechanics (`book-distill` hashes with `sha256sum` on every run) and the EPUB branch's `unzip` requirement (not bundled with Git Bash); PDF-only use needs neither. |
| event-storming | 0.5.3 | Simulation teardown phrased shell-agnostically at both sites (`rm -rf` on POSIX/Git Bash, `Remove-Item -Recurse -Force` on PowerShell) instead of unconditional `rm -rf`. |
| repo-hygiene | 0.2.1 | `clean`'s PreToolUse destructive-guard hook moves from a bare-`.sh` command to the interpreter-named exec form (`command: "bash"`, `args: […]`) — the doctrine-prescribed Windows-safe spawn shape, matching disk-hygiene's existing `command: "python"` precedent. |

## Verification

- `scripts/validate-plugins.sh`, `node scripts/generate-catalog.mjs --check`, and `node scripts/validate-plugin-contracts.mjs` (1429 files) green.
- `plugins/repo-hygiene/.../destructive-guard.test.sh`: 30/30 passing after the hook-form change.
- The dim-9 work landed separately: hook channel in #328, skill channel in #329. With this tranche, every dim-9/dim-10 FAIL enumerated in #317 is addressed (actionlint's and work-items' dim-10 items were folded into those PRs).

## Related

Closes #317 (together with #328 and #329, which carry tranches A and B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
