### PR TITLE
docs(consumer-config-layering): ratify policy-floor precedence-inversion exception class (#649)

### DIFF
--- a/docs/conventions/consumer-config-layering/CHANGELOG.md
+++ b/docs/conventions/consumer-config-layering/CHANGELOG.md
@@ -6,6 +6,17 @@ semantics, and overlay naming. Per-concern keys and schema are versioned by thei
 change independently. A change to the precedence order or the meaning of a layer is a major bump;
 adding an optional layer or relaxing a rule additively is a minor bump.
 
+## 1.1 — 2026-07-20
+
+Additive relaxation (minor bump): ratified a named exception class. Default precedence is unchanged for
+every surface; the change carves out one surface class that may invert precedence direction on conflict.
+
+- **Sanctioned exception class — policy-floor precedence inversion.** A surface whose team layer encodes
+  a policy floor personal layers may extend or tighten but never weaken may invert precedence so the
+  team layer wins a direct conflict, provided personal layers stay add/tighten-only and provenance is
+  reported. Such a surface is conformant, not a tolerated deviation. `standards` is the exemplar; ruled
+  in #649.
+
 ## 1.0 — 2026-07-20
 
 Initial published contract, extracted from the tracked-rich-config seam in `docs/MIGRATION-PLAYBOOK.md`

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -71,6 +71,30 @@ not.
 **A surface using per-key override must declare it** in its own contract, next to its keys. The
 declaration is what makes it a design decision a reviewer can check rather than an accident.
 
+### Sanctioned exception class: policy-floor precedence inversion
+
+One class of surface — and only this class — inverts the precedence *direction* above while staying
+additive on every other axis. A **policy-floor surface** encodes, in its team-tracked layer, a floor
+that personal layers may extend or tighten but must never weaken. On a **direct conflict the team
+layer wins**, the reverse of the default where a later layer refines an earlier one. It never drops a
+base layer wholesale; it only decides who wins a conflict.
+
+A surface qualifies for this class only when all three hold:
+
+1. Its team layer is a genuine **policy floor** — a shared standard whose whole purpose is that a
+   personal layer cannot loosen it; personal weakening of a team-agreed rule is the failure mode worth
+   structurally preventing.
+2. Personal layers (user-global and overlay) remain **add/tighten-only** — they may never supply a
+   looser value that takes effect.
+3. **Provenance is reported** — when a personal-layer rule materially shapes output, the surface names
+   the contributing layer, so a reader can tell a team floor from a personal addition.
+
+This mirrors well-established prior art — managed settings that supersede user settings, org-enforced
+rulesets a repo cannot loosen, MDM managed preferences — where a higher-authority layer may be extended
+but not weakened. A surface in this class is **conformant, not a tolerated deviation**, and must declare
+the inversion in its own contract next to its keys. The class was ratified by #649; `standards` is its
+exemplar.
+
 ## Overlay naming and the consumer `.gitignore`
 
 The overlay is spelled `*.local.*` — the stem, `.local`, then the original extension. One spelling
@@ -132,15 +156,19 @@ docs and are deliberately decoupled from this number.
 
 ## Deviations
 
-Recorded as **observed**, not ratified. Listing a deviation here documents that it exists and diverges;
-it does not bless it. Ruling on each — correct the surface, or amend this contract — is a separate
-human-gated decision.
+Recorded here whether or not ratified. Listing a deviation documents that it exists and diverges; it
+does not by itself bless it. Ratifying one — as #649 did for the policy-floor precedence-inversion
+class above — moves it from observed to sanctioned. Ruling on each remaining deviation (correct the
+surface, or amend this contract) is a separate human-gated decision.
+
+**Ratified as a sanctioned exception class:**
+
+- **`standards` inverts precedence** — the exemplar of the policy-floor precedence-inversion class
+  above (ratified by #649). Personal layers may add or tighten only; the team-tracked layer wins a
+  direct conflict, with provenance reported. It is conformant to that class, not a tolerated deviation.
 
 **Declared** — the surface states its divergence and why:
 
-- **`standards` inverts precedence.** Personal layers may add or tighten only; the team-tracked layer
-  wins a direct conflict, with provenance reported. The stated rationale is that a personal layer
-  loosening a shared engineering standard is the failure mode worth structurally preventing.
 - **`autonomy` exempts its security axes.** Layers refine additively as the contract requires, except
   that no repo-local value may supply or override a security axis at all — a stricter rule than this
   contract, in the direction of safety.
@@ -169,7 +197,7 @@ open.
 | `toolchain` / `ecosystem-commands` | `.claude/ecosystems/<ecosystem>.yaml` | all three | conforms |
 | `codebase-health` | `.claude/codebase-health.md` | all three | conforms (concatenating, with a declared empty-list opt-out) |
 | `autonomy` | `.claude/autonomy/binding.json` | all three, plus an org rung | declared deviation |
-| `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | declared deviation |
+| `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | conforms via the policy-floor precedence-inversion class (ratified #649) |
 | `disk-hygiene` | `.claude/disk-hygiene.json` | user-global + team | declared deviation; no overlay layer |
 | `ai-briefing` | `.claude/ai-briefing/` | team only | undeclared: overlay recommended, never resolved |
 | `code-tidying` | `.claude/tidy-lanes/<lane>.md` | team only | single-layer over a bundled default |

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -161,14 +161,21 @@ does not by itself bless it. Ratifying one — as #649 did for the policy-floor 
 class above — moves it from observed to sanctioned. Ruling on each remaining deviation (correct the
 surface, or amend this contract) is a separate human-gated decision.
 
-**Ratified as a sanctioned exception class:**
+**Ratified as a sanctioned exception class — one axis only:**
 
-- **`standards` inverts precedence** — the exemplar of the policy-floor precedence-inversion class
+- **`standards` precedence inversion** — the exemplar of the policy-floor precedence-inversion class
   above (ratified by #649). Personal layers may add or tighten only; the team-tracked layer wins a
-  direct conflict, with provenance reported. It is conformant to that class, not a tolerated deviation.
+  direct conflict, with provenance reported. Conformant to that class, not a tolerated deviation.
+  **This ratification covers the precedence axis alone.** `standards` also diverges on layer *location*
+  (see Declared, below), which #649 did not rule on and which remains observed.
 
 **Declared** — the surface states its divergence and why:
 
+- **`standards` locates its layers outside `.claude/`.** Its team and overlay layers live at
+  `<standards_dir>/` (default `docs/standards/`) with a setup-owned in-directory `.gitignore`, rather
+  than the contract's `${CLAUDE_PROJECT_DIR}/.claude/<name>` and `*.local.*` paths — deliberately,
+  because writes under `.claude/` are permission-guarded. **Observed, not ratified:** #649 ruled the
+  precedence axis only; the location model is a separate, still-open ruling.
 - **`autonomy` exempts its security axes.** Layers refine additively as the contract requires, except
   that no repo-local value may supply or override a security axis at all — a stricter rule than this
   contract, in the direction of safety.
@@ -197,7 +204,7 @@ open.
 | `toolchain` / `ecosystem-commands` | `.claude/ecosystems/<ecosystem>.yaml` | all three | conforms |
 | `codebase-health` | `.claude/codebase-health.md` | all three | conforms (concatenating, with a declared empty-list opt-out) |
 | `autonomy` | `.claude/autonomy/binding.json` | all three, plus an org rung | declared deviation |
-| `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | conforms via the policy-floor precedence-inversion class (ratified #649) |
+| `standards` (`planning`, `review`) | `<standards_dir>/`, rooted by `.claude/standards.yaml` | all three | precedence inversion ratified via policy-floor class (#649); layer location outside `.claude/` still observed, not ratified |
 | `disk-hygiene` | `.claude/disk-hygiene.json` | user-global + team | declared deviation; no overlay layer |
 | `ai-briefing` | `.claude/ai-briefing/` | team only | undeclared: overlay recommended, never resolved |
 | `code-tidying` | `.claude/tidy-lanes/<lane>.md` | team only | single-layer over a bundled default |


### PR DESCRIPTION
## What

Ratifies the `standards` precedence inversion as a **named, sanctioned exception class** in the consumer-config layering contract — the disposition [#649](https://github.com/melodic-software/claude-code-plugins/issues/649) recommended for that surface ("reads as defensible" / policy-floor).

- **README** (`docs/conventions/consumer-config-layering/README.md`): defines the **policy-floor precedence-inversion** class under Merge semantics (team layer wins a direct conflict; personal layers stay add/tighten-only; provenance reported — with a three-part qualification test and external prior art). Moves `standards` from an observed deviation to the ratified exemplar; reconciles the Deviations intro and the Implementers conformance cell.
- **CHANGELOG**: 1.1 entry.

## Why a minor bump

Default precedence (user → team → local, additive-preferred) is unchanged for every surface; this only carves out a conditional inversion for one surface *class*. That is additive relaxation → **minor** per the contract's own SemVer note. The contract version lives solely in `CHANGELOG.md`; the Convention registry row in `PLUGIN-PHILOSOPHY.md` names-and-points without a version, so no lockstep drift.

## Scope

Deliberately narrow: the policy-floor class + `standards` only. The other two deviations named in #649 are dispositioned via follow-up issues, each owning its own contract-row update:

- **#701** `code-tidying` docs-prose lane → **CORRECT** (decompose to per-key override), `status: ready`.
- **#703** `songwriting` template overrides → **decomposability decision gates correct-vs-ratify**, `status: needs-decision` (human-gated; not yet actionable).

Applied under operator momentum delegation; **veto window open** — conventions remain operator-owned and any veto reverts mechanically.

Closes #649

## Related

- #701 — `code-tidying` docs-prose conformance correction (this PR does not close it).
- #703 — `songwriting` decomposability decision (human-gated; this PR does not close it).
- #647 / #660 — `source-control` per-key deviation; confirmed by the ratified per-key path, already merged, unaffected.
