### PR TITLE
docs(topics): flip boris-video-absorption Phase 8 to DONE after medley trial

### DIFF
--- a/docs/topics/boris-video-absorption/PLAN.md
+++ b/docs/topics/boris-video-absorption/PLAN.md
@@ -200,7 +200,7 @@ Files (home slice, not repo):
 - **Sanity Check:** CI green on PR; `gh pr view` shows mergeable; all
   phase tags [DONE].
 
-### Phase 8: trial run (post-merge validation) [TODO]
+### Phase 8: trial run (post-merge validation) [DONE]
 
 - After plugins update, run the enriched flow end-to-end on a real UI
   change in a consumer repo: config surface resolved + reported,
@@ -208,6 +208,11 @@ Files (home slice, not repo):
   deliberately), evidence table carries session artifacts.
 - **Sanity Check:** recording artifact exists on disk; gap report emitted
   on induced prereq failure; operator reviews the recording.
+- Ran 2026-07-21 in medley (identity-server login-page change, Aspire
+  orchestrator, local-only): all sanity checks passed, plus the
+  prompt-over-config precedence bonus assertion (explicit headed
+  instruction beat the local overlay's `browser_mode: headless`).
+  Evidence stayed on disk (gitignored) in the consumer repo.
 
 ## Blast radius
 


### PR DESCRIPTION
## What

Flips the last open phase tag in `docs/topics/boris-video-absorption/PLAN.md` — Phase 8 (post-merge trial) — to `[DONE]`, with a short trial record.

## Trial summary (medley, 2026-07-21, local-only)

- Config surface resolved with per-key provenance (local overlay `.claude/testing/e2e.local.md`; team + user-global layers absent)
- `recording: video` honored — WebM artifact on disk (gitignored in consumer repo)
- Induced prereq failure (run before orchestrator start) → hard STOP + structured verification-environment gap report
- Evidence table carried session artifacts (recording path, playwright session ID, transcript pointers)
- Bonus: explicit "run this headed" prompt beat the overlay's `browser_mode: headless`
- Operator reviewed the recording

Docs-only; no plugin content changes.

## Related

No linked issue. Related: #845 (phases 1–7 of the same PLAN, merged).