### PR TITLE
ci(pr-issue-linkage): exempt dependabot[bot] from the body gate (signed supersede of #748)

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -29,6 +29,9 @@ concurrency:
 jobs:
   pr-issue-linkage:
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@d7734df8c557084edc2df7cf578cf62ad2f261e4 # d7734df 2026-07-20
     with:
       runner: ubuntu-24.04
+      # dependabot PR bodies cannot carry the closing-keyword + `## Related`
+      # markers this gate requires; exempt the login so its PRs are mergeable.
+      exempt-authors: 'dependabot[bot]'


### PR DESCRIPTION
## Summary

Caller opt-in for the `exempt-authors` input on the shared
`pr-issue-linkage` reusable. dependabot PR bodies cannot carry the
closing-keyword + `## Related` markers this required gate demands, so
every dependency-update PR currently fails the check and is unmergeable
(see #669 for a live example blocked by this today). Passing
`exempt-authors: 'dependabot[bot]'` skips body validation for that
login only.

The pin is bumped to `melodic-software/ci-workflows@d7734df8c557084edc2df7cf578cf62ad2f261e4`,
the merge SHA of ci-workflows#171, so `exempt-authors` is live rather
than a no-op.

## Governance

Prepared under **operator momentum delegation**; standard **veto
window** applies — object on this PR before merge.

Closes #684

## Related

- #748 (superseded by this PR — blocked by `required_signatures`; see
  close comment for detail)
- Upstream reusable change: melodic-software/ci-workflows#149 (request),
  melodic-software/ci-workflows#171 (implementation, merged)
- Follow-up: melodic-software/ci-workflows#157 (bump this pin across
  other consumers)
- #669 (dependabot PR currently unmergeable without this exemption)
