### PR TITLE
fix(review): gate quality-gate pr mode PR-comment posting behind explicit opt-in

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.1]
+
+### Fixed
+
+- **`quality-gate` pr mode gates the PR-comment-posting orchestrator behind
+  explicit opt-in** (un-sanctioned side-effect fix). The `code-review`
+  orchestrator's PR mode posts findings as a PR comment, which violates the
+  review modes' report-only contract; `context/pr.md` previously presented it
+  as the ungated "Primary path." It now carries the same **PR-mutation gate**
+  the sibling `fanout` skill already applies to the identical call: when the
+  branch has an open PR, the posting mode is dispatched only on explicit user
+  opt-in ("post the review comment"), otherwise it is skipped (the skip is
+  named in the review report) and review falls to the read-only manual path.
+
 ## [0.14.0]
 
 ### Changed

--- a/plugins/review/skills/quality-gate/context/pr.md
+++ b/plugins/review/skills/quality-gate/context/pr.md
@@ -2,13 +2,15 @@
 
 Reviews an existing GitHub PR with git-history context.
 
-## Primary path — `code-review` orchestrator plugin (when installed)
+## `code-review` orchestrator plugin (when installed)
 
-When the `code-review` plugin (from the `claude-plugins-official` marketplace) is available, invoke `/code-review:code-review`. It detects the current branch's PR, runs parallel review agents with confidence scoring, and posts findings as a PR comment.
+When the `code-review` plugin (from the `claude-plugins-official` marketplace) is available, `/code-review:code-review` detects the current branch's PR and runs parallel review agents with confidence scoring against it.
 
-## Fallback — manual PR review
+**PR-mutation gate:** its PR mode posts findings as a PR comment, which violates the review modes' report-only contract; when the branch has an open PR, dispatch it only on explicit user opt-in ("post the review comment"), otherwise skip it and name the skip in the review report — fall to the read-only manual path below.
 
-When the plugin is absent:
+## Manual PR review (default read-only path)
+
+Used when the plugin is absent, or when the opt-in above is withheld:
 
 1. `gh pr diff` for the change set (page it — large PRs flood context)
 2. Apply the project's review criteria (or `${CLAUDE_PLUGIN_ROOT}/context/severity.md` baseline) manually, or dispatch this plugin's `code-reviewer` agent against the PR's merge-base diff


### PR DESCRIPTION
## Summary

`plugins/review/skills/quality-gate/context/pr.md` presented the `code-review` orchestrator's PR mode — which **posts findings as a PR comment** — as the ungated "Primary path." This emits an outward GitHub artifact without user consent. The `review` plugin's own sibling `fanout` skill already treats this exact call as a violation of the review modes' report-only contract and gates it; `quality-gate` did not. This brings `pr.md` under the same explicit-opt-in gate `fanout` uses, so the two are consistent.

## Fix

Mirrored `fanout`'s `**PR-mutation gate:**` clause into `pr.md` and dropped the "Primary path"/"Fallback" framing that was the defect:

- The `code-review` orchestrator section is no longer imperative; the PR-posting mode is dispatched **only on explicit user opt-in**, otherwise skipped and the skip is named, falling to the read-only manual path (now the default).

**Line mirrored** — `plugins/review/skills/fanout/SKILL.md:76`:

> its PR mode posts findings as a PR comment, which violates the review modes' report-only contract; when the branch has an open PR, dispatch it only on explicit user opt-in ("post the review comment"), otherwise skip it and name the skip in `## Surfaces`.

**Opt-in wording adopted** in `pr.md`:

> **PR-mutation gate:** its PR mode posts findings as a PR comment, which violates the review modes' report-only contract; when the branch has an open PR, dispatch it only on explicit user opt-in ("post the review comment"), otherwise skip it and name the skip in the review report — fall to the read-only manual path below.

**One deliberate adaptation:** `fanout` names the skip in its `## Surfaces` section; `pr.md` has no such section (quality-gate reports via its Step 3 findings table), so the clause reads "name the skip in the review report." The gate mechanism and opt-in trigger are otherwise identical to `fanout`'s — no new gating mechanism was invented.

Version bumped `review` 0.14.0 → 0.14.1 (patch; defect fix aligning `pr` mode with the plugin's pre-existing report-only contract, `fix`-typed) with a `### Fixed` CHANGELOG entry.

## Verification

Gates run on the changed markdown, all green:

- `markdownlint-cli2` v0.23.1 (repo-pinned `.markdownlint-cli2.jsonc`) — `Summary: 0 issues in 0 files`
- `editorconfig-checker` v3.8.0 — rc=0, no output
- `typos` (typos-cli 1.44.0, `_typos.toml`) — rc=0, no output

## Related

- Closes #434 (review plugin — un-sanctioned side effect: quality-gate `pr` mode posts a PR comment with no opt-in gate)
- Gating precedent mirrored: sibling `fanout` skill, `plugins/review/skills/fanout/SKILL.md:76` (PR-mutation gate on the identical `/code-review:code-review` call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
