### PR TITLE
feat(typos-format): per-file typos autofix hook plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -58,6 +58,18 @@
       }
     },
     {
+      "name": "typos-format",
+      "source": "./plugins/typos-format",
+      "category": "development",
+      "tags": ["typos", "spelling", "spell-checker", "formatter", "linter", "hook"],
+      "relevance": {
+        "topic": "spelling",
+        "signals": {
+          "cli": ["typos"]
+        }
+      }
+    },
+    {
       "name": "eol-normalizer",
       "displayName": "EOL Normalizer",
       "source": "./plugins/eol-normalizer",

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 - [`bash-format`](plugins/bash-format) — Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.
 - [`biome-format`](plugins/biome-format) — Auto-format and lint JS/TS/JSX/JSON on edit via Biome, only when a biome.json governs the repo — using the consuming repo's own Biome config.
 - [`ruff-format`](plugins/ruff-format) — Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.
+- [`typos-format`](plugins/typos-format) — Auto-fix source-code spelling mistakes on edit via typos, using the consuming repo's own _typos.toml allowlist.
 - [`eol-normalizer`](plugins/eol-normalizer) — Normalize a written file's working-tree line endings to its .gitattributes eol value on edit — symmetric CRLF/LF driven by git check-attr, advisory and never blocking.
 - [`powershell-format`](plugins/powershell-format) — Auto-format and lint PowerShell on edit via PSScriptAnalyzer, only when a PSScriptAnalyzerSettings.psd1 governs the repo — using the consuming repo's own analyzer settings.
 - [`actionlint`](plugins/actionlint) — Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "typos-format",
+  "version": "0.1.0",
+  "description": "Auto-fix source-code spelling mistakes on edit via typos, using the consuming repo's own _typos.toml allowlist.",
+  "author": {
+    "name": "Melodic Software",
+    "email": "info@melodicsoftware.com"
+  },
+  "license": "MIT",
+  "keywords": [
+    "typos",
+    "spelling",
+    "spell-checker",
+    "formatter",
+    "linter",
+    "hook"
+  ],
+  "userConfig": {
+    "typos_format_enabled": {
+      "type": "boolean",
+      "title": "typos-format hook",
+      "description": "Auto-fix spelling mistakes on Write/Edit of any file via typos -w",
+      "default": true
+    }
+  }
+}

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to the `typos-format` plugin are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
+
+## [0.1.0]
+
+### Added
+
+- Initial release. `PostToolUse` hook on `Write|Edit` runs `typos --force-exclude -w
+  --format json` against the edited file (no extension filter — `typos` is a
+  cross-language spell checker), auto-fixing every unambiguous typo and surfacing residual
+  (ambiguous) findings via `additionalContext`, always advisory (exit `0`).
+- Zero-config by design: ships no rules of its own, and discovers the consuming repo's
+  optional `_typos.toml` (or `typos.toml`/`.typos.toml`/a `[tool.typos]`/
+  `[workspace.metadata.typos]`/`[package.metadata.typos]` section) the same way `typos`
+  itself does — anchored on the edited file, not this hook's working directory.
+- `typos_format_enabled` `userConfig` kill switch (default `true`), read through the
+  native `CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED` hook-process mirror.
+- Missing `jq` or `typos` degrades to a visible once-per-session skip notice on both the
+  agent (`additionalContext`) and user (`systemMessage`) channels; never a silent no-op.
+- Hook-telemetry envelope (`hook: "typos-format"`) emitted opt-in via `HOOK_TELEMETRY_SINK`,
+  gated so the unwired default path spawns zero telemetry-only subprocesses.
+- `/typos-format:setup` skill on the uniform check-centric contract (`check` read-only,
+  `apply` guidance-only — every prerequisite is a `PATH` binary or the native toggle, so
+  there is no write path).

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -1,0 +1,92 @@
+# typos-format
+
+A Claude Code plugin that auto-fixes source-code spelling mistakes the moment you edit
+a file. On every `Write` or `Edit` it runs [`typos -w`](https://github.com/crate-ci/typos)
+against the edited file, applying every unambiguous correction and surfacing the residual
+(ambiguous) findings back to Claude as advisory context.
+
+It ships no rules of its own — `typos` carries its own built-in spelling dictionary and
+runs with zero configuration. It uses **your repository's own optional `_typos.toml`**
+(or `typos.toml`, `.typos.toml`, a `[tool.typos]` section in `pyproject.toml`, or a
+`[workspace.metadata.typos]`/`[package.metadata.typos]` section in `Cargo.toml`) to widen
+its allowlist — for project-specific names, acronyms, or intentionally-kept misspellings —
+and to exclude files, exactly as `typos` itself would if you ran it by hand.
+
+## Behavior
+
+- **Auto-fix on edit.** Every typo `typos` can correct unambiguously is applied in place.
+- **Advisory, never blocking.** The hook always exits `0`. A residual finding — a typo with
+  more than one plausible correction, which `typos` deliberately declines to apply
+  unassisted — is reported via `additionalContext`; it never rejects the edit. Make a
+  commit hook or CI your hard gate.
+- **No file-type filter.** `typos` is a cross-language spell checker, not a
+  single-ecosystem formatter, so this hook runs on every edited file and lets `typos`'
+  own binary-content detection and your `_typos.toml` `[files]` excludes decide what
+  actually gets checked.
+- **Config and excludes from the consumer.** `typos` discovers its config by walking up
+  from the **edited file itself** — not from this hook's own working directory — so
+  discovery is correct regardless of where a session's shell happens to be. The hook
+  passes `--force-exclude` so a `[files]` `extend-exclude` entry in your config is honored
+  even for a file edited directly (by default `typos` only applies that exclude list
+  during its own directory walk, not to an explicitly-named path).
+
+## Requirements
+
+The hook requires the following tools:
+
+- Bash 3.2 or later. On native Windows, install
+  [Git for Windows](https://code.claude.com/docs/en/setup#set-up-on-windows) so
+  Claude Code can run this Bash hook; WSL is also supported.
+- [`jq`](https://jqlang.org/) to parse hook input and emit structured context.
+- [`typos`](https://github.com/crate-ci/typos#install), installed explicitly on `PATH`
+  (a downloaded release binary, or via Cargo, Homebrew, Conda, or Pacman).
+
+Missing prerequisites do not block an edit. Following Claude Code's
+[PostToolUse contract](https://code.claude.com/docs/en/hooks#posttooluse-decision-control),
+the hook exits `0` and reports a once-per-session notice to both Claude
+(`additionalContext`) and you (`systemMessage`). It never installs `typos`, falls back to
+a package runner, or performs a network request during a hook run.
+
+Telemetry timing uses `EPOCHREALTIME` (Bash 5.0+); on older Bash the telemetry envelope is
+skipped while the fix still runs.
+
+## Install
+
+```shell
+/plugin marketplace add melodic-software/claude-code-plugins
+/plugin install typos-format@melodic-software
+```
+
+Then verify the runtime prerequisites with `/typos-format:setup check`;
+`/typos-format:setup apply` re-runs the check and points at remediation for anything it
+reports.
+
+## Configuration
+
+Spelling corrections themselves are never configured here — the plugin's only rule source
+is `typos`' own built-in dictionary plus whatever your repository's `_typos.toml` extends.
+To silence a false positive (a name, acronym, or intentional spelling) or exclude a path,
+edit your repo's `_typos.toml` — see the
+[false positives](https://github.com/crate-ci/typos#false-positives) section of the typos
+README and its [configuration reference](https://github.com/crate-ci/typos/blob/master/docs/reference.md).
+
+One `userConfig` option tunes the hook itself:
+
+| Option | Type | Default | Effect |
+|--------|------|---------|--------|
+| `typos_format_enabled` | boolean | `true` | Toggle the typos-format hook; set `false` for a clean no-op. |
+
+Set it interactively with `/plugin configure typos-format`, or headless on the install
+command:
+
+```shell
+claude plugin install typos-format@melodic-software --config typos_format_enabled=false
+```
+
+This option is user-scoped (stored in your user settings, not the project's). To disable
+spell-checking for a single repository, disable the whole plugin in that project's
+`enabledPlugins` instead.
+
+## License
+
+MIT (SPDX-License-Identifier: MIT).

--- a/plugins/typos-format/hooks/hook-utils.sh
+++ b/plugins/typos-format/hooks/hook-utils.sh
@@ -1,0 +1,1048 @@
+# shellcheck shell=bash
+# Shared hook utility library for this marketplace's hook plugins. Sourced
+# (not executed): kill switch, file_path parsing + path normalization,
+# repo-root resolution, additionalContext accumulator, telemetry envelope.
+#
+# SINGLE SOURCE OF TRUTH: lib/hook-utils.sh at the marketplace repo root. The
+# copies at plugins/*/hooks/hook-utils.sh exist because installed plugins are
+# cache-isolated and must be self-contained — never edit a copy. Edit the
+# source and run scripts/sync-hook-utils.sh; CI rejects drifted copies.
+
+# Guard against double-sourcing.
+[[ -n "${_HOOK_UTILS_LOADED:-}" ]] && return 0
+readonly _HOOK_UTILS_LOADED=1
+
+# Per-hook kill switch via the plugin's <name>_enabled userConfig boolean,
+# read from the hook-process CLAUDE_PLUGIN_OPTION_<NAME>_ENABLED mirror.
+# Exits 0 (allow) if disabled. Place after source, before stdin parsing.
+#   hook::check_enabled "MARKDOWN_FORMAT"  # checks CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED
+hook::check_enabled() {
+  local var_name="CLAUDE_PLUGIN_OPTION_${1}_ENABLED"
+  if [[ "${!var_name:-true}" != "true" ]]; then
+    exit 0
+  fi
+}
+
+# --- Prerequisite visibility --------------------------------------------------
+# Doctrine: a missing runtime prerequisite must surface to BOTH the agent
+# (additionalContext) and the user (systemMessage) — a silently skipped feature
+# is a defect. Everything in this section is jq-FREE by design: the most common
+# missing prerequisite is jq itself.
+
+# JSON-escape a string for embedding in a hand-built JSON document. Escapes
+# backslash, double quote, and the line-structure control bytes by name
+# (\n \r \t); the remaining C0 bytes JSON forbids raw are dropped — notice text
+# never carries meaningful control bytes beyond line structure. Byte-safe under
+# UTF-8: every escaped byte is ASCII, and UTF-8 continuation bytes are >= 0x80.
+hook::json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # tr drops the residual C0 bytes; if tr itself is unavailable, fall back to
+  # the escaped string as-is — notice text is hook-authored and does not carry
+  # raw control bytes in practice.
+  local out
+  out=$(printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037' 2>/dev/null) || out="$s"
+  printf '%s' "$out"
+}
+
+# Emit hook JSON carrying an agent-channel context (additionalContext) and/or a
+# user-channel message (systemMessage) as ONE document — CC parses the hook's
+# whole stdout as a single JSON doc, so a run that has both lint findings and a
+# pending skip notice must compose them here rather than print twice. Either
+# channel may be empty; emits nothing when both are.
+#   hook::emit_channels PostToolUse "$ctx" "$sysmsg"
+hook::emit_channels() {
+  local event="$1" ctx="$2" sysmsg="$3"
+  [[ -n "$ctx" || -n "$sysmsg" ]] || return 0
+  local out="{"
+  if [[ -n "$ctx" ]]; then
+    out+='"hookSpecificOutput":{"hookEventName":"'"$(hook::json_escape "$event")"'","additionalContext":"'"$(hook::json_escape "$ctx")"'"}'
+    [[ -n "$sysmsg" ]] && out+=","
+  fi
+  [[ -n "$sysmsg" ]] && out+='"systemMessage":"'"$(hook::json_escape "$sysmsg")"'"'
+  out+="}"
+  printf '%s\n' "$out"
+}
+
+# Visible skip notice: the same message on both channels. The caller must exit 0
+# right after unless it composes via hook::emit_channels itself.
+#   hook::emit_skip_notice PostToolUse "my-plugin: tool X not found — ..."
+hook::emit_skip_notice() {
+  hook::emit_channels "$1" "$2" "$2"
+}
+
+# systemMessage-only variant for hook events with no additionalContext channel
+# (e.g. Notification).
+hook::emit_system_message() {
+  hook::emit_channels "" "" "$1"
+}
+
+# Once-per-session gate for skip notices. Returns 0 (emit now) the first time a
+# given <key> fires in the current session, 1 afterwards — a missing-tool notice
+# behind a broad matcher (every Write|Edit) must not repeat on every edit. The
+# session id is regex-extracted from the raw hook input JSON (jq-free, see
+# section header); marker files live under ${CLAUDE_PLUGIN_DATA} (survives
+# plugin updates; mkdir -p defensively since creation is documented only on
+# first *reference*) and markers older than 7 days are pruned so per-session
+# files cannot accumulate unboundedly. Fails open toward visibility: when no
+# marker can be tracked, emit every time.
+#   hook::notice_once "my-plugin-jq" "$INPUT" && hook::emit_skip_notice ...
+hook::notice_once() {
+  local key="$1" input="${2:-}" session="no-session"
+  if [[ "$input" =~ \"session_id\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    session="${BASH_REMATCH[1]}"
+    session="${session//[^A-Za-z0-9_-]/-}"
+  fi
+  local dir="${CLAUDE_PLUGIN_DATA:-}"
+  [[ -n "$dir" ]] || return 0
+  dir="$dir/skip-notices"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  find "$dir" -type f -mtime +7 -delete 2>/dev/null
+  local marker="$dir/${key}.${session}"
+  [[ -f "$marker" ]] && return 1
+  : >"$marker" 2>/dev/null
+  return 0
+}
+
+# Best-effort jq-free extraction of tool_input.file_path from the raw hook
+# input, for the applicability pre-filter an extension-scoped hook runs BEFORE
+# its jq gate — a missing-jq notice must never fire for an edit the hook would
+# not process anyway (e.g. a README edit reaching a workflow-lint hook whose
+# Write|Edit matcher is broader than its file filter). The value is returned
+# JSON-escaped (backslashes doubled); that is fine for extension/segment
+# matching, which is all the pre-filter does. Returns 1 when no file_path is
+# present.
+#   RAW_FILE=$(hook::raw_file_path "$INPUT") || exit 0
+hook::raw_file_path() {
+  [[ "$1" =~ \"file_path\"[[:space:]]*:[[:space:]]*\"(([^\"\\]|\\.)*)\" ]] || return 1
+  [[ -n "${BASH_REMATCH[1]}" ]] || return 1
+  printf '%s' "${BASH_REMATCH[1]}"
+}
+
+# jq gate for hooks whose input parsing cannot proceed without it. When jq is
+# absent: one visible skip notice per session, then exit 0 — an advisory hook
+# never blocks the tool over a missing prerequisite. Place after
+# hook::check_enabled (and after any jq-free applicability pre-filter), passing
+# the buffered stdin for session scoping.
+#   hook::require_jq PostToolUse my-plugin "$INPUT"
+hook::require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  local event="$1" plugin="$2" input="${3:-}"
+  if hook::notice_once "${plugin}-jq" "$input"; then
+    hook::emit_skip_notice "$event" \
+      "$plugin: jq not found on PATH — hook skipped for this session. Install jq (https://jqlang.org/download/) to enable it."
+  fi
+  exit 0
+}
+
+# Normalize a path for the membership comparison below: backslashes → forward
+# slashes, and — only on Windows/MSYS, whose filesystem is case-insensitive —
+# fold a leading drive (POSIX `/c/...` or `c:/...`) to an upper-case drive
+# letter + lower-cased remainder so the byte-exact comparison is effectively
+# case-insensitive. The fold is gated on the host (OSTYPE), NOT on the path
+# shape: on a case-sensitive POSIX filesystem a real single-letter top-level
+# directory such as `/c/Repo` must pass through unchanged, otherwise it would
+# collapse with `/c/repo` and the membership guard would admit a sibling
+# outside CLAUDE_PROJECT_DIR. The result is used ONLY for comparison; the
+# emitted path is always the caller's original.
+hook::normalize_path() {
+  local p="${1//\\//}"
+  case "${OSTYPE:-}" in
+  msys* | cygwin* | win32)
+    if [[ "$p" =~ ^/([a-zA-Z])/ || "$p" =~ ^([a-zA-Z]):/ ]]; then
+      local rest="${p:2}"
+      printf '%s' "${BASH_REMATCH[1]^}:${rest,,}"
+      return
+    fi
+    ;;
+  *) ;; # POSIX hosts: case-sensitive FS, no drive fold — pass through below
+  esac
+  printf '%s' "$p"
+}
+
+# Canonicalize to a physical path — symlinks resolved — for the membership
+# comparison below, so an in-project symlink pointing outside the project root
+# cannot defeat the guard (the lexical path would pass the prefix check while
+# the write lands elsewhere). GNU realpath ships with Git Bash and Linux
+# coreutils; readlink -f covers the BSD/macOS hosts that have no realpath.
+# When neither resolver exists the caller falls back to comparing the lexical
+# path as before — the guard is defense-in-depth scoping for a file the agent
+# already wrote via its own tools, so degrading to the historical comparison
+# beats silently disabling the hook on those hosts.
+hook::physical_path() {
+  local resolved
+  if resolved=$(realpath -- "$1" 2>/dev/null) || resolved=$(readlink -f -- "$1" 2>/dev/null); then
+    if [[ -n "$resolved" ]]; then
+      printf '%s' "$resolved"
+      return
+    fi
+  fi
+  printf '%s' "$1"
+}
+
+# Parse file_path from PostToolUse JSON on stdin; validate existence and (when
+# CLAUDE_PROJECT_DIR is set) project membership. Both sides of the membership
+# comparison are canonicalized (symlinks resolved) first, so neither an
+# escaping symlink nor a project root reached via a symlinked path (e.g.
+# macOS /tmp) skews the verdict. Outputs the path on success. Returns 1 to skip.
+#   FILE=$(hook::read_file_path) || exit 0
+hook::read_file_path() {
+  local file
+  file=$(jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+  [[ -n "$file" ]] || return 1
+  [[ -f "$file" ]] || return 1
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    local norm_file norm_project
+    norm_file=$(hook::normalize_path "$(hook::physical_path "$file")")
+    norm_project=$(hook::normalize_path "$(hook::physical_path "${CLAUDE_PROJECT_DIR}")")
+    norm_project="${norm_project%/}"
+    # Anchor on a path-segment boundary: accept the project root itself or a
+    # child under it, but not a sibling whose name merely shares the prefix
+    # (e.g. /c/repo must not admit /c/repo-backup/...).
+    if [[ "$norm_file" != "$norm_project" && "$norm_file" != "$norm_project"/* ]]; then
+      return 1
+    fi
+  fi
+  printf '%s' "$file"
+}
+
+# Resolve the repository root (working-tree top) for a path inside the tree.
+# markdownlint config auto-discovery is CWD-anchored, so the hook cd's here
+# before linting. File-anchored (`git -C "$hint" rev-parse --show-toplevel`)
+# so it is correct for clones, linked worktrees, and bare-hub clones; falls
+# back to the hint (with a trailing /.claude stripped) when git cannot resolve.
+#   ROOT=$(hook::repo_root "$some_path")
+hook::repo_root() {
+  local hint="${1:-.}"
+  local root
+  root=$(git -C "$hint" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+  if [[ -z "$root" ]]; then
+    root="$hint"
+    root="${root%/.claude}"
+    root="${root%\\.claude}"
+  fi
+  printf '%s' "$root"
+}
+
+# Buffer a complete JSON payload from stdin, tolerating Windows Win32-pipe
+# late-EOF stalls via a bounded read on the inherited fd0. Returns the payload
+# on success; returns 1 on empty/incomplete stdin (caller skips), or 2 when the
+# read timed out before a complete JSON payload arrived (caller may block).
+# Bound is the stdin_read_timeout userConfig option in seconds (read via
+# CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT, default 2). jq (when present)
+# distinguishes a truncated read from a genuinely small-but-complete payload; a
+# missing/broken jq (exit 127) fails open like absent jq.
+#   INPUT=$(hook::buffer_stdin) || exit 0
+hook::buffer_stdin() {
+  local input="" read_status=0 read_timeout="${CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT:-2}" start_epoch elapsed_ms timeout_ms
+  start_epoch=${EPOCHREALTIME:-}
+  IFS= read -r -d '' -t "$read_timeout" input || read_status=$?
+  input=$(printf '%s' "$input" | tr -d '\r')
+  [[ -n "$input" ]] || return 1
+  local jq_rc=0
+  if [[ "$read_status" -ne 0 ]] && command -v jq >/dev/null 2>&1; then
+    jq -e . >/dev/null 2>&1 <<<"$input" || jq_rc=$?
+  fi
+  if [[ "$read_status" -ne 0 && "$jq_rc" -ne 0 && "$jq_rc" -ne 127 ]]; then
+    elapsed_ms=$(awk -v start="$start_epoch" -v end="$EPOCHREALTIME" 'BEGIN { printf "%.0f", (end - start) * 1000 }')
+    timeout_ms=$(awk -v timeout="$read_timeout" 'BEGIN { printf "%.0f", timeout * 1000 }')
+    if [[ "$elapsed_ms" =~ ^[0-9]+$ && "$timeout_ms" =~ ^[0-9]+$ ]] &&
+      ((elapsed_ms + 100 >= timeout_ms)); then
+      echo "BLOCKED: hook stdin timed out before a complete JSON payload arrived." >&2
+      return 2
+    fi
+    return 1
+  fi
+  printf '%s' "$input"
+}
+
+# Extract a single jq field from a buffered input string. CR-stripped. Returns 1
+# when the field is empty or jq fails, so the caller can skip.
+#   FIELD=$(hook::jq_field "$INPUT" '.tool_input.file_path') || exit 0
+hook::jq_field() {
+  local field
+  field=$(jq -r "(${2} // empty)"' | gsub("\r";"")' <<<"$1" 2>/dev/null)
+  [[ -n "$field" ]] || return 1
+  printf '%s' "$field"
+}
+
+# Reduce a tool + optional Bash command to a privacy-safe subject label. For
+# Bash, returns "Bash:<first-token>" (leading sudo / VAR=val prefixes stripped,
+# basename applied) — never the full command. For any other tool, returns the
+# tool name unchanged. Carries no argument body, path, or command tail.
+#
+# Whitespace-splitting is only safe when no quoted value spans the whitespace.
+# A quoted assignment value (e.g. `TOKEN="a b" curl …`) would otherwise leak a
+# fragment of the value into the token, so any token carrying a quote aborts to a
+# bare "Bash" subject rather than risk exposing part of the value.
+#   SUBJECT=$(hook::extract_bash_subject "$TOOL" "$CMD")
+hook::extract_bash_subject() {
+  local tool="$1" cmd="${2:-}"
+  if [[ "$tool" != "Bash" ]]; then
+    printf '%s' "$tool"
+    return 0
+  fi
+  # Trim leading whitespace so the first token is real.
+  cmd="${cmd#"${cmd%%[![:space:]]*}"}"
+  local first_token="${cmd%%[[:space:]]*}"
+  while [[ "$first_token" == "sudo" || "$first_token" == *=* ]] &&
+    [[ -n "$cmd" && "$cmd" == *[[:space:]]* ]]; do
+    # A quote in the prefix token means a quoted value spans the next whitespace;
+    # we cannot tokenize it safely — bail rather than leak a value fragment.
+    if [[ "$first_token" == *[\"\']* ]]; then
+      printf '%s' "$tool"
+      return 0
+    fi
+    cmd="${cmd#*[[:space:]]}"
+    cmd="${cmd#"${cmd%%[![:space:]]*}"}"
+    first_token="${cmd%%[[:space:]]*}"
+  done
+  # The resolved command token itself must not carry a quote (e.g. a value that
+  # ended here), which would likewise be a value fragment.
+  if [[ "$first_token" == *[\"\']* ]]; then
+    printf '%s' "$tool"
+    return 0
+  fi
+  first_token="${first_token##*/}"
+  if [[ -n "$first_token" ]]; then
+    printf 'Bash:%s' "$first_token"
+  else
+    printf '%s' "$tool"
+  fi
+}
+
+# Append one line to a JSONL file, serialized under an flock advisory lock when
+# flock is present (bounded 2s wait; a lost race drops the line rather than
+# blocking) and a best-effort bare append otherwise. Fire-and-forget: never
+# fails the caller. Used by audit hooks that maintain a bespoke second store.
+#   hook::append_jsonl <file> <line>
+hook::append_jsonl() {
+  local file="$1" line="$2"
+  if command -v flock >/dev/null 2>&1; then
+    (
+      flock -w 2 9 || exit 0
+      printf '%s\n' "$line" >>"$file"
+    ) 9>"${file}.lock" 2>/dev/null
+  else
+    printf '%s\n' "$line" >>"$file" 2>/dev/null
+  fi
+}
+
+# Per-hook stdout context accumulator. ctx_reset at entry, ctx_append per line,
+# ctx_flush once at exit with the hook event name.
+_HOOK_CTX_BUFFER=""
+
+hook::ctx_reset() {
+  _HOOK_CTX_BUFFER=""
+}
+
+hook::ctx_append() {
+  _HOOK_CTX_BUFFER+="$1"$'\n'
+}
+
+# Emit the accumulated context as hookSpecificOutput JSON, then clear the buffer.
+hook::ctx_flush() {
+  local event_name="$1"
+  local trimmed="${_HOOK_CTX_BUFFER%"${_HOOK_CTX_BUFFER##*[![:space:]]}"}"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  hook::emit_additional_context "$event_name" "$trimmed"
+  hook::ctx_reset
+}
+
+# Cheap telemetry opt-in probe — true iff a consumer wired a sink. Producers
+# gate telemetry-payload construction on this (repo-relative path
+# normalization, data JSON) so the unwired default path spawns zero
+# telemetry-only subprocesses. Pure shell test, no subprocess.
+# hook::emit_telemetry re-checks the sink itself, so skipping this probe
+# costs only wasted payload work, never correctness.
+hook::telemetry_enabled() {
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]]
+}
+
+# Emit one telemetry envelope per hook run to the consumer-set sink.
+# Fire-and-forget: sink is dispatched in the background; the hook never waits
+# on it and its failure never affects the hook's own exit code or stdout.
+# Opt-in guard: HOOK_TELEMETRY_SINK unset or empty → return 0 immediately.
+# Fail-open: jq absent → return 0 immediately.
+#
+# Usage:
+#   hook::emit_telemetry <hook_id> <hook_event> <status> <start_epoch> <data_json> [repo_root]
+#
+# <start_epoch>  Value of $EPOCHREALTIME captured by the caller before work began.
+#               Handles both '.' and ',' as the decimal separator (LC_NUMERIC).
+# <data_json>   Pre-built JSON object for the `data` field.
+# <repo_root>   Optional consuming-repo root, used to resolve a RELATIVE
+#               HOOK_TELEMETRY_SINK. The caller passes the root it already
+#               resolved for data.file; ignored when the sink is absolute.
+#
+# Sink path resolution: HOOK_TELEMETRY_SINK may be absolute OR relative to the
+# consuming repo root. Absolute (POSIX /… or Windows X:\ / X:/) is used as-is; a
+# relative value is joined onto <repo_root> (or $CLAUDE_PROJECT_DIR when no root
+# is passed), and skipped fail-open if neither is available. Relative is the
+# portable, team-shared wiring form: CC injects settings.json env values
+# literally (no ${VAR} expansion), so a relative path tracked in settings.json is
+# the only clone-portable, worktree-safe option.
+#
+# NEVER writes to fd1 (the hook's stdout / additionalContext channel).
+hook::emit_telemetry() {
+  # Opt-in guard.
+  [[ -n "${HOOK_TELEMETRY_SINK:-}" ]] || return 0
+  # Fail-open when jq is absent.
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local hook_id="$1"
+  local hook_event="$2"
+  local status="$3"
+  local start_epoch="$4"
+  local data_json="$5"
+  local repo_root="${6:-}"
+
+  # Compute duration_ms from caller's $EPOCHREALTIME snapshot to now.
+  # Both '.' and ',' separators handled; 10# prefix prevents octal misreading
+  # of fractional parts with leading zeros (e.g. .045123 → 10#045123 = 45123).
+  # EPOCHREALTIME is Bash 5.0+; on an older host it (and the caller's start
+  # snapshot) is empty. Skip telemetry fail-open rather than abort under set -u —
+  # the same silent-skip the caller's `START=${EPOCHREALTIME:-}` guard intends.
+  local now=${EPOCHREALTIME:-}
+  [[ -n "$start_epoch" && -n "$now" ]] || return 0
+  local s_s="${start_epoch%[.,]*}" s_f="${start_epoch#*[.,]}"
+  local e_s="${now%[.,]*}" e_f="${now#*[.,]}"
+  local duration_ms=$(((e_s * 1000000 + 10#$e_f - s_s * 1000000 - 10#$s_f) / 1000))
+
+  # True UTC timestamp (TZ= prefix overrides LC_ALL / local TZ; the Z is not a lie).
+  local timestamp
+  timestamp=$(TZ=UTC printf '%(%Y-%m-%dT%H:%M:%SZ)T' -1)
+
+  # Build the envelope. Redirect jq stderr to /dev/null; output goes to a local
+  # variable — never to fd1.
+  local envelope
+  envelope=$(jq -n \
+    --arg schema_version "1.0" \
+    --arg timestamp "$timestamp" \
+    --arg hook "$hook_id" \
+    --arg hook_event "$hook_event" \
+    --arg status "$status" \
+    --argjson duration_ms "$duration_ms" \
+    --argjson data "$data_json" \
+    '{schema_version:$schema_version,timestamp:$timestamp,hook:$hook,hook_event:$hook_event,status:$status,duration_ms:$duration_ms,data:$data}' \
+    2>/dev/null) || return 0
+
+  # Resolve the sink path. A relative HOOK_TELEMETRY_SINK is joined onto the
+  # consuming repo root (portable, tracked wiring); absolute is used as-is. A
+  # relative value with no anchor is skipped fail-open — never exec a path the
+  # drifted hook CWD would resolve incorrectly.
+  local sink="$HOOK_TELEMETRY_SINK"
+  case "$sink" in
+  /* | [A-Za-z]:[/\\]*) ;;
+  *)
+    local root="${repo_root:-${CLAUDE_PROJECT_DIR:-}}"
+    [[ -n "$root" ]] || return 0
+    sink="${root%/}/$sink"
+    ;;
+  esac
+
+  # Fire-and-forget: pipe the envelope to the sink in a background subshell.
+  # The subshell's stdout AND stderr are redirected to /dev/null so the sink
+  # cannot write to the hook's fd1 (the additionalContext channel) and the
+  # backgrounded subshell does not hold a copy of the hook's fd1 open — which
+  # would block any command substitution wrapping the hook until the sink exits
+  # (the "C1 fd1-inheritance blocker"). The sink is quoted — it is a single
+  # executable path (wrap in a script to pass arguments).
+  printf '%s\n' "$envelope" | ("$sink" >/dev/null 2>&1) &
+}
+
+# Print cross-host hook JSON to stdout (exit 0). No-op when context is empty.
+# Shape: { hookSpecificOutput: { hookEventName[, additionalContext] } }.
+hook::emit_additional_context() {
+  local event_name="$1"
+  local context="$2"
+  [[ -n "$context" ]] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  jq -n \
+    --arg event "$event_name" \
+    --arg ctx "$context" \
+    '{hookSpecificOutput: (
+      {hookEventName: $event}
+      + (if $ctx != "" then {additionalContext: $ctx} else {} end)
+    )}'
+}
+
+# ---------------------------------------------------------------------------
+# Argv-grammar-faithful Bash command parsing for git guards. The command is
+# parsed the way the shell builds argv — top-level segments split on unquoted
+# control operators, each tokenized into argv words honoring '…', "…", $'…'
+# (ANSI-C), and backslash escapes — then a real git executable is resolved at
+# the segment's command position past env-var assignments and known wrappers,
+# and its subcommand resolved past git global options.
+#
+# Static matching over the literal command string only: shell variable and
+# command substitution ($VAR, $(…)) are NOT evaluated. Guards built on this
+# are friction against accidental/casual bypass, not a sandbox.
+
+# Decode an ANSI-C `$'…'` body to its literal bytes (\xHH, \NNN octal, \uHHHH,
+# \n, \\, …). %-escaped so the body can never act as a printf format specifier;
+# `--` guards a body that begins with `-`. Errors are swallowed (fail-open on a
+# malformed body — the raw text still flows through the caller unchanged).
+hook::ansi_c_decode() {
+  local b="${1//%/%%}"
+  # shellcheck disable=SC2059  # the body IS the format — that is how ANSI-C escapes decode; %-escaped above so it cannot inject a specifier
+  printf -- "$b" 2>/dev/null
+}
+
+# Split a GNU `env -S` operand the way env does: whitespace-separated words
+# honoring "…" and '…' quotes and backslash escapes — so a flag quoted inside
+# the operand (`env -S 'git push "--force"'`) still surfaces as its unquoted
+# argv word. env's $VAR expansion inside the operand is NOT evaluated (static
+# analysis over the literal string — same residual as the segment tokenizer).
+# Result in the global HOOK_ENV_S_WORDS array.
+# shellcheck disable=SC2034  # result global is consumed by hook::git_resolve_index
+# shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
+hook::env_s_split() {
+  local s="$1" i c n=${#1} word="" have=0
+  HOOK_ENV_S_WORDS=()
+  for ((i = 0; i < n; i++)); do
+    c="${s:i:1}"
+    case "$c" in
+    "'")
+      ((i++))
+      while ((i < n)) && [[ "${s:i:1}" != "'" ]]; do
+        word+="${s:i:1}"
+        ((i++))
+      done
+      have=1
+      ;;
+    '"')
+      ((i++))
+      while ((i < n)) && [[ "${s:i:1}" != '"' ]]; do
+        if [[ "${s:i:1}" == '\' ]] && ((i + 1 < n)); then
+          word+="${s:i+1:1}"
+          ((i += 2))
+          continue
+        fi
+        word+="${s:i:1}"
+        ((i++))
+      done
+      have=1
+      ;;
+    '\')
+      if ((i + 1 < n)); then
+        word+="${s:i+1:1}"
+        ((i++))
+      fi
+      have=1
+      ;;
+    ' ' | $'\t')
+      if ((have)); then
+        HOOK_ENV_S_WORDS+=("$word")
+        word=""
+        have=0
+      fi
+      ;;
+    *)
+      word+="$c"
+      have=1
+      ;;
+    esac
+  done
+  ((have)) && HOOK_ENV_S_WORDS+=("$word")
+}
+
+# Detect a `sh -c` style shell wrapper in a segment's argv: a shell at the
+# command position (after leading env-var assignments) carrying a `-c` flag.
+# On match, the command-string operand lands in HOOK_SHELL_C_OPERAND for the
+# caller to re-parse with hook::bash_parse_segments — the operand is a full
+# shell command (operators, quoting, everything), so re-parsing with the same
+# tokenizer is the faithful treatment. Wrappers stacked in front of the shell
+# (`sudo bash -c …`) are NOT resolved here — a documented residual of the
+# static-matcher posture. A shell invoked on a script file (no -c) never
+# matches: file contents cannot be inspected statically.
+# shellcheck disable=SC2034  # result global is consumed by the sourcing guard
+hook::shell_c_operand() {
+  local -a w=("$@")
+  local n=${#w[@]} i=0 b t has_c=0
+  # Skip leading VAR=val assignments, mirroring the git resolver.
+  while ((i < n)) && [[ "${w[i]}" == *=* && "${w[i]}" != -* ]]; do ((i++)); done
+  ((i < n)) || return 1
+  b="${w[i]##*/}"
+  b="${b##*\\}"
+  case "${OSTYPE:-}" in
+  msys* | cygwin* | win32)
+    b="${b,,}"
+    b="${b%.exe}"
+    ;;
+  *) ;;
+  esac
+  case "$b" in
+  bash | sh | zsh | dash | ksh | mksh) ;;
+  *) return 1 ;;
+  esac
+  ((i++))
+  while ((i < n)); do
+    t="${w[i]}"
+    case "$t" in
+    --)
+      ((i++))
+      break
+      ;;
+    # -o/-O (and +o/+O) consume a set/shopt operand; --rcfile/--init-file
+    # consume a startup-file operand (bash) — none of these ends the option
+    # scan, so `bash --rcfile /dev/null -c '…'` still reaches its -c.
+    -o | +o | -O | +O | --rcfile | --init-file) ((i += 2)) ;;
+    -*)
+      [[ "$t" =~ ^-[A-Za-z]+$ && "$t" == *c* ]] && has_c=1
+      ((i++))
+      ;;
+    *) break ;;
+    esac
+  done
+  ((has_c)) || return 1
+  ((i < n)) || return 1
+  HOOK_SHELL_C_OPERAND="${w[i]}"
+  return 0
+}
+
+# Does an argv word name the git executable? Basename compared exactly on
+# POSIX; on Windows/MSYS also case-folded and `.exe`-stripped (mirrors the
+# OS-gate in hook::normalize_path) so `GIT` / `git.exe` are caught there but a
+# case-variant stays distinct on a case-sensitive POSIX filesystem.
+hook::git_is_bin() {
+  local b="${1##*/}"
+  b="${b##*\\}"
+  case "${OSTYPE:-}" in
+  msys* | cygwin* | win32)
+    local lc="${b,,}"
+    lc="${lc%.exe}"
+    [[ "$lc" == "git" ]]
+    ;;
+  *) [[ "$b" == "git" ]] ;;
+  esac
+}
+
+# Locate a real `git` executable at the segment's command position (after
+# env-var prefixes and known wrappers), or return 1 when absent. Results go in
+# globals, NOT a $( ) echo: `env -S` splicing rewrites the argv, and the caller
+# must match on the rewritten words, so the index alone is not enough.
+#   HOOK_GIT_RESOLVED_GI    — index of git in HOOK_GIT_RESOLVED_WORDS
+#   HOOK_GIT_RESOLVED_WORDS — the (possibly rewritten) segment argv
+# shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
+# shellcheck disable=SC2034  # result globals are consumed by the sourcing guard, not this file
+hook::git_resolve_index() {
+  HOOK_GIT_RESOLVED_WORDS=("$@")
+  HOOK_GIT_RESOLVED_GI=-1
+  # shellcheck disable=SC2178  # nameref to the array result global, not a string assignment
+  local -n w=HOOK_GIT_RESOLVED_WORDS
+  local n=${#w[@]} i=0 tok
+
+  while ((i < n)); do
+    tok="${w[i]}"
+    if [[ "$tok" == *=* ]]; then
+      ((i++))
+      continue
+    fi
+
+    case "${tok##*/}" in
+    env)
+      ((i++))
+      while ((i < n)) && [[ "${w[i]}" == -* ]]; do
+        case "${w[i]}" in
+        # -S/--split-string re-splits its operand into argv (GNU env), so a
+        # quoted 'git commit --no-verify' would otherwise hide from the
+        # resolver as one non-git word. Splice the split words back into the
+        # scan and restart at the command position.
+        -S | --split-string)
+          local sval=""
+          ((i + 1 < n)) && sval="${w[i + 1]}"
+          hook::env_s_split "$sval"
+          w=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"} "${w[@]:i+2}")
+          n=${#w[@]}
+          i=0
+          continue 2
+          ;;
+        -S* | --split-string=*)
+          local sval="${w[i]#-S}"
+          sval="${sval#--split-string=}"
+          hook::env_s_split "$sval"
+          w=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"} "${w[@]:i+1}")
+          n=${#w[@]}
+          i=0
+          continue 2
+          ;;
+        -u | --unset | -C | --chdir) ((i += 2)) ;;
+        -*) ((i++)) ;;
+        *) ((i++)) ;;
+        esac
+      done
+      continue
+      ;;
+    nice | nohup)
+      ((i++))
+      while ((i < n)) && [[ "${w[i]}" == -* ]]; do
+        case "${w[i]}" in
+        -n | --adjustment) ((i += 2)) ;;
+        --adjustment=*) ((i++)) ;;
+        -*) ((i++)) ;;
+        *) break ;;
+        esac
+      done
+      if ((i < n)) && [[ "${w[i]}" =~ ^-?[0-9]+$ ]]; then
+        ((i++))
+      fi
+      continue
+      ;;
+    sudo)
+      ((i++))
+      while ((i < n)) && [[ "${w[i]}" == -* ]]; do
+        case "${w[i]}" in
+        -u | -g | -h | -p | -C | -D | -R | -T | --user | --group | --chdir) ((i += 2)) ;;
+        -*) ((i++)) ;;
+        *) ((i++)) ;;
+        esac
+      done
+      continue
+      ;;
+    timeout)
+      ((i++))
+      while ((i < n)) && [[ "${w[i]}" == -* ]]; do
+        case "${w[i]}" in
+        -s | --signal | -k | --kill-after) ((i += 2)) ;;
+        --preserve-status | --foreground | --verbose) ((i++)) ;;
+        -*) ((i++)) ;;
+        *) break ;;
+        esac
+      done
+      if ((i < n)) && [[ "${w[i]}" =~ ^[0-9]+([.][0-9]+)?(s|m|h|d)?$ ]]; then
+        ((i++))
+      fi
+      continue
+      ;;
+    # eval concatenates and re-executes its arguments, so for the unquoted
+    # form (`eval git commit ...`) scanning the following words is exact.
+    # command/exec carry their own options before the real command
+    # (`command [-pVv]`, `exec [-cl] [-a name]`) and an optional `--`
+    # end-of-options marker (`command -- git …`) — skip them so the git
+    # command behind the wrapper is still resolved. But `command -v`/`-V`
+    # only PRINT the command's path/description — nothing runs — so a git
+    # word behind them is a probe, not an invocation: bail out.
+    command | exec | builtin | eval | !)
+      local is_command=0
+      [[ "${tok##*/}" == "command" ]] && is_command=1
+      ((i++))
+      while ((i < n)) && [[ "${w[i]}" == -* && "${w[i]}" != "--" ]]; do
+        if ((is_command)) && [[ "${w[i]}" == -*[vV]* ]]; then
+          return 1
+        fi
+        [[ "${w[i]}" == "-a" ]] && ((i++))
+        ((i++))
+      done
+      ((i < n)) && [[ "${w[i]}" == "--" ]] && ((i++))
+      continue
+      ;;
+    time)
+      ((i++))
+      if ((i < n)) && [[ "${w[i]}" == "-p" ]]; then
+        ((i++))
+      fi
+      continue
+      ;;
+    # Compound-command reserved words at the execution position: a command
+    # can directly follow any of these within one segment (`if git …`,
+    # `then git …`, `do git …`), so skip them and keep resolving.
+    if | then | elif | else | while | until | for | do | case | select | coproc | '{' | '}')
+      ((i++))
+      continue
+      ;;
+    *)
+      if hook::git_is_bin "$tok"; then
+        HOOK_GIT_RESOLVED_GI=$i
+        return 0
+      fi
+      return 1
+      ;;
+    esac
+  done
+  return 1
+}
+
+# Resolve the git subcommand in an already-resolved segment: walk words after
+# the git executable, skipping git global options. The listed options consume
+# the FOLLOWING word as their value (two-word form); their =-forms and every
+# other option are single words handled by the generic `-*` skip. Results in
+# globals:
+#   HOOK_GIT_SUB           — the subcommand word ("" when none found)
+#   HOOK_GIT_SUB_IDX       — its index in the argv (-1 when none)
+#   HOOK_GIT_CONFIG_VALUES — values of -c/--config/--config-env options, in
+#                            order, so a guard can inspect config assignments
+#                            without re-walking (commit messages and pathspecs
+#                            are never collected here)
+# Call as: hook::git_resolve_subcommand <git-index> <argv words...>
+# shellcheck disable=SC2034  # result globals are consumed by the sourcing guard, not this file
+hook::git_resolve_subcommand() {
+  local gi="$1"
+  shift
+  local -a w=("$@")
+  local nseg=${#w[@]} j gw
+  HOOK_GIT_SUB=""
+  HOOK_GIT_SUB_IDX=-1
+  HOOK_GIT_CONFIG_VALUES=()
+
+  j=$((gi + 1))
+  while ((j < nseg)); do
+    gw="${w[j]}"
+    case "$gw" in
+    -c | --config | --config-env)
+      ((j + 1 < nseg)) && HOOK_GIT_CONFIG_VALUES+=("${w[j + 1]}")
+      ((j += 2))
+      ;;
+    --config=* | --config-env=*)
+      HOOK_GIT_CONFIG_VALUES+=("${gw#*=}")
+      ((j++))
+      ;;
+    -C | --git-dir | --work-tree | --namespace | --super-prefix | --attr-source | --exec-path)
+      ((j += 2))
+      ;;
+    -*)
+      ((j++))
+      ;;
+    *)
+      HOOK_GIT_SUB="$gw"
+      HOOK_GIT_SUB_IDX=$j
+      return 0
+      ;;
+    esac
+  done
+  return 1
+}
+
+# Single linear pass: read the command into a char array once (O(n)), then walk
+# it splitting top-level segments on UNQUOTED control operators and tokenizing
+# each segment into argv words honoring '…', "…", $'…', and backslash escapes
+# (including backslash-newline continuation). Each completed segment is passed
+# to the callback as it closes, so no full segment list is retained.
+# Call as: hook::bash_parse_segments <command-string> <callback>; the callback
+# receives one segment's argv words as "$@".
+# shellcheck disable=SC1003  # '\' compares a literal backslash char, not a quote escape
+hook::bash_parse_segments() {
+  local cmd="$1" cb="$2"
+  local -a chars=()
+  local c nx
+  while IFS= read -rN1 c; do chars+=("$c"); done < <(printf '%s' "$cmd")
+  local n=${#chars[@]} i
+  local word="" have=0 skipnext=0
+  local -a seg=()
+  # Pending heredoc delimiters (FIFO) and their `<<-` tab-strip flags. A
+  # heredoc body is the command's stdin, not commands — recorded when `<<`
+  # is seen and skipped wholesale at the command-line newline.
+  local -a hd_delims=() hd_strip=()
+
+  for ((i = 0; i < n; i++)); do
+    c="${chars[i]}"
+    case "$c" in
+    "'")
+      ((i++))
+      while ((i < n)) && [[ "${chars[i]}" != "'" ]]; do
+        word+="${chars[i]}"
+        ((i++))
+      done
+      have=1
+      ;;
+    '"')
+      ((i++))
+      while ((i < n)) && [[ "${chars[i]}" != '"' ]]; do
+        if [[ "${chars[i]}" == '\' ]] && ((i + 1 < n)); then
+          nx="${chars[i + 1]}"
+          case "$nx" in
+          '"' | '\' | '$' | '`')
+            word+="$nx"
+            ((i += 2))
+            continue
+            ;;
+          $'\n')
+            ((i += 2))
+            continue
+            ;;
+          *) ;;
+          esac
+        fi
+        word+="${chars[i]}"
+        ((i++))
+      done
+      have=1
+      ;;
+    '$')
+      if ((i + 1 < n)) && [[ "${chars[i + 1]}" == "'" ]]; then
+        i=$((i + 2))
+        local body=""
+        while ((i < n)) && [[ "${chars[i]}" != "'" ]]; do
+          if [[ "${chars[i]}" == '\' ]] && ((i + 1 < n)); then
+            body+="${chars[i]}${chars[i + 1]}"
+            ((i += 2))
+            continue
+          fi
+          body+="${chars[i]}"
+          ((i++))
+        done
+        word+="$(hook::ansi_c_decode "$body")"
+        have=1
+      else
+        word+="$c"
+        have=1
+      fi
+      ;;
+    '\')
+      if ((i + 1 < n)); then
+        nx="${chars[i + 1]}"
+        if [[ "$nx" == $'\n' ]]; then
+          ((i++))
+        else
+          word+="$nx"
+          ((i++))
+          have=1
+        fi
+      else
+        have=1
+      fi
+      ;;
+    ' ' | $'\t')
+      if ((have)); then
+        if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
+        word=""
+        have=0
+      fi
+      ;;
+    '>' | '<')
+      # Redirection: bash removes the operator and its target word from
+      # argv (redirections may appear anywhere in a simple command), so
+      # `git reset --hard>/tmp/out` still runs reset --hard. A pure-digit
+      # word immediately before the operator is its fd prefix, not argv;
+      # an fd-dup/close form (`2>&1`, `>&-`) has no target word to skip.
+      if ((have)); then
+        if [[ "$word" =~ ^[0-9]+$ ]]; then
+          :
+        elif ((skipnext)); then
+          skipnext=0
+        else
+          seg+=("$word")
+        fi
+        word=""
+        have=0
+      fi
+      # Heredoc `<<` / `<<-` (but NOT here-string `<<<`): the body on the
+      # following lines is the command's stdin, so record the delimiter and
+      # let the newline handler skip the body. A quoted/backslashed delimiter
+      # (`<<'EOF'`, `<<\EOF`) still terminates on a line reading `EOF`.
+      if [[ "$c" == '<' ]] && ((i + 1 < n)) && [[ "${chars[i + 1]}" == '<' ]] \
+        && { ((i + 2 >= n)) || [[ "${chars[i + 2]}" != '<' ]]; }; then
+        ((i++))
+        local hstrip=0
+        if ((i + 1 < n)) && [[ "${chars[i + 1]}" == '-' ]]; then
+          hstrip=1
+          ((i++))
+        fi
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" == ' ' || "${chars[i + 1]}" == $'\t' ]]; do ((i++)); done
+        local delim=""
+        while ((i + 1 < n)); do
+          nx="${chars[i + 1]}"
+          case "$nx" in
+          ' ' | $'\t' | $'\n' | ';' | '&' | '|' | '<' | '>') break ;;
+          "'")
+            ((i++))
+            while ((i + 1 < n)) && [[ "${chars[i + 1]}" != "'" ]]; do
+              delim+="${chars[i + 1]}"
+              ((i++))
+            done
+            ((i + 1 < n)) && ((i++))
+            ;;
+          '"')
+            ((i++))
+            while ((i + 1 < n)) && [[ "${chars[i + 1]}" != '"' ]]; do
+              delim+="${chars[i + 1]}"
+              ((i++))
+            done
+            ((i + 1 < n)) && ((i++))
+            ;;
+          '\')
+            ((i++))
+            ((i + 1 < n)) && {
+              delim+="${chars[i + 1]}"
+              ((i++))
+            }
+            ;;
+          *)
+            delim+="$nx"
+            ((i++))
+            ;;
+          esac
+        done
+        hd_delims+=("$delim")
+        hd_strip+=("$hstrip")
+        continue
+      fi
+      if ((i + 1 < n)) && [[ "${chars[i + 1]}" == '(' ]]; then
+        # Process substitution <(list)/>(list): the list is a real command
+        # substituted as a filename — it satisfies any pending target and
+        # the '(' separator splits it into a segment that gets scanned.
+        skipnext=0
+      else
+        while ((i + 1 < n)) && [[ "${chars[i + 1]}" == [\<\>] ]]; do ((i++)); done
+        if ((i + 1 < n)) && [[ "${chars[i + 1]}" == '&' ]]; then
+          ((i++))
+          if ((i + 1 < n)) && [[ "${chars[i + 1]}" == [0-9-] ]]; then
+            while ((i + 1 < n)) && [[ "${chars[i + 1]}" == [0-9-] ]]; do ((i++)); done
+          else
+            skipnext=1
+          fi
+        else
+          skipnext=1
+        fi
+      fi
+      ;;
+    ';' | '&' | '|' | '(' | ')' | '`' | $'\n')
+      if ((have)); then
+        if ((skipnext)); then skipnext=0; else seg+=("$word"); fi
+        word=""
+        have=0
+      fi
+      if ((${#seg[@]})); then
+        "$cb" "${seg[@]}"
+        seg=()
+      fi
+      # A command-line newline ends the line that introduced any pending
+      # heredocs; their bodies (up to and including each delimiter line) are
+      # stdin, so consume them without tokenizing. Delimiters match in FIFO
+      # order; `<<-` strips leading tabs from body lines before comparing.
+      if [[ "$c" == $'\n' ]] && ((${#hd_delims[@]})); then
+        local hidx line lc d strip
+        for ((hidx = 0; hidx < ${#hd_delims[@]}; hidx++)); do
+          d="${hd_delims[hidx]}"
+          strip="${hd_strip[hidx]}"
+          while ((i + 1 < n)); do
+            line=""
+            while ((i + 1 < n)) && [[ "${chars[i + 1]}" != $'\n' ]]; do
+              line+="${chars[i + 1]}"
+              ((i++))
+            done
+            ((i + 1 < n)) && ((i++))
+            lc="$line"
+            if ((strip)); then
+              while [[ "$lc" == $'\t'* ]]; do lc="${lc#?}"; done
+            fi
+            [[ "$lc" == "$d" ]] && break
+          done
+        done
+        hd_delims=()
+        hd_strip=()
+      fi
+      ;;
+    *)
+      word+="$c"
+      have=1
+      ;;
+    esac
+  done
+  if ((have)) && ((!skipnext)); then seg+=("$word"); fi
+  if ((${#seg[@]})); then "$cb" "${seg[@]}"; fi
+}

--- a/plugins/typos-format/hooks/hooks.json
+++ b/plugins/typos-format/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/typos-format.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-fix source-code spelling mistakes via typos.
+# Triggered on every Write|Edit — typos is a cross-language spell checker, not
+# a single-ecosystem formatter, so no extension filter narrows it; typos' own
+# binary-content detection and the consumer's _typos.toml [files] excludes
+# (honored via --force-exclude below) decide what actually gets checked.
+#
+# ADVISORY: always exits 0. `typos -w` auto-fixes every unambiguous typo;
+# residual findings (ambiguous corrections typos declines to apply
+# unassisted) surface via additionalContext but never block the edit. A
+# commit hook or CI is the hard gate.
+#
+# Zero-config: typos ships a built-in dictionary and runs immediately with no
+# required setup — it ships none of its own rules and imposes nothing beyond
+# that dictionary. It discovers the consuming repo's own optional
+# typos.toml/_typos.toml/.typos.toml (or a [tool.typos] section in
+# Cargo.toml/pyproject.toml) by walking up from the edited file itself, not
+# from the hook's CWD (verified against typos-cli 1.44.0: passing an absolute
+# file path from an unrelated working directory still discovers a config
+# several directories above it) — so, unlike markdownlint-cli2, this hook
+# never needs to `cd` to the repo root for discovery to work.
+
+set -uo pipefail
+
+# Read inherited fd0 directly (bare cat) — NEVER `</dev/stdin`: on Windows Git
+# Bash, CC spawns hooks with stdin = a Win32 pipe that `/dev/stdin` cannot
+# resolve (ENOENT -> silent no-op). stdin is read ONCE here and fed to both
+# hook::read_file_path (file_path) and the tool_name parse below; reading fd0
+# twice would drain the pipe on the second call.
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "TYPOS_FORMAT"
+
+# Capture $EPOCHREALTIME immediately after kill-switch so duration_ms covers
+# the fix work (pre-fix exits below do not emit telemetry). EPOCHREALTIME is
+# Bash 5.0+; on older bash it is unset, so default to empty — referencing it
+# bare under `set -u` would abort before the advisory exit 0, failing every
+# edit.
+start=${EPOCHREALTIME:-}
+
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array. Two
+# guards: the high-res start stamp (empty on Bash < 5.0, so telemetry is
+# skipped rather than aborting the fix) and the sink opt-in. The data payload
+# costs a jq subprocess, so it is built here after both guards — never on the
+# unwired path.
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "typos-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
+}
+
+INPUT=$(hook::buffer_stdin) || exit 0
+
+# jq is required to parse Claude Code's hook payload and to emit structured
+# PostToolUse context. Absent -> visible once-per-session skip notice on both
+# the agent and user channels, exit 0.
+hook::require_jq PostToolUse typos-format "$INPUT"
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+
+# Resolve repo root early — only needed to compute the schema-required
+# repo-relative path in data.file (typos' own config discovery is
+# file-anchored, so nothing else here depends on it).
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+
+# Telemetry-payload precursors — TOOL and FILE_REL feed only the envelope's
+# data object, so both are built only when a sink is wired: the unwired
+# default path spawns zero telemetry-only subprocesses (the tool_name jq
+# parse, and 2x cygpath on Windows).
+#
+# FILE_REL is the repo-relative path: schema requires "relative to the
+# consuming repo root". On Windows Git Bash, git rev-parse --show-toplevel
+# returns a drive-letter path while FILE may be in POSIX mount form. Normalize
+# both through cygpath -lm (long name, forward-slash mixed form) when
+# available so the prefix strip compares the same representation. On
+# Linux/macOS, cygpath is absent and both paths are already POSIX. Falls back
+# to raw FILE on any normalization error.
+TOOL=""
+FILE_REL="$FILE"
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  if command -v cygpath >/dev/null 2>&1; then
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+      FILE_REL="${_file_lm#"$_root_lm"/}"
+    fi
+  else
+    FILE_REL="${FILE#"$REPO_ROOT"/}"
+  fi
+fi
+
+# Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
+# findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
+# object — NOT an interpolation of TOOL/FILE_REL, which could inject quotes or
+# backslashes from a path and corrupt the envelope. The fallback is essentially
+# unreachable in practice (it fires only if `jq -n` fails, and when jq is absent
+# hook::emit_telemetry drops the envelope anyway), so losing the values here is
+# harmless and strictly safer than emitting malformed JSON.
+build_data_json() {
+  jq -n \
+    --arg tool "$TOOL" \
+    --arg file "$FILE_REL" \
+    --argjson findings "$1" \
+    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null ||
+    printf '{"tool":"","file":"","findings":[]}'
+}
+
+TYPOS_BIN="$(command -v typos 2>/dev/null)" || TYPOS_BIN=""
+if [[ -z "$TYPOS_BIN" ]]; then
+  if hook::notice_once "typos-format-typos" "$INPUT"; then
+    hook::emit_skip_notice PostToolUse \
+      "typos-format: 'typos' was not found on PATH — spell-check skipped for this session. Install: https://github.com/crate-ci/typos#install (this hook never downloads or executes an unpinned tool)."
+  fi
+  emit_tel "skipped" '[]'
+  exit 0
+fi
+
+# --force-exclude makes the consumer's own [files] extend-exclude apply even
+# to this explicitly-named file — typos otherwise only honors that exclude
+# list during its own directory walk, not for a path given directly on the
+# command line (verified against typos-cli 1.44.0). -w applies every
+# unambiguous fix in place; --format json emits one compact JSON object per
+# REMAINING (unfixed) finding and nothing at all for a fully-fixed file —
+# verified empirically that fixed typos never appear in this output, only
+# residual ambiguous corrections typos declined to apply unassisted.
+#
+# Exit codes (typos-cli 1.44.0, undocumented beyond the README's --format
+# json callout but verified to hold for the default text format too): 0 =
+# clean (nothing remains after -w), 2 = findings remain, anything else = the
+# tool itself broke (bad invocation, internal error) rather than rendering a
+# spelling judgment. No `cd` here — unlike markdownlint-cli2's CWD-anchored
+# discovery, typos resolves config from the FILE argument itself, so this
+# hook's own CWD is irrelevant to what governs the run.
+OUTPUT=$("$TYPOS_BIN" --force-exclude -w --format json "$FILE" 2>&1)
+RC=$?
+
+if [[ $RC -eq 0 ]]; then
+  emit_tel "ok" '[]'
+  exit 0
+fi
+
+if [[ $RC -eq 2 && -n "$OUTPUT" ]]; then
+  hook::ctx_reset
+  hook::ctx_append "typos-format: $(basename "$FILE") has residual spelling findings (ambiguous corrections, advisory):"
+  findings_raw=""
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    desc=$(printf '%s' "$line" | jq -r 'select(.type=="typo") | "\(.typo) -> \(.corrections | join(", ")) (line \(.line_num))"' 2>/dev/null)
+    [[ -n "$desc" ]] || continue
+    hook::ctx_append "  $desc"
+    findings_raw+="$desc"$'\n'
+  done <<<"$OUTPUT"
+  hook::ctx_flush PostToolUse
+
+  FINDINGS_JSON='[]'
+  if [[ -n "$findings_raw" ]]; then
+    FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
+  fi
+  emit_tel "ok" "$FINDINGS_JSON"
+  exit 0
+fi
+
+# typos broke for non-lint reasons (bad config, internal error) — no judgment
+# was made. Surface the diagnostic via additionalContext (NOT stderr — an
+# advisory hook's exit-0 stderr can trip a false "Hook Error" label). Record
+# as "skipped" (the tool never ran to judgment), the same status as the
+# no-binary path.
+hook::ctx_reset
+hook::ctx_append "typos-format: typos failed for $(basename "$FILE") (no diagnostics; tool break, not a finding):"
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  hook::ctx_append "  $line"
+done <<<"$OUTPUT"
+hook::ctx_flush PostToolUse
+emit_tel "skipped" '[]'
+exit 0

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -1,0 +1,585 @@
+#!/usr/bin/env bash
+# Black-box contract test for typos-format.sh (the typos-format plugin hook).
+#
+# Proves WIRING: the hook fires on every Write|Edit (no extension filter),
+# runs `typos -w` from the file's own path (no repo-root `cd`, since typos'
+# config discovery is file-anchored, not CWD-anchored), auto-fixes unambiguous
+# typos, surfaces residual (ambiguous) findings via additionalContext
+# (advisory, exit 0), honors the kill switch, discovers a consumer
+# _typos.toml several directories above the edited file regardless of the
+# hook's own working directory, respects the consumer's [files] extend-exclude
+# for an explicitly-edited file via --force-exclude, and emits a schema-valid
+# telemetry envelope. No source-repo policy prose in the surfaced context.
+#
+# Self-contained: builds throwaway git repos with runtime-generated fixtures.
+# The hook is invoked as a subprocess from an UNRELATED cwd so file-anchored
+# config discovery is genuinely exercised (running from the repo root would
+# false-pass a hook that silently depended on its own cwd).
+#
+# Requires a real typos binary: $TYPOS_TEST_BIN if set, else `typos` on PATH.
+# Without one the behavioral assertions cannot run, so the suite skips.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/typos-format.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# Resolve a real typos binary. Skip the suite when none is available (mirrors
+# ruff-format/bash-format: an individual contract test SKIPs rather than
+# fails when its optional tool is absent).
+if [[ -n "${TYPOS_TEST_BIN:-}" && -x "${TYPOS_TEST_BIN}" ]]; then
+  REAL_TYPOS="${TYPOS_TEST_BIN}"
+elif command -v typos >/dev/null 2>&1; then
+  REAL_TYPOS="$(command -v typos)"
+else
+  echo "SKIP: no typos binary (set TYPOS_TEST_BIN or put typos on PATH) -- typos-format hook tests skipped"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+UNRELATED="$(mktemp -d)"
+cleanup() { rm -rf "$WORK" "$UNRELATED"; }
+trap cleanup EXIT
+
+# make_sink <body> -> path to an executable single-command stub sink running
+# <body> (which reads the envelope on stdin). HOOK_TELEMETRY_SINK must be a
+# single executable path, not a command-with-args, so tests point it at a stub.
+make_sink() {
+  local s
+  s="$(mktemp -p "$WORK" sink.XXXXXX)"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '%s\n' "$1"
+  } >"$s"
+  chmod +x "$s"
+  printf '%s' "$s"
+}
+
+# wait_for_sink <file> [tries] -> block until <file> is non-empty (the
+# fire-and-forget sink flushed) or the bound elapses, polling in 20ms steps.
+wait_for_sink() {
+  local f="$1" tries="${2:-150}"
+  while ((tries-- > 0)); do
+    if [[ -s "$f" ]]; then
+      return 0
+    fi
+    sleep 0.02
+  done
+  return 1
+}
+
+# Invoke the hook from an unrelated cwd. CLAUDE_PROJECT_DIR is left UNSET so
+# read_file_path's membership guard is disabled (not part of the fire gate);
+# this isolates fix behavior from any path-form mismatch in the guard.
+run_hook() {
+  local file_path="$1"
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK"
+  )
+}
+
+REPO="$WORK/consumer"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email t@t.t
+git -C "$REPO" config user.name t
+
+# --- Fixture A: unambiguous typo, fully fixable -> clean after fix ----------
+FA="$REPO/fixtureA.txt"
+printf 'This has a recieve typo.\n' >"$FA"
+
+OUT_A="$(run_hook "$FA")"
+RC_A=$?
+if [[ $RC_A -eq 0 ]]; then ok "fixtureA exit 0"; else fail "fixtureA exit $RC_A"; fi
+if [[ -z "$OUT_A" ]]; then ok "fixtureA empty stdout (clean after fix)"; else fail "fixtureA stdout not empty: $OUT_A"; fi
+if grep -q '^This has a receive typo\.$' "$FA"; then
+  ok "fixtureA --write-changes applied unambiguous fix"
+else
+  fail "fixtureA not fixed: $(cat "$FA")"
+fi
+
+# --- Fixture B: fixable + ambiguous residual (typos-cli 1.44.0: `fo` has 5 --
+# candidate corrections and is never auto-applied) -------------------------
+FB="$REPO/fixtureB.txt"
+printf 'This has a mroe typo and an ambiguous fo case.\n' >"$FB"
+
+OUT_B="$(run_hook "$FB")"
+RC_B=$?
+if [[ $RC_B -eq 0 ]]; then ok "fixtureB exit 0"; else fail "fixtureB exit $RC_B"; fi
+if grep -q ' more ' "$FB" && ! grep -q ' mroe ' "$FB"; then
+  ok "fixtureB unambiguous fix (mroe -> more) applied"
+else
+  fail "fixtureB unambiguous fix missing: $(cat "$FB")"
+fi
+if grep -q ' fo ' "$FB"; then
+  ok "fixtureB ambiguous word left untouched (fo)"
+else
+  fail "fixtureB ambiguous word was altered: $(cat "$FB")"
+fi
+CTX_B=""
+if [[ -n "$OUT_B" ]] && printf '%s' "$OUT_B" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  CTX_B="$(printf '%s' "$OUT_B" | jq -r '.hookSpecificOutput.additionalContext')"
+  ok "fixtureB emitted hookSpecificOutput.additionalContext"
+else
+  fail "fixtureB no additionalContext JSON: $OUT_B"
+fi
+if printf '%s' "$CTX_B" | grep -q 'fo ->'; then
+  ok "fixtureB ctx names the residual typo (fo)"
+else
+  fail "fixtureB ctx missing residual typo: $CTX_B"
+fi
+if printf '%s' "$CTX_B" | grep -qi 'mroe'; then
+  fail "fixtureB ctx still lists the already-fixed typo (mroe)"
+else
+  ok "fixtureB ctx omits the already-fixed typo"
+fi
+
+# --- No extension filter: an arbitrary non-code file is still processed -----
+FC="$REPO/fixtureC.someweirdext"
+printf 'This has a recieve typo.\n' >"$FC"
+# shellcheck disable=SC2034  # stdout captured so the $(...) subshell fully drains; only the exit code is asserted here
+OUT_C="$(run_hook "$FC")"
+RC_C=$?
+if [[ $RC_C -eq 0 ]]; then ok "fixtureC (unusual extension) exit 0"; else fail "fixtureC exit $RC_C"; fi
+if grep -q '^This has a receive typo\.$' "$FC"; then
+  ok "fixtureC (unusual extension) still fixed -- no extension gate"
+else
+  fail "fixtureC not fixed: $(cat "$FC")"
+fi
+
+# --- Missing .txt: fire gate skips (mirrors sibling formatter hooks) --------
+OUT_M="$(run_hook "$REPO/does-not-exist.txt")"
+RC_M=$?
+if [[ $RC_M -eq 0 && -z "$OUT_M" ]]; then
+  ok "missing file skipped"
+else
+  fail "missing file not skipped (rc=$RC_M out=$OUT_M)"
+fi
+
+# --- Consumer _typos.toml discovered several directories above the edited --
+# file, from an UNRELATED hook cwd (file-anchored discovery, not CWD-anchored)
+NESTED="$REPO/nested/sub/dir"
+mkdir -p "$NESTED"
+printf '[default.extend-words]\nmroe = "mroe"\n' >"$REPO/nested/_typos.toml"
+FD="$NESTED/fixtureD.txt"
+printf 'This has a mroe typo and recieve too.\n' >"$FD"
+
+# shellcheck disable=SC2034  # stdout captured so the $(...) subshell fully drains; only the exit code is asserted here
+OUT_D="$(run_hook "$FD")"
+RC_D=$?
+if [[ $RC_D -eq 0 ]]; then ok "fixtureD exit 0"; else fail "fixtureD exit $RC_D"; fi
+if grep -q ' mroe ' "$FD"; then
+  ok "fixtureD nested _typos.toml allowlist respected (mroe left alone)"
+else
+  fail "fixtureD allowlisted word was altered: $(cat "$FD")"
+fi
+if grep -q ' receive ' "$FD"; then
+  ok "fixtureD still fixed the non-allowlisted typo (recieve -> receive)"
+else
+  fail "fixtureD non-allowlisted typo not fixed: $(cat "$FD")"
+fi
+
+# --- force-exclude: a consumer [files] extend-exclude entry is honored for --
+# an explicitly-edited file, not silently overridden the way a bare CLI
+# invocation would (typos-cli 1.44.0: extend-exclude is ignored for a
+# directly-named path unless --force-exclude is passed).
+EXREPO="$WORK/exclude-consumer"
+mkdir -p "$EXREPO"
+git -C "$EXREPO" init -q
+git -C "$EXREPO" config user.email t@t.t
+git -C "$EXREPO" config user.name t
+printf '[files]\nextend-exclude = ["excluded.txt"]\n' >"$EXREPO/_typos.toml"
+FE="$EXREPO/excluded.txt"
+printf 'This has a recieve typo.\n' >"$FE"
+
+OUT_E="$(run_hook "$FE")"
+RC_E=$?
+if [[ $RC_E -eq 0 && -z "$OUT_E" ]]; then
+  ok "excluded file: exit 0, no advisory"
+else
+  fail "excluded file not silent (rc=$RC_E out=$OUT_E)"
+fi
+if grep -q ' recieve ' "$FE"; then
+  ok "excluded file left byte-for-byte untouched"
+else
+  fail "excluded file was modified despite extend-exclude: $(cat "$FE")"
+fi
+
+# --- Tool break (malformed consumer config): advisory, not a finding --------
+BADREPO="$WORK/badcfg-consumer"
+mkdir -p "$BADREPO"
+git -C "$BADREPO" init -q
+git -C "$BADREPO" config user.email t@t.t
+git -C "$BADREPO" config user.name t
+printf 'this is not valid toml [[[\n' >"$BADREPO/_typos.toml"
+FBAD="$BADREPO/f.txt"
+printf 'clean text.\n' >"$FBAD"
+
+OUT_BAD="$(run_hook "$FBAD")"
+RC_BAD=$?
+if [[ $RC_BAD -eq 0 ]]; then ok "tool-break case: hook exit 0 (advisory)"; else fail "tool-break case: hook exit $RC_BAD"; fi
+if printf '%s' "$OUT_BAD" | jq -e '.hookSpecificOutput.additionalContext | contains("tool break, not a finding")' >/dev/null 2>&1; then
+  ok "tool-break case emits a tool-break advisory (not a spelling finding)"
+else
+  fail "tool-break advisory absent: $OUT_BAD"
+fi
+
+# --- Kill switch: disabled hook is a no-op ----------------------------------
+FK="$REPO/fixtureK.txt"
+printf 'This has a recieve typo.\n' >"$FK"
+OUT_K="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FK" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=false PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_K=$?
+if [[ $RC_K -eq 0 && -z "$OUT_K" ]]; then
+  ok "kill switch disables hook"
+else
+  fail "kill switch failed (rc=$RC_K out=$OUT_K)"
+fi
+if grep -q ' recieve ' "$FK"; then
+  ok "kill switch: file left untouched"
+else
+  fail "kill switch: file was modified despite the toggle being off: $(cat "$FK")"
+fi
+
+# --- Missing typos: visible advisory on both channels -----------------------
+# Fake-bin dir of exec wrappers forwarding to the REAL tool for everything
+# except typos itself (an explicit allowlist PATH, not a subtractive one --
+# jq and typos share the same install directory on this machine, so removing
+# a directory from PATH would hide both).
+FAKEBIN="$(mktemp -d -p "$WORK" fakebin.XXXXXX)"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$FAKEBIN/$t"
+  chmod +x "$FAKEBIN/$t"
+done
+
+FNT="$REPO/fixtureNoTypos.txt"
+printf 'This has a recieve typo.\n' >"$FNT"
+PD_NO_TYPOS="$(mktemp -d -p "$WORK" pd.XXXXXX)"
+OUT_NO_TYPOS="$(cd "$UNRELATED" && printf '{"session_id":"test-notypos-1","tool_input":{"file_path":"%s"}}' "$FNT" |
+  env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$PD_NO_TYPOS" CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true bash "$HOOK")"
+RC_NO_TYPOS=$?
+if [[ $RC_NO_TYPOS -eq 0 ]]; then ok "missing typos exits 0 (advisory)"; else fail "missing typos exit $RC_NO_TYPOS"; fi
+if printf '%s' "$OUT_NO_TYPOS" | jq -e '(.hookSpecificOutput.additionalContext | contains("was not found on PATH")) and (.systemMessage | contains("was not found on PATH"))' >/dev/null 2>&1; then
+  ok "missing typos emits visible notice on both channels"
+else
+  fail "missing typos warning absent: $OUT_NO_TYPOS"
+fi
+if grep -q ' recieve ' "$FNT"; then
+  ok "missing typos: file left untouched"
+else
+  fail "missing typos: file was modified: $(cat "$FNT")"
+fi
+OUT_NO_TYPOS_2="$(cd "$UNRELATED" && printf '{"session_id":"test-notypos-1","tool_input":{"file_path":"%s"}}' "$FNT" |
+  env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$PD_NO_TYPOS" CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true bash "$HOOK")"
+if [[ -z "$OUT_NO_TYPOS_2" ]]; then
+  ok "missing typos: second run same session is silent (once-per-session)"
+else
+  fail "missing typos: second run not silent: $OUT_NO_TYPOS_2"
+fi
+
+# --- Missing jq: visible advisory, no malformed parsing ---------------------
+NO_JQ_ENV="$WORK/no-jq.bashenv"
+cat >"$NO_JQ_ENV" <<'EOF'
+command() {
+  if [[ "${1:-}" == "-v" && "${2:-}" == "jq" ]]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+EOF
+FNJ="$REPO/fixtureNoJq.txt"
+printf 'This has a recieve typo.\n' >"$FNJ"
+PD_NO_JQ="$(mktemp -d -p "$WORK" pd.XXXXXX)"
+OUT_NO_JQ="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FNJ" |
+  env -u CLAUDE_PROJECT_DIR BASH_ENV="$NO_JQ_ENV" CLAUDE_PLUGIN_DATA="$PD_NO_JQ" CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_NO_JQ=$?
+if [[ $RC_NO_JQ -eq 0 ]]; then ok "missing jq exits 0 (advisory)"; else fail "missing jq exit $RC_NO_JQ"; fi
+if printf '%s' "$OUT_NO_JQ" | jq -e '(.hookSpecificOutput.additionalContext | contains("jq not found on PATH")) and (.systemMessage | contains("jq not found on PATH"))' >/dev/null 2>&1; then
+  ok "missing jq emits visible notice on both channels"
+else
+  fail "missing jq warning absent: $OUT_NO_JQ"
+fi
+
+# ============================================================================
+# Phase 2: hook telemetry tests
+# ============================================================================
+
+# --- Telemetry sink unset -> hook stdout + exit identical to pre-change -----
+FA2="$REPO/fixtureA2.txt"
+printf 'This has a recieve typo.\n' >"$FA2"
+OUT_A_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"}}' "$FA2" |
+  env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_A_NOSINK=$?
+if [[ $RC_A_NOSINK -eq 0 ]]; then ok "telemetry/sink-unset: exit 0 (parity)"; else fail "telemetry/sink-unset: expected 0, got $RC_A_NOSINK"; fi
+if [[ -z "$OUT_A_NOSINK" ]]; then ok "telemetry/sink-unset: empty stdout (parity)"; else fail "telemetry/sink-unset: stdout not empty: $OUT_A_NOSINK"; fi
+
+FB2="$REPO/fixtureB2.txt"
+printf 'This has a mroe typo and an ambiguous fo case.\n' >"$FB2"
+OUT_B_NOSINK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Edit"}' "$FB2" |
+  env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_B_NOSINK=$?
+if [[ $RC_B_NOSINK -eq 0 ]]; then ok "telemetry/sink-unset B: exit 0 (parity)"; else fail "telemetry/sink-unset B: expected 0, got $RC_B_NOSINK"; fi
+if printf '%s' "$OUT_B_NOSINK" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  ok "telemetry/sink-unset B: additionalContext present (parity)"
+else
+  fail "telemetry/sink-unset B: no additionalContext: $OUT_B_NOSINK"
+fi
+if printf '%s' "$OUT_B_NOSINK" | jq -e '.schema_version' >/dev/null 2>&1; then
+  fail "telemetry/sink-unset B: envelope leaked to hook stdout"
+else
+  ok "telemetry/sink-unset B: no envelope in hook stdout"
+fi
+
+# --- Stub sink: residual finding -> schema-valid envelope, status ok --------
+TEL_FILE="$(mktemp)"
+STUB_SINK="$(make_sink "cat >\"$TEL_FILE\"")"
+FT="$REPO/fixtureT.txt"
+printf 'This has a mroe typo and an ambiguous fo case.\n' >"$FT"
+# shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_FILE
+_OUT_T="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FT" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_SINK" PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_T=$?
+wait_for_sink "$TEL_FILE"
+
+if [[ $RC_T -eq 0 ]]; then ok "telemetry/stub-sink: hook exit 0"; else fail "telemetry/stub-sink: hook exit $RC_T"; fi
+if [[ -s "$TEL_FILE" ]]; then
+  ok "telemetry/stub-sink: envelope received"
+  for field in schema_version timestamp hook hook_event status duration_ms data; do
+    if jq -e "has(\"$field\")" "$TEL_FILE" >/dev/null 2>&1; then
+      ok "telemetry/envelope: $field present"
+    else
+      fail "telemetry/envelope: $field missing. file=$(cat "$TEL_FILE")"
+    fi
+  done
+  TEL_HOOK="$(jq -r '.hook' "$TEL_FILE")"
+  if [[ "$TEL_HOOK" == "typos-format" ]]; then ok "telemetry/envelope: hook is typos-format"; else fail "telemetry/envelope: hook expected typos-format, got $TEL_HOOK"; fi
+  TEL_STATUS="$(jq -r '.status' "$TEL_FILE")"
+  if [[ "$TEL_STATUS" == "ok" ]]; then ok "telemetry/envelope: status ok"; else fail "telemetry/envelope: status expected ok, got $TEL_STATUS"; fi
+  TEL_FINDINGS_LEN="$(jq '.data.findings | length' "$TEL_FILE")"
+  if [[ "$TEL_FINDINGS_LEN" -eq 1 ]]; then
+    ok "telemetry/envelope: findings has exactly 1 item (residual only, no already-fixed noise)"
+  else
+    fail "telemetry/envelope: findings expected 1, got $TEL_FINDINGS_LEN: $(jq '.data.findings' "$TEL_FILE")"
+  fi
+  if jq -e '.data.findings[0] | test("fo")' "$TEL_FILE" >/dev/null 2>&1; then
+    ok "telemetry/envelope: findings[0] names the residual typo (fo)"
+  else
+    fail "telemetry/envelope: findings[0] does not name fo: $(jq '.data.findings[0]' "$TEL_FILE")"
+  fi
+  TEL_TOOL="$(jq -r '.data.tool' "$TEL_FILE")"
+  if [[ "$TEL_TOOL" == "Write" ]]; then ok "telemetry/envelope: data.tool is Write"; else fail "telemetry/envelope: data.tool expected Write, got $TEL_TOOL"; fi
+  TEL_FILE_VAL="$(jq -r '.data.file' "$TEL_FILE")"
+  if [[ -n "$TEL_FILE_VAL" && "$TEL_FILE_VAL" != /* && "$TEL_FILE_VAL" != ?:* ]]; then
+    ok "telemetry/envelope: data.file is repo-relative ($TEL_FILE_VAL)"
+  else
+    fail "telemetry/envelope: data.file expected repo-relative, got: $TEL_FILE_VAL"
+  fi
+  TEL_SV="$(jq -r '.schema_version' "$TEL_FILE")"
+  if [[ "$TEL_SV" == "1.0" ]]; then ok "telemetry/envelope: schema_version 1.0"; else fail "telemetry/envelope: schema_version expected 1.0, got $TEL_SV"; fi
+  if jq -e '.duration_ms | type == "number" and . >= 0 and floor == .' "$TEL_FILE" >/dev/null 2>&1; then
+    ok "telemetry/envelope: duration_ms is non-negative integer"
+  else
+    fail "telemetry/envelope: duration_ms invalid: $(jq .duration_ms "$TEL_FILE")"
+  fi
+else
+  fail "telemetry/stub-sink: no envelope written to sink"
+fi
+rm -f "$TEL_FILE"
+
+# --- Stub sink: clean file -> status ok, findings empty array ---------------
+TEL_CLEAN="$(mktemp)"
+STUB_CLEAN="$(make_sink "cat >\"$TEL_CLEAN\"")"
+FCLEAN="$REPO/fixtureClean.txt"
+printf 'Some clean text.\n' >"$FCLEAN"
+# shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_CLEAN
+_OUT_CLEAN="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FCLEAN" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_CLEAN" PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_CLEAN=$?
+wait_for_sink "$TEL_CLEAN"
+if [[ $RC_CLEAN -eq 0 ]]; then ok "telemetry/clean: hook exit 0"; else fail "telemetry/clean: hook exit $RC_CLEAN"; fi
+if [[ -s "$TEL_CLEAN" ]]; then
+  STATUS_CLEAN="$(jq -r '.status' "$TEL_CLEAN")"
+  if [[ "$STATUS_CLEAN" == "ok" ]]; then ok "telemetry/clean: status ok"; else fail "telemetry/clean: status expected ok, got $STATUS_CLEAN"; fi
+  FINDINGS_CLEAN="$(jq '.data.findings | length' "$TEL_CLEAN")"
+  if [[ "$FINDINGS_CLEAN" -eq 0 ]]; then ok "telemetry/clean: findings empty array"; else fail "telemetry/clean: findings should be empty, got $FINDINGS_CLEAN items"; fi
+else
+  fail "telemetry/clean: no envelope written"
+fi
+rm -f "$TEL_CLEAN"
+
+# --- Stub sink: missing-typos path reports status skipped -------------------
+TEL_SKIP="$(mktemp)"
+STUB_SKIP="$(make_sink "cat >\"$TEL_SKIP\"")"
+FSKIP="$REPO/fixtureSkipTel.txt"
+printf 'This has a recieve typo.\n' >"$FSKIP"
+PD_SKIP_TEL="$(mktemp -d -p "$WORK" pd.XXXXXX)"
+# shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_SKIP
+_OUT_SKIP_TEL="$(cd "$UNRELATED" && printf '{"session_id":"test-notypos-tel","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FSKIP" |
+  env -u CLAUDE_PROJECT_DIR PATH="$FAKEBIN" CLAUDE_PLUGIN_DATA="$PD_SKIP_TEL" CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$STUB_SKIP" bash "$HOOK")"
+wait_for_sink "$TEL_SKIP"
+if [[ -s "$TEL_SKIP" ]] && [[ "$(jq -r '.status' "$TEL_SKIP")" == "skipped" ]]; then
+  ok "telemetry/missing-typos: status skipped"
+else
+  fail "telemetry/missing-typos: expected status skipped: $(cat "$TEL_SKIP" 2>/dev/null)"
+fi
+rm -f "$TEL_SKIP"
+
+# --- Stub sink non-zero exit -> hook exit 0 unaffected ----------------------
+FAIL_SINK_FILE="$(mktemp)"
+FAIL_SINK="$(make_sink "cat >\"$FAIL_SINK_FILE\"; exit 1")"
+FFS="$REPO/fixtureFailSink.txt"
+printf 'Some clean text.\n' >"$FFS"
+# shellcheck disable=SC2034  # stdout captured for timing correctness; exit code is the assertion
+_OUT_FS="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FFS" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$FAIL_SINK" PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_FS=$?
+wait_for_sink "$FAIL_SINK_FILE"
+if [[ $RC_FS -eq 0 ]]; then ok "telemetry/fail-sink: hook exit 0 despite sink failure"; else fail "telemetry/fail-sink: hook exit $RC_FS, expected 0"; fi
+rm -f "$FAIL_SINK_FILE"
+
+# --- Slow sink (C1 detector): hook returns in <<3s ---------------------------
+SLOW_SINK="$(make_sink "cat >/dev/null; sleep 3")"
+FSS="$REPO/fixtureSlowSink.txt"
+printf 'Some clean text.\n' >"$FSS"
+TS_SLOW_START=$EPOCHREALTIME
+# shellcheck disable=SC2034  # stdout captured so the $(...) blocks until fd1 closes -- proves no fd1 leak
+_OUT_SLOW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FSS" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$SLOW_SINK" PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_SLOW=$?
+TS_SLOW_END=$EPOCHREALTIME
+SS="${TS_SLOW_START%[.,]*}"
+SF="${TS_SLOW_START#*[.,]}"
+ES="${TS_SLOW_END%[.,]*}"
+EF="${TS_SLOW_END#*[.,]}"
+SLOW_MS=$(((ES * 1000000 + 10#$EF - SS * 1000000 - 10#$SF) / 1000))
+
+echo "  (C1 slow-sink elapsed: ${SLOW_MS}ms)"
+if [[ $RC_SLOW -eq 0 ]]; then ok "telemetry/slow-sink: hook exit 0"; else fail "telemetry/slow-sink: hook exit $RC_SLOW"; fi
+if [[ $SLOW_MS -lt 2000 ]]; then
+  ok "telemetry/slow-sink: returned in ${SLOW_MS}ms (<<3000ms = C1 passes)"
+else
+  fail "telemetry/slow-sink: returned in ${SLOW_MS}ms -- fd1 leak blocks (C1 FAIL)"
+fi
+
+# --- Emit never leaks to hook stdout -----------------------------------------
+TEL_LEAK="$(mktemp)"
+LEAK_SINK="$(make_sink "cat >\"$TEL_LEAK\"")"
+FLEAK="$REPO/fixtureLeakCheck.txt"
+printf 'This has a mroe typo and an ambiguous fo case.\n' >"$FLEAK"
+OUT_LEAK="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FLEAK" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$LEAK_SINK" PATH="$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+wait_for_sink "$TEL_LEAK"
+
+if printf '%s' "$OUT_LEAK" | jq -e '.schema_version' >/dev/null 2>&1; then
+  fail "telemetry/stdout-leak: envelope schema_version found in hook stdout"
+elif printf '%s' "$OUT_LEAK" | jq -e '.duration_ms' >/dev/null 2>&1; then
+  fail "telemetry/stdout-leak: envelope duration_ms found in hook stdout"
+else
+  ok "telemetry/stdout-leak: no envelope in hook stdout"
+fi
+if printf '%s' "$OUT_LEAK" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  ok "telemetry/stdout-leak: additionalContext still present when sink set"
+else
+  fail "telemetry/stdout-leak: additionalContext missing when sink set: $OUT_LEAK"
+fi
+rm -f "$TEL_LEAK"
+
+# --- Unwired producer runs zero telemetry-only subprocesses -------------------
+# The telemetry payload (tool_name jq parse, cygpath path normalization, data
+# JSON build) must be gated on sink presence. Count subprocess spawns via PATH
+# shims: a cygpath shim that logs and echoes its last argument unchanged, and a
+# jq shim that logs then delegates to the real jq so hook behavior is
+# unaffected. cygpath assertions filter on the hook's `-lm` flag.
+SHIM_DIR="$WORK/shims"
+mkdir -p "$SHIM_DIR"
+CYG_LOG="$WORK/cygpath.log"
+JQ_LOG="$WORK/jq.log"
+REAL_JQ="$(command -v jq)"
+cat >"$SHIM_DIR/cygpath" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$CYG_LOG"
+printf '%s\n' "\${!#}"
+EOF
+cat >"$SHIM_DIR/jq" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$JQ_LOG"
+exec "$REAL_JQ" "\$@"
+EOF
+chmod +x "$SHIM_DIR/cygpath" "$SHIM_DIR/jq"
+
+count_lm() { grep -c -- '-lm' "$CYG_LOG" 2>/dev/null || true; }
+
+: >"$CYG_LOG"
+: >"$JQ_LOG"
+FGATE="$REPO/fixtureGate.txt"
+printf 'Clean text.\n' >"$FGATE"
+OUT_GATE="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FGATE" |
+  env -u CLAUDE_PROJECT_DIR -u HOOK_TELEMETRY_SINK CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true PATH="$SHIM_DIR:$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+RC_GATE=$?
+if [[ $RC_GATE -eq 0 && -z "$OUT_GATE" ]]; then
+  ok "telemetry-gate/unwired: exit 0, empty stdout"
+else
+  fail "telemetry-gate/unwired: rc=$RC_GATE out=$OUT_GATE"
+fi
+CYG_LM_UNWIRED="$(count_lm)"
+if [[ "$CYG_LM_UNWIRED" -eq 0 ]]; then
+  ok "telemetry-gate/unwired: zero cygpath -lm spawns"
+else
+  fail "telemetry-gate/unwired: $CYG_LM_UNWIRED cygpath -lm spawns: $(cat "$CYG_LOG")"
+fi
+JQ_UNWIRED="$(wc -l <"$JQ_LOG")"
+if [[ "$JQ_UNWIRED" -eq 2 ]]; then
+  ok "telemetry-gate/unwired: exactly 2 jq spawns (stdin probe + file_path parse)"
+else
+  fail "telemetry-gate/unwired: expected 2 jq spawns, got $JQ_UNWIRED: $(cat "$JQ_LOG")"
+fi
+
+# Wired (stub sink), same fixture shape: the payload construction must still
+# run -- positive control proving the shims observe the telemetry spawns.
+: >"$CYG_LOG"
+: >"$JQ_LOG"
+TEL_GATE="$(mktemp)"
+GATE_SINK="$(make_sink "cat >\"$TEL_GATE\"")"
+FGATEW="$REPO/fixtureGateWired.txt"
+printf 'Clean text.\n' >"$FGATEW"
+# shellcheck disable=SC2034  # stdout captured for timing correctness; content checked via TEL_GATE
+_OUT_GW="$(cd "$UNRELATED" && printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$FGATEW" |
+  env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true HOOK_TELEMETRY_SINK="$GATE_SINK" PATH="$SHIM_DIR:$(dirname "$REAL_TYPOS"):$PATH" bash "$HOOK")"
+wait_for_sink "$TEL_GATE"
+CYG_LM_WIRED="$(count_lm)"
+if [[ "$CYG_LM_WIRED" -eq 2 ]]; then
+  ok "telemetry-gate/wired: 2 cygpath -lm spawns (FILE + REPO_ROOT normalization)"
+else
+  fail "telemetry-gate/wired: expected 2 cygpath -lm spawns, got $CYG_LM_WIRED: $(cat "$CYG_LOG")"
+fi
+JQ_WIRED="$(wc -l <"$JQ_LOG")"
+if [[ "$JQ_WIRED" -gt 1 ]]; then
+  ok "telemetry-gate/wired: payload jq spawns present ($JQ_WIRED total)"
+else
+  fail "telemetry-gate/wired: expected >1 jq spawns, got $JQ_WIRED: $(cat "$JQ_LOG")"
+fi
+if [[ -s "$TEL_GATE" ]] && jq -e '.data.tool == "Write"' "$TEL_GATE" >/dev/null 2>&1; then
+  ok "telemetry-gate/wired: envelope delivered with data.tool intact"
+else
+  fail "telemetry-gate/wired: envelope missing or data.tool wrong: $(cat "$TEL_GATE" 2>/dev/null)"
+fi
+rm -f "$TEL_GATE"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/plugins/typos-format/skills/setup/SKILL.md
+++ b/plugins/typos-format/skills/setup/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: setup
+description: "Verify the typos-format hook's runtime prerequisites and configuration for this repository. Use when: 'set up typos-format', 'configure typos-format', 'is typos-format working', spell-check fixes silently aren't happening, or the hook reported a missing prerequisite. Actions: check (read-only verification, default) | apply (resolve what check found). Re-runnable and safe."
+argument-hint: "check | apply"
+user-invocable: true
+disable-model-invocation: true
+---
+
+## Purpose
+
+Thin check-centric setup per the uniform contract: `check` inspects and reports, `apply`
+resolves. This plugin owns no consumer-project configuration — the spelling dictionary and
+its allowlist come from `typos`' own built-in list plus the repository's own `_typos.toml`,
+and the only tunable is the native `userConfig` toggle. `typos` is a standalone system
+binary the plugin never bundles or installs into a repository, so `apply` is
+guidance-only with **no write path** — it never modifies the repository, user settings, or
+the plugin cache.
+
+Action routing: no argument or `check` runs the check; `apply` runs the check first, then
+offers remediation guidance. Both are non-interactive — never prompt when the action is given.
+
+## `check` (read-only)
+
+The hook script (`${CLAUDE_PLUGIN_ROOT}/hooks/typos-format.sh`) is the single source of
+truth for what it requires and how it resolves things. **Read it first** — probe what it
+actually does, don't recite this file. Then run each probe via Bash and report a
+PASS/FAIL/INFO table with one remediation line per FAIL. Do not modify anything.
+
+When the plugin's toggle is disabled, every prerequisite absence downgrades from FAIL to
+INFO — the hook exits through its enabled-gate before probing anything, so a deliberately
+disabled plugin is not broken. Report the probes informationally and note that re-enabling
+restores the FAIL semantics.
+
+1. **Bash version** — check against the hook's documented floor (README Requirements),
+   noting any features the hook degrades without (for example telemetry's `EPOCHREALTIME`,
+   a Bash 5.0+ builtin).
+2. **`jq`** — `command -v jq`. FAIL if absent: the hook then skips with a visible
+   once-per-session notice instead of fixing anything.
+3. **`typos`** — `command -v typos`. FAIL if absent: the hook skips with a visible
+   once-per-session notice. Then confirm the resolved binary actually executes — run
+   `typos --version` (present-but-broken is still a FAIL, with the execution error in the
+   remediation line).
+4. **Consumer `_typos.toml`** — mirror `typos`' own discovery: it walks up from a target
+   file toward the filesystem root looking for `typos.toml`, `_typos.toml`, `.typos.toml`,
+   `Cargo.toml` (`[workspace.metadata.typos]`/`[package.metadata.typos]`), or
+   `pyproject.toml` (`[tool.typos]`), stopping at the first hit — run
+   `typos --dump-config -` from the repository root to see the effective merged config
+   typos itself resolves, and report whether any project-level config file exists (or
+   INFO that none does — absence is not a defect; typos' built-in dictionary still runs).
+5. **Hook toggle** — report the effective `typos_format_enabled` value:
+   `${user_config.typos_format_enabled}` (unexpanded or empty means default `true`).
+6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+   (`/plugin` → Installed) rather than parsing settings files.
+
+## `apply` (idempotent)
+
+Run `check`, then for each FAIL point at the resolution — this skill installs nothing:
+
+- missing `typos`: point at the
+  [install guide](https://github.com/crate-ci/typos#install) (prebuilt release binary, or
+  `cargo install typos-cli --locked` / `brew install typos-cli` / `conda install typos` /
+  `pacman -S typos`, whichever the repository's own toolchain already favors); this skill
+  never installs system packages.
+- missing `jq` / Bash: platform install instructions from the README Requirements section.
+- a false positive (a name, acronym, or intentional spelling `typos` flags): point at the
+  [false positives](https://github.com/crate-ci/typos#false-positives) guidance —
+  `extend-words`, `extend-identifiers`, or `extend-ignore-re` in `_typos.toml` — but this
+  skill does not write the file; the correction is the consumer's own call.
+- toggle off: direct to `/plugin configure typos-format` (interactive, any
+  time). Headless: `--config` only applies on a fresh install (ignored once installed), so
+  reconfigure via `claude plugin uninstall typos-format` then
+  `claude plugin install typos-format@<marketplace> --config typos_format_enabled=true`;
+  this skill never writes user settings or `pluginConfigs`.
+
+After pointing at a remediation, re-run the relevant `check` probe and report its actual
+result — never claim resolved on the reader's report that they installed something.
+
+Re-running `apply` after everything passes changes nothing and reports "already configured".
+
+## What this skill does NOT do
+
+- Run the spell checker — editing any file exercises the hook end-to-end. The only
+  execution `check` performs is the harmless `typos --version` liveness probe and a
+  read-only `typos --dump-config -`; it never fixes or touches repository content.
+- Write anything: not the repository (including `_typos.toml`), not Claude Code user
+  settings, not `pluginConfigs`, not the plugin cache. Every prerequisite is a `PATH`
+  binary or the native toggle, so remediation is guidance only.
+- Download or execute tools during `check` beyond the read-only presence and
+  `--version`/`--dump-config` probes.


### PR DESCRIPTION
## Summary

New plugin — `plugins/typos-format/` — a PostToolUse hook that runs `typos -w` on every
edited file, auto-fixing unambiguous spelling mistakes and surfacing residual (ambiguous)
findings via `additionalContext`. Zero-config: uses typos' built-in dictionary and the
consuming repo's own optional `_typos.toml` allowlist.

## Fix

- `PostToolUse` hook on `Write|Edit`, no extension filter (typos is a cross-language spell
  checker, not a single-ecosystem formatter) — `typos --force-exclude -w --format json
  <file>` runs against every edited file.
- `--force-exclude` is load-bearing, not cosmetic: verified empirically (typos-cli 1.44.0)
  that without it, an explicitly-named file bypasses BOTH the consumer's `[files]
  extend-exclude` globs AND typos' own binary-file detection — an unflagged hook would
  scan every binary edit for garbage "typos". With it, both are honored.
- Config/allowlist discovery is anchored on the **edited file itself**, not the hook's cwd
  (verified: an absolute file path checked from an unrelated working directory still
  resolves a `_typos.toml` several directories above it) — so, unlike markdownlint-cli2,
  this hook never needs to `cd` to the repo root.
- `typos -w --format json` in one pass already yields exactly the residual findings —
  fixed typos never appear in that output (verified), so no separate fix-then-verify pass
  is needed (simpler than the markdown-format/ruff-format two-pass shape).
- Exit codes (verified against typos-cli 1.44.0, undocumented beyond the CLI's own
  `--format json` note): `0` = clean, `2` = residual findings remain, anything else = the
  tool itself broke (bad config, internal error) rather than rendering a spelling judgment.
- Advisory only: hook always exits `0`. Kill switch: `typos_format_enabled` `userConfig`
  boolean (default `true`).
- `/typos-format:setup` skill on the uniform check-centric contract (`check` read-only,
  `apply` guidance-only — every prerequisite is a `PATH` binary or the native toggle, so
  there is no write path).
- Initial version **`0.1.0`** — confirmed via `git log` on `bash-lint`'s (now `bash-format`)
  founding commit that a brand-new plugin's first `plugin.json` uses `0.1.0` with no
  `CHANGELOG.md` entry at creation; the changelog only starts recording at the first
  subsequent change. No clearer format-hook precedent exists for a from-scratch plugin.

## Verification

- `bash plugins/typos-format/hooks/typos-format.test.sh` — 63/64 assertions pass. The one
  failure (`telemetry/slow-sink` C1 fd1-leak timing, expects <2000ms) is a pre-existing
  platform-specific flake on this Windows/Git Bash machine, **not** introduced by this
  change: `plugins/markdown-format/hooks/markdown-format.test.sh` (untouched, already on
  `main`) fails the identical assertion on the same machine (5182ms vs. the 2000ms bound).
- `scripts/sync-hook-utils.sh --check` — pass (11/11 plugin copies match `lib/hook-utils.sh`).
- `scripts/check-silent-skips.sh` — pass (missing-`typos`/missing-`jq` paths use
  `hook::notice_once` + `hook::emit_skip_notice`).
- `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` — pass.
- `node scripts/validate-plugin-contracts.mjs` — pass (1913 plugin files checked).
- `node scripts/generate-catalog.mjs --check` — pass (catalog in sync with `marketplace.json`).
- `claude plugin validate plugins/typos-format/` — pass.
- Every empirical claim above (config-discovery anchor, `--force-exclude` behavior, exit
  codes, ambiguous-correction handling) was independently re-derived by hand against a real
  `typos-cli 1.44.0` binary before this PR touched any file — see prior turns in the
  authoring session for the raw transcript.

Known gap, left as-is on purpose: CI's `plugin-gate` job does not install `typos` (unlike
`shellcheck`/`biome`/`ruff`, which it does install), so `typos-format.test.sh` will SKIP
there rather than execute its behavioral assertions — this mirrors the existing, documented
`shfmt`-optional precedent in `scripts/run-plugin-tests.sh` ("an individual test SKIPs when
an optional tool it needs is absent"). Provisioning `typos` onto the CI runner is a
separate, shared-`ci.yml` change outside this PR's scope.

Closes #831

## Related

- Epic: #830
- Brief item 1, `docs/topics/lint-static-analysis-gaps/PLAN.md`
- Templated from `plugins/markdown-format/` (issue-named primary template) and
  `plugins/ruff-format/` (closer analog for the config-driven exclude/discovery shape,
  e.g. `--force-exclude` rationale)

## Provenance note

This worktree was briefed as "completely clean, no prior work" but already contained a
complete, uncommitted implementation (hook script, tests, README, CHANGELOG, setup skill,
plus `marketplace.json`/`README.md` edits) from an untracked prior session. Before building
on it, every non-trivial behavioral claim in the code/tests/docs was independently
re-verified by hand against a real `typos` binary (see Verification above) rather than
trusted as-is; nothing was taken on faith. It matched my own independent findings closely,
so it was kept rather than rewritten.