### PR TITLE
fix(disk-hygiene): define "suspicious" for unhinted home-root entries

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.2]
+
+### Fixed
+
+- **The `clean` skill's step 2 now defines "suspicious" for home-directory targets.** A prior
+  fix covered the `tmp_*` hint-glob gap but left two findings open: an unhinted agent-session
+  status file has no shared name shape to glob, and SKILL.md never said what "suspicious"
+  meant for an unhinted entry. Both are the same gap: the scan snapshot already records every
+  walked entry with a possibly-empty `hints` list, so the data was always there, just never
+  triaged. Step 2 now instructs the model to treat any loose root-level entry at a user-home
+  target that is not in `protected_exact_names` and does not match a recognizable app/config
+  convention as suspicious, closing the triage gap without inventing a fabricated
+  baseline-policy.json glob for a naming pattern the evidence doesn't support. (#287)
+
 ## [0.4.1]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -86,6 +86,13 @@ rule below.
 
 ## 2. Establish evidence and ownership
 
+A hint annotation is not the only trigger for triage: at a user-home target, treat any loose
+root-level entry that is not in `protected_exact_names` and does not belong to a recognizable
+app/config convention as suspicious too — the snapshot already carries it (every walked entry is
+recorded with a possibly-empty `hints` list), so nothing further needs discovering, only judging.
+This positional read is how session-state droppings that share no common name (a runner-controller
+status snapshot, a one-off data export) surface for ownership triage even without a matching hint.
+
 For each hinted or suspicious entry, inspect enough neighboring content and metadata to answer:
 
 1. What created it? Prefer a manifest, log, documented naming contract, sibling structure, or owning


### PR DESCRIPTION
## Summary

Closes the two gaps #286 left open from issue #287: the `clean` skill's step 2 said to inspect
"hinted or suspicious" entries but never defined "suspicious" for an entry with no hint, so
unhinted agent-session droppings at a home-directory root (a status snapshot, a one-off export)
were never triaged even though the scan snapshot already records every walked entry.

## Fix

- `plugins/disk-hygiene/skills/clean/SKILL.md` §2: added a paragraph defining "suspicious" for
  a user-home target — any loose root-level entry not in `protected_exact_names` and not
  matching a recognizable app/config convention. This single guidance addition realizes both of
  #286's open findings (the undefined "suspicious" criteria, and the agent-session status-file
  heuristic) since they're the same positional gap: the engine already snapshots every walked
  entry with a possibly-empty `hints` list, so the data was always available, just never acted
  on.
- `plugins/disk-hygiene/skills/clean/reference/baseline-policy.json` is intentionally
  **untouched**. The issue's `tmp_*` hint-glob gap already shipped in #286/v0.3.0. The remaining
  class of entries (`melo-lap-001-*.json`, `org_usage.json`) shares no common name shape — the
  issue itself calls a generic glob "admittedly hard" — so adding a baseline-policy.json pattern
  here would mean fabricating a naming convention the evidence doesn't support. The positional
  SKILL.md guidance is the mechanism the issue's own notes suggest as the alternative.
- Bumped `plugins/disk-hygiene/.claude-plugin/plugin.json` 0.4.1 → 0.4.2 and added a matching
  CHANGELOG entry.

## Verification

- Confirmed the linchpin empirically before writing the guidance: `hygiene.py`'s snapshot walk
  (`scripts/hygiene.py:608-615`) appends every walked entry with `"hints": matching_hints(...)`
  (possibly empty), not just hinted ones — so the new guidance has real data to act on.
- Ran the repo's skill-quality gate: `bash scripts/check-changed-skills.sh origin/main` — PASS,
  0 errors (SKILL.md 235/500 lines, well under the hard cap; only a pre-existing soft
  line-count WARN, unrelated to this change).

Closes #287

## Related

- #286 landed the `tmp_*`/`scratch*` baseline-policy.json hints and explicitly scoped this
  issue's remaining two findings as open; this PR closes them.