### PR TITLE
ci: skip claude-review for the standards-sync bot

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,6 +47,9 @@ jobs:
     uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
     with:
       runner: ${{ needs.select-review.outputs.runner || 'ubuntu-24.04' }}
+      # Passing skip-actors replaces the reusable's default (dependabot[bot]),
+      # so the default member is restated alongside the sync bot.
+      skip-actors: "dependabot[bot],melodic-standards-sync[bot]"
     # Pass only the one named secret (least privilege) rather than `secrets:
     # inherit`, which would forward every parent secret to the called workflow.
     secrets:


### PR DESCRIPTION
Adds `melodic-standards-sync[bot]` to the claude-review caller's `skip-actors` (restating the reusable's default member `dependabot[bot]`, since passing the input replaces the default). Today a sync PR's review job spins up and no-ops — the bot is neither allowed nor skipped. A clean skip saves fleet time and Claude tokens on mechanical config syncs, which remain covered by CI, do-not-merge, and pr-issue-linkage gates.

No linked issue.

## Related

- melodic-software/standards#174
- melodic-software/ci-workflows#142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZxBP1B8Hf7ZRaqDrP6ma9
