### PR TITLE
fix(review): declare allowed-tools so quality-gate survives headless runs (#290)

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.6]
+
+### Fixed
+
+- **`quality-gate` slash invocation no longer dies silently in headless
+  sessions.** The skill's *Pre-computed context* block injects dynamic context
+  via the `` !`<command>` `` syntax, which is preprocessing that runs during
+  prompt expansion — before the model turn — so the permission gate sits *above*
+  the shell. In a non-interactive session (`claude -p "/review:quality-gate …"`)
+  the `gh pr list` preflight was permission-denied during that preprocessing,
+  and the whole invocation aborted with empty output and exit 0 — total silent
+  failure with no model output. The in-command `|| echo "unknown"` guard is
+  structurally incapable of catching this: the denial happens a layer above the
+  shell, so the shell string (and its `||` fallback) never runs. Prose
+  invocation degraded gracefully only because it has no dynamic-context
+  preprocessing — the model issues `gh` as an ordinary Bash *tool* call whose
+  denial returns a handleable result. Fix: declare `allowed-tools` frontmatter
+  authorizing every segment of the three compound pre-computed lines
+  (`git branch --show-current`, `git status`, `head`, `echo`, `gh pr list`), the
+  documented canonical mechanism for dynamic-context bash, matching the
+  `pressure-test` and `wayfind` in-repo precedents. The existing `|| echo`
+  fallbacks are retained — they cover a different failure mode (`gh` missing /
+  unauthenticated / no PRs) that `allowed-tools` does not touch. Narrow,
+  read-only, non-interpreter allow rules that carry into auto mode; the
+  `git branch` rule matches only its actual use, `git branch --show-current`.
+
 ## [0.14.5]
 
 ### Fixed

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -27,7 +27,9 @@ All notable changes to the `review` plugin are documented here. Format follows
   fallbacks are retained — they cover a different failure mode (`gh` missing /
   unauthenticated / no PRs) that `allowed-tools` does not touch. Narrow,
   read-only, non-interpreter allow rules that carry into auto mode; the
-  `git branch` rule matches only its actual use, `git branch --show-current`.
+  git-branch rule is pinned to the exact read-only invocation
+  (`git branch --show-current`), so mutating `git branch` forms stay outside
+  the grant.
 
 ## [0.14.5]
 

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -25,11 +25,12 @@ All notable changes to the `review` plugin are documented here. Format follows
   documented canonical mechanism for dynamic-context bash, matching the
   `pressure-test` and `wayfind` in-repo precedents. The existing `|| echo`
   fallbacks are retained — they cover a different failure mode (`gh` missing /
-  unauthenticated / no PRs) that `allowed-tools` does not touch. Narrow,
-  read-only, non-interpreter allow rules that carry into auto mode; the
-  git-branch rule is pinned to the exact read-only invocation
-  (`git branch --show-current`), so mutating `git branch` forms stay outside
-  the grant.
+  unauthenticated / no PRs) that `allowed-tools` does not touch. The three
+  fixed pre-computed lines are granted as EXACT full-command rules (no
+  prefix wildcards), so neither mutating subcommands nor output-redirection
+  writes (`echo payload > file`, `head src > dst`) fall inside the grant;
+  the only wildcard kept is `Bash(gh pr list:*)` for the documented uncapped
+  fallback query.
 
 ## [0.14.5]
 

--- a/plugins/review/skills/quality-gate/SKILL.md
+++ b/plugins/review/skills/quality-gate/SKILL.md
@@ -4,7 +4,7 @@ description: "Single-lens review checkpoint between 'code works' and 'code is re
 argument-hint: "[mode] (e.g., /review:quality-gate, /review:quality-gate self, /review:quality-gate security, /review:quality-gate slice <name>)"
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(git branch --show-current:*)", "Bash(git status:*)", "Bash(head:*)", "Bash(echo:*)", "Bash(gh pr list:*)"]
+allowed-tools: ["Bash(git branch --show-current 2>/dev/null || echo \"unknown\")", "Bash(git status --porcelain 2>/dev/null | head -20 || echo \"unavailable\")", "Bash(gh pr list --json number,title,headRefName,baseRefName --limit 10 2>/dev/null || echo \"unknown\")", "Bash(gh pr list:*)"]
 ---
 
 ## Pre-computed context

--- a/plugins/review/skills/quality-gate/SKILL.md
+++ b/plugins/review/skills/quality-gate/SKILL.md
@@ -4,7 +4,7 @@ description: "Single-lens review checkpoint between 'code works' and 'code is re
 argument-hint: "[mode] (e.g., /review:quality-gate, /review:quality-gate self, /review:quality-gate security, /review:quality-gate slice <name>)"
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(git branch:*)", "Bash(git status:*)", "Bash(head:*)", "Bash(echo:*)", "Bash(gh pr list:*)"]
+allowed-tools: ["Bash(git branch --show-current:*)", "Bash(git status:*)", "Bash(head:*)", "Bash(echo:*)", "Bash(gh pr list:*)"]
 ---
 
 ## Pre-computed context

--- a/plugins/review/skills/quality-gate/SKILL.md
+++ b/plugins/review/skills/quality-gate/SKILL.md
@@ -4,6 +4,7 @@ description: "Single-lens review checkpoint between 'code works' and 'code is re
 argument-hint: "[mode] (e.g., /review:quality-gate, /review:quality-gate self, /review:quality-gate security, /review:quality-gate slice <name>)"
 user-invocable: true
 disable-model-invocation: false
+allowed-tools: ["Bash(git branch:*)", "Bash(git status:*)", "Bash(head:*)", "Bash(echo:*)", "Bash(gh pr list:*)"]
 ---
 
 ## Pre-computed context


### PR DESCRIPTION
## Summary
Signed supersede of PR #658 (identical tree, single signed commit). #658's original lane commit was unsigned and the org ruleset's required_signatures blocks it; the branch content — digest-verified MERGE-READY — is unchanged here.

## Fix
Declares the five allowed-tools rules on the review quality-gate skill so its pre-computed dynamic-context lines survive headless runs (issue #290 candidate 3). Includes the 0.14.6 version bump + CHANGELOG entry (re-homed above #673's 0.14.5) and the digest's wording soften (four rules read-only; `Bash(git branch:*)` scoped in practice to `git branch --show-current`).

## Verification
Carried from the digested branch at identical tree: validate-plugins.sh green, validate-plugin-contracts.mjs green (1793 files), standards-binding.test.sh PASS=8 FAIL=0, 17/17 CI checks green pre-supersede. CI re-runs here.

## Related
Closes #290
Supersedes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FM1RfM3jHkgenpdbMv4o64