### PR TITLE
feat(session-flow): add reanchor session-freshness skill (0.9.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -240,7 +240,7 @@
       "name": "session-flow",
       "source": "./plugins/session-flow",
       "category": "workflow",
-      "tags": ["workflow", "handoff", "keep-going", "resume", "recover", "retro", "retrospective", "session", "orchestration", "skill"]
+      "tags": ["workflow", "handoff", "keep-going", "resume", "recover", "retro", "retrospective", "session", "orchestration", "reanchor", "freshness", "skill"]
     },
     {
       "name": "tdd",

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 ### Workflow
 
-- [`session-flow`](plugins/session-flow) — Session-lifecycle toolkit of five skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), and orchestrate (arm a session or worker with proactive-orchestration imperatives).
+- [`session-flow`](plugins/session-flow) — Session-lifecycle toolkit of six skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), orchestrate (arm a session or worker with proactive-orchestration imperatives), and reanchor (verify a session's working assumptions are still true against live reality — referenced PRs/issues/branches, base-branch drift, renamed/version-drifted surfaces, stale memory-tier files — before building on them).
 
 ### Project Management
 

--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.8.0",
-  "description": "Session-lifecycle toolkit of five skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), and orchestrate (arm a session or worker with proactive-orchestration imperatives).",
+  "version": "0.9.0",
+  "description": "Session-lifecycle toolkit of six skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), orchestrate (arm a session or worker with proactive-orchestration imperatives), and reanchor (verify a session's working assumptions are still true against live reality — referenced PRs/issues/branches, base-branch drift, renamed/version-drifted surfaces, stale memory-tier files — before building on them).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["workflow", "handoff", "keep-going", "resume", "recover", "retrospective", "session", "checkpoint", "orchestration", "skill"]
+  "keywords": ["workflow", "handoff", "keep-going", "resume", "recover", "retrospective", "session", "checkpoint", "orchestration", "reanchor", "freshness", "skill"]
 }

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — session-flow plugin
 
+## 0.9.0 — 2026-07-18
+
+Added:
+
+- reanchor: new skill. Verifies a session's working assumptions against live
+  reality before it builds on them — for the PRs/issues/branches a handoff or
+  locked plan references it confirms each is still in the claimed state, checks
+  base-branch drift, confirms cited skills/plugins still exist under that name
+  and that installed versions match the repo source, and flags memory-tier
+  entries whose subjects have since landed. It reports the drift and re-anchors;
+  it does not resume the work (keep-going), inventory worktrees
+  (/source-control:worktree status), or triage PR feedback
+  (/source-control:babysit-prs). The plugin now bundles six skills.
+
 ## 0.8.0 — 2026-07-17
 
 Changed:

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -6,13 +6,12 @@ Added:
 
 - reanchor: new skill. Verifies a session's working assumptions against live
   reality before it builds on them — for the PRs/issues/branches a handoff or
-  locked plan references it confirms each is still in the claimed state, checks
-  base-branch drift, confirms cited skills/plugins still exist under that name
-  and that installed versions match the repo source, and flags memory-tier
-  entries whose subjects have since landed. It reports the drift and re-anchors;
-  it does not resume the work (keep-going), inventory worktrees
-  (/source-control:worktree status), or triage PR feedback
-  (/source-control:babysit-prs). The plugin now bundles six skills.
+  locked plan references it confirms each is still in the claimed state, reports
+  current behind-base divergence, confirms cited skills/plugins still exist under
+  that name and that installed versions match the repo source, and flags
+  memory-tier entries whose subjects have since landed. It reports the drift and
+  re-anchors; it does not resume the work (the keep-going sibling), enumerate
+  worktrees, or triage PR feedback. The plugin now bundles six skills.
 
 ## 0.8.0 — 2026-07-17
 

--- a/plugins/session-flow/README.md
+++ b/plugins/session-flow/README.md
@@ -1,8 +1,9 @@
 # session-flow
 
-A Claude Code plugin bundling five skills for one cohesive capability: managing the lifecycle of a
+A Claude Code plugin bundling six skills for one cohesive capability: managing the lifecycle of a
 working session — where you are in the work, how to pause and resume it, how to recover it after an
-interruption, what to learn from it, and how to arm it for delegation-heavy tasks.
+interruption, whether its assumptions are still current, what to learn from it, and how to arm it
+for delegation-heavy tasks.
 
 | Skill | Question it answers |
 |---|---|
@@ -11,6 +12,7 @@ interruption, what to learn from it, and how to arm it for delegation-heavy task
 | `/session-flow:keep-going` | We were interrupted — what was running, what survived, and where does the main task continue? |
 | `/session-flow:retro` | What happened this session, what did we learn, and how do we codify it? |
 | `/session-flow:orchestrate` | How do I arm this session (or a spawned worker) with proactive-orchestration imperatives? |
+| `/session-flow:reanchor` | Are this session's assumptions still true, or has reality moved under them? |
 
 ## What each skill does
 
@@ -87,6 +89,21 @@ paste-ready, tool-agnostic brief for a spawned worker or fresh session.
 /session-flow:orchestrate                # prime this session
 /session-flow:orchestrate worker         # paste-ready worker brief
 /session-flow:orchestrate handoff compact # headline-only fresh-session brief
+```
+
+### reanchor
+
+Verifies a session's working assumptions against live reality before it builds on them — the
+premise-freshness counterpart to `keep-going`'s recovery. For the PRs, issues, and branches a
+handoff or locked plan references, it confirms each is still in the claimed state; checks whether
+the working branch's base has drifted; confirms cited skills/plugins still exist under that name
+and that installed versions match the repo source; and flags memory-tier entries whose subjects
+have since landed. It reports the drift and hands back a re-anchored picture — it does not resume
+the work (that is `keep-going`), inventory worktrees (`/source-control:worktree` status), or triage
+PR feedback (`/source-control:babysit-prs`).
+
+```shell
+/session-flow:reanchor            # verify session premises → report drift → re-anchored picture
 ```
 
 ## Consumer conventions

--- a/plugins/session-flow/README.md
+++ b/plugins/session-flow/README.md
@@ -96,11 +96,13 @@ paste-ready, tool-agnostic brief for a spawned worker or fresh session.
 Verifies a session's working assumptions against live reality before it builds on them — the
 premise-freshness counterpart to `keep-going`'s recovery. For the PRs, issues, and branches a
 handoff or locked plan references, it confirms each is still in the claimed state; checks whether
-the working branch's base has drifted; confirms cited skills/plugins still exist under that name
-and that installed versions match the repo source; and flags memory-tier entries whose subjects
-have since landed. It reports the drift and hands back a re-anchored picture — it does not resume
-the work (that is `keep-going`), inventory worktrees (`/source-control:worktree` status), or triage
-PR feedback (`/source-control:babysit-prs`).
+the working branch is now behind its base; confirms cited skills/plugins still exist under that
+name and that installed versions match the repo source; and flags memory-tier entries whose
+subjects have since landed. It reports the drift and hands back a re-anchored picture — it does not
+resume the work (that is `keep-going`), enumerate worktrees, or triage PR feedback. When
+`source-control` is installed it cites that plugin's `worktree` status for the cross-worktree
+inventory and leaves PR-feedback triage to `babysit-prs`; otherwise it does the reduced local
+checks and reports the fuller inventory as unavailable.
 
 ```shell
 /session-flow:reanchor            # verify session premises → report drift → re-anchored picture

--- a/plugins/session-flow/README.md
+++ b/plugins/session-flow/README.md
@@ -133,5 +133,8 @@ The skills adapt to the consuming repo rather than imposing structure:
 No `userConfig`. State: retro score history persists under the plugin's `${CLAUDE_PLUGIN_DATA}`
 directory (per-project files) — never in the consumer's repo. Handoff save-points are memory-tier
 working files in the consumer's project (`.work/handoffs/` by default) — machine-local, never
-committed. Network: none — the bundled transcript parser is stdlib-only Python 3.10+ reading local
-`~/.claude/projects/` transcripts.
+committed. Network: `reanchor` queries live host state via `git`/`gh` to verify a session's
+referenced PRs/issues/branches and installed-vs-repo plugin versions, and degrades to reporting
+what it could not verify when that authenticated egress is unavailable; every other skill is
+network-free (the retro transcript parser is stdlib-only Python 3.10+ reading local
+`~/.claude/projects/` transcripts).

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reanchor
-description: "Verify a session's working assumptions are still true before building on them — referenced PRs/issues/branches still in the state a handoff or plan claims, base-branch drift, cited skills/plugins that were renamed or version-drifted, and memory-tier files whose subjects have since landed. Reports what drifted and re-anchors; does not resume the work. Use when: 'reanchor', 're-anchor', 'is this still current', 'verify my assumptions', 'has main moved since', 'are these premises still valid', 'is the handoff stale', 'resuming an old plan', 'check freshness'. Not for resuming work (use /session-flow:keep-going), per-worktree staleness (use /source-control:worktree status), PR feedback triage (use /source-control:babysit-prs), or re-anchoring a standing behavioral rule/discipline (that is the re-anchor plugin — this re-anchors factual premises, not rules)."
+description: "Verify a session's working assumptions are still true before building on them — referenced PRs/issues/branches still in the state a handoff or plan claims, base-branch drift, cited skills/plugins that were renamed or version-drifted, and memory-tier files whose subjects have since landed. Reports what drifted and re-anchors; does not resume the work. Use when: 'reanchor', 're-anchor', 'is this still current', 'verify my assumptions', 'has main moved since', 'are these premises still valid', 'is the handoff stale', 'resuming an old plan', 'check freshness'. Not for resuming work (use /session-flow:keep-going), the cross-worktree staleness inventory, PR feedback triage, or re-anchoring a standing behavioral rule (this re-anchors factual premises, not rules)."
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -73,8 +73,8 @@ back up.
   it is installed; reanchor never performs them — it only checks whether a
   *referenced* PR is still in its claimed state.
 - **Does not re-anchor a standing rule or discipline.** Correcting behavioral
-  doctrine mid-session is the `re-anchor` plugin's concern; this skill re-anchors
-  factual assumptions, not rules.
+  doctrine mid-session (a standing-rule re-anchor) is a separate concern; this
+  skill re-anchors factual assumptions against live reality, not rules.
 - **Does not auto-fix drift.** It reports; the session decides.
 
 ## Gotchas

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: reanchor
+description: "Verify a session's working assumptions are still true before building on them — referenced PRs/issues/branches still in the state a handoff or plan claims, base-branch drift, cited skills/plugins that were renamed or version-drifted, and memory-tier files whose subjects have since landed. Reports what drifted and re-anchors; does not resume the work. Use when: 'reanchor', 're-anchor', 'is this still current', 'verify my assumptions', 'has main moved since', 'are these premises still valid', 'is the handoff stale', 'resuming an old plan', 'check freshness'. Not for resuming work (use /session-flow:keep-going), per-worktree staleness (use /source-control:worktree status), or PR feedback triage (use /source-control:babysit-prs)."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Reanchor
+
+## Purpose
+
+Long-lived and resumed sessions act on stale premises: main has moved, a
+referenced PR merged or changed shape, a cited skill was renamed, an installed
+plugin shipped a new version, a locked plan references work that has since
+landed. Nothing re-verifies those assumptions against live reality before the
+session builds on them. This skill re-anchors a session's working assumptions —
+checks each premise its inputs depend on against the current state, reports what
+drifted, and hands back a corrected picture to plan from.
+
+It verifies premises; it does not resume the work. Run it before continuing on
+old inputs, then hand to `/session-flow:keep-going` to actually pick the work
+back up.
+
+## What it re-anchors
+
+1. **Handoff / plan premises.** For every PR, issue, or branch a handoff or
+   locked plan references, confirm it is still in the state the document claims
+   — open vs merged/closed, same head, same base, not renamed. A plan that
+   assumes an in-flight PR is often built on one that already landed.
+2. **Base-branch drift.** Check whether the working branch's base has moved
+   since the session's inputs were written — the branch may now be behind, or a
+   premise ("this isn't on main yet") may already be false. For the full
+   per-worktree staleness inventory (behind-base counts, dirty state, PR
+   linkage), cite `/source-control:worktree` status rather than recomputing it.
+3. **Renamed / retired / version-drifted surfaces.** For the skills, plugins,
+   and commands the session's inputs name, confirm they still exist under that
+   name and that installed plugin versions match the repo source — a rename or a
+   version bump silently invalidates cited invocations and assumed behavior.
+4. **Stale memory-tier files.** For the session's handoff / todo / working-memory
+   files, flag entries whose subjects have since merged or landed, so the next
+   step neither re-does settled work nor chases a closed thread.
+
+## Flow
+
+1. Gather the session's inputs — the handoff / plan / memory files and any PRs,
+   issues, branches, skills, or plugin versions they name.
+2. Run the four checks above against live reality (git, `gh`, installed vs
+   repo-source manifests).
+3. Report drift as a short list — premise → claimed state → actual state — plus
+   the re-anchored picture. Surface it; do not silently rewrite the plan or
+   auto-fix. The session re-plans on the corrected reality.
+
+## What this skill does NOT do
+
+- **Does not resume or continue the work.** It verifies premises; picking the
+  work back up is `/session-flow:keep-going`.
+- **Does not inventory worktrees.** Per-worktree/branch staleness (behind-base
+  counts, dirty state, PR linkage) lives in `/source-control:worktree` status;
+  this skill cites it, never reimplements it.
+- **Does not classify PR feedback or run the PR loop.** Per-PR fresh-evidence
+  discipline and feedback triage stay in `/source-control:babysit-prs`; reanchor
+  only checks whether a *referenced* PR is still in its claimed state.
+- **Does not re-anchor a standing rule or discipline.** Correcting behavioral
+  doctrine mid-session is the `re-anchor` plugin's concern; this skill re-anchors
+  factual assumptions, not rules.
+- **Does not auto-fix drift.** It reports; the session decides.
+
+## Gotchas
+
+- A premise that "looks" current is the failure mode: a PR cited as open may
+  have merged minutes ago; a plugin cited by version may have bumped. Check the
+  live source, never the input's own claim.
+- Scope to what the session's inputs actually reference — re-anchoring is bounded
+  by the premises in play, not a full-repo audit.
+- It composes with, not replaces, its neighbors: reanchor to learn what drifted,
+  then `keep-going` to resume, `/source-control:worktree` status for the worktree
+  inventory, `/source-control:babysit-prs` for PR work.

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -28,8 +28,9 @@ back up.
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch is now behind its
-   base. Derive the base from the referenced PR's base branch (or, absent a PR,
-   the remote's default HEAD) — not an assumed `main` — and mark the check
+   base. Derive the base from the base branch of the PR whose head is the current
+   working branch (or, absent such a PR, the remote's default HEAD) — not another
+   referenced PR's base and not an assumed `main` — and mark the check
    unverifiable if the base cannot be resolved. Fetch that resolved base ref
    explicitly and count against the just-fetched tip: `git fetch <remote>
    <base-branch>`, then measure against `FETCH_HEAD`
@@ -48,9 +49,10 @@ back up.
 3. **Renamed / retired / version-drifted surfaces.** For the skills, plugins,
    and commands the session's inputs name, confirm they still exist under that
    name and — when the session is working inside a plugin's source tree — that
-   the installed version (from the documented installed-plugins state) matches
-   that source manifest; a rename or version bump silently invalidates cited
-   invocations and assumed behavior. When a cited plugin's source manifest is not
+   the version effective in the current project's scope (honoring user / project /
+   local scope precedence, not merely the highest installed version a plugin
+   listing reports) matches that source manifest; a rename or version bump
+   silently invalidates cited invocations and assumed behavior. When a cited plugin's source manifest is not
    locatable in the working tree, report the version comparison as unverifiable
    rather than guessing Claude Code's internal cache layout.
 4. **Stale memory-tier files.** For the session's handoff / todo / working-memory

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -28,10 +28,12 @@ back up.
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch is now behind its
-   base. Fetch the base first (`git fetch`) so the behind-count is measured
-   against the live remote base, not a stale local `origin/<base>` ref that can
-   read 0 even after the remote moved; if that fetch cannot run, report the check
-   as unverifiable rather than assuming none. Unless the inputs record a base-tip
+   base. Resolve the base's remote and branch and fetch that ref explicitly
+   (`git fetch <remote> <base-branch>`) — a bare `git fetch` can exit 0 while
+   updating only the tracked branch in a single-branch or shallow checkout,
+   leaving the base stale and the behind-count falsely clean. Measure the
+   behind-count against the freshly fetched base; if the fetch cannot run, report
+   the check as unverifiable rather than assuming none. Unless the inputs record a base-tip
    or merge-base baseline, report the *current* divergence rather than claiming
    it all accrued since the inputs were written — the branch may already have
    been behind. This is reanchor's own check. `/source-control:worktree`, when
@@ -41,8 +43,12 @@ back up.
    drift evidence here.
 3. **Renamed / retired / version-drifted surfaces.** For the skills, plugins,
    and commands the session's inputs name, confirm they still exist under that
-   name and that installed plugin versions match the repo source — a rename or a
-   version bump silently invalidates cited invocations and assumed behavior.
+   name and — when the session is working inside a plugin's source tree — that
+   the installed version (from the documented installed-plugins state) matches
+   that source manifest; a rename or version bump silently invalidates cited
+   invocations and assumed behavior. When a cited plugin's source manifest is not
+   locatable in the working tree, report the version comparison as unverifiable
+   rather than guessing Claude Code's internal cache layout.
 4. **Stale memory-tier files.** For the session's handoff / todo / working-memory
    files, flag entries whose subjects have since merged or landed, so the next
    step neither re-does settled work nor chases a closed thread.

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -28,12 +28,13 @@ back up.
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch's base has moved
-   since the session's inputs were written — the branch may now be behind, or a
-   premise ("this isn't on main yet") may already be false. When
-   `/source-control:worktree` is installed, cite its status for the full
-   per-worktree staleness inventory (behind-base counts, dirty state, PR
-   linkage) instead of recomputing it; otherwise do the reduced local check (a
-   `git` behind-count) and report the fuller inventory as unavailable.
+   since the session's inputs were written — compute the behind-count yourself
+   with `git`, since a premise ("this isn't on main yet") may already be false.
+   This is reanchor's own check. `/source-control:worktree` status, when
+   installed, is a related but distinct capability — a cross-worktree inventory
+   by path / branch / PR / commit-age staleness — that does not report
+   behind-base or dirty-tree signal; cite it for that inventory, not for the
+   drift evidence here.
 3. **Renamed / retired / version-drifted surfaces.** For the skills, plugins,
    and commands the session's inputs name, confirm they still exist under that
    name and that installed plugin versions match the repo source — a rename or a
@@ -56,11 +57,11 @@ back up.
 
 - **Does not resume or continue the work.** It verifies premises; picking the
   work back up is `/session-flow:keep-going`.
-- **Does not inventory worktrees.** Per-worktree/branch staleness (behind-base
-  counts, dirty state, PR linkage) lives in `/source-control:worktree` status
-  when that plugin is installed; this skill cites it, never reimplements it, and
-  falls back to a reduced local base-drift check (flagging the fuller inventory
-  as unavailable) when it is absent.
+- **Does not inventory worktrees.** Enumerating every worktree by
+  path / branch / PR / commit-age staleness is `/source-control:worktree`
+  status's job when that plugin is installed; reanchor does its own base-drift
+  check (a `git` behind-count on the working branch) and never reimplements that
+  cross-worktree inventory.
 - **Does not classify PR feedback or run the PR loop.** Per-PR fresh-evidence
   discipline and feedback triage are `/source-control:babysit-prs`'s job when
   it is installed; reanchor never performs them — it only checks whether a

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reanchor
-description: "Verify a session's working assumptions are still true before building on them — referenced PRs/issues/branches still in the state a handoff or plan claims, base-branch drift, cited skills/plugins that were renamed or version-drifted, and memory-tier files whose subjects have since landed. Reports what drifted and re-anchors; does not resume the work. Use when: 'reanchor', 're-anchor', 'is this still current', 'verify my assumptions', 'has main moved since', 'are these premises still valid', 'is the handoff stale', 'resuming an old plan', 'check freshness'. Not for resuming work (use /session-flow:keep-going), per-worktree staleness (use /source-control:worktree status), or PR feedback triage (use /source-control:babysit-prs)."
+description: "Verify a session's working assumptions are still true before building on them — referenced PRs/issues/branches still in the state a handoff or plan claims, base-branch drift, cited skills/plugins that were renamed or version-drifted, and memory-tier files whose subjects have since landed. Reports what drifted and re-anchors; does not resume the work. Use when: 'reanchor', 're-anchor', 'is this still current', 'verify my assumptions', 'has main moved since', 'are these premises still valid', 'is the handoff stale', 'resuming an old plan', 'check freshness'. Not for resuming work (use /session-flow:keep-going), per-worktree staleness (use /source-control:worktree status), PR feedback triage (use /source-control:babysit-prs), or re-anchoring a standing behavioral rule/discipline (that is the re-anchor plugin — this re-anchors factual premises, not rules)."
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -29,9 +29,11 @@ back up.
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch's base has moved
    since the session's inputs were written — the branch may now be behind, or a
-   premise ("this isn't on main yet") may already be false. For the full
+   premise ("this isn't on main yet") may already be false. When
+   `/source-control:worktree` is installed, cite its status for the full
    per-worktree staleness inventory (behind-base counts, dirty state, PR
-   linkage), cite `/source-control:worktree` status rather than recomputing it.
+   linkage) instead of recomputing it; otherwise do the reduced local check (a
+   `git` behind-count) and report the fuller inventory as unavailable.
 3. **Renamed / retired / version-drifted surfaces.** For the skills, plugins,
    and commands the session's inputs name, confirm they still exist under that
    name and that installed plugin versions match the repo source — a rename or a
@@ -55,11 +57,14 @@ back up.
 - **Does not resume or continue the work.** It verifies premises; picking the
   work back up is `/session-flow:keep-going`.
 - **Does not inventory worktrees.** Per-worktree/branch staleness (behind-base
-  counts, dirty state, PR linkage) lives in `/source-control:worktree` status;
-  this skill cites it, never reimplements it.
+  counts, dirty state, PR linkage) lives in `/source-control:worktree` status
+  when that plugin is installed; this skill cites it, never reimplements it, and
+  falls back to a reduced local base-drift check (flagging the fuller inventory
+  as unavailable) when it is absent.
 - **Does not classify PR feedback or run the PR loop.** Per-PR fresh-evidence
-  discipline and feedback triage stay in `/source-control:babysit-prs`; reanchor
-  only checks whether a *referenced* PR is still in its claimed state.
+  discipline and feedback triage are `/source-control:babysit-prs`'s job when
+  it is installed; reanchor never performs them — it only checks whether a
+  *referenced* PR is still in its claimed state.
 - **Does not re-anchor a standing rule or discipline.** Correcting behavioral
   doctrine mid-session is the `re-anchor` plugin's concern; this skill re-anchors
   factual assumptions, not rules.
@@ -73,5 +78,6 @@ back up.
 - Scope to what the session's inputs actually reference — re-anchoring is bounded
   by the premises in play, not a full-repo audit.
 - It composes with, not replaces, its neighbors: reanchor to learn what drifted,
-  then `keep-going` to resume, `/source-control:worktree` status for the worktree
-  inventory, `/source-control:babysit-prs` for PR work.
+  then `keep-going` (same plugin) to resume; and, when they are installed,
+  `/source-control:worktree` status for the worktree inventory and
+  `/source-control:babysit-prs` for PR work.

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -28,9 +28,11 @@ back up.
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch's base has moved
-   since the session's inputs were written — compute the behind-count yourself
-   with `git`, since a premise ("this isn't on main yet") may already be false.
-   This is reanchor's own check. `/source-control:worktree` status, when
+   since the session's inputs were written. Fetch the base branch first (`git
+   fetch`) so the behind-count is measured against the live remote base, not a
+   stale local `origin/<base>` ref that can read 0 even after the remote moved;
+   if that fetch cannot run, report base-drift as unverifiable rather than
+   assuming none. This is reanchor's own check. `/source-control:worktree`, when
    installed, is a related but distinct capability — a cross-worktree inventory
    by path / branch / PR / commit-age staleness — that does not report
    behind-base or dirty-tree signal; cite it for that inventory, not for the
@@ -47,8 +49,12 @@ back up.
 
 1. Gather the session's inputs — the handoff / plan / memory files and any PRs,
    issues, branches, skills, or plugin versions they name.
-2. Run the four checks above against live reality (git, `gh`, installed vs
-   repo-source manifests).
+2. Run the four checks above against live reality — fetch/read the live source
+   (`git fetch` the base, query `gh`, read installed vs repo-source manifests).
+   When a check cannot reach what it needs (no network, no `gh`, no fetch),
+   report that premise as **unverifiable** rather than assuming it is unchanged;
+   a silent "no drift" from stale local state is the exact failure this skill
+   exists to prevent.
 3. Report drift as a short list — premise → claimed state → actual state — plus
    the re-anchored picture. Surface it; do not silently rewrite the plan or
    auto-fix. The session re-plans on the corrected reality.

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -28,8 +28,11 @@ back up.
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch is now behind its
-   base. Fetch the resolved base ref explicitly and count against the just-fetched
-   tip: `git fetch <remote> <base-branch>`, then measure against `FETCH_HEAD`
+   base. Derive the base from the referenced PR's base branch (or, absent a PR,
+   the remote's default HEAD) — not an assumed `main` — and mark the check
+   unverifiable if the base cannot be resolved. Fetch that resolved base ref
+   explicitly and count against the just-fetched tip: `git fetch <remote>
+   <base-branch>`, then measure against `FETCH_HEAD`
    (e.g. `git rev-list --count HEAD..FETCH_HEAD`). A bare `git fetch`, or a count
    against a local `origin/<base>` tracking ref, can read falsely clean in a
    single-branch or shallow checkout where that ref was never updated —

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -28,12 +28,13 @@ back up.
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
 2. **Base-branch drift.** Check whether the working branch is now behind its
-   base. Resolve the base's remote and branch and fetch that ref explicitly
-   (`git fetch <remote> <base-branch>`) — a bare `git fetch` can exit 0 while
-   updating only the tracked branch in a single-branch or shallow checkout,
-   leaving the base stale and the behind-count falsely clean. Measure the
-   behind-count against the freshly fetched base; if the fetch cannot run, report
-   the check as unverifiable rather than assuming none. Unless the inputs record a base-tip
+   base. Fetch the resolved base ref explicitly and count against the just-fetched
+   tip: `git fetch <remote> <base-branch>`, then measure against `FETCH_HEAD`
+   (e.g. `git rev-list --count HEAD..FETCH_HEAD`). A bare `git fetch`, or a count
+   against a local `origin/<base>` tracking ref, can read falsely clean in a
+   single-branch or shallow checkout where that ref was never updated —
+   `FETCH_HEAD` always holds what this fetch actually retrieved. If the fetch
+   cannot run, report the check as unverifiable rather than assuming none. Unless the inputs record a base-tip
    or merge-base baseline, report the *current* divergence rather than claiming
    it all accrued since the inputs were written — the branch may already have
    been behind. This is reanchor's own check. `/source-control:worktree`, when

--- a/plugins/session-flow/skills/reanchor/SKILL.md
+++ b/plugins/session-flow/skills/reanchor/SKILL.md
@@ -27,12 +27,14 @@ back up.
    locked plan references, confirm it is still in the state the document claims
    — open vs merged/closed, same head, same base, not renamed. A plan that
    assumes an in-flight PR is often built on one that already landed.
-2. **Base-branch drift.** Check whether the working branch's base has moved
-   since the session's inputs were written. Fetch the base branch first (`git
-   fetch`) so the behind-count is measured against the live remote base, not a
-   stale local `origin/<base>` ref that can read 0 even after the remote moved;
-   if that fetch cannot run, report base-drift as unverifiable rather than
-   assuming none. This is reanchor's own check. `/source-control:worktree`, when
+2. **Base-branch drift.** Check whether the working branch is now behind its
+   base. Fetch the base first (`git fetch`) so the behind-count is measured
+   against the live remote base, not a stale local `origin/<base>` ref that can
+   read 0 even after the remote moved; if that fetch cannot run, report the check
+   as unverifiable rather than assuming none. Unless the inputs record a base-tip
+   or merge-base baseline, report the *current* divergence rather than claiming
+   it all accrued since the inputs were written — the branch may already have
+   been behind. This is reanchor's own check. `/source-control:worktree`, when
    installed, is a related but distinct capability — a cross-worktree inventory
    by path / branch / PR / commit-age staleness — that does not report
    behind-base or dirty-tree signal; cite it for that inventory, not for the

--- a/plugins/session-flow/skills/reanchor/evals/evals.json
+++ b/plugins/session-flow/skills/reanchor/evals/evals.json
@@ -53,34 +53,34 @@
       "id": 5,
       "name": "negative-routing-worktree-inventory",
       "prompt": "Give me the staleness inventory across all my worktrees — which are stale by last-commit age and which have open PRs.",
-      "expected_output": "/source-control:worktree status handles the cross-worktree inventory (path, branch, PR linkage, commit-age staleness); reanchor does not load — that inventory is a separate capability, distinct from reanchor's own base-drift check.",
+      "expected_output": "The cross-worktree inventory (path, branch, PR linkage, commit-age staleness) is source-control's worktree status when that plugin is installed, and reported as an unavailable capability otherwise; either way reanchor does not load — that inventory is distinct from reanchor's own base-drift check.",
       "files": [],
       "expectations": [
-        "Routes to /source-control:worktree status for the worktree inventory",
-        "reanchor is not invoked to enumerate worktrees"
+        "reanchor is not invoked to enumerate worktrees",
+        "The worktree inventory routes to /source-control:worktree status when installed, or is reported unavailable otherwise"
       ]
     },
     {
       "id": 6,
       "name": "negative-routing-pr-feedback-triage",
       "prompt": "Go through my open PRs, classify the bot and human review feedback, and handle the safe follow-ups.",
-      "expected_output": "/source-control:babysit-prs handles the per-PR fresh-evidence discipline and feedback triage; reanchor does not load — it only checks whether a referenced PR is still in its claimed state, it never classifies PR feedback or runs the loop.",
+      "expected_output": "Per-PR feedback triage is source-control's babysit-prs when that plugin is installed, and an unavailable capability otherwise; either way reanchor does not load — it only checks whether a referenced PR is still in its claimed state, never classifying feedback or running the loop.",
       "files": [],
       "expectations": [
-        "Routes to /source-control:babysit-prs for feedback classification and follow-up",
-        "reanchor is not invoked to triage PR feedback or run the PR loop"
+        "reanchor is not invoked to triage PR feedback or run the PR loop",
+        "PR-feedback triage routes to /source-control:babysit-prs when installed, or is reported unavailable otherwise"
       ]
     },
     {
       "id": 7,
       "name": "negative-routing-rule-discipline-is-re-anchor-plugin",
       "prompt": "You've been drifting from the no-assumptions rule mid-task — re-anchor to that standing rule and audit the work in flight against it.",
-      "expected_output": "The re-anchor plugin's discipline-corrector skills handle re-anchoring a standing behavioral rule and auditing in-flight work against it; session-flow:reanchor does not load — it re-anchors factual session assumptions against live reality, not behavioral doctrine.",
+      "expected_output": "Re-anchoring a standing behavioral rule and auditing in-flight work against it is a separate discipline concern (the re-anchor plugin's, when installed); session-flow:reanchor does not load — it re-anchors factual session assumptions against live reality, not behavioral doctrine.",
       "files": [],
       "expectations": [
-        "Routes to the re-anchor plugin for standing-rule/discipline correction",
         "session-flow:reanchor is not invoked for behavioral-rule re-anchoring",
-        "Distinguishes factual-premise freshness (reanchor) from rule discipline (re-anchor plugin)"
+        "Standing-rule/discipline correction routes to the re-anchor plugin when installed, else is treated as outside reanchor's scope",
+        "Distinguishes factual-premise freshness (reanchor) from rule discipline"
       ]
     }
   ]

--- a/plugins/session-flow/skills/reanchor/evals/evals.json
+++ b/plugins/session-flow/skills/reanchor/evals/evals.json
@@ -18,12 +18,12 @@
       "id": 2,
       "name": "plugin-version-drift",
       "prompt": "This handoff says to use a plugin skill a certain way, but that was written a while ago. Are the installed plugin versions still what the handoff assumes?",
-      "expected_output": "reanchor compares the installed plugin versions against the repo-source versions for the surfaces the handoff cites, and flags any drift (a version bump or a renamed/retired skill) that would silently invalidate the cited invocation or its assumed behavior.",
+      "expected_output": "reanchor confirms the cited surfaces still exist under that name and, when their source manifest is locatable in the working tree, compares the installed version against it and flags any drift; when the source manifest is not locatable, it reports the version comparison as unverifiable rather than guessing internal cache paths.",
       "files": [],
       "expectations": [
-        "Compares installed vs repo-source plugin versions for the cited surfaces",
-        "Flags renamed/retired/version-drifted skills or plugins the inputs name",
-        "Frames the drift as invalidating the handoff's assumed invocation/behavior"
+        "Confirms cited skills/plugins still exist under the named surface",
+        "Compares installed vs source-manifest version when the source is locatable in the working tree",
+        "Reports the comparison as unverifiable rather than guessing cache paths when the source is not locatable"
       ]
     },
     {

--- a/plugins/session-flow/skills/reanchor/evals/evals.json
+++ b/plugins/session-flow/skills/reanchor/evals/evals.json
@@ -1,0 +1,87 @@
+{
+  "skill_name": "reanchor",
+  "evals": [
+    {
+      "id": 1,
+      "name": "resuming-old-plan-verify-premises",
+      "prompt": "I'm picking this plan back up after a few days. Before I act on it, is everything it assumes still true? It references a couple of open PRs and a branch that wasn't on main yet.",
+      "expected_output": "reanchor loads and verifies the plan's premises against live reality: for each referenced PR/issue/branch it checks the current state (still open vs merged/closed, same head/base, not renamed) and whether the branch's base has moved, then reports premise -> claimed state -> actual state plus the re-anchored picture. It does not resume the work itself.",
+      "files": [],
+      "expectations": [
+        "Routes to reanchor (verify premises), not straight into executing the plan",
+        "Checks each referenced PR/issue/branch's live state rather than trusting the plan's claim",
+        "Reports drift as claimed-vs-actual and hands back a corrected picture",
+        "Does not itself resume/continue the work"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "plugin-version-drift",
+      "prompt": "This handoff says to use a plugin skill a certain way, but that was written a while ago. Are the installed plugin versions still what the handoff assumes?",
+      "expected_output": "reanchor compares the installed plugin versions against the repo-source versions for the surfaces the handoff cites, and flags any drift (a version bump or a renamed/retired skill) that would silently invalidate the cited invocation or its assumed behavior.",
+      "files": [],
+      "expectations": [
+        "Compares installed vs repo-source plugin versions for the cited surfaces",
+        "Flags renamed/retired/version-drifted skills or plugins the inputs name",
+        "Frames the drift as invalidating the handoff's assumed invocation/behavior"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "stale-memory-and-base-drift",
+      "prompt": "Re-anchor this session — the handoff and todo file are from before the weekend and I think some of it already landed, plus main has probably moved.",
+      "expected_output": "reanchor flags handoff/todo entries whose subjects have since merged or landed (so settled work is not redone), checks whether the working branch's base has moved since the inputs were written, and reports the drift. For the full per-worktree staleness inventory it points at /source-control:worktree status rather than recomputing it.",
+      "files": [],
+      "expectations": [
+        "Flags memory-tier entries whose subjects have since merged/landed",
+        "Checks base-branch drift since the inputs were written",
+        "Cites /source-control:worktree status for the full worktree inventory instead of reimplementing it"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "negative-routing-resume-is-keep-going",
+      "prompt": "We got cut off — pick up where you left off and keep going with what was running.",
+      "expected_output": "/session-flow:keep-going handles this (recover off-thread work and continue); reanchor does not load — its job is verifying premises, not resuming the work.",
+      "files": [],
+      "expectations": [
+        "Routes to /session-flow:keep-going for recover-and-continue",
+        "reanchor is not invoked for resuming/continuing work"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "negative-routing-worktree-inventory",
+      "prompt": "Give me the staleness inventory across all my worktrees — which are behind their base, dirty, or have open PRs.",
+      "expected_output": "/source-control:worktree status handles the per-worktree/branch staleness inventory (behind-base counts, dirty state, PR linkage); reanchor does not load — it cites that inventory as an input, it does not compute it.",
+      "files": [],
+      "expectations": [
+        "Routes to /source-control:worktree status for the worktree inventory",
+        "reanchor is not invoked to compute per-worktree staleness"
+      ]
+    },
+    {
+      "id": 6,
+      "name": "negative-routing-pr-feedback-triage",
+      "prompt": "Go through my open PRs, classify the bot and human review feedback, and handle the safe follow-ups.",
+      "expected_output": "/source-control:babysit-prs handles the per-PR fresh-evidence discipline and feedback triage; reanchor does not load — it only checks whether a referenced PR is still in its claimed state, it never classifies PR feedback or runs the loop.",
+      "files": [],
+      "expectations": [
+        "Routes to /source-control:babysit-prs for feedback classification and follow-up",
+        "reanchor is not invoked to triage PR feedback or run the PR loop"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "negative-routing-rule-discipline-is-re-anchor-plugin",
+      "prompt": "You've been drifting from the no-assumptions rule mid-task — re-anchor to that standing rule and audit the work in flight against it.",
+      "expected_output": "The re-anchor plugin's discipline-corrector skills handle re-anchoring a standing behavioral rule and auditing in-flight work against it; session-flow:reanchor does not load — it re-anchors factual session assumptions against live reality, not behavioral doctrine.",
+      "files": [],
+      "expectations": [
+        "Routes to the re-anchor plugin for standing-rule/discipline correction",
+        "session-flow:reanchor is not invoked for behavioral-rule re-anchoring",
+        "Distinguishes factual-premise freshness (reanchor) from rule discipline (re-anchor plugin)"
+      ]
+    }
+  ]
+}

--- a/plugins/session-flow/skills/reanchor/evals/evals.json
+++ b/plugins/session-flow/skills/reanchor/evals/evals.json
@@ -52,12 +52,12 @@
     {
       "id": 5,
       "name": "negative-routing-worktree-inventory",
-      "prompt": "Give me the staleness inventory across all my worktrees — which are behind their base, dirty, or have open PRs.",
-      "expected_output": "/source-control:worktree status handles the per-worktree/branch staleness inventory (behind-base counts, dirty state, PR linkage); reanchor does not load — it cites that inventory as an input, it does not compute it.",
+      "prompt": "Give me the staleness inventory across all my worktrees — which are stale by last-commit age and which have open PRs.",
+      "expected_output": "/source-control:worktree status handles the cross-worktree inventory (path, branch, PR linkage, commit-age staleness); reanchor does not load — that inventory is a separate capability, distinct from reanchor's own base-drift check.",
       "files": [],
       "expectations": [
         "Routes to /source-control:worktree status for the worktree inventory",
-        "reanchor is not invoked to compute per-worktree staleness"
+        "reanchor is not invoked to enumerate worktrees"
       ]
     },
     {

--- a/plugins/session-flow/skills/reanchor/evals/evals.json
+++ b/plugins/session-flow/skills/reanchor/evals/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "name": "resuming-old-plan-verify-premises",
       "prompt": "I'm picking this plan back up after a few days. Before I act on it, is everything it assumes still true? It references a couple of open PRs and a branch that wasn't on main yet.",
-      "expected_output": "reanchor loads and verifies the plan's premises against live reality: for each referenced PR/issue/branch it checks the current state (still open vs merged/closed, same head/base, not renamed) and whether the branch's base has moved, then reports premise -> claimed state -> actual state plus the re-anchored picture. It does not resume the work itself.",
+      "expected_output": "reanchor loads and verifies the plan's premises against live reality: for each referenced PR/issue/branch it checks the current state (still open vs merged/closed, same head/base, not renamed) and whether the working branch is now behind its base, then reports premise -> claimed state -> actual state plus the re-anchored picture. It does not resume the work itself.",
       "files": [],
       "expectations": [
         "Routes to reanchor (verify premises), not straight into executing the plan",
@@ -28,14 +28,14 @@
     },
     {
       "id": 3,
-      "name": "stale-memory-and-base-drift",
+      "name": "stale-memory-and-current-base-divergence",
       "prompt": "Re-anchor this session — the handoff and todo file are from before the weekend and I think some of it already landed, plus main has probably moved.",
-      "expected_output": "reanchor flags handoff/todo entries whose subjects have since merged or landed (so settled work is not redone), checks whether the working branch's base has moved since the inputs were written, and reports the drift. For the full per-worktree staleness inventory it points at /source-control:worktree status rather than recomputing it.",
+      "expected_output": "reanchor flags handoff/todo entries whose subjects have since merged or landed (so settled work is not redone), then fetches the base and reports the working branch's CURRENT behind-base divergence — without attributing pre-existing behind-commits to post-handoff drift, since the handoff records no base-tip baseline.",
       "files": [],
       "expectations": [
         "Flags memory-tier entries whose subjects have since merged/landed",
-        "Checks base-branch drift since the inputs were written",
-        "Cites /source-control:worktree status for the full worktree inventory instead of reimplementing it"
+        "Fetches the base and reports current behind-base divergence",
+        "Does not claim the divergence all accrued since the inputs were written when no baseline SHA is recorded"
       ]
     },
     {


### PR DESCRIPTION
## What

Adds `reanchor` to the **session-flow** plugin (0.8.0 → 0.9.0) — the freshness/re-anchor skill tracked by #312 (ledger B16, last step of the babysit-prs migration). It re-anchors a session's working assumptions against live reality before the session builds on them.

**Scan boundary (signed off):** four checks —
1. Handoff/plan premise verification (referenced PRs/issues/branches still in the claimed state).
2. Base-branch drift.
3. Renamed/retired/version-drifted cited surfaces (installed vs repo-source plugin versions — the exact failure this migration hit).
4. Stale memory-tier files whose subjects have since landed.

It reports drift and re-anchors; it does not auto-fix.

## Placement + boundary

Placed in **session-flow** for functional cohesion with its session-lifecycle siblings (`handoff`, `keep-going`, `retro`, `orchestrate`), not the `re-anchor` plugin (which is passive discipline-correctors for standing rules — a different concern, distinguished by eval id 7). Boundary is **cross-cite only, no overlap copy**: resuming work stays in `keep-going`, per-worktree staleness in `/source-control:worktree` status, per-PR feedback triage in `/source-control:babysit-prs`.

## Evals

7 routing evals — 3 positive covering all four checks, 4 negative distinguishing `keep-going`, `worktree` status, `babysit-prs`, and the `re-anchor` plugin.

## Validation

`validate-plugins.sh` green (contracts, catalog drift, strict marketplace); markdownlint clean; skill-quality `check-skill.sh reanchor` PASS (0 errors/warnings, 77/500 lines, description 735/1536). Root catalog README regenerated.

## Related

- #322 — babysit-prs convergence (PR-B); this skill is the final step (B16) of that migration.
- Migration ledger B16 — `docs/topics/babysit-prs-migration/PLAN.md` (Brief AC7).

Closes #312
