### PR TITLE
fix(session-flow): derive retro HANDOFF_DIR from resolved memory_dir

### DIFF
--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Session-lifecycle toolkit of seven skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear, with optional --bg background-agent launch), keep-going (recover and continue after any interruption — inventory off-thread work, inspect its real state, resume or restart it, then continue the main task), clean-stop (get to a durable, linked stopping point before the machine may go away — sweep every repo/worktree for uncommitted, unpushed, or PR-less work, push it durable, put breadcrumbs in PR/issue bodies, then give a free-and-clear verdict), retro (structured session retrospective with transcript metrics and learning codification), orchestrate (arm a session or worker with proactive-orchestration imperatives), and reanchor (verify a session's working assumptions are still true against live reality — referenced PRs/issues/branches, base-branch drift, renamed/version-drifted surfaces, stale memory-tier files — before building on them).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — session-flow plugin
 
+## 0.10.2 — 2026-07-19
+
+Fixed:
+
+- retro: the Phase 1.1 multi-session snippet now derives `HANDOFF_DIR` from the
+  resolved `memory_dir` (reads the `.claude/topic-docs.yaml` concern file, falls
+  back to `.work`) instead of hard-coding the bare default `.work/handoffs`. A
+  copy-as-is run of the snippet previously bypassed the memory_dir seam, missing
+  the handoff chain in any repo that relocates its memory tier.
+
 ## 0.10.1 — 2026-07-19
 
 Changed:

--- a/plugins/session-flow/skills/retro/context/session.md
+++ b/plugins/session-flow/skills/retro/context/session.md
@@ -43,11 +43,18 @@ done
 # Single-session form:
 "$PY" "$PARSER" --sessions "${CLAUDE_CODE_SESSION_ID}" --base "$SESSION_DATA_DIR"
 
-# Multi-session form (handoff chain exists). Set HANDOFF_DIR to the resolved
-# <memory_dir>/handoffs — the concern file's memory_dir first, else the consuming
-# repo's documented save-point location (see the handoff skill's "Where handoffs
-# live"); the plugin default is .work/handoffs/.
-HANDOFF_DIR=.work/handoffs
+# Multi-session form (handoff chain exists). Derive HANDOFF_DIR from the resolved
+# memory_dir — the concern file's memory_dir key, else the plugin default .work.
+# For the full resolution order (documented save-point locations, no-project-root
+# fallback) see the handoff skill's "Where handoffs live".
+MEMORY_DIR=.work
+if [[ -f .claude/topic-docs.yaml ]]; then
+  VAL=$(sed -n 's/^memory_dir:[[:space:]]*//p' .claude/topic-docs.yaml | head -1)
+  VAL="${VAL%%#*}"; VAL="${VAL//[[:space:]]/}"; VAL="${VAL%/}"
+  VAL="${VAL#\"}"; VAL="${VAL%\"}"; VAL="${VAL#\'}"; VAL="${VAL%\'}"
+  [[ -n "$VAL" ]] && MEMORY_DIR="$VAL"
+fi
+HANDOFF_DIR="$MEMORY_DIR/handoffs"
 NEWEST=$(ls -1 "$HANDOFF_DIR"/*-handoff-*.md 2>/dev/null | sort | tail -1)
 "$PY" "$PARSER" --chain-from "$NEWEST" --current-session "${CLAUDE_CODE_SESSION_ID}" --base "$SESSION_DATA_DIR"
 ```

--- a/plugins/session-flow/skills/retro/context/session.md
+++ b/plugins/session-flow/skills/retro/context/session.md
@@ -50,7 +50,7 @@ done
 MEMORY_DIR=.work
 if [[ -f .claude/topic-docs.yaml ]]; then
   VAL=$(sed -n 's/^memory_dir:[[:space:]]*//p' .claude/topic-docs.yaml | head -1)
-  VAL="${VAL%%#*}"; VAL="${VAL//[[:space:]]/}"; VAL="${VAL%/}"
+  VAL="${VAL%%#*}"; VAL="${VAL%"${VAL##*[![:space:]]}"}"; VAL="${VAL%/}"
   VAL="${VAL#\"}"; VAL="${VAL%\"}"; VAL="${VAL#\'}"; VAL="${VAL%\'}"
   [[ -n "$VAL" ]] && MEMORY_DIR="$VAL"
 fi


### PR DESCRIPTION
## Summary

The retro Phase 1.1 multi-session snippet (`plugins/session-flow/skills/retro/context/session.md`) hard-coded `HANDOFF_DIR=.work/handoffs` directly beneath an instruction to resolve it from the concern file's `memory_dir`. A copy-as-is execution encoded the bare default and bypassed the memory_dir seam — missing the handoff chain in any repo that relocates its memory tier via `.claude/topic-docs.yaml`.

The snippet now derives `HANDOFF_DIR` from the resolved `memory_dir`: it reads the `.claude/topic-docs.yaml` concern file's `memory_dir` key and falls back to `.work`, matching the topic-docs.yaml parse shape already used elsewhere in the fleet. Comment prose trimmed to describe what the snippet actually performs, pointing to the handoff skill for the full resolution order.

Version bumped 0.10.1 -> 0.10.2 with a matching CHANGELOG entry.

Closes #420

## Related

- Work-readiness `.work`-convention sweep: this is one instance of a broader pattern where copy-as-is snippets encode the bare `.work` default instead of resolving the memory_dir seam.
- Sibling memory_dir-seam item #419 in the claude-memory plugin tracks the same seam from the auto-memory side.
- No ADRs or decision-log entries are closed by this change.