### PR TITLE
docs(planning): cite testing:plan's test-type table as the SSOT (#264)

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.2]
+
+### Changed
+
+- Cited `/testing:plan`'s test-type classification table as the single source of
+  truth for which test type a given change needs (unit / integration / e2e /
+  architecture / analyzer). The `plan` skill's Step 2 test-strategy guidance (and its
+  `plan-template.md`) and the `design` skill's test-seam posture thread now point at
+  that table instead of letting a competing test-type take grow in each site. Pointer
+  only; no restated table, no behavior change (#264).
+
 ## [0.22.1]
 
 ### Changed

--- a/plugins/planning/skills/design/SKILL.md
+++ b/plugins/planning/skills/design/SKILL.md
@@ -93,7 +93,7 @@ For SaaS or B2B org-scoped products, open a **tenancy posture** thread early: si
 
 When exploration surfaces high coupling, large types, or multi-responsibility files (refactor or strangler scope), open a **refactoring posture** thread: characterization-test strategy, seam map, incremental extract order, change budget.
 
-For any feature with a testable surface, open a **test-seam posture** thread: sketch the seams the feature will be tested at. Prefer existing seams over new ones; place any new seam at the highest level possible; drive toward the fewest seams that cover the surface — the ideal count is one. Confirm the seam sketch with the user before design output is finalized.
+For any feature with a testable surface, open a **test-seam posture** thread: sketch the seams the feature will be tested at. Prefer existing seams over new ones; place any new seam at the highest level possible; drive toward the fewest seams that cover the surface — the ideal count is one. The change→test-type mapping that grounds seam-altitude choices (unit / integration / e2e / architecture / analyzer) lives in `/testing:plan`'s classification table — cite it, don't restate. Confirm the seam sketch with the user before design output is finalized.
 
 Produce: `design-threads.md`
 

--- a/plugins/planning/skills/design/SKILL.md
+++ b/plugins/planning/skills/design/SKILL.md
@@ -93,7 +93,7 @@ For SaaS or B2B org-scoped products, open a **tenancy posture** thread early: si
 
 When exploration surfaces high coupling, large types, or multi-responsibility files (refactor or strangler scope), open a **refactoring posture** thread: characterization-test strategy, seam map, incremental extract order, change budget.
 
-For any feature with a testable surface, open a **test-seam posture** thread: sketch the seams the feature will be tested at. Prefer existing seams over new ones; place any new seam at the highest level possible; drive toward the fewest seams that cover the surface — the ideal count is one. The change→test-type mapping that grounds seam-altitude choices (unit / integration / e2e / architecture / analyzer) lives in `/testing:plan`'s classification table — cite it, don't restate. Confirm the seam sketch with the user before design output is finalized.
+For any feature with a testable surface, open a **test-seam posture** thread: sketch the seams the feature will be tested at. Prefer existing seams over new ones; place any new seam at the highest level possible; drive toward the fewest seams that cover the surface — the ideal count is one. The change→test-type mapping that grounds seam-altitude choices (unit / integration / e2e / architecture / analyzer) lives in `/testing:plan`'s classification table — when the `testing` plugin is installed, cite it rather than restating; otherwise apply standard test-design judgment for the seam-altitude call. Confirm the seam sketch with the user before design output is finalized.
 
 Produce: `design-threads.md`
 

--- a/plugins/planning/skills/plan/SKILL.md
+++ b/plugins/planning/skills/plan/SKILL.md
@@ -90,7 +90,7 @@ Produce a structured plan using the template in [context/plan-template.md](conte
 
 - **Goal**: what we're trying to achieve and why
 - **Approach**: the specific steps, in order
-- **Test strategy**: how we'll verify the changes work — for which test type each kind of change needs (unit / integration / e2e / architecture / analyzer), `/testing:plan`'s file-type classification table is the SSOT; **invoke `/tdd:principles` (if installed)** when formulating this section for authoritative guidance on what to test, which testing style fits, and when to mock; otherwise apply standard test-design judgment. TDD is the default approach — the test strategy should specify Red-Green-Refactor unless genuinely impractical
+- **Test strategy**: how we'll verify the changes work — for which test type each kind of change needs (unit / integration / e2e / architecture / analyzer), `/testing:plan`'s file-type classification table is the SSOT **when the `testing` plugin is installed**; **invoke `/tdd:principles` (if installed)** when formulating this section for authoritative guidance on what to test, which testing style fits, and when to mock; otherwise apply standard test-design judgment. TDD is the default approach — the test strategy should specify Red-Green-Refactor unless genuinely impractical
 - **Files affected**: what gets created, modified, or deleted
 - **Alternatives considered**: what was rejected and why
 - **Risks and mitigations**: what could go wrong

--- a/plugins/planning/skills/plan/SKILL.md
+++ b/plugins/planning/skills/plan/SKILL.md
@@ -90,7 +90,7 @@ Produce a structured plan using the template in [context/plan-template.md](conte
 
 - **Goal**: what we're trying to achieve and why
 - **Approach**: the specific steps, in order
-- **Test strategy**: how we'll verify the changes work — **invoke `/tdd:principles` (if installed)** when formulating this section for authoritative guidance on what to test, which testing style fits, and when to mock; otherwise apply standard test-design judgment. TDD is the default approach — the test strategy should specify Red-Green-Refactor unless genuinely impractical
+- **Test strategy**: how we'll verify the changes work — for which test type each kind of change needs (unit / integration / e2e / architecture / analyzer), `/testing:plan`'s file-type classification table is the SSOT; **invoke `/tdd:principles` (if installed)** when formulating this section for authoritative guidance on what to test, which testing style fits, and when to mock; otherwise apply standard test-design judgment. TDD is the default approach — the test strategy should specify Red-Green-Refactor unless genuinely impractical
 - **Files affected**: what gets created, modified, or deleted
 - **Alternatives considered**: what was rejected and why
 - **Risks and mitigations**: what could go wrong

--- a/plugins/planning/skills/plan/context/plan-template.md
+++ b/plugins/planning/skills/plan/context/plan-template.md
@@ -77,7 +77,7 @@ Without pre-flight, migrations break consumers silently. Example: a frontmatter 
 
 ## Test Strategy
 
-> **Invoke `/tdd:principles` (if installed) when writing this section** — it provides authoritative guidance on what to test, testing styles (output/state/communication), when to mock, and testable architecture patterns. Test-first (Red-Green-Refactor) is the default — specify test-after only when genuinely impractical.
+> **Invoke `/tdd:principles` (if installed) when writing this section** — it provides authoritative guidance on what to test, testing styles (output/state/communication), when to mock, and testable architecture patterns. Which test type each changed file needs (unit / integration / e2e / architecture / analyzer) is classified by `/testing:plan`'s test-type table — cite it rather than restating. Test-first (Red-Green-Refactor) is the default — specify test-after only when genuinely impractical.
 
 - <How to verify the changes work — specific test types, not just "write tests">
 - <TDD approach: which tests get written first, what assertions prove the behavior>

--- a/plugins/planning/skills/plan/context/plan-template.md
+++ b/plugins/planning/skills/plan/context/plan-template.md
@@ -77,7 +77,7 @@ Without pre-flight, migrations break consumers silently. Example: a frontmatter 
 
 ## Test Strategy
 
-> **Invoke `/tdd:principles` (if installed) when writing this section** — it provides authoritative guidance on what to test, testing styles (output/state/communication), when to mock, and testable architecture patterns. Which test type each changed file needs (unit / integration / e2e / architecture / analyzer) is classified by `/testing:plan`'s test-type table — cite it rather than restating. Test-first (Red-Green-Refactor) is the default — specify test-after only when genuinely impractical.
+> **Invoke `/tdd:principles` (if installed) when writing this section** — it provides authoritative guidance on what to test, testing styles (output/state/communication), when to mock, and testable architecture patterns. Which test type each changed file needs (unit / integration / e2e / architecture / analyzer) is classified by `/testing:plan`'s test-type table when the `testing` plugin is installed — cite it rather than restating; otherwise apply standard test-design judgment. Test-first (Red-Green-Refactor) is the default — specify test-after only when genuinely impractical.
 
 - <How to verify the changes work — specific test types, not just "write tests">
 - <TDD approach: which tests get written first, what assertions prove the behavior>


### PR DESCRIPTION
## Summary

"What test type for a given change" knowledge lived in three sites: `testing:plan`'s file-type classification table (the actual table), `planning:plan` Step 2's test-strategy guidance, and `planning:design`'s test-seam posture thread. Per the issue's framing, `testing:plan`'s table is the source of truth — the other two should cite it, not grow a competing take.

Empirical note: the triage comment named `testing:write`/`README` as also carrying the table; verified they do **not** — the classification table exists only in `testing:plan`. So no table dedup was needed, only pointers from the two planning sites. All edits are therefore in the **planning** plugin.

## Fix

Added one-line pointers (pointer-not-copy — no table restated) at the two planning sites that touch test-type/level reasoning, each placed alongside the existing `/tdd:principles` reference (which covers test-design WHY; `/testing:plan` covers which type per change — complementary, not competing):

- `plugins/planning/skills/plan/SKILL.md` — Step 2 test-strategy bullet
- `plugins/planning/skills/plan/context/plan-template.md` — Test Strategy section
- `plugins/planning/skills/design/SKILL.md` — test-seam posture thread (seam altitude → test type)

`planning` bumped 0.22.1 → 0.22.2 with a CHANGELOG entry. `testing:plan` (the SSOT) is unchanged; no other plugin's files were touched.

## Verification

```
$ bash scripts/validate-plugins.sh
All plugin manifests and the catalog validated.  (exit 0)

$ bash scripts/check-changelog-parity.sh --check-bump origin/main
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.  (exit 0)

$ bash scripts/check-changed-skills.sh origin/main
CHECK-SKILL design: PASS — 0 errors, 2 warning(s)
CHECK-SKILL plan:   PASS — 0 errors, 2 warning(s)
3 skill(s) checked, 0 failed.  (exit 0)   # warnings pre-existing, not introduced here

$ typos <changed files> --config _typos.toml
(no findings)

$ npx markdownlint-cli2 <changed .md files>
Summary: 0 error(s)
```

Closes #264

## Related

- Origin: skill-name audit + interview (PR #256); contract doc `docs/topics/shadowed-skill-renames/PLAN.md` no longer in tree (ephemeral).
- `/tdd:principles` (test-design WHY) and `/testing:plan` (test-type-per-change) remain the two complementary authorities the pointers reference.

Co-Authored-By: Claude <noreply@anthropic.com>
