### PR TITLE
fix(testing): credit inspect/ask on files:[] evals over doc-permitted default (#626)

### DIFF
--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), and failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.4]
+
+### Changed
+
+- Reworded two `files: []` (context-free) eval expectations to credit a consumer-agnostic inspect/ask
+  path equally with a doc-permitted default, rather than pre-committing to one answer. The `diagnose`
+  fixture-collision case (case 1) now grades recognition of the process-global singleton / shared-state
+  root cause plus inspecting the project's fixture layout or asking for its documented convention, with
+  the specific mechanism demoted to a non-exhaustive example instead of the asserted answer. The `write`
+  shared-library placement case (case 2) now grades the single-project-vs-cross-project judgment and
+  deferral to the project's documented convention, keeping the create-a-test-project decision while
+  dropping the co-location pre-commitment (`context/organize.md` permits co-location for single-project
+  integration tests and centralization for cross-project ones). Eval expectations only; no skill
+  behavior, routing, or context files changed.
+
 ## [0.2.3]
 
 ### Changed

--- a/plugins/testing/skills/diagnose/evals/evals.json
+++ b/plugins/testing/skills/diagnose/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "A test run failed with a 'logger is frozen / already initialized' error",
-      "expected_output": "Routes to context/investigate.md. Immediately recognizes the symptom as a process-global singleton / shared-state collision rather than a transient error. Explains the shared-state root cause, then inspects the project's fixture layout or asks for its documented fixture convention before committing to a specific mechanism (rather than asserting one, e.g. multiple fixture instances where a shared-collection fixture is required). Does NOT suggest retrying.",
+      "expected_output": "Routes to context/investigate.md. Immediately recognizes the symptom as a process-global singleton / shared-state collision rather than a transient error. Explains the shared-state root cause, then inspects the project's fixture layout or asks for its documented fixture convention before committing to a specific mechanism (e.g. asserting that multiple fixture instances are needed when a shared-collection fixture is required, or vice versa). Does NOT suggest retrying.",
       "files": []
     },
     {

--- a/plugins/testing/skills/diagnose/evals/evals.json
+++ b/plugins/testing/skills/diagnose/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "A test run failed with a 'logger is frozen / already initialized' error",
-      "expected_output": "Routes to context/investigate.md. Immediately recognizes the symptom as a process-global singleton / shared-state collision — a test acquiring its own per-class fixture where the project's shared-collection fixture is required — rather than a transient error. Explains the shared-state root cause and consults the consuming project's documented fixture convention for the correct shared-collection pattern. Does NOT suggest retrying.",
+      "expected_output": "Routes to context/investigate.md. Immediately recognizes the symptom as a process-global singleton / shared-state collision rather than a transient error. Explains the shared-state root cause, then inspects the project's fixture layout or asks for its documented fixture convention before committing to a specific mechanism (rather than asserting one, e.g. multiple fixture instances where a shared-collection fixture is required). Does NOT suggest retrying.",
       "files": []
     },
     {

--- a/plugins/testing/skills/write/evals/evals.json
+++ b/plugins/testing/skills/write/evals/evals.json
@@ -10,7 +10,7 @@
     {
       "id": 2,
       "prompt": "Where should I put integration tests for a new shared library?",
-      "expected_output": "Routes to context/organize.md. Evaluates whether the library has testable behavior (business logic, conditional branching) vs pure contracts. If testable: a dedicated test project co-located with the library, following the consuming project's documented naming and location convention. If contracts only: no dedicated test project needed, transitive coverage acceptable.",
+      "expected_output": "Routes to context/organize.md. Evaluates whether the library has testable behavior (business logic, conditional branching) vs pure contracts. If testable: a dedicated test project is warranted; its placement turns on whether the integration tests are single-project (co-locate with the library) or cross-project (centralize under the integration-test root) — inspects or asks for the consuming project's documented naming and location convention to decide, rather than pre-committing to either branch. If contracts only: no dedicated test project needed, transitive coverage acceptable.",
       "files": []
     }
   ]


### PR DESCRIPTION
## Summary

Two `expected_output` entries on context-free (`files: []`) eval prompts pre-committed to one doc-permitted default answer, when a consumer-agnostic "recognize the root cause, then inspect the project's layout or ask for its convention" answer is equally correct per the same context doc and could be misgraded as a miss. This reword grades the *decision + deferral* explicitly, crediting the inspect/ask path equally with the default. Eval expectation text only — no skill behavior, routing, or context files change. This is a narrow eval-design leniency refinement, distinct from the token-coupling axis already closed by #589/#428.

## Fix

**`plugins/testing/skills/diagnose/evals/evals.json` (case 1)** — the shared-collection fixture mechanism, which maps to `context/investigate.md` (process-global singleton → multiple fixture instances → consult the project's fixture convention), was asserted as *the* answer. It is now demoted to a non-exhaustive example; the expectation grades recognizing the shared-state root cause and inspecting the project's fixture layout or asking for its documented convention before committing to a mechanism. `Does NOT suggest retrying` is retained.

**`plugins/testing/skills/write/evals/evals.json` (case 2)** — `context/organize.md` permits co-location for single-project integration tests and centralization for cross-project ones; whether a *shared* library's tests are single- vs cross-project is exactly the judgment under test, so "a dedicated test project co-located with the library" pre-committed to one branch. The reword keeps the create-a-test-project decision but replaces the co-location default with the single-vs-cross-project judgment plus deferral to the project's documented naming and location convention.

## Verification

**Before / after `expected_output` diffs**

`diagnose` case 1:
- Before: `Immediately recognizes the symptom as a process-global singleton / shared-state collision — a test acquiring its own per-class fixture where the project's shared-collection fixture is required — rather than a transient error. Explains the shared-state root cause and consults the consuming project's documented fixture convention for the correct shared-collection pattern.`
- After: `Immediately recognizes the symptom as a process-global singleton / shared-state collision rather than a transient error. Explains the shared-state root cause, then inspects the project's fixture layout or asks for its documented fixture convention before committing to a specific mechanism (rather than asserting one, e.g. multiple fixture instances where a shared-collection fixture is required).`

`write` case 2:
- Before: `If testable: a dedicated test project co-located with the library, following the consuming project's documented naming and location convention.`
- After: `If testable: a dedicated test project is warranted; its placement turns on whether the integration tests are single-project (co-locate with the library) or cross-project (centralize under the integration-test root) — inspects or asks for the consuming project's documented naming and location convention to decide, rather than pre-committing to either branch.`

**Both files parse and conform to the evals schema** (`check-jsonschema` against `plugins/skill-quality/reference/evals.schema.json`):

```
=== diagnose ===
ok -- validation done
=== write ===
ok -- validation done
```

**Static quality gate** (`plugins/skill-quality/scripts/check-skill.sh`):

```
CHECK-SKILL diagnose: PASS — 0 errors, 1 warning(s)
CHECK-SKILL write: PASS — 0 errors, 1 warning(s)
```

The single WARN on each (`description has no 'Use when:' trigger phrasing`) is pre-existing on the SKILL.md frontmatter and unrelated to the eval edits.

Closes #626

## Related

- #626 — this refinement.
- #428 / #589 — the sibling-but-distinct prior fix that removed private-source-repo token coupling from these same two eval files; that axis is fully closed and untouched here.
- #531 — mechanical agnosticism-enforcement lint lane; would not catch grading leniency (orthogonal).
- #530 — eval execution / regression-detection infra; about running evals, not the criteria text (orthogonal).

🤖 Generated with a Claude Code implementation subagent (issue #626)
