### PR TITLE
fix(claude-memory): resolve memory_dir from topic-docs seam in orphan-rule-check

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Audits the Claude Code instruction/memory layer — CLAUDE.md, CLAUDE.local.md, .claude/rules/, and auto-memory — against a checklist derived from official Claude Code documentation. A deterministic script-backed spine (MEMORY.md index integrity, orphan always-loaded rules) yields identical findings on identical repo state; judgment-tier checks apply fixed criteria with model reading. Actions: audit (default), fix (per-item approval), update (refresh criteria from current docs), report.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.1]
+
+### Fixed
+
+- **`orphan-rule-check` now resolves the excluded memory tier from the topic-docs seam**
+  instead of hardcoding `.work/`. The reference search reads `memory_dir` from
+  `.claude/topic-docs.yaml` (falling back to `.work/` when unset) and excludes that path,
+  so a consumer that overrides `memory_dir` no longer has its real memory tier scanned —
+  ephemeral files there can no longer register false references that mask an orphan rule.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.sh
+++ b/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.sh
@@ -10,10 +10,12 @@
 # Path-scoped rules (`paths:` frontmatter) are EXEMPT — they load only on matching-file
 # Read, so being unreferenced costs nothing per session.
 #
-# Reference search is tracked-files-only (git grep), excluding `.work/` (a common
-# ephemeral task-artifact dir) and the rule's own file. Gitignored files (e.g.
-# CLAUDE.local.md) are excluded automatically — a per-user override file is not a
-# shared reference.
+# Reference search is tracked-files-only (git grep), excluding the in-repo memory tier
+# (the topic-docs seam `memory_dir`, default `.work/`) and the rule's own file. Reading
+# the seam rather than hardcoding the default keeps a consumer's overridden memory tier —
+# ephemeral task artifacts — out of the search so it cannot register false references.
+# Gitignored files (e.g. CLAUDE.local.md) are excluded automatically — a per-user
+# override file is not a shared reference.
 #
 # WARN-tier / advisory: prints findings, ALWAYS exits 0. Consumed by the audit
 # skill (check RD1).
@@ -36,8 +38,8 @@ Usage: orphan-rule-check.sh [--count|--help]
   --help     this message
 
 Always-loaded = no `paths:` frontmatter. Path-scoped rules are exempt. Reference
-search is git-grep over tracked files, excluding `.work/` and the rule's own file.
-Advisory — always exits 0.
+search is git-grep over tracked files, excluding the in-repo memory tier (topic-docs
+`memory_dir`, default `.work/`) and the rule's own file. Advisory — always exits 0.
 EOF
   exit 0
 fi
@@ -51,6 +53,20 @@ if [[ -z "$repo_root" ]]; then
   exit 1
 fi
 cd "$repo_root" || exit 1
+
+# Resolve the in-repo memory tier from the topic-docs seam (`.claude/topic-docs.yaml`
+# `memory_dir`) — the same sed-extract shape as docs-hygiene's noise-shapes.sh — and
+# exclude THAT path from the reference search, falling back to the convention default
+# `.work` only when the seam is unset. NOTE: this is the tracked in-repo tier, distinct
+# from the auto-memory dir the sibling resolve-memory-dir.sh derives.
+memory_dir=".work"
+topic_docs="${repo_root}/.claude/topic-docs.yaml"
+if [[ -f "$topic_docs" ]]; then
+  seam=$(sed -n 's/^memory_dir:[[:space:]]*//p' "$topic_docs" | head -1)
+  seam="${seam%%#*}"; seam="${seam//[[:space:]]/}"; seam="${seam%/}"
+  seam="${seam#\"}"; seam="${seam%\"}"; seam="${seam#\'}"; seam="${seam%\'}"
+  [[ -n "$seam" ]] && memory_dir="$seam"
+fi
 
 # A rule is always-loaded unless its frontmatter declares `paths:`. Frontmatter is the
 # leading `---` ... `---` block.
@@ -70,9 +86,9 @@ shopt -s nullglob
 for file in .claude/rules/*.md; do
   is_always_loaded "$file" || continue
   base=$(basename "$file")
-  # Any tracked file (outside .work/, excluding the rule itself) referencing the
-  # basename. -xF: fixed-string whole-line match, so path dots stay literal.
-  local_refs=$(git grep -l -F -- "$base" -- ':(exclude).work/' 2>/dev/null | grep -vcxF -- "$file" || true)
+  # Any tracked file (outside the memory tier, excluding the rule itself) referencing
+  # the basename. -xF: fixed-string whole-line match, so path dots stay literal.
+  local_refs=$(git grep -l -F -- "$base" -- ":(exclude)${memory_dir}/" 2>/dev/null | grep -vcxF -- "$file" || true)
   [[ "$local_refs" -eq 0 ]] && orphans+=("$base")
 done
 shopt -u nullglob

--- a/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.sh
+++ b/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.sh
@@ -63,7 +63,7 @@ memory_dir=".work"
 topic_docs="${repo_root}/.claude/topic-docs.yaml"
 if [[ -f "$topic_docs" ]]; then
   seam=$(sed -n 's/^memory_dir:[[:space:]]*//p' "$topic_docs" | head -1)
-  seam="${seam%%#*}"; seam="${seam//[[:space:]]/}"; seam="${seam%/}"
+  seam="${seam%%#*}"; seam="${seam%"${seam##*[![:space:]]}"}"; seam="${seam%/}"
   seam="${seam#\"}"; seam="${seam%\"}"; seam="${seam#\'}"; seam="${seam%\'}"
   [[ -n "$seam" ]] && memory_dir="$seam"
 fi

--- a/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.test.sh
@@ -97,6 +97,40 @@ assert_eq "--count == 0 after referencing" "0" "$OUT"
 OUT=$(cd "$REPO" && bash "$SCRIPT")
 assert_contains "clean repo reports no orphans" "$OUT" "No orphan"
 
+# --- Case 6: topic-docs `memory_dir` override moves the excluded tier ---------------
+# A consumer that overrides memory_dir must have THAT tier excluded (refs there don't
+# count) AND `.work/` must stop being excluded (refs there now count) — the additive
+# bug (exclude both) fails the .work assertion below.
+
+OVR="$TEST_TMPDIR/override"
+make_repo "$OVR"
+mkdir -p "$OVR/.claude/rules" "$OVR/.scratch" "$OVR/.work"
+printf 'memory_dir: .scratch\n' >"$OVR/.claude/topic-docs.yaml"
+# rule A referenced ONLY from the overridden memory tier (.scratch/) => still ORPHAN
+printf '# Rule A\n\nbody\n' >"$OVR/.claude/rules/a.md"
+printf 'see a.md\n' >"$OVR/.scratch/refA.md"
+# rule B referenced ONLY from .work/ => NOT orphan (.work no longer excluded)
+printf '# Rule B\n\nbody\n' >"$OVR/.claude/rules/b.md"
+printf 'see b.md\n' >"$OVR/.work/refB.md"
+(cd "$OVR" && git add -A && git commit -q -m "override fixture")
+
+OUT=$(cd "$OVR" && bash "$SCRIPT")
+assert_contains "override: ref in resolved memory_dir (.scratch) is excluded => a.md orphan" "$OUT" "a.md"
+assert_not_contains "override: .work ref counts (no longer excluded) => b.md not orphan" "$OUT" "b.md"
+
+# --- Case 7: no topic-docs.yaml => `.work/` fallback still holds ---------------------
+
+FB="$TEST_TMPDIR/fallback"
+make_repo "$FB"
+mkdir -p "$FB/.claude/rules" "$FB/.work"
+# rule C referenced ONLY from .work/ => ORPHAN (default excludes .work)
+printf '# Rule C\n\nbody\n' >"$FB/.claude/rules/c.md"
+printf 'see c.md\n' >"$FB/.work/refC.md"
+(cd "$FB" && git add -A && git commit -q -m "fallback fixture")
+
+OUT=$(cd "$FB" && bash "$SCRIPT")
+assert_contains "fallback: .work ref excluded by default => c.md orphan" "$OUT" "c.md"
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"
   exit 0

--- a/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/orphan-rule-check.test.sh
@@ -28,14 +28,14 @@ assert_exit() {
 }
 assert_contains() {
   case "$2" in
-    *"$3"*) pass "$1" ;;
-    *) fail "$1" "expected to contain: $3" ;;
+  *"$3"*) pass "$1" ;;
+  *) fail "$1" "expected to contain: $3" ;;
   esac
 }
 assert_not_contains() {
   case "$2" in
-    *"$3"*) fail "$1" "unexpected substring: $3" ;;
-    *) pass "$1" ;;
+  *"$3"*) fail "$1" "unexpected substring: $3" ;;
+  *) pass "$1" ;;
   esac
 }
 
@@ -130,6 +130,23 @@ printf 'see c.md\n' >"$FB/.work/refC.md"
 
 OUT=$(cd "$FB" && bash "$SCRIPT")
 assert_contains "fallback: .work ref excluded by default => c.md orphan" "$OUT" "c.md"
+
+# --- Case 8: interior whitespace in a quoted memory_dir is preserved -----------------
+# A collapsing strip (${seam//[[:space:]]/}) turns `.scratch dir` into `.scratchdir`, so
+# the real tier is NOT excluded and its ref counts — masking the orphan. Trailing-trim
+# preserves the interior space: the tier IS excluded and the rule stays an orphan.
+
+WS="$TEST_TMPDIR/whitespace"
+make_repo "$WS"
+mkdir -p "$WS/.claude/rules" "$WS/.scratch dir"
+printf 'memory_dir: ".scratch dir"\n' >"$WS/.claude/topic-docs.yaml"
+# rule D referenced ONLY from the space-containing memory tier => still ORPHAN
+printf '# Rule D\n\nbody\n' >"$WS/.claude/rules/d.md"
+printf 'see d.md\n' >"$WS/.scratch dir/refD.md"
+(cd "$WS" && git add -A && git commit -q -m "whitespace fixture")
+
+OUT=$(cd "$WS" && bash "$SCRIPT")
+assert_contains "whitespace: ref in quoted '.scratch dir' tier is excluded => d.md orphan" "$OUT" "d.md"
 
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"


### PR DESCRIPTION
## Summary

`orphan-rule-check.sh` hardcoded the literal `.work/` exclusion in its reference search instead of reading `memory_dir` from the topic-docs seam (`.claude/topic-docs.yaml`). A consumer that overrides `memory_dir` therefore had its **real** memory tier scanned, so ephemeral files there registered false "references" that could mask an orphan always-loaded rule. This couples the check to the convention's default NAME rather than the externalized seam.

## Fix

- Resolve `memory_dir` from `${repo_root}/.claude/topic-docs.yaml` using the **same sed-extract shape** as the fleet precedent `plugins/docs-hygiene/skills/audit-noise/scripts/lib/noise-shapes.sh:15-38`, and exclude THAT path in the `git grep` pathspec.
- Fall back to the convention default `.work/` only when the seam is unset.
- Update the three `.work/` references (header comment, `--help` text, inline comment) to describe the resolved tier instead of the hardcoded literal.
- Tests add discriminating cases proving the excluded tier **moves** under an override (the overridden dir is excluded AND `.work/` stops being excluded — an additive "exclude both" bug fails these) and that the `.work/` fallback still holds when the seam is absent.

## Verification

- `bash plugins/claude-memory/skills/audit/scripts/orphan-rule-check.test.sh` — all 12 checks pass (3 new).
- `shellcheck --rcfile=.shellcheckrc` on both changed scripts — clean.
- `typos --config _typos.toml` + `markdownlint-cli2 --config .markdownlint-cli2.jsonc` on `CHANGELOG.md` — clean (0 issues).

## Related

- Part of the work-readiness `.work`-convention sweep: the always-loaded-rule reference search must resolve the in-repo memory tier from the externalized seam, not the default name.
- Mirrors the memory_dir-resolution precedent in `docs-hygiene` `noise-shapes.sh` (same sed-extract from `.claude/topic-docs.yaml`).
- Sibling seam item #420 (`retro` resolve-memory-dir) applies the same seam-resolution shape in session-flow; this PR is the `claude-memory` audit-tier counterpart.
- No ADRs or decision-log entries are closed by this change (behavior-preserving default; seam-resolution mechanics only).

Closes #419