### PR TITLE
fix(markdown-format,playwright): drop unreachable repo-root LICENSE pointer, state MIT inline

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.4]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.5.3]
 
 ### Changed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -95,5 +95,4 @@ project's `enabledPlugins` instead.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playwright",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Live E2E browser automation via Microsoft's @playwright/cli — named sessions, accessibility-ref snapshots, click/fill by ref, screenshots, console and network capture, mocking, tracing, video, and auth state, with artifacts written to disk so only paths enter context, plus a vendored upstream baseline and maintainer drift-check update flow.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `playwright` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. The vendored Apache-2.0 upstream license reference (shipped
+  in-plugin) is unchanged. No behavior change.
+
 ## [0.3.1]
 
 ### Changed

--- a/plugins/playwright/README.md
+++ b/plugins/playwright/README.md
@@ -76,9 +76,8 @@ defaults.
 
 ## License
 
-This plugin's original content is MIT (SPDX-License-Identifier: MIT) — see the
-LICENSE file at the root of the melodic-software/claude-code-plugins
-repository. The vendored upstream skill in `vendor/` (and the reference files
-derived from it) are Microsoft's `@playwright/cli` content, licensed
-Apache-2.0 (SPDX-License-Identifier: Apache-2.0) — the upstream license text
-ships at `skills/playwright/vendor/LICENSE`.
+This plugin's original content is MIT (SPDX-License-Identifier: MIT). The
+vendored upstream skill in `vendor/` (and the reference files derived from it)
+are Microsoft's `@playwright/cli` content, licensed Apache-2.0
+(SPDX-License-Identifier: Apache-2.0) — the upstream license text ships at
+`skills/playwright/vendor/LICENSE`.


### PR DESCRIPTION
## Summary

The `markdown-format` and `playwright` README License sections pointed at a
`LICENSE` file at the marketplace-repo root. An installed consumer runs each
plugin from an isolated cache and cannot reach a file outside the plugin
boundary, so the pointer dangled (cache-isolation rule: reference only files
inside the plugin). Both READMEs already stated the license inline as
`MIT (SPDX-License-Identifier: MIT)`, matching each `plugin.json` — the fix is
pure deletion of the trailing repo-root pointer.

## Fix

- `plugins/markdown-format/README.md` — drop the repo-root `LICENSE` pointer;
  keep `MIT (SPDX-License-Identifier: MIT)` (`plugin.json` `license` = `MIT`).
- `plugins/playwright/README.md` — drop the repo-root pointer for the plugin's
  own MIT license; the in-plugin vendored Apache-2.0 reference
  (`skills/playwright/vendor/LICENSE`, inside the plugin boundary) is unchanged
  and kept distinct (`plugin.json` `license` = `MIT AND Apache-2.0`).
- Patch-bump each plugin: `markdown-format` `0.5.3` → `0.5.4`, `playwright`
  `0.3.1` → `0.3.2`, with a CHANGELOG entry in each.

Fleet-wide: the same broken pointer appears in **39 other plugin READMEs**
(all already state MIT inline). Out of scope here; enumerated and filed as
#537. Reproduce: `grep -rniE "at the root of|root of (the )?melodic" plugins/*/README.md`.

## Verification

Repo-pinned gates run locally on the four changed markdown files, using the
repo's own configs (`.markdownlint-cli2.jsonc`, `_typos.toml`,
`.editorconfig-checker.json`):

- `markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)` — `Summary: 0 error(s)`
- `typos --config _typos.toml` — no errors
- `editorconfig-checker` — no errors
- Both `plugin.json` parse as valid JSON after the version bumps.

## Related

- Closes #426
- #537 — fleet-wide follow-up (39 remaining plugin READMEs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
