### PR TITLE
fix(guardrails): buffer stdin before parsing in cli-flag-verify hook

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.1]
+
+### Fixed
+
+- **`cli-flag-verify` now buffers stdin via `hook::buffer_stdin` instead of reading fd0
+  directly.** It was the last hook entry script whose stdin parse ran `jq` against the
+  inherited, unbounded fd0 — `hook::read_file_path` — leaving it exposed to the Windows
+  Win32-pipe late-EOF stall the [0.8.0] migration closed for every other hook. The payload
+  is now buffered once through the bounded `read -t` helper and piped into
+  `hook::read_file_path`. As an advisory hook it skips silently on any read failure — empty
+  stdin (rc 1) and read timeout (rc 2) alike — matching its advisory siblings
+  `flag-commit-pr-skill-bypass` and `workflow-resilience-check`.
+
 ## [0.9.0]
 
 ### Added

--- a/plugins/guardrails/hooks/cli-flag-verify.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.sh
@@ -47,7 +47,11 @@ hook::ctx_reset
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 VERIFIER="$PLUGIN_ROOT/lib/verification/verify-cli-flag.sh"
 
-FILE=$(hook::read_file_path) || exit 0
+# hook::buffer_stdin encapsulates the Win32-pipe-safe bounded fd0 read; empty
+# or timed-out stdin skips this advisory hook. Pipe the buffered payload into
+# hook::read_file_path so its jq no longer reads the inherited fd0 directly.
+INPUT=$(hook::buffer_stdin) || exit 0
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 IS_MD=false
 case "$FILE" in
 *.md) IS_MD=true ;;

--- a/plugins/guardrails/hooks/cli-flag-verify.test.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.test.sh
@@ -138,6 +138,17 @@ OUT=$(PATH="$FAKE_BIN_DIR:$PATH" CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS=faket
   CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_SKIP_BINS=faketool bash "$HOOK" <<<"$dis_input" 2>&1); RC=$?
 assert_exit "per-binary skip → exit 0" 0 "$RC"
 
+# Empty stdin: hook::buffer_stdin returns 1 (no payload) → this advisory hook
+# skips silently. Guards the skip contract through the migrated buffered-read
+# path. NOTE: a here-string / /dev/null cannot reproduce the Win32
+# late-EOF pipe stall the fix targets, and rc-2 (timeout) collapses to the same
+# silent exit 0 as rc-1 for an advisory hook — so this asserts the skip contract,
+# not the stall itself.
+OUT=$(PATH="$FAKE_BIN_DIR:$PATH" CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS=faketool \
+  bash "$HOOK" </dev/null 2>&1); RC=$?
+assert_exit "empty stdin → exit 0" 0 "$RC"
+assert_silent "empty stdin → no output" "$OUT"
+
 # ============================ TELEMETRY ====================================
 TEL="$(mktemp -p "$TEST_TMPDIR")"
 SINK="$(make_sink "cat >\"$TEL\"")"


### PR DESCRIPTION
Closes #446

`hook::read_file_path` ran jq directly against the inherited fd0 with no read bound in `cli-flag-verify.sh` — the last remaining fd0-direct reader after the fleet-wide `hook::buffer_stdin` migration, same Windows Win32-pipe late-EOF stall class. Fix per the issue's decided shape: buffer first, pipe the payload into the parser; empty/timed-out stdin skips this advisory hook (plain `|| exit 0` collapse matching its class and its siblings). Guardrails 0.9.0 → 0.9.1 + CHANGELOG.

Verification: `cli-flag-verify.test.sh` PASS=37 FAIL=0 (35 baseline + 2 new empty-stdin skip-contract assertions); shellcheck clean. The new test asserts the skip contract, not the stall itself — a here-string/`/dev/null` harness cannot reproduce the Win32 late-EOF stall; behavior-preservation evidence is the suite green before/after with every case now routed through the buffered read.

## Related

- #443 / #444 (the `hook::buffer_stdin` migration this completes)
- #547 (hook-precision umbrella; this member carries its skip-contract guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
