### PR TITLE
fix(work-items): guard work Step 5 against loop-prompts that dispatch without claiming (#581)

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.4]
+
+### Fixed
+
+- **`/work-items:work` Step 5 guards against loop-prompts that restate dispatch without the claim (`#581`).**
+  Step 5's sequence already put the seam `claim` (assignee + lease) first, but a hand-authored loop-prompt
+  standing-rule that restates "dispatch every picked issue to a subagent in its own out-of-tree worktree"
+  reads as a complete execution contract on its own and never mentions claiming — so an orchestrator
+  following that loop-prompt literally did the worktree isolation and skipped the seam's race-safe claim
+  entirely (observed twice on live loop-lane sessions, leaving actively-worked issues unassigned with no
+  lease). A prominent guard note at the head of Step 5 now states the claim-before-dispatch invariant the
+  skill enforces regardless of loop-prompt wording: worktree isolation is not the collision signal between
+  concurrent lanes, the seam claim is, and dispatching a subagent before the claim is held is a defect even
+  when the loop-prompt never named the claim step. Documentation/guidance only — no skill-code or seam
+  behavior change; eval 1 gains a matching expectation.
+
 ## [0.14.3]
 
 ### Fixed

--- a/plugins/work-items/skills/work/SKILL.md
+++ b/plugins/work-items/skills/work/SKILL.md
@@ -127,6 +127,8 @@ Before claiming, verify the item is still actionable:
 
 ### Step 5: Claim and execute
 
+> **The seam claim (assignee + lease) is a non-optional prerequisite of this step — claim-before-dispatch is an invariant this skill enforces, not merely an implication of the sub-step ordering below.** An external loop-prompt or standing-rule that restates "dispatch every picked issue to a subagent in its own out-of-tree worktree" describes only the execute sub-step; it is **not** a complete execution contract and is **not** a substitute for claiming. Worktree isolation is not a race-safe collision signal between concurrent lanes — the seam claim is. Acquire the claim first, before branching or dispatching a subagent, regardless of whether the invoking loop-prompt mentioned claiming: dispatching a subagent before the claim is held is a defect even when the loop-prompt's own wording never named the claim step.
+
 On user confirmation ("yes"):
 
 1. **Claim via the seam** — the atomic, race-safe acquisition (assign `@me` → lease → back off on a foreign earlier lease):

--- a/plugins/work-items/skills/work/evals/evals.json
+++ b/plugins/work-items/skills/work/evals/evals.json
@@ -13,6 +13,7 @@
         "Selects from the frontier via `work-item-tracker.sh list-frontier` (open, `blocked_by_count == 0`, unassigned); `--autonomous` additionally excludes `needs-human`",
         "Acquires via the seam `work-item-tracker.sh claim` (assignee + lease comment, same-identity aware) — NOT a `status:considering`/`status:claimed` label hold protocol",
         "On a lost race (`claim` exit 7) advances to the next candidate rather than retrying the same item",
+        "Treats the seam claim (assignee + lease) as a non-optional prerequisite of dispatch — an external loop-prompt restating \"dispatch in an out-of-tree worktree\" does not substitute for it, and dispatching a subagent before the claim is held is a defect even when the loop-prompt never named the claim step",
         "For autonomous execution, defaults to orchestrator-dispatch — dispatches a scope-fenced implementation subagent that edits in its own out-of-tree worktree (chaining to `/implementation:implement-dispatch` for mechanics, `/source-control:worktree` for the worktree), orchestrator never edits source; the interactive all-inline path is `/implementation:implement`",
         "Whichever execution path runs, follows every step of the consuming project's development workflow first — no shortcuts, no skipped research"
       ]

--- a/plugins/work-items/skills/work/evals/evals.json
+++ b/plugins/work-items/skills/work/evals/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "name": "work-auto-selects-one-item-via-seam-claim",
       "prompt": "/work-items:work",
-      "expected_output": "Reclaims stale leases at session start (idempotent), auto-selects exactly ONE item from the frontier (open, unblocked, unassigned) via the seam list-frontier, then acquires it through the seam claim verb (assignee + lease record, race-safe) before executing it. Autonomous execution defaults to orchestrator-dispatch — a scope-fenced implementation subagent in its own out-of-tree worktree, orchestrator never editing source. The claim identity is the authenticated session user, never the bot.",
+      "expected_output": "Reclaims stale leases at session start (idempotent), auto-selects exactly ONE item from the frontier (open, unblocked, unassigned) via the seam list-frontier, then acquires it through the seam claim verb (assignee + lease record, race-safe) before executing it. Autonomous execution defaults to orchestrator-dispatch — a scope-fenced implementation subagent in its own out-of-tree worktree, orchestrator never editing source. The seam claim is a non-optional prerequisite of dispatch: an external loop-prompt restating dispatch-in-a-worktree never substitutes for it, and dispatching before the claim is held is a defect. The claim identity is the authenticated session user, never the bot.",
       "files": [],
       "expectations": [
         "Runs an idempotent session-start reclaim (`work-item-tracker.sh reclaim`) before selecting — never releases a live lease",


### PR DESCRIPTION
## Summary

`/work-items:work` Step 5 already sequences the seam `claim` (assignee + lease) first, before branch/dispatch — the skill's own contract is correct. The gap #581 documents sits one layer above: a hand-authored loop-prompt standing-rule that restates "dispatch every picked issue to a subagent in its own out-of-tree worktree" reads as a complete execution contract and never mentions claiming, so an orchestrator following that loop-prompt literally did the worktree isolation and skipped the seam's race-safe claim entirely — observed twice on live loop-lane sessions (issues actively worked and shipped as PRs while sitting unassigned with no lease). Documentation/guidance gap, not a skill-code defect (per triage). Patch bump `0.14.3` → `0.14.4`.

## Fix

- **Prominent guard note at the head of Step 5** (`plugins/work-items/skills/work/SKILL.md`) stating the claim-before-dispatch invariant this skill enforces regardless of loop-prompt wording: an external loop-prompt/standing-rule restating "dispatch ... in its own out-of-tree worktree" describes only the execute sub-step, is not a complete execution contract, and is not a substitute for the claim; worktree isolation is not the race-safe collision signal between concurrent lanes, the seam claim is; dispatching a subagent before the claim is held is a defect even when the loop-prompt never named the claim step. Self-contained and placed before the numbered sub-steps (no renumbering).
- **Eval 1 gains a matching expectation** (`plugins/work-items/skills/work/evals/evals.json`) so the fixture asserts the claim-is-a-non-optional-prerequisite invariant, not just claim-before-execute ordering.
- Version bump + `CHANGELOG.md` entry.

**Scope (per the issue and triage note).** #480 — the future loop-prompt-authoring skill that would host this guidance for hand-authored lane prompts — does not exist yet; not blocked on or created here. A repo-wide search for other in-repo surfaces that restate "dispatch ... out-of-tree worktree" as a full contract found none to patch: the `babysit-prs` loop is a different lane (PR checkout, not dispatch-to-worktree), and the `autonomy` runner design pack already models a mandatory `leased` (race-safe claim) state before `executing`/dispatch — it reinforces the invariant rather than dropping it. No new enforcement mechanism was invented: there is no execution seam between "agent reads SKILL.md" and "agent dispatches" that could gate on the claim, so the guidance layer is the only place the invariant can live — a code-level guard was considered and correctly declined.

## Verification

- `bash scripts/validate-plugins.sh` — green (all plugin manifests + catalog).
- `node scripts/validate-plugin-contracts.mjs` — green (33 setup skills, 1807 plugin files checked).
- `bash scripts/check-changed-skills.sh origin/main` — `CHECK-SKILL work: PASS — 0 errors, 1 warning`. The lone WARN ("no Gotchas surface") is pre-existing and not introduced here.
- `markdownlint-cli2 plugins/work-items/skills/work/SKILL.md` — 0 errors.
- `evals.json` and `plugin.json` parse as valid JSON; all four changed files carry no trailing whitespace or tabs.

Closes #581

## Related

- #480 — loop-prompt-authoring guidance (the natural home for calling this out to hand-authored lane prompts). Does not exist yet; related-but-out-of-scope, not created here.
- #513 — role-separated mini-SDLC composition; adjacent (role separation during execution) but not this gap (the claim step being skippable at pick time).

🤖 Generated with a Claude Code implementation subagent (issue #581)

---------

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
