### PR TITLE
fix(kindle-dedrm): checkout-gate update re-pins, single-source the pins (0.5.0)

### DIFF
--- a/plugins/kindle-dedrm/.claude-plugin/plugin.json
+++ b/plugins/kindle-dedrm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kindle-dedrm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Manage the Kindle for PC 2.8.0 + Calibre DeDRM workflow for personal-use ebook DRM removal on books you own (Windows only). Action router with setup, sync, update, cleanup, and status, each state mutation paired with a documented compensating reversal.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/kindle-dedrm/CHANGELOG.md
+++ b/plugins/kindle-dedrm/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `kindle-dedrm` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.0]
+
+### Changed
+
+- **`update` re-pins are checkout-gated** (fleet conformance wave, dim 15 —
+  cache isolation). Applying an accepted drift recommendation now requires
+  `${CLAUDE_PLUGIN_ROOT}` to be a git working tree; in installed form the
+  skill stops after the drift report and routes the change to the plugin's
+  source repository — bundled reference files are never edited in the
+  read-only plugin cache.
+- **Pins single-sourced**: `check-drift.sh` now parses every pin from
+  `references/versions.md` (fail-hard on a pin it cannot read) instead of
+  carrying a duplicate hardcoded copy that went stale after re-pins; the
+  local-download verify also derives the installer filename from the pinned
+  URL.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/kindle-dedrm/skills/kindle-dedrm/SKILL.md
+++ b/plugins/kindle-dedrm/skills/kindle-dedrm/SKILL.md
@@ -96,9 +96,20 @@ Sources monitored:
 
 Output: drift report listing each source's status (`current` / `stale` / `unreachable`) and recommended action (`re-download` / `update version pin` / `manual review`). User decides what to act on; update action itself does not apply changes.
 
-When the user accepts a drift recommendation:
+When the user accepts a drift recommendation, the re-pin edit is **maintainer work, gated
+on a working-tree checkout**: applying it requires `${CLAUDE_PLUGIN_ROOT}` to be inside a
+git working tree (`git -C "${CLAUDE_PLUGIN_ROOT}" rev-parse --is-inside-work-tree`
+succeeds — a marketplace clone or a `--plugin-dir` load). In installed form
+`${CLAUDE_PLUGIN_ROOT}` is the read-only plugin cache: **stop** after the drift report and
+direct the change to the plugin's source repository (file an issue or PR there); never
+edit bundled files in the cache. Consumers then receive the re-pin through
+`/plugin marketplace update`.
 
-1. Apply the change to the relevant `references/*.md` file (update pin, refresh page summary).
+In a checkout, when the user accepts a drift recommendation:
+
+1. Apply the change to `references/versions.md` (update pin, refresh page summary) — the
+   single source of truth; `check-drift.sh` parses its pins from that file, so no second
+   copy needs editing.
 2. Run the affected portion of `setup` (e.g., re-download DeDRM_tools if a new pre-release is selected).
 3. Verify the workflow still works end-to-end on at least one book (run `sync` mode against a single test book).
 

--- a/plugins/kindle-dedrm/skills/kindle-dedrm/scripts/check-drift.sh
+++ b/plugins/kindle-dedrm/skills/kindle-dedrm/scripts/check-drift.sh
@@ -7,18 +7,45 @@
 
 set -uo pipefail
 
-# Captured pins (KEEP IN SYNC with references/versions.md)
-PINNED_KFC_URL="https://kindleforpc.s3.amazonaws.com/70980/KindleForPC-installer-2.8.70980.exe"
-PINNED_KFC_SHA="2ed64ee0fb5ad94032d6d9824d4efbeeea435255c963e9393d949259b87ebfa4"
+# Captured pins — parsed from references/versions.md (single source of truth;
+# a re-pin edits that file once and this script follows). Parsing is fail-hard:
+# a pin this script cannot read is a pin it must not silently skip verifying.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSIONS_MD="${SCRIPT_DIR}/../references/versions.md"
+SOURCES_MD="${SCRIPT_DIR}/../references/sources.md"
 
-PINNED_DEDRM_TAG="v10.0.20"
-PINNED_DEDRM_SHA="c908be142934a7a030d890ba023ba32becc4f8ef4637bd42d8efdcef90b3f2d2"
+# pin <file> <section-heading> <row-label> — value of `| label | `value` |`
+# within the named "## section", first match wins.
+pin() {
+  local file="$1" section="$2" label="$3" value
+  value=$(awk -v sec="## ${section}" -v lab="${label}" '
+    $0 == sec { insec = 1; next }
+    insec && /^## / { exit }
+    insec && $0 ~ "^\\| " lab " \\|" {
+      if (match($0, /`[^`]+`/)) { print substr($0, RSTART + 1, RLENGTH - 2); exit }
+    }' "${file}" | tr -d '\r')
+  if [[ -z "${value}" ]]; then
+    echo "check-drift: cannot parse pin '${label}' (section '${section}') from ${file}" >&2
+    exit 2
+  fi
+  printf '%s' "${value}"
+}
 
-PINNED_KKF_FILENAME="Kindle_Key_Finder_2026.04.28.JH.zip"
-PINNED_KKF_URL="https://techy-notes.com/content/files/2026/04/${PINNED_KKF_FILENAME}"
-PINNED_KKF_SHA="0a55b58ad3953eed6b6a2e81bf6a4c053b7d08c420a5d622ab3c14f8a208d46d"
+PINNED_KFC_URL="$(pin "${VERSIONS_MD}" "Kindle for PC" "Installer URL")"
+PINNED_KFC_SHA="$(pin "${VERSIONS_MD}" "Kindle for PC" "SHA256")"
 
-PINNED_TUTORIAL_URL="https://techy-notes.com/remove-drm-from-kindle-ebooks/"
+PINNED_DEDRM_TAG="$(pin "${VERSIONS_MD}" "DeDRM_tools (Satsuoni fork)" "Pinned tag")"
+PINNED_DEDRM_SHA="$(pin "${VERSIONS_MD}" "DeDRM_tools (Satsuoni fork)" "SHA256")"
+
+PINNED_KKF_FILENAME="$(pin "${VERSIONS_MD}" "Kindle_Key_Finder (techy-notes.com)" "Pinned filename")"
+PINNED_KKF_URL="$(pin "${VERSIONS_MD}" "Kindle_Key_Finder (techy-notes.com)" "Captured URL")"
+PINNED_KKF_SHA="$(pin "${VERSIONS_MD}" "Kindle_Key_Finder (techy-notes.com)" "SHA256")"
+
+PINNED_TUTORIAL_URL="$(grep -oE 'https://techy-notes\.com/remove-drm-from-kindle-ebooks/' "${SOURCES_MD}" | head -1)"
+if [[ -z "${PINNED_TUTORIAL_URL}" ]]; then
+  echo "check-drift: cannot parse tutorial URL from ${SOURCES_MD}" >&2
+  exit 2
+fi
 
 ok() { echo "  [OK]      $*"; }
 stale() { echo "  [STALE]   $*"; }
@@ -34,13 +61,13 @@ echo
 echo "Kindle for PC installer:"
 HTTP=$(curl -sI -o /dev/null -w "%{http_code}" "${PINNED_KFC_URL}" 2>/dev/null || echo "000")
 case "${HTTP}" in
-  200) ok "${PINNED_KFC_URL} → HTTP 200 (URL still serving 2.8.0.70980)" ;;
-  403 | 404)
-    unreachable "${PINNED_KFC_URL} → HTTP ${HTTP} (Amazon may have revoked)"
-    note "Find alternate mirror — see references/sources.md 'How to add a new source'"
-    ;;
-  000) unreachable "${PINNED_KFC_URL} → no response (network or DNS issue)" ;;
-  *) stale "${PINNED_KFC_URL} → HTTP ${HTTP} (unexpected)" ;;
+200) ok "${PINNED_KFC_URL} → HTTP 200 (URL still serving 2.8.0.70980)" ;;
+403 | 404)
+  unreachable "${PINNED_KFC_URL} → HTTP ${HTTP} (Amazon may have revoked)"
+  note "Find alternate mirror — see references/sources.md 'How to add a new source'"
+  ;;
+000) unreachable "${PINNED_KFC_URL} → no response (network or DNS issue)" ;;
+*) stale "${PINNED_KFC_URL} → HTTP ${HTTP} (unexpected)" ;;
 esac
 echo
 
@@ -63,9 +90,9 @@ ARTICLE_BODY=$(curl -s "${PINNED_TUTORIAL_URL}" 2>/dev/null || echo "")
 if [[ -z "${ARTICLE_BODY}" ]]; then
   unreachable "${PINNED_TUTORIAL_URL} → no response"
 else
-  CURRENT_KKF=$(echo "${ARTICLE_BODY}" \
-    | grep -oE 'https://techy-notes\.com/content/files/[0-9]+/[0-9]+/Kindle_Key_Finder_[0-9.]+\.JH\.zip' \
-    | head -1)
+  CURRENT_KKF=$(echo "${ARTICLE_BODY}" |
+    grep -oE 'https://techy-notes\.com/content/files/[0-9]+/[0-9]+/Kindle_Key_Finder_[0-9.]+\.JH\.zip' |
+    head -1)
   if [[ -z "${CURRENT_KKF}" ]]; then
     stale "Could not extract Kindle_Key_Finder URL from article body"
     note "Article structure may have changed — re-WebFetch and inspect"
@@ -109,7 +136,7 @@ verify_sha() {
     note "  ${label}: not present at ${path}"
   fi
 }
-verify_sha "${DL_DIR}/KindleForPC-installer-2.8.70980.exe" "${PINNED_KFC_SHA}" "KindleForPC installer"
+verify_sha "${DL_DIR}/$(basename "${PINNED_KFC_URL}")" "${PINNED_KFC_SHA}" "KindleForPC installer"
 KKF_MATCHES=("${DL_DIR}"/Kindle_Key_Finder_*.JH.zip)
 KKF_LOCAL="${KKF_MATCHES[0]}"
 [[ -e "${KKF_LOCAL}" ]] && verify_sha "${KKF_LOCAL}" "${PINNED_KKF_SHA}" "Kindle_Key_Finder zip"


### PR DESCRIPTION
## Summary

Wave #318 slice (epic #313): the fleet's single dim-15 cache-isolation FAIL.

- **Checkout gate**: the `update` action's re-pin edit now requires `${CLAUDE_PLUGIN_ROOT}` to be a git working tree (marketplace clone or `--plugin-dir` load). In installed form the skill stops after the drift report and routes the change to the plugin's source repository — bundled `references/*.md` are never edited in the read-only plugin cache. Same maintainer-facing posture as the playwright/firecrawl update flows.
- **Pins single-sourced**: `check-drift.sh`'s duplicated hardcoded pin block (which went stale after any re-pin) is replaced by a fail-hard parser over `references/versions.md` — a pin the script cannot read is a pin it must not silently skip verifying. The local-download verify derives the installer filename from the pinned URL instead of a third hardcoded copy.
- **Live-verified**: the rewritten script ran end-to-end — pins parse from the reference file, and the report surfaced real upstream drift (DeDRM fork `v10.0.28` vs pinned `v10.0.20`; tutorial article restructured) for a future maintainer re-pin in a checkout.

Remaining #318 after this: the naming renames (tournaments running; per-name decisions with the user).

## Verification

markdownlint, `typos`, `validate-plugins.sh`, `bash -n` + live script run: green locally.

## Related

- Part of #318
- Part of #313

No linked issue: security slice of #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)