### PR TITLE
fix(session-flow): make worker model tier an explicit spawn decision (0.9.1)

### DIFF
--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Session-lifecycle toolkit of six skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), retro (structured session retrospective with transcript metrics and learning codification), orchestrate (arm a session or worker with proactive-orchestration imperatives), and reanchor (verify a session's working assumptions are still true against live reality — referenced PRs/issues/branches, base-branch drift, renamed/version-drifted surfaces, stale memory-tier files — before building on them).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — session-flow plugin
 
+## 0.9.1 — 2026-07-18
+
+Fixed:
+
+- orchestrate: worker model tier is now an explicit spawn decision. SPEC EVERY SPAWN adds the
+  model tier to the per-worker spec, and CALIBRATE TO CONDITIONS adds per-worker tiering (cheap
+  tier for high-volume mechanical work, parent tier reserved for judgment-heavy
+  synthesis/verify; wider fan-out defaults cheaper). Closes the failure mode where a wide
+  fan-out silently inherited the parent session's premium model on every worker — an omitted
+  model defaults to `inherit` per the subagents doc (resolution order and cost-control quote
+  now cited in `context/sources.md`).
+
 ## 0.9.0 — 2026-07-18
 
 Added:

--- a/plugins/session-flow/skills/orchestrate/SKILL.md
+++ b/plugins/session-flow/skills/orchestrate/SKILL.md
@@ -42,8 +42,9 @@ told:
    research: never split one feature across agents. Multi-agent costs 3–10× the tokens (returns
    cost context too), so spend it on value + parallelism, not convenience.
 2. SPEC EVERY SPAWN — give each worker an objective, an output format, the tools/sources to use,
-   and explicit task boundaries. Vague delegation makes workers duplicate each other, leave gaps,
-   or wander.
+   explicit task boundaries, and a deliberately chosen model tier. Vague delegation makes workers
+   duplicate each other, leave gaps, or wander; an unspecified model silently inherits the parent
+   session's — often its most expensive — model.
 3. FRESH-CONTEXT VERIFY — after an edit batch or a finding set, hand it to a SEPARATE verifier;
    never self-audit in the context that produced it. Give the verifier concrete pass/fail criteria
    ("run the full suite, report all failures"), scope it to correctness/requirements (not style),
@@ -65,7 +66,12 @@ told:
    / rate-limit headroom (thin headroom caps how many workers you run at once). Sizing is
    small/medium/large — a small ask stays single-agent, a medium one fans out a few, only a large
    genuinely-independent surface earns a wide or nested tree. Single-agent is the floor, not the
-   fallback.
+   fallback. Per-worker model tier is part of sizing: match the tier to the SUBTASK, not the
+   parent session — high-volume mechanical work (search, extraction, per-item transforms,
+   formatting) runs on a cheaper tier; the parent tier is reserved for judgment-heavy synthesis,
+   verification, and adjudication. The wider the fan-out, the cheaper the default per-worker
+   tier — a wide fan-out on the parent's premium model is a decision to justify explicitly,
+   never a default to inherit.
 
 Discipline: trigger-evaluation is mandatory; the ACTION stays calibrated (delegate on value +
 parallelism, not convenience). Treat every worker's return as unverified synthesis — verify

--- a/plugins/session-flow/skills/orchestrate/SKILL.md
+++ b/plugins/session-flow/skills/orchestrate/SKILL.md
@@ -43,8 +43,8 @@ told:
    cost context too), so spend it on value + parallelism, not convenience.
 2. SPEC EVERY SPAWN — give each worker an objective, an output format, the tools/sources to use,
    explicit task boundaries, and a deliberately chosen model tier. Vague delegation makes workers
-   duplicate each other, leave gaps, or wander; an unspecified model silently inherits the parent
-   session's — often its most expensive — model.
+   duplicate each other, leave gaps, or wander; absent a consumer-level subagent-model override,
+   an unspecified model silently inherits the parent session's — often its most expensive — model.
 3. FRESH-CONTEXT VERIFY — after an edit batch or a finding set, hand it to a SEPARATE verifier;
    never self-audit in the context that produced it. Give the verifier concrete pass/fail criteria
    ("run the full suite, report all failures"), scope it to correctness/requirements (not style),

--- a/plugins/session-flow/skills/orchestrate/context/sources.md
+++ b/plugins/session-flow/skills/orchestrate/context/sources.md
@@ -112,3 +112,11 @@ Part-sourced, part authoring convention — the boundary is called out per facto
   they scale the same underlying trade-offs (a fresh-context verifier is worth leaning on when one
   is on hand; a filling window is itself the context-protection trigger imperative 1 names; thin
   rate-limit headroom is a hard ceiling on parallel workers).
+- **Per-worker model tier is an explicit spawn decision.** The subagents doc names cost control as
+  a purpose of subagents: "Control costs by routing tasks to faster, cheaper models like Haiku"
+  *(verbatim, verified)*, and documents the model-resolution order — `CLAUDE_CODE_SUBAGENT_MODEL`
+  env var, then the per-invocation `model` parameter, then the agent definition's `model`
+  frontmatter, then the main conversation's model; an omitted `model` "defaults to `inherit`"
+  *(verbatim, verified)*. A spawn that never states a tier therefore runs every worker on the
+  parent session's model — the mechanism behind premium-model fan-outs (imperatives 2 and 7's
+  tiering clauses). — <https://code.claude.com/docs/en/sub-agents>


### PR DESCRIPTION
## What

The `/session-flow:orchestrate` skill let an armed session fan out 100+ workers without a model stated on any spawn. Per the official subagents doc, an omitted `model` **defaults to `inherit`** (resolution order: `CLAUDE_CODE_SUBAGENT_MODEL` env var → per-invocation `model` param → agent frontmatter → main conversation's model), so every worker silently ran on the parent session's premium model. Observed: a 100–200-agent run entirely on Fable.

## Changes

- **SPEC EVERY SPAWN** (imperative 2): the per-worker spec now includes "a deliberately chosen model tier", with the silent-inheritance failure mode named.
- **CALIBRATE TO CONDITIONS** (imperative 7): per-worker tiering added to sizing — high-volume mechanical work runs on a cheaper tier; the parent tier is reserved for judgment-heavy synthesis/verification/adjudication; the wider the fan-out, the cheaper the default per-worker tier; a wide premium-tier fan-out must be justified explicitly, never inherited.
- **context/sources.md**: cites the subagents doc's verbatim cost-control guidance ("Control costs by routing tasks to faster, cheaper models like Haiku") and the model-resolution order.
- session-flow `0.9.0 → 0.9.1` (rebased over the 0.9.0 reanchor-skill release), CHANGELOG entry.

## Why guidance, not enforcement

The skill is instruction text — it cannot set a model itself. The blunt environment-level guard (`CLAUDE_CODE_SUBAGENT_MODEL`) remains available to consumers and is deliberately not prescribed: it flattens ALL subagents to one tier, including judgment-heavy verifiers.

## Fresh-docs mandate

Fetched this session and cited: <https://code.claude.com/docs/en/sub-agents> (model resolution, omitted-defaults-to-inherit, cost-control quote).

## Gates

- markdownlint-cli2 (repo config) on the three changed markdown files: 0 errors
- `claude plugin validate ./plugins/session-flow`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLztic1sFn2CVFJsubr7pu

## Related



No linked issue.