### PR TITLE
docs(autonomy): codify scheduler ruling pointer-style; de-copy upstream scheduling facts

### DIFF
--- a/docs/topics/autonomy-ignition/PLAN.md
+++ b/docs/topics/autonomy-ignition/PLAN.md
@@ -41,8 +41,19 @@ with no human help, not autonomous merge.
   inference of class; unlabeled = skip. `.claude/autonomy/**` and label mutation are
   excluded from the run's allowlist.
 - #440 outward-write posture: report-only-compatible evidence.
-- Upstream recheck standing trigger (done 2026-07-21: desktop-scheduled-tasks doc — native
-  overlap-skip, single catch-up, worktree toggle, per-task model + permission pickers).
+- **Scheduler ruling (operator, 2026-07-21):** primary = Claude Code Desktop scheduled task
+  (per the native-first amendment on #778); fallback = OS scheduler + `claude -p` headless
+  (the amendment's "can't be easily managed" exit clause — a legitimate flip if running the
+  Desktop app continuously proves burdensome); excluded = session-scoped CLI scheduling
+  (`/loop` / cron tools), unfit for a standing unattended routine per its own documentation.
+  The WHY lives upstream, not here — surface properties, comparison table, and expiry
+  semantics are owned by the living docs:
+  <https://code.claude.com/docs/en/desktop-scheduled-tasks> and
+  <https://code.claude.com/docs/en/scheduled-tasks> (verified 2026-07-21). This ruling is
+  expected to be overtaken — a durable CLI-native surface may ship; the standing
+  recheck-against-upstream trigger (re-verify the scheduling landscape at every build
+  touchpoint) is the mechanism that catches it. Trust the fetched docs at each touchpoint,
+  never this note's recollection of them.
 - STANDING ORCHESTRATION CONTRACT: builders in worktrees, agents never touch git, main
   thread verifies empirically before every commit.
 

--- a/docs/topics/ladder-climb-roadmap/PLAN.md
+++ b/docs/topics/ladder-climb-roadmap/PLAN.md
@@ -104,14 +104,16 @@ permission preflight.
 Unattended-execution design surfaces the sub-topic plan MUST cover (fresh-context review
 2026-07-21):
 
-- **Machine availability**: Desktop tasks run only while the app is open and the machine is
-  awake (doc-verified 2026-07-21). Work items: app autostart on login, power/keep-awake
-  configuration (operator choice), reboot/Windows-update survival, missed-fire detection.
-- **Catch-up + overlap**: natively bounded — exactly one catch-up run for the most recent
-  missed time (older discarded), and an in-progress run causes the next fire to be SKIPPED
-  (both doc-verified 2026-07-21). Residual design work: prompt guardrails for stale-time
-  catch-up runs, and drain idempotency (claim discipline on the dispatch seam so a catch-up +
-  manual run can never double-drain an item).
+- **Machine availability**: the Desktop surface's run conditions (app/machine state) are
+  owned by <https://code.claude.com/docs/en/desktop-scheduled-tasks> — read them there at
+  build time. Design consequence (verified against that page 2026-07-21): work items for app
+  autostart on login, power/keep-awake configuration (operator choice), reboot/Windows-update
+  survival, missed-fire detection.
+- **Catch-up + overlap**: the surface's native catch-up and overlap semantics are owned by
+  the same page — verify them at each touchpoint, don't trust a recap. Residual design work
+  regardless of those semantics: prompt guardrails for stale-time catch-up runs, and drain
+  idempotency (claim discipline on the dispatch seam so a catch-up + manual run can never
+  double-drain an item).
 - **Partial-run reconciliation**: `dontAsk` denies out-of-allowlist calls mid-run — plan for
   branch-without-PR, PR-without-evidence-row, claimed-but-not-drained states: named retry /
   orphan-cleanup / reconciliation items, not a single "failure handling" tap.


### PR DESCRIPTION
Operator directive + /re-anchor:point-dont-copy pass: the which-scheduler ruling is codified once in the ignition plan (Desktop native primary per the #778 amendment; OS scheduler + `claude -p` fallback via the amendment's exit clause; session-scoped CLI `/loop`/cron excluded) pointing at the living docs for every upstream-owned fact, with the standing recheck-against-upstream trigger named as the mechanism that catches a future durable CLI-native surface. Paraphrased upstream semantics in the roadmap's Phase I section converted to pointers; dated empirical probes and mechanically-verifiable check commands kept as project-owned content.

No linked issue (tracks #778 without closing it).

## Related

- #778 (scheduler amendment + ruling home), https://code.claude.com/docs/en/desktop-scheduled-tasks, https://code.claude.com/docs/en/scheduled-tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdeVMaDzwP26bNiDjqM59Q
