### PR TITLE
fix(kindle-dedrm): re-pin DeDRM_tools v10.0.28, repoint moved tutorial (0.6.1)

### DIFF
--- a/plugins/kindle-dedrm/.claude-plugin/plugin.json
+++ b/plugins/kindle-dedrm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kindle-dedrm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Manage the Kindle for PC 2.8.0 + Calibre DeDRM workflow for personal-use ebook DRM removal on books you own (Windows only). Action router with setup, sync, update, cleanup, and status, each state mutation paired with a documented compensating reversal.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/kindle-dedrm/CHANGELOG.md
+++ b/plugins/kindle-dedrm/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the `kindle-dedrm` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Changed
+
+- **DeDRM_tools pin re-pinned `v10.0.20` → `v10.0.28`** (maintainer re-pin;
+  upstream drift confirmed live 2026-07-19). New asset SHA256
+  `520cce70…c362947` (1,944,296 bytes, asset date 2026-07-14), fetched and
+  hash-verified; the prior pin is recorded for rollback. A full single-book
+  extraction was NOT re-run (manual, machine-bound) — the only consumed file,
+  `DeDRM_plugin.zip`, is present; the v10.0.28 additions (Frida/MSIX decrypt
+  tools) target the newer MSIX Kindle app and are not used by this skill.
+- **Tutorial URL repointed + drift probe reworked.** The primary tutorial moved
+  from `remove-drm-from-kindle-ebooks/` (now HTTP 404) to
+  `drm-removal-from-kindle-ebook-purchases-old-method/` and is now
+  subscriber-gated, so the `update` action can no longer walk its body for the
+  current Key_Finder zip URL. `check-drift.sh` now HEAD-probes the pinned direct
+  Key_Finder zip URL as the authoritative signal (still serving the
+  byte-identical zip, SHA-verified 2026-07-19); roll-forward auto-discovery is a
+  documented capability loss until a subscriber re-confirms new builds by hand.
+
+### Deferred
+
+- **Obsolescence watch:** upstream relabeled the entire Kindle-for-PC + KFX
+  approach the "OLD Method" and is pushing an MSIX-app successor
+  (`msix-amazon-kindle-reading-app-dedrm/`). Trigger to migrate: the pinned
+  Kindle-for-PC 2.8.0 installer URL or the Key_Finder zip going non-200. Sources
+  retained in `references/sources.md`.
+
 ## [0.6.0]
 
 ### Changed

--- a/plugins/kindle-dedrm/skills/manage/SKILL.md
+++ b/plugins/kindle-dedrm/skills/manage/SKILL.md
@@ -89,8 +89,8 @@ Sources monitored:
 |---|---|---|
 | `kindleforpc.s3.amazonaws.com/70980/KindleForPC-installer-2.8.70980.exe` | HEAD request returns non-200 | URL pinned in `references/versions.md`; alternate mirror needed if revoked |
 | `github.com/Satsuoni/DeDRM_tools` releases | Newest pre-release tag differs from baseline | Last-known-good tag in `references/versions.md` |
-| `techy-notes.com/remove-drm-from-kindle-ebooks/` article body | Page hash differs (URL re-fetch + diff) | Last-fetched body summary in `references/sources.md` |
-| `techy-notes.com/content/files/<YYYY>/<MM>/Kindle_Key_Finder_<YYYY.MM.DD>.JH.zip` | Date in URL rolled forward | Last-known URL pattern in `references/versions.md` |
+| `techy-notes.com/drm-removal-from-kindle-ebook-purchases-old-method/` article (subscriber-gated) | HEAD non-200 (article moved again) | Slug + status in `references/sources.md` |
+| `techy-notes.com/content/files/<YYYY>/<MM>/Kindle_Key_Finder_<YYYY.MM.DD>.JH.zip` | HEAD non-200 on the pinned direct URL (revoked / rolled) | Pinned direct URL in `references/versions.md` |
 | `epubor.com` companion article | Page hash differs | Secondary reference; lower priority |
 | KFXKeyExtractor / KFXArchiver supported Kindle versions (in Key_Finder source) | New entry in `code/modules/utils.py` `KFXARCHIVER_TOOL_MAP` | Captured in `references/versions.md` |
 

--- a/plugins/kindle-dedrm/skills/manage/references/sources.md
+++ b/plugins/kindle-dedrm/skills/manage/references/sources.md
@@ -6,13 +6,13 @@ Every URL this skill depends on, with purpose, drift signal, and last-fetched fi
 
 | Field | Value |
 |---|---|
-| URL | `https://techy-notes.com/remove-drm-from-kindle-ebooks/` |
+| URL | `https://techy-notes.com/drm-removal-from-kindle-ebook-purchases-old-method/` |
 | Purpose | Procedural source of truth — exact step ordering, plugin names, current Key_Finder zip URL |
 | Drift signal | Page body diff |
-| Last-fetched | 2026-05-10 |
+| Last-fetched | 2026-05-10 (at the prior URL) |
 | Last-fetched key claims | (a) Kindle for PC 2.8.0(70980) is the only working version; (b) DeDRM_tools v10.0.14+ pre-release required; (c) Kindle_Key_Finder 2026.04.28.JH zip is current; (d) KFX Input plugin from Calibre's "Get new plugins" catalog |
 
-The `update` action re-fetches this URL via WebFetch and compares against "Last-fetched key claims" above. If version pin or zip URL changes, propagate to `references/versions.md`.
+Upstream moved 2026-07 (re-probed 2026-07-19): the prior URL `remove-drm-from-kindle-ebooks/` now returns HTTP 404. Its successor is inferred to be `drm-removal-from-kindle-ebook-purchases-old-method/` (the site relabeled the Kindle-for-PC + KFXKeyExtractor approach the "OLD Method" and returns HTTP 200 for that slug) — NOT read-confirmed as the same procedure, because the article is now subscriber-gated. The `update` action can therefore no longer walk the public body for the current Key_Finder zip URL; it HEAD-probes the pinned direct zip URL in `references/versions.md` instead. Propagate any new pin there. See the epubor secondary below and the MSIX-successor note when the OLD Method finally breaks.
 
 ## Secondary tutorial (cross-check)
 
@@ -57,12 +57,12 @@ If Amazon revokes the URL, this skill is significantly compromised — alternate
 | Field | Value |
 |---|---|
 | URL pattern | `https://techy-notes.com/content/files/<YYYY>/<MM>/Kindle_Key_Finder_<YYYY.MM.DD>.JH.zip` |
-| Discovered via | Tutorial article body (techy-notes.com primary) |
+| Discovered via | Pinned direct URL (article-body discovery lost to paywall — see below) |
 | Purpose | Phase orchestrator that bundles tools + Python phases |
-| Drift signal | Article body links a different filename / date |
-| Last-fetched URL | `https://techy-notes.com/content/files/2026/04/Kindle_Key_Finder_2026.04.28.JH.zip` |
+| Drift signal | HEAD-probe of the pinned direct zip URL (non-200 = revoked/rolled) |
+| Last-fetched URL | `https://techy-notes.com/content/files/2026/04/Kindle_Key_Finder_2026.04.28.JH.zip` (still serving byte-identical zip, SHA-verified 2026-07-19) |
 
-Date in URL rolls forward when author publishes a new build. `update` action approach: WebFetch tutorial article, regex for `Kindle_Key_Finder_\d{4}\.\d{2}\.\d{2}\.JH\.zip`, compare against pinned filename in `references/versions.md`.
+Date in URL rolls forward when the author publishes a new build. The original `update` approach — WebFetch the tutorial article, regex `Kindle_Key_Finder_\d{4}\.\d{2}\.\d{2}\.JH\.zip`, compare against the pinned filename — no longer works: the article is subscriber-gated as of 2026-07 (see Primary tutorial), so its public body carries no zip link. The drift check now HEAD-probes the pinned direct URL instead; roll-forward to a NEW build requires a subscriber to read the current article and update the pin by hand.
 
 ## Calibre
 
@@ -91,7 +91,7 @@ Avoid Microsoft Store version (sandboxed, blocks file access). `Run_keyfinder.ba
 ```text
 [OK]      Kindle for PC installer URL          (HEAD 200, 285 MB unchanged)
 [OK]      DeDRM_tools latest pre-release       (v10.0.20 == pinned)
-[STALE]   Kindle_Key_Finder zip URL            (article body: Kindle_Key_Finder_2026.06.15.JH.zip; pinned: 2026.04.28.JH)
+[OK]      Kindle_Key_Finder zip URL            (HEAD 200 on pinned direct URL; roll-forward discovery paywalled)
 [OK]      Tutorial article body                (page hash unchanged)
 [STALE]   Tool support matrix                  (utils.py adds 2.9.2 — KFXARCHIVER_TOOL_MAP grew)
 ```

--- a/plugins/kindle-dedrm/skills/manage/references/versions.md
+++ b/plugins/kindle-dedrm/skills/manage/references/versions.md
@@ -1,6 +1,6 @@
 # Captured version pins
 
-Versions, URLs, and SHA256 hashes verified working on 2026-05-10. The `update` action diffs upstream against these. Treat each row as a Tier 0 fact at the date captured; verify before re-using.
+URLs and SHA256 hashes as captured at each row's `Captured` date (initial capture 2026-05-10; DeDRM archive re-fetched + SHA-verified and upstream URLs re-probed 2026-07-19). A `Captured` date attests the artifact was downloaded and its hash matched — NOT that a full single-book extraction was re-run at that date (that is manual and machine-bound; see "How to refresh this file"). The `update` action diffs upstream against these. Treat each row as a Tier 0 fact at the date captured; verify before re-using.
 
 ## Kindle for PC
 
@@ -22,32 +22,39 @@ Observed staged update during 2026-05-10 setup: `2.9.1.71006`. Captured installe
 
 | Field | Value |
 |---|---|
-| Pinned tag | `v10.0.20` |
+| Pinned tag | `v10.0.28` |
 | Pre-release | yes (Satsuoni's fork ships pre-releases as the user-facing channel) |
-| Asset URL | `https://github.com/Satsuoni/DeDRM_tools/releases/download/v10.0.20/DeDRM_tools.zip` |
-| SHA256 | `c908be142934a7a030d890ba023ba32becc4f8ef4637bd42d8efdcef90b3f2d2` |
-| File size | 1.1 MB (1,112,576 bytes) |
-| Asset date | 2026-04-18 |
-| Captured | 2026-05-10 |
+| Asset URL | `https://github.com/Satsuoni/DeDRM_tools/releases/download/v10.0.28/DeDRM_tools.zip` |
+| SHA256 | `520cce704edf9ae26e43196efe2871daf9b25d6cb489aa56051626801c362947` |
+| File size | 1.9 MB (1,944,296 bytes) |
+| Asset date | 2026-07-14 |
+| Captured | 2026-07-19 |
+
+Previous pin for rollback: `v10.0.20` (SHA256 `c908be142934a7a030d890ba023ba32becc4f8ef4637bd42d8efdcef90b3f2d2`, 1,112,576 bytes, asset date 2026-04-18, captured 2026-05-10).
 
 Repo: `https://github.com/Satsuoni/DeDRM_tools` — fork of the original NoDRM/Apprentice Harper DeDRM_tools, maintained specifically for compatibility with current Kindle for PC / KFX format. Upstream `noDRM/DeDRM_tools` is also viable but lags this fork on KFX support.
 
-Asset contents (verified 2026-05-10):
+Asset contents (verified 2026-07-19, v10.0.28):
 
 ```text
-DeDRM_plugin.zip            (Calibre plugin to install)
+DeDRM_plugin.zip                    (Calibre plugin to install)
 DeDRM_plugin_ReadMe.txt
-KFXArchiver291.exe          (Kindle 2.9.1 fallback extractor)
-KFXKeyExtractor28.exe       (Kindle 2.8.x primary extractor)
-KFXKeyExtractor282.exe      (alternate name for same)
-kindleFridaInstr.py         (Frida-based extraction for newer Kindle)
-KRFKeyExtractor.exe         (KRF key extractor)
-Obok_plugin.zip             (Kobo DRM removal — different ecosystem)
+KFXArchiver291.exe                  (Kindle 2.9.1 fallback extractor)
+KFXKeyExtractor28.exe               (Kindle 2.8.x primary extractor)
+KFXKeyExtractor282.exe              (alternate name for same)
+KRFKeyExtractor.exe                 (KRF key extractor)
+compiled_agent.js                   (NEW in v10.0.28: MSIX/Frida agent)
+kindleFridaDecrypt.py               (NEW: Frida-based decrypt, newer Kindle)
+kindleFridaInstr.py                 (Frida-based extraction for newer Kindle)
+kindledecr_arm64                    (NEW: ARM64 decryptor binary)
+kindledecr_x84_64                   (NEW: x86-64 decryptor binary; upstream spelling)
+MSIXKFXArchiverMobi1_18632.exe      (NEW: MSIX Kindle-app KFX/Mobi archiver)
+Obok_plugin.zip                     (Kobo DRM removal — different ecosystem)
 obok_plugin_ReadMe.txt
 ReadMe_Overview.txt
 ```
 
-For `kindle-dedrm`, only `DeDRM_plugin.zip` is consumed directly (loaded into Calibre via "Load plugin from file"). The `.exe` files are also bundled inside `Kindle_Key_Finder` so usually not needed from this archive.
+For `kindle-dedrm`, only `DeDRM_plugin.zip` is consumed directly (loaded into Calibre via "Load plugin from file"). The `.exe` files are also bundled inside `Kindle_Key_Finder` so usually not needed from this archive. The v10.0.28 additions target the newer MSIX "Amazon Kindle" reading app (Frida-instrumented decrypt path); the Kindle-for-PC 2.8.0 offset extractors this skill relies on are unchanged.
 
 ## Kindle_Key_Finder (techy-notes.com)
 
@@ -61,7 +68,7 @@ For `kindle-dedrm`, only `DeDRM_plugin.zip` is consumed directly (loaded into Ca
 | Internal version label | `2026.04.28.JH` (date-based, no semver) |
 | Captured | 2026-05-10 |
 
-Author rolls the URL forward periodically (date in filename + path matches build date). The `update` action's drift check walks the article body at `https://techy-notes.com/remove-drm-from-kindle-ebooks/` and extracts the current download link rather than guessing the next date.
+Author rolls the URL forward periodically (date in filename + path matches build date). The pinned direct URL above still serves the byte-identical zip (re-fetched + SHA-verified 2026-07-19). Roll-forward auto-discovery is currently BROKEN upstream: the tutorial article moved from `remove-drm-from-kindle-ebooks/` (now HTTP 404) to `drm-removal-from-kindle-ebook-purchases-old-method/` and is now behind a subscriber paywall, so the public article body no longer exposes the zip link for the `update` probe to walk. Until that changes, the drift check HEAD-probes the pinned direct zip URL as the authoritative signal; a maintainer with a techy-notes subscription must re-confirm any new build's URL by hand.
 
 Bundled tools (verified 2026-05-10):
 

--- a/plugins/kindle-dedrm/skills/manage/references/workflow.md
+++ b/plugins/kindle-dedrm/skills/manage/references/workflow.md
@@ -53,8 +53,18 @@ curl -L -o "DeDRM_tools-${LATEST_TAG}.zip" \
 # The former article-body discovery is dead — the tutorial is subscriber-gated
 # as of 2026-07 (see references/sources.md), so a new build's URL can only be
 # obtained by a subscriber reading the current article and re-pinning by hand.
+# This block runs from ~/Downloads, so no relative path can reach the plugin's
+# references directory. Before running, substitute the absolute path of the
+# versions.md that sits next to this workflow file (the same file the DeDRM
+# fallback above reads) for VERSIONS_MD_ABS_PATH. The guard refuses to continue
+# with the placeholder still in place.
+VERSIONS_MD="VERSIONS_MD_ABS_PATH"
+if [[ "${VERSIONS_MD}" == "VERSIONS_MD_ABS_PATH" || ! -f "${VERSIONS_MD}" ]]; then
+  echo "versions.md path not substituted or not found — set VERSIONS_MD to the absolute path of references/versions.md, then rerun." >&2
+  exit 1
+fi
 ZIP_URL=$(awk '/^## Kindle_Key_Finder/{s=1} s&&/^\| Captured URL \|/{if(match($0,/`[^`]+`/)){print substr($0,RSTART+1,RLENGTH-2);exit}}' \
-  ../references/versions.md)
+  "${VERSIONS_MD}")
 if [[ -z "${ZIP_URL}" ]]; then
   echo "Key_Finder URL not found in references/versions.md — repair the pin, then rerun from this step." >&2
   exit 1

--- a/plugins/kindle-dedrm/skills/manage/references/workflow.md
+++ b/plugins/kindle-dedrm/skills/manage/references/workflow.md
@@ -49,14 +49,14 @@ fi
 curl -L -o "DeDRM_tools-${LATEST_TAG}.zip" \
   "https://github.com/Satsuoni/DeDRM_tools/releases/download/${LATEST_TAG}/DeDRM_tools.zip"
 
-# Resolve the current Kindle_Key_Finder zip URL from the tutorial article body.
-# An empty match STOPS the block here — continuing would hit the hash and
-# extraction steps with no artifact and fail later with misleading errors.
-ZIP_URL=$(curl -s https://techy-notes.com/remove-drm-from-kindle-ebooks/ \
-  | grep -oE 'https://techy-notes\.com/content/files/[0-9]+/[0-9]+/Kindle_Key_Finder_[0-9.]+\.JH\.zip' \
-  | head -1)
+# Kindle_Key_Finder zip: use the pinned direct URL from references/versions.md.
+# The former article-body discovery is dead — the tutorial is subscriber-gated
+# as of 2026-07 (see references/sources.md), so a new build's URL can only be
+# obtained by a subscriber reading the current article and re-pinning by hand.
+ZIP_URL=$(awk '/^## Kindle_Key_Finder/{s=1} s&&/^\| Captured URL \|/{if(match($0,/`[^`]+`/)){print substr($0,RSTART+1,RLENGTH-2);exit}}' \
+  ../references/versions.md)
 if [[ -z "${ZIP_URL}" ]]; then
-  echo "Key_Finder URL not found in the article — follow references/sources.md 'How to add a new source' for a mirror, then rerun from this step." >&2
+  echo "Key_Finder URL not found in references/versions.md — repair the pin, then rerun from this step." >&2
   exit 1
 fi
 curl -L -o "$(basename "$ZIP_URL")" "$ZIP_URL"

--- a/plugins/kindle-dedrm/skills/manage/scripts/check-drift.sh
+++ b/plugins/kindle-dedrm/skills/manage/scripts/check-drift.sh
@@ -41,7 +41,7 @@ PINNED_KKF_FILENAME="$(pin "${VERSIONS_MD}" "Kindle_Key_Finder (techy-notes.com)
 PINNED_KKF_URL="$(pin "${VERSIONS_MD}" "Kindle_Key_Finder (techy-notes.com)" "Captured URL")"
 PINNED_KKF_SHA="$(pin "${VERSIONS_MD}" "Kindle_Key_Finder (techy-notes.com)" "SHA256")"
 
-PINNED_TUTORIAL_URL="$(grep -oE 'https://techy-notes\.com/remove-drm-from-kindle-ebooks/' "${SOURCES_MD}" | head -1)"
+PINNED_TUTORIAL_URL="$(grep -oE 'https://techy-notes\.com/[a-z0-9-]+/' "${SOURCES_MD}" | head -1)"
 if [[ -z "${PINNED_TUTORIAL_URL}" ]]; then
   echo "check-drift: cannot parse tutorial URL from ${SOURCES_MD}" >&2
   exit 2
@@ -54,7 +54,7 @@ note() { echo "            $*"; }
 
 echo "=== kindle-dedrm: drift report ==="
 echo
-echo "Captured baselines from references/versions.md (last verified 2026-05-10)."
+echo "Captured baselines from references/versions.md (see each row's Captured date)."
 echo
 
 # --- Source 1: Kindle for PC installer URL ---
@@ -84,37 +84,39 @@ else
 fi
 echo
 
-# --- Source 3: Tutorial article body (probe for current Key_Finder URL) ---
-echo "Kindle_Key_Finder zip URL (parsed from tutorial article):"
-ARTICLE_BODY=$(curl -s "${PINNED_TUTORIAL_URL}" 2>/dev/null || echo "")
-if [[ -z "${ARTICLE_BODY}" ]]; then
-  unreachable "${PINNED_TUTORIAL_URL} → no response"
-else
-  CURRENT_KKF=$(echo "${ARTICLE_BODY}" |
-    grep -oE 'https://techy-notes\.com/content/files/[0-9]+/[0-9]+/Kindle_Key_Finder_[0-9.]+\.JH\.zip' |
-    head -1)
-  if [[ -z "${CURRENT_KKF}" ]]; then
-    stale "Could not extract Kindle_Key_Finder URL from article body"
-    note "Article structure may have changed — re-WebFetch and inspect"
-  elif [[ "${CURRENT_KKF}" == "${PINNED_KKF_URL}" ]]; then
-    ok "article links pinned URL (${PINNED_KKF_FILENAME})"
-  else
-    stale "article links new URL: ${CURRENT_KKF}"
-    note "Pinned: ${PINNED_KKF_URL}"
-    note "Update references/versions.md Kindle_Key_Finder section, download, recompute SHA256"
-  fi
-fi
+# --- Source 3: Kindle_Key_Finder zip — HEAD the pinned direct URL ---
+# Roll-forward auto-discovery via the tutorial article body is dead: the
+# article moved and is now subscriber-gated (see references/sources.md), so its
+# public body carries no zip link. HEAD the pinned direct URL as the
+# authoritative signal — a non-200 means the author revoked or rolled it, at
+# which point a subscriber must read the current article and re-pin by hand.
+echo "Kindle_Key_Finder zip (pinned direct URL — article-body discovery paywalled):"
+KKF_HTTP=$(curl -sI -o /dev/null -w "%{http_code}" "${PINNED_KKF_URL}" 2>/dev/null || echo "000")
+case "${KKF_HTTP}" in
+200) ok "${PINNED_KKF_URL} → HTTP 200 (${PINNED_KKF_FILENAME} still served)" ;;
+403 | 404)
+  stale "${PINNED_KKF_URL} → HTTP ${KKF_HTTP} (revoked or rolled forward)"
+  note "Subscriber must read the current techy-notes article for the new zip URL, then re-pin references/versions.md + recompute SHA256"
+  ;;
+000) unreachable "${PINNED_KKF_URL} → no response (network or DNS issue)" ;;
+*) stale "${PINNED_KKF_URL} → HTTP ${KKF_HTTP} (unexpected)" ;;
+esac
 echo
 
-# --- Source 4: Tutorial article body hash (informational, not actionable) ---
-echo "Tutorial article (techy-notes.com):"
-if [[ -n "${ARTICLE_BODY}" ]]; then
-  HASH=$(echo "${ARTICLE_BODY}" | sha256sum | awk '{print $1}')
-  note "current SHA256 of article body: ${HASH}"
-  note "(no captured baseline — content changes are normal and not actionable unless versions/URLs differ)"
-else
-  unreachable "${PINNED_TUTORIAL_URL}"
-fi
+# --- Source 4: Tutorial article reachability (informational) ---
+# The article is subscriber-gated, so no body diff is possible; a HEAD probe
+# just confirms the current slug still resolves. A 404 here means the author
+# moved or unpublished the page again — re-discover via the site sitemap.
+echo "Tutorial article (techy-notes.com — subscriber-gated):"
+ART_HTTP=$(curl -sI -o /dev/null -w "%{http_code}" "${PINNED_TUTORIAL_URL}" 2>/dev/null || echo "000")
+case "${ART_HTTP}" in
+200) note "${PINNED_TUTORIAL_URL} → HTTP 200 (slug resolves; body paywalled, not diffable)" ;;
+000) unreachable "${PINNED_TUTORIAL_URL} → no response" ;;
+*)
+  stale "${PINNED_TUTORIAL_URL} → HTTP ${ART_HTTP} (article moved again)"
+  note "Re-discover via https://techy-notes.com/sitemap-posts.xml, update references/sources.md"
+  ;;
+esac
 echo
 
 # --- Source 5: Local download SHAs ---


### PR DESCRIPTION
## Summary

Deferred backlog item from epic #313: the kindle-dedrm maintainer re-pin. Upstream drift was confirmed live via the checkout-gated `update` flow (this worktree is a real clone — the #368 gate concerns only the read-only installed cache).

- **DeDRM_tools `v10.0.20` → `v10.0.28`** — the fork's newest pre-release (its user-facing channel). New asset SHA256 `520cce70…c362947` (1,944,296 bytes, asset date 2026-07-14), fetched and hash-verified; prior pin recorded for rollback. The only file this skill consumes, `DeDRM_plugin.zip`, is present; the v10.0.28 additions (Frida/MSIX decrypt tools) target the newer MSIX Kindle app and are unused here. **A full single-book extraction was NOT re-run** (manual + machine-bound) — the pin attests fetch + SHA only, stated plainly in CHANGELOG and `versions.md`.
- **Tutorial moved + drift probe reworked.** `remove-drm-from-kindle-ebooks/` now returns HTTP 404; repointed to `drm-removal-from-kindle-ebook-purchases-old-method/`. This successor is **inferred**, not read-confirmed — the article is now subscriber-gated, so its body couldn't be read; the only evidence is the 200 on the "OLD Method" slug. Consequently `check-drift.sh` can no longer walk the public body for the current Key_Finder zip URL; it now **HEAD-probes the pinned direct zip URL** as the authoritative signal (still serving the byte-identical zip, SHA-verified 2026-07-19). Roll-forward auto-discovery is a **documented capability loss** until a subscriber re-pins by hand.
- Asset-contents block, workflow.md fetch step, and SKILL.md source table updated to match.

### Deferred (recorded, not chased)

Upstream relabeled the entire Kindle-for-PC + KFXKeyExtractor approach the **"OLD Method"** and is pushing an MSIX-app successor (`msix-amazon-kindle-reading-app-dedrm/`). That's a plausible obsolescence trigger for this whole plugin. Migration is out of scope here; recorded in the CHANGELOG `Deferred` section and `references/sources.md` with the source URLs. Migration trigger: the pinned Kindle-for-PC installer or the Key_Finder zip going non-200.

## Verification

`bash -n` + shellcheck (clean), live `check-drift.sh` run (all sources OK post-change), `validate-plugins.sh`, `validate-plugin-contracts.mjs`, markdownlint, `typos` — green locally.

## Related

- Part of #313 (deferred backlog item; epic stays open — remaining items land separately).

No linked issue: maintainer re-pin under epic #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)