### PR TITLE
refactor(hooks): read stdin via hook::buffer_stdin in advisory hooks (8 plugins)

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -35,7 +35,7 @@ emit_tel() {
   hook::emit_telemetry "$@"
 }
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
 # hook would not lint anyway (the Write|Edit matcher is broader than the

--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.5.0]
 
 ### Added

--- a/plugins/bash-format/hooks/bash-format.sh
+++ b/plugins/bash-format/hooks/bash-format.sh
@@ -37,7 +37,7 @@ emit_tel() {
   hook::emit_telemetry "$@"
 }
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
 # hook would not process anyway (the Write|Edit matcher is broader than the

--- a/plugins/biome-format/.claude-plugin/plugin.json
+++ b/plugins/biome-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "biome-format",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/biome-format/CHANGELOG.md
+++ b/plugins/biome-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `biome-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -41,7 +41,7 @@ emit_tel() {
   hook::emit_telemetry "$@"
 }
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
 # hook would not process anyway (the Write|Edit matcher is broader than the

--- a/plugins/desktop-notification/.claude-plugin/plugin.json
+++ b/plugins/desktop-notification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "desktop-notification",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Alert you when Claude Code needs input — an audible terminal bell, an OSC 9 terminal notification, and an OS-native toast (macOS/Linux) on permission and idle prompts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/desktop-notification/CHANGELOG.md
+++ b/plugins/desktop-notification/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `desktop-notification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/desktop-notification/hooks/desktop-notification.sh
+++ b/plugins/desktop-notification/hooks/desktop-notification.sh
@@ -39,11 +39,10 @@ hook::check_enabled "DESKTOP_NOTIFICATION"
 # advisory exit 0. Empty start => telemetry is skipped, the hook still notifies.
 start=${EPOCHREALTIME:-}
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
-# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
-# resolve (ENOENT → silent no-op). stdin is read ONCE here and both fields are
-# parsed from the buffered value; reading fd0 twice would drain the pipe.
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read. stdin is
+# read ONCE here and both fields are parsed from the buffered value; reading fd0
+# twice would drain the pipe.
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq is load-bearing for parsing and for the terminalSequence emission; absent →
 # visible once-per-session notice instead of silently dropping every

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/eol-normalizer/hooks/eol-normalizer.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.sh
@@ -44,7 +44,7 @@ emit_tel() {
 # shellcheck source=normalize-eol.sh
 source "$(dirname "${BASH_SOURCE[0]}")/normalize-eol.sh"
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq is load-bearing for input parsing; absent → visible once-per-session skip
 # notice instead of silently disabling the whole hook (dim-9 doctrine).

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.2]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.5.1]
 
 ### Changed

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -35,7 +35,7 @@ emit_tel() {
   hook::emit_telemetry "markdown-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
 # hook would not process anyway (the Write|Edit matcher is broader than the

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -710,9 +710,11 @@ chmod +x "$SHIM_DIR/cygpath" "$SHIM_DIR/jq"
 
 count_lm() { grep -c -- '-lm' "$CYG_LOG" 2>/dev/null || true; }
 
-# Unwired (sink unset), clean fixture: the only legitimate jq spawn is
-# hook::read_file_path's file_path parse — TOOL, FILE_REL and data_json are
-# all telemetry-only and must not be built.
+# Unwired (sink unset), clean fixture: the legitimate jq spawns are
+# hook::buffer_stdin's payload-completeness probe (`jq -e .` — a piped read
+# always ends read -d '' with a non-zero status at EOF, so the probe runs on
+# every invocation) and hook::read_file_path's file_path parse — TOOL, FILE_REL
+# and data_json are all telemetry-only and must not be built.
 : >"$CYG_LOG"
 : >"$JQ_LOG"
 printf '# Gate Doc\n\nClean text.\n' >"$REPO/fixtureGate.md"
@@ -731,10 +733,10 @@ else
   fail "telemetry-gate/unwired: $CYG_LM_UNWIRED cygpath -lm spawns: $(cat "$CYG_LOG")"
 fi
 JQ_UNWIRED="$(wc -l <"$JQ_LOG")"
-if [[ "$JQ_UNWIRED" -eq 1 ]]; then
-  ok "telemetry-gate/unwired: exactly 1 jq spawn (file_path parse only)"
+if [[ "$JQ_UNWIRED" -eq 2 ]]; then
+  ok "telemetry-gate/unwired: exactly 2 jq spawns (stdin probe + file_path parse)"
 else
-  fail "telemetry-gate/unwired: expected 1 jq spawn, got $JQ_UNWIRED: $(cat "$JQ_LOG")"
+  fail "telemetry-gate/unwired: expected 2 jq spawns, got $JQ_UNWIRED: $(cat "$JQ_LOG")"
 fi
 
 # Wired (stub sink), same fixture shape: the payload construction must still

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.2]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.4.1]
 
 ### Changed

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -45,7 +45,7 @@ emit_tel() {
   hook::emit_telemetry "$@"
 }
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
 # hook would not process anyway (the Write|Edit matcher is broader than the

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Changed
+
+- Hook stdin is read via the shared `hook::buffer_stdin` helper (bounded `read -t`,
+  default 2s) instead of a bare `cat`, so a Windows Win32-pipe late-EOF stall can no
+  longer hang the hook indefinitely. Empty or timed-out stdin exits as a skip, matching
+  the existing empty-payload behavior.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/ruff-format/hooks/ruff-format.sh
+++ b/plugins/ruff-format/hooks/ruff-format.sh
@@ -49,7 +49,7 @@ emit_tel() {
   hook::emit_telemetry "$@"
 }
 
-INPUT=$(cat)
+INPUT=$(hook::buffer_stdin) || exit 0
 
 # jq-free applicability pre-filter: never emit the jq notice for an edit this
 # hook would not process anyway (the Write|Edit matcher is broader than the


### PR DESCRIPTION
## Summary

Replaces the bare `INPUT=$(cat)` fd0 read in the 8 advisory entry hooks (actionlint, bash-format, biome-format, ruff-format, markdown-format, powershell-format, eol-normalizer, desktop-notification) with the shared `hook::buffer_stdin` helper. The bare `cat` blocks indefinitely on the Windows Win32-pipe late-EOF stall; `buffer_stdin` bounds the read (default 2s) and returns the payload, so a stalled pipe degrades to a visible skip instead of hanging the hook. Empty or timed-out stdin exits 0, matching the existing empty-payload skip behavior.

Scope decisions (from the #313 item-3 scout):

- **No `stdin_read_timeout` manifest options are re-added.** The option was deliberately removed from these plugins in the #323 review ("least churn" option); the 2s default bound fixes the actual defect. Only `claude-ops` still declares the knob.
- **`claude-ops/hook-telemetry-sink.sh` is intentionally untouched**: it reads a fire-and-forget producer telemetry envelope (not a hook payload) whose producer discards stdout+stderr, its bare `cat` is `silent-skip-ok`-annotated, and it must never block.
- The 7 guardrails hooks ship separately with fail-closed timeout semantics for the 5 blocking guards.

Test change: markdown-format's telemetry-gate assertion now expects the additional `jq -e .` payload-completeness probe `buffer_stdin` spawns (a piped read always ends `read -d ''` with a non-zero status at EOF, so the probe runs every invocation).

Version bumps: actionlint 0.4.1, bash-format 0.5.1, biome-format 0.4.1, ruff-format 0.4.1, markdown-format 0.5.2, powershell-format 0.4.2, eol-normalizer 0.4.1, desktop-notification 0.4.1.

## Verification

- shellcheck (`--rcfile=.shellcheckrc`) + `shfmt -d` clean on all 8 hooks
- All 8 hook test suites green (35/39/3/50/65/46/35/54 passes)
- `validate-plugins.sh`, `validate-plugin-contracts.mjs`, `check-silent-skips.sh` clean
- markdownlint clean on all touched CHANGELOGs

## Related

Epic #313 (deferred-backlog item 3, advisory half). Also relates to #317, #323.

No linked issue: incremental epic work; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)