### PR TITLE
fix(testing): guard unguarded dotnet cross-plugin ref, frame .NET enrichment lists as stack-specific

### DIFF
--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), and failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.1]
+
+### Changed
+
+- Cross-plugin marketplace-skill references brought under the presence-gated guard and reframed as
+  stack-specific. The unguarded inline `dotnet-test:*` parenthetical in `write` (per-cycle checklist)
+  is removed; its detection-layer skills moved under `write`'s now-guarded
+  `## Marketplace plugin skills (invoke only when installed)` list. The all-.NET enrichment lists in
+  `write`, `organize`, `plan`, `run-e2e`, and `diagnose` now state the `dotnet-*` skills apply only
+  when your stack is .NET, so a non-.NET consumer is not handed a dead list as the universal path.
+  No hard dependencies; every reference stays optional and installed-gated.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/testing/skills/diagnose/context/investigate.md
+++ b/plugins/testing/skills/diagnose/context/investigate.md
@@ -54,5 +54,7 @@ Most test runners parallelize across test classes / assemblies / modules. Proces
 
 ## Marketplace plugin skills (invoke only when installed)
 
+These are .NET-ecosystem plugin skills — applicable when your stack is .NET:
+
 - **`dotnet-diag:analyzing-dotnet-performance`** — scan for ~50 performance anti-patterns (async deadlocks, memory pressure, GC stalls) when tests timeout or run intermittently slow
 - **`dotnet-msbuild:binlog-failure-analysis`** — replay MSBuild binary logs to diagnose build infrastructure failures masquerading as test failures (missing references, wrong TFM, analyzer conflicts)

--- a/plugins/testing/skills/diagnose/context/loop.md
+++ b/plugins/testing/skills/diagnose/context/loop.md
@@ -109,5 +109,7 @@ When the loop is invoked standalone (outside `/implementation:implement`):
 
 ## Marketplace plugin skills (invoke only when installed)
 
+These are .NET-ecosystem plugin skills — applicable when your stack is .NET:
+
 - **`dotnet-test:mtp-hot-reload`** — enable MTP hot reload for rapid test iteration without rebuilding. Requires `Microsoft.Testing.Extensions.HotReload` package + `TESTINGPLATFORM_HOTRELOAD_ENABLED=1`. Use `dotnet run --project` (not `dotnet test`) for hot reload mode
 - **`dotnet-diag:analyzing-dotnet-performance`** — scan for async deadlocks, timing races, and GC pressure when intermittent failures suggest performance-related root causes

--- a/plugins/testing/skills/plan/SKILL.md
+++ b/plugins/testing/skills/plan/SKILL.md
@@ -104,5 +104,7 @@ Present the test plan to the user. Then suggest:
 
 ## Marketplace plugin skills (invoke only when installed)
 
+These enrichment skills are ecosystem-specific — the `dotnet-test` skill applies when your stack is .NET; `document-skills:webapp-testing` is stack-agnostic:
+
 - **`dotnet-test:code-testing-agent`** — multi-agent pipeline for comprehensive gap analysis and structured test generation. Use when the test plan reveals significant coverage gaps requiring many new tests
 - **`document-skills:webapp-testing`** — Playwright patterns for E2E test planning. Use when the test plan includes UI or API verification scenarios that need end-to-end coverage

--- a/plugins/testing/skills/run-e2e/context/e2e.md
+++ b/plugins/testing/skills/run-e2e/context/e2e.md
@@ -133,5 +133,7 @@ When a test element can't be found:
 
 ## Marketplace plugin skills (invoke only when installed)
 
+These enrichment skills are tool-specific — invoke each only when it matches your stack and tooling:
+
 - **`cloudflare:web-perf`** — measure Core Web Vitals (FCP, LCP, TBT, CLS, Speed Index) via Chrome DevTools MCP. Use for performance verification baselines during E2E testing
 - **`document-skills:webapp-testing`** — Playwright-based test automation patterns including semantic locators, accessibility-first selectors, and multi-step workflow scripting

--- a/plugins/testing/skills/write/context/organize.md
+++ b/plugins/testing/skills/write/context/organize.md
@@ -60,5 +60,7 @@ Track per-repo via the repo's own testing-conventions documentation — architec
 
 ## Marketplace plugin skills (invoke only when installed)
 
+These are .NET-ecosystem plugin skills — applicable when your stack is .NET:
+
 - **`dotnet-test:crap-score`** — calculate CRAP (Change Risk Anti-Patterns) scores to prioritize which untested code is riskiest. Combines cyclomatic complexity with coverage data to identify methods where tests would have the highest impact
 - **`dotnet-test:test-anti-patterns`** — scan existing test projects for anti-patterns (flakiness indicators, over-mocking, missing assertions, shared static state). Use when assessing test quality during reorganization

--- a/plugins/testing/skills/write/context/write.md
+++ b/plugins/testing/skills/write/context/write.md
@@ -75,7 +75,7 @@ After each Red→Green→Refactor cycle, verify:
 - [ ] Test uses public interface only
 - [ ] Test would survive internal refactor
 - [ ] One logical assertion per test — one behavioral concept, not one `Assert` statement
-- [ ] No tautological assertions — expected values are independently sourced (literal, hand-computed, known fixture), never recomputed the same way the code under test computes them; a round-trip/identity check of output against input proves nothing (detection layer: `dotnet-test:test-anti-patterns` + `dotnet-test:assertion-quality` plugins)
+- [ ] No tautological assertions — expected values are independently sourced (literal, hand-computed, known fixture), never recomputed the same way the code under test computes them; a round-trip/identity check of output against input proves nothing
 - [ ] Code is minimal for this test
 - [ ] No speculative features added
 
@@ -135,8 +135,10 @@ No tests needed for:
 - **Fix + green test committed together** — the fix and its proof are atomic
 - **Commit before refactoring** — separate structural from behavioral commits
 
-## Marketplace plugin skills
+## Marketplace plugin skills (invoke only when installed)
 
-When writing tests, consider loading these marketplace plugin skills for guidance:
+These are .NET-ecosystem plugin skills — applicable when your stack is .NET:
 
 - **`dotnet-test:code-testing-agent`** — multi-agent pipeline for comprehensive test generation (researcher → planner → implementer → builder → tester → fixer → linter). Invoke for complex test scenarios requiring gap analysis and structured implementation
+- **`dotnet-test:test-anti-patterns`** — scan existing test projects for anti-patterns (flakiness indicators, over-mocking, missing assertions, shared static state) as a detection layer for the per-cycle checklist above
+- **`dotnet-test:assertion-quality`** — flag tautological and weak assertions where expected values are recomputed the same way the code under test computes them


### PR DESCRIPTION
## Summary

The `testing` plugin bills as ecosystem-agnostic (see `plugin.json`), but its marketplace-skill enrichment handed non-.NET consumers a .NET-only path as the universal one, and it carried one bare unguarded cross-plugin reference — the exact "defect" `docs/PLUGIN-PHILOSOPHY.md` names (every cross-plugin reference must be declared or presence-gated). None of the referenced `dotnet-*` plugins exist in this marketplace (same pattern as siblings #405/#412/#422). This PR guards the stray reference and reframes the enrichment lists as stack-specific, keeping every reference optional and installed-gated — no hard dependencies added.

## Fix

Guard adopted verbatim across all six lists: `## Marketplace plugin skills (invoke only when installed)`.

- **`skills/write/context/write.md:78`** — removed the unguarded inline parenthetical `(detection layer: dotnet-test:test-anti-patterns + dotnet-test:assertion-quality plugins)` from the per-cycle checklist item. Its two detection-layer skills were **moved** under `write`'s marketplace list (orchestrator preferred moving over dropping).
- **`skills/write/context/write.md:138`** — added the `(invoke only when installed)` suffix to this heading; it was the **only** one of the six missing it. Lead-in: `These are .NET-ecosystem plugin skills — applicable when your stack is .NET:`
- **`skills/write/context/organize.md:61`** (all .NET) — lead-in: `These are .NET-ecosystem plugin skills — applicable when your stack is .NET:`
- **`skills/diagnose/context/investigate.md:55`** (all .NET) — lead-in: `These are .NET-ecosystem plugin skills — applicable when your stack is .NET:`
- **`skills/diagnose/context/loop.md:110`** (all .NET) — lead-in: `These are .NET-ecosystem plugin skills — applicable when your stack is .NET:`
- **`skills/plan/SKILL.md:105`** (mixed: `dotnet-test:*` + `document-skills:webapp-testing`) — lead-in: `These enrichment skills are ecosystem-specific — the \`dotnet-test\` skill applies when your stack is .NET; \`document-skills:webapp-testing\` is stack-agnostic:`
- **`skills/run-e2e/context/e2e.md:134`** (no .NET: `cloudflare:web-perf` + `document-skills:webapp-testing`) — lead-in: `These enrichment skills are tool-specific — invoke each only when it matches your stack and tooling:` (deliberately **not** a .NET label, since neither entry is .NET).
- Bumped `testing` `0.2.0 → 0.2.1` (`plugin.json`) with a matching `## [0.2.1] / ### Changed` CHANGELOG entry, mirroring the 0.1.1/0.1.2 content-fix precedent.

The four all-.NET lists share one byte-identical lead-in; `plan` and `run-e2e` use accurate variants because a blanket ".NET" tag would be false there. The consistent through-line is the identical guarded heading + one stack-qualifier lead-in per list.

## Verification

Ran on the changed markdown, all green, nothing suppressed:

- `markdownlint-cli2` (repo-pinned v0.23.0, `.markdownlint-cli2.jsonc`) — `Linting: 12 file(s) / Summary: 0 error(s)`.
- `editorconfig-checker` (`ec`) on all 8 changed files — exit 0, no findings.
- `typos` on `plugins/testing/` — exit 0, clean.
- `scripts/validate-plugins.sh` and `scripts/validate-plugin-contracts.mjs` — both pass (manifest + catalog + 1586 plugin files). None of the changed files appear in `scripts/cross-plugin-source-registry.txt`, so no upstream sync is involved.

## Related

- Closes #430 (source issue — hardcoded opinion + missing seam guard in `testing`).
- Sibling issues sharing the same `dotnet-*`/`cloudflare:*` unguarded/ecosystem-coupled pattern, tracked separately: #405 (`implementation`), #412 (`toolchain`), #422 (`verification`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
