### PR TITLE
feat(planning): name underspecification in planning-pipeline skills

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.2]
+
+### Added
+
+- Named the **underspecification**/**underspecified** concept — a task missing the
+  constraints needed to act safely — in the planning-pipeline skills that already
+  cover it: `interview` (description trigger keywords + Purpose, as the pipeline's
+  underspecification resolver), `prd` (routing an underspecified engineering task to
+  `/interview`), and `design` (Purpose, naming the concept its underspecified-types
+  gap-finding instantiates). Vocabulary only; no behavior change.
+
 ## [0.21.1]
 
 ### Changed

--- a/plugins/planning/skills/design/SKILL.md
+++ b/plugins/planning/skills/design/SKILL.md
@@ -16,7 +16,7 @@ Arguments: `$ARGUMENTS`
 
 ## Purpose
 
-Design exploration answers WHAT before `/planning:plan` answers HOW. Without it, implementation plans are built on unexamined assumptions — the wrong types, wrong boundaries, wrong package topology. This skill structures the exploratory work so that every `/planning:plan` plan starts from a design the user has validated through iterative discussion.
+Design exploration answers WHAT before `/planning:plan` answers HOW. Without it, implementation plans are built on unexamined assumptions — the wrong types, wrong boundaries, wrong package topology: the shape **underspecification** takes once the task contract is set but the design is not. This skill structures the exploratory work so that every `/planning:plan` plan starts from a design the user has validated through iterative discussion.
 
 This is the step between research and planning: exploration maps existing code, research gathers external facts, this skill synthesizes both into a concrete design, and `/planning:plan` plans implementation of that design. Upstream: when the PROBLEM itself is still rough — no chosen approach to design — diverge first via `/brainstorm` (cheapest→most-ambitious candidates, user reacts), then design the direction that resonated.
 

--- a/plugins/planning/skills/interview/SKILL.md
+++ b/plugins/planning/skills/interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: interview
-description: "Interview relentlessly to reach shared understanding on a plan, decision, or idea — questions arrive in frontier rounds: every question whose prerequisites are settled asked together as one numbered set, each with a recommendation. Routes by context: an engineering task locks a task contract (goal, constraints, acceptance criteria, named assumptions) into a PLAN.md Brief that feeds the planning pipeline; a general decision drives to a shared understanding and stops. Synthesizes directly when intent is clear, runs the rounds loop when gaps remain, or interviews relentlessly on request. Use proactively before behavior-changing work when intent is ambiguous, or on explicit request ('interview me', 'lock the brief', 'spec this task', 'grill me'); skip for mechanical work (typo/lint/whitespace/rename) and casual conversation."
+description: "Interview relentlessly to reach shared understanding on a plan, decision, or idea — questions arrive in frontier rounds: every question whose prerequisites are settled asked together as one numbered set, each with a recommendation. Routes by context: an engineering task locks a task contract (goal, constraints, acceptance criteria, named assumptions) into a PLAN.md Brief that feeds the planning pipeline; a general decision drives to a shared understanding and stops. Synthesizes directly when intent is clear, runs the rounds loop when gaps remain, or interviews relentlessly on request. Use proactively before behavior-changing work when intent is ambiguous or underspecified, or on explicit request ('interview me', 'lock the brief', 'spec this task', 'grill me', 'this is underspecified'); skip for mechanical work (typo/lint/whitespace/rename) and casual conversation."
 argument-hint: "[action] [topic] (e.g., /planning:interview, /planning:interview me, /planning:interview lock, /planning:interview <topic>)"
 user-invocable: true
 disable-model-invocation: false
@@ -18,7 +18,7 @@ Arguments: `$ARGUMENTS`
 
 ## Purpose
 
-Most rework comes from acting on assumptions the user never made and the agent never surfaced. `/interview` prevents it: a structured pass driving every load-bearing unknown to a decision OR capturing it as a named, explicit assumption — before exploration, planning, or execution start.
+Most rework comes from acting on assumptions the user never made and the agent never surfaced — an **underspecified** task, one missing the constraints needed to act safely. `/interview` is the pipeline's underspecification resolver: a structured pass driving every load-bearing unknown to a decision OR capturing it as a named, explicit assumption — before exploration, planning, or execution start.
 
 The **pre-clarity** stage — upstream of exploration, research, and `/planning:plan`. `/planning:plan` presupposes a coherent task; `/interview` produces one out of fuzzy intent. The contract it writes is the target every later stage aims at.
 

--- a/plugins/planning/skills/prd/SKILL.md
+++ b/plugins/planning/skills/prd/SKILL.md
@@ -23,7 +23,7 @@ Most product-feature rework comes from skipping the *what for whom and why* laye
 This is the **product-intent** stage. **Upstream of exploration**, **upstream of `/planning:plan`**, and may run **before or alongside `/interview`** depending on task shape:
 
 - `/prd` — answers *what should we build, for whom, and why*. Outcome-focused. Required for new user-facing features, business-driven changes, cross-team initiatives
-- `/interview` — answers *what is the engineering contract for this task*. Constraint and acceptance-criteria focused. Required whenever intent is fuzzy, regardless of source
+- `/interview` — answers *what is the engineering contract for this task*. Constraint and acceptance-criteria focused. Required whenever intent is fuzzy or underspecified, regardless of source
 - Complementary, not redundant. A product feature usually wants both: `/prd` (product intent) → `/interview` (engineering contract) → exploration → research → `/design` → `/planning:plan`. Engineering-internal work skips `/prd` entirely
 
 The PRD is **never an implementation plan**. Boundaries: problem, users, success — yes. Architecture, files, tests, code shapes — no. That is `/planning:plan`'s job. If the user pulls toward implementation mid-PRD, anchor back to *what for whom* and let `/planning:plan` pick up after.


### PR DESCRIPTION
## Summary

Names the **underspecification**/**underspecified** concept — a task/prompt missing the constraints needed to act safely — in the existing planning-pipeline skills that already cover it, so the pipeline shares one term for it. Vocabulary only; no behavior change. Per the 2026-07-19 `/planning:interview` decision, this adds **no new skill and no new reference doc**.

### Changes

- **`interview`** — adds `underspecified` + the `'this is underspecified'` trigger phrase to the frontmatter `description`, and frames the Purpose as *the pipeline's underspecification resolver* (interview is where the pipeline resolves underspecification).
- **`prd`** — one-line mention at its ambiguity-routing point: an *underspecified* engineering task routes to `/interview`.
- **`design`** — one-line mention in Purpose, naming the concept that its existing *underspecified-types* gap-finding (Phase 5) instantiates.
- Version bump `0.21.1 → 0.21.2` + Keep-a-Changelog entry.

### `wayfind` — evaluated and SKIPPED (deferred sub-decision, arbitrated here)

Read `wayfind/SKILL.md` in full. Its body deals with **fog** — uncertainty too vague to even *phrase* as a sharp question (its "Not-yet-specified" section, its fog-vs-sharp test) — and it routes phrasable-but-unresolved work *downstream* to `/interview`. Underspecification as this issue defines it (missing constraints you *can* name) is interview's territory, not wayfind's. The `Not-yet-specified` ≈ `underspecified` overlap is surface vocabulary, not concept coverage. Adding the term would blur the fog-vs-sharp boundary that is wayfind's core distinction. **Skipped** — it does not already cover the concept.

### Keyword placement (deferred sub-decision, arbiter)

Every touched description stays well under the listing-budget cap and preserves all existing trigger phrases (verified by `/skill-quality:check`). Only `interview`'s description changed (834 → 878 chars); `prd`/`design` mentions are one-liners in the body, not the description.

## Verification

- `/skill-quality:check` (via `plugins/skill-quality/scripts/check-skill.sh`, skills-root pointed at `plugins/planning/skills`) on all three touched skills: **PASS, 0 errors** each. Trigger-keyword preservation vs base ref: interview 4/4, prd 3/3, design 4/4 preserved. Remaining WARNs (soft 200-line target, no `Use when:` phrasing, no gotchas surface) are pre-existing and advisory — none introduced by this change.
- `typos` (`_typos.toml`, typos-cli 1.44.0) on all 5 changed files: **clean, exit 0**.
- `markdownlint-cli2` (`.markdownlint-cli2.jsonc`, v0.23.1) on the 4 changed markdown files: **0 issues**.

## Fresh-docs citations (frontmatter schema + description's triggering role)

- https://code.claude.com/docs/en/skills — confirms `description` is what Claude uses to decide when to apply/trigger a skill, and that the combined `description` + `when_to_use` text is truncated at **1,536 characters** in the skill listing. (Redirected from the legacy `https://docs.claude.com/en/docs/claude-code/skills`.)

Closes #402

## Related

Planning-vocabulary item from the 2026-07-19 `/planning:interview` decision (alternatives — a new skill and a new reference doc — were explicitly declined there). No ADRs or decision-log entries are closed by this PR.