### PR TITLE
fix(source-control): actionable owner/repo diagnostic on readiness-gate fetch failure

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.8]
+
+### Fixed
+
+- **`babysit-readiness-gate.sh` now emits an actionable diagnostic when the live comment fetch
+  fails, instead of an undifferentiated exit 4 (#475).** The gate shells out to
+  `fetch-all-pr-comments.sh`, which auto-derives owner/repo from the current directory via
+  `gh repo view`; from a cwd that is not a checkout of the target repo (e.g. a targeted-recheck
+  pass) that derivation returns empty and the fetch exits non-zero, which the gate previously
+  surfaced only as `fetch-all-pr-comments.sh failed for PR <N>` + exit 4 — the same exit code as a
+  missing `jq`. The gate's failure message now names the cwd it resolved from and the
+  `FETCH_COMMENTS_OWNER` / `FETCH_COMMENTS_REPO` override, `fetch-all-pr-comments.sh`'s own
+  "cannot resolve owner/repo" message names the cwd and the override, the gate's `--help` and
+  exit-code documentation cover the override, and the `babysit-prs` worker checklist (SKILL.md,
+  `reference/loop.md`) documents it as a prerequisite for out-of-checkout passes. No behavior
+  change to the readiness verdict or exit codes; only the diagnostics and docs.
+
 ## [0.15.7]
 
 ### Added

--- a/plugins/source-control/scripts/babysit-readiness-gate.sh
+++ b/plugins/source-control/scripts/babysit-readiness-gate.sh
@@ -47,6 +47,12 @@
 #                              babysit_self_logins userConfig option here
 #   babysit-readiness-gate.sh --help
 #
+# Repo resolution (live comment fetch): owner/repo is auto-derived from the
+#   CURRENT directory via `gh repo view`, so run this from a checkout of the
+#   target repo. When that cannot resolve (e.g. a recheck pass whose cwd is not
+#   the target repo), export FETCH_COMMENTS_OWNER and FETCH_COMMENTS_REPO to
+#   override — the gate passes them through to fetch-all-pr-comments.sh.
+#
 # Stdout (machine-readable, always emitted on a check run):
 #   READINESS_OK findings=<n> classified=<n> checklist=<clean|n/a>
 #   READINESS_BLOCKED reason=<under-decomposed|checklist-incomplete> findings=<n> classified=<n> unticked=<n>
@@ -55,7 +61,8 @@
 #   0  ready (decomposition satisfied + checklist clean/absent)
 #   1  blocked (READINESS_BLOCKED names the reason)
 #   3  invalid argument
-#   4  prerequisite missing (jq)
+#   4  prerequisite missing (jq), or the PR comment fetch failed — see stderr
+#      for the cause (owner/repo may be unresolved; see Repo resolution above)
 
 set -uo pipefail
 
@@ -68,7 +75,7 @@ SELF_CSV=""
 EXTRA_SELF_CSV=""
 
 usage() {
-  sed -n '2,58p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,65p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
   exit 0
 }
 
@@ -141,7 +148,8 @@ if [[ -n "$COMMENTS_JSON" ]]; then
   COMMENTS="$(cat "$COMMENTS_JSON")"
 else
   COMMENTS="$(bash "$SCRIPT_DIR/fetch-all-pr-comments.sh" "$PR_NUMBER")" || {
-    printf 'babysit-readiness-gate: fetch-all-pr-comments.sh failed for PR %s\n' "$PR_NUMBER" >&2
+    printf 'babysit-readiness-gate: could not fetch comments for PR %s (fetch-all-pr-comments error above).\n' "$PR_NUMBER" >&2
+    printf 'babysit-readiness-gate: owner/repo is auto-derived from the current directory (%s) via gh repo view. Run from a checkout of the target repo, or export FETCH_COMMENTS_OWNER and FETCH_COMMENTS_REPO to override.\n' "$PWD" >&2
     exit 4
   }
 fi

--- a/plugins/source-control/scripts/babysit-readiness-gate.test.sh
+++ b/plugins/source-control/scripts/babysit-readiness-gate.test.sh
@@ -34,6 +34,9 @@ mkjson() { # mkjson <name> <jq-array-expr>
 help_out=$(bash "$GATE" --help 2>&1)
 assert_exit "--help exit 0" 0 "$?"
 assert_contains "--help describes the gate" "$help_out" "readiness pre-gate"
+# --help must surface the owner/repo override so a worker whose cwd is not the
+# target repo can fix the fetch-failure exit 4 without trial-and-error.
+assert_contains "--help documents the env-var override" "$help_out" "FETCH_COMMENTS_OWNER"
 
 # --- Case: unknown flag ---
 bash "$GATE" 123 --bogus >/dev/null 2>&1
@@ -394,5 +397,25 @@ F=$(mkjson conv-overclassified '[
   {author:"me[bot]", body:"| 1 | a | VALID | x |\n| 2 | spurious | INCORRECT | y |"}
 ]')
 converge "over-classified-cap" "$F"
+
+# --- Case: live fetch failure emits an actionable owner/repo diagnostic ------
+# Run WITHOUT --comments-json from a cwd `gh repo view` cannot resolve: the gate's
+# fetch shell-out fails, and the gate must exit 4 with stderr naming the
+# FETCH_COMMENTS_OWNER/FETCH_COMMENTS_REPO override — not a bare failure line that
+# leaves a worker guessing (the exit-4-without-context report this gate fixes).
+NOREPO_BIN="$TEST_TMPDIR/bin-norepo"
+mkdir -p "$NOREPO_BIN"
+cat >"$NOREPO_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"repo view"*) printf '' ;;
+  *) printf '[]' ;;
+esac
+STUB
+chmod +x "$NOREPO_BIN/gh"
+fetch_rc=$(PATH="$NOREPO_BIN:$PATH" bash "$GATE" 123 >/dev/null 2>&1; echo $?)
+assert_exit "live-fetch-failure exit 4" 4 "$fetch_rc"
+fetch_err=$(PATH="$NOREPO_BIN:$PATH" bash "$GATE" 123 2>&1 1>/dev/null)
+assert_contains "live-fetch-failure names the env-var override" "$fetch_err" "FETCH_COMMENTS_OWNER"
 
 [[ $FAILED -eq 0 ]] || exit 1

--- a/plugins/source-control/scripts/fetch-all-pr-comments.sh
+++ b/plugins/source-control/scripts/fetch-all-pr-comments.sh
@@ -98,7 +98,7 @@ else
 fi
 
 if [[ -z "$OWNER" || -z "$REPO" ]]; then
-  printf 'fetch-all-pr-comments: cannot resolve owner/repo (set FETCH_COMMENTS_OWNER + FETCH_COMMENTS_REPO)\n' >&2
+  printf 'fetch-all-pr-comments: cannot resolve owner/repo - gh repo view found no repository for the current directory (%s). Run from a checkout of the target repo, or set FETCH_COMMENTS_OWNER + FETCH_COMMENTS_REPO.\n' "$PWD" >&2
   exit 2
 fi
 

--- a/plugins/source-control/scripts/fetch-all-pr-comments.test.sh
+++ b/plugins/source-control/scripts/fetch-all-pr-comments.test.sh
@@ -196,6 +196,36 @@ assert_eq "empty PR exits 0" "0" "$rc"
 empty_count=$(printf '%s' "$out" | jq 'length')
 assert_eq "empty PR returns empty array" "0" "$empty_count"
 
+# Case 9: unresolvable owner/repo (empty `gh repo view`, no env override) — the
+# root cause of the babysit gate's exit-4 failure mode. Must exit 2 with an
+# actionable message that names the FETCH_COMMENTS_OWNER/FETCH_COMMENTS_REPO
+# override, not a bare "cannot resolve".
+NOREPO_STUB="$TEST_TMPDIR/bin-norepo/gh"
+mkdir -p "$TEST_TMPDIR/bin-norepo"
+cat >"$NOREPO_STUB" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"repo view"*) printf '' ;;
+  *) printf '[]' ;;
+esac
+STUB
+chmod +x "$NOREPO_STUB"
+
+rc=$(
+  PATH="$TEST_TMPDIR/bin-norepo:$PATH" bash "$SCRIPT" "$PR_NUM" >/dev/null 2>&1
+  echo $?
+)
+assert_eq "unresolvable owner/repo exits 2" "2" "$rc"
+err=$(PATH="$TEST_TMPDIR/bin-norepo:$PATH" bash "$SCRIPT" "$PR_NUM" 2>&1 1>/dev/null)
+assert_contains "unresolvable owner/repo names the env-var override" "$err" "FETCH_COMMENTS_OWNER"
+
+# Case 10: env-var override resolves owner/repo even when `gh repo view` is empty,
+# so a worker whose cwd is not the target repo has a documented escape hatch.
+out=$(FETCH_COMMENTS_OWNER=o FETCH_COMMENTS_REPO=r \
+  PATH="$TEST_TMPDIR/bin-norepo:$PATH" bash "$SCRIPT" "$PR_NUM" 2>/dev/null)
+rc=$?
+assert_eq "env-var override resolves owner/repo (exit 0)" "0" "$rc"
+
 # ---- Summary ----------------------------------------------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then

--- a/plugins/source-control/skills/babysit-prs/SKILL.md
+++ b/plugins/source-control/skills/babysit-prs/SKILL.md
@@ -334,7 +334,7 @@ Execute for EACH PR discovered, oldest first. Detailed mechanics:
 - [ ] **Step 0 — PR discovery:** open PRs in scope (tier-scoped author filter), oldest-first
   FIFO (§5.0.2). Zero PRs → report and schedule the idle wake
 - [ ] **Step 0.1 — Evidence-based fresh rescan:** fetch ALL comments via the bundled
-  `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-all-pr-comments.sh`, filter own prior replies, classify
+  `${CLAUDE_PLUGIN_ROOT}/scripts/fetch-all-pr-comments.sh` (derives owner/repo from the current directory; from a cwd that is not a checkout of the target repo, export `FETCH_COMMENTS_OWNER`/`FETCH_COMMENTS_REPO` first — also unblocks the readiness gate's exit 4), filter own prior replies, classify
   addressed/unaddressed from GitHub evidence (§5.0.3). GitHub is the source of truth, not model
   memory
 - [ ] **Step 0.2 — Branch checkout:** `gh pr checkout <N>` with worktree/dirty-tree pre-checks;

--- a/plugins/source-control/skills/babysit-prs/reference/loop.md
+++ b/plugins/source-control/skills/babysit-prs/reference/loop.md
@@ -74,7 +74,10 @@ not model memory, not prior-iteration state, not comment counts (why:
 2. **CI check** — `gh pr checks <N> --json bucket -q '[.[] | .bucket] | unique'`
 3. **Fetch ALL comments** — run
    `bash "${CLAUDE_PLUGIN_ROOT}/scripts/fetch-all-pr-comments.sh" <N>` to retrieve every comment
-   from all 3 API surfaces (review-thread, issue-level, PR reviews). Full bodies, not counts
+   from all 3 API surfaces (review-thread, issue-level, PR reviews). Full bodies, not counts. The
+   script derives owner/repo from the current directory via `gh repo view`; from a cwd that is not
+   a checkout of the target repo (e.g. a targeted-recheck pass), export `FETCH_COMMENTS_OWNER` and
+   `FETCH_COMMENTS_REPO` first, else it exits with "cannot resolve owner/repo"
 4. **Filter own prior replies + classify addressed/unaddressed** per
    [review-discipline.md](../../../reference/review-discipline.md) §1
 5. **Extract findings** per [review-discipline.md](../../../reference/review-discipline.md) §2 —
@@ -287,7 +290,10 @@ verification gates per [review-discipline.md](../../../reference/review-discipli
   append `--extra-self "${user_config.babysit_self_logins}"`. Exit 0 `READINESS_OK`
   is REQUIRED to proceed. Exit 1 `READINESS_BLOCKED reason=under-decomposed` means
   classification rows < source findings → decompose + classify the missing findings, then
-  re-run. THEN confirm: all checks terminal + 2-min cooldown
+  re-run. Exit 4 means jq is missing or the comment fetch failed — the stderr names the fix; the
+  common cause is owner/repo unresolved from a cwd that is not a checkout of the target repo, fixed
+  by exporting `FETCH_COMMENTS_OWNER`/`FETCH_COMMENTS_REPO` (inherited into
+  `fetch-all-pr-comments.sh`). THEN confirm: all checks terminal + 2-min cooldown
 - [ ] **F** — Per-finding classification table + readiness report (see §5.5)
 
 **"Done" means GitHub shows evidence.** A per-finding work item is addressed only when the


### PR DESCRIPTION
## Summary

`babysit-readiness-gate.sh <N>` (safe-tier babysit) could exit `4` with only a
generic `fetch-all-pr-comments.sh failed for PR <N>` line — the same exit code
as a missing `jq` — leaving a worker following the documented invocation to
rediscover, by trial and error, that setting `FETCH_COMMENTS_OWNER` /
`FETCH_COMMENTS_REPO` fixes it. This makes that failure mode self-explanatory
and documents the override in the worker contract.

## Fix

Root cause: the gate shells out to `fetch-all-pr-comments.sh`, which
auto-derives owner/repo from the current directory via `gh repo view`. The
auto-derive already works from a checkout of the target repo; it returns empty
only when the cwd is not such a checkout (e.g. a targeted-recheck pass that
never runs `gh pr checkout`). That is inherent to cwd-based resolution — the
`FETCH_COMMENTS_OWNER`/`FETCH_COMMENTS_REPO` override is the cwd-independent
escape hatch, and it already worked; it was just undocumented and the failure
was undifferentiated. So this change is diagnostics + docs, with **no behavior
change to the readiness verdict or exit codes**:

- **Gate diagnostic** — on fetch failure the gate now prints the resolved cwd
  and names the `FETCH_COMMENTS_OWNER`/`FETCH_COMMENTS_REPO` override (and the
  "run from the target repo checkout" fix), in addition to `fetch-all-pr-comments.sh`'s
  own stderr. Its `--help` gains a "Repo resolution" section and the exit-`4`
  doc now covers the fetch-failure case, not just missing `jq`.
- **Fetch diagnostic** — `fetch-all-pr-comments.sh`'s `cannot resolve owner/repo`
  message now names the cwd `gh repo view` was resolved from and the override.
- **Worker contract** — `SKILL.md` (Step 0.1) and `reference/loop.md` (§5.0.3
  fetch step, §5.1.3 gate step E) document the override as a prerequisite for
  passes whose cwd is not the target-repo checkout.

Considered and rejected: a new `--repo owner/repo` flag. The env-var override
already provides cwd-independent resolution, so a flag would duplicate a working
mechanism for no gain; keeping the surface small.

## Verification

- **Reproduced** the exit `4` from a non-repo cwd, then confirmed the new
  diagnostic names the cwd and both env vars, still exiting `4`.
- **`babysit-readiness-gate.test.sh`** — added a gate-level case: with a
  `gh repo view`→empty stub on `PATH` and no `--comments-json`, the gate exits
  `4` and its stderr names `FETCH_COMMENTS_OWNER`; plus a `--help`-documents-the-override
  assertion. **63/63 pass.**
- **`fetch-all-pr-comments.test.sh`** — added: unresolvable owner/repo exits `2`
  with the actionable message, and the env-var override resolves owner/repo even
  when `gh repo view` is empty. **17/17 pass.**
- `shellcheck` clean on all four scripts; `skill-quality check babysit-prs`
  **PASS** (`SKILL.md` 499/500, markdownlint clean).

## Related

- Closes #475.
- #465 — readiness gate over-counts lifetime P-badges as findings (a separate
  gate counting bug; context only, not fixed here).
- #787 — `babysit_merge.py` read-only invocation blocked by the host auto-mode
  permission classifier (sibling `babysit-prs` issue; context only, not fixed here).

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1V3gkrfSf75isB8MiDy3o
