### PR TITLE
docs(autonomy,source-control): codify Boris-intent audit — attribution seams, merge-tier precision precondition, ADR 0002 ruling

### DIFF
--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -1,6 +1,6 @@
 # Default-on AI review: advisory lanes with earned promotion to blocking
 
-- Status: accepted (interim — pending the #509 enforcement design ruling)
+- Status: accepted
 - Date: 2026-07-20
 
 ## Context
@@ -41,6 +41,33 @@ This is the interim posture pending #509's enforcement design session (operator-
 that session's question, and it may promote the security lane to a required gate on its own
 terms without a further precision window.
 
+## Addendum (2026-07-21): #509 enforcement ruling
+
+The #509 enforcement design session ruled. Execution evidence — proof that the security pass
+RAN on every PR — is promoted to a **required status check** on the protected base, so a PR
+cannot merge without the security workflow having reported. A diff with no security-sensitive
+surface gets an explicit not-applicable verdict from a **job-level conditional** inside the
+always-running workflow — never workflow-level `paths` filtering, which would leave the required
+check **Pending** forever and wedge every prose PR. The required check proves the pass ran; it
+does not gate on the verdict.
+
+VERDICT gating is unchanged: the security lane stays **advisory** per the guardrail matrix's
+knob floors and this ADR's earned-promotion discipline (Decision §2). The ruling promotes
+*execution evidence to required*, not *findings to blocking* — flipping the verdict to blocking
+still requires the earned precision window.
+
+Evidence model: the **check run** is canonical — API-queryable, and creatable only by the App
+that runs the pass, so a branch cannot forge it. A workflow-applied **label** is a glance layer
+only; labels are Triage-flippable — any actor with Triage access or above can add or remove one,
+a lower bar than the App-only check creation — so a label is never evidence that the pass ran;
+the required check is.
+
+Attribution: this enforcement is the operator's mandate backed by verified consensus practice —
+OpenSSF Scorecard's branch-protection criteria, GitHub's protected-branch documentation, and
+NIST SP 800-218A's same-bar-for-agent-and-human principle — **not** the source playbook, which
+never prescribes a merge gate. The playbook grounds default-on invocation (Boris step-2); the
+required-check enforcement is ours. A merge-queue revisit trigger is recorded below.
+
 ## Revisit triggers
 
 - The security lane's findings prove precise over a sustained window → open the promotion
@@ -49,3 +76,6 @@ terms without a further precision window.
   scope before considering demotion.
 - ci-workflows ships a release changing either reusable workflow's contract → re-pin the
   callers through the ordinary Dependabot/SHA-bump path.
+- A merge queue is enabled on the base → the security workflow must add the `merge_group`
+  trigger, or its required check is never reported for queued PRs (a required check that never
+  runs blocks the merge).

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -51,6 +51,13 @@ always-running workflow — never workflow-level `paths` filtering, which would 
 check **Pending** forever and wedge every prose PR. The required check proves the pass ran; it
 does not gate on the verdict.
 
+Implementation ordering is load-bearing: as of this addendum the caller still uses
+workflow-level `paths` filtering, so the ruleset must NOT mark this check required until the
+caller restructure (always-running workflow, job-level conditional) has landed — flipping the
+requirement first would wedge every prose PR exactly as described above. Sequence: caller
+restructure (this repo) → workflow always-report shape (ci-workflows) → required check
+(github-iac ruleset), each verifiable before the next.
+
 VERDICT gating is unchanged: the security lane stays **advisory** per the guardrail matrix's
 knob floors and this ADR's earned-promotion discipline (Decision §2). The ruling promotes
 *execution evidence to required*, not *findings to blocking* — flipping the verdict to blocking

--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
 Versions 0.1.0–0.7.0 predate this file (introduced with 0.7.1); their history lives in the
 merged work-package PRs (#333, #343, #356, #372, #377, #600, #676).
 
+## [0.7.4]
+
+### Changed
+
+- **Boris-intent attribution seams marked across the guardrail contract.** Three surgical
+  attributions distinguish this contract's own instantiation from the source playbook's posture,
+  closing UNMARKED-EXTENSION seams a Boris-intent audit found (zero violations, three seams). The
+  guardrail hub now states that the step-4 sentence it quotes verbatim is the playbook's while the
+  five-class taxonomy, blocking knobs, and promotion predicates are this contract's mechanism; the
+  security-review leaf marks review-as-merge-gate (the `blocking` knob) as this contract's own
+  layer over the playbook's advisory-review-feeding-a-human-merge posture; and the work-classes
+  leaf attributes the numeric-predicate promotion/demotion apparatus as this contract's
+  quantification of the playbook's qualitative "earned widespread trust" bar. Documentation only —
+  no contract semantics change.
+
 ## [0.7.3]
 
 ### Added

--- a/plugins/autonomy/reference/guardrails.md
+++ b/plugins/autonomy/reference/guardrails.md
@@ -12,7 +12,9 @@ org-binding outcome on the binding seam.
 
 The matrix instantiates the Boris playbook's step-4 sentence verbatim — "enforcing the right
 guardrails for each type of work" — as a table: one row per work class, one column per
-guardrail axis.
+guardrail axis. That sentence is the playbook's; the five-class taxonomy, the per-layer
+blocking knobs, and the promotion predicates that fill the cells are this contract's own
+instantiation of it — the playbook names the obligation, this contract supplies the mechanism.
 
 | Class | Min isolation (unattended) | Verification | Merge policy | Cost tier | Escalation |
 |---|---|---|---|---|---|

--- a/plugins/autonomy/reference/guardrails/security-review.md
+++ b/plugins/autonomy/reference/guardrails/security-review.md
@@ -32,6 +32,10 @@ Every layer × class cell carries one knob: `advisory` | `blocking`.
 - `advisory` — findings are recorded on the item's verification record and surfaced to
   the human merge gate; they never block on their own.
 
+That a failing verdict can gate the merge at all is this contract's own instantiation: the
+Boris playbook keeps automated review a default feeding a human merge, never a gate, so the
+`blocking` knob layers a gate onto that advisory posture rather than inheriting it.
+
 Knobs are security-sensitive and bind ONLY on the org's security governance surface (the
 settings-as-code home, outside the blast radius of the agents they govern — an
 agent-writable blocking knob is a bypass channel). Shipped defaults:

--- a/plugins/autonomy/reference/guardrails/work-classes.md
+++ b/plugins/autonomy/reference/guardrails/work-classes.md
@@ -45,6 +45,11 @@ any execution surface below `L3`, and the class's merge policy never promotes.
 
 ## Promotion and demotion
 
+This promotion apparatus — numeric predicate, human-ratified flip, automatic fail-closed
+demotion — is this contract's quantification of the Boris playbook's qualitative bar that no
+autonomy scales before the loop has "earned widespread trust": the trust requirement is the
+playbook's, the evidence predicate over telemetry that measures it is this contract's.
+
 Every promotable matrix cell carries a per-cell promotion trigger with one contract-fixed
 shape: an **evidence predicate over queryable telemetry** — verification outcomes recorded
 per the [telemetry contract](../telemetry.md) are the evidence base.

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.5]
+
+### Changed
+
+- **`babysit-prs` autopilot merge tier (#476) gains a bot-review precision enabling precondition,
+  still shipped DISABLED.** `reference/safety.md` now documents a second operator enabling
+  precondition alongside the review-workflow requiredness one: the tier may be enabled only after
+  the fleet's bot-review lane has demonstrated recorded precision over a sustained window — the same
+  earned-promotion trigger ADR 0002 sets for flipping an advisory review lane to a blocking gate
+  (precision proven over a sustained window, ratified as a reviewed change citing the evidence,
+  never a calendar flip and never operator discretion alone). Because the tier lets a fleet-produced
+  approval satisfy a required-review ruleset, it promotes that lane from advisory to merge-deciding
+  and inherits the same evidence bar. Prose/contract change only — no behavioral shift to the merge
+  gate, which remains fail-closed and DISABLED absent `babysit_autopilot_merge_tier`.
+
 ## [0.15.4]
 
 ### Fixed

--- a/plugins/source-control/skills/babysit-prs/reference/safety.md
+++ b/plugins/source-control/skills/babysit-prs/reference/safety.md
@@ -217,6 +217,17 @@ it, and any later gate-off flip, is a separate announced operator step.
   is an operator enabling precondition, verified before the flip, not something the merge gate can
   self-enforce.
 
+- **Bot-review precision precondition (enabling).** Enable the tier ONLY after the fleet's bot-review
+  lane has demonstrated recorded precision over a sustained window — the same earned-promotion trigger
+  ADR 0002 sets for flipping an advisory review lane to a blocking gate. The tier lets a
+  fleet-produced approval satisfy a required-review ruleset, which promotes that lane from advisory to
+  merge-deciding, so it is earned on that same evidence bar: precision proven over a sustained window
+  and ratified as a reviewed change citing that evidence — never a calendar flip, and operator
+  discretion alone is insufficient. Absent a recorded precision window for the reviewing bot, do not
+  enable the tier. The requiredness precondition above governs whether the review workflow ran; this
+  one governs whether its verdicts have earned the authority to stand in for a human approval, and
+  like requiredness it is an operator enabling precondition the merge gate cannot self-enforce.
+
 ## Harness Permission Layer
 
 A permission denial can come from two different layers. Tell them apart before deciding how to


### PR DESCRIPTION
Closes #509 — the enforcement/evidencing design ruling is recorded in ADR 0002's dated addendum (execution evidence → required status check via always-run workflow + job-level conditional; verdict gating unchanged, stays on the earned-promotion discipline; check run canonical evidence, label glance-only; merge_group revisit trigger added; enforcement attributed to the operator mandate + OpenSSF/GitHub/NIST consensus, not the source playbook).

Also lands the Boris-intent audit's other outcomes: three attribution seams in the autonomy guardrail contracts (blocking knob, promotion predicates, matrix instantiation — the playbook names the obligation, the contracts supply the mechanism), and the autopilot merge tier's new **bot-review precision precondition** in babysit safety (the tier lets a bot approval satisfy a required-review ruleset, so enabling it is earned on the same recorded-precision bar as any advisory→blocking flip; operator discretion alone insufficient; tier remains DISABLED).

Verification: markdownlint 0 errors across all nine touched files; versions match CHANGELOG heads (autonomy 0.7.4, source-control 0.15.5); UTF-8 punctuation preserved byte-for-byte outside edits.

## Related

- #509 (closes — ruling comment on the issue mirrors the addendum)
- #476 (merge tier whose enable-gate this tightens)
- #440 / #513 (sibling audit outcomes recorded as issue comments)
- #778 (the ignition item these contracts govern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
