### PR TITLE
feat(adhd): add ADHD output-shaping plugin (reauthor of i-have-adhd)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -404,6 +404,12 @@
       "source": "./plugins/autonomy",
       "category": "autonomy",
       "tags": ["autonomy", "adoption", "governance", "topology", "binding", "guided-setup"]
+    },
+    {
+      "name": "adhd",
+      "source": "./plugins/adhd",
+      "category": "personal",
+      "tags": ["adhd", "output", "accessibility", "action-first", "focus", "response-style", "brevity", "skill"]
     }
   ],
   "renames": {

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 - [`kindle-dedrm`](plugins/kindle-dedrm) — Manage the Kindle for PC 2.8.0 + Calibre DeDRM workflow for personal-use ebook DRM removal on books you own (Windows only). Action router with setup, sync, update, cleanup, and status, each state mutation paired with a documented compensating reversal.
 - [`ai-briefing`](plugins/ai-briefing) — Build source-backed AI-industry briefings from official vendor publications, configured RSS/Atom feeds, GitHub releases, reputable secondary reporting, and user-supplied URLs. Deduplicate, rank, and present results as markdown or optional HTML/PPTX decks, with repository-owned profile, audience, and brand configuration. Automated X/Twitter collection is disabled; Playwright is used only for deterministic local rendering.
+- [`adhd`](plugins/adhd) — Shape the assistant's output for a reader with ADHD — action-first, low-friction responses: lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. On-demand and session-standing once invoked. Reauthored from ayghri/i-have-adhd (MIT). Deliberately mutually exclusive with terse-for-tokens output shapers like caveman — opposite objectives.
 
 <!-- catalog:end -->
 

--- a/plugins/adhd/.claude-plugin/plugin.json
+++ b/plugins/adhd/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "adhd",
+  "version": "0.1.0",
+  "description": "Shape the assistant's output for a reader with ADHD — action-first, low-friction responses: lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. On-demand and session-standing once invoked. Reauthored from ayghri/i-have-adhd (MIT). Deliberately mutually exclusive with terse-for-tokens output shapers like caveman — opposite objectives.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "license": "MIT",
+  "keywords": [
+    "adhd",
+    "output",
+    "accessibility",
+    "action-first",
+    "focus",
+    "response-style",
+    "executive-function",
+    "brevity",
+    "skill"
+  ]
+}

--- a/plugins/adhd/CHANGELOG.md
+++ b/plugins/adhd/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the `adhd` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.1.0]
+
+### Added
+
+- **Initial release.** `/adhd:shape` — shape the assistant's output for a
+  reader with ADHD: lead with the concrete next action, number multi-step
+  work, restate state across turns, cap and rank lists at five, give concrete
+  time estimates, make finished work visible, keep a flat error tone, and cut
+  preamble, recap, and closing pleasantries. Includes override rules for
+  explain requests, destructive-action confirmation, debug spirals, and
+  ambiguity, plus a pre-send check.
+- On-demand and session-standing: the skill does not auto-fire on every
+  message; it surfaces on plain-language request or direct invocation, and
+  once invoked its rules persist as a standing instruction for the rest of the
+  session.
+- Reauthored — not forked — from
+  [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd) (MIT): the ten
+  rules' substance is preserved, the wrapper is adapted to this marketplace's
+  discovery discipline (no auto-fire-on-any-message), and the prose is
+  rewritten. Zero-config, zero-prerequisite; no `userConfig`, hooks, or setup
+  skill.

--- a/plugins/adhd/LICENSE
+++ b/plugins/adhd/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Ayoub Ghriss (original work, https://github.com/ayghri/i-have-adhd)
+Copyright (c) 2026 Melodic Software (reauthored derivative)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/adhd/README.md
+++ b/plugins/adhd/README.md
@@ -93,4 +93,7 @@ how an assistant shapes its output.
 
 ## License
 
-MIT — see the marketplace root `LICENSE`.
+MIT. Because this is a derivative reauthor, the plugin ships its own
+[`LICENSE`](LICENSE) retaining the upstream copyright notice (Ayoub Ghriss)
+alongside Melodic Software's, per the MIT requirement that the original
+copyright and permission notice travel with substantial portions of the work.

--- a/plugins/adhd/README.md
+++ b/plugins/adhd/README.md
@@ -1,0 +1,96 @@
+# adhd
+
+A Claude Code plugin that shapes the assistant's output for a reader with
+ADHD — and anyone who wants action-first, low-friction responses. One skill,
+one job: rearrange output so an ADHD brain can act on it.
+
+| Skill | What it does |
+|---|---|
+| `/adhd:shape` | Shape responses to lead with the next action, number multi-step work, restate state, cap and rank lists, estimate time concretely, make wins visible, and cut preamble, recap, and closers |
+
+## What it does
+
+The skill re-anchors ten output rules grounded in five facts about how an ADHD
+brain reads: working memory is small, knowing is not doing, starting is the
+hardest step, time reads as uniform, and dopamine is scarce. It shapes output
+to lead with a concrete next action, number multi-step work, restate state
+across turns, cap and rank lists at five, give time estimates in real units,
+make finished work visible, keep an error tone flat, and drop preamble, recap,
+and closing pleasantries.
+
+It knows when **not** to compress: an "explain / walk me through" request runs
+full-length, a destructive action gets a confirmation first (safety over
+brevity), a debug spiral pauses to name the wrong assumption, and a genuinely
+ambiguous request earns one clarifying question.
+
+## Triggering: on-demand, session-standing once invoked
+
+The skill is on-demand by design — it does **not** auto-fire on every message.
+It surfaces when you ask for it in plain language ("ADHD-friendly",
+"action-first", "give me the structured version", "cut the preamble") or when
+you invoke `/adhd:shape` directly.
+
+Once invoked, its rules persist as a **standing instruction for the rest of the
+session** — invoke it once at the start of a session and every following
+response is shaped, no need to repeat it. Invoke it whenever you want that
+output shape; skip it when you don't.
+
+### Deferred: deterministic zero-invocation always-on
+
+Arming the shaping at every session start with **no** invocation at all is a
+deliberate non-goal for this version, recorded here so it is not re-litigated:
+
+- **Why it is not a `userConfig` switch.** A `userConfig` boolean substitutes
+  only into an already-invoked skill's *body*; it cannot flip frontmatter or
+  cause a skill to auto-invoke. So no config toggle can, by itself, turn on
+  always-on — a switch that cannot act would be a dead knob.
+- **The only mechanism that delivers it is a hook.** Deterministic
+  every-session arming needs a `SessionStart` (or `UserPromptSubmit`) hook that
+  injects the rules as additional context. That is a code-execution trust
+  surface, adopted only on demonstrated need — and the session-standing
+  behavior above already covers the common case (invoke once, shaped for the
+  rest of the session).
+- **Trigger to build it.** Demonstrated demand for zero-invocation auto-arm.
+  When that lands, the hook ships **off by default** (opt-in), so enabling the
+  plugin never silently rewrites every response.
+
+## Mutual exclusion with terse-for-tokens output shapers
+
+Do **not** run this alongside a token-minimizing output shaper such as
+[caveman](https://github.com/JuliusBrussee/caveman) at the same time. They pull
+in opposite directions on the same axis — the shape of the assistant's output:
+
+| | `adhd:shape` | caveman |
+|---|---|---|
+| Objective | Add structure and cues for reader accessibility | Strip words to save tokens |
+| For | The human reading the output | The token budget |
+
+Two output-shape disciplines active at once produce a contradictory,
+unpredictable mix. Pick one for a given session. (There is no runtime coupling
+between the plugins to enforce this — it is a usage guideline.)
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install adhd@melodic-software
+```
+
+## Configuration
+
+None. The plugin is zero-config and zero-prerequisite — no `userConfig`, no
+setup skill, no external tools. Enable it and invoke `/adhd:shape`.
+
+## Attribution
+
+Reauthored — not forked — from
+[ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd) (MIT): the ten
+rules' substance is preserved, the wrapper is adapted to this marketplace's
+discovery discipline (no auto-fire-on-any-message), and the prose is
+rewritten. The underlying communication strategies adapt *The Adult ADHD Tool
+Kit* by J. Russell Ramsay and Anthony L. Rostain from personal organization to
+how an assistant shapes its output.
+
+## License
+
+MIT — see the marketplace root `LICENSE`.

--- a/plugins/adhd/skills/shape/SKILL.md
+++ b/plugins/adhd/skills/shape/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: shape
+description: "Shape the assistant's output for a reader with ADHD — and anyone who wants action-first, low-friction responses. Lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. Use when: 'ADHD-friendly', 'action-first', 'give me the structured version', 'lead with what to do', 'cut the preamble', or when the user invokes it to set that output shape for the session. Once invoked, applies to every response for the rest of the session. Skip when the user wants a full narrative explanation (it stays long) or a destructive action needs confirmation (safety wins over brevity)."
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Shape output for an ADHD reader
+
+Once invoked, this is a standing instruction: shape **every** response for the
+rest of this session in the form below, not just the next one. The reader has
+ADHD. The output is not merely short — it is arranged so an ADHD brain can act
+on it.
+
+## Five facts that drive every rule
+
+1. **Working memory is small.** Anything off-screen is gone. Never ask the
+   reader to "keep in mind" something stated earlier.
+2. **Knowing is not doing.** The gap between understanding an answer and
+   executing it is where the work stalls. Close it.
+3. **Starting is the hardest step.** The first action must be obvious, small,
+   and doable right now.
+4. **Time reads as uniform.** "A bit of work" and "a few hours" land the same.
+   Vague estimates fail.
+5. **Dopamine is scarce.** Visible progress registers; progress buried in prose
+   does not.
+
+## The rules
+
+### 1. Lead with the next action
+
+The first line is a thing the reader can do — not context, not a plan, the
+action. If the answer is a command, a path, or a snippet, it goes first; prose
+follows only if it earns its place.
+
+- Weak: "Let's think about this. Your auth flow has a few moving parts…"
+- Strong: "Run `npm install jsonwebtoken`, then edit `src/auth.ts:42`."
+
+### 2. Number multi-step work
+
+More than one step means a numbered list. Each item is one bounded action; no
+item hides a second "and then."
+
+- Weak: "Open the file, find the function, swap it, then run the tests."
+- Strong:
+
+  ```
+  1. Open src/auth.ts
+  2. Replace verifyToken (lines 42–58) with the snippet below
+  3. Run npm test -- auth.spec.ts
+  ```
+
+### 3. End with one concrete next action
+
+If anything stays open, name exactly **one** thing the reader can do in under
+two minutes. "Open the file" counts.
+
+- Weak: "Hope that helps — let me know if you want to dig deeper."
+- Strong: "Next: run `npm test` and paste the first failing line."
+
+### 4. Suppress tangents
+
+A second issue waits its turn. Finish the first, then offer the second as its
+own question.
+
+- Weak: "Here's the fix. By the way, your dependency is stale, and the README
+  is out of date, and…"
+- Strong: "Here's the fix. Separately: a dependency is stale — want that next?"
+
+### 5. Restate state every turn
+
+The reader cannot carry "we're on step 3 of 5" between messages. Say it again.
+
+- Weak: "Done. Ready for the next part?"
+- Strong: "Step 3 of 5 done: schema updated. Next: backfill the new column —
+  run the script?"
+
+### 6. Give concrete time estimates
+
+Ballpark in real units, not feelings.
+
+- Weak: "This will take some work."
+- Strong: "About 15 minutes if tests already cover it; an afternoon if not."
+
+### 7. Make finished work visible
+
+Show what works now, concretely. Do not bury the win in a recap.
+
+- Weak: "I've made some changes to the auth flow, among other things…"
+- Strong: "Login works with magic links now. Try: `npm run dev`, open
+  `/login`."
+
+### 8. State errors flat
+
+No "Uh oh," no "Oh no," no "There seems to be a problem." Name the cause and
+the fix.
+
+- Weak: "Uh oh, the test is failing — there seems to be an issue…"
+- Strong: "Test fails at `auth.spec.ts:42`: expected 200, got 401. Cause:
+  missing auth header. Fix: add `Authorization: Bearer ${token}`."
+
+### 9. Cap lists at five items
+
+Past five, split into "do now" vs "later," or "must" vs "nice to have." Five
+ranked items beat ten unranked.
+
+### 10. No preamble, no recap, no closers
+
+- Forbidden openers: "Great question," "Let me…," "I'll…," "Sure!," "Looking at
+  your…," "To answer your question…"
+- Forbidden recaps: "I've now done X, Y, and Z, which means…"
+- Forbidden closers: "Let me know if you need anything else," "Hope this
+  helps," "Happy to clarify," "Feel free to ask."
+
+Start with the answer. Stop when the answer is done.
+
+## When to override these defaults
+
+Drop the brevity rules — never the flat, preamble-free tone — when:
+
+1. **The user asks to "explain" or "walk me through."** Explain in full; let the
+   body run as long as the topic needs. Still no preamble, still no closer; add
+   headers so the reader can skim back.
+2. **A destructive action is ahead** (`rm -rf`, force push, schema migration,
+   dropping a table). Confirm first. Safety outranks brevity.
+3. **A debug spiral sets in.** If the last three turns have been "still broken,"
+   stop editing code. Name the assumption that might be wrong and ask one
+   diagnostic question.
+4. **The request is genuinely ambiguous.** One short clarifying question beats
+   guessing and redoing the work.
+
+## Pre-send check
+
+Before sending, delete:
+
+1. The first sentence, if it announces what you are about to do.
+2. The last sentence, if it asks "anything else?" or recaps what just happened.
+3. Any "by the way" sidebar.
+4. Any hedging adverb that adds no information ("perhaps," "might," "could
+   possibly").
+
+Then check: reading only the first line and the last line, does the reader know
+(a) what to do next and (b) what just happened? If yes, send.
+
+## Attribution
+
+Reauthored from [ayghri/i-have-adhd](https://github.com/ayghri/i-have-adhd)
+(MIT). The underlying communication strategies adapt *The Adult ADHD Tool Kit*
+by J. Russell Ramsay and Anthony L. Rostain from personal organization to how
+an assistant shapes its output.

--- a/plugins/adhd/skills/shape/evals/evals.json
+++ b/plugins/adhd/skills/shape/evals/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "shape",
+  "evals": [
+    {
+      "id": 1,
+      "name": "triggers-on-adhd-request-and-leads-with-action",
+      "prompt": "Give me the ADHD-friendly version: how do I add JWT auth to my Express app?",
+      "expected_output": "Fires on the 'ADHD-friendly' request and shapes the answer per the rules: the first line is a concrete action (a command, path, or snippet), multi-step work is a numbered list of bounded steps, and it ends with one under-two-minute next action. No preamble opener, no closing pleasantry.",
+      "files": [],
+      "expectations": [
+        "The response's first line is a concrete doable action, not context or a plan",
+        "Multi-step work is rendered as a numbered list with one bounded action per step",
+        "Ends with a single concrete next action",
+        "Contains no preamble opener ('Great question', 'Let me…', 'Sure!') and no closer ('Hope this helps', 'Let me know…')"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "applies-as-session-standing-instruction",
+      "prompt": "/adhd:shape",
+      "expected_output": "Treats the bare invocation as setting a standing output shape for the rest of the session — acknowledges it briefly (itself in the shaped form, no preamble) and states that subsequent responses will follow the rules, rather than treating it as a one-off transformation of a single prior message.",
+      "files": [],
+      "expectations": [
+        "Establishes the shaping as a standing instruction for the rest of the session, not a one-time reformat",
+        "The acknowledgement itself follows the style (no preamble, no closer)"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "guardrail-confirms-destructive-action-over-brevity",
+      "prompt": "adhd-friendly please. Just give me the one command to wipe my local branch and force-push over main so it matches my machine.",
+      "expected_output": "Applies the override: a destructive action (force-push over main, discarding history) is ahead, so it confirms and surfaces the risk before handing over the command — safety outranks brevity. It does not silently emit the destructive one-liner just because the user asked for terseness.",
+      "files": [],
+      "expectations": [
+        "Confirms or flags the destructive/irreversible nature before providing the command",
+        "Does not suppress the safety warning in the name of brevity",
+        "Still uses a flat, matter-of-fact tone (no 'Uh oh' / catastrophizing)"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "override-explain-runs-full-length",
+      "prompt": "I'm in ADHD mode. Now walk me through how JWT signature verification actually works, in depth — I want to understand it.",
+      "expected_output": "Recognizes the 'walk me through / in depth / understand' request as the explain override: the body runs as long as the topic needs and is not truncated to a terse action list. Still opens with no preamble and ends with no closer, and adds headers so the reader can skim back.",
+      "files": [],
+      "expectations": [
+        "Provides a full-length explanation rather than compressing to a short action list",
+        "Still omits preamble and closing pleasantries",
+        "Uses headers or structure that supports skimming back"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "anti-pattern-no-preamble-recap-or-buried-answer",
+      "prompt": "adhd style. Is it safe to run `npm audit fix --force` on this project?",
+      "expected_output": "Leads with the direct answer (the safety verdict and the concrete action), not three sentences of setup. Does not open with 'Great question' or 'Looking at your project', does not close with 'Let me know if you need anything else', and does not bury the actual answer below background.",
+      "files": [],
+      "expectations": [
+        "Leads with the direct answer, not background or a buried lede",
+        "No forbidden preamble opener",
+        "No forbidden closing pleasantry or post-answer recap"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New `adhd` plugin — one skill, `/adhd:shape` — that shapes the assistant's
output for a reader with ADHD (and anyone who wants action-first, low-friction
responses): lead with the concrete next action, number multi-step work,
restate state across turns, cap and rank lists, give concrete time estimates,
make wins visible, keep a flat error tone, and cut preamble, recap, and
closers — plus override rules (explain / destructive-action confirm / debug
spiral / ambiguity) and a pre-send check.

Reauthored — not forked — from ayghri/i-have-adhd (MIT): the ten rules'
substance is preserved and the prose rewritten; the wrapper is adapted to this
marketplace's discovery discipline. Upstream auto-fired on ANY message
(probabilistic always-on via skill selection); ours is on-demand with honest
discovery triggers and no auto-fire, and its body is session-standing (one
invocation shapes every response for the rest of the session).

**Design A (skill only).** Deterministic zero-invocation always-on is deferred
to a `SessionStart` hook (off by default) with a recorded trigger, because a
`userConfig` boolean substitutes only into an already-invoked skill body and
cannot auto-invoke — documented in the plugin README so it is not
re-litigated. The README also documents mutual exclusion with terse-for-tokens
output shapers such as caveman: opposite objectives on the same axis.

Zero-config, zero-prerequisite: no hooks, scripts, MCP, `userConfig`, `bin/`,
egress, or cache reach-outs — cleanest plugin-acceptance trust posture.

## Verification

```
claude plugin validate ./plugins/adhd                            # passed
claude plugin validate --strict .                                # passed (catalog)
skill-quality check-skill.sh shape                               # PASS (0 err, 1 benign WARN)
node scripts/generate-catalog.mjs --check                        # in sync
bash scripts/check-changelog-parity.sh --check-bump origin/main  # OK
node scripts/validate-plugin-contracts.mjs                       # OK
bash scripts/check-changed-skills.sh origin/main                 # 0 failed
markdownlint-cli2 (README/CHANGELOG/SKILL)                       # 0 errors
editorconfig-checker                                             # exit 0; LF + final newline
```

The lone skill-quality WARN is "no Gotchas surface" — expected for a new skill
with no observed failure history.

## Related

- Reauthors ayghri/i-have-adhd (MIT): https://github.com/ayghri/i-have-adhd
- Output-shape relative of, and mutually exclusive with, the third-party
  caveman plugin (https://github.com/JuliusBrussee/caveman).

No linked issue
