### PR TITLE
fix(repo-hygiene): gate git-tree-reset on unresolvable upstream, never reset --hard @{u}

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.2]
+
+### Fixed
+
+- **`git-tree-reset.sh` — unresolvable upstream now gated before any destructive op.**
+  When a branch's upstream is configured (`branch.<name>.remote` + `.merge`) but its
+  remote-tracking ref is absent — e.g. a feature branch whose squash-merged PR left the
+  remote branch deleted and pruned — `git rev-parse --abbrev-ref '@{u}'` prints the literal
+  token `@{u}` rather than a ref name, and the trailing pipe masked git's non-zero exit, so
+  the non-empty guard passed and `UPSTREAM=@{u}`. On `--apply` this reached `git reset --hard
+  @{u}` → `fatal: ambiguous argument '@{u}'`, and (before the reset-success gate) `git clean
+  -fdx` still ran — a partial destructive op (tree cleaned but not reset). The script now
+  verifies `@{u}` resolves to a real ref (a local-only upstream, `branch.remote="."`, still
+  resolves and passes) and otherwise skips the repo with `Blocked: upstream-unresolved
+  (<remote>/<branch>)` and `PlannedReset`/`PlannedClean: none` before any `reset`/`clean`,
+  exiting 6. A literal `@{u}` can never reach `reset --hard`.
+
 ## [0.3.1]
 
 ### Fixed

--- a/plugins/repo-hygiene/skills/clean/context/git-tree-reset.md
+++ b/plugins/repo-hygiene/skills/clean/context/git-tree-reset.md
@@ -33,7 +33,7 @@ Skill data (`.claude/skills/*/data/`) is preserved unconditionally — no flag r
 
 ### Gates (script-enforced)
 
-- Upstream tracking branch required (`@{u}`).
+- Upstream tracking branch required (`@{u}`); a configured-but-unresolvable upstream — remote-tracking ref absent (e.g. a squash-merged branch whose remote was deleted and pruned), where `@{u}` degrades to the literal token — is a first-class gate: skip the repo with `Blocked: upstream-unresolved (<remote>/<branch>)` before any destructive op, so a literal `@{u}` can never reach `reset --hard` (exit 6).
 - Blocks on default branch (`main`/`master`/resolved default) unless `--force-default-branch` (exit 3).
 - Aborts when HEAD is ahead of upstream unless `--allow-unpushed` (exit 4) — prevents silent loss of unpushed commits.
 - Aborts the apply if `reset --hard` fails (exit 5) — `clean` and the restore guard never run, so a failed reset can never leave the tree cleaned but not reset.

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
@@ -117,7 +117,8 @@ fi
 if ! git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
   UNRESOLVED_REMOTE="$(git config "branch.${CURRENT_BRANCH}.remote" 2>/dev/null | tr -d '\r' || true)"
   UNRESOLVED_MERGE="$(git config "branch.${CURRENT_BRANCH}.merge" 2>/dev/null | tr -d '\r' || true)"
-  printf 'Blocked: upstream-unresolved (%s/%s)\n' "${UNRESOLVED_REMOTE:-?}" "${UNRESOLVED_MERGE#refs/heads/}"
+  UNRESOLVED_MERGE_LABEL="${UNRESOLVED_MERGE#refs/heads/}"
+  printf 'Blocked: upstream-unresolved (%s/%s)\n' "${UNRESOLVED_REMOTE:-?}" "${UNRESOLVED_MERGE_LABEL:-?}"
   printf 'PlannedReset: none\n'
   printf 'PlannedClean: none\n'
   exit 6

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
@@ -21,7 +21,8 @@
 #
 # Exit: 0 success; 1 not a git repo; 2 usage/validation error;
 #       3 blocked on default branch; 4 blocked on unpushed commits;
-#       5 reset --hard failed (apply aborted before clean).
+#       5 reset --hard failed (apply aborted before clean);
+#       6 blocked on unresolvable upstream (configured but remote-tracking ref absent).
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -61,7 +62,8 @@ Output labels:
   Unremovable: <count> (apply only — files git clean could not delete, e.g. locked)
 
 Exit: 0; 1 not a git repo; 2 usage error; 3 blocked default branch; 4 unpushed commits;
-      5 reset --hard failed (apply aborted before clean).
+      5 reset --hard failed (apply aborted before clean);
+      6 blocked on unresolvable upstream (configured but remote-tracking ref absent).
 EOF
 }
 
@@ -98,6 +100,27 @@ UPSTREAM="$(git rev-parse --abbrev-ref '@{u}' 2>/dev/null | tr -d '\r' || true)"
 if [[ -z "$UPSTREAM" ]]; then
   echo "git-tree-reset.sh: no upstream tracking branch (set with git push -u)" >&2
   exit 2
+fi
+
+# Gate an unresolvable upstream before any destructive op. When the upstream is
+# configured (branch.<name>.remote + .merge) but its remote-tracking ref is
+# absent — e.g. a feature branch whose squash-merged PR left the remote branch
+# deleted and pruned — git rev-parse --abbrev-ref '@{u}' prints the LITERAL token
+# @{u} instead of a ref name, and the pipe above masks git's non-zero exit, so
+# the empty-guard passes and UPSTREAM=@{u}. Left unchecked, git reset --hard @{u}
+# fails with "fatal: ambiguous argument '@{u}'" AFTER the guards, and (pre-#460)
+# git clean -fdx would still run — a partial destructive op. Verify @{u} names a
+# real, resolvable ref (a local-only upstream, branch.remote=".", still resolves
+# to its local branch and passes); if not, skip the repo with a clear reason
+# before any label output whose values (e.g. AheadCount) @{u} would silently
+# corrupt. Never let a literal @{u} reach reset --hard.
+if ! git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
+  UNRESOLVED_REMOTE="$(git config "branch.${CURRENT_BRANCH}.remote" 2>/dev/null | tr -d '\r' || true)"
+  UNRESOLVED_MERGE="$(git config "branch.${CURRENT_BRANCH}.merge" 2>/dev/null | tr -d '\r' || true)"
+  printf 'Blocked: upstream-unresolved (%s/%s)\n' "${UNRESOLVED_REMOTE:-?}" "${UNRESOLVED_MERGE#refs/heads/}"
+  printf 'PlannedReset: none\n'
+  printf 'PlannedClean: none\n'
+  exit 6
 fi
 
 # Fetch the remote the current branch actually tracks, not a hardcoded origin —

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
@@ -151,6 +151,50 @@ assert_not_contains "reset failure emits no clean success line" "$out" "AppliedC
 assert_contains "reset failure emits AppliedClean: none" "$out" "AppliedClean: none"
 assert_file_exists "reset failure skips clean (untracked survives)" "$R2/scratch.txt"
 
+# --- 10. unresolvable upstream gated before any destructive op (exit 6) ---
+# Upstream configured (branch.<name>.remote + .merge) but its remote-tracking ref
+# absent — a feature branch whose remote branch was deleted and pruned (squash-
+# merge aftermath). git rev-parse --abbrev-ref '@{u}' degrades to the literal
+# token @{u}; without the resolution gate that literal reaches git reset --hard.
+# Needs a real remote so the config points at an existing remote whose ref was
+# pruned (a config pointing at a non-existent remote gives empty output → exit 2).
+REMOTE="$TEST_TMPDIR/remote.git"
+git init --bare "$REMOTE" >/dev/null 2>&1
+R3="$TEST_TMPDIR/repo-upstream-gone"
+git init "$R3" >/dev/null 2>&1
+git -C "$R3" config user.email "t@example.com"
+git -C "$R3" config user.name "Test"
+echo tracked >"$R3/tracked.txt"
+git -C "$R3" add -A
+git -C "$R3" commit -m "init" >/dev/null
+git -C "$R3" branch -M main
+git -C "$R3" remote add origin "$REMOTE"
+git -C "$R3" push -u origin main >/dev/null 2>&1
+git -C "$R3" checkout -b feat/gone >/dev/null 2>&1
+git -C "$R3" push -u origin feat/gone >/dev/null 2>&1
+git -C "$R3" push origin --delete feat/gone >/dev/null 2>&1
+git -C "$R3" fetch --prune origin >/dev/null 2>&1
+echo untracked >"$R3/scratch.txt"
+
+# Dry-run gates too (before it would print a misleading PlannedReset to @{u}).
+rc=0
+out="$(bash -c "cd '$R3' && bash '$RESET' --dry-run" 2>&1)" || rc=$?
+assert_exit "unresolvable upstream dry-run exits 6" 6 "$rc"
+assert_contains "unresolvable upstream dry-run reports block" "$out" "Blocked: upstream-unresolved (origin/feat/gone)"
+assert_not_contains "unresolvable upstream dry-run plans no reset to literal @{u}" "$out" "reset --hard @{u}"
+
+# Apply path runs NO destructive command: exit 6, block message, planned none,
+# no AppliedReset/AppliedClean lines, and the untracked file survives.
+rc=0
+out="$(bash -c "cd '$R3' && bash '$RESET' --apply" 2>&1)" || rc=$?
+assert_exit "unresolvable upstream apply exits 6" 6 "$rc"
+assert_contains "unresolvable upstream apply reports block" "$out" "Blocked: upstream-unresolved (origin/feat/gone)"
+assert_contains "unresolvable upstream apply plans no reset" "$out" "PlannedReset: none"
+assert_contains "unresolvable upstream apply plans no clean" "$out" "PlannedClean: none"
+assert_not_contains "unresolvable upstream runs no reset --hard" "$out" "reset --hard"
+assert_not_contains "unresolvable upstream runs no clean" "$out" "AppliedClean"
+assert_file_exists "unresolvable upstream skips clean (untracked survives)" "$R3/scratch.txt"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1


### PR DESCRIPTION
## Summary

`plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh` (the `tree` action of `/repo-hygiene:clean`) did a **partial destructive op** on a branch whose upstream is configured but whose remote-tracking ref is absent — e.g. a feature branch whose squash-merged PR left the remote branch deleted and pruned.

When `refs/remotes/<remote>/<branch>` is gone, `git rev-parse --abbrev-ref '@{u}'` prints the **literal token** `@{u}` instead of a ref name, and the trailing `| tr -d '\r' || true` pipe masks git's non-zero exit — so the non-empty guard passes and `UPSTREAM=@{u}`. On `--apply` this reached `git reset --hard @{u}` → `fatal: ambiguous argument '@{u}'`, and (before the reset-success gate #460) `git clean -fdx` still ran, leaving the tree cleaned but not reset.

## Fix

Add a first-class resolution gate immediately after the existing no-upstream check, **before any label output or destructive op**. It verifies `@{u}` names a real, resolvable ref and, if not, skips the repo:

```sh
if ! git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
  UNRESOLVED_REMOTE="$(git config "branch.${CURRENT_BRANCH}.remote" 2>/dev/null | tr -d '\r' || true)"
  UNRESOLVED_MERGE="$(git config "branch.${CURRENT_BRANCH}.merge" 2>/dev/null | tr -d '\r' || true)"
  printf 'Blocked: upstream-unresolved (%s/%s)\n' "${UNRESOLVED_REMOTE:-?}" "${UNRESOLVED_MERGE#refs/heads/}"
  printf 'PlannedReset: none\n'
  printf 'PlannedClean: none\n'
  exit 6
fi
```

- Verifies `@{u}` **directly** (the actual reset target), robust against the literal-token quirk regardless of what `--abbrev-ref` echoed.
- A local-only upstream (`branch.<name>.remote="."`) still resolves to its local branch → gate falls through → **resolvable common case is unchanged** (existing dry-run / apply / default-branch / unpushed / reset-fail tests all still pass).
- Distinct exit code `6` (vs exit `2` "no upstream"): different remediation — configured-but-remote-ref-gone (`fetch --prune` / delete branch) vs never-configured (`push -u`). Mirrors #460's convention of a distinct code per gate.
- No destructive command (`reset`/`clean`) can run on the unresolved path — the gate returns before the dry-run preview and before the apply block.

Also bumps `repo-hygiene` `0.3.1` → `0.3.2` (patch, bug), adds the CHANGELOG entry, extends the header exit map + `git-tree-reset.md` gate list, and adds a regression test.

## Verification

**Lint (all clean):**
- `shellcheck --rcfile .shellcheckrc` on `git-tree-reset.sh` and `git-tree-reset.test.sh` → both clean.
- `typos`, `editorconfig-checker`, `markdownlint-cli2` on changed md + json → 0 findings.

**Test suite:** `git-tree-reset.test.sh` → 37/37 pass, including the new pruned-upstream case asserting exit 6, the `Blocked:` message, `PlannedReset`/`PlannedClean: none`, no `AppliedReset`/`AppliedClean` line, and the untracked file surviving.

**Empirical before/after** (real bare remote; `feat/gone` pushed, remote branch deleted + pruned; `--dry-run` to sidestep the reset-guard hook):

BEFORE (pre-fix script) — the smoking gun:

```text
Upstream: @{u}
Blocked: none
PlannedReset: git reset --hard @{u}
PlannedClean: git clean -fdx (+18 preserve excludes)
--- clean preview (git clean -fdxn, default-preserve applied) ---
Would remove scratch.txt
exit=0
```

On `--apply` this hits `fatal: ambiguous argument '@{u}'`.

AFTER (fixed script) — no destructive op planned or run:

```text
Blocked: upstream-unresolved (origin/feat/gone)
PlannedReset: none
PlannedClean: none
exit=6
```

`scratch.txt` still present: yes.

## Related

Closes #393.

- Source: #393.
- Companions in the same `git-tree-reset.sh` gate family: #394, #460 (reset-success gate, merged — this PR coordinates with it: `clean` never runs when the reset precondition fails), #395, #396. This PR is scoped strictly to the `@{u}`-resolution gate; the others are noted here, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
