### PR TITLE
fix(claude-ops): use type -P for jq prereq check to avoid wrapper shadowing

### DIFF
--- a/plugins/claude-ops/skills/lanes/scripts/machine-behavior.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/machine-behavior.sh
@@ -60,7 +60,7 @@ err() { printf 'ERROR: %s\n' "$*" >&2; }
 
 usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "${BASH_SOURCE[0]}"; }
 
-command -v jq >/dev/null 2>&1 || {
+type -P jq >/dev/null 2>&1 || {
   err "jq not found (required)"
   exit 4
 }

--- a/plugins/claude-ops/skills/lanes/scripts/machine-behavior.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/machine-behavior.test.sh
@@ -11,6 +11,7 @@
 #   - missing / malformed installed_plugins.json degrades to `unavailable`
 #   - a --plugin naming no installed plugin is reported, not silently empty
 #   - argument + repo validation exit codes
+#   - missing jq BINARY (not just the in-script wrapper function) exits 4
 #
 # PATH-stubs `gh` and `git` and env-overrides the installed_plugins.json path so
 # no real CLI, network, or on-disk plugin state is touched.
@@ -186,6 +187,22 @@ assert_eq "--plugin with no value exits 3" 3 "$rc"
 out="$(MACHINE_BEHAVIOR_INSTALLED_JSON="$INSTALLED" bash "$SCRIPT" --repo "$TMP/does-not-exist" 2>&1)"
 rc=$?
 assert_eq "--repo non-directory exits 4" 4 "$rc"
+
+# ============================================================================
+# jq binary missing exits 4 — regression guard for the jq() wrapper (defined
+# before this prereq check) shadowing `command -v jq` and fail-opening the
+# guard. A PATH with no jq binary must still be caught by `type -P jq`, which
+# looks at PATH executables only and ignores the wrapper function.
+# ============================================================================
+# Resolve bash's own absolute path first so invoking it below needs no PATH
+# lookup; then restrict the child's PATH to just STUB_BIN (the git/gh stubs),
+# which never contains jq — reaching the prereq check without an external jq
+# binary anywhere in PATH, on any platform.
+BASH_BIN="$(command -v bash)"
+out="$(PATH="$STUB_BIN" MACHINE_BEHAVIOR_INSTALLED_JSON="$INSTALLED" "$BASH_BIN" "$SCRIPT" --repo "$TMP" 2>&1)"
+rc=$?
+assert_eq "missing jq binary exits 4" 4 "$rc"
+assert_contains "missing jq binary message" "$out" "jq not found"
 
 # ============================================================================
 echo

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
@@ -71,7 +71,7 @@ err() { printf 'ERROR: %s\n' "$*" >&2; }
 usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "${BASH_SOURCE[0]}"; }
 
 for bin in gh jq; do
-  command -v "$bin" >/dev/null 2>&1 || {
+  type -P "$bin" >/dev/null 2>&1 || {
     err "$bin not found (required)"
     exit 4
   }

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
@@ -11,6 +11,7 @@
 #     missing body-file
 #   - --dry-run resolves the action but performs no write
 #   - `-` reads the body from stdin
+#   - missing jq BINARY (not just the in-script wrapper function) exits 4
 #
 # PATH-stubs `gh`; the stub logs every mutating call and serves a fixture
 # comment list, so no network or real issue is touched.
@@ -295,6 +296,22 @@ out="$(printf 'lane: from-stdin\n' | STUB_COMMENTS_FILE="$TMP/empty.json" bash "
 rc=$?
 assert_eq "stdin body exits 0" 0 "$rc"
 assert_contains "stdin body creates a comment" "$out" "created comment 999"
+
+# ============================================================================
+# jq binary missing exits 4 — regression guard for the jq() wrapper (defined
+# before this prereq check) shadowing `command -v jq` and fail-opening the
+# guard. A PATH with no jq binary (only the gh stub) must still be caught by
+# `type -P jq`, which looks at PATH executables only and ignores the wrapper.
+# ============================================================================
+# Resolve bash's own absolute path first so invoking it below needs no PATH
+# lookup; then restrict the child's PATH to just STUB_BIN (the gh stub),
+# which never contains jq — reaching the prereq check without an external jq
+# binary anywhere in PATH, on any platform.
+BASH_BIN="$(command -v bash)"
+out="$(PATH="$STUB_BIN" "$BASH_BIN" "$SCRIPT" --repo "$REPO" --issue 502 --marker "lane:triage" --body-file "$BODY" --body-dir "$SAFE_DIR" 2>&1)"
+rc=$?
+assert_eq "missing jq binary exits 4" 4 "$rc"
+assert_contains "missing jq binary message" "$out" "jq not found"
 
 # ============================================================================
 echo


### PR DESCRIPTION
## Summary

`telemetry-upsert.sh` and `machine-behavior.sh` each define a `jq()` wrapper function (to strip CRLF from native-Windows jq output) *before* checking for the jq binary with `command -v jq`. Since `command -v` resolves shell functions ahead of PATH executables, the prerequisite check passed even with no jq binary installed — defeating the guard and letting both scripts fail open instead of the documented `exit 4`.

Fix: use `type -P jq` (and, in the `telemetry-upsert.sh` loop, `type -P` for both `gh`/`jq`), which searches PATH executables only and ignores functions/aliases/builtins — so the guard now catches a missing binary regardless of definition order.

Closes #812

## Sites fixed

- `plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh` (prereq loop, was L73-78)
- `plugins/claude-ops/skills/lanes/scripts/machine-behavior.sh` (prereq check, was L63-66)

A third file with a `jq()` wrapper, `plugins/claude-ops/skills/plugins/scripts/fleet-state.sh`, was checked and does **not** have this bug — its `command -v jq` check already runs before the wrapper is defined, so it wasn't touched.

## Empirical verification

**Before (bug reproduced against the actual scripts, jq absent from PATH):**
```
$ PATH=<no-jq> bash ./machine-behavior.sh --repo .
== MACHINE-BEHAVIOR ==
...
  unavailable (installed_plugins.json is not valid JSON: ...)
EXIT CODE: 0        # should be 4
```

**After (same PATH):**
```
$ PATH=<no-jq> bash ./machine-behavior.sh --repo .
ERROR: jq not found (required)
EXIT CODE: 4

$ PATH=<no-jq> bash ./telemetry-upsert.sh --repo o/r --issue 1 --marker "lane:x" --body-file /dev/null
ERROR: jq not found (required)
EXIT CODE: 4
```

Regression tests were also confirmed to actually catch the bug: reverting the one-line `telemetry-upsert.sh` fix and re-running `telemetry-upsert.test.sh` fails the new case (exit 3 with a `dirname: command not found` error, since the falsely-passed guard let the script proceed further before breaking) — proving the test isn't vacuously passing.

## Test plan

- [x] Added a regression case to `machine-behavior.test.sh` and `telemetry-upsert.test.sh`: run the script with a PATH containing the gh/git stub(s) but no jq binary anywhere, assert exit 4 and the "jq not found" message.
- [x] Confirmed both new cases fail against the pre-fix code and pass against the fix.
- [x] Full existing suites pass: `machine-behavior.test.sh` (26/26), `telemetry-upsert.test.sh` (38/38).
- [x] `shellcheck` clean on all four modified files.

## Related

- `plugins/claude-ops/skills/plugins/scripts/fleet-state.sh` — carries the same `jq()` CRLF-stripping wrapper, but orders its `command -v jq` guard *before* the wrapper is defined, so it is not vulnerable to this shadowing and is deliberately left unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
