### PR TITLE
docs(autonomy): record every un-tracked D1 deferral as a durable trigger row

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the `autonomy` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+Versions 0.1.0–0.7.0 predate this file (introduced with 0.7.1); their history lives in the
+merged work-package PRs (#333, #343, #356, #372, #377, #600, #676).
+
+## [0.7.1]
+
+### Added
+
+- **D1 deferral sweep — every out-of-package note from the WP1–WP7 design rounds now has a
+  durable trigger record (`#353`).** The README roadmap gains the fleet guardrail
+  materializations, fleet routine stand-up + existing-scheduler reconciliation,
+  vendor-binding capability templates, and cost-enforcement rows; the trigger register gains
+  the second-binding-consumer cross-repo drift check; `reference/return-accounting.md`
+  records the per-work-class precision-graduation deferral beside its band-stability rule.
+  Documentation only — no contract semantics change.

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -64,6 +64,10 @@ locked (no step-skipping — trust before scale).
 | Capability | Trigger |
 |---|---|
 | Fleet adapter materializations (reusable workflows, labels, drain routine) | Work-item backlog, post trigger-package graduation. |
+| Fleet guardrail materializations (binding instances, workflow gates, scanner wiring) | Work-item backlog, post guardrail-package graduation. |
+| Fleet routine stand-up + existing-scheduler reconciliation | Work-item backlog, post routine-package graduation. |
+| Vendor-binding capability templates (routine/workflow files) | Build stage, post-architect. |
+| Cost enforcement (hard spend caps; cost tiers stay policy vocabulary until then) | 3→4 transition work begins. |
 | Runner charter execution pack (design pack shipped) | The runner build trigger fires (charter's own conditions). |
 
 ## Trigger register (plugin-scoped)
@@ -72,6 +76,7 @@ locked (no step-skipping — trust before scale).
 |---|---|
 | Role vocabulary changes in `reference/role-topology.md` | Update the org-policy home's binding instance doc to the new vocabulary version. |
 | A second plugin consumes `.claude/autonomy/` config | Graduate the binding schema to a versioned concern contract per the marketplace's concern-named-folder convention. |
+| A second repository consumes the security binding | Stand up a mechanical cross-repo binding drift check. |
 
 ## Configuration
 

--- a/plugins/autonomy/reference/return-accounting.md
+++ b/plugins/autonomy/reference/return-accounting.md
@@ -57,7 +57,12 @@ Aggregation derives avoided cost from the pair; the attestor never prorates.
 The band set and counterfactual enum are contract-stable: any change is a reviewed contract
 migration, never per-org variation (org-custom bands break cross-org aggregation).
 Per-work-class precision graduation (finer bands for a class the guardrail matrix names) is
-deferred with a trigger: aggregate data proving a class needs finer resolution.
+deferred with a trigger: aggregate data proving a class needs finer resolution. The record
+never grows a class field for this: segmentation joins each record to its work item (the
+telemetry contract's join attribute) and reads the item's admission-time class from the
+governed queue's protected admission data — the surface that stamped and verified the class
+at admission — falling back to re-derivation through the security-surface classification
+rules (current-epoch class, a stated approximation) where queue history is not retained.
 
 ## Record lifecycle — attestation is asynchronous
 

--- a/plugins/autonomy/reference/return-accounting.md
+++ b/plugins/autonomy/reference/return-accounting.md
@@ -56,6 +56,8 @@ Aggregation derives avoided cost from the pair; the attestor never prorates.
 
 The band set and counterfactual enum are contract-stable: any change is a reviewed contract
 migration, never per-org variation (org-custom bands break cross-org aggregation).
+Per-work-class precision graduation (finer bands for a class the guardrail matrix names) is
+deferred with a trigger: aggregate data proving a class needs finer resolution.
 
 ## Record lifecycle — attestation is asynchronous
 


### PR DESCRIPTION
## Summary

D1 sweep for #353: the WP1–WP7 PLAN out-of-package notes (mined from the merged PR bodies #333/#343/#356/#372/#377/#600/#676) contained 31 deferred notes; every note that named no tracking issue and had no contract-recorded trigger now has a durable home:

- **README roadmap** gains four trigger-gated rows: fleet guardrail materializations (WP5), fleet routine stand-up + existing-scheduler reconciliation (WP6), vendor-binding capability templates (WP6), cost enforcement / hard spend caps (WP5, 3→4 trigger).
- **Trigger register** gains the second-binding-consumer cross-repo drift check (WP1).
- **`reference/return-accounting.md`** records the per-work-class precision-graduation deferral beside its band-stability rule (WP3).
- **CHANGELOG.md created** for the autonomy plugin (first entry; 0.1.0–0.7.0 history stays in the WP PR bodies) + version bump to 0.7.1 — starts the CHANGELOG-parity posture #663 gates on.

All other mined notes were already covered: tracked issues (#351, #352, #694–#697), contract-recorded triggers (telemetry immutable-ID, return-accounting expansion/revisit), delivered sibling WPs, resolved `/architect` questions, or the user-held dormant triggers (runner build T4, L3 backend, merge serialization, mid-run interrupt, org-enablement, cross-team). Full disposition table lands as a comment on #353 at close.

Documentation only — no contract semantics change.

## Related

- #685 (effort-end prune that moved the PLAN records into the merged PR bodies)
- #663 (CHANGELOG-parity gate this PR's new CHANGELOG.md starts satisfying)
- WP delivery PRs mined: #333, #343, #356, #372, #377, #600, #676

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)


