### PR TITLE
refactor(guardrails): buffer_stdin stdin reads; blocking guards fail closed on timeout

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.0]
+
+### Changed
+
+- All seven hook entry scripts read stdin via the shared `hook::buffer_stdin` helper
+  (bounded `read -t`, default 2s) instead of a bare `cat`, so a Windows Win32-pipe
+  late-EOF stall can no longer hang a hook — and with it every tool call — indefinitely.
+- **Blocking guards now fail closed on a stdin read timeout.** When `hook::buffer_stdin`
+  returns 2 (the read timed out before a complete JSON payload arrived), the five
+  blocking guards (`block-dangerous-git`, `block-hook-bypass`, `block-no-verify`,
+  `secret-pattern-detection`, `hardcoded-path-check`) exit 2 with the BLOCKED reason on
+  stderr instead of skipping: a guard that could not evaluate the tool call must not
+  wave it through. Empty stdin still skips, matching the previous empty-payload
+  behavior. The two advisory hooks (`flag-commit-pr-skill-bypass`,
+  `workflow-resilience-check`) skip on any read failure, as before.
+
 ## [0.7.1]
 
 ### Fixed

--- a/plugins/guardrails/hooks/block-dangerous-git.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.sh
@@ -49,10 +49,16 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
-# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
-# resolve (ENOENT → silent no-op).
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read. rc 1
+# (empty stdin) skips like the empty-COMMAND guard below; rc 2 (read timed out
+# before a complete payload) FAILS CLOSED — the guard cannot evaluate the tool
+# call, and a silent skip would pass exactly the traffic this guard exists to
+# stop. buffer_stdin already printed the BLOCKED reason to stderr.
+INPUT=$(hook::buffer_stdin) || {
+  rc=$?
+  ((rc == 2)) && exit 2
+  exit 0
+}
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
 [[ -n "$COMMAND" ]] || exit 0
 
@@ -119,8 +125,8 @@ abbrev_match() {
 is_push_value_opt() {
   local x="$1"
   [[ "$x" == *=* ]] && return 1
-  abbrev_match "push-option" "$x" 2 || abbrev_match "repo" "$x" 3 \
-    || abbrev_match "receive-pack" "$x" 4 || abbrev_match "exec" "$x" 1
+  abbrev_match "push-option" "$x" 2 || abbrev_match "repo" "$x" 3 ||
+    abbrev_match "receive-pack" "$x" 4 || abbrev_match "exec" "$x" 1
 }
 
 # Is an operand a worktree-wide pathspec? `.` from the repo root, the
@@ -281,8 +287,8 @@ check_segment() {
         fi
         ;;&
       *)
-        if [[ "$x" == "-n" ]] || abbrev_match "dry-run" "$x" 2 \
-          || [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *n* ]]; then
+        if [[ "$x" == "-n" ]] || abbrev_match "dry-run" "$x" 2 ||
+          [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *n* ]]; then
           dry=1
         fi
         ;;
@@ -417,8 +423,8 @@ check_segment() {
         [[ "$rest" == *n* ]] && dry=1
         continue
       fi
-      if [[ "$x" == "-n" ]] || abbrev_match "dry-run" "$x" 1 \
-        || [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *n* ]]; then
+      if [[ "$x" == "-n" ]] || abbrev_match "dry-run" "$x" 1 ||
+        [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *n* ]]; then
         dry=1
       fi
     done
@@ -521,13 +527,13 @@ check_segment() {
         # Value-taking options in accepted abbreviated form (--c for
         # --conflict, --or for --orphan — verified unique floors) consume
         # the next word, which must not count as an operand.
-        if [[ "$x" != *=* ]] \
-          && { abbrev_match "conflict" "$x" 1 || abbrev_match "orphan" "$x" 2; }; then
+        if [[ "$x" != *=* ]] &&
+          { abbrev_match "conflict" "$x" 1 || abbrev_match "orphan" "$x" 2; }; then
           ((k += 2))
           continue
         fi
-        if [[ "$x" == "-f" ]] || abbrev_match "force" "$x" 1 \
-          || [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *f* ]]; then
+        if [[ "$x" == "-f" ]] || abbrev_match "force" "$x" 1 ||
+          [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *f* ]]; then
           block "checkout-force" \
             "BLOCKED: git checkout -f/--force throws away local modifications." \
             "Commit or stash first, or allow via the block_dangerous_git_allow option (add checkout-force)."
@@ -576,9 +582,9 @@ check_segment() {
         continue
         ;;
       *)
-        if [[ "$x" == "-f" ]] || abbrev_match "force" "$x" 1 \
-          || abbrev_match "discard-changes" "$x" 2 \
-          || [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *f* ]]; then
+        if [[ "$x" == "-f" ]] || abbrev_match "force" "$x" 1 ||
+          abbrev_match "discard-changes" "$x" 2 ||
+          [[ "$x" =~ ^-[A-Za-z]+$ && "$x" == *f* ]]; then
           block "checkout-force" \
             "BLOCKED: git switch -f/--discard-changes throws away local modifications." \
             "Commit or stash first, or allow via the block_dangerous_git_allow option (add checkout-force)."
@@ -668,8 +674,8 @@ check_segment() {
           # Value-taking options in accepted abbreviated form (--so for
           # --source, --c for --conflict — verified unique floors) consume
           # the next word, which must not count as a positive pathspec.
-          if [[ "$x" != *=* ]] \
-            && { abbrev_match "source" "$x" 2 || abbrev_match "conflict" "$x" 1; }; then
+          if [[ "$x" != *=* ]] &&
+            { abbrev_match "source" "$x" 2 || abbrev_match "conflict" "$x" 1; }; then
             ((k += 2))
             continue
           fi

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -41,10 +41,16 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
-# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
-# resolve (ENOENT → silent no-op).
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read. rc 1
+# (empty stdin) skips like the empty-COMMAND guard below; rc 2 (read timed out
+# before a complete payload) FAILS CLOSED — the guard cannot evaluate the tool
+# call, and a silent skip would pass exactly the traffic this guard exists to
+# stop. buffer_stdin already printed the BLOCKED reason to stderr.
+INPUT=$(hook::buffer_stdin) || {
+  rc=$?
+  ((rc == 2)) && exit 2
+  exit 0
+}
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
 [[ -n "$COMMAND" ]] || exit 0
 

--- a/plugins/guardrails/hooks/block-no-verify.sh
+++ b/plugins/guardrails/hooks/block-no-verify.sh
@@ -47,10 +47,16 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
-# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
-# resolve (ENOENT → silent no-op).
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read. rc 1
+# (empty stdin) skips like the empty-COMMAND guard below; rc 2 (read timed out
+# before a complete payload) FAILS CLOSED — the guard cannot evaluate the tool
+# call, and a silent skip would pass exactly the traffic this guard exists to
+# stop. buffer_stdin already printed the BLOCKED reason to stderr.
+INPUT=$(hook::buffer_stdin) || {
+  rc=$?
+  ((rc == 2)) && exit 2
+  exit 0
+}
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
 [[ -n "$COMMAND" ]] || exit 0
 

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
@@ -59,10 +59,9 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
-# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
-# resolve (ENOENT → silent no-op).
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read; empty
+# or timed-out stdin skips this advisory hook.
+INPUT=$(hook::buffer_stdin) || exit 0
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
 [[ -n "$COMMAND" ]] || exit 0
 

--- a/plugins/guardrails/hooks/hardcoded-path-check.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.sh
@@ -42,9 +42,17 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin` (Windows Git Bash
-# Win32-pipe ENOENT → silent no-op). Buffer once; parse each field from it.
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read; buffer
+# once, parse each field from it. rc 1 (empty stdin) skips like the empty-field
+# guards below; rc 2 (read timed out before a complete payload) FAILS CLOSED —
+# the guard cannot evaluate the tool call, and a silent skip would pass exactly
+# the traffic this guard exists to stop. buffer_stdin already printed the
+# BLOCKED reason to stderr.
+INPUT=$(hook::buffer_stdin) || {
+  rc=$?
+  ((rc == 2)) && exit 2
+  exit 0
+}
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null | tr -d '\r')
 
 case "$TOOL" in

--- a/plugins/guardrails/hooks/secret-pattern-detection.sh
+++ b/plugins/guardrails/hooks/secret-pattern-detection.sh
@@ -35,9 +35,17 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin` (Windows Git Bash
-# Win32-pipe ENOENT → silent no-op). Buffer once; parse each field from it.
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read; buffer
+# once, parse each field from it. rc 1 (empty stdin) skips like the empty-field
+# guards below; rc 2 (read timed out before a complete payload) FAILS CLOSED —
+# the guard cannot evaluate the tool call, and a silent skip would pass exactly
+# the traffic this guard exists to stop. buffer_stdin already printed the
+# BLOCKED reason to stderr.
+INPUT=$(hook::buffer_stdin) || {
+  rc=$?
+  ((rc == 2)) && exit 2
+  exit 0
+}
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null | tr -d '\r')
 
 case "$TOOL" in

--- a/plugins/guardrails/hooks/workflow-resilience-check.sh
+++ b/plugins/guardrails/hooks/workflow-resilience-check.sh
@@ -26,10 +26,9 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
-# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
-# resolve (ENOENT → silent no-op).
-INPUT=$(cat)
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read; empty
+# or timed-out stdin skips this advisory hook.
+INPUT=$(hook::buffer_stdin) || exit 0
 SCRIPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.script // empty' 2>/dev/null | tr -d '\r')
 SCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.scriptPath // empty' 2>/dev/null | tr -d '\r')
 


### PR DESCRIPTION
## Summary

Second half of the #313 item-3 stdin migration (sibling: #443, the 8 advisory plugins). All seven guardrails entry hooks now read stdin via the shared `hook::buffer_stdin` helper (bounded `read -t`, default 2s) instead of a bare `cat`, so the Windows Win32-pipe late-EOF stall can no longer hang a hook — and with it every tool call — indefinitely.

**The load-bearing decision — blocking guards fail closed on timeout.** `hook::buffer_stdin` distinguishes rc 1 (empty/incomplete stdin) from rc 2 (read timed out before a complete JSON payload). The audit-hook idiom collapses both to a skip; for a security guard that would fail OPEN — a timed-out read means the guard could not evaluate the command, and skipping would pass exactly the traffic it exists to stop (dangerous git, hook bypass, `--no-verify`, secrets, hardcoded paths). Instead:

- **5 blocking guards** (`block-dangerous-git`, `block-hook-bypass`, `block-no-verify`, `secret-pattern-detection`, `hardcoded-path-check`): rc 2 → `exit 2` (block; `buffer_stdin` already printed the `BLOCKED:` reason to stderr); rc 1 → `exit 0` (skip, matching the previous empty-payload behavior — these guards already skipped on empty `COMMAND`/fields after the bare `cat`).
- **2 advisory hooks** (`flag-commit-pr-skill-bypass`, `workflow-resilience-check`): any read failure → skip, as before.

guardrails **0.8.0** (behavior change on the timeout path; the previous behavior was an indefinite hang, not a skip).

## Verification

- shellcheck (`--rcfile=.shellcheckrc`) + `shfmt -d` clean on all 7 hooks
- All 7 guardrails test suites green (194/37/75/44/28/19/10 passes)
- markdownlint clean on the CHANGELOG

## Related

Epic #313 (deferred-backlog item 3, guardrails half). Sibling PR #443. Also relates to #317, #323.

No linked issue: incremental epic work; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)