### PR TITLE
feat(ci): add skill-quality static gate lane for changed skills (#530)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,41 @@ jobs:
           grep -q '"miro_create_board"' smoke-out.json
           rm -f smoke-out.json
 
+  # Skill-regression net: the only lane that invokes the skill-quality checker.
+  # On a PR it runs the static contract gate (trigger-keyword preservation vs
+  # the base ref, frontmatter, line caps, broken refs, evals presence) over each
+  # changed skill under plugins/*/skills/**, replacing the work lane's manual
+  # high-blast-radius skill-diff read with a deterministic check. Eval sets are
+  # schema-validated on every event. The job itself never skips (a skipped
+  # required job reports success to branch protection) — only the PR-diff step
+  # is event-gated, and the self-test and eval-schema steps give push a passing
+  # path.
+  skill-quality-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the PR base ref resolves for the changed-skill diff
+          # and the checker's git-backed trigger-preservation check.
+          fetch-depth: 0
+      # Self-test first so a broken orchestrator can never mask a real skill
+      # regression behind a green gate.
+      - name: Test the changed-skill gate
+        run: bash scripts/check-changed-skills.test.sh
+      - name: Gate changed skills on the static skill-quality contract
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-changed-skills.sh "origin/$BASE_REF"
+      - name: Validate every eval set against the bundled schema
+        uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
+        with:
+          schemafile: plugins/skill-quality/reference/evals.schema.json
+          files: plugins/*/skills/*/evals/evals.json
+
   runner-policy:
     name: Runner policy
     runs-on: ubuntu-24.04
@@ -367,6 +402,7 @@ jobs:
       - plugin-gate
       - miro-plugin
       - runner-policy
+      - skill-quality-gate
       - zizmor
     # Fail-closed through execution: !cancelled() (never a success-guard) so a
     # lane failure still runs this required aggregate and the result join below

--- a/scripts/check-changed-skills.sh
+++ b/scripts/check-changed-skills.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Deterministic skill-regression gate for the skills a PR changes.
+#
+#   scripts/check-changed-skills.sh <base-ref>
+#
+# For every skill under plugins/*/skills/** touched vs <base-ref>, run the
+# skill-quality static contract gate (plugins/skill-quality/scripts/check-skill.sh
+# — trigger-keyword preservation vs the base ref, frontmatter, listing-budget
+# and line caps, broken internal refs, evals presence, committed artifacts).
+# Any FAIL fails this gate. It replaces the work lane's manual high-blast-radius
+# skill-diff read with a deterministic check, and is the first lane to invoke the
+# otherwise-uninvoked skill-quality checker.
+#
+# <base-ref> (e.g. origin/main) is BOTH the changed-file diff base and
+# CHECK_SKILL_BASE_REF, so the checker's git-backed checks compare the PR head
+# against the same base a reviewer would — a rewrite that silently drops a
+# `description` trigger phrase is caught here, not at merge.
+#
+# markdownlint (check 6) is skipped here (CHECK_SKILL_SKIP_MARKDOWNLINT=1):
+# SKILL.md markdown is already gated by the hygiene lane's markdown check, and
+# `npx --no-install markdownlint-cli2` would only WARN-skip on a hosted runner
+# without the package. Eval-schema validation (validate-evals) is a separate CI
+# step — the check-jsonschema composite action over every evals.json.
+#
+# Exit 0 = every changed skill passes (or none changed); 1 = one or more failed;
+# 2 = usage / environment error (fail closed — never a silent skip).
+#
+# CHECK_SKILL_BIN overrides the checker path (test injection).
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+BASE="${1:?usage: check-changed-skills.sh <base-ref>}"
+
+if ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+  printf 'Error: base ref %s is not a valid commit\n' "$BASE" >&2
+  exit 2
+fi
+
+CHECKER="${CHECK_SKILL_BIN:-plugins/skill-quality/scripts/check-skill.sh}"
+if [[ ! -f "$CHECKER" ]]; then
+  printf 'Error: skill checker not found: %s\n' "$CHECKER" >&2
+  exit 2
+fi
+
+# Changed skill dirs, mapped from any touched path (including vendor/ subtrees)
+# to the owning plugins/<plugin>/skills/<skill> dir and de-duplicated.
+mapfile -t changed < <(
+  git diff --name-only "$BASE" -- 'plugins/' |
+    sed -nE 's#^(plugins/[^/]+/skills/[^/]+)/.*#\1#p' |
+    sort -u
+)
+
+checked=0
+failed=0
+
+for skill_dir in "${changed[@]}"; do
+  # A deletion/rename-away leaves no SKILL.md in the tree — not a regression to
+  # gate (and the checker would FAIL "not found"). Skip those.
+  [[ -f "$skill_dir/SKILL.md" ]] || continue
+  skills_root="${skill_dir%/*}" # plugins/<plugin>/skills
+  skill_name="${skill_dir##*/}" # <skill>
+  checked=$((checked + 1))
+  printf '=== %s ===\n' "$skill_dir"
+  if CHECK_SKILL_SKILLS_ROOT="$PWD/$skills_root" \
+    CHECK_SKILL_BASE_REF="$BASE" \
+    CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+    bash "$CHECKER" "$skill_name"; then
+    :
+  else
+    failed=$((failed + 1))
+  fi
+done
+
+if ((checked == 0)); then
+  echo "No changed skills under plugins/*/skills/ — nothing to gate."
+  exit 0
+fi
+
+printf '\n%d skill(s) checked, %d failed.\n' "$checked" "$failed"
+((failed == 0))

--- a/scripts/check-changed-skills.test.sh
+++ b/scripts/check-changed-skills.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Unit tests for check-changed-skills.sh. Each scenario builds a throwaway git
+# repo, commits a base tree of skills, applies working-tree changes, and runs
+# the script with the base commit as <base-ref>. The skill checker is stubbed
+# (CHECK_SKILL_BIN) so the tests exercise the orchestrator — changed-skill
+# detection, vendor-subtree mapping, dedupe, deletion filtering, env
+# passthrough, and pass/fail aggregation — not check-skill.sh itself.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SELF_DIR/check-changed-skills.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# A stub checker shared by every scenario: records each invocation (skill name +
+# forwarded env) to $CHECK_LOG, and FAILs iff the skill is named "bad".
+STUB="$(mktemp)"
+cat >"$STUB" <<'EOF'
+#!/usr/bin/env bash
+printf 'name=%s root=%s base=%s\n' "$1" "$CHECK_SKILL_SKILLS_ROOT" "$CHECK_SKILL_BASE_REF" >>"$CHECK_LOG"
+[[ "$1" == "bad" ]] && exit 1
+exit 0
+EOF
+chmod +x "$STUB"
+
+mk_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email t@t.test
+  git -C "$dir" config user.name test
+  git -C "$dir" config commit.gpgsign false
+  mkdir -p "$dir/scripts"
+  cp "$SCRIPT" "$dir/scripts/check-changed-skills.sh"
+  printf '%s' "$dir"
+}
+
+# add_skill <repo> <plugin> <skill> [relpath]  — write a file in a skill dir.
+add_skill() {
+  local repo="$1" plugin="$2" skill="$3" rel="${4:-SKILL.md}"
+  local path="$repo/plugins/$plugin/skills/$skill/$rel"
+  mkdir -p "$(dirname "$path")"
+  printf 'content %s\n' "$RANDOM" >"$path"
+}
+
+commit_all() { git -C "$1" add -A && git -C "$1" commit -qm "$2"; }
+base_sha() { git -C "$1" rev-parse HEAD; }
+
+# run <repo> <base>  — invoke the script from the repo root, stub as checker.
+run() (
+  cd "$1" && CHECK_SKILL_BIN="$STUB" CHECK_LOG="$1/checklog" \
+    bash scripts/check-changed-skills.sh "$2"
+)
+
+# --- no changed skills passes (nothing to gate) ----------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+printf 'unrelated\n' >"$r/README.md" # non-skill change
+if out="$(run "$r" "$b" 2>&1)"; then
+  if echo "$out" | grep -q "nothing to gate"; then
+    ok "no changed skills passes"
+  else
+    fail "expected nothing-to-gate message, got: $out"
+  fi
+else
+  fail "no changed skills should pass, got: $out"
+fi
+rm -rf "$r"
+
+# --- one changed skill, checker passes -------------------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 alpha SKILL.md # modify
+if out="$(run "$r" "$b" 2>&1)"; then
+  if echo "$out" | grep -q "1 skill(s) checked, 0 failed"; then
+    ok "one passing skill passes"
+  else
+    fail "expected 1 checked 0 failed, got: $out"
+  fi
+else
+  fail "passing skill should pass, got: $out"
+fi
+rm -rf "$r"
+
+# --- a failing checker fails the gate --------------------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 bad
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 bad SKILL.md
+if run "$r" "$b" >/dev/null 2>&1; then
+  fail "a failing skill checker should fail the gate"
+else
+  ok "failing skill checker fails the gate"
+fi
+rm -rf "$r"
+
+# --- vendor-subtree change maps to the owning skill, deduped ---------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 alpha SKILL.md # touch two paths in one skill
+add_skill "$r" p1 alpha vendor/tool/SKILL.md
+run "$r" "$b" >/dev/null 2>&1
+n="$(grep -c "name=alpha" "$r/checklog" 2>/dev/null || echo 0)"
+if [[ "$n" == "1" ]]; then
+  ok "vendor subtree maps to owning skill, checked once"
+else
+  fail "expected alpha checked exactly once, got $n"
+fi
+rm -rf "$r"
+
+# --- env passthrough: skills root and base ref reach the checker -----------
+r="$(mk_repo)"
+add_skill "$r" p2 beta
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p2 beta SKILL.md
+run "$r" "$b" >/dev/null 2>&1
+if grep -q "name=beta root=$r/plugins/p2/skills base=$b" "$r/checklog" 2>/dev/null; then
+  ok "checker receives skill name, skills root, and base ref"
+else
+  fail "env passthrough wrong, got: $(cat "$r/checklog" 2>/dev/null)"
+fi
+rm -rf "$r"
+
+# --- a deleted skill is filtered, not gated --------------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+add_skill "$r" p1 gone
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+rm -rf "$r/plugins/p1/skills/gone"
+if out="$(run "$r" "$b" 2>&1)"; then
+  if echo "$out" | grep -q "nothing to gate"; then
+    ok "deleted skill is filtered out"
+  else
+    fail "deleted-only change should gate nothing, got: $out"
+  fi
+else
+  fail "deleting a skill should not fail the gate, got: $out"
+fi
+rm -rf "$r"
+
+# --- an invalid base ref fails closed (env error) --------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+commit_all "$r" base >/dev/null
+run "$r" "does-not-exist" >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 2 ]]; then
+  ok "invalid base ref exits 2 (fail closed)"
+else
+  fail "invalid base ref should exit 2, got $rc"
+fi
+rm -rf "$r"
+
+# --- a missing checker fails closed ----------------------------------------
+r="$(mk_repo)"
+add_skill "$r" p1 alpha
+commit_all "$r" base >/dev/null
+b="$(base_sha "$r")"
+add_skill "$r" p1 alpha SKILL.md
+(cd "$r" && CHECK_SKILL_BIN="$r/nope.sh" CHECK_LOG="$r/l" \
+  bash scripts/check-changed-skills.sh "$b") >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 2 ]]; then
+  ok "missing checker exits 2 (fail closed)"
+else
+  fail "missing checker should exit 2, got $rc"
+fi
+rm -rf "$r"
+
+rm -f "$STUB"
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

This repo edits its own skills daily via the autonomous pipeline, yet no CI lane invoked the `skill-quality` checker — 120 `evals/evals.json` went unexecuted and the 17-check static gate (`skill-quality:check`) was invoked by nothing. This wires that checker into CI as a deterministic skill-regression net.

Implements **stage 1 only** of #530 (the "cheap, now" deterministic lane). Stages 2-5 (model-graded judges, frozen regression suite, pass^k autopilot-unlock metric, clean-state isolation) remain a separate decompose target per the ratified operator decision on the issue.

## Fix

New `skill-quality-gate` job in `.github/workflows/ci.yml`, added to the `ci-status` required aggregate:

- **Static gate (`scripts/check-changed-skills.sh`)** — on a PR, for each skill under `plugins/*/skills/**` the diff touches, runs `plugins/skill-quality/scripts/check-skill.sh` with `CHECK_SKILL_SKILLS_ROOT` set to the owning plugin's `skills/` dir and `CHECK_SKILL_BASE_REF` set to the PR base. Because the checker's trigger-keyword-preservation check diffs against that base, a rewrite that silently drops a `description` trigger phrase (an auto-invocation regression) fails the check — replacing the work lane's manual high-blast-radius diff read with a deterministic one. Vendor subtrees map to the owning skill; deleted skills are filtered; any FAIL (or env error) exits non-zero. `markdownlint` (check 6) is deliberately skipped here (`CHECK_SKILL_SKIP_MARKDOWNLINT=1`) — SKILL.md markdown is already gated by the hygiene lane.
- **validate-evals** — the existing `check-jsonschema` composite action schema-validates every `evals/evals.json` against the bundled `plugins/skill-quality/reference/evals.schema.json`.
- **Self-test (`scripts/check-changed-skills.test.sh`)** — runs first so a broken orchestrator cannot mask a real regression behind a green gate.

**No silent-skip (#445 precedent):** the job itself never skips (a skipped required job reports success to branch protection) — only the inner PR-diff step is event-gated (mirroring `hook-utils-sync`'s `--check-bump`), and the self-test + eval-schema steps give push-to-main a passing path. Missing base ref or missing checker fails closed (exit 2).

**No new reusable action:** reuses this repo's own local script plus the already-referenced `check-jsonschema` composite action — no change to `melodic-software/ci-workflows`.

**No plugin modified → no version bump** (consistent with CI-only PR #490, which bumped nothing). No plugin frontmatter, triggers, hooks, or cross-plugin contracts are touched.

## Verification

Local, in the worktree:

- **Orchestrator unit tests** — `bash scripts/check-changed-skills.test.sh` → `PASS=8 FAIL=0` (covers changed-skill detection, vendor-subtree mapping, dedupe, deletion filtering, env passthrough, pass/fail aggregation, fail-closed on bad base ref / missing checker).
- **ShellCheck** — `shellcheck --rcfile .shellcheckrc scripts/check-changed-skills.sh scripts/check-changed-skills.test.sh` → clean.
- **End-to-end, real `check-skill.sh` against real skills** (`scripts/check-changed-skills.sh origin/main`):
  - Happy path (a changed skill with no regression) → `PASS`, exit 0.
  - Simulated regression (dropped the `'lint my skill'` trigger from `skill-quality/check`) → `FAIL: dropped trigger keyword(s) vs origin/main (auto-invocation regression): 'lint my skill'`, exit 1.
- **validate-evals** — `check-jsonschema --schemafile plugins/skill-quality/reference/evals.schema.json` over all `plugins/*/skills/*/evals/evals.json` → 120/120 pass today (glob matches exactly the 120 eval sets, excludes vendor).

Closes #603

## Related

- #530 — this PR is stage 1 of the staged quality-net umbrella; stages 2-5 stay a decompose target.
- #445 — mechanical-conformance CI backlog; this extends gating from conformance to behavior and follows its silent-skip-gate anti-pattern warning.
- #477-#480 — the rule→skill absorption lifecycle whose regression net this begins to supply.
- #513 — the mini-SDLC verify lane that consumes these gates.
