### PR TITLE
fix(testing): decouple diagnose/write evals from source-repo layout (#428)

### DIFF
--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), and failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.3]
+
+### Changed
+
+- Neutralized repo-coupled `expected_output` in `diagnose` and `write` evals so they grade the
+  underlying decision, not one private monorepo's layout. The `diagnose` fixture-collision case now
+  grades recognition of a process-global singleton / shared-state collision and deferral to the
+  project's documented fixture convention (dropping the `MonolithApi.Tests` /
+  `MonolithApiTestFixture.CollectionName` names). The `write` cases now grade co-located placement and
+  naming per the consuming project's documented conventions, and the testable-vs-contracts decision,
+  without naming any project, path, or framework (dropping `Platform.Messaging`, `libs/dotnet/`, and the
+  ghost `testing.md` reference to xUnit v3 / Shouldly — this plugin ships `write.md`/`organize.md` and
+  defers framework/assertion choices to the consuming project). Eval prompts/expectations only; no skill
+  behavior, routing, or context files changed.
+
 ## [0.2.2]
 
 ### Changed

--- a/plugins/testing/skills/diagnose/evals/evals.json
+++ b/plugins/testing/skills/diagnose/evals/evals.json
@@ -3,8 +3,8 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "dotnet test failed with 'Bootstrap logger is frozen' error",
-      "expected_output": "Routes to context/investigate.md. Immediately identifies the MonolithApi.Tests collection fixture issue — test class is using IClassFixture<WebApplicationFactory<Program>> instead of [Collection(MonolithApiTestFixture.CollectionName)]. Explains the process-global singleton root cause. Does NOT suggest retrying.",
+      "prompt": "A test run failed with a 'logger is frozen / already initialized' error",
+      "expected_output": "Routes to context/investigate.md. Immediately recognizes the symptom as a process-global singleton / shared-state collision — a test acquiring its own per-class fixture where the project's shared-collection fixture is required — rather than a transient error. Explains the shared-state root cause and consults the consuming project's documented fixture convention for the correct shared-collection pattern. Does NOT suggest retrying.",
       "files": []
     },
     {

--- a/plugins/testing/skills/write/evals/evals.json
+++ b/plugins/testing/skills/write/evals/evals.json
@@ -4,13 +4,13 @@
     {
       "id": 1,
       "prompt": "I just wrote a new command handler for creating template items. Write tests for it.",
-      "expected_output": "Routes to context/write.md. Identifies the handler as Application layer code needing unit tests. Follows TDD: generates test list (happy path, validation failures, edge cases), names tests using {Method}_Should{Behavior}_When{Condition} pattern, places in co-located {Project}.Tests/ directory. References testing.md for framework conventions (xUnit v3, Shouldly).",
+      "expected_output": "Routes to context/write.md. Identifies the handler as application-layer logic needing unit tests. Follows TDD: generates a test list (happy path, validation failures, edge cases), names tests using the consuming project's documented naming pattern (mirroring the ecosystem's own idiom when undocumented), and places them in the project's documented co-located test location. Defers to the consuming project's documented framework and assertion conventions rather than assuming any specific stack.",
       "files": []
     },
     {
       "id": 2,
-      "prompt": "Where should I put integration tests for a new Platform.Messaging library?",
-      "expected_output": "Routes to context/organize.md. Evaluates whether the library has testable behavior (business logic, conditional branching) vs pure contracts. If testable: co-located Platform.Messaging.Tests/ in libs/dotnet/. If contracts only: no dedicated test project needed, transitive coverage acceptable.",
+      "prompt": "Where should I put integration tests for a new shared library?",
+      "expected_output": "Routes to context/organize.md. Evaluates whether the library has testable behavior (business logic, conditional branching) vs pure contracts. If testable: a dedicated test project co-located with the library, following the consuming project's documented naming and location convention. If contracts only: no dedicated test project needed, transitive coverage acceptable.",
       "files": []
     }
   ]


### PR DESCRIPTION
## Summary

The `testing` plugin's `diagnose` and `write` eval `expected_output` graded against one private source monorepo's actual project names, paths, and frameworks — asserting them as the correct answer. The fixture meant to prove repo-agnosticism instead graded one shop's layout, violating `docs/PLUGIN-PHILOSOPHY.md` § Design boundary ("runtime behavior must not depend on … repository names … or an undocumented consumer layout") and `docs/MIGRATION-PLAYBOOK.md` per-plugin gate step 3 ("De-couple from the source repo"). A ghost `testing.md` reference (this plugin ships `write.md`/`organize.md`) rode along from the source plugin.

## Fix

Rewrote the coupled expectations to grade the underlying **decision**, not any named project/path/framework — mirroring how the skills' own context files (`write/context/write.md`, `write/context/organize.md`) already frame `.NET`/xUnit as *illustrative* and defer conventions to the consuming project:

- **`diagnose` case 1** — now grades recognition of a process-global singleton / shared-state fixture collision and deferral to the project's documented fixture convention. Drops `MonolithApi.Tests` / `[Collection(MonolithApiTestFixture.CollectionName)]`; prompt genericized off `dotnet test`.
- **`write` case 1** — now grades co-located placement and naming per the project's documented conventions, and defers framework/assertion choice to the consuming project. Drops the ghost `testing.md` reference and `{Project}.Tests/` / xUnit v3 / Shouldly.
- **`write` case 2** — now grades the testable-vs-contracts decision and co-location per project convention. Drops `Platform.Messaging` / `Platform.Messaging.Tests/` / `libs/dotnet/`.

Version bump `testing` 0.2.2 → 0.2.3 (patch) with a `CHANGELOG.md` entry. Eval prompts/expectations only — no skill behavior, routing, or context files changed.

## Verification

Blast radius confined to the two flagged files — `plan/` and `run-e2e/` evals carry none of the private tokens:

```
$ grep -rniE "MonolithApi|Platform\.Messaging|libs/dotnet|Shouldly|xUnit|testing\.md|\{Project\}\.Tests" \
    plugins/testing/skills/diagnose/evals plugins/testing/skills/write/evals
CLEAN-no-tokens
```

Both eval files parse as JSON and conform to the bundled `plugins/skill-quality/reference/evals.schema.json` (required keys, `additionalProperties:false`, types):

```
SCHEMA-CONFORMS plugins/testing/skills/diagnose/evals/evals.json (2 cases)
SCHEMA-CONFORMS plugins/testing/skills/write/evals/evals.json (2 cases)
```

The repo's skill contract gate passes on both skills:

```
CHECK-SKILL diagnose: PASS — 0 errors, 1 warning(s)
CHECK-SKILL write: PASS — 0 errors, 1 warning(s)
```

(The single WARN is a pre-existing `SKILL.md` description-phrasing note, unrelated to this eval-only change.)

Closes #428

## Related

- Issue #428 (highest-severity finding for the `testing` plugin). Continues the agnosticism work started in `testing` 0.2.2, which reframed the skills' prose/samples but did not reach the evals.
- No sibling PRs: `gh pr list --search "428"` returns none, and no open PR touches `plugins/testing/.claude-plugin/plugin.json` or `CHANGELOG.md`, so 0.2.3 is uncontested.

🤖 Generated with a Claude Code implementation subagent (issue #428)
