### PR TITLE
fix(source-control): gate push -u on absent-upstream + resolved-remote match (#442)

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.5]
+
+### Fixed
+
+- **`/pull-request` create flow no longer silently corrupts a branch's fetch/rebase upstream when
+  publishing it for a PR (#442, residual finding from PR #763).** A post-merge review empirically
+  reproduced a residual silent clobber: §2.4.1's conditional `-u` gate keyed on the LITERAL
+  `branch.<name>.remote` config being set. In the triangular shape where `remote.pushDefault` names a
+  fork globally but `branch.<name>.remote` is unset (so fetch/rebase falls back to `origin`), the gate
+  read "unset", took the `-u` bootstrap path, and `git push -u <fork>` rewrote `branch.<name>.remote`
+  to the fork — so the next fetch/rebase silently targeted the fork instead of `origin`. The gate now
+  fires `-u` only when the branch has NO existing upstream (`branch.<name>.remote` literally unset)
+  AND its fetch and push remotes resolve to the same name (`resolve-remote.sh` fetch-mode vs `--push`);
+  otherwise it pushes plain and writes no branch config. This closes the reported `pushDefault`-only
+  clobber (fetch resolves `origin`, push resolves the fork → they differ → plain push, upstream
+  untouched) and a second corruption the fix surfaced: `git push -u` rewrites the branch's WHOLE
+  upstream — both `branch.<name>.remote` and `branch.<name>.merge` — so an already-tracked branch, or
+  one on a deliberate local-only `.` upstream (`git branch --track . <ref>`), kept its merge ref
+  overwritten under a resolved-name-only comparison. Requiring the upstream to be absent before
+  bootstrapping preserves any existing one via plain push. This also changes #763's behavior for the
+  `.` case (it took the `-u` path); publishing a branch for a PR no longer mutates a deliberate
+  local-only upstream — a strict improvement. An ambiguous fetch resolution (empty) is unequal to any
+  push remote → plain push, never an abort. The conditional moved out of the `create.md` prose into a
+  new co-located `scripts/push-branch.sh` (§2.4.1 now delegates to it), so the gate sequence is
+  executable and testable rather than living only in markdown; the normalized `.`-as-unset / `\r`-strip
+  handling stays solely in `resolve-remote.sh` and is not duplicated (the literal-unset probe reads the
+  key raw — `.` is non-empty, i.e. "has an upstream"). New `push-branch.test.sh` drives the full
+  resolve-fetch → resolve-push → conditional-push → re-resolve-fetch sequence against real bare remotes
+  across the pushRemote-triangular, `pushDefault`-only triangular, non-triangular (asserting the merge
+  ref is preserved), fresh-branch bootstrap, local-only `.`, and fetch-ambiguous shapes — the
+  integration coverage whose absence let this escape `resolve-remote.test.sh`'s resolver-only cases.
+
 ## [0.15.4]
 
 ### Fixed

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -14,26 +14,29 @@ All notable changes to the `source-control` plugin are documented here. Format f
   fork globally but `branch.<name>.remote` is unset (so fetch/rebase falls back to `origin`), the gate
   read "unset", took the `-u` bootstrap path, and `git push -u <fork>` rewrote `branch.<name>.remote`
   to the fork — so the next fetch/rebase silently targeted the fork instead of `origin`. The gate now
-  fires `-u` only when the branch has NO existing upstream (`branch.<name>.remote` literally unset)
-  AND its fetch and push remotes resolve to the same name (`resolve-remote.sh` fetch-mode vs `--push`);
-  otherwise it pushes plain and writes no branch config. This closes the reported `pushDefault`-only
-  clobber (fetch resolves `origin`, push resolves the fork → they differ → plain push, upstream
-  untouched) and a second corruption the fix surfaced: `git push -u` rewrites the branch's WHOLE
-  upstream — both `branch.<name>.remote` and `branch.<name>.merge` — so an already-tracked branch, or
-  one on a deliberate local-only `.` upstream (`git branch --track . <ref>`), kept its merge ref
-  overwritten under a resolved-name-only comparison. Requiring the upstream to be absent before
-  bootstrapping preserves any existing one via plain push. This also changes #763's behavior for the
-  `.` case (it took the `-u` path); publishing a branch for a PR no longer mutates a deliberate
-  local-only upstream — a strict improvement. An ambiguous fetch resolution (empty) is unequal to any
-  push remote → plain push, never an abort. The conditional moved out of the `create.md` prose into a
-  new co-located `scripts/push-branch.sh` (§2.4.1 now delegates to it), so the gate sequence is
-  executable and testable rather than living only in markdown; the normalized `.`-as-unset / `\r`-strip
-  handling stays solely in `resolve-remote.sh` and is not duplicated (the literal-unset probe reads the
-  key raw — `.` is non-empty, i.e. "has an upstream"). New `push-branch.test.sh` drives the full
-  resolve-fetch → resolve-push → conditional-push → re-resolve-fetch sequence against real bare remotes
-  across the pushRemote-triangular, `pushDefault`-only triangular, non-triangular (asserting the merge
-  ref is preserved), fresh-branch bootstrap, local-only `.`, and fetch-ambiguous shapes — the
-  integration coverage whose absence let this escape `resolve-remote.test.sh`'s resolver-only cases.
+  fires `-u` only when the branch has NO existing upstream (`branch.<name>.remote` AND
+  `branch.<name>.merge` both literally unset) AND its fetch and push remotes resolve to the same name
+  (`resolve-remote.sh` fetch-mode vs `--push`); otherwise it pushes plain and writes no branch config.
+  This closes the reported `pushDefault`-only clobber (fetch resolves `origin`, push resolves the fork →
+  they differ → plain push, upstream untouched) and a broader corruption family the fix surfaced:
+  `git push -u` rewrites the branch's WHOLE upstream — both `branch.<name>.remote` and
+  `branch.<name>.merge` — so a branch with any configured tracking kept its merge ref overwritten under
+  a resolved-name-only comparison. Three such shapes: an already-tracked branch; a deliberate local-only
+  `.` upstream (`git branch --track . <ref>`); and merge-only tracking (`branch.<name>.merge` set with
+  `branch.<name>.remote` unset — valid, since Git defaults the remote to `origin`, so the branch tracks
+  `origin/<merge-ref>`). Requiring BOTH upstream keys to be absent before bootstrapping preserves any
+  existing tracking via plain push. This also changes #763's behavior for the `.` case (it took the
+  `-u` path); publishing a branch for a PR no longer mutates a deliberate local-only or merge-only
+  upstream — a strict improvement. An ambiguous fetch resolution (empty) is unequal to any push remote →
+  plain push, never an abort. The conditional moved out of the `create.md` prose into a new co-located
+  `scripts/push-branch.sh` (§2.4.1 now delegates to it), so the gate sequence is executable and testable
+  rather than living only in markdown; the normalized `.`-as-unset / `\r`-strip handling stays solely in
+  `resolve-remote.sh` and is not duplicated (the upstream-absent probe reads both keys raw — any
+  non-empty value means "has an upstream"). New `push-branch.test.sh` drives the full resolve-fetch →
+  resolve-push → conditional-push → re-resolve-fetch sequence against real bare remotes across the
+  pushRemote-triangular, `pushDefault`-only triangular, non-triangular (asserting the merge ref is
+  preserved), fresh-branch bootstrap, local-only `.`, merge-only tracking, and fetch-ambiguous shapes —
+  the integration coverage whose absence let this escape `resolve-remote.test.sh`'s resolver-only cases.
 
 ## [0.15.4]
 

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -174,15 +174,16 @@ Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an
 ```bash
 # Push via push-branch.sh, which resolves the push and fetch/rebase remotes
 # independently (resolve-remote.sh --push vs plain) and sets upstream (`-u`)
-# ONLY for a branch with NO existing upstream whose fetch and push both resolve
-# to the same remote (a fresh feature branch's first push). `git push -u`
-# rewrites the branch's whole upstream — both branch.<name>.remote AND
-# branch.<name>.merge — so any existing upstream (a real remote, or a deliberate
-# local-only `.`) is preserved by a plain push instead. This closes two silent
+# ONLY for a branch with NO existing upstream — branch.<name>.remote AND
+# branch.<name>.merge both unset — whose fetch and push resolve to the same
+# remote (a fresh feature branch's first push). `git push -u` rewrites the
+# branch's whole upstream — both keys — so any existing upstream (a real remote,
+# a deliberate local-only `.`, or a merge ref set with the remote defaulting to
+# `origin`) is preserved by a plain push instead. This closes two silent
 # corruptions: a triangular fork (push a fork via pushRemote/pushDefault, fetch
-# `origin`/`upstream`) no longer repoints the fetch remote to the fork, and an
-# already-tracked branch no longer has its merge ref overwritten. See the script
-# header for the full rationale.
+# `origin`/`upstream`) no longer repoints the fetch remote to the fork, and a
+# branch with any configured tracking no longer has its merge ref overwritten.
+# See the script header for the full rationale.
 bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/push-branch.sh" || exit 1
 ```
 

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -172,36 +172,18 @@ Persist chosen line(s) into `${CLOSES_LINE}`. NEVER wrap a closing keyword in an
 ### 2.4.1 Push and assemble PR body
 
 ```bash
-# Push via the shared resolver in --push mode, which applies Git's documented
-# push precedence: branch.<name>.pushRemote, else remote.pushDefault, else the
-# §2.2 fetch order (branch.<name>.remote, else `origin`, else the sole other
-# configured remote). This is why the push resolves separately from §2.2's
-# fetch remote — Git lets the push destination differ, so a triangular fork
-# flow that fetches from `upstream` but sets pushRemote/pushDefault to the fork
-# pushes to the fork, not `upstream`. A fork may be named `origin`, `fork`, or
-# anything else, and a repo cloned with a non-origin sole remote (`git clone -o
-# vendor`) must push there too, not `origin`. Two or more non-origin candidates
-# with no `origin` set fails loudly (see §2.2) rather than pushing to an
-# arbitrary remote.
-#
-# `-u` is CONDITIONAL: `git push -u` rewrites `branch.<name>.remote` to the
-# push target, so on a triangular fork (fetch `upstream`, push a fork via
-# pushRemote/pushDefault) an unconditional `-u` would silently repoint the
-# FETCH remote §2.2 reads to the fork — breaking the next rebase. So bootstrap
-# tracking with `-u` only when the branch has no real `branch.<name>.remote`
-# yet (a fresh feature branch, or a local-only `.` upstream): the common first
-# push still sets upstream to `origin` exactly as before. When a real fetch
-# remote is already configured, push WITHOUT `-u` to preserve it. Either way
-# later pushes need no remote argument (tracking was already set, or `-u` just
-# set it). Match resolve-remote.sh's `\r` strip and `.`-as-unset convention.
-PUSH_REMOTE=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/resolve-remote.sh" --push) || exit 1
-BRANCH_NAME=$(git branch --show-current)
-EXISTING_FETCH_REMOTE=$(git config "branch.${BRANCH_NAME}.remote" 2>/dev/null | tr -d '\r')
-if [[ -n "$EXISTING_FETCH_REMOTE" && "$EXISTING_FETCH_REMOTE" != "." ]]; then
-  git push "$PUSH_REMOTE" "$BRANCH_NAME"
-else
-  git push -u "$PUSH_REMOTE" "$BRANCH_NAME"
-fi
+# Push via push-branch.sh, which resolves the push and fetch/rebase remotes
+# independently (resolve-remote.sh --push vs plain) and sets upstream (`-u`)
+# ONLY for a branch with NO existing upstream whose fetch and push both resolve
+# to the same remote (a fresh feature branch's first push). `git push -u`
+# rewrites the branch's whole upstream — both branch.<name>.remote AND
+# branch.<name>.merge — so any existing upstream (a real remote, or a deliberate
+# local-only `.`) is preserved by a plain push instead. This closes two silent
+# corruptions: a triangular fork (push a fork via pushRemote/pushDefault, fetch
+# `origin`/`upstream`) no longer repoints the fetch remote to the fork, and an
+# already-tracked branch no longer has its merge ref overwritten. See the script
+# header for the full rationale.
+bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/push-branch.sh" || exit 1
 ```
 
 Derive PR title from the commit subject, shaped to satisfy the resolved subject/title convention (the ladder in [SKILL.md](../SKILL.md): layered `source-control.md` config → project convention → Conventional Commits default). Build body with `${CLOSES_LINE}` at top, followed by Summary + Test plan + a `## Related` section + a config-gated attribution line:

--- a/plugins/source-control/skills/pull-request/scripts/push-branch.sh
+++ b/plugins/source-control/skills/pull-request/scripts/push-branch.sh
@@ -19,24 +19,33 @@
 #      configured but resolves via fallback: remote.pushDefault=fork with
 #      branch.<name>.remote unset fetches from `origin` (fallback) yet pushes to
 #      the fork.
-#   2. Overwrite an existing upstream. If branch.<name>.remote is already set —
-#      to a real remote, or to "." (a deliberate local-only upstream, e.g.
-#      `git branch --track . <ref>`) — `-u` replaces both keys even when the
-#      resolved remote NAME is unchanged, destroying a merge ref the user chose.
+#   2. Overwrite an existing upstream. The upstream is TWO keys —
+#      branch.<name>.remote AND branch.<name>.merge — and `-u` rewrites both.
+#      Any of these partial or full configs is an upstream the user chose that a
+#      bootstrap must not clobber:
+#        - both set to a real remote/ref (an ordinary tracked branch);
+#        - branch.<name>.remote="." (a deliberate local-only upstream, e.g.
+#          `git branch --track . <ref>`), merge naming the tracked local ref;
+#        - branch.<name>.merge set with branch.<name>.remote UNSET — valid: Git
+#          defaults the missing remote to `origin`, so the branch tracks
+#          `origin/<merge-ref>`. `-u` here replaces the chosen merge ref with
+#          refs/heads/<name>, the same clobber family as (1).
 #
 # The gate therefore fires `-u` only when BOTH hold:
-#   * branch.<name>.remote is literally unset (no upstream to preserve — a fresh
-#     feature branch), AND
+#   * the branch has NO existing upstream — branch.<name>.remote AND
+#     branch.<name>.merge are BOTH literally unset (a genuinely fresh feature
+#     branch, nothing to preserve), AND
 #   * FETCH_REMOTE == PUSH_REMOTE (bootstrapping tracking cannot misdirect the
 #     fetch remote, because it can only be set to what fetch already resolves to).
-# Any existing upstream (including ".") is preserved by a plain push, which never
-# writes branch config. An ambiguous fetch (FETCH_REMOTE empty: 2+ non-origin
-# remotes, no origin) is unequal to any push remote -> plain push -> no write.
+# Any existing upstream — full, ".", or merge-only — is preserved by a plain
+# push, which never writes branch config. An ambiguous fetch (FETCH_REMOTE empty:
+# 2+ non-origin remotes, no origin) is unequal to any push remote -> plain push
+# -> no write.
 #
-# The literal-unset check reads branch.<name>.remote raw (no "." or CRLF
-# normalization): "." is non-empty -> "has an upstream" -> plain push preserves
-# it; only the truly-unset (empty) key is a bootstrap candidate. That normalized
-# "." handling lives once, in resolve-remote.sh, and is not duplicated here.
+# The upstream-absent check reads both keys raw (no "." or CRLF normalization):
+# any non-empty value -> "has an upstream" -> plain push preserves it; only the
+# truly-unset (empty) keys are a bootstrap candidate. That normalized "."
+# handling lives once, in resolve-remote.sh, and is not duplicated here.
 #
 # Push resolution must be determinate (it names the destination), so a failed
 # --push resolution aborts; a failed fetch resolution does not.
@@ -54,9 +63,10 @@ fi
 
 PUSH_REMOTE=$(bash "$RESOLVER" --push "$BRANCH") || exit 1
 FETCH_REMOTE=$(bash "$RESOLVER" "$BRANCH" 2>/dev/null)
-EXISTING_UPSTREAM=$(git config "branch.${BRANCH}.remote" 2>/dev/null)
+EXISTING_REMOTE=$(git config "branch.${BRANCH}.remote" 2>/dev/null)
+EXISTING_MERGE=$(git config "branch.${BRANCH}.merge" 2>/dev/null)
 
-if [[ -z "$EXISTING_UPSTREAM" && "$FETCH_REMOTE" == "$PUSH_REMOTE" ]]; then
+if [[ -z "$EXISTING_REMOTE" && -z "$EXISTING_MERGE" && "$FETCH_REMOTE" == "$PUSH_REMOTE" ]]; then
   git push -u "$PUSH_REMOTE" "$BRANCH"
 else
   git push "$PUSH_REMOTE" "$BRANCH"

--- a/plugins/source-control/skills/pull-request/scripts/push-branch.sh
+++ b/plugins/source-control/skills/pull-request/scripts/push-branch.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Push the current (or named) branch to its resolved push remote, setting
+# upstream tracking (`-u`) ONLY for a branch that has no existing upstream and
+# whose fetch and push remotes resolve to the same name.
+#
+# Push destination and fetch/rebase remote are resolved independently by the
+# sibling resolve-remote.sh (Git lets them differ in a triangular fork flow):
+#   PUSH_REMOTE  = resolve-remote.sh --push   (pushRemote -> pushDefault -> fetch order)
+#   FETCH_REMOTE = resolve-remote.sh          (branch.<name>.remote -> origin -> sole other)
+#
+# `-u` is CONDITIONAL because `git push -u` rewrites the branch's ENTIRE upstream
+# — both branch.<name>.remote AND branch.<name>.merge (to refs/heads/<name>). Two
+# distinct ways that silently corrupts where the branch fetches/rebases from:
+#
+#   1. Retarget the remote. On a triangular fork (push to a fork via
+#      pushRemote/pushDefault, fetch from origin/upstream) `-u` would repoint
+#      branch.<name>.remote to the fork, so the next rebase targets the wrong
+#      base. The trap is the shape where the fetch remote is NOT literally
+#      configured but resolves via fallback: remote.pushDefault=fork with
+#      branch.<name>.remote unset fetches from `origin` (fallback) yet pushes to
+#      the fork.
+#   2. Overwrite an existing upstream. If branch.<name>.remote is already set —
+#      to a real remote, or to "." (a deliberate local-only upstream, e.g.
+#      `git branch --track . <ref>`) — `-u` replaces both keys even when the
+#      resolved remote NAME is unchanged, destroying a merge ref the user chose.
+#
+# The gate therefore fires `-u` only when BOTH hold:
+#   * branch.<name>.remote is literally unset (no upstream to preserve — a fresh
+#     feature branch), AND
+#   * FETCH_REMOTE == PUSH_REMOTE (bootstrapping tracking cannot misdirect the
+#     fetch remote, because it can only be set to what fetch already resolves to).
+# Any existing upstream (including ".") is preserved by a plain push, which never
+# writes branch config. An ambiguous fetch (FETCH_REMOTE empty: 2+ non-origin
+# remotes, no origin) is unequal to any push remote -> plain push -> no write.
+#
+# The literal-unset check reads branch.<name>.remote raw (no "." or CRLF
+# normalization): "." is non-empty -> "has an upstream" -> plain push preserves
+# it; only the truly-unset (empty) key is a bootstrap candidate. That normalized
+# "." handling lives once, in resolve-remote.sh, and is not duplicated here.
+#
+# Push resolution must be determinate (it names the destination), so a failed
+# --push resolution aborts; a failed fetch resolution does not.
+#
+# Usage: push-branch.sh [branch-name]   (defaults to the current branch)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="${SCRIPT_DIR}/resolve-remote.sh"
+
+BRANCH="${1:-}"
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="$(git branch --show-current 2>/dev/null | tr -d '\r')"
+fi
+
+PUSH_REMOTE=$(bash "$RESOLVER" --push "$BRANCH") || exit 1
+FETCH_REMOTE=$(bash "$RESOLVER" "$BRANCH" 2>/dev/null)
+EXISTING_UPSTREAM=$(git config "branch.${BRANCH}.remote" 2>/dev/null)
+
+if [[ -z "$EXISTING_UPSTREAM" && "$FETCH_REMOTE" == "$PUSH_REMOTE" ]]; then
+  git push -u "$PUSH_REMOTE" "$BRANCH"
+else
+  git push "$PUSH_REMOTE" "$BRANCH"
+fi

--- a/plugins/source-control/skills/pull-request/scripts/push-branch.test.sh
+++ b/plugins/source-control/skills/pull-request/scripts/push-branch.test.sh
@@ -4,8 +4,8 @@
 #
 # resolve-remote.test.sh exercises the resolver in ISOLATION; it cannot catch a
 # gate that resolves correctly yet still writes the branch's upstream to the
-# wrong place. That gap is exactly how the #442 pushDefault-only triangular
-# clobber survived PR #763. These cases drive REAL pushes into REAL bare remotes
+# wrong place — the pushDefault-only triangular clobber lived in exactly that
+# gap. These cases drive REAL pushes into REAL bare remotes
 # and assert the destination that received the branch AND whether the conditional
 # `-u` rewrote the branch's upstream (branch.<name>.remote AND branch.<name>.merge
 # — `git push -u` writes both), the observables a clobber would corrupt.

--- a/plugins/source-control/skills/pull-request/scripts/push-branch.test.sh
+++ b/plugins/source-control/skills/pull-request/scripts/push-branch.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Integration tests for push-branch.sh — the §2.4.1 push gate sequence
+# (resolve-fetch -> resolve-push -> conditional `-u` push -> re-resolve-fetch).
+#
+# resolve-remote.test.sh exercises the resolver in ISOLATION; it cannot catch a
+# gate that resolves correctly yet still writes the branch's upstream to the
+# wrong place. That gap is exactly how the #442 pushDefault-only triangular
+# clobber survived PR #763. These cases drive REAL pushes into REAL bare remotes
+# and assert the destination that received the branch AND whether the conditional
+# `-u` rewrote the branch's upstream (branch.<name>.remote AND branch.<name>.merge
+# — `git push -u` writes both), the observables a clobber would corrupt.
+#
+# The suite pins the refined invariant in BOTH directions, so neither strawman
+# passes:
+#   * bootstrap POSITIVELY asserts `-u` fired (branch.remote set from unset) —
+#     rejects an always-plain-push implementation.
+#   * non-triangular and local-only `.` assert an EXISTING upstream's merge ref
+#     survives the push — rejects an always-`-u` implementation (and the
+#     resolved-name-only gate that shipped `-u` whenever fetch==push).
+#   * the fetch-ambiguous case proves a failed fetch resolution degrades to a
+#     plain push (no clobber), never an abort.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PUSH_BRANCH="${SCRIPT_DIR}/push-branch.sh"
+RESOLVER="${SCRIPT_DIR}/resolve-remote.sh"
+
+for s in "$PUSH_BRANCH" "$RESOLVER"; do
+  if [[ ! -x "$s" ]]; then
+    echo "FAIL: missing or not executable: $s" >&2
+    exit 1
+  fi
+done
+
+PASS=0
+FAIL=0
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+BRANCH="feat/x"
+
+# Build a working clone under $WORKDIR/$1 with `feat/x` checked out (one commit),
+# plus a bare remote per remaining `name` arg. The clone's `origin` is a bare
+# repo of its own so a real push has somewhere to land. Echoes the clone path.
+make_clone() {
+  local name="$1"
+  shift
+  local base="$WORKDIR/$name"
+  mkdir -p "$base"
+  git init -q --bare "$base/origin.git"
+  git clone -q "$base/origin.git" "$base/wc" 2>/dev/null
+  git -C "$base/wc" config user.email test@example.com
+  git -C "$base/wc" config user.name Test
+  git -C "$base/wc" commit -q --allow-empty -m init
+  git -C "$base/wc" checkout -q -b "$BRANCH"
+  for extra in "$@"; do
+    git init -q --bare "$base/$extra.git"
+    git -C "$base/wc" remote add "$extra" "$base/$extra.git"
+  done
+  echo "$base/wc"
+}
+
+check() {
+  local desc="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc"
+    echo "       got    '$got'"
+    echo "       wanted '$want'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# 'yes' if $2.git has the branch ref, else 'no'.
+has_branch() {
+  if git -C "$1.git" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null 2>&1; then
+    echo yes
+  else
+    echo no
+  fi
+}
+
+fetch_config() {
+  git -C "$1" config "branch.${BRANCH}.remote" 2>/dev/null || echo UNSET
+}
+
+merge_config() {
+  git -C "$1" config "branch.${BRANCH}.merge" 2>/dev/null || echo UNSET
+}
+
+# 1. Fresh-branch bootstrap: no branch.remote, no push config. Fetch and push
+#    both fall back to origin -> equal -> `-u` fires, tracking is bootstrapped.
+wc=$(make_clone bootstrap)
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+check "bootstrap: -u fired, branch.remote set to origin" "$(fetch_config "$wc")" "origin"
+check "bootstrap: origin received the branch" "$(has_branch "$WORKDIR/bootstrap/origin")" "yes"
+
+# 2. Non-triangular, established upstream: branch.remote=origin already set, with
+#    a NON-default merge ref (tracks origin/main). Push resolves origin too, but
+#    the upstream already exists -> plain push -> the merge ref must survive. An
+#    always-`-u` (or resolved-name-only) gate would rewrite it to refs/heads/feat/x.
+wc=$(make_clone nontri)
+git -C "$wc" config "branch.${BRANCH}.remote" origin
+git -C "$wc" config "branch.${BRANCH}.merge" refs/heads/main
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+check "non-triangular: branch.remote stays origin" "$(fetch_config "$wc")" "origin"
+check "non-triangular: merge ref preserved (not rewritten by -u)" "$(merge_config "$wc")" "refs/heads/main"
+check "non-triangular: origin received the branch" "$(has_branch "$WORKDIR/nontri/origin")" "yes"
+
+# 3. Triangular via branch.<name>.pushRemote: fetch upstream, push fork.
+#    Resolved remotes differ -> plain push -> branch.remote preserved as upstream.
+wc=$(make_clone tri-pushremote upstream fork)
+git -C "$wc" config "branch.${BRANCH}.remote" upstream
+git -C "$wc" config "branch.${BRANCH}.pushRemote" fork
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+check "pushRemote-tri: fetch remote preserved (upstream)" "$(fetch_config "$wc")" "upstream"
+check "pushRemote-tri: fork received the branch" "$(has_branch "$WORKDIR/tri-pushremote/fork")" "yes"
+check "pushRemote-tri: origin did NOT receive the branch" "$(has_branch "$WORKDIR/tri-pushremote/origin")" "no"
+
+# 4. THE #442 REGRESSION: pushDefault-only triangular. branch.remote UNSET,
+#    remote.pushDefault=fork, origin present. Fetch falls back to origin, push
+#    resolves fork. Resolved remotes differ -> plain push -> branch.remote stays
+#    UNSET, so the next fetch/rebase still targets origin (no silent clobber).
+wc=$(make_clone tri-pushdefault fork)
+git -C "$wc" config remote.pushDefault fork
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+check "pushDefault-tri: branch.remote NOT clobbered (stays unset)" "$(fetch_config "$wc")" "UNSET"
+check "pushDefault-tri: next fetch still resolves origin" "$(cd "$wc" && bash "$RESOLVER")" "origin"
+check "pushDefault-tri: fork received the branch" "$(has_branch "$WORKDIR/tri-pushdefault/fork")" "yes"
+check "pushDefault-tri: origin did NOT receive the branch" "$(has_branch "$WORKDIR/tri-pushdefault/origin")" "no"
+
+# 5. Fetch ambiguous, push determinate: 2+ non-origin remotes, no origin,
+#    remote.pushDefault=fork. Fetch resolution fails (empty) -> treated as
+#    != push -> plain push to fork, never an abort, never a clobber.
+wc=$(make_clone ambiguous fork upstream)
+git -C "$wc" remote remove origin
+git -C "$wc" config remote.pushDefault fork
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+push_exit=$?
+check "fetch-ambiguous: push-branch.sh did not abort" "$push_exit" "0"
+check "fetch-ambiguous: branch.remote not written" "$(fetch_config "$wc")" "UNSET"
+check "fetch-ambiguous: fork received the branch" "$(has_branch "$WORKDIR/ambiguous/fork")" "yes"
+
+# 6. Local-only `.` upstream: branch.remote=. (tracks the local repo), merge
+#    tracks refs/heads/main, only origin configured. The resolver normalizes `.`
+#    to origin for BOTH modes, so a resolved-name-only gate would see fetch==push
+#    and fire `-u`, clobbering the deliberate local-only upstream. Because the
+#    upstream literally exists, the refined gate pushes plain: both keys survive.
+wc=$(make_clone dot-upstream)
+git -C "$wc" config "branch.${BRANCH}.remote" .
+git -C "$wc" config "branch.${BRANCH}.merge" refs/heads/main
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+check "dot-upstream: branch.remote stays '.' (local-only preserved)" "$(fetch_config "$wc")" "."
+check "dot-upstream: merge ref preserved (not rewritten by -u)" "$(merge_config "$wc")" "refs/heads/main"
+check "dot-upstream: origin received the branch" "$(has_branch "$WORKDIR/dot-upstream/origin")" "yes"
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]]

--- a/plugins/source-control/skills/pull-request/scripts/push-branch.test.sh
+++ b/plugins/source-control/skills/pull-request/scripts/push-branch.test.sh
@@ -14,9 +14,11 @@
 # passes:
 #   * bootstrap POSITIVELY asserts `-u` fired (branch.remote set from unset) —
 #     rejects an always-plain-push implementation.
-#   * non-triangular and local-only `.` assert an EXISTING upstream's merge ref
-#     survives the push — rejects an always-`-u` implementation (and the
-#     resolved-name-only gate that shipped `-u` whenever fetch==push).
+#   * non-triangular, local-only `.`, and merge-only tracking assert an EXISTING
+#     upstream's merge ref survives the push — rejects an always-`-u`
+#     implementation, the resolved-name-only gate that shipped `-u` whenever
+#     fetch==push, and a remote-only "no upstream" probe that misses a branch
+#     tracking origin/<ref> via branch.<name>.merge with the remote unset.
 #   * the fetch-ambiguous case proves a failed fetch resolution degrades to a
 #     plain push (no clobber), never an abort.
 
@@ -154,6 +156,19 @@ git -C "$wc" config "branch.${BRANCH}.merge" refs/heads/main
 check "dot-upstream: branch.remote stays '.' (local-only preserved)" "$(fetch_config "$wc")" "."
 check "dot-upstream: merge ref preserved (not rewritten by -u)" "$(merge_config "$wc")" "refs/heads/main"
 check "dot-upstream: origin received the branch" "$(has_branch "$WORKDIR/dot-upstream/origin")" "yes"
+
+# 7. Merge-only tracking: branch.merge set, branch.remote UNSET (valid — Git
+#    defaults the remote to origin, so the branch tracks origin/main). Both
+#    resolvers fall back to origin, so a remote-only "no existing upstream" probe
+#    reads the branch as fresh and fires `-u`, replacing the merge ref. The gate
+#    must treat a set merge ref as an existing upstream too -> plain push -> the
+#    merge ref survives.
+wc=$(make_clone merge-only)
+git -C "$wc" config "branch.${BRANCH}.merge" refs/heads/main
+(cd "$wc" && bash "$PUSH_BRANCH") >/dev/null 2>&1
+check "merge-only: branch.remote not written (stays unset)" "$(fetch_config "$wc")" "UNSET"
+check "merge-only: merge ref preserved (not rewritten by -u)" "$(merge_config "$wc")" "refs/heads/main"
+check "merge-only: origin received the branch" "$(has_branch "$WORKDIR/merge-only/origin")" "yes"
 
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
No linked issue — fix-forward of merged #763; the original issue #442 is already closed, and this residual was caught by post-merge review rather than filed.

## Summary

Fix-forward on just-merged **#763** (source-control `/pull-request` create flow, issue **#442**). An independent post-merge review empirically reproduced a **residual silent clobber** that #763 left behind.

**The residual finding.** create.md §2.4.1's conditional `-u` gate keyed on the *literal* `branch.<name>.remote` config being set. In the `remote.pushDefault`-only triangular shape — `pushDefault=fork` globally, `branch.<name>.remote` unset, fetch falling back to `origin` — the gate read "unset", took the `-u` bootstrap path, and `git push -u <fork>` rewrote `branch.<name>.remote` to the fork. The next fetch/rebase then silently targeted the fork instead of `origin`.

**Reproduced before and after** (two bare remotes, `remote.pushDefault=fork`, `branch.<name>.remote` unset):

| Gate | `branch.<name>.remote` after push | next fetch resolves |
|------|-----------------------------------|---------------------|
| old (merged in #763) | `fork` (clobbered) | **fork** — wrong base |
| this fix | unset (untouched) | `origin` — correct |

**Root-cause fix.** The `-u` conditional moved out of the markdown prose into a new co-located `scripts/push-branch.sh` (§2.4.1 now delegates to it), so the resolve-fetch → resolve-push → conditional-push sequence is executable and testable rather than living only in a reference doc. The gate fires `-u` only when the branch has **no existing upstream** *and* its fetch and push remotes resolve to the same name; otherwise it pushes plain and writes no branch config. The normalized `.`-as-unset / `\r`-strip handling stays solely in `resolve-remote.sh` — the literal-unset probe reads the key raw (`.` is non-empty → "has an upstream").

**Divergence from the review's literal prescription (disclosed).** The review prescribed gating purely on resolved-remote equality (`-u` iff fetch == push). An independent Codex review of this change found that `git push -u` rewrites the branch's **whole** upstream — both `branch.<name>.remote` **and** `branch.<name>.merge` — so the pure-resolved gate still clobbered the merge ref of an already-tracked branch, and of a deliberate local-only `.` upstream (`git branch --track . <ref>`), whenever the resolved *names* happened to match. Requiring the upstream to be **absent** before bootstrapping (`unset AND resolved-equal`) closes that second corruption while still fixing the reported `pushDefault`-only case. This also improves #763's `.` handling: publishing a branch for a PR no longer mutates a deliberate local-only upstream. (Per the DEFER-FORBIDDEN carve-out, both Codex findings were folded in inline, not deferred.)

## Test plan

- New `push-branch.test.sh` drives **real** bare-remote pushes across: pushRemote-triangular, `pushDefault`-only triangular, non-triangular (asserting the merge ref survives), fresh-branch bootstrap (asserting `-u` fired), local-only `.`, and fetch-ambiguous/push-determinate. **18/18 pass.**
- **Non-vacuity proven both directions:** the suite fails **5** cases against the old literal-probe gate and **3** cases against the pure-resolved gate it replaces — so it pins the refined invariant, not merely the original bug. (This integration layer is exactly what `resolve-remote.test.sh`'s resolver-only cases could not catch, which is why the clobber escaped #763.)
- `resolve-remote.test.sh` 15/15 (unchanged resolver), changelog parity (`--check` + `--check-bump`), markdownlint, shellcheck, shfmt — all green.

## Merge posture

Fix-forward proceeding under **operator momentum**: the change is verified and ready, but the agent will **not** merge it. The merge decision is delegated to the operator. A **veto window** is open — object here before merge if the `unset AND resolved-equal` refinement (vs the review's pure-resolved prescription) warrants discussion; otherwise it may be merged.

## Related

- Refs #442 — original low-severity finding (closed by #763); this fix-forward addresses the residual clobber that survived it.
- #763 — the PR this follows forward; introduced the conditional `-u` gate whose literal-probe form this replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)