### PR TITLE
fix(repo): add pull_request_template scaffolding ## Related contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+Fill in each section and delete these guidance comments before submitting.
+
+The pr-issue-linkage check requires BOTH a native closing keyword AND a
+non-empty ## Related section. It strips HTML comments before validating, so an
+unedited template does not pass until you replace the placeholders with real
+content.
+-->
+
+Closes #
+
+<!--
+Native GitHub closing keyword for the issue this PR closes on merge: replace the
+bare `#` above with the issue number (e.g. Closes #123). Closes/Fixes/Resolves
+are all honored, case-insensitive. If this PR closes no issue, replace the whole
+line with: No linked issue
+-->
+
+## Summary
+
+<!-- What this PR changes and why, in a sentence or two. -->
+
+## Fix
+
+<!-- The concrete change: what you altered and how it addresses the problem. -->
+
+## Verification
+
+<!-- Concrete evidence the change works: commands run, gates passed, output. -->
+
+## Related
+
+<!--
+Issues, PRs, ADRs, or decision-log entries this PR references but does NOT close.
+Required non-empty. Use `Refs #N` to link an issue without closing it.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,5 +32,7 @@ line with: No linked issue
 
 <!--
 Issues, PRs, ADRs, or decision-log entries this PR references but does NOT close.
-Required non-empty. Use `Refs #N` to link an issue without closing it.
+Required non-empty even when the closing-keyword line above is `No linked issue`
+— if nothing applies, put `N/A`. Use `Refs #N` to link an issue without closing
+it.
 -->


### PR DESCRIPTION
Closes #462

## Summary

PRs fail the `pr-issue-linkage` CI check because no `.github/pull_request_template.md` existed to scaffold the `## Related` section and native closing keyword the check requires. Authors discovered the contract only after a red CI run. This adds the template so web/editor authors scaffold a passing body up front, and documents the contract in one place.

## Fix

Add `.github/pull_request_template.md` scaffolding, in order, a `Closes #` closing-keyword placeholder plus `## Summary` / `## Fix` / `## Verification` / `## Related`. Section-level guidance lives in HTML comments. The reusable validator (`melodic-software/ci-workflows` `pr-issue-linkage.yml`, pinned at `90f1c54`) is the single source of truth — the template only mirrors the exact `## Related` heading and the closing-keyword contract it enforces; no validator logic is duplicated.

Scope note on accuracy: this does **not** retroactively fix the agent-authored PRs that failed this check. Those used `gh pr create --body "..."`, which fully overrides `.github/pull_request_template.md` (cli/cli#10751), so templates never applied to them. This template helps human/web/editor authors and documents the contract; the agent path is covered separately by front-loading the contract into worker briefs, and the `/source-control:pull-request` create-flow half is tracked in #487.

By design, an unedited template does **not** pass the check: the validator strips HTML comments before validating (its explicit anti-"vacuous pass" guard), so the placeholders must be filled with real linkage before a PR goes green.

## Verification

Repo-pinned gates run against the new file — all clean:

- `markdownlint-cli2` v0.23.1 (config `.markdownlint-cli2.jsonc`, schema pinned v0.23.0): `Summary: 0 issues`.
- `editorconfig-checker` v3.8.0 (config `.editorconfig-checker.json`): exit 0, no output.
- `typos` v1.44.0 (config `_typos.toml`): exit 0, no output.

Mirror against the validator's own regex (copied verbatim from the pinned reusable and run locally):

- Raw template as-is → `["## Related" empty, "Missing closing keyword"]` — correctly fails-until-filled (comments stripped, no `#N` digit), matching the check's design.
- A filled copy (`Closes #462` + `## Related` bullets) → `[]` — clean pass.
- Heading name: `/^##\s+related$/i` matches `## Related`; rejects `### Related` and `## Related Issues`.

This PR body itself demonstrates a passing body: it carries `Closes #462` and a non-empty `## Related` section.

## Related

- Source issue: #462
- Follow-up (deferred half — `/source-control:pull-request` create flow emits the skeleton): #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
