### PR TITLE
feat(ci): add portability-lint gate for ecosystem/forge-agnostic skills (#531)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,33 @@ jobs:
           schemafile: plugins/skill-quality/reference/evals.schema.json
           files: plugins/*/skills/*/evals/evals.json
 
+  # Portability lint: skills declared ecosystem/forge/tracker-agnostic must not
+  # ship bare hardcoded stack/forge/branch/tracker defaults — the coupling class
+  # the external reviewer re-caught PR after PR. On a PR it scans the skill files
+  # the change touches (not the whole corpus) against the coupling-token list, so
+  # enabling a token class prevents NEW coupling without red-lining existing
+  # violations that member issues own. The job itself never skips (a skipped
+  # required job reports success to branch protection) — only the PR-diff step is
+  # event-gated, and the self-test gives push a passing path and stops a broken
+  # detector masking a real violation behind a green gate.
+  portability-lint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the PR base ref resolves for the changed-file diff.
+          fetch-depth: 0
+      - name: Test the portability gate
+        run: bash scripts/check-skill-portability.test.sh
+      - name: Gate changed skill files on the portability contract
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-skill-portability.sh "origin/$BASE_REF"
+
   runner-policy:
     name: Runner policy
     runs-on: ubuntu-24.04
@@ -408,6 +435,7 @@ jobs:
       - miro-plugin
       - runner-policy
       - skill-quality-gate
+      - portability-lint
       - zizmor
     # Fail-closed through execution: !cancelled() (never a success-guard) so a
     # lane failure still runs this required aggregate and the result join below

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -135,6 +135,14 @@ as defaults. This governs every plugin and every convention, not one class. Two 
    table assuming them. A convention a consumer could reasonably do differently belongs in lane 2, as
    a discovered-and-externalized extensibility point, never as a lane-1 default.
 
+A bare lane-1 hardcode in a skill declared agnostic — a fixed default branch, forge, ecosystem, or
+tracker where the consuming repo could reasonably differ — is a defect, mechanically caught rather
+than asserted only in prose. A detection-first or presence-gated use is compliant. A capability
+genuinely and inherently locked to one branch, forge, ecosystem, or tracker declares that narrower,
+inherent scope at the coupling site — the same declared-narrower-boundary allowance the
+cross-platform contract makes for OS platform — rather than shipping the assumption bare under a
+neutral name.
+
 ## Configuration ownership and scope
 
 Choose one authoritative owner for each value:

--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -137,13 +137,17 @@ scan_file() {
   awk '
     function is_annotated(l) { return l ~ /portability-ok:/ }
     function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /<!--/ }
-    # Guard markers for the active branch class: a detection-first ladder or a
-    # presence-gated use, which is the correct pattern, not a bare assumption.
+    # Guard markers for the active branch class: branch-detection evidence ONLY
+    # (a symbolic-ref / merge-base / origin/HEAD ladder that documents an
+    # origin/main last-resort fallback is the correct pattern, not a bare
+    # assumption). Generic optional-dependency presence prose ("if using",
+    # "when present") is NOT branch-resolution evidence and must not sanction a
+    # bare branch default; a future class that genuinely needs presence guards
+    # adds its own class-scoped markers here when it is enabled.
     function is_guarded(l) {
       return l ~ /origin\/HEAD/ || l ~ /symbolic-ref/ || l ~ /merge-base/ ||
         l ~ /baseRefName/ || l ~ /[Ff]allback/ || l ~ /[Ff]alling back/ ||
-        l ~ /-> *origin\// || l ~ /if installed/ || l ~ /if using/ ||
-        l ~ /when installed/ || l ~ /when present/
+        l ~ /-> *origin\//
     }
     # Pass 1: collect active ERE patterns from the token list.
     FNR == NR {
@@ -180,7 +184,13 @@ for file in "${files[@]}"; do
     printf 'Error: no such file: %s\n' "$file" >&2
     exit 2
   fi
-  out="$(scan_file "$file")"
+  # Propagate a scanner fault (e.g. a malformed active ERE token makes awk exit
+  # non-zero with no stdout): without this the empty $out reads as "clean" and
+  # the file is silently skipped — the exact false negative fail-closed forbids.
+  out="$(scan_file "$file")" || {
+    printf 'Error: gate scanner failed on %s — failing closed\n' "$file" >&2
+    exit 2
+  }
   if [[ -n "$out" ]]; then
     while IFS= read -r v; do
       echo "COUPLING: ${file}:${v}" >&2

--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -112,7 +112,11 @@ case "$mode" in
   fi
   # Diff on plugins/ then filter the skill path in-script: a `plugins/*/skills/`
   # git pathspec does not match under git's default (non-pathname) globbing.
-  while IFS= read -r f; do
+  # NUL-delimited (-z) so a pathname Git would C-quote (non-ASCII bytes under the
+  # default core.quotePath, or a literal quote/backslash) arrives verbatim: a
+  # quoted `"plugins/…"` would miss the glob below and the file would be silently
+  # dropped — the silent exclusion the contract forbids.
+  while IFS= read -r -d '' f; do
     case "$f" in
     plugins/*/skills/*) ;;
     *) continue ;;
@@ -120,7 +124,7 @@ case "$mode" in
     is_scannable "$f" || continue
     [[ -f "$f" ]] || continue # a rename-away/deletion leaves nothing to scan
     files+=("$f")
-  done < <(git diff --name-only --diff-filter=d "$base" -- 'plugins/' | sort -u)
+  done < <(git diff --name-only --diff-filter=d -z "$base" -- 'plugins/' | sort -z -u)
   ;;
 esac
 

--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -31,9 +31,12 @@
 # violations wait for the owning follow-up fix or the file's next edit.
 #
 # A token hit fails UNLESS one of three reviewer-visible escapes applies:
-#   1. detection-first / presence-gated use — auto-recognized guard markers on
-#      the hit line (an `origin/HEAD` / symbolic-ref / merge-base ladder that
-#      falls back to origin/main is the CORRECT pattern, not a bare assumption);
+#   1. a detection-first resolution use — an auto-recognized branch-resolution
+#      command on the hit line (an `origin/HEAD` / symbolic-ref / merge-base /
+#      PR-baseRefName ladder that falls back to origin/main is the CORRECT
+#      pattern, not a bare assumption); the resolution command is the evidence,
+#      not the surrounding prose, so a bare default whose resolution is not
+#      co-located on the line flags and uses a per-site portability-ok escape;
 #   2. a per-site recorded exemption `portability-ok: <reason>` on the hit line
 #      or in the contiguous comment block directly above it;
 #   3. a whole-file `portability-scope: <reason>` declaration anywhere in the
@@ -138,16 +141,20 @@ scan_file() {
     function is_annotated(l) { return l ~ /portability-ok:/ }
     function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /<!--/ }
     # Guard markers for the active branch class: branch-detection evidence ONLY
-    # (a symbolic-ref / merge-base / origin/HEAD ladder that documents an
-    # origin/main last-resort fallback is the correct pattern, not a bare
-    # assumption). Generic optional-dependency presence prose ("if using",
-    # "when present") is NOT branch-resolution evidence and must not sanction a
-    # bare branch default; a future class that genuinely needs presence guards
-    # adds its own class-scoped markers here when it is enabled.
+    # — a symbolic-ref / merge-base / origin/HEAD / PR-baseRefName resolution
+    # command (or a `-> origin/` symbolic-ref target) co-located on the hit line.
+    # The resolution command IS the evidence; prose alone is not. So the bare
+    # word "fallback" / "falling back" is NOT a marker (an unrelated "as a
+    # fallback, run git diff origin/main" imposes main with no resolution
+    # evidence), nor is optional-dependency presence prose ("if using",
+    # "when present"). A bare default whose resolution evidence is not
+    # co-located on the line must flag — a reviewer cannot see it is guarded
+    # either; a legitimately split-across-lines ladder uses the per-site
+    # portability-ok escape. A future class needing other markers adds them
+    # here when it is enabled.
     function is_guarded(l) {
       return l ~ /origin\/HEAD/ || l ~ /symbolic-ref/ || l ~ /merge-base/ ||
-        l ~ /baseRefName/ || l ~ /[Ff]allback/ || l ~ /[Ff]alling back/ ||
-        l ~ /-> *origin\//
+        l ~ /baseRefName/ || l ~ /-> *origin\//
     }
     # Pass 1: collect active ERE patterns from the token list.
     FNR == NR {
@@ -204,7 +211,8 @@ if ((violations > 0)); then
     echo
     echo "A skill declared ecosystem/forge/tracker-agnostic must not hardcode a"
     echo "stack/forge/branch/tracker default. Resolve the coupling, or — when the"
-    echo "use is legitimate — make it detection-first/presence-gated, add a"
+    echo "use is legitimate — co-locate the branch-resolution command on the"
+    echo "line (detection-first), add a"
     echo "'portability-ok: <reason>' comment at the site, or declare an inherent"
     echo "narrower scope with 'portability-scope: <reason>' in the file."
   } >&2

--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Portability-lint gate: skills declared ecosystem/forge/tracker-agnostic must
+# not ship bare hardcoded stack/forge/branch/tracker defaults. The agnosticism
+# contract lives in docs/PLUGIN-PHILOSOPHY.md (Design boundary,
+# Two-lane convention posture, Cross-platform contract's declared-narrower-scope
+# allowance); prose states it but cannot self-verify, so this gate turns the
+# assertion into a mechanical check.
+#
+#   scripts/check-skill-portability.sh <base-ref>   gate skill files a PR changed
+#   scripts/check-skill-portability.sh --all         audit every skill file
+#   scripts/check-skill-portability.sh --paths F...   scan exactly these files
+#
+# WHAT is detected is data, not logic: the coupling tokens live in
+# scripts/skill-portability-tokens.txt (override with SKILL_PORTABILITY_TOKENS),
+# one ERE pattern per active line, so a reviewer re-catch is a one-line data edit
+# and rollout stages one token-class at a time. HOW a legitimate hit is excused
+# is this script's job.
+#
+# Scope declaration, resolved per the ratified declaration-first plan: no new
+# frontmatter field. A skill is agnostic by default — the Design boundary already
+# binds every plugin — so the gated set is "the skill files a change touches",
+# exactly as the skill-quality gate scopes itself. A skill with an inherent,
+# declared narrower scope (a genuinely forge- or ecosystem-locked capability
+# under a neutral name) opts out with a reviewer-visible comment, reusing the
+# annotated-exemption shape the silent-skip gate established rather than inventing
+# a declaration mechanism.
+#
+# Changed-FILE (not whole-skill-dir) scoping keeps a PR responsible only for the
+# files it actually edits, so enabling a token class never red-lines main: main's
+# push event scans nothing (the self-test is the push path), and existing
+# violations wait for the owning follow-up fix or the file's next edit.
+#
+# A token hit fails UNLESS one of three reviewer-visible escapes applies:
+#   1. detection-first / presence-gated use — auto-recognized guard markers on
+#      the hit line (an `origin/HEAD` / symbolic-ref / merge-base ladder that
+#      falls back to origin/main is the CORRECT pattern, not a bare assumption);
+#   2. a per-site recorded exemption `portability-ok: <reason>` on the hit line
+#      or in the contiguous comment block directly above it;
+#   3. a whole-file `portability-scope: <reason>` declaration anywhere in the
+#      file (the inherent, declared narrower boundary).
+#
+# This is a grep-level tripwire, not a semantic proof. Guard markers are seeded
+# for the one active class (branch/default-branch); enabling a further class
+# revisits them here, proven against an `--all` audit first.
+#
+# Files scanned within a changed skill: *.md and *.sh, excluding *.test.sh (test
+# fixtures), vendor/ (upstream-synced copies with their own drift gate), and
+# evals/ (eval fixtures carry adversarial example prompts by design).
+#
+# Exit 0 = clean (or nothing in scope); 1 = one or more violations; 2 = usage /
+# environment error (fail closed — never a silent skip).
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+TOKENS="${SKILL_PORTABILITY_TOKENS:-scripts/skill-portability-tokens.txt}"
+if [[ ! -f "$TOKENS" ]]; then
+  printf 'Error: token list not found: %s\n' "$TOKENS" >&2
+  exit 2
+fi
+
+usage() {
+  printf 'usage: check-skill-portability.sh <base-ref> | --all | --paths FILE...\n' >&2
+  exit 2
+}
+
+# is_scannable <path> — a skill file the gate authors are responsible for.
+is_scannable() {
+  local f="$1"
+  case "$f" in
+  */vendor/* | */evals/*) return 1 ;;
+  *.test.sh) return 1 ;;
+  *.md | *.sh) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# Resolve the file set for the requested mode.
+files=()
+if (($# == 0)); then
+  usage
+fi
+
+mode="$1"
+case "$mode" in
+--all)
+  shift
+  (($# == 0)) || usage
+  while IFS= read -r f; do
+    is_scannable "$f" && files+=("$f")
+  done < <(find plugins -type f -path 'plugins/*/skills/*' \( -name '*.md' -o -name '*.sh' \) | sort)
+  ;;
+--paths)
+  shift
+  (($# > 0)) || usage
+  files=("$@")
+  ;;
+-*)
+  usage
+  ;;
+*)
+  # Changed-file mode: <base-ref>.
+  base="$mode"
+  shift
+  (($# == 0)) || usage
+  if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+    printf 'Error: base ref %s is not a valid commit\n' "$base" >&2
+    exit 2
+  fi
+  # Diff on plugins/ then filter the skill path in-script: a `plugins/*/skills/`
+  # git pathspec does not match under git's default (non-pathname) globbing.
+  while IFS= read -r f; do
+    case "$f" in
+    plugins/*/skills/*) ;;
+    *) continue ;;
+    esac
+    is_scannable "$f" || continue
+    [[ -f "$f" ]] || continue # a rename-away/deletion leaves nothing to scan
+    files+=("$f")
+  done < <(git diff --name-only --diff-filter=d "$base" -- 'plugins/' | sort -u)
+  ;;
+esac
+
+if ((${#files[@]} == 0)); then
+  echo "No skill files in scope — nothing to gate."
+  exit 0
+fi
+
+# scan_file <path> — print `LINE: token -> text` for each unexcused hit.
+scan_file() {
+  local file="$1"
+  # A whole-file declared narrower scope (the inherent-boundary case) excuses
+  # every hit in the file; the declaration is visible in the diff.
+  if grep -qE 'portability-scope:' -- "$file"; then
+    return 0
+  fi
+  awk '
+    function is_annotated(l) { return l ~ /portability-ok:/ }
+    function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /<!--/ }
+    # Guard markers for the active branch class: a detection-first ladder or a
+    # presence-gated use, which is the correct pattern, not a bare assumption.
+    function is_guarded(l) {
+      return l ~ /origin\/HEAD/ || l ~ /symbolic-ref/ || l ~ /merge-base/ ||
+        l ~ /baseRefName/ || l ~ /[Ff]allback/ || l ~ /[Ff]alling back/ ||
+        l ~ /-> *origin\// || l ~ /if installed/ || l ~ /if using/ ||
+        l ~ /when installed/ || l ~ /when present/
+    }
+    # Pass 1: collect active ERE patterns from the token list.
+    FNR == NR {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      if (line == "" || line ~ /^#/) next
+      patterns[++np] = line
+      next
+    }
+    # Pass 2: scan the target file.
+    {
+      line = $0
+      annotated_above = pending_annot
+      if (is_comment(line)) {
+        if (is_annotated(line)) pending_annot = 1
+      } else {
+        pending_annot = 0
+      }
+      for (i = 1; i <= np; i++) {
+        if (line ~ patterns[i]) {
+          if (is_annotated(line) || annotated_above) continue
+          if (is_guarded(line)) continue
+          printf "%d: %s -> %s\n", FNR, patterns[i], line
+        }
+      }
+    }
+  ' "$TOKENS" "$file"
+}
+
+violations=0
+for file in "${files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    printf 'Error: no such file: %s\n' "$file" >&2
+    exit 2
+  fi
+  out="$(scan_file "$file")"
+  if [[ -n "$out" ]]; then
+    while IFS= read -r v; do
+      echo "COUPLING: ${file}:${v}" >&2
+      violations=$((violations + 1))
+    done <<<"$out"
+  fi
+done
+
+if ((violations > 0)); then
+  {
+    echo
+    echo "A skill declared ecosystem/forge/tracker-agnostic must not hardcode a"
+    echo "stack/forge/branch/tracker default. Resolve the coupling, or — when the"
+    echo "use is legitimate — make it detection-first/presence-gated, add a"
+    echo "'portability-ok: <reason>' comment at the site, or declare an inherent"
+    echo "narrower scope with 'portability-scope: <reason>' in the file."
+  } >&2
+  exit 1
+fi
+echo "No unexcused coupling tokens in ${#files[@]} skill file(s)."

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -82,6 +82,17 @@ else
 fi
 rm -f "$f"
 
+# --- the bare word "fallback" does NOT guard a bare branch default ----------
+f="$(tmpfile 'As a fallback for a network timeout, run git diff origin/main.')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "standalone 'fallback' prose must not guard a bare branch default: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "standalone 'fallback' prose does not guard the active branch token"
+else
+  fail "expected line 1 flagged for bare origin/main under 'fallback' prose, got: $out"
+fi
+rm -f "$f"
+
 # --- a malformed active token fails closed (exit 2), not a silent pass ------
 BAD_TOKENS="$(mktemp)"
 printf 'origin/(main\n' >"$BAD_TOKENS" # unmatched '(' — invalid ERE, awk faults

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -71,6 +71,29 @@ else
 fi
 rm -f "$f"
 
+# --- generic presence prose does NOT guard a bare branch default -----------
+f="$(tmpfile 'If using a rebase workflow, diff origin/main first.')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "generic 'if using' prose must not guard a bare branch default: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "generic optional-dependency prose does not guard the active branch token"
+else
+  fail "expected line 1 flagged for bare origin/main under 'if using' prose, got: $out"
+fi
+rm -f "$f"
+
+# --- a malformed active token fails closed (exit 2), not a silent pass ------
+BAD_TOKENS="$(mktemp)"
+printf 'origin/(main\n' >"$BAD_TOKENS" # unmatched '(' — invalid ERE, awk faults
+f="$(tmpfile 'diff against origin/main here')"
+SKILL_PORTABILITY_TOKENS="$BAD_TOKENS" bash "$SCRIPT" --paths "$f" >/dev/null 2>&1
+if [[ "$?" -eq 2 ]]; then
+  ok "malformed active token exits 2 (fail closed, no silent pass)"
+else
+  fail "malformed active token should exit 2, not silently treat the file as clean"
+fi
+rm -f "$f" "$BAD_TOKENS"
+
 # --- same-line portability-ok annotation passes ----------------------------
 f="$(tmpfile 'reset --hard origin/main <!-- portability-ok: fixture asserts the hardcode on purpose -->')"
 if scan_paths "$f" >/dev/null 2>&1; then
@@ -97,10 +120,10 @@ now a plain line
 diff against origin/main again')"
 if out="$(scan_paths "$f" 2>&1)"; then
   fail "annotation should not sanction a later hit, got success: $out"
-elif echo "$out" | grep -q ":4:"; then
-  ok "annotation does not leak past intervening code"
+elif echo "$out" | grep -q ":4:" && ! echo "$out" | grep -q ":2:"; then
+  ok "annotation covers line 2 only and does not leak past intervening code"
 else
-  fail "expected only line 4 flagged, got: $out"
+  fail "expected line 4 flagged and line 2 clean, got: $out"
 fi
 rm -f "$f"
 

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Unit tests for check-skill-portability.sh. Synthetic cases run through --paths
+# mode against files in a temp dir with a minimal single-pattern token list
+# (SKILL_PORTABILITY_TOKENS); the exclusion case builds a synthetic plugins/ tree
+# and runs the script's --all mode from a fixture root, exactly as the
+# silent-skip suite does. Two cases run against the REAL corpus to prove the
+# bare-vs-guarded discrimination on live files, not only synthetic ones.
+# shellcheck disable=SC2016  # fixture bodies are literal skill content in single quotes; expansion is never wanted
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+SCRIPT="$SELF_DIR/check-skill-portability.sh"
+REAL_TOKENS="$REPO_ROOT/scripts/skill-portability-tokens.txt"
+
+# Minimal token list: just the active branch class, so a synthetic case is not
+# coupled to the shipping list's staged entries.
+TEST_TOKENS="$(mktemp)"
+printf 'origin/(main|master)\n' >"$TEST_TOKENS"
+trap 'rm -f "$TEST_TOKENS"' EXIT
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# scan_paths <file>... — run the gate over explicit paths with the test tokens.
+scan_paths() {
+  SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash "$SCRIPT" --paths "$@"
+}
+
+tmpfile() {
+  local f
+  f="$(mktemp --suffix=.md)"
+  printf '%s\n' "$1" >"$f"
+  printf '%s' "$f"
+}
+
+# --- bare origin/main fails with file:line ---------------------------------
+f="$(tmpfile 'Base the diff on origin/main for the review.')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "bare origin/main should fail, got success: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "bare origin/main fails with file:line"
+else
+  fail "expected COUPLING with file:line, got: $out"
+fi
+rm -f "$f"
+
+# --- bare origin/master also fails -----------------------------------------
+f="$(tmpfile 'git checkout -b feature origin/master')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  fail "bare origin/master should fail"
+else
+  ok "bare origin/master fails"
+fi
+rm -f "$f"
+
+# --- detection-ladder use (origin/HEAD fallback) passes --------------------
+f="$(tmpfile 'git merge-base origin/HEAD HEAD (falling back to origin/main, then HEAD)')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "detection-first ladder passes (guarded)"
+else
+  fail "detection-ladder use should pass"
+fi
+rm -f "$f"
+
+# --- same-line portability-ok annotation passes ----------------------------
+f="$(tmpfile 'reset --hard origin/main <!-- portability-ok: fixture asserts the hardcode on purpose -->')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "same-line portability-ok passes"
+else
+  fail "same-line portability-ok should pass"
+fi
+rm -f "$f"
+
+# --- portability-ok in the comment block above passes ----------------------
+f="$(tmpfile '<!-- portability-ok: this reference is intentionally pinned -->
+The base branch is origin/main here.')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "comment-block-above portability-ok passes"
+else
+  fail "comment-block-above portability-ok should pass"
+fi
+rm -f "$f"
+
+# --- annotation does not leak past intervening code ------------------------
+f="$(tmpfile '<!-- portability-ok: covers only the next line -->
+diff against origin/main here
+now a plain line
+diff against origin/main again')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "annotation should not sanction a later hit, got success: $out"
+elif echo "$out" | grep -q ":4:"; then
+  ok "annotation does not leak past intervening code"
+else
+  fail "expected only line 4 flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- whole-file portability-scope declaration passes -----------------------
+f="$(tmpfile '<!-- portability-scope: forge=github — inherent, declared boundary -->
+This skill diffs origin/main and pushes with origin/master.')"
+if scan_paths "$f" >/dev/null 2>&1; then
+  ok "whole-file portability-scope passes"
+else
+  fail "whole-file portability-scope should pass"
+fi
+rm -f "$f"
+
+# --- staged (commented) tokens stay inactive under the REAL token list -----
+f="$(mktemp --suffix=.md)"
+printf '%s\n' 'This agnostic skill mentions dotnet and raw.githubusercontent.com.' >"$f"
+if SKILL_PORTABILITY_TOKENS="$REAL_TOKENS" bash "$SCRIPT" --paths "$f" >/dev/null 2>&1; then
+  ok "staged tokens (dotnet, raw.githubusercontent) are inactive in the shipped list"
+else
+  fail "shipped list should only enforce the active branch class"
+fi
+rm -f "$f"
+
+# --- missing token list fails closed (exit 2) ------------------------------
+f="$(tmpfile 'origin/main')"
+SKILL_PORTABILITY_TOKENS="/nonexistent/tokens.txt" bash "$SCRIPT" --paths "$f" >/dev/null 2>&1
+if [[ "$?" -eq 2 ]]; then
+  ok "missing token list exits 2 (fail closed)"
+else
+  fail "missing token list should exit 2"
+fi
+rm -f "$f"
+
+# --- an invalid base ref fails closed (exit 2) -----------------------------
+(cd "$REPO_ROOT" && SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash "$SCRIPT" definitely-not-a-ref >/dev/null 2>&1)
+if [[ "$?" -eq 2 ]]; then
+  ok "invalid base ref exits 2 (fail closed)"
+else
+  fail "invalid base ref should exit 2"
+fi
+
+# --- --all excludes vendor/, evals/, and *.test.sh -------------------------
+fx="$(mktemp -d)"
+mkdir -p "$fx/scripts" "$fx/plugins/alpha/skills/x/vendor" "$fx/plugins/alpha/skills/x/evals"
+cp "$SCRIPT" "$fx/scripts/"
+printf 'diff against origin/main\n' >"$fx/plugins/alpha/skills/x/SKILL.md"
+printf 'origin/main\n' >"$fx/plugins/alpha/skills/x/vendor/upstream.md"
+printf 'origin/main\n' >"$fx/plugins/alpha/skills/x/evals/e.md"
+printf 'origin/main\n' >"$fx/plugins/alpha/skills/x/gen.test.sh"
+out="$(cd "$fx" && SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash scripts/check-skill-portability.sh --all 2>&1)"
+rc=$?
+if [[ "$rc" -ne 0 ]] &&
+  echo "$out" | grep -q 'skills/x/SKILL.md' &&
+  ! echo "$out" | grep -qE 'vendor/|evals/|test\.sh'; then
+  ok "--all scans SKILL.md but excludes vendor/, evals/, and *.test.sh"
+else
+  fail "--all exclusion set wrong (rc=$rc): $out"
+fi
+rm -rf "$fx"
+
+# --- empty scope passes ----------------------------------------------------
+fx="$(mktemp -d)"
+mkdir -p "$fx/scripts" "$fx/plugins"
+cp "$SCRIPT" "$fx/scripts/"
+if (cd "$fx" && SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash scripts/check-skill-portability.sh --all >/dev/null 2>&1); then
+  ok "empty skill tree passes"
+else
+  fail "empty skill tree should pass"
+fi
+rm -rf "$fx"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -209,7 +209,7 @@ rm -rf "$fx"
 # --- diff-mode reads a Git-quoted (non-ASCII) changed path -----------------
 # A changed file whose pathname triggers Git's C-style quoting (here a non-ASCII
 # byte; core.quotePath defaults on) must still be gated. Without -z, git diff
-# emits `"plugins/.../caf\303\251.md"`, the leading quote misses the
+# emits `"plugins/.../quoted-\303\251.md"`, the leading quote misses the
 # plugins/*/skills/* glob, and the file is silently dropped — the silent
 # exclusion the contract forbids. The fixture commits one ASCII-named and one
 # non-ASCII-named coupling file, then diffs against the empty base commit: the
@@ -219,7 +219,7 @@ rm -rf "$fx"
 fx="$(mktemp -d)"
 mkdir -p "$fx/scripts"
 cp "$SCRIPT" "$fx/scripts/"
-quoted_name="$(printf 'caf\303\251.md')" # café.md in UTF-8 — non-ASCII, triggers Git quoting
+quoted_name="$(printf 'quoted-\303\251.md')" # trailing U+00E9 byte — non-ASCII, triggers Git quoting
 out="$(
   cd "$fx" &&
     git init -q &&

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -206,6 +206,44 @@ else
 fi
 rm -rf "$fx"
 
+# --- diff-mode reads a Git-quoted (non-ASCII) changed path -----------------
+# A changed file whose pathname triggers Git's C-style quoting (here a non-ASCII
+# byte; core.quotePath defaults on) must still be gated. Without -z, git diff
+# emits `"plugins/.../caf\303\251.md"`, the leading quote misses the
+# plugins/*/skills/* glob, and the file is silently dropped — the silent
+# exclusion the contract forbids. The fixture commits one ASCII-named and one
+# non-ASCII-named coupling file, then diffs against the empty base commit: the
+# ASCII hit proves -z left the common path intact, and two COUPLING lines prove
+# the quoted path was read, not skipped. The non-ASCII name is built with octal
+# escapes so this test source stays pure ASCII.
+fx="$(mktemp -d)"
+mkdir -p "$fx/scripts"
+cp "$SCRIPT" "$fx/scripts/"
+quoted_name="$(printf 'caf\303\251.md')" # café.md in UTF-8 — non-ASCII, triggers Git quoting
+out="$(
+  cd "$fx" &&
+    git init -q &&
+    git config user.email test@example.com &&
+    git config user.name test &&
+    git commit -q --allow-empty -m base &&
+    base="$(git rev-parse HEAD)" &&
+    mkdir -p 'plugins/p/skills/s' &&
+    printf 'diff against origin/main\n' >'plugins/p/skills/s/plain.md' &&
+    printf 'diff against origin/main\n' >"plugins/p/skills/s/${quoted_name}" &&
+    git add -A >/dev/null 2>&1 &&
+    git commit -q -m add-skills &&
+    SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash scripts/check-skill-portability.sh "$base" 2>&1
+)"
+rc=$?
+if [[ "$rc" -ne 0 ]] &&
+  echo "$out" | grep -q 'plain.md:1:' &&
+  [[ "$(echo "$out" | grep -c 'COUPLING:')" -eq 2 ]]; then
+  ok "diff-mode gates a Git-quoted (non-ASCII) changed path (not silently dropped)"
+else
+  fail "diff-mode should flag both the ASCII and non-ASCII coupling files (rc=$rc): $out"
+fi
+rm -rf "$fx"
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/skill-portability-tokens.txt
+++ b/scripts/skill-portability-tokens.txt
@@ -1,0 +1,57 @@
+# Portability-lint token list — coupling tokens that break declared skill
+# agnosticism (issue #531). Each ACTIVE line is one ERE pattern that
+# scripts/check-skill-portability.sh matches against changed skill files.
+#
+# Ownership / growth: this list is the gate's data, deliberately kept OUT of the
+# script so a reviewer re-catch of this coupling class becomes a one-line data
+# change, never a gate-logic edit. Every reviewer re-catch of a bare stack /
+# forge / branch / tracker default is a missing token — add it here (or uncomment
+# a staged class once its member issue lands and the corpus is proven clean for
+# it), closing the loop so the gate is self-improving.
+#
+# Rollout is one token-class at a time (ratified decision on #531, Option A): a
+# staged class stays commented with its enable-trigger until the class is proven
+# green against the real corpus. Changed-file scoping (see the script header)
+# means an active class only ever gates the files a PR actually touches, so
+# enabling a class never red-lines main — it prevents NEW coupling and forces a
+# fix-or-declare when a coupled file is next edited.
+#
+# Format: blank lines and lines beginning with `#` are ignored; every other line
+# is an ERE pattern (leading/trailing whitespace trimmed). Labels live in the
+# comment above each pattern, never on the pattern line.
+#
+# Escaping a legitimate hit (all three are comments the reviewer sees in the diff,
+# never a frontmatter field — see the script header for detection detail):
+#   - a detection-first / presence-gated use is auto-recognized (guard markers);
+#   - a per-site recorded exemption:  `portability-ok: <reason>`;
+#   - a whole-file inherent, declared narrower scope (the #441 case):
+#     `portability-scope: <reason>`.
+
+# --- ACTIVE ---
+
+# Branch / default-branch hardcode (the #467 review-churn class: "branch/remote
+# x4"). A bare `origin/main` / `origin/master` asserts the consumer's default
+# branch instead of resolving it (symbolic-ref / merge-base / origin/HEAD, with
+# origin/main only as a documented last-resort fallback — those detection-ladder
+# uses are auto-recognized as guarded).
+origin/(main|master)
+
+# --- STAGED (commented until the class is proven clean against the corpus) ---
+
+# Ecosystem hardcode: .NET-flavored defaults in an ecosystem-agnostic skill
+# (#491 #492). Enable when the .NET-example member issues land and an audit run
+# (`--all`) shows the agnostic skills clean (ecosystem-specific plugins declare
+# `portability-scope`). Bare token is high-volume in the corpus today (56 files).
+# dotnet
+# \bClean Arch(itecture)?\b
+
+# Forge/marketplace-internal hardcode: a hardcoded raw GitHub content URL where a
+# portable fetch or a declared scope belongs. Enable when #405 and the forge-lock
+# members (e.g. #441 declares source-control's inherent GitHub scope) land.
+# raw\.githubusercontent\.com
+
+# Tracker hardcode: bare `gh` tracker calls in a tracker-agnostic skill that
+# should route the work-item seam (#416). Enable once the seam-routing members
+# land; `gh` is legitimate in forge-scope-declared skills, so this class needs
+# the declared-scope escape hatch exercised first.
+# \bgh (issue|api|pr|label)

--- a/scripts/skill-portability-tokens.txt
+++ b/scripts/skill-portability-tokens.txt
@@ -39,12 +39,13 @@ origin/(main|master)
 # --- STAGED (commented until the class is proven clean against the corpus) ---
 #
 # Before enabling ANY staged class below, beyond the corpus audit:
-#   - Audit and tighten `is_guarded()` in check-skill-portability.sh against the
-#     class's real false-guard risk. Its markers are seeded for the active
-#     branch/default-branch class; the generic presence signals (`if using`,
-#     `when installed`, `when present`) would spuriously guard a bare ecosystem
-#     hardcode like "useful if using .NET — requires dotnet CLI" once the dotnet
-#     or gh class is live — a hardcode, not a legitimately guarded use.
+#   - Audit and EXTEND `is_guarded()` in check-skill-portability.sh with the
+#     markers the new class legitimately needs. Its markers are scoped to the
+#     active branch/default-branch class — branch-detection evidence only. A
+#     class that genuinely needs optional-dependency presence signals (e.g.
+#     "useful if using .NET — requires dotnet CLI") must add its own
+#     class-scoped markers; a generic `if using` / `when present` must never
+#     guard a bare hardcode, or the gate goes green on a real coupling.
 #   - If the pattern uses `\b` as a word boundary, it is NOT reliable: POSIX ERE
 #     defines no word-boundary escape, and on common awks (gawk AND mawk/nawk)
 #     `\b` matches a literal backspace byte, not a boundary — verified: gawk uses

--- a/scripts/skill-portability-tokens.txt
+++ b/scripts/skill-portability-tokens.txt
@@ -37,6 +37,22 @@
 origin/(main|master)
 
 # --- STAGED (commented until the class is proven clean against the corpus) ---
+#
+# Before enabling ANY staged class below, beyond the corpus audit:
+#   - Audit and tighten `is_guarded()` in check-skill-portability.sh against the
+#     class's real false-guard risk. Its markers are seeded for the active
+#     branch/default-branch class; the generic presence signals (`if using`,
+#     `when installed`, `when present`) would spuriously guard a bare ecosystem
+#     hardcode like "useful if using .NET — requires dotnet CLI" once the dotnet
+#     or gh class is live — a hardcode, not a legitimately guarded use.
+#   - If the pattern uses `\b` as a word boundary, it is NOT reliable: POSIX ERE
+#     defines no word-boundary escape, and on common awks (gawk AND mawk/nawk)
+#     `\b` matches a literal backspace byte, not a boundary — verified: gawk uses
+#     `\y` for that, and `\bdotnet\b` matches nothing here. So a `\b`-anchored
+#     class silently never matches (gate stays green while missing real
+#     violations). Rewrite to a POSIX-safe boundary before activating, e.g.
+#     `(^|[^a-zA-Z0-9_])dotnet([^a-zA-Z0-9_]|$)`, or a simpler `[Dd]otnet`-style
+#     alternative.
 
 # Ecosystem hardcode: .NET-flavored defaults in an ecosystem-agnostic skill
 # (#491 #492). Enable when the .NET-example member issues land and an audit run


### PR DESCRIPTION
## Summary

Skills declared ecosystem/forge/tracker-agnostic ship bare hardcoded
stack/forge/branch/tracker defaults because agnosticism was asserted in prose and
never enforced mechanically — the dominant review-churn class, re-caught by the
external reviewer PR after PR (branch/remote hardcodes, seam-conditional eval,
.NET-flavored examples). This adds a fail-closed CI lane that mechanically detects
that coupling instead of paying for it at review time again and again.

Detection only — this PR builds the gate. Fixing the existing violations stays
with the member issues below.

## Fix

A new `portability-lint` lane (`.github/workflows/ci.yml`) wired into the required
`ci-status` aggregate, plus a repo-local detector:

- **`scripts/check-skill-portability.sh`** — scans skill files for coupling tokens.
  On a PR it scans only the skill files the change **touches** (mirroring the
  `skill-quality-gate` changed-diff pattern), so enabling a token class prevents
  **new** coupling without red-lining pre-existing violations — main's push event
  scans nothing (self-test is the push path), and existing hits wait for their
  owning follow-up fix or the file's next edit.
- **`scripts/skill-portability-tokens.txt`** — the token list as external,
  extensible **data** (not logic buried in bash), so a reviewer re-catch is a
  one-line data edit. Seeded with **one active class** — the branch/default-branch
  hardcode (`origin/main` / `origin/master`) — per the ratified one-token-class-at-
  a-time rollout; further classes (`dotnet`/`Clean Arch`, `raw.githubusercontent`,
  bare `gh` tracker calls) are staged as commented entries with enable-triggers.
- **Never-skip shape**: the job is unconditional; only the PR-diff step is
  event-gated, and a self-test step runs first so a broken detector can never mask
  a real violation behind a green gate.

**Design decisions** (resolved per the ratified plan, not invented):

- *How a skill declares agnosticism scope* — **no new frontmatter field**. A skill
  is agnostic by default (the Design boundary already binds every plugin), so the
  gated set is the files a change touches. A hit is excused three ways, all
  reviewer-visible comments (reusing the silent-skip gate's annotated-exemption
  shape): an auto-recognized detection-first / presence-gated use; a per-site
  `portability-ok: <reason>`; or a whole-file `portability-scope: <reason>`
  declaring an inherent narrower boundary (the forge-locked-under-a-neutral-name
  case). This distinguishes **guarded** refs (fine) from **bare** ones, as the
  guarded-forward-ref disposition requires.
- `docs/PLUGIN-PHILOSOPHY.md` gains one doctrine sentence extending the existing
  declared-narrower-boundary allowance from OS platform to the
  forge/ecosystem/tracker axis.

No `plugins/<name>/` directory is touched, so no version bump / CHANGELOG entry is
needed (matching the CI-gate precedent).

## Verification

- **Self-test suite** (`scripts/check-skill-portability.test.sh`, runs in CI):
  `PASS=12 FAIL=0` — covers bare-token FAIL with file:line, detection-ladder pass,
  same-line and comment-block-above `portability-ok`, annotation non-leak past
  intervening code, whole-file `portability-scope`, staged tokens staying inactive
  under the shipped list, fail-closed exit 2 on missing token list / invalid base
  ref, the vendor/evals/`*.test.sh` exclusion set, and empty scope.

- **Catches a real violation, passes a real legit use** (the bare-vs-guarded
  discrimination that drives this class), on live corpus files:

  ```
  $ scripts/check-skill-portability.sh --paths plugins/work-items/skills/track/actions/start.md
  COUPLING: plugins/work-items/skills/track/actions/start.md:61: origin/(main|master) -> ... git checkout -b <type>/<N>-<slug> origin/main ...
  COUPLING: plugins/work-items/skills/track/actions/start.md:65: origin/(main|master) -> ... git checkout -b <type>/<N>-<slug> origin/main ...
  (exit 1)

  $ scripts/check-skill-portability.sh --paths plugins/review/skills/fanout/SKILL.md
  No unexcused coupling tokens in 1 skill file(s).   # detection-first origin/HEAD ladder → guarded
  (exit 0)
  ```

- **Calibrated against the full corpus** (`--all`): the active branch class flags
  exactly 3 genuine bare hardcodes in 2 files (owned by member issues; changed-file
  scoping keeps them off main) and correctly passes the detection-ladder uses in
  `review/*` and excludes evals/test fixtures.

- **Changed-file CI path proven** against a real base ref (16 changed skills gated,
  all clean). Local checks green: `shellcheck` (repo `.shellcheckrc`), `shfmt`,
  `actionlint`, comment-residue detector (T1=T2=T3=0), `typos`.

Closes #620

Part of #531 (umbrella stays open — stages remain; child #620 carries this PR's shipped scope per the #603 pattern).

## Related

- Member coupling instances (this is prevention; it does not block them): #404
  #405 #406 #408 #410 #412 #415 #416 #418 #421 #422 #423 #428 #429 #432 #438 #439
  #441 #442
- #445 — sibling CI-gate backlog (mechanical conformance only; explicitly not
  coupling)
- #412 — guarded-forward-ref disposition the gate honors (guarded ≠ bare)
- #441 — declared narrower-scope exemption the `portability-scope` mechanism serves
- #467 — the branch/remote review-churn the seed active class targets
- #453 — seam-conditional eval re-catch of this class
- #491 #492 — .NET-flavored-example hand-fixes a future staged class would obviate
- #611 — post-green review finding (annotation-carry pending_annot doesn't distinguish inline vs block HTML comments), deferred out of this PR's scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyLj6oaFVTE6xFuoYCC2KC
