### PR TITLE
feat(toolchain): add lychee-offline to cross-cutting ecosystem default

### DIFF
--- a/plugins/toolchain/.claude-plugin/plugin.json
+++ b/plugins/toolchain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "toolchain",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Repo-agnostic polyglot verification toolchain: build + test + lint for changed files across .NET, Python, TypeScript, Bash, PowerShell, Markdown, Go, YAML, and cross-cutting surfaces (`/toolchain:check`, `/toolchain:lint`), plus a re-runnable `/toolchain:setup` with check (report the configured ecosystems and their command surface) and apply (interview, infer, and write the tracked per-ecosystem command config those skills resolve first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/toolchain/CHANGELOG.md
+++ b/plugins/toolchain/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `toolchain` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.0]
+
+### Added
+
+- **`lychee-offline` added to the `cross-cutting` ecosystem default.** The bundled
+  `reference/ecosystems/cross-cutting.yaml` `check-cmd` now runs `lychee --offline --no-progress
+  './**/*.md'` alongside `typos`/`gitleaks`/editorconfig-checker — on-disk link/anchor integrity,
+  network-free (`--offline` skips external URLs; only local file and fragment targets are verified).
+  Opt-in follows the same per-tool-config pattern as the existing cross-cutting tools: an optional
+  `lychee.toml` at repo root customizes the ruleset (exclusions, fragment-check mode), absent means
+  lychee's own defaults. `install-hint` gains the `lycheeverse.lychee` winget package / `lychee`
+  brew formula. Per Brief item 3, `docs/topics/lint-static-analysis-gaps/PLAN.md`. Closes #833.
+
 ## [0.8.0]
 
 ### Added
@@ -74,7 +87,6 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 - Skills with `!` dynamic-context injections now declare `shell: bash` explicitly, per
   the pinned precompute convention — bash-only pipelines must not fall through to a
   PowerShell host.
-
 ## [0.5.1]
 
 ### Changed

--- a/plugins/toolchain/CHANGELOG.md
+++ b/plugins/toolchain/CHANGELOG.md
@@ -87,6 +87,7 @@ All notable changes to the `toolchain` plugin are documented here. Format follow
 - Skills with `!` dynamic-context injections now declare `shell: bash` explicitly, per
   the pinned precompute convention — bash-only pipelines must not fall through to a
   PowerShell host.
+
 ## [0.5.1]
 
 ### Changed

--- a/plugins/toolchain/reference/ecosystems/cross-cutting.yaml
+++ b/plugins/toolchain/reference/ecosystems/cross-cutting.yaml
@@ -12,10 +12,13 @@ check-cmd: |
   gitleaks detect --source . --redact --no-banner --no-git
   # editorconfig-checker — binary name varies by install method (ec / editorconfig-checker / ec-windows-amd64)
   "$EC_BIN"
+  # lychee-offline — on-disk link/anchor integrity; --offline = no network (external URLs skipped)
+  lychee --offline --no-progress './**/*.md'
 fix-cmd: null
-opt-in: "each tool's own config at repo root (_typos.toml, .gitleaks.toml, .editorconfig-checker.json / .editorconfig)"
+opt-in: "each tool's own config at repo root (_typos.toml, .gitleaks.toml, .editorconfig-checker.json / .editorconfig, lychee.toml)"
 install-hint: |
   typos: winget install Crate-CI.Typos | brew install typos-cli
   gitleaks: winget install Gitleaks.Gitleaks | brew install gitleaks
   editorconfig-checker: winget install EditorConfig-Checker.EditorConfig-Checker | brew install editorconfig-checker
+  lychee: winget install lycheeverse.lychee | brew install lychee
 notes: "Lint-only — owned by /toolchain:lint. /toolchain:check does not run this ecosystem."

--- a/plugins/toolchain/skills/lint/evals/evals.json
+++ b/plugins/toolchain/skills/lint/evals/evals.json
@@ -30,7 +30,7 @@
       "id": 3,
       "name": "owns-yaml-and-cross-cutting-surfaces",
       "prompt": "/toolchain:lint all — the change set includes a GitHub Actions workflow YAML and touches several text files across the repo.",
-      "expected_output": "Runs the lint-only `yaml` and `cross-cutting` surfaces that /toolchain:check does not — yaml for the workflow file, and cross-cutting (typos/gitleaks/editorconfig-checker) when any text file changed and the repo opts into those tools — resolving the editorconfig-checker binary-name variant before substituting it in.",
+      "expected_output": "Runs the lint-only `yaml` and `cross-cutting` surfaces that /toolchain:check does not — yaml for the workflow file, and cross-cutting (typos/gitleaks/editorconfig-checker/lychee-offline) when any text file changed and the repo opts into those tools — resolving the editorconfig-checker binary-name variant before substituting it in.",
       "files": [],
       "expectations": [
         "Runs the `yaml` surface for the workflow file (a `/toolchain:lint`-only surface not covered by `/toolchain:check`)",

--- a/plugins/toolchain/skills/setup/SKILL.md
+++ b/plugins/toolchain/skills/setup/SKILL.md
@@ -81,7 +81,7 @@ then specialize it to the repo:
 - **markdown** — a markdownlint config present.
 - **yaml** — `.github/workflows/` present (lint-only surface — `/toolchain:lint` runs it,
   `/toolchain:check` does not).
-- **cross-cutting** — repo-root config for `typos`/`gitleaks`/editorconfig-checker present (lint-only).
+- **cross-cutting** — repo-root config for `typos`/`gitleaks`/editorconfig-checker/`lychee-offline` present (lint-only).
 
 Repo-specific CI-parity gates beyond plain build/test/lint (lockfile drift, generated-artifact
 freshness, schema regeneration) belong in the ecosystem file's `gates` array — draft one when the

--- a/plugins/toolchain/skills/setup/SKILL.md
+++ b/plugins/toolchain/skills/setup/SKILL.md
@@ -81,7 +81,7 @@ then specialize it to the repo:
 - **markdown** — a markdownlint config present.
 - **yaml** — `.github/workflows/` present (lint-only surface — `/toolchain:lint` runs it,
   `/toolchain:check` does not).
-- **cross-cutting** — repo-root config for `typos`/`gitleaks`/editorconfig-checker/`lychee-offline` present (lint-only).
+- **cross-cutting** — repo-root config for `typos`/`gitleaks`/`editorconfig-checker`/`lychee-offline` present (lint-only).
 
 Repo-specific CI-parity gates beyond plain build/test/lint (lockfile drift, generated-artifact
 freshness, schema regeneration) belong in the ecosystem file's `gates` array — draft one when the


### PR DESCRIPTION
## Summary

Adds `lychee-offline` to the `toolchain` plugin's bundled `cross-cutting.yaml` ecosystem
default, alongside the existing `typos`/`gitleaks`/editorconfig-checker tools — on-disk
link/anchor integrity checking with no network dependency.

## Fix

- `reference/ecosystems/cross-cutting.yaml`: `check-cmd` gains
  `lychee --offline --no-progress './**/*.md'` (`--offline` = "Only check local files and
  block network requests" per lychee's own CLI help — external URLs are skipped, only local
  file and fragment targets are verified); `opt-in` and `install-hint` documented following
  the same per-tool-config pattern as the existing tools (optional `lychee.toml` at repo
  root customizes the ruleset; absent means lychee's own defaults).
- `skills/setup/SKILL.md`: cross-cutting inference-candidate line mentions `lychee-offline`,
  and all four cross-cutting tool names backtick-wrapped consistently.
- `skills/lint/evals/evals.json`: eval 3's `expected_output` updated to include
  `lychee-offline` in the enumerated cross-cutting tool set.
- `plugins/toolchain/.claude-plugin/plugin.json` + `CHANGELOG.md`: version bump.

**Version note**: sibling PR #859 (issue #834) landed first and took the intervening
`0.6.0`/`0.7.0` versions; PR #910 (issue #832) then landed `0.8.0`. Rebased onto current
`main` and renumbered to `0.9.0`, sequential CHANGELOG history intact. Collision with #859
is resolved (merged); `do-not-merge` label removed.

## Verification

- Confirmed `--offline` and `--no-progress` are real lychee CLI flags, and the winget
  package id (`lycheeverse.lychee`) / brew formula (`lychee`) are correct, against lychee's
  own upstream README (`lycheeverse/lychee`, `master` branch, Installation and Commandline
  usage sections).
- Smoke-tested the actual `check-cmd` (`lychee --offline --no-progress './**/*.md'`) against
  this repo: 0 errors across 2645 links (1079 unique, 1056 excluded).
- `evals.json` still parses as valid JSON; structural shape (required `id`/`prompt` fields)
  unchanged — only `expected_output` prose edited.
- `skills/setup/SKILL.md` re-checked against the 500-line skill-quality hard cap.
- Rebased onto current `origin/main`; `claude plugin validate --strict`,
  `node scripts/validate-plugin-contracts.mjs`, and full `bash scripts/run-plugin-tests.sh`
  all green.

Closes #833

## Related

- Epic: #830
- Brief item 3, `docs/topics/lint-static-analysis-gaps/PLAN.md`
- Sibling PR on the same plugin: #859 (issue #834, pyright) — merged, serialization resolved