### PR TITLE
fix(discovery): inline deferred-backend rationale, drop dead ADR path

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Structured discovery before changes: explore the local codebase (inline or in an isolated forked subagent) and run disciplined multi-source external research with source tiers, falsification, and recency gates — persisting EXPLORE.md / RESEARCH.md handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — discovery plugin
 
+## 0.7.2 — 2026-07-19
+
+### Changed
+
+- **`/discovery:setup` no longer cites the marketplace-repo ADR by bare path.** Both
+  `vault_backend: gitbook` deferral notes in `skills/setup/SKILL.md` inlined the rationale
+  directly — git remains the storage layer because GitBook offers no concurrency-safe, lossless
+  write path — replacing the dead `docs/adr/…` reference that resolves to nothing in the
+  cache-isolated installed plugin. Behavior is unchanged; gitbook stays deferred and non-writable.
+
 ## 0.7.0 — 2026-07-18
 
 ### Changed

--- a/plugins/discovery/skills/setup/SKILL.md
+++ b/plugins/discovery/skills/setup/SKILL.md
@@ -44,7 +44,7 @@ Report the effective concern and the guard result as a PASS/FAIL/INFO table. Do 
    if a consumer ignore rule matches — an uncommittable "committed" tier — and surface the exact rule
    and source line. Resolving the rule is the consumer's edit.
 4. **Deferred backend.** If the effective `vault_backend` is `gitbook`, INFO: it is reserved but not
-   enabled — git remains the vault's storage layer because GitBook offers no concurrency-safe,
+   enabled — git remains the storage layer because GitBook offers no concurrency-safe,
    lossless write path — so it is deferred and non-writable; durable writes still target `docs` until
    a later reviewed decision enables it.
 
@@ -61,7 +61,7 @@ reports "already configured".
    consumer-documented knowledge-vault backend. Offer every schema key and preserve every key an
    existing file carries — a re-run never drops one; do not invent options beyond the schema. `gitbook`
    is reserved but not enabled as a `vault_backend` value — git remains the storage layer because
-   GitBook offers no concurrency-safe, lossless write path: when offering or preserving it, report
+   GitBook offers no concurrency-safe, lossless write path. When offering or preserving it, report
    that it is deferred and non-writable — durable writes still target `docs` — and never configure or
    test a GitBook API, MCP, or Git Sync writer; offer to replace the key with `docs` only if the user
    chooses that change.

--- a/plugins/discovery/skills/setup/SKILL.md
+++ b/plugins/discovery/skills/setup/SKILL.md
@@ -44,8 +44,9 @@ Report the effective concern and the guard result as a PASS/FAIL/INFO table. Do 
    if a consumer ignore rule matches — an uncommittable "committed" tier — and surface the exact rule
    and source line. Resolving the rule is the consumer's edit.
 4. **Deferred backend.** If the effective `vault_backend` is `gitbook`, INFO: it is reserved but not
-   enabled (see `docs/adr/0001-defer-gitbook-as-knowledge-vault-backend.md`) — deferred and
-   non-writable; durable writes still target `docs` until a later reviewed decision enables it.
+   enabled — git remains the vault's storage layer because GitBook offers no concurrency-safe,
+   lossless write path — so it is deferred and non-writable; durable writes still target `docs` until
+   a later reviewed decision enables it.
 
 ## `apply` (idempotent)
 
@@ -59,8 +60,8 @@ reports "already configured".
    solo/offline mode (contract kinds join the memory tier); a non-`docs` `vault_backend` names a
    consumer-documented knowledge-vault backend. Offer every schema key and preserve every key an
    existing file carries — a re-run never drops one; do not invent options beyond the schema. `gitbook`
-   is reserved but not enabled as a `vault_backend` value (see
-   `docs/adr/0001-defer-gitbook-as-knowledge-vault-backend.md`): when offering or preserving it, report
+   is reserved but not enabled as a `vault_backend` value — git remains the storage layer because
+   GitBook offers no concurrency-safe, lossless write path: when offering or preserving it, report
    that it is deferred and non-writable — durable writes still target `docs` — and never configure or
    test a GitBook API, MCP, or Git Sync writer; offer to replace the key with `docs` only if the user
    chooses that change.


### PR DESCRIPTION
## Summary

`/discovery:setup` cited a marketplace-repo ADR by bare path
(`docs/adr/0001-defer-gitbook-as-knowledge-vault-backend.md`) at both `vault_backend: gitbook`
deferral call sites (`skills/setup/SKILL.md:47` and `:63`). That ADR is a publisher-repo file — not
bundled in the plugin and not present in the consumer repo — so in the cache-isolated installed
plugin form the reference resolves to nothing, leaving a consumer reading the setup skill on a dead
path. This violates PLUGIN-PHILOSOPHY cache-isolation and the never-cross-reference-file-names rule.

## Change

- Inlined the one-sentence rationale directly at both call sites — *git remains the storage layer
  because GitBook offers no concurrency-safe, lossless write path* — replacing the bare ADR path.
  The existing "deferred and non-writable; durable writes target `docs`" wording is preserved.
- No dead path remains; behavior is unchanged.
- Bumped `plugins/discovery` `0.7.0` → `0.7.2` and added a Keep-a-Changelog `## [0.7.2]` Changed
  entry. (`0.5.1`'s historical CHANGELOG entry citing the same ADR path is intentionally left as-is.)

Closes #407

## Related
- Stacks on PR #458 (issue #409, discovery plugin); if #458 merges first this PR needs a trivial version/CHANGELOG rebase to keep 0.7.2 above 0.7.1.
- No ADRs or decision-log entries are closed by this PR.