### PR TITLE
fix(source-control): drop Refs #N from pull-request create opt-out gate (#630)

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention and babysit-prs config, or apply — interview the repo and write the tracked convention config), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable per repo via a tracked .claude/source-control.md config written by a re-runnable setup skill; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -16,8 +16,12 @@ All notable changes to the `source-control` plugin are documented here. Format f
   CI gate on push. The regex now drops `Refs #N` (`^No related issue:` only), so any body the local
   gate passes the validator also passes (a strict safe subset). `Refs #N` remains a valid
   link-without-close reference in the `## Related` section; the §2.4.0 orphan-PR prompt, the §2.4.1
-  asymmetry note, and the §2.4.2 gate messages were reconciled to match. Narrow same-repo fix
-  (option 1); extending the upstream validator to accept `Refs #N` was out of scope.
+  asymmetry note, and the §2.4.2 gate messages were reconciled to match. The §2.4.0 multi-issue
+  prompt still offers `Refs #Y`, but its accepted `Refs` lines now route into `## Related` rather
+  than onto the closing-keyword line, and the `closed-branch-issue-does-not-autoclose` eval's
+  expected output was aligned to the two-option orphan prompt (`Closes` or `No related issue:`).
+  Narrow same-repo fix (option 1); extending the upstream validator to accept `Refs #N` was out of
+  scope.
 
 ## [0.13.1]
 

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.13.2]
+
+### Fixed
+
+- **`pull-request` create flow no longer treats a bare `Refs #N` as a closing-keyword opt-out in its
+  §2.4.2 pre-create gate.** The local gate's `OPTOUT_REGEX` accepted `Refs #N`, but the real
+  `pr-issue-linkage` reusable CI workflow (`melodic-software/ci-workflows` `pr-issue-linkage.yml`,
+  the SHA this repo pins) accepts only a native closing keyword (`Closes`/`Fixes`/`Resolves #N`) or a
+  literal `No linked issue` / `No related issue:` phrase for its closing-keyword half — `Refs #N` is
+  not in that set. A `Refs #N`-only body therefore cleared the skill's own gate yet still failed the
+  CI gate on push. The regex now drops `Refs #N` (`^No related issue:` only), so any body the local
+  gate passes the validator also passes (a strict safe subset). `Refs #N` remains a valid
+  link-without-close reference in the `## Related` section; the §2.4.0 orphan-PR prompt, the §2.4.1
+  asymmetry note, and the §2.4.2 gate messages were reconciled to match. Narrow same-repo fix
+  (option 1); extending the upstream validator to accept `Refs #N` was out of scope.
+
 ## [0.13.1]
 
 ### Fixed

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -94,7 +94,7 @@
       "id": 8,
       "name": "closed-branch-issue-does-not-autoclose",
       "prompt": "/pull-request create from branch fix/321-stale-link. GitHub reports issue #321 exists but its state is CLOSED.",
-      "expected_output": "The skill does not emit `Closes #321`. A branch-derived number is accepted only when `gh issue view --json state` returns `OPEN`; a closed issue falls through to the orphan-PR prompt for an explicit Closes, Refs, or no-related-issue choice.",
+      "expected_output": "The skill does not emit `Closes #321`. A branch-derived number is accepted only when `gh issue view --json state` returns `OPEN`; a closed issue falls through to the orphan-PR prompt for an explicit Closes or no-related-issue choice.",
       "files": [],
       "expectations": [
         "It checks the live issue state rather than treating a successful gh issue view as sufficient",

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -145,11 +145,12 @@ fi
 
 Append each accepted line to `${CLOSES_LINE}` (newline-separated). GitHub accepts one keyword per issue, comma- or newline-separated.
 
-**Branch lacks issue number (orphan PR — drift sweep, hotfix, refactor):** prompt with three options:
+**Branch lacks issue number (orphan PR — drift sweep, hotfix, refactor):** prompt with two options:
 
 1. `Closes #<N>` — provide a number to auto-close on merge
-2. `Refs #<N>` — link without closing
-3. `No related issue: <reason>` — orphan PR, no linkage
+2. `No related issue: <reason>` — orphan PR, no linkage
+
+To reference an issue this PR does **not** close, put a `Refs #N — <why>` line in the `## Related` section (§2.4.1), not on the closing-keyword line: a bare `Refs #N` satisfies neither the §2.4.2 pre-create gate nor the real `pr-issue-linkage` validator's closing-keyword half, so such a PR still picks one of the two options above.
 
 Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an HTML comment — `<!-- Closes #N -->` is parsed as a valid keyword and will auto-close the issue on merge. Fenced code blocks ARE inert, so example snippets are safe.
 
@@ -198,7 +199,7 @@ BODY+="$TEMPLATE"
 - **Closing-keyword line** (`${CLOSES_LINE}` at top): always populated by §2.4.0 (branch-derived `Closes #N`, the multi-issue prompt, or the orphan-PR opt-out) and asserted by the §2.4.2 gate before create — a required, always-present scaffold, not a conditional decoration.
 - **`## Related` section**: defaults to the literal `N/A` so the section is non-empty by default. Replace `N/A` with genuinely related-but-not-closed references — sibling PRs, ADRs, or decision-log entries (`Refs #N — <why>`, matching the repo's own `## Related` convention) — whenever they exist; leave `N/A` only when nothing else applies. The issue this PR *closes* belongs on the closing-keyword line, not here.
 
-Note the opt-out asymmetry: a `pr-issue-linkage` validator honors only a real closing keyword or a literal `No linked issue` / `No related issue:` phrase for its closing-keyword half — a bare `Refs #N` opt-out (§2.4.0 option 2) does **not** satisfy it. When the branch resolves a real `Closes #N` (the common path) both halves pass; a `Refs #N`-only PR still needs a `No related issue:` line to clear the gate.
+A `Refs #N` line links an issue without closing it and belongs in the `## Related` section, never on the closing-keyword line: it satisfies the closing-keyword half of **neither** the §2.4.2 pre-create gate nor the real `pr-issue-linkage` validator — only a real closing keyword or a literal `No linked issue` / `No related issue:` phrase does. When the branch resolves a real `Closes #N` (the common path) both halves pass; a PR that closes nothing needs a `No related issue:` line to clear the gate.
 
 ### 2.4.2 Verify closing-keyword line (pre-create gate)
 
@@ -210,7 +211,10 @@ Before invoking `gh pr create`, grep assembled `$BODY` for a valid closing keywo
 # linked-issues docs. The 3-keyword shortcut (Closes|Fixes|Resolves)
 # misses 6 valid forms GitHub auto-close honors.
 KEYWORD_REGEX='^(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? #[0-9]+'
-OPTOUT_REGEX='^(Refs #[0-9]+|No related issue:)'
+# Only `No related issue:` — a bare `Refs #N` links without closing and does NOT
+# satisfy the real pr-issue-linkage validator's closing-keyword half, so accepting
+# it here would clear a body the CI gate then rejects.
+OPTOUT_REGEX='^No related issue:'
 
 if printf '%s\n' "$BODY" | grep -iE "$KEYWORD_REGEX" >/dev/null; then
   :  # closing keyword present — gate passes
@@ -220,14 +224,14 @@ else
   # No closing keyword AND no opt-out marker. §2.4.0's orphan-PR prompt
   # should have populated one. If we reach here, either the prompt was
   # skipped or `$CLOSES_LINE` is empty.
-  echo "⚠ PR body lacks a closing keyword (Closes/Fixes/Resolves #N, case-insensitive, optional colon) AND no opt-out marker (Refs #N / No related issue:)." >&2
-  echo "  Re-run §2.4.0's orphan-PR prompt to choose: Closes #N | Refs #N | No related issue: <reason>" >&2
+  echo "⚠ PR body lacks a closing keyword (Closes/Fixes/Resolves #N, case-insensitive, optional colon) AND no opt-out marker (No related issue:)." >&2
+  echo "  Re-run §2.4.0's orphan-PR prompt to choose: Closes #N | No related issue: <reason>" >&2
   echo "  Aborting PR creation. (Silent proceed would orphan the PR from any tracked issue.)" >&2
   exit 1
 fi
 ```
 
-When user explicitly selected `Refs #<N>` or `No related issue: <reason>` in §2.4.0, gate passes silently — opt-out is a legitimate path for refactors, drift sweeps, and hotfixes. Gate exists to catch the case where §2.4.0 fell through without populating `$CLOSES_LINE`.
+When user explicitly selected `No related issue: <reason>` in §2.4.0, the gate passes silently — the opt-out is a legitimate path for refactors, drift sweeps, and hotfixes. Gate exists to catch the case where §2.4.0 fell through without populating `$CLOSES_LINE`.
 
 ### 2.4.3 Create PR
 

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -131,7 +131,7 @@ if [[ -n "$ISSUE_NUM" ]]; then
     CLOSES_LINE="Closes #${ISSUE_NUM}"
   else
     echo "⚠ Branch suggests Closes #${ISSUE_NUM}, but that issue is missing or not open in this repo. Falling back to interactive prompt." >&2
-    ISSUE_NUM=""   # fall through to orphan-PR 3-option prompt below
+    ISSUE_NUM=""   # fall through to orphan-PR 2-option prompt below
   fi
 fi
 # If still empty, the orphan-PR prompt populates CLOSES_LINE below.
@@ -143,7 +143,7 @@ fi
 
 > *"This PR closes #N. Any other issues to close on merge? List them one per line (`Closes #X`), use `Refs #Y` to link without closing, or `no` to skip."*
 
-Append each accepted line to `${CLOSES_LINE}` (newline-separated). GitHub accepts one keyword per issue, comma- or newline-separated.
+Append each accepted `Closes #X` line to `${CLOSES_LINE}` (newline-separated); route each `Refs #Y` line into the `## Related` section instead (§2.4.1, replacing its `N/A`), never onto the closing-keyword line — the same rule the orphan-PR and `## Related` guidance below apply to every non-closing reference. GitHub accepts one keyword per issue, comma- or newline-separated.
 
 **Branch lacks issue number (orphan PR — drift sweep, hotfix, refactor):** prompt with two options:
 


### PR DESCRIPTION
## Summary

The `pull-request` create flow's §2.4.2 pre-create gate treated a bare `Refs #N` line as a valid closing-keyword opt-out, but the real `pr-issue-linkage` reusable CI workflow does not accept `Refs #N`. A PR body that satisfied the skill's own local gate could therefore still fail the CI gate on push. This is the narrow, same-repo fix (issue #630, option 1): align the skill's local opt-out marker set to the validator by dropping `Refs #N`.

## Fix

In `plugins/source-control/skills/pull-request/reference/create.md`:

- **§2.4.2** `OPTOUT_REGEX` drops `Refs #N`: `^(Refs #[0-9]+|No related issue:)` → `^No related issue:`. A rationale comment explains why `Refs #N` is excluded. The two abort-message lines no longer list `Refs #N` as an opt-out.
- **§2.4.0** orphan-PR prompt reduced from three options to two (`Closes #N` / `No related issue:`); a `Refs #N` link-without-close reference is now explicitly routed to the `## Related` section instead of the closing-keyword line.
- **§2.4.1** asymmetry note rewritten: a `Refs #N` line satisfies the closing-keyword half of neither the §2.4.2 gate nor the real validator.
- The §2.4.2 "gate passes silently" prose no longer names `Refs #N` as a silent-pass path.

`Refs #N` remains valid where it always belonged — as a link-without-close reference inside the `## Related` section (§2.4.1) and in the multi-issue prompt where a primary `Closes #N` already carries the gate. Extending the upstream validator to accept `Refs #N` (option 2) requires a change in `melodic-software/ci-workflows` and is out of scope for this lane.

`source-control` bumped 0.13.1 → 0.13.2 (patch — contract-alignment bug fix) with a matching CHANGELOG entry at the top.

## Verification

**The real validator's accepted set** — read live from the pinned reusable source (`melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml` @ `90f1c54935203fa31b5b3d1f41531228be2c2b7f`, the SHA this repo's `.github/workflows/pr-issue-linkage.yml` pins). Its closing-keyword half accepts exactly two forms:

```js
const CLOSING_KEYWORD =
  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:[\w.-]+\/[\w.-]+)?#\d+\b/i;
const NO_ISSUE_MARKER = /\bno (?:linked|related) issue\b/i;
```

`Refs #N` matches neither.

**The skill's local gate after this change** (§2.4.2):

```bash
KEYWORD_REGEX='^(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? #[0-9]+'
# Only `No related issue:` — a bare `Refs #N` links without closing and does NOT
# satisfy the real pr-issue-linkage validator's closing-keyword half, so accepting
# it here would clear a body the CI gate then rejects.
OPTOUT_REGEX='^No related issue:'
```

`Refs #N` no longer matches `OPTOUT_REGEX` — the specific false-accept this issue reports is eliminated.

**Marker-set relationship.** The two sets are not literally identical, and this PR does not claim they are: the validator additionally honors `No linked issue`, owner/repo-qualified keywords, and looser-whitespace keyword forms that the line-anchored local gate does not. What now holds is the safety property that was broken: **every body the local gate passes, the validator also passes** (the local gate is a strict safe subset). The one marker the local gate accepted that the validator rejects — `Refs #N` — has been removed, so a "skill-gate-satisfied" body can no longer fail the real CI gate on this axis. The skill only ever emits `No related issue:` (never the sibling `No linked issue` phrasing), so the local gate is deliberately mirrored to what the skill produces, not widened to the validator's full superset.

**No stale references remain.** Grep of the whole plugin for `Refs #`:

```
create.md:144  multi-issue prompt — `Refs #Y` links additional issues (primary `Closes #N` carries the gate)
create.md:153  new prose — routes link-without-close refs to `## Related`
create.md:200  `## Related` section usage (correct)
create.md:202  rewritten asymmetry note — `Refs #N` satisfies neither gate
create.md:214  new OPTOUT_REGEX rationale comment
```

Every surviving `Refs #` is either legitimate `## Related` / multi-issue linking or prose that now states `Refs #N` does **not** satisfy the gate. No occurrence presents `Refs #N` as a closing-keyword opt-out.

Closes #630

## Related

- #630 — the issue this PR closes (option 1, the narrow same-repo fix).
- #487 / PR #629 — the sibling work this builds on: #629 added the `## Related` scaffold to the create flow and *documented* this `Refs #N` opt-out asymmetry in §2.4.1 as a known, deliberately-out-of-scope gap; this PR is the follow-up that closes it.

🤖 Generated with a Claude Code implementation subagent (issue #630)
