### PR TITLE
perf(ci): short-circuit hygiene's docs-irrelevant linters on docs-only diffs (#628)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,20 @@ jobs:
   # public repositories); the local-runner selector is not permitted here. The
   # short hygiene checks still share one checkout to avoid per-check setup
   # churn.
+  # Docs-linting lane. Markdownlint / typos / editorconfig / gitleaks /
+  # eol-renormalize / comment-hygiene / machine-specific-paths read the changed
+  # docs themselves and run on every diff. The docs-IRRELEVANT full-repo linters
+  # (ShellCheck, actionlint, the four check-jsonschema steps, exec-bit) cannot be
+  # affected by a diff confined to the docs-only allowlist
+  # (scripts/docs-only-paths.txt), so on such a diff they report an honest
+  # evaluated-and-not-applicable success. The job NEVER skips — only those inner
+  # steps are gated, via the same never-skip, self-test-first, fail-closed
+  # detector plugin-gate/miro-plugin use. The detector self-test runs
+  # unconditionally so a broken detector cannot mask a regression, and detection
+  # is fail-closed toward running the full suite. The gated steps' intentional
+  # docs-only skip is mapped to `success` in the CHECK_RESULTS feed below (where
+  # the step provably did not run), never by weakening the aggregator — it still
+  # fails closed on any real non-`success` outcome.
   hygiene:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -34,7 +48,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Full history so the PR base ref resolves for the docs-only diff.
           fetch-depth: 0
+      - name: Test the docs-only detector
+        run: bash scripts/check-docs-only.test.sh
+      - name: Detect a docs-only diff
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-docs-only.sh "origin/$BASE_REF"
       - name: Lint markdown
         id: markdown
         continue-on-error: true
@@ -67,6 +90,7 @@ jobs:
 
       - name: Lint shell scripts
         id: shellcheck
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/shellcheck@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
         with:
@@ -74,11 +98,13 @@ jobs:
 
       - name: Lint workflows
         id: actionlint
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/actionlint@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
 
       - name: Validate marketplace manifest
         id: marketplace_schema
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
         with:
@@ -86,6 +112,7 @@ jobs:
           files: .claude-plugin/marketplace.json
       - name: Validate plugin manifests
         id: plugin_schema
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
         with:
@@ -93,6 +120,7 @@ jobs:
           files: plugins/*/.claude-plugin/plugin.json
       - name: Validate dependabot.yml
         id: dependabot_schema
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
         with:
@@ -100,6 +128,7 @@ jobs:
           files: .github/dependabot.yml
       - name: Validate workflows
         id: workflow_schema
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/check-jsonschema@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
         with:
@@ -114,6 +143,7 @@ jobs:
 
       - name: Verify shebang files are executable
         id: exec_bit
+        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/exec-bit@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
 
@@ -150,6 +180,10 @@ jobs:
             :(exclude)plugins/code-tidying/skills/audit-comment-residue/scripts/**
             :(exclude)plugins/code-tidying/skills/audit-comment-residue/evals/**
 
+      - name: Report docs-irrelevant checks not applicable to a docs-only diff
+        if: steps.scope.outputs.docs_only == 'true'
+        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the docs-irrelevant full-repo linters (shellcheck, actionlint, check-jsonschema x4, exec-bit) cannot be affected — reporting success for them."
+
       - name: Test hygiene result aggregation
         run: scripts/aggregate-hygiene-results.sh --self-test
 
@@ -157,18 +191,25 @@ jobs:
         if: always()
         env:
           # Display names (left) are annotations; step ids (right) use underscores.
+          # The docs-irrelevant linters carry `if: docs_only != 'true'`, so on a
+          # docs-only diff they are skipped (never run) — their intentional skip
+          # is mapped to `success` here BECAUSE the step provably did not run, so
+          # no real outcome is masked. The aggregator stays fail-closed on any
+          # real non-`success` (including `skipped`); it is never told to pass on
+          # `skipped`. The condition (docs_only == 'true') is the exact inverse of
+          # each gate, so the two can never disagree.
           CHECK_RESULTS: |
             markdown=${{ steps.markdown.outcome }}
             typos=${{ steps.typos.outcome }}
             gitleaks=${{ steps.gitleaks.outcome }}
             editorconfig=${{ steps.editorconfig.outcome }}
-            shellcheck=${{ steps.shellcheck.outcome }}
-            actionlint=${{ steps.actionlint.outcome }}
-            marketplace-schema=${{ steps.marketplace_schema.outcome }}
-            plugin-schema=${{ steps.plugin_schema.outcome }}
-            dependabot-schema=${{ steps.dependabot_schema.outcome }}
-            workflow-schema=${{ steps.workflow_schema.outcome }}
-            exec-bit=${{ steps.exec_bit.outcome }}
+            shellcheck=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.shellcheck.outcome }}
+            actionlint=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.actionlint.outcome }}
+            marketplace-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.marketplace_schema.outcome }}
+            plugin-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.plugin_schema.outcome }}
+            dependabot-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.dependabot_schema.outcome }}
+            workflow-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.workflow_schema.outcome }}
+            exec-bit=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.exec_bit.outcome }}
             machine-specific-paths=${{ steps.machine_paths.outcome }}
             eol-renormalize=${{ steps.eol.outcome }}
             comment-hygiene=${{ steps.comment_hygiene.outcome }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,18 @@ jobs:
   # churn.
   # Docs-linting lane. Markdownlint / typos / editorconfig / gitleaks /
   # eol-renormalize / comment-hygiene / machine-specific-paths read the changed
-  # docs themselves and run on every diff. The docs-IRRELEVANT full-repo linters
-  # (ShellCheck, actionlint, the four check-jsonschema steps, exec-bit) cannot be
-  # affected by a diff confined to the docs-only allowlist
-  # (scripts/docs-only-paths.txt), so on such a diff they report an honest
-  # evaluated-and-not-applicable success. The job NEVER skips — only those inner
-  # steps are gated, via the same never-skip, self-test-first, fail-closed
-  # detector plugin-gate/miro-plugin use. The detector self-test runs
+  # docs themselves and run on every diff. actionlint and the four
+  # check-jsonschema steps read fixed, path-scoped inputs (.github/workflows/**
+  # and the named manifests) that a diff confined to the docs-only allowlist
+  # (scripts/docs-only-paths.txt) cannot touch, so on such a diff they report an
+  # honest evaluated-and-not-applicable success. ShellCheck and exec-bit are NOT
+  # gated: both scan the whole repo extension- and directory-agnostically
+  # (ShellCheck lints every tracked *.sh/*.bash, exec-bit flags every tracked
+  # shebang file recorded 100644), so a shell/shebang file added under an
+  # otherwise docs-only prefix like docs/topics/ is real input they must still
+  # catch — gating them would open a fail-closed hole. The job NEVER skips — only
+  # the path-scoped steps are gated, via the same never-skip, self-test-first,
+  # fail-closed detector plugin-gate/miro-plugin use. The detector self-test runs
   # unconditionally so a broken detector cannot mask a regression, and detection
   # is fail-closed toward running the full suite. The gated steps' intentional
   # docs-only skip is mapped to `success` in the CHECK_RESULTS feed below (where
@@ -90,7 +95,6 @@ jobs:
 
       - name: Lint shell scripts
         id: shellcheck
-        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/shellcheck@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
         with:
@@ -143,7 +147,6 @@ jobs:
 
       - name: Verify shebang files are executable
         id: exec_bit
-        if: steps.scope.outputs.docs_only != 'true'
         continue-on-error: true
         uses: melodic-software/ci-workflows/.github/actions/exec-bit@c2654182bc2d78f7909795df78304d482aa69226 # c265418 2026-07-13
 
@@ -182,7 +185,7 @@ jobs:
 
       - name: Report docs-irrelevant checks not applicable to a docs-only diff
         if: steps.scope.outputs.docs_only == 'true'
-        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the docs-irrelevant full-repo linters (shellcheck, actionlint, check-jsonschema x4, exec-bit) cannot be affected — reporting success for them."
+        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the path-scoped linters (actionlint, check-jsonschema x4) cannot be affected — reporting success for them. ShellCheck and exec-bit scan the whole repo and stay unconditional."
 
       - name: Test hygiene result aggregation
         run: scripts/aggregate-hygiene-results.sh --self-test
@@ -191,25 +194,27 @@ jobs:
         if: always()
         env:
           # Display names (left) are annotations; step ids (right) use underscores.
-          # The docs-irrelevant linters carry `if: docs_only != 'true'`, so on a
-          # docs-only diff they are skipped (never run) — their intentional skip
-          # is mapped to `success` here BECAUSE the step provably did not run, so
-          # no real outcome is masked. The aggregator stays fail-closed on any
-          # real non-`success` (including `skipped`); it is never told to pass on
-          # `skipped`. The condition (docs_only == 'true') is the exact inverse of
-          # each gate, so the two can never disagree.
+          # The path-scoped linters (actionlint, the four check-jsonschema steps)
+          # carry `if: docs_only != 'true'`, so on a docs-only diff they are
+          # skipped (never run) — their intentional skip is mapped to `success`
+          # here BECAUSE the step provably did not run, so no real outcome is
+          # masked. The aggregator stays fail-closed on any real non-`success`
+          # (including `skipped`); it is never told to pass on `skipped`. The
+          # condition (docs_only == 'true') is the exact inverse of each gate, so
+          # the two can never disagree. ShellCheck and exec-bit are unconditional
+          # (whole-repo scanners), so they feed their raw outcome.
           CHECK_RESULTS: |
             markdown=${{ steps.markdown.outcome }}
             typos=${{ steps.typos.outcome }}
             gitleaks=${{ steps.gitleaks.outcome }}
             editorconfig=${{ steps.editorconfig.outcome }}
-            shellcheck=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.shellcheck.outcome }}
+            shellcheck=${{ steps.shellcheck.outcome }}
             actionlint=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.actionlint.outcome }}
             marketplace-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.marketplace_schema.outcome }}
             plugin-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.plugin_schema.outcome }}
             dependabot-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.dependabot_schema.outcome }}
             workflow-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.workflow_schema.outcome }}
-            exec-bit=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.exec_bit.outcome }}
+            exec-bit=${{ steps.exec_bit.outcome }}
             machine-specific-paths=${{ steps.machine_paths.outcome }}
             eol-renormalize=${{ steps.eol.outcome }}
             comment-hygiene=${{ steps.comment_hygiene.outcome }}

--- a/scripts/check-docs-only.test.sh
+++ b/scripts/check-docs-only.test.sh
@@ -93,6 +93,14 @@ assert_flag "toolchain lockfile" false "package-lock.json"
 assert_flag "sibling of an allowed prefix (docs/topics-archive/)" false "docs/topics-archive/old.md"
 assert_flag "mixed docs+code" false "docs/topics/example/PLAN.md" "plugins/p1/skills/alpha/SKILL.md"
 
+# --- hygiene job's docs-irrelevant step set: their inputs are NOT docs-only --
+# ShellCheck (scripts/, plugins/**), actionlint + workflow-schema (.github/
+# workflows/) are already pinned false above; these pin the remaining check-
+# jsonschema inputs so a widened allowlist that let one through fails the suite.
+assert_flag "marketplace manifest (marketplace-schema reads it)" false ".claude-plugin/marketplace.json"
+assert_flag "plugin manifest (plugin-schema reads it)" false "plugins/p1/.claude-plugin/plugin.json"
+assert_flag "dependabot.yml (dependabot-schema reads it)" false ".github/dependabot.yml"
+
 # --- fail-closed paths: emit false, exit 0 (run full, never block) ---------
 repo="$(mk_repo)"
 out="$(cd "$repo" && bash scripts/check-docs-only.sh "does-not-exist" 2>/dev/null)"

--- a/scripts/docs-only-paths.txt
+++ b/scripts/docs-only-paths.txt
@@ -1,7 +1,8 @@
 # Docs-only allowlist — path prefixes that feed NO code lane, so a PR whose diff
-# is confined to them lets the heavy lanes (plugin-gate, miro-plugin) report an
-# honest evaluated-and-not-applicable success instead of running their full
-# suites. Consumed by scripts/check-docs-only.sh.
+# is confined to them lets the heavy lanes (plugin-gate, miro-plugin) and the
+# hygiene job's docs-irrelevant full-repo linters report an honest
+# evaluated-and-not-applicable success instead of running their full suites.
+# Consumed by scripts/check-docs-only.sh.
 #
 # ALLOWLIST, NOT BLOCKLIST — by design. A blocklist ("skip on any doc the
 # validators don't currently read") silently turns false-green the day a
@@ -10,11 +11,21 @@
 # run. That is why the seed is deliberately narrow.
 #
 # Adding an entry is a two-part proof, enforced by the self-test:
-#   1. The prefix must feed no code lane. Today the only lanes this gate wraps
-#      are plugin-gate (runs hermetic plugins/**/*.test.sh, then validates
-#      manifests + catalog: reads README.md, docs/PLUGIN-ARTIFACT-PROTOCOL.md,
-#      docs/CATALOG-TAXONOMY.md) and miro-plugin (reads only plugins/miro/**).
-#      NONE of those read the paths below — that is the inertness proof.
+#   1. The prefix must feed no code lane. Today the lanes this gate wraps are:
+#      - plugin-gate: hermetic plugins/**/*.test.sh, then manifest + catalog
+#        validation (reads README.md, docs/PLUGIN-ARTIFACT-PROTOCOL.md,
+#        docs/CATALOG-TAXONOMY.md);
+#      - miro-plugin: reads only plugins/miro/**;
+#      - hygiene's docs-irrelevant subset — ShellCheck (lints *.sh under
+#        scripts/ + plugins/**), actionlint + the workflow check-jsonschema
+#        (read .github/workflows/**), the marketplace / plugin / dependabot
+#        check-jsonschema steps (read .claude-plugin/marketplace.json,
+#        plugins/*/.claude-plugin/plugin.json, .github/dependabot.yml), and
+#        exec-bit (scans shebang files for the executable bit).
+#      NONE of those read the paths below — that is the inertness proof. (The
+#      hygiene DOCS-linters — markdown, typos, editorconfig, gitleaks,
+#      eol-renormalize, comment-hygiene, machine-specific-paths — DO read the
+#      changed docs and stay unconditional; they are not gated on this list.)
 #   2. A matching case in scripts/check-docs-only.test.sh must pin it.
 #
 # Prefixes match by literal string prefix; keep the trailing slash so

--- a/scripts/docs-only-paths.txt
+++ b/scripts/docs-only-paths.txt
@@ -1,6 +1,6 @@
 # Docs-only allowlist — path prefixes that feed NO code lane, so a PR whose diff
 # is confined to them lets the heavy lanes (plugin-gate, miro-plugin) and the
-# hygiene job's docs-irrelevant full-repo linters report an honest
+# hygiene job's path-scoped linters report an honest
 # evaluated-and-not-applicable success instead of running their full suites.
 # Consumed by scripts/check-docs-only.sh.
 #
@@ -16,16 +16,20 @@
 #        validation (reads README.md, docs/PLUGIN-ARTIFACT-PROTOCOL.md,
 #        docs/CATALOG-TAXONOMY.md);
 #      - miro-plugin: reads only plugins/miro/**;
-#      - hygiene's docs-irrelevant subset — ShellCheck (lints *.sh under
-#        scripts/ + plugins/**), actionlint + the workflow check-jsonschema
-#        (read .github/workflows/**), the marketplace / plugin / dependabot
-#        check-jsonschema steps (read .claude-plugin/marketplace.json,
-#        plugins/*/.claude-plugin/plugin.json, .github/dependabot.yml), and
-#        exec-bit (scans shebang files for the executable bit).
-#      NONE of those read the paths below — that is the inertness proof. (The
-#      hygiene DOCS-linters — markdown, typos, editorconfig, gitleaks,
-#      eol-renormalize, comment-hygiene, machine-specific-paths — DO read the
-#      changed docs and stay unconditional; they are not gated on this list.)
+#      - hygiene's path-scoped subset — actionlint + the workflow
+#        check-jsonschema (read .github/workflows/**), and the marketplace /
+#        plugin / dependabot check-jsonschema steps (read
+#        .claude-plugin/marketplace.json, plugins/*/.claude-plugin/plugin.json,
+#        .github/dependabot.yml).
+#      NONE of those read the paths below — that is the inertness proof. The
+#      remaining hygiene checks stay UNCONDITIONAL and are not gated on this
+#      list: markdown, typos, editorconfig, gitleaks, eol-renormalize,
+#      comment-hygiene, machine-specific-paths read the changed docs directly;
+#      ShellCheck (lints every tracked *.sh/*.bash) and exec-bit (flags every
+#      tracked shebang file recorded 100644) scan the whole repo extension- and
+#      directory-agnostically, so a shell/shebang file added under docs/topics/
+#      IS input they must still catch — gating them would open a fail-closed
+#      hole.
 #   2. A matching case in scripts/check-docs-only.test.sh must pin it.
 #
 # Prefixes match by literal string prefix; keep the trailing slash so


### PR DESCRIPTION
## Summary

Docs-only PRs still paid the `hygiene` job's path-scoped linter cost — `actionlint` and four `check-jsonschema` steps — for a diff that provably cannot affect any of them. #617 (via #622) short-circuited `plugin-gate` and `miro-plugin`, which cut runner-minutes but not the merge-latency bottleneck. This applies the SAME self-test-first, fail-closed, inner-step-gated discipline to `hygiene`'s genuinely path-scoped subset, so those runs report an honest evaluated-and-not-applicable success instead of running.

`ShellCheck` and `exec-bit` are deliberately NOT gated: both scan the whole repo extension- and directory-agnostically (`ShellCheck` lints every tracked `*.sh`/`*.bash` via `git ls-files`; `exec-bit` flags every tracked shebang file recorded `100644` via `git grep -- .`), so a shell or shebang file added under an otherwise docs-only prefix like `docs/topics/` is real input they must still catch. They run on every diff alongside the docs-linting checks that read the changed docs directly: `markdown`, `typos`, `editorconfig`, `gitleaks`, `eol-renormalize`, `comment-hygiene`, `machine-specific-paths`.

> **Scope of the perf win (honest):** the initial revision of this PR also gated `ShellCheck` (~53s, the dominant cost) and `exec-bit`. Bot review (P2, thread on `ci.yml`) surfaced that both are whole-repo scanners, so gating them opened a **fail-closed hole** — a docs-only PR adding a mode-`100644` shebang file (or a `*.sh`) under `docs/topics/` skipped both and the ternary mapped them to `success`, letting a file the commit procedure requires `exec-bit` to catch merge unlinted. Ungating them (commit `f73be27`) closes the hole but removes the dominant ShellCheck skip, so the remaining docs-only win is limited to `actionlint` + the four `check-jsonschema` steps. A perf-recovery follow-up (cache/pin the ShellCheck install, which downloads a release tarball every run) is tracked separately and lives in `melodic-software/ci-workflows`, not this repo.

## Fix

Reuses the existing `scripts/check-docs-only.sh` detector and `scripts/docs-only-paths.txt` allowlist from #622 unchanged — no new detector.

In the `hygiene` job (`.github/workflows/ci.yml`):

- Added the always-run `Test the docs-only detector` self-test and a PR-only `Detect a docs-only diff` step (`id: scope`), mirroring `plugin-gate`/`miro-plugin`. The checkout already had `fetch-depth: 0`, so the base ref resolves.
- Gated exactly the five path-scoped steps with `if: steps.scope.outputs.docs_only != 'true'`: `actionlint`, `marketplace_schema`, `plugin_schema`, `dependabot_schema`, `workflow_schema`. `shellcheck` and `exec_bit` stay unconditional.
- The job never skips and the aggregator is never weakened. The `hygiene` job uses `continue-on-error: true` per step plus a `CHECK_RESULTS` feed into `scripts/aggregate-hygiene-results.sh`, which fails closed on any non-`success` outcome (including `skipped`). A gated step that skips would therefore red the job — so each gated entry in `CHECK_RESULTS` maps the intentional docs-only skip to `success` in the expression layer:

  ```yaml
  actionlint=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.actionlint.outcome }}
  ```

  This is honest, not a swallow: the ternary condition (`docs_only == 'true'`) is the exact inverse of each step's gate, so `success` is fed ONLY for a step that provably did not run — no real outcome is ever masked. The two whole-repo scanners (`shellcheck`, `exec-bit`) feed their raw `.outcome`. The aggregator script is untouched and still fails closed on any real `failure` (or a `skipped` it isn't told to tolerate). This is the same evaluated-and-not-applicable success `plugin-gate` reports with its log step, expressed here through the feed the hygiene job already uses.
- Added an explicit `Report docs-irrelevant checks not applicable` log step (gated on `docs_only == 'true'`) so a human reading a green run understands why those checks show skipped.

Also extended the two non-workflow artifacts per the established two-part-proof discipline:

- `scripts/docs-only-paths.txt` — updated the inertness-proof comment to name only the genuinely path-scoped gated subset (`actionlint` + the four schema checks, none of which read `docs/topics/`) and to state explicitly that `ShellCheck` and `exec-bit` scan the whole repo and stay unconditional (as do the docs-linters). Allowlist itself unchanged (still `docs/topics/` only — no growth).
- `scripts/check-docs-only.test.sh` — added three cases pinning the remaining `check-jsonschema` inputs to `false` (`.claude-plugin/marketplace.json`, `plugins/*/.claude-plugin/plugin.json`, `.github/dependabot.yml`); the `actionlint` / workflow-schema inputs (`.github/workflows/ci.yml`) were already pinned false. These fail the moment someone widens the allowlist to cover an input a gated check reads.

## Verification

Run in the worktree (Git Bash):

- **`bash scripts/check-docs-only.test.sh` → `PASS=19 FAIL=0`.** Confirms `docs/topics/`-only → `true` and every gated check's input (`.github/workflows/ci.yml`, `.claude-plugin/marketplace.json`, `plugins/*/.claude-plugin/plugin.json`, `.github/dependabot.yml`, lockfiles) → `false`.
- **`scripts/aggregate-hygiene-results.sh --self-test` → `Hygiene result aggregation contract passed.`** The aggregator is unchanged and still fails closed on a named empty/`failure`/non-`success` outcome.
- **`actionlint .github/workflows/ci.yml` → clean.** Validates the five added gate conditions and the five ternary expressions in `CHECK_RESULTS`.
- **`shellcheck --rcfile .shellcheckrc` and `shfmt -d`** on the edited/reused scripts → clean, no diff.

Honest scope of what this PR's own CI proves: this PR touches `.github/` and `scripts/`, so on it `docs_only=false` and the full hygiene suite runs — a live proof only of the run-path (nothing is wrongly skipped on a code diff). The skip-path is not live-observable here by construction; it is proven by the detector unit test (`docs/topics/`-only → `true`) plus the gate/expression logic being the exact inverse of each other. Correctness of the intentional-skip → `success` mapping rests on that unit test and the expression, not on a fabricated observation.

**Versioning/changelog:** none. No `plugins/<name>/` directory is touched — this is a repo-root CI-only change — so per the precedent #622 followed (matching CI-only #490/#593) there is no plugin version bump or CHANGELOG entry.

Closes #628

## Related

- #628 — this issue.
- #617 (closed) / #622 (merged) — the established precedent this extends: same `scripts/check-docs-only.sh` detector, same self-test-first / fail-closed / inner-step-gated discipline, applied to `hygiene` instead of `plugin-gate`/`miro-plugin`.
- #532 — the false-green / liveness class this must not reintroduce. A job-level skip (or teaching the aggregator to pass on `skipped`) is exactly that shape and is deliberately avoided: the job always runs, the detector self-tests first, and only inner steps are gated with their skip reported as an honest not-applicable success.

🤖 Generated with a Claude Code implementation subagent (issue #628)
