### PR TITLE
docs(review): describe /simplify as an optional in-session skill, not bundled

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.2]
+
+### Fixed
+
+- **`fanout` fix-pass docs describe `/simplify` as an optional in-session skill,
+  not "bundled"** (doc-accuracy fix). No `simplify` skill ships under
+  `plugins/review/`; the plugin bundles the `fanout`, `quality-gate`, and `setup`
+  skills, while `/simplify` is an external/built-in skill resolved from the
+  session. `context/fix-pass-mode.md` and the `fanout` eval expectation now call
+  the cleanup-class route the "optional in-session `/simplify`" skill. Behavior is
+  unchanged — the existing fallback ("when available in the session; otherwise
+  apply the cleanup findings directly, one file at a time") already degrades
+  gracefully; only the inaccurate "bundled" descriptor is dropped.
+
 ## [0.14.1]
 
 ### Fixed

--- a/plugins/review/skills/fanout/context/fix-pass-mode.md
+++ b/plugins/review/skills/fanout/context/fix-pass-mode.md
@@ -1,6 +1,6 @@
 # Fix-pass mode — apply persisted findings
 
-The skill's `fix` action: consume the newest persisted findings file for the CURRENT branch, split findings by class, and apply — cleanup-class via the bundled `/simplify` skill, correctness-class via sequential scope-fenced fixes. The review modes are findings-only; this action is the only one that mutates the working tree.
+The skill's `fix` action: consume the newest persisted findings file for the CURRENT branch, split findings by class, and apply — cleanup-class via the optional in-session `/simplify` skill, correctness-class via sequential scope-fenced fixes. The review modes are findings-only; this action is the only one that mutates the working tree.
 
 ## Step 1: Locate the findings file (current branch ONLY)
 
@@ -14,7 +14,7 @@ Read the file. Parse the `## Findings` table (per `default-mode.md` "Findings-fi
 
 | Class | What it is | Route |
 |---|---|---|
-| **cleanup** | Quality improvement that does NOT change behavior: reuse/dedup, simplification, naming, readability, dead-code removal, semantics-preserving efficiency | bundled `/simplify` |
+| **cleanup** | Quality improvement that does NOT change behavior: reuse/dedup, simplification, naming, readability, dead-code removal, semantics-preserving efficiency | optional in-session `/simplify` |
 | **correctness** | Behavioral defect: bug, security vulnerability, logic error, race condition, data-loss risk, missing error handling at a boundary, broken contract | sequential scope-fenced fix OR surface to the user |
 
 Classification rules:
@@ -49,9 +49,9 @@ Apply one finding at a time — concurrent fixes risk silent overwrite (last wri
 - **Surface instead of auto-applying** when a fix is low-confidence, needs architectural judgment, or has high blast radius. Auto-apply only clear, contained, high-confidence fixes.
 - After each fix, re-read the touched region to confirm the edit landed as intended.
 
-### Cleanup-class → bundled `/simplify`
+### Cleanup-class → optional in-session `/simplify`
 
-Invoke the bundled `/simplify` skill (when available in the session; otherwise apply the cleanup findings directly, one file at a time).
+Invoke the `/simplify` skill when available in the session; otherwise apply the cleanup findings directly, one file at a time.
 
 - `/simplify` rediscovers cleanups from the working-tree diff — it does NOT read the findings file. Sound when the findings are fresh vs the working tree; note it when the findings timestamp lags far behind the latest commits.
 - Zero cleanup-class findings → skip entirely; do not invoke it to "tidy anyway".

--- a/plugins/review/skills/fanout/evals/evals.json
+++ b/plugins/review/skills/fanout/evals/evals.json
@@ -210,7 +210,7 @@
       "id": 18,
       "name": "fix-pass-splits-mixed-class-findings",
       "prompt": "[Scenario: a current-branch findings file with both a cleanup-class (extract-helper) finding and a correctness-class (CRITICAL security) finding.] /review:fanout fix",
-      "expected_output": "Fix-pass classifies findings by class and routes cleanup-class findings to /simplify while applying correctness-class findings via sequential scope-fenced fixes.",
+      "expected_output": "Fix-pass classifies findings by class and routes cleanup-class findings to the optional in-session /simplify skill while applying correctness-class findings via sequential scope-fenced fixes.",
       "files": [],
       "expectations": [
         "Locates the newest findings file for the CURRENT branch only",

--- a/plugins/review/skills/fanout/evals/evals.json
+++ b/plugins/review/skills/fanout/evals/evals.json
@@ -214,7 +214,7 @@
       "files": [],
       "expectations": [
         "Locates the newest findings file for the CURRENT branch only",
-        "Classifies the cleanup-class finding and routes it to the bundled /simplify skill",
+        "Classifies the cleanup-class finding and routes it to the optional in-session /simplify skill",
         "Classifies the correctness-class finding and applies it via a sequential scope-fenced fix, not via /simplify",
         "Emits the classification plan and confirms before mutating the working tree in an interactive session"
       ]


### PR DESCRIPTION
## Summary

The `review` plugin's `fanout` fix-pass docs described the cleanup-class routing target, `/simplify`, as a "bundled" skill. That is inaccurate: no `simplify` skill ships under `plugins/review/` — the plugin bundles `fanout`, `quality-gate`, and `setup`. `/simplify` is an external/built-in skill resolved from the session. This doc-accuracy fix drops the "bundled" descriptor and describes `/simplify` as an optional in-session skill, keeping the existing graceful-degradation fallback intact.

## Fix

- `plugins/review/skills/fanout/context/fix-pass-mode.md` — intro (line 3), the class-routing table (line 17), and the cleanup-class heading (line 52) now call the route the "optional in-session `/simplify`" skill. The body invocation line drops "bundled" and relies on the existing "when available in the session; otherwise apply the cleanup findings directly, one file at a time" fallback (no duplicate descriptor).
- `plugins/review/skills/fanout/evals/evals.json` — the fix-pass eval expectation string updated from "bundled /simplify skill" to "optional in-session /simplify skill" for consistency.
- No config, gate, or behavior change: the graceful-degradation guard already existed. No skill frontmatter `description` or trigger keywords were touched (fix-pass-mode.md opens with a Markdown heading, not YAML frontmatter).
- Historical CHANGELOG entries left factually intact (line 140's "never routed to `/simplify`" carries no false "bundled" descriptor).
- `plugins/review` version bumped `0.14.1` → `0.14.2` (doc = patch) with a matching CHANGELOG entry, mirroring the recent 0.14.1 pattern.

## Verification

Run on the changed files (repo-pinned config where applicable):

- `markdownlint-cli2 v0.18.1` (`--config .markdownlint-cli2.jsonc`) on `fix-pass-mode.md` + `CHANGELOG.md` — `Summary: 0 error(s)`.
- `editorconfig-checker v3.8.0` on all four changed files — exit 0, no violations.
- `typos` (`--config _typos.toml`) on the three changed content files — exit 0, clean.

## Related

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
