### PR TITLE
fix(verification): neutralize .NET/PowerShell-flavored examples in agnostic skills

### DIFF
--- a/plugins/verification/.claude-plugin/plugin.json
+++ b/plugins/verification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "verification",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Outcome-verification stage: prove a change achieved its intended outcome (`/verification:confirm` \u2014 a mechanical build/test/lint prerequisite gate, then intent-match + evidence + verdict with the criterion auto-detected by change type), and verify measurable-improvement claims against a planning-time baseline (`/verification:measure`), never fabricating numbers.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/verification/CHANGELOG.md
+++ b/plugins/verification/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `verification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.3]
+
+### Changed
+
+- Neutralized the .NET/C#/PowerShell-flavored illustrative examples in the
+  stack-agnostic `confirm` and `measure` skills so a non-.NET consumer isn't
+  handed a stack-specific illustration as the universal path: the reproduction-test
+  example uses a generic descriptive name and failure, and the metric/perf
+  "how to check" cells count import/dependency declarations and point to "your
+  test runner"/"your benchmark harness" instead of `using`/`ProjectReference`/
+  `dotnet test`/BenchmarkDotNet. The Unix-shell `wc -l` line-count assumption is
+  now stated shell-neutrally (`wc -l` on POSIX/Git Bash, `Measure-Object -Line`
+  in PowerShell), honoring the cross-platform "never assume Bash" contract. The
+  named marketplace-plugin evidence pointers (`dotnet-*`) are unchanged.
+
 ## [0.2.2]
 
 ### Changed

--- a/plugins/verification/skills/confirm/context/fix.md
+++ b/plugins/verification/skills/confirm/context/fix.md
@@ -49,8 +49,8 @@ Gold standard for fix confirmation is a test that:
 If `/testing:diagnose` was used, this test should already exist. Reference it by name:
 
 ```
-Reproduction test: UserService_ShouldReturnNull_WhenUserIsDeleted
-- Fails on commit abc1234 (pre-fix): NullReferenceException
+Reproduction test: returns_null_when_user_is_deleted (name it per your framework's convention)
+- Fails on commit abc1234 (pre-fix): the reported failure (e.g. a null-dereference crash)
 - Passes on commit def5678 (post-fix): returns null as expected
 ```
 

--- a/plugins/verification/skills/confirm/context/fix.md
+++ b/plugins/verification/skills/confirm/context/fix.md
@@ -49,7 +49,7 @@ Gold standard for fix confirmation is a test that:
 If `/testing:diagnose` was used, this test should already exist. Reference it by name:
 
 ```
-Reproduction test: returns_null_when_user_is_deleted (name it per your framework's convention)
+Reproduction test: returns_null_when_user_is_deleted  # name it per your framework's convention
 - Fails on commit abc1234 (pre-fix): the reported failure (e.g. a null-dereference crash)
 - Passes on commit def5678 (post-fix): returns null as expected
 ```

--- a/plugins/verification/skills/measure/context/metrics.md
+++ b/plugins/verification/skills/measure/context/metrics.md
@@ -11,17 +11,17 @@ Quality is partly subjective, but some aspects ARE measurable:
 | Quality aspect | Measurable proxy | How to check |
 |---------------|-----------------|--------------|
 | Complexity | Cyclomatic complexity, nesting depth | Count conditionals, measure max nesting |
-| Size | Lines of code, file count, method length | `wc -l`, `git diff --stat` |
-| Coupling | Dependency count, import count | Count `using`/`import`, `ProjectReference` count |
+| Size | Lines of code, file count, method length | Line counter (`wc -l` on POSIX/Git Bash, `Measure-Object -Line` in PowerShell), `git diff --stat` |
+| Coupling | Dependency count, import count | Count import/dependency declarations (`import`/`require`/`using`, package or project references) |
 | Cohesion | Methods per class, related functionality | Inspect class responsibility |
 | Duplication | Repeated code blocks | Grep for similar patterns |
-| Test coverage | Test count, assertion count | `dotnet test` output, test inventory |
+| Test coverage | Test count, assertion count | Your test runner's output, test inventory |
 | API surface | Public member count | Count `public` declarations |
 
 ## `baseline` phase (at planning time)
 
 1. **Map the claim to a proxy** — "simpler" → fewer lines / lower complexity / less nesting; "cleaner" → better naming / less duplication; "more maintainable" → fewer deps / better cohesion / more tests; "better organized" → feature-aligned structure / reduced coupling.
-2. **Capture pre-change metrics** for the chosen proxies (`git show <base>:<file> | wc -l`, complexity count, dependency count). Store in the topic's memory-tier baselines directory (SKILL.md "Two-phase model" — machine-bound, never committed) and record in the plan.
+2. **Capture pre-change metrics** for the chosen proxies (line count from `git show <base>:<file>` piped to a line counter — `wc -l` on POSIX/Git Bash, `Measure-Object -Line` in PowerShell; complexity count, dependency count). Store in the topic's memory-tier baselines directory (SKILL.md "Two-phase model" — machine-bound, never committed) and record in the plan.
 
 ## `compare` phase (at `/verification:measure metrics`)
 

--- a/plugins/verification/skills/measure/context/performance.md
+++ b/plugins/verification/skills/measure/context/performance.md
@@ -11,10 +11,10 @@ When a plan claims a perf improvement:
 
    | Claim type | Metrics | How to measure |
    |-----------|---------|---------------|
-   | Faster execution | Wall time, CPU time | `dotnet test` timing, `Measure-Command`, `time` |
-   | Faster build | Build time | `dotnet build` timing, CI run durations |
-   | Less memory | Peak RSS, allocation count | `dotnet-counters`, `dotnet-trace`, profiler |
-   | Fewer allocations | Allocation rate, GC pressure | BenchmarkDotNet, `dotnet-counters` |
+   | Faster execution | Wall time, CPU time | Your test runner's timing output, a shell timer (`time` on POSIX/Git Bash, `Measure-Command` in PowerShell) |
+   | Faster build | Build time | Your build tool's timing output, CI run durations |
+   | Less memory | Peak RSS, allocation count | Your platform's profiler or memory-counter tooling |
+   | Fewer allocations | Allocation rate, GC pressure | Your benchmark harness, allocation profiler |
    | Better throughput | Requests/sec, items/sec | Load test, benchmark harness |
    | Reduced latency | P50, P95, P99 | Tracing dashboard, load tests |
 


### PR DESCRIPTION
## Summary

The `verification` plugin's `confirm` and `measure` skills are sold as ecosystem-agnostic, but their illustrative examples leaned .NET/C#/PowerShell, and two "how to check" cells assumed a Unix shell (`wc -l`) against the cross-platform "never assume Bash" contract. A non-.NET consumer was handed a stack-specific illustration as the universal path. This patch neutralizes the examples while keeping the guidance concrete and useful.

## Fix

- `skills/confirm/context/fix.md` — reproduction-test example now uses a generic descriptive name (`returns_null_when_user_is_deleted`, "name it per your framework's convention") and a generic failure ("the reported failure (e.g. a null-dereference crash)") instead of `UserService_ShouldReturnNull_WhenUserIsDeleted` / `NullReferenceException`.
- `skills/measure/context/metrics.md` — coupling row counts "import/dependency declarations (`import`/`require`/`using`, package or project references)" instead of `using`/`ProjectReference`; coverage row points to "your test runner's output" instead of `dotnet test`; both `wc -l` sites are now stated shell-neutrally (`wc -l` on POSIX/Git Bash, `Measure-Object -Line` in PowerShell), mirroring the both-forms pattern established in #331.
- `skills/measure/context/performance.md` — metric "how to measure" cells point to "your test runner", "your build tool", "your platform's profiler", and "your benchmark harness", with the shell timer given for both shells (`time` on POSIX/Git Bash, `Measure-Command` in PowerShell) instead of `dotnet test`/`dotnet-counters`/BenchmarkDotNet as the only path.
- The named marketplace-plugin evidence pointers (`dotnet-*:*`) at the bottom of both `measure` files are unchanged — those are real named plugins used as evidence sources, not universal-path illustrations, and #424 deliberately did not flag them.
- `verification` bumped `0.2.2` → `0.2.3` (docs = patch) with a CHANGELOG entry.

## Verification

Gates run in this Windows environment against the changed markdown; all clean, nothing suppressed:

- `markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)` (repo-pinned) on the four changed `.md` files — `Summary: 0 error(s)`.
- `typos-cli 1.44.0` on the four changed `.md` files — exit 0, no output.
- `editorconfig-checker v3.8.0` on the changed `.md` files plus `plugin.json` — exit 0, no findings.
- `plugin.json` re-parsed as valid JSON; version reads `0.2.3`.

## Related

Closes #424. Sibling stack-bias issues in the same work-readiness sweep, same pattern: #430, #429, #428 (all `testing` plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)