### PR TITLE
docs(plugins): drop unreachable repo-root LICENSE pointer from 13 READMEs (wave 2)

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Structured discovery before changes: explore the local codebase (inline or in an isolated forked subagent) and run disciplined multi-source external research with source tiers, falsification, and recency gates — persisting EXPLORE.md / RESEARCH.md handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — discovery plugin
 
+## [0.8.1] — 2026-07-20
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.8.0] — 2026-07-20
 
 ### Added

--- a/plugins/discovery/README.md
+++ b/plugins/discovery/README.md
@@ -54,5 +54,4 @@ interview.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Documentation-hygiene toolkit of five skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), and rename-references (sweep stale references after renames).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — docs-hygiene plugin
 
+## [0.7.1] — 2026-07-20
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.7.0] — 2026-07-18
 
 Changed:

--- a/plugins/docs-hygiene/README.md
+++ b/plugins/docs-hygiene/README.md
@@ -54,5 +54,4 @@ snapshots under the plugin's own data directory.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/domain-driven-design/.claude-plugin/plugin.json
+++ b/plugins/domain-driven-design/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domain-driven-design",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Domain-driven-design practice skills. Today: actively maintains a consuming project's ubiquitous-language glossary — resolves ambiguous or overloaded terms, records canonical language and rejected synonyms, sharpens what-it-IS definitions, and routes entries to already-known bounded contexts without discovering boundaries.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/domain-driven-design/CHANGELOG.md
+++ b/plugins/domain-driven-design/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `domain-driven-design` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.2.0]
 
 ### Changed (breaking)

--- a/plugins/domain-driven-design/README.md
+++ b/plugins/domain-driven-design/README.md
@@ -33,5 +33,4 @@ installs it automatically.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/education/.claude-plugin/plugin.json
+++ b/plugins/education/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "education",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Interactive multi-session learning coach: teaches a general subject or a concept grounded in the consuming repo through the Knowledge-Skills-Wisdom progression, with persistent per-topic learning state. Also a single-session domain primer.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/education/CHANGELOG.md
+++ b/plugins/education/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `education` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.3.1]
 
 ### Changed

--- a/plugins/education/README.md
+++ b/plugins/education/README.md
@@ -63,5 +63,4 @@ plugin itself.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/eol-normalizer/.claude-plugin/plugin.json
+++ b/plugins/eol-normalizer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "eol-normalizer",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/eol-normalizer/CHANGELOG.md
+++ b/plugins/eol-normalizer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `eol-normalizer` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.4.1]
 
 ### Changed

--- a/plugins/eol-normalizer/README.md
+++ b/plugins/eol-normalizer/README.md
@@ -80,5 +80,4 @@ project's `enabledPlugins` instead.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/event-storming/.claude-plugin/plugin.json
+++ b/plugins/event-storming/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "event-storming",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "EventStorming for domain discovery \u2014 a methodology skill (Big Picture / Process Modeling / Design-Level facilitation reference, notation, patterns) and a simulation skill (agentic multi-persona workshops that produce a structured-markdown model by default; a live Miro-board rendering path is available when the first-party miro plugin is enabled).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/event-storming/CHANGELOG.md
+++ b/plugins/event-storming/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `event-storming` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.5]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.5.4]
 
 ### Changed

--- a/plugins/event-storming/README.md
+++ b/plugins/event-storming/README.md
@@ -66,5 +66,4 @@ into your project tree.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/firecrawl/.claude-plugin/plugin.json
+++ b/plugins/firecrawl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "firecrawl",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Web scraping, search, crawling, and file parsing through the firecrawl-cli binary with a write-to-disk-then-Read pattern that keeps large results out of context — plus a gated maintainer update flow tracking the upstream CLI and skill source.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/firecrawl/CHANGELOG.md
+++ b/plugins/firecrawl/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `firecrawl` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.3.0]
 
 ### Added

--- a/plugins/firecrawl/README.md
+++ b/plugins/firecrawl/README.md
@@ -59,5 +59,4 @@ additionally reaches `registry.npmjs.org` and `www.firecrawl.dev`.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/implementation/.claude-plugin/plugin.json
+++ b/plugins/implementation/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "implementation",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Disciplined implementation stage: execute approved plans inline (`/implementation:implement`) or via orchestrated worker subagents (`/implementation:implement-dispatch`) with incremental validation, TDD-by-default cadence, green-checkpoint commits, scope-fence drift detection, and divergence detection that routes back to planning. Build/test/lint, testing, and outcome verification live in the companion `toolchain`, `testing`, and `verification` plugins, invoked when installed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/implementation/CHANGELOG.md
+++ b/plugins/implementation/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `implementation` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.5]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.7.4]
 
 ### Changed

--- a/plugins/implementation/README.md
+++ b/plugins/implementation/README.md
@@ -77,5 +77,4 @@ for and persists it. This plugin declares no userConfig options.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/kindle-dedrm/.claude-plugin/plugin.json
+++ b/plugins/kindle-dedrm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "kindle-dedrm",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Manage the Kindle for PC 2.8.0 + Calibre DeDRM workflow for personal-use ebook DRM removal on books you own (Windows only). Action router with setup, sync, update, cleanup, and status, each state mutation paired with a documented compensating reversal.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/kindle-dedrm/CHANGELOG.md
+++ b/plugins/kindle-dedrm/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `kindle-dedrm` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.6.1]
 
 ### Changed

--- a/plugins/kindle-dedrm/README.md
+++ b/plugins/kindle-dedrm/README.md
@@ -96,5 +96,4 @@ it writes no Claude Code user settings or `pluginConfigs`.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), and a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.8.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.8.1]
 
 ### Changed

--- a/plugins/knowledge/README.md
+++ b/plugins/knowledge/README.md
@@ -110,5 +110,4 @@ because a `sensitive` option persists as plaintext on Windows today.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/machine-health/.claude-plugin/plugin.json
+++ b/plugins/machine-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "machine-health",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Workstation health audit: OS-specific checks (disk, OS updates, security posture, CISA KEV correlation) run from a versioned catalog with trend-aware severity, approval-gated remediations, and dated markdown reports. Windows fully implemented; macOS/Linux scaffolded (report UNKNOWN and stop). Machine state persists in the plugin data directory; the report directory and check catalog are configurable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/machine-health/CHANGELOG.md
+++ b/plugins/machine-health/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `machine-health` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.6.0]
 
 ### Changed

--- a/plugins/machine-health/README.md
+++ b/plugins/machine-health/README.md
@@ -80,5 +80,4 @@ pwsh -NoProfile -File plugins/machine-health/skills/audit/tests/Invoke-MachineHe
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/mcp-tools/.claude-plugin/plugin.json
+++ b/plugins/mcp-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mcp-tools",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Audits MCP server tool definitions against MCP-specification and Anthropic tool-design criteria and reports a per-tool PASS/WARN/FAIL scorecard covering description, parameters, naming, and annotations. Language-agnostic — Python (FastMCP), TypeScript, and .NET.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/mcp-tools/CHANGELOG.md
+++ b/plugins/mcp-tools/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `mcp-tools` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.2.1]
 
 ### Changed

--- a/plugins/mcp-tools/README.md
+++ b/plugins/mcp-tools/README.md
@@ -61,5 +61,4 @@ scorecard is returned in the response.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.3]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.22.2]
 
 ### Changed

--- a/plugins/planning/README.md
+++ b/plugins/planning/README.md
@@ -66,5 +66,4 @@ concern file `.claude/topic-docs.yaml` (`contract_dir`, `memory_dir`,
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).


### PR DESCRIPTION
No linked issue — wave 2 of 3; #537 stays open until all 39 plugins are done.

Same recipe as wave-1 PR #755 for the next 13 plugins alphabetically; guardrails is deferred to wave 3 because two in-flight guardrails version bumps (#757 lane) serialize ahead of it. Per-plugin patch bump + CHANGELOG entry; discovery and docs-hygiene entries carry dates per those plugins' own changelog convention.

Verification: repro grep returns 0 hits over the 13 wave-2 READMEs; all 13 manifest versions match their CHANGELOG top entry; base predates #755 so wave-1 plugins intentionally still carry the pointer here (no file overlap between waves).

## Related

- #537 (wave 2 of 3)
- #755 (wave 1)
- #426 (the two-plugin fix this mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
