### PR TITLE
fix(claude-ops): close 3 residual fleet-state.sh gaps from PR #248

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.15.4",
+  "version": "0.16.0",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.0]
+
+### Added
+
+- **`plugins` skill — `fleet-state.sh` now emits `missing_from_user_install`.**
+  A new user-scope completeness field (catalog ids not installed at `user`
+  scope, minus any explicitly opted out) alongside the existing all-scope
+  `missing_from_install`. `sync` Step 4 now keys its user-scope install offer
+  off this field: a plugin installed only at `project`/`local` scope was absent
+  from all-scope `missing_from_install` and so was never offered a user-scope
+  install, silently breaking the "usable from any directory" guarantee for it.
+  The existing `missing_from_install` field and its all-scope semantics are
+  unchanged; the report template (`SKILL.md`) references the new field for its
+  "needs install" action. (#254)
+
+### Fixed
+
+- **`plugins` skill — `fleet-state.sh` shape validation now checks each plugin
+  entry, not just the top-level type.** A drifted individual entry (a non-array
+  value) passed the `{plugins: {...}}` object check, then failed inside the
+  installed-flatten `jq` pipeline in a command substitution; with `set -uo
+  pipefail` but no `set -e` the failure was swallowed and the script exited 0
+  with `installed: []` instead of failing loud per its stated design. The check
+  now asserts every entry is an array and exits 2 on drift. (#254)
+- **`plugins` skill — `fleet-state.sh --marketplace` with no name now exits 2
+  instead of infinite-looping.** With one positional param left, `shift 2`
+  failed silently (no `set -e`), leaving `$1` unchanged so the arg loop re-read
+  `--marketplace` forever and the post-loop guard was never reached. The empty
+  check now runs inside the `--marketplace` branch, before `shift`. (#254)
+
 ## [0.15.4]
 
 ### Changed

--- a/plugins/claude-ops/skills/plugins/SKILL.md
+++ b/plugins/claude-ops/skills/plugins/SKILL.md
@@ -95,7 +95,7 @@ Installed: <N> new catalog plugin(s) — <id>@<marketplace> (only when N > 0; pe
 Divergences: <N> project-scope install(s) behind user scope → run `/claude-ops:plugins converge`
   (N = actionable only — versionsMatch:false; same-version multi-scope installs are not counted
   or listed here)
-Action needed: <bulleted list — missing_from_install, missing_from_enabled, CLI failures,
+Action needed: <bulleted list — missing_from_user_install, missing_from_enabled, CLI failures,
   unknown/orphaned plugins> (omit section entirely when empty)
 ```
 

--- a/plugins/claude-ops/skills/plugins/context/sync.md
+++ b/plugins/claude-ops/skills/plugins/context/sync.md
@@ -74,8 +74,12 @@ One call per plugin — `claude plugin update` takes a single `<plugin>` argumen
 
 ## Step 4 — Install new catalog plugins (per `install_new` policy)
 
-Take `fleet-state.sh`'s `missing_from_install` (already excludes anything explicitly opted out with
-`enabledPlugins: false` in any scope — never re-offer a deliberate decline). Apply the configured
+Take `fleet-state.sh`'s `missing_from_user_install` — catalog ids not installed at `user` scope
+(already excludes anything explicitly opted out with `enabledPlugins: false` in any scope — never
+re-offer a deliberate decline). This is deliberately user-scope, not the all-scope `missing_from_install`:
+a plugin installed only at `project`/`local` scope is absent from `missing_from_install` yet still not
+usable from other directories, so installing at `user` scope below (the "usable from any directory"
+guarantee) must key off user-scope completeness. Apply the configured
 policy — SKILL.md's `${user_config.install_new}` line renders the actual value; that render, not this
 step's prose, is what to branch on:
 
@@ -85,12 +89,12 @@ step's prose, is what to branch on:
 - **`none`** — install nothing; list the entries under "Action needed" in the report only
 
 **Caveat (document, don't silently absorb):** with `install_new: all`, a catalog plugin that's
-installed and then *disabled* (not uninstalled — `enabledPlugins: false` still recorded, install
-record still present) is correctly excluded (it's not in `missing_from_install`, it's an installed,
-opted-out plugin). But a plugin that's *uninstalled entirely* without ever setting `false` reappears
-in `missing_from_install` on the very next sync and gets reinstalled — `install_new: all` has no
-memory of "I removed this on purpose." If that's not the intent, uninstall AND disable
-(`enabledPlugins: false`), or switch the policy to `ask`/`none`.
+installed at `user` scope and then *disabled* (not uninstalled — `enabledPlugins: false` still
+recorded, install record still present) is correctly excluded (it's not in `missing_from_user_install`,
+it's an installed, opted-out plugin). But a plugin that's *uninstalled entirely* without ever setting
+`false` reappears in `missing_from_user_install` on the very next sync and gets reinstalled —
+`install_new: all` has no memory of "I removed this on purpose." If that's not the intent, uninstall
+AND disable (`enabledPlugins: false`), or switch the policy to `ask`/`none`.
 
 ## Step 5 — `enabledPlugins` completeness
 

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
@@ -19,8 +19,13 @@
 #
 # Output (stdout): one JSON object.
 #   Single marketplace: {marketplace, catalog, installed, enabled,
-#     missing_from_install, missing_from_enabled, divergences}
+#     missing_from_install, missing_from_user_install, missing_from_enabled,
+#     divergences}
 #     — or {marketplace: {name, error}} on a resolvable per-marketplace failure.
+#   missing_from_install is all-scope (catalog minus installed anywhere);
+#   missing_from_user_install is user-scope only (catalog minus user-scope
+#   installed), the signal `sync` Step 4 uses to keep every plugin usable from
+#   any directory. Both exclude ids explicitly opted out (false) in any scope.
 #   --all: {marketplaces: {"<name>": <single-marketplace shape>, ...}}
 #
 # Exit codes:
@@ -97,8 +102,8 @@ require_json() {
 }
 
 require_json "$INSTALLED_JSON" "installed_plugins.json"
-if [[ "$(jq -r 'has("plugins") and (.plugins | type == "object")' "$INSTALLED_JSON")" != "true" ]]; then
-  echo "ERROR: installed_plugins.json does not match the expected {plugins: {...}} shape: $INSTALLED_JSON" >&2
+if [[ "$(jq -r 'has("plugins") and (.plugins | type == "object") and (.plugins | to_entries | all(.value | type == "array"))' "$INSTALLED_JSON")" != "true" ]]; then
+  echo "ERROR: installed_plugins.json does not match the expected {plugins: {<id>: [...]}} shape: $INSTALLED_JSON" >&2
   exit 2
 fi
 
@@ -281,6 +286,21 @@ emit_marketplace() {
     --argjson falseIds "$explicit_false_ids" \
     '($catalog - $installed) - $falseIds')
 
+  # User-scope completeness, distinct from all-scope missing_from_install: a
+  # plugin installed only at project/local scope is present all-scope but not
+  # usable from other directories, so `sync` Step 4 (which installs at user
+  # scope for the "usable from any directory" guarantee) must key off this, not
+  # missing_from_install. Same opt-out exclusion as above.
+  local user_installed_ids
+  user_installed_ids=$(jq -c '[.[] | select(.scope == "user") | .id] | unique' <<<"$installed")
+
+  local missing_from_user_install
+  missing_from_user_install=$(jq -cn \
+    --argjson catalog "$catalog_ids" \
+    --argjson userInstalled "$user_installed_ids" \
+    --argjson falseIds "$explicit_false_ids" \
+    '($catalog - $userInstalled) - $falseIds')
+
   local known_at_mp
   known_at_mp=$(jq -c --arg suffix "@$name" '[.[] | select(endswith($suffix))]' <<<"$known_ids")
 
@@ -327,6 +347,7 @@ emit_marketplace() {
     --argjson installed "$installed" \
     --argjson enabled "$enabled_at_mp" \
     --argjson missingInstall "$missing_from_install" \
+    --argjson missingUserInstall "$missing_from_user_install" \
     --argjson missingEnabled "$missing_from_enabled" \
     --argjson divergences "$divergences" \
     '{
@@ -335,6 +356,7 @@ emit_marketplace() {
       installed: $installed,
       enabled: $enabled,
       missing_from_install: $missingInstall,
+      missing_from_user_install: $missingUserInstall,
       missing_from_enabled: $missingEnabled,
       divergences: $divergences
     }'
@@ -349,6 +371,13 @@ while [[ $# -gt 0 ]]; do
   --marketplace)
     MODE="single"
     TARGET="${2:-}"
+    # Guard here, before `shift 2`: with no following arg only one positional
+    # param remains, `shift 2` fails (no set -e), $1 stays "--marketplace", and
+    # the loop spins forever — the post-loop empty check is never reached.
+    if [[ -z "$TARGET" ]]; then
+      echo "ERROR: --marketplace requires a name" >&2
+      exit 2
+    fi
     shift 2
     ;;
   --all)
@@ -372,10 +401,6 @@ default)
   emit_marketplace "$TARGET" || exit 1
   ;;
 single)
-  if [[ -z "$TARGET" ]]; then
-    echo "ERROR: --marketplace requires a name" >&2
-    exit 2
-  fi
   emit_marketplace "$TARGET" || exit 1
   ;;
 all)

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
@@ -492,6 +492,84 @@ rc=$?
 assert_exit "jq missing: exit 2" 2 "$rc"
 assert_contains "jq missing: actionable notice" "$out" "jq required"
 
+# ============================================================================
+# Case: missing_from_user_install is user-scope completeness, distinct from
+# all-scope missing_from_install. A plugin installed ONLY at project/local
+# scope is present all-scope (absent from missing_from_install) yet absent at
+# user scope, so it MUST surface in missing_from_user_install — otherwise sync
+# Step 4 never offers to install it at user scope and the "usable from any
+# directory" guarantee silently fails for it. A user-scope install is excluded
+# from both; an opt-out (false, any scope) is excluded from both.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+write "$case_dir/installed_plugins.json" '{
+  "version": 1,
+  "plugins": {
+    "alpha@market1": [{"scope": "project", "projectPath": "<PROJECT_ROOT>/sample-repo", "installPath": "x", "version": "0.1.0"}],
+    "gamma@market1": [{"scope": "user", "installPath": "y", "version": "0.1.0"}]
+  }
+}'
+write "$case_dir/known_marketplaces.json" '{"market1": {"source": {"source": "github", "repo": "example/market1"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+write "$case_dir/catalog/market1.json" '{"plugins": [{"name": "alpha"}, {"name": "beta"}, {"name": "gamma"}]}'
+ARGS=(--marketplace market1)
+out=$(run_state "$case_dir")
+missing_install=$(jq -cS '.missing_from_install' <<<"$out" 2>/dev/null)
+assert_eq "user-scope: project-only install is present all-scope, absent from missing_from_install" '["beta@market1"]' "$missing_install"
+missing_user_install=$(jq -cS '.missing_from_user_install' <<<"$out" 2>/dev/null)
+assert_eq "user-scope: project-only + never-installed both surface, user-scope install excluded" '["alpha@market1","beta@market1"]' "$missing_user_install"
+
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+write "$case_dir/known_marketplaces.json" '{"market1": {"source": {"source": "github", "repo": "example/market1"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+write "$case_dir/catalog/market1.json" '{"plugins": [{"name": "alpha"}, {"name": "beta"}]}'
+write "$case_dir/user_settings.json" '{"enabledPlugins": {"alpha@market1": false}}'
+ARGS=(--marketplace market1)
+out=$(run_state "$case_dir")
+missing_user_install=$(jq -cS '.missing_from_user_install' <<<"$out" 2>/dev/null)
+assert_eq "user-scope: opt-out excluded from missing_from_user_install too" '["beta@market1"]' "$missing_user_install"
+
+# ============================================================================
+# Case: a drifted individual plugin entry (non-array value) must fail loud —
+# the top-level shape check alone passed it through, and the non-array then
+# broke the installed-flatten pipeline inside a command substitution, which
+# (no set -e) was swallowed and exited 0 with installed:[] instead of failing
+# per the file's stated fail-loud-on-drift design.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+write "$case_dir/installed_plugins.json" '{"version": 1, "plugins": {"alpha@market1": "not-an-array"}}'
+write "$case_dir/known_marketplaces.json" '{"market1": {"source": {"source": "github", "repo": "example/market1"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+write "$case_dir/catalog/market1.json" '{"plugins": [{"name": "alpha"}]}'
+ARGS=(--marketplace market1)
+out=$(run_state "$case_dir")
+rc=$?
+assert_exit "non-array plugin entry: exit 2" 2 "$rc"
+assert_contains "non-array plugin entry: error names the file" "$out" "installed_plugins.json"
+
+# ============================================================================
+# Case: --marketplace with no following name must exit 2 immediately, NOT
+# infinite-loop. `shift 2` with one positional param left fails silently (no
+# set -e), leaving $1 unchanged so the arg loop re-reads --marketplace forever;
+# the in-branch guard exits before shift. timeout catches a regression (a hang
+# returns 124, failing the assertion) instead of hanging the whole suite.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+write "$case_dir/installed_plugins.json" '{"version":1,"plugins":{}}'
+write "$case_dir/known_marketplaces.json" '{}'
+write "$case_dir/user_settings.json" '{"enabledPlugins":{}}'
+out=$(timeout 10 env \
+  FLEET_STATE_INSTALLED_JSON="$case_dir/installed_plugins.json" \
+  FLEET_STATE_MARKETPLACES_JSON="$case_dir/known_marketplaces.json" \
+  FLEET_STATE_USER_SETTINGS="$case_dir/user_settings.json" \
+  FLEET_STATE_CATALOG_DIR="$case_dir/catalog" \
+  FLEET_STATE_HOOK_UTILS="$SCRIPT_DIR/../../../hooks/hook-utils.sh" \
+  bash "$SCRIPT" --marketplace 2>&1)
+rc=$?
+assert_exit "--marketplace no arg: exit 2, not an infinite loop" 2 "$rc"
+assert_contains "--marketplace no arg: actionable error" "$out" "requires a name"
+
 # --- Summary -------------------------------------------------------------
 printf '\n%d cases, %d failed\n' "$CASE_NUM" "$FAILED"
 [[ "$FAILED" -eq 0 ]] && exit 0


### PR DESCRIPTION
## Summary

Closes the three deferred, independently-corroborated (Codex + claude[bot]) review findings from PR #248's review cycle against `plugins/claude-ops/skills/plugins/scripts/fleet-state.sh`. Each was verified VALID but deferred out of #248 to bound an already-long (6+ round) fix/review loop. All fixed here with TDD regression tests (red-then-green).

Version bumped `0.15.4` → `0.16.0` (minor: adds a new consumable output field).

## Fix

**1 — user-scope install completeness (additive, no behavior change to the existing field).**
`fleet-state.sh` now emits a new field `missing_from_user_install` = catalog minus *user-scope*-installed minus opted-out, alongside the untouched all-scope `missing_from_install`. A plugin installed only at `project`/`local` scope was present all-scope (absent from `missing_from_install`) and so was never offered a `user`-scope install by `sync` Step 4 — silently breaking the "usable from any directory" guarantee for it. `sync.md` Step 4 now keys its user-scope install offer off the new field. The existing `missing_from_install` field and its all-scope semantics are unchanged.
Chosen approach: the additive option from the issue (new field), not the redefinition option — no behavior change to any existing consumer.
Beyond the literal instruction: `SKILL.md`'s report template ("Action needed") reference was also switched to `missing_from_user_install`, so the report and Step 4 name the same signal (safe — `missing_from_user_install` ⊇ `missing_from_install` always, since user-installed ⊆ all-installed). `scope-semantics.md`'s reference was deliberately left on `missing_from_install` — it documents the preserved all-scope field's rename-coverage semantics.

**2 — per-plugin shape validation.**
The shape check validated `.plugins` is an object but not that each entry is an array. A drifted non-array entry passed the check, then failed inside the installed-flatten `jq` pipeline in a command substitution; with `set -uo pipefail` but no `set -e` the failure was swallowed and the script exited **0** with `installed: []` instead of failing loud per its stated design. The check now also asserts `(.plugins | to_entries | all(.value | type == "array"))` and exits 2 on drift.

**3 — `--marketplace` with no name.**
`fleet-state.sh --marketplace` (no following arg) set `TARGET=""`, then `shift 2` failed silently (only one positional param left, no `set -e`), leaving `$1` unchanged so the arg loop re-read `--marketplace` forever; the post-loop `-z "$TARGET"` guard was never reached. The empty check now runs inside the `--marketplace` branch before `shift`, exiting 2. The now-dead post-loop guard was removed.

## Verification

TDD: three regression cases were added and run **against the unfixed script first** to prove each bug, then the fixes were applied.

Before (unfixed script — the three new cases red, proving each bug):

```
FAIL: user-scope: project-only + never-installed both surface, user-scope install excluded
FAIL: user-scope: opt-out excluded from missing_from_user_install too
FAIL: non-array plugin entry: exit 2
  detail: expected exit 2, got 0            # #2: swallowed failure — exited 0 with installed:[]
FAIL: --marketplace no arg: exit 2, not an infinite loop
  detail: expected exit 2, got 124          # #3: 124 = timeout killed the infinite loop
FAIL: --marketplace no arg: actionable error
```

After (fixed script — full suite green):

```
PASS: --marketplace no arg: exit 2, not an infinite loop
PASS: --marketplace no arg: actionable error

23 cases, 0 failed
```

`shellcheck` (both scripts) and `markdownlint-cli2` (all changed markdown) report clean:

```
SHELLCHECK CLEAN
Summary: 0 error(s)
```

Closes #254

## Related

- Closes #254 — the tracking issue enumerating all three findings.
- Follow-up from PR #248 (`feat/claude-ops-plugins-skill`), the origin review cycle where these three were verified VALID and deliberately deferred.
- #797 — follow-up: `FLEET_STATE_HOOK_UTILS`'s test-only override isn't gated to test contexts at runtime. Pre-existing (unchanged by this PR), out of scope here — filed post-green per the lane's review-deferral rule.

