### PR TITLE
fix(repo-hygiene): --repo consumes consecutive glob paths in tree-batch (#650)

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Fixed
+
+- **`tree-batch` — `--repo` now consumes every consecutive path, so the documented
+  shell-glob form works.** `--repo ~/repos/*` reaches the script as one `--repo`
+  flag followed by N positional paths (the shell expands the glob before exec), but
+  the arg-parsing arm consumed only the first: the second expanded path hit the
+  unknown-argument default and the batch exited 2. The documented glob usage
+  therefore always failed whenever the glob matched more than one directory. The
+  `--repo` arm now greedily ingests every consecutive non-flag path, halting at the
+  next `-`-prefixed flag or end of args, so the advertised `--repo ~/repos/*` form
+  is ingested whole. Repeated `--repo` and `--repos-from -` are unchanged. A bare
+  `--repo` with no following path (end of args or immediately followed by a flag)
+  now fails loud with a usage error instead of silently absorbing the next flag as a
+  directory. (#650)
+
 ## [0.4.2]
 
 ### Fixed

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -19,7 +19,7 @@
 #
 # Usage:
 #   git-tree-reset-batch.sh [--dry-run|--apply]
-#                           [--repo DIR]... [--repos-from FILE|-]...
+#                           [--repo DIR...]... [--repos-from FILE|-]...
 #                           [--skip ENTRY]... [--skip-from FILE]...
 #                           [--include-dirty]
 #                           [--force-default-branch] [--include-deps]
@@ -27,8 +27,9 @@
 # Default: --dry-run.
 #
 # Repo sources (a `ghq list`, a shell glob, or an explicit list all reduce to a
-# path list): --repo (repeatable, and how a shell glob arrives after expansion),
-# and --repos-from FILE (or - for stdin; how `ghq list -p` output is ingested).
+# path list): --repo (repeatable, and consumes every consecutive non-flag path so
+# a shell glob — `--repo ~/repos/*` — arrives whole after expansion), and
+# --repos-from FILE (or - for stdin; how `ghq list -p` output is ingested).
 #
 # Skip list: --skip ENTRY (repeatable) / --skip-from FILE. An entry may be an
 # absolute path or a trailing owner/repo or repo segment; matching is separator-
@@ -59,7 +60,7 @@ with a separator-agnostic skip list and a dirty-by-default guard.
 
 Usage:
   git-tree-reset-batch.sh [--dry-run|--apply]
-                          [--repo DIR]... [--repos-from FILE|-]...
+                          [--repo DIR...]... [--repos-from FILE|-]...
                           [--skip ENTRY]... [--skip-from FILE]...
                           [--include-dirty]
                           [--force-default-branch] [--include-deps]
@@ -68,7 +69,10 @@ Usage:
 Default: --dry-run (inventory only; no mutations).
 
 Repo sources (combine freely; deduped by canonical toplevel):
-  --repo DIR         a repository (repeatable; a shell glob expands to these).
+  --repo DIR...      one or more repositories (repeatable). Consumes every
+                     consecutive non-flag path, so a shell glob (--repo
+                     ~/repos/*) is ingested whole; consumption stops at the
+                     next flag.
   --repos-from FILE  newline-delimited repo paths (FILE, or - for stdin; the way
                      `ghq list -p` output is ingested). Repeatable.
 
@@ -136,9 +140,21 @@ while [[ $# -gt 0 ]]; do
   --include-deps) INCLUDE_DEPS=1 ;;
   --include-secrets) INCLUDE_SECRETS=1 ;;
   --repo)
-    [[ $# -ge 2 ]] || fail_usage "--repo requires a directory"
-    REPO_INPUTS+=("$2")
+    # Consume every consecutive non-flag arg, not just the first, so a shell glob
+    # (`--repo ~/repos/*`) — which the shell expands to N positional paths behind a
+    # single --repo — is ingested whole. Consumption stops at the next recognized
+    # token (any `-`-prefixed flag) or end of args; every flag in this parser is
+    # `-`-prefixed and repo paths are directories that never start with `-`, so the
+    # boundary is unambiguous. The `$2 != -*` guard is set -u-safe: [[ ]] does not
+    # expand $2 when $# < 2. `continue` skips the loop's trailing shift because this
+    # arm has already shifted past the flag and all the paths it consumed.
+    [[ $# -ge 2 && "$2" != -* ]] || fail_usage "--repo requires a directory"
     shift
+    while [[ $# -gt 0 && "$1" != -* ]]; do
+      REPO_INPUTS+=("$1")
+      shift
+    done
+    continue
     ;;
   --repos-from)
     [[ $# -ge 2 ]] || fail_usage "--repos-from requires a file or -"

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.test.sh
@@ -325,6 +325,36 @@ out="$(bash "$BATCH" --dry-run --repos-from "$NOEOL_REPOS" 2>&1)" || true
 assert_contains "unterminated repos-from still enumerates the repo" "$out" "Repos: 1"
 assert_contains "unterminated repos-from repo would reset" "$out" "would-reset"
 
+# --- 23. a single --repo consumes consecutive paths (shell-glob-after-expansion) ---
+# `--repo ~/repos/*` reaches the script as ONE --repo flag followed by N positional
+# paths (the shell expanded the glob before exec). A single --repo must ingest every
+# one of them, which the pre-fix single-arg arm could not: it took the first path and
+# the second hit the unknown-arg default (exit 2). Simulate the expanded glob with two
+# explicit consecutive paths after one --repo.
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" "$SKIP_REPO" 2>&1)" || true
+assert_contains "single --repo ingests both consecutive glob paths" "$out" "Repos: 2"
+
+# --- 24. consumption STOPS at the next flag (does not swallow it as a path) ---
+# The discriminating case: `--repo A B --skip keepme`. Repos: 2 alone would also pass
+# for an over-greedy loop that ate --skip and its value; the load-bearing assertion is
+# that --skip was still parsed AS A FLAG (skip-list fires on the keepme repo), proving
+# the greedy consumption halts at the `-`-prefixed boundary.
+out="$(bash "$BATCH" --dry-run --repo "$CLEAN_REPO" "$SKIP_REPO" --skip 'keepme' 2>&1)" || true
+assert_contains "greedy --repo still enumerates both paths" "$out" "Repos: 2"
+assert_contains "greedy --repo stops at --skip (parsed as a flag, not a path)" "$out" "skip-list"
+assert_not_contains "--skip value 'keepme' was not swallowed as a repo path" "$out" "UnmatchedSkip: keepme"
+
+# --- 25. --repo with no path (immediately at a flag or end of args) is a usage error ---
+# A bare --repo followed by another flag has no path to consume; it must fail loud
+# (exit 2), not silently absorb the following flag as a directory path (the pre-fix
+# single-arg arm did the latter, classifying e.g. `--skip` as a blocked non-directory).
+rc=0
+bash "$BATCH" --dry-run --repo --skip 'x' >/dev/null 2>&1 || rc=$?
+assert_exit "--repo immediately followed by a flag exits 2" 2 "$rc"
+rc=0
+bash "$BATCH" --dry-run --repo >/dev/null 2>&1 || rc=$?
+assert_exit "trailing --repo with no path exits 2" 2 "$rc"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1


### PR DESCRIPTION
## Summary

`git-tree-reset-batch.sh` documented `--repo ~/repos/*` as the shell-glob usage form, but a single `--repo` flag consumed only the first expanded path. A shell glob reaches the script as one `--repo` flag followed by N positional paths (the shell expands the glob before exec); the second path hit the unknown-argument default case and the batch exited 2. The advertised glob form therefore always failed whenever the glob matched more than one directory.

## Fix

Chose **option 1 (the dispatch's recommended default): make `--repo` consume consecutive non-flag args**, so the advertised `--repo ~/repos/*` form works as documented and users need not learn a different invocation.

The `--repo` arm now greedily ingests every consecutive path, halting at the next `-`-prefixed flag or end of args. This is unambiguous in this parser: **every** flag it recognizes (`--dry-run`, `--apply`, `--include-dirty`, `--force-default-branch`, `--include-deps`, `--include-secrets`, `--repo`, `--repos-from`, `--skip`, `--skip-from`, `-h/--help`) is `-`-prefixed, and repo paths are directories that never start with `-`. Investigated the full parse loop first per the dispatch guidance — no genuine ambiguity or flag-interaction conflict exists, so no fallback to option 2 was needed. The `$2 != -*` guard is `set -u`-safe (`[[ ]]` does not expand `$2` when `$# < 2`).

Scope is `--repo` only, matching the issue; `--skip` stays single-value. The header comment and the `usage()` heredoc are both updated (the "how a shell glob arrives after expansion" line is now actually true).

**Behavior change (strictly better):** a bare `--repo` with no following path — end of args, or immediately followed by a flag such as `--repo --skip x` — now fails loud with `--repo requires a directory` (exit 2). Previously it silently absorbed the following flag as a directory path, which then surfaced as a blocked non-directory outcome. No existing test relied on the old behavior.

## Verification

Full suite on the live environment (Git Bash on Windows — the Windows-only case-fold assertion runs here), all 61 assertions pass (55 pre-existing + 6 new); no regression across any prior case:

```
$ bash git-tree-reset-batch.test.sh
...
PASS: [55] unterminated repos-from repo would reset
PASS: [56] single --repo ingests both consecutive glob paths
PASS: [57] greedy --repo still enumerates both paths
PASS: [58] greedy --repo stops at --skip (parsed as a flag, not a path)
PASS: [59] --skip value 'keepme' was not swallowed as a repo path
PASS: [60] --repo immediately followed by a flag exits 2
PASS: [61] trailing --repo with no path exits 2
OK: git-tree-reset-batch.sh tests passed
```

New tests prove all three requirements:
- **[56]** a single `--repo A B` (a shell-glob-after-expansion, the exact failing case) ingests both paths — `Repos: 2` — where the pre-fix single-arg arm exited 2.
- **[58]/[59]** the discriminating stop-at-flag proof: `--repo A B --skip keepme` still enumerates `Repos: 2` **and** `--skip` is parsed as a flag (`skip-list` fires; `keepme` is not swallowed as a third path). `Repos: 2` alone would also pass an over-greedy loop — the `skip-list` assertion is what actually proves consumption halts at the flag boundary.
- **[60]/[61]** a path-less `--repo` (before a flag, or trailing) is a usage error (exit 2).

Existing invocation patterns are unchanged and still covered green: repeated `--repo` (tests exercising three `--repo` flags), `--repos-from FILE`, and `--repos-from -` (stdin). `shellcheck -x` is clean.

Closes #650

## Related

- #650 (this bug)
- #397 / PR #614 — origin of `git-tree-reset-batch.sh` and of the Codex P2 review finding (thread `PRRT_kwDOTCGFQM6SLwE5`) deferred at the time per the loop-breaker rule.

🤖 Generated with a Claude Code implementation subagent (issue #650)
