### PR TITLE
feat(implementation): make implement mode-context optional-collaborator refs ecosystem-neutral

### DIFF
--- a/plugins/implementation/.claude-plugin/plugin.json
+++ b/plugins/implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "implementation",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Disciplined implementation stage: execute approved plans inline (`/implementation:implement`) or via orchestrated worker subagents (`/implementation:implement-dispatch`) with incremental validation, TDD-by-default cadence, green-checkpoint commits, scope-fence drift detection, and divergence detection that routes back to planning. Build/test/lint, testing, and outcome verification live in the companion `toolchain`, `testing`, and `verification` plugins, invoked when installed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/implementation/CHANGELOG.md
+++ b/plugins/implementation/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `implementation` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.3]
+
+### Changed
+
+- Ecosystem-neutral optional-capability references: the `implement` skill's mode contexts
+  (`skills/implement/context/feature.md`, `bugfix.md`, `refactor.md`) no longer name a specific
+  ecosystem's marketplace skills as the only optional collaborators. Each "Marketplace plugin skills"
+  section is restated as an "Optional capability skills" section that names the *capability* needed
+  (project scaffolding, performance diagnosis, build-failure analysis, build-config anti-pattern
+  scanning, project-reference validation) and instructs resolving the concrete skill from what the
+  target environment has installed, with a stated fallback to the project's own workflow when none is
+  installed — per the `docs/conventions/seam-phrasing/` shape and the `docs/PLUGIN-PHILOSOPHY.md`
+  design boundary. Presence-gating is preserved; no hardcoded tool name replaces the removed ones.
+
 ## [0.7.2]
 
 ### Changed

--- a/plugins/implementation/CHANGELOG.md
+++ b/plugins/implementation/CHANGELOG.md
@@ -7,15 +7,15 @@ All notable changes to the `implementation` plugin are documented here. Format f
 
 ### Changed
 
-- Ecosystem-neutral optional-capability references: the `implement` skill's mode contexts
-  (`skills/implement/context/feature.md`, `bugfix.md`, `refactor.md`) no longer name a specific
-  ecosystem's marketplace skills as the only optional collaborators. Each "Marketplace plugin skills"
-  section is restated as an "Optional capability skills" section that names the *capability* needed
-  (project scaffolding, performance diagnosis, build-failure analysis, build-config anti-pattern
-  scanning, project-reference validation) and instructs resolving the concrete skill from what the
-  target environment has installed, with a stated fallback to the project's own workflow when none is
-  installed — per the `docs/conventions/seam-phrasing/` shape and the `docs/PLUGIN-PHILOSOPHY.md`
-  design boundary. Presence-gating is preserved; no hardcoded tool name replaces the removed ones.
+- Stack-qualified the `implement` skill's optional-collaborator references: the mode contexts
+  (`skills/implement/context/feature.md`, `bugfix.md`, `refactor.md`) retain their `dotnet-*`
+  marketplace-skill names and `## Marketplace plugin skills (invoke only when installed)` presence
+  gate, and each now opens with a lead-in that frames those skills as .NET-ecosystem forward
+  references — invoked only when your stack is .NET and the plugin is installed — with an explicit
+  fallback to the project's own tooling otherwise, so a non-.NET consumer keeps the generic path
+  first-class rather than being handed a dead list. Matches the conforming `testing` (#491) and
+  `verification` (#526) pattern per the ratified #412 disposition governing #405. No reference
+  removal; every reference stays optional and installed-gated.
 
 ## [0.7.2]
 

--- a/plugins/implementation/skills/implement/context/bugfix.md
+++ b/plugins/implementation/skills/implement/context/bugfix.md
@@ -21,9 +21,9 @@ Bug fixes follow a bottom-up approach: reproduce, isolate, fix, prove. Temptatio
 - **Expanding scope** — a bug fix that also refactors the surrounding code is two changes. Commit the fix first, refactor separately
 - **Fixing the symptom** — null check at the call site instead of fixing why the value is null in the first place
 
-## Optional capability skills (invoke the installed skill that provides it)
+## Marketplace plugin skills (invoke only when installed)
 
-Name the capability you need, not a specific tool; resolve the concrete skill from what the target environment has installed, and fall back to the project's own workflow when none provides it.
+These are .NET-ecosystem plugin skills — invoke each only when your stack is .NET and its plugin is installed; otherwise fall back to the project's own diagnostic tooling:
 
-- **Performance diagnosis** — when the bug involves async deadlocks, memory pressure, or timing issues, invoke an installed performance-diagnosis skill for systematic anti-pattern scanning
-- **Build-failure analysis** — when a build-system failure masquerades as a code bug (wrong assembly loaded, missing reference, analyzer conflict), invoke an installed build-diagnosis skill to trace it to the build rather than the code
+- **`dotnet-diag:analyzing-dotnet-performance`** — when the bug involves async deadlocks, memory pressure, or timing issues, invoke for systematic anti-pattern scanning (~50 patterns across async, memory, strings, collections)
+- **`dotnet-msbuild:binlog-failure-analysis`** — when a build system failure masquerades as a code bug (wrong assembly loaded, missing reference, analyzer conflict), invoke to replay the MSBuild binary log for diagnosis

--- a/plugins/implementation/skills/implement/context/bugfix.md
+++ b/plugins/implementation/skills/implement/context/bugfix.md
@@ -21,7 +21,9 @@ Bug fixes follow a bottom-up approach: reproduce, isolate, fix, prove. Temptatio
 - **Expanding scope** — a bug fix that also refactors the surrounding code is two changes. Commit the fix first, refactor separately
 - **Fixing the symptom** — null check at the call site instead of fixing why the value is null in the first place
 
-## Marketplace plugin skills (invoke only when installed)
+## Optional capability skills (invoke the installed skill that provides it)
 
-- **`dotnet-diag:analyzing-dotnet-performance`** — when the bug involves async deadlocks, memory pressure, or timing issues, invoke for systematic anti-pattern scanning (~50 patterns across async, memory, strings, collections)
-- **`dotnet-msbuild:binlog-failure-analysis`** — when a build system failure masquerades as a code bug (wrong assembly loaded, missing reference, analyzer conflict), invoke to replay the MSBuild binary log for diagnosis
+Name the capability you need, not a specific tool; resolve the concrete skill from what the target environment has installed, and fall back to the project's own workflow when none provides it.
+
+- **Performance diagnosis** — when the bug involves async deadlocks, memory pressure, or timing issues, invoke an installed performance-diagnosis skill for systematic anti-pattern scanning
+- **Build-failure analysis** — when a build-system failure masquerades as a code bug (wrong assembly loaded, missing reference, analyzer conflict), invoke an installed build-diagnosis skill to trace it to the build rather than the code

--- a/plugins/implementation/skills/implement/context/feature.md
+++ b/plugins/implementation/skills/implement/context/feature.md
@@ -26,7 +26,9 @@ Commit after each of these milestones:
 - **Implementing everything before testing anything** — large untested batches hide compounding errors
 - **Skipping the scaffold commit** — if the scaffold is wrong (wrong project, wrong namespace, wrong layer), you want to revert just the scaffold, not scaffold plus implementation
 
-## Marketplace plugin skills (invoke only when installed)
+## Optional capability skills (invoke the installed skill that provides it)
 
-- **`dotnet-ai:mcp-csharp-create`** — when implementing a new C# MCP server, invoke for scaffolding guidance (project templates, tool/prompt/resource implementation, stdio and HTTP transport configuration)
-- **`dotnet-template-engine:template-instantiation`** — when creating a new .NET project, invoke for template selection with CPM adaptation and latest NuGet version resolution
+Name the capability you need, not a specific tool; resolve the concrete skill from what the target environment has installed, and fall back to the project's own workflow when none provides it.
+
+- **Project scaffolding** — when creating a new project, invoke an installed scaffolding/template skill for the target ecosystem for template selection, dependency-manifest adaptation, and latest-version resolution
+- **Service/protocol-server scaffolding** — when standing up a new service or protocol server (e.g. an MCP server), invoke an installed skill that scaffolds it: project layout, endpoint/tool/resource wiring, and transport configuration

--- a/plugins/implementation/skills/implement/context/feature.md
+++ b/plugins/implementation/skills/implement/context/feature.md
@@ -26,9 +26,9 @@ Commit after each of these milestones:
 - **Implementing everything before testing anything** — large untested batches hide compounding errors
 - **Skipping the scaffold commit** — if the scaffold is wrong (wrong project, wrong namespace, wrong layer), you want to revert just the scaffold, not scaffold plus implementation
 
-## Optional capability skills (invoke the installed skill that provides it)
+## Marketplace plugin skills (invoke only when installed)
 
-Name the capability you need, not a specific tool; resolve the concrete skill from what the target environment has installed, and fall back to the project's own workflow when none provides it.
+These are .NET-ecosystem plugin skills — invoke each only when your stack is .NET and its plugin is installed; otherwise fall back to the project's own scaffolding tooling:
 
-- **Project scaffolding** — when creating a new project, invoke an installed scaffolding/template skill for the target ecosystem for template selection, dependency-manifest adaptation, and latest-version resolution
-- **Service/protocol-server scaffolding** — when standing up a new service or protocol server (e.g. an MCP server), invoke an installed skill that scaffolds it: project layout, endpoint/tool/resource wiring, and transport configuration
+- **`dotnet-ai:mcp-csharp-create`** — when implementing a new C# MCP server, invoke for scaffolding guidance (project templates, tool/prompt/resource implementation, stdio and HTTP transport configuration)
+- **`dotnet-template-engine:template-instantiation`** — when creating a new .NET project, invoke for template selection with CPM adaptation and latest NuGet version resolution

--- a/plugins/implementation/skills/implement/context/refactor.md
+++ b/plugins/implementation/skills/implement/context/refactor.md
@@ -31,7 +31,9 @@ These go in separate commits. Squash merge collapses them on main, but separate 
 - **Refactoring without tests** — if code lacks test coverage, add characterization tests first (separate commit), then refactor. Otherwise you have no safety net
 - **Big-bang refactors** — moving 20 files in one commit. If something breaks, you can't tell which move caused it. Incremental commits are free on feature branches
 
-## Marketplace plugin skills (invoke only when installed)
+## Optional capability skills (invoke the installed skill that provides it)
 
-- **`dotnet-msbuild:msbuild-antipatterns`** — after moving types across projects, invoke to scan changed .csproj/.props/.targets for anti-patterns introduced by the restructuring (missing PrivateAssets, stale references, unconditional overrides)
-- **`dotnet-msbuild:resolve-project-references`** — when renaming or moving projects, invoke to detect broken or circular references in the MSBuild dependency graph before committing
+Name the capability you need, not a specific tool; resolve the concrete skill from what the target environment has installed, and fall back to the project's own workflow when none provides it.
+
+- **Build-config anti-pattern scanning** — after moving types across projects, invoke an installed skill that scans the changed build/project files for anti-patterns introduced by the restructuring (stale references, unscoped package assets, unconditional overrides)
+- **Project-reference validation** — when renaming or moving projects, invoke an installed skill that detects broken or circular references in the build dependency graph before committing

--- a/plugins/implementation/skills/implement/context/refactor.md
+++ b/plugins/implementation/skills/implement/context/refactor.md
@@ -31,9 +31,9 @@ These go in separate commits. Squash merge collapses them on main, but separate 
 - **Refactoring without tests** — if code lacks test coverage, add characterization tests first (separate commit), then refactor. Otherwise you have no safety net
 - **Big-bang refactors** — moving 20 files in one commit. If something breaks, you can't tell which move caused it. Incremental commits are free on feature branches
 
-## Optional capability skills (invoke the installed skill that provides it)
+## Marketplace plugin skills (invoke only when installed)
 
-Name the capability you need, not a specific tool; resolve the concrete skill from what the target environment has installed, and fall back to the project's own workflow when none provides it.
+These are .NET-ecosystem plugin skills — invoke each only when your stack is .NET and its plugin is installed; otherwise fall back to the project's own build/reference tooling:
 
-- **Build-config anti-pattern scanning** — after moving types across projects, invoke an installed skill that scans the changed build/project files for anti-patterns introduced by the restructuring (stale references, unscoped package assets, unconditional overrides)
-- **Project-reference validation** — when renaming or moving projects, invoke an installed skill that detects broken or circular references in the build dependency graph before committing
+- **`dotnet-msbuild:msbuild-antipatterns`** — after moving types across projects, invoke to scan changed .csproj/.props/.targets for anti-patterns introduced by the restructuring (missing PrivateAssets, stale references, unconditional overrides)
+- **`dotnet-msbuild:resolve-project-references`** — when renaming or moving projects, invoke to detect broken or circular references in the MSBuild dependency graph before committing


### PR DESCRIPTION
## Summary

Reworked per the ratified #412 disposition (which governs #405): the implementation plugin's mode-context files KEEP their `dotnet-*` marketplace-skill names and the `## Marketplace plugin skills (invoke only when installed)` presence gate, and gain a stack-qualified lead-in with a generic-path fallback — the #491/#526 conforming pattern. An earlier revision of this branch genericized/renamed those references; that approach was rejected by the maintainer ruling and has been fully reverted (commit 08f8e2c4ef).

## Fix

- feature.md / bugfix.md / refactor.md: all six `dotnet-*` skill references retained verbatim under the intact presence-gated heading; a .NET-ecosystem forward-reference lead-in added ("stack-qualified, invoke only when installed, otherwise the generic path applies"). No reference removal, no renames, no command-string changes.
- CHANGELOG [0.7.3]: describes the stack-qualification accurately ("retain their dotnet-* names… No reference removal").
- plugin.json 0.7.2 → 0.7.3 (patch, from current main).

## Verification

- CI green (all checks incl. portability-lint); the review bot independently re-reviewed the reworked diff and confirmed conformance to the #491/#526 pattern and the #412 disposition.
- Zero review threads; `git diff origin/main` on the three context files shows only heading-preserved + lead-in-added.

Closes #405

## Related

- #412 (the governing maintainer disposition; sibling PR #583 applies the same ruling to toolchain/dotnet.md)
- #491 / #526 (merged precedent pattern for presence-gated stack-qualified references)
