### PR TITLE
fix(implementation): defer branch-name grammar to consumer convention

### DIFF
--- a/plugins/implementation/.claude-plugin/plugin.json
+++ b/plugins/implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "implementation",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Disciplined implementation stage: execute approved plans inline (`/implementation:implement`) or via orchestrated worker subagents (`/implementation:implement-dispatch`) with incremental validation, TDD-by-default cadence, green-checkpoint commits, scope-fence drift detection, and divergence detection that routes back to planning. Build/test/lint, testing, and outcome verification live in the companion `toolchain`, `testing`, and `verification` plugins, invoked when installed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/implementation/CHANGELOG.md
+++ b/plugins/implementation/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `implementation` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.1]
+
+### Fixed
+
+- Branch-naming grammar in `/implementation:implement` Step 1 and its gotchas no longer presents
+  `<type>/<description>` as the mandated form; it now defers to the consuming project's branch-naming
+  convention (its `CLAUDE.md` / rules) and frames `<type>/<description>` as a common default, mirroring
+  the commit-message convention deferral. The branch-check eval is reframed to accept any convention-
+  compliant branch name rather than a single hardcoded grammar.
+
 ## [0.7.0]
 
 ### Changed

--- a/plugins/implementation/CHANGELOG.md
+++ b/plugins/implementation/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the `implementation` plugin are documented here. Format f
 
 - Branch-naming grammar in `/implementation:implement` Step 1 and its gotchas no longer presents
   `<type>/<description>` as the mandated form; it now defers to the consuming project's branch-naming
-  convention (its `CLAUDE.md` / rules) and frames `<type>/<description>` as a common default, mirroring
+  convention (its `CLAUDE.md` / `AGENTS.md` / rules) and frames `<type>/<description>` as a common default, mirroring
   the commit-message convention deferral. The branch-check eval is reframed to accept any convention-
   compliant branch name rather than a single hardcoded grammar.
 

--- a/plugins/implementation/skills/implement/SKILL.md
+++ b/plugins/implementation/skills/implement/SKILL.md
@@ -53,7 +53,7 @@ If `$ARGUMENTS` specifies a mode (`feature`, `fix`, `refactor`, `config`), use t
 Before writing code, verify the knowledge base:
 
 - **Is there an approved plan?** If yes, use it as execution roadmap. If no plan exists and the task is non-trivial (3+ files, new project, cross-cutting change), suggest a planning pass first — `/planning:plan` when the planning plugin is installed, otherwise whatever plan skill the consuming setup provides (check what's actually available; never invent skill names). For trivial changes (single-file fix, small config edit), proceed without a formal plan
-- **Is the branch correct?** Check pre-computed branch. If on the default branch (`main`/`master`) and the project's workflow expects feature branches, stop and create one following the consuming project's branch-naming convention (check its `CLAUDE.md` / rules; `<type>/<description>` is a common default) — `git checkout -b <branch>`, or `/source-control:worktree` when that plugin is installed
+- **Is the branch correct?** Check pre-computed branch. If on the default branch (`main`/`master`) and the project's workflow expects feature branches, stop and create one following the consuming project's branch-naming convention (check its `CLAUDE.md` / `AGENTS.md` / rules; `<type>/<description>` is a common default) — `git checkout -b <branch>`, or `/source-control:worktree` when that plugin is installed
 - **Are there uncommitted changes?** If dirty working tree with unrelated changes, flag it — don't mix concerns in one commit
 
 ## Step 2: Execute with Incremental Validation

--- a/plugins/implementation/skills/implement/SKILL.md
+++ b/plugins/implementation/skills/implement/SKILL.md
@@ -53,7 +53,7 @@ If `$ARGUMENTS` specifies a mode (`feature`, `fix`, `refactor`, `config`), use t
 Before writing code, verify the knowledge base:
 
 - **Is there an approved plan?** If yes, use it as execution roadmap. If no plan exists and the task is non-trivial (3+ files, new project, cross-cutting change), suggest a planning pass first — `/planning:plan` when the planning plugin is installed, otherwise whatever plan skill the consuming setup provides (check what's actually available; never invent skill names). For trivial changes (single-file fix, small config edit), proceed without a formal plan
-- **Is the branch correct?** Check pre-computed branch. If on the default branch (`main`/`master`) and the project's workflow expects feature branches, stop and create one (`git checkout -b <type>/<description>`, or `/source-control:worktree` when that plugin is installed)
+- **Is the branch correct?** Check pre-computed branch. If on the default branch (`main`/`master`) and the project's workflow expects feature branches, stop and create one following the consuming project's branch-naming convention (check its `CLAUDE.md` / rules; `<type>/<description>` is a common default) — `git checkout -b <branch>`, or `/source-control:worktree` when that plugin is installed
 - **Are there uncommitted changes?** If dirty working tree with unrelated changes, flag it — don't mix concerns in one commit
 
 ## Step 2: Execute with Incremental Validation

--- a/plugins/implementation/skills/implement/context/gotchas.md
+++ b/plugins/implementation/skills/implement/context/gotchas.md
@@ -26,7 +26,7 @@ Build this file iteratively from real failure patterns encountered during implem
 
 **Why it's bad**: Not catastrophic, but it wastes the work-on-main commit cycle. You either rebase the work onto a new branch or rewrite history.
 
-**How to avoid**: Step 1 of `/implementation:implement` checks the branch. `git checkout -b <type>/<description>` takes 2 seconds.
+**How to avoid**: Step 1 of `/implementation:implement` checks the branch. Creating one — `git checkout -b <branch>`, following the project's branch-naming convention (`<type>/<description>` is a common default) — takes 2 seconds.
 
 ### Mixing concerns in commits
 

--- a/plugins/implementation/skills/implement/evals/evals.json
+++ b/plugins/implementation/skills/implement/evals/evals.json
@@ -18,12 +18,13 @@
       "id": 2,
       "name": "branch-check-stops-on-default-branch",
       "prompt": "/implementation:implement feature — start building the new export endpoint. (Assume the working session is currently on the `main` branch in a PR-based repo.)",
-      "expected_output": "The Step 1 prerequisite check detects the session is on the default branch in a feature-branch workflow and stops to create a feature branch (git checkout -b, or /source-control:worktree when installed) BEFORE the first edit — it does not begin editing on main.",
+      "expected_output": "The Step 1 prerequisite check detects the session is on the default branch in a feature-branch workflow and stops to create a feature branch (git checkout -b following the project's branch-naming convention, or /source-control:worktree when installed) BEFORE the first edit — it does not begin editing on main. It does not mandate a specific branch-name grammar.",
       "files": [],
       "expectations": [
         "Detects that the current branch is the default branch (main/master) in a feature-branch workflow",
         "Creates or directs creation of a feature branch before the first code edit, rather than editing on the default branch",
-        "Does NOT proceed to write code on the default branch and leave branch creation for later"
+        "Does NOT proceed to write code on the default branch and leave branch creation for later",
+        "Does NOT mandate a specific branch-name grammar — treats `<type>/<description>` as one acceptable form, not the only correct one"
       ]
     },
     {

--- a/plugins/implementation/skills/implement/evals/evals.json
+++ b/plugins/implementation/skills/implement/evals/evals.json
@@ -24,7 +24,7 @@
         "Detects that the current branch is the default branch (main/master) in a feature-branch workflow",
         "Creates or directs creation of a feature branch before the first code edit, rather than editing on the default branch",
         "Does NOT proceed to write code on the default branch and leave branch creation for later",
-        "Does NOT mandate a specific branch-name grammar — treats `<type>/<description>` as one acceptable form, not the only correct one"
+        "Does NOT mandate a specific branch-name grammar — defers to the consuming project's declared branch-naming convention, treating `<type>/<description>` only as the fallback default when no convention is declared"
       ]
     },
     {


### PR DESCRIPTION
## Summary

The branch-name grammar `<type>/<description>` was presented as *the* form in the `implementation` plugin's `implement` skill, with no deferral to the consumer's branch-naming convention. Target environments using Jira-key branches (`SW2-12345-desc`, `feature/SW2-12345`) diverge, breaking agnosticism (extensibility seam 3 + the convention-resolution ladder: read the declared value before defaulting).

The fix mirrors the **same file's** commit-message convention treatment (SKILL.md, Step 2 commit discipline), which already defers to the consumer's `CLAUDE.md` / rules and frames Conventional Commits as "a common default".

## Changes

- **`skills/implement/SKILL.md`** (Step 1 prerequisite check): branch creation now defers to the consuming project's branch-naming convention (its `CLAUDE.md` / rules) and presents `<type>/<description>` as a common default rather than the required form. The `/source-control:worktree` pointer is unchanged.
- **`skills/implement/context/gotchas.md`** (branch-check gotcha): the `<type>/<description>` example now reads as a common default following the project's convention, keeping the "takes 2 seconds" point.
- **`skills/implement/evals/evals.json`** (eval `branch-check-stops-on-default-branch`): reframed as a grammar-agnostic acceptance guard. Note: the file did **not** literally contain `<type>/<description>` — the eval already accepted convention-deferring behavior — so the edit makes that acceptance explicit (`expected_output` no longer implies a bare `git checkout -b` as *the* mechanism; a new expectation asserts no specific grammar is mandated) rather than removing a hardcode that was not there.
- **Version**: `0.7.0` → `0.7.1`; matching `## [0.7.1]` `### Fixed` CHANGELOG entry.

## Verification

- `npx markdownlint-cli2` on all changed `.md` — 0 issues.
- `jq -e .` on `evals.json` — valid JSON; edits stay within schema-allowed fields.
- `jq -e .version` on `plugin.json` — `"0.7.1"`.
- No trailing whitespace / all final newlines present (editorconfig).

Closes #403

## Related

- Same work-readiness sweep (audit vs `docs/PLUGIN-PHILOSOPHY.md` + `docs/MIGRATION-PLAYBOOK.md`) as sibling agnosticism findings #404, #407, #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)