### PR TITLE
docs(topics): verify #617 docs-only short-circuit (throwaway)

### DIFF
--- a/docs/topics/_verify-617/NOTES.md
+++ b/docs/topics/_verify-617/NOTES.md
@@ -1,0 +1,4 @@
+# Verify 617
+
+Throwaway docs-only file to observe the docs-only CI short-circuit on
+`plugin-gate` and `miro-plugin`. Deleted together with the branch.


### PR DESCRIPTION
Throwaway verification PR for #617 — observing the docs-only short-circuit on `plugin-gate` and `miro-plugin`. Closed and both temp branches deleted immediately after.

No linked issue

## Related

N/A — verification throwaway for #622.
