### PR TITLE
fix(claude-ops): add missing default to install_new userConfig

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",
@@ -37,7 +37,8 @@
     "install_new": {
       "type": "string",
       "title": "New-plugin install policy for the plugins skill's sync action",
-      "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default — offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\"."
+      "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default — offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\".",
+      "default": "ask"
     },
     "api_error_audit_enabled": {
       "type": "boolean",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.1]
+
+### Fixed
+
+- **`install_new` userConfig had no `default` key.** SKILL.md's `plugins` skill renders
+  `${user_config.install_new}` expecting Claude Code to substitute the configured value, falling
+  back to `"ask"` when unset; with no declared default, the literal placeholder leaked through
+  unrendered instead. Added `"default": "ask"` to the `install_new` entry in `plugin.json`,
+  matching what the entry's own description already documented and the pattern every boolean
+  option in the manifest already follows (e.g. `api_error_audit_enabled`).
+
 ## [0.17.0]
 
 ### Added


### PR DESCRIPTION
## Summary

- `claude-ops`'s `install_new` userConfig entry had no `"default"` key, even though its own `description` documents `"ask"` as the default.
- The `plugins` skill's SKILL.md renders `${user_config.install_new}` expecting Claude Code's substitution mechanism to fill in `"ask"` when unset — with no declared default, the literal placeholder string leaked through unrendered instead.

## Fix

- Added `"default": "ask"` to the `install_new` entry in `plugins/claude-ops/.claude-plugin/plugin.json`, matching the pattern every other option in the manifest already follows (e.g. `api_error_audit_enabled` declares `"default": true`).
- No SKILL.md/README.md changes needed — both already describe `ask` as the default in prose; only the manifest itself lacked the machine-readable default.
- Bumped `plugins/claude-ops/.claude-plugin/plugin.json` version `0.17.0` → `0.17.1` and added a matching `CHANGELOG.md` entry.

## Verification

```
$ bash scripts/validate-plugins.sh
✔ Validation passed  (all plugin manifests, including claude-ops)
All plugin manifests and the catalog validated.

$ bash scripts/check-changelog-parity.sh --check-bump origin/main
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.

$ npx markdownlint-cli2 plugins/claude-ops/CHANGELOG.md
Summary: 0 error(s)
```

Commit is signed (`git log --show-signature`: "Good git signature").

Closes #786

## Related

- #786 — the bug this PR fixes.