### PR TITLE
docs: own consumer-config layering as a Convention registry concern

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -219,7 +219,7 @@ one increment past the precedent). Behavioral gaps the docs leave open are resol
      *audience* or *deployment* — a different framing, ranking lens, or branding per team / client /
      context — add a profile axis to the folder form. Files at `.claude/<plugin>/` are the **default
      profile**; each `.claude/<plugin>/<profile-name>/` subfolder is a **named profile** that overlays
-     the default per key (the same additive semantics as the resolution rule below — a named profile
+     the default per key (the same additive semantics the layering contract below fixes — a named profile
      refines the root, absent keys fall through). A single-config consumer never nests: its files sit at
      the root, which *is* the default profile, so growing a profile later is additive (drop a sibling
      subfolder), never a reorg — and there is no reserved `default/`/`team/` name to collide with. Pick
@@ -231,13 +231,11 @@ one increment past the precedent). Behavioral gaps the docs leave open are resol
      splits config across *plugins* (concern axis); this splits it across *audiences* within one plugin
      (profile axis) — the two compose (`.claude/<concern>/<profile-name>/`). Reference adopter:
      [`ai-briefing`](ai-briefing-design.md).
-   - **Resolution + override semantics.** Resolve **user-global → team (project) → local overlay**,
-     **additive-preferred**: a later layer adds to or refines earlier layers rather than silently
-     replacing them. The first-party precedent concatenates; a plugin that genuinely must override does
-     so per key, never by dropping the base layer wholesale.
-   - **Recommended consumer `.gitignore`.** Ship the overlay convention with the one line the consumer
-     adds: `.claude/*.local.*` (and `.claude/<plugin>/**/*.local.*` for the folder form) — personal
-     overlays stay out of version control, team config stays tracked.
+   - **Resolution + override semantics, overlay naming, and the recommended consumer `.gitignore`
+     line** are owned by [`docs/conventions/consumer-config-layering/`](conventions/consumer-config-layering/README.md)
+     — the layering axis is cross-cutting, so it is contracted once there rather than restated per
+     seam. A surface declares its own keys and schema here or in its own owner doc, and points there
+     for how its layers merge.
 3. **Consumer `CLAUDE.md` / `.claude/rules` steering. [SPEC]** A plugin's skill and agent components
    run in the model's context and already read the consuming project's own rules — the default surface
    for project conventions, naming, and policy, requiring no plugin-side wiring. (Hook scripts do not
@@ -655,8 +653,15 @@ plugins-reference, and hooks pages 2026-07-17; re-verify per the `CLAUDE.md` fre
    never put a secret there. Claude Code reads this key from user settings, `--settings`, and managed settings,
    not project or local settings. Endpoints and toggles are fine as non-sensitive. Every option is documented.
 4. **Cache isolation — no reach-outs.** References only files inside the plugin via `${CLAUDE_PLUGIN_ROOT}`;
-   persists state in `${CLAUDE_PLUGIN_DATA}`. No `../` reach-outs, no absolute paths, no reading consumer files
-   outside `${CLAUDE_PROJECT_DIR}`.
+   persists state in `${CLAUDE_PLUGIN_DATA}`. No `../` reach-outs, no constructed absolute paths, no reading
+   **consumer repository** files outside `${CLAUDE_PROJECT_DIR}`.
+   - **The operator's own `~/.claude/` is not consumer repository data.** Reading a documented user-global
+     config file there is sanctioned rather than a reach-out: criterion 3 above already stores consumer
+     credentials at `~/.claude/.credentials.json`, and seam 2 mandates an optional `~/.claude/<plugin>.md`
+     user-global layer — a criterion that forbade the read would contradict both. Read only the documented
+     path for the plugin's own declared config; anything broader is a reach-out again. What this criterion
+     targets is a plugin wandering out of the repository it was pointed at, not the operator's own Claude
+     Code home.
 5. **Data egress — telemetry & network.** Any telemetry (e.g. `HOOK_TELEMETRY_SINK`) is opt-in (unset = exact
    no-op), never writes to the hook's stdout/`additionalContext` channel, and emits only the declared envelope —
    no payload beyond the documented schema. Name any other outbound network call and justify it.

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -263,6 +263,7 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Lifecycle artifact protocol | [`docs/PLUGIN-ARTIFACT-PROTOCOL.md`](PLUGIN-ARTIFACT-PROTOCOL.md) |
 | Shared hook utility library | `lib/hook-utils.sh`, synced by `scripts/sync-hook-utils.sh` |
 | Cross-plugin shared-source clusters | `scripts/cross-plugin-source-registry.txt` |
+| Consumer-config layering and precedence | [`docs/conventions/consumer-config-layering/`](conventions/consumer-config-layering/README.md) |
 | Ecosystem command resolution | [`docs/conventions/ecosystem-commands/`](conventions/ecosystem-commands/README.md) |
 | Hook telemetry | [`docs/conventions/hook-telemetry/`](conventions/hook-telemetry/README.md) |
 | Permission-rule hygiene | [`docs/conventions/permission-rule-hygiene/`](conventions/permission-rule-hygiene/README.md) |

--- a/docs/conventions/consumer-config-layering/CHANGELOG.md
+++ b/docs/conventions/consumer-config-layering/CHANGELOG.md
@@ -14,6 +14,7 @@ so fleet audits have a Convention registry row to check. No rule changed in the 
 - Layer set and precedence: user-global → team → local overlay, resolved in that order.
 - Override semantics: additive-preferred; per-key override is sanctioned for scalar and closed-list
   keys and must be declared; wholesale replacement of a base layer is forbidden.
-- Overlay naming: `*.local.*`, with the single recommended consumer `.gitignore` line.
+- Overlay naming: `*.local.*`, with one recursive consumer `.gitignore` line covering flat,
+  folder-form, and profiled surfaces alike.
 - Resolution algorithm, including the repo-root anchoring rule and the per-layer gitignore verdicts.
 - Deviations recorded as observed, not ratified.

--- a/docs/conventions/consumer-config-layering/CHANGELOG.md
+++ b/docs/conventions/consumer-config-layering/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Consumer-Config Layering Convention — Changelog
+
+Notable changes to the consumer-config layering contract. The contract is versioned by
+`contract_version` (SemVer) and governs the layering axis only — layer set, precedence, override
+semantics, and overlay naming. Per-concern keys and schema are versioned by their own owner docs and
+change independently. A change to the precedence order or the meaning of a layer is a major bump;
+adding an optional layer or relaxing a rule additively is a minor bump.
+
+## 1.0 — 2026-07-20
+
+Initial published contract, extracted from the tracked-rich-config seam in `docs/MIGRATION-PLAYBOOK.md`
+so fleet audits have a Convention registry row to check. No rule changed in the extraction.
+
+- Layer set and precedence: user-global → team → local overlay, resolved in that order.
+- Override semantics: additive-preferred; per-key override is sanctioned for scalar and closed-list
+  keys and must be declared; wholesale replacement of a base layer is forbidden.
+- Overlay naming: `*.local.*`, with the single recommended consumer `.gitignore` line.
+- Resolution algorithm, including the repo-root anchoring rule and the per-layer gitignore verdicts.
+- Deviations recorded as observed, not ratified.

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -159,11 +159,13 @@ human-gated decision.
 ## Implementers
 
 Conformance is tracked, not assumed. A surface is listed here whether or not it conforms — the gap is
-the point.
+the point. Each row states the surface's conformance **as it exists on `main`**, never as a
+migration intends it to be; a row that ran ahead of the code would report a closed gap that is still
+open.
 
 | Surface | Consumer config path | Layers | Conformance |
 |---|---|---|---|
-| `source-control` | `.claude/source-control.md` | all three | conforms (declared per-key override) |
+| `source-control` | `.claude/source-control.md` | team only | single-layer; migration to all three in flight (#647) |
 | `toolchain` / `ecosystem-commands` | `.claude/ecosystems/<ecosystem>.yaml` | all three | conforms |
 | `codebase-health` | `.claude/codebase-health.md` | all three | conforms (concatenating, with a declared empty-list opt-out) |
 | `autonomy` | `.claude/autonomy/binding.json` | all three, plus an org rung | declared deviation |
@@ -176,7 +178,7 @@ the point.
 | `work-items` | `.work-item-tracker.json` | team only | single-layer; resolves by CWD-to-root climb rather than anchoring at the repo root |
 
 Migrating a single-layer surface is one change against that surface's own plugin, not a fleet-wide
-sweep. `source-control` is the worked example.
+sweep — and each migration updates its own row in the same change.
 
 ### Overlay spelling drift
 

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -1,0 +1,183 @@
+# Consumer-Config Layering Convention
+
+A versioned, marketplace-wide contract for **how** a plugin's consumer-tracked configuration layers —
+which layers exist, what order they resolve in, and what a later layer may do to an earlier one. Every
+plugin that reads config from a consuming repo resolves it the same way, so an operator who learns one
+surface has learned all of them.
+
+This directory is the source of truth: `README.md` (the contract), `CHANGELOG.md` (version history).
+
+## Boundary — this contract owns the axis, never the keys
+
+It governs **layering and precedence only**. Which keys a config surface has, what they mean, and how
+they are validated belong to that concern's own owner doc under `docs/conventions/<concern>/`, or to
+the plugin's own bundled reference. The two compose: a per-concern doc declares its keys and points
+here for how its layers merge.
+
+The distinction is what keeps this doc from colliding with the one-owner-doc-per-shared-concern rule.
+Layering is a genuinely cross-cutting axis every config surface shares; keys are not.
+
+## The layers
+
+Three layers, each optional, resolved in this order — a later layer refines an earlier one:
+
+| Order | Layer | Path | Belongs to |
+|---|---|---|---|
+| 1 | user-global | `~/.claude/<name>` | the operator, across every repo and machine they work in |
+| 2 | team | `${CLAUDE_PROJECT_DIR}/.claude/<name>` | the consuming repository, tracked in version control |
+| 3 | local overlay | `${CLAUDE_PROJECT_DIR}/.claude/<stem>.local.<ext>` | one operator in one repo, gitignored |
+
+`<name>` is the surface's own filename — a single file (`source-control.md`, `standards.yaml`) or a
+file inside a concern- or plugin-named folder (`.claude/ecosystems/<ecosystem>.yaml`). The folder form
+takes the same three layers, and the overlay suffix attaches to the leaf file, not the folder.
+
+**All three layers absent is a valid state**, not an error. The surface falls through to whatever the
+plugin's own resolution ladder specifies next — inference from the repo's own files, an interview, or
+a bundled default.
+
+### Why these three and not others
+
+Each layer answers a question the others cannot. User-global carries a preference across repos, which
+a tracked file structurally cannot — a per-user setting cannot decide the location or content of a
+team-shared artifact. The team layer is the only layer teammates receive. The overlay is the only
+place a personal deviation can live without either editing the shared file or going uncommitted and
+lost. Dropping any one of them reintroduces a problem the other two cannot solve.
+
+## Merge semantics
+
+**Additive-preferred.** A later layer *adds to or refines* earlier layers. It never silently replaces
+them wholesale.
+
+Two sanctioned forms, in order of preference:
+
+1. **Concatenate.** Every layer that exists is loaded and appended. Correct when the content is prose
+   the model reads as guidance — the layers genuinely accumulate, and a reader wants all of them. This
+   is what the first-party precedent does.
+2. **Per-key override.** A later layer replaces an earlier layer's value **key by key**; a key absent
+   from a later layer keeps the earlier value. Correct when the values are scalars or closed lists,
+   where concatenation is meaningless or actively wrong — two anchored regexes cannot concatenate into
+   a third valid regex, and two attribution-trailer templates would emit two trailers.
+
+**Wholesale replacement is forbidden.** A layer that "overrides this file entirely" or takes the first
+matching layer and stops is outside the contract: it turns every key the overlay does not mention into
+a silent loss of the base layer's value, which is exactly the failure additive-preferred exists to
+prevent. Both sanctioned forms preserve unmentioned keys; wholesale replacement is the one that does
+not.
+
+**A surface using per-key override must declare it** in its own contract, next to its keys. The
+declaration is what makes it a design decision a reviewer can check rather than an accident.
+
+## Overlay naming and the consumer `.gitignore`
+
+The overlay is spelled `*.local.*` — the stem, `.local`, then the original extension. One spelling
+across the fleet is the point: a consumer adds one `.gitignore` line and every current and future
+surface is covered.
+
+```gitignore
+.claude/*.local.*
+```
+
+Folder-form surfaces need the recursive form as well:
+
+```gitignore
+.claude/**/*.local.*
+```
+
+**No plugin writes the consumer's `.gitignore`.** A setup skill recommends the line and leaves the
+edit to the consumer; their ignore file is their artifact.
+
+## Resolution algorithm
+
+A plugin implementing this contract:
+
+1. **Anchors at the repo root** before any repo-relative read — `${CLAUDE_PROJECT_DIR}` when set,
+   otherwise `git rev-parse --show-toplevel`. Never a CWD-relative path: invoked from a nested
+   directory, a CWD-relative read finds a nonexistent `<subdir>/.claude/...`, misses the real config,
+   and silently degrades to a lower rung. Re-resolve the root in every self-contained shell call.
+2. **Reads every layer that exists**, in order, and merges per the surface's declared semantics.
+   Reading one layer and stopping is not resolution.
+3. **Reports which layer supplied each value** whenever it surfaces the effective config to a human.
+   A reader who cannot see which layer won cannot tell why the plugin behaves as it does.
+4. **Degrades soft on a malformed layer** — surface the error, name the layer, resolve as if that
+   layer were absent. Unknown keys are inert. A consuming repo may validate its own files in a gate;
+   plugins do not hard-fail on them.
+
+### Per-layer verification verdicts
+
+The same tracked/ignored question produces opposite correct answers per layer, so a single shared
+check is always wrong for two of the three:
+
+| Layer | Version control | On violation |
+|---|---|---|
+| user-global | outside the worktree — **no git command applies** | n/a |
+| team | must be tracked | hard STOP: teammates would never receive the shared convention |
+| local overlay | must be gitignored, never staged | FAIL: a personal deviation can reach team history |
+
+The user-global row is not an omission. `git check-ignore` and `git status` against a path outside the
+repository return a meaningless verdict — or a confidently wrong one when the operator's home
+directory is itself a git repository.
+
+## Versioning
+
+`contract_version` (SemVer) versions this contract; the number lives in `CHANGELOG.md`. A change to
+the precedence order or to what a layer means is a major bump. Adding an optional layer, or relaxing a
+rule additively, is a minor bump. Per-concern key schemas version independently under their own owner
+docs and are deliberately decoupled from this number.
+
+## Deviations
+
+Recorded as **observed**, not ratified. Listing a deviation here documents that it exists and diverges;
+it does not bless it. Ruling on each — correct the surface, or amend this contract — is a separate
+human-gated decision.
+
+**Declared** — the surface states its divergence and why:
+
+- **`standards` inverts precedence.** Personal layers may add or tighten only; the team-tracked layer
+  wins a direct conflict, with provenance reported. The stated rationale is that a personal layer
+  loosening a shared engineering standard is the failure mode worth structurally preventing.
+- **`autonomy` exempts its security axes.** Layers refine additively as the contract requires, except
+  that no repo-local value may supply or override a security axis at all — a stricter rule than this
+  contract, in the direction of safety.
+- **`disk-hygiene`'s `--policy` replaces both standing layers.** Its standing layers merge additively
+  (overlays may disable or add hints and add protected globs, never weaken a hard guard); the
+  wholesale replacement is confined to an explicit per-invocation flag, not a file layer.
+
+**Undeclared** — divergence with no recorded rationale:
+
+- **`ai-briefing` advertises an overlay layer it does not implement.** Its setup recommends a
+  `.claude/ai-briefing/**/*.local.*` gitignore line, but no read path resolves a `.local.*` file and
+  no file defines what one would do. Its documented resolution covers profile *selection* only, never
+  layer precedence.
+- **`codebase-health` enumerates three layers without stating how they merge.** The layer set and
+  order are correct; whether merging concatenates or overrides per key is unstated, so an
+  implementer or an operator cannot predict the effective config.
+
+## Implementers
+
+Conformance is tracked, not assumed. A surface is listed here whether or not it conforms — the gap is
+the point.
+
+| Surface | Consumer config path | Layers | Conformance |
+|---|---|---|---|
+| `source-control` | `.claude/source-control.md` | all three | conforms (declared per-key override) |
+| `toolchain` / `ecosystem-commands` | `.claude/ecosystems/<ecosystem>.yaml` | all three | conforms |
+| `codebase-health` | `.claude/codebase-health.md` | all three | merge semantics undocumented |
+| `autonomy` | `.claude/autonomy/binding.json` | all three, plus an org rung | declared deviation |
+| `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | declared deviation |
+| `disk-hygiene` | `.claude/disk-hygiene.json` | user-global + team | declared deviation; no overlay layer |
+| `ai-briefing` | `.claude/ai-briefing/` | team only | undeclared: overlay recommended, never resolved |
+| `code-tidying` | `.claude/tidy-lanes/<lane>.md` | team only | single-layer over a bundled default |
+| `topic-docs` | `.claude/topic-docs.yaml` | team only | single-layer |
+| `repo-fleet-hygiene` | `.claude/repo-fleet-hygiene.conf` | team only | single-layer |
+| `work-items` | `.work-item-tracker.json` | team only | single-layer; resolves by CWD-to-root climb rather than anchoring at the repo root |
+
+Migrating a single-layer surface is one change against that surface's own plugin, not a fleet-wide
+sweep. `source-control` is the worked example.
+
+### Overlay spelling drift
+
+One recommended `.gitignore` line is the goal; the fleet currently ships four spellings —
+`.claude/*.local.*`, `.claude/ecosystems/*.local.*`, `.claude/autonomy/**/*.local.*`, and a bare
+`*.local.md` inside a setup-owned `<standards_dir>/.gitignore`. Each is individually correct for its
+surface and collectively they defeat the one-line promise. Consolidating them is a per-surface change
+tracked by the rows above, not a rule this contract can retroactively impose.

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -27,9 +27,13 @@ Three layers, each optional, resolved in this order — a later layer refines an
 | 2 | team | `${CLAUDE_PROJECT_DIR}/.claude/<name>` | the consuming repository, tracked in version control |
 | 3 | local overlay | `${CLAUDE_PROJECT_DIR}/.claude/<stem>.local.<ext>` | one operator in one repo, gitignored |
 
-`<name>` is the surface's own filename — a single file (`source-control.md`, `standards.yaml`) or a
-file inside a concern- or plugin-named folder (`.claude/ecosystems/<ecosystem>.yaml`). The folder form
-takes the same three layers, and the overlay suffix attaches to the leaf file, not the folder.
+`<name>` is the surface's whole path **relative to `.claude/`**, not just its leaf filename. For a
+single-file surface that is `source-control.md`; for a folder-form surface it is
+`ecosystems/<ecosystem>.yaml`, giving a user-global layer at
+`~/.claude/ecosystems/<ecosystem>.yaml`. The folder hierarchy is part of the surface's identity and
+repeats in every layer — collapsing it to the leaf would point the user-global layer at a different
+file than the team layer. `<stem>.local.<ext>` follows the same rule: the overlay suffix attaches to
+the leaf file, never to a folder in the path.
 
 **All three layers absent is a valid state**, not an error. The surface falls through to whatever the
 plugin's own resolution ladder specifies next — inference from the repo's own files, an interview, or
@@ -74,14 +78,16 @@ across the fleet is the point: a consumer adds one `.gitignore` line and every c
 surface is covered.
 
 ```gitignore
-.claude/*.local.*
-```
-
-Folder-form surfaces need the recursive form as well:
-
-```gitignore
 .claude/**/*.local.*
 ```
+
+That is the whole convention — **one line, recursive form, for every surface**. `.claude/**/` matches
+zero or more directories, so this single rule covers a flat `.claude/source-control.local.md`, a
+one-deep `.claude/ecosystems/python.local.yaml`, and a profiled
+`.claude/ai-briefing/<profile>/x.local.md` alike, while leaving team files tracked. The narrower
+`.claude/*.local.*` is what several surfaces currently recommend and it silently fails to ignore any
+folder-form overlay; recommend the recursive form instead, and never ask a consumer for two lines
+where one is exact.
 
 **No plugin writes the consumer's `.gitignore`.** A setup skill recommends the line and leaves the
 edit to the consumer; their ignore file is their artifact.
@@ -147,10 +153,8 @@ human-gated decision.
 - **`ai-briefing` advertises an overlay layer it does not implement.** Its setup recommends a
   `.claude/ai-briefing/**/*.local.*` gitignore line, but no read path resolves a `.local.*` file and
   no file defines what one would do. Its documented resolution covers profile *selection* only, never
-  layer precedence.
-- **`codebase-health` enumerates three layers without stating how they merge.** The layer set and
-  order are correct; whether merging concatenates or overrides per key is unstated, so an
-  implementer or an operator cannot predict the effective config.
+  layer precedence. This is the only surface telling consumers to gitignore a layer that has no
+  effect.
 
 ## Implementers
 
@@ -161,7 +165,7 @@ the point.
 |---|---|---|---|
 | `source-control` | `.claude/source-control.md` | all three | conforms (declared per-key override) |
 | `toolchain` / `ecosystem-commands` | `.claude/ecosystems/<ecosystem>.yaml` | all three | conforms |
-| `codebase-health` | `.claude/codebase-health.md` | all three | merge semantics undocumented |
+| `codebase-health` | `.claude/codebase-health.md` | all three | conforms (concatenating, with a declared empty-list opt-out) |
 | `autonomy` | `.claude/autonomy/binding.json` | all three, plus an org rung | declared deviation |
 | `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | declared deviation |
 | `disk-hygiene` | `.claude/disk-hygiene.json` | user-global + team | declared deviation; no overlay layer |
@@ -176,8 +180,11 @@ sweep. `source-control` is the worked example.
 
 ### Overlay spelling drift
 
-One recommended `.gitignore` line is the goal; the fleet currently ships four spellings —
-`.claude/*.local.*`, `.claude/ecosystems/*.local.*`, `.claude/autonomy/**/*.local.*`, and a bare
-`*.local.md` inside a setup-owned `<standards_dir>/.gitignore`. Each is individually correct for its
-surface and collectively they defeat the one-line promise. Consolidating them is a per-surface change
-tracked by the rows above, not a rule this contract can retroactively impose.
+The fleet currently ships four spellings — `.claude/*.local.*`, `.claude/ecosystems/*.local.*`,
+`.claude/autonomy/**/*.local.*`, and a bare `*.local.md` inside a setup-owned
+`<standards_dir>/.gitignore`. Each is narrowly correct for its own surface, and collectively they
+defeat the one-line promise: a consumer running three plugins is asked for three lines, and the two
+non-recursive spellings would silently miss a nested overlay if their surface ever grew a folder.
+The recursive line above subsumes all four. Converging each surface's recommendation on it is a
+per-surface change tracked by the rows above, not a rule this contract can retroactively impose on
+config already written into consumer repositories.


### PR DESCRIPTION
Closes #648

## Summary

The tracked-rich-config seam in `docs/MIGRATION-PLAYBOOK.md` fixes the resolution order for every consumer-config surface in the fleet. `docs/PLUGIN-PHILOSOPHY.md` states that fleet audits check conformance **per registry row** — and this rule had no row, so nothing audited it.

Adds `docs/conventions/consumer-config-layering/` (README + CHANGELOG, following the `hook-telemetry` shape), registers it in the Convention registry, and points seam 2 at it rather than restating the rules in two places.

**The contract owns the axis, never the keys.** Layer set, precedence, override semantics, overlay naming, and the resolution algorithm. Which keys a surface has and how they validate stay with that concern's own owner doc. That boundary is what keeps this from colliding with "One owner doc per shared concern" — layering is genuinely cross-cutting; keys are not.

Deviations are recorded **as observed, not ratified**. Ruling on them is a separate human-gated decision (#649) and nothing here rules on anything.

## Correction to the issue's evidence table

The issue cites **15 surfaces**. A direct re-census found **12**, and two of the issue's verdicts do not survive reading the files:

| Issue's claim | What the files say |
|---|---|
| `songwriting` — undeclared deviation, "first-match-wins, freezes the template" | `songwriting` has no consumer-config surface at all. Its only `.claude/` read is the consuming project's `CLAUDE.md` / `.claude/rules` (`skills/setup/SKILL.md:58`) — that is seam 3 steering, not seam 2 tracked config. Not a row. |
| `code-tidying` — undeclared deviation ("overrides this file entirely") | The phrase is real (`skills/tidy/lanes/docs-prose.md:14`), but the thing being overridden is the plugin's own **bundled** lane file, not a consumer layer. That is a bundled-default rung, structurally the same as `toolchain`'s rung 4. Recorded as single-layer over a bundled default. |
| `work-items` (×2), `standards.yaml`, `out-of-scope` counted as separate single-layer surfaces | `out-of-scope` is not a plugin. `standards.yaml` is the root-relocation knob **of** the `standards` surface, not a second surface. `work-items` is one surface — and it is the one the census nearly missed, because its config is `.work-item-tracker.json` at the repo root rather than under `.claude/`. It is in the table. |

Net: fewer surfaces, and one genuinely new finding — **`ai-briefing` advertises an overlay layer it does not implement.** Its setup recommends a `.claude/ai-briefing/**/*.local.*` gitignore line, but no read path resolves a `.local.*` file and nothing defines what one would do. That is the only surface telling consumers to gitignore a layer that has no effect.

Every file:line in the table was re-read directly rather than taken from a summary.

## Also: security criterion 4

Narrowed per the maintainer ruling on #660. Its "no absolute paths, no reading consumer files outside `${CLAUDE_PROJECT_DIR}`" wording read as forbidding the `~/.claude/<plugin>.md` user-global that **seam 2 mandates** and that **criterion 3 already uses** for consumer credentials — a self-contradiction a reviewer hit in practice on #660. It now says consumer *repository* files and carves out the operator's own Claude Code home explicitly, so the next plugin author does not re-litigate it.

## Test plan

- `markdownlint-cli2` across `docs/**/*.md` with the repo config — 0 errors.
- `typos --config _typos.toml docs/` — clean.
- Every relative link in the four changed/added files resolved against the working tree by hand. `link-check` is a weekly `fail: false` cron, so nothing gates this at PR time.
- Census citations spot-checked by reading the cited line directly: `toolchain/reference/resolution-ladder.md:32`, `autonomy/skills/setup/SKILL.md:355`, `docs/conventions/standards/README.md:35`, `disk-hygiene/skills/clean/SKILL.md:77`, `code-tidying/skills/tidy/SKILL.md:58`, `docs/conventions/topic-docs/README.md:224`, `ai-briefing/skills/generate/SKILL.md:63`, `codebase-health/skills/audit/SKILL.md:70`, `repo-fleet-hygiene/skills/setup/SKILL.md:20`.

Docs-only; no plugin behavior changes.

## Related

- #647 / #660 — the first per-plugin conformance migration (`source-control`); independent of this PR, and currently held under a `do-not-merge` label
- #649 — the deviation rulings this PR deliberately does not make