### PR TITLE
docs(review): document quality-gate code mode vs built-in /code-review boundary

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.7]
+
+### Added
+
+- **`quality-gate` code mode documents its boundary with the built-in
+  `/code-review`.** The mode triggers on "code review" and reviews the current
+  diff — the same target Claude Code's bundled `/code-review` skill covers — yet
+  `context/code.md` never acknowledged the built-in existed, leaving a user with
+  no basis to choose between them. The context file now carries a **Boundary**
+  section: reach for this mode when the review must ground in the project's own
+  standards and severity vocabulary (resolved through the standards index), stay
+  report-only, and land in the gate's unified findings report; reach for the
+  always-available built-in `/code-review` for a fast zero-dependency pass or its
+  `ultra` cloud deep-dive when project-standards grounding is not the point,
+  noting that its `--fix` / `--comment` flags mutate and sit outside the review
+  modes' report-only contract. Documents the boundary rather than dispatching the
+  built-in as a leaf surface — code mode's convention-grounded dispatch
+  (`pr-review-toolkit` / `code-reviewer`) is not duplicated review logic that a
+  thin router would remove, and delegating to the generic built-in would drop the
+  standards grounding, the unified report, and the report-only guarantee.
+
 ## [0.14.6]
 
 ### Fixed

--- a/plugins/review/skills/quality-gate/context/code.md
+++ b/plugins/review/skills/quality-gate/context/code.md
@@ -2,6 +2,13 @@
 
 Specialized multi-aspect code feedback during development, before the formal PR gate.
 
+## Boundary — the bundled `/code-review` command
+
+Claude Code ships a built-in `/code-review` bundled skill that reviews the same target this mode does — the branch's commits ahead of upstream plus uncommitted working-tree changes — for correctness bugs and reuse, simplification, and efficiency cleanups. It is always available (no plugin install), honors effort levels, and its `ultra` argument runs a deeper cloud review. Because it overlaps this mode on the "code review" trigger and the current diff, choose deliberately:
+
+- **This mode** when the review must ground in the project's own standards and severity vocabulary (resolved through the standards index), stay report-only, and land in the gate's unified findings report alongside the other lenses. It dispatches convention-aware reviewers — the paths below.
+- **`/code-review`** for a fast zero-dependency pass, or its `ultra` cloud deep-dive, when project-standards grounding is not the point. It does not read `REVIEW.md`, and its `--fix` / `--comment` flags mutate the working tree or PR — outside this mode's report-only contract, so reach for those only on explicit user opt-in (the sibling `pr` mode gates the same side effect).
+
 ## Primary path — `pr-review-toolkit` orchestrator plugin (when installed)
 
 When the `pr-review-toolkit` plugin (from the `claude-plugins-official` marketplace) is available, invoke `/pr-review-toolkit:review-pr` with aspects detected from the changed files:

--- a/plugins/review/skills/quality-gate/context/code.md
+++ b/plugins/review/skills/quality-gate/context/code.md
@@ -2,9 +2,9 @@
 
 Specialized multi-aspect code feedback during development, before the formal PR gate.
 
-## Boundary — the bundled `/code-review` command
+## Boundary — the built-in `/code-review` skill
 
-Claude Code ships a built-in `/code-review` bundled skill that reviews the same target this mode does — the branch's commits ahead of upstream plus uncommitted working-tree changes — for correctness bugs and reuse, simplification, and efficiency cleanups. It is always available (no plugin install), honors effort levels, and its `ultra` argument runs a deeper cloud review. Because it overlaps this mode on the "code review" trigger and the current diff, choose deliberately:
+Claude Code ships a built-in `/code-review` bundled skill that reviews the same target this mode does — the branch's commits ahead of upstream plus uncommitted working-tree changes — for correctness bugs and reuse, simplification, and efficiency cleanups. It is always available (no plugin install), honors effort levels, and its `ultra` mode runs a deeper cloud review. Because it overlaps this mode on the "code review" trigger and the current diff, choose deliberately:
 
 - **This mode** when the review must ground in the project's own standards and severity vocabulary (resolved through the standards index), stay report-only, and land in the gate's unified findings report alongside the other lenses. It dispatches convention-aware reviewers — the paths below.
 - **`/code-review`** for a fast zero-dependency pass, or its `ultra` cloud deep-dive, when project-standards grounding is not the point. It does not read `REVIEW.md`, and its `--fix` / `--comment` flags mutate the working tree or PR — outside this mode's report-only contract, so reach for those only on explicit user opt-in (the sibling `pr` mode gates the same side effect).

--- a/plugins/review/skills/quality-gate/context/code.md
+++ b/plugins/review/skills/quality-gate/context/code.md
@@ -6,7 +6,7 @@ Specialized multi-aspect code feedback during development, before the formal PR 
 
 Claude Code ships a built-in `/code-review` bundled skill that reviews the same target this mode does — the branch's commits ahead of upstream plus uncommitted working-tree changes — for correctness bugs and reuse, simplification, and efficiency cleanups. It is always available (no plugin install), honors effort levels, and its `ultra` mode runs a deeper cloud review. Because it overlaps this mode on the "code review" trigger and the current diff, choose deliberately:
 
-- **This mode** when the review must ground in the project's own standards and severity vocabulary (resolved through the standards index), stay report-only, and land in the gate's unified findings report alongside the other lenses. It dispatches convention-aware reviewers — the paths below.
+- **This mode** when the review must ground in the project's own standards and severity vocabulary (resolved through the standards index), stay report-only, and land in the gate's unified findings report. It dispatches convention-aware reviewers — the paths below. (This is one lens per invocation; for a breadth fan-out across many review surfaces, reach for this plugin's `fanout` skill.)
 - **`/code-review`** for a fast zero-dependency pass, or its `ultra` cloud deep-dive, when project-standards grounding is not the point. It does not read `REVIEW.md`, and its `--fix` / `--comment` flags mutate the working tree or PR — outside this mode's report-only contract, so reach for those only on explicit user opt-in (the sibling `pr` mode gates the same side effect).
 
 ## Primary path — `pr-review-toolkit` orchestrator plugin (when installed)


### PR DESCRIPTION
Closes #266

## Summary

`quality-gate`'s code mode triggers on "code review" and reviews the current diff — the same job Claude Code's bundled `/code-review` skill does — yet `context/code.md` never mentioned the built-in, leaving a user or agent with no basis to choose between them.

## Fix

Chose **Option A (document the boundary)** over Option B (dispatch `/code-review` as a leaf surface). Added a **Boundary** section to `plugins/review/skills/quality-gate/context/code.md`:

- **This mode** when the review must ground in the project's own standards and severity vocabulary (resolved through the standards index), stay report-only, and land in the gate's unified findings report alongside the other lenses.
- **Built-in `/code-review`** for a fast zero-dependency pass or its `ultra` cloud deep-dive when project-standards grounding is not the point — noting it does not read `REVIEW.md` and its `--fix` / `--comment` flags mutate (outside the review modes' report-only contract).

Option B was rejected: code mode's dispatch (`pr-review-toolkit` / `code-reviewer`) is already convention-aware routing, not duplicated review logic a thin router would remove. Delegating to the generic built-in would drop the standards grounding, the unified report, and the report-only guarantee — and `/code-review`'s `--fix`/`--comment` side effects would breach the same report-only contract the sibling `pr` mode already gates. Name stays `quality-gate` (per the issue).

`plugins/review` version bumped `0.14.6` → `0.14.7` (docs-only patch) with a top-inserted `CHANGELOG.md` entry.

## Verification

`/code-review` facts confirmed against official docs (https://code.claude.com/docs/en/code-review, commands/skills references): bundled built-in skill; local review covers "branch's commits ahead of upstream plus uncommitted changes" for "correctness bugs and reuse, simplification, and efficiency cleanups"; does not read `REVIEW.md`; supports `--fix`/`--comment`, effort levels, and `ultra` cloud deep-dive.

```
$ python -c "import json; ... plugin.json"
plugin.json: valid JSON, version 0.14.7

$ npx markdownlint-cli2@0.23.0 <changed .md files>
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Linting: 2 file(s)
Summary: 0 error(s)
```

## Related

- Refs #732 — deferred: `pr.md`/README still frame `code-review` as an optional marketplace plugin (stale; it is bundled/built-in). Out of scope for this PR; needs its own verification pass to untangle the local command vs the managed GitHub App service.