### PR TITLE
docs: codify batch-1 operator precedents (two-lane defaults + built-in-first gate) (#557)

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -260,6 +260,12 @@ The **adopted** rule for how a plugin settles a value at runtime, applied to eve
 No baked repo assumptions, ever. A plugin never hardcodes a consumer's layout; it reads a declared
 value, infers-and-records, or asks — never guesses silently.
 
+This ladder is the runtime application of the durable convention posture owned by
+[PLUGIN-PHILOSOPHY.md § Two-lane convention posture](PLUGIN-PHILOSOPHY.md): a pre-prescribed
+convention is a hardcoded dependency, so a plugin ships a default only in lane 1 (a good-practice
+value that cannot conflict in any consuming repo) and otherwise takes lane 2 — its setup discovers
+the consumer's convention and externalizes it as an extensibility point the ladder then resolves.
+
 ## Setup action — required iff the criteria hold
 
 Whether a plugin needs a `setup` skill, and the uniform contract it follows (`setup` name,

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -77,6 +77,13 @@ Prefer a built-in native mechanism — `userConfig`, a native component type, a 
 event — over any custom extensibility point. Build custom only on genuine misfit, and document the
 misfit where the custom mechanism lives.
 
+Built-in-first is a gate on every customization surface, not a preference. Before building
+any custom config surface — a YAML concern file, a bespoke seam — first verify against the *current*
+official Claude Code plugin documentation that no native mechanism (`userConfig`, environment
+variables, a built-in per-repo config surface) can host the need; the platform moves, so re-fetch
+the documentation rather than trusting memory or an old summary. A custom extensibility point is the
+fallback only where the built-in surface genuinely cannot support the need.
+
 Adoption gate, applied per mechanism: adopt a native mechanism when it
 
 1. fills a real existing gap — never adopt for novelty;
@@ -108,6 +115,25 @@ native one matures into fitness.
 | [Themes](https://code.claude.com/docs/en/plugins-reference) | Wait | Experimental (`experimental.themes`); schema may change between releases. Re-verify before each audit. | 2026-07-17 |
 | [Channels](https://code.claude.com/docs/en/plugins-reference) | Wait | No longer carries an official experimental label, but fails the adoption gate today: no fleet gap it fills. Re-verify before each audit. | 2026-07-17 |
 | [Dependencies](https://code.claude.com/docs/en/plugin-dependencies) | Adopt on need (hard requires only) | See the design boundary: hard requires only, semver-constrained, released via `{name}--v{version}` tags. None exist in this fleet today. | 2026-07-17 |
+
+## Two-lane convention posture
+
+A plugin must not arrive at an arbitrary consuming repo carrying pre-prescribed conventions. A
+convention baked in as a fixed default — a branch-naming grammar, a commit structure, a directory
+layout — is a hardcoded assumption that the consumer's practice will never differ from the plugin's;
+that is the definition of a dependency, and dependencies are externalized and abstracted, not shipped
+as defaults. This governs every plugin and every convention, not one class. Two lanes hold:
+
+1. **Non-conflicting good-practice defaults.** A shipped default is legitimate only when it is a
+   good-practice value that cannot conflict in *any* repo the plugin drops into. This lane is narrow:
+   most conventions a consumer already holds an opinion on (Conventional Commits in a repo that does
+   not use them, for instance) do not qualify, because dropping the plugin in would then impose the
+   wrong convention.
+2. **Discover via setup, externalize as configuration.** In the general case the plugin's setup
+   action or skill discovers the consuming repo's conventions — branch naming, commit structure,
+   patterns — and externalizes them as configuration extensibility points rather than coming to the
+   table assuming them. A convention a consumer could reasonably do differently belongs in lane 2, as
+   a discovered-and-externalized extensibility point, never as a lane-1 default.
 
 ## Configuration ownership and scope
 

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -79,8 +79,8 @@ misfit where the custom mechanism lives.
 
 Built-in-first is a gate on every customization surface, not a preference. Before building
 any custom config surface — a YAML concern file, a bespoke seam — first verify against the *current*
-official Claude Code plugin documentation that no native mechanism (`userConfig`, environment
-variables, a built-in per-repo config surface) can host the need; the platform moves, so re-fetch
+official Claude Code plugin documentation that no native mechanism (`userConfig`, a built-in
+per-repo config surface) can host the need; the platform moves, so re-fetch
 the documentation rather than trusting memory or an old summary. A custom extensibility point is the
 fallback only where the built-in surface genuinely cannot support the need.
 


### PR DESCRIPTION
## Summary

Two fleet-wide operator precedents from decision-session batch 1 (2026-07-19) were established as rulings inside issue-specific comment threads (#415, #423) but never written into the shared source-of-truth doc. This transcribes both into `docs/PLUGIN-PHILOSOPHY.md` (SSOT) in the file's existing voice, and points the migration playbook up at them. Docs-only; no plugin code touched.

The task framing assumed one PHILOSOPHY section + one pointer, but the file's reality overrode it faithfully: **Precedent 2's home already exists** (the `Native-first` section already carries its thesis), so it was *strengthened* rather than duplicated; **Precedent 1 had no home**, so it got a new section. The convention-resolution *mechanism* lives in the playbook, so the pointer attaches there. Two touchpoints, no duplicated prose — more faithful to the repo's pointer-over-copy convention than restating `Native-first` would have been.

## Change

- **`docs/PLUGIN-PHILOSOPHY.md` § Native-first — Precedent 2 (built-in-first customization gate, from the #423 ruling).** Added the build-time gate the section lacked: before building any custom config surface (YAML concern file, bespoke seam), verify against *current* official Claude Code plugin documentation that no native mechanism (`userConfig`, environment variables, built-in per-repo config) can host the need; custom is the fallback only on genuine misfit. The section already said "prefer native / build custom only on misfit" — only the doc-verification gate is net-new, so only that was added.
- **`docs/PLUGIN-PHILOSOPHY.md` § Two-lane convention posture — Precedent 1 (from the #415 ruling).** New section: a pre-prescribed convention is a hardcoded dependency to externalize; lane 1 is non-conflicting good-practice defaults, lane 2 is discover-via-setup and externalize as configuration extensibility points. States the durable principle only — the runtime mechanism (the ladder) stays in the playbook and points back up.
- **`docs/MIGRATION-PLAYBOOK.md` § Convention-resolution ladder — pointer, not copy.** The ladder now names the new posture as its durable principle and links to it, using the repo's existing `§`-label link style. No prose restated.

Transcribed from the primary-source operator ruling comments on #415 and #423, not paraphrased from the #557 body. Provenance stays in those rulings and this PR/commit; PHILOSOPHY does not inline-cite issue numbers (matching how the fresh-eyes doctrine landed via #306).

## Verification

**Precedents now live in `PLUGIN-PHILOSOPHY.md` (diff excerpt):**

New section:
```
+## Two-lane convention posture
+
+A plugin must not arrive at an arbitrary consuming repo carrying pre-prescribed conventions. A
+convention baked in as a fixed default ... is a hardcoded assumption ...; that is the definition of
+a dependency, and dependencies are externalized and abstracted, not shipped as defaults ...
+1. **Non-conflicting good-practice defaults.** A shipped default is legitimate only when it ... cannot conflict in *any* repo ...
+2. **Discover via setup, externalize as configuration.** ... the plugin's setup action or skill discovers the consuming repo's conventions ... and externalizes them as configuration extensibility points ...
```
Native-first gate (added paragraph):
```
+Built-in-first is a gate on every customization surface, not a preference. Before building
+any custom config surface — a YAML concern file, a bespoke seam — first verify against the *current*
+official Claude Code plugin documentation that no native mechanism (`userConfig`, environment
+variables, a built-in per-repo config surface) can host the need ...
```

**Migration-playbook pointer resolves to the right section.** The repo has **zero** fragment-anchor links in `docs/*.md` (`grep -roE '\]\([^)]+\.md#[a-z0-9-]+\)' docs/*.md` → 0 matches); the established convention is a file-level link with a `§ Section Name` label (existing examples at MIGRATION-PLAYBOOK.md:267 and :575). The new link `[PLUGIN-PHILOSOPHY.md § Two-lane convention posture](PLUGIN-PHILOSOPHY.md)` matches that convention exactly, and its `§` label names the new section heading verbatim.

**Markdown linter clean (real output, `.markdownlint-cli2.jsonc` — the config the CI `Lint markdown` lane uses):**
```
markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)
Linting: 2 file(s)
Summary: 0 error(s)
```
**editorconfig-checker clean** (config `.editorconfig-checker.json`, the CI editorconfig lane's config): exit 0, no findings.

**Version bump: none required, and none made — deliberately.** This is a docs-only change touching no `plugin.json` (`git diff --name-only` → only the two `docs/*.md` files). The controlling precedent is #306 (`e4c996cf` "docs: codify the fresh-eyes checkpoint rule in plugin doctrine") — the closest analog, also a doctrine-codification change to `PLUGIN-PHILOSOPHY.md`; `git show --stat` confirms it touched only `docs/PLUGIN-PHILOSOPHY.md` and bumped no plugin version. Per-plugin `CHANGELOG.md` / version-bump delivery applies to changes to a plugin's own files (the version is the update cache key); a `docs/` change delivers nothing to a consumer and has no bump vehicle.

Closes #557

## Related

- **#557** — this codification issue.
- **#415** — source ruling for Precedent 1 (two-lane convention posture). Not edited; its ruling remains the decision provenance.
- **#423** — source ruling for Precedent 2 (built-in-first customization gate). Not edited; its ruling remains the decision provenance.
- **#531** — the future portability-lint lane. A backlog comment was posted noting both precedents as future mechanical-check candidates, with links to the new PHILOSOPHY sections — no code/label change there: https://github.com/melodic-software/claude-code-plugins/issues/531#issuecomment-5018427852

🤖 Generated with a Claude Code implementation subagent (issue #557)