### PR TITLE
feat(work-items): container-scoped frontier and sub-item enumeration verb

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.0]
+
+Close the work-item-tracker seam's container read-verb gap (`#498`): the seam reserves `work-map`
+containers as a first-class use case but had no way to operate one within scope. The frontier was
+repo-global only, its rows dropped parent linkage, an unassigned/unblocked container surfaced as its
+own frontier item, and no verb enumerated a container's children — collectively blocking a clean
+container-based consumer (surfaced by the `#416` wayfind-routing planning pass). Related but distinct:
+`#416` (the wayfind consumer) and `#379` (the Jira adapter, a different backend).
+
+### Added
+
+- **`list-sub-items <parent-id> [--state open|closed|all]` (new seam + adapter verb).** Enumerates a
+  container's DIRECT children as full normalized item objects (same `{items:[…]}` envelope as
+  `list-items`), each re-parented to the container. Raw enumeration — closed and nested-container
+  children are kept, so the "decisions-so-far" closed-children invariant check and sub-map traversal
+  both have a seam path. `--state` defaults to `all`. Both adapters implement it: the GitHub adapter
+  resolves children through the native `subIssues` link and intersects with `list-items` (its list
+  surface omits parent linkage), so its truncation bound is `list-items`' own (`list_items_max`);
+  the offline `local-markdown` adapter matches on the stored `parent` frontmatter.
+- **`list-frontier --parent <container-id>` (container-scoped frontier).** Scopes the frontier to one
+  container's children — core reads `list-sub-items` for that container instead of the repo-global
+  `list-items`, then applies the identical filter. Gates on the adapter's `list-sub-items` capability.
+
+### Fixed
+
+- **A container is never its own frontier item (`#498` obs #3).** `list-frontier` now excludes any item
+  carrying the container label (`work-map`) unconditionally — global and `--parent`-scoped alike, and
+  under `--autonomous` — fixing the correctness wart where an unassigned, unblocked container passed the
+  frontier filter and surfaced itself. The container label is a named constant (`WIT_CONTAINER_LABEL`)
+  matching the CONTRACT term; per-repo remapping is deferred to the `config.role_labels` convention.
+
 ## [0.15.0]
 
 Close the work-items entry-invariant gap where a missing provider binding (`.work-item-tracker.json`)

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -33,6 +33,11 @@ container-based consumer (surfaced by the `#416` wayfind-routing planning pass).
   under `--autonomous` — fixing the correctness wart where an unassigned, unblocked container passed the
   frontier filter and surfaced itself. The container label is a named constant (`WIT_CONTAINER_LABEL`)
   matching the CONTRACT term; per-repo remapping is deferred to the `config.role_labels` convention.
+- **`list-frontier --parent` rejects `--repo` instead of silently dropping it (`#498`).** A container is
+  addressed by its qualified id, which already carries the repo, so `--repo` cannot re-target a
+  container-scoped frontier. The scoped path never threaded `list_args`, so a caller passing both flags
+  had `--repo` silently ignored. Passing both is now a usage error (exit `2`) with a clear message,
+  matching the seam's fail-loud convention for invalid arg combinations.
 
 ## [0.15.0]
 

--- a/plugins/work-items/reference/tracker-seam.md
+++ b/plugins/work-items/reference/tracker-seam.md
@@ -45,8 +45,8 @@ routes rather than halting unconditionally.
   actionable, never a silent default and never a raw mid-flow `exit 3`** — but it does not halt the
   invocation unconditionally:
   - **Seam coordination verbs** (`create-item`, `get-item`, `claim`, `renew-lease`, `reclaim`,
-    `link-blocks`, `add-sub-item`, `list-frontier`, `capabilities`) cannot run without a binding —
-    the seam hard-errors `exit 3`
+    `link-blocks`, `add-sub-item`, `list-sub-items`, `list-frontier`, `capabilities`) cannot run
+    without a binding — the seam hard-errors `exit 3`
     (`${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md` "Exit codes"). Before the first
     coordination verb, if no binding resolves, surface a message that distinguishes the two ways to
     arrive here rather than dead-ending on the raw `exit 3`: **(1) setup was never run** → run
@@ -71,7 +71,7 @@ routes rather than halting unconditionally.
 Adapters resolve the opposite way — **consumer-local-first, plugin-bundled fallback**
 (`${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md` "Adapter resolution") — so a repo can add
 an unshipped provider or shadow a bundled one without forking the plugin. Coordination — create, claim
-(assignee + lease), lease renew/reclaim, dependency links, sub-items, frontier selection, single-item
+(assignee + lease), lease renew/reclaim, dependency links, sub-items, child enumeration, frontier selection, single-item
 fetch — uses seam verbs directly. Operations without a core verb (listing with arbitrary filters,
 search, aggregation, close, label/comment edits) are provider-specific; for the bound GitHub adapter
 their mechanics live in `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/github/README.md`. The
@@ -84,7 +84,7 @@ ways:
 
 | Kind | Where |
 |------|-------|
-| **Coordination** — create, claim (assignee + lease), renew/reclaim lease, dependency links, sub-items, frontier selection, single-item fetch | Seam verbs: the resolved `"$TRACKER" <verb>` dispatcher — contract in `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md` |
+| **Coordination** — create, claim (assignee + lease), renew/reclaim lease, dependency links, sub-items, child enumeration (`list-sub-items`), frontier selection (incl. `--parent`-scoped), single-item fetch | Seam verbs: the resolved `"$TRACKER" <verb>` dispatcher — contract in `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md` |
 | **Provider mechanics** — list with filters, search, aggregate/count, close, label/assignee edits, comments | The bound adapter's operations reference (GitHub: `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/adapters/github/README.md`) |
 
 Coordination claims are race-safe at the seam (assignee + lease comment; `${CLAUDE_PLUGIN_ROOT}/tools/work-item-tracker/CONTRACT.md` "Lease protocol") — the retired hold→verify→claim label dance is gone. Reads are non-mutating; writes route through the adapter's identity policy.

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -51,30 +51,53 @@ work-item-tracker.sh renew-lease <id> --lease-comment-id <n>
 work-item-tracker.sh reclaim <id>
 work-item-tracker.sh link-blocks <id> --blocked-by <id>
 work-item-tracker.sh add-sub-item <id> --parent <id>
-work-item-tracker.sh list-frontier [--autonomous] [--repo <o>/<r>]
+work-item-tracker.sh list-sub-items <parent-id> [--state open|closed|all]
+work-item-tracker.sh list-frontier [--autonomous] [--parent <container-id>] [--repo <o>/<r>]
 work-item-tracker.sh capabilities
 ```
 
+`list-sub-items` enumerates a container's **direct** children as full normalized item objects
+(same envelope as `list-items`), each carrying the container as its `parent_id`. It is a RAW
+enumeration — closed children and nested-container children are kept (the closed-children
+invariant check and sub-map traversal both need them); frontier filtering is the separate
+core-side step below. The container is addressed by its qualified id, which carries the repo, so
+there is no `--repo` flag. `--state` defaults to `all`.
+
 `list-frontier` is a CORE-side derivation (no provider has a native counterpart): it calls
 the adapter's `list-items` and filters `state == open` AND `blocked_by_count == 0` AND no
-assignee. With `--autonomous`, items labeled `needs-human` are additionally excluded —
-the filter runs core-side over the labels `list-items` already returns; provider search
-syntax never leaves the adapter.
+assignee AND not a container (a `work-map` item is never its own frontier item — see
+"Containers and state"). With `--autonomous`, items labeled `needs-human` are additionally
+excluded — the filter runs core-side over the labels `list-items` already returns; provider
+search syntax never leaves the adapter. With `--parent <container-id>` the frontier is scoped
+to one container: core reads the adapter's `list-sub-items` for that container instead of the
+repo-global `list-items`, then applies the identical filter (so a nested sub-map among the
+children is likewise excluded). `--parent` gates on the adapter's `list-sub-items` capability,
+not `list-items`.
 
 ## Adapter contract
 
 Adapters live at `adapters/<provider>/` as verb-per-script (`<verb>.sh`) plus a
 `capabilities.json` manifest. Adapter verb set = core public set **minus `list-frontier`
-plus `list-items`**:
+plus `list-items`** (`list-sub-items` is both a core and an adapter verb — it has a native
+counterpart, unlike the core-derived `list-frontier`):
 
 ```text
 adapters/<provider>/list-items.sh [--state open|closed|all] [--repo <o>/<r>]
+adapters/<provider>/list-sub-items.sh <parent-id> [--state open|closed|all]
 ```
 
 - `list-items` returns RAW candidates (state, assignees, labels, open-blocker count) and
   MUST have explicit pagination semantics: fetch up to the `limits.list_items_max`
   declared in its `capabilities.json` (never a client default — `gh` truncates at 30
   silently). Exceeding the ceiling is a documented truncation, not an error.
+- `list-sub-items` returns the RAW children of `<parent-id>` in the same `{items:[…]}`
+  envelope, each item's `parent_id` set to the container. Where a provider's list surface
+  omits parent linkage (GitHub's does — see "JSON output contract"), the adapter resolves
+  children through the provider's native sub-item link (GitHub's `subIssues`) and intersects
+  with `list-items` output; its truncation bound is therefore `list-items`' own
+  (`limits.list_items_max`), safe while `sub_items_per_parent <= list_items_max`. A child in
+  another repo is out of scope for this repo-keyed intersect (documented truncation, not an
+  error). A parent with no children returns an empty `items` array, never an error.
 - An adapter MAY keep shared helpers (e.g. `common.sh`); only `<verb>.sh` files named in
   the manifest are contract surface.
 - A verb declared `false` in the manifest exits `6` with a clear stderr message when
@@ -139,7 +162,8 @@ Normalized item object:
   `parent_id: null` when the provider's list surface omits parent data (GitHub's does);
   `get-item` is authoritative for parent linkage.
 
-Envelopes: `list-items` and `list-frontier` emit `{"schema_version":"1.0","items":[…]}`.
+Envelopes: `list-items`, `list-sub-items`, and `list-frontier` emit
+`{"schema_version":"1.0","items":[…]}`.
 
 Per-verb result objects:
 
@@ -152,6 +176,7 @@ Per-verb result objects:
 | `reclaim` | `id, reclaimed` (bool), `reason` |
 | `link-blocks` | `id, blocked_by, linked: true` |
 | `add-sub-item` | `id, parent_id, linked: true` |
+| `list-sub-items` | `{items:[…]}` envelope of normalized item objects (each `parent_id` = the container) |
 | `capabilities` | manifest object (see below) |
 
 ## ID grammar
@@ -229,8 +254,15 @@ carry the check).
 Two axes, one item model: a **container** is an ordinary item carrying the `work-map`
 label (a navigable graph root — wayfind maps, decompose breakdowns); **state** is the
 provider's native open/closed. Containers are never claimable by workers (no
-`agent-ready`); frontier machinery is label-agnostic and simply never surfaces items that
-are assigned or blocked.
+`agent-ready`), so **a container is never its own frontier item**: `list-frontier` excludes
+any item carrying the container label, unconditionally (global and `--parent`-scoped alike).
+The container label is a named constant (`WIT_CONTAINER_LABEL`, default `work-map`) matching
+this contract term; making it a per-repo remap (a consumer wanting a different marker) is
+deferred to the `config.role_labels` convention (label-taxonomy.md "Canonical roles"), keyed
+off that same first request — not a parallel binding key. Read one container's children with
+`list-sub-items <container>`; read the workable frontier within one container with
+`list-frontier --parent <container>`. Aside from that exclusion the frontier is
+label-agnostic and simply never surfaces items that are assigned or blocked.
 
 ## Capabilities manifest
 

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -72,7 +72,9 @@ search syntax never leaves the adapter. With `--parent <container-id>` the front
 to one container: core reads the adapter's `list-sub-items` for that container instead of the
 repo-global `list-items`, then applies the identical filter (so a nested sub-map among the
 children is likewise excluded). `--parent` gates on the adapter's `list-sub-items` capability,
-not `list-items`.
+not `list-items`. `--repo` is incompatible with `--parent`: a container is addressed by its
+qualified id, which already carries the repo, so `--repo` cannot re-target a container-scoped
+frontier. Passing both is a usage error (exit `2`), not a silent drop.
 
 ## Adapter contract
 

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/capabilities.json
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/capabilities.json
@@ -10,6 +10,7 @@
     "link-blocks": true,
     "add-sub-item": true,
     "list-items": true,
+    "list-sub-items": true,
     "capabilities": true
   },
   "features": {

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# list-sub-items <parent-id> [--state open|closed|all] — adapter contract
+# (CONTRACT.md "Adapter contract"). Enumerates a container's DIRECT children as
+# full normalized item objects (same envelope as list-items), each with
+# parent_id set to the container. Raw enumeration: it does NOT drop closed or
+# nested-container children — the closed-children invariant and sub-map
+# traversal both need them (frontier filtering is a separate core-side step).
+#
+# GitHub carries native sub-issues but its list surface omits parent linkage
+# (CONTRACT.md "JSON output contract"), so children cannot be found by filtering
+# list-items rows. Two reads instead: the parent's native subIssues connection
+# yields the child NUMBERS, then the adapter's own list-items output is filtered
+# to that set (reusing its exact normalized projection) and re-parented. Same
+# repo only: subIssues nodes in another repo are dropped (the intersect is
+# number-keyed against this repo's list). Truncation bound is list-items' own
+# (limits.list_items_max) — safe while sub_items_per_parent <= list_items_max.
+set -uo pipefail
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+wit_help_if_requested "usage: list-sub-items <parent-id> [--state open|closed|all]" "$@"
+
+id="${1:-}"
+[[ -n "$id" ]] || wit_usage_error "usage: list-sub-items <parent-id> [--state open|closed|all]"
+shift
+state="all"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state)
+      [[ $# -ge 2 ]] || wit_usage_error "--state needs a value"
+      state="$2"
+      shift 2
+      ;;
+    *) wit_usage_error "unknown argument: $1" ;;
+  esac
+done
+case "$state" in
+  open | closed | all) ;;
+  *) wit_usage_error "--state must be open|closed|all (got: $state)" ;;
+esac
+wit_require_github_id "$id" || wit_usage_error "malformed or non-github id: $id (expected github:<owner>/<repo>#<number>)"
+target_repo="$WIT_ID_OWNER/$WIT_ID_REPO"
+
+# Native child numbers, scoped to the parent's own repo (a cross-repo sub-issue's
+# number would collide with an unrelated same-numbered issue in this repo).
+wit_run_gh read issue view "$WIT_ID_NUMBER" -R "$target_repo" --json subIssues
+child_nums="$(printf '%s\n' "$WIT_GH_OUT" |
+  jq -c --arg repo "$target_repo" \
+    '[(.subIssues.nodes // [])[] | select(.repository.nameWithOwner == $repo) | .number]')"
+
+if [[ "$child_nums" == "[]" ]]; then
+  jq -cn --arg sv "$WIT_SCHEMA_VERSION" '{schema_version: $sv, items: []}'
+  exit 0
+fi
+
+# Reuse list-items' normalized envelope, then keep only the child rows and stamp
+# the known parent (list rows carry parent_id: null — GitHub omits it in bulk).
+# $() swallows the sibling's exit-on-error; propagate its code.
+items_env="$(bash "$WIT_GH_ADAPTER_DIR/list-items.sh" --state "$state" --repo "$target_repo")" || exit "$?"
+printf '%s\n' "$items_env" | jq -c --argjson nums "$child_nums" --arg pid "$id" '{
+  schema_version: .schema_version,
+  items: [
+    .items[]
+    | select((.id | split("#")[-1] | tonumber) as $n | $nums | index($n))
+    | .parent_id = $pid
+  ]
+}'

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/list-sub-items.test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # FAILED/CASE_NUM initialized by the sourced helper
+# Offline contract stub — the GitHub subIssues + intersect path needs live gh, so
+# its behavior is exercised by the on-demand e2e-probe; here we assert only the
+# skill-script contract (--help) and the pre-I/O usage-error paths.
+set -uo pipefail
+S="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/list-sub-items.sh"
+source "$(dirname "$S")/../../lib/verb-test-helpers.sh"
+
+assert_help "$S"
+assert_usage_error "$S"                                    # no parent id
+assert_usage_error "$S" "github:o/r#1" --state bogus       # bad state
+assert_usage_error "$S" "not-an-id"                        # malformed id
+assert_usage_error "$S" "local-markdown:o/r#1"             # foreign provider
+[[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/capabilities.json
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/capabilities.json
@@ -10,6 +10,7 @@
     "link-blocks": true,
     "add-sub-item": true,
     "list-items": true,
+    "list-sub-items": true,
     "capabilities": true
   },
   "features": {

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# list-sub-items <parent-id> [--state open|closed|all] — adapter contract
+# (CONTRACT.md "Adapter contract"). Enumerates a container's DIRECT children as
+# full normalized item objects (same envelope as list-items), each carrying its
+# stored parent_id. Raw enumeration: closed and nested-container children are
+# kept (frontier filtering is a separate core-side step). Offline — the parent
+# link lives in each item's frontmatter, so no native sub-issue surface is
+# needed; matches by the stored (JSON-quoted) `parent` field.
+set -uo pipefail
+# shellcheck source=common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+wit_help_if_requested "usage: list-sub-items <parent-id> [--state open|closed|all]" "$@"
+
+id="${1:-}"
+[[ -n "$id" ]] || wit_usage_error "usage: list-sub-items <parent-id> [--state open|closed|all]"
+shift
+state="all"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --state)
+      [[ $# -ge 2 ]] || wit_usage_error "--state needs a value"
+      state="$2"
+      shift 2
+      ;;
+    *) wit_usage_error "unknown argument: $1" ;;
+  esac
+done
+case "$state" in
+  open | closed | all) ;;
+  *) wit_usage_error "--state must be open|closed|all (got: $state)" ;;
+esac
+wit_require_local_id "$id" || wit_usage_error "malformed or non-local-markdown id: $id (expected local-markdown:<owner>/<repo>#<number>)"
+
+wit_need_storage
+# The `parent` frontmatter field stores the JSON-quoted id (create-item.sh), so
+# compare against the quoted form, never the bare id.
+parent_quoted="$(jq -cn --arg p "$id" '$p')"
+
+numbers=()
+shopt -s nullglob
+for f in "$WIT_STORAGE_DIR"/*.md; do
+  base="$(basename "$f" .md)"
+  [[ "$base" =~ ^[0-9]+$ ]] || continue
+  numbers+=("$base")
+done
+
+{
+  for n in $(printf '%s\n' "${numbers[@]+"${numbers[@]}"}" | sort -n); do
+    file="$(wit_item_file "$n")"
+    [[ "$(wit_fm_field "$file" parent)" == "$parent_quoted" ]] || continue
+    item_state="$(wit_fm_field "$file" state)"
+    case "$state" in
+      all) ;;
+      open) [[ "$item_state" == '"open"' ]] || continue ;;
+      closed) [[ "$item_state" == '"closed"' ]] || continue ;;
+      *) ;; # unreachable: --state is validated to open|closed|all at parse time
+    esac
+    wit_emit_local_item "$n" true
+  done
+} | jq -c -s --arg sv "$WIT_SCHEMA_VERSION" '{schema_version: $sv, items: .}'

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# End-to-end list-sub-items behavior through the core CLI against the offline
+# local-markdown store (issue #498): direct-child enumeration with state
+# filtering and parent stamping, the container-scoped frontier (list-frontier
+# --parent), and container exclusion from every frontier. Runs in CI, offline.
+# shellcheck disable=SC2154  # FAILED/CASE_NUM initialized by the sourced lib
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRACKER="$SCRIPT_DIR/../../work-item-tracker.sh"
+source "$SCRIPT_DIR/../../tests/lib.sh"
+
+STORAGE="$(mktemp -d)"
+BINDING="$(mktemp)"
+jq -cn --arg dir "$STORAGE" \
+  '{schema_version: "1.0", provider: "local-markdown", config: {lease_ttl_hours: 24, storage_dir: $dir}}' \
+  >"$BINDING"
+export WORK_ITEM_TRACKER_BINDING="$BINDING"
+cleanup() { rm -rf "$STORAGE" "${STORAGE_REAL:-}"; rm -f "$BINDING"; }
+trap cleanup EXIT
+
+new() { bash "$TRACKER" create-item "$@" | jq -r '.id'; }
+
+# A container (work-map) with two direct children, an unrelated leaf, and a
+# grandchild (proves enumeration is DIRECT children only). Capture C2's full
+# record to recover the store's on-disk path from its own reported url — the
+# tracker resolves the storage dir itself (and MSYS may translate it), so never
+# assume the outer $STORAGE is where files land.
+MAP="$(new --title map --labels work-map)"
+C1="$(new --title c1 --parent "$MAP")"
+C2_JSON="$(bash "$TRACKER" create-item --title c2 --parent "$MAP")"
+C2="$(jq -r '.id' <<<"$C2_JSON")"
+C2_FILE="$(jq -r '.url' <<<"$C2_JSON" | sed 's#^file://##')"
+STORAGE_REAL="$(dirname "$C2_FILE")"
+LEAF="$(new --title unrelated)"
+GC="$(new --title grandchild --parent "$C1")"
+
+# Close C2 by editing its stored state (this offline adapter has no close verb;
+# resolution is a provider-native state change — see e2e-probe.sh).
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+wit_fm_set "$C2_FILE" state '"closed"'
+
+sub_ids() { bash "$TRACKER" list-sub-items "$@" | jq -c '[.items[].id]'; }
+
+# --- enumeration: direct children only, both states, correctly parented ---
+ALL="$(sub_ids "$MAP")"
+assert_contains "list-sub-items holds open child C1" "$ALL" "$C1"
+assert_contains "list-sub-items holds closed child C2" "$ALL" "$C2"
+assert_not_contains "list-sub-items excludes the container itself" "$ALL" "$MAP"
+assert_not_contains "list-sub-items excludes an unrelated leaf" "$ALL" "$LEAF"
+assert_not_contains "list-sub-items excludes a grandchild (direct children only)" "$ALL" "$GC"
+assert_eq "list-sub-items (default all) child count" "2" "$(bash "$TRACKER" list-sub-items "$MAP" | jq '.items | length')"
+assert_eq "children carry parent_id" "$MAP $MAP" \
+  "$(bash "$TRACKER" list-sub-items "$MAP" | jq -r '[.items[].parent_id] | join(" ")')"
+
+# --- state filtering ---
+assert_eq "list-sub-items --state open keeps only C1" "$C1" \
+  "$(bash "$TRACKER" list-sub-items "$MAP" --state open | jq -r '[.items[].id] | join(",")')"
+assert_eq "list-sub-items --state closed keeps only C2" "$C2" \
+  "$(bash "$TRACKER" list-sub-items "$MAP" --state closed | jq -r '[.items[].id] | join(",")')"
+
+# --- a leaf has no children ---
+assert_eq "list-sub-items on a leaf is empty" "0" \
+  "$(bash "$TRACKER" list-sub-items "$LEAF" | jq '.items | length')"
+
+# --- container-scoped frontier (list-frontier --parent) ---
+PFRONT="$(bash "$TRACKER" list-frontier --parent "$MAP" | jq -c '[.items[].id]')"
+assert_contains "scoped frontier holds the open child C1" "$PFRONT" "$C1"
+assert_not_contains "scoped frontier drops the closed child C2" "$PFRONT" "$C2"
+assert_not_contains "scoped frontier drops the grandchild (not a direct child)" "$PFRONT" "$GC"
+assert_not_contains "scoped frontier never holds the container" "$PFRONT" "$MAP"
+
+# --- container exclusion from the GLOBAL frontier (issue #498 obs #3) ---
+GFRONT="$(bash "$TRACKER" list-frontier | jq -c '[.items[].id]')"
+assert_not_contains "global frontier excludes the unassigned/unblocked container" "$GFRONT" "$MAP"
+assert_contains "global frontier still holds the workable leaf" "$GFRONT" "$LEAF"
+
+[[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # End-to-end list-sub-items behavior through the core CLI against the offline
-# local-markdown store (issue #498): direct-child enumeration with state
+# local-markdown store: direct-child enumeration with state
 # filtering and parent stamping, the container-scoped frontier (list-frontier
 # --parent), and container exclusion from every frontier. Runs in CI, offline.
 # shellcheck disable=SC2154  # FAILED/CASE_NUM initialized by the sourced lib
@@ -71,7 +71,7 @@ assert_not_contains "scoped frontier drops the closed child C2" "$PFRONT" "$C2"
 assert_not_contains "scoped frontier drops the grandchild (not a direct child)" "$PFRONT" "$GC"
 assert_not_contains "scoped frontier never holds the container" "$PFRONT" "$MAP"
 
-# --- container exclusion from the GLOBAL frontier (issue #498 obs #3) ---
+# --- container exclusion from the GLOBAL frontier (a container never surfaces itself) ---
 GFRONT="$(bash "$TRACKER" list-frontier | jq -c '[.items[].id]')"
 assert_not_contains "global frontier excludes the unassigned/unblocked container" "$GFRONT" "$MAP"
 assert_contains "global frontier still holds the workable leaf" "$GFRONT" "$LEAF"

--- a/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
@@ -80,7 +80,7 @@ assert_eq "item2 parent is map" "$MAP_ID" "$(jq -r '.parent_id' <<<"$ITEM2")"
 assert_eq "item2 blocked" "1" "$(jq -r '.blocked_by_count' <<<"$ITEM2")"
 
 # 3. Frontier: item1 claimable, item2 blocked, and the map (a container) never
-# surfaces itself (issue #498 obs #3).
+# surfaces itself as its own frontier item.
 FRONTIER="$(wit list-frontier --repo "$REPO")"
 record "frontier before claim" "$FRONTIER"
 IDS="$(jq -c '[.items[].id]' <<<"$FRONTIER")"
@@ -88,7 +88,7 @@ assert_contains "frontier holds item1" "$IDS" "$ITEM1_ID"
 assert_not_contains "frontier hides blocked item2" "$IDS" "$ITEM2_ID"
 assert_not_contains "frontier excludes the unblocked container map" "$IDS" "$MAP_ID"
 
-# 3b. Sub-item enumeration + container-scoped frontier (issue #498). list-sub-items
+# 3b. Sub-item enumeration + container-scoped frontier. list-sub-items
 # returns BOTH children (raw enumeration keeps blocked/closed); the scoped
 # frontier applies the same filter as the global one — item1 in, blocked item2
 # out, and the map never its own frontier item.

--- a/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
@@ -79,12 +79,32 @@ record "create item2 (task, blocked by item1)" "$ITEM2"
 assert_eq "item2 parent is map" "$MAP_ID" "$(jq -r '.parent_id' <<<"$ITEM2")"
 assert_eq "item2 blocked" "1" "$(jq -r '.blocked_by_count' <<<"$ITEM2")"
 
-# 3. Frontier: item1 claimable, item2 blocked.
+# 3. Frontier: item1 claimable, item2 blocked, and the map (a container) never
+# surfaces itself (issue #498 obs #3).
 FRONTIER="$(wit list-frontier --repo "$REPO")"
 record "frontier before claim" "$FRONTIER"
 IDS="$(jq -c '[.items[].id]' <<<"$FRONTIER")"
 assert_contains "frontier holds item1" "$IDS" "$ITEM1_ID"
 assert_not_contains "frontier hides blocked item2" "$IDS" "$ITEM2_ID"
+assert_not_contains "frontier excludes the unblocked container map" "$IDS" "$MAP_ID"
+
+# 3b. Sub-item enumeration + container-scoped frontier (issue #498). list-sub-items
+# returns BOTH children (raw enumeration keeps blocked/closed); the scoped
+# frontier applies the same filter as the global one — item1 in, blocked item2
+# out, and the map never its own frontier item.
+SUBS="$(wit list-sub-items "$MAP_ID")"
+record "map sub-items" "$SUBS"
+SUB_IDS="$(jq -c '[.items[].id]' <<<"$SUBS")"
+assert_contains "sub-items hold item1" "$SUB_IDS" "$ITEM1_ID"
+assert_contains "sub-items hold blocked item2" "$SUB_IDS" "$ITEM2_ID"
+assert_eq "sub-items are re-parented to the map" "$MAP_ID" "$(jq -r '.items[0].parent_id' <<<"$SUBS")"
+
+PFRONTIER="$(wit list-frontier --parent "$MAP_ID")"
+record "scoped frontier before claim" "$PFRONTIER"
+PIDS="$(jq -c '[.items[].id]' <<<"$PFRONTIER")"
+assert_contains "scoped frontier holds item1" "$PIDS" "$ITEM1_ID"
+assert_not_contains "scoped frontier hides blocked item2" "$PIDS" "$ITEM2_ID"
+assert_not_contains "scoped frontier excludes the map itself" "$PIDS" "$MAP_ID"
 
 # 4. Claim item1 (assignee + lease comment).
 CLAIM="$(wit claim "$ITEM1_ID" --session-id "e2e-$TS")"

--- a/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
@@ -117,6 +117,10 @@ done
 if ! verb_supported list-items; then
   wit_case "unsupported list-items gates list-frontier → exit 6" 6 list-frontier
 fi
+if ! verb_supported list-sub-items; then
+  wit_case "unsupported list-sub-items → exit 6" 6 list-sub-items "$FAKE_ID"
+  wit_case "unsupported list-sub-items gates list-frontier --parent → exit 6" 6 list-frontier --parent "$FAKE_ID"
+fi
 
 # --- create-item ---
 
@@ -169,6 +173,24 @@ if verb_supported add-sub-item && [[ -n "$ITEM_A_ID" && -n "$ITEM_B_ID" ]]; then
   wit_case "add-sub-item B under A" 0 add-sub-item "$ITEM_B_ID" --parent "$ITEM_A_ID"
   wit_case "get-item B sees parent" 0 get-item "$ITEM_B_ID"
   assert_eq "B parent_id" "$ITEM_A_ID" "$(jq -r '.parent_id' <<<"$WIT_OUT")"
+fi
+
+# --- sub-item enumeration + container-scoped frontier ---
+# B is now a child of A (add-sub-item above) and blocked by A (link-blocks
+# above), so it enumerates as A's child but is filtered out of A's scoped
+# frontier while still blocked.
+if verb_supported list-sub-items && verb_supported add-sub-item && [[ -n "$ITEM_A_ID" && -n "$ITEM_B_ID" ]]; then
+  wit_case "list-sub-items A" 0 list-sub-items "$ITEM_A_ID"
+  assert_schema_version "list-sub-items A"
+  assert_contains "A's children hold B" "$(jq -c '[.items[].id]' <<<"$WIT_OUT")" "$ITEM_B_ID"
+  assert_eq "enumerated child B is re-parented to A" "$ITEM_A_ID" \
+    "$(jq -r '.items[0].parent_id' <<<"$WIT_OUT")"
+  wit_case "list-sub-items malformed parent id → usage" 2 list-sub-items "not-an-id"
+
+  wit_case "list-frontier --parent A" 0 list-frontier --parent "$ITEM_A_ID"
+  assert_schema_version "list-frontier --parent A"
+  assert_not_contains "scoped frontier drops blocked child B" \
+    "$(jq -c '[.items[].id]' <<<"$WIT_OUT")" "$ITEM_B_ID"
 fi
 
 # --- frontier ---

--- a/plugins/work-items/tools/work-item-tracker/lib/frontier.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/frontier.sh
@@ -1,22 +1,34 @@
 #!/usr/bin/env bash
 # Core-side frontier derivation (CONTRACT.md "Verbs (core public surface)"):
-# frontier = open AND zero open blockers AND unassigned; --autonomous additionally
-# drops items labeled with the configured "human-gated" role label (default
-# needs-human; label-taxonomy.md "Canonical roles", config.role_labels). Runs
-# over the adapter's list-items envelope — provider search syntax never reaches
-# this layer. Sourced.
+# frontier = open AND zero open blockers AND unassigned AND not a container;
+# --autonomous additionally drops items labeled with the configured "human-gated"
+# role label (default needs-human; label-taxonomy.md "Canonical roles",
+# config.role_labels). Runs over the adapter's list-items envelope (or, for a
+# container-scoped frontier, its list-sub-items envelope) — provider search
+# syntax never reaches this layer. Sourced.
 
 [[ -n "${_WIT_FRONTIER_LOADED:-}" ]] && return 0
 readonly _WIT_FRONTIER_LOADED=1
 
-# wit_filter_frontier <autonomous:true|false> [<human-gated-label>] — stdin:
-# list-items envelope; stdout: frontier envelope (same schema_version
-# passthrough). The label defaults to "needs-human"; callers resolving a
-# binding should pass WIT_HUMAN_GATED_LABEL (lib/binding.sh) instead of relying
-# on that default, so a repo's configured remap is honored.
+# The container marker (CONTRACT.md "Containers and state"): an ordinary item
+# carrying this label is a navigable graph root (wayfind maps, decompose
+# breakdowns), never a claimable worker item — so it is never its own frontier
+# item. A named constant, not a baked literal: it matches the documented CONTRACT
+# term. Making the string configurable (a consumer wanting a non-`work-map`
+# marker) is deferred to the label-taxonomy config.role_labels convention, keyed
+# off that same first request — not a parallel binding key.
+readonly WIT_CONTAINER_LABEL="work-map"
+
+# wit_filter_frontier <autonomous:true|false> [<human-gated-label>] [<container-label>]
+# — stdin: list-items (or list-sub-items) envelope; stdout: frontier envelope
+# (same schema_version passthrough). human-gated defaults to "needs-human";
+# callers resolving a binding should pass WIT_HUMAN_GATED_LABEL (lib/binding.sh)
+# so a repo's configured remap is honored. container defaults to
+# WIT_CONTAINER_LABEL; a container item is dropped from every frontier
+# unconditionally (issue #498 obs #3 — a container must never surface itself).
 wit_filter_frontier() {
-  local autonomous="${1:-false}" human_gated="${2:-needs-human}"
-  jq -c --arg auto "$autonomous" --arg human_gated "$human_gated" '{
+  local autonomous="${1:-false}" human_gated="${2:-needs-human}" container="${3:-$WIT_CONTAINER_LABEL}"
+  jq -c --arg auto "$autonomous" --arg human_gated "$human_gated" --arg container "$container" '{
     schema_version: .schema_version,
     items: [
       .items[]
@@ -24,6 +36,7 @@ wit_filter_frontier() {
           .state == "open"
           and .blocked_by_count == 0
           and ((.assignees // []) | length == 0)
+          and (((.labels // []) | index($container)) | not)
           and (if $auto == "true"
                then (((.labels // []) | index($human_gated)) | not)
                else true

--- a/plugins/work-items/tools/work-item-tracker/lib/frontier.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/frontier.sh
@@ -25,7 +25,7 @@ readonly WIT_CONTAINER_LABEL="work-map"
 # callers resolving a binding should pass WIT_HUMAN_GATED_LABEL (lib/binding.sh)
 # so a repo's configured remap is honored. container defaults to
 # WIT_CONTAINER_LABEL; a container item is dropped from every frontier
-# unconditionally (issue #498 obs #3 — a container must never surface itself).
+# unconditionally — a container must never surface itself.
 wit_filter_frontier() {
   local autonomous="${1:-false}" human_gated="${2:-needs-human}" container="${3:-$WIT_CONTAINER_LABEL}"
   jq -c --arg auto "$autonomous" --arg human_gated "$human_gated" --arg container "$container" '{

--- a/plugins/work-items/tools/work-item-tracker/lib/frontier.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/frontier.test.sh
@@ -51,4 +51,36 @@ SPARSE='{"schema_version":"1.0","items":[{"id":"github:o/r#9","state":"open","bl
 OUT="$(wit_filter_frontier true <<<"$SPARSE")"
 assert_eq "sparse item survives filters" "1" "$(jq '.items | length' <<<"$OUT")"
 
+# Container exclusion (issue #498 obs #3): a container item (default work-map
+# label) that is itself open/unassigned/unblocked must never surface as its own
+# frontier item — unconditionally, not only under --autonomous.
+CONTAINERS='{
+  "schema_version": "1.0",
+  "items": [
+    {"id":"github:o/r#1","state":"open","assignees":[],"labels":[],"blocked_by_count":0},
+    {"id":"github:o/r#10","state":"open","assignees":[],"labels":["work-map"],"blocked_by_count":0}
+  ]
+}'
+OUT="$(wit_filter_frontier false <<<"$CONTAINERS")"
+IDS="$(jq -r '[.items[].id] | join(",")' <<<"$OUT")"
+assert_eq "default frontier excludes the container (work-map)" "github:o/r#1" "$IDS"
+OUT="$(wit_filter_frontier true <<<"$CONTAINERS")"
+IDS="$(jq -r '[.items[].id] | join(",")' <<<"$OUT")"
+assert_eq "autonomous frontier also excludes the container" "github:o/r#1" "$IDS"
+
+# A non-default container label passed explicitly is honored (parity with the
+# human-gated remap path); the stale default no longer excludes.
+REMAP_CONTAINER='{
+  "schema_version": "1.0",
+  "items": [
+    {"id":"github:o/r#1","state":"open","assignees":[],"labels":[],"blocked_by_count":0},
+    {"id":"github:o/r#10","state":"open","assignees":[],"labels":["work-map"],"blocked_by_count":0},
+    {"id":"github:o/r#11","state":"open","assignees":[],"labels":["decision-map"],"blocked_by_count":0}
+  ]
+}'
+OUT="$(wit_filter_frontier false "needs-human" "decision-map" <<<"$REMAP_CONTAINER")"
+IDS="$(jq -r '[.items[].id] | join(",")' <<<"$OUT")"
+assert_eq "explicit container label excludes the remap, not the stale default" \
+  "github:o/r#1,github:o/r#10" "$IDS"
+
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/work-items/tools/work-item-tracker/lib/frontier.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/lib/frontier.test.sh
@@ -51,7 +51,7 @@ SPARSE='{"schema_version":"1.0","items":[{"id":"github:o/r#9","state":"open","bl
 OUT="$(wit_filter_frontier true <<<"$SPARSE")"
 assert_eq "sparse item survives filters" "1" "$(jq '.items | length' <<<"$OUT")"
 
-# Container exclusion (issue #498 obs #3): a container item (default work-map
+# Container exclusion: a container item (default work-map
 # label) that is itself open/unassigned/unblocked must never surface as its own
 # frontier item — unconditionally, not only under --autonomous.
 CONTAINERS='{

--- a/plugins/work-items/tools/work-item-tracker/work-item-tracker.sh
+++ b/plugins/work-items/tools/work-item-tracker/work-item-tracker.sh
@@ -56,7 +56,8 @@ Verbs:
   reclaim <id>
   link-blocks <id> --blocked-by <id>
   add-sub-item <id> --parent <id>
-  list-frontier [--autonomous] [--repo <owner>/<repo>]
+  list-sub-items <parent-id> [--state open|closed|all]
+  list-frontier [--autonomous] [--parent <container-id>] [--repo <owner>/<repo>]
   capabilities
 Contract: tools/work-item-tracker/CONTRACT.md
 EOF
@@ -113,9 +114,22 @@ main() {
 
   local adapter_verb="$verb"
   case "$verb" in
-  create-item | get-item | claim | renew-lease | reclaim | link-blocks | add-sub-item | capabilities) ;;
+  create-item | get-item | claim | renew-lease | reclaim | link-blocks | add-sub-item | list-sub-items | capabilities) ;;
   list-frontier)
+    # Frontier is a core-side derivation over the adapter's list surface: the
+    # global frontier reads list-items; a container-scoped frontier (--parent)
+    # reads list-sub-items. The scoped verb is chosen HERE, before the capability
+    # gate below, so an adapter that supports list-items but not list-sub-items
+    # degrades explicitly (exit 6) instead of passing the gate then failing the
+    # scoped call.
     adapter_verb="list-items"
+    local a
+    for a in "$@"; do
+      if [[ "$a" == "--parent" ]]; then
+        adapter_verb="list-sub-items"
+        break
+      fi
+    done
     ;;
   *)
     usage
@@ -131,12 +145,20 @@ main() {
 
   local out rc
   if [[ "$verb" == "list-frontier" ]]; then
-    local autonomous="false" list_args=()
+    local autonomous="false" parent="" list_args=()
     while [[ $# -gt 0 ]]; do
       case "$1" in
       --autonomous)
         autonomous="true"
         shift
+        ;;
+      --parent)
+        [[ $# -ge 2 ]] || {
+          usage
+          exit "$EX_USAGE"
+        }
+        parent="$2"
+        shift 2
         ;;
       --repo)
         [[ $# -ge 2 ]] || {
@@ -152,12 +174,21 @@ main() {
         ;;
       esac
     done
-    out="$(bash "$adapter_dir/list-items.sh" --state open "${list_args[@]+"${list_args[@]}"}")"
+    if [[ -n "$parent" ]]; then
+      # Container-scoped frontier: enumerate the container's children (the
+      # container's own repo is carried by its qualified id, so --repo does not
+      # re-target here) and apply the same filter — including container exclusion,
+      # so a nested sub-map among the children is never itself a frontier item.
+      out="$(bash "$adapter_dir/list-sub-items.sh" "$parent" --state open)"
+    else
+      out="$(bash "$adapter_dir/list-items.sh" --state open "${list_args[@]+"${list_args[@]}"}")"
+    fi
     rc=$?
     if ((rc != 0)); then
       exit "$rc"
     fi
-    printf '%s\n' "$out" | wit_strip_cr | wit_filter_frontier "$autonomous" "${WIT_HUMAN_GATED_LABEL:-needs-human}"
+    printf '%s\n' "$out" | wit_strip_cr |
+      wit_filter_frontier "$autonomous" "${WIT_HUMAN_GATED_LABEL:-needs-human}" "$WIT_CONTAINER_LABEL"
     exit 0
   fi
 

--- a/plugins/work-items/tools/work-item-tracker/work-item-tracker.sh
+++ b/plugins/work-items/tools/work-item-tracker/work-item-tracker.sh
@@ -174,6 +174,14 @@ main() {
         ;;
       esac
     done
+    if [[ -n "$parent" && ${#list_args[@]} -gt 0 ]]; then
+      # --repo cannot re-target a container-scoped frontier (the container's own
+      # repo is carried by its qualified id), so accepting it would silently
+      # discard the flag. Reject the combination loudly instead — the repo's
+      # convention is fail-loud on invalid arg combinations, not silent-drop.
+      printf 'work-item-tracker: --repo is not valid with --parent (container id carries the repo)\n' >&2
+      exit "$EX_USAGE"
+    fi
     if [[ -n "$parent" ]]; then
       # Container-scoped frontier: enumerate the container's children (the
       # container's own repo is carried by its qualified id, so --repo does not

--- a/plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/work-item-tracker.test.sh
@@ -28,6 +28,7 @@ cat >"$FAKE_DIR/capabilities.json" <<'EOF'
     "link-blocks": true,
     "add-sub-item": true,
     "list-items": true,
+    "list-sub-items": true,
     "capabilities": true
   }
 }
@@ -39,6 +40,10 @@ EOF
 cat >"$FAKE_DIR/list-items.sh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\r\n' '{"schema_version":"1.0","items":[{"id":"fake:o/r#1","state":"open","assignees":[],"labels":[],"blocked_by_count":0},{"id":"fake:o/r#2","state":"open","assignees":[],"labels":["needs-human"],"blocked_by_count":0},{"id":"fake:o/r#3","state":"open","assignees":[],"labels":[],"blocked_by_count":1}]}'
+EOF
+cat >"$FAKE_DIR/list-sub-items.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"schema_version":"1.0","items":[]}'
 EOF
 cat >"$FAKE_DIR/get-item.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -105,6 +110,13 @@ assert_eq "autonomous frontier drops needs-human" "fake:o/r#1" "$IDS"
 
 run_dispatcher list-frontier --bogus >/dev/null 2>&1
 assert_eq "list-frontier bad flag → exit 2" "2" "$?"
+
+# --parent + --repo is an invalid combination: --repo cannot re-target a
+# container-scoped frontier, so it must be rejected loudly, not silently dropped.
+ERR="$(run_dispatcher list-frontier --parent 'fake:o/r#9' --repo o/r 2>&1 >/dev/null)"
+RC_CAPTURE=$?
+assert_eq "list-frontier --parent + --repo → exit 2" "2" "$RC_CAPTURE"
+assert_contains "--parent + --repo error names --repo/--parent" "$ERR" "--repo is not valid with --parent"
 
 # --- two-root adapter resolution (CONTRACT.md "Adapter resolution") ---
 # WIT_ADAPTERS_DIR is left UNSET here so the consumer-local-first / plugin-bundled


### PR DESCRIPTION
## Summary

The work-item-tracker seam reserves `work-map` **containers** as a first-class use case, but its read side was repo-global only — there was no way to operate one container within scope (#498). Concretely: `list-frontier` had no container scoping, its rows drop parent linkage (GitHub's list surface omits it), an unassigned/unblocked container surfaced as **its own** frontier item, and no verb enumerated a container's children (needed for a closed-children invariant check). Surfaced by the #416 wayfind-routing planning pass.

## Fix

- **`list-sub-items <parent-id> [--state open|closed|all]`** — new seam + adapter verb. Returns a container's **direct** children as full normalized item objects (same `{items:[…]}` envelope as `list-items`), each re-parented to the container. Raw enumeration — closed and nested-container children are kept (the closed-children invariant check and sub-map traversal need them). `--state` defaults to `all`. Both adapters implement it: GitHub resolves children via the native `subIssues` link and intersects with `list-items` output (its list surface omits parent linkage, so the child set can't be derived from rows); the offline `local-markdown` adapter matches on the stored `parent` frontmatter.
- **`list-frontier --parent <container-id>`** — container-scoped frontier. Core reads `list-sub-items` for that container instead of the repo-global `list-items`, then applies the identical filter. The scoped verb is chosen **before** the capability gate, so an adapter with `list-items` but not `list-sub-items` degrades explicitly (exit 6) rather than passing the gate then failing mid-call.
- **Container exclusion (obs #3).** `list-frontier` now excludes any item carrying the container label (`work-map`) **unconditionally** — global and `--parent`-scoped, and under `--autonomous`. Justification: the CONTRACT already states containers are never claimable by workers, so this is a correctness fix, not a policy toggle — deliberately not behind a flag.

Design notes for the reviewer:
- The container label is a named constant (`WIT_CONTAINER_LABEL`, default `work-map`) matching the CONTRACT term — not a new binding key. Per-repo remapping is **deferred** to the existing `config.role_labels` convention, keyed off the first consumer that needs a non-`work-map` marker.
- Obs #2 (global rows drop parent linkage) is addressed by the `--parent` scoping path, **not** by enriching global `list-items` rows — GitHub's bulk list surface genuinely omits `parent`, and `get-item` remains authoritative for a single item's parentage (unchanged CONTRACT stance).
- Container exclusion lives only in the core frontier filter; `list-sub-items` stays a raw enumeration (nested sub-maps and closed children must survive it).

Version `0.15.0` → `0.16.0` (additive); CHANGELOG entry added.

## Verification

All commands run in the worktree on the rebased branch (tip of `origin/main` + this commit).

New behavioral test — `local-markdown list-sub-items` end-to-end through the core CLI (offline, CI-runnable):

```
$ bash plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.test.sh
PASS: [1] list-sub-items holds open child C1
PASS: [2] list-sub-items holds closed child C2
PASS: [3] list-sub-items excludes the container itself
PASS: [4] list-sub-items excludes an unrelated leaf
PASS: [5] list-sub-items excludes a grandchild (direct children only)
PASS: [6] list-sub-items (default all) child count
PASS: [7] children carry parent_id
PASS: [8] list-sub-items --state open keeps only C1
PASS: [9] list-sub-items --state closed keeps only C2
PASS: [10] list-sub-items on a leaf is empty
PASS: [11] scoped frontier holds the open child C1
PASS: [12] scoped frontier drops the closed child C2
PASS: [13] scoped frontier drops the grandchild (not a direct child)
PASS: [14] scoped frontier never holds the container
PASS: [15] global frontier excludes the unassigned/unblocked container
PASS: [16] global frontier still holds the workable leaf
```

Core frontier filter unit test (container exclusion added):

```
$ bash plugins/work-items/tools/work-item-tracker/lib/frontier.test.sh
PASS: [7] default frontier excludes the container (work-map)
PASS: [8] autonomous frontier also excludes the container
PASS: [9] explicit container label excludes the remap, not the stale default
... (9 cases, 0 failed)
```

Abstract conformance suite through the core CLI (exercises `list-sub-items` + `list-frontier --parent` for the adapter — CI runs this offline binding):

```
$ bash plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh --binding local-markdown
PASS: [43] list-sub-items A (exit code)
PASS: [46] A's children hold B
PASS: [47] enumerated child B is re-parented to A
PASS: [50] list-frontier --parent A (exit code)
PASS: [53] scoped frontier drops blocked child B
Conformance (local-markdown): 72 cases, 0 failed
```

Full `work-items` plugin test suite + shellcheck (`0.11.0`, repo `.shellcheckrc`) over all changed/new shell files — both clean:

```
$ find plugins/work-items -name '*.test.sh' | while read t; do bash "$t"; done   # all pass, 0 failures
$ shellcheck -x <changed .sh + .test.sh>                                          # rc=0, no findings
$ bash scripts/check-changelog-parity.sh --check-bump origin/main                 # Every changed plugin has its CHANGELOG entry.
```

The GitHub `subIssues`+intersect path runs only under the on-demand `e2e-probe` (needs a live sandbox repo), which was **not** executed here; its `subIssues` node shape (`id/number/title/url/state/repository.nameWithOwner` — no `assignees/labels/blockedBy`, hence the intersect-with-`list-items` design) was verified against gh's own source (`cli/cli api/queries_issue.go`, `LinkedIssue` struct). e2e-probe was extended with container-exclusion and `list-sub-items`/`--parent` assertions for when it is next run against a sandbox.

Closes #498

## Related

- #498 — the seam's own read-verb coverage for containers (this PR).
- #416 — routes `planning:wayfind` through the seam (the consumer that surfaced this gap); related but distinct, unblocked by this change.
- #379 — Jira adapter (a different backend); related but distinct.
