### PR TITLE
fix(work-items): clear raw-intake marker on every triage side-exit (#562)

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.1]
+
+### Fixed
+
+- **Triage side-exit routing now clears the raw-intake marker on every outcome (`#562`).** The
+  closing invariant in the triage skill only named `status:ready` and the two role labels as
+  contradictory with the raw marker, and pinned the marker to a single hardcoded label string. A
+  status side-exit — `status:needs-decision`, `status:needs-info`, human-gated (`needs-human`), or
+  the terminal `status:ready` — could leave `needs-triage` attached, so an already-decided item
+  (e.g. `#505`, routed to `status:needs-decision`) resurfaced in the next cycle's needs-triage queue
+  as if it were unrouted intake, wasting a read-and-confirm pass every cycle. The invariant is now
+  exhaustive across the routing space — **every** open-keeping outcome removes the raw marker in the
+  same edit — and framed around the abstract raw-intake marker resolved from the live label set
+  rather than a hardcoded prefix, so it holds regardless of which axis a repo files `needs-triage`
+  under. Doc-only; absorbed into the triage `SKILL.md` alongside the `#478` routing rules.
+
 ## [0.16.0]
 
 Close the work-item-tracker seam's container read-verb gap (`#498`): the seam reserves `work-map`

--- a/plugins/work-items/skills/triage/SKILL.md
+++ b/plugins/work-items/skills/triage/SKILL.md
@@ -117,7 +117,7 @@ Only after verification (or for enhancements, where the open question is scope, 
 
 ### 5. Apply outcome
 
-Every outcome is a **transition off raw**, not a layer on top of it. Applying an outcome **clears the raw-intake marker**: remove `status:needs-triage` (and the item leaves the unlabeled raw state) in the same edit that applies the labels below. The label sets in the table are the item's **resulting** state, not deltas stacked over `status:needs-triage` — normalization replaces the raw marker, it never adds to it.
+Every outcome is a **transition off raw**, not a layer on top of it. Applying an outcome **clears the raw-intake marker** — the default `needs-triage` label a fresh item carries before triage, resolved from the live set (whichever axis the repo files it under) — in the same edit that applies the labels below, and the item leaves the unlabeled raw state. The label sets in the table are the item's **resulting** state, not deltas stacked over the raw marker — normalization replaces the raw marker, it never adds to it.
 
 | Outcome | Action |
 |---------|--------|
@@ -141,7 +141,7 @@ Label edits, comments, and closes route through the adapter's write mechanics (a
 
 **Closing invariant — no outcome leaves a re-selectable raw item.** The attention view lists *open* items and re-selects anything still carrying the raw marker, so every outcome must leave the item unre-selectable:
 
-- Outcomes that keep the item **open** (briefed/ready, a role label, or `status:needs-info`) **clear `status:needs-triage`**. A raw marker alongside `status:ready`, the autonomous-eligible role label, or the human-gated role label is a contradiction — the attention view reads it as still-raw and re-triages it every cycle. If an item shows both, the briefed state is the truth; clear the stale raw marker.
+- **Every routing outcome that keeps the item open clears the raw-intake marker in the same edit that applies the outcome's labels — no exceptions across the routing space.** `status:ready` (briefed/ready and decision-defaulted), the autonomous-eligible role label, the human-gated role label (default `needs-human`), `status:needs-decision`, and `status:needs-info` each **remove the raw marker**; never leave both the raw marker and a routing label present. A raw marker alongside any routing label is a contradiction — the open-only attention view reads it as still-raw and re-triages it every cycle, so an already-decided item re-enters the needs-triage queue as if it were unrouted intake and wastes a read-and-confirm pass. If an item shows both, the routed state is the truth; clear the stale raw marker.
 - **Close** (already implemented / wontfix / duplicate) drops the item from the open-only attention frontier, so the raw marker is moot — a closed item never re-triages.
 
 ## Needs-info template


### PR DESCRIPTION
## Summary

The `/work-items:triage` skill's closing invariant did not reliably clear the raw-intake `needs-triage` marker when routing an item to a status side-exit. Its enumeration only named `status:ready` and the two role labels as contradictory with the raw marker, omitting `status:needs-decision` and `status:needs-info`, and it pinned the marker to a hardcoded `status:needs-triage` string. As a result an already-decided item could keep the raw marker and resurface in the next cycle's needs-triage queue as if it were unrouted intake — wasting a read-and-confirm pass every cycle.

## Fix

Doc-only change to `plugins/work-items/skills/triage/SKILL.md`:

- Made the closing invariant **exhaustive across the routing space**: every open-keeping outcome — `status:ready` (briefed/ready and decision-defaulted), the autonomous-eligible role label, the human-gated role label (`needs-human`), `status:needs-decision`, and `status:needs-info` — removes the raw marker **in the same edit** that applies the outcome's labels; never leave both present.
- Reframed the "Apply outcome" preamble and the invariant around the **abstract raw-intake marker resolved from the live label set** rather than a hardcoded prefix, so the instruction is correct regardless of which axis a repo files `needs-triage` under (this repo deploys it as `priority: needs-triage`; the plugin's own taxonomy grammar mandates reading members from the live set).

Extends the `#478` routing rules already absorbed into the triage `SKILL.md` (that issue is closed; the skill is now the invariant's natural home).

### Follow-up findings (non-blocking, out of this PR's charter)

- This repo's live raw marker is `priority: needs-triage`, but `SKILL.md` (state table, attention view), `evals.json`, and the two reference docs snapshot it as `status:needs-triage`. The abstract framing here makes the fix correct regardless; reconciling the axis mismatch is a maintainer taxonomy decision spanning shared docs.
- `status:needs-decision` is a live routing outcome (`#505` carries it) that the triage state machine does not model (its briefed exits are delegable / decision-defaulted / human-gated / needs-info). Worth a follow-up to align the state machine with the deployed label set.

## Verification

Branch fast-forwarded to current `origin/main` before verifying (it was 3 commits behind, which produced a false `skill-quality` parity flag until updated).

- `scripts/validate-plugins.sh` — all plugin manifests + catalog: `Validation passed`
- `scripts/check-changelog-parity.sh --check-bump origin/main` — `Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.`
- `scripts/check-skill-portability.sh origin/main` — `No unexcused coupling tokens in 1 skill file(s).`
- `scripts/check-changed-skills.sh origin/main` — `CHECK-SKILL triage: PASS — 0 errors, 1 warning(s)` (pre-existing no-Gotchas warning)
- `scripts/check-skill-leaf-names.sh --check` — `All 8 cross-plugin skill leaf-name collisions are registered.`
- `markdownlint-cli2` on both changed markdown files — `Summary: 0 error(s)`
- `plugin.json` — valid JSON; version bumped `0.16.0` -> `0.16.1`

Closes #562

## Related

- #562 — the reported bug
- #478 — v4 loop-prompt routing rules absorption (closed; this invariant extends the absorbed rules in the triage skill)
- #505 — the triggering example (routed to `status:needs-decision` but still carried the raw marker)