### PR TITLE
fix(work-items): resolve consumer-local gh-bot.sh wrapper independent of adapter location

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.2]
+
+### Fixed
+
+- **GitHub adapter resolves a consumer-local `gh-bot.sh` wrapper independent of adapter location
+  (`#365`).** `common.sh` resolved the bot wrapper relative to the adapter's own directory
+  (`${CLAUDE_PLUGIN_ROOT}/tools/github-auth/gh-bot.sh` in the normal bundled path), so a consuming
+  repo's wrapper at `${CLAUDE_PROJECT_DIR}/tools/github-auth/gh-bot.sh` — the path CONTRACT.md's
+  "Identity routing" section already documented as the override — was never found, and tracker writes
+  silently fell back to the ambient `gh` (session-user) identity. `wit_gh_resolve_bot_wrapper` now
+  checks the consumer-local path first, falling back to the plugin-bundled path, mirroring the
+  adapter's own consumer-local-first/plugin-bundled-fallback resolution (CONTRACT.md "Adapter
+  resolution"). CONTRACT.md's "Identity routing" section is updated to match.
+
 ## [0.18.1]
 
 ### Changed

--- a/plugins/work-items/tools/work-item-tracker/CONTRACT.md
+++ b/plugins/work-items/tools/work-item-tracker/CONTRACT.md
@@ -284,10 +284,13 @@ runtime (e.g. GitHub: 100 sub-issues/parent, 8 nesting levels, 50 dependencies/t
 ## Identity routing (GitHub adapter)
 
 Tracker WRITES (item create, lease comments, reclaim notes) route through an optional bot wrapper
-(`gh-bot.sh`) when the consuming repo provides one, and fall back to bare `gh` when it is absent. The
-shipped adapter resolves the wrapper relative to its own location (`…/github-auth/gh-bot.sh` beside the
-seam tree): a plugin install bundles no wrapper, so writes use bare `gh` (plugin-lift portability); a
-repo that wants bot-attributed writes provides the wrapper at that path in its own tree. CLAIMS always
+(`gh-bot.sh`) when a wrapper is found, and fall back to bare `gh` when neither location has one.
+Resolution is consumer-local-first, plugin-bundled fallback — mirroring "Adapter resolution": the
+adapter checks `${CLAUDE_PROJECT_DIR}/tools/github-auth/gh-bot.sh` first, independent of where the
+adapter itself resolved from (so a shadowed consumer-local adapter still finds the consumer's wrapper),
+then falls back to `…/github-auth/gh-bot.sh` bundled beside the seam tree. A plugin install ships no
+wrapper at either path, so writes use bare `gh` by default (plugin-lift portability); a repo that wants
+bot-attributed writes provides the wrapper at its own project root, with zero vendoring. CLAIMS always
 assign the authenticated human user via bare `gh` (`@me` must resolve to the session identity, not the
 bot). Reads are bare `gh`.
 

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.sh
@@ -34,7 +34,26 @@ wit_gh_require_seam_lib "$WIT_GH_ADAPTER_DIR/../../lib/lease.sh"
 # shellcheck source=../../lib/lease.sh
 source "$WIT_GH_ADAPTER_DIR/../../lib/lease.sh"
 
-readonly WIT_GH_BOT="$WIT_GH_ADAPTER_DIR/../../../github-auth/gh-bot.sh"
+# wit_gh_resolve_bot_wrapper — echo the bot wrapper path using consumer-local-first
+# resolution (CONTRACT.md "Identity routing (GitHub adapter)"), mirroring the
+# adapter two-root resolution (CONTRACT.md "Adapter resolution"): a consuming
+# repo's own wrapper at ${CLAUDE_PROJECT_DIR}/tools/github-auth/gh-bot.sh wins,
+# independent of where the adapter itself resolved from (a shadowed
+# consumer-local adapter must still find the consumer's wrapper, not miss it via
+# its own directory); otherwise the plugin-bundled path beside this adapter tree.
+wit_gh_resolve_bot_wrapper() {
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local consumer_wrapper="$CLAUDE_PROJECT_DIR/tools/github-auth/gh-bot.sh"
+    if [[ -f "$consumer_wrapper" ]]; then
+      printf '%s\n' "$consumer_wrapper"
+      return 0
+    fi
+  fi
+  printf '%s\n' "$WIT_GH_ADAPTER_DIR/../../../github-auth/gh-bot.sh"
+}
+
+WIT_GH_BOT="$(wit_gh_resolve_bot_wrapper)"
+readonly WIT_GH_BOT
 
 readonly EX_INTERNAL=1
 readonly EX_USAGE=2

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/common.test.sh
@@ -27,4 +27,28 @@ assert_eq "lease marker constant" "<!-- work-item-lease v1 " "$WIT_LEASE_MARKER"
 assert_eq "404 → not-found (5)" "5" "$(wit_map_gh_error 'HTTP 404 Not Found')"
 assert_eq "rate limit → unavailable (8)" "8" "$(wit_map_gh_error 'API rate limit exceeded')"
 
+# Bot-wrapper resolution (CONTRACT.md "Identity routing (GitHub adapter)"):
+# consumer-local-first, plugin-bundled fallback, regardless of adapter location.
+CONSUMER_ROOT="$(mktemp -d)"
+mkdir -p "$CONSUMER_ROOT/tools/github-auth"
+CONSUMER_WRAPPER="$CONSUMER_ROOT/tools/github-auth/gh-bot.sh"
+: >"$CONSUMER_WRAPPER"
+EMPTY_ROOT="$(mktemp -d)"
+BUNDLED="$WIT_GH_ADAPTER_DIR/../../../github-auth/gh-bot.sh"
+
+RESOLVED="$(CLAUDE_PROJECT_DIR="$CONSUMER_ROOT" wit_gh_resolve_bot_wrapper)"
+if [[ "$RESOLVED" -ef "$CONSUMER_WRAPPER" ]]; then
+  pass "resolves consumer-local wrapper first when present"
+else
+  fail "resolves consumer-local wrapper first when present" "$CONSUMER_WRAPPER" "$RESOLVED"
+fi
+
+RESOLVED_EMPTY_PROJECT="$(CLAUDE_PROJECT_DIR="$EMPTY_ROOT" wit_gh_resolve_bot_wrapper)"
+assert_eq "falls back to bundled path when consumer has none" "$BUNDLED" "$RESOLVED_EMPTY_PROJECT"
+
+RESOLVED_UNSET="$(unset CLAUDE_PROJECT_DIR; wit_gh_resolve_bot_wrapper)"
+assert_eq "falls back to bundled path when CLAUDE_PROJECT_DIR unset" "$BUNDLED" "$RESOLVED_UNSET"
+
+rm -rf "$CONSUMER_ROOT" "$EMPTY_ROOT"
+
 [[ $FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- The GitHub adapter's `WIT_GH_BOT` resolved the bot wrapper relative to the adapter's own directory (`${CLAUDE_PLUGIN_ROOT}/tools/github-auth/gh-bot.sh` in the normal bundled path), never checking the consumer-local override path CONTRACT.md already documented (`${CLAUDE_PROJECT_DIR}/tools/github-auth/gh-bot.sh`).
- As a result, a consuming repo's own bot wrapper was never found, and all tracker writes (item create, lease/reclaim comments) silently fell back to the ambient `gh` (session-user) identity instead of bot attribution.

## Fix

- `common.sh`: extracted `wit_gh_resolve_bot_wrapper`, which now resolves the bot wrapper **consumer-local-first, plugin-bundled fallback** — checking `${CLAUDE_PROJECT_DIR}/tools/github-auth/gh-bot.sh` first (independent of where the adapter itself resolved from, so a shadowed consumer-local adapter still finds the consumer's wrapper), then falling back to the bundled path beside the seam tree. This mirrors the existing two-rule adapter resolution documented in CONTRACT.md's "Adapter resolution" section.
- `CONTRACT.md`: updated the "Identity routing (GitHub adapter)" section to document the corrected consumer-local-first/plugin-bundled-fallback resolution order (previously it documented the buggy adapter-relative-only behavior).
- `common.test.sh`: added regression coverage for `wit_gh_resolve_bot_wrapper` — resolves the consumer-local wrapper when present, falls back to the bundled path when the consumer has none, and falls back when `CLAUDE_PROJECT_DIR` is unset.

## Verification

Full adapter + dispatcher test suite run, all green:

```
$ bash adapters/github/common.test.sh
PASS: [1] common.sh exposes gh_write
PASS: [2] common.sh exposes wit_run_gh
PASS: [3] common.sh exposes wit_resolve_repo
PASS: [4] common.sh exposes wit_emit_item
PASS: [5] common.sh exposes wit_lease_json
PASS: [6] common.sh exposes wit_lease_is_live
PASS: [7] common.sh exposes wit_list_lease_comments
PASS: [8] common.sh exposes wit_help_if_requested
PASS: [9] common.sh exposes wit_map_gh_error
PASS: [10] lease marker constant
PASS: [11] 404 → not-found (5)
PASS: [12] rate limit → unavailable (8)
PASS: [13] resolves consumer-local wrapper first when present
PASS: [14] falls back to bundled path when consumer has none
PASS: [15] falls back to bundled path when CLAUDE_PROJECT_DIR unset
```

All other `adapters/github/*.test.sh` files and `work-item-tracker.test.sh` (including its own consumer-local/adapter-resolution cases) also pass unchanged.

`shellcheck` on both modified shell files: no findings.

Closes #365

## Related

- #365
- Originates from the #224 review thread (deferred dependency #1, option (c))