### PR TITLE
feat(work-items): loop-start permission preflight — detect and report once, never self-apply

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -22,17 +22,20 @@ broader grants.
   (`git add`, `git commit`, `git push`, `gh pr create`, `gh issue comment`) is denied by a matching
   deny rule or is not covered by any `Bash()`/`PowerShell()` allow rule; (c) the configured
   out-of-tree worktree root is not covered by `additionalDirectories`. A verb counts as covered only
-  by an **open** grant — the bare verb or its open-glob form (`git commit` / `git commit *` /
-  `git commit:*`); a narrower flag-scoped rule (`git commit --amend`, a force-with-lease-only push)
-  is reported as a gap, since the lane's arbitrary invocation would still prompt. Deny wins over
-  allow: a deny rule of the same open shape keeps the verb a gap (reported distinctly as denied) even
-  when allowed — matched exact-shape only, never by glob simulation, so the flag-scoped standard deny
-  floor is never false-flagged. The worktree-root check is root-agnostic (coverage of the
-  passed root, never a hardcoded path), and Windows and git-bash path spellings are folded to one
-  comparable form. `--project-root` reads the dispatched worker worktree's own per-checkout project
-  settings instead of the main checkout's, so the main checkout's grants cannot mask a worker-side
-  gap (user-global settings apply everywhere regardless). Always exits `0`; `--count` reports the GAP
-  total for a scripted gate. No live permission probe.
+  by an **open-glob** grant (`git commit *` / `git commit:*`); a bare-exact rule (`git commit`,
+  which permits only the argumentless command a real call never is) or a flag-scoped rule
+  (`git commit --amend`, a force-with-lease-only push) is reported as a gap, since the lane's
+  arbitrary invocation would still prompt. Deny wins over allow: a deny rule of the verb keeps it a
+  gap (reported distinctly as denied) even when allowed — matched exact-shape only (never glob
+  simulation) so the flag-scoped standard deny floor is never false-flagged, but erring **wider**
+  than coverage by also counting the bare spelling (a false *denied* is safe). The worktree-root
+  check is root-agnostic (coverage of the passed root, never a hardcoded path), and Windows and
+  git-bash path spellings are folded to one comparable form. Under `--worktree-root` (the autonomous
+  signal) the coverage reads exclude this checkout's gitignored `settings.local.json`, which a fresh
+  linked worktree would not carry, so a local-only grant here cannot mask a worker-side gap; the
+  interactive path keeps local, and deny always reads it. `--project-root` reads a dispatched worker
+  worktree's own tracked project settings instead of the main checkout's. Always exits `0`; `--count`
+  reports the GAP total for a scripted gate. No live permission probe.
 - **Preflight reference (`#495`).** New `reference/permission-preflight.md` is the source of truth
   for the preconditions: it points at the `melodic-software/standards` `claude-permissions`
   component (`components/claude-permissions/`, composed operator-side via the dotfiles chezmoi seam)

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.0]
+
+Add a loop-start permission preflight so the unattended `work` (and, by shared contract,
+`source-control:babysit-prs`) lanes report a missing grant or untrusted worktree root **once, up
+front**, instead of stopping for a per-operation prompt mid-cycle (`#495`). Report-only by design:
+the assistant cannot self-apply the fix — the auto-mode classifier blocks an agent broadening its
+own `permissions.allow`, and a plugin `settings.json` grant is inert — so the check detects and
+points at the operator-side remediation, never edits settings, and never retries a denial into
+broader grants.
+
+### Added
+
+- **Loop-start permission preflight (`#495`).** New `skills/work/scripts/preflight.sh` (with
+  `preflight.test.sh`) reads the effective `permissions.allow` / `permissions.additionalDirectories`
+  from user-global and project settings and reports three conditions: (a) cwd is not a git repo (a
+  note — a worktree-operating lane still proceeds); (b) a probed core working verb
+  (`git commit`, `git push`, `gh pr create`, `gh issue comment`) is not covered by any
+  `Bash()`/`PowerShell()` allow rule; (c) the configured out-of-tree worktree root is not covered by
+  `additionalDirectories`. The verb match accepts the narrow bare-command spellings that survive
+  auto mode, the worktree-root check is root-agnostic (coverage of the passed root, never a
+  hardcoded path), and Windows and git-bash path spellings are folded to one comparable form. Always
+  exits `0`; `--count` reports the GAP total for a scripted gate. No live permission probe.
+- **Preflight reference (`#495`).** New `reference/permission-preflight.md` is the source of truth
+  for the preconditions: it points at the `melodic-software/standards` `claude-permissions`
+  component (`components/claude-permissions/`, composed operator-side via the dotfiles chezmoi seam)
+  as the canonical allow/deny floor rather than restating a list, documents the trusted
+  sibling-worktree-root `additionalDirectories` guidance, and records the detect-and-report /
+  never-self-apply contract. The `work` skill wires the check as the first loop-start action, ahead
+  of the binding preflight.
+
 ## [0.16.1]
 
 ### Fixed

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -22,20 +22,21 @@ broader grants.
   (`git add`, `git commit`, `git push`, `gh pr create`, `gh issue comment`) is denied by a matching
   deny rule or is not covered by any `Bash()`/`PowerShell()` allow rule; (c) the configured
   out-of-tree worktree root is not covered by `additionalDirectories`. A verb counts as covered only
-  by an **open-glob** grant (`git commit *` / `git commit:*`); a bare-exact rule (`git commit`,
-  which permits only the argumentless command a real call never is) or a flag-scoped rule
-  (`git commit --amend`, a force-with-lease-only push) is reported as a gap, since the lane's
-  arbitrary invocation would still prompt. Deny wins over allow: a deny rule of the verb keeps it a
-  gap (reported distinctly as denied) even when allowed — matched exact-shape only (never glob
-  simulation) so the flag-scoped standard deny floor is never false-flagged, but erring **wider**
-  than coverage by also counting the bare spelling (a false *denied* is safe). The worktree-root
-  check is root-agnostic (coverage of the passed root, never a hardcoded path), and Windows and
-  git-bash path spellings are folded to one comparable form. Under `--worktree-root` (the autonomous
-  signal) the coverage reads exclude this checkout's gitignored `settings.local.json`, which a fresh
-  linked worktree would not carry, so a local-only grant here cannot mask a worker-side gap; the
-  interactive path keeps local, and deny always reads it. `--project-root` reads a dispatched worker
-  worktree's own tracked project settings instead of the main checkout's. Always exits `0`; `--count`
-  reports the GAP total for a scripted gate. No live permission probe.
+  by an **open-glob** grant (`git commit *` / `git commit:*`); a flag-scoped rule
+  (`git commit --amend`, a force-with-lease-only push) is a gap, and a **bare-exact** rule
+  (`git commit`) is a gap reported with a distinct message — it covers an argumentless caller (the
+  babysit fix cycle's plain `git push`) but not the work lane's argument-carrying call, so the remedy
+  is the open glob. Deny wins over allow: a deny rule of the verb keeps it a gap (reported distinctly
+  as denied) even when allowed — matched exact-shape only (never glob simulation) so the flag-scoped
+  standard deny floor is never false-flagged, but erring **wider** than coverage by also counting the
+  bare spelling (a false *denied* is safe). The worktree-root check is root-agnostic (coverage of the
+  passed root, never a hardcoded path), and Windows and git-bash path spellings are folded to one
+  comparable form. Per-checkout `settings.local.json` handling: under `--worktree-root` with no
+  distinct `--project-root` (pre-dispatch) the coverage reads exclude this checkout's gitignored
+  local file, which a fresh worktree would not carry, so a local-only grant cannot mask a worker-side
+  gap; a distinct `--project-root` (a named worker checkout) instead reads that worktree's OWN
+  `settings.local.json`; the interactive path keeps local; deny always reads it. Always exits `0`;
+  `--count` reports the GAP total for a scripted gate. No live permission probe.
 - **Preflight reference (`#495`).** New `reference/permission-preflight.md` is the source of truth
   for the preconditions: it points at the `melodic-software/standards` `claude-permissions`
   component (`components/claude-permissions/`, composed operator-side via the dotfiles chezmoi seam)

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -19,12 +19,20 @@ broader grants.
   `preflight.test.sh`) reads the effective `permissions.allow` / `permissions.additionalDirectories`
   from user-global and project settings and reports three conditions: (a) cwd is not a git repo (a
   note — a worktree-operating lane still proceeds); (b) a probed core working verb
-  (`git commit`, `git push`, `gh pr create`, `gh issue comment`) is not covered by any
-  `Bash()`/`PowerShell()` allow rule; (c) the configured out-of-tree worktree root is not covered by
-  `additionalDirectories`. The verb match accepts the narrow bare-command spellings that survive
-  auto mode, the worktree-root check is root-agnostic (coverage of the passed root, never a
-  hardcoded path), and Windows and git-bash path spellings are folded to one comparable form. Always
-  exits `0`; `--count` reports the GAP total for a scripted gate. No live permission probe.
+  (`git add`, `git commit`, `git push`, `gh pr create`, `gh issue comment`) is denied by a matching
+  deny rule or is not covered by any `Bash()`/`PowerShell()` allow rule; (c) the configured
+  out-of-tree worktree root is not covered by `additionalDirectories`. A verb counts as covered only
+  by an **open** grant — the bare verb or its open-glob form (`git commit` / `git commit *` /
+  `git commit:*`); a narrower flag-scoped rule (`git commit --amend`, a force-with-lease-only push)
+  is reported as a gap, since the lane's arbitrary invocation would still prompt. Deny wins over
+  allow: a deny rule of the same open shape keeps the verb a gap (reported distinctly as denied) even
+  when allowed — matched exact-shape only, never by glob simulation, so the flag-scoped standard deny
+  floor is never false-flagged. The worktree-root check is root-agnostic (coverage of the
+  passed root, never a hardcoded path), and Windows and git-bash path spellings are folded to one
+  comparable form. `--project-root` reads the dispatched worker worktree's own per-checkout project
+  settings instead of the main checkout's, so the main checkout's grants cannot mask a worker-side
+  gap (user-global settings apply everywhere regardless). Always exits `0`; `--count` reports the GAP
+  total for a scripted gate. No live permission probe.
 - **Preflight reference (`#495`).** New `reference/permission-preflight.md` is the source of truth
   for the preconditions: it points at the `melodic-software/standards` `claude-permissions`
   component (`components/claude-permissions/`, composed operator-side via the dotfiles chezmoi seam)

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -48,11 +48,14 @@ The preflight probes a small representative subset of the allow floor — `git a
 is probed too) — reading the effective `permissions.allow` from the operator's user-global settings
 and the project settings. It never runs a live permission probe. A verb counts as covered only by an
 **open-glob** grant — `Bash(git commit *)` or `Bash(git commit:*)`. A **bare-exact** rule
-(`Bash(git commit)`) is **not** coverage: it permits only the argumentless command, and a lane
-invocation always carries arguments, so the real call would still prompt. A narrower, flag-scoped
-rule (`Bash(git commit --amend)`, a force-with-lease-only push rule) is likewise not coverage. A
-missing verb means the floor is not composed in on this machine; the remediation is to apply the
-component operator-side, not to add a one-off rule.
+(`Bash(git commit)`) is **not** coverage: it permits only the argumentless command, and a work-lane
+invocation always carries arguments, so the real call would still prompt. When a gapped verb has
+*only* a bare-exact grant, the gap message says so precisely — that grant does cover an argumentless
+caller (e.g. the babysit fix cycle's plain `git push`) but not the work lane's argument-carrying
+call, and the remedy is to add the open glob (`git push *`). A narrower, flag-scoped rule
+(`Bash(git commit --amend)`, a force-with-lease-only push rule) is likewise not coverage. A missing
+verb means the floor is not composed in on this machine; the remediation is to apply the component
+operator-side, not to add a one-off rule.
 
 **Deny wins over allow.** Because `permissions.deny` overrides `permissions.allow` in the permission
 model, the check first tests each probed verb against the effective **deny** rules: a deny rule of
@@ -65,15 +68,22 @@ wildcard spanning it) is not caught here. That conservatism never false-flags th
 floor, whose destructive-verb rules are flag-scoped (`git push --force …`) rather than the bare
 `git push` / `git commit` / `git add` shape.
 
-**The autonomous path ignores this checkout's `settings.local.json`.** `settings.local.json` is
-gitignored, so a fresh linked worktree the lane dispatches a worker into carries this checkout's
-tracked `.claude/settings.json` but **not** its local file — a grant that lives only in local here
-would be absent there, and reading it would mask a worker-side gap. So when `--worktree-root` is
-passed (the autonomous signal), the **coverage** reads (allow + `additionalDirectories`) use
-user-global + tracked project settings only, and the report header says so. The interactive/default
-path (no `--worktree-root`) keeps local settings in scope. Deny always reads local regardless — the
-same err-wide rationale. Pair this with `--project-root <worker-worktree>` (below) to read the
-worker's own tracked project settings instead of this checkout's.
+**`settings.local.json` scope on the autonomous path.** `settings.local.json` is gitignored, so a
+fresh linked worktree the lane dispatches a worker into carries this checkout's tracked
+`.claude/settings.json` but **not** its local file. Two cases:
+
+- **Pre-dispatch** — `--worktree-root` is passed but no distinct `--project-root` (the worker is not
+  yet created). A grant living only in this checkout's local file would be absent in the fresh
+  worktree, and reading it would mask a worker-side gap, so the **coverage** reads (allow +
+  `additionalDirectories`) drop local — user-global + tracked project settings only — and the report
+  header says so.
+- **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
+  differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
+  `settings.local.json` (the worker's file, not this parent's); nothing is masked, and the header
+  names the source.
+
+The interactive/default path (no `--worktree-root`) keeps local settings in scope. Deny always reads
+local regardless — the same err-wide rationale.
 
 ## The trusted worktree root — `additionalDirectories`
 
@@ -122,16 +132,18 @@ ones probed:
   --project-root <dispatched-worker-worktree> --worktree-root <configured-worktree-root>
 ```
 
-`--project-root` defaults to the current checkout. User-global settings apply everywhere and are
-read regardless of it; only the project layer is re-pointed.
+`--project-root` defaults to the current checkout. A distinct one (a different toplevel) re-points
+the project layer to that worker checkout and reads its own `settings.local.json`; without it, the
+autonomous path drops this checkout's local file (see the `settings.local.json` scope note above).
+User-global settings apply everywhere and are read regardless.
 
 It is report-only and always exits `0`. Each output line is one of:
 
 - `NOTE (a) …` — the cwd is not a git repository. Informational: a lane operating in an out-of-tree
   worktree proceeds once `(c)` is covered; a lane that needs a checkout at the cwd cannot.
-- `GAP (b) …` — a probed working verb is denied by a matching deny rule, or is not covered by any
-  allow rule (the message distinguishes the two). Remediate operator-side: resolve the deny rule, or
-  compose the standards floor in (above).
+- `GAP (b) …` — a probed working verb is denied by a matching deny rule, has only a bare-exact
+  (argumentless) allow, or is not covered at all (the message distinguishes the three). Remediate
+  operator-side: resolve the deny rule, add the open glob, or compose the standards floor in (above).
 - `GAP (c) …` — the worktree root is not covered by `additionalDirectories`. Add the entry (above).
 - `NOTE (c) …` — no worktree root was passed, so coverage was not checked.
 

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -1,0 +1,103 @@
+# Permission preflight
+
+The unattended `work` and `babysit-prs` lanes only run without mid-cycle permission prompts when
+two things hold before the loop starts: the core git/gh working verbs are pre-approved, and the
+out-of-tree worktree root is a trusted write directory. This reference is the source of truth for
+what those preconditions are and how the loop-start check reports them. It is consumed by
+`work` (wired at loop start) and applies verbatim to `source-control:babysit-prs`, which shares the
+same grant and worktree-root needs.
+
+## Why a preflight, not a fixer
+
+The assistant **cannot self-apply** the remediation, for two independent reasons the repo's
+[permission-rule-hygiene convention](../../../docs/conventions/permission-rule-hygiene/README.md)
+documents in full:
+
+- The auto-mode classifier routes any write to `.claude/` settings through itself and refuses an
+  agent that tries to broaden its own `permissions.allow` — self-privilege-escalation is blocked.
+- A `permissions` block shipped in a plugin's `settings.json` is inert; a plugin `settings.json`
+  honors only the `agent` and `subagentStatusLine` keys.
+
+So the operative grants live **operator-side**, and the loop-start step only **detects and reports**
+the gap once, up front. It never edits settings, and never retries a permission/classifier denial
+into broader grants (the never-self-retry posture — a denial is a stop, not a signal to widen).
+
+## The allow floor — point at the standards component
+
+Do not hand-maintain an allowlist here. The fleet's reviewed permission floor is the
+`claude-permissions` component in the `melodic-software/standards` repository
+(`components/claude-permissions/`): one canonical `permissions.allow` / `permissions.deny` set,
+distributed as data and composed into each operator's live `~/.claude/settings.json` by the
+dotfiles repository's chezmoi modify-template (union of the canonical floor with locally-accumulated
+rules; the deny floor is never relaxed below the component).
+
+What it covers, at a glance (read the component for the authoritative list):
+
+- **allow** — the read-only git/gh inspection verbs plus the routine non-destructive working verbs
+  an unattended loop needs without prompting: `git add` / `commit` / non-force `push` /
+  `checkout` / `switch`, and `gh` PR and issue CRUD including `gh pr create` and
+  `gh issue comment`. Rules are the narrow bare-command shape (`Bash(git commit *)`, not
+  `Bash(git *)`) that survives auto mode; the broad interpreter-wildcard shapes are dropped on
+  entering auto mode and are the anti-pattern the convention above flags.
+- **deny** — the destructive-verb safety floor (force-push, hard reset, `clean`, checkout/restore
+  discards, forced branch deletion, `--no-verify` bypass), the `gh api` DELETE surface, hook-disable
+  environment prefixes, and secret-material `Read()` patterns. Deny always wins over allow.
+
+The preflight probes a small representative subset of the allow floor — `git commit`, `git push`,
+`gh pr create`, `gh issue comment` — reading the effective `permissions.allow` from the operator's
+user-global settings and the project's `.claude/settings.json` / `settings.local.json`. It never
+runs a live permission probe. A missing verb means the floor is not composed in on this machine;
+the remediation is to apply the component operator-side, not to add a one-off rule.
+
+## The trusted worktree root — `additionalDirectories`
+
+`acceptEdits` auto-approves writes only inside the workspace root; it never auto-approves a write
+**outside** it. The autonomous lanes dispatch implementation subagents into their own out-of-tree
+worktrees (lifecycle owned by `source-control:worktree`), so every edit in a worktree is an
+out-of-workspace write that prompts unless the worktree root is registered as a trusted directory
+via `permissions.additionalDirectories`.
+
+The fleet convention is a dedicated worktree root **sibling to the repo**, not the OS temp dir — a
+`.worktrees/`-style directory (`source-control:worktree` creates worktrees under Claude Code's
+default sibling layout; `babysit-prs` defaults its `babysit_worktree_root` to the `worktrees`
+subdirectory of the plugin data directory). The exact root is operator-configurable and not yet a
+single documented constant across the fleet (the interim loop stopgap trusts `~/.claude-loop-worktrees`),
+so the preflight checks **coverage of whatever root the lane is configured to use** — it does not
+hardcode a path. Register that root once, operator-side:
+
+```jsonc
+// ~/.claude/settings.json (or the project's .claude/settings.json)
+{
+  "permissions": {
+    "additionalDirectories": ["<your out-of-tree worktree root>"]
+  }
+}
+```
+
+An entry covers the root when it equals the root or is an ancestor of it; a single sibling-root
+entry therefore trusts every per-PR worktree created beneath it.
+
+## Running the check
+
+The `work` skill invokes the script at loop start; run it directly to preview the gaps:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/preflight.sh" --worktree-root <configured-worktree-root>
+```
+
+It is report-only and always exits `0`. Each output line is one of:
+
+- `NOTE (a) …` — the cwd is not a git repository. Informational: a lane operating in an out-of-tree
+  worktree proceeds once `(c)` is covered; a lane that needs a checkout at the cwd cannot.
+- `GAP (b) …` — a probed working verb is not covered by any allow rule. Remediate by composing the
+  standards floor operator-side (above).
+- `GAP (c) …` — the worktree root is not covered by `additionalDirectories`. Add the entry (above).
+- `NOTE (c) …` — no worktree root was passed, so coverage was not checked.
+
+`--count` prints just the integer GAP count (NOTEs excluded) for a scripted gate. Surface any gap
+**once, at loop start**, with the exact remediation, then proceed or degrade per the lane's
+report-only posture — never rediscover the gap as per-operation prompts mid-cycle.
+
+The check itself is a single up-front, read-only invocation (`git rev-parse` plus `jq` reads of
+settings files) — it grants nothing and needs no allow rule of its own; a one-time classifier pass
+for it at loop start is not the mid-cycle-prompt problem this step exists to remove.

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -46,22 +46,34 @@ What it covers, at a glance (read the component for the authoritative list):
 The preflight probes a small representative subset of the allow floor — `git add`, `git commit`,
 `git push`, `gh pr create`, `gh issue comment` (a commit flow stages before it commits, so `git add`
 is probed too) — reading the effective `permissions.allow` from the operator's user-global settings
-and the project's `.claude/settings.json` / `settings.local.json`. It never runs a live permission
-probe. A verb counts as covered only by an **open** grant — the bare verb (`Bash(git commit)`) or
-its open-glob form (`Bash(git commit *)` / `Bash(git commit:*)`). A narrower, flag-scoped rule
-(`Bash(git commit --amend)`, a force-with-lease-only push rule) is **not** coverage: the lane's
-arbitrary `git commit` / `git push` would still prompt, so it is reported as a gap. A missing verb
-means the floor is not composed in on this machine; the remediation is to apply the component
-operator-side, not to add a one-off rule.
+and the project settings. It never runs a live permission probe. A verb counts as covered only by an
+**open-glob** grant — `Bash(git commit *)` or `Bash(git commit:*)`. A **bare-exact** rule
+(`Bash(git commit)`) is **not** coverage: it permits only the argumentless command, and a lane
+invocation always carries arguments, so the real call would still prompt. A narrower, flag-scoped
+rule (`Bash(git commit --amend)`, a force-with-lease-only push rule) is likewise not coverage. A
+missing verb means the floor is not composed in on this machine; the remediation is to apply the
+component operator-side, not to add a one-off rule.
 
 **Deny wins over allow.** Because `permissions.deny` overrides `permissions.allow` in the permission
 model, the check first tests each probed verb against the effective **deny** rules: a deny rule of
-the bare verb or its open-glob form keeps the verb a gap (reported distinctly as *denied*, not
-*missing*) even when an identical allow rule exists — the lane still cannot run it. This deny match
-is **exact-shape only**: it does not simulate glob semantics, so a broader deny pattern that would
-match the verb at runtime (a wildcard spanning it) is not caught here. That conservatism is
-deliberate — it never false-flags the standard deny floor, whose destructive-verb rules are
-flag-scoped (`git push --force …`) rather than the bare `git push` / `git commit` / `git add` shape.
+the verb (bare, or its open-glob form) keeps the verb a gap (reported distinctly as *denied*, not
+*missing*) even when an identical allow rule exists — the lane still cannot run it. Deny matching
+deliberately errs **wider** than coverage — it also counts the bare-exact spelling, because a
+false *denied* report is safe whereas a missed one is not. It is still **exact-shape only**: it does
+not simulate glob semantics, so a broader deny pattern that would match the verb at runtime (a
+wildcard spanning it) is not caught here. That conservatism never false-flags the standard deny
+floor, whose destructive-verb rules are flag-scoped (`git push --force …`) rather than the bare
+`git push` / `git commit` / `git add` shape.
+
+**The autonomous path ignores this checkout's `settings.local.json`.** `settings.local.json` is
+gitignored, so a fresh linked worktree the lane dispatches a worker into carries this checkout's
+tracked `.claude/settings.json` but **not** its local file — a grant that lives only in local here
+would be absent there, and reading it would mask a worker-side gap. So when `--worktree-root` is
+passed (the autonomous signal), the **coverage** reads (allow + `additionalDirectories`) use
+user-global + tracked project settings only, and the report header says so. The interactive/default
+path (no `--worktree-root`) keeps local settings in scope. Deny always reads local regardless — the
+same err-wide rationale. Pair this with `--project-root <worker-worktree>` (below) to read the
+worker's own tracked project settings instead of this checkout's.
 
 ## The trusted worktree root — `additionalDirectories`
 

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -43,11 +43,25 @@ What it covers, at a glance (read the component for the authoritative list):
   discards, forced branch deletion, `--no-verify` bypass), the `gh api` DELETE surface, hook-disable
   environment prefixes, and secret-material `Read()` patterns. Deny always wins over allow.
 
-The preflight probes a small representative subset of the allow floor — `git commit`, `git push`,
-`gh pr create`, `gh issue comment` — reading the effective `permissions.allow` from the operator's
-user-global settings and the project's `.claude/settings.json` / `settings.local.json`. It never
-runs a live permission probe. A missing verb means the floor is not composed in on this machine;
-the remediation is to apply the component operator-side, not to add a one-off rule.
+The preflight probes a small representative subset of the allow floor — `git add`, `git commit`,
+`git push`, `gh pr create`, `gh issue comment` (a commit flow stages before it commits, so `git add`
+is probed too) — reading the effective `permissions.allow` from the operator's user-global settings
+and the project's `.claude/settings.json` / `settings.local.json`. It never runs a live permission
+probe. A verb counts as covered only by an **open** grant — the bare verb (`Bash(git commit)`) or
+its open-glob form (`Bash(git commit *)` / `Bash(git commit:*)`). A narrower, flag-scoped rule
+(`Bash(git commit --amend)`, a force-with-lease-only push rule) is **not** coverage: the lane's
+arbitrary `git commit` / `git push` would still prompt, so it is reported as a gap. A missing verb
+means the floor is not composed in on this machine; the remediation is to apply the component
+operator-side, not to add a one-off rule.
+
+**Deny wins over allow.** Because `permissions.deny` overrides `permissions.allow` in the permission
+model, the check first tests each probed verb against the effective **deny** rules: a deny rule of
+the bare verb or its open-glob form keeps the verb a gap (reported distinctly as *denied*, not
+*missing*) even when an identical allow rule exists — the lane still cannot run it. This deny match
+is **exact-shape only**: it does not simulate glob semantics, so a broader deny pattern that would
+match the verb at runtime (a wildcard spanning it) is not caught here. That conservatism is
+deliberate — it never false-flags the standard deny floor, whose destructive-verb rules are
+flag-scoped (`git push --force …`) rather than the bare `git push` / `git commit` / `git add` shape.
 
 ## The trusted worktree root — `additionalDirectories`
 
@@ -85,12 +99,27 @@ The `work` skill invokes the script at loop start; run it directly to preview th
 "${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/preflight.sh" --worktree-root <configured-worktree-root>
 ```
 
+**Check the worktree the lane actually runs in.** Project `.claude/settings(.local).json` is
+per-checkout, so a fresh linked worktree can carry different grants than the main checkout — and the
+main checkout's grants would otherwise mask a worker-side gap. When the orchestrator dispatches a
+worker into a worktree, pass that worktree as `--project-root` so its own project settings are the
+ones probed:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/preflight.sh" \
+  --project-root <dispatched-worker-worktree> --worktree-root <configured-worktree-root>
+```
+
+`--project-root` defaults to the current checkout. User-global settings apply everywhere and are
+read regardless of it; only the project layer is re-pointed.
+
 It is report-only and always exits `0`. Each output line is one of:
 
 - `NOTE (a) …` — the cwd is not a git repository. Informational: a lane operating in an out-of-tree
   worktree proceeds once `(c)` is covered; a lane that needs a checkout at the cwd cannot.
-- `GAP (b) …` — a probed working verb is not covered by any allow rule. Remediate by composing the
-  standards floor operator-side (above).
+- `GAP (b) …` — a probed working verb is denied by a matching deny rule, or is not covered by any
+  allow rule (the message distinguishes the two). Remediate operator-side: resolve the deny rule, or
+  compose the standards floor in (above).
 - `GAP (c) …` — the worktree root is not covered by `additionalDirectories`. Add the entry (above).
 - `NOTE (c) …` — no worktree root was passed, so coverage was not checked.
 

--- a/plugins/work-items/skills/work/SKILL.md
+++ b/plugins/work-items/skills/work/SKILL.md
@@ -34,6 +34,26 @@ derive `<slug>` per its slug spec and, on the session's first memory-tier write,
 memory root's self-ignore guard (a `.gitignore` containing `*`, created and announced when absent).
 Tick each step as completed.
 
+## Permission preflight (before Step 0)
+
+The **first** loop-start action — ahead of the binding preflight — surfaces any missing permission
+grant or untrusted worktree root **once, up front**, so the unattended lane never rediscovers it as
+a mid-cycle prompt. Pass the out-of-tree worktree root this lane is configured to dispatch into
+(the `/source-control:worktree` layout); omit `--worktree-root` only for a fully inline run.
+
+```bash
+PREFLIGHT="${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/preflight.sh"
+"$PREFLIGHT" --worktree-root "<configured-worktree-root>"
+```
+
+The check is **report-only** and always exits `0`. On any `GAP`, surface the exact remediation once
+and continue per this lane's report-only posture — the fix is **operator-side** (the standards
+permission floor and the local `additionalDirectories` seam) and is **never self-applied**: the
+classifier blocks an agent broadening its own `permissions.allow`, and a plugin `settings.json`
+grant is inert. Never retry a permission denial into broader grants. The full contract, remediation,
+and the `/source-control:babysit-prs` applicability note live in
+[`${CLAUDE_PLUGIN_ROOT}/reference/permission-preflight.md`](${CLAUDE_PLUGIN_ROOT}/reference/permission-preflight.md).
+
 ## Binding preflight (before Step 0)
 
 Step 0's `reclaim` is this lane's **first seam coordination verb**, so the binding-presence entry

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -268,6 +268,9 @@ dir_covered() {
   while IFS= read -r entry; do
     [[ -n "$entry" ]] || continue
     entry="$(normalize_path "$entry")"
+    # Filesystem root authorizes every absolute path ("" after the trailing-slash
+    # strip would otherwise expand to //* and match nothing).
+    [[ "$entry" == "/" || "$entry" == "" ]] && return 0
     [[ "$want" == "$entry" ]] && return 0
     case "$want" in
       "$entry"/*) return 0 ;;

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -212,9 +212,19 @@ normalize_path() {
   p="$(printf '%s' "$p" | tr '\\' '/')"
   case "$p" in
     [A-Za-z]:/*)
-      drive="$(printf '%s' "${p%%:*}" | tr '[:upper:]' '[:lower:]')"
+      # Windows filesystems are case-insensitive: fold the WHOLE path, not just
+      # the drive letter, so D:/Repos/.Worktrees and /d/repos/.worktrees compare
+      # equal. Non-drive (POSIX) paths stay case-sensitive.
+      p="$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')"
+      drive="${p%%:*}"
       rest="${p#*:}"
       p="/$drive$rest"
+      ;;
+    /[A-Za-z]/*)
+      # Git-bash drive spelling (/d/Repos/…) is the same case-insensitive
+      # Windows filesystem — fold it too. A true POSIX single-letter root
+      # directory is the accepted (rare, documented) collision.
+      p="$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')"
       ;;
     *) ;;
   esac

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# preflight.sh — loop-start permission preflight for the unattended work /
+# babysit lanes. Detects and REPORTS, once and up front, the conditions that
+# otherwise surface as mid-cycle permission prompts:
+#   (a) the working directory is not a git repository — a NOTE, since a lane
+#       that operates in an out-of-tree worktree can still proceed once (c) is
+#       covered; the SKILL interprets it against the lane's needs.
+#   (b) a core git/gh working verb is missing from the effective allow-list
+#       (probe set: git commit, git push, gh pr create, gh issue comment).
+#   (c) the configured out-of-tree worktree root is not covered by any
+#       permissions.additionalDirectories entry, so acceptEdits prompts on
+#       every write into it.
+#
+# REPORT-ONLY by design (issue #495): the assistant cannot self-apply the
+# remediation — the auto-mode classifier blocks an agent editing its own
+# permissions.allow, and a permissions block shipped in a plugin settings.json
+# is inert (docs/conventions/permission-rule-hygiene). This script never edits
+# settings; it prints the exact operator remediation and ALWAYS exits 0.
+# Findings never fail the run.
+#
+# Effective settings (union of permissions.allow / additionalDirectories):
+#   user-global : ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json
+#   project     : <root>/.claude/settings.json, <root>/.claude/settings.local.json
+# Probe root: $PREFLIGHT_FIXTURE_DIR (tests) else $PWD; project settings resolve
+# against the git toplevel of that root when it is a repo, else the root itself.
+#
+# Requires jq (exits 2 when absent).
+#
+# Usage:
+#   preflight.sh [--worktree-root <path>]   # report lines; exit 0
+#   preflight.sh --count [--worktree-root <path>]   # gap count only; exit 0
+#   preflight.sh --help
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+preflight.sh — report the loop-start permission gaps for the work/babysit lanes.
+
+Usage: preflight.sh [--worktree-root <path>] [--count] [--help]
+
+  (no arg)          print one line per condition, then a PREFLIGHT summary; exit 0
+  --worktree-root P check that some permissions.additionalDirectories entry covers P
+                    (also read from PREFLIGHT_WORKTREE_ROOT); omitted → NOTE, not checked
+  --count           print the integer GAP count only (NOTEs excluded); exit 0
+  --help            this message
+
+Reports three conditions from the effective settings — (a) cwd not a git repo,
+(b) a probed git/gh verb missing from permissions.allow, (c) the worktree root
+not covered by additionalDirectories. Report-only: never edits settings, always
+exits 0. The remediation is operator-side (see reference/permission-preflight.md).
+Requires jq (exit 2 when absent).
+EOF
+}
+
+mode="report"
+worktree_root="${PREFLIGHT_WORKTREE_ROOT:-}"
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --count)
+      mode="count"
+      shift
+      ;;
+    --worktree-root)
+      shift
+      [[ "$#" -gt 0 ]] || {
+        echo "ERROR: --worktree-root requires a path" >&2
+        exit 2
+      }
+      worktree_root="$1"
+      shift
+      ;;
+    --worktree-root=*)
+      worktree_root="${1#--worktree-root=}"
+      shift
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq required" >&2
+  exit 2
+fi
+
+# --- Settings resolution ------------------------------------------------------
+CHECK_DIR="${PREFLIGHT_FIXTURE_DIR:-$PWD}"
+repo_root="$(git -C "$CHECK_DIR" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
+proj_base="${repo_root:-$CHECK_DIR}"
+user_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+
+read_array() {
+  # read_array <file> <jq-path> — one element per line; silent on a missing or
+  # non-JSON file (a settings file may legitimately not exist).
+  local file="$1" path="$2"
+  [[ -f "$file" ]] || return 0
+  tr -d '\r' <"$file" | jq -e . >/dev/null 2>&1 || return 0
+  tr -d '\r' <"$file" | jq -r "$path // [] | .[]" 2>/dev/null | tr -d '\r'
+}
+
+collect() {
+  # collect <jq-path> — union the path across user-global + project settings.
+  local path="$1"
+  read_array "$user_settings" "$path"
+  read_array "$proj_base/.claude/settings.json" "$path"
+  read_array "$proj_base/.claude/settings.local.json" "$path"
+}
+
+ALL_ALLOW="$(collect '.permissions.allow')"
+ALL_ADDDIRS="$(collect '.permissions.additionalDirectories')"
+
+# --- Matchers -----------------------------------------------------------------
+verb_covered() {
+  # verb_covered <verb> — true when some Bash()/PowerShell() allow rule grants
+  # <verb> exactly or as a boundary-prefixed command. The boundary (space, ':',
+  # '*', or end) keeps a distinct verb (git commit-tree) from covering 'git
+  # commit'. Runs in the current shell (heredoc, not a pipe) so return escapes.
+  local verb="$1" rule inner
+  while IFS= read -r rule; do
+    [[ -n "$rule" ]] || continue
+    case "$rule" in
+      "Bash("*")") inner="${rule#Bash(}" ;;
+      "PowerShell("*")") inner="${rule#PowerShell(}" ;;
+      *) continue ;;
+    esac
+    inner="${inner%)}"
+    [[ "$inner" == "$verb" ]] && return 0
+    case "$inner" in
+      "$verb "* | "$verb:"* | "$verb"'*'*) return 0 ;;
+      *) ;;
+    esac
+  done <<RULES
+$ALL_ALLOW
+RULES
+  return 1
+}
+
+normalize_path() {
+  # Fold a path to one comparable form: backslashes → slashes, lower-case and
+  # de-colon a leading Windows drive (D:\repos → /d/repos, matching the git-bash
+  # /d/repos spelling), strip a trailing slash. Literal only — no symlink
+  # resolution, since permission rules match the command string literally.
+  local p="$1" drive rest
+  # shellcheck disable=SC1003  # '\\' is tr's escaped backslash (one char), not a quote escape
+  p="$(printf '%s' "$p" | tr '\\' '/')"
+  case "$p" in
+    [A-Za-z]:/*)
+      drive="$(printf '%s' "${p%%:*}" | tr '[:upper:]' '[:lower:]')"
+      rest="${p#*:}"
+      p="/$drive$rest"
+      ;;
+    *) ;;
+  esac
+  case "$p" in
+    ?*/) p="${p%/}" ;;
+    *) ;;
+  esac
+  printf '%s' "$p"
+}
+
+dir_covered() {
+  # dir_covered <path> — true when some additionalDirectories entry equals the
+  # path or is an ancestor of it, after normalization.
+  local want entry
+  want="$(normalize_path "$1")"
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    entry="$(normalize_path "$entry")"
+    [[ "$want" == "$entry" ]] && return 0
+    case "$want" in
+      "$entry"/*) return 0 ;;
+      *) ;;
+    esac
+  done <<DIRS
+$ALL_ADDDIRS
+DIRS
+  return 1
+}
+
+# --- Checks -------------------------------------------------------------------
+findings=()
+gapcount=0
+emit_gap() {
+  findings+=("GAP $1")
+  gapcount=$((gapcount + 1))
+}
+emit_note() { findings+=("NOTE $1"); }
+
+# (a) cwd not a git repo — informational; a worktree-operating lane may still run.
+if [[ -z "$repo_root" ]]; then
+  emit_note "(a) '$CHECK_DIR' is not a git repository. A lane that needs a checkout at the cwd cannot claim, branch, or push here; a lane that operates in an out-of-tree worktree proceeds once (c) is covered."
+fi
+
+# (b) probed working verbs missing from the effective allow-list.
+while IFS= read -r verb; do
+  [[ -n "$verb" ]] || continue
+  verb_covered "$verb" && continue
+  emit_gap "(b) no Bash()/PowerShell() allow rule covers '$verb'. Apply the fleet permission floor operator-side (standards components/claude-permissions, composed into settings via dotfiles#233) — never a plugin self-grant. See reference/permission-preflight.md."
+done <<PROBES
+git commit
+git push
+gh pr create
+gh issue comment
+PROBES
+
+# (c) worktree root not covered by additionalDirectories.
+if [[ -n "$worktree_root" ]]; then
+  if ! dir_covered "$worktree_root"; then
+    emit_gap "(c) no permissions.additionalDirectories entry covers the worktree root '$worktree_root'; acceptEdits will prompt on every out-of-tree write. Add it operator-side. See reference/permission-preflight.md."
+  fi
+else
+  emit_note "(c) worktree root not provided (--worktree-root / PREFLIGHT_WORKTREE_ROOT unset) — additionalDirectories coverage not checked. Pass the lane's out-of-tree worktree root to verify it."
+fi
+
+# --- Output -------------------------------------------------------------------
+if [[ "$mode" == "count" ]]; then
+  printf '%s\n' "$gapcount"
+  exit 0
+fi
+
+if [[ "${#findings[@]}" -eq 0 ]]; then
+  echo "PREFLIGHT: OK — cwd is a git repo, probed grants present, worktree root covered."
+  exit 0
+fi
+
+printf '%s\n' "${findings[@]}"
+if [[ "$gapcount" -eq 0 ]]; then
+  echo "PREFLIGHT: OK — ${#findings[@]} note(s), 0 gap(s)."
+else
+  echo "PREFLIGHT: $gapcount gap(s) — remediate operator-side before the unattended loop; the assistant cannot self-apply (see reference/permission-preflight.md)."
+fi
+exit 0

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -45,7 +45,9 @@ Usage: preflight.sh [--worktree-root <path>] [--project-root <path>] [--count] [
 
   (no arg)          print one line per condition, then a PREFLIGHT summary; exit 0
   --worktree-root P check that some permissions.additionalDirectories entry covers P
-                    (also read from PREFLIGHT_WORKTREE_ROOT); omitted → NOTE, not checked
+                    (also read from PREFLIGHT_WORKTREE_ROOT); omitted → NOTE, not checked.
+                    The autonomous signal: coverage reads then exclude this checkout's
+                    gitignored settings.local.json (a fresh worktree lacks it)
   --project-root P  read project settings from P's checkout instead of the cwd's
                     (also read from PREFLIGHT_PROJECT_ROOT) — pass the dispatched
                     worker worktree so its own grants are checked, not the main one's
@@ -134,31 +136,50 @@ read_array() {
 }
 
 collect() {
-  # collect <jq-path> — union the path across user-global + project settings.
-  local path="$1"
+  # collect <jq-path> <local-mode> — union the path across user-global + tracked
+  # project settings, plus the gitignored project settings.local.json only when
+  # <local-mode> is "with-local". A fresh linked worktree carries the tracked
+  # .claude/settings.json but NOT the gitignored settings.local.json, so in the
+  # autonomous (--worktree-root) path this checkout's local grants would mask a
+  # worker-side gap; the coverage reads drop local there. Deny always keeps local
+  # (erring wide on deny never masks a gap).
+  local path="$1" local_mode="$2"
   read_array "$user_settings" "$path"
   read_array "$proj_base/.claude/settings.json" "$path"
-  read_array "$proj_base/.claude/settings.local.json" "$path"
+  [[ "$local_mode" == "with-local" ]] && read_array "$proj_base/.claude/settings.local.json" "$path"
 }
 
-ALL_ALLOW="$(collect '.permissions.allow')"
-ALL_DENY="$(collect '.permissions.deny')"
-ALL_ADDDIRS="$(collect '.permissions.additionalDirectories')"
+# --worktree-root is the autonomous signal: exclude this checkout's local settings
+# from the COVERAGE reads (allow + additionalDirectories); the interactive/default
+# path keeps them. Deny always reads local.
+if [[ -n "$worktree_root" ]]; then
+  cov_local="no-local"
+else
+  cov_local="with-local"
+fi
+ALL_ALLOW="$(collect '.permissions.allow' "$cov_local")"
+ALL_DENY="$(collect '.permissions.deny' "with-local")"
+ALL_ADDDIRS="$(collect '.permissions.additionalDirectories' "$cov_local")"
 
 # --- Matchers -----------------------------------------------------------------
 verb_in_rules() {
-  # verb_in_rules <verb> <rules> — true when some Bash()/PowerShell() rule in the
-  # newline-separated <rules> is an OPEN-shape grant of <verb>: the bare verb
-  # (`git commit`) or its open-glob form (`git commit *` / `git commit:*`). A
-  # rule whose next token is a specific flag or argument (`git commit --amend`, a
-  # force-with-lease-only push) does NOT match — it is a narrower slice, so the
-  # lane's arbitrary invocation of the bare verb would still prompt (for allow)
-  # or still run (for deny). Exact-shape only, by deliberate design: this does
-  # NOT simulate glob semantics, so a broader deny pattern that would match the
-  # verb at runtime is not detected here. The `'*'` is a quoted literal asterisk,
-  # so each arm matches one exact rule spelling, not a prefix. Runs in the
-  # current shell (heredoc, not a pipe) so return escapes.
-  local verb="$1" rules="$2" rule inner
+  # verb_in_rules <verb> <rules> <match-bare> — true when some Bash()/PowerShell()
+  # rule in the newline-separated <rules> grants <verb> in an open shape: the
+  # open-glob form (`git commit *` / `git commit:*`), plus — only when
+  # <match-bare> is "bare" — the argumentless bare verb (`git commit`).
+  #   COVERAGE (allow) excludes bare: `Bash(git commit)` permits only the literal
+  #   argumentless command, and a lane invocation always carries args, so a
+  #   bare-exact allow does NOT cover the verb — the real call would still prompt.
+  #   DENY includes bare: erring wide on deny is safe (a bare deny still signals
+  #   the verb is off-limits).
+  # A rule whose next token is a specific flag or argument (`git commit --amend`,
+  # a force-with-lease-only push) never matches — it is a narrower slice.
+  # Exact-shape only, by deliberate design: this does NOT simulate glob semantics,
+  # so a broader deny pattern that would match the verb at runtime is not detected
+  # here. The `'*'` is a quoted literal asterisk, so each arm matches one exact
+  # rule spelling, not a prefix. Runs in the current shell (heredoc, not a pipe)
+  # so return escapes.
+  local verb="$1" rules="$2" match_bare="$3" rule inner
   while IFS= read -r rule; do
     [[ -n "$rule" ]] || continue
     case "$rule" in
@@ -168,17 +189,18 @@ verb_in_rules() {
     esac
     inner="${inner%)}"
     case "$inner" in
-      "$verb" | "$verb "'*' | "$verb:"'*') return 0 ;;
+      "$verb "'*' | "$verb:"'*') return 0 ;;
       *) ;;
     esac
+    [[ "$match_bare" == "bare" && "$inner" == "$verb" ]] && return 0
   done <<RULES
 $rules
 RULES
   return 1
 }
 
-verb_covered() { verb_in_rules "$1" "$ALL_ALLOW"; }
-verb_denied() { verb_in_rules "$1" "$ALL_DENY"; }
+verb_covered() { verb_in_rules "$1" "$ALL_ALLOW" "open-glob-only"; }
+verb_denied() { verb_in_rules "$1" "$ALL_DENY" "bare"; }
 
 normalize_path() {
   # Fold a path to one comparable form: backslashes → slashes, lower-case and
@@ -268,6 +290,10 @@ fi
 if [[ "$mode" == "count" ]]; then
   printf '%s\n' "$gapcount"
   exit 0
+fi
+
+if [[ -n "$worktree_root" ]]; then
+  echo "PREFLIGHT: autonomous mode (--worktree-root set) — coverage read excludes this checkout's gitignored settings.local.json, which a fresh worktree would not carry; deny rules still include it."
 fi
 
 if [[ "${#findings[@]}" -eq 0 ]]; then

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -46,11 +46,13 @@ Usage: preflight.sh [--worktree-root <path>] [--project-root <path>] [--count] [
   (no arg)          print one line per condition, then a PREFLIGHT summary; exit 0
   --worktree-root P check that some permissions.additionalDirectories entry covers P
                     (also read from PREFLIGHT_WORKTREE_ROOT); omitted → NOTE, not checked.
-                    The autonomous signal: coverage reads then exclude this checkout's
-                    gitignored settings.local.json (a fresh worktree lacks it)
+                    The autonomous signal: unless a distinct --project-root is given,
+                    coverage reads exclude this checkout's gitignored settings.local.json
+                    (a not-yet-created worktree lacks it)
   --project-root P  read project settings from P's checkout instead of the cwd's
                     (also read from PREFLIGHT_PROJECT_ROOT) — pass the dispatched
-                    worker worktree so its own grants are checked, not the main one's
+                    worker worktree so ITS OWN grants (incl. its settings.local.json)
+                    are checked, not the main checkout's
   --count           print the integer GAP count only (NOTEs excluded); exit 0
   --help            this message
 
@@ -149,10 +151,24 @@ collect() {
   [[ "$local_mode" == "with-local" ]] && read_array "$proj_base/.claude/settings.local.json" "$path"
 }
 
-# --worktree-root is the autonomous signal: exclude this checkout's local settings
-# from the COVERAGE reads (allow + additionalDirectories); the interactive/default
-# path keeps them. Deny always reads local.
-if [[ -n "$worktree_root" ]]; then
+# Local-settings scope for the COVERAGE reads (allow + additionalDirectories):
+#   - A DISTINCT --project-root (a worker worktree whose toplevel differs from this
+#     checkout) names a real, existing checkout — read ITS OWN settings.local.json
+#     (the worker's file, not this parent's); nothing is masked.
+#   - Otherwise, --worktree-root (the autonomous signal) is pre-dispatch: the worker
+#     is not yet created, so exclude this checkout's gitignored settings.local.json,
+#     which a fresh worktree would not carry, lest a local-only grant mask a gap.
+#   - The interactive/default path keeps local.
+# Deny always reads local (erring wide on deny never masks a gap).
+distinct_project_root=""
+if [[ -n "$project_root" && "$proj_base" != "$repo_root" ]]; then
+  distinct_project_root="yes"
+fi
+local_excluded=""
+if [[ -n "$worktree_root" && -z "$distinct_project_root" ]]; then
+  local_excluded="yes"
+fi
+if [[ -n "$local_excluded" ]]; then
   cov_local="no-local"
 else
   cov_local="with-local"
@@ -163,15 +179,19 @@ ALL_ADDDIRS="$(collect '.permissions.additionalDirectories' "$cov_local")"
 
 # --- Matchers -----------------------------------------------------------------
 verb_in_rules() {
-  # verb_in_rules <verb> <rules> <match-bare> — true when some Bash()/PowerShell()
-  # rule in the newline-separated <rules> grants <verb> in an open shape: the
-  # open-glob form (`git commit *` / `git commit:*`), plus — only when
-  # <match-bare> is "bare" — the argumentless bare verb (`git commit`).
-  #   COVERAGE (allow) excludes bare: `Bash(git commit)` permits only the literal
-  #   argumentless command, and a lane invocation always carries args, so a
-  #   bare-exact allow does NOT cover the verb — the real call would still prompt.
-  #   DENY includes bare: erring wide on deny is safe (a bare deny still signals
-  #   the verb is off-limits).
+  # verb_in_rules <verb> <rules> <mode> — true when some Bash()/PowerShell() rule
+  # in the newline-separated <rules> grants <verb> in a shape the <mode> accepts:
+  #   open-glob-only — the open-glob form only (`git commit *` / `git commit:*`).
+  #                    Used for COVERAGE: a bare-exact `Bash(git commit)` permits
+  #                    only the argumentless command, and a work-lane invocation
+  #                    always carries args, so bare does NOT cover.
+  #   bare           — open-glob OR the argumentless bare verb (`git commit`).
+  #                    Used for DENY: erring wide is safe (a bare deny still
+  #                    signals the verb is off-limits).
+  #   bare-exact-only — the bare verb only. Used to sharpen the gap message when
+  #                    open-glob coverage is absent but a bare-only grant exists
+  #                    (it serves an argumentless caller like babysit's plain
+  #                    `git push`, but not the work lane's argument-carrying call).
   # A rule whose next token is a specific flag or argument (`git commit --amend`,
   # a force-with-lease-only push) never matches — it is a narrower slice.
   # Exact-shape only, by deliberate design: this does NOT simulate glob semantics,
@@ -179,7 +199,7 @@ verb_in_rules() {
   # here. The `'*'` is a quoted literal asterisk, so each arm matches one exact
   # rule spelling, not a prefix. Runs in the current shell (heredoc, not a pipe)
   # so return escapes.
-  local verb="$1" rules="$2" match_bare="$3" rule inner
+  local verb="$1" rules="$2" mode="$3" rule inner
   while IFS= read -r rule; do
     [[ -n "$rule" ]] || continue
     case "$rule" in
@@ -188,11 +208,15 @@ verb_in_rules() {
       *) continue ;;
     esac
     inner="${inner%)}"
-    case "$inner" in
-      "$verb "'*' | "$verb:"'*') return 0 ;;
-      *) ;;
-    esac
-    [[ "$match_bare" == "bare" && "$inner" == "$verb" ]] && return 0
+    if [[ "$mode" != "bare-exact-only" ]]; then
+      case "$inner" in
+        "$verb "'*' | "$verb:"'*') return 0 ;;
+        *) ;;
+      esac
+    fi
+    if [[ "$mode" == "bare" || "$mode" == "bare-exact-only" ]]; then
+      [[ "$inner" == "$verb" ]] && return 0
+    fi
   done <<RULES
 $rules
 RULES
@@ -201,6 +225,7 @@ RULES
 
 verb_covered() { verb_in_rules "$1" "$ALL_ALLOW" "open-glob-only"; }
 verb_denied() { verb_in_rules "$1" "$ALL_DENY" "bare"; }
+verb_bare_exact() { verb_in_rules "$1" "$ALL_ALLOW" "bare-exact-only"; }
 
 normalize_path() {
   # Fold a path to one comparable form: backslashes → slashes, lower-case and
@@ -278,6 +303,10 @@ while IFS= read -r verb; do
     continue
   fi
   verb_covered "$verb" && continue
+  if verb_bare_exact "$verb"; then
+    emit_gap "(b) '$verb' has only a bare-exact allow rule: it covers argumentless invocations (e.g. the babysit fix cycle's plain \`git push\`) but not argument-carrying ones (the work lane's \`$verb …\`). Grant the open glob (\`$verb *\`) operator-side. See reference/permission-preflight.md."
+    continue
+  fi
   emit_gap "(b) no Bash()/PowerShell() allow rule covers '$verb'. Apply the fleet permission floor operator-side (standards components/claude-permissions, composed into settings via dotfiles#233) — never a plugin self-grant. See reference/permission-preflight.md."
 done <<PROBES
 git add
@@ -302,8 +331,10 @@ if [[ "$mode" == "count" ]]; then
   exit 0
 fi
 
-if [[ -n "$worktree_root" ]]; then
-  echo "PREFLIGHT: autonomous mode (--worktree-root set) — coverage read excludes this checkout's gitignored settings.local.json, which a fresh worktree would not carry; deny rules still include it."
+if [[ -n "$local_excluded" ]]; then
+  echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read excludes this checkout's gitignored settings.local.json, which a fresh worktree would not carry; deny rules still include it."
+elif [[ -n "$distinct_project_root" ]]; then
+  echo "PREFLIGHT: reading project settings (incl. settings.local.json) from --project-root '$proj_base'."
 fi
 
 if [[ "${#findings[@]}" -eq 0 ]]; then

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -5,13 +5,14 @@
 #   (a) the working directory is not a git repository — a NOTE, since a lane
 #       that operates in an out-of-tree worktree can still proceed once (c) is
 #       covered; the SKILL interprets it against the lane's needs.
-#   (b) a core git/gh working verb is missing from the effective allow-list
-#       (probe set: git commit, git push, gh pr create, gh issue comment).
+#   (b) a core git/gh working verb (probe set: git add, git commit, git push,
+#       gh pr create, gh issue comment) is blocked by a matching deny rule, or
+#       is missing from the effective allow-list. Deny wins over allow.
 #   (c) the configured out-of-tree worktree root is not covered by any
 #       permissions.additionalDirectories entry, so acceptEdits prompts on
 #       every write into it.
 #
-# REPORT-ONLY by design (issue #495): the assistant cannot self-apply the
+# REPORT-ONLY by design: the assistant cannot self-apply the
 # remediation — the auto-mode classifier blocks an agent editing its own
 # permissions.allow, and a permissions block shipped in a plugin settings.json
 # is inert (docs/conventions/permission-rule-hygiene). This script never edits
@@ -19,16 +20,19 @@
 # Findings never fail the run.
 #
 # Effective settings (union of permissions.allow / additionalDirectories):
-#   user-global : ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json
-#   project     : <root>/.claude/settings.json, <root>/.claude/settings.local.json
-# Probe root: $PREFLIGHT_FIXTURE_DIR (tests) else $PWD; project settings resolve
-# against the git toplevel of that root when it is a repo, else the root itself.
+#   user-global : ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json (applies everywhere)
+#   project     : <project-root>/.claude/settings.json, .../settings.local.json
+# The cwd probed for (a) is $PREFLIGHT_FIXTURE_DIR (tests) else $PWD. Project
+# settings are read from --project-root (default: the cwd checkout) resolved to
+# its git toplevel; pass the worker worktree the lane dispatches into so its own
+# project settings are checked rather than the main checkout's, which could
+# otherwise mask a worker-side gap. $PREFLIGHT_PROJECT_ROOT is the env fallback.
 #
 # Requires jq (exits 2 when absent).
 #
 # Usage:
-#   preflight.sh [--worktree-root <path>]   # report lines; exit 0
-#   preflight.sh --count [--worktree-root <path>]   # gap count only; exit 0
+#   preflight.sh [--worktree-root <path>] [--project-root <path>]   # report; exit 0
+#   preflight.sh --count [--worktree-root <path>] [--project-root <path>]   # gap count
 #   preflight.sh --help
 
 set -uo pipefail
@@ -37,24 +41,28 @@ usage() {
   cat <<'EOF'
 preflight.sh — report the loop-start permission gaps for the work/babysit lanes.
 
-Usage: preflight.sh [--worktree-root <path>] [--count] [--help]
+Usage: preflight.sh [--worktree-root <path>] [--project-root <path>] [--count] [--help]
 
   (no arg)          print one line per condition, then a PREFLIGHT summary; exit 0
   --worktree-root P check that some permissions.additionalDirectories entry covers P
                     (also read from PREFLIGHT_WORKTREE_ROOT); omitted → NOTE, not checked
+  --project-root P  read project settings from P's checkout instead of the cwd's
+                    (also read from PREFLIGHT_PROJECT_ROOT) — pass the dispatched
+                    worker worktree so its own grants are checked, not the main one's
   --count           print the integer GAP count only (NOTEs excluded); exit 0
   --help            this message
 
 Reports three conditions from the effective settings — (a) cwd not a git repo,
-(b) a probed git/gh verb missing from permissions.allow, (c) the worktree root
-not covered by additionalDirectories. Report-only: never edits settings, always
-exits 0. The remediation is operator-side (see reference/permission-preflight.md).
+(b) a probed git/gh verb denied or missing from permissions.allow, (c) the
+worktree root not covered by additionalDirectories. Report-only: never edits
+settings, always exits 0. Remediation is operator-side (see reference/permission-preflight.md).
 Requires jq (exit 2 when absent).
 EOF
 }
 
 mode="report"
 worktree_root="${PREFLIGHT_WORKTREE_ROOT:-}"
+project_root="${PREFLIGHT_PROJECT_ROOT:-}"
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     -h | --help)
@@ -78,6 +86,19 @@ while [[ "$#" -gt 0 ]]; do
       worktree_root="${1#--worktree-root=}"
       shift
       ;;
+    --project-root)
+      shift
+      [[ "$#" -gt 0 ]] || {
+        echo "ERROR: --project-root requires a path" >&2
+        exit 2
+      }
+      project_root="$1"
+      shift
+      ;;
+    --project-root=*)
+      project_root="${1#--project-root=}"
+      shift
+      ;;
     *)
       echo "ERROR: unknown argument: $1" >&2
       exit 2
@@ -91,9 +112,16 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # --- Settings resolution ------------------------------------------------------
+# (a) is about the actual cwd; project settings are read from --project-root when
+# given (the worker worktree the orchestrator is dispatching into), else the cwd
+# checkout. Reading the dispatched worktree's own project settings is what keeps
+# the main checkout's grants from masking a worker-side gap. User-global settings
+# apply everywhere and are read regardless.
 CHECK_DIR="${PREFLIGHT_FIXTURE_DIR:-$PWD}"
 repo_root="$(git -C "$CHECK_DIR" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
-proj_base="${repo_root:-$CHECK_DIR}"
+proj_src="${project_root:-$CHECK_DIR}"
+proj_toplevel="$(git -C "$proj_src" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
+proj_base="${proj_toplevel:-$proj_src}"
 user_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 
 read_array() {
@@ -114,15 +142,23 @@ collect() {
 }
 
 ALL_ALLOW="$(collect '.permissions.allow')"
+ALL_DENY="$(collect '.permissions.deny')"
 ALL_ADDDIRS="$(collect '.permissions.additionalDirectories')"
 
 # --- Matchers -----------------------------------------------------------------
-verb_covered() {
-  # verb_covered <verb> — true when some Bash()/PowerShell() allow rule grants
-  # <verb> exactly or as a boundary-prefixed command. The boundary (space, ':',
-  # '*', or end) keeps a distinct verb (git commit-tree) from covering 'git
-  # commit'. Runs in the current shell (heredoc, not a pipe) so return escapes.
-  local verb="$1" rule inner
+verb_in_rules() {
+  # verb_in_rules <verb> <rules> — true when some Bash()/PowerShell() rule in the
+  # newline-separated <rules> is an OPEN-shape grant of <verb>: the bare verb
+  # (`git commit`) or its open-glob form (`git commit *` / `git commit:*`). A
+  # rule whose next token is a specific flag or argument (`git commit --amend`, a
+  # force-with-lease-only push) does NOT match — it is a narrower slice, so the
+  # lane's arbitrary invocation of the bare verb would still prompt (for allow)
+  # or still run (for deny). Exact-shape only, by deliberate design: this does
+  # NOT simulate glob semantics, so a broader deny pattern that would match the
+  # verb at runtime is not detected here. The `'*'` is a quoted literal asterisk,
+  # so each arm matches one exact rule spelling, not a prefix. Runs in the
+  # current shell (heredoc, not a pipe) so return escapes.
+  local verb="$1" rules="$2" rule inner
   while IFS= read -r rule; do
     [[ -n "$rule" ]] || continue
     case "$rule" in
@@ -131,16 +167,18 @@ verb_covered() {
       *) continue ;;
     esac
     inner="${inner%)}"
-    [[ "$inner" == "$verb" ]] && return 0
     case "$inner" in
-      "$verb "* | "$verb:"* | "$verb"'*'*) return 0 ;;
+      "$verb" | "$verb "'*' | "$verb:"'*') return 0 ;;
       *) ;;
     esac
   done <<RULES
-$ALL_ALLOW
+$rules
 RULES
   return 1
 }
+
+verb_covered() { verb_in_rules "$1" "$ALL_ALLOW"; }
+verb_denied() { verb_in_rules "$1" "$ALL_DENY"; }
 
 normalize_path() {
   # Fold a path to one comparable form: backslashes → slashes, lower-case and
@@ -198,12 +236,19 @@ if [[ -z "$repo_root" ]]; then
   emit_note "(a) '$CHECK_DIR' is not a git repository. A lane that needs a checkout at the cwd cannot claim, branch, or push here; a lane that operates in an out-of-tree worktree proceeds once (c) is covered."
 fi
 
-# (b) probed working verbs missing from the effective allow-list.
+# (b) probed working verbs blocked by deny, or missing from the effective
+# allow-list. Deny is checked first because deny wins over allow in the
+# permission model — an allowed-but-denied verb is still unrunnable.
 while IFS= read -r verb; do
   [[ -n "$verb" ]] || continue
+  if verb_denied "$verb"; then
+    emit_gap "(b) '$verb' is DENIED by a matching deny rule (deny wins over allow), so the unattended lane cannot run it even if allowed. Resolve the deny rule operator-side before relying on this verb. See reference/permission-preflight.md."
+    continue
+  fi
   verb_covered "$verb" && continue
   emit_gap "(b) no Bash()/PowerShell() allow rule covers '$verb'. Apply the fleet permission floor operator-side (standards components/claude-permissions, composed into settings via dotfiles#233) — never a plugin self-grant. See reference/permission-preflight.md."
 done <<PROBES
+git add
 git commit
 git push
 gh pr create

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -171,15 +171,19 @@ assert_contains "flag-specific push rule leaves git push a gap" "$OUT" "'git pus
 assert_not_contains "the open gh pr create rule is not a gap" "$OUT" "'gh pr create'"
 assert_eq "two flag-masked verbs → two (b) gaps" "2" "$(run "$REPO" "$CFG7B" --count)"
 
-# --- Case 7c: a bare-exact allow rule is NOT coverage -----------------------
+# --- Case 7c: a bare-exact allow is not coverage, with a nuanced gap message -
 CFG7C="$TEST_TMPDIR/cfg7c"
-# Bash(git commit) permits only the argumentless command; a lane invocation
-# always carries args, so a bare-exact allow must NOT count as covering the verb.
+# Bash(git push) permits only the argumentless command (which babysit's fix cycle
+# does run) but not the work lane's argument-carrying call, so it is still a GAP —
+# reported with that nuance, not the generic missing-allow message.
 write_settings "$CFG7C" \
-  '["Bash(git add *)","Bash(git commit)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
 OUT=$(run "$REPO" "$CFG7C")
-assert_contains "bare-exact commit rule leaves git commit a gap" "$OUT" "'git commit'"
-assert_eq "bare-exact allow → one gap" "1" "$(run "$REPO" "$CFG7C" --count)"
+assert_contains "bare-only push is still a gap" "$OUT" "'git push'"
+assert_contains "gap names the bare-exact-only case" "$OUT" "bare-exact allow rule"
+assert_contains "gap points at the open-glob remedy" "$OUT" "Grant the open glob"
+assert_not_contains "bare-only push not the generic missing-allow message" "$OUT" "no Bash()/PowerShell() allow rule covers 'git push'"
+assert_eq "bare-only allow → one gap" "1" "$(run "$REPO" "$CFG7C" --count)"
 
 # --- Case 8: worktree root not covered → GAP (c) ----------------------------
 CFG8="$TEST_TMPDIR/cfg8"
@@ -294,6 +298,27 @@ OUT=$(run "$REPO3" "$CFG16" --worktree-root "$POSIX_CHILD")
 assert_contains "autonomous path drops local → gh pr create gap surfaces" "$OUT" "'gh pr create'"
 assert_contains "report header notes the local exclusion" "$OUT" "settings.local.json"
 assert_eq "autonomous path drops local grant → one gap" "1" "$(run "$REPO3" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 17: a distinct --project-root reads the worker's OWN local settings -
+# When --project-root names a real worker worktree (toplevel differs from cwd),
+# read ITS OWN settings.local.json — the worker's file, present in that checkout —
+# instead of excluding local. The pre-dispatch exclusion (case 16) applies only
+# when no distinct --project-root is given.
+WORKER2="$TEST_TMPDIR/worker-local"
+git init -q "$WORKER2"
+WORKER2TOP="$(git -C "$WORKER2" rev-parse --show-toplevel)"
+mkdir -p "$WORKER2TOP/.claude"
+CFG17="$TEST_TMPDIR/cfg17"
+# gh pr create lives ONLY in the worker's own local file; user-global lacks it.
+write_settings "$CFG17" \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$WORKER2TOP/.claude/settings.local.json"
+assert_eq "distinct project-root reads the worker's own local grant" "0" "$(run "$REPO" "$CFG17" --project-root "$WORKER2" --count --worktree-root "$POSIX_CHILD")"
+OUT=$(run "$REPO" "$CFG17" --project-root "$WORKER2" --worktree-root "$POSIX_CHILD")
+assert_contains "distinct project-root header names the source" "$OUT" "from --project-root"
+# Without the distinct --project-root (pre-dispatch), local is excluded → gap.
+assert_eq "no distinct project-root excludes local → one gap" "1" "$(run "$REPO" "$CFG17" --count --worktree-root "$POSIX_CHILD")"
 
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -320,6 +320,13 @@ assert_contains "distinct project-root header names the source" "$OUT" "from --p
 # Without the distinct --project-root (pre-dispatch), local is excluded → gap.
 assert_eq "no distinct project-root excludes local → one gap" "1" "$(run "$REPO" "$CFG17" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Case 18: filesystem root entry authorizes every absolute path ------------
+CFG18="$TEST_TMPDIR/cfg18"
+# MSYS_NO_PATHCONV stops git-bash rewriting the bare "/" argument to the Git
+# install root before jq sees it.
+MSYS_NO_PATHCONV=1 write_settings "$CFG18" "$FULL_ALLOW" "/"
+assert_eq "root additionalDirectories entry covers any worktree root" "0" "$(run "$REPO" "$CFG18" --count --worktree-root "$POSIX_CHILD")"
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"
   exit 0

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -140,10 +140,11 @@ assert_eq "git add is the only missing verb → one gap" "1" "$(run "$REPO" "$CF
 
 # --- Case 6: verb spelling variants all recognized --------------------------
 CFG6="$TEST_TMPDIR/cfg6"
-# Exact (git push), starred (git commit *), colon (gh issue comment:*), and a
-# PowerShell-spelled rule (gh pr create) — every probe covered by a distinct form.
+# Space open-glob (git commit *), colon open-glob (gh issue comment:*), and a
+# PowerShell-spelled open glob (gh pr create *) — every probe covered by a
+# distinct open-glob form (a bare-exact rule is NOT coverage; see case 7c).
 write_settings "$CFG6" \
-  '["Bash(git add *)","Bash(git commit *)","Bash(git push)","PowerShell(gh pr create *)","Bash(gh issue comment:*)"]'
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","PowerShell(gh pr create *)","Bash(gh issue comment:*)"]'
 # No worktree-root arg → (c) is a note, so --count reflects only the (b) verb probe.
 assert_eq "all spelling variants recognized → 0 (b) gaps" "0" "$(run "$REPO" "$CFG6" --count)"
 OUT=$(run "$REPO" "$CFG6")
@@ -161,8 +162,7 @@ assert_contains "commit-tree does not cover commit" "$OUT" "'git commit'"
 CFG7B="$TEST_TMPDIR/cfg7b"
 # A flag-scoped commit rule and a force-with-lease-only push rule are narrower
 # than the plain verb — the lane's arbitrary `git commit` / `git push` would
-# still prompt — so they must NOT count as coverage; only the bare verb or its
-# open-glob form does.
+# still prompt — so they must NOT count as coverage; only an open-glob form does.
 write_settings "$CFG7B" \
   '["Bash(git add *)","Bash(git commit --amend)","Bash(git push --force-with-lease *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
 OUT=$(run "$REPO" "$CFG7B")
@@ -170,6 +170,16 @@ assert_contains "flag-specific commit rule leaves git commit a gap" "$OUT" "'git
 assert_contains "flag-specific push rule leaves git push a gap" "$OUT" "'git push'"
 assert_not_contains "the open gh pr create rule is not a gap" "$OUT" "'gh pr create'"
 assert_eq "two flag-masked verbs → two (b) gaps" "2" "$(run "$REPO" "$CFG7B" --count)"
+
+# --- Case 7c: a bare-exact allow rule is NOT coverage -----------------------
+CFG7C="$TEST_TMPDIR/cfg7c"
+# Bash(git commit) permits only the argumentless command; a lane invocation
+# always carries args, so a bare-exact allow must NOT count as covering the verb.
+write_settings "$CFG7C" \
+  '["Bash(git add *)","Bash(git commit)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+OUT=$(run "$REPO" "$CFG7C")
+assert_contains "bare-exact commit rule leaves git commit a gap" "$OUT" "'git commit'"
+assert_eq "bare-exact allow → one gap" "1" "$(run "$REPO" "$CFG7C" --count)"
 
 # --- Case 8: worktree root not covered → GAP (c) ----------------------------
 CFG8="$TEST_TMPDIR/cfg8"
@@ -190,33 +200,37 @@ assert_contains "no root arg emits NOTE (c)" "$OUT" "NOTE (c)"
 assert_contains "NOTE (c) explains it was not checked" "$OUT" "not checked"
 assert_eq "no root arg is a note, not a gap" "0" "$(run "$REPO" "$CFG3" --count)"
 
-# --- Case 11: project settings.local.json is unioned in ---------------------
+# --- Case 11: interactive path unions in project settings.local.json --------
 REPO2="$TEST_TMPDIR/proj-local"
 mkdir -p "$REPO2"
 git init -q "$REPO2"
 PROJ="$(git -C "$REPO2" rev-parse --show-toplevel)"
 mkdir -p "$PROJ/.claude"
-# User-global misses gh pr create; project settings.local.json supplies it.
+# User-global misses gh pr create; project settings.local.json supplies it. The
+# interactive/default path (no --worktree-root) reads local, so the gap closes.
+# (The autonomous path excludes local — that is case 16.)
 CFG11="$TEST_TMPDIR/cfg11"
 write_settings "$CFG11" \
   '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
   "$WIN_ROOT"
 jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$PROJ/.claude/settings.local.json"
-assert_eq "project settings.local.json closes the verb gap" "0" "$(run "$REPO2" "$CFG11" --count --worktree-root "$POSIX_CHILD")"
+assert_eq "interactive path reads settings.local.json" "0" "$(run "$REPO2" "$CFG11" --count)"
 
 # --- Case 12: --count is a bare integer -------------------------------------
 CNT=$(run "$NONREPO" "$CFG8" --count --worktree-root "$POSIX_CHILD")
 assert_eq "count of the one (c) gap (note (a) excluded)" "1" "$CNT"
 
 # --- Case 13: --project-root reads the worker worktree's own settings --------
-# The main checkout grants gh pr create in its project settings; a dispatched
-# worker worktree does not. Without --project-root the main grant MASKS the
-# worker gap; --project-root pointing at the worker surfaces it.
+# The main checkout grants gh pr create in its TRACKED project settings.json (a
+# fresh worktree would carry it too); a dispatched worker worktree here does not.
+# Without --project-root the main grant MASKS the worker gap; --project-root
+# pointing at the worker surfaces it. Tracked (not local) so it is independent of
+# the autonomous local-exclusion under test in case 16.
 MAINCO="$TEST_TMPDIR/main-checkout"
 git init -q "$MAINCO"
 MAINTOP="$(git -C "$MAINCO" rev-parse --show-toplevel)"
 mkdir -p "$MAINTOP/.claude"
-jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$MAINTOP/.claude/settings.local.json"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$MAINTOP/.claude/settings.json"
 WORKER="$TEST_TMPDIR/worker-worktree"
 git init -q "$WORKER"
 # User-global carries the other three probe verbs plus the trusted root, but not
@@ -260,6 +274,26 @@ OUT=$(run "$REPO" "$CFG15")
 assert_contains "deny-only verb is a gap" "$OUT" "'git add'"
 assert_contains "deny-only gap has the DENIED message" "$OUT" "is DENIED"
 assert_eq "deny-only verb → exactly one gap" "1" "$(run "$REPO" "$CFG15" --count)"
+
+# --- Case 16: --worktree-root excludes settings.local.json from coverage -----
+# A grant present ONLY in this checkout's gitignored settings.local.json is not
+# carried by a fresh worktree. The interactive path reads local (gap closed); the
+# autonomous path (--worktree-root) drops local, so the worker-side gap surfaces.
+REPO3="$TEST_TMPDIR/local-mask"
+git init -q "$REPO3"
+PROJ3="$(git -C "$REPO3" rev-parse --show-toplevel)"
+mkdir -p "$PROJ3/.claude"
+CFG16="$TEST_TMPDIR/cfg16"
+# User-global carries four verbs plus the trusted root; local supplies gh pr create.
+write_settings "$CFG16" \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$PROJ3/.claude/settings.local.json"
+assert_eq "interactive path reads local grant → no gap" "0" "$(run "$REPO3" "$CFG16" --count)"
+OUT=$(run "$REPO3" "$CFG16" --worktree-root "$POSIX_CHILD")
+assert_contains "autonomous path drops local → gh pr create gap surfaces" "$OUT" "'gh pr create'"
+assert_contains "report header notes the local exclusion" "$OUT" "settings.local.json"
+assert_eq "autonomous path drops local grant → one gap" "1" "$(run "$REPO3" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
 
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -69,7 +69,7 @@ write_settings() {
     --args "$@" >"$cfg/settings.json"
 }
 
-FULL_ALLOW='["Bash(git commit *)","Bash(git push)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+FULL_ALLOW='["Bash(git add *)","Bash(git commit *)","Bash(git push)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
 
 # Runtime-assembled Windows path (no contiguous path literal in source).
 # shellcheck disable=SC1003  # BS is a literal single backslash, not a quote escape
@@ -118,7 +118,7 @@ assert_eq "non-repo is a note, not a gap" "0" "$(run "$NONREPO" "$CFG3" --count 
 CFG5="$TEST_TMPDIR/cfg5"
 # All probe verbs but gh pr create (mirrors this fleet's interim-stopgap gap).
 write_settings "$CFG5" \
-  '["Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
   "$WIN_ROOT"
 OUT=$(run "$REPO" "$CFG5" --worktree-root "$POSIX_CHILD")
 assert_contains "missing verb emits GAP (b)" "$OUT" "GAP (b)"
@@ -127,12 +127,23 @@ assert_contains "GAP points at the standards floor" "$OUT" "components/claude-pe
 assert_not_contains "present verbs not flagged" "$OUT" "'git commit'"
 assert_eq "one missing verb → one gap" "1" "$(run "$REPO" "$CFG5" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Case 5b: git add is a probed verb --------------------------------------
+# A commit flow stages first, so `git add` must be probed alongside the others.
+CFG5B="$TEST_TMPDIR/cfg5b"
+# Everything but git add.
+write_settings "$CFG5B" \
+  '["Bash(git commit *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+OUT=$(run "$REPO" "$CFG5B" --worktree-root "$POSIX_CHILD")
+assert_contains "missing git add emits a gap" "$OUT" "'git add'"
+assert_eq "git add is the only missing verb → one gap" "1" "$(run "$REPO" "$CFG5B" --count --worktree-root "$POSIX_CHILD")"
+
 # --- Case 6: verb spelling variants all recognized --------------------------
 CFG6="$TEST_TMPDIR/cfg6"
 # Exact (git push), starred (git commit *), colon (gh issue comment:*), and a
 # PowerShell-spelled rule (gh pr create) — every probe covered by a distinct form.
 write_settings "$CFG6" \
-  '["Bash(git commit *)","Bash(git push)","PowerShell(gh pr create *)","Bash(gh issue comment:*)"]'
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push)","PowerShell(gh pr create *)","Bash(gh issue comment:*)"]'
 # No worktree-root arg → (c) is a note, so --count reflects only the (b) verb probe.
 assert_eq "all spelling variants recognized → 0 (b) gaps" "0" "$(run "$REPO" "$CFG6" --count)"
 OUT=$(run "$REPO" "$CFG6")
@@ -142,9 +153,23 @@ assert_not_contains "spelling variants leave no (b) gap" "$OUT" "GAP (b)"
 CFG7="$TEST_TMPDIR/cfg7"
 # git commit-tree must NOT satisfy the 'git commit' probe.
 write_settings "$CFG7" \
-  '["Bash(git commit-tree *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+  '["Bash(git add *)","Bash(git commit-tree *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
 OUT=$(run "$REPO" "$CFG7" --worktree-root "$POSIX_CHILD")
 assert_contains "commit-tree does not cover commit" "$OUT" "'git commit'"
+
+# --- Case 7b: flag-specific rule does NOT cover the bare verb ----------------
+CFG7B="$TEST_TMPDIR/cfg7b"
+# A flag-scoped commit rule and a force-with-lease-only push rule are narrower
+# than the plain verb — the lane's arbitrary `git commit` / `git push` would
+# still prompt — so they must NOT count as coverage; only the bare verb or its
+# open-glob form does.
+write_settings "$CFG7B" \
+  '["Bash(git add *)","Bash(git commit --amend)","Bash(git push --force-with-lease *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+OUT=$(run "$REPO" "$CFG7B")
+assert_contains "flag-specific commit rule leaves git commit a gap" "$OUT" "'git commit'"
+assert_contains "flag-specific push rule leaves git push a gap" "$OUT" "'git push'"
+assert_not_contains "the open gh pr create rule is not a gap" "$OUT" "'gh pr create'"
+assert_eq "two flag-masked verbs → two (b) gaps" "2" "$(run "$REPO" "$CFG7B" --count)"
 
 # --- Case 8: worktree root not covered → GAP (c) ----------------------------
 CFG8="$TEST_TMPDIR/cfg8"
@@ -174,7 +199,7 @@ mkdir -p "$PROJ/.claude"
 # User-global misses gh pr create; project settings.local.json supplies it.
 CFG11="$TEST_TMPDIR/cfg11"
 write_settings "$CFG11" \
-  '["Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
   "$WIN_ROOT"
 jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$PROJ/.claude/settings.local.json"
 assert_eq "project settings.local.json closes the verb gap" "0" "$(run "$REPO2" "$CFG11" --count --worktree-root "$POSIX_CHILD")"
@@ -182,6 +207,59 @@ assert_eq "project settings.local.json closes the verb gap" "0" "$(run "$REPO2" 
 # --- Case 12: --count is a bare integer -------------------------------------
 CNT=$(run "$NONREPO" "$CFG8" --count --worktree-root "$POSIX_CHILD")
 assert_eq "count of the one (c) gap (note (a) excluded)" "1" "$CNT"
+
+# --- Case 13: --project-root reads the worker worktree's own settings --------
+# The main checkout grants gh pr create in its project settings; a dispatched
+# worker worktree does not. Without --project-root the main grant MASKS the
+# worker gap; --project-root pointing at the worker surfaces it.
+MAINCO="$TEST_TMPDIR/main-checkout"
+git init -q "$MAINCO"
+MAINTOP="$(git -C "$MAINCO" rev-parse --show-toplevel)"
+mkdir -p "$MAINTOP/.claude"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$MAINTOP/.claude/settings.local.json"
+WORKER="$TEST_TMPDIR/worker-worktree"
+git init -q "$WORKER"
+# User-global carries the other three probe verbs plus the trusted root, but not
+# gh pr create — so only the project layer decides that verb.
+CFG13="$TEST_TMPDIR/cfg13"
+write_settings "$CFG13" \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+assert_eq "main-checkout grant masks the gap without --project-root" "0" "$(run "$MAINCO" "$CFG13" --count --worktree-root "$POSIX_CHILD")"
+OUT=$(run "$MAINCO" "$CFG13" --project-root "$WORKER" --worktree-root "$POSIX_CHILD")
+assert_contains "--project-root surfaces the worker-side gap" "$OUT" "'gh pr create'"
+assert_eq "worker-side gap counted under --project-root" "1" "$(run "$MAINCO" "$CFG13" --project-root "$WORKER" --count --worktree-root "$POSIX_CHILD")"
+
+# write_deny <config-dir> <allow-json-array> <deny-json-array>
+write_deny() {
+  local cfg="$1" allow="$2" deny="$3"
+  mkdir -p "$cfg"
+  jq -n --argjson a "$allow" --argjson d "$deny" \
+    '{permissions:{allow:$a, deny:$d}}' >"$cfg/settings.json"
+}
+
+# --- Case 14: allow + deny same verb → GAP (denied, deny wins) ---------------
+CFG14="$TEST_TMPDIR/cfg14"
+# git commit is BOTH allowed and denied (open-shape) — deny wins, so it stays a gap.
+write_deny "$CFG14" \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]' \
+  '["Bash(git commit *)"]'
+OUT=$(run "$REPO" "$CFG14")
+assert_contains "allowed-but-denied verb is a gap" "$OUT" "'git commit'"
+assert_contains "denied gap has the distinct DENIED message" "$OUT" "is DENIED"
+assert_not_contains "denied verb not reported as a missing-allow gap" "$OUT" "no Bash()/PowerShell() allow rule covers 'git commit'"
+assert_eq "allow+deny same verb → exactly one gap" "1" "$(run "$REPO" "$CFG14" --count)"
+
+# --- Case 15: deny-only verb → GAP (denied) ---------------------------------
+CFG15="$TEST_TMPDIR/cfg15"
+# git add is denied and not allowed anywhere; the other four are allowed.
+write_deny "$CFG15" \
+  '["Bash(git commit *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]' \
+  '["Bash(git add)"]'
+OUT=$(run "$REPO" "$CFG15")
+assert_contains "deny-only verb is a gap" "$OUT" "'git add'"
+assert_contains "deny-only gap has the DENIED message" "$OUT" "is DENIED"
+assert_eq "deny-only verb → exactly one gap" "1" "$(run "$REPO" "$CFG15" --count)"
 
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Regression tests for preflight.sh (self-contained — ships with the plugin).
+#
+# Every check is injected via fixtures: PREFLIGHT_FIXTURE_DIR is the probe root
+# (a bare temp dir is not-a-repo; `git init` makes it one) and CLAUDE_CONFIG_DIR
+# points user-global settings at a fixture so the real ~/.claude never leaks in.
+# Windows-path fixtures are assembled from separator fragments so no contiguous
+# machine-path literal appears in this file's source bytes.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/preflight.sh"
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+FAILED=0
+CASE_NUM=0
+
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  detail: %s\n' "$1" "$2" >&2
+}
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected: $2, actual: $3"; fi
+}
+assert_exit() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected exit $2, got $3"; fi
+}
+assert_contains() {
+  case "$2" in
+    *"$3"*) pass "$1" ;;
+    *) fail "$1" "expected to contain: $3" ;;
+  esac
+}
+assert_not_contains() {
+  case "$2" in
+    *"$3"*) fail "$1" "unexpected substring: $3" ;;
+    *) pass "$1" ;;
+  esac
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not installed" >&2
+  exit 0
+fi
+
+# run <fixture-dir> <config-dir> [args...]
+run() {
+  local fx="$1" cfg="$2"
+  shift 2
+  PREFLIGHT_FIXTURE_DIR="$fx" CLAUDE_CONFIG_DIR="$cfg" bash "$SCRIPT" "$@"
+}
+
+# write_settings <config-dir> <allow-json-array> [dir ...]
+# additionalDirectories entries are passed as plain path strings and JSON-encoded
+# by jq (--args), so backslash-bearing Windows paths never break the JSON.
+write_settings() {
+  local cfg="$1" allow="$2"
+  shift 2
+  mkdir -p "$cfg"
+  jq -n --argjson a "$allow" \
+    '{permissions:{allow:$a, additionalDirectories:$ARGS.positional}}' \
+    --args "$@" >"$cfg/settings.json"
+}
+
+FULL_ALLOW='["Bash(git commit *)","Bash(git push)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+
+# Runtime-assembled Windows path (no contiguous path literal in source).
+# shellcheck disable=SC1003  # BS is a literal single backslash, not a quote escape
+BS='\'
+SL='/'
+WIN_ROOT="D:${BS}repos${BS}.worktrees"
+POSIX_CHILD="${SL}d${SL}repos${SL}.worktrees${SL}495-x"
+
+# --- Case 1: --help ----------------------------------------------------------
+rc=0
+OUT=$(bash "$SCRIPT" --help) || rc=$?
+assert_exit "--help exits 0" 0 "$rc"
+assert_contains "--help prints usage" "$OUT" "Usage:"
+
+# --- Case 2: missing jq exits 2 ---------------------------------------------
+real_bash=$(command -v bash)
+empty_path_dir="$TEST_TMPDIR/empty-path"
+mkdir -p "$empty_path_dir"
+rc=0
+err_out=$(PATH="$empty_path_dir" "$real_bash" "$SCRIPT" 2>&1) || rc=$?
+assert_exit "exit 2 when jq missing" 2 "$rc"
+assert_contains "jq required message" "$err_out" "jq required"
+
+# --- Case 3: clean repo, full grants, covered worktree root → OK -------------
+REPO="$TEST_TMPDIR/clean-repo"
+mkdir -p "$REPO"
+git init -q "$REPO"
+CFG3="$TEST_TMPDIR/cfg3"
+write_settings "$CFG3" "$FULL_ALLOW" "$WIN_ROOT"
+rc=0
+OUT=$(run "$REPO" "$CFG3" --worktree-root "$POSIX_CHILD") || rc=$?
+assert_exit "clean run exits 0" 0 "$rc"
+assert_contains "clean run reports OK" "$OUT" "PREFLIGHT: OK"
+assert_not_contains "clean run has no GAP" "$OUT" "GAP"
+assert_eq "clean run gap count 0" "0" "$(run "$REPO" "$CFG3" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 4: non-repo cwd → NOTE (a), still zero gaps ------------------------
+NONREPO="$TEST_TMPDIR/not-a-repo"
+mkdir -p "$NONREPO"
+OUT=$(run "$NONREPO" "$CFG3" --worktree-root "$POSIX_CHILD")
+assert_contains "non-repo emits NOTE (a)" "$OUT" "NOTE (a)"
+assert_contains "non-repo names the dir" "$OUT" "is not a git repository"
+assert_eq "non-repo is a note, not a gap" "0" "$(run "$NONREPO" "$CFG3" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 5: missing verb → GAP (b) -----------------------------------------
+CFG5="$TEST_TMPDIR/cfg5"
+# All probe verbs but gh pr create (mirrors this fleet's interim-stopgap gap).
+write_settings "$CFG5" \
+  '["Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+OUT=$(run "$REPO" "$CFG5" --worktree-root "$POSIX_CHILD")
+assert_contains "missing verb emits GAP (b)" "$OUT" "GAP (b)"
+assert_contains "GAP names the missing verb" "$OUT" "'gh pr create'"
+assert_contains "GAP points at the standards floor" "$OUT" "components/claude-permissions"
+assert_not_contains "present verbs not flagged" "$OUT" "'git commit'"
+assert_eq "one missing verb → one gap" "1" "$(run "$REPO" "$CFG5" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 6: verb spelling variants all recognized --------------------------
+CFG6="$TEST_TMPDIR/cfg6"
+# Exact (git push), starred (git commit *), colon (gh issue comment:*), and a
+# PowerShell-spelled rule (gh pr create) — every probe covered by a distinct form.
+write_settings "$CFG6" \
+  '["Bash(git commit *)","Bash(git push)","PowerShell(gh pr create *)","Bash(gh issue comment:*)"]'
+# No worktree-root arg → (c) is a note, so --count reflects only the (b) verb probe.
+assert_eq "all spelling variants recognized → 0 (b) gaps" "0" "$(run "$REPO" "$CFG6" --count)"
+OUT=$(run "$REPO" "$CFG6")
+assert_not_contains "spelling variants leave no (b) gap" "$OUT" "GAP (b)"
+
+# --- Case 7: verb-boundary false-positive guard -----------------------------
+CFG7="$TEST_TMPDIR/cfg7"
+# git commit-tree must NOT satisfy the 'git commit' probe.
+write_settings "$CFG7" \
+  '["Bash(git commit-tree *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]'
+OUT=$(run "$REPO" "$CFG7" --worktree-root "$POSIX_CHILD")
+assert_contains "commit-tree does not cover commit" "$OUT" "'git commit'"
+
+# --- Case 8: worktree root not covered → GAP (c) ----------------------------
+CFG8="$TEST_TMPDIR/cfg8"
+write_settings "$CFG8" "$FULL_ALLOW" "/some/other/root"
+OUT=$(run "$REPO" "$CFG8" --worktree-root "$POSIX_CHILD")
+assert_contains "uncovered root emits GAP (c)" "$OUT" "GAP (c)"
+assert_contains "GAP (c) names additionalDirectories" "$OUT" "additionalDirectories"
+assert_eq "uncovered root → one gap" "1" "$(run "$REPO" "$CFG8" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 9: cross-form Windows/POSIX path coverage --------------------------
+# additionalDirectories entry in Windows form (D:\repos\.worktrees) must cover a
+# child expressed in git-bash POSIX form (/d/repos/.worktrees/495-x).
+assert_eq "Windows-form entry covers POSIX-form child" "0" "$(run "$REPO" "$CFG3" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 10: worktree root not provided → NOTE (c), no gap -----------------
+OUT=$(run "$REPO" "$CFG3")
+assert_contains "no root arg emits NOTE (c)" "$OUT" "NOTE (c)"
+assert_contains "NOTE (c) explains it was not checked" "$OUT" "not checked"
+assert_eq "no root arg is a note, not a gap" "0" "$(run "$REPO" "$CFG3" --count)"
+
+# --- Case 11: project settings.local.json is unioned in ---------------------
+REPO2="$TEST_TMPDIR/proj-local"
+mkdir -p "$REPO2"
+git init -q "$REPO2"
+PROJ="$(git -C "$REPO2" rev-parse --show-toplevel)"
+mkdir -p "$PROJ/.claude"
+# User-global misses gh pr create; project settings.local.json supplies it.
+CFG11="$TEST_TMPDIR/cfg11"
+write_settings "$CFG11" \
+  '["Bash(git commit *)","Bash(git push *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$PROJ/.claude/settings.local.json"
+assert_eq "project settings.local.json closes the verb gap" "0" "$(run "$REPO2" "$CFG11" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 12: --count is a bare integer -------------------------------------
+CNT=$(run "$NONREPO" "$CFG8" --count --worktree-root "$POSIX_CHILD")
+assert_eq "count of the one (c) gap (note (a) excluded)" "1" "$CNT"
+
+if [[ "$FAILED" -eq 0 ]]; then
+  printf '\nAll %d checks passed.\n' "$CASE_NUM"
+  exit 0
+fi
+printf '\n%d/%d checks failed.\n' "$FAILED" "$CASE_NUM" >&2
+exit 1


### PR DESCRIPTION
## Summary

Ships #495's three fix directions:

1. **Reviewed permissions recipe by pointer**: `reference/permission-preflight.md` cites the standards `claude-permissions` component (the fleet's canonical allow/deny floor, merged today: 60 allow incl. PowerShell read-parity, 244 deny) composed operator-side via the dotfiles chezmoi seam — no restated list to drift.
2. **Trusted worktree-root guidance**: the sibling out-of-tree worktree root plus the matching `permissions.additionalDirectories` entry, root-agnostic.
3. **Loop-start preflight check**: `skills/work/scripts/preflight.sh` reports ONCE, up front — cwd-not-a-repo (note), probed core verbs (`git commit`, `git push`, `gh pr create`, `gh issue comment`) uncovered by any allow rule, worktree root not in `additionalDirectories`. Always exits 0 (report-only), `--count` for scripted gating, no live permission probe. **Never self-applies**: the auto-mode classifier blocks an agent editing its own `permissions.allow` (empirically hit during #495's own remediation attempt), so the check detects and points at operator-side remediation. Wired as the work skill's first loop-start action; babysit-prs applicability noted by pointer (no cross-plugin edit).

28/28 hermetic test cases; shellcheck/shfmt/markdownlint/typos/validate-plugin-contracts/changelog-parity all green. Live smoke on this machine correctly flagged two real gaps. Version 0.17.0 (composed above the concurrently-merged 0.16.0 container-verbs entry).

## Related

- melodic-software/standards#210 (the claude-permissions floor this consumes)
- melodic-software/dotfiles#242 (the composition seam the remediation points at)
- #697 (the mining evidence for the report-only constraint)

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)
