### PR TITLE
ci(pr-issue-linkage): exempt dependabot[bot] from the body gate

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -29,6 +29,13 @@ concurrency:
 jobs:
   pr-issue-linkage:
     permissions: {}
+    # DRAFT / BLOCKED: pin still points at the pre-exemption SHA. Before marking
+    # this PR ready, bump @90f1c54 to the merge SHA of ci-workflows#171 (Closes
+    # ci-workflows#149) — the exempt-authors input below is a no-op until the
+    # reusable at the pinned SHA understands it.
     uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
       runner: ubuntu-24.04
+      # dependabot PR bodies cannot carry the closing-keyword + `## Related`
+      # markers this gate requires; exempt the login so its PRs are mergeable.
+      exempt-authors: 'dependabot[bot]'

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -29,11 +29,7 @@ concurrency:
 jobs:
   pr-issue-linkage:
     permissions: {}
-    # DRAFT / BLOCKED: pin still points at the pre-exemption SHA. Before marking
-    # this PR ready, bump @90f1c54 to the merge SHA of ci-workflows#171 (Closes
-    # ci-workflows#149) — the exempt-authors input below is a no-op until the
-    # reusable at the pinned SHA understands it.
-    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@d7734df8c557084edc2df7cf578cf62ad2f261e4 # d7734df 2026-07-20
     with:
       runner: ubuntu-24.04
       # dependabot PR bodies cannot carry the closing-keyword + `## Related`


### PR DESCRIPTION
## Summary

Caller opt-in for the new `exempt-authors` input on the shared
`pr-issue-linkage` reusable. dependabot PR bodies cannot carry the
closing-keyword + `## Related` markers this required gate demands, so
every dependency-update PR currently fails the check and is unmergeable.
Passing `exempt-authors: 'dependabot[bot]'` skips body validation for
that login only.

## DRAFT — blocked, do not merge yet

<!-- pin-bump placeholder: update @90f1c54 to the #149 merge SHA before ready -->

This PR is **blocked-by melodic-software/ci-workflows#149** (implemented in
ci-workflows#171). The pinned reusable SHA still points at the
pre-exemption commit `@90f1c54`, so the `exempt-authors` line is a **no-op**
until the pin is bumped. A YAML comment at the pin marks this.

**Before marking ready:**
1. Wait for ci-workflows#171 to merge.
2. Bump the `uses:` pin from `@90f1c54935203fa31b5b3d1f41531228be2c2b7f`
   to the merge SHA of #171 (update the trailing `# <short> <date>` comment too).
3. Remove the DRAFT/BLOCKED YAML comment at the pin.
4. Mark ready for review.

## Governance

Prepared under **operator momentum delegation**; standard **veto window**
applies — object on this PR or the upstream ci-workflows#171 before merge.

Closes #684

## Related

- Upstream reusable change (blocked-by): melodic-software/ci-workflows#171
