### PR TITLE
docs(claude-ops): record why lanes staleness probe stays a body instruction (#864)

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.3]
+
+### Changed
+
+- **lanes: recorded why the mid-session staleness git probe is not `!`-injected.**
+  Evaluated the lanes skill's git probes against the precompute convention (#864).
+  The two `git rev-parse --show-toplevel` probes in `SKILL.md`'s front matter are
+  already `!` dynamic-context injections (fallback + `shell: bash`), so nothing to
+  convert there. The `context/refresh.md` staleness probe correctly stays a body
+  instruction — it fails all four conditions: conditional (only when weighing a
+  restart), needs a computed `<lane-launch-commit>` argument, and its `git fetch`
+  is an unbounded network round-trip that mutates remote-tracking refs. Added that
+  reason inline so a future reader does not re-litigate the decision.
+
 ## [0.17.2]
 
 ### Changed

--- a/plugins/claude-ops/skills/lanes/context/refresh.md
+++ b/plugins/claude-ops/skills/lanes/context/refresh.md
@@ -56,6 +56,16 @@ launch pulls first, so a running lane's skills correspond to that commit). Any
 output = an unconsumed merge. Swap the pathspec for whichever installed plugin a
 lane runs.
 
+**Not an `!` injection candidate.** This probe is deliberately a body instruction,
+not `!` dynamic-context injection — it fails every condition of the precompute
+convention (playbooks skill-authoring `reference/precompute-context.md`). It is
+**conditional**, consulted only when weighing a restart rather than up front on
+every `lanes` invocation; it needs a **computed argument** (`<lane-launch-commit>`,
+plus the pathspec of whichever plugin a lane runs) that a single-pass injection
+cannot supply; and its `git fetch` is **neither bounded nor pure-read** — a network
+round-trip that also updates remote-tracking refs. Safe to run by hand (it touches
+no branch or worktree), wrong to inline at load time.
+
 Getting those changes onto disk on restart (marketplace refresh + per-scope
 update) is the `plugins` skill's job — see its
 [context/sync.md](../../plugins/context/sync.md); the lanes launch already runs


### PR DESCRIPTION
## What

Evaluate the lanes skill's deterministic, read-only git probes against the pinned precompute convention (`plugins/playbooks/skills/skill-authoring/reference/precompute-context.md`) and either convert each to `!` dynamic-context injection or record why it fails the four conditions.

## Per-probe verdict

| Git probe | Location | Verdict |
|---|---|---|
| `git rev-parse --show-toplevel` (repo root) | `SKILL.md` front matter | **Already converted** — `!` injection with `\|\| echo` fallback; `shell: bash` declared. |
| `git rev-parse --show-toplevel` (lane-config resolution) | `SKILL.md` front matter | **Already converted** — `!` injection with `\|\| echo` fallback. |
| staleness probe: `git fetch origin` + `git symbolic-ref` + `git log <lane-launch-commit>..<default> -- <plugin-path>` | `context/refresh.md` | **Recorded reason it fails all four conditions** — stays a body instruction. |

The two front-matter probes were `!`-injected at the skill's creation (#616) and gained `shell: bash` in 0.17.2 — already compliant, nothing to convert.

## Why the staleness probe is not an injection candidate

It fails **every** convention condition:

- **Not deterministic/read-only + not cheap/bounded** — `git fetch` is a network round-trip (latency-variable, can hang) that also updates remote-tracking refs.
- **Not needed up front every invocation** — consulted only when weighing a restart, not on a plain `status`/`stop`/`start`.
- **Not judgment-independent** — needs a computed `<lane-launch-commit>` argument (the running lane's launch point) plus the pathspec of whichever plugin the lane runs; a single-pass injection cannot supply either.

Recorded inline in `context/refresh.md` so a future reader does not re-litigate it.

## Automated gate

skill-quality Check 18 (precompute opportunity) scans only `SKILL.md` fenced shell blocks and is silent when the skill already injects with `!` — lanes does — so the gate was already satisfied; this PR adds no new `!` blocks.

## Changes

- `context/refresh.md` — durable "Not an `!` injection candidate" note next to the staleness probe.
- `claude-ops` version `0.17.2` → `0.17.3` + matching CHANGELOG entry (changelog-parity gate).

## Verification

- `check-skill.sh lanes` — PASS (0 errors, 0 warnings; markdownlint clean, 163/500 lines)
- `check-changelog-parity.sh --check` and `--check-bump origin/main` — PASS
- `validate-plugins.sh` + `claude plugin validate .` — PASS
- markdownlint on changed files — 0 errors

Closes #864

## Related

- #791 — origin of the side-finding
- #616 — original `!` conversion of the front-matter probes
- #860 — shell-declaration fleet sweep that added `shell: bash`

