### PR TITLE
fix(ci): scope changelog-parity bump check to the PR's own diff

### DIFF
--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -124,6 +124,29 @@ if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
   exit 2
 fi
 
+# Scope the bump check to plugins THIS change set actually touched. A stale
+# branch whose base ref (main) has advanced an UNTOUCHED plugin's version must
+# not red-line on it and force a merge-from-main — the untouched plugin is not in
+# the PR's own diff. Three-dot base...HEAD is diff(merge-base(base,HEAD), HEAD),
+# i.e. only the commits unique to this branch, so a version main advanced after
+# the branch forked is excluded whether CI checks out the PR head or the
+# auto-merge commit. The filter keys on the MANIFEST path, not the plugin root:
+# the gate compares .version in exactly plugins/<name>/.claude-plugin/plugin.json,
+# so a version bump is definitionally a change to that file — manifest-scoping is
+# precisely "plugins whose version this change set could have changed," and (unlike
+# plugin-root scoping) a cosmetic touch elsewhere under the plugin dir cannot pull
+# a main-only advance back into scope.
+declare -A bumped_candidate
+while IFS= read -r path; do
+  case "$path" in
+  plugins/*/.claude-plugin/plugin.json)
+    rest="${path#plugins/}"
+    bumped_candidate["${rest%%/*}"]=1
+    ;;
+  *) ;;
+  esac
+done < <(git diff --name-only "$base...HEAD" 2>/dev/null)
+
 undocumented=0
 malformed=0
 preexisting=0
@@ -131,6 +154,11 @@ for manifest in "${manifests[@]}"; do
   plugin_dir="${manifest%/.claude-plugin/plugin.json}"
   name="${plugin_dir##*/}"
   changelog="$plugin_dir/CHANGELOG.md"
+
+  # Only plugins whose manifest this change set touched are in scope (see the
+  # bumped_candidate note above); a plugin main advanced but this branch never
+  # touched is not the PR's to document.
+  [[ -n "${bumped_candidate[$name]:-}" ]] || continue
 
   base_version="$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)"
   # Absent at base => new plugin in this change set; the static --check owns

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -137,6 +137,20 @@ fi
 # plugin-root scoping) a cosmetic touch elsewhere under the plugin dir cannot pull
 # a main-only advance back into scope.
 declare -A bumped_candidate
+# Read the change set's touched paths via COMMAND substitution, not process
+# substitution: this gate is a required CI merge check, and a git failure here
+# must fail loud, never silently pass. Process substitution swallows git's exit
+# status, so a diff that genuinely cannot be computed (e.g. no common ancestor
+# between "$base" and HEAD -> "fatal: no merge base", exit 128) would yield an
+# empty result, skip every plugin's bumped_candidate guard below, and let the
+# gate exit 0 without checking anything (fail-open). Command substitution
+# propagates that non-zero status so the guard fires. A legitimate empty diff
+# ("zero files changed") succeeds with empty output and correctly leaves
+# bumped_candidate empty.
+if ! diff_paths="$(git diff --name-only "$base...HEAD")"; then
+  echo "check-changelog-parity: 'git diff --name-only $base...HEAD' failed (no common ancestor between '$base' and HEAD, or history not fetched deeply enough); refusing to pass without checking." >&2
+  exit 2
+fi
 while IFS= read -r path; do
   case "$path" in
   plugins/*/.claude-plugin/plugin.json)
@@ -145,7 +159,7 @@ while IFS= read -r path; do
     ;;
   *) ;;
   esac
-done < <(git diff --name-only "$base...HEAD" 2>/dev/null)
+done <<<"$diff_paths"
 
 undocumented=0
 malformed=0

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -297,6 +297,81 @@ git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm add-beta
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "new plugin skipped by --check-bump"; else fail "new plugin wrongly failed --check-bump"; fi
 rm -rf "$repo"
 
+# =================== --check-bump branch staleness (#693) ================
+
+# BRANCH STALENESS (untouched plugin advanced only on the base ref): main bumps
+# alpha 1.0.0 -> 1.1.0 while the PR branch, forked before that bump, never touches
+# alpha (it edits only beta). The base ref sees alpha at 1.1.0 and the stale branch
+# at 1.0.0, but alpha is outside the branch's own diff, so it must NOT be flagged
+# -- no re-merge treadmill. Proves the bump check is scoped to base...HEAD.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+mk_plugin "$repo" beta 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/beta/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+fork="$(git -C "$repo" rev-parse HEAD)"
+# main advances alpha (a plugin the PR never touches)
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
+main="$(git -C "$repo" rev-parse HEAD)"
+# PR branch forks from base and edits only beta's changelog (alpha left stale)
+git -C "$repo" checkout -q -b pr "$fork"
+printf '# Changelog\n\ntypo fix\n\n## [1.0.0]\n' >"$repo/plugins/beta/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits beta only'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "untouched plugin advanced only on the base ref is not flagged (branch staleness scoped out)"; else fail "branch-staleness wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# MANIFEST-SCOPED (cosmetic touch does not pull a main-only advance into scope):
+# main advances alpha; the PR touches only alpha's README, never alpha's manifest.
+# Plugin-root scoping would drag alpha back in and red-line it; manifest scoping
+# leaves it out -> rc=0. Locks the filter granularity to the manifest path.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+fork="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
+main="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q -b pr "$fork"
+printf 'docs\n' >"$repo/plugins/alpha/README.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits alpha README only'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "cosmetic touch under a plugin dir does not pull a main-only advance into scope (manifest-scoped)"; else fail "manifest-scoping regressed to plugin-root: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# COUNTERPART (a plugin the branch DID bump is still checked): main advances alpha
+# (untouched by the PR) AND the PR bumps beta's manifest without adding beta's
+# entry. alpha is scoped out; beta -- whose manifest the change set touched -- must
+# still fail UNDOCUMENTED. Proves diff-scoping narrows the check, not disables it.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+mk_plugin "$repo" beta 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/beta/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+fork="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.1.0]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
+main="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q -b pr "$fork"
+printf '{ "name": "beta", "version": "2.0.0" }\n' >"$repo/plugins/beta/.claude-plugin/plugin.json"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr bumps beta, no entry'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"beta"* && "$out" != *"alpha"* ]]; then ok "a plugin the branch bumped is still checked while the main-only advance is scoped out"; else fail "diff-scoping mis-scoped: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
 # unresolvable base ref -> exit 2
 repo="$(mk_repo)"
 git_init "$repo"

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -372,6 +372,28 @@ rc=$?
 if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"beta"* && "$out" != *"alpha"* ]]; then ok "a plugin the branch bumped is still checked while the main-only advance is scoped out"; else fail "diff-scoping incorrectly scoped: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
+# NO COMMON ANCESTOR (git diff cannot compute a diff): base is a resolvable
+# commit but shares no history with HEAD (an orphan root), so 'git diff
+# base...HEAD' fails ("fatal: no merge base", exit 128). The gate must fail LOUD
+# (exit 2), not silently pass: an empty result from a FAILED git invocation would
+# skip every plugin and let this required merge gate exit 0 without checking
+# anything (fail-open). This is distinct from a legitimate "zero files changed"
+# diff, which git computes successfully and which must still pass (covered above).
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+# Orphan branch: a second root commit with no ancestor in common with base.
+git -C "$repo" checkout -q --orphan orphan
+git -C "$repo" rm -rq --cached . >/dev/null 2>&1 || true
+mk_plugin "$repo" alpha 1.1.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'orphan root'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"failed"* ]]; then ok "no common ancestor -> git diff fails -> gate fails loud (exit 2), never silent pass"; else fail "no-common-ancestor did not fail loud: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
 # unresolvable base ref -> exit 2
 repo="$(mk_repo)"
 git_init "$repo"

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -369,7 +369,7 @@ printf '{ "name": "beta", "version": "2.0.0" }\n' >"$repo/plugins/beta/.claude-p
 git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr bumps beta, no entry'
 out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$main" 2>&1)"
 rc=$?
-if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"beta"* && "$out" != *"alpha"* ]]; then ok "a plugin the branch bumped is still checked while the main-only advance is scoped out"; else fail "diff-scoping mis-scoped: rc=$rc out='$out'"; fi
+if [[ $rc -ne 0 && "$out" == *"UNDOCUMENTED BUMP"*"beta"* && "$out" != *"alpha"* ]]; then ok "a plugin the branch bumped is still checked while the main-only advance is scoped out"; else fail "diff-scoping incorrectly scoped: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
 # unresolvable base ref -> exit 2


### PR DESCRIPTION
## Summary

The `--check-bump` gate's PRE-EXISTING-ENTRY arm compared **every** versioned plugin's manifest against the base ref. When `main` advanced any plugin's version while a PR was open, the PR's stale branch red-lined on a plugin it never touched — forcing an unnecessary merge-from-main on every base advance. Observed twice on #681 (work-items 0.14.2 → 0.14.4; #681 never touched work-items).

## Fix

Scope the bump loop to plugins whose **manifest** changed in the branch's own diff:

- `git diff --name-only base...HEAD` — three-dot isolates `diff(merge-base(base,HEAD), HEAD)`, the commits unique to this branch. A version `main` advanced after the branch forked is excluded whether CI checks out the PR head or the auto-merge commit.
- The filter keys on the manifest path `plugins/<name>/.claude-plugin/plugin.json`, **tighter than the issue's "plugin roots" wording**. A version bump is definitionally a change to that file, so manifest-scoping is precisely "plugins whose version this change set could have changed" — and, unlike plugin-root scoping, a cosmetic touch elsewhere under a plugin dir cannot pull a main-only advance back into scope (the same treadmill, just triggered by a stray edit).

Plugins the branch never touched are left out of the check entirely; plugins the branch did touch are checked exactly as before.

## Verification

Full self-test suite (extended with three branch-staleness cases: main-only advance not flagged, the discriminating cosmetic-touch/manifest-scoping case, and a counterpart proving a branch-bumped plugin is still checked):

```
$ bash scripts/check-changelog-parity.test.sh
...
ok: untouched plugin advanced only on the base ref is not flagged (branch staleness scoped out)
ok: cosmetic touch under a plugin dir does not pull a main-only advance into scope (manifest-scoped)
ok: a plugin the branch bumped is still checked while the main-only advance is scoped out
...
PASS=24 FAIL=0
```

Live check against the real repo:

```
$ scripts/check-changelog-parity.sh --check-bump origin/main
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.
```

`shellcheck` clean on both files.

Closes #693

## Related

- #693 — this fix
- #681 — the PR where the re-merge treadmill was first observed
