### PR TITLE
fix(verification): presence-gate dotnet/cloudflare cross-plugin refs in measure contexts

### DIFF
--- a/plugins/verification/.claude-plugin/plugin.json
+++ b/plugins/verification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "verification",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Outcome-verification stage: prove a change achieved its intended outcome (`/verification:confirm` \u2014 a mechanical build/test/lint prerequisite gate, then intent-match + evidence + verdict with the criterion auto-detected by change type), and verify measurable-improvement claims against a planning-time baseline (`/verification:measure`), never fabricating numbers.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/verification/CHANGELOG.md
+++ b/plugins/verification/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to the `verification` plugin are documented here. Format fol
   otherwise falling back to the project's own tooling — the generic complexity/coverage or
   benchmark/profiling harness where that fits, with a tailored per-bullet fallback where the
   evidence type differs (query logging / database profiling / ORM diagnostics for EF-query
-  analysis, web-vitals tooling for Core Web Vitals). This removes the bare unguarded cross-plugin
+  analysis, a test-quality analyzer or test-smell review checklist for test-quality analysis,
+  web-vitals tooling for Core Web Vitals). This removes the bare unguarded cross-plugin
   reference `docs/PLUGIN-PHILOSOPHY.md` names as a defect; no hard dependencies added, every
   reference stays optional.
 

--- a/plugins/verification/CHANGELOG.md
+++ b/plugins/verification/CHANGELOG.md
@@ -12,9 +12,12 @@ All notable changes to the `verification` plugin are documented here. Format fol
   `## Marketplace plugin skills (invoke only when installed)` guard heading (matching the `testing`
   plugin's gated lists) plus a lead-in that frames the `dotnet-*` skills as .NET-only and
   `cloudflare:web-perf` as web-frontend-only, each invoked only when its plugin is installed and
-  otherwise falling back to the project's own complexity/coverage or benchmark/profiling tooling.
-  This removes the bare unguarded cross-plugin reference `docs/PLUGIN-PHILOSOPHY.md` names as a
-  defect; no hard dependencies added, every reference stays optional.
+  otherwise falling back to the project's own tooling — the generic complexity/coverage or
+  benchmark/profiling harness where that fits, with a tailored per-bullet fallback where the
+  evidence type differs (query logging / database profiling / ORM diagnostics for EF-query
+  analysis, web-vitals tooling for Core Web Vitals). This removes the bare unguarded cross-plugin
+  reference `docs/PLUGIN-PHILOSOPHY.md` names as a defect; no hard dependencies added, every
+  reference stays optional.
 
 ## [0.2.3]
 

--- a/plugins/verification/CHANGELOG.md
+++ b/plugins/verification/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `verification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.4]
+
+### Changed
+
+- Presence-gated the `dotnet-*`/`cloudflare` marketplace-skill evidence pointers in the `measure`
+  contexts, superseding 0.2.3's "unchanged" note. `metrics` and `performance` now carry the
+  `## Marketplace plugin skills (invoke only when installed)` guard heading (matching the `testing`
+  plugin's gated lists) plus a lead-in that frames the `dotnet-*` skills as .NET-only and
+  `cloudflare:web-perf` as web-frontend-only, each invoked only when its plugin is installed and
+  otherwise falling back to the project's own complexity/coverage or benchmark/profiling tooling.
+  This removes the bare unguarded cross-plugin reference `docs/PLUGIN-PHILOSOPHY.md` names as a
+  defect; no hard dependencies added, every reference stays optional.
+
 ## [0.2.3]
 
 ### Changed

--- a/plugins/verification/skills/measure/context/metrics.md
+++ b/plugins/verification/skills/measure/context/metrics.md
@@ -65,7 +65,9 @@ Quality is partly subjective, but some aspects ARE measurable:
 - **More abstractions isn't always better** — a `UserServiceFactory` → `UserService` → `UserRepository` chain is worse than the repository directly unless each layer earns its place.
 - **Don't confuse motion with progress** — renaming files / reorganizing directories / reformatting is housekeeping, not quality improvement. Valid, but don't claim it improved quality.
 
-## Marketplace plugin skills (evidence sources when the collector lands)
+## Marketplace plugin skills (invoke only when installed)
+
+These are .NET-ecosystem plugin skills — invoke each only when your stack is .NET and its plugin is installed; otherwise draw the same evidence from the project's own complexity/coverage tooling:
 
 - **CRAP scores** — `dotnet-test:crap-score` combines cyclomatic complexity + coverage into one risk metric ("safer to change" evidence).
 - **Test quality** — `dotnet-test:test-anti-patterns` detects test smells before claiming suite improvements.

--- a/plugins/verification/skills/measure/context/metrics.md
+++ b/plugins/verification/skills/measure/context/metrics.md
@@ -71,4 +71,4 @@ These are .NET-ecosystem plugin skills — invoke each only when your stack is .
 
 - **CRAP scores** — `dotnet-test:crap-score` combines cyclomatic complexity + coverage into one risk metric ("safer to change" evidence).
 - **Test quality** — `dotnet-test:test-anti-patterns` detects test smells before claiming suite improvements.
-- **EF Core queries** — `dotnet-data:optimizing-ef-core-queries` for N+1 detection / query-optimization evidence.
+- **EF Core queries** — `dotnet-data:optimizing-ef-core-queries` for N+1 detection / query-optimization evidence; if absent, use the project's own query logging, database profiling, or ORM diagnostics — the complexity/coverage fallback above won't reveal N+1 or query plans.

--- a/plugins/verification/skills/measure/context/metrics.md
+++ b/plugins/verification/skills/measure/context/metrics.md
@@ -70,5 +70,5 @@ Quality is partly subjective, but some aspects ARE measurable:
 These are .NET-ecosystem plugin skills — invoke each only when your stack is .NET and its plugin is installed; otherwise draw the same evidence from the project's own complexity/coverage tooling:
 
 - **CRAP scores** — `dotnet-test:crap-score` combines cyclomatic complexity + coverage into one risk metric ("safer to change" evidence).
-- **Test quality** — `dotnet-test:test-anti-patterns` detects test smells before claiming suite improvements.
+- **Test quality** — `dotnet-test:test-anti-patterns` detects test smells before claiming suite improvements; if absent, use the project's own test-quality analyzer or an explicit test-smell review checklist — the complexity/coverage fallback above won't surface over-mocking, flakiness, or tautological tests.
 - **EF Core queries** — `dotnet-data:optimizing-ef-core-queries` for N+1 detection / query-optimization evidence; if absent, use the project's own query logging, database profiling, or ORM diagnostics — the complexity/coverage fallback above won't reveal N+1 or query plans.

--- a/plugins/verification/skills/measure/context/performance.md
+++ b/plugins/verification/skills/measure/context/performance.md
@@ -65,4 +65,4 @@ These enrichment skills are stack-specific — the `dotnet-*` skills apply when 
 - **Code-level perf** — `dotnet-diag:analyzing-dotnet-performance` scans ~50 anti-patterns (async deadlocks, GC pressure, string allocation).
 - **Microbenchmarks** — `dotnet-diag:microbenchmarking` for BenchmarkDotNet setup + methodology.
 - **Build perf** — `dotnet-msbuild:build-perf-baseline` / `build-perf-diagnostics`.
-- **Web perf** — `cloudflare:web-perf` for Core Web Vitals via Chrome DevTools.
+- **Web perf** — `cloudflare:web-perf` for Core Web Vitals via Chrome DevTools; if absent, use the project's own web vitals tooling (Lighthouse, PageSpeed Insights, or your CI web perf runner) — the benchmark/profiling fallback above targets code perf, not web vitals.

--- a/plugins/verification/skills/measure/context/performance.md
+++ b/plugins/verification/skills/measure/context/performance.md
@@ -58,7 +58,9 @@ When a plan claims a perf improvement:
 - **Micro-optimization without macro impact** — saving 1ms in a function inside a 200ms request is noise, not signal.
 - **Forgetting warm-up** — first-run JIT + cold cache inflate initial measurements. Discard the first run or include warm-up.
 
-## Marketplace plugin skills (evidence sources when the harness lands)
+## Marketplace plugin skills (invoke only when installed)
+
+These enrichment skills are stack-specific — the `dotnet-*` skills apply when your stack is .NET, `cloudflare:web-perf` when you ship a web frontend; invoke each only when its plugin is installed, otherwise draw the same evidence from the project's own benchmark/profiling harness:
 
 - **Code-level perf** — `dotnet-diag:analyzing-dotnet-performance` scans ~50 anti-patterns (async deadlocks, GC pressure, string allocation).
 - **Microbenchmarks** — `dotnet-diag:microbenchmarking` for BenchmarkDotNet setup + methodology.


### PR DESCRIPTION
## Summary

The `verification` plugin's `measure` skill billed `dotnet-*` and `cloudflare` marketplace-plugin skills as evidence sources in two measure contexts with **no presence gate and no fallback** — the exact "defect" `docs/PLUGIN-PHILOSOPHY.md` names (every cross-plugin reference must be declared or presence-gated). None of the referenced plugins exist in this marketplace, while every other cross-plugin ref in the same plugin (`/toolchain:*`, `/testing:run-e2e`, `/review:quality-gate`) is already gated. This PR brings the two stray lists under the same guard and reframes them as stack-specific, keeping every reference optional and installed-gated — no hard dependencies added.

## Fix

Guard heading adopted verbatim from the `testing` sibling (#491) on both lists: `## Marketplace plugin skills (invoke only when installed)`. Each list gains one stack-qualifier lead-in ending in a colon, carrying the install-gate + fallback idiom `confirm/SKILL.md` already uses ("when the plugin is installed … else the project's own tooling").

- **`plugins/verification/skills/measure/context/metrics.md:68`** (all .NET: `dotnet-test:crap-score`, `dotnet-test:test-anti-patterns`, `dotnet-data:optimizing-ef-core-queries`) — lead-in: `These are .NET-ecosystem plugin skills — invoke each only when your stack is .NET and its plugin is installed; otherwise draw the same evidence from the project's own complexity/coverage tooling:`
- **`plugins/verification/skills/measure/context/performance.md:61`** (mixed: `dotnet-diag:analyzing-dotnet-performance`, `dotnet-diag:microbenchmarking`, `dotnet-msbuild:build-perf-baseline`, `cloudflare:web-perf`) — lead-in: `These enrichment skills are stack-specific — the \`dotnet-*\` skills apply when your stack is .NET, \`cloudflare:web-perf\` when you ship a web frontend; invoke each only when its plugin is installed, otherwise draw the same evidence from the project's own benchmark/profiling harness:` (deliberately **not** a blanket .NET label, since `cloudflare:web-perf` is not .NET).
- Bumped `verification` `0.2.3 → 0.2.4` (`plugin.json`) with a matching `## [0.2.4] / ### Changed` CHANGELOG entry that explicitly supersedes 0.2.3's "the `dotnet-*` evidence pointers are unchanged" note.

A completeness grep for `dotnet-|cloudflare` across `plugins/verification/` confirms these two `## Marketplace plugin skills` headings are the only occurrences — no stray inline references (the trap #491 hit in `write.md`).

## Verification

Ran on the changed files, all green, nothing suppressed:

- `markdownlint-cli2` (repo config `.markdownlint-cli2.jsonc`) on the 3 changed md files — `Linting: 3 file(s) / Summary: 0 error(s)`.
- `editorconfig-checker` on the 3 md files + `plugin.json` — exit 0, no findings.
- `typos` on `plugins/verification/` — exit 0, clean.
- `scripts/validate-plugins.sh` — `✔ Validation passed` (manifest + catalog).
- `scripts/validate-plugin-contracts.mjs` — `33 setup skills and 1586 plugin files checked`, pass.
- Neither changed context file appears in `scripts/cross-plugin-source-registry.txt`, so no upstream sync is involved.

## Related

- Closes #422 (source issue — bare unguarded `dotnet-*`/`cloudflare` cross-plugin refs in `verification`'s `measure` contexts).
- Sibling issues sharing the same `dotnet-*`/`cloudflare:*` unguarded/ecosystem-coupled pattern: #405 (`implementation`), #412 (`toolchain`), #430 (`testing`, fixed in #491 — the guard pattern this PR mirrors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
