### PR TITLE
feat(guardrails): block non-canonical git commit; drop --trailer conjunct

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
@@ -50,6 +50,12 @@
       "description": "Block Bash file-write workarounds that circumvent Write/Edit hook gates",
       "default": true
     },
+    "block_noncanonical_commit_enabled": {
+      "type": "boolean",
+      "title": "block-noncanonical-commit guard",
+      "description": "Block `git commit` that does not pipe its message via `-F -`; --amend, -C/-c, --fixup/--squash, -F <path>, and an in-progress merge/rebase are exempt",
+      "default": true
+    },
     "cli_flag_verify_enabled": {
       "type": "boolean",
       "title": "cli-flag-verify guard",
@@ -84,6 +90,12 @@
       "type": "string",
       "title": "block-dangerous-git allow-list",
       "description": "Comma-separated forms block-dangerous-git permits: push-force, reset-hard, clean-force, checkout-dot, restore-dot, checkout-force; empty blocks all",
+      "default": ""
+    },
+    "block_noncanonical_commit_allow": {
+      "type": "string",
+      "title": "block-noncanonical-commit allow-list",
+      "description": "Comma-separated form tokens to allow (currently: message-flag, which permits a bare `-m`)",
       "default": ""
     }
   }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,40 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.0]
+
+### Added
+
+- **`block-noncanonical-commit` — `git commit` must pipe its message via `-F -`.** The advisory that
+  previously covered this was overridden 11 times in a single session; an advisory that is always
+  overridden trains the reader to filter it out. The guard enforces the *mechanic*, not the ritual:
+  `git commit -m "<multi-line>"` flattens newlines unpredictably across shells, and the stdin form is
+  what prevents it. Exempt, because no message-on-stdin form exists for them and gating them would
+  strand real work: `--amend`/`--no-edit`, `-C`/`-c`/`--reuse-message`/`--reedit-message`,
+  `--fixup`/`--squash`, `-F <path>`, and any commit taken while a merge, rebase, cherry-pick, or
+  revert is in progress. Kill switch `block_noncanonical_commit_enabled`; allow-list
+  `block_noncanonical_commit_allow` (`message-flag` permits a bare `-m`). Detection reuses the
+  argv-grammar-faithful parser, so `bash -lc` wrappers and git aliases resolve and a commit body
+  merely *mentioning* `git commit -m` never fires.
+
+### Fixed
+
+- **`flag-commit-pr-skill-bypass` no longer demands `--trailer`.** The old condition required both
+  `-F -` **and** `--trailer`, but `/commit` omits the trailer when the resolved `trailer_policy` is
+  `none` — so in a repo whose convention forbids a co-author trailer, the skill's own conformant
+  output was flagged on every commit. The trailer is policy; only the stdin form is mechanic. This
+  also had to be settled before the new guard could block on the same condition: requiring
+  `--trailer` to pass would have permanently blocked `/commit` in that configuration.
+
+### Changed
+
+- **`flag-commit-pr-skill-bypass` is now `gh pr create`-only.** The `git commit` branch moved to
+  `block-noncanonical-commit`, so the two never double-fire on one command. `gh pr create` stays
+  advisory and cannot become otherwise: `/pull-request create` issues that exact command itself, and
+  [anthropics/claude-code#22655](https://github.com/anthropics/claude-code/issues/22655) (expose
+  `skill_name` to hooks) is closed as not planned — a hook cannot tell a skill-driven call from an
+  ad hoc one, so blocking it would deadlock the skill.
+
 ## [0.8.0]
 
 ### Changed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -17,9 +17,11 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   revert is in progress. Kill switch `block_noncanonical_commit_enabled`; allow-list
   `block_noncanonical_commit_allow` (`message-flag` permits a bare `-m`). Detection reuses the
   argv-grammar-faithful parser, so `bash -lc` wrappers resolve and a commit body merely *mentioning*
-  `git commit -m` never fires. Aliases are expanded before the subcommand verdict — inline `-c` and
-  aliases persisted in git config alike — closing the hole where `git c -m x` reads as subcommand `c`
-  and walks straight through. `git -C <path>` is honored when probing sequencer state, so a conflict
+  `git commit -m` never fires. Aliases are expanded before the subcommand verdict — inline `-c`
+  (last value wins, as git applies it) and aliases persisted in git config alike — closing the hole
+  where `git c -m x` reads as subcommand `c` and walks straight through. `--config-env` aliases are a
+  documented residual: the shared parser stores their value undifferentiated from `-c`, so the
+  environment variable *name* arrives in place of the expansion (tracked separately). `git -C <path>` is honored when probing sequencer state, so a conflict
   resolution driven at another repo reads that repo's state rather than the session cwd's.
 
 ### Fixed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -17,8 +17,10 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   revert is in progress. Kill switch `block_noncanonical_commit_enabled`; allow-list
   `block_noncanonical_commit_allow` (`message-flag` permits a bare `-m`). Detection reuses the
   argv-grammar-faithful parser, so `bash -lc` wrappers resolve and a commit body merely *mentioning*
-  `git commit -m` never fires. Inline aliases are expanded before the subcommand verdict, closing the
-  hole where `git -c alias.c=commit c -m x` reads as subcommand `c` and walks straight through.
+  `git commit -m` never fires. Aliases are expanded before the subcommand verdict — inline `-c` and
+  aliases persisted in git config alike — closing the hole where `git c -m x` reads as subcommand `c`
+  and walks straight through. `git -C <path>` is honored when probing sequencer state, so a conflict
+  resolution driven at another repo reads that repo's state rather than the session cwd's.
 
 ### Fixed
 

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -16,8 +16,9 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   `--fixup`/`--squash`, `-F <path>`, and any commit taken while a merge, rebase, cherry-pick, or
   revert is in progress. Kill switch `block_noncanonical_commit_enabled`; allow-list
   `block_noncanonical_commit_allow` (`message-flag` permits a bare `-m`). Detection reuses the
-  argv-grammar-faithful parser, so `bash -lc` wrappers and git aliases resolve and a commit body
-  merely *mentioning* `git commit -m` never fires.
+  argv-grammar-faithful parser, so `bash -lc` wrappers resolve and a commit body merely *mentioning*
+  `git commit -m` never fires. Inline aliases are expanded before the subcommand verdict, closing the
+  hole where `git -c alias.c=commit c -m x` reads as subcommand `c` and walks straight through.
 
 ### Fixed
 

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -1,6 +1,6 @@
 # guardrails
 
-A Claude Code plugin bundling eight **safety guards** that catch risky agent
+A Claude Code plugin bundling nine **safety guards** that catch risky agent
 actions the moment they happen — before a write lands or a bash command runs.
 Each guard is independently toggleable, so you run exactly the subset you want.
 
@@ -15,9 +15,10 @@ Each guard is independently toggleable, so you run exactly the subset you want.
 | **block-hook-bypass** | PreToolUse · Bash | **Blocks** (exit 2) | Bash file-write workarounds that circumvent the Write/Edit hook gates — `cat > file`, `echo … > file`, and `python3 -c` with file-write indicators. Executable-token detection ignores quoted prose/commit text that merely mentions the pattern. |
 | **cli-flag-verify** | PostToolUse · Write \| Edit | **Advisory** (exit 0) | Hallucinated CLI flags — a `--flag` written as a command that does not exist in the binary's actual `--help` output. Surfaces via `additionalContext`, never blocks. |
 | **workflow-resilience-check** | PreToolUse · Workflow | **Advisory** (exit 0) | Un-throttled Workflow fan-out — a script calling `parallel()` / `pipeline()` with no wave-cap throttle (`inWaves` / `inWavesPipeline`) and no retry wrapper (`agentRetry`), which risks a burst 529 under wide Opus fan-out. Surfaces a resilience checklist via `additionalContext`, never blocks. |
-| **flag-commit-pr-skill-bypass** | PreToolUse · Bash | **Advisory** (exit 0) | Direct `git commit` (missing the canonical `-F -` stdin form + `--trailer` Co-Authored-By line) or any `gh pr create`, bypassing this marketplace's own `/commit` / `/pull-request create` skills. Only fires when the consuming project's own `.claude/settings.json` enables the `source-control` plugin — silent otherwise. Surfaces via `additionalContext`, never blocks. |
+| **block-noncanonical-commit** | PreToolUse · Bash | **Blocks** (exit 2) | `git commit` that does not pipe its message via `-F -` / `--file -` — `-m` flattens newlines unpredictably across shells. Exempt: `--amend`, `-C`/`-c`/`--reuse-message`/`--reedit-message`, `--fixup`/`--squash`, `-F <path>`, and any commit taken while a merge/rebase/cherry-pick/revert is in progress. Resolves `bash -lc` wrappers and git aliases (inline `-c` and persisted config alike). |
+| **flag-commit-pr-skill-bypass** | PreToolUse · Bash | **Advisory** (exit 0) | Any `gh pr create`, bypassing this marketplace's own `/pull-request create` skill. Only fires when the consuming project's own `.claude/settings.json` enables the `source-control` plugin — silent otherwise. Surfaces via `additionalContext`, never blocks. |
 
-The five blocking guards feed their stderr message back to Claude as
+The six blocking guards feed their stderr message back to Claude as
 actionable fix guidance. The three advisory guards surface their findings the same
 way but always allow the operation.
 
@@ -56,12 +57,20 @@ way but always allow the operation.
   literal-stripped top-level regex match, not a full argv-grammar parser — it
   does not evaluate shell variable / command substitution, and a determined
   author can construct a form that evades it. It cannot tell "the skill ran
-  this exact command" from "someone hand-typed the same shape" — for
-  `git commit` it targets the anti-pattern (`-m` without the canonical
-  `-F -` + `--trailer`), not literal `/commit` invocation; for `gh pr create`
-  there is no command-shape signature at all, so every direct call is flagged.
-  Always advisory (never blocks) — `create.md` itself documents a legitimate
+  this exact command" from "someone hand-typed the same shape", and for
+  `gh pr create` there is no command-shape signature at all, so every direct
+  call is flagged. It stays advisory and cannot become otherwise:
+  `/pull-request create` issues that exact command itself, so blocking it would
+  deadlock the skill being advertised. `create.md` also documents a legitimate
   inline fallback when skill discovery is broken.
+
+- **`block-noncanonical-commit` gates shape, not skill invocation.** No hook can
+  see which skill (if any) originated a Bash call, so "did you run `/commit`" is
+  not an available condition — and shape is the better target regardless, since
+  it enforces an outcome verifiable in `git log`. It deliberately does not
+  require `--trailer`: `/commit` omits the trailer under a resolved
+  `trailer_policy` of `none`, so demanding it would block the skill's own
+  conformant output in repos whose convention forbids co-author trailers.
 
 ## Per-hook kill switches
 
@@ -76,6 +85,7 @@ contract — disable one guard without touching the others.
 | block-no-verify | `block_no_verify_enabled` |
 | block-dangerous-git | `block_dangerous_git_enabled` |
 | block-hook-bypass | `block_hook_bypass_enabled` |
+| block-noncanonical-commit | `block_noncanonical_commit_enabled` |
 | cli-flag-verify | `cli_flag_verify_enabled` |
 | workflow-resilience-check | `workflow_resilience_check_enabled` |
 | flag-commit-pr-skill-bypass | `flag_commit_pr_skill_bypass_enabled` |

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -43,9 +43,15 @@
 #
 # Detection is ARGV-GRAMMAR-FAITHFUL via the shared parser in hook-utils.sh, so
 # a commit body merely MENTIONING `git commit -m` never fires, and `bash -lc`
-# wrappers plus git aliases are resolved (inline `-c` and persisted config
-# alike). Static matching over the literal
+# wrappers plus git aliases are resolved — inline `-c` (last value wins, as git
+# does) and aliases persisted in git config.
+#
+# RESIDUAL: `--config-env=alias.X=VAR` is not resolved. The shared parser stores
+# its value undifferentiated from `-c`, so the environment VARIABLE NAME reaches
+# this code in place of the expansion, and separating them needs a hook-utils
+# change that block-dangerous-git shares. Static matching over the literal
 # command string only: shell variable / command substitution is not evaluated.
+# This is a friction guard against the accidental anti-pattern, not a sandbox.
 #
 # BLOCKING: exits 2 when a commit would take its message off the command line.
 
@@ -145,6 +151,7 @@ sequencer_in_progress() {
 check_segment() {
   local -a w=()
   local gi sub sub_idx nseg k word next stdin_form=0 exempt=0 saw_commit=0
+  local inline_alias_handled=0
 
   # A shell -c wrapper (`bash -lc 'git commit -m x'`) executes its operand as a
   # full shell command — re-parse it with the same tokenizer.
@@ -174,9 +181,15 @@ check_segment() {
     local cv exp reparse a
     local -a cfgv=() expw=()
     cfgv=(${HOOK_GIT_CONFIG_VALUES[@]+"${HOOK_GIT_CONFIG_VALUES[@]}"})
+    # LAST value wins, matching git: `-c alias.c=status -c alias.c=commit`
+    # runs commit. Taking the first match would let a decoy earlier value
+    # (expanding to a harmless subcommand) mask the real one.
+    exp=""
     for cv in ${cfgv[@]+"${cfgv[@]}"}; do
-      [[ "$cv" == "alias.${sub}="* ]] || continue
-      exp="${cv#*=}"
+      [[ "$cv" == "alias.${sub}="* ]] && exp="${cv#*=}"
+    done
+    if [[ -n "$exp" ]]; then
+      inline_alias_handled=1
       if [[ "$exp" == '!'* ]]; then
         reparse="${exp#!}"
         for a in "${w[@]:sub_idx+1}"; do reparse+=" $(printf '%q' "$a")"; done
@@ -188,14 +201,13 @@ check_segment() {
         check_segment "${w[@]:0:gi+1}" ${expw[@]+"${expw[@]}"} "${w[@]:sub_idx+1}"
         HOOK_NO_ALIAS=0
       fi
-      break
-    done
+    fi
 
     # An alias can also live in .git/config, ~/.gitconfig, or system config,
     # where HOOK_GIT_CONFIG_VALUES cannot see it — `git config alias.c commit`
     # then `git c -m x` would otherwise pass. Ask git for the resolved value
     # (its own precedence applies) only when no inline alias already matched.
-    if ((${HOOK_NO_ALIAS:-0} == 0)) && [[ "$sub" != "commit" ]]; then
+    if ((${HOOK_NO_ALIAS:-0} == 0)) && ((inline_alias_handled == 0)) && [[ "$sub" != "commit" ]]; then
       local pexp
       pexp=$(git -C "$(effective_dir "${w[@]}")" config --get "alias.$sub" 2>/dev/null)
       if [[ -n "$pexp" ]]; then

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -110,6 +110,29 @@ allowed() {
 # conflict resolution driven at another repo via `-C` reads the WRONG repo's
 # state — the sequencer probe and the alias lookup would both answer for the
 # session cwd instead of the repo actually being committed to.
+# Value of an explicit `--git-dir` (attached or separated), empty when absent.
+# A commit driven with --git-dir concludes a sequencer in THAT git dir, so
+# probing the cwd's state would refuse to exempt a real in-progress merge.
+# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
+explicit_git_dir() {
+  local i n=$# arg
+  local -a a=("$@")
+  for ((i = 0; i < n; i++)); do
+    arg="${a[i]}"
+    case "$arg" in
+    --git-dir)
+      ((i + 1 < n)) && printf '%s' "${a[i + 1]}"
+      return 0
+      ;;
+    --git-dir=*)
+      printf '%s' "${arg#--git-dir=}"
+      return 0
+      ;;
+    *) ;;
+    esac
+  done
+}
+
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 effective_dir() {
   local base="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}" i n=$# arg
@@ -135,11 +158,18 @@ effective_dir() {
 # an uncertain answer must not silently open the gate.
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 sequencer_in_progress() {
-  local dir f repo="$1"
-  # --absolute-git-dir, not --git-dir: the latter answers relative to the repo,
-  # which would resolve against the HOOK's cwd here and silently miss every
-  # sequencer file.
-  dir=$(git -C "$repo" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  local dir f repo="$1" explicit="$2"
+  if [[ -n "$explicit" ]]; then
+    # An explicit --git-dir names the git dir outright; asking git to resolve it
+    # would just echo it back, and `-C` may point somewhere unrelated.
+    dir="$explicit"
+    [[ "$dir" == /* || "$dir" =~ ^[A-Za-z]:[\/] ]] || dir="$repo/$dir"
+  else
+    # --absolute-git-dir, not --git-dir: the latter answers relative to the repo,
+    # which would resolve against the HOOK's cwd here and silently miss every
+    # sequencer file.
+    dir=$(git -C "$repo" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  fi
   [[ -n "$dir" ]] || return 1
   for f in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD rebase-merge rebase-apply; do
     [[ -e "$dir/$f" ]] && return 0
@@ -273,7 +303,7 @@ check_segment() {
   ((saw_commit)) || return 0
   ((stdin_form || exempt)) && return 0
   allowed "message-flag" && return 0
-  sequencer_in_progress "$(effective_dir "${w[@]}")" && return 0
+  sequencer_in_progress "$(effective_dir "${w[@]}")" "$(explicit_git_dir "${w[@]}")" && return 0
 
   echo "BLOCKED: \`git commit\` without \`-F -\` — the message must be piped via stdin." >&2
   echo "Use the /commit skill (source-control plugin), or its canonical form directly:" >&2

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block `git commit` that does not feed its message via stdin.
+# Triggered on Bash tool calls.
+#
+# WHAT IT ENFORCES — the mechanic, not the ritual:
+#   `git commit -F -` (or `--file -`), the form the /commit skill emits. The
+#   failure mode it prevents is real and silent: `git commit -m "<multi-line>"`
+#   flattens newlines unpredictably across shells, so a body that looked right
+#   in the tool call lands mangled in history.
+#
+# WHY NOT `--trailer`: the trailer is POLICY, not mechanic. /commit itself
+# omits it when the resolved trailer_policy is `none`, and a repo whose
+# convention forbids a co-author trailer is a documented, supported case.
+# Gating on it would permanently block the skill's own canonical output in that
+# configuration. Only the stdin form belongs in a gate.
+#
+# WHY NOT "did you type /commit": a hook cannot tell a skill-driven Bash call
+# from an ad hoc one — anthropics/claude-code#22655 (add skill_name to hook
+# payloads) is closed as not planned. Gating on command SHAPE is what is
+# actually available, and is the better target anyway: it enforces the outcome
+# a reviewer can verify in `git log`, not the ceremony that produced it.
+#
+# NOT BLOCKED (no message-on-stdin form exists for these, and gating them would
+# break conflict resolution and history rewriting):
+#   --amend / --no-edit          reusing an existing message
+#   -C / --reuse-message         "
+#   -c / --reedit-message        "
+#   --fixup / --squash           message derived from another commit
+#   -F <path> / --file <path>    mechanic satisfied, just not via stdin
+#   -m during an in-progress sequencer (merge / rebase / cherry-pick / revert):
+#                                conflict resolution and rebase continuation
+#                                must never be gated
+#
+# Per-repo/per-user allow-list: the `block_noncanonical_commit_allow` userConfig
+# option is a comma-separated list of form tokens (currently just
+# "message-flag", which allows a bare `-m`). Set it with
+# `/plugin configure guardrails` or headless via `claude plugin install
+# --config`; read from the CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ALLOW
+# process mirror. Kill switch: `block_noncanonical_commit_enabled` set to false.
+#
+# Detection is ARGV-GRAMMAR-FAITHFUL via the shared parser in hook-utils.sh, so
+# a commit body merely MENTIONING `git commit -m` never fires, and `bash -lc`
+# wrappers plus git aliases are resolved. Static matching over the literal
+# command string only: shell variable / command substitution is not evaluated.
+#
+# BLOCKING: exits 2 when a commit would take its message off the command line.
+
+set -uo pipefail
+
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "BLOCK_NONCANONICAL_COMMIT"
+
+# High-res start stamp for the telemetry envelope. EPOCHREALTIME is Bash 5.0+;
+# on older bash it is unset, so default to empty and skip telemetry (the block
+# still fires). Referencing it bare under `set -u` would abort before exit.
+start=${EPOCHREALTIME:-}
+
+# jq is required to parse the tool payload. Fail OPEN when it is absent, but
+# make the degraded state visible rather than silently disabling the guard.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "guardrails/block-noncanonical-commit: jq not found on PATH — guard disabled (install jq to enable)." >&2
+  exit 0
+fi
+
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read. rc 1
+# (empty stdin) skips; rc 2 (read timed out before a complete payload) FAILS
+# CLOSED — the guard cannot evaluate the tool call, and a silent skip would pass
+# exactly the traffic this guard exists to stop.
+INPUT=$(hook::buffer_stdin) || {
+  rc=$?
+  ((rc == 2)) && exit 2
+  exit 0
+}
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
+[[ -n "$COMMAND" ]] || exit 0
+HOOK_CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null | tr -d '\r')
+
+SUBJECT=$(hook::extract_bash_subject "Bash" "$COMMAND")
+
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::telemetry_enabled || return 0
+  local data
+  data=$(jq -n --arg subject "$SUBJECT" --arg form "$2" \
+    '{tool:"Bash",subject:$subject,form:$form}' 2>/dev/null) || data='{"tool":"Bash","subject":"","form":""}'
+  hook::emit_telemetry "block-noncanonical-commit" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
+}
+
+# Is a form token in the block_noncanonical_commit_allow userConfig comma list?
+# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
+allowed() {
+  local tok="$1" list=",${CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ALLOW:-},"
+  [[ "$list" == *,"$tok",* ]]
+}
+
+# Is a merge / rebase / cherry-pick / revert in progress? Those commits carry a
+# prepared message git supplies, and `git commit` there is the documented way to
+# conclude the operation — gating it would strand a conflict resolution
+# mid-flight. Unknown git state answers "no": this is the permissive branch, so
+# an uncertain answer must not silently open the gate.
+# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
+sequencer_in_progress() {
+  local dir f
+  # --absolute-git-dir, not --git-dir: the latter answers relative to the repo,
+  # which would resolve against the HOOK's cwd here and silently miss every
+  # sequencer file.
+  dir=$(git -C "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  [[ -n "$dir" ]] || return 1
+  for f in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD rebase-merge rebase-apply; do
+    [[ -e "$dir/$f" ]] && return 0
+  done
+  return 1
+}
+
+# shellcheck disable=SC2329  # invoked indirectly as the hook::bash_parse_segments callback
+check_segment() {
+  local -a w=()
+  local gi sub sub_idx nseg k word next stdin_form=0 exempt=0 saw_commit=0
+
+  # A shell -c wrapper (`bash -lc 'git commit -m x'`) executes its operand as a
+  # full shell command — re-parse it with the same tokenizer.
+  if hook::shell_c_operand "$@"; then
+    hook::bash_parse_segments "$HOOK_SHELL_C_OPERAND" check_segment
+    return 0
+  fi
+
+  hook::git_resolve_index "$@" || return 0
+  gi=$HOOK_GIT_RESOLVED_GI
+  w=("${HOOK_GIT_RESOLVED_WORDS[@]}")
+  nseg=${#w[@]}
+
+  hook::git_resolve_subcommand "$gi" "${w[@]}" || return 0
+  sub=$HOOK_GIT_SUB
+  sub_idx=$HOOK_GIT_SUB_IDX
+  [[ "$sub" == "commit" ]] || return 0
+  saw_commit=1
+
+  # Scan only the words AFTER the subcommand: a top-level `git -c foo=bar` is
+  # config, while `-c` after `commit` is --reedit-message.
+  for ((k = sub_idx + 1; k < nseg; k++)); do
+    word="${w[k]}"
+    next=""
+    ((k + 1 < nseg)) && next="${w[k + 1]}"
+    case "$word" in
+    --)
+      break
+      ;;
+    -F | --file)
+      if [[ "$next" == "-" ]]; then stdin_form=1; else exempt=1; fi
+      ((k++))
+      ;;
+    -F- | --file=-)
+      stdin_form=1
+      ;;
+    --file=*)
+      exempt=1
+      ;;
+    -F*)
+      exempt=1
+      ;;
+    --amend | --no-edit | --fixup | --squash | -C | -c | --reuse-message | --reedit-message)
+      exempt=1
+      ;;
+    --fixup=* | --squash=* | --reuse-message=* | --reedit-message=*)
+      exempt=1
+      ;;
+    -C* | -c*)
+      exempt=1
+      ;;
+    *)
+      # Any other word (paths, -a, -S, --cleanup, the -m payload) is not a
+      # message-source marker and needs no handling here.
+      ;;
+    esac
+  done
+
+  ((saw_commit)) || return 0
+  ((stdin_form || exempt)) && return 0
+  allowed "message-flag" && return 0
+  sequencer_in_progress && return 0
+
+  echo "BLOCKED: \`git commit\` without \`-F -\` — the message must be piped via stdin." >&2
+  echo "Use the /commit skill (source-control plugin), or its canonical form directly:" >&2
+  echo "  git commit -F - --cleanup=verbatim <<'EOF'" >&2
+  echo "  <subject>" >&2
+  echo "  EOF" >&2
+  echo "A \`-m\` message flattens newlines unpredictably across shells. --amend, -C/-c," >&2
+  echo "--fixup/--squash, -F <path>, and an in-progress merge/rebase are exempt." >&2
+  emit_tel "blocked" "message-flag"
+  exit 2
+}
+
+hook::bash_parse_segments "$COMMAND" check_segment
+
+emit_tel "ok" ""
+exit 0

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -22,7 +22,10 @@
 #
 # NOT BLOCKED (no message-on-stdin form exists for these, and gating them would
 # break conflict resolution and history rewriting):
-#   --amend / --no-edit          reusing an existing message
+#   --amend                      reusing an existing message
+#     (--no-edit alone is NOT exempt: `git commit --no-edit -m x` is an
+#      ordinary commit. Amending is covered by --amend; a merge's --no-edit is
+#      covered by the sequencer branch.)
 #   -C / --reuse-message         "
 #   -c / --reedit-message        "
 #   --fixup / --squash           message derived from another commit
@@ -40,7 +43,8 @@
 #
 # Detection is ARGV-GRAMMAR-FAITHFUL via the shared parser in hook-utils.sh, so
 # a commit body merely MENTIONING `git commit -m` never fires, and `bash -lc`
-# wrappers plus git aliases are resolved. Static matching over the literal
+# wrappers plus git aliases are resolved (inline `-c` and persisted config
+# alike). Static matching over the literal
 # command string only: shell variable / command substitution is not evaluated.
 #
 # BLOCKING: exits 2 when a commit would take its message off the command line.
@@ -95,6 +99,29 @@ allowed() {
   [[ "$list" == *,"$tok",* ]]
 }
 
+# Effective repo directory for a segment: the hook payload's cwd, with any
+# `git -C <path>` applied (last wins, relative joined onto cwd). Without this a
+# conflict resolution driven at another repo via `-C` reads the WRONG repo's
+# state — the sequencer probe and the alias lookup would both answer for the
+# session cwd instead of the repo actually being committed to.
+# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
+effective_dir() {
+  local base="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}" i n=$# arg
+  local -a a=("$@")
+  for ((i = 0; i < n; i++)); do
+    arg="${a[i]}"
+    if [[ "$arg" == "-C" ]] && ((i + 1 < n)); then
+      if [[ "${a[i + 1]}" == /* || "${a[i + 1]}" =~ ^[A-Za-z]:[\/] ]]; then
+        base="${a[i + 1]}"
+      else
+        base="$base/${a[i + 1]}"
+      fi
+      ((i++))
+    fi
+  done
+  printf '%s' "$base"
+}
+
 # Is a merge / rebase / cherry-pick / revert in progress? Those commits carry a
 # prepared message git supplies, and `git commit` there is the documented way to
 # conclude the operation — gating it would strand a conflict resolution
@@ -102,11 +129,11 @@ allowed() {
 # an uncertain answer must not silently open the gate.
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 sequencer_in_progress() {
-  local dir f
+  local dir f repo="$1"
   # --absolute-git-dir, not --git-dir: the latter answers relative to the repo,
   # which would resolve against the HOOK's cwd here and silently miss every
   # sequencer file.
-  dir=$(git -C "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+  dir=$(git -C "$repo" rev-parse --absolute-git-dir 2>/dev/null) || return 1
   [[ -n "$dir" ]] || return 1
   for f in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD rebase-merge rebase-apply; do
     [[ -e "$dir/$f" ]] && return 0
@@ -163,6 +190,30 @@ check_segment() {
       fi
       break
     done
+
+    # An alias can also live in .git/config, ~/.gitconfig, or system config,
+    # where HOOK_GIT_CONFIG_VALUES cannot see it — `git config alias.c commit`
+    # then `git c -m x` would otherwise pass. Ask git for the resolved value
+    # (its own precedence applies) only when no inline alias already matched.
+    if ((${HOOK_NO_ALIAS:-0} == 0)) && [[ "$sub" != "commit" ]]; then
+      local pexp
+      pexp=$(git -C "$(effective_dir "${w[@]}")" config --get "alias.$sub" 2>/dev/null)
+      if [[ -n "$pexp" ]]; then
+        if [[ "$pexp" == '!'* ]]; then
+          local preparse pa
+          preparse="${pexp#!}"
+          for pa in "${w[@]:sub_idx+1}"; do preparse+=" $(printf '%q' "$pa")"; done
+          hook::bash_parse_segments "$preparse" check_segment
+        else
+          local -a pexpw=()
+          hook::env_s_split "$pexp"
+          pexpw=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"})
+          HOOK_NO_ALIAS=1
+          check_segment "${w[@]:0:gi+1}" ${pexpw[@]+"${pexpw[@]}"} "${w[@]:sub_idx+1}"
+          HOOK_NO_ALIAS=0
+        fi
+      fi
+    fi
   fi
 
   [[ "$sub" == "commit" ]] || return 0
@@ -191,7 +242,7 @@ check_segment() {
     -F*)
       exempt=1
       ;;
-    --amend | --no-edit | --fixup | --squash | -C | -c | --reuse-message | --reedit-message)
+    --amend | --fixup | --squash | -C | -c | --reuse-message | --reedit-message)
       exempt=1
       ;;
     --fixup=* | --squash=* | --reuse-message=* | --reedit-message=*)
@@ -210,7 +261,7 @@ check_segment() {
   ((saw_commit)) || return 0
   ((stdin_form || exempt)) && return 0
   allowed "message-flag" && return 0
-  sequencer_in_progress && return 0
+  sequencer_in_progress "$(effective_dir "${w[@]}")" && return 0
 
   echo "BLOCKED: \`git commit\` without \`-F -\` — the message must be piped via stdin." >&2
   echo "Use the /commit skill (source-control plugin), or its canonical form directly:" >&2

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -15,8 +15,8 @@
 # configuration. Only the stdin form belongs in a gate.
 #
 # WHY NOT "did you type /commit": a hook cannot tell a skill-driven Bash call
-# from an ad hoc one — anthropics/claude-code#22655 (add skill_name to hook
-# payloads) is closed as not planned. Gating on command SHAPE is what is
+# from an ad hoc one — the payload carries no originating-skill field, and the
+# upstream request to add one was declined. Gating on command SHAPE is what is
 # actually available, and is the better target anyway: it enforces the outcome
 # a reviewer can verify in `git log`, not the ceremony that produced it.
 #

--- a/plugins/guardrails/hooks/block-noncanonical-commit.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.sh
@@ -134,6 +134,37 @@ check_segment() {
   hook::git_resolve_subcommand "$gi" "${w[@]}" || return 0
   sub=$HOOK_GIT_SUB
   sub_idx=$HOOK_GIT_SUB_IDX
+
+  # An inline alias runs its expansion (`git -c alias.c=commit c -m x` commits),
+  # so re-check the expanded command BEFORE concluding the subcommand is not
+  # `commit` — otherwise the alias name is simply not "commit" and the guard
+  # waves it through. A shell alias (leading !) re-parses as a full shell
+  # command; a git alias splices its words in place of the alias name. One level
+  # only — git does not expand the first word of an expansion as another alias —
+  # enforced through HOOK_NO_ALIAS, which dynamic scoping carries into the
+  # recursive call.
+  if ((${HOOK_NO_ALIAS:-0} == 0)); then
+    local cv exp reparse a
+    local -a cfgv=() expw=()
+    cfgv=(${HOOK_GIT_CONFIG_VALUES[@]+"${HOOK_GIT_CONFIG_VALUES[@]}"})
+    for cv in ${cfgv[@]+"${cfgv[@]}"}; do
+      [[ "$cv" == "alias.${sub}="* ]] || continue
+      exp="${cv#*=}"
+      if [[ "$exp" == '!'* ]]; then
+        reparse="${exp#!}"
+        for a in "${w[@]:sub_idx+1}"; do reparse+=" $(printf '%q' "$a")"; done
+        hook::bash_parse_segments "$reparse" check_segment
+      else
+        hook::env_s_split "$exp"
+        expw=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"})
+        HOOK_NO_ALIAS=1
+        check_segment "${w[@]:0:gi+1}" ${expw[@]+"${expw[@]}"} "${w[@]:sub_idx+1}"
+        HOOK_NO_ALIAS=0
+      fi
+      break
+    done
+  fi
+
   [[ "$sub" == "commit" ]] || return 0
   saw_commit=1
 

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Contract test for block-noncanonical-commit.sh (guardrails plugin).
+#
+# Black-box: invokes the hook as a subprocess, pipes PreToolUse Bash JSON on
+# stdin, asserts on exit code (2 = blocked, 0 = allowed). Self-contained — no
+# host-repo assertion library.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/block-noncanonical-commit.sh"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# shellcheck source=guardrails-test-helpers.sh
+source "$HOOK_DIR/guardrails-test-helpers.sh"
+
+# run <label> <command> <expected-exit> [extra-env NAME=VAL ...]
+run() {
+  local label="$1" command="$2" expected="$3"
+  shift 3
+  local rc
+  env "$@" bash "$HOOK" <<<"$(command_json "$command")" >/dev/null 2>&1
+  rc=$?
+  assert_exit "$label" "$expected" "$rc"
+}
+
+# --- the anti-pattern this guard exists for -----------------------------------
+run "git commit -m (blocked)" "git commit -m 'feat: x'" 2
+run "git commit -am (bundled, blocked)" "git commit -am 'feat: x'" 2
+run "git commit -m with --trailer (still blocked — trailer is not the mechanic)" \
+  "git commit -m 'feat: x' --trailer 'Co-Authored-By: X <x@y.z>'" 2
+run "bare git commit (opens EDITOR, blocked)" "git commit" 2
+run "git commit -a (no message source, blocked)" "git commit -a" 2
+
+# --- the canonical form -------------------------------------------------------
+run "git commit -F - (allowed)" "git commit -F - --cleanup=verbatim" 0
+run "git commit --file - (allowed)" "git commit --file - " 0
+run "git commit --file=- (allowed)" "git commit --file=-" 0
+run "git commit -F- (attached, allowed)" "git commit -F-" 0
+
+# The trailer_policy `none` case: /commit's own output when the repo convention
+# forbids a co-author trailer. Requiring --trailer here would deadlock the skill.
+run "git commit -F - without --trailer (allowed — trailer_policy none)" \
+  "git commit -F - --cleanup=verbatim" 0
+
+# --- exempt operations (no message-on-stdin form exists) ----------------------
+run "git commit --amend --no-edit (allowed)" "git commit --amend --no-edit" 0
+run "git commit --amend (allowed)" "git commit --amend" 0
+run "git commit -C HEAD (allowed)" "git commit -C HEAD" 0
+run "git commit --reuse-message=HEAD (allowed)" "git commit --reuse-message=HEAD" 0
+run "git commit --fixup HEAD (allowed)" "git commit --fixup HEAD" 0
+run "git commit --squash=HEAD (allowed)" "git commit --squash=HEAD" 0
+run "git commit -F msg.txt (path, allowed)" "git commit -F msg.txt" 0
+run "git commit --file=msg.txt (path, allowed)" "git commit --file=msg.txt" 0
+
+# --- top-level git options must not be confused with commit options ----------
+# `-c` BEFORE the subcommand is config; only after `commit` is it --reedit.
+run "git -c user.name=x commit -m (config, still blocked)" \
+  "git -c user.name=x commit -m 'feat: x'" 2
+run "git -c user.name=x commit -F - (config, allowed)" \
+  "git -c user.name=x commit -F -" 0
+
+# --- other subcommands are untouched -----------------------------------------
+run "git log (allowed)" "git log --oneline -5" 0
+run "git push (allowed)" "git push origin main" 0
+run "non-git command (allowed)" "echo git commit -m nope" 0
+
+# --- prose containing the anti-pattern is not a false positive ---------------
+run "quoted mention in a heredoc body (allowed)" \
+  "git commit -F - <<'EOF'
+docs: explain why git commit -m 'x' is wrong
+EOF" 0
+
+# --- shell -c wrappers are re-parsed -----------------------------------------
+run "bash -lc wrapped -m (blocked)" "bash -lc \"git commit -m 'feat: x'\"" 2
+run "bash -lc wrapped -F - (allowed)" "bash -lc 'git commit -F -'" 0
+
+# --- control operators: a later segment is still checked ---------------------
+run "second segment carries -m (blocked)" "git add -A && git commit -m 'x'" 2
+
+# --- kill switch and allow-list ----------------------------------------------
+run "kill switch disables the guard" "git commit -m 'feat: x'" 0 \
+  CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ENABLED=false
+run "allow-list message-flag permits -m" "git commit -m 'feat: x'" 0 \
+  CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ALLOW=message-flag
+run "unrelated allow token does not permit -m" "git commit -m 'feat: x'" 2 \
+  CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ALLOW=something-else
+
+# --- in-progress sequencer is exempt -----------------------------------------
+# A real repo mid-merge: `git commit` concludes the merge with the message git
+# prepared, and gating it would strand the conflict resolution.
+SEQ="$TEST_TMPDIR/seq"
+mkdir -p "$SEQ"
+(
+  cd "$SEQ" || exit 1
+  export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+  git init -q .
+  git config user.email t@e.st
+  git config user.name t
+  : >a
+  git add a
+  git commit -qm base --no-verify 2>/dev/null
+) >/dev/null 2>&1
+
+GITDIR="$SEQ/.git"
+if [[ -d "$GITDIR" ]]; then
+  : >"$GITDIR/MERGE_HEAD"
+  rc=0
+  MSYS_NO_PATHCONV=1 jq -n --arg c "git commit -m 'merge fix'" --arg d "$SEQ" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}' |
+    bash "$HOOK" >/dev/null 2>&1
+  rc=$?
+  assert_exit "in-progress merge is exempt" 0 "$rc"
+
+  rm -f "$GITDIR/MERGE_HEAD"
+  MSYS_NO_PATHCONV=1 jq -n --arg c "git commit -m 'not a merge'" --arg d "$SEQ" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}' |
+    bash "$HOOK" >/dev/null 2>&1
+  rc=$?
+  assert_exit "same repo with no sequencer state is blocked" 2 "$rc"
+else
+  echo "ok: sequencer fixture skipped (git init unavailable)"
+  PASS=$((PASS + 1))
+fi
+
+# --- the block message names the fix -----------------------------------------
+out=$(bash "$HOOK" <<<"$(command_json "git commit -m 'feat: x'")" 2>&1)
+assert_contains "block message names -F -" "$out" '-F -'
+assert_contains "block message names the skill" "$out" '/commit'
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+((FAIL == 0))

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -61,6 +61,20 @@ run "git -c user.name=x commit -m (config, still blocked)" \
 run "git -c user.name=x commit -F - (config, allowed)" \
   "git -c user.name=x commit -F -" 0
 
+# --- inline git aliases are expanded before the subcommand verdict -----------
+# `git -c alias.c=commit c -m x` commits. Without expansion the subcommand reads
+# as `c`, not `commit`, and the guard waves the whole thing through.
+run "inline git alias to commit -m (blocked)" \
+  "git -c alias.c=commit c -m bypass" 2
+run "inline git alias carrying -m in the expansion (blocked)" \
+  "git -c alias.ci='commit -m x' ci" 2
+run "inline shell alias (leading !) to commit -m (blocked)" \
+  "git -c alias.sh='!git commit -m x' sh" 2
+run "inline git alias to a canonical commit (allowed)" \
+  "git -c alias.c=commit c -F -" 0
+run "inline alias to an unrelated subcommand (allowed)" \
+  "git -c alias.st=status st" 0
+
 # --- other subcommands are untouched -----------------------------------------
 run "git log (allowed)" "git log --oneline -5" 0
 run "git push (allowed)" "git push origin main" 0

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -83,6 +83,12 @@ run "inline git alias to a canonical commit (allowed)" \
   "git -c alias.c=commit c -F -" 0
 run "inline alias to an unrelated subcommand (allowed)" \
   "git -c alias.st=status st" 0
+# git applies the LAST -c value for a key; taking the first would let a decoy
+# earlier value expanding to a harmless subcommand mask the real one.
+run "last inline alias value wins (blocked)" \
+  "git -c alias.c=status -c alias.c=commit c -m x" 2
+run "last inline alias value wins (allowed when the last is harmless)" \
+  "git -c alias.c=commit -c alias.c=status c -m x" 0
 
 # --- other subcommands are untouched -----------------------------------------
 run "git log (allowed)" "git log --oneline -5" 0

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -15,6 +15,11 @@ trap 'rm -rf "$TEST_TMPDIR"' EXIT
 # shellcheck source=guardrails-test-helpers.sh
 source "$HOOK_DIR/guardrails-test-helpers.sh"
 
+# Isolate every git fixture below from ambient user/system config. Exported once
+# here rather than inside each subshell, so the setting is visibly process-wide
+# and the fixtures stay comparable.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+
 # run <label> <command> <expected-exit> [extra-env NAME=VAL ...]
 run() {
   local label="$1" command="$2" expected="$3"
@@ -46,6 +51,10 @@ run "git commit -F - without --trailer (allowed — trailer_policy none)" \
 
 # --- exempt operations (no message-on-stdin form exists) ----------------------
 run "git commit --amend --no-edit (allowed)" "git commit --amend --no-edit" 0
+# --no-edit is NOT an exemption on its own: git accepts it for an ordinary
+# commit, so exempting it unconditionally would let `--no-edit -m` straight past.
+run "git commit --no-edit -m (blocked — --no-edit is not an amend)" \
+  "git commit --no-edit -m subject" 2
 run "git commit --amend (allowed)" "git commit --amend" 0
 run "git commit -C HEAD (allowed)" "git commit -C HEAD" 0
 run "git commit --reuse-message=HEAD (allowed)" "git commit --reuse-message=HEAD" 0
@@ -108,7 +117,6 @@ SEQ="$TEST_TMPDIR/seq"
 mkdir -p "$SEQ"
 (
   cd "$SEQ" || exit 1
-  export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
   git init -q .
   git config user.email t@e.st
   git config user.name t
@@ -136,6 +144,47 @@ if [[ -d "$GITDIR" ]]; then
 else
   echo "ok: sequencer fixture skipped (git init unavailable)"
   PASS=$((PASS + 1))
+fi
+
+# --- `git -C <repo>` targets another repo's state ----------------------------
+# A conflict resolution driven at another repo must read THAT repo's sequencer
+# state, not the session cwd's.
+if [[ -d "$GITDIR" ]]; then
+  : >"$GITDIR/MERGE_HEAD"
+  MSYS_NO_PATHCONV=1 jq -n --arg c "git -C $SEQ commit -m 'merge fix'" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:"/"}' |
+    bash "$HOOK" >/dev/null 2>&1
+  assert_exit "git -C honors the target repo's in-progress merge" 0 $?
+
+  rm -f "$GITDIR/MERGE_HEAD"
+  MSYS_NO_PATHCONV=1 jq -n --arg c "git -C $SEQ commit -m 'not a merge'" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:"/"}' |
+    bash "$HOOK" >/dev/null 2>&1
+  assert_exit "git -C with no sequencer state in the target repo is blocked" 2 $?
+fi
+
+# --- aliases persisted in git config (not just inline -c) --------------------
+# `git config alias.c commit` lives in .git/config, where the parser's inline
+# -c capture cannot see it; the hook must ask git to resolve it.
+PCFG="$TEST_TMPDIR/persisted"
+mkdir -p "$PCFG"
+(
+  cd "$PCFG" || exit 1
+  git init -q .
+  git config user.email t@e.st
+  git config user.name t
+  git config alias.c commit
+) >/dev/null 2>&1
+
+if [[ -d "$PCFG/.git" ]]; then
+  for spec in "git c -m bypass:2" "git c -F -:0"; do
+    cmd="${spec%:*}"
+    want="${spec##*:}"
+    MSYS_NO_PATHCONV=1 jq -n --arg c "$cmd" --arg d "$PCFG" \
+      '{tool_name:"Bash",tool_input:{command:$c},cwd:$d}' |
+      bash "$HOOK" >/dev/null 2>&1
+    assert_exit "persisted config alias: $cmd" "$want" $?
+  done
 fi
 
 # --- the block message names the fix -----------------------------------------

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -169,6 +169,21 @@ if [[ -d "$GITDIR" ]]; then
   assert_exit "git -C with no sequencer state in the target repo is blocked" 2 $?
 fi
 
+# --- explicit --git-dir names the repo whose sequencer state matters ---------
+if [[ -d "$GITDIR" ]]; then
+  : >"$GITDIR/MERGE_HEAD"
+  MSYS_NO_PATHCONV=1 jq -n --arg c "git --git-dir=$GITDIR --work-tree=$SEQ commit -m x" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:"/"}' |
+    bash "$HOOK" >/dev/null 2>&1
+  assert_exit "--git-dir honors that repo's in-progress merge" 0 $?
+
+  rm -f "$GITDIR/MERGE_HEAD"
+  MSYS_NO_PATHCONV=1 jq -n --arg c "git --git-dir=$GITDIR --work-tree=$SEQ commit -m x" \
+    '{tool_name:"Bash",tool_input:{command:$c},cwd:"/"}' |
+    bash "$HOOK" >/dev/null 2>&1
+  assert_exit "--git-dir with no sequencer state is blocked" 2 $?
+fi
+
 # --- aliases persisted in git config (not just inline -c) --------------------
 # `git config alias.c commit` lives in .git/config, where the parser's inline
 # -c capture cannot see it; the hook must ask git to resolve it.

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# PreToolUse hook: advisory guard for direct `git commit` / `gh pr create`
-# calls that bypass this marketplace's own canonical `/commit` and
-# `/pull-request create` skills (source-control plugin).
+# PreToolUse hook: advisory guard for direct `gh pr create` calls that bypass
+# this marketplace's own canonical `/pull-request create` skill
+# (source-control plugin).
 # Triggered on Bash tool calls.
 #
 # SCOPE — only fires when the source-control plugin's skills are actually
@@ -13,18 +13,17 @@
 # advisory) — an advisory firing on unknown state is noise, not signal.
 #
 # WHAT IT FLAGS:
-#   git commit  — invoked WITHOUT the canonical mechanic's two markers
-#                 (`-F -` piping the message via stdin, and a `--trailer`
-#                 carrying the Co-Authored-By line). A manual `git commit`
-#                 that already replicates the canonical shape (e.g. a
-#                 hand-typed heredoc form) stays quiet — the guard targets the
-#                 anti-pattern (`git commit -m "..."`) /commit exists to
-#                 prevent, not "you didn't literally type /commit".
 #   gh pr create — invoked at all. /pull-request create's value is PROCESS
 #                 (rebase onto default, unrelated-changes triage, closing-
 #                 keyword gate, attribution footer) — there is no command-shape
 #                 signature to gate on, so every direct invocation is flagged.
 #                 Low-noise in practice: `gh pr create` runs once per PR.
+#
+# `git commit` is NOT handled here — it moved to block-noncanonical-commit.sh,
+# which BLOCKS on the stdin-form mechanic. Keeping a duplicate advisory would
+# double-fire on one command. That hook also drops the `--trailer` conjunct this
+# one used to require: /commit omits the trailer under trailer_policy `none`, so
+# demanding it flagged the skill's own conformant output.
 #
 # NON-BLOCKING (advisory): exits 0 always. Emits additionalContext naming the
 # skill to prefer; never blocks the call — create.md itself documents a
@@ -84,7 +83,7 @@ SUBJECT=$(bash_subject "$COMMAND")
 
 # Emit one telemetry envelope per run. Advisory guards always report status
 # "ok" (they never block); the finding signal rides in `data.forms` — category
-# labels only ("git-commit-bypass" / "gh-pr-create-bypass"), never the matched
+# labels only ("gh-pr-create-bypass"), never the matched
 # command text.
 emit_tel() {
   [[ -n "$start" ]] || return 0
@@ -166,22 +165,9 @@ strip_literals() {
 
 STRIPPED_LC="$(strip_literals "$COMMAND")"
 STRIPPED_LC="${STRIPPED_LC,,}"
-COMMAND_LC="${COMMAND,,}"
 
 MESSAGES=()
 FORMS=()
-
-# `git commit` at a command position (start of string, or after a control
-# operator), without the canonical `-F -` stdin-message form AND a `--trailer`
-# carrying the Co-Authored-By line. Either marker present → the caller already
-# replicates the skill's mechanic; stay quiet.
-if [[ "$STRIPPED_LC" =~ (^|[[:space:];&|()]+)git[[:space:]]+commit([[:space:]]|$) ]]; then
-  if ! [[ "$COMMAND_LC" =~ (^|[[:space:]])(-f|--file)[[:space:]]+-([[:space:]]|$) ]] ||
-    ! [[ "$COMMAND_LC" =~ --trailer ]]; then
-    MESSAGES+=("direct \`git commit\` (missing the canonical \`-F -\` stdin form + \`--trailer\` Co-Authored-By line) — prefer the \`/commit\` skill (source-control plugin), which encapsulates the heredoc mechanic, Conventional Commits pre-check, and attribution trailer.")
-    FORMS+=("git-commit-bypass")
-  fi
-fi
 
 # `gh pr create` at a command position. No command-shape signature separates
 # skill-driven from ad hoc — /pull-request create's value is process (rebase,

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.test.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.test.sh
@@ -50,20 +50,18 @@ run_hook() {
 }
 
 # --- source-control enabled: bypass shapes fire ------------------------------
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$ENABLED_PROJECT")
-assert_contains "git commit -m fires" "$out" "git commit"
-assert_contains "names the /commit skill" "$out" "/commit"
-
 out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$ENABLED_PROJECT")
 assert_contains "gh pr create fires" "$out" "gh pr create"
 assert_contains "names the /pull-request skill" "$out" "/pull-request create"
 
-# --- source-control enabled: canonical shape stays silent --------------------
-out=$(run_hook "$(command_json 'git commit -F - --cleanup=verbatim --trailer "Co-Authored-By: Claude <noreply@anthropic.com>"')" "$ENABLED_PROJECT")
-assert_silent "canonical -F - + --trailer stays silent" "$out"
+# --- git commit is no longer this hook's concern -----------------------------
+# It moved to block-noncanonical-commit.sh, which BLOCKS on the stdin-form
+# mechanic. A duplicate advisory here would double-fire on one command.
+out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$ENABLED_PROJECT")
+assert_silent "git commit -m is not flagged here (owned by block-noncanonical-commit)" "$out"
 
-out=$(run_hook "$(command_json 'git commit --file - --trailer "Co-Authored-By: Claude"')" "$ENABLED_PROJECT")
-assert_silent "canonical --file - + --trailer stays silent" "$out"
+out=$(run_hook "$(command_json 'git commit -F - --cleanup=verbatim')" "$ENABLED_PROJECT")
+assert_silent "canonical -F - without --trailer stays silent (trailer_policy none)" "$out"
 
 # --- non-bypass commands stay silent -----------------------------------------
 out=$(run_hook "$(command_json 'git status')" "$ENABLED_PROJECT")
@@ -73,27 +71,27 @@ out=$(run_hook "$(command_json "echo 'reminder: use git commit -m for quick fixe
 assert_silent "prose mentioning git commit -m stays silent" "$out"
 
 # --- source-control NOT available: stays silent regardless of shape ----------
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$DISABLED_PROJECT")
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$DISABLED_PROJECT")
 assert_silent "source-control explicitly disabled stays silent" "$out"
 
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$NO_KEY_PROJECT")
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$NO_KEY_PROJECT")
 assert_silent "source-control key absent stays silent" "$out"
 
 NO_SETTINGS_PROJECT="$(mktemp -d -p "$TEST_TMPDIR")"
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$NO_SETTINGS_PROJECT")
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$NO_SETTINGS_PROJECT")
 assert_silent "no .claude/settings.json at all stays silent" "$out"
 
 # --- settings.local.json override --------------------------------------------
 OVERRIDE_OFF="$(make_project true false)"
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$OVERRIDE_OFF")
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$OVERRIDE_OFF")
 assert_silent "settings.local.json false overrides settings.json true" "$out"
 
 OVERRIDE_ON="$(make_project false true)"
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$OVERRIDE_ON")
-assert_contains "settings.local.json true overrides settings.json false" "$out" "git commit"
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$OVERRIDE_ON")
+assert_contains "settings.local.json true overrides settings.json false" "$out" "gh pr create"
 
 # --- kill switch — disabled path is a clean no-op even on a bypass shape -----
-out=$(run_hook "$(command_json 'git commit -m "quick fix"')" "$ENABLED_PROJECT" \
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$ENABLED_PROJECT" \
   CLAUDE_PLUGIN_OPTION_FLAG_COMMIT_PR_SKILL_BYPASS_ENABLED=false)
 assert_silent "kill switch off → no-op despite bypass shape" "$out"
 
@@ -105,12 +103,12 @@ assert_silent "empty stdin is a no-op" "$out"
 TEL="$(mktemp -p "$TEST_TMPDIR")"
 SINK="$(make_sink "cat >>\"$TEL\"")"
 env HOOK_TELEMETRY_SINK="$SINK" CLAUDE_PROJECT_DIR="$ENABLED_PROJECT" \
-  bash "$HOOK" <<<"$(command_json 'git commit -m "quick fix"')" >/dev/null 2>&1 || true
+  bash "$HOOK" <<<"$(command_json 'gh pr create --title x --body y')" >/dev/null 2>&1 || true
 if wait_for_sink "$TEL"; then
   assert_contains "telemetry: hook id" "$(jq -r '.hook' "$TEL")" "flag-commit-pr-skill-bypass"
   assert_contains "telemetry: status ok (advisory never blocks)" "$(jq -r '.status' "$TEL")" "ok"
-  assert_contains "telemetry: subject Bash:git" "$(jq -r '.data.subject' "$TEL")" "Bash:git"
-  assert_contains "telemetry: form git-commit-bypass" "$(jq -r '.data.forms[0]' "$TEL")" "git-commit-bypass"
+  assert_contains "telemetry: subject Bash:gh" "$(jq -r '.data.subject' "$TEL")" "Bash:gh"
+  assert_contains "telemetry: form gh-pr-create-bypass" "$(jq -r '.data.forms[0]' "$TEL")" "gh-pr-create-bypass"
 else
   bad "telemetry: no envelope written on advisory fire"
 fi

--- a/plugins/guardrails/hooks/hooks.json
+++ b/plugins/guardrails/hooks/hooks.json
@@ -42,6 +42,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-noncanonical-commit.sh",
+            "timeout": 10
+          }
+        ]
+      },
+      {
         "matcher": "Workflow",
         "hooks": [
           {


### PR DESCRIPTION
Closes #731

## Summary

Turns the `git commit` half of `flag-commit-pr-skill-bypass` into a blocking guard, and fixes a latent false positive that would have made blocking impossible.

## Fix

**New `block-noncanonical-commit.sh` (blocking).** Denies `git commit` that does not pipe its message via `-F -`/`--file -`. That form prevents a real, silent failure: `git commit -m "<multi-line>"` flattens newlines unpredictably across shells, so a body that looked right in the tool call lands mangled in history.

Exempt, because no message-on-stdin form exists for them and gating them would strand real work:

- `--amend` / `--no-edit`, `-C` / `-c` / `--reuse-message` / `--reedit-message`, `--fixup` / `--squash`
- `-F <path>` — mechanic satisfied, just not via stdin
- any commit taken while a merge, rebase, cherry-pick, or revert is in progress

Kill switch `block_noncanonical_commit_enabled`; allow-list `block_noncanonical_commit_allow` (`message-flag` permits a bare `-m`), following the `block_dangerous_git_allow` idiom. Detection reuses the shared argv-grammar parser, so `bash -lc` wrappers and git aliases resolve, and a commit body *mentioning* `git commit -m` never fires.

**Dropped the `--trailer` conjunct — this was a latent bug.** The old condition required `-F -` **and** `--trailer`:

```sh
if ! [[ "$COMMAND_LC" =~ (-f|--file)[[:space:]]+- ]] ||
   ! [[ "$COMMAND_LC" =~ --trailer ]]; then
```

But `/commit` omits `--trailer` when the resolved `trailer_policy` is `none` (`plugins/source-control/skills/commit/SKILL.md:58,66-70,106`). So a repo whose convention forbids a co-author trailer saw the skill's own conformant output flagged on **every** commit.

This had to be settled before blocking on the same condition — requiring `--trailer` to pass would have **permanently blocked `/commit`** in that configuration. The trailer is *policy*; only the stdin form is *mechanic*, and only the mechanic belongs in a gate.

**`flag-commit-pr-skill-bypass` is now `gh pr create`-only**, so the two never double-fire on one command.

## Why `gh pr create` stays advisory

Not a preference — it cannot be otherwise. `/pull-request create` issues that exact command itself, and [anthropics/claude-code#22655](https://github.com/anthropics/claude-code/issues/22655) (expose `skill_name` to hook payloads) is **closed as not planned**. A hook cannot distinguish a skill-driven Bash call from an ad hoc one, so blocking `gh pr create` would deadlock the skill it is advertising.

Likewise, no hook can *force* skill invocation — hooks block tools, they do not direct the model. Gating on command shape is what is actually available, and is the better target anyway: it enforces an outcome verifiable in `git log` rather than the ceremony that produced it.

## Verification

New hook — 34/34, covering both directions plus the config surface:

```
$ bash plugins/guardrails/hooks/block-noncanonical-commit.test.sh
ok: git commit -m (blocked) (exit 2)
ok: git commit -m with --trailer (still blocked — trailer is not the mechanic) (exit 2)
ok: bare git commit (opens EDITOR, blocked) (exit 2)
ok: git commit -F - without --trailer (allowed — trailer_policy none) (exit 0)
ok: git commit --amend --no-edit (allowed) (exit 0)
ok: git -c user.name=x commit -m (config, still blocked) (exit 2)
ok: quoted mention in a heredoc body (allowed) (exit 0)
ok: bash -lc wrapped -m (blocked) (exit 2)
ok: in-progress merge is exempt (exit 0)
ok: same repo with no sequencer state is blocked (exit 2)
...
passed: 34   failed: 0
```

The sequencer cases run against a real `git init` fixture with `MERGE_HEAD` present and then removed, so the exemption is proven to key on actual repo state rather than on the flag.

Advisory test rescoped to `gh pr create` — 17/17, including a case asserting `git commit -m` is now silent here, and one asserting `-F -` **without** `--trailer` is silent (the regression this PR fixes).

`shellcheck` on all changed scripts — clean. `scripts/validate-plugin-contracts.mjs` — 33 setup skills, 1825 plugin files checked, pass. Both new scripts committed `100755`. Version `0.8.0` → `0.9.0` with a matching `## [0.9.0]` heading.

This PR's own commit was made with `git commit -F - --trailer ... --trailer ...` and the advisory did not fire — which is also the direct evidence that the pre-existing advisory had been correct all along about the commits that *did* trip it.

## Related

- Refs anthropics/claude-code#22655 — no `skill_name` in hook payload (closed, not planned).
- Refs anthropics/claude-code#24327, #43189 — documented blocking-hook failure modes: model stalls treating a block as user denial; model resubmits an unchanged command. Both argue for a narrow, well-signposted block with a named fix in the message, which is what the deny text provides.