### PR TITLE
fix(disk-hygiene): guard resolves authorized data root from hook argv

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Fixed
+
+- **The skill-frontmatter guard now receives its authorized data root.**
+  `destructive_guard.py` read the authoritative data root only from the
+  `CLAUDE_PLUGIN_DATA` environment variable, which the runtime does not inject
+  into a skill-frontmatter hook's process environment. As a result `--data-root`
+  never validated and the `scan`/`preview`/`apply` engine lane failed closed on
+  every guarded invocation, on all platforms. The `clean` skill's hook now
+  passes the root as a runtime-substituted `--authorized-data-root
+  ${CLAUDE_PLUGIN_DATA}` argument — inline placeholder substitution resolves in
+  hook arguments where environment injection does not — and the guard reads its
+  authority from that argument, honoring `CLAUDE_PLUGIN_DATA` only as a fallback.
+  The security property is unchanged: the authority is a runtime-substituted
+  value the model cannot forge, validated against the model-supplied
+  `--data-root`.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -19,7 +19,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   authority from that argument, honoring `CLAUDE_PLUGIN_DATA` only as a fallback.
   The security property is unchanged: the authority is a runtime-substituted
   value the model cannot forge, validated against the model-supplied
-  `--data-root`.
+  `--data-root`. The unsubstituted-placeholder fallback matches only the exact
+  `${CLAUDE_PLUGIN_DATA}` token, so a real data-root path that merely contains
+  the `${` sequence is preserved as the authority instead of being discarded.
 
 ## [0.4.0]
 

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -10,7 +10,7 @@ hooks:
       hooks:
         - type: command
           command: "python"
-          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py"]
+          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
 ---
 
 # Disk hygiene
@@ -56,9 +56,9 @@ stay there, never in the target or `${CLAUDE_PLUGIN_ROOT}`. Run:
   --project-dir "${CLAUDE_PROJECT_DIR}" --data-root "${CLAUDE_PLUGIN_DATA}"
 ```
 
-The guard validates `--data-root` against the value its own hook process received, so generated
-state provably lands in the plugin data directory even when the shell environment lacks
-`CLAUDE_PLUGIN_DATA`.
+The guard validates `--data-root` against the authorized data root it receives as a
+runtime-substituted hook argument (`${CLAUDE_PLUGIN_DATA}`), so generated state provably lands in the
+plugin data directory even when the shell environment lacks `CLAUDE_PLUGIN_DATA`.
 
 For a large root (a home directory, anything whose recursive walk could exceed the engine's entry
 cap), start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -54,9 +54,10 @@ The skill-scoped Bash guard accepts only complete literal words in the three dec
 shapes. It rejects every Bash expansion family, glob/word-splitting input, redirection, operator,
 escape, and compound-command form before validating arguments. Canonical script-path comparison uses
 the host platform's path case rules; POSIX path identity is never case-folded. A `--data-root` value
-is accepted only when it matches the `CLAUDE_PLUGIN_DATA` the guard's own hook process received from
-the runtime — the shell environment is never trusted for it, and absent hook authority the flag fails
-closed. `--max-depth` accepts only a bare positive-integer literal.
+is accepted only when it matches the authorized data root the guard receives as a runtime-substituted
+hook argument (`${CLAUDE_PLUGIN_DATA}`) — the shell environment is never trusted for it (an env var is
+honored only as a fallback), and absent that authority the flag fails closed. `--max-depth` accepts
+only a bare positive-integer literal.
 
 The same guard also covers the PowerShell tool with the inverse tradeoff: PowerShell stays open for
 read-only support work, while engine invocations are hard-denied (Bash is the only engine lane) and

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -108,16 +108,46 @@ def _data_root_key(value: str) -> str:
     return os.path.normcase(os.fspath(Path(value).expanduser().resolve(strict=False)))
 
 
-def _is_authorized_data_root(value: str) -> bool:
-    """Accept only the data root this hook process was told about by the runtime."""
-    authority = os.environ.get("CLAUDE_PLUGIN_DATA")
+_AUTHORIZED_DATA_ROOT_FLAG = "--authorized-data-root"
+
+
+def _argv_authorized_data_root(argv: list[str]) -> str | None:
+    """Read the authorized data root the runtime substituted into the hook argv.
+
+    The skill-frontmatter hook passes ``--authorized-data-root ${CLAUDE_PLUGIN_DATA}``;
+    inline placeholder substitution resolves in hook arguments even where
+    environment injection does not, so the guard's own argv is the authoritative,
+    model-unforgeable channel for the data root.
+    """
+    for index, token in enumerate(argv):
+        if token == _AUTHORIZED_DATA_ROOT_FLAG and index + 1 < len(argv):
+            return argv[index + 1]
+        prefix = f"{_AUTHORIZED_DATA_ROOT_FLAG}="
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
+def resolve_authorized_data_root() -> str | None:
+    """Resolve the authoritative data root from the hook argv, then the environment.
+
+    A literal, unsubstituted placeholder is treated as absent so the environment
+    fallback still applies.
+    """
+    from_argv = _argv_authorized_data_root(sys.argv[1:])
+    if from_argv and "${" not in from_argv:
+        return from_argv
+    return os.environ.get("CLAUDE_PLUGIN_DATA")
+
+
+def _is_authorized_data_root(value: str, authority: str | None) -> bool:
+    """Accept only the data root the runtime told this hook to authorize."""
     if not authority:
         return False
     return _data_root_key(value) == _data_root_key(authority)
 
 
-def _display_data_root() -> str | None:
-    authority = os.environ.get("CLAUDE_PLUGIN_DATA")
+def _display_data_root(authority: str | None) -> str | None:
     if not authority:
         return None
     return os.fspath(Path(authority).expanduser().resolve(strict=False)).replace(
@@ -125,17 +155,19 @@ def _display_data_root() -> str | None:
     )
 
 
-def _valid_optional_value(flag: str, value: str) -> bool:
+def _valid_optional_value(flag: str, value: str, authority: str | None) -> bool:
     if not _argument(value):
         return False
     if flag == "--max-depth":
         return re.fullmatch(r"[1-9][0-9]{0,3}", value) is not None
     if flag == "--data-root":
-        return _is_authorized_data_root(value)
+        return _is_authorized_data_root(value, authority)
     return True
 
 
-def _consume_optional_pairs(tokens: list[str], allowed: frozenset[str]) -> bool:
+def _consume_optional_pairs(
+    tokens: list[str], allowed: frozenset[str], authority: str | None
+) -> bool:
     seen: list[str] = []
     while tokens:
         flag = tokens[0]
@@ -143,7 +175,7 @@ def _consume_optional_pairs(tokens: list[str], allowed: frozenset[str]) -> bool:
             flag not in allowed
             or flag in seen
             or len(tokens) < 2
-            or not _valid_optional_value(flag, tokens[1])
+            or not _valid_optional_value(flag, tokens[1], authority)
         ):
             return False
         seen.append(flag)
@@ -151,7 +183,7 @@ def _consume_optional_pairs(tokens: list[str], allowed: frozenset[str]) -> bool:
     return True
 
 
-def classify_exact_engine_command(command: str) -> str | None:
+def classify_exact_engine_command(command: str, authority: str | None) -> str | None:
     """Return scan/preview/apply only for one complete, canonical invocation."""
     tokens = _literal_shell_words(command)
     if tokens is None:
@@ -174,6 +206,7 @@ def classify_exact_engine_command(command: str) -> str | None:
         if not _consume_optional_pairs(
             tokens[7:],
             frozenset({"--policy", "--project-dir", "--data-root", "--max-depth"}),
+            authority,
         ):
             return None
         return "scan"
@@ -184,7 +217,9 @@ def classify_exact_engine_command(command: str) -> str | None:
             and _argument(tokens[4])
             and tokens[5] == "--plan"
             and _argument(tokens[6])
-            and _consume_optional_pairs(tokens[7:], frozenset({"--data-root"}))
+            and _consume_optional_pairs(
+                tokens[7:], frozenset({"--data-root"}), authority
+            )
         )
         return "preview" if valid else None
     if tokens[2] == "apply":
@@ -203,15 +238,17 @@ def classify_exact_engine_command(command: str) -> str | None:
                 re.fullmatch(r"[0-9a-f]{24}", tokens[11]) is not None,
                 tokens[12] == "--report",
                 _argument(tokens[13]),
-                _consume_optional_pairs(tokens[14:], frozenset({"--data-root"})),
+                _consume_optional_pairs(
+                    tokens[14:], frozenset({"--data-root"}), authority
+                ),
             )
         )
         return "apply" if valid else None
     return None
 
 
-def is_exact_engine_apply(command: str) -> bool:
-    return classify_exact_engine_command(command) == "apply"
+def is_exact_engine_apply(command: str, authority: str | None) -> bool:
+    return classify_exact_engine_command(command, authority) == "apply"
 
 
 _POWERSHELL_MUTATION_WORDS = re.compile(
@@ -257,14 +294,15 @@ def powershell_decision(command: str) -> tuple[str, str] | None:
     return None
 
 
-def _bash_denial_guidance() -> str:
-    data_root = _display_data_root()
+def _bash_denial_guidance(authority: str | None) -> str:
+    data_root = _display_data_root(authority)
     data_sentence = (
         f' Pass --data-root "{data_root}" so generated state lands in the plugin data directory.'
         if data_root
         else (
-            " The hook process did not receive CLAUDE_PLUGIN_DATA, so --data-root"
-            " cannot be validated and engine calls fail closed."
+            " The guard did not receive an authorized data root (neither the"
+            f" {_AUTHORIZED_DATA_ROOT_FLAG} hook argument nor CLAUDE_PLUGIN_DATA),"
+            " so --data-root cannot be validated and engine calls fail closed."
         )
     )
     return (
@@ -299,7 +337,8 @@ def main() -> int:
             print(json.dumps(decision(*verdict)))
         return 0
 
-    command_kind = classify_exact_engine_command(command)
+    authority = resolve_authorized_data_root()
+    command_kind = classify_exact_engine_command(command, authority)
     enabled = os.environ.get("CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED", "true").lower() != "false"
     if command_kind in {"scan", "preview"}:
         print(
@@ -324,7 +363,7 @@ def main() -> int:
     reason = (
         "Disk-hygiene execution is disabled; only exact bundled scan and preview invocations are permitted."
         if command_kind == "apply"
-        else _bash_denial_guidance()
+        else _bash_denial_guidance(authority)
     )
     print(json.dumps(decision("deny", reason)))
     return 0

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -109,6 +109,8 @@ def _data_root_key(value: str) -> str:
 
 
 _AUTHORIZED_DATA_ROOT_FLAG = "--authorized-data-root"
+_CLAUDE_PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA"
+_AUTHORIZED_DATA_ROOT_PLACEHOLDER = f"${{{_CLAUDE_PLUGIN_DATA_ENV}}}"
 
 
 def _argv_authorized_data_root(argv: list[str]) -> str | None:
@@ -135,9 +137,9 @@ def resolve_authorized_data_root() -> str | None:
     fallback still applies.
     """
     from_argv = _argv_authorized_data_root(sys.argv[1:])
-    if from_argv and "${" not in from_argv:
+    if from_argv and from_argv != _AUTHORIZED_DATA_ROOT_PLACEHOLDER:
         return from_argv
-    return os.environ.get("CLAUDE_PLUGIN_DATA")
+    return os.environ.get(_CLAUDE_PLUGIN_DATA_ENV)
 
 
 def _is_authorized_data_root(value: str, authority: str | None) -> bool:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1466,6 +1466,17 @@ class GuardTests(unittest.TestCase):
                     guard.resolve_authorized_data_root(),
                     "an unsubstituted placeholder must fall back to the environment",
                 )
+            with mock.patch.object(
+                guard.sys,
+                "argv",
+                [script, "--authorized-data-root", "/data/${weird}/root"],
+            ):
+                self.assertEqual(
+                    "/data/${weird}/root",
+                    guard.resolve_authorized_data_root(),
+                    "only the exact placeholder is rejected; a real path that merely "
+                    "contains ${ must be preserved as the argv authority",
+                )
 
     def test_skill_hook_passes_authorized_data_root_flag_matching_constant(
         self,

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1372,6 +1372,53 @@ class GuardTests(unittest.TestCase):
                 ]["permissionDecision"],
             )
 
+    def test_guard_authorizes_preview_data_root_from_hook_argv_without_env(
+        self,
+    ) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory() as temporary:
+            authorized = str(Path(temporary).resolve() / "plugin-data")
+            other = str(Path(temporary).resolve() / "elsewhere")
+            base = (
+                f'"{self.python_command()}" "{script}" preview --snapshot s --plan p'
+            )
+            self.assertEqual(
+                "allow",
+                self.run_guard_hook_argv(
+                    f'{base} --data-root "{authorized}"', authorized
+                )["hookSpecificOutput"]["permissionDecision"],
+            )
+            self.assertEqual(
+                "deny",
+                self.run_guard_hook_argv(f'{base} --data-root "{other}"', authorized)[
+                    "hookSpecificOutput"
+                ]["permissionDecision"],
+            )
+
+    def test_guard_authorizes_apply_data_root_from_hook_argv_without_env(
+        self,
+    ) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory() as temporary:
+            authorized = str(Path(temporary).resolve() / "plugin-data")
+            other = str(Path(temporary).resolve() / "elsewhere")
+            base = (
+                f'"{self.python_command()}" "{script}" apply --execute --snapshot s '
+                f'--plan p --confirm-tier high --approval-token {"a" * 24} --report r'
+            )
+            self.assertEqual(
+                "ask",
+                self.run_guard_hook_argv(
+                    f'{base} --data-root "{authorized}"', authorized
+                )["hookSpecificOutput"]["permissionDecision"],
+            )
+            self.assertEqual(
+                "deny",
+                self.run_guard_hook_argv(f'{base} --data-root "{other}"', authorized)[
+                    "hookSpecificOutput"
+                ]["permissionDecision"],
+            )
+
     def test_guard_denies_data_root_when_argv_and_env_both_absent(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"
         with tempfile.TemporaryDirectory() as temporary:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1324,6 +1324,131 @@ class GuardTests(unittest.TestCase):
                 "deny", result["hookSpecificOutput"]["permissionDecision"]
             )
 
+    def run_guard_hook_argv(
+        self, command: str, authorized: str | None
+    ) -> dict[str, object]:
+        """Drive the guard with the data root supplied via hook argv, not the env.
+
+        Mirrors the skill-frontmatter hook, which substitutes
+        ``--authorized-data-root ${CLAUDE_PLUGIN_DATA}`` into the guard's own argv
+        while CLAUDE_PLUGIN_DATA is absent from the hook process environment.
+        """
+        argv = [str(SCRIPT_DIR / "destructive_guard.py")]
+        if authorized is not None:
+            argv += ["--authorized-data-root", authorized]
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key != "CLAUDE_PLUGIN_DATA"
+        }
+        environment["CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED"] = "true"
+        stdin = io.StringIO(json.dumps({"tool_input": {"command": command}}))
+        stdout = io.StringIO()
+        with (
+            mock.patch("sys.stdin", stdin),
+            redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", argv),
+            mock.patch.dict("os.environ", environment, clear=True),
+        ):
+            self.assertEqual(0, guard.main())
+        return json.loads(stdout.getvalue())
+
+    def test_guard_authorizes_data_root_from_hook_argv_without_env(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory() as temporary:
+            authorized = str(Path(temporary).resolve() / "plugin-data")
+            other = str(Path(temporary).resolve() / "elsewhere")
+            base = f'"{self.python_command()}" "{script}" scan --target t --output s'
+            self.assertEqual(
+                "allow",
+                self.run_guard_hook_argv(
+                    f'{base} --data-root "{authorized}"', authorized
+                )["hookSpecificOutput"]["permissionDecision"],
+            )
+            self.assertEqual(
+                "deny",
+                self.run_guard_hook_argv(f'{base} --data-root "{other}"', authorized)[
+                    "hookSpecificOutput"
+                ]["permissionDecision"],
+            )
+
+    def test_guard_denies_data_root_when_argv_and_env_both_absent(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory() as temporary:
+            target = str(Path(temporary).resolve())
+            base = f'"{self.python_command()}" "{script}" scan --target t --output s'
+            result = self.run_guard_hook_argv(
+                f'{base} --data-root "{target}"', None
+            )
+            self.assertEqual(
+                "deny", result["hookSpecificOutput"]["permissionDecision"]
+            )
+            self.assertIn(
+                "--authorized-data-root",
+                result["hookSpecificOutput"]["permissionDecisionReason"],
+            )
+
+    def test_argv_authorized_data_root_parses_both_arg_spellings(self) -> None:
+        self.assertEqual(
+            "/data", guard._argv_authorized_data_root(["--authorized-data-root", "/data"])
+        )
+        self.assertEqual(
+            "/data", guard._argv_authorized_data_root(["--authorized-data-root=/data"])
+        )
+        self.assertIsNone(guard._argv_authorized_data_root(["--other", "/data"]))
+        self.assertIsNone(guard._argv_authorized_data_root(["--authorized-data-root"]))
+
+    def test_resolve_authorized_data_root_precedence(self) -> None:
+        script = str(SCRIPT_DIR / "destructive_guard.py")
+        with mock.patch.dict(
+            "os.environ", {"CLAUDE_PLUGIN_DATA": "/from-env"}, clear=False
+        ):
+            with mock.patch.object(
+                guard.sys, "argv", [script, "--authorized-data-root", "/from-argv"]
+            ):
+                self.assertEqual("/from-argv", guard.resolve_authorized_data_root())
+            with mock.patch.object(guard.sys, "argv", [script]):
+                self.assertEqual("/from-env", guard.resolve_authorized_data_root())
+            with mock.patch.object(
+                guard.sys,
+                "argv",
+                [script, "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"],
+            ):
+                self.assertEqual(
+                    "/from-env",
+                    guard.resolve_authorized_data_root(),
+                    "an unsubstituted placeholder must fall back to the environment",
+                )
+
+    def test_skill_hook_passes_authorized_data_root_flag_matching_constant(
+        self,
+    ) -> None:
+        """Lock the config<->code seam the fix depends on.
+
+        The frontmatter hook must pass the exact flag literal the guard parses,
+        immediately followed by the ${CLAUDE_PLUGIN_DATA} placeholder. If either
+        side is renamed without the other, the guard silently loses its authority
+        and the engine lane fails closed — the regression this test guards.
+        """
+        skill = SCRIPT_DIR.parent / "SKILL.md"
+        text = skill.read_text(encoding="utf-8")
+        args_line = next(
+            (
+                line
+                for line in text.splitlines()
+                if "destructive_guard.py" in line and "args:" in line
+            ),
+            None,
+        )
+        self.assertIsNotNone(args_line, "frontmatter hook args line not found")
+        assert args_line is not None
+        array_text = args_line[args_line.index("[") : args_line.rindex("]") + 1]
+        args = json.loads(array_text)
+        self.assertTrue(args[0].endswith("destructive_guard.py"), args)
+        self.assertIn(guard._AUTHORIZED_DATA_ROOT_FLAG, args)
+        flag_index = args.index(guard._AUTHORIZED_DATA_ROOT_FLAG)
+        self.assertEqual("${CLAUDE_PLUGIN_DATA}", args[flag_index + 1])
+
     def test_guard_scan_max_depth_accepts_only_positive_integer_literal(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"
         base = f'"{self.python_command()}" "{script}" scan --target t --output s'


### PR DESCRIPTION
## Summary

The `disk-hygiene` `clean` skill declares `destructive_guard.py` as a PreToolUse
skill-frontmatter hook. The guard read its authorized data root only from the
`CLAUDE_PLUGIN_DATA` environment variable, but the runtime does not inject that
variable into a skill-frontmatter hook's process environment. As a result
`--data-root` never validated and the `scan`/`preview`/`apply` engine lane failed
closed on every guarded invocation — on all platforms — making the plugin's core
engine unreachable through its sanctioned Bash lane.

## Fix

Root cause: the guard depended on environment-variable injection, but per the
[plugins reference](https://code.claude.com/docs/en/plugins-reference) inline
placeholder substitution (`${CLAUDE_PLUGIN_DATA}`) resolves in hook arguments
"anywhere the placeholder appears," and the reference explicitly recommends exec
form with `args` so each path is passed as one argument. Inline substitution was
already proven to work in this exact frontmatter context (`${CLAUDE_PLUGIN_ROOT}`
resolves — the guard script path loads and executes); only environment injection
was missing.

- `skills/clean/SKILL.md` frontmatter hook now passes the root as a
  runtime-substituted argument: `--authorized-data-root ${CLAUDE_PLUGIN_DATA}`.
- `destructive_guard.py` resolves its authority from that hook argv
  (`resolve_authorized_data_root`), honoring `CLAUDE_PLUGIN_DATA` only as a
  fallback. The authority is resolved once in `main()` and threaded explicitly
  down the classification chain instead of being read from `os.environ` deep in
  the leaf validator.
- Doc sentences that asserted the false "the hook process received
  `CLAUDE_PLUGIN_DATA`" mechanism are corrected in `SKILL.md` and
  `reference/safety-model.md` to describe the runtime-substituted argument.

Security property is unchanged: the authority comes from the guard's **own**
process argv (harness-substituted, model-unforgeable), a channel distinct from
the model-supplied `--data-root` inside the gated Bash command; the latter is
validated against the former and can never become its own authority.

## Verification

- `python -m unittest test_hygiene` — 71 passed, 4 skipped (Linux-only platform
  gates). Adds 4 tests: argv authorizes matching `--data-root` with
  `CLAUDE_PLUGIN_DATA` absent from the environment; mismatch denied; deny when
  neither argv nor env supplies authority; argv-over-env precedence with
  literal-placeholder fallback.
- Scripted end-to-end proof (real subprocess, real argv, `CLAUDE_PLUGIN_DATA`
  removed from the environment — the exact failing scenario):
  - with `--authorized-data-root <root>` → `permissionDecision: allow`
  - same command without the argv (old wiring) → `permissionDecision: deny`,
    citing the now-accurate "neither the `--authorized-data-root` hook argument
    nor `CLAUDE_PLUGIN_DATA`" guidance.
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` — pass
  (version bumped `0.4.0` → `0.4.1`, `## [0.4.1]` entry added).
- `markdownlint-cli2` on the three changed markdown files — 0 errors.

Not covered by units: live-harness end-to-end substitution of
`${CLAUDE_PLUGIN_DATA}` in a skill-frontmatter hook's `args`. This rests on the
plugins-reference guarantee (same inline-substitution pass as
`${CLAUDE_PLUGIN_ROOT}`, which empirically resolves in this exact position) — it
cannot be exercised without the running harness.

Closes #376

## Related

- Same env-injection root cause, deliberately **not** folded here (separately
  tracked): #382 (the `disk_hygiene_enabled` kill switch reads
  `CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED` from the hook env, also absent —
  ~2 lines once this argv plumbing exists), #386 (the broader doc sweep beyond
  the two sentences this change falsifies), #385 (`setup:check` liveness probe).
- Umbrella: #532 (false-green / dead-capability convention). This is the engine-
  liveness instance; opened as a draft pending that umbrella's decision.
