### PR TITLE
docs: land wave #318's doctrine reconciliations (items 1-5)

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -226,9 +226,10 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Ecosystem command resolution | [`docs/conventions/ecosystem-commands/`](conventions/ecosystem-commands/README.md) |
 | Hook telemetry | [`docs/conventions/hook-telemetry/`](conventions/hook-telemetry/README.md) |
 | Permission-rule hygiene | [`docs/conventions/permission-rule-hygiene/`](conventions/permission-rule-hygiene/README.md) |
+| Repository standards index | [`docs/conventions/standards/`](conventions/standards/README.md) |
 | Skill layout contract and evals schema | `skill-quality` plugin (contract gate + bundled schema) |
 | Review severity vocabulary | `review` plugin (`context/severity.md`) |
-| Seam phrasing (presence-gated fallbacks) | Unowned — already used by multiple plugins without an owner doc: a tracked non-conformance and an audit dimension. No further adoption until an owner doc lands |
+| Seam phrasing (presence-gated fallbacks) | [`docs/conventions/seam-phrasing/`](conventions/seam-phrasing/README.md) |
 
 ## Cross-platform contract
 

--- a/docs/conventions/seam-phrasing/README.md
+++ b/docs/conventions/seam-phrasing/README.md
@@ -1,0 +1,37 @@
+# Seam phrasing — presence-gated cross-plugin references
+
+Owner doc for the shared phrasing convention every optional cross-plugin reference uses.
+The design rule it implements lives in the plugin philosophy's design boundary: optional
+collaboration is presence-gated with a documented fallback, and a bare unguarded
+cross-plugin reference is a defect. This doc owns the *phrasing shape*; the philosophy owns
+the *rule*.
+
+## The shape
+
+Every optional reference to another plugin's skill carries, at the reference site:
+
+1. **The gate** — an explicit installed-ness condition on the invocation:
+   "invoke `/other-plugin:skill` (if that plugin is installed)" or an equivalent
+   "when the `<name>` plugin is installed" clause. The gate names the plugin, not the
+   marketplace (marketplace-qualified IDs never appear in reusable content).
+2. **The fallback** — what the skill does instead, stated in the same sentence or the one
+   adjacent: degrade to a bundled capability, record into the artifact at hand, or report
+   the missing optional capability clearly. "Skip silently" is not a fallback.
+3. **Ownership framing** — when the collaborator owns a concern (a glossary, a tracker
+   seam, a stage skill), the reference says what it owns so the fallback's scope is
+   evident. Descriptive ownership tables need no gate when every invocation site nearby is
+   gated; the gate belongs where the invocation is instructed.
+
+## What this convention is not
+
+- Not for hard requires: a plugin genuinely broken without its collaborator declares the
+  native manifest `dependencies` entry instead, and needs no gate phrasing.
+- Not a tool-availability check: probing for a CLI or MCP tool at runtime is the
+  prerequisites-and-failure-behavior rules' territory.
+
+## Conformance
+
+Fleet audits check dim-11-adjacent seam phrasing against this shape: gate present, fallback
+stated, no marketplace qualification. Existing adopters (work-items' tracker seam,
+claude-ops' known-issues reference, session-flow's stage-skill preference, planning's
+glossary hand-off) conform by carrying all three elements at each instructed invocation.

--- a/docs/conventions/topic-docs/README.md
+++ b/docs/conventions/topic-docs/README.md
@@ -38,11 +38,15 @@ Locations are the documented defaults; the tracked concern file's
 `contract_dir` / `memory_dir` keys override the memory and contract
 roots everywhere this contract or a binding names them.
 
-`.claude/observability/` is the **sole** sanctioned generated surface
-under `.claude/`: hook scripts cannot read consumer `CLAUDE.md` (they see
-env and files only) and `${CLAUDE_PLUGIN_DATA}` is machine-global rather
-than per-project, so project-scoped telemetry has no other home. This is
-an exception, not a precedent.
+`.claude/observability/` is the sole generated surface under `.claude/`
+that **this contract** sanctions: hook scripts cannot read consumer
+`CLAUDE.md` (they see env and files only) and `${CLAUDE_PLUGIN_DATA}` is
+machine-global rather than per-project, so project-scoped telemetry has
+no other home. This is an exception, not a precedent — and it scopes to
+this contract only: the platform itself also generates under `.claude/`
+(native subagent `memory: project|local` roots at
+`.claude/agent-memory/` and `.claude/agent-memory-local/`), which is
+Claude Code's surface to govern, not this contract's.
 
 Two kinds are deliberately **absent**: `history.md` (append-only decision
 log — git log, PR threads, and tracker comments provide this natively for

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",
@@ -31,8 +31,5 @@
     "stress-test",
     "implementation-plan",
     "skill"
-  ],
-  "dependencies": [
-    "domain-driven-design"
   ]
 }

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.0]
+
+### Changed
+
+- **`domain-driven-design` dependency downgraded to presence-gated
+  collaboration** (fleet conformance wave: native `dependencies` are reserved
+  for plugins genuinely broken without their collaborator, and every planning
+  skill works standalone). The manifest entry is removed — the plugin no
+  longer auto-installs; every `/domain-driven-design:ubiquitous-language`
+  invocation site now carries the installed-ness gate and a stated fallback
+  (terms recorded in the design artifacts / Brief glossary notes).
+
 ## [0.20.0]
 
 ### Changed

--- a/plugins/planning/README.md
+++ b/plugins/planning/README.md
@@ -24,8 +24,9 @@ The pipeline composes end-to-end — `wayfind` charts the fog upstream when an e
 is too big to hold at once, then `brainstorm → prd → interview → design →
 design-handoff → plan` with `devils-advocate` attacking the plan before
 approval — while `/domain-driven-design:ubiquitous-language` is invoked whenever
-those workflows resolve vocabulary (this plugin declares a dependency on the
-`domain-driven-design` plugin, so it auto-installs). Every skill also works standalone.
+those workflows resolve vocabulary, when the `domain-driven-design` plugin is
+installed; without it, resolved terms are recorded in the design artifacts
+themselves. Every skill also works standalone.
 
 ## Works in any repo
 

--- a/plugins/planning/skills/design/SKILL.md
+++ b/plugins/planning/skills/design/SKILL.md
@@ -105,8 +105,10 @@ Derive types from capabilities:
 - Contracts: interfaces with method signatures
 - Follow the consuming project's naming conventions (interface naming, context-relative naming, name-collision avoidance with common library types, namespace conventions) — read its rules before naming
 - Follow the project's codified design principles (e.g. Law of Demeter, dependency direction, disambiguating overloaded terms) where it declares them; otherwise apply standard low-coupling/high-cohesion defaults
-- Invoke `/domain-driven-design:ubiquitous-language` the moment a domain term resolves so the
-  active glossary owner applies the consumer's existing format, placement, and context routing
+- Invoke `/domain-driven-design:ubiquitous-language` (if that plugin is installed) the moment a
+  domain term resolves so the active glossary owner applies the consumer's existing format,
+  placement, and context routing; without it, record the resolved term and rejected synonyms in
+  the design artifacts directly
 
 Produce: `type-inventory.md`
 
@@ -144,8 +146,9 @@ A cross-cutting naming review of the full type inventory, run once type modeling
 2. Check collisions with common library/framework type names (e.g. a bare `Result<T>` when the stack already ships one)
 3. Check overloaded-term disambiguation and domain accuracy against the project's domain vocabulary
 4. Record decisions in a terminology table inside `type-inventory.md`
-5. Invoke `/domain-driven-design:ubiquitous-language` to sync resolved terms and rejected synonyms
-   into the consuming project's active glossary
+5. Invoke `/domain-driven-design:ubiquitous-language` (if installed) to sync resolved terms and
+   rejected synonyms into the consuming project's active glossary; the terminology table above is
+   the standalone fallback
 
 ## Handoff gate (`handoff` action)
 

--- a/plugins/planning/skills/interview/SKILL.md
+++ b/plugins/planning/skills/interview/SKILL.md
@@ -60,7 +60,8 @@ The Q&A path of this skill is one engine wrapped in a stop condition and an outp
 2. **Survey-then-deep** — before asking blind, do a fast breadth pass (repo files, recent commits, existing skills, relevant project rules) so questions land in real context
 3. **Climb-to-anchor** — find the nearest `CLAUDE.md`, `AGENTS.md`, domain-vocabulary file, or module README by walking UP from the relevant directory toward repo root; let those shape questions instead of asking what is already documented
 4. **Immediate doc maintenance** *(engineering sessions only)* — when an answer resolves a domain
-   term, invoke `/domain-driven-design:ubiquitous-language` IMMEDIATELY between questions, not
+   term, invoke `/domain-driven-design:ubiquitous-language` (if that plugin is installed — else
+   record the term in the Brief's glossary notes) IMMEDIATELY between questions, not
    batched at end. Route
    decisions, gotchas, and conventions to their proper homes (ADR, project rules, side note) in the
    same response. A general session writes no repo docs — it drives to a shared-understanding summary
@@ -116,7 +117,8 @@ When the task touches domain concepts, these behaviors activate during Q&A. The 
 - **glossary challenge** — when the user uses a domain term two ways, or a term collides with an existing definition, probe it
 - **domain scenario exploration** — invent edge cases that probe concept boundaries ("what happens when a Customer cancels half an Order?")
 - **inline vocabulary update** *(engineering sessions only)* — when a term resolves, invoke
-  `/domain-driven-design:ubiquitous-language` immediately. That skill owns discovery-first
+  `/domain-driven-design:ubiquitous-language` immediately (if that plugin is installed; else
+  record the term in the Brief's glossary notes). That skill owns discovery-first
   placement, the consumer's
   file shape, purity, canonical terms, rejected synonyms, and known-context routing; the interview
   resumes after the update


### PR DESCRIPTION
## Summary

First slice of wave #318 (epic #313): the five doctrine-update findings from the fleet audit, fixed in the docs rather than the plugins.

1. **Kill-switch reconciliation** — verified already landed (playbook security review requires the per-hook userConfig boolean; the generalization mapping routes `HOOK_<OLD>_ENABLED` → userConfig). No edit; recorded here so the finding closes.
2. **Convention registry** gains the repository-standards row (`docs/conventions/standards/` landed with #291, never registered).
3. **Topic-docs contract** — the "`.claude/observability/` is the sole sanctioned generated surface under `.claude/`" claim now scopes to the contract itself; the platform's native subagent `memory: project|local` roots (`.claude/agent-memory[-local]/`) are Claude Code's to govern, not the contract's to forbid.
4. **planning 0.21.0** — `domain-driven-design` manifest dependency downgraded to presence-gated collaboration (design boundary: `dependencies` are for genuinely-broken-without; every planning skill works standalone). All five invocation sites gated with stated fallbacks.
5. **Seam-phrasing owner doc** — `docs/conventions/seam-phrasing/README.md` (gate + fallback + ownership framing); registry row flips from "Unowned".

Remaining #318 slices: registry single-home pointer fixes (session-flow, code-tidying), the kindle-dedrm update-flow security restructure, the two mutation-on-bare-invocation fixes, and the naming-grammar rename matrix (breaking — prepared as explicit per-name decisions, not blanket-renamed).

## Verification

markdownlint (docs + planning), `typos`, `validate-plugins.sh`, contract gate (33 setup skills): green locally.

## Related

- Part of #318
- Part of #313

No linked issue: doctrine slice of #318 — the issue closes with the wave's final slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)