### PR TITLE
fix(work-items): github adapter lease-coordination robustness (#370)

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.3]
+
+### Fixed
+
+- **GitHub adapter `renew-lease` no longer revives an expired lease (`#370`).** `renew-lease` confirmed
+  the handle still matched the active (newest non-superseded) lease but never checked liveness, so a
+  crashed or delayed holder retaining its handle past `renewed_at + ttl_hours` — with no newer lease
+  comment — could PATCH a fresh `renewed_at` and reclaim an item another worker had reasonably treated
+  as expired, defeating TTL-based handoff. It now checks `wit_lease_is_live` immediately before
+  patching and returns a conflict (exit `7`) for an expired lease instead of reviving it.
+- **GitHub adapter `reclaim` unassigns only the expired lease's holder (`#370`).** On the expired-lease
+  + no-activity path `reclaim` read all assignees and removed every one, silently unassigning a user
+  added manually after the old lease or a concurrent claimer added before the snapshot — in the
+  concurrent case leaving that claimer's live lease in place while the frontier treated the item as
+  unassigned (two workers on one item). Removal is now scoped to the lease's `holder`, and ownership is
+  revalidated immediately before mutating (the lease must still be the active, expired lease) so a
+  concurrent claim during the activity-check window aborts the reclaim as a no-op rather than stripping
+  the new owner. The shared active-lease selection is extracted to `wit_select_active_lease`
+  (`lib/lease.sh`), reused by both verbs.
+
 ## [0.14.2]
 
 ### Fixed

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   comment — could PATCH a fresh `renewed_at` and reclaim an item another worker had reasonably treated
   as expired, defeating TTL-based handoff. It now checks `wit_lease_is_live` immediately before
   patching and returns a conflict (exit `7`) for an expired lease instead of reviving it.
-- **GitHub adapter `reclaim` unassigns only the expired lease's holder (`#370`).** On the expired-lease
-  + no-activity path `reclaim` read all assignees and removed every one, silently unassigning a user
+- **GitHub adapter `reclaim` unassigns only the expired lease's holder (`#370`).** On the expired-lease,
+  no-activity path `reclaim` read all assignees and removed every one, silently unassigning a user
   added manually after the old lease or a concurrent claimer added before the snapshot — in the
   concurrent case leaving that claimer's live lease in place while the frontier treated the item as
   unassigned (two workers on one item). Removal is now scoped to the lease's `holder`, and ownership is

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -187,6 +187,10 @@ issue comment with a machine marker:
   reclaim/back-off by adding `"superseded_at":"<ISO>"` to the JSON.
 - A lease is **live** when it has no `superseded_at` and `renewed_at + ttl_hours` is in
   the future. `ttl_hours` defaults from binding `config.lease_ttl_hours`.
+- `renew-lease` renews **only a live lease**. A lease that is still the active
+  (non-superseded) lease but already **expired** — `renewed_at + ttl_hours` elapsed with
+  no back-off yet — is refused (exit `7`), never revived: a delayed holder must not undo a
+  TTL-based handoff. Recovery from an expired lease is a fresh claim/reclaim, not a renew.
 - `session_id` is diagnostic metadata only — optional and collision-prone; a
   missing/duplicate `session_id` still counts as a competing lease.
 - The **lease handle** (`lease_comment_id`, emitted by `claim`/`renew-lease`) is
@@ -210,9 +214,15 @@ Claim sequence (race-safe, same-identity aware):
 Reclaim (idempotent, run at session start — no scheduled sweep): when the latest lease is
 expired, check activity (non-lease comments since `renewed_at`; open cross-referenced
 PRs via the issue timeline). Activity → renew the lease in place, `reclaimed: false`.
-No activity → clear assignees, supersede the lease, append an explanatory comment,
-`reclaimed: true`. A live lease is never reclaimed. Branch-push activity signals are not
-implemented (deferred; comments + PR cross-references carry the check).
+No activity → unassign **only the expired lease's `holder`** (a co-assignee added by a
+human or a concurrent claimer is left in place — removing it would strip a live claim and
+leave the frontier treating the item as unassigned), supersede the lease, append an
+explanatory comment, `reclaimed: true`. Ownership is **revalidated immediately before the
+mutation** — the activity round-trips open a window in which a concurrent claimer can renew
+or supersede the lease; if the active lease is no longer this one, or is now live, reclaim
+is a no-op (`reclaimed: false`), never a mutation. A live lease is never reclaimed.
+Branch-push activity signals are not implemented (deferred; comments + PR cross-references
+carry the check).
 
 ## Containers and state
 

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
@@ -2,7 +2,7 @@
 # GitHub-adapter lease-coordination correctness that the abstract conformance
 # suite cannot assert (that suite needs a live GitHub target; these cases drive
 # specific renew-lease/reclaim decision paths deterministically against a stubbed
-# gh). Covers issue #370:
+# gh). Covers two lease-coordination findings:
 #   (1) renew-lease REFUSES an expired lease even when it is still the active
 #       (non-superseded) lease whose handle matches — no revive, exit 7, no PATCH;
 #   (2) reclaim removes ONLY the expired lease's holder, leaving a co-assignee

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# GitHub-adapter lease-coordination correctness that the abstract conformance
+# suite cannot assert (that suite needs a live GitHub target; these cases drive
+# specific renew-lease/reclaim decision paths deterministically against a stubbed
+# gh). Covers issue #370:
+#   (1) renew-lease REFUSES an expired lease even when it is still the active
+#       (non-superseded) lease whose handle matches — no revive, exit 7, no PATCH;
+#   (2) reclaim removes ONLY the expired lease's holder, leaving a co-assignee
+#       (manual or concurrent claimer) in place; and revalidates ownership before
+#       mutating, so a concurrent claim during the activity window aborts cleanly.
+# shellcheck disable=SC2154  # FAILED/CASE_NUM initialized by the sourced lib
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../tests/lib.sh"
+
+RENEW="$SCRIPT_DIR/renew-lease.sh"
+RECLAIM="$SCRIPT_DIR/reclaim.sh"
+ID="github:acme/widgets#1"
+
+# --- gh stub: a bash function (always wins over the external gh, and is inherited
+# by the `bash <verb>.sh` child via `export -f`). It reads canned responses from
+# $GH_STUB_DIR and appends write ops to calls.log, dispatching on the flags/paths
+# each call carries — the two reads of the same /comments endpoint are told apart
+# by --jq (`length` = activity count) vs (lease list), and successive lease-list
+# reads pick lease-comments-<n> when present so a revalidation read can differ. ---
+gh() {
+  local d="${GH_STUB_DIR:?}" args="$*" a prev n
+  case "$args" in
+    *"--method PATCH"*)
+      for a in "$@"; do
+        case "$a" in repos/*/issues/comments/*) printf 'PATCH %s\n' "${a##*/comments/}" >>"$d/calls.log" ;; *) : ;; esac
+      done
+      printf '1\n'
+      ;;
+    *"--remove-assignee"*)
+      prev=""
+      for a in "$@"; do
+        [[ "$prev" == "--remove-assignee" ]] && printf 'REMOVE_ASSIGNEE %s\n' "$a" >>"$d/calls.log"
+        prev="$a"
+      done
+      ;;
+    *"--json assignees"*) cat "$d/assignees" ;;
+    *"/timeline"*) cat "$d/pr-activity" 2>/dev/null || printf '0\n' ;;
+    *"--paginate"*)
+      case "$args" in
+        *length*) cat "$d/comment-activity" 2>/dev/null || printf '0\n' ;;
+        *)
+          n=$(( $(cat "$d/lease-comments.count" 2>/dev/null || printf '0') + 1 ))
+          printf '%s\n' "$n" >"$d/lease-comments.count"
+          if [[ -f "$d/lease-comments-$n" ]]; then cat "$d/lease-comments-$n"; else cat "$d/lease-comments"; fi
+          ;;
+      esac
+      ;;
+    *"issues/comments/"*) cat "$d/comment" ;;
+    *"-f body="*) printf 'POST_COMMENT\n' >>"$d/calls.log"; printf '1\n' ;;
+    *) printf 'gh-stub: unhandled: %s\n' "$args" >&2; return 90 ;;
+  esac
+}
+export -f gh
+
+# marker <holder> <renewed_at> <ttl> — echo a lease marker comment body.
+marker() {
+  local json
+  json="$(jq -cn --arg h "$1" --arg r "$2" --argjson t "$3" \
+    '{schema_version:"1.0", holder:$h, acquired_at:"2020-01-01T00:00:00Z", renewed_at:$r, ttl_hours:$t}')"
+  printf '<!-- work-item-lease v1 %s -->' "$json"
+}
+
+lease_array() { jq -cn --argjson id "$1" --arg body "$2" '[{id:$id, node_id:"MDEx", body:$body, created_at:"2020-01-01T00:00:00Z"}]'; }
+
+new_scenario() { GH_STUB_DIR="$(mktemp -d)"; export GH_STUB_DIR; : >"$GH_STUB_DIR/calls.log"; }
+calls() { cat "$GH_STUB_DIR/calls.log"; }
+cleanup_scenario() { rm -rf "$GH_STUB_DIR"; }
+
+PAST="2020-01-01T00:00:00Z"   # renewed_at + ttl long elapsed → expired
+FUTURE="2099-01-01T00:00:00Z" # renewed_at in the future → unambiguously live
+
+# ===========================================================================
+# Finding 1 — renew-lease must refuse an expired active lease (no revive).
+# ===========================================================================
+
+# [expired] active lease matches the handle but has elapsed its TTL.
+new_scenario
+EXP_MARKER="$(marker alice "$PAST" 24)"
+lease_array 123 "$EXP_MARKER" >"$GH_STUB_DIR/lease-comments"
+jq -cn --arg b "$EXP_MARKER" '{body:$b, issue:"1"}' >"$GH_STUB_DIR/comment"
+set +e
+bash "$RENEW" "$ID" --lease-comment-id 123 >/dev/null 2>&1
+rc=$?
+set -e 2>/dev/null || true
+assert_eq "renew-lease returns conflict (7) for an expired active lease" "7" "$rc"
+if grep -q '^PATCH' "$GH_STUB_DIR/calls.log"; then
+  fail "renew-lease does NOT revive the expired lease (no PATCH)" "no PATCH logged" "PATCH logged"
+else
+  pass "renew-lease does NOT revive the expired lease (no PATCH)"
+fi
+cleanup_scenario
+
+# [live control] the same flow on a LIVE active lease must still renew (guards the
+# fix against refusing a legitimate renewal).
+new_scenario
+LIVE_MARKER="$(marker alice "$FUTURE" 24)"
+lease_array 123 "$LIVE_MARKER" >"$GH_STUB_DIR/lease-comments"
+jq -cn --arg b "$LIVE_MARKER" '{body:$b, issue:"1"}' >"$GH_STUB_DIR/comment"
+out="$(bash "$RENEW" "$ID" --lease-comment-id 123 2>/dev/null)"; rc=$?
+assert_eq "renew-lease succeeds (0) for a live active lease" "0" "$rc"
+assert_eq "renew-lease emits the renewed lease record" "$ID" "$(jq -r '.id' <<<"$out")"
+assert_contains "renew-lease PATCHes the live lease comment" "$(calls)" "PATCH 123"
+cleanup_scenario
+
+# ===========================================================================
+# Finding 2 — reclaim removes ONLY the expired lease's holder.
+# ===========================================================================
+
+# [holder-only] expired lease held by alice; bob is a co-assignee (manual add or a
+# concurrent claimer). No activity → reclaim must unassign alice ONLY.
+new_scenario
+EXP_MARKER="$(marker alice "$PAST" 24)"
+lease_array 123 "$EXP_MARKER" >"$GH_STUB_DIR/lease-comments"
+jq -cn '["alice","bob"]' >"$GH_STUB_DIR/assignees"
+out="$(bash "$RECLAIM" "$ID" 2>/dev/null)"; rc=$?
+assert_eq "reclaim succeeds (0)" "0" "$rc"
+assert_eq "reclaim reports reclaimed:true" "true" "$(jq -r '.reclaimed' <<<"$out")"
+assert_contains "reclaim removes the expired lease holder (alice)" "$(calls)" "REMOVE_ASSIGNEE alice"
+assert_not_contains "reclaim leaves the co-assignee (bob) untouched" "$(calls)" "REMOVE_ASSIGNEE bob"
+cleanup_scenario
+
+# [revalidation] a concurrent claimer supersedes the lease during the activity
+# window: the revalidation read (lease-comments-2) shows a different active lease.
+# reclaim must abort as a no-op (reclaimed:false) and mutate NOTHING.
+new_scenario
+EXP_MARKER="$(marker alice "$PAST" 24)"
+CONCURRENT_MARKER="$(marker carol "$FUTURE" 24)"
+lease_array 123 "$EXP_MARKER" >"$GH_STUB_DIR/lease-comments-1"
+lease_array 200 "$CONCURRENT_MARKER" >"$GH_STUB_DIR/lease-comments-2"
+jq -cn '["alice","carol"]' >"$GH_STUB_DIR/assignees"
+out="$(bash "$RECLAIM" "$ID" 2>/dev/null)"; rc=$?
+assert_eq "reclaim succeeds (0) on a concurrent-claim revalidation" "0" "$rc"
+assert_eq "reclaim reports reclaimed:false when the lease changed under it" "false" "$(jq -r '.reclaimed' <<<"$out")"
+assert_not_contains "reclaim removes NO assignee when revalidation fails" "$(calls)" "REMOVE_ASSIGNEE"
+assert_not_contains "reclaim does not supersede when revalidation fails" "$(calls)" "PATCH"
+cleanup_scenario
+
+[[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
@@ -41,6 +41,8 @@ gh() {
       done
       ;;
     *"--json assignees"*) cat "$d/assignees" ;;
+    # The timeline read also carries --paginate, so it must be matched by its path
+    # BEFORE the generic --paginate (/comments) branch below — order is load-bearing.
     *"/timeline"*) cat "$d/pr-activity" 2>/dev/null || printf '0\n' ;;
     *"--paginate"*)
       case "$args" in

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/lease-coordination.test.sh
@@ -144,4 +144,21 @@ assert_not_contains "reclaim removes NO assignee when revalidation fails" "$(cal
 assert_not_contains "reclaim does not supersede when revalidation fails" "$(calls)" "PATCH"
 cleanup_scenario
 
+# [revalidation, same id renewed] the OTHER revalidation branch: a concurrent
+# renew-lease completes IN PLACE during the activity window — same active id (123),
+# but renewed_at now in the future (live). reclaim must abort as a no-op too, never
+# unassigning the holder whose lease was just legitimately renewed.
+new_scenario
+EXP_MARKER="$(marker alice "$PAST" 24)"
+RENEWED_MARKER="$(marker alice "$FUTURE" 24)"
+lease_array 123 "$EXP_MARKER" >"$GH_STUB_DIR/lease-comments-1"
+lease_array 123 "$RENEWED_MARKER" >"$GH_STUB_DIR/lease-comments-2"
+jq -cn '["alice"]' >"$GH_STUB_DIR/assignees"
+out="$(bash "$RECLAIM" "$ID" 2>/dev/null)"; rc=$?
+assert_eq "reclaim succeeds (0) when the lease was renewed in place during the window" "0" "$rc"
+assert_eq "reclaim reports reclaimed:false when the lease was renewed in place" "false" "$(jq -r '.reclaimed' <<<"$out")"
+assert_not_contains "reclaim removes NO assignee when the lease was renewed in place" "$(calls)" "REMOVE_ASSIGNEE"
+assert_not_contains "reclaim does not supersede when the lease was renewed in place" "$(calls)" "PATCH"
+cleanup_scenario
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/reclaim.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/reclaim.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # reclaim <id> — CONTRACT.md "Lease protocol". Idempotent session-start reclaim:
-# expired lease + no activity → clear assignees, supersede lease, note; activity →
-# renew in place. Never touches a live lease or a manual (lease-less) assignment.
+# expired lease + no activity → unassign the lease holder only, supersede lease,
+# note; activity → renew in place. Never touches a live lease, a co-assignee that
+# does not hold the expired lease, or a manual (lease-less) assignment.
 set -uo pipefail
 # shellcheck source=common.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
@@ -23,22 +24,14 @@ emit() {
 # is not misreported as "no lease record" (which would let reclaim proceed).
 leases="$(wit_list_lease_comments "$owner" "$repo" "$number")" || exit "$?"
 
-# Select the ACTIVE lease = newest NON-superseded lease comment. Not blind
-# `last`: a claim that backs off supersedes its own newer comment, so the
-# highest-id comment can be a superseded back-off while an earlier comment is
-# the still-active lease — picking `last` there would falsely report "already
-# superseded" and never reclaim the genuinely expired active lease.
-lease_comment_id=""
-lease_json=""
-while IFS= read -r row; do
-  [[ -n "$row" ]] || continue
-  cand="$(wit_lease_json "$(jq -r '.body' <<<"$row")")"
-  [[ -n "$cand" ]] || continue
-  [[ "$(jq -r '.superseded_at // empty' <<<"$cand")" == "" ]] || continue
-  lease_comment_id="$(jq -r '.id' <<<"$row")"
-  lease_json="$cand"
-  break
-done < <(jq -c 'sort_by(.id) | reverse | .[]' <<<"$leases")
+# Select the ACTIVE lease = newest NON-superseded lease comment (not blind `last`:
+# a back-off supersedes its own newer comment, so the highest-id comment can be a
+# superseded back-off while an earlier comment is the still-active lease — picking
+# `last` there would falsely report "already superseded" and never reclaim the
+# genuinely expired active lease).
+wit_select_active_lease "$leases"
+lease_comment_id="$WIT_ACTIVE_LEASE_ID"
+lease_json="$WIT_ACTIVE_LEASE_JSON"
 
 [[ -n "$lease_json" ]] || emit false "no active lease record"
 
@@ -66,12 +59,31 @@ if ((comment_activity > 0 || pr_activity > 0)); then
   emit false "activity detected; lease renewed"
 fi
 
-# Expired + inactive: clear assignees, supersede, note.
+# Expired + inactive → reclaim. Revalidate first: the lease was selected before
+# the two activity round-trips above, a TOCTOU window in which a concurrent
+# claimer can renew or supersede it. Re-read leases and confirm THIS is still the
+# active lease and still expired; if another worker won the item in that window,
+# reclaim is a no-op for this idempotent session-start sweep (reclaimed:false) —
+# not a conflict, and emphatically not a mutation that would strip the new owner.
+leases="$(wit_list_lease_comments "$owner" "$repo" "$number")" || exit "$?"
+wit_select_active_lease "$leases"
+if [[ "$WIT_ACTIVE_LEASE_ID" != "$lease_comment_id" ]]; then
+  emit false "lease superseded by a concurrent claim during reclaim"
+fi
+if wit_lease_is_live "$WIT_ACTIVE_LEASE_JSON" "$(date -u +%s)"; then
+  emit false "lease renewed during reclaim"
+fi
+
+# Remove ONLY the expired lease's holder — never a co-assignee a human added after
+# the lease or a concurrent claimer added before this snapshot. Removing all
+# assignees would strip a live claim and leave the frontier treating the item as
+# unassigned while that lease stays live: two workers on one item. Guard on a
+# fresh assignee read so a holder already unassigned (idempotent re-run) is a no-op.
+holder="$(jq -r '.holder' <<<"$lease_json")"
 wit_run_gh read issue view "$number" -R "$owner/$repo" --json assignees --jq '[.assignees[].login]'
-while IFS= read -r assignee; do
-  [[ -n "$assignee" ]] || continue
-  wit_run_gh write issue edit "$number" -R "$owner/$repo" --remove-assignee "$assignee"
-done < <(jq -r '.[]' <<<"$WIT_GH_OUT")
+if jq -e --arg h "$holder" 'any(.[]; . == $h)' <<<"$WIT_GH_OUT" >/dev/null; then
+  wit_run_gh write issue edit "$number" -R "$owner/$repo" --remove-assignee "$holder"
+fi
 
 superseded="$(jq -c --arg ts "$now" '. + {superseded_at: $ts}' <<<"$lease_json")"
 wit_run_gh write api --method PATCH "repos/$owner/$repo/issues/comments/$lease_comment_id" \

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/renew-lease.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/renew-lease.sh
@@ -54,18 +54,22 @@ fi
 # lease records and let a stale session keep work it no longer owns. Require this
 # comment to BE the current active lease = the newest non-superseded lease.
 leases="$(wit_list_lease_comments "$owner" "$repo" "$number")" || exit "$?"
-active_id=""
-while IFS= read -r row; do
-  [[ -n "$row" ]] || continue
-  cand="$(wit_lease_json "$(jq -r '.body' <<<"$row")")"
-  [[ -n "$cand" ]] || continue
-  [[ "$(jq -r '.superseded_at // empty' <<<"$cand")" == "" ]] || continue
-  active_id="$(jq -r '.id' <<<"$row")"
-  break
-done < <(jq -c 'sort_by(.id) | reverse | .[]' <<<"$leases")
-if [[ "$active_id" != "$lease_comment_id" ]]; then
+wit_select_active_lease "$leases"
+if [[ "$WIT_ACTIVE_LEASE_ID" != "$lease_comment_id" ]]; then
   printf 'renew-lease: comment %s is not the active lease (superseded by a newer claim, comment %s)\n' \
-    "$lease_comment_id" "${active_id:-none}" >&2
+    "$lease_comment_id" "${WIT_ACTIVE_LEASE_ID:-none}" >&2
+  exit "$EX_CONFLICT"
+fi
+
+# Being the active (non-superseded) lease is still not enough: an active lease can
+# be EXPIRED — `renewed_at + ttl_hours` already elapsed — without a superseding
+# comment yet, e.g. a crashed/delayed holder that never backed off. Renewing that
+# would revive a lease another worker has reasonably treated as expired and handed
+# off, defeating TTL-based handoff. Refuse the renewal (conflict) for an expired
+# lease; recovery is a fresh claim/reclaim, not a revive of the dead handle.
+if ! wit_lease_is_live "$lease_json" "$(date -u +%s)"; then
+  printf 'renew-lease: lease %s is expired (renewed_at + ttl_hours elapsed); not renewing\n' \
+    "$lease_comment_id" >&2
   exit "$EX_CONFLICT"
 fi
 

--- a/plugins/work-items/tools/work-item-tracker/lib/lease.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/lease.sh
@@ -30,6 +30,30 @@ wit_iso_to_epoch() {
     || return 1
 }
 
+# wit_select_active_lease <lease-comment-rows-json> — from a JSON array of lease
+# comment rows ({id, body, ...}), select the ACTIVE lease = the newest (highest
+# id) NON-superseded lease, and set WIT_ACTIVE_LEASE_ID / WIT_ACTIVE_LEASE_JSON
+# (both empty when no active lease exists). Not blind `last`: a claim that backs
+# off supersedes its own newer comment, so the highest-id comment can be a
+# superseded back-off while an earlier comment is the still-active lease.
+WIT_ACTIVE_LEASE_ID=""
+WIT_ACTIVE_LEASE_JSON=""
+wit_select_active_lease() {
+  local leases="$1" row cand
+  WIT_ACTIVE_LEASE_ID=""
+  WIT_ACTIVE_LEASE_JSON=""
+  while IFS= read -r row; do
+    [[ -n "$row" ]] || continue
+    cand="$(wit_lease_json "$(jq -r '.body' <<<"$row")")"
+    [[ -n "$cand" ]] || continue
+    [[ "$(jq -r '.superseded_at // empty' <<<"$cand")" == "" ]] || continue
+    WIT_ACTIVE_LEASE_ID="$(jq -r '.id' <<<"$row")"
+    WIT_ACTIVE_LEASE_JSON="$cand"
+    break
+  done < <(jq -c 'sort_by(.id) | reverse | .[]' <<<"$leases")
+  export WIT_ACTIVE_LEASE_ID WIT_ACTIVE_LEASE_JSON
+}
+
 # wit_lease_is_live <lease-json> <now-epoch> — 0 when no superseded_at and not expired.
 wit_lease_is_live() {
   local lease="$1" now_epoch="$2" renewed ttl renewed_epoch

--- a/plugins/work-items/tools/work-item-tracker/lib/lease.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/lease.test.sh
@@ -31,4 +31,33 @@ if wit_lease_is_live "$FRESH_LIVE" "$NOW"; then pass "fresh 24h lease is live"; 
 SUPERSEDED="$(jq -cn --arg t "$NOW_ISO" '{renewed_at:$t, ttl_hours:24, superseded_at:$t}')"
 if wit_lease_is_live "$SUPERSEDED" "$NOW"; then fail "superseded lease not live" "not live" "live"; else pass "superseded lease not live"; fi
 
+# Active-lease selection: newest NON-superseded lease wins, and it is the marker's
+# own selection (a superseded higher-id back-off does not mask the still-active
+# earlier lease — the subtlety both renew-lease and reclaim depend on).
+mk() { printf '<!-- work-item-lease v1 %s -->' "$1"; }
+BODY_A="$(mk "$(jq -cn '{holder:"a"}')")"
+BODY_B="$(mk "$(jq -cn '{holder:"b"}')")"
+BODY_B_SUP="$(mk "$(jq -cn '{holder:"b", superseded_at:"2020-01-01T00:00:00Z"}')")"
+
+LEASES_ONE="$(jq -cn --arg a "$BODY_A" '[{id:10, body:$a}]')"
+wit_select_active_lease "$LEASES_ONE"
+assert_eq "select: single active lease id" "10" "$WIT_ACTIVE_LEASE_ID"
+assert_eq "select: single active lease holder" "a" "$(jq -r '.holder' <<<"$WIT_ACTIVE_LEASE_JSON")"
+
+# Higher-id (100) is a superseded back-off; the active lease is the earlier id 10.
+LEASES_BACKOFF="$(jq -cn --arg a "$BODY_A" --arg b "$BODY_B_SUP" '[{id:10, body:$a}, {id:100, body:$b}]')"
+wit_select_active_lease "$LEASES_BACKOFF"
+assert_eq "select: superseded back-off does not mask active lease" "10" "$WIT_ACTIVE_LEASE_ID"
+
+# Two live leases: the newest (highest id) wins.
+LEASES_TWO_LIVE="$(jq -cn --arg a "$BODY_A" --arg b "$BODY_B" '[{id:10, body:$a}, {id:100, body:$b}]')"
+wit_select_active_lease "$LEASES_TWO_LIVE"
+assert_eq "select: newest non-superseded lease wins" "100" "$WIT_ACTIVE_LEASE_ID"
+
+# No active lease: all superseded → both out-params empty.
+LEASES_NONE="$(jq -cn --arg b "$BODY_B_SUP" '[{id:100, body:$b}]')"
+wit_select_active_lease "$LEASES_NONE"
+assert_eq "select: no active lease → empty id" "" "$WIT_ACTIVE_LEASE_ID"
+assert_eq "select: no active lease → empty json" "" "$WIT_ACTIVE_LEASE_JSON"
+
 [[ $FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Follow-up from #224. Closes two lease-coordination correctness gaps in the GitHub adapter's `renew-lease.sh` and `reclaim.sh` — both in code relocated byte-for-byte from medley by #224 (not changed there), handled as the single hardening pass the issue calls for. No new adapter capability; a bug fix, so a patch bump (`0.14.2` → `0.14.3`). This is the GitHub-adapter sibling of #367 (local-markdown), shipped earlier this session.

## Fix

**Finding 1 (P1) — `renew-lease` revived an expired lease.** `renew-lease` selected the active (newest non-superseded) lease, confirmed `active_id == lease_comment_id`, and PATCHed a fresh `renewed_at` — but never checked liveness first. A worker retaining its handle past `renewed_at + ttl_hours`, with no newer lease comment, still matched `active_id`, so the PATCH revived an expired lease and defeated TTL-based handoff: a crashed/delayed worker could reclaim an item another worker had reasonably treated as expired.

- `renew-lease.sh` now checks `wit_lease_is_live` immediately before patching and returns a conflict (`exit 7`) for an expired-but-not-superseded active lease instead of reviving it. Recovery from an expired lease is a fresh claim/reclaim, not a revive of the dead handle.

**Finding 2 (P1) — `reclaim` removed assignees that did not hold the expired lease.** On the expired-lease + no-activity path, `reclaim` read every assignee (`[.assignees[].login]`) and removed each one — not just the lease's `holder`. A user manually assigned after the old lease, or a concurrent claimer added before this assignee snapshot, was silently unassigned; in the concurrent case that claimer's live lease stayed while the frontier treated the item as unassigned (two workers on one item).

- `reclaim.sh` now removes **only the expired lease's `holder`** (guarded on a fresh assignee read so an already-unassigned holder is a no-op), leaving co-assignees untouched.
- Ownership is **revalidated immediately before mutating**: the lease was selected before the two activity round-trips, a TOCTOU window in which a concurrent claimer can renew or supersede it. `reclaim` re-reads the leases and confirms this is still the active *and still expired* lease; if a concurrent claim won the item in that window, reclaim is a no-op (`reclaimed: false`) — never a mutation that strips the new owner.

Both verbs now share `wit_select_active_lease` (extracted to `lib/lease.sh`) instead of a third copy of the active-lease selection loop. `CONTRACT.md`'s "Lease protocol" documents both semantics (renew refuses an expired lease; reclaim is holder-only and revalidated).

## Verification

New offline test `adapters/github/lease-coordination.test.sh` drives both fixes against a stubbed `gh` (the GitHub-adapter conformance binding requires a live target, so these decision-path cases live in a dedicated test — mirroring the sibling's `claim-integrity.test.sh` precedent). It asserts on the recorded write/remove call-log, not just exit codes.

Against the fix — `bash adapters/github/lease-coordination.test.sh`, exit 0 (cases 14–17 cover the concurrent in-place-renew revalidation branch, added per review):

```
PASS: [1] renew-lease returns conflict (7) for an expired active lease
PASS: [2] renew-lease does NOT revive the expired lease (no PATCH)
PASS: [3] renew-lease succeeds (0) for a live active lease
PASS: [4] renew-lease emits the renewed lease record
PASS: [5] renew-lease PATCHes the live lease comment
PASS: [6] reclaim succeeds (0)
PASS: [7] reclaim reports reclaimed:true
PASS: [8] reclaim removes the expired lease holder (alice)
PASS: [9] reclaim leaves the co-assignee (bob) untouched
PASS: [10] reclaim succeeds (0) on a concurrent-claim revalidation
PASS: [11] reclaim reports reclaimed:false when the lease changed under it
PASS: [12] reclaim removes NO assignee when revalidation fails
PASS: [13] reclaim does not supersede when revalidation fails
PASS: [14] reclaim succeeds (0) when the lease was renewed in place during the window
PASS: [15] reclaim reports reclaimed:false when the lease was renewed in place
PASS: [16] reclaim removes NO assignee when the lease was renewed in place
PASS: [17] reclaim does not supersede when the lease was renewed in place
```

Discrimination proof — the (13-case) test against the **pre-fix** `renew-lease.sh`/`reclaim.sh` at `origin/main` (exit 1), confirming the cases fail without the fix and are not passing for the wrong reason:

```
FAIL: [1] renew-lease returns conflict (7) for an expired active lease — expected 7 got 0
FAIL: [2] renew-lease does NOT revive the expired lease (no PATCH) — expected no PATCH logged got PATCH logged
PASS: [3] renew-lease succeeds (0) for a live active lease
PASS: [4] renew-lease emits the renewed lease record
PASS: [5] renew-lease PATCHes the live lease comment
PASS: [6] reclaim succeeds (0)
PASS: [7] reclaim reports reclaimed:true
PASS: [8] reclaim removes the expired lease holder (alice)
FAIL: [9] reclaim leaves the co-assignee (bob) untouched — forbidden REMOVE_ASSIGNEE bob present
PASS: [10] reclaim succeeds (0) on a concurrent-claim revalidation
FAIL: [11] reclaim reports reclaimed:false when the lease changed under it — expected false got true
FAIL: [12] reclaim removes NO assignee when revalidation fails — forbidden REMOVE_ASSIGNEE present
FAIL: [13] reclaim does not supersede when revalidation fails — forbidden PATCH present
```

Direct unit coverage of the extracted helper added to `lib/lease.test.sh` (newest-non-superseded selection, superseded back-off not masking an earlier active lease, empty out-params when none) — 15/15 pass. Full `plugins/work-items/**/*.test.sh` sweep green; ShellCheck clean (`--rcfile .shellcheckrc`) on every changed script; changed files carry no trailing whitespace or tabs.

Closes #370

## Related

- #370 — this issue.
- #224 — the bundle-seam PR (shape A) that relocated this code byte-for-byte; both findings were deferred there by author delegation.
- #367 — the sibling `local-markdown` lease/assignee-integrity fix shipped earlier this session (same lease-integrity class, different adapter).

🤖 Generated with a Claude Code implementation subagent (issue #370)
