### PR TITLE
docs(roadmap): record Phase II steps 1-2 landed

### DIFF
--- a/docs/topics/ladder-climb-roadmap/PLAN.md
+++ b/docs/topics/ladder-climb-roadmap/PLAN.md
@@ -154,6 +154,11 @@ ADR-0002-guarded ordering, three repos, ownership seams respected:
 > required check. Full rationale + evidence: ADR 0002 "ordering correction" addendum. Ruleset
 > flip stays LAST (unchanged). Step 0 ran as written: sole consumer = this repo's caller;
 > captured context `security-review / security-review`.
+>
+> Status (2026-07-21): steps 1–2 LANDED — ci-workflows#189 (reusable always-report shape,
+> pin `99cb082`), standards#229 + sync #827 (reviewed runner-input contract for the new pin),
+> #825 (this caller adopts `paths`, context verified unchanged live). Remaining: docs-only
+> skip-path verification PR, then step 3 (github-iac required check) behind its user gate.
 
 0. Pre-flight consumer check (FIRST work item): enumerate every consumer of the ci-workflows
    reusable security workflow before reshaping it — org-wide


### PR DESCRIPTION
## What

Append the Phase II status line to the roadmap PLAN scope-change note: steps 1–2 landed (ci-workflows#189, standards#229 + sync #827, #825).

## Why

This PR is ALSO the plan's step-1 sanity check: it is docs-only (matches none of the caller's 26 security-sensitive patterns), so it must show `security-review / changes` = pass and `security-review / security-review` = skipped (name-stable not-applicable verdict — not Pending, not absent). That observed result gets cited at the step-3 user gate before the ruleset PR opens.

No linked issue (status note; #509 completes at step 3).

## Related

- #509 — enforcement rail
- #825, melodic-software/ci-workflows#189, melodic-software/standards#229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
