### PR TITLE
fix(testing): make fallback naming/example defaults ecosystem-relative, not .NET-only

### DIFF
--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), and failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to the `testing` plugin are documented here. Format follows
   consuming ecosystem's own idiom). The lone worked `[Fact]` code sample in `write/context/write.md` and
   the lone `dotnet test` regression block in `diagnose/context/loop.md` now carry an "illustrative (.NET)"
   label, with the regression block routed through `/toolchain:check` as SSOT for the exact per-ecosystem
-  command. Framing and labeling only — TDD cadence, Four Pillars, verify-through-the-interface, the
+  command (falling back to the project's own test command when the `toolchain` plugin is absent, matching
+  `write`'s handoff). Framing and labeling only — TDD cadence, Four Pillars, verify-through-the-interface, the
   reproduce→fix→retest→regression loop, and all routing/handoff are unchanged; no code, template, or
   command string was altered.
 

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.2]
+
+### Changed
+
+- Fallback naming defaults, the sole worked code sample, and the sole regression command are reframed
+  as ecosystem-relative rather than .NET-only. The PascalCase `{Method}_Should{Behavior}_When{Condition}`
+  naming forms (in `write`, `write/context/write.md`, `write/context/organize.md`, `plan`) are demoted
+  from "the universal default" to one labeled illustrative (.NET/xUnit) example, routed first through the
+  convention-resolution ladder (use the project's documented pattern; when undocumented, mirror the
+  consuming ecosystem's own idiom). The lone worked `[Fact]` code sample in `write/context/write.md` and
+  the lone `dotnet test` regression block in `diagnose/context/loop.md` now carry an "illustrative (.NET)"
+  label, with the regression block routed through `/toolchain:check` as SSOT for the exact per-ecosystem
+  command. Framing and labeling only — TDD cadence, Four Pillars, verify-through-the-interface, the
+  reproduce→fix→retest→regression loop, and all routing/handoff are unchanged; no code, template, or
+  command string was altered.
+
 ## [0.2.1]
 
 ### Changed

--- a/plugins/testing/skills/diagnose/context/loop.md
+++ b/plugins/testing/skills/diagnose/context/loop.md
@@ -54,7 +54,7 @@ The failing test from step 1 must now pass. If it still fails:
 
 ### Step 5: Regression
 
-Run the full test suite for the affected project(s). Not just the test you wrote — ALL tests that could be impacted.
+Run the full test suite for the affected project(s). Not just the test you wrote — ALL tests that could be impacted. `/toolchain:check` is SSOT for the exact per-ecosystem command; the block below is illustrative (.NET):
 
 ```bash
 # Single project

--- a/plugins/testing/skills/diagnose/context/loop.md
+++ b/plugins/testing/skills/diagnose/context/loop.md
@@ -54,7 +54,7 @@ The failing test from step 1 must now pass. If it still fails:
 
 ### Step 5: Regression
 
-Run the full test suite for the affected project(s). Not just the test you wrote — ALL tests that could be impacted. `/toolchain:check` is SSOT for the exact per-ecosystem command; the block below is illustrative (.NET):
+Run the full test suite for the affected project(s). Not just the test you wrote — ALL tests that could be impacted. `/toolchain:check` is SSOT for the exact per-ecosystem command (or the project's own test command when the `toolchain` plugin is absent); the block below is illustrative (.NET):
 
 ```bash
 # Single project

--- a/plugins/testing/skills/plan/SKILL.md
+++ b/plugins/testing/skills/plan/SKILL.md
@@ -45,7 +45,7 @@ Classify each changed file:
 
 ### 2. Generate the test plan
 
-For each change area, produce:
+For each change area, produce (test-name forms follow the project's documented pattern; when undocumented, mirror the ecosystem's idiom — the PascalCase placeholders below are illustrative (.NET/xUnit)):
 
 ```markdown
 ## Test Plan for [branch/PR description]

--- a/plugins/testing/skills/write/SKILL.md
+++ b/plugins/testing/skills/write/SKILL.md
@@ -38,7 +38,7 @@ Read the relevant context file before proceeding. Both draw on the consuming pro
 
 - **Test behavior, not implementation** — assert on what the user sees or what the API returns, not internal state (Kent C. Dodds: "The more your tests resemble the way your software is used, the more confidence they can give you")
 - **Four Pillars** (Vladimir Khorikov): protection against regressions, resistance to refactoring, fast feedback, maintainability — every test scores well on all four
-- **Naming** — follow the project's documented patterns; sensible defaults by test type: unit `{Method}_Should{Behavior}_When{Condition}`, integration `{Subject}_{Behavior}`, architecture `{Subject}_Should{Constraint}`
+- **Naming** — use the project's documented naming pattern; when undocumented, mirror the consuming ecosystem's own idiom (never impose one language's convention on another). The forms below are illustrative (.NET/xUnit) — adapt casing/separators to the target ecosystem: unit `{Method}_Should{Behavior}_When{Condition}`, integration `{Subject}_{Behavior}`, architecture `{Subject}_Should{Constraint}`
 - When uncertain about a testing decision (mock or not, output vs state test), load `/tdd:principles` (when the `tdd` plugin is installed) for authoritative Beck/Khorikov guidance
 
 ## Handoff

--- a/plugins/testing/skills/write/context/organize.md
+++ b/plugins/testing/skills/write/context/organize.md
@@ -50,7 +50,7 @@ Where a process-global singleton, expensive lifecycle, or framework-side limitat
 
 ## Naming
 
-- Test class: `{ClassUnderTest}Tests`
+- Test class: the project's documented test-class naming; when undocumented, mirror the ecosystem's idiom (`{ClassUnderTest}Tests` illustrates the .NET convention)
 - Test project: the project's unit-test naming convention (e.g. `{Project}.Tests` for .NET co-located)
 - Test file mirrors the structure of the code it tests
 

--- a/plugins/testing/skills/write/context/write.md
+++ b/plugins/testing/skills/write/context/write.md
@@ -52,7 +52,7 @@ When invoked from `/implementation:implement` (plan already approved) or as part
    | Layer dependencies, naming, conventions | Architecture | project's architecture-test project, when one exists |
    | Critical user journeys end-to-end | E2E | project's browser-automation tooling (see `/testing:run-e2e`) |
 
-3. **Write the failing test first** (Red) — the test name IS the specification:
+3. **Write the failing test first** (Red) — the test name IS the specification. Use the project's documented naming pattern; when undocumented, mirror the ecosystem's idiom. The forms below are illustrative (.NET/xUnit) — adapt casing/separators to the target ecosystem:
    - Unit: `{Method}_Should{Behavior}_When{Condition}`
    - Integration: `{Subject}_{Behavior}` or `{Subject}_{Behavior}_{Context}`
    - Architecture: `{Subject}_Should{Constraint}`
@@ -90,7 +90,7 @@ Every test should score well on all four:
 
 ## Verify through the interface, not around it
 
-Tests that bypass the public interface to verify side effects are coupled to implementation. Verify through the same interface callers use:
+Tests that bypass the public interface to verify side effects are coupled to implementation. Verify through the same interface callers use (illustrative — .NET/xUnit; the principle is ecosystem-agnostic):
 
 ```csharp
 // BAD: Bypasses interface — coupled to storage implementation


### PR DESCRIPTION
## Summary

The `testing` plugin is billed as ecosystem-agnostic, but a Python/Go/JS/Rust consumer who documents nothing lands on C#/.NET idioms as canonical: the fallback naming defaults, the only worked code sample, and the sole regression command were all uniformly .NET with no neutral counterpart. The skills already hedge correctly elsewhere ("comes from the consuming project's testing conventions") — this patch aligns the *defaults* with that existing seam. Framing and labeling only.

## Fix

Every house-stack form that read as THE default is now routed first through the convention-resolution ladder — use the project's documented pattern; when undocumented, mirror the consuming ecosystem's own idiom — and the .NET form demoted to one labeled illustrative example. No `{...}` template, code block, or command string was altered.

- `skills/write/SKILL.md` — "Naming" bullet reworded into the ladder; the PascalCase forms labeled "illustrative (.NET/xUnit) — adapt casing/separators to the target ecosystem".
- `skills/write/context/write.md` — Step 3 naming block gets the ladder lead-in + "illustrative (.NET/xUnit)" label (bullets unchanged); the lone worked `[Fact]` sample's lead-in now reads "(illustrative — .NET/xUnit; the principle is ecosystem-agnostic)" (code block unchanged).
- `skills/write/context/organize.md` — bare "## Naming" test-class form routed through the ladder, `{ClassUnderTest}Tests` kept as the labeled .NET illustration.
- `skills/diagnose/context/loop.md` — Step 5 regression prose routes through `/toolchain:check` (SSOT for the exact per-ecosystem command); the `dotnet test` block labeled illustrative (.NET), command unchanged.
- `skills/plan/SKILL.md` — Step 2 output template prefaced with the ladder; the PascalCase placeholders labeled illustrative (.NET/xUnit), template unchanged.
- `testing` bumped `0.2.1` → `0.2.2` (docs = patch) with a CHANGELOG entry.

No skill frontmatter `description` or trigger keywords were touched — all edits are body prose. Cited sites already ecosystem-relative (`write`/`diagnose` Gotchas, `diagnose/context/investigate.md`, `run-e2e/context/non-ui.md`, and the already-hedged `organize`/`plan` table rows) were left byte-identical.

## Verification

Repo-pinned gates run in this Windows environment against the changed markdown; all clean, nothing suppressed:

- `markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)` with the repo's auto-discovered `.markdownlint-cli2.jsonc` on the six changed `.md` files — `Summary: 0 error(s)`.
- `typos-cli 1.44.0` on the six changed `.md` files — exit 0, no output.
- `editorconfig-checker v3.8.0` on the six changed `.md` files plus `plugin.json` — exit 0, no findings.
- `plugin.json` re-parsed as valid JSON; version reads `0.2.2`.

## Related

Closes #429. Sibling stack-bias issues from the same work-readiness sweep, same pattern: #430, #424, #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
