### PR TITLE
docs(naming): separate the invocation guarantee from picker display

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -153,6 +153,15 @@ Applying that precedence, the grammar of an invocation is `/<namespace>:<skill>`
 The one residual caution is model-side: avoid a skill leaf name *identical* to a bundled skill's
 (auto-invocation ambiguity when the model matches descriptions); similarity alone is fine.
 
+**That namespace guarantee covers invocation, not the slash-command listing.** The picker labels a
+row with the skill's short name and keeps the namespaced form as a hidden alias, so a leaf name
+shared across plugins reads identically in the list even though each is separately invocable; the
+plugin name reaches the reader through the description, which renders as `(<plugin-name>)
+<description>`. See the philosophy's Naming section for the full display contract. Two consequences
+for this playbook: prefix typeahead groups a family by its **leaf** name, which is what the
+base-concept-first rule above is buying; and a deliberately shared leaf name (`setup` across every
+plugin that ships one) is legible only if each description's first clause names its object.
+
 ## Extensibility model — what works today
 
 These are the proven, documented mechanisms for consumer customization that do not confuse the agent.

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -75,8 +75,9 @@ That guarantee is about **resolution**, and it does not extend to **display**. T
 picker lists a skill by its short name and registers the namespaced form as a hidden alias — so
 `/planning:` still filters to that plugin's skills, but `planning:plan` is not what the row is
 labelled. Origin travels in the description instead: a plugin skill renders as
-`(<plugin-name>) <description>`, a personal or project skill as `<description> (user)` or
-`(project)`, and a built-in, bundled, or MCP entry carries no marker at all. So sibling short names
+`(<plugin-name>) <description>`, a personal skill as `<description> (user)`, a project skill as
+`(project)` or `(project, gitignored)` depending on whether it came from shared or local settings,
+and a built-in, bundled, or MCP entry carries no marker at all. So sibling short names
 across different plugins are unambiguous to *invoke* and identical to *read* — a shared leaf name
 costs legibility in the description column, never correctness. Weigh it there; never rename to buy
 display uniqueness, and keep the description's first clause carrying the distinguishing object,

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -71,6 +71,17 @@ Skills specification allows. Never degrade a name to dodge a built-in command: p
 namespaced and cannot collide with other levels. When a name matches a built-in, the bare token
 still belongs to the built-in; the namespaced form is the plugin skill's only command.
 
+That guarantee is about **resolution**, and it does not extend to **display**. The slash-command
+picker lists a skill by its short name and registers the namespaced form as a hidden alias — so
+`/planning:` still filters to that plugin's skills, but `planning:plan` is not what the row is
+labelled. Origin travels in the description instead: a plugin skill renders as
+`(<plugin-name>) <description>`, a personal or project skill as `<description> (user)` or
+`(project)`, and a built-in, bundled, or MCP entry carries no marker at all. So sibling short names
+across different plugins are unambiguous to *invoke* and identical to *read* — a shared leaf name
+costs legibility in the description column, never correctness. Weigh it there; never rename to buy
+display uniqueness, and keep the description's first clause carrying the distinguishing object,
+since that column is what a reader actually scans.
+
 ## Native-first
 
 Prefer a built-in native mechanism — `userConfig`, a native component type, a native lifecycle

--- a/docs/topics/plugin-organization/PLAN.md
+++ b/docs/topics/plugin-organization/PLAN.md
@@ -78,10 +78,21 @@ history; grouping lives in marketplace metadata.
 - Empty `deployment` category — created when first deploy plugin lands.
 - `music` → `creative` rename — trigger: a non-music creative plugin lands.
 - fable-5 regeneration — trigger: model-version change (self-authored, no upstream).
+- Namespaced picker labels — trigger: anthropics/claude-code#25150 ships a namespaced name column.
+  Until then the leaf name is the label and the plugin name reaches the reader via the description
+  prefix; revisit whether any description carries disambiguating text it would no longer need.
 
 ### Deferred questions
 
-- Empirical check: typeahead prefix filtering on plugin-skill leaf names — `/planning:plan`.
+- ~~Empirical check: typeahead prefix filtering on plugin-skill leaf names — `/planning:plan`.~~
+  **Resolved (Claude Code 2.1.215).** The picker labels each row with the **leaf** name and registers
+  the namespaced form as a hidden alias, so `/planning:` filters correctly while the row still reads
+  `plan`. Typeahead therefore groups families by leaf name — the base-concept-first rule (D20) is
+  what makes that grouping work. Origin is rendered in the description as `(<plugin-name>) …`, which
+  is the only thing distinguishing the 8 shared leaf names (`setup` ×33, `audit` ×6,
+  `check`/`clean`/`diagnose`/`plan`/`workflow`/`write` ×2). D19 stands unchanged: every one of those
+  is separately invocable, so no name was kept or dropped on a mistaken premise. Doctrine updated in
+  `docs/PLUGIN-PHILOSOPHY.md` (Naming) and `docs/MIGRATION-PLAYBOOK.md` (Naming).
 - session-flow category label `workflow` — judgment call (no marketplace precedent); revisit if a stronger authoritative label emerges.
 
 ## Plan


### PR DESCRIPTION
Closes #710

## Summary

The naming doctrine reasons about invocation namespacing and model-side auto-invocation ambiguity, but never about what a human reads in the `/` slash-command picker. This adds that dimension. No renames, no behavior change.

## Fix

`docs/PLUGIN-PHILOSOPHY.md` (Naming) — a new paragraph after the built-in-collision rule, separating the two guarantees: namespacing owns **resolution**, not **display**. Records what the picker actually renders per source, and reframes a shared leaf name as a legibility cost paid in the description column rather than a correctness problem.

`docs/MIGRATION-PLAYBOOK.md` (Naming) — the same distinction where built-in collisions are discussed, plus the two consequences specific to this playbook: prefix typeahead groups a family by its **leaf** name (which is what the existing base-concept-first rule buys), and a deliberately shared leaf name like `setup` is legible only if each description's first clause names its object.

`docs/topics/plugin-organization/PLAN.md` — resolves the standing deferred question *"Empirical check: typeahead prefix filtering on plugin-skill leaf names"* in place, and adds an out-of-scope trigger row for upstream anthropics/claude-code#25150.

## Verification

Read from the shipping Claude Code 2.1.215 bundle, not from docs — the official docs state plugin skills are named `/my-plugin:review`, which is true of the Skill tool and of the alias, but not of the picker's name column.

```js
function W6e(e){ return e.filter(kur).map((t)=>{
  let r=pp(t),
      n=t.name!==r&&t.name.includes(":")?t.name:void 0,
      o=n&&!t.aliases?.includes(n)?[...t.aliases??[],n]:t.aliases;
  return {name:r, description:j6e(t), argumentHint:t.argumentHint||"", aliases:o?.length?o:void 0}
})}
```

```js
if(e.source==="plugin"){
  let t=e.pluginInfo?.pluginManifest;
  if(t) return `(${wE(t)}) ${e.description}`;
  return `${e.description} (plugin)`
}
if(e.source==="builtin"||e.source==="mcp"||e.source==="bundled") return e.description;
return `${e.description} (${d5(e.source)})`
```

Where `pp(e){return e.userFacingName?.()??e.name}` and `d5` maps `userSettings`→`user`, `projectSettings`→`project`, `localSettings`→`project, gitignored`.

Confirmed visually in the live picker: the two `/clean` rows render the plugin name in parens ahead of the description, so the `pluginManifest` branch is the one that fires.

Current collision surface measured across the repo — 143 skills, 51 plugins, 8 shared leaf names:

| Leaf name | Plugins |
|---|---|
| `setup` | 33 |
| `audit` | 6 |
| `check`, `clean`, `diagnose`, `plan`, `workflow`, `write` | 2 each |

Gates run locally on the changed files: `markdownlint-cli2` — 0 errors.

## Related

- Refs anthropics/claude-code#25150 — open upstream bug: picker shows flat names instead of the namespaced form.
- Refs anthropics/claude-code#50486 — closed *not planned*: request to namespace plugin skills like commands.
- Refs #280 — the naming-grammar rollout whose D19 decision this confirms rather than revisits.