### PR TITLE
fix: bare-invocation read-only + registry single-home pointer fixes (4 plugins)

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Claude Code operations toolkit. Five skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.13.0]
+
+### Changed
+
+- **BREAKING: `known-issues scan` is read-only on bare invocation** (fleet
+  conformance wave: the naming doctrine's `scan` verb contract). It reports
+  untracked references and prints the registering invocation; the registry
+  write now requires the explicit `scan --add` override.
+
 ## [0.12.0]
 
 ### Changed

--- a/plugins/claude-ops/skills/known-issues/SKILL.md
+++ b/plugins/claude-ops/skills/known-issues/SKILL.md
@@ -43,7 +43,7 @@ instead keep the registry inside their repository — git-tracked and team-share
 
 | File | Purpose | Who edits |
 | --- | --- | --- |
-| `<registry-dir>/registry.json` | All tracked Claude product GitHub issues with status, category, affected files, and what's blocked | Skill (on search/scan/check-all), via `scripts/registry_manager.py` — see the registry-location rule above |
+| `<registry-dir>/registry.json` | All tracked Claude product GitHub issues with status, category, affected files, and what's blocked | Skill (on search/`scan --add`/check-all), via `scripts/registry_manager.py` — see the registry-location rule above |
 
 Read `context/registry-schema.md` for the full `registry.json` schema and field enums.
 
@@ -56,7 +56,7 @@ Parse `$ARGUMENTS` to extract action (first token) and remaining arguments.
 | `status` | Quick health summary — registry stats + quality snapshot (DEFAULT when no args) |
 | `search` | Search GitHub Issues for bugs on a specific feature (default when args look like a feature name) |
 | `check-all` | Check ALL tracked registry issues — find newly resolved ones, create follow-up TODOs |
-| `scan` | Grep the current repo for GitHub issue references and add missing ones to registry |
+| `scan` | Grep the current repo for GitHub issue references and report untracked ones (read-only); `scan --add` also registers them |
 | `list` | Show all tracked issues grouped by status and category |
 | `quality` | Full quality check — benchmarks + status page + recent GitHub degradation reports |
 | `create` | Draft and file GitHub issue on anthropics/claude-code using their template format |

--- a/plugins/claude-ops/skills/known-issues/context/action-scan.md
+++ b/plugins/claude-ops/skills/known-issues/context/action-scan.md
@@ -1,8 +1,12 @@
 # Action: `scan`
 
-**Usage:** `/known-issues scan`
+**Usage:** `/known-issues scan` (report-only) · `/known-issues scan --add` (also register)
 
-Grep entire repo for GitHub issue references (pattern: `#NNNNN` with `github.com/anthropics` or `github.com/microsoft/mcp` context) and add ones not in registry.
+Grep the entire repo for GitHub issue references (pattern: `#NNNNN` with
+`github.com/anthropics` or `github.com/microsoft/mcp` context) and report the ones not in
+the registry. Per the naming doctrine's verb contract, bare `scan` is **read-only**: it
+finds, cross-references, and reports. Registering the findings mutates the registry and
+therefore requires the explicit `--add` override.
 
 ## Process
 
@@ -10,8 +14,10 @@ Grep entire repo for GitHub issue references (pattern: `#NNNNN` with `github.com
 2. Search bare references in likely surfaces (adapt to the consumer repo): `grep -rn '#[0-9]\{4,5\}' .claude/ docs/ CLAUDE.md --include='*.md'`
 3. Parse unique issue numbers and repos
 4. Cross-reference with `registry.json` — identify issues NOT yet tracked
-5. For each new issue, fetch metadata via `gh issue view` and add to registry
-6. Present summary of what was found and added
+5. **Bare `scan` stops here**: report untracked references (with `gh issue view` metadata
+   where cheap) and print the exact `scan --add` invocation that would register them.
+6. **With `--add` only**: for each new issue, fetch metadata via `gh issue view` and add to
+   the registry, then present what was added.
 
 ## Output format
 
@@ -20,7 +26,7 @@ Grep entire repo for GitHub issue references (pattern: `#NNNNN` with `github.com
 
 ### Already Tracked: M issues
 
-### Newly Added: K issues
+### Untracked: K issues (run `scan --add` to register)
 
 | # | Repo | Title | Category | Found In |
 |---|------|-------|----------|----------|
@@ -32,3 +38,5 @@ Grep entire repo for GitHub issue references (pattern: `#NNNNN` with `github.com
 |-----------|----------|--------|
 | #99999 | file.md:L10 | Remove reference or verify issue number |
 ```
+
+With `--add`, the "Untracked" section becomes "Newly Added" and reports the registry write.

--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps recently changed files through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract; /code-tidying:comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Changed
+
+- **batch-simplify resolves verification commands through the registered
+  ecosystem-command owner** (fleet conformance wave, registry single-home).
+  The baked per-ecosystem command table is gone: `/toolchain:build` when
+  installed, else the project's own canonical commands, else manifest-derived
+  entry points — never a memorized list.
+
 ## [0.5.0]
 
 ### Changed

--- a/plugins/code-tidying/skills/batch-simplify/context/reference.md
+++ b/plugins/code-tidying/skills/batch-simplify/context/reference.md
@@ -57,16 +57,16 @@ If zero items were deferred across all groups, state explicitly: *"No items defe
 
 ## Ecosystem verification commands (Phase 7)
 
-Prefer the consuming project's own canonical commands (its `CLAUDE.md` / CI config usually names them — e.g. warnings-as-errors flags, custom test runners). Generic fallbacks when none are declared:
+Resolve each group's verification command through the registered ecosystem-command owner —
+do not maintain a command table here. In order:
 
-| Group ecosystem | Fallback verification |
-|----------------|-----------------------|
-| .NET | `dotnet build` + `dotnet test` from the project dir |
-| TypeScript/JavaScript | `npx biome check .` (or the project's lint script) + `npm test` from the project dir |
-| Python | `ruff check .` + `pytest` from the project dir |
-| Bash | `shellcheck <files>` + `shfmt -d <files>` |
-| PowerShell | `pwsh -NoProfile -NonInteractive -Command "Invoke-ScriptAnalyzer -Path <files>"` |
-| Markdown (docs flag) | `npx markdownlint-cli2 <files>` (with the project's config when present) |
-| Mixed/config | the dominant ecosystem's build + `jq . < file` for JSON validity |
+1. When the `toolchain` plugin is installed, `/toolchain:build` (scoped to the group's
+   files) IS the verification step — it resolves the consuming project's tracked
+   per-ecosystem command config and its own portable defaults.
+2. Otherwise, the consuming project's own canonical commands (its `CLAUDE.md` / CI config
+   usually names them — e.g. warnings-as-errors flags, custom test runners).
+3. Otherwise, the ecosystem's ordinary build/lint/test entry points, inferred from the
+   group's manifests (never a memorized command list — read the project's scripts,
+   `Makefile`, or manifest to pick them).
 
 Include the group's verification step in each simplifier agent's prompt so the agent self-verifies before returning; Phase 7 re-runs it as the safety net.

--- a/plugins/code-tidying/skills/batch-simplify/context/reference.md
+++ b/plugins/code-tidying/skills/batch-simplify/context/reference.md
@@ -60,7 +60,7 @@ If zero items were deferred across all groups, state explicitly: *"No items defe
 Resolve each group's verification command through the registered ecosystem-command owner —
 do not maintain a command table here. In order:
 
-1. When the `toolchain` plugin is installed, `/toolchain:build` (scoped to the group's
+1. When the `toolchain` plugin is installed, `/toolchain:check` (scoped to the group's
    files) IS the verification step — it resolves the consuming project's tracked
    per-ecosystem command config and its own portable defaults.
 2. Otherwise, the consuming project's own canonical commands (its `CLAUDE.md` / CI config

--- a/plugins/codebase-health/.claude-plugin/plugin.json
+++ b/plugins/codebase-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "codebase-health",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Repo-wide drift audit between docs, config, code, and architecture: verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings, and fixes or presents for review. Audit dimensions are configurable through a tracked .claude/codebase-health.md config file written by the setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/codebase-health/CHANGELOG.md
+++ b/plugins/codebase-health/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `codebase-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.0]
+
+### Changed
+
+- **BREAKING: `audit` is read-only on bare invocation** (fleet conformance
+  wave: the naming doctrine's `audit` verb contract). It reports and stops;
+  auto-fix phases now require the explicit `--fix` flag. `--review-only` is
+  accepted as a legacy alias for the new default and no longer needs to be
+  passed.
+
 ## [0.5.0]
 
 ### Changed

--- a/plugins/codebase-health/README.md
+++ b/plugins/codebase-health/README.md
@@ -18,14 +18,14 @@ claims about itself are true.
 
 Eight phases (0–7): prime the repo's conventions, discover via per-file fan-out, independently
 validate each finding (a separate agent re-verifies — never self-review), categorize and present in a
-severity-rated table with a verified-non-issues proof-of-thoroughness list, then — unless
-`--review-only` — fix in priority order, verify against the repo's own gates, self-review, and
-retrospect.
+severity-rated table with a verified-non-issues proof-of-thoroughness list. Bare invocation is
+read-only — it reports and stops; with the explicit `--fix` flag it continues: fix in priority
+order, verify against the repo's own gates, self-review, and retrospect.
 
 ```shell
-/codebase-health:audit                      # audit every configured dimension (scope-gated)
-/codebase-health:audit docs/ --docs-only    # one dimension, scoped to a subtree
-/codebase-health:audit README.md --review-only   # scoped, present findings, no fixes
+/codebase-health:audit                      # report-only audit of every configured dimension (scope-gated)
+/codebase-health:audit docs/ --docs-only    # one dimension, scoped to a subtree, report-only
+/codebase-health:audit README.md --fix      # scoped, then apply the auto-fixes
 ```
 
 Dimension filters (`--docs-only`, `--code-only`, `--config-only`, `--arch-only`) are mutually

--- a/plugins/codebase-health/skills/audit/SKILL.md
+++ b/plugins/codebase-health/skills/audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit
-description: "Audit a codebase for drift between docs, config, code, and architecture. Verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings, auto-fixes or presents for review. Use when: 'audit codebase', 'check for drift', 'verify docs', 'full audit'. Flags: `--review-only` (present findings, no auto-fix), `--docs-only`, `--code-only`, `--config-only`, `--arch-only`."
-argument-hint: "[scope] [--review-only] [--docs-only|--code-only|--config-only|--arch-only]"
+description: "Audit a codebase for drift between docs, config, code, and architecture. Verifies every factual claim against reality via parallel subagent fan-out, severity-rates findings and reports read-only; `--fix` applies the auto-fixes. Use when: 'audit codebase', 'check for drift', 'verify docs', 'full audit'. Flags: `--fix` (apply auto-fixes after reporting), `--docs-only`, `--code-only`, `--config-only`, `--arch-only`."
+argument-hint: "[scope] [--fix] [--docs-only|--code-only|--config-only|--arch-only]"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -21,7 +21,10 @@ Arguments: `$ARGUMENTS`
 Parse `$ARGUMENTS` for:
 
 - **Scope** (optional): directory or file path to limit the audit (default: entire repo)
-- **`--review-only`**: present findings for user approval before fixing; do NOT auto-fix
+- **`--fix`**: apply the auto-fixes after reporting. Per the naming doctrine's verb
+  contract, bare `audit` is READ-ONLY — it reports and stops; every mutation sits behind
+  this explicit override. (`--review-only` is accepted as a legacy alias for the bare
+  read-only default.)
 - **Dimension filters** (optional, mutually exclusive):
   - `--docs-only`: only documentation checks
   - `--code-only`: only code-quality checks
@@ -32,11 +35,12 @@ If no filter is specified, audit every active dimension — the Phase 1 per-file
 dimension order irrelevant (each file gets its own subagent). Enumerate `primary-sources` across all
 active dimensions and dispatch per file.
 
-## Model auto-invoke default
+## Read-only default
 
-When the model invokes this skill without explicit user authorization to auto-fix, treat the run as
-**`--review-only`**. Phases 4–6 (auto-fix) and Phase 7 (retrospective) run only when the user
-explicitly requests fixes or omits `--review-only` with clear fix intent.
+Bare invocation — by the user or the model — reports and stops. Phases 4–6 (auto-fix) and
+Phase 7 (retrospective) run only under an explicit `--fix` from the user (or an equally
+explicit "fix what you find" instruction in their prose); model auto-invocation never
+supplies `--fix` on its own.
 
 ---
 
@@ -93,7 +97,7 @@ Never hardcode a repo layout; read a declared value, infer-and-record, or ask.
 For any audit run (Phases 0-7), copy
 `${CLAUDE_PLUGIN_ROOT}/skills/audit/templates/checklist.md` into wherever the consuming
 repo keeps working task notes (or keep it in-response). Tick each phase as completed. Phases 4-7 may
-SKIP per `--review-only` mode.
+SKIP unless `--fix` was given.
 
 ---
 
@@ -214,13 +218,14 @@ If the audit finds no discrepancies, report a clean bill of health:
 - State explicitly: "No findings. All claims verified as correct."
 - Do NOT invent findings to justify the audit. A clean codebase is the goal, not a guaranteed list
   of issues.
-- Skip Phases 4-6 (nothing to fix). If not `--review-only`, proceed to Phase 7 (Retrospective) with
+- Skip Phases 4-6 (nothing to fix). With `--fix`, proceed to Phase 7 (Retrospective) with
   scope/coverage observations.
 
-### Review-only gate
+### Fix gate
 
-**If `--review-only`**: present the full report and **STOP**.
-**If autonomous**: present the summary count and continue to Phase 4.
+**Without `--fix`** (the default, including every model auto-invocation): present the full
+report and **STOP**.
+**With `--fix`**: present the summary count and continue to Phase 4.
 
 ---
 

--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Session-lifecycle toolkit of seven skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), clean-stop (get to a durable, linked stopping point before the machine may go away — sweep every repo/worktree for uncommitted, unpushed, or PR-less work, push it durable, put breadcrumbs in PR/issue bodies, then give a free-and-clear verdict), retro (structured session retrospective with transcript metrics and learning codification), orchestrate (arm a session or worker with proactive-orchestration imperatives), and reanchor (verify a session's working assumptions are still true against live reality — referenced PRs/issues/branches, base-branch drift, renamed/version-drifted surfaces, stale memory-tier files — before building on them).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — session-flow plugin
 
+## 0.10.1 — 2026-07-19
+
+Changed:
+
+- Topic-docs binding points instead of restating (fleet conformance wave,
+  registry single-home): the binding doc no longer restates the contract's
+  five-rung resolution order and runtime guards — it applies the contract's
+  own sections and keeps only the plugin-specific no-project-root fallback
+  detail.
+
 ## 0.10.0 — 2026-07-18
 
 Added:

--- a/plugins/session-flow/reference/topic-docs.md
+++ b/plugins/session-flow/reference/topic-docs.md
@@ -27,25 +27,12 @@ in one worktree is invisible to a session resuming in another. The workflow chec
 ledger the contract's `.worktreeinclude` template carries into new worktrees where the consuming
 repo materializes it; handoffs are session-scoped and deliberately not carried.
 
-## Resolution (the contract's five-rung order, earlier wins)
+## Resolution and runtime guards
 
-1. `.claude/topic-docs.yaml` present → use its `memory_dir`.
-2. A save-point / work-journal convention declared in the consumer's `CLAUDE.md` /
-   `.claude/rules` → use it, and offer to persist it into the concern file.
-3. An existing conforming layout inferred from the repo (a self-ignoring memory root holding
-   save-points) → confirm with the user, persist to the concern file.
-4. Ask once — one question, recommended option first; persist the answer to the concern file.
-5. The documented default memory root: `.work` (save-points in `.work/handoffs/`, the workflow
-   checklist in `.work/<slug>/`).
-
-**No project root** (no git toplevel or project marker): interactive → ask (current directory or an
-explicit path); non-interactive → `${CLAUDE_PLUGIN_DATA}/topic-docs/handoffs/` with the absolute
-path announced prominently and nothing persisted.
-
-## Runtime guards
-
-- **Self-ignore guard:** the session's first memory-tier write verifies the **resolved memory
-  root** (whatever `memory_dir` names — never a hardcoded `.work`) contains a `.gitignore` with
-  `*`, creating it (announced) when absent — fresh clones heal on first write. Once per session,
-  per the contract.
-- No session-flow skill ever edits the consumer's root `.gitignore`.
+The contract owns both, identically for every implementer — apply its "Resolution order"
+and "Runtime guards" sections as written (the five-rung order with its no-project-root
+branch, the once-per-session self-ignore guard on the resolved memory root, the
+never-edit-the-consumer's-root-`.gitignore` rule). This binding adds only the
+plugin-specific application detail: session-flow's no-project-root non-interactive
+fallback lands handoffs under `${CLAUDE_PLUGIN_DATA}/topic-docs/handoffs/` with the
+absolute path announced prominently and nothing persisted.


### PR DESCRIPTION
## Summary

Wave #318 slice (epic #313): the two verb-contract violations and the two registry single-home restatements.

- **claude-ops 0.13.0** — BREAKING: `known-issues scan` is read-only on bare invocation per the `scan` verb contract; it reports untracked references and prints the registering invocation. The registry write moves behind the explicit `scan --add` override.
- **codebase-health 0.6.0** — BREAKING: bare `audit` reports and **stops**; the auto-fix phases (4–7) require the explicit `--fix` flag. `--review-only` remains accepted as a legacy alias of the new default. Model auto-invocation never supplies `--fix` on its own.
- **session-flow 0.10.1** — the topic-docs binding no longer restates the contract's five-rung resolution order and runtime guards (the contract labels them "identical in every implementer"); it points and keeps only the plugin-specific no-project-root fallback detail.
- **code-tidying 0.5.1** — batch-simplify's baked verification-command table is gone: commands resolve through the registered ecosystem-command owner (`/toolchain:build` when installed → the project's canonical commands → manifest-derived entry points), never a memorized list.

Remaining #318 slices after this: the kindle-dedrm update-flow security restructure (dim 15) and the naming rename matrix (breaking; awaiting per-name decisions).

## Verification

markdownlint, `typos`, `validate-plugins.sh`, contract gate: green locally.

## Related

- Part of #318
- Part of #313

No linked issue: verb-contract + single-home slice of #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)