### PR TITLE
feat(repo-hygiene): tree-batch multi-repo clean/tree mode with skip-list + dirty guard

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.0]
+
+### Added
+
+- **`tree-batch` — multi-repo working-tree reset with a skip-list and a dirty guard.**
+  A new `clean` action that runs the `tree` tier across a set of repositories
+  (`ghq list` output via `--repos-from -`, a shell glob, or explicit `--repo`
+  flags) behind a single dry-run -> confirm -> apply gate, then reports a per-repo
+  outcome summary (`would-reset` / `done` / `skipped` / `blocked` / `failed`). It
+  is a thin orchestrator: every per-repo reset delegates to the unchanged
+  `git-tree-reset.sh`, so all single-repo safety gates are reused verbatim and the
+  single-repo behavior is untouched.
+
+  Closes the gap that caused an unrecoverable data loss when an operator
+  hand-rolled a `ghq list` reset loop. Two defects are fixed as first-class
+  behavior: (1) **separator-agnostic skip-matching** — a skip entry and the
+  enumerated repo path are each normalized to a canonical separator-agnostic key
+  (`clean_path_key`) before comparison, so a Windows `\`-path skip entry reliably
+  matches a repo whose path git enumerated with `/` (the exact match that silently
+  failed and reset a repo that should have been skipped); a skip entry matching no
+  repo is surfaced as `UnmatchedSkip:`, never silently ignored. (2) **Dirty-by-
+  default guard** — a repo with uncommitted/untracked changes or unpushed commits
+  is skipped with a reported reason; `--include-dirty` opts in and is gated with
+  its own explicit confirmation, like `--include-secrets`.
+
 ## [0.3.3]
 
 ### Fixed

--- a/plugins/repo-hygiene/README.md
+++ b/plugins/repo-hygiene/README.md
@@ -20,11 +20,26 @@ the conversation, or presents a menu and falls back to the safe `scan`.
 | `build` | Remove build artifacts (`bin`/`obj`/`build`/`dist`/`out`/`target`/`TestResults`, `*.binlog`), includes caches; runs a runtime-detected `dotnet clean` when a `*.slnx`/`*.sln` and `dotnet` are present | Low |
 | `git` | Prune stale worktree/remote metadata and gc; audit branches (merged / PR-merged / stale) and delete only on per-branch opt-in | Low |
 | `tree` | Reset the working tree like a fresh pull — `git reset --hard` + `git clean -fdx` | **Destructive** |
+| `tree-batch` | Run `tree` across many repos (`ghq list`, a glob, or an explicit list) behind one confirmation gate, with a separator-agnostic skip list and a dirty-by-default guard | **Destructive** |
 | `all` | Sweep `caches` + `build` + `git` — **never** the `tree` reset | Medium |
 
 Tiers are cumulative (`build` includes `caches`; `all` = `build` + `git`), and
-`tree` is never composed into `all` — one mistaken sweep cannot trigger a
-`reset --hard`.
+neither `tree` nor `tree-batch` is composed into `all` — one mistaken sweep cannot
+trigger a `reset --hard`.
+
+### Multi-repo reset (`tree-batch`)
+
+`tree-batch` is the supported way to reset a fleet of repos to a fresh-pull state
+without hand-rolling a loop. It skips any repo with uncommitted/untracked changes
+or unpushed commits **by default** (opt in with `--include-dirty`), and its skip
+list is matched separator-agnostically, so a `\`-path skip entry reliably protects
+a repo enumerated with `/` paths — the failure that lost an uncommitted edit in an
+ad-hoc loop. A skip entry that matches nothing is reported, never silently ignored.
+
+```shell
+# Dry-run the whole ghq tree, skipping one repo (the agent shows the plan first):
+ghq list -p | /repo-hygiene:clean tree-batch --repos-from - --skip melodic-software/standards
+```
 
 ## Safety model
 

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: clean
-description: "Repo hygiene action-router: scan (inventory), caches, build, git (prune/branch audit), tree (destructive fresh-pull reset), all. Bare invocation detects intent from conversation or shows a menu. Dry-run-first; destructive actions require explicit confirmation. Use when: clean, disk space, remove caches, build artifacts, fresh pull, fresh clone state, reset to origin, stale branches, repo hygiene. Skip: removing git worktree directories (a worktree-management tool handles those)."
+description: "Repo hygiene action-router: scan (inventory), caches, build, git (prune/branch audit), tree (destructive fresh-pull reset), tree-batch (multi-repo tree reset with skip-list + dirty guard), all. Bare invocation detects intent from conversation or shows a menu. Dry-run-first; destructive actions require explicit confirmation. Use when: clean, disk space, remove caches, build artifacts, fresh pull, fresh clone state, reset to origin, reset all my repos, stale branches, repo hygiene. Skip: removing git worktree directories (a worktree-management tool handles those)."
 user-invocable: true
-argument-hint: "[scan|caches|build|git|tree|all|aliases…] (bare → menu or auto-detect)"
+argument-hint: "[scan|caches|build|git|tree|tree-batch|all|aliases…] (bare → menu or auto-detect)"
 allowed-tools:
   - Bash(bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/*)
 hooks:
@@ -48,9 +48,10 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/resolve-clean-action.sh $ARGUMEN
 | `build` | Clear build output and logs | Low | Yes (includes caches) | — |
 | `git` | Prune stale git metadata; audit branches | Low | No | Yes |
 | `tree` | Reset working tree like a fresh pull | **Destructive** | No (always dry-run first) | **Never** |
+| `tree-batch` | Reset many repos like a fresh pull (skip-list + dirty guard) | **Destructive** | No (always dry-run first) | **Never** |
 | `all` | Sweep caches + build + git hygiene | Medium | Yes | — |
 
-Tiers cumulative: `build` includes `caches`. `all` = `build` + `git`. **`tree` is never composed into `all`.**
+Tiers cumulative: `build` includes `caches`. `all` = `build` + `git`. **Neither `tree` nor `tree-batch` is ever composed into `all`.**
 
 Aliases (`fresh`, `inventory`, `artifacts`, …): [context/action-router.md](context/action-router.md).
 
@@ -119,6 +120,14 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 `bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/git-tree-reset.sh` — default `--dry-run`. Detail: [context/git-tree-reset.md](context/git-tree-reset.md). Default-preserve; opt-in `--include-deps` / `--include-secrets`; `--allow-unpushed` when HEAD is ahead of upstream.
 
 **Mandatory gate:** show dry-run output → `AskUserQuestion` → only then `--apply`. Surface the dry-run's `PreserveDeps` / `PreserveSecrets` / `AheadCount` lines in the confirmation so the user knows what survives. An exit 4 (`unpushed-commits`) or non-zero `AheadCount` means HEAD has unpushed commits — confirm loss before adding `--allow-unpushed`. Autonomous sessions: abort. Post-step: after a tree reset that removed dependencies, suggest reinstalling them with the project's own bootstrap/setup and re-validating the environment. For a truly pristine tree, close running dev tooling first (MCP servers, telemetry collectors, build/test watchers) — live processes recreate ignored dirs (`obj/`, `node_modules/`, and the like) the moment they are deleted, and may hold locks that surface as `Unremovable:`.
+
+### 6.5. Tree batch — multi-repo (destructive)
+
+`bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/git-tree-reset-batch.sh` — default `--dry-run`. Runs §6 `tree` across a set of repos behind one gate, with a separator-agnostic skip list and a dirty-by-default guard. Detail + examples: [context/git-tree-reset-batch.md](context/git-tree-reset-batch.md). Additive over §6 — the batch layer runs no destructive git itself; each per-repo reset delegates to the unchanged `git-tree-reset.sh`, preserving every single-repo gate.
+
+Repo sources: `--repo` (repeatable; a shell glob expands to these) and `--repos-from FILE|-` (ingests `ghq list -p` output). Skip list: `--skip ENTRY` / `--skip-from FILE` (absolute path, `owner/repo`, or bare `repo`; separator-agnostic). Passthrough to the child: `--force-default-branch` / `--include-deps` / `--include-secrets`.
+
+**Mandatory gate (single, batch-wide):** show the `--dry-run` whole-batch plan (per-repo `Outcome`/`Reason`, the `Summary` totals, and any `UnmatchedSkip:` warnings) → `AskUserQuestion` **once** → only then `--apply` **once**. Do not gate per repo. A fresh-clone fleet is typically all on the default branch, so expect an all-blocked dry-run unless `--force-default-branch` — surface that in the confirmation. `--include-dirty` re-enables the exact data-loss vector (resets repos with uncommitted/untracked changes or unpushed commits); it needs its own explicit confirmation naming the dirty repos, exactly like `--include-secrets`. Autonomous sessions: abort.
 
 ### 7. Orphaned path removal (destructive, on explicit request only)
 

--- a/plugins/repo-hygiene/skills/clean/context/action-router.md
+++ b/plugins/repo-hygiene/skills/clean/context/action-router.md
@@ -11,9 +11,10 @@ SKILL.md carries the action table headline; this file carries alias resolution, 
 | `build` | "Clear build output and logs" | `bin/`, `obj/`, `dist/`, dotnet clean driver, … | Low | **Never** |
 | `git` | "Prune stale git metadata" | `worktree prune`, `remote prune`, `gc`, branch audit | Low | Prune/gc only after user OK; branch delete always opt-in |
 | `tree` | "Reset working tree like a fresh pull" | `fetch` + `reset --hard` upstream + `clean -fdx` (default-preserve secrets/deps/skill-data; `--include-deps` / `--include-secrets` to widen) | **Destructive** | **Never** |
+| `tree-batch` | "Reset all my repos like a fresh pull" | `tree` across a repo set behind one gate; separator-agnostic skip list; dirty/unpushed skipped unless `--include-dirty` | **Destructive** | **Never** |
 | `all` | "Sweep caches, build artifacts, and git hygiene" | `build` + `git` (not `tree`) | Medium | **Never** |
 
-**`tree` is never part of `all`.** One mistaken sweep must not run a `reset --hard`. (`tree` itself now preserves `.env`, `node_modules/`, `.venv/` by default — see `reference/cleanup-config.md` "tree".)
+**Neither `tree` nor `tree-batch` is part of `all`.** One mistaken sweep must not run a `reset --hard`. (`tree` itself now preserves `.env`, `node_modules/`, `.venv/` by default — see `reference/cleanup-config.md` "tree".)
 
 ## Token resolution (script)
 
@@ -30,9 +31,10 @@ Emits `Action: <canonical|menu>`. Single-token aliases:
 | `build`, `artifacts`, `artifact`, `bin`, `obj`, `output` | `build` |
 | `git`, `branches`, `branch`, `prune`, `gc` | `git` |
 | `tree`, `fresh`, `fresh-pull`, `fresh-pull-state`, `pristine`, `reset-tree`, `working-tree` | `tree` |
+| `tree-batch`, `batch`, `fleet`, `multi-repo`, `reset-all` | `tree-batch` |
 | `all`, `sweep`, `everything` | `all` |
 
-Multi-token phrase heuristics (when no single token matches): `fresh pull`, `fresh clone`, `reset to origin`, `wipe ignored` → `tree`; disk-space phrases → `scan`; stale/merged branch phrases → `git`.
+Multi-token phrase heuristics (when no single token matches): `reset all`, `all my repos`, `every repo`, `across repos`, `ghq list` → `tree-batch`; `fresh pull`, `fresh clone`, `reset to origin`, `wipe ignored` → `tree`; disk-space phrases → `scan`; stale/merged branch phrases → `git`.
 
 Conflicting tokens → `menu`.
 
@@ -54,8 +56,9 @@ Default when still unsure after one question: **`scan`** (safest).
 | `caches`, `build`, `all` | `preflight.sh` + tier scripts `--dry-run` | `AskUserQuestion` when preflight non-empty OR before `--apply` |
 | `git` | `git-prune.sh --dry-run`, `git-branch-audit.sh` | Before `--apply` prune; before any branch deletion |
 | `tree` | `git-tree-reset.sh --dry-run` (always) | **Mandatory** `AskUserQuestion` before `--apply` (surface `PreserveDeps`/`PreserveSecrets`/`AheadCount`); a non-zero `AheadCount` or exit 4 needs explicit unpushed-loss confirmation before `--allow-unpushed`; `--include-secrets` is UNRECOVERABLE — confirm separately; never autonomous |
+| `tree-batch` | `git-tree-reset-batch.sh --dry-run` (always) | **Mandatory** single batch-wide `AskUserQuestion` before `--apply` (surface the per-repo `Outcome`/`Reason`, `Summary`, and `UnmatchedSkip:`); one gate for the whole batch, never per repo; `--include-dirty` re-enables the data-loss vector — confirm separately naming the dirty repos, like `--include-secrets`; never autonomous. Detail: [git-tree-reset-batch.md](git-tree-reset-batch.md) |
 
-Autonomous sessions (`CLAUDE_CODE_REMOTE`, `/loop`, `/schedule`): destructive tiers (`tree`, and `--apply` on caches/build/all) **abort** — same rule as preflight §1.5.
+Autonomous sessions (`CLAUDE_CODE_REMOTE`, `/loop`, `/schedule`): destructive tiers (`tree`, `tree-batch`, and `--apply` on caches/build/all) **abort** — same rule as preflight §1.5.
 
 ## Post-`tree` steps (emit, do not auto-run)
 

--- a/plugins/repo-hygiene/skills/clean/context/git-tree-reset-batch.md
+++ b/plugins/repo-hygiene/skills/clean/context/git-tree-reset-batch.md
@@ -90,7 +90,11 @@ confirmed the plan — the dry-run surfaces this before any mutation.
 
 - **Single batch-wide gate:** run `--dry-run` once, show the whole-batch plan (the
   per-repo outcomes + `Summary` + any `UnmatchedSkip`), `AskUserQuestion` once, then
-  `--apply` once. One confirmation covers the batch — do not gate per repo.
+  `--apply` once. One confirmation covers the batch — do not gate per repo. When the
+  repo list comes from `--repos-from -` (stdin), the `--apply` invocation must re-run
+  the same `ghq list -p | …` pipe (stdin is consumed once); the list is re-enumerated
+  at apply, a benign window in the same class as the child's fetch-between-dry-run-and-
+  apply.
 - `--include-dirty` and `--include-secrets` each need their own explicit
   confirmation; the `--include-dirty` confirmation must name the dirty repos whose
   uncommitted changes will be discarded.

--- a/plugins/repo-hygiene/skills/clean/context/git-tree-reset-batch.md
+++ b/plugins/repo-hygiene/skills/clean/context/git-tree-reset-batch.md
@@ -1,0 +1,126 @@
+# The `tree-batch` action — multi-repo working-tree realignment
+
+Full detail for the batch `tree` mode. SKILL.md §6.5 carries the headline; this
+file carries gates, the script contract, and examples. The single-repo `tree`
+action ([git-tree-reset.md](git-tree-reset.md)) is unchanged; `tree-batch` is an
+additive orchestrator over it.
+
+## Why this exists
+
+A hand-rolled `ghq list` reset loop `reset --hard`'d a repo it was meant to skip:
+the skip-match compared a Windows backslash path against a forward-slash path and
+silently failed, discarding an uncommitted `.claude/settings.json` edit that was
+never staged and could not be recovered. `tree-batch` is the supported capability
+that closes both defects — separator-agnostic skip-matching and a dirty-by-default
+guard — so the batch reset never has to be hand-rolled again.
+
+## Scope
+
+**In:** run the single-repo `tree` reset across a set of repositories behind one
+confirmation gate, with a skip list and a dirty guard, then report a per-repo
+outcome summary.
+
+**Out:** the other tiers (`caches` / `build` / `git` / `all`) — `tree` is the
+destructive tier that caused the incident and the only one whose batch form needs
+these guards; a multi-tier batch is a possible future extension, not built here.
+Also out (delegated to the single-repo `tree`, unchanged): the actual reset /
+clean / upstream resolution / reparse-point restore. The batch layer runs no
+destructive git command itself.
+
+## Script
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/git-tree-reset-batch.sh \
+  [--dry-run|--apply] \
+  [--repo DIR]... [--repos-from FILE|-]... \
+  [--skip ENTRY]... [--skip-from FILE]... \
+  [--include-dirty] \
+  [--force-default-branch] [--include-deps] [--include-secrets]
+```
+
+Default: `--dry-run`. Output labels and full flag help: script `--help`.
+
+### Repo sources
+
+A `ghq list`, a shell glob, and an explicit list all reduce to a path list:
+
+| Source | How |
+| --- | --- |
+| explicit list | `--repo DIR` (repeatable) |
+| shell glob | the shell expands it into repeated `--repo DIR` |
+| `ghq list` | `ghq list -p \| … --repos-from -` (or `--repos-from FILE`) |
+
+Inputs are resolved to their canonical toplevel (`git rev-parse --show-toplevel`)
+and deduped, so the same repo named two ways is processed once.
+
+### Skip list (separator-agnostic — the core fix)
+
+`--skip ENTRY` (repeatable) / `--skip-from FILE`. Each enumerated repo path and
+each skip entry is normalized to a separator-agnostic key before comparison, so a
+skip written with `\` matches a repo path enumerated with `/` and vice versa. An
+entry may be an absolute path, an `owner/repo` suffix, or a bare `repo` name;
+matching is anchored on segment boundaries (`repo` never matches `other-repo`). A
+skip entry that matches **no** enumerated repo is reported as `UnmatchedSkip:` —
+the silent skip-failure that caused the data loss is now a visible warning.
+
+### Dirty guard (skip dirty by default)
+
+A repo with uncommitted or untracked changes, OR unpushed commits, is **skipped**
+by default with the reason reported. `--include-dirty` opts in and passes
+`--allow-unpushed` through so unpushed repos actually reset. This re-enables the
+exact data-loss vector, so it is gated like `--include-secrets`: its own explicit
+confirmation, naming which repos' uncommitted changes will be discarded.
+
+### Per-repo outcome
+
+Each repo emits `Repo:` / `Outcome:` / `Reason:`. Outcomes: `would-reset` (dry-run)
+/ `done` (apply) / `skipped` (skip-list, dirty, or no-upstream) / `blocked`
+(default-branch, upstream-unresolved, or a non-git input) / `failed` (child reset
+failed mid-apply). A closing `Summary:` line totals each bucket. Child exit codes
+map straight through, so single-repo safety semantics are preserved verbatim.
+
+### Default-branch reality
+
+A "fresh-clone state" fleet is typically all on the default branch, and the child
+blocks a default-branch reset unless `--force-default-branch`. Expect an all-blocked
+dry-run summary in that case and pass `--force-default-branch` once you have
+confirmed the plan — the dry-run surfaces this before any mutation.
+
+## Gates
+
+- **Single batch-wide gate:** run `--dry-run` once, show the whole-batch plan (the
+  per-repo outcomes + `Summary` + any `UnmatchedSkip`), `AskUserQuestion` once, then
+  `--apply` once. One confirmation covers the batch — do not gate per repo.
+- `--include-dirty` and `--include-secrets` each need their own explicit
+  confirmation; the `--include-dirty` confirmation must name the dirty repos whose
+  uncommitted changes will be discarded.
+- **Autonomous sessions** (`CLAUDE_CODE_REMOTE`, `/loop`, `/schedule`): the batch
+  `--apply` aborts, same as the single-repo `tree` — user re-invokes interactively.
+- The wrapper runs each child reset as a subprocess, so the session destructive
+  guard sees only `bash git-tree-reset-batch.sh`, not an inline `reset --hard` —
+  invoke via the wrapper, never inline git.
+
+## Examples
+
+Dry-run the whole ghq tree, skipping one repo, keeping the batch on feature
+branches only:
+
+```bash
+ghq list -p | bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/git-tree-reset-batch.sh \
+  --repos-from - --skip melodic-software/standards
+```
+
+Apply across an explicit set that is on default branches (fresh-clone reset),
+after confirming the dry-run:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/git-tree-reset-batch.sh --apply \
+  --force-default-branch --repo ~/repos/a --repo ~/repos/b
+```
+
+Include dirty repos (discards their uncommitted changes — confirm separately):
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/git-tree-reset-batch.sh --apply \
+  --include-dirty --repos-from repos.txt
+```

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# Multi-repo working-tree realignment: run the single-repo git-tree-reset.sh
+# `tree` tier across a set of repositories behind one confirmation gate, with a
+# separator-agnostic skip list and a dirty-by-default guard.
+#
+# This is a thin orchestrator. It never runs a destructive git command itself:
+# every reset/clean is delegated to the UNCHANGED git-tree-reset.sh, so every
+# single-repo safety gate (upstream resolution, default-branch block, reset-
+# success gate, reparse-point restore, unpushed-commit block) is reused verbatim.
+# The batch layer adds only enumeration, skip-matching, the dirty guard, a per-
+# repo outcome summary, and a single batch-wide dry-run -> confirm -> apply gate.
+#
+# Motivation: an ad-hoc `ghq list` reset loop reset --hard a repo it was meant to
+# skip because the skip-match compared a Windows backslash path against a forward-
+# slash path and silently failed, losing an uncommitted edit. Both defects are
+# closed here: skip entries and enumerated repo paths are normalized to a
+# canonical separator-agnostic key before comparison (clean_skip_matches), and
+# dirty/unpushed repos are skipped unless --include-dirty is passed explicitly.
+#
+# Usage:
+#   git-tree-reset-batch.sh [--dry-run|--apply]
+#                           [--repo DIR]... [--repos-from FILE|-]...
+#                           [--skip ENTRY]... [--skip-from FILE]...
+#                           [--include-dirty]
+#                           [--force-default-branch] [--include-deps]
+#                           [--include-secrets] [--help]
+# Default: --dry-run.
+#
+# Repo sources (a `ghq list`, a shell glob, or an explicit list all reduce to a
+# path list): --repo (repeatable, and how a shell glob arrives after expansion),
+# and --repos-from FILE (or - for stdin; how `ghq list -p` output is ingested).
+#
+# Skip list: --skip ENTRY (repeatable) / --skip-from FILE. An entry may be an
+# absolute path or a trailing owner/repo or repo segment; matching is separator-
+# agnostic. A skip entry that matches NO enumerated repo is reported as
+# UnmatchedSkip so a typo can never silently fail to protect a repo again.
+#
+# Dirty guard: a repo with uncommitted or untracked changes OR unpushed commits
+# is SKIPPED by default. --include-dirty opts in (and passes --allow-unpushed
+# through so unpushed repos actually reset) -- this re-enables the exact data-loss
+# vector, so the caller confirms it separately per the skill gate.
+#
+# Exit: 0 batch ran to completion (skips/blocks are normal, reported outcomes);
+#       1 one or more repos failed mid-apply (child exit 5 -- partial reset);
+#       2 usage/validation error (no repos, bad flag).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/clean-common.sh
+source "$SCRIPT_DIR/lib/clean-common.sh"
+TREE_RESET="$SCRIPT_DIR/git-tree-reset.sh"
+
+usage() {
+  cat <<'EOF'
+git-tree-reset-batch.sh — run the tree reset across many repos behind one gate,
+with a separator-agnostic skip list and a dirty-by-default guard.
+
+Usage:
+  git-tree-reset-batch.sh [--dry-run|--apply]
+                          [--repo DIR]... [--repos-from FILE|-]...
+                          [--skip ENTRY]... [--skip-from FILE]...
+                          [--include-dirty]
+                          [--force-default-branch] [--include-deps]
+                          [--include-secrets] [--help]
+
+Default: --dry-run (inventory only; no mutations).
+
+Repo sources (combine freely; deduped by canonical toplevel):
+  --repo DIR         a repository (repeatable; a shell glob expands to these).
+  --repos-from FILE  newline-delimited repo paths (FILE, or - for stdin; the way
+                     `ghq list -p` output is ingested). Repeatable.
+
+Skip list (separator-agnostic; entry = absolute path or owner/repo or repo):
+  --skip ENTRY       skip a repo (repeatable).
+  --skip-from FILE   newline-delimited skip entries.
+
+Dirty guard:
+  --include-dirty    also reset repos with uncommitted/untracked changes or
+                     unpushed commits (default: skip them). Passes --allow-unpushed
+                     to the child. UNRECOVERABLE for uncommitted changes.
+
+Passed through to git-tree-reset.sh per repo:
+  --force-default-branch   allow repos checked out on their default branch
+                           (a fresh-clone fleet is typically all on main).
+  --include-deps           also remove node_modules/.venv/vendor.
+  --include-secrets        also remove secrets / local config (UNRECOVERABLE).
+
+Per-repo Outcome: would-reset | done | skipped | blocked. Reason names the cause.
+Summary line: repos / reset / skipped / blocked / failed counts.
+
+Exit: 0 ran to completion; 1 a repo failed mid-apply (child exit 5); 2 usage error.
+EOF
+}
+
+DRY_RUN=1
+INCLUDE_DIRTY=0
+FORCE_DEFAULT=0
+INCLUDE_DEPS=0
+INCLUDE_SECRETS=0
+REPO_INPUTS=()
+SKIP_INPUTS=()
+
+fail_usage() {
+  echo "git-tree-reset-batch.sh: $1" >&2
+  exit 2
+}
+
+read_lines_into() {
+  # read_lines_into <array-name> <file|->  — append non-empty trimmed lines.
+  local -n _dest="$1"
+  local src="$2" line
+  if [[ "$src" == "-" ]]; then
+    while IFS= read -r line; do
+      line="${line%$'\r'}"
+      [[ -n "$line" ]] && _dest+=("$line")
+    done
+  else
+    [[ -f "$src" ]] || fail_usage "file not found: $src"
+    while IFS= read -r line; do
+      line="${line%$'\r'}"
+      [[ -n "$line" ]] && _dest+=("$line")
+    done <"$src"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --dry-run) DRY_RUN=1 ;;
+  --apply) DRY_RUN=0 ;;
+  --include-dirty) INCLUDE_DIRTY=1 ;;
+  --force-default-branch) FORCE_DEFAULT=1 ;;
+  --include-deps) INCLUDE_DEPS=1 ;;
+  --include-secrets) INCLUDE_SECRETS=1 ;;
+  --repo)
+    [[ $# -ge 2 ]] || fail_usage "--repo requires a directory"
+    REPO_INPUTS+=("$2")
+    shift
+    ;;
+  --repos-from)
+    [[ $# -ge 2 ]] || fail_usage "--repos-from requires a file or -"
+    read_lines_into REPO_INPUTS "$2"
+    shift
+    ;;
+  --skip)
+    [[ $# -ge 2 ]] || fail_usage "--skip requires an entry"
+    SKIP_INPUTS+=("$2")
+    shift
+    ;;
+  --skip-from)
+    [[ $# -ge 2 ]] || fail_usage "--skip-from requires a file"
+    read_lines_into SKIP_INPUTS "$2"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *) fail_usage "unknown arg '$1'" ;;
+  esac
+  shift
+done
+
+[[ ${#REPO_INPUTS[@]} -gt 0 ]] || fail_usage "no repos given (use --repo and/or --repos-from)"
+
+# Resolve every input to its canonical toplevel and dedupe by comparison key.
+# An input that is not a directory or not a git working tree is reported as a
+# blocked outcome rather than silently dropped.
+REPO_TOPS=()
+REPO_KEYS=()
+INVALID_INPUTS=()
+INVALID_REASONS=()
+
+key_seen() {
+  local k="$1" e
+  for e in "${REPO_KEYS[@]:-}"; do [[ "$e" == "$k" ]] && return 0; done
+  return 1
+}
+
+for input in "${REPO_INPUTS[@]}"; do
+  [[ -n "$input" ]] || continue
+  if [[ ! -d "$input" ]]; then
+    INVALID_INPUTS+=("$input")
+    INVALID_REASONS+=("not-a-directory")
+    continue
+  fi
+  top="$(git -C "$input" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
+  if [[ -z "$top" ]]; then
+    INVALID_INPUTS+=("$input")
+    INVALID_REASONS+=("not-a-git-repo")
+    continue
+  fi
+  key="$(clean_path_key "$top")"
+  key_seen "$key" && continue
+  REPO_TOPS+=("$top")
+  REPO_KEYS+=("$key")
+done
+
+# Per-skip match tracking so a skip that protects nothing is surfaced loudly.
+SKIP_HITS=()
+for ((s = 0; s < ${#SKIP_INPUTS[@]}; s++)); do SKIP_HITS+=(0); done
+
+repo_dirty_reason() {
+  # Echo a dirty reason (uncommitted/untracked or unpushed) or nothing if clean.
+  local top="$1" porcelain ahead
+  porcelain="$(git -C "$top" status --porcelain 2>/dev/null)"
+  if [[ -n "$porcelain" ]]; then
+    printf 'dirty (uncommitted or untracked changes)'
+    return 0
+  fi
+  # Unpushed only counts when an upstream actually resolves; a repo with no
+  # upstream is not "unpushed" (the child reports no-upstream when it runs).
+  if git -C "$top" rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
+    ahead="$(git -C "$top" rev-list --count '@{u}..HEAD' 2>/dev/null | tr -d ' ' || echo 0)"
+    if [[ "${ahead:-0}" -gt 0 ]]; then
+      printf 'unpushed (%s commit(s) ahead of upstream)' "$ahead"
+      return 0
+    fi
+  fi
+  printf ''
+}
+
+# Flags passed through to the single-repo child for every repo that runs.
+CHILD_PASS=()
+[[ "$FORCE_DEFAULT" -eq 1 ]] && CHILD_PASS+=(--force-default-branch)
+[[ "$INCLUDE_DEPS" -eq 1 ]] && CHILD_PASS+=(--include-deps)
+[[ "$INCLUDE_SECRETS" -eq 1 ]] && CHILD_PASS+=(--include-secrets)
+# --include-dirty accepts discarding unpushed commits too, so unblock the child's
+# unpushed gate; a no-op when a repo is not ahead of its upstream.
+[[ "$INCLUDE_DIRTY" -eq 1 ]] && CHILD_PASS+=(--allow-unpushed)
+
+emit() {
+  printf 'Repo: %s\n' "$1"
+  printf 'Outcome: %s\n' "$2"
+  printf 'Reason: %s\n' "$3"
+  printf '%s\n' '---'
+}
+
+COUNT_RESET=0
+COUNT_SKIPPED=0
+COUNT_BLOCKED=0
+COUNT_FAILED=0
+
+printf 'Repo Fleet Tree Reset\n'
+printf 'Mode: %s\n' "$([[ "$DRY_RUN" -eq 1 ]] && echo 'dry-run (no mutations)' || echo 'apply (destructive)')"
+printf 'IncludeDirty: %s\n' "$([[ "$INCLUDE_DIRTY" -eq 1 ]] && echo yes || echo no)"
+printf 'Repos: %s\n' "${#REPO_TOPS[@]}"
+printf '%s\n' '---'
+
+for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
+  top="${REPO_TOPS[$i]}"
+  key="${REPO_KEYS[$i]}"
+
+  # 1. Skip list (separator-agnostic).
+  matched=""
+  for ((s = 0; s < ${#SKIP_INPUTS[@]}; s++)); do
+    if clean_skip_matches "$key" "${SKIP_INPUTS[$s]}"; then
+      matched="${SKIP_INPUTS[$s]}"
+      SKIP_HITS[s]=1
+    fi
+  done
+  if [[ -n "$matched" ]]; then
+    emit "$top" skipped "skip-list ($matched)"
+    COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
+    continue
+  fi
+
+  # 2. Dirty guard (skip unless --include-dirty).
+  if [[ "$INCLUDE_DIRTY" -eq 0 ]]; then
+    dirty="$(repo_dirty_reason "$top")"
+    if [[ -n "$dirty" ]]; then
+      emit "$top" skipped "$dirty (pass --include-dirty to reset anyway)"
+      COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
+      continue
+    fi
+  fi
+
+  # 3. Delegate to the unchanged single-repo tree reset.
+  rc=0
+  out="$(cd "$top" && bash "$TREE_RESET" "$([[ "$DRY_RUN" -eq 1 ]] && echo --dry-run || echo --apply)" "${CHILD_PASS[@]}" 2>&1)" || rc=$?
+  case "$rc" in
+  0)
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      emit "$top" would-reset none
+    else
+      emit "$top" "done" none
+    fi
+    COUNT_RESET=$((COUNT_RESET + 1))
+    ;;
+  2)
+    emit "$top" skipped "no upstream tracking branch"
+    COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
+    ;;
+  3)
+    emit "$top" blocked "default-branch (pass --force-default-branch)"
+    COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
+    ;;
+  4)
+    emit "$top" blocked "unpushed commits (pass --include-dirty)"
+    COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
+    ;;
+  5)
+    emit "$top" failed "reset --hard failed mid-apply (child output below)"
+    printf '%s\n' "$out" >&2
+    COUNT_FAILED=$((COUNT_FAILED + 1))
+    ;;
+  6)
+    emit "$top" blocked "upstream-unresolved"
+    COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
+    ;;
+  *)
+    emit "$top" blocked "tree-reset error (child exit $rc)"
+    COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
+    ;;
+  esac
+done
+
+# Invalid inputs reported as blocked outcomes.
+for ((i = 0; i < ${#INVALID_INPUTS[@]}; i++)); do
+  emit "${INVALID_INPUTS[$i]}" blocked "${INVALID_REASONS[$i]}"
+  COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
+done
+
+# Surface skip entries that matched nothing — the silent-skip-failure that caused
+# the original data loss now becomes a visible warning.
+for ((s = 0; s < ${#SKIP_INPUTS[@]}; s++)); do
+  if [[ "${SKIP_HITS[$s]}" -eq 0 ]]; then
+    printf 'UnmatchedSkip: %s\n' "${SKIP_INPUTS[$s]}"
+  fi
+done
+
+printf 'Summary: repos=%s reset=%s skipped=%s blocked=%s failed=%s\n' \
+  "${#REPO_TOPS[@]}" "$COUNT_RESET" "$COUNT_SKIPPED" "$COUNT_BLOCKED" "$COUNT_FAILED"
+
+[[ "$COUNT_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -172,7 +172,7 @@ INVALID_REASONS=()
 
 key_seen() {
   local k="$1" e
-  for e in "${REPO_KEYS[@]:-}"; do [[ "$e" == "$k" ]] && return 0; done
+  for e in "${REPO_KEYS[@]}"; do [[ "$e" == "$k" ]] && return 0; done
   return 1
 }
 
@@ -295,7 +295,10 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
     COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
     ;;
   4)
-    emit "$top" blocked "unpushed commits (pass --include-dirty)"
+    # Reachable only without --include-dirty (which passes --allow-unpushed): the
+    # child re-gates unpushed after its fetch, so a repo that looked not-ahead at
+    # the batch dirty-check can become ahead once fetch advances the upstream.
+    emit "$top" blocked "unpushed commits after fetch (pass --include-dirty)"
     COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
     ;;
   5)

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -114,13 +114,13 @@ read_lines_into() {
   local -n _dest="$1"
   local src="$2" line
   if [[ "$src" == "-" ]]; then
-    while IFS= read -r line; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
       line="${line%$'\r'}"
       [[ -n "$line" ]] && _dest+=("$line")
     done
   else
     [[ -f "$src" ]] || fail_usage "file not found: $src"
-    while IFS= read -r line; do
+    while IFS= read -r line || [[ -n "$line" ]]; do
       line="${line%$'\r'}"
       [[ -n "$line" ]] && _dest+=("$line")
     done <"$src"

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -41,7 +41,9 @@
 # vector, so the caller confirms it separately per the skill gate.
 #
 # Exit: 0 batch ran to completion (skips/blocks are normal, reported outcomes);
-#       1 one or more repos failed mid-apply (child exit 5 -- partial reset);
+#       1 one or more repos failed mid-apply -- a partial destructive apply the
+#         child reports non-zero: exit 5 (reset --hard failed) or exit 7 (reset
+#         succeeded but git clean failed, so the tree is reset-but-not-cleaned);
 #       2 usage/validation error (no repos, bad flag).
 set -uo pipefail
 
@@ -85,10 +87,12 @@ Passed through to git-tree-reset.sh per repo:
   --include-deps           also remove node_modules/.venv/vendor.
   --include-secrets        also remove secrets / local config (UNRECOVERABLE).
 
-Per-repo Outcome: would-reset | done | skipped | blocked. Reason names the cause.
+Per-repo Outcome: would-reset | done | skipped | blocked | failed. Reason names
+the cause; a would-reset/done Reason also names discarded dirty edits (include-
+dirty) and any files git clean could not remove (locked / in use).
 Summary line: repos / reset / skipped / blocked / failed counts.
 
-Exit: 0 ran to completion; 1 a repo failed mid-apply (child exit 5); 2 usage error.
+Exit: 0 ran to completion; 1 a repo failed mid-apply (child exit 5 or 7); 2 usage error.
 EOF
 }
 
@@ -279,10 +283,34 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
   out="$(cd "$top" && bash "$TREE_RESET" "$([[ "$DRY_RUN" -eq 1 ]] && echo --dry-run || echo --apply)" "${CHILD_PASS[@]}" 2>&1)" || rc=$?
   case "$rc" in
   0)
+    # The child exits 0 for a clean success AND for two success-with-signal cases
+    # the batch must not flatten to a bare outcome: an --include-dirty reset
+    # discards uncommitted/untracked edits (child TrackedDirty>0), and a clean
+    # that hit locked/in-use paths leaves them behind (child Unremovable>0, exit 0
+    # by design). Both are documented child output labels; surface them in the
+    # per-repo Reason so the --include-dirty dry-run confirmation can name the
+    # repos whose edits it will discard, and an operator never reads an incomplete
+    # clean as a completed reset. TrackedDirty is read from child output (not
+    # recomputed) because on apply the repo is already reset by this point.
+    tracked_dirty="$(printf '%s\n' "$out" | sed -n 's/^TrackedDirty: //p' | head -1)"
+    reason=none
+    if [[ "$INCLUDE_DIRTY" -eq 1 && "${tracked_dirty:-0}" -gt 0 ]]; then
+      if [[ "$DRY_RUN" -eq 1 ]]; then
+        reason="$tracked_dirty uncommitted/untracked change(s) would be discarded"
+      else
+        reason="$tracked_dirty uncommitted/untracked change(s) discarded"
+      fi
+    fi
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      emit "$top" would-reset none
+      emit "$top" would-reset "$reason"
     else
-      emit "$top" "done" none
+      unremovable="$(printf '%s\n' "$out" | sed -n 's/^Unremovable: //p' | head -1)"
+      if [[ "${unremovable:-0}" -gt 0 ]]; then
+        note="incomplete clean: $unremovable path(s) unremovable (locked / in use)"
+        if [[ "$reason" == none ]]; then reason="$note"; else reason="$reason; $note"; fi
+        printf '%s\n' "$out" | grep -E 'could not be removed|failed to remove' >&2 || true
+      fi
+      emit "$top" "done" "$reason"
     fi
     COUNT_RESET=$((COUNT_RESET + 1))
     ;;
@@ -303,6 +331,16 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
     ;;
   5)
     emit "$top" failed "reset --hard failed mid-apply (child output below)"
+    printf '%s\n' "$out" >&2
+    COUNT_FAILED=$((COUNT_FAILED + 1))
+    ;;
+  7)
+    # reset --hard succeeded but git clean failed for a non-locked-file reason: a
+    # partial destructive apply (tree reset, untracked removal incomplete), which
+    # the child reports non-zero. Treat it as failed like exit 5 so the batch
+    # summary and exit status never report a repo that was only partly realigned
+    # as a completed reset.
+    emit "$top" failed "clean failed after a successful reset -- partial apply, tree not fully cleaned (child output below)"
     printf '%s\n' "$out" >&2
     COUNT_FAILED=$((COUNT_FAILED + 1))
     ;;

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -283,23 +283,28 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
   out="$(cd "$top" && bash "$TREE_RESET" "$([[ "$DRY_RUN" -eq 1 ]] && echo --dry-run || echo --apply)" "${CHILD_PASS[@]}" 2>&1)" || rc=$?
   case "$rc" in
   0)
-    # The child exits 0 for a clean success AND for two success-with-signal cases
-    # the batch must not flatten to a bare outcome: an --include-dirty reset
-    # discards uncommitted/untracked edits (child TrackedDirty>0), and a clean
-    # that hit locked/in-use paths leaves them behind (child Unremovable>0, exit 0
-    # by design). Both are documented child output labels; surface them in the
-    # per-repo Reason so the --include-dirty dry-run confirmation can name the
-    # repos whose edits it will discard, and an operator never reads an incomplete
-    # clean as a completed reset. TrackedDirty is read from child output (not
-    # recomputed) because on apply the repo is already reset by this point.
+    # The child exits 0 for a clean success AND for success-with-signal cases the
+    # batch must not flatten to a bare outcome: an --include-dirty reset discards
+    # uncommitted/untracked edits (child TrackedDirty) AND unpushed commits (child
+    # AheadCount -- reset away because --include-dirty passes --allow-unpushed), and
+    # a clean that hit locked/in-use paths leaves them behind (child Unremovable>0,
+    # exit 0 by design). All are documented child output labels; surface them in the
+    # per-repo Reason so the --include-dirty dry-run confirmation can name every repo
+    # whose edits or commits it discards, and an operator never reads an incomplete
+    # clean as a completed reset. Counts are read from child output (not recomputed)
+    # because on apply the repo is already reset by this point.
     tracked_dirty="$(printf '%s\n' "$out" | sed -n 's/^TrackedDirty: //p' | head -1)"
+    ahead="$(printf '%s\n' "$out" | sed -n 's/^AheadCount: //p' | head -1)"
     reason=none
-    if [[ "$INCLUDE_DIRTY" -eq 1 && "${tracked_dirty:-0}" -gt 0 ]]; then
-      if [[ "$DRY_RUN" -eq 1 ]]; then
-        reason="$tracked_dirty uncommitted/untracked change(s) would be discarded"
-      else
-        reason="$tracked_dirty uncommitted/untracked change(s) discarded"
+    if [[ "$INCLUDE_DIRTY" -eq 1 ]]; then
+      verb="$([[ "$DRY_RUN" -eq 1 ]] && echo 'would be discarded' || echo 'discarded')"
+      discards=""
+      [[ "${tracked_dirty:-0}" -gt 0 ]] && discards="$tracked_dirty uncommitted/untracked change(s) $verb"
+      if [[ "${ahead:-0}" -gt 0 ]]; then
+        ahead_note="$ahead unpushed commit(s) $verb"
+        if [[ -n "$discards" ]]; then discards="$discards; $ahead_note"; else discards="$ahead_note"; fi
       fi
+      [[ -n "$discards" ]] && reason="$discards"
     fi
     if [[ "$DRY_RUN" -eq 1 ]]; then
       emit "$top" would-reset "$reason"

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -302,6 +302,29 @@ out="$(bash "$BATCH" --dry-run --include-dirty --repo "$AHEAD_REPO" 2>&1)" || tr
 assert_contains "include-dirty dry-run still plans the ahead repo reset" "$out" "would-reset"
 assert_contains "include-dirty dry-run names the discarded unpushed commits" "$out" "1 unpushed commit(s) would be discarded"
 
+# --- 21. read_lines_into keeps a FINAL line with no trailing newline (data-loss guard) ---
+# A skip file written without a trailing newline (printf '%s', not '%s\n') must still
+# protect its repo. The dropped-final-line bug silently empties a single-entry skip list,
+# fires no UnmatchedSkip warning (the entry never enters the array), and resets the repo
+# the operator meant to spare — the exact data-loss shape this feature exists to close.
+NOEOL_SKIP="$TEST_TMPDIR/skips-noeol.txt"
+printf '%s' 'acme\keepme' >"$NOEOL_SKIP" # deliberately no trailing newline
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" --repo "$SKIP_REPO" --skip-from "$NOEOL_SKIP" 2>&1)" || true
+assert_contains "unterminated skip entry still skips its repo" "$out" "skip-list"
+assert_not_contains "unterminated matched skip not reported unmatched" "$out" "UnmatchedSkip:"
+# A typo'd unterminated entry must still surface as UnmatchedSkip (guard stays active).
+NOEOL_TYPO="$TEST_TMPDIR/skips-noeol-typo.txt"
+printf '%s' 'no/such-repo' >"$NOEOL_TYPO" # no trailing newline
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" --skip-from "$NOEOL_TYPO" 2>&1)" || true
+assert_contains "unterminated typo skip surfaced as UnmatchedSkip" "$out" "UnmatchedSkip: no/such-repo"
+
+# --- 22. --repos-from keeps a final unterminated line too (same shared helper) ---
+NOEOL_REPOS="$TEST_TMPDIR/repos-noeol.txt"
+printf '%s' "$CLEAN_REPO" >"$NOEOL_REPOS" # single repo path, no trailing newline
+out="$(bash "$BATCH" --dry-run --repos-from "$NOEOL_REPOS" 2>&1)" || true
+assert_contains "unterminated repos-from still enumerates the repo" "$out" "Repos: 1"
+assert_contains "unterminated repos-from repo would reset" "$out" "would-reset"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Tests for git-tree-reset-batch.sh and the separator-agnostic skip matcher.
+#
+# The headline cases reproduce the data-loss incident this feature closes:
+#   - clean_skip_matches as a PURE STRING FUNCTION: a skip entry written with
+#     Windows backslashes must match a forward-slash repo key (the exact bug).
+#     This is deterministic on the Linux CI runner, where a backslash is a legal
+#     filename byte, not a separator — the only way to prove the fix reliably.
+#   - integration: a skip-listed repo is skipped; a dirty repo is skipped by
+#     default and reset only with --include-dirty; an unmatched skip is surfaced.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/test-helpers.sh
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+# shellcheck source=lib/clean-common.sh
+source "$SCRIPT_DIR/lib/clean-common.sh"
+
+BATCH="$SCRIPT_DIR/git-tree-reset-batch.sh"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+FAILED=0
+
+is_windows=false
+case "$(uname -s 2>/dev/null || true)" in
+MINGW* | MSYS* | CYGWIN*) is_windows=true ;;
+*) ;;
+esac
+
+# --- 1. --help ---
+rc=0
+bash "$BATCH" --help >/dev/null 2>&1 || rc=$?
+assert_exit "--help exits 0" 0 "$rc"
+
+# --- 2. no repos is a usage error (exit 2) ---
+rc=0
+bash "$BATCH" >/dev/null 2>&1 || rc=$?
+assert_exit "no repos exits 2" 2 "$rc"
+
+# --- 3. clean_skip_matches: the exact mixed-separator bug, as a pure function ---
+# repo_key is what enumeration produces: a rev-parse toplevel (forward slashes)
+# run through clean_path_key. On Linux that leaves case intact.
+REPO_KEY="$(clean_path_key '/home/op/ghq/github.com/acme/keepme')"
+
+# A skip entry written with Windows backslashes (the incident's failing case).
+if clean_skip_matches "$REPO_KEY" 'acme\keepme'; then
+  pass "backslash skip entry matches forward-slash repo key (the incident bug, now fixed)"
+else
+  fail "backslash skip entry matches forward-slash repo key" "match" "no-match"
+fi
+
+# Forward-slash short form and bare repo name also match.
+if clean_skip_matches "$REPO_KEY" 'acme/keepme'; then
+  pass "forward-slash owner/repo skip matches"
+else
+  fail "forward-slash owner/repo skip matches" "match" "no-match"
+fi
+if clean_skip_matches "$REPO_KEY" 'keepme'; then
+  pass "bare repo-name skip matches on segment boundary"
+else
+  fail "bare repo-name skip matches" "match" "no-match"
+fi
+# Full absolute path with backslashes matches the forward-slash toplevel.
+if clean_skip_matches "$REPO_KEY" '/home/op/ghq/github.com/acme/keepme'; then
+  pass "absolute-path skip matches exact toplevel"
+else
+  fail "absolute-path skip matches exact toplevel" "match" "no-match"
+fi
+
+# --- 4. clean_skip_matches: no over-matching (segment boundary anchored) ---
+if clean_skip_matches "$REPO_KEY" 'eepme'; then
+  fail "partial trailing segment must NOT match" "no-match" "match"
+else
+  pass "partial trailing segment 'eepme' does not match 'keepme'"
+fi
+# A sibling repo sharing a suffix name must not be caught.
+OTHER_KEY="$(clean_path_key '/home/op/ghq/github.com/acme/other-keepme')"
+if clean_skip_matches "$OTHER_KEY" 'keepme'; then
+  fail "sibling 'other-keepme' must NOT be skipped by 'keepme'" "no-match" "match"
+else
+  pass "sibling 'other-keepme' is not matched by bare 'keepme'"
+fi
+# Wrong owner path does not match.
+if clean_skip_matches "$REPO_KEY" 'other/keepme'; then
+  fail "wrong owner path must NOT match" "no-match" "match"
+else
+  pass "wrong-owner 'other/keepme' does not match"
+fi
+
+# --- 5. clean_path_key: case folding only on Windows ---
+if [[ "$is_windows" == "true" ]]; then
+  if clean_skip_matches "$(clean_path_key 'C:/Repos/Acme/KeepMe')" 'acme\keepme'; then
+    pass "Windows: skip match is case-insensitive"
+  else
+    fail "Windows: skip match is case-insensitive" "match" "no-match"
+  fi
+else
+  skip_case "case-fold assertion is Windows-only"
+fi
+
+# --- Integration fixtures ---
+# make_repo <name> — a repo under an owner dir (acme/<name>) on a feature branch
+# whose upstream is local main. Nesting under an owner segment lets the skip-list
+# integration test exercise a mixed-separator owner/repo entry (acme\<name>). The
+# local upstream (branch.remote=".") means no shared-remote push contention.
+make_repo() {
+  local name="$1"
+  local dir="$TEST_TMPDIR/acme/$name"
+  git init "$dir" >/dev/null 2>&1
+  git -C "$dir" config user.email "t@example.com"
+  git -C "$dir" config user.name "Test"
+  echo tracked >"$dir/tracked.txt"
+  git -C "$dir" add -A
+  git -C "$dir" commit -m init >/dev/null
+  git -C "$dir" branch -M main
+  # Feature branch tracking local main so the default-branch guard does not block
+  # the reset (isolates the batch-layer behavior under test).
+  git -C "$dir" checkout -b feat/x >/dev/null 2>&1
+  git -C "$dir" config branch.feat/x.remote .
+  git -C "$dir" config branch.feat/x.merge refs/heads/main
+  printf '%s' "$dir"
+}
+
+CLEAN_REPO="$(make_repo clean-repo)"
+SKIP_REPO="$(make_repo keepme)"
+DIRTY_REPO="$(make_repo dirty-repo)"
+# Give the dirty repo an uncommitted tracked edit — the incident's exact shape.
+echo local-edit >>"$DIRTY_REPO/tracked.txt"
+
+# --- 6. dry-run: skip-listed repo skipped, clean+dirty classified ---
+out="$(bash "$BATCH" --dry-run \
+  --repo "$CLEAN_REPO" --repo "$SKIP_REPO" --repo "$DIRTY_REPO" \
+  --skip 'acme\keepme' 2>&1)" || true
+assert_contains "dry-run reports mode" "$out" "Mode: dry-run"
+assert_contains "clean repo would reset" "$out" "would-reset"
+assert_contains "skip-listed repo is skipped" "$out" "skip-list"
+assert_contains "dirty repo skipped by default" "$out" "dirty (uncommitted or untracked changes)"
+# keepme was skipped via a backslash short form → it must NOT be reported unmatched.
+assert_not_contains "matched backslash skip is not reported unmatched" "$out" "UnmatchedSkip: acme\\keepme"
+
+# --- 7. unmatched skip entry is surfaced (no silent skip failure) ---
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" --skip 'no/such-repo' 2>&1)" || true
+assert_contains "unmatched skip entry surfaced" "$out" "UnmatchedSkip: no/such-repo"
+
+# --- 8. apply: dirty repo skipped by default preserves its uncommitted edit ---
+rc=0
+out="$(bash "$BATCH" --apply --repo "$DIRTY_REPO" 2>&1)" || rc=$?
+assert_exit "apply over a skipped-only batch exits 0" 0 "$rc"
+assert_contains "dirty repo skipped on apply" "$out" "skipped"
+if grep -q "local-edit" "$DIRTY_REPO/tracked.txt"; then
+  pass "dirty repo's uncommitted edit PRESERVED (default skip prevents data loss)"
+else
+  fail "dirty repo's uncommitted edit preserved" "present" "lost"
+fi
+
+# --- 9. apply --include-dirty: dirty repo IS reset, edit discarded ---
+rc=0
+out="$(bash "$BATCH" --apply --include-dirty --repo "$DIRTY_REPO" 2>&1)" || rc=$?
+assert_exit "apply --include-dirty exits 0" 0 "$rc"
+assert_contains "include-dirty resets the dirty repo" "$out" "done"
+if grep -q "local-edit" "$DIRTY_REPO/tracked.txt"; then
+  fail "include-dirty discards the uncommitted edit" "discarded" "still-present"
+else
+  pass "include-dirty reset discarded the uncommitted edit (opt-in honored)"
+fi
+
+# --- 10. clean repo actually resets an untracked file away on apply ---
+echo scratch >"$CLEAN_REPO/scratch.txt"
+rc=0
+out="$(bash "$BATCH" --apply --repo "$CLEAN_REPO" --include-dirty 2>&1)" || rc=$?
+assert_exit "clean-repo apply exits 0" 0 "$rc"
+assert_contains "clean repo reports done" "$out" "done"
+assert_file_absent "apply removed the untracked scratch file" "$CLEAN_REPO/scratch.txt"
+
+# --- 11. default-branch repo is blocked without --force-default-branch ---
+DEFAULT_REPO="$(make_repo default-branch-repo)"
+git -C "$DEFAULT_REPO" checkout main >/dev/null 2>&1
+git -C "$DEFAULT_REPO" config branch.main.remote .
+git -C "$DEFAULT_REPO" config branch.main.merge refs/heads/main
+out="$(bash "$BATCH" --dry-run --repo "$DEFAULT_REPO" 2>&1)" || true
+assert_contains "default-branch repo blocked" "$out" "default-branch (pass --force-default-branch)"
+assert_contains "summary counts the block" "$out" "blocked=1"
+
+# --- 12. --repos-from ingests a newline-delimited list (ghq list shape) ---
+LIST="$TEST_TMPDIR/repos.txt"
+printf '%s\n%s\n' "$CLEAN_REPO" "$SKIP_REPO" >"$LIST"
+out="$(bash "$BATCH" --dry-run --repos-from "$LIST" --skip 'keepme' 2>&1)" || true
+assert_contains "repos-from enumerates the listed repos" "$out" "Repos: 2"
+assert_contains "repos-from honors the skip list" "$out" "skip-list"
+
+# --- 13. non-git input reported as blocked, not silently dropped ---
+mkdir -p "$TEST_TMPDIR/not-a-repo"
+out="$(bash "$BATCH" --dry-run --repo "$TEST_TMPDIR/not-a-repo" 2>&1)" || true
+assert_contains "non-git input reported blocked" "$out" "not-a-git-repo"
+
+if [[ $FAILED -ne 0 ]]; then
+  echo "FAILED: $FAILED test(s)"
+  exit 1
+fi
+echo "OK: git-tree-reset-batch.sh tests passed"

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -228,6 +228,68 @@ assert_exit "child reset failure makes the batch exit 1" 1 "$rc"
 assert_contains "failed repo reported as failed" "$out" "failed"
 assert_contains "summary counts the failure" "$out" "failed=1"
 
+# --- 17. a child clean failure after a successful reset (exit 7) is a failure ---
+# Shim only `git clean` to exit non-zero with a NON-locked-file message: the child
+# reset --hard succeeds, then git clean fails for a reason other than locked files
+# (UNREMOVABLE=0) → child exit 7, a partial destructive apply. The batch must treat
+# it as `failed` (not `blocked`), count it, and exit non-zero — never report a
+# reset-but-not-cleaned repo as a completed batch.
+CLEAN_FAIL_REPO="$(make_repo clean-fail-repo)"
+CLEAN_SHIM="$TEST_TMPDIR/git-clean-fail-shim"
+mkdir -p "$CLEAN_SHIM"
+cat >"$CLEAN_SHIM/git" <<SHIMEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "clean" ]]; then
+  echo "fatal: simulated clean failure (non-locked cause)" >&2
+  exit 1
+fi
+exec "$REAL_GIT" "\$@"
+SHIMEOF
+chmod +x "$CLEAN_SHIM/git"
+rc=0
+out="$(PATH="$CLEAN_SHIM:$PATH" bash "$BATCH" --apply --repo "$CLEAN_FAIL_REPO" 2>&1)" || rc=$?
+assert_exit "child clean failure (exit 7) makes the batch exit 1" 1 "$rc"
+assert_contains "exit-7 repo reported as failed" "$out" "failed"
+assert_contains "exit-7 reason names the partial apply" "$out" "clean failed after a successful reset"
+assert_contains "summary counts the exit-7 failure" "$out" "failed=1"
+
+# --- 18. an incomplete clean (child Unremovable>0, exit 0) is surfaced, not hidden ---
+# Shim `git clean` to print a 'failed to remove' warning and exit non-zero: the
+# child counts it as UNREMOVABLE=1 and, by design, still exits 0 (locked/in-use
+# files are non-fatal). The batch must keep the repo in the reset (success) bucket
+# yet name the incomplete clean in the per-repo Reason so an operator never reads
+# it as a fully realigned tree.
+UNREMOVABLE_REPO="$(make_repo unremovable-repo)"
+UNREMOVABLE_SHIM="$TEST_TMPDIR/git-unremovable-shim"
+mkdir -p "$UNREMOVABLE_SHIM"
+cat >"$UNREMOVABLE_SHIM/git" <<SHIMEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "clean" ]]; then
+  echo "warning: failed to remove obj/locked.bin: Device or resource busy" >&2
+  exit 1
+fi
+exec "$REAL_GIT" "\$@"
+SHIMEOF
+chmod +x "$UNREMOVABLE_SHIM/git"
+rc=0
+out="$(PATH="$UNREMOVABLE_SHIM:$PATH" bash "$BATCH" --apply --repo "$UNREMOVABLE_REPO" 2>&1)" || rc=$?
+assert_exit "incomplete clean still exits 0 (locked files are non-fatal)" 0 "$rc"
+assert_contains "incomplete-clean repo still reported done" "$out" "done"
+assert_contains "incomplete clean named in the reason" "$out" "incomplete clean: 1 path(s) unremovable"
+assert_contains "incomplete clean stays in the reset bucket" "$out" "reset=1"
+assert_contains "incomplete clean is not a failure" "$out" "failed=0"
+
+# --- 19. --include-dirty dry-run names the dirty repos it will discard ---
+# The skill's batch confirmation must name the repos whose uncommitted/untracked
+# edits --include-dirty discards. With the dirty guard bypassed, a plain dry-run
+# would emit would-reset/none; the batch must instead read the child's TrackedDirty
+# and name the count so the confirmation gate has the information it requires.
+DIRTY_DRY_REPO="$(make_repo dirty-dry-repo)"
+echo local-edit >>"$DIRTY_DRY_REPO/tracked.txt"
+out="$(bash "$BATCH" --dry-run --include-dirty --repo "$DIRTY_DRY_REPO" 2>&1)" || true
+assert_contains "include-dirty dry-run still plans the reset" "$out" "would-reset"
+assert_contains "include-dirty dry-run names the discarded dirty edits" "$out" "uncommitted/untracked change(s) would be discarded"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -290,6 +290,18 @@ out="$(bash "$BATCH" --dry-run --include-dirty --repo "$DIRTY_DRY_REPO" 2>&1)" |
 assert_contains "include-dirty dry-run still plans the reset" "$out" "would-reset"
 assert_contains "include-dirty dry-run names the discarded dirty edits" "$out" "uncommitted/untracked change(s) would be discarded"
 
+# --- 20. --include-dirty dry-run names discarded UNPUSHED commits on a clean tree ---
+# A repo with a clean working tree but unpushed commits (ahead of upstream) is
+# skipped by the dirty guard by default; under --include-dirty it resets away those
+# commits. TrackedDirty is 0, so only the child's AheadCount reveals the loss — the
+# confirmation must name it, mirroring the tracked-edit case in test 19.
+AHEAD_REPO="$(make_repo ahead-repo)"
+echo committed-ahead >>"$AHEAD_REPO/tracked.txt"
+git -C "$AHEAD_REPO" commit -aqm "unpushed commit ahead of upstream"
+out="$(bash "$BATCH" --dry-run --include-dirty --repo "$AHEAD_REPO" 2>&1)" || true
+assert_contains "include-dirty dry-run still plans the ahead repo reset" "$out" "would-reset"
+assert_contains "include-dirty dry-run names the discarded unpushed commits" "$out" "1 unpushed commit(s) would be discarded"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -193,6 +193,41 @@ mkdir -p "$TEST_TMPDIR/not-a-repo"
 out="$(bash "$BATCH" --dry-run --repo "$TEST_TMPDIR/not-a-repo" 2>&1)" || true
 assert_contains "non-git input reported blocked" "$out" "not-a-git-repo"
 
+# --- 14. --repos-from - reads the list from stdin (the primary ghq-list flow) ---
+out="$(printf '%s\n' "$CLEAN_REPO" | bash "$BATCH" --dry-run --repos-from - 2>&1)" || true
+assert_contains "stdin list enumerates one repo" "$out" "Repos: 1"
+assert_contains "stdin list repo would reset" "$out" "would-reset"
+
+# --- 15. --skip-from FILE applies skip entries from a file ---
+SKIPFILE="$TEST_TMPDIR/skips.txt"
+printf '%s\n' 'acme\keepme' >"$SKIPFILE"
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" --repo "$SKIP_REPO" --skip-from "$SKIPFILE" 2>&1)" || true
+assert_contains "skip-from file skips the listed repo" "$out" "skip-list"
+assert_not_contains "skip-from matched entry not reported unmatched" "$out" "UnmatchedSkip:"
+
+# --- 16. a child reset failure (exit 5) propagates to failed count + exit 1 ---
+# Intercept only `git reset` via a PATH shim (delegating every other subcommand
+# to real git); the single-repo child exits 5, which the batch must surface as a
+# `failed` outcome, count it, and exit non-zero.
+FAIL_REPO="$(make_repo reset-fail-repo)"
+REAL_GIT="$(command -v git)"
+SHIM="$TEST_TMPDIR/git-shim"
+mkdir -p "$SHIM"
+cat >"$SHIM/git" <<SHIMEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "reset" ]]; then
+  echo "fatal: simulated reset --hard failure" >&2
+  exit 1
+fi
+exec "$REAL_GIT" "\$@"
+SHIMEOF
+chmod +x "$SHIM/git"
+rc=0
+out="$(PATH="$SHIM:$PATH" bash "$BATCH" --apply --repo "$FAIL_REPO" 2>&1)" || rc=$?
+assert_exit "child reset failure makes the batch exit 1" 1 "$rc"
+assert_contains "failed repo reported as failed" "$out" "failed"
+assert_contains "summary counts the failure" "$out" "failed=1"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -40,7 +40,7 @@ assert_exit "no repos exits 2" 2 "$rc"
 # --- 3. clean_skip_matches: the exact mixed-separator bug, as a pure function ---
 # repo_key is what enumeration produces: a rev-parse toplevel (forward slashes)
 # run through clean_path_key. On Linux that leaves case intact.
-REPO_KEY="$(clean_path_key '/home/op/ghq/github.com/acme/keepme')"
+REPO_KEY="$(clean_path_key '/fleet/acme/keepme')"
 
 # A skip entry written with Windows backslashes (the incident's failing case).
 if clean_skip_matches "$REPO_KEY" 'acme\keepme'; then
@@ -61,7 +61,7 @@ else
   fail "bare repo-name skip matches" "match" "no-match"
 fi
 # Full absolute path with backslashes matches the forward-slash toplevel.
-if clean_skip_matches "$REPO_KEY" '/home/op/ghq/github.com/acme/keepme'; then
+if clean_skip_matches "$REPO_KEY" '/fleet/acme/keepme'; then
   pass "absolute-path skip matches exact toplevel"
 else
   fail "absolute-path skip matches exact toplevel" "match" "no-match"
@@ -74,7 +74,7 @@ else
   pass "partial trailing segment 'eepme' does not match 'keepme'"
 fi
 # A sibling repo sharing a suffix name must not be caught.
-OTHER_KEY="$(clean_path_key '/home/op/ghq/github.com/acme/other-keepme')"
+OTHER_KEY="$(clean_path_key '/fleet/acme/other-keepme')"
 if clean_skip_matches "$OTHER_KEY" 'keepme'; then
   fail "sibling 'other-keepme' must NOT be skipped by 'keepme'" "no-match" "match"
 else

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -4,6 +4,12 @@
 # shellcheck source=cleanup-paths.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cleanup-paths.sh"
 
+# Resolve the OS once at source time. clean_path_key runs twice per repo across a
+# batch (toplevel + each skip comparison), so forking uname on every call is
+# hundreds of needless subprocesses on a large fleet — worst on Windows/MSYS
+# where process creation is slow.
+_CLEAN_OS="$(uname -s 2>/dev/null || true)"
+
 clean_repo_root() {
   local root
   root="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
@@ -20,7 +26,7 @@ clean_repo_root() {
 clean_path_key() {
   local value="${1//\\//}"
   while [[ "$value" == */ && "$value" != "/" ]]; do value="${value%/}"; done
-  case "$(uname -s 2>/dev/null || true)" in
+  case "$_CLEAN_OS" in
   MINGW* | MSYS* | CYGWIN*) printf '%s' "$value" | tr '[:upper:]' '[:lower:]' ;;
   *) printf '%s' "$value" ;;
   esac

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -10,6 +10,36 @@ clean_repo_root() {
   printf '%s' "$root"
 }
 
+# Normalize a filesystem path to a comparison key: backslashes -> forward
+# slashes, collapse trailing slashes, and lowercase on case-insensitive
+# platforms (Windows via MSYS/Cygwin). This is the exact fix for the multi-repo
+# batch skip-list data-loss incident: a skip entry written with Windows
+# backslashes must compare equal to a repo path that git enumerated with forward
+# slashes (git rev-parse always emits forward slashes) and vice versa. Never
+# string-match raw paths across the two conventions.
+clean_path_key() {
+  local value="${1//\\//}"
+  while [[ "$value" == */ && "$value" != "/" ]]; do value="${value%/}"; done
+  case "$(uname -s 2>/dev/null || true)" in
+  MINGW* | MSYS* | CYGWIN*) printf '%s' "$value" | tr '[:upper:]' '[:lower:]' ;;
+  *) printf '%s' "$value" ;;
+  esac
+}
+
+# Return 0 when a canonical repo key (a rev-parse --show-toplevel path already
+# run through clean_path_key) matches a skip-list entry, separator-agnostic and
+# (on Windows) case-insensitive. The entry may be an absolute path or a trailing
+# path-segment sequence (owner/repo or repo); matching is anchored on segment
+# boundaries so a skip of "repo" never silently matches ".../other-repo".
+clean_skip_matches() {
+  local repo_key="$1" skip_key
+  skip_key="$(clean_path_key "$2")"
+  [[ -n "$skip_key" ]] || return 1
+  [[ "$repo_key" == "$skip_key" ]] && return 0
+  [[ "$repo_key" == *"/$skip_key" ]] && return 0
+  return 1
+}
+
 clean_path_is_tracked() {
   local repo_root="$1" rel="$2"
   git -C "$repo_root" ls-files --error-unmatch "$rel" >/dev/null 2>&1

--- a/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.sh
@@ -50,6 +50,9 @@ resolve_one() {
   tree | fresh | fresh-pull | fresh-pull-state | pristine | reset-tree | working-tree)
     printf 'tree'
     ;;
+  tree-batch | batch | fleet | multi-repo | reset-all)
+    printf 'tree-batch'
+    ;;
   all | sweep | everything)
     printf 'all'
     ;;
@@ -75,6 +78,9 @@ done
 
 if [[ -z "$canonical" ]]; then
   case "$joined" in
+  *reset\ all* | *all\ my\ repos* | *all\ repos* | *every\ repo* | *across\ repos* | *ghq\ list*)
+    canonical=tree-batch
+    ;;
   *fresh\ pull* | *fresh\ clone* | *like\ a\ fresh* | *reset\ to\ origin* | *wipe\ ignored*)
     canonical=tree
     ;;

--- a/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.sh
@@ -62,10 +62,30 @@ resolve_one() {
   esac
 }
 
+# A whole-phrase fleet intent ("reset all my repos", "every repo", "ghq list").
+# Kept in one place so the token loop and the no-token fallback below agree on
+# what reads as a multi-repo reset.
+is_fleet_phrase() {
+  case "$1" in
+  *reset\ all* | *all\ my\ repos* | *all\ repos* | *every\ repo* | *across\ repos* | *ghq\ list*)
+    return 0
+    ;;
+  *) return 1 ;;
+  esac
+}
+
 canonical=""
 for token in "$@"; do
   lower="$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')"
   hit="$(resolve_one "$lower")"
+  # A bare "all" token is the single-repo `all` tier, but inside a fleet phrase it
+  # names the multi-repo tree-batch. Let the phrase win over the token so "reset
+  # all my repos" routes to tree-batch instead of the single-repo sweep. A genuine
+  # conflict with another explicit token (e.g. "scan all repos") still falls to the
+  # menu via the mismatch check below.
+  if [[ "$hit" == "all" ]] && is_fleet_phrase "$joined"; then
+    hit=tree-batch
+  fi
   if [[ -n "$hit" ]]; then
     if [[ -z "$canonical" ]]; then
       canonical="$hit"
@@ -77,24 +97,25 @@ for token in "$@"; do
 done
 
 if [[ -z "$canonical" ]]; then
-  case "$joined" in
-  *reset\ all* | *all\ my\ repos* | *all\ repos* | *every\ repo* | *across\ repos* | *ghq\ list*)
+  if is_fleet_phrase "$joined"; then
     canonical=tree-batch
-    ;;
-  *fresh\ pull* | *fresh\ clone* | *like\ a\ fresh* | *reset\ to\ origin* | *wipe\ ignored*)
-    canonical=tree
-    ;;
-  *disk\ space* | *taking\ up\ space* | *what*using*space* | *how\ much*)
-    canonical=scan
-    ;;
-  *node_modules* | *\.venv* | *build\ output* | *bin/*obj*)
-    canonical=build
-    ;;
-  *stale\ branch* | *merged\ branch*)
-    canonical=git
-    ;;
-  *) ;;
-  esac
+  else
+    case "$joined" in
+    *fresh\ pull* | *fresh\ clone* | *like\ a\ fresh* | *reset\ to\ origin* | *wipe\ ignored*)
+      canonical=tree
+      ;;
+    *disk\ space* | *taking\ up\ space* | *what*using*space* | *how\ much*)
+      canonical=scan
+      ;;
+    *node_modules* | *\.venv* | *build\ output* | *bin/*obj*)
+      canonical=build
+      ;;
+    *stale\ branch* | *merged\ branch*)
+      canonical=git
+      ;;
+    *) ;;
+    esac
+  fi
 fi
 
 if [[ -z "$canonical" ]]; then

--- a/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.test.sh
@@ -30,6 +30,15 @@ assert_action "fleet alias" "fleet" "tree-batch"
 assert_action "every-repo phrase" "reset every repo" "tree-batch"
 assert_action "ghq list phrase" "reset from ghq list" "tree-batch"
 assert_action "conflicting tokens -> menu" "scan tree" "menu"
+# A bare "all" token must not preempt a fleet phrase: "reset all my repos" is the
+# multi-repo tree-batch, not the single-repo `all` sweep.
+assert_action "all-my-repos phrase beats bare all token" "reset all my repos" "tree-batch"
+assert_action "reset-all phrase -> tree-batch" "reset all" "tree-batch"
+# Regression guard: bare "all" with no fleet phrase is still the single-repo tier.
+assert_action "bare all -> single-repo all" "all" "all"
+assert_action "everything alias -> single-repo all" "everything" "all"
+# A genuine conflict (explicit non-all token + fleet phrase) still routes to menu.
+assert_action "scan + fleet phrase -> menu" "scan all repos" "menu"
 
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"

--- a/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.test.sh
@@ -24,6 +24,11 @@ assert_action "fresh alias" "fresh" "tree"
 assert_action "fresh-pull alias" "fresh-pull" "tree"
 assert_action "build alias" "artifacts" "build"
 assert_action "git alias" "branches" "git"
+assert_action "tree-batch token" "tree-batch" "tree-batch"
+assert_action "batch alias" "batch" "tree-batch"
+assert_action "fleet alias" "fleet" "tree-batch"
+assert_action "every-repo phrase" "reset every repo" "tree-batch"
+assert_action "ghq list phrase" "reset from ghq list" "tree-batch"
 assert_action "conflicting tokens -> menu" "scan tree" "menu"
 
 if [[ $FAILED -ne 0 ]]; then


### PR DESCRIPTION
## Summary

`/repo-hygiene:clean` operated on a single repo, so resetting many repos to a fresh-pull state meant hand-rolling a loop — which, in the incident that motivated #397, caused an **unrecoverable data loss**: an ad-hoc `ghq list` loop `reset --hard`'d a repo it was meant to skip because the skip-match compared a Windows backslash path against a forward-slash path and silently failed, discarding an uncommitted edit.

This adds a first-class `tree-batch` action: run the destructive `tree` tier across a set of repos behind **one** dry-run → confirm → apply gate, with a **separator-agnostic skip list** and a **dirty-by-default guard**, then report a per-repo outcome summary. It is additive — the single-repo `tree` behavior is unchanged.

## Implementation

- **New orchestrator** `skills/clean/scripts/git-tree-reset-batch.sh` (default `--dry-run`). A thin layer that runs **no destructive git itself**: each per-repo reset delegates to the unchanged `git-tree-reset.sh`, and the child's exit codes (0/2/3/4/5/6) map straight into the per-repo outcome — so every single-repo safety gate (upstream resolution, default-branch block, reset-success gate, reparse-point restore, unpushed block) is reused verbatim.
- **Repo sources** (a `ghq list`, a shell glob, and an explicit list all reduce to a path list): `--repo DIR` (repeatable; a glob expands to these) and `--repos-from FILE|-` (ingests `ghq list -p` via stdin). Inputs are canonicalized via `git rev-parse --show-toplevel` and deduped.
- **Separator-agnostic skip-matching (the core fix)** — new `clean_path_key` / `clean_skip_matches` helpers in `scripts/lib/clean-common.sh` normalize both the enumerated repo path and each skip entry to a canonical, separator-agnostic (and, on Windows, case-insensitive) key before comparing, anchored on segment boundaries (`repo` never matches `other-repo`). A skip entry an operator supplies with `\` now reliably matches a repo git enumerated with `/`. A skip that matches **nothing** is surfaced as `UnmatchedSkip:` — the silent skip-failure that caused the loss is now a visible warning.
- **Dirty-by-default guard** — a repo with uncommitted/untracked changes or unpushed commits is skipped with a reported reason; `--include-dirty` opts in (passing `--allow-unpushed` through) and is gated with its own explicit confirmation, like `--include-secrets`.
- **Single batch-wide gate** — the SKILL/action-router docs require one `AskUserQuestion` over the whole-batch dry-run plan (per-repo `Outcome`/`Reason`, `Summary`, `UnmatchedSkip:`), never per repo, and autonomous sessions abort — mirroring the existing single-repo `tree` gate.
- **Router + docs**: `tree-batch` (aliases `batch`/`fleet`/…) added to `resolve-clean-action.sh`; SKILL.md §6.5, `context/git-tree-reset-batch.md`, action-router.md, and the README document the batch flow with examples. Version bumped `0.3.3` → `0.4.0` with a CHANGELOG entry.

**Scope:** `tree` is the destructive tier that caused the incident and the only one whose batch form needs these guards, so `tree-batch` is tree-only; a multi-tier batch is a possible future extension and the orchestrator does not preclude it.

## Verification

New `git-tree-reset-batch.test.sh` (30 cases) plus the router test. The headline cases reproduce the exact incident; the mixed-separator match is proven as a **pure string function** on the Linux CI runner, where a backslash is a literal byte (the only way to prove the fix deterministically). Real output:

```
PASS: [3] backslash skip entry matches forward-slash repo key (the incident bug, now fixed)
PASS: [7] partial trailing segment 'eepme' does not match 'keepme'
PASS: [8] sibling 'other-keepme' is not matched by bare 'keepme'
PASS: [13] skip-listed repo is skipped
PASS: [14] dirty repo skipped by default
PASS: [16] unmatched skip entry surfaced
PASS: [19] dirty repo's uncommitted edit PRESERVED (default skip prevents data loss)
PASS: [21] include-dirty resets the dirty repo
PASS: [22] include-dirty reset discarded the uncommitted edit (opt-in honored)
PASS: [26] default-branch repo blocked
OK: git-tree-reset-batch.sh tests passed
```

Full suite and lint (all repo-hygiene tests pass; new scripts clean under the repo's shellcheck rc and shfmt):

```
SHELLCHECK CLEAN
SHFMT CLEAN
PASS plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
PASS plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.test.sh
PASS plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.test.sh
... (all 12 repo-hygiene *.test.sh pass)
✔ Validation passed   (scripts/validate-plugins.sh)
No unregistered or drifted cross-plugin source clusters found.
```

Both halves of the anti-data-loss contract are proven: a mixed-separator skip entry now correctly skips the repo (tests 3/13), and a dirty repo is skipped with its uncommitted edit preserved by default (tests 14/19) yet reset only under the explicit `--include-dirty` opt-in (tests 21/22).

Closes #397

## Related

- #397 — this feature.
- #395 / #396 — sibling repo-hygiene work this session, **not** touched here. #395's fix (`git-tree-reset` `AppliedClean` honesty) is already merged and is the `0.3.3` this branch builds on; #396 was investigated and found already resolved by a prior merge with no new PR.

🤖 Generated with a Claude Code implementation subagent (issue #397)
