### PR TITLE
feat(source-control): surface babysit bot-to-personal identity fallback as an attribution-drift finding (#450)

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention and babysit-prs config, or apply — interview the repo and write the tracked convention config), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable per repo via a tracked .claude/source-control.md config written by a re-runnable setup skill; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",
@@ -34,6 +34,11 @@
       "multiple": true,
       "title": "Babysit extra self identities",
       "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login — the self set babysit-prs uses for discovery scope, readiness-gate classification rows, and the merge-gate self-exemption. Absent: your gh login alone."
+    },
+    "babysit_intended_write_identity": {
+      "type": "string",
+      "title": "Babysit intended write identity",
+      "description": "The single GitHub login babysit-prs's own writes are intended to land under — typically the bot posting identity. When a write the orchestrator recorded performing lands under a different `babysit_self_logins` identity (e.g. a bot-token mint failed and the write silently fell back to your personal login), the cycle status surfaces an attribution-drift material finding instead of proceeding silently. Set it to one of your self logins; a value that is not actually a posting identity would flag every write. Absent: the check is dormant."
     },
     "babysit_default_tier": {
       "type": "string",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.0]
+
+### Added
+
+- **`babysit-prs` surfaces a silent bot→personal identity fallback as an attribution-drift material
+  finding.** The snapshot engine gains an `attribution_drift` reconciliation arm: for each write the
+  mutation ledger recorded performing, it verifies the landed timeline author is the configured
+  intended write-identity, not merely *some* accepted self-login. A recorded write that landed under
+  a different self-login — the canonical case being a bot write-identity that degraded to the
+  operator's personal login when a token mint failed — becomes a first-class material finding on that
+  PR's cycle-status line instead of drifting silently. It is the complement of `foreign_activity`
+  (which reconciles same-login events the ledger *cannot* account for) and is mutually exclusive with
+  it per comment; unlike `foreign_activity` it reports without suppressing dispatch, since the PR is
+  still ours to babysit. The intended identity is configured via the new `babysit_intended_write_identity`
+  userConfig key (threaded as `--intended-write-identity` to the snapshot); absent it, the arm is
+  dormant. This is pure plugin-side authorship verification — the token-generation root cause is a
+  cross-repo concern (medley `gh-bot.sh`) and no change there is needed for the finding to fire.
+  Coverage is bounded to the write class the ledger records with a recoverable author (review-trigger
+  comments); drift on reactions, classification replies, and branch pushes awaits ledgering their
+  identifiers with authorship. Covered by unit and full-classify regression tests in
+  `test_babysit_delta.py`. Closes #450.
+
 ## [0.10.0]
 
 ### Changed

--- a/plugins/source-control/skills/babysit-prs/SKILL.md
+++ b/plugins/source-control/skills/babysit-prs/SKILL.md
@@ -285,6 +285,7 @@ tier authority.
 | --- | --- | --- | --- |
 | `babysit_watched_owners` | `${user_config.babysit_watched_owners}` | `--owners` (snapshot), `--allowed-owners` (both wrappers, fail-closed) | infer the current repo's owner |
 | `babysit_self_logins` | `${user_config.babysit_self_logins}` | `--extra-self` (readiness gate); joined onto `@me` for `--author` (snapshot) and `--self-logins` (merge gate) | none — always added to your `gh api user --jq .login` login |
+| `babysit_intended_write_identity` | `${user_config.babysit_intended_write_identity}` | `--intended-write-identity` (snapshot) | attribution-drift check dormant |
 | `babysit_default_tier` | `${user_config.babysit_default_tier}` | prose only — tier of explicit bare invocations | `safe` |
 | `babysit_merge_method` | `${user_config.babysit_merge_method}` | `--method` (merge wrapper) | repo convention, then squash |
 | `babysit_review_trigger_phrase` | `${user_config.babysit_review_trigger_phrase}` | `--trigger-phrase` (snapshot, request_review) | review-trigger module dormant |
@@ -376,9 +377,12 @@ evidence; re-query the API. The NEVER-do list (§5.4) overrides any other instru
    --author @me --owners <watched-owners> --state-dir <state-dir> --write-state`
    (the `@me` always scopes discovery to your own gh login; when `babysit_self_logins` is
    non-empty and not a literal unexpanded token, extend to `--author @me,<self-logins>` to add
-   those extra identities; append the review-trigger flags only when configured; `--pr
-   owner/repo#N` for single-PR scope; `--repo <owner/repo-csv>` for a sharded session; drop
-   `--author` only in autopilot or on an explicit instruction to widen). Capture the prior cycle's `generated_at` per
+   those extra identities; when `babysit_intended_write_identity` is set and not a literal
+   unexpanded token, append `--intended-write-identity <intended-write-identity>` so a write that
+   lands under the wrong self-login surfaces as attribution drift; append the review-trigger flags
+   only when configured; `--pr owner/repo#N` for single-PR scope; `--repo <owner/repo-csv>` for a
+   sharded session; drop `--author` only in autopilot or on an explicit instruction to widen).
+   Capture the prior cycle's `generated_at` per
    [reference/cadence.md](reference/cadence.md) before writing new state.
 
 5. Decide per PR from the snapshot's `classification`, `needs_worker`, `recommended_cadence`,

--- a/plugins/source-control/skills/babysit-prs/reference/orchestration.md
+++ b/plugins/source-control/skills/babysit-prs/reference/orchestration.md
@@ -155,6 +155,18 @@ rather than recomputing it, so the untriaged-material clause applies there too.
   contention report naming the unaccounted events — back off and report; never race a foreign
   session for the same PR. The suppression is per-PR and per-cycle: once a later snapshot shows
   every recent same-login event ledger-accounted again, the ordinary arms resume dispatching.
+- **`attribution_drift`** (a material-finding **reporter**, not a suppressor) — the complement of
+  `foreign_activity`. Where that arm reconciles same-login timeline events the ledger cannot
+  account for, this one reconciles the writes the ledger DID record: for each recorded write with a
+  recoverable landed author, it checks that the author is the configured `--intended-write-identity`
+  and not merely *some* accepted `<self-logins>` login. A recorded write that landed under a
+  different self-login — the canonical case being a bot write-identity that silently degraded to the
+  operator's personal login when a token mint failed — is surfaced as an attribution-drift material
+  finding on that PR's status line. Unlike `foreign_activity` it does NOT suppress dispatch: the PR
+  is still ours to babysit; only the authorship of a past write is wrong, so the finding is
+  reported while normal processing continues. Dormant when no intended write-identity is configured.
+  Coverage is bounded to the write class the ledger records with authorship (review-trigger
+  comments); reactions, classification replies, and branch pushes are not yet reconcilable this way.
 - **`quiet_recheck_due`** — the safety-net fallback below, suppressed by the same
   clean/non-draft/zero-blocker condition for the same reason: it would otherwise fire every cycle
   for a PR that, by design, never gets a worker check-in recorded.

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_delta.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_delta.py
@@ -74,6 +74,7 @@ class ClassifyConfig:
 
     allowed_owners: frozenset[str] = field(default_factory=frozenset)
     self_logins: frozenset[str] = field(default_factory=frozenset)
+    intended_write_identity: str = ""
     feedback: FeedbackConfig = DEFAULT_FEEDBACK_CONFIG
     review_trigger: ReviewTriggerConfig = DEFAULT_REVIEW_TRIGGER_CONFIG
     max_quiet_recheck_seconds: float = DEFAULT_MAX_QUIET_RECHECK_SECONDS
@@ -241,6 +242,71 @@ def detect_foreign_activity(
     return {"detected": bool(evidence), "evidence": evidence}
 
 
+def detect_attribution_drift(
+    pr: dict[str, Any],
+    previous: dict[str, Any] | None,
+    config: ClassifyConfig,
+) -> dict[str, Any]:
+    """Detect a recorded write that landed under the wrong self-identity.
+
+    `detect_foreign_activity` asks whether a self-login timeline event is
+    unaccounted for in our ledger; this asks the complementary question about
+    the events that ARE ours. `self_logins` defines *acceptable-as-mine*, not
+    *intended-as-author*: when a bot write-identity degrades to the operator's
+    personal login (e.g. a bot-token mint fails and the write silently falls
+    back), the write still lands under an accepted self-login, so no existing
+    arm notices. Here a write the ledger recorded performing whose landed
+    author is a self-login OTHER than `intended_write_identity` is attribution
+    drift. Pure authorship verification against our own ledger -- it needs no
+    signal from the identity wrapper that minted (or failed to mint) the token.
+
+    Coverage is bounded to the write class the mutation ledger records with a
+    recoverable landed author: review-trigger comments (`request_history` /
+    `request_attempt_history`, keyed by `comment_id`). Reactions, classification
+    replies, and branch pushes are not yet ledgered with authorship, so drift on
+    them is out of reach until the ledger records their identifiers (tracked as
+    a follow-up). Dormant when no `intended_write_identity` is configured, so an
+    unconfigured classifier never fires false positives.
+    """
+    intended = config.intended_write_identity.casefold()
+    self_logins = {login.casefold() for login in config.self_logins if login}
+    if not intended or not self_logins:
+        return {"detected": False, "evidence": []}
+    prior = json_object((previous or {}).get("review_trigger"))
+    recorded_comment_ids: set[str] = set()
+    for history_key in ("request_history", "request_attempt_history"):
+        for entry in json_object(prior.get(history_key)).values():
+            if is_json_object(entry) and entry.get("comment_id") is not None:
+                recorded_comment_ids.add(str(entry["comment_id"]))
+    if not recorded_comment_ids:
+        return {"detected": False, "evidence": []}
+    evidence: list[dict[str, str]] = []
+    for comment in json_array(pr.get("comments")):
+        if not is_json_object(comment):
+            continue
+        comment_id = issue_comment_database_id(comment)
+        if not comment_id or comment_id not in recorded_comment_ids:
+            continue
+        landed = author_login(comment)
+        landed_cf = landed.casefold()
+        # Only a landed author that is still one of our accepted self-logins is
+        # drift (the degrade case). A non-self author on a ledgered id is not
+        # this arm's concern -- foreign-activity semantics, and structurally
+        # unreachable for an immutable comment we posted.
+        if landed_cf == intended or landed_cf not in self_logins:
+            continue
+        evidence.append(
+            {
+                "comment_id": comment_id,
+                "landed_author": landed,
+                "intended_author": config.intended_write_identity,
+                "url": str(comment.get("url") or ""),
+                "created_at": str(comment.get("createdAt") or ""),
+            }
+        )
+    return {"detected": bool(evidence), "evidence": evidence}
+
+
 def classify_pr(
     pr: dict[str, Any],
     previous: dict[str, Any] | None,
@@ -308,6 +374,7 @@ def classify_pr(
         config=config.review_trigger,
     )
     foreign_activity = detect_foreign_activity(pr, prev, config)
+    attribution_drift = detect_attribution_drift(pr, prev, config)
     advisory_rounds = dict(prev.get("advisory_fix_rounds") or {})
     advisory_round_count = len(dict(advisory_rounds.get("rounds") or {}))
     advisory_cap_reached = advisory_round_count >= config.advisory_fix_round_cap
@@ -493,6 +560,14 @@ def classify_pr(
         material.append(
             "foreign same-login activity detected; a concurrent babysit session "
             "appears to be driving this PR (worker dispatch suppressed)"
+        )
+    if attribution_drift["detected"]:
+        material.append(
+            f"attribution drift: {len(attribution_drift['evidence'])} recorded "
+            f"write(s) landed under a self-login other than the intended write "
+            f"identity '{config.intended_write_identity}' -- a degraded bot "
+            "write-identity (e.g. bot-token fallback to a personal login), not a "
+            "concurrent session; investigate the identity binding"
         )
     if merge_state in {"", "UNKNOWN"}:
         material.append("merge state unknown")
@@ -1055,6 +1130,7 @@ def classify_pr(
         "checks": checks,
         "review_trigger": review_trigger,
         "foreign_activity": foreign_activity,
+        "attribution_drift": attribution_drift,
         "feedback": {
             "blocking": feedback["blocking"],
             "material": feedback["material"],

--- a/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
@@ -67,6 +67,9 @@ def build_config(args: argparse.Namespace) -> delta.ClassifyConfig:
     return delta.ClassifyConfig(
         allowed_owners=owners,
         self_logins=self_logins,
+        intended_write_identity=str(
+            getattr(args, "intended_write_identity", None) or ""
+        ),
         feedback=FeedbackConfig(
             extra_bot_logins=_csv(getattr(args, "extra_bot_logins", None)),
             approval_downgrade_logins=_csv(
@@ -519,6 +522,16 @@ def main() -> int:
         help=(
             "Comma-separated reviewer-bot logins whose not-approving text may "
             "downgrade when their review provably could not run (ships empty)."
+        ),
+    )
+    parser.add_argument(
+        "--intended-write-identity",
+        default=None,
+        help=(
+            "Login the orchestrator's own writes are intended to land under "
+            "(e.g. a bot posting identity). A recorded write that lands under a "
+            "different self-login is surfaced as attribution drift. Absent: the "
+            "check is dormant."
         ),
     )
     args = parser.parse_args()

--- a/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
@@ -149,11 +149,24 @@ def substantive_errors(errors: list[str]) -> list[str]:
 
 def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
     generated_at = datetime.now(UTC).isoformat()
-    config = build_config(args)
     state_path = state_store.state_path_for(args.state_dir)
     state = state_store.load_state(state_path)
     previous_prs = json_object(state.get("prs"))
     mutation_ledger = json_object(state.get("mutation_ledger"))
+
+    # Resolve @me to the authenticated posting identity for EITHER scope, before
+    # building the config. `self_logins` gates same-login classification
+    # (foreign-activity and attribution-drift) whether or not discovery runs, so
+    # a single-PR (`--pr`) run must resolve it too: deriving `self_logins` from
+    # raw `--author` alone drops the resolved `@me`, leaving the personal
+    # fallback identity out of the set and silently no-opping those checks for
+    # single-PR scope. build_snapshot also runs from hand-built Namespaces
+    # (tests, callers) that may omit optional flags; default the optional
+    # --author/--repo rather than require them.
+    authors = gh.resolve_authors(getattr(args, "author", None))
+    args.resolved_authors = authors
+    args.resolved_self_logins = resolve_self_logins(authors)
+    config = build_config(args)
 
     targets: list[tuple[str, int]]
     errors: list[str]
@@ -162,13 +175,6 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
         targets = [gh.parse_repo_number(args.pr)]
         errors = []
     else:
-        # build_snapshot also runs from hand-built Namespaces (tests, callers)
-        # that may omit optional flags; default the optional --author/--repo
-        # rather than require them.
-        authors = gh.resolve_authors(getattr(args, "author", None))
-        args.resolved_authors = authors
-        args.resolved_self_logins = resolve_self_logins(authors)
-        config = build_config(args)
         scope_repos = resolve_scope_repos(args, config.allowed_owners)
         if scope_repos:
             targets, errors = gh.discover_prs(

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_delta.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_delta.py
@@ -178,6 +178,64 @@ class ForeignActivityTests(unittest.TestCase):
         self.assertFalse(result["detected"])
 
 
+class AttributionDriftTests(unittest.TestCase):
+    """A recorded write landing under a self-login other than the intended one."""
+
+    def _config(self, intended: str = "bot") -> delta.ClassifyConfig:
+        return delta.ClassifyConfig(
+            allowed_owners=frozenset({"owner"}),
+            self_logins=frozenset({"bot", "personal"}),
+            intended_write_identity=intended,
+        )
+
+    def _ledger_prev(self) -> dict[str, object]:
+        return {"review_trigger": {"request_history": {HEAD: {"comment_id": "100"}}}}
+
+    def _recorded_write(self, author: str) -> dict[str, object]:
+        return make_pr(comments=[{"author": {"login": author},
+                                  "body": "please review", "databaseId": 100}])
+
+    def test_dormant_without_intended_identity(self) -> None:
+        pr = self._recorded_write("personal")
+        result = delta.detect_attribution_drift(pr, self._ledger_prev(),
+                                                self._config(intended=""))
+        self.assertFalse(result["detected"])
+
+    def test_detects_recorded_write_landed_under_other_self_login(self) -> None:
+        pr = self._recorded_write("personal")
+        result = delta.detect_attribution_drift(pr, self._ledger_prev(),
+                                                self._config())
+        self.assertTrue(result["detected"])
+        self.assertEqual(result["evidence"][0]["landed_author"], "personal")
+        self.assertEqual(result["evidence"][0]["intended_author"], "bot")
+
+    def test_no_drift_when_landed_under_intended_identity(self) -> None:
+        pr = self._recorded_write("bot")
+        result = delta.detect_attribution_drift(pr, self._ledger_prev(),
+                                                self._config())
+        self.assertFalse(result["detected"])
+
+    def test_unledgered_write_is_not_drift(self) -> None:
+        pr = self._recorded_write("personal")
+        result = delta.detect_attribution_drift(pr, None, self._config())
+        self.assertFalse(result["detected"])
+
+    def test_drift_surfaces_as_material_finding_via_classify(self) -> None:
+        # Acceptance path: the finding must ride the cycle-status material
+        # channel, not merely the raw detector return -- and with no gh-bot.sh
+        # (token wrapper) in the loop at all.
+        pr = self._recorded_write("personal")
+        prev = make_prev(review_trigger={"request_history":
+                                         {HEAD: {"comment_id": "100"}}})
+        result = delta.classify_pr(pr, prev, None, OBS, config=self._config())
+        self.assertTrue(result["attribution_drift"]["detected"])
+        self.assertTrue(
+            any("attribution drift" in finding
+                for finding in result["material_findings"]),
+            result["material_findings"],
+        )
+
+
 class SuppressibleDeltaArmTests(unittest.TestCase):
     """Each suppressible arm: reason present only when NOT direct-gate-ready."""
 

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_pr_queue_snapshot.py
@@ -174,5 +174,36 @@ class BuildConfigSelfLoginsTests(unittest.TestCase):
         self.assertEqual(config.self_logins, frozenset({"alice"}))
 
 
+class SinglePrScopeSelfLoginTests(unittest.TestCase):
+    """`--pr` scope must resolve @me into the self-login set, not just discovery.
+
+    Regression: the single-PR path once skipped `resolve_self_logins`, so the
+    personal fallback identity was absent from `self_logins` and every
+    same-login check (foreign-activity, attribution-drift) silently no-opped for
+    single-PR runs even though `--pr` scope is a supported invocation.
+    """
+
+    def test_single_pr_run_resolves_me_into_self_logins(self) -> None:
+        with tempfile.TemporaryDirectory() as state_dir:
+            args = argparse.Namespace(
+                pr="owner/repo#1",
+                author="@me",
+                state_dir=state_dir,
+                write_state=False,
+            )
+            # view_pr raises so the per-PR loop is a no-op; the assertion is
+            # about the identity resolution that runs before it.
+            with mock.patch.object(gh, "resolve_author", return_value="kyle-sexton"), \
+                 mock.patch.object(gh, "resolve_authors", return_value=[]), \
+                 mock.patch.object(
+                     gh, "parse_repo_number", return_value=("owner/repo", 1)
+                 ), \
+                 mock.patch.object(
+                     gh, "view_pr", side_effect=RuntimeError("stop")
+                 ):
+                snapshot.build_snapshot(args)
+            self.assertIn("kyle-sexton", args.resolved_self_logins)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

On a safe-tier worker run against `melodic-software/medley`, the consumer's identity wrapper reported "Bot token generation failed, using personal identity" and every write silently landed authored as the personal user. The fallback was local-log-only: nothing reached the babysit orchestrator or the PR, so attribution drifted with no signal unless a human read the worker transcript.

Per the maintainer decision on #450, the token machinery itself is sound where creds are bound — the medley-session failure is environment/scope-specific (unbound creds or the App not installed on that repo), owned by medley (`tools/github-auth/gh-bot.sh`) and tracked separately. This repo's actionable fix is **observability**: make the silent bot→personal degrade a first-class, orchestrator-visible finding. No `gh-bot.sh` change is required for the finding to fire.

## Change

Adds an `attribution_drift` reconciliation arm to the babysit-prs snapshot engine, extending the existing ledger↔timeline reconciliation with an intended-write-identity dimension:

- **New concept.** `babysit_self_logins` defines *acceptable-as-mine*, not *intended-as-author*. This introduces the intended-write-identity notion via a new `babysit_intended_write_identity` userConfig key (threaded as `--intended-write-identity` to the snapshot).
- **Detection.** For each write the mutation ledger recorded performing, the arm verifies the landed timeline author is the intended write-identity, not merely *some* accepted self-login. A recorded write that landed under a different self-login — the canonical bot-token-fallback-to-personal case — is attribution drift.
- **Surface.** It rides the existing material-finding / cycle-status channel (the same surface `foreign_activity` uses), naming the drift and the affected PR on that PR's status line. No new silent-log-only path.
- **Complement of `foreign_activity`, not a change to it.** That arm reconciles same-login timeline events the ledger *cannot* account for; this reconciles the writes it *did* record. They are mutually exclusive per comment (in-ledger vs not-in-ledger), so the new dimension is purely additive. Unlike `foreign_activity`, drift **reports without suppressing dispatch** — the PR is still ours to babysit; only a past write's authorship is wrong.
- **Degrade behavior.** Dormant when no intended write-identity is configured, so an unconfigured classifier never fires false positives.

Coverage is bounded to the write class the ledger records with a recoverable author (review-trigger comments); drift on reactions, classification replies, and branch pushes is out of reach until the ledger records their identifiers with authorship (see deferred follow-up below).

Docs updated: `SKILL.md` (config table row + snapshot invocation threading), `reference/orchestration.md` (the arm, and why it reports rather than suppresses), `CHANGELOG.md` (0.11.0). Version bumped `0.10.0` → `0.11.0`.

## Verification

- New unit + full-classify regression tests in `test_babysit_delta.py` (`AttributionDriftTests`): dormant-without-intended, detects-drift, no-drift-when-intended, unledgered-write-is-not-drift, and the acceptance path — the finding lands in `material_findings` via `classify_pr` with no `gh-bot.sh` in the loop (trivially true; there is no `gh-bot.sh` in this repo).
- Full engine suite green (224 tests, up from 217), `ruff` clean, guarded-wrapper behavior checks pass.
- `markdownlint-cli2` and `typos` clean on all changed markdown; `git diff --check` clean.

## Deferred follow-up (not filed)

- Broaden the babysit mutation ledger to record reaction, classification-reply, and branch-push identifiers with authorship, then extend `attribution_drift` detection to those write classes — closing the coverage gap this PR's review-trigger-only reconciliation leaves.

Closes #450.

## Related

- #450 — this PR.
- #476 — autopilot merge tier; lists #450 as a prerequisite. **Unblocked by** this PR (stronger write autonomy makes silent attribution drift materially worse, so drift must be orchestrator-visible first); not addressed here.
- #454 — sibling issue in the same bot-identity / permissions cluster. **Not addressed here.**
- medley `tools/github-auth/gh-bot.sh` — the token-generation root cause (bot token mint failing and falling back). **Cross-repo, owned by and tracked against medley; no change here** — this PR only makes the drift visible.

🤖 Generated with a Claude Code implementation subagent (issue #450)
