### PR TITLE
fix(work-items): reconcile triage step-2 wait-gate with autonomous mode (#459)

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.3]
+
+### Fixed
+
+- **Triage's step-2 wait-gate no longer contradicts its own autonomous mode.** The "Recommend
+  category + state" step ended with a flat "Wait for the user's direction before mutating anything,"
+  while the AI disclaimer section presupposed the opposite — autonomous/agent sessions that mutate
+  without a human turn. No branch selected between them, so an operator following step 2 could not triage
+  autonomously and an autonomous lane necessarily violated step 2. The gate is now an explicit
+  two-branch direction gate: interactive sessions (a human present, no standing lane rules) keep the
+  wait-gate; autonomous `/loop` / `/schedule` AFK lanes treat their standing rules as the direction
+  the gate requires and proceed without a human turn (the mode the AI disclaimer already anticipates),
+  so the gate is satisfied by the lane's mandate rather than silently ignored.
+
 ## [0.12.2]
 
 ### Fixed

--- a/plugins/work-items/skills/triage/SKILL.md
+++ b/plugins/work-items/skills/triage/SKILL.md
@@ -86,7 +86,12 @@ Classify **bug vs enhancement** first — it steers the rest of the flow (bugs g
 - **Priority label** (`priority:p0-critical` through `priority:p3-low`)
 - **Target state** — from the state machine above: needs-info, briefed for human-gated, or on track to autonomous-eligible
 
-Wait for the user's direction before mutating anything.
+**Direction gate.** Recommending is read-only; the gate governs *mutation* — labels, comments, closes, item creation — and which side of it you are on is fixed by how triage was invoked:
+
+- **Interactive session** — a human operator is present and no standing lane rules were supplied. Present the recommendation and **wait for the user's explicit direction** before mutating anything. This is the default whenever the invocation carries no autonomous mandate.
+- **Autonomous lane** — triage is running unattended as a `/loop` or `/schedule` AFK session whose standing rules — the directive supplied with its `/loop` / `/schedule` invocation — already authorize triage mutations. Those standing rules **are** the direction this gate requires: treat the gate as satisfied and proceed through verification and outcome without a human turn, prefixing every comment and item you create with the AI disclaimer. There is no operator turn to wait for, so blocking here would deadlock the lane — the gate is met by the lane's mandate, not skipped.
+
+The autonomous branch is the mode the AI disclaimer already anticipates: a session that mutates without a human turn. The two are one mode, not a contradiction.
 
 ### 3. Verify — BEFORE any interview
 

--- a/plugins/work-items/skills/triage/evals/evals.json
+++ b/plugins/work-items/skills/triage/evals/evals.json
@@ -67,6 +67,19 @@
         "Recognizes that clearing the raw marker does not orphan the item — it re-enters the attention view through the needs-info-with-reporter-activity bucket on reporter reply, not the raw-marker bucket",
         "Distinguishes this desired re-entry (needs-info bucket on re-engagement) from the silent-loop re-selection that a leftover raw marker would cause every cycle"
       ]
+    },
+    {
+      "id": 6,
+      "name": "triage-autonomous-lane-treats-standing-rules-as-direction",
+      "prompt": "/work-items:triage 71 — running unattended as a /loop AFK lane whose standing rules authorize triage label and comment mutations; #71 is an external bug report you have just reproduced",
+      "expected_output": "Recognizes the autonomous branch of the direction gate: the lane's standing rules ARE the direction the gate requires, so it proceeds through verification and outcome without waiting for a human turn rather than blocking (which would deadlock the lane). Applies the outcome's label and comment writes and prefixes every comment and item it creates with the AI disclaimer. Does not fall back to the interactive wait-gate, which applies only when a human operator is present and no standing lane rules were supplied.",
+      "files": [],
+      "expectations": [
+        "Selects the autonomous-lane branch of the direction gate — the /loop standing rules satisfy the direction requirement, so mutation proceeds without a human turn",
+        "Does NOT wait for explicit user direction — that gate is the interactive-session default, not the autonomous-lane path; blocking here would deadlock the lane",
+        "Prefixes every comment and item it creates with the AI disclaimer during the autonomous session",
+        "Routes the label/comment writes through the bound adapter's mechanics and any item creation through the seam `create-item` — no inline provider commands"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `triage` skill contradicted itself for autonomous/agent sessions. Step 2 ("Recommend category + state") ended with a flat *"Wait for the user's direction before mutating anything,"* while the "AI disclaimer" section explicitly presupposed the opposite — sessions that *"[create] comments or items during autonomous/agent triage sessions"*, i.e. mutate without a human turn. No branch selected between them, so an operator following step 2 literally could not triage autonomously, and an autonomous lane necessarily violated step 2.

## Fix

Replace the single wait-line at the end of step 2 with an explicit, checkable two-branch **direction gate**:

- **Interactive session** — a human operator is present and no standing lane rules were supplied. Keep the wait-gate: present the recommendation and wait for explicit user direction before mutating. This is the default.
- **Autonomous lane** — triage runs unattended as a `/loop` / `/schedule` AFK session whose standing rules (the directive supplied with the invocation) already authorize triage mutations. Those standing rules **are** the direction the gate requires: the gate is treated as *satisfied* and triage proceeds without a human turn, prefixing every comment and item with the AI disclaimer. Blocking here would deadlock the lane, so the gate is met by the lane's mandate rather than silently ignored.

A closing sentence names the autonomous branch as the exact mode the AI disclaimer already anticipates, so the two sections read as one mode instead of a contradiction. This is the minimal reconciliation the issue asks for — the interactive gate is preserved verbatim; only the autonomous carve-out is added. It uses the plugin family's existing vocabulary (`/loop`, `/schedule`, AFK, standing rules, interactive vs unattended) rather than inventing new terms, and points at the real operative signal (standing rules supplied with the invocation) rather than a `userConfig`/session flag the plugin does not ship.

An eval (`triage-autonomous-lane-treats-standing-rules-as-direction`) guards the new branch against regression; the existing interactive-PR eval (which asserts the wait-gate) is unchanged.

## Verification

Repo lint gates, run against the changed files in the worktree (all pass):

```
$ markdownlint-cli2 plugins/work-items/skills/triage/SKILL.md plugins/work-items/CHANGELOG.md
Linting: 2 file(s)
Summary: 0 error(s)

$ typos plugins/work-items/skills/triage/ plugins/work-items/CHANGELOG.md plugins/work-items/.claude-plugin/plugin.json
(exit 0, no output)

$ editorconfig-checker plugins/work-items/skills/triage/SKILL.md plugins/work-items/CHANGELOG.md plugins/work-items/.claude-plugin/plugin.json plugins/work-items/skills/triage/evals/evals.json
(exit 0, no output)
```

`plugins/work-items/.claude-plugin/plugin.json` bumped `0.12.2` → `0.12.3` (patch — documentation/behavioral clarification, no new capability) with a matching `CHANGELOG.md` entry. No other file pins the version (`marketplace.json` references the plugin by source path, not version).

Closes #459

## Related

- Source issue: #459.
- #449 (triage seam no-local-checkout mode) is textually adjacent — it also surfaces when the skill runs unattended — but distinct: #449 is about the seam assuming a project root, this is about the human-in-the-loop gate assuming an interactive operator. **Not touched here.**
- #570 — follow-up issue for two non-blocking documentation nits raised by the post-green bot review (undefined "standing rules" term collision with re-anchor's sense; no guidance for the ambiguous general-authorization middle case). Deferred, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011V31qpAHP3jfs76B9d5Rfo