### PR TITLE
fix(work-items): triage outcomes must clear the raw-intake marker

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.2]
+
+### Fixed
+
+- **Triage outcomes now clear the raw-intake marker.** The `triage` skill's "Apply outcome" step
+  listed the labels each outcome adds but never said to remove `status:needs-triage`, so applying an
+  outcome stacked `status:ready` and the role label on top of the raw marker. The attention view
+  re-selects any open item still carrying the marker, so triaged items re-triaged every cycle
+  (silent-loop-kill class). Step 5 now states that every outcome is a transition off raw that
+  replaces the marker rather than adding to it, and a closing invariant forbids a raw marker
+  alongside a briefed/ready or role label on an open item.
+
 ## [0.12.1]
 
 ### Changed

--- a/plugins/work-items/skills/triage/SKILL.md
+++ b/plugins/work-items/skills/triage/SKILL.md
@@ -103,6 +103,8 @@ Only after verification (or for enhancements, where the open question is scope, 
 
 ### 5. Apply outcome
 
+Every outcome is a **transition off raw**, not a layer on top of it. Applying an outcome **clears the raw-intake marker**: remove `status:needs-triage` (and the item leaves the unlabeled raw state) in the same edit that applies the labels below. The label sets in the table are the item's **resulting** state, not deltas stacked over `status:needs-triage` — normalization replaces the raw marker, it never adds to it.
+
 | Outcome | Action |
 |---------|--------|
 | Briefed, delegable | Write the brief per [`${CLAUDE_PLUGIN_ROOT}/reference/agent-brief.md`](${CLAUDE_PLUGIN_ROOT}/reference/agent-brief.md) — durability over precision: behavioral contracts and named interfaces, **no file paths or line numbers** — apply labels + the autonomous-eligible role label (default `agent-ready`) |
@@ -116,6 +118,11 @@ Only after verification (or for enhancements, where the open question is scope, 
 For a PR, the outcome addresses the attached code explicitly: adopt the diff (briefed for an agent or human to carry forward), rework it (brief describes the gap between the diff and the verified requirement), or decline it (close with rationale — and the ledger entry when it's a rejected enhancement).
 
 Label edits, comments, and closes route through the adapter's write mechanics (adapter: "Edit labels / assignees", "Comment on item / edit a comment", "Close item"); the gather + attention-view reads are bare. Item creation, when triage spawns follow-up work, goes through the seam `create-item` verb (`/work-items:track add` is the canonical path).
+
+**Closing invariant — no outcome leaves a re-selectable raw item.** The attention view lists *open* items and re-selects anything still carrying the raw marker, so every outcome must leave the item unre-selectable:
+
+- Outcomes that keep the item **open** (briefed/ready, a role label, or `status:needs-info`) **clear `status:needs-triage`**. A raw marker alongside `status:ready`, the autonomous-eligible role label, or the human-gated role label is a contradiction — the attention view reads it as still-raw and re-triages it every cycle. If an item shows both, the briefed state is the truth; clear the stale raw marker.
+- **Close** (already implemented / wontfix / duplicate) drops the item from the open-only attention frontier, so the raw marker is moot — a closed item never re-triages.
 
 ## Needs-info template
 

--- a/plugins/work-items/skills/triage/evals/evals.json
+++ b/plugins/work-items/skills/triage/evals/evals.json
@@ -54,6 +54,19 @@
         "States the closing invariant: an open item carries no raw marker alongside a briefed/ready or role label — that contradiction re-selects the item in the attention view every cycle",
         "Recognizes that a close outcome instead drops the item from the open-only attention frontier, making the raw marker moot"
       ]
+    },
+    {
+      "id": 5,
+      "name": "triage-needs-info-outcome-clears-the-raw-intake-marker",
+      "prompt": "/work-items:triage 42 — #42 is an external bug report currently tagged status:needs-triage; the description is too thin to reproduce and you are marking it needs-info",
+      "expected_output": "Applying the needs-info outcome removes status:needs-triage in the same edit that applies status:needs-info plus the structured needs-info comment — the open item is left carrying status:needs-info alone, never stacked on the raw marker. Notes that this does not orphan the item: the attention view re-selects it through the needs-info-with-reporter-activity bucket on the reporter's reply, which is the desired re-entry point, rather than through the raw-marker bucket every cycle.",
+      "files": [],
+      "expectations": [
+        "Clears the raw-intake marker (`status:needs-triage`) in the same edit that applies `status:needs-info` — the needs-info outcome is a transition off raw, not an addition on top of it",
+        "Leaves the open item carrying `status:needs-info` alone, without `status:needs-triage` still attached",
+        "Recognizes that clearing the raw marker does not orphan the item — it re-enters the attention view through the needs-info-with-reporter-activity bucket on reporter reply, not the raw-marker bucket",
+        "Distinguishes this desired re-entry (needs-info bucket on re-engagement) from the silent-loop re-selection that a leftover raw marker would cause every cycle"
+      ]
     }
   ]
 }

--- a/plugins/work-items/skills/triage/evals/evals.json
+++ b/plugins/work-items/skills/triage/evals/evals.json
@@ -41,6 +41,19 @@
         "Performs no triage writes on the item — no label changes, no needs-info comment, no close",
         "Notes the attention view excludes decompose output by construction (born-labeled items never land in the unlabeled or needs-triage buckets)"
       ]
+    },
+    {
+      "id": 4,
+      "name": "triage-outcome-clears-the-raw-intake-marker",
+      "prompt": "/work-items:triage 42 — #42 is an external bug report currently tagged status:needs-triage; you have verified it and are ready to brief it for autonomous pickup",
+      "expected_output": "Applying the briefed-and-delegable outcome removes status:needs-triage as part of the same edit that applies the brief labels plus the autonomous-eligible role label — normalization replaces the raw marker rather than stacking status:ready and the role label on top of it. Notes that leaving status:needs-triage alongside a briefed/ready or role label is a contradiction the open-only attention view reads as still-raw and would re-triage every cycle.",
+      "files": [],
+      "expectations": [
+        "Clears the raw-intake marker (`status:needs-triage`) in the same edit that applies the outcome's labels — treats the outcome as a transition off raw, not an addition on top of it",
+        "Applies the resulting state (brief + `status:ready` + autonomous-eligible role label) without leaving `status:needs-triage` attached",
+        "States the closing invariant: an open item carries no raw marker alongside a briefed/ready or role label — that contradiction re-selects the item in the attention view every cycle",
+        "Recognizes that a close outcome instead drops the item from the open-only attention frontier, making the raw marker moot"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `work-items:triage` skill's "Apply outcome" step (step 5) listed the labels each terminal outcome *adds* but never said to *remove* the raw-intake marker (`status:needs-triage`). Applying an outcome therefore stacked `status:ready` + the role label on top of `needs-triage`. The attention view lists open items and re-selects anything still carrying the raw marker, so every triaged item re-entered triage forever — the silent-loop-kill class (#480).

## Fix

Two edits to `plugins/work-items/skills/triage/SKILL.md`, plus an eval and the version/CHANGELOG bump. Marker clearing is stated once as a normalization principle covering all rows (rather than repeated per row).

**Step 5 lead-in (new — before the outcome table):**

> Every outcome is a **transition off raw**, not a layer on top of it. Applying an outcome **clears the raw-intake marker**: remove `status:needs-triage` (and the item leaves the unlabeled raw state) in the same edit that applies the labels below. The label sets in the table are the item's **resulting** state, not deltas stacked over `status:needs-triage` — normalization replaces the raw marker, it never adds to it.

**Closing invariant (new — end of step 5):**

> **Closing invariant — no outcome leaves a re-selectable raw item.** The attention view lists *open* items and re-selects anything still carrying the raw marker, so every outcome must leave the item unre-selectable:
>
> - Outcomes that keep the item **open** (briefed/ready, a role label, or `status:needs-info`) **clear `status:needs-triage`**. A raw marker alongside `status:ready`, the autonomous-eligible role label, or the human-gated role label is a contradiction — the attention view reads it as still-raw and re-triages it every cycle. If an item shows both, the briefed state is the truth; clear the stale raw marker.
> - **Close** (already implemented / wontfix / duplicate) drops the item from the open-only attention frontier, so the raw marker is moot — a closed item never re-triages.

The close/open split is deliberate: an absolute "no outcome leaves a raw marker" is false for closes (closing does not strip labels), so the invariant names the mechanism that actually kills the loop for each branch.

The marker is unambiguously `status:needs-triage` (Status axis — `label-taxonomy.md` line 20; Triage states table line 46). The issue's "`priority: needs-triage`" is a misstatement (the `priority:` axis encodes p0–p3 urgency), so no new label was invented and the existing state-machine vocabulary is used throughout.

Also added eval #4 (`triage-outcome-clears-the-raw-intake-marker`) asserting the marker is cleared in the same edit as the outcome labels. Patch bump `0.12.1` → `0.12.2` (docs/behavior fix) + `### Fixed` CHANGELOG entry.

## Verification

Repo-pinned gates on the changed files, all green:

- `markdownlint-cli2` (`.markdownlint-cli2.jsonc`) on `SKILL.md` + `CHANGELOG.md` — `Summary: 0 error(s)`
- `typos` (`_typos.toml`) on all changed files — exit 0
- `editorconfig-checker` (`.editorconfig-checker.json`) on all 4 changed files — `0 errors`
- `scripts/validate-plugins.sh` — `All plugin manifests and the catalog validated`
- `scripts/validate-plugin-contracts.mjs` — `33 setup skills and 1586 plugin files checked`
- `evals.json` + `plugin.json` parse as valid JSON

## Related

- Source: #488
- Class: silent-loop-kill (#480)

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
