### PR TITLE
feat(planning): route incumbency-driven plan-review findings to incumbent mode

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.24.3]
+
+### Changed
+
+- `devils-advocate` plan-review mode now routes incumbency-driven assumptions to the
+  `incumbent` mode instead of leaving them as prose. When Round 2's evidence check finds
+  an assumption whose *only* support is that the status quo already uses the thing
+  ("we already use X"), the resulting finding's Mitigation names the follow-up —
+  `/planning:devils-advocate incumbent <target>`, the Alternatives Sweep on that
+  incumbent. Suggestion only: it is never auto-run, so scope stays one mode per
+  invocation. An assumption also backed by a requirement, benchmark, or doc is verified
+  on that evidence and does not trigger the routing.
+
 ## [0.24.2]
 
 ### Changed

--- a/plugins/planning/skills/devils-advocate/SKILL.md
+++ b/plugins/planning/skills/devils-advocate/SKILL.md
@@ -106,6 +106,8 @@ Present findings:
 | 1 | `transcript_path` in stdin | YES | Official docs confirm base field | None — assumption holds |
 | 2 | `if` field fires under skip-perms | NO | silently no-ops (known issue) | CRITICAL — use explicit guards |
 
+**Incumbency-only support fails this check.** An assumption whose *only* backing is that the status quo already relies on the thing — "we already use X", with no requirement, benchmark, or doc behind the original choice — is unverified by definition (per Purpose: incumbency is evidence of what is, never proof it still fits). It flows to a Round 3 finding whose **Mitigation names the follow-up**: `/planning:devils-advocate incumbent <target>` — the Alternatives Sweep on that incumbent. Suggest it; never auto-run it — scope stays one mode per invocation. An assumption *also* backed by a requirement, benchmark, or doc is verified on that evidence and does not trigger this.
+
 ### Round 3: Failure Scenarios and Mitigations
 
 For each unverified or partially verified assumption, propose:
@@ -205,6 +207,7 @@ Based on findings, suggest relevant follow-up actions:
 
 - Verifying the changes end-to-end (`/verification:confirm` if installed) if code changes were involved
 - Targeted research rounds (`/discovery:research` if installed, or the strongest research capability available) if critical assumptions remain unverified
+- Running the Alternatives Sweep on any incumbent a Round 2 finding flagged as supported only by incumbency — the finding's Mitigation already names the invocation
 - Filing deferred research or monitoring items in the project's work-item tracker (`/work-items:track` if installed)
 
 ## What This Skill Does NOT Do

--- a/plugins/planning/skills/devils-advocate/evals/evals.json
+++ b/plugins/planning/skills/devils-advocate/evals/evals.json
@@ -108,6 +108,18 @@
         "Output does not attempt to diagnose production slow queries or current system health",
         "Output reframes toward the pre-implementation choice (is this database still the right fit vs alternatives) or points elsewhere for the runtime audit"
       ]
+    },
+    {
+      "id": 10,
+      "name": "plan-review-incumbency-assumption-suggests-incumbent-mode",
+      "prompt": "/planning:devils-advocate stress-test this plan before we build it: the new metrics service will serialize every payload with our in-house YAML encoder — we already use it across the other services, so we'll wire it in here too. Poke holes.",
+      "expected_output": "Running in plan-review (default) mode, the skill detects that the plan's choice of the in-house encoder is supported only by incumbency ('we already use it'), treats that assumption as unverified rather than accepting it, and its finding names `/planning:devils-advocate incumbent <target>` as the suggested follow-up (the Alternatives Sweep on that incumbent) — without switching modes or auto-running the sweep, keeping scope to one mode per invocation.",
+      "files": [],
+      "expectations": [
+        "Output stays in plan-review mode (extracts assumptions / runs the rounds) and does NOT itself run the Alternatives Sweep on the in-house encoder in this invocation",
+        "Output flags the in-house-encoder choice as supported only by incumbency ('we already use it') and therefore unverified, rather than accepting it as evidence the choice still fits",
+        "Output's finding names the exact follow-up `/planning:devils-advocate incumbent <target>` (the Alternatives Sweep on that incumbent) as a suggestion, not as an action it performs now"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

In `devils-advocate` **plan-review mode** (Rounds 1–4), when Round 2's evidence check finds an assumption whose *only* support is incumbency ("we already use X"), the finding now names the follow-up — `/planning:devils-advocate incumbent <target>`, the Alternatives Sweep on that incumbent — instead of leaving it as prose. Suggestion only: it is **never auto-run**, so scope stays one mode per invocation.

Deferred enhancement recorded in #823 (the `incumbent` mode itself).

## Why this placement

Incumbency is not evidence (the skill's Purpose already says "we already use it is evidence of what is, never proof it still fits"). So an incumbency-only assumption *fails* the Round 2 evidence check → becomes an unverified assumption → flows to a Round 3 finding whose **Mitigation** names the sweep. That ties the suggestion to finding output, per the acceptance. The authoritative rule (command + "suggest, never auto-run, one mode per invocation" + trigger precision) lives once in Round 2; Suggested Next Steps carries a bare pointer.

Trigger precision: an assumption *also* backed by a requirement, benchmark, or doc is verified on that evidence and does **not** trigger the routing.

## Eval

Adds case 10 (`plan-review-incumbency-assumption-suggests-incumbent-mode`): a plain plan-review prompt whose plan leans on an in-house encoder justified only by "we already use it." Expectations verify it (a) stays in plan-review mode and does NOT run the sweep, (b) flags the choice as incumbency-only/unverified, (c) names the exact `/planning:devils-advocate incumbent <target>` follow-up as a suggestion. Distinct from case 6 (direct `incumbent`-mode invocation).

## Version

Bumps `planning` to 0.24.3 with a CHANGELOG entry (same diff, changelog-parity gate).

## Gates run (all green locally)

- `skill-quality` check-skill: PASS (0 errors; pre-existing WARNs only)
- markdownlint-cli2: 0 errors
- eval JSON valid + validates against `evals.schema.json`
- `check-changelog-parity.sh` `--check` and `--check-bump origin/main`: pass
- `validate-plugins.sh`: all manifests + catalog pass

## Related

- #823 — devils-advocate `incumbent` mode (the mode this PR routes to); the deferred enhancement implemented here was recorded there. Not closed by this PR.

Closes #866
