### PR TITLE
ci(runner-policy): declare public visibility, hosted-only CI

### DIFF
--- a/.github/runner-policy.json
+++ b/.github/runner-policy.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "repositoryOwner": "melodic-software",
-  "visibility": "private",
-  "selfHostedCi": true,
+  "visibility": "public",
+  "selfHostedCi": false,
   "exceptions": {}
 }


### PR DESCRIPTION
Repository is now public. Public repos get free unlimited GitHub-hosted runners and must not route to the self-hosted fleet.

Declare `visibility: public` and `selfHostedCi: false` in the local runner-policy declaration so it matches actual visibility and the `ci-status` runner-policy lane passes.