### PR TITLE
fix(markdown-format): remove internal fleet-audit jargon from consumer-facing text

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.3]
+
+### Changed
+
+- Documentation-only prose hygiene: reworded changelog entries and hook comments
+  to describe past changes in consumer-meaningful terms, dropping
+  maintainer-internal vocabulary and a cross-plugin reference. No behavior
+  change to the hook or its output.
+
 ## [0.5.2]
 
 ### Changed
@@ -18,15 +27,13 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 
 - Setup `check` downgrades every prerequisite absence from FAIL to INFO while
   the plugin's toggle is disabled (the hook exits through its enabled-gate
-  before probing, so a deliberately disabled plugin is not broken) — the same
-  class fix applied across the fleet's other hook-plugin setups.
+  before probing, so a deliberately disabled plugin is not broken).
 
 ## [0.5.0]
 
 ### Added
 
-- **`setup` skill on the uniform contract** (fleet conformance wave, dim 8 —
-  the fleet's first conforming exemplar). `check` verifies the hook's runtime
+- **`setup` skill on the uniform contract.** `check` verifies the hook's runtime
   prerequisites read-only (Bash, `jq`, `markdownlint-cli2` resolution,
   discovered markdownlint config + trust boundary, effective toggle);
   `apply` re-checks and resolves — guidance for system tools and the native
@@ -40,15 +47,15 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 
 ### Changed
 
-- Refresh of the bundled shared hook-utils library, which gains the git argv-grammar parser used by
-  the guardrails plugin's git guards. No behavioral change to this plugin's hooks.
+- Refresh of the bundled shared hook-utils library, which gains a git argv-grammar parser used by
+  git-guard hooks. No behavioral change to this plugin's hooks.
 
 ## [0.4.0]
 
 ### Changed
 
-- **Missing-prerequisite notices now reach the user too, once per session**
-  (prerequisite-visibility wave). The jq and markdownlint-cli2 absence
+- **Missing-prerequisite notices now reach the user too, once per session.**
+  The jq and markdownlint-cli2 absence
   warnings — previously an `additionalContext`-only message repeated on every
   edit — now use the shared visible-skip mechanism: one notice per session on
   both channels (`additionalContext` for Claude, `systemMessage` for the

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -48,7 +48,7 @@ esac
 
 # jq is required to parse Claude Code's hook payload and to emit structured
 # PostToolUse context. Absent → visible once-per-session skip notice on both
-# the agent and user channels (dim-9 doctrine), exit 0.
+# the agent and user channels, exit 0.
 hook::require_jq PostToolUse markdown-format "$INPUT"
 
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
@@ -151,7 +151,7 @@ elif REPO_MDLINT="$(resolve_repo_markdownlint)"; then
 else
   # Never invoke a package runner here: hooks must not download or execute an
   # unpinned package as a side effect of editing a file. Degrade visibly on
-  # both channels, once per session (dim-9 doctrine).
+  # both channels, once per session.
   if hook::notice_once "markdown-format-markdownlint" "$INPUT"; then
     hook::emit_skip_notice PostToolUse \
       "markdown-format: markdownlint-cli2 is neither on PATH nor available as a contained repository-local node_modules/.bin executable — Markdown lint skipped for this session. Install it explicitly; this hook does not invoke npx or download tools."

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -4,7 +4,7 @@
 # Proves WIRING, not baseline parity: that the hook fires on *.md/*.mdc, skips
 # otherwise, runs markdownlint-cli2 --fix from the linted file's repo root
 # (config discovery is CWD-anchored), preserves --fix bytes, and surfaces
-# residual findings via additionalContext with no medley-policy prose.
+# residual findings via additionalContext with no repo-specific policy prose.
 #
 # Self-contained: builds a throwaway git repo with its own markdownlint config
 # and runtime-generated fixtures (CRLF preserved via printf, never committed —
@@ -201,11 +201,11 @@ if printf '%s' "$CTX_B" | grep -q 'MD024'; then
 else
   fail "fixtureB ctx missing MD024: $CTX_B"
 fi
-# Genericized wrapper: medley-policy tail must be gone.
+# Genericized wrapper: the repo-specific policy tail must be gone.
 if printf '%s' "$CTX_B" | grep -qi 'commit/CI will block'; then
-  fail "fixtureB ctx still has medley policy tail"
+  fail "fixtureB ctx still has repo-specific policy tail"
 else
-  ok "fixtureB ctx dropped medley policy tail"
+  ok "fixtureB ctx dropped repo-specific policy tail"
 fi
 
 # --- Fire gate: non-.md extension skips -------------------------------------


### PR DESCRIPTION
## Summary

Internal fleet-audit jargon and internal/sibling names leaked into consumer-facing shipped files for the `markdown-format` plugin. The CHANGELOG is definitively consumer-facing (read on version bumps), so external consumers saw maintainer-only vocabulary that means nothing to them, plus a cross-reference to a sibling plugin. This is a prose-hygiene pass — not a config seam.

## Fix

- **CHANGELOG.md (rewritten in place, factual record preserved):**
  - `0.5.1`: dropped the trailing "the same class fix applied across the fleet's other hook-plugin setups".
  - `0.5.0`: removed "(fleet conformance wave, dim 8 — the fleet's first conforming exemplar)".
  - `0.4.1`: sibling-plugin reference ("the guardrails plugin's git guards") described generically as "git-guard hooks" — also satisfies the never-cross-reference-plugin-names rule.
  - `0.4.0`: removed the same-class "(prerequisite-visibility wave)" rollout jargon. This instance was **not** in the issue's enumerated list but is the identical jargon class in the same consumer-facing file; removed deliberately so the hygiene pass is complete rather than leaving matching jargon behind.
- **hooks/markdown-format.sh:** stripped "(dim-9 doctrine)" from two comments (lines 51, 154).
- **hooks/markdown-format.test.sh:** renamed "medley-policy"/"medley policy tail" to "repo-specific policy" in the header comment and `ok`/`fail` message strings.
- Added `0.5.3` CHANGELOG entry and bumped `plugin.json` `0.5.2 → 0.5.3` (docs/comment hygiene = patch), mirroring PR #443's two-file convention. `marketplace.json` carries no version field, so `plugin.json` is the sole version source.

### Zero behavior change (hook files)

Hook `.sh`/`.test.sh` edits are **comments and human-readable `ok`/`fail` message strings only**. No executable logic, control flow, or matched pattern changed. Critically, the test's residual-prose assertion greps the literal `'commit/CI will block'` (unchanged) — "medley" was never load-bearing in any assertion.

## Verification

All gates run against the changed files; all pass, none suppressed:

- **markdownlint-cli2** v0.18.1 (`--config .markdownlint-cli2.jsonc`) on `CHANGELOG.md` → `0 error(s)`.
- **shellcheck** (repo `.shellcheckrc`) on both changed hook `.sh`/`.test.sh` → clean (exit 0).
- **editorconfig-checker** v3.8.0 on all 4 changed files → clean (exit 0).
- **typos** 1.44.0 (repo `_typos.toml`) on `plugins/markdown-format/` → clean (exit 0). Removing "medley"/"dim" altered no allowlist entries (none existed for these terms).
- **Hook contract test** (`markdown-format.test.sh`) → `PASS=65 FAIL=0`, empirically confirming no behavior change.

## Related

- Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)