### PR TITLE
docs(plugins): drop unreachable repo-root LICENSE pointer from final 13 READMEs (wave 3)

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.3]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.9.2]
 
 ### Fixed

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -162,5 +162,4 @@ check reports with guidance.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.2.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/playbooks/README.md
+++ b/plugins/playbooks/README.md
@@ -52,5 +52,4 @@ working-tree checkout.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/powershell-format/.claude-plugin/plugin.json
+++ b/plugins/powershell-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powershell-format",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/powershell-format/CHANGELOG.md
+++ b/plugins/powershell-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `powershell-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.4.2]
 
 ### Changed

--- a/plugins/powershell-format/README.md
+++ b/plugins/powershell-format/README.md
@@ -98,5 +98,4 @@ plugin in that project's `enabledPlugins` instead.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/prototype/.claude-plugin/plugin.json
+++ b/plugins/prototype/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "prototype",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Builds throwaway code to answer a design question before committing to architecture — a logic facet (an interactive terminal app over a portable state model) and a UI facet (radically different visual variants on one route).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/prototype/CHANGELOG.md
+++ b/plugins/prototype/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `prototype` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.3.0]
 
 ### Changed

--- a/plugins/prototype/README.md
+++ b/plugins/prototype/README.md
@@ -54,5 +54,4 @@ already uses; the plugin adds no runtime of its own.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.4]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.4.3]
 
 ### Fixed

--- a/plugins/repo-hygiene/README.md
+++ b/plugins/repo-hygiene/README.md
@@ -92,5 +92,4 @@ extension point, not yet exposed as configuration.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.8]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.14.7]
 
 ### Added

--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -88,5 +88,4 @@ findings location in your `CLAUDE.md`/rules overrides the default path.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.4.1]
 
 ### Changed

--- a/plugins/ruff-format/README.md
+++ b/plugins/ruff-format/README.md
@@ -94,5 +94,4 @@ To turn the plugin off for a single repository, disable it in that project's
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Songwriting craft companion — eight concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.6.0]
 
 ### Changed (breaking)

--- a/plugins/songwriting/README.md
+++ b/plugins/songwriting/README.md
@@ -74,7 +74,6 @@ internal rhyme generation.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository. Pat Pattison's books are cited as methodology
+MIT (SPDX-License-Identifier: MIT). Pat Pattison's books are cited as methodology
 sources; the plugin contains distilled craft guidance and short verified anchor quotes, not book
 text.

--- a/plugins/tdd/.claude-plugin/plugin.json
+++ b/plugins/tdd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tdd",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A TDD knowledge base distilled from cover-to-cover readings of Kent Beck's Test-Driven Development: By Example and Vladimir Khorikov's Unit Testing: Principles, Practices, and Patterns — fourteen author-attributed reference files behind a routing table plus a no-load quick decision guide, answering the WHY behind test design decisions.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/tdd/CHANGELOG.md
+++ b/plugins/tdd/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `tdd` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/tdd/README.md
+++ b/plugins/tdd/README.md
@@ -44,5 +44,4 @@ configure, no state, no scripts, no network access.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), and failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.2.5]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.2.4]
 
 ### Changed

--- a/plugins/testing/README.md
+++ b/plugins/testing/README.md
@@ -43,5 +43,4 @@ This plugin declares no userConfig options.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/toolchain/.claude-plugin/plugin.json
+++ b/plugins/toolchain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "toolchain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Repo-agnostic polyglot verification toolchain: build + test + lint for changed files across .NET, Python, TypeScript, Bash, PowerShell, Markdown, YAML, and cross-cutting surfaces (`/toolchain:check`, `/toolchain:lint`), plus a re-runnable `/toolchain:setup` with check (report the configured ecosystems and their command surface) and apply (interview, infer, and write the tracked per-ecosystem command config those skills resolve first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/toolchain/CHANGELOG.md
+++ b/plugins/toolchain/CHANGELOG.md
@@ -16,15 +16,15 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 ### Removed
 
-- **`/toolchain:setup` no longer offers the topic-docs concern file â€” relocated to the lifecycle
+- **`/toolchain:setup` no longer offers the topic-docs concern file — relocated to the lifecycle
   plugins that own it.** Setup step 6 wrote `.claude/topic-docs.yaml`, a consumer config resolved by
   the `implementation` and `verification` plugins for artifact placement; no `/toolchain:*` skill reads
   it, so this build/test/lint plugin was writing another plugin's consumer config. Setup is now scoped
   solely to the ecosystem command surface it owns (the tracked `.claude/ecosystems/*.yaml` files):
   `check` no longer reports the topic-docs concern and `apply` no longer offers it, and the orphaned
   `reference/topic-docs.md` binding that only step 6 read is removed. The shared concern file is offered
-  by each lifecycle plugin's own setup â€” `/discovery:setup`, `/planning:setup`, and the new
-  `/verification:setup` â€” independent of whether the others are installed. Closes #263.
+  by each lifecycle plugin's own setup — `/discovery:setup`, `/planning:setup`, and the new
+  `/verification:setup` — independent of whether the others are installed. Closes #263.
 
 ## [0.4.3]
 
@@ -33,7 +33,7 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 - **Presence-gated `dotnet-msbuild:*` build-diagnostics references in `context/dotnet.md` reframed as
   .NET-ecosystem forward references.** The `## Marketplace plugin skills for build diagnostics (invoke
   only when installed)` list gains a lead-in that frames its `dotnet-msbuild:*` skills as applicable
-  when your stack is .NET and as forward references to the planned `dotnet-*` plugin family â€” invoked
+  when your stack is .NET and as forward references to the planned `dotnet-*` plugin family — invoked
   only when the plugin is installed, otherwise falling back to the section's own prose remediation and
   binlog gotcha (the generic path stays first-class). Framing only: no skill reference was removed,
   renamed, or genericized, and no command string was altered. Aligns this file with the presence-gated
@@ -50,10 +50,10 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
   `branch.<name>.remote`, but when that was unset (an unpushed feature branch) it forced `REMOTE=origin`
   unconditionally. In a clone made with a differently named remote (`git clone -o vendor`) that has no
   `origin` and no pushed upstream, `origin` does not exist, so `git symbolic-ref refs/remotes/origin/HEAD`
-  and every subsequent probe failed and the branch diff was skipped ("branch diff unavailable") â€” the
+  and every subsequent probe failed and the branch diff was skipped ("branch diff unavailable") — the
   `origin` fallback the 0.4.1 note claimed "still resolves" a `git clone -o vendor` did not hold for the
-  not-yet-pushed case. Both call sites now probe candidate remotes in priority order â€” the branch's
-  tracking remote, then `origin` if present, then the rest â€” and select the first whose default branch
+  not-yet-pushed case. Both call sites now probe candidate remotes in priority order — the branch's
+  tracking remote, then `origin` if present, then the rest — and select the first whose default branch
   resolves to a locally available `refs/remotes/<remote>/<branch>` tracking ref. This also skips a remote
   that was added but never fetched (whose `git ls-remote` default-branch query succeeds over the network
   but leaves no local ref for `git merge-base`) in favor of a later remote that has one, rather than
@@ -77,9 +77,9 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 - **Default branch resolved by detection, not assumption.** The clean-working-tree branch-diff
   fallback in `/toolchain:check` and `/toolchain:lint` carried a bare `<default-branch>` placeholder
-  with no resolution guidance, so the model would likely guess `main`/`master` â€” a baked repo
+  with no resolution guidance, so the model would likely guess `main`/`master` — a baked repo
   assumption the convention-resolution discipline forbids. Both call sites now resolve the tracked
-  remote (`branch.<name>.remote`, falling back to `origin` â€” never a hardcoded remote name, so a repo
+  remote (`branch.<name>.remote`, falling back to `origin` — never a hardcoded remote name, so a repo
   cloned with a different remote name still resolves), then the default branch via
   `git symbolic-ref --short refs/remotes/$REMOTE/HEAD` (with the `$REMOTE/` prefix stripped), falling
   back to a `git ls-remote --symref "$REMOTE" HEAD` query of that remote's own default branch, matching
@@ -94,13 +94,13 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 ### Changed
 
-- **`/toolchain:setup` adopts the uniform setup contract** (fleet conformance wave) â€” delivering the
+- **`/toolchain:setup` adopts the uniform setup contract** (fleet conformance wave) — delivering the
   `apply` action the 0.3.0 topic-docs note recorded as the contract's follow-on. The skill now splits
   into a read-only `check` action (default) that reports which ecosystems are configured, each one's
-  resolved build/test/lint command surface, and the topic-docs concern file â€” validating the tracked
+  resolved build/test/lint command surface, and the topic-docs concern file — validating the tracked
   files against the contract's `ecosystem.schema.json`, treating an unconfigured ecosystem as INFO
   (the bundled rung-4 default resolves) and FAILing only a configured-but-broken file (schema-invalid,
-  or excluded by `.gitignore`) â€” and an `apply` action that infers and writes the tracked config. The
+  or excluded by `.gitignore`) — and an `apply` action that infers and writes the tracked config. The
   previous interview (infer per-ecosystem commands, write `.claude/ecosystems/*.yaml`, offer
   `.claude/topic-docs.yaml`) becomes `apply`'s interview path; `apply <ecosystem>` scopes the run to
   one ecosystem and writes an unambiguous inference non-interactively. The per-ecosystem inference,
@@ -140,7 +140,7 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 ### Added
 
-- Initial release â€” three skills extracted from the `implementation` plugin (skill names unchanged):
+- Initial release — three skills extracted from the `implementation` plugin (skill names unchanged):
   `/toolchain:build` (polyglot build + test + lint for changed files, resolved through the four-rung
   ecosystem-commands ladder), `/toolchain:lint` (lint + format only, plus the `yaml` and `cross-cutting`
   surfaces), and `/toolchain:setup` (re-runnable writer of the tracked `.claude/ecosystems/*.yaml`
@@ -149,4 +149,4 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
   `reference/ecosystems/`, and the plugin-local `reference/topic-docs.md` binding that `/toolchain:setup`
   reads to offer the topic-docs concern file.
 - Cross-plugin references to the `verification` plugin's `/verification:confirm` are informational and
-  degrade gracefully â€” this plugin never hard-depends on any other plugin.
+  degrade gracefully — this plugin never hard-depends on any other plugin.

--- a/plugins/toolchain/CHANGELOG.md
+++ b/plugins/toolchain/CHANGELOG.md
@@ -3,19 +3,28 @@
 All notable changes to the `toolchain` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.5.0]
 
 ### Removed
 
-- **`/toolchain:setup` no longer offers the topic-docs concern file — relocated to the lifecycle
+- **`/toolchain:setup` no longer offers the topic-docs concern file â€” relocated to the lifecycle
   plugins that own it.** Setup step 6 wrote `.claude/topic-docs.yaml`, a consumer config resolved by
   the `implementation` and `verification` plugins for artifact placement; no `/toolchain:*` skill reads
   it, so this build/test/lint plugin was writing another plugin's consumer config. Setup is now scoped
   solely to the ecosystem command surface it owns (the tracked `.claude/ecosystems/*.yaml` files):
   `check` no longer reports the topic-docs concern and `apply` no longer offers it, and the orphaned
   `reference/topic-docs.md` binding that only step 6 read is removed. The shared concern file is offered
-  by each lifecycle plugin's own setup — `/discovery:setup`, `/planning:setup`, and the new
-  `/verification:setup` — independent of whether the others are installed. Closes #263.
+  by each lifecycle plugin's own setup â€” `/discovery:setup`, `/planning:setup`, and the new
+  `/verification:setup` â€” independent of whether the others are installed. Closes #263.
 
 ## [0.4.3]
 
@@ -24,7 +33,7 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 - **Presence-gated `dotnet-msbuild:*` build-diagnostics references in `context/dotnet.md` reframed as
   .NET-ecosystem forward references.** The `## Marketplace plugin skills for build diagnostics (invoke
   only when installed)` list gains a lead-in that frames its `dotnet-msbuild:*` skills as applicable
-  when your stack is .NET and as forward references to the planned `dotnet-*` plugin family — invoked
+  when your stack is .NET and as forward references to the planned `dotnet-*` plugin family â€” invoked
   only when the plugin is installed, otherwise falling back to the section's own prose remediation and
   binlog gotcha (the generic path stays first-class). Framing only: no skill reference was removed,
   renamed, or genericized, and no command string was altered. Aligns this file with the presence-gated
@@ -41,10 +50,10 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
   `branch.<name>.remote`, but when that was unset (an unpushed feature branch) it forced `REMOTE=origin`
   unconditionally. In a clone made with a differently named remote (`git clone -o vendor`) that has no
   `origin` and no pushed upstream, `origin` does not exist, so `git symbolic-ref refs/remotes/origin/HEAD`
-  and every subsequent probe failed and the branch diff was skipped ("branch diff unavailable") — the
+  and every subsequent probe failed and the branch diff was skipped ("branch diff unavailable") â€” the
   `origin` fallback the 0.4.1 note claimed "still resolves" a `git clone -o vendor` did not hold for the
-  not-yet-pushed case. Both call sites now probe candidate remotes in priority order — the branch's
-  tracking remote, then `origin` if present, then the rest — and select the first whose default branch
+  not-yet-pushed case. Both call sites now probe candidate remotes in priority order â€” the branch's
+  tracking remote, then `origin` if present, then the rest â€” and select the first whose default branch
   resolves to a locally available `refs/remotes/<remote>/<branch>` tracking ref. This also skips a remote
   that was added but never fetched (whose `git ls-remote` default-branch query succeeds over the network
   but leaves no local ref for `git merge-base`) in favor of a later remote that has one, rather than
@@ -68,9 +77,9 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 - **Default branch resolved by detection, not assumption.** The clean-working-tree branch-diff
   fallback in `/toolchain:check` and `/toolchain:lint` carried a bare `<default-branch>` placeholder
-  with no resolution guidance, so the model would likely guess `main`/`master` — a baked repo
+  with no resolution guidance, so the model would likely guess `main`/`master` â€” a baked repo
   assumption the convention-resolution discipline forbids. Both call sites now resolve the tracked
-  remote (`branch.<name>.remote`, falling back to `origin` — never a hardcoded remote name, so a repo
+  remote (`branch.<name>.remote`, falling back to `origin` â€” never a hardcoded remote name, so a repo
   cloned with a different remote name still resolves), then the default branch via
   `git symbolic-ref --short refs/remotes/$REMOTE/HEAD` (with the `$REMOTE/` prefix stripped), falling
   back to a `git ls-remote --symref "$REMOTE" HEAD` query of that remote's own default branch, matching
@@ -85,13 +94,13 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 ### Changed
 
-- **`/toolchain:setup` adopts the uniform setup contract** (fleet conformance wave) — delivering the
+- **`/toolchain:setup` adopts the uniform setup contract** (fleet conformance wave) â€” delivering the
   `apply` action the 0.3.0 topic-docs note recorded as the contract's follow-on. The skill now splits
   into a read-only `check` action (default) that reports which ecosystems are configured, each one's
-  resolved build/test/lint command surface, and the topic-docs concern file — validating the tracked
+  resolved build/test/lint command surface, and the topic-docs concern file â€” validating the tracked
   files against the contract's `ecosystem.schema.json`, treating an unconfigured ecosystem as INFO
   (the bundled rung-4 default resolves) and FAILing only a configured-but-broken file (schema-invalid,
-  or excluded by `.gitignore`) — and an `apply` action that infers and writes the tracked config. The
+  or excluded by `.gitignore`) â€” and an `apply` action that infers and writes the tracked config. The
   previous interview (infer per-ecosystem commands, write `.claude/ecosystems/*.yaml`, offer
   `.claude/topic-docs.yaml`) becomes `apply`'s interview path; `apply <ecosystem>` scopes the run to
   one ecosystem and writes an unambiguous inference non-interactively. The per-ecosystem inference,
@@ -131,7 +140,7 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 
 ### Added
 
-- Initial release — three skills extracted from the `implementation` plugin (skill names unchanged):
+- Initial release â€” three skills extracted from the `implementation` plugin (skill names unchanged):
   `/toolchain:build` (polyglot build + test + lint for changed files, resolved through the four-rung
   ecosystem-commands ladder), `/toolchain:lint` (lint + format only, plus the `yaml` and `cross-cutting`
   surfaces), and `/toolchain:setup` (re-runnable writer of the tracked `.claude/ecosystems/*.yaml`
@@ -140,4 +149,4 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
   `reference/ecosystems/`, and the plugin-local `reference/topic-docs.md` binding that `/toolchain:setup`
   reads to offer the topic-docs concern file.
 - Cross-plugin references to the `verification` plugin's `/verification:confirm` are informational and
-  degrade gracefully — this plugin never hard-depends on any other plugin.
+  degrade gracefully â€” this plugin never hard-depends on any other plugin.

--- a/plugins/toolchain/README.md
+++ b/plugins/toolchain/README.md
@@ -43,5 +43,4 @@ reports the effective configuration). This plugin declares no userConfig options
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/verification/.claude-plugin/plugin.json
+++ b/plugins/verification/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "verification",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Outcome-verification stage: prove a change achieved its intended outcome (`/verification:confirm` \u2014 a mechanical build/test/lint prerequisite gate, then intent-match + evidence + verdict with the criterion auto-detected by change type), and verify measurable-improvement claims against a planning-time baseline (`/verification:measure`), never fabricating numbers.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/verification/CHANGELOG.md
+++ b/plugins/verification/CHANGELOG.md
@@ -16,11 +16,11 @@ All notable changes to the `verification` plugin are documented here. Format fol
 
 ### Added
 
-- **`/verification:setup` â€” settles the topic-docs seam for the consuming repo.** Offers the tracked
+- **`/verification:setup` — settles the topic-docs seam for the consuming repo.** Offers the tracked
   `.claude/topic-docs.yaml` concern file that governs where `/verification:confirm` lands its manifests
   (contract tier) and `/verification:measure` lands its baselines and raw captures (memory tier). `check`
-  (default) reports the effective concern read-only; `apply` persists it â€” non-interactively from
-  complete `<key>=<value>` arguments or via a one-question, recommendation-first interview â€” running the
+  (default) reports the effective concern read-only; `apply` persists it — non-interactively from
+  complete `<key>=<value>` arguments or via a one-question, recommendation-first interview — running the
   committed-tier `git check-ignore` guard before writing and never editing the consumer's root
   `.gitignore`. Mirrors the `/discovery:setup` and `/planning:setup` pattern, offering the shared file
   independent of whether the sibling lifecycle plugins are installed. This concern was previously offered
@@ -35,7 +35,7 @@ All notable changes to the `verification` plugin are documented here. Format fol
   `## Marketplace plugin skills (invoke only when installed)` guard heading (matching the `testing`
   plugin's gated lists) plus a lead-in that frames the `dotnet-*` skills as .NET-only and
   `cloudflare:web-perf` as web-frontend-only, each invoked only when its plugin is installed and
-  otherwise falling back to the project's own tooling â€” the generic complexity/coverage or
+  otherwise falling back to the project's own tooling — the generic complexity/coverage or
   benchmark/profiling harness where that fits, with a tailored per-bullet fallback where the
   evidence type differs (query logging / database profiling / ORM diagnostics for EF-query
   analysis, a test-quality analyzer or test-smell review checklist for test-quality analysis,
@@ -70,7 +70,7 @@ All notable changes to the `verification` plugin are documented here. Format fol
 ### Changed
 
 - **Freshness rider on the bundled `/verify` + `/run` availability claim**
-  (fleet conformance wave). The â‰¥ 2.1.145 floor is re-verified against the
+  (fleet conformance wave). The ≥ 2.1.145 floor is re-verified against the
   official bundled-skills docs and now carries a verified-date + link.
 
 ## [0.2.0]
@@ -79,7 +79,7 @@ All notable changes to the `verification` plugin are documented here. Format fol
 
 - Adopt topic-docs contract 2.0.0 (visibility semantics): `reference/topic-docs.md` states
   baselines and raw captures are checkout-local, and `/verification:measure` writes distilled
-  values only into `PLAN.md` â€” never a memory-slice capture path (pointer discipline).
+  values only into `PLAN.md` — never a memory-slice capture path (pointer discipline).
 
 ## [0.1.1]
 
@@ -91,9 +91,9 @@ All notable changes to the `verification` plugin are documented here. Format fol
 
 ### Added
 
-- Initial release â€” two skills extracted and renamed from the `implementation` plugin's `verify-*`
-  skills: `/verification:confirm` (was `verify-changes` â€” the mechanical prerequisite gate then
-  intent-match + evidence + verdict) and `/verification:measure` (was `verify-improvement` â€”
+- Initial release — two skills extracted and renamed from the `implementation` plugin's `verify-*`
+  skills: `/verification:confirm` (was `verify-changes` — the mechanical prerequisite gate then
+  intent-match + evidence + verdict) and `/verification:measure` (was `verify-improvement` —
   baseline/compare measurable-improvement verification). Skill trigger phrases and evals are preserved;
   only the namespace and leaf names changed.
 - Bundled reference: the plugin-local `reference/topic-docs.md` binding (verification manifests and
@@ -102,4 +102,4 @@ All notable changes to the `verification` plugin are documented here. Format fol
 - Cross-plugin delegation degrades gracefully: the Stage-1 mechanical pass delegates to
   `/toolchain:build` and `/toolchain:lint` when the `toolchain` plugin is installed (else the project's
   ecosystem-native commands), and live-app verification prefers `/testing:run-e2e` when the `testing` plugin
-  is installed (else bundled `/verify` + `/run` or a manual orchestrator launch) â€” no hard dependencies.
+  is installed (else bundled `/verify` + `/run` or a manual orchestrator launch) — no hard dependencies.

--- a/plugins/verification/CHANGELOG.md
+++ b/plugins/verification/CHANGELOG.md
@@ -3,15 +3,24 @@
 All notable changes to the `verification` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.3.0]
 
 ### Added
 
-- **`/verification:setup` — settles the topic-docs seam for the consuming repo.** Offers the tracked
+- **`/verification:setup` â€” settles the topic-docs seam for the consuming repo.** Offers the tracked
   `.claude/topic-docs.yaml` concern file that governs where `/verification:confirm` lands its manifests
   (contract tier) and `/verification:measure` lands its baselines and raw captures (memory tier). `check`
-  (default) reports the effective concern read-only; `apply` persists it — non-interactively from
-  complete `<key>=<value>` arguments or via a one-question, recommendation-first interview — running the
+  (default) reports the effective concern read-only; `apply` persists it â€” non-interactively from
+  complete `<key>=<value>` arguments or via a one-question, recommendation-first interview â€” running the
   committed-tier `git check-ignore` guard before writing and never editing the consumer's root
   `.gitignore`. Mirrors the `/discovery:setup` and `/planning:setup` pattern, offering the shared file
   independent of whether the sibling lifecycle plugins are installed. This concern was previously offered
@@ -26,7 +35,7 @@ All notable changes to the `verification` plugin are documented here. Format fol
   `## Marketplace plugin skills (invoke only when installed)` guard heading (matching the `testing`
   plugin's gated lists) plus a lead-in that frames the `dotnet-*` skills as .NET-only and
   `cloudflare:web-perf` as web-frontend-only, each invoked only when its plugin is installed and
-  otherwise falling back to the project's own tooling — the generic complexity/coverage or
+  otherwise falling back to the project's own tooling â€” the generic complexity/coverage or
   benchmark/profiling harness where that fits, with a tailored per-bullet fallback where the
   evidence type differs (query logging / database profiling / ORM diagnostics for EF-query
   analysis, a test-quality analyzer or test-smell review checklist for test-quality analysis,
@@ -61,7 +70,7 @@ All notable changes to the `verification` plugin are documented here. Format fol
 ### Changed
 
 - **Freshness rider on the bundled `/verify` + `/run` availability claim**
-  (fleet conformance wave). The ≥ 2.1.145 floor is re-verified against the
+  (fleet conformance wave). The â‰¥ 2.1.145 floor is re-verified against the
   official bundled-skills docs and now carries a verified-date + link.
 
 ## [0.2.0]
@@ -70,7 +79,7 @@ All notable changes to the `verification` plugin are documented here. Format fol
 
 - Adopt topic-docs contract 2.0.0 (visibility semantics): `reference/topic-docs.md` states
   baselines and raw captures are checkout-local, and `/verification:measure` writes distilled
-  values only into `PLAN.md` — never a memory-slice capture path (pointer discipline).
+  values only into `PLAN.md` â€” never a memory-slice capture path (pointer discipline).
 
 ## [0.1.1]
 
@@ -82,9 +91,9 @@ All notable changes to the `verification` plugin are documented here. Format fol
 
 ### Added
 
-- Initial release — two skills extracted and renamed from the `implementation` plugin's `verify-*`
-  skills: `/verification:confirm` (was `verify-changes` — the mechanical prerequisite gate then
-  intent-match + evidence + verdict) and `/verification:measure` (was `verify-improvement` —
+- Initial release â€” two skills extracted and renamed from the `implementation` plugin's `verify-*`
+  skills: `/verification:confirm` (was `verify-changes` â€” the mechanical prerequisite gate then
+  intent-match + evidence + verdict) and `/verification:measure` (was `verify-improvement` â€”
   baseline/compare measurable-improvement verification). Skill trigger phrases and evals are preserved;
   only the namespace and leaf names changed.
 - Bundled reference: the plugin-local `reference/topic-docs.md` binding (verification manifests and
@@ -93,4 +102,4 @@ All notable changes to the `verification` plugin are documented here. Format fol
 - Cross-plugin delegation degrades gracefully: the Stage-1 mechanical pass delegates to
   `/toolchain:build` and `/toolchain:lint` when the `toolchain` plugin is installed (else the project's
   ecosystem-native commands), and live-app verification prefers `/testing:run-e2e` when the `testing` plugin
-  is installed (else bundled `/verify` + `/run` or a manual orchestrator launch) — no hard dependencies.
+  is installed (else bundled `/verify` + `/run` or a manual orchestrator launch) â€” no hard dependencies.

--- a/plugins/verification/README.md
+++ b/plugins/verification/README.md
@@ -48,5 +48,4 @@ concern read-only, `apply` writes it). This plugin declares no userConfig option
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the `LICENSE` file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.2]
+
+### Changed
+
+- Documentation-only: the License section now states the plugin's own MIT
+  license inline and no longer points at a `LICENSE` file at the repository
+  root, which an installed consumer running from the isolated plugin cache
+  cannot reach. No behavior change.
+
 ## [0.17.1]
 
 Paginate the github adapter's *open linked PRs* signal so the `/work-items:work` frontier filter

--- a/plugins/work-items/README.md
+++ b/plugins/work-items/README.md
@@ -129,5 +129,4 @@ gracefully when any of these are absent.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). See the LICENSE file at the root of the
-melodic-software/claude-code-plugins repository.
+MIT (SPDX-License-Identifier: MIT).


### PR DESCRIPTION
Closes #537 — final wave; repo-wide repro grep (`at the root of|root of (the )?melodic`) returns zero across all `plugins/*/README.md` on this branch.

Supersedes #766 (identical change, rebased): #737 landed toolchain 0.5.0 / verification 0.3.0 mid-grace, so those two stack as 0.5.1 / 0.3.1; guardrails (0.9.2→0.9.3) and work-items (0.17.1→0.17.2) stack above their own mid-flight entries as before. All 13 manifests match their CHANGELOG top entry; songwriting's methodology-attribution note preserved.

## Related

- #537 (wave 3 of 3 — closes)
- #766 (superseded — pre-rebase head of this same change)
- #755 / #758 (waves 1–2)
- #426 (the two-plugin fix this mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
