### PR TITLE
ci: adopt the public hosted-runner posture

### DIFF
--- a/.github/runner-policy.json
+++ b/.github/runner-policy.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "repositoryOwner": "melodic-software",
-  "visibility": "private",
-  "selfHostedCi": true,
+  "visibility": "public",
+  "selfHostedCi": false,
   "exceptions": {}
 }

--- a/.github/standards/runner-policy/policy.json
+++ b/.github/standards/runner-policy/policy.json
@@ -13,7 +13,8 @@
       "melodic-software/ci-workflows/.github/workflows/select-runner.yml@f2d5e06757201f2fce187096a2c6fa805836c3d2",
       "melodic-software/ci-workflows/.github/workflows/select-runner.yml@3931f91ccba9bfe97500196091ae2cc039672952",
       "melodic-software/ci-workflows/.github/workflows/select-runner.yml@cdc5917c15aade1995bd810b60d818cadc635b52",
-      "melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5"
+      "melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5",
+      "melodic-software/ci-workflows/.github/workflows/select-runner.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f"
     ]
   },
   "approvedReusableWorkflowContracts": {
@@ -159,6 +160,15 @@
         "app-private-key": "${{ secrets.STANDARDS_SYNC_APP_PRIVATE_KEY }}"
       }
     },
+    "melodic-software/ci-workflows/.github/workflows/standards-sync.yml@0b45b9fb1755649455e3bb2b9c56c619a412b06b": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "allowedInputs": ["runner", "manifest", "standards-ref", "dry-run", "targets"],
+      "allowedSecrets": {
+        "app-client-id": "${{ secrets.STANDARDS_SYNC_APP_CLIENT_ID }}",
+        "app-private-key": "${{ secrets.STANDARDS_SYNC_APP_PRIVATE_KEY }}"
+      }
+    },
     "melodic-software/ci-workflows/.github/workflows/zizmor.yml@99ac2f8c5b09dbb785d4eaf18465cbd96c30290c": {
       "routing": "hosted-only",
       "allowedInputs": ["paths"],
@@ -289,6 +299,62 @@
       ],
       "allowedSecrets": {},
       "fixedRunsOn": ["windows-2025"]
+    },
+    "melodic-software/ci-workflows/.github/workflows/claude-review.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "allowedInputs": ["runner", "skip-actors"],
+      "allowedSecrets": {
+        "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+      },
+      "allowedCallerPermissions": {
+        "contents": "read",
+        "pull-requests": "write",
+        "id-token": "write"
+      }
+    },
+    "melodic-software/ci-workflows/.github/workflows/link-check.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "allowedInputs": [
+        "runner",
+        "args",
+        "issue-title",
+        "issue-labels",
+        "issue-type",
+        "auto-close"
+      ],
+      "allowedSecrets": {},
+      "allowedCallerPermissions": {
+        "contents": "read",
+        "issues": "write"
+      }
+    },
+    "melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "selectorResultInput": "prerequisite-result",
+      "allowedInputs": ["runner", "prerequisite-result"],
+      "allowedSecrets": {}
+    },
+    "melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "selectorResultInput": "prerequisite-result",
+      "allowedInputs": ["runner", "prerequisite-result"],
+      "allowedSecrets": {}
+    },
+    "melodic-software/ci-workflows/.github/workflows/zizmor.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "allowedInputs": ["runner", "paths"],
+      "allowedSecrets": {}
+    },
+    "melodic-software/ci-workflows/.github/workflows/osv-scanner.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f": {
+      "routing": "runner-input",
+      "runnerInput": "runner",
+      "allowedInputs": ["runner"],
+      "allowedSecrets": {}
     }
   },
   "canonicalSelectorInputs": {
@@ -324,7 +390,6 @@
   "hostedExceptionReasons": [
     "dependabot",
     "docker-socket",
-    "hosted-control-plane",
     "job-container",
     "privileged-control-plane",
     "publication",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,29 +22,12 @@ concurrency:
 # local ci-status gateway aggregates every lane into the
 # single required check the org ci-gate ruleset keys on.
 jobs:
-  # One governed routing gate feeds every lane in this workflow: the liveness
-  # selector makes one routing decision per workflow instead of fanning out
-  # identical preflights. The short hygiene checks still share one checkout and
-  # one ephemeral worker to avoid runner-registration churn. A
-  # selector/configuration failure blocks the complete workload; it cannot
-  # silently redirect to paid hosted Linux.
-  select-runner:
-    name: Select runner
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
+  # Public repository: every lane runs on GitHub-hosted ubuntu-24.04 (free for
+  # public repositories); the local-runner selector is not permitted here. The
+  # short hygiene checks still share one checkout to avoid per-check setup
+  # churn.
   hygiene:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -187,20 +170,16 @@ jobs:
         run: scripts/aggregate-hygiene-results.sh
 
   zizmor:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
     permissions:
       contents: read
     # Advisory Actions security lint; findings annotate without blocking.
-    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
+    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
-      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+      runner: ubuntu-24.04
       paths: .
 
   hook-utils-sync:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -220,9 +199,7 @@ jobs:
         run: scripts/sync-hook-utils.sh --check-bump "origin/$BASE_REF"
 
   standards-contract-sync:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -242,9 +219,7 @@ jobs:
         run: scripts/sync-standards-contract.sh --check-bump "origin/$BASE_REF"
 
   cross-plugin-source-drift:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -257,9 +232,7 @@ jobs:
         run: bash scripts/check-cross-plugin-source-drift.test.sh
 
   plugin-gate:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -309,9 +282,7 @@ jobs:
   # and fails on any drift, then runs the bundle over stdio so a build that
   # compiles but cannot serve MCP is caught here, not on a consumer's machine.
   miro-plugin:
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Check out
@@ -351,9 +322,7 @@ jobs:
 
   runner-policy:
     name: Runner policy
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -377,7 +346,6 @@ jobs:
 
   ci-status:
     needs:
-      - select-runner
       - hygiene
       - hook-utils-sync
       - standards-contract-sync
@@ -387,12 +355,11 @@ jobs:
       - runner-policy
       - zizmor
     # Fail-closed through execution: !cancelled() (never a success-guard) so a
-    # selector/fleet failure still runs this required aggregate on the hosted
-    # fallback and the result join below turns it red. A success-guard would skip
-    # the job, and a skipped required check reports success to branch protection.
-    # Happy path routes to the fleet (github-iac#78).
+    # lane failure still runs this required aggregate and the result join below
+    # turns it red. A success-guard would skip the job, and a skipped required
+    # check reports success to branch protection.
     if: ${{ !cancelled() }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Aggregate lane results

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ name: claude-review
 # Fork PRs receive no secrets and a read-only token, so they are simply not
 # reviewed by design (no token-exfiltration surface). Requires `claude-code-plugins` to be
 # in the CLAUDE_CODE_OAUTH_TOKEN org secret's selected-repositories scope.
+# Public repo: runs on the reusable's hosted default runner.
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
@@ -16,37 +17,14 @@ permissions:
   contents: read
 
 jobs:
-  # Resolves the capped review tier's label (not the default fleet label) so
-  # reviews queue on the dedicated review scale set instead of competing with
-  # build capacity. Routing through the fleet also retires the old
-  # strict-policy skip guard: review no longer depends on the hosted lane.
-  select-review:
-    name: Select runner
-    permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_REVIEW_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-
   review:
-    needs: select-review
-    # !cancelled() overrides GitHub's skip propagation, so selector success must
-    # be required explicitly: a hard-failed selector emits no runner output and
-    # the hosted fallback below would otherwise run this privileged job.
-    if: ${{ !cancelled() && needs.select-review.result == 'success' }}
     permissions:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
-      runner: ${{ needs.select-review.outputs.runner || 'ubuntu-24.04' }}
+      runner: ubuntu-24.04
       # Passing skip-actors replaces the reusable's default (dependabot[bot]),
       # so the default member is restated alongside the sync bot.
       skip-actors: "dependabot[bot],melodic-standards-sync[bot]"

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -9,7 +9,9 @@ name: do-not-merge
 # that passed before the label was applied stays green and the merge is never
 # blocked. `merge_group` re-checks the label in the queue (inert without a
 # queue). The emitted required-check context is `do-not-merge / do-not-merge`.
+# Public repo: runs on the reusable's hosted default runner.
 on:
+  # zizmor: ignore[dangerous-triggers] metadata-only gate; rationale in the header comment
   pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
@@ -25,30 +27,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  select-runner:
-    name: Select runner
-    permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-
   do-not-merge:
-    needs: select-runner
-    # Fail-closed selector-result reporter: always() so every routing outcome
-    # materializes the required check. The reusable receives the selector result
-    # and fail-closes on any non-success before evaluating the label, so a
-    # routing failure never dispatches this gate to paid hosted Linux.
-    if: ${{ always() }}
     permissions:
       pull-requests: read
     uses: melodic-software/ci-workflows/.github/workflows/do-not-merge-gate.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18 gh-CLI-free label refetch
     with:
-      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
-      prerequisite-result: ${{ needs.select-runner.result }}
+      runner: ubuntu-24.04

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -3,7 +3,8 @@ name: link-check
 # Advisory online external-link check (not part of ci-status). Runs weekly and
 # on demand; files a rolling tracking issue on failure rather than gating merges.
 # Deterministic on-disk link integrity is covered separately by the offline
-# lychee check; this lane catches dead external URLs in the docs.
+# lychee check; this lane catches dead external URLs in the docs. Public repo:
+# runs on the reusable's hosted default runner.
 on:
   schedule:
     - cron: '23 6 * * 1'
@@ -13,34 +14,15 @@ permissions:
   contents: read
 
 jobs:
-  select-runner:
-    name: Select runner
-    permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-
   link-check:
-    # Routes through the governed selector to the fleet; the old strict-policy
-    # pause is retired now that this issue-writing lane no longer depends on
-    # hosted compute.
-    needs: select-runner
-    if: ${{ !cancelled() && needs.select-runner.result == 'success' }}
     # issues: write is scoped to this job (least privilege) — only the called
     # workflow files the rolling tracking issue.
     permissions:
       contents: read
       issues: write
-    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
+    uses: melodic-software/ci-workflows/.github/workflows/link-check.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
-      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
+      runner: ubuntu-24.04
       args: >-
         --cache
         --max-cache-age 7d

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -9,8 +9,10 @@ name: pr-issue-linkage
 # and runs no head code. `edited` re-validates on a body edit. `merge_group`
 # reports the check green in the queue (the body was validated at PR time; inert
 # without a queue). The emitted required-check context is
-# `pr-issue-linkage / pr-issue-linkage`.
+# `pr-issue-linkage / pr-issue-linkage`. Public repo: runs on the reusable's
+# hosted default runner.
 on:
+  # zizmor: ignore[dangerous-triggers] metadata-only gate; rationale in the header comment
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
   merge_group:
@@ -25,29 +27,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  select-runner:
-    name: Select runner
-    permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-
   pr-issue-linkage:
-    needs: select-runner
-    # Fail-closed selector-result reporter: always() so every routing outcome
-    # materializes the required check. The reusable receives the selector result
-    # and fail-closes on any non-success before validating the body, so a
-    # routing failure never dispatches this gate to paid hosted Linux.
-    if: ${{ always() }}
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
-      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
-      prerequisite-result: ${{ needs.select-runner.result }}
+      runner: ubuntu-24.04

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,7 +4,8 @@ name: pr-title
 # workflow from ci-workflows. Repos are squash-only with the squash title set to
 # PR_TITLE, so the PR title becomes the default-branch subject — this gates the
 # Conventional-Commits history. `edited` re-validates on a re-title. The emitted
-# required-check context is `pr-title / pr-title`.
+# required-check context is `pr-title / pr-title`. Public repo: runs on the
+# reusable's hosted default runner.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -20,52 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  select-runner:
-    name: Select runner for PR title
-    uses: melodic-software/ci-workflows/.github/workflows/select-runner.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
-    with:
-      policy: ${{ vars.CI_RUNNER_POLICY }}
-      self-hosted-label: ${{ vars.CI_SELF_HOSTED_LABEL }}
-      hosted-runner: ${{ vars.CI_HOSTED_RUNNER }}
-      scope: ${{ vars.CI_RUNNER_SCOPE }}
-      managed-runner-prefix: ${{ vars.CI_MANAGED_RUNNER_PREFIX }}
-      observer-client-id: ${{ vars.CI_RUNNER_OBSERVER_CLIENT_ID }}
-    secrets:
-      observer-private-key: ${{ secrets.CI_RUNNER_OBSERVER_PRIVATE_KEY }}
-
-  validate-pr-title:
-    # Fail-closed selector-result reporter: always() so every routing outcome
-    # materializes the required check. The reusable receives the selector result
-    # and fail-closes on any non-success, reporting the check as failed rather
-    # than dispatching validation to paid hosted Linux.
-    if: ${{ always() }}
-    needs: select-runner
+  pr-title:
     permissions:
       pull-requests: read # Reads the pull-request title for validation.
-    uses: melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@ec91c3433a8c3c0a7ebbdd239286e5a6a25eeec5 # ec91c34 2026-07-17
+    uses: melodic-software/ci-workflows/.github/workflows/semantic-pr.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
-      runner: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
-      prerequisite-result: ${{ needs.select-runner.result }}
-
-  pr-title:
-    name: pr-title / pr-title
-    needs: [select-runner, validate-pr-title]
-    # Fail-closed through execution: !cancelled() (never a success-guard) so a
-    # selector failure still runs this required wrapper on the hosted fallback
-    # and the step below turns it red. A success-guard would skip the job, and a
-    # skipped required check reports success to branch protection. Happy path
-    # routes to the fleet (github-iac#78).
-    if: ${{ !cancelled() }}
-    runs-on: ${{ needs.select-runner.outputs.runner || 'ubuntu-24.04' }}
-    permissions: {}
-    steps:
-      - name: Enforce routing and semantic validation results
-        env:
-          SELECTOR_RESULT: ${{ needs.select-runner.result }}
-          VALIDATION_RESULT: ${{ needs.validate-pr-title.result }}
-        run: |
-          if [[ "$SELECTOR_RESULT" != success || "$VALIDATION_RESULT" != success ]]; then
-            echo "Required PR-title gate failed: selector=$SELECTOR_RESULT validation=$VALIDATION_RESULT"
-            exit 1
-          fi
-          echo "PR-title routing and semantic validation passed."
+      runner: ubuntu-24.04

--- a/docs/CI-RUNNER-ROUTING.md
+++ b/docs/CI-RUNNER-ROUTING.md
@@ -1,107 +1,50 @@
 # CI runner routing
 
-This repository is private even though it publishes a public-facing plugin
-marketplace. Eligible read-only Linux validation jobs use the organization
-local fleet and queue there until capacity is available. Privileged,
-untrusted, or structurally incompatible work stays on explicit GitHub-hosted
-images.
+This repository is public, so every lane runs on GitHub-hosted
+`ubuntu-24.04` — free for public repositories — and the organization's
+runner-policy engine forbids local-runner selector routing here outright
+(`public-self-hosted-routing`). There is no selector preflight, no observer
+credential, and no self-hosted exception inventory in this repository.
 
 ## Configuration contract
 
-Workflow source contains no organization runner label, host name, or GitHub App
-identifier. GitHub IaC owns the nonsecret organization variables:
+`.github/runner-policy.json` declares `visibility: "public"` and
+`selfHostedCi: false`; the policy engine cross-checks that declaration against
+the live repository-visibility evidence on every CI run and fails closed on a
+mismatch, so a visibility change must land together with the matching posture
+change in this repository's workflows.
 
-- `CI_RUNNER_POLICY` (`self-hosted-only` or the emergency `hosted-only` kill
-  switch)
-- `CI_SELF_HOSTED_LABEL`
-- `CI_HOSTED_RUNNER`
-- `CI_RUNNER_SCOPE`
-- `CI_MANAGED_RUNNER_PREFIX`
-- `CI_RUNNER_OBSERVER_CLIENT_ID`
-
-The caller passes only `CI_RUNNER_OBSERVER_PRIVATE_KEY`, by name, to the
-reviewed selector. It never uses `secrets: inherit`. Strict
-`self-hosted-only` routing does not mint or require that observer credential;
-the input remains explicit for the separately reviewed inventory-based policy.
-Host registration keys and controller credentials never enter GitHub Actions
-or worker containers.
-
-All callers pin
-`melodic-software/ci-workflows/.github/workflows/select-runner.yml` to the
-independently reviewed commit recorded in `.github/runner-policy.json`'s
-standards-distributed policy. GitHub documents a full commit SHA as the safest
-reusable-workflow reference. Dependabot watches the GitHub Actions dependency,
-but every executable pin update remains a reviewed pull request.
+Workflow source contains no organization runner label, host name, or GitHub
+App identifier. Reviewed reusable workflows from `melodic-software/ci-workflows`
+are pinned to the full commit SHA recorded as an approved contract in the
+standards-distributed `.github/standards/runner-policy/policy.json`, and each
+call passes its `runner` input explicitly (`ubuntu-24.04`). GitHub documents a
+full commit SHA as the safest reusable-workflow reference. Dependabot watches
+the GitHub Actions dependency, but every executable pin update remains a
+reviewed pull request.
 
 ## Routing and failure behavior
 
-Each workflow runs a single selector preflight shared by every eligible job it
-schedules. Each workload requires both `!cancelled()` and a successful selector
-result, then uses the policy-required expression
-`needs.select-runner.outputs.runner || 'ubuntu-24.04'`. The success gate is
-load-bearing: invalid strict configuration or selector infrastructure failure
-blocks the dependent workloads instead of silently redirecting them to paid
-hosted Linux. The selector remains a separate, short preflight job. Its
-two-minute workflow timeout does not limit the downstream workload jobs, which
-retain their own timeouts.
+The `ci-status` required check depends on every workload lane and requires
+each result to be `success`, failing closed through execution
+(`!cancelled()`, never a success-guard, so a skipped lane cannot report
+success to branch protection). The metadata gates (`do-not-merge`,
+`pr-issue-linkage`) run on `pull_request_target` so the base-branch definition
+evaluates, and emit their required contexts from the reusable's hosted default
+runner. Fork pull requests receive no secrets and no automated review, by
+design.
 
-For `self-hosted-only`, the selector validates the exact centrally allowlisted
-managed label and returns it without querying runner inventory or minting the
-observer token. Trusted private `push`, `schedule`, `workflow_dispatch`, and
-same-repository `pull_request` workloads—including reruns—therefore stay on the
-local queue until the controller supplies capacity. The selector returns the
-reviewed hosted image for the emergency `hosted-only` policy and for security
-boundaries: public repositories, fork pull requests, Dependabot, and event
-classes outside the local allowlist, including `merge_group`.
+## Toolchain integrity
 
-The `ci-status` required check depends only on workload lanes and requires every
-workload result to be `success`; selectors are intentionally excluded from the
-required gateway. A failed selector leaves its workload non-successful, so the
-gateway fails closed. PR-title semantic validation uses the same selector
-success gate, while a tiny hosted `pr-title / pr-title` control-plane job emits
-the existing required context and fails when selection or validation is not
-successful.
-
-One selector preflight per workflow makes the routing decision once instead of
-fanning out identical jobs, and every required-check edge still passes through
-the same explicit, policy-auditable selector gate. In strict mode it returns
-the same governed label for every lane; the fleet, not a stale inventory
-snapshot, enforces concurrency. Bursts queue on that label, one ephemeral
-container accepts each job, and a re-run reuses the prior attempt's successful
-selector output, so reruns remain local instead of becoming a paid recovery
-path.
-
-## Hosted boundaries
-
-The machine-readable exceptions in `.github/runner-policy.json` are the complete
-hosted inventory:
-
-- `zizmor` needs Docker for a container action; local workers have no Docker
-  socket;
-- `runner-policy` must audit routing independently of the fleet;
-- `ci-status` must aggregate required workload outcomes independently of the
-  fleet it governs;
-- `pr-title / pr-title` must report a failed required context even when strict
-  selection prevents the semantic workload from starting;
-- `claude-review` has `pull-requests: write` and `id-token: write`; and
-- `link-check` has `issues: write`.
-
-Forks and Dependabot always execute eligible validation on GitHub-hosted
-compute, and the observer-token action is skipped. `merge_group` is included on
-both required-check workflows so a future merge queue receives the same
-`ci-status` and `pr-title / pr-title` contexts; those runs route hosted.
-
-The plugin-gate toolchain is also identical on hosted and local compute. Node
-executables are integrity-locked in `package-lock.json`, Ruff is pinned to the
-Ubuntu x64 wheel and SHA-256 in `.github/requirements-ci.txt`, and Dependabot
-tracks both dependency roots. CI consumes those manifests with `npm ci` and
-hash-required `pip`, never mutable global installs.
+The plugin-gate toolchain is identical everywhere it runs. Node executables
+are integrity-locked in `package-lock.json`, Ruff is pinned to the Ubuntu x64
+wheel and SHA-256 in `.github/requirements-ci.txt`, and Dependabot tracks both
+dependency roots. CI consumes those manifests with `npm ci` and hash-required
+`pip`, never mutable global installs.
 
 ## Authoritative references
 
 - [Reuse workflows and pin a commit SHA](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
 - [Reusable workflow runner and permission behavior](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations)
-- [Secure use of self-hosted runners](https://docs.github.com/en/actions/reference/security/secure-use)
-- [Self-hosted runner routing](https://docs.github.com/en/actions/reference/runners/self-hosted-runners)
 - [`merge_group` and required checks](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group)
 - [Dependabot configuration options](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)


### PR DESCRIPTION
## What

Declare `visibility: "public"` in `.github/runner-policy.json` (selfHostedCi false) and remove the `select-runner` job from all six workflows: every lane runs on GitHub-hosted `ubuntu-24.04`, each reviewed reusable receives its `runner` input explicitly, and pins move to `90f1c54`. This branch also carries the standards-sync materialization from #345 (the 90f1c54 contract registrations the policy engine needs) — #345's diff becomes empty once this merges.

## Why

The repository is public but its runner policy declared private — the engine fails closed on that mismatch, which is the `Runner policy` red on #345 and every current PR. Same reconciliation as melodic-software/standards#200: for public repositories the engine forbids local-runner selector routing outright, so the fix is the full hosted conversion. Hosted minutes are free for public repositories, and this removes ccp's CI + claude-review load from the self-hosted fleet — ccp was the largest queue consumer today (37 queued runs at peak).

## Verification

The synced policy engine passes with public visibility evidence (`--repository-visibility public`); actionlint clean on all six workflows. Required-check contexts are preserved (`ci-status`, `do-not-merge / do-not-merge`, `pr-issue-linkage / pr-issue-linkage`, `pr-title / pr-title`).

## Related

Closes #347. melodic-software/standards#200 (same posture conversion), #345 (sync distribution folded in), melodic-software/ci-workflows#141/#144 (the 90f1c54 revision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZxBP1B8Hf7ZRaqDrP6ma9

