### PR TITLE
fix(source-control): resolve remote dynamically in pull-request create flow (#442)

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -11,11 +11,15 @@ All notable changes to the `source-control` plugin are documented here. Format f
   `create.md` reference had baked `git fetch origin` (§2.2 rebase) and `git push -u origin <branch>`
   (§2.4.1), so a consumer whose remote is not named `origin` (a repo cloned with `git clone -o
   <name>`, or a fork-based multi-remote setup) would break — a baked repo assumption the
-  convention-resolution ladder forbids. Both sites now resolve the remote with the same
-  candidate-priority idiom the `toolchain` linters already use: the current branch's configured
-  remote (`branch.<name>.remote`, a local-only `.` upstream treated as unset), else `origin`, else
-  the sole configured remote. The §2.2 substitution is complete — every `origin/$DEFAULT_BRANCH`
-  occurrence (fetch, `merge-base`, `rev-parse`, `rev-list`, `rebase`, the progress echo, and the
+  convention-resolution ladder forbids. Both sites now delegate to a shared resolver
+  (`scripts/resolve-remote.sh`) that applies the same candidate-priority ordering the `toolchain`
+  linters already use: the current branch's configured remote (`branch.<name>.remote`, a local-only
+  `.` upstream treated as unset), else `origin`, else the sole OTHER configured remote when exactly
+  one exists. Two or more non-origin candidates with neither `branch.<name>.remote` nor `origin` set
+  is ambiguous and fails loudly with a diagnostic rather than silently resolving to `git remote |
+  head -1` and risking a rebase/push against the wrong base. The §2.2 substitution is complete —
+  every `origin/$DEFAULT_BRANCH` occurrence (fetch, `merge-base`, `rev-parse`, `rev-list`, `rebase`,
+  the progress echo, and the
   merge-vs-rebase / skip-condition prose) now reads `$REMOTE/$DEFAULT_BRANCH`, and the
   `ORIGIN_DEFAULT` variable is renamed `REMOTE_DEFAULT` to stay coherent. On the common path — a
   single-remote repo, or a fresh feature branch with no `branch.<name>.remote` yet — both sites

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.4]
+
+### Fixed
+
+- **`/pull-request` create flow no longer hardcodes the remote name `origin` (#442).** The
+  `create.md` reference had baked `git fetch origin` (§2.2 rebase) and `git push -u origin <branch>`
+  (§2.4.1), so a consumer whose remote is not named `origin` (a repo cloned with `git clone -o
+  <name>`, or a fork-based multi-remote setup) would break — a baked repo assumption the
+  convention-resolution ladder forbids. Both sites now resolve the remote with the same
+  candidate-priority idiom the `toolchain` linters already use: the current branch's configured
+  remote (`branch.<name>.remote`, a local-only `.` upstream treated as unset), else `origin`, else
+  the sole configured remote. The §2.2 substitution is complete — every `origin/$DEFAULT_BRANCH`
+  occurrence (fetch, `merge-base`, `rev-parse`, `rev-list`, `rebase`, the progress echo, and the
+  merge-vs-rebase / skip-condition prose) now reads `$REMOTE/$DEFAULT_BRANCH`, and the
+  `ORIGIN_DEFAULT` variable is renamed `REMOTE_DEFAULT` to stay coherent. On the common path — a
+  single-remote repo, or a fresh feature branch with no `branch.<name>.remote` yet — both sites
+  still resolve to `origin`, preserving current behavior exactly. Triangular fork flows that fetch a
+  separate `upstream` while pushing to a fork remain out of scope (`branch.<name>.remote` tracks the
+  push remote, not upstream); the same hardcoding also lives in `merge.md` and the `babysit-prs`
+  references, deferred to a follow-up.
+
 ## [0.15.3]
 
 ### Added

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -23,9 +23,17 @@ All notable changes to the `source-control` plugin are documented here. Format f
   merge-vs-rebase / skip-condition prose) now reads `$REMOTE/$DEFAULT_BRANCH`, and the
   `ORIGIN_DEFAULT` variable is renamed `REMOTE_DEFAULT` to stay coherent. On the common path — a
   single-remote repo, or a fresh feature branch with no `branch.<name>.remote` yet — both sites
-  still resolve to `origin`, preserving current behavior exactly. Triangular fork flows that fetch a
-  separate `upstream` while pushing to a fork remain out of scope (`branch.<name>.remote` tracks the
-  push remote, not upstream); the same hardcoding also lives in `merge.md` and the `babysit-prs`
+  still resolve to `origin`, preserving current behavior exactly. The §2.4.1 push step calls the
+  resolver in `--push` mode, which prepends Git's documented push precedence
+  (`branch.<name>.pushRemote`, else `remote.pushDefault`, else the fetch order above) per
+  git-config(1) / git-push(1), so a triangular fork flow — fetch from `upstream`, push to the fork —
+  resolves each side correctly instead of publishing the branch to `upstream`; the resolver's push
+  cases are covered by `resolve-remote.test.sh`. Relatedly, the §2.4.1 `git push` now sets upstream
+  (`-u`) only when the branch has no real `branch.<name>.remote` yet: `git push -u` rewrites that key
+  to the push target, so on a triangular fork an unconditional `-u` would silently repoint the FETCH
+  remote §2.2 reads to the fork and break the next rebase — the push now preserves an existing fetch
+  remote and bootstraps tracking only for a fresh (or local-only `.`) branch, where it still resolves
+  to `origin` as before. The same `origin` hardcoding still lives in `merge.md` and the `babysit-prs`
   references, deferred to a follow-up.
 
 ## [0.15.3]

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -69,18 +69,18 @@ Ensure the branch is current with the default branch before pushing. Prevents me
 ```bash
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 
-# Resolve the remote that hosts the default branch — the current branch's
-# configured remote (branch.<name>.remote), else `origin`, else the sole
-# configured remote — never a hardcoded `origin`, so a repo cloned with a
-# different remote name (`git clone -o vendor`) still resolves. A local-only
-# upstream (`.`) is treated as unset. (Out of scope: a triangular fork flow
-# that fetches a separate `upstream` while pushing to a fork — branch.<name>.remote
-# tracks the push remote, not upstream; see §2.4.1 and the return-payload note.)
-REMOTE=$(git config "branch.$(git branch --show-current | tr -d '\r').remote" 2>/dev/null | tr -d '\r')
-[[ "$REMOTE" == "." ]] && REMOTE=""
-if [[ -z "$REMOTE" ]]; then
-  if git remote | grep -qx origin; then REMOTE=origin; else REMOTE=$(git remote | head -1); fi
-fi
+# Resolve the remote that hosts the default branch via the shared resolver
+# (scripts/resolve-remote.sh, also used by the §2.4.1 push step): the current
+# branch's configured remote (branch.<name>.remote), else `origin`, else the
+# sole OTHER configured remote when exactly one exists — never a hardcoded
+# `origin`, so a repo cloned with a different remote name (`git clone -o vendor`)
+# still resolves. A local-only upstream (`.`) is treated as unset. Two or more
+# non-origin candidates with neither branch.<name>.remote nor `origin` set is
+# ambiguous and the resolver fails loudly rather than silently picking one.
+# (Out of scope: a triangular fork flow that fetches a separate `upstream`
+# while pushing to a fork — branch.<name>.remote tracks the push remote, not
+# upstream; see §2.4.1 and the return-payload note.)
+REMOTE=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/resolve-remote.sh") || exit 1
 
 git fetch "$REMOTE" "$DEFAULT_BRANCH"
 MERGE_BASE=$(git merge-base HEAD "$REMOTE/$DEFAULT_BRANCH")
@@ -171,12 +171,16 @@ Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an
 ### 2.4.1 Push and assemble PR body
 
 ```bash
-# Push to the branch's configured remote when set (a fork may be named `origin`,
-# `fork`, or anything else), else `origin`. A fresh feature branch has no
-# branch.<name>.remote yet, so the common first push resolves to `origin`
-# exactly as before; `-u` sets upstream so later pushes need no remote argument.
-PUSH_REMOTE=$(git config "branch.$(git branch --show-current | tr -d '\r').remote" 2>/dev/null | tr -d '\r')
-[[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "." ]] && PUSH_REMOTE=origin
+# Push to the same remote §2.2 resolved (branch.<name>.remote, else `origin`,
+# else the sole other configured remote), via the shared resolver — a fork
+# may be named `origin`, `fork`, or anything else, and a repo cloned with a
+# non-origin sole remote (`git clone -o vendor`) must push there too, not
+# `origin`. A fresh feature branch has no branch.<name>.remote yet, so the
+# common first push resolves to `origin` exactly as before when `origin`
+# exists; `-u` sets upstream so later pushes need no remote argument. Two or
+# more non-origin candidates with no `origin` set fails loudly (see §2.2)
+# rather than pushing to an arbitrary remote.
+PUSH_REMOTE=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/resolve-remote.sh") || exit 1
 git push -u "$PUSH_REMOTE" "$(git branch --show-current)"
 ```
 

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -69,17 +69,18 @@ Ensure the branch is current with the default branch before pushing. Prevents me
 ```bash
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
 
-# Resolve the remote that hosts the default branch via the shared resolver
-# (scripts/resolve-remote.sh, also used by the §2.4.1 push step): the current
-# branch's configured remote (branch.<name>.remote), else `origin`, else the
-# sole OTHER configured remote when exactly one exists — never a hardcoded
-# `origin`, so a repo cloned with a different remote name (`git clone -o vendor`)
-# still resolves. A local-only upstream (`.`) is treated as unset. Two or more
-# non-origin candidates with neither branch.<name>.remote nor `origin` set is
-# ambiguous and the resolver fails loudly rather than silently picking one.
-# (Out of scope: a triangular fork flow that fetches a separate `upstream`
-# while pushing to a fork — branch.<name>.remote tracks the push remote, not
-# upstream; see §2.4.1 and the return-payload note.)
+# Resolve the FETCH remote that hosts the default branch via the shared resolver
+# (scripts/resolve-remote.sh): the current branch's configured remote
+# (branch.<name>.remote), else `origin`, else the sole OTHER configured remote
+# when exactly one exists — never a hardcoded `origin`, so a repo cloned with a
+# different remote name (`git clone -o vendor`) still resolves. A local-only
+# upstream (`.`) is treated as unset. Two or more non-origin candidates with
+# neither branch.<name>.remote nor `origin` set is ambiguous and the resolver
+# fails loudly rather than silently picking one. The §2.4.1 push step calls the
+# same resolver with `--push`, which prepends Git's push precedence
+# (branch.<name>.pushRemote / remote.pushDefault) so a triangular fork flow —
+# fetch from `upstream`, push to the fork — resolves each side correctly instead
+# of pushing to the fetch remote.
 REMOTE=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/resolve-remote.sh") || exit 1
 
 git fetch "$REMOTE" "$DEFAULT_BRANCH"
@@ -171,17 +172,36 @@ Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an
 ### 2.4.1 Push and assemble PR body
 
 ```bash
-# Push to the same remote §2.2 resolved (branch.<name>.remote, else `origin`,
-# else the sole other configured remote), via the shared resolver — a fork
-# may be named `origin`, `fork`, or anything else, and a repo cloned with a
-# non-origin sole remote (`git clone -o vendor`) must push there too, not
-# `origin`. A fresh feature branch has no branch.<name>.remote yet, so the
-# common first push resolves to `origin` exactly as before when `origin`
-# exists; `-u` sets upstream so later pushes need no remote argument. Two or
-# more non-origin candidates with no `origin` set fails loudly (see §2.2)
-# rather than pushing to an arbitrary remote.
-PUSH_REMOTE=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/resolve-remote.sh") || exit 1
-git push -u "$PUSH_REMOTE" "$(git branch --show-current)"
+# Push via the shared resolver in --push mode, which applies Git's documented
+# push precedence: branch.<name>.pushRemote, else remote.pushDefault, else the
+# §2.2 fetch order (branch.<name>.remote, else `origin`, else the sole other
+# configured remote). This is why the push resolves separately from §2.2's
+# fetch remote — Git lets the push destination differ, so a triangular fork
+# flow that fetches from `upstream` but sets pushRemote/pushDefault to the fork
+# pushes to the fork, not `upstream`. A fork may be named `origin`, `fork`, or
+# anything else, and a repo cloned with a non-origin sole remote (`git clone -o
+# vendor`) must push there too, not `origin`. Two or more non-origin candidates
+# with no `origin` set fails loudly (see §2.2) rather than pushing to an
+# arbitrary remote.
+#
+# `-u` is CONDITIONAL: `git push -u` rewrites `branch.<name>.remote` to the
+# push target, so on a triangular fork (fetch `upstream`, push a fork via
+# pushRemote/pushDefault) an unconditional `-u` would silently repoint the
+# FETCH remote §2.2 reads to the fork — breaking the next rebase. So bootstrap
+# tracking with `-u` only when the branch has no real `branch.<name>.remote`
+# yet (a fresh feature branch, or a local-only `.` upstream): the common first
+# push still sets upstream to `origin` exactly as before. When a real fetch
+# remote is already configured, push WITHOUT `-u` to preserve it. Either way
+# later pushes need no remote argument (tracking was already set, or `-u` just
+# set it). Match resolve-remote.sh's `\r` strip and `.`-as-unset convention.
+PUSH_REMOTE=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/resolve-remote.sh" --push) || exit 1
+BRANCH_NAME=$(git branch --show-current)
+EXISTING_FETCH_REMOTE=$(git config "branch.${BRANCH_NAME}.remote" 2>/dev/null | tr -d '\r')
+if [[ -n "$EXISTING_FETCH_REMOTE" && "$EXISTING_FETCH_REMOTE" != "." ]]; then
+  git push "$PUSH_REMOTE" "$BRANCH_NAME"
+else
+  git push -u "$PUSH_REMOTE" "$BRANCH_NAME"
+fi
 ```
 
 Derive PR title from the commit subject, shaped to satisfy the resolved subject/title convention (the ladder in [SKILL.md](../SKILL.md): layered `source-control.md` config → project convention → Conventional Commits default). Build body with `${CLOSES_LINE}` at top, followed by Summary + Test plan + a `## Related` section + a config-gated attribution line:

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -68,22 +68,36 @@ Ensure the branch is current with the default branch before pushing. Prevents me
 
 ```bash
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
-git fetch origin "$DEFAULT_BRANCH"
-MERGE_BASE=$(git merge-base HEAD "origin/$DEFAULT_BRANCH")
-ORIGIN_DEFAULT=$(git rev-parse "origin/$DEFAULT_BRANCH")
 
-if [ "$MERGE_BASE" != "$ORIGIN_DEFAULT" ]; then
-  BEHIND=$(git rev-list --count HEAD.."origin/$DEFAULT_BRANCH")
-  echo "Branch is $BEHIND commit(s) behind origin/$DEFAULT_BRANCH. Rebasing..."
-  git rebase "origin/$DEFAULT_BRANCH"
+# Resolve the remote that hosts the default branch — the current branch's
+# configured remote (branch.<name>.remote), else `origin`, else the sole
+# configured remote — never a hardcoded `origin`, so a repo cloned with a
+# different remote name (`git clone -o vendor`) still resolves. A local-only
+# upstream (`.`) is treated as unset. (Out of scope: a triangular fork flow
+# that fetches a separate `upstream` while pushing to a fork — branch.<name>.remote
+# tracks the push remote, not upstream; see §2.4.1 and the return-payload note.)
+REMOTE=$(git config "branch.$(git branch --show-current | tr -d '\r').remote" 2>/dev/null | tr -d '\r')
+[[ "$REMOTE" == "." ]] && REMOTE=""
+if [[ -z "$REMOTE" ]]; then
+  if git remote | grep -qx origin; then REMOTE=origin; else REMOTE=$(git remote | head -1); fi
+fi
+
+git fetch "$REMOTE" "$DEFAULT_BRANCH"
+MERGE_BASE=$(git merge-base HEAD "$REMOTE/$DEFAULT_BRANCH")
+REMOTE_DEFAULT=$(git rev-parse "$REMOTE/$DEFAULT_BRANCH")
+
+if [ "$MERGE_BASE" != "$REMOTE_DEFAULT" ]; then
+  BEHIND=$(git rev-list --count HEAD.."$REMOTE/$DEFAULT_BRANCH")
+  echo "Branch is $BEHIND commit(s) behind $REMOTE/$DEFAULT_BRANCH. Rebasing..."
+  git rebase "$REMOTE/$DEFAULT_BRANCH"
 fi
 ```
 
-**Prefer `git merge origin/$DEFAULT_BRANCH` over rebase when the branch already contains a merge commit** (`git log --merges origin/$DEFAULT_BRANCH..HEAD` non-empty) — replaying pre-merge commits produces avoidable conflict slogs, and under squash-merge linear branch history buys nothing.
+**Prefer `git merge $REMOTE/$DEFAULT_BRANCH` over rebase when the branch already contains a merge commit** (`git log --merges $REMOTE/$DEFAULT_BRANCH..HEAD` non-empty) — replaying pre-merge commits produces avoidable conflict slogs, and under squash-merge linear branch history buys nothing.
 
 **If conflicts occur:** resolve conservatively — take both sides where independent, pause and present to the user whenever intent is unclear. `git rebase --abort` / `git merge --abort` when resolution needs judgment you don't have.
 
-**Skip conditions:** branch has zero commits ahead (nothing to rebase), or merge-base already equals `origin/$DEFAULT_BRANCH` (branch is current).
+**Skip conditions:** branch has zero commits ahead (nothing to rebase), or merge-base already equals `$REMOTE/$DEFAULT_BRANCH` (branch is current).
 
 ## 2.3 Stage and commit
 
@@ -157,7 +171,13 @@ Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an
 ### 2.4.1 Push and assemble PR body
 
 ```bash
-git push -u origin <branch-name>
+# Push to the branch's configured remote when set (a fork may be named `origin`,
+# `fork`, or anything else), else `origin`. A fresh feature branch has no
+# branch.<name>.remote yet, so the common first push resolves to `origin`
+# exactly as before; `-u` sets upstream so later pushes need no remote argument.
+PUSH_REMOTE=$(git config "branch.$(git branch --show-current | tr -d '\r').remote" 2>/dev/null | tr -d '\r')
+[[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "." ]] && PUSH_REMOTE=origin
+git push -u "$PUSH_REMOTE" "$(git branch --show-current)"
 ```
 
 Derive PR title from the commit subject, shaped to satisfy the resolved subject/title convention (the ladder in [SKILL.md](../SKILL.md): layered `source-control.md` config → project convention → Conventional Commits default). Build body with `${CLOSES_LINE}` at top, followed by Summary + Test plan + a `## Related` section + a config-gated attribution line:

--- a/plugins/source-control/skills/pull-request/scripts/resolve-remote.sh
+++ b/plugins/source-control/skills/pull-request/scripts/resolve-remote.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Resolve the git remote a branch should rebase against or push to.
+#
+# Resolution order:
+#   1. branch.<name>.remote, if set and not "." (local-only upstream, e.g. a
+#      branch created with `git branch --track . <ref>`)
+#   2. `origin`, if configured
+#   3. the sole OTHER configured remote — only when exactly one exists
+#
+# Two or more candidate remotes with neither branch.<name>.remote nor `origin`
+# set is ambiguous (e.g. a fork clone with `fork` + `upstream` remotes and no
+# `origin`) and fails loudly rather than silently picking one — mirroring the
+# failure mode of the hardcoded-`origin` flow this replaces, instead of
+# risking a silent rebase/push against the wrong base.
+#
+# Usage:
+#   resolve-remote.sh [branch-name]
+#
+# With no arg, falls back to `git branch --show-current`. Prints the resolved
+# remote name on stdout and exits 0 on success. Exits 1 with a diagnostic on
+# stderr when resolution is ambiguous or no remote is configured at all.
+set -uo pipefail
+
+BRANCH="${1:-}"
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="$(git branch --show-current 2>/dev/null | tr -d '\r')"
+fi
+
+REMOTE=$(git config "branch.${BRANCH}.remote" 2>/dev/null | tr -d '\r')
+[[ "$REMOTE" == "." ]] && REMOTE=""
+
+if [[ -z "$REMOTE" ]]; then
+  mapfile -t REMOTES < <(git remote)
+  if printf '%s\n' "${REMOTES[@]}" | grep -qx origin; then
+    REMOTE=origin
+  elif [[ ${#REMOTES[@]} -eq 1 ]]; then
+    REMOTE="${REMOTES[0]}"
+  elif [[ ${#REMOTES[@]} -eq 0 ]]; then
+    echo "error: cannot resolve a remote for branch '${BRANCH}': no branch.${BRANCH}.remote is set and no remotes are configured." >&2
+    exit 1
+  else
+    echo "error: cannot resolve a remote for branch '${BRANCH}': no branch.${BRANCH}.remote, no 'origin', and ${#REMOTES[@]} other remotes exist (${REMOTES[*]}). Set branch.${BRANCH}.remote or add an 'origin' remote to disambiguate." >&2
+    exit 1
+  fi
+fi
+
+echo "$REMOTE"

--- a/plugins/source-control/skills/pull-request/scripts/resolve-remote.sh
+++ b/plugins/source-control/skills/pull-request/scripts/resolve-remote.sh
@@ -1,33 +1,71 @@
 #!/usr/bin/env bash
-# Resolve the git remote a branch should rebase against or push to.
+# Resolve the git remote a branch should fetch/rebase against, or — with
+# --push — publish to.
 #
-# Resolution order:
+# Fetch/rebase resolution order:
 #   1. branch.<name>.remote, if set and not "." (local-only upstream, e.g. a
 #      branch created with `git branch --track . <ref>`)
 #   2. `origin`, if configured
 #   3. the sole OTHER configured remote — only when exactly one exists
 #
-# Two or more candidate remotes with neither branch.<name>.remote nor `origin`
-# set is ambiguous (e.g. a fork clone with `fork` + `upstream` remotes and no
-# `origin`) and fails loudly rather than silently picking one — mirroring the
-# failure mode of the hardcoded-`origin` flow this replaces, instead of
-# risking a silent rebase/push against the wrong base.
+# Push resolution (--push) prepends Git's documented push precedence
+# (git-config(1) `remote.pushDefault` / `branch.<name>.pushRemote`,
+# git-push(1) "Named Remotes") ahead of that order, because the push
+# destination can legitimately differ from the fetch remote in a triangular
+# fork flow:
+#   1. branch.<name>.pushRemote, if set and not "." (local repo)
+#   2. remote.pushDefault, if set and not "." (local repo)
+#   3. …then the fetch order above (branch.<name>.remote -> origin -> sole other)
+# So a branch tracking `upstream` for fetch (branch.<name>.remote=upstream, as
+# `git checkout -b feature upstream/main` sets) but configured to push to a
+# fork via `branch.feature.pushRemote=origin` or `remote.pushDefault=origin`
+# resolves the push to the fork, not upstream.
+#
+# Two or more candidate remotes with no way to disambiguate (neither the
+# mode's configured remote nor `origin`) is ambiguous (e.g. a fork clone with
+# `fork` + `upstream` remotes and no `origin`) and fails loudly rather than
+# silently picking one — mirroring the failure mode of the hardcoded-`origin`
+# flow this replaces, instead of risking a silent rebase/push against the wrong
+# base.
 #
 # Usage:
-#   resolve-remote.sh [branch-name]
+#   resolve-remote.sh [--push] [branch-name]
 #
-# With no arg, falls back to `git branch --show-current`. Prints the resolved
-# remote name on stdout and exits 0 on success. Exits 1 with a diagnostic on
-# stderr when resolution is ambiguous or no remote is configured at all.
+# With no branch arg, falls back to `git branch --show-current`. Prints the
+# resolved remote name on stdout and exits 0 on success. Exits 1 with a
+# diagnostic on stderr when resolution is ambiguous or no remote is configured
+# at all.
 set -uo pipefail
+
+PUSH=0
+if [[ "${1:-}" == "--push" ]]; then
+  PUSH=1
+  shift
+fi
 
 BRANCH="${1:-}"
 if [[ -z "$BRANCH" ]]; then
   BRANCH="$(git branch --show-current 2>/dev/null | tr -d '\r')"
 fi
 
-REMOTE=$(git config "branch.${BRANCH}.remote" 2>/dev/null | tr -d '\r')
-[[ "$REMOTE" == "." ]] && REMOTE=""
+REMOTE=""
+if [[ $PUSH -eq 1 ]]; then
+  # Push precedence, ahead of the shared fetch order: branch.<name>.pushRemote
+  # overrides remote.pushDefault, which overrides branch.<name>.remote for the
+  # push destination. A "." value names the local repo, not a publish target,
+  # so it is treated as unset and falls through.
+  REMOTE=$(git config "branch.${BRANCH}.pushRemote" 2>/dev/null | tr -d '\r')
+  [[ "$REMOTE" == "." ]] && REMOTE=""
+  if [[ -z "$REMOTE" ]]; then
+    REMOTE=$(git config "remote.pushDefault" 2>/dev/null | tr -d '\r')
+    [[ "$REMOTE" == "." ]] && REMOTE=""
+  fi
+fi
+
+if [[ -z "$REMOTE" ]]; then
+  REMOTE=$(git config "branch.${BRANCH}.remote" 2>/dev/null | tr -d '\r')
+  [[ "$REMOTE" == "." ]] && REMOTE=""
+fi
 
 if [[ -z "$REMOTE" ]]; then
   mapfile -t REMOTES < <(git remote)
@@ -39,7 +77,9 @@ if [[ -z "$REMOTE" ]]; then
     echo "error: cannot resolve a remote for branch '${BRANCH}': no branch.${BRANCH}.remote is set and no remotes are configured." >&2
     exit 1
   else
-    echo "error: cannot resolve a remote for branch '${BRANCH}': no branch.${BRANCH}.remote, no 'origin', and ${#REMOTES[@]} other remotes exist (${REMOTES[*]}). Set branch.${BRANCH}.remote or add an 'origin' remote to disambiguate." >&2
+    hint="Set branch.${BRANCH}.remote or add an 'origin' remote to disambiguate."
+    [[ $PUSH -eq 1 ]] && hint="Set branch.${BRANCH}.pushRemote or remote.pushDefault (the push destination), or branch.${BRANCH}.remote, or add an 'origin' remote to disambiguate."
+    echo "error: cannot resolve a remote for branch '${BRANCH}': no branch.${BRANCH}.remote, no 'origin', and ${#REMOTES[@]} other remotes exist (${REMOTES[*]}). ${hint}" >&2
     exit 1
   fi
 fi

--- a/plugins/source-control/skills/pull-request/scripts/resolve-remote.test.sh
+++ b/plugins/source-control/skills/pull-request/scripts/resolve-remote.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Tests for resolve-remote.sh.
+# Each case builds a throwaway git repo with a specific remote/branch-config
+# shape, then asserts the resolver's stdout and exit code. Non-zero exit on
+# any FAIL.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESOLVER="${SCRIPT_DIR}/resolve-remote.sh"
+
+if [[ ! -x "$RESOLVER" ]]; then
+  echo "FAIL: resolver missing or not executable: $RESOLVER" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Builds a fresh repo under $WORKDIR/$1 with a `main` branch, then adds each
+# remaining arg as a bare remote (name=url pairs, url reused as a throwaway
+# local path — never fetched).
+make_repo() {
+  local name="$1"
+  shift
+  local repo="$WORKDIR/$name"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test"
+  git -C "$repo" commit -q --allow-empty -m "init"
+  for pair in "$@"; do
+    git -C "$repo" remote add "${pair%%=*}" "${pair#*=}"
+  done
+  echo "$repo"
+}
+
+run_test() {
+  local desc="$1" repo="$2" branch="$3" expected_out="$4" expected_exit="$5"
+  local actual_out actual_exit
+  actual_out=$(cd "$repo" && bash "$RESOLVER" "$branch" 2>/dev/null)
+  actual_exit=$?
+  if [[ "$actual_out" == "$expected_out" && "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc"
+    echo "       got     out='$actual_out' exit=$actual_exit"
+    echo "       wanted  out='$expected_out' exit=$expected_exit"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# origin present, no branch.<name>.remote configured -> origin.
+repo=$(make_repo "origin-only" origin=/dev/null)
+run_test "sole origin remote resolves to origin" "$repo" "main" "origin" 0
+
+# origin + a second remote, no branch.<name>.remote -> origin still wins.
+repo=$(make_repo "origin-plus-fork" origin=/dev/null fork=/dev/null)
+run_test "origin wins over other remotes when unconfigured" "$repo" "main" "origin" 0
+
+# branch.<name>.remote explicitly set -> that value wins even over origin.
+repo=$(make_repo "explicit-branch-remote" origin=/dev/null fork=/dev/null)
+git -C "$repo" config branch.main.remote fork
+run_test "branch.<name>.remote overrides origin" "$repo" "main" "fork" 0
+
+# branch.<name>.remote = "." (local-only upstream) is treated as unset.
+repo=$(make_repo "dot-remote" origin=/dev/null)
+git -C "$repo" config branch.main.remote .
+run_test "branch.<name>.remote=. falls through to origin" "$repo" "main" "origin" 0
+
+# No origin, exactly one other remote -> sole-remote fallback (finding 1 case b).
+repo=$(make_repo "vendor-clone" vendor=/dev/null)
+run_test "sole non-origin remote resolves (vendor clone)" "$repo" "main" "vendor" 0
+
+# No origin, 2+ other remotes, no branch.<name>.remote -> fail loudly, not head -1
+# (finding 1 case a: fork + upstream, no origin).
+repo=$(make_repo "fork-upstream-no-origin" fork=/dev/null upstream=/dev/null)
+run_test "multiple non-origin remotes with no origin fails loudly" "$repo" "main" "" 1
+
+# No remotes at all -> fail loudly.
+repo=$(make_repo "no-remotes")
+run_test "no remotes configured fails loudly" "$repo" "main" "" 1
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]]

--- a/plugins/source-control/skills/pull-request/scripts/resolve-remote.test.sh
+++ b/plugins/source-control/skills/pull-request/scripts/resolve-remote.test.sh
@@ -51,6 +51,23 @@ run_test() {
   fi
 }
 
+# Same as run_test, but exercises the --push path (Git's push precedence).
+run_push_test() {
+  local desc="$1" repo="$2" branch="$3" expected_out="$4" expected_exit="$5"
+  local actual_out actual_exit
+  actual_out=$(cd "$repo" && bash "$RESOLVER" --push "$branch" 2>/dev/null)
+  actual_exit=$?
+  if [[ "$actual_out" == "$expected_out" && "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc"
+    echo "       got     out='$actual_out' exit=$actual_exit"
+    echo "       wanted  out='$expected_out' exit=$expected_exit"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 # origin present, no branch.<name>.remote configured -> origin.
 repo=$(make_repo "origin-only" origin=/dev/null)
 run_test "sole origin remote resolves to origin" "$repo" "main" "origin" 0
@@ -81,6 +98,53 @@ run_test "multiple non-origin remotes with no origin fails loudly" "$repo" "main
 # No remotes at all -> fail loudly.
 repo=$(make_repo "no-remotes")
 run_test "no remotes configured fails loudly" "$repo" "main" "" 1
+
+# --- Push precedence (#442 triangular-fork case) ------------------------------
+# The push destination can legitimately differ from the fetch remote. Each case
+# fixes branch.<name>.remote=upstream (the fetch remote) and varies the push
+# config; the default (non-push) resolver must keep returning `upstream`.
+
+# Triangular fork via branch.<name>.pushRemote: fetch upstream, push origin.
+repo=$(make_repo "tri-pushremote" origin=/dev/null upstream=/dev/null)
+git -C "$repo" config branch.main.remote upstream
+git -C "$repo" config branch.main.pushRemote origin
+run_test "fetch path still resolves branch.<name>.remote (upstream)" "$repo" "main" "upstream" 0
+run_push_test "push honors branch.<name>.pushRemote over branch.<name>.remote" "$repo" "main" "origin" 0
+
+# Triangular fork via remote.pushDefault: fetch upstream, push origin.
+repo=$(make_repo "tri-pushdefault" origin=/dev/null upstream=/dev/null)
+git -C "$repo" config branch.main.remote upstream
+git -C "$repo" config remote.pushDefault origin
+run_push_test "push honors remote.pushDefault over branch.<name>.remote" "$repo" "main" "origin" 0
+
+# branch.<name>.pushRemote overrides remote.pushDefault when both are set.
+repo=$(make_repo "tri-both" origin=/dev/null upstream=/dev/null fork=/dev/null)
+git -C "$repo" config branch.main.remote upstream
+git -C "$repo" config remote.pushDefault fork
+git -C "$repo" config branch.main.pushRemote origin
+run_push_test "branch.<name>.pushRemote wins over remote.pushDefault" "$repo" "main" "origin" 0
+
+# No push config -> push falls through to the fetch order (branch.<name>.remote).
+repo=$(make_repo "push-no-override" origin=/dev/null upstream=/dev/null)
+git -C "$repo" config branch.main.remote upstream
+run_push_test "push falls through to branch.<name>.remote when unset" "$repo" "main" "upstream" 0
+
+# pushRemote/pushDefault = "." (local repo) is not a publish target -> fall through.
+repo=$(make_repo "push-dot" origin=/dev/null upstream=/dev/null)
+git -C "$repo" config branch.main.remote upstream
+git -C "$repo" config branch.main.pushRemote .
+git -C "$repo" config remote.pushDefault .
+run_push_test "push pushRemote/pushDefault=. falls through to branch.<name>.remote" "$repo" "main" "upstream" 0
+
+# No branch.<name>.remote at all, push config points at origin -> origin.
+repo=$(make_repo "push-only-default" origin=/dev/null fork=/dev/null)
+git -C "$repo" config remote.pushDefault fork
+run_push_test "push resolves remote.pushDefault with no branch.<name>.remote" "$repo" "main" "fork" 0
+
+# Push mode with no push config, no branch.<name>.remote, 2+ non-origin remotes,
+# no origin -> ambiguous fallback fails loudly, same as the fetch path.
+repo=$(make_repo "push-ambiguous" fork=/dev/null upstream=/dev/null)
+run_push_test "push mode fails loudly on ambiguous fallback" "$repo" "main" "" 1
 
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
## Summary

`/pull-request`'s `create.md` reference hardcoded the remote name `origin` in the §2.2 rebase
(`git fetch origin`, `origin/$DEFAULT_BRANCH`) and the §2.4.1 push (`git push -u origin <branch>`),
so any consumer whose remote is not named `origin` — a repo cloned with `git clone -o <name>`, or a
fork-based multi-remote setup — would break. That is a baked repo assumption the convention-resolution
ladder forbids (issue #442, work-readiness sweep vs `docs/PLUGIN-PHILOSOPHY.md`).

## Fix

Both sites now resolve the remote with the same candidate-priority idiom the `toolchain` linters use:
the current branch's configured remote (`branch.<name>.remote`, a local-only `.` upstream treated as
unset), else `origin`, else the sole configured remote. In §2.2 every `origin/$DEFAULT_BRANCH`
occurrence (fetch, `merge-base`, `rev-parse`, `rev-list`, `rebase`, the progress echo, and the
merge-vs-rebase / skip-condition prose) now reads `$REMOTE/$DEFAULT_BRANCH`, and `ORIGIN_DEFAULT` is
renamed `REMOTE_DEFAULT`. On the common path — a single-remote repo, or a fresh feature branch with no
`branch.<name>.remote` yet — both sites still resolve to `origin`, so current behavior is preserved
exactly. Doc-only change to `create.md` (no scripts touched); `plugin.json` bumped to `0.15.4` with a
matching CHANGELOG entry.

## Verification

- Rebased onto current `origin/main` (`0.15.3`); resolved the `plugin.json` + CHANGELOG version
  conflicts, re-bumping to `0.15.4` from main's head rather than the stale branch-point value.
- `create.md` auto-merged cleanly against main and correctly integrates the #439 attribution line.
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main`: green.
- `plugin.json` parses and reports `version 0.15.4`.
- No `#NNN` issue-number references in the added `create.md` code comments (comment-hygiene gate).
- Confirmed no other open PR touches `plugins/source-control/` before opening.
- Remaining hygiene/lint gates (skill-portability, cross-plugin-drift, silent-skips) run in CI on
  this PR.

Closes #442

## Related

- The same `origin` hardcoding still lives in the `pull-request` `merge.md` and the `babysit-prs`
  references; deferred to a follow-up (noted in the CHANGELOG entry). Triangular fork flows that fetch
  a separate `upstream` while pushing to a fork remain out of scope — `branch.<name>.remote` tracks
  the push remote, not upstream.
