### PR TITLE
fix(playwright): drop tracker-shaped token from artifact-naming example

### DIFF
--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playwright",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Live E2E browser automation via Microsoft's @playwright/cli — named sessions, accessibility-ref snapshots, click/fill by ref, screenshots, console and network capture, mocking, tracing, video, and auth state, with artifacts written to disk so only paths enter context, plus a vendored upstream baseline and maintainer drift-check update flow.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `playwright` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Changed
+
+- Artifact-naming example in the tracing/video reference drops the tracker-shaped
+  `issue-123` token for an agnostic `<descriptive-name>` placeholder, so the
+  destination comes from the consumer's own project conventions rather than
+  presuming GitHub-integer issue numbering and a mandated `docs/evidence/` layout.
+
 ## [0.3.0]
 
 ### Added

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to the `playwright` plugin are documented here. Format follo
 ### Changed
 
 - Artifact-naming example in the tracing/video reference drops the tracker-shaped
-  `issue-123` token for an agnostic `<descriptive-name>` placeholder, so the
-  destination comes from the consumer's own project conventions rather than
-  presuming GitHub-integer issue numbering and a mandated `docs/evidence/` layout.
+  `issue-123` filename token and the hardcoded `docs/evidence/` directory for
+  agnostic `<artifact-dir>/<descriptive-name>` placeholders, so the destination
+  comes from the consumer's own project conventions rather than presuming
+  GitHub-integer issue numbering and a mandated evidence-directory layout.
 
 ## [0.3.0]
 

--- a/plugins/playwright/skills/playwright/reference/tracing-and-video.md
+++ b/plugins/playwright/skills/playwright/reference/tracing-and-video.md
@@ -71,7 +71,7 @@ When capturing for a PR or bug report:
 3. **Start capture** (`tracing-start` or `video-start <name>.webm`)
 4. **Perform the flow** using refs from snapshot
 5. **Stop capture** (`tracing-stop` or `video-stop`)
-6. **Move output to a meaningful location** — don't leave artifacts named `page-<timestamp>.png` in `.playwright-cli/`; use `--filename=` or `mv` to something like `docs/evidence/issue-123.webm`
+6. **Move output to a meaningful location** — don't leave artifacts named `page-<timestamp>.png` in `.playwright-cli/`; use `--filename=` or `mv` to something like `docs/evidence/<descriptive-name>.webm`
 
 ## Known costs
 

--- a/plugins/playwright/skills/playwright/reference/tracing-and-video.md
+++ b/plugins/playwright/skills/playwright/reference/tracing-and-video.md
@@ -71,7 +71,7 @@ When capturing for a PR or bug report:
 3. **Start capture** (`tracing-start` or `video-start <name>.webm`)
 4. **Perform the flow** using refs from snapshot
 5. **Stop capture** (`tracing-stop` or `video-stop`)
-6. **Move output to a meaningful location** — don't leave artifacts named `page-<timestamp>.png` in `.playwright-cli/`; use `--filename=` or `mv` to something like `docs/evidence/<descriptive-name>.webm`
+6. **Move output to a meaningful location** — don't leave artifacts named `page-<timestamp>.png` in `.playwright-cli/`; use `--filename=` or `mv` to something like `<artifact-dir>/<descriptive-name>.webm`
 
 ## Known costs
 


### PR DESCRIPTION
## Summary

The tracing/video reference (`plugins/playwright/skills/playwright/reference/tracing-and-video.md`) used `docs/evidence/issue-123.webm` as the artifact-naming exemplar. That token presumes GitHub-integer issue numbering and a `docs/evidence/` layout — a consumer keying work items as `SW2-12345` (Jira/Azure DevOps) does not match, which breaks the plugin's "reads your conventions, assumes none" posture.

This replaces the tracker-shaped token with an agnostic `docs/evidence/<descriptive-name>.webm` placeholder. The destination now comes from the consumer's own project context (which the plugin already claims to read); no new layout is mandated. The surrounding "move output to a meaningful location" rule was already agnostic and is unchanged.

## Changes

- `plugins/playwright/skills/playwright/reference/tracing-and-video.md` — `issue-123` → `<descriptive-name>` in the illustrative example.
- `plugins/playwright/.claude-plugin/plugin.json` — version 0.3.0 → 0.3.1.
- `plugins/playwright/CHANGELOG.md` — `## [0.3.1]` Keep-a-Changelog entry.

## Related

Part of the work-readiness agnosticism sweep — aligning plugin docs with the "reads your conventions, assumes none" posture described in `docs/PLUGIN-PHILOSOPHY.md`. No ADRs or decision-log entries are closed by this change; it is a LOW-severity illustrative-token fix with no contract impact.

Closes #427
