### PR TITLE
feat(claude-ops): document lane mid-session staleness & restart cadence (#514)

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.3]
+
+### Added
+
+- **`lanes` skill — mid-session staleness & restart-cadence guidance
+  (`context/refresh.md`).** Loop lanes merge fixes to the very plugins they run on,
+  but a running lane keeps the skill versions it loaded at launch. New
+  documentation establishes, against current Claude Code docs, that a true
+  mid-session hot-reload of a running loop lane is not achievable — a live session
+  retains its launch-time plugin versions, `/loop` never re-reads a skill's body on
+  later cycles, and a loop cannot self-trigger `/reload-plugins` — so restart is the
+  honest refresh mechanism (composing with the #496 context-reset cadence). Adds a
+  read-only git probe to detect an unconsumed self-fix on `origin/main` and a
+  trigger-based + periodic-floor restart cadence keyed to `/claude-ops:lanes
+  restart`. SKILL.md gains a summary section, a cross-reference, and an eval. No
+  script or behavior change. (#514)
+
 ## [0.15.2]
 
 ### Changed

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   honest refresh mechanism (composing with the #496 context-reset cadence). Adds a
   read-only git probe to detect an unconsumed self-fix on `origin/main` and a
   trigger-based + periodic-floor restart cadence keyed to `/claude-ops:lanes
-  restart`. SKILL.md gains a summary section, a cross-reference, and an eval. No
+  restart`. The probe resolves the repo's default branch rather than assuming
+  `main`. SKILL.md gains a summary section, a cross-reference, and an eval. No
   script or behavior change. (#514)
 
 ## [0.15.2]

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -80,8 +80,8 @@ feature to build around — it is verified Claude Code behavior (a live session 
 its launch-time plugin versions, `/loop` never re-reads a skill's body on later
 cycles, and a loop can't self-trigger `/reload-plugins`). Restart is the honest
 refresh mechanism — the same `restart` that clears context bloat (#496). Detect an
-unconsumed self-fix with a read-only git probe against `origin/main`, then restart
-that lane at its next cycle boundary. Full reasoning, the probe, and the cadence
+unconsumed self-fix with a read-only git probe against the repo's default branch,
+then restart that lane at its next cycle boundary. Full reasoning, the probe, and the cadence
 live in [context/refresh.md](context/refresh.md) — read it before answering "why is
 my merged fix not live in the lane?" or setting a restart frequency.
 

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -72,6 +72,19 @@ authoring skill) is slated to own durable prompt storage. When it lands, repoint
 `prompt_dir` at that home; the launcher resolves the prompt dir in exactly one place
 (`resolve_prompt_dir` in the script), which is the single seam to update.
 
+## Mid-session staleness & restart cadence
+
+A **running** lane keeps the skill versions it loaded at launch: a fix merged to a
+plugin the lane runs does **not** reach that lane mid-session. This is not a missing
+feature to build around — it is verified Claude Code behavior (a live session keeps
+its launch-time plugin versions, `/loop` never re-reads a skill's body on later
+cycles, and a loop can't self-trigger `/reload-plugins`). Restart is the honest
+refresh mechanism — the same `restart` that clears context bloat (#496). Detect an
+unconsumed self-fix with a read-only git probe against `origin/main`, then restart
+that lane at its next cycle boundary. Full reasoning, the probe, and the cadence
+live in [context/refresh.md](context/refresh.md) — read it before answering "why is
+my merged fix not live in the lane?" or setting a restart frequency.
+
 ## Verified CLI surface
 
 The launcher shells out only to primitives confirmed on this machine's `claude`
@@ -102,6 +115,9 @@ only for a configured lane name.
 
 ## Cross-references
 
+- [context/refresh.md](context/refresh.md) — why a running lane can't hot-reload a
+  merged fix to its own skills, the git staleness probe, and the restart cadence
+  (#514).
 - `/claude-ops:plugins` — the authoritative, richer plugin-fleet sync (scope
   divergence, new-catalog installs). This skill's marketplace refresh is the light
   `claude plugin marketplace update` step of a launch, not a substitute.

--- a/plugins/claude-ops/skills/lanes/context/refresh.md
+++ b/plugins/claude-ops/skills/lanes/context/refresh.md
@@ -39,14 +39,16 @@ skill body is already fixed in context.
 
 ## Detecting that a self-fix landed (checkable git probe)
 
-Don't restart blindly. A lane is stale for one of its plugins when `origin/main`
-carries commits touching that plugin's path since the lane launched. Read-only,
-pure git:
+Don't restart blindly. A lane is stale for one of its plugins when the repo's
+default branch carries commits touching that plugin's path since the lane launched.
+Read-only, pure git — resolve the default branch rather than assuming `main`:
 
 ```bash
-git fetch origin main -q
+git fetch origin -q
+# default branch of this repo — never hardcode main/master
+default="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)"
 # merged changes to the claude-ops plugin the running lane has NOT consumed
-git log --oneline <lane-launch-commit>..origin/main -- plugins/claude-ops/
+git log --oneline "<lane-launch-commit>..${default}" -- plugins/claude-ops/
 ```
 
 `<lane-launch-commit>` is the repo HEAD when `lanes start`/`restart` last ran (the

--- a/plugins/claude-ops/skills/lanes/context/refresh.md
+++ b/plugins/claude-ops/skills/lanes/context/refresh.md
@@ -1,0 +1,74 @@
+# Mid-session refresh: why a running lane can't hot-reload its own fix
+
+Loop lanes routinely merge fixes to the very plugins they run on (`babysit` fixes
+`babysit`, the work lane fixes `work-items`). The question this file answers
+(#514): can a **running** lane consume a just-merged fix to its own skill files
+without an operator restart?
+
+## Empirical answer: no true mid-session hot-reload for a running loop lane
+
+Three independently sufficient facts, each verified against current Claude Code
+docs, block it — any one alone is decisive:
+
+1. **A running session keeps its launch-time plugin versions.** Merging to the
+   marketplace source does nothing to a live session until the local install is
+   updated; Claude Code's post-start auto-update runs once (random delay ≤ 10 min)
+   and "the running session keeps using the versions it loaded at launch"
+   ([discover-plugins](https://code.claude.com/docs/en/discover-plugins)).
+
+2. **`/loop` does not re-read the skill each cycle.** A rendered `SKILL.md` enters
+   the conversation once and "stays there for the rest of the session … Claude Code
+   does not re-read the skill file on later turns"; an identical re-invocation gets
+   an "already loaded" note, not a fresh read from disk
+   ([skills — Skill content lifecycle](https://code.claude.com/docs/en/skills#skill-content-lifecycle)).
+   So even an updated on-disk copy is never re-injected into the running loop.
+
+3. **A loop can't reload itself.** `/reload-plugins` is a built-in command; a
+   scheduled/loop fire delivers built-in commands to Claude "as plain text instead
+   of executing" them, so a lane cannot self-trigger a reload mid-run
+   ([scheduled-tasks](https://code.claude.com/docs/en/scheduled-tasks)).
+
+`/reload-plugins` *does* pick up on-disk `SKILL.md` edits for an **interactive**
+session ([plugins-reference](https://code.claude.com/docs/en/plugins-reference)),
+but that path needs a human to type it and does not reach an autonomous loop whose
+skill body is already fixed in context.
+
+**Conclusion:** restart is the honest mechanism. It also resets context bloat
+(composes with #496's restart discipline), so the live decision is restart
+*frequency*, not hot reload.
+
+## Detecting that a self-fix landed (checkable git probe)
+
+Don't restart blindly. A lane is stale for one of its plugins when `origin/main`
+carries commits touching that plugin's path since the lane launched. Read-only,
+pure git:
+
+```bash
+git fetch origin main -q
+# merged changes to the claude-ops plugin the running lane has NOT consumed
+git log --oneline <lane-launch-commit>..origin/main -- plugins/claude-ops/
+```
+
+`<lane-launch-commit>` is the repo HEAD when `lanes start`/`restart` last ran (the
+launch pulls first, so a running lane's skills correspond to that commit). Any
+output = an unconsumed merge. Swap the pathspec for whichever installed plugin a
+lane runs.
+
+Getting those changes onto disk on restart (marketplace refresh + per-scope
+update) is the `plugins` skill's job — see its
+[context/sync.md](../../plugins/context/sync.md); the lanes launch already runs
+`claude plugin marketplace update`. Not duplicated here.
+
+## Restart cadence
+
+- **Trigger-based:** when the probe shows a merge touching a plugin a lane runs,
+  restart that lane at its next cycle boundary — `/claude-ops:lanes restart <lane>`
+  re-pulls, refreshes the marketplace, and relaunches from the canonical prompt,
+  so the merged skill body loads. Restart discards the lane's in-flight
+  conversation, so prefer a cycle boundary over mid-cycle.
+- **Periodic floor:** even with no detected merge, restart lanes on the daily
+  harvest/reset cadence (the same restart that clears context bloat, #496). This
+  bounds self-fix staleness to at most one cadence interval.
+- **Until restart:** a behavior known-broken-but-fixed-on-main must be carried as a
+  temporary workaround in the loop prompt — the existing prompt rule for *unmerged*
+  fixes, extended here to *merged-but-not-yet-reloaded* fixes.

--- a/plugins/claude-ops/skills/lanes/evals/evals.json
+++ b/plugins/claude-ops/skills/lanes/evals/evals.json
@@ -61,6 +61,19 @@
         "Output states this is provisional and that durable prompt storage is issue #480's responsibility, not this skill's",
         "Output does not claim this skill builds or owns durable prompt storage"
       ]
+    },
+    {
+      "id": 6,
+      "name": "running-lane-cannot-hot-reload-own-fix",
+      "prompt": "I merged a fix to the babysit skill. My babysit loop lane is still running the old behavior. Will it pick up the fix on its own, or do I have to restart it?",
+      "expected_output": "It will NOT pick up the fix on its own — a running lane keeps the skill versions it loaded at launch, /loop never re-reads a skill's body on later cycles, and a loop cannot self-trigger /reload-plugins. Restart is the honest refresh mechanism (the same restart that clears context bloat). Detect the unconsumed self-fix with a read-only git probe (origin/main commits touching the plugin path since the lane's launch commit), then `/claude-ops:lanes restart <lane>` at the next cycle boundary to re-pull, refresh the marketplace, and relaunch. See context/refresh.md.",
+      "files": [],
+      "expectations": [
+        "Output states the running lane will NOT auto-consume the merged fix and explains restart is required",
+        "Output attributes this to verified Claude Code behavior (launch-time versions retained, /loop does not re-read the skill body, loop can't self-trigger /reload-plugins) rather than a fixable gap in this skill",
+        "Output points to the git staleness probe and `lanes restart` at a cycle boundary as the mechanism",
+        "Output does not claim a true mid-session hot-reload of a running loop lane is achievable"
+      ]
     }
   ]
 }

--- a/plugins/claude-ops/skills/lanes/evals/evals.json
+++ b/plugins/claude-ops/skills/lanes/evals/evals.json
@@ -66,7 +66,7 @@
       "id": 6,
       "name": "running-lane-cannot-hot-reload-own-fix",
       "prompt": "I merged a fix to the babysit skill. My babysit loop lane is still running the old behavior. Will it pick up the fix on its own, or do I have to restart it?",
-      "expected_output": "It will NOT pick up the fix on its own — a running lane keeps the skill versions it loaded at launch, /loop never re-reads a skill's body on later cycles, and a loop cannot self-trigger /reload-plugins. Restart is the honest refresh mechanism (the same restart that clears context bloat). Detect the unconsumed self-fix with a read-only git probe (origin/main commits touching the plugin path since the lane's launch commit), then `/claude-ops:lanes restart <lane>` at the next cycle boundary to re-pull, refresh the marketplace, and relaunch. See context/refresh.md.",
+      "expected_output": "It will NOT pick up the fix on its own — a running lane keeps the skill versions it loaded at launch, /loop never re-reads a skill's body on later cycles, and a loop cannot self-trigger /reload-plugins. Restart is the honest refresh mechanism (the same restart that clears context bloat). Detect the unconsumed self-fix with a read-only git probe (default-branch commits touching the plugin path since the lane's launch commit, resolving the default branch rather than assuming main), then `/claude-ops:lanes restart <lane>` at the next cycle boundary to re-pull, refresh the marketplace, and relaunch. See context/refresh.md.",
       "files": [],
       "expectations": [
         "Output states the running lane will NOT auto-consume the merged fix and explains restart is required",


### PR DESCRIPTION
## Summary

Loop lanes routinely merge fixes to the very plugins they run on (`babysit` fixes `babysit`, the work lane fixes `work-items`). But a **running** lane keeps executing the skill versions loaded at session start — a merged self-fix does not reach that lane until an operator restarts it. #514 asks whether a live lane can consume its own merged improvements without a human-driven restart, and explicitly accepts a documented restart cadence if a true mid-session hot-reload isn't feasible.

**It isn't feasible** — verified against current Claude Code docs, three independent blockers each settle it:

1. A running session keeps the plugin versions it loaded at launch; post-start auto-update runs once (≤10 min delay) and "the running session keeps using the versions it loaded at launch" ([discover-plugins](https://code.claude.com/docs/en/discover-plugins)).
2. `/loop` does **not** re-read a skill's `SKILL.md` on later cycles — a rendered body enters the conversation once and "stays there for the rest of the session … Claude Code does not re-read the skill file on later turns"; an identical re-invocation gets an "already loaded" note, not a fresh disk read ([skills — Skill content lifecycle](https://code.claude.com/docs/en/skills#skill-content-lifecycle)).
3. A loop can't reload itself — `/reload-plugins` is a built-in command, and a scheduled/loop fire delivers built-in commands to Claude "as plain text instead of executing" them ([scheduled-tasks](https://code.claude.com/docs/en/scheduled-tasks)).

`/reload-plugins` *does* pick up on-disk `SKILL.md` edits for an **interactive** session ([plugins-reference](https://code.claude.com/docs/en/plugins-reference)), but that needs a human to type it and cannot reach an autonomous loop whose skill body is already fixed in context. So **restart is the honest refresh mechanism** — the same restart that resets context bloat (composing with #496).

## Fix

Doc-only (no launcher or behavior change). The `lanes` skill already owns the launch/refresh/restart lifecycle and the gap is purely *between* launches, so this is its home.

- **New `context/refresh.md`** — the empirical reasoning above with doc citations; a read-only **git staleness probe** (`git log --oneline <lane-launch-commit>..origin/main -- plugins/<plugin>/`) to detect a merged self-fix the running lane has not consumed; and a restart cadence: trigger-based (`/claude-ops:lanes restart <lane>` at the next cycle boundary when the probe shows a merge) plus a periodic floor (the daily harvest/reset restart, #496). It points at the `plugins` skill's `sync.md` for the general marketplace-refresh/update mechanics rather than duplicating them.
- **`SKILL.md`** — a summary "Mid-session staleness & restart cadence" section and a cross-reference to `refresh.md`.
- **`evals/evals.json`** — a new eval (id 6) asserting a running lane won't auto-consume a merged fix, that this is verified harness behavior (not a fixable gap in this skill), and that restart via the git probe + `lanes restart` is the mechanism.
- Version `0.15.2` → **`0.15.3`** (patch — matches the doc-only precedent set by 0.15.2) + matching `CHANGELOG.md` entry.

## Verification

`skill-quality:check lanes` — **PASS**, 0 errors, 0 warnings:

```
INFO: description length 652/1536 chars
INFO: all 7 base-ref trigger phrase(s) preserved
INFO: SKILL.md 128/500 lines
INFO: markdownlint clean
INFO: script test passed: scripts/lane-launcher.test.sh
INFO: no metadata.category in frontmatter (optional — category not machine-readable)

CHECK-SKILL lanes: PASS — 0 errors, 0 warning(s)
```

`skill-quality:check validate-evals lanes` (via `check-jsonschema` against the bundled schema) — **conforms**: `ok -- validation done`.

Documented git staleness probe runs clean in the worktree (syntax + pathspec valid; empty output = up to date, expected since the branch sits at `origin/main` HEAD):

```
$ git log --oneline HEAD~3..origin/main -- plugins/claude-ops/
(exit 0)
```

Empirical claims are docs-sourced (linked inline in Summary), not training-data recall.

Closes #514

## Related

- #514 — the issue this closes.
- #496 (context economy / restart discipline) — the restart cadence documented here composes with #496's context-reset restart; both converge on "restart is the mechanism." A sibling worker is concurrently authoring a claude-ops context-economy contract under `plugins/claude-ops/skills/lanes/` for #496 — no PR touching `plugins/claude-ops/` was open at this PR's creation (rechecked immediately before pushing), so this is not serialized behind one, but reviewers should sequence the two if the #496 PR opens against the same directory.
- #535 / #538 — adjacent loop-mechanics issues, cited for context only; not addressed here.
- #480 (durable prompt storage) — the lanes skill's existing forward dependency; untouched by this PR.
- #792 — follow-up: `lane-launcher.sh` never captures `<lane-launch-commit>`, leaving this PR's `refresh.md` staleness probe unfillable in practice. VALID, deferred (doc-only PR scope; both review passes classified it non-blocking) — filed post-green per the lane's review-deferral rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1V3gkrfSf75isB8MiDy3o

