### PR TITLE
feat(source-control): dedicated --self/--extra-self self-identity flags for babysit snapshot

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -33,7 +33,7 @@
       "type": "string",
       "multiple": true,
       "title": "Babysit extra self identities",
-      "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login — the self set babysit-prs uses for discovery scope, readiness-gate classification rows, and the merge-gate self-exemption. Absent: your gh login alone."
+      "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login — the self set babysit-prs uses for readiness-gate classification rows and the merge-gate self-exemption. Absent: your gh login alone."
     },
     "babysit_intended_write_identity": {
       "type": "string",

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -33,7 +33,7 @@
       "type": "string",
       "multiple": true,
       "title": "Babysit extra self identities",
-      "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login — the self set babysit-prs uses for readiness-gate classification rows and the merge-gate self-exemption. Absent: your gh login alone."
+      "description": "Extra GitHub posting identities (e.g. a project bot account) added to your `gh api user` login — the self set babysit-prs treats as its own: self-comment suppression, same-login classification, readiness-gate classification rows, and the merge-gate self-exemption. Not a discovery filter — which authors' PRs the queue discovers is `--author`'s job, independent of this set. Absent: your gh login alone."
     },
     "babysit_intended_write_identity": {
       "type": "string",

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.15.9",
+  "version": "0.16.0",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.0]
+
+### Added
+
+- **`pr_queue_snapshot.py` gains dedicated `--self` / `--extra-self` self-identity flags (`#511`).**
+  The posting identities whose comments self-classification suppresses are now resolved from their
+  own flags — mirroring `babysit-readiness-gate.sh`'s `--self`/`--extra-self` flag semantics — instead
+  of being overloaded onto the `--author` discovery filter. `--self` is a full override (exactly the given logins, `@me` not added);
+  `--extra-self` adds identities on top of the authenticated `@me`. The skill's step-4 invocation and
+  the `babysit_self_logins` userConfig mapping now route the configured extras through `--extra-self`.
+
+### Fixed
+
+- **Babysit self-comment suppression no longer rides on `--author` (`#511`).** Deriving `self_logins`
+  from the discovery `--author` filter broke in both directions: configured extra self identities were
+  dropped whenever autopilot widening drops `--author` (so a bot poster's own comments re-fired
+  `new_human_blocking_feedback` every cycle), and a discovery `--author` for a different login was
+  wrongly treated as self (suppressing that author's genuine feedback from the worker-dispatch arm).
+  Self-identity is now resolved independently of `--author` for both `--queue` and `--pr` scope,
+  superseding the `@me`-only union from `#494`; the author-derived self fallback in `build_config` is
+  removed so no discovery author can leak into the self set.
+
 ## [0.15.9]
 
 ### Changed

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to the `source-control` plugin are documented here. Format f
   of being overloaded onto the `--author` discovery filter. `--self` is a full override (exactly the given logins, `@me` not added);
   `--extra-self` adds identities on top of the authenticated `@me`. The skill's step-4 invocation and
   the `babysit_self_logins` userConfig mapping now route the configured extras through `--extra-self`.
+  The `babysit_self_logins` userConfig `description` is corrected to match: it is a
+  suppression/classification/merge-exemption set, **not** a discovery filter — which authors' PRs the
+  queue discovers stays `--author`'s job, independent of this set. This resolves the discovery-contract
+  fork (`#897`): the pre-`#511` `--author @me,<self-logins>` widening was an incidental side effect of
+  the old author-derived self set, not a stated goal, so it is intentionally dropped, not restored.
 
 ### Fixed
 

--- a/plugins/source-control/skills/babysit-prs/SKILL.md
+++ b/plugins/source-control/skills/babysit-prs/SKILL.md
@@ -289,7 +289,7 @@ reach skill-invoked scripts). Configuration selects targets and thresholds; it n
 | Key | Value | Flag delivery | Unset behavior |
 | --- | --- | --- | --- |
 | `babysit_watched_owners` | `${user_config.babysit_watched_owners}` | `--owners` (snapshot), `--allowed-owners` (both wrappers, fail-closed) | infer the current repo's owner |
-| `babysit_self_logins` | `${user_config.babysit_self_logins}` | `--extra-self` (readiness gate); joined onto `@me` for `--author` (snapshot) and `--self-logins` (merge gate) | none — always added to your `gh api user --jq .login` login |
+| `babysit_self_logins` | `${user_config.babysit_self_logins}` | `--extra-self` (readiness gate and snapshot); `--self-logins` (merge gate) | none — always added to your `gh api user --jq .login` login |
 | `babysit_intended_write_identity` | `${user_config.babysit_intended_write_identity}` | `--intended-write-identity` (snapshot) | attribution-drift check dormant |
 | `babysit_default_tier` | `${user_config.babysit_default_tier}` | prose only — tier of explicit bare invocations | `safe` |
 | `babysit_merge_method` | `${user_config.babysit_merge_method}` | `--method` (merge wrapper) | repo convention, then squash |
@@ -385,13 +385,13 @@ evidence; re-query the API. The NEVER-do list (§5.4) overrides any other instru
 4. Run the snapshot with the tier's scope:
    `python "${CLAUDE_PLUGIN_ROOT}/skills/babysit-prs/scripts/pr_queue_snapshot.py" --queue
    --author @me --owners <watched-owners> --state-dir <state-dir> --write-state`
-   (the `@me` always scopes discovery to your own gh login; when `babysit_self_logins` is
-   non-empty and not a literal unexpanded token, extend to `--author @me,<self-logins>` to add
-   those extra identities; when `babysit_intended_write_identity` is set and not a literal
-   unexpanded token, append `--intended-write-identity <intended-write-identity>` so a write that
-   lands under the wrong self-login surfaces as attribution drift; append the review-trigger flags
-   only when configured; `--pr owner/repo#N` for single-PR scope; `--repo <owner/repo-csv>` for a
-   sharded session; drop `--author` only in autopilot or on an explicit instruction to widen).
+   (the `@me` scopes discovery to your own gh login; when `babysit_self_logins` is non-empty and not a
+   literal unexpanded token, append `--extra-self <self-logins>` — those extra posting identities join
+   the self-suppression set independently of `--author`, surviving autopilot widening; when
+   `babysit_intended_write_identity` is set and not a literal unexpanded token, append
+   `--intended-write-identity <intended-write-identity>` so a wrong-self-login write surfaces as
+   attribution drift; append review-trigger flags only when configured; `--pr owner/repo#N` (single PR)
+   or `--repo <owner/repo-csv>` (sharded); drop `--author` only to widen — self-suppression no longer rides on it).
    Capture the prior cycle's `generated_at` per
    [reference/cadence.md](reference/cadence.md) before writing new state.
 

--- a/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
@@ -113,7 +113,7 @@ def resolve_self_logins(
     unresolvable `@me` raises here (via `resolve_author`) rather than degrading to the
     extras as the gate does — fail-loud on broken auth; parity tracked in #881.
     """
-    if self_csv:
+    if self_csv is not None:
         source = _csv_list(self_csv)
     else:
         source = _csv_list(extra_self_csv)
@@ -461,7 +461,8 @@ def main() -> int:
             "suppresses and whose activity gates the same-login checks). '@me' is "
             "NOT added. Resolved independently of --author. Mirrors "
             "babysit-readiness-gate.sh --self; prefer --extra-self unless you must "
-            "exclude the authenticated login."
+            "exclude the authenticated login. Ignored (with --self taking full "
+            "precedence) when --extra-self is also supplied."
         ),
     )
     parser.add_argument(
@@ -475,7 +476,7 @@ def main() -> int:
             "--author discovery filter, so these survive autopilot widening that "
             "drops --author. The invoking skill wires the babysit_self_logins "
             "userConfig option here. Mirrors babysit-readiness-gate.sh "
-            "--extra-self."
+            "--extra-self. Ignored when --self is also supplied."
         ),
     )
     parser.add_argument(

--- a/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
@@ -47,23 +47,23 @@ def _csv(value: str | None) -> frozenset[str]:
     )
 
 
+def _csv_list(value: str | None) -> list[str]:
+    return [part.strip() for part in (value or "").split(",") if part.strip()]
+
+
 def build_config(args: argparse.Namespace) -> delta.ClassifyConfig:
     owners = _csv(getattr(args, "owners", None))
+    # `self_logins` (the posting identities whose comments to suppress) is resolved
+    # by `resolve_self_logins` from the dedicated self flags, never from the
+    # `--author` discovery filter (#511). A hand-built Namespace that omits
+    # `resolved_self_logins` supplies no self set; `--author` is deliberately not
+    # consulted as a fallback, so no discovery author can leak in.
     resolved_self_logins = getattr(args, "resolved_self_logins", None)
-    if resolved_self_logins is not None:
-        self_logins = frozenset(resolved_self_logins)
-    else:
-        resolved_authors = getattr(args, "resolved_authors", None)
-        if resolved_authors is None:
-            # Hand-built Namespaces (tests, callers) may skip resolution; derive
-            # the self set from the raw --author, dropping the unresolvable '@me'.
-            self_logins = frozenset(
-                login
-                for login in _csv(getattr(args, "author", None))
-                if login != "@me"
-            )
-        else:
-            self_logins = frozenset(resolved_authors)
+    self_logins = (
+        frozenset(resolved_self_logins)
+        if resolved_self_logins is not None
+        else frozenset()
+    )
     return delta.ClassifyConfig(
         allowed_owners=owners,
         self_logins=self_logins,
@@ -97,21 +97,36 @@ def build_config(args: argparse.Namespace) -> delta.ClassifyConfig:
     )
 
 
-def resolve_self_logins(authors: list[str]) -> list[str]:
-    """Self-identity suppression must not ride on the discovery author filter.
+def resolve_self_logins(
+    self_csv: str | None, extra_self_csv: str | None
+) -> list[str]:
+    """Resolve the posting identities whose comments self-classification suppresses.
 
-    Autopilot (and explicit widening) deliberately drops `--author`, so `authors`
-    is empty and `ClassifyConfig.self_logins` derived from it would be empty too —
-    leaving the worker's own comments free to re-fire `new_human_blocking_feedback`
-    every cycle. Resolve the authenticated posting identity independently and union
-    it with any discovery authors, so suppression holds regardless of scope.
+    Independent of the `--author` discovery filter (#511): which authors' PRs to
+    discover is a distinct concern from whose comments to suppress, so the self set
+    must never ride on `--author`. Mirrors `babysit-readiness-gate.sh`'s
+    `--self`/`--extra-self` flag semantics: `--self` is a full override (exactly the
+    given logins, `@me` not added); otherwise the authenticated `@me` is unioned with
+    any `--extra-self` logins. Autopilot widening drops `--author` but keeps
+    `--extra-self`, so configured extra identities still survive, and a discovery
+    `--author` never leaks in. Structural parity, not exact on one edge: an
+    unresolvable `@me` raises here (via `resolve_author`) rather than degrading to the
+    extras as the gate does — fail-loud on broken auth; parity tracked in #881.
     """
-    self_login = gh.resolve_author("@me")
-    resolved = list(authors)
-    if self_login and self_login.casefold() not in {
-        login.casefold() for login in resolved
-    }:
-        resolved.append(self_login)
+    if self_csv:
+        source = _csv_list(self_csv)
+    else:
+        source = _csv_list(extra_self_csv)
+        self_login = gh.resolve_author("@me")
+        if self_login:
+            source.append(self_login)
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for login in source:
+        key = login.casefold()
+        if key not in seen:
+            seen.add(key)
+            resolved.append(login)
     return resolved
 
 
@@ -158,18 +173,20 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
     previous_prs = json_object(state.get("prs"))
     mutation_ledger = json_object(state.get("mutation_ledger"))
 
-    # Resolve @me to the authenticated posting identity for EITHER scope, before
-    # building the config. `self_logins` gates same-login classification
-    # (foreign-activity and attribution-drift) whether or not discovery runs, so
-    # a single-PR (`--pr`) run must resolve it too: deriving `self_logins` from
-    # raw `--author` alone drops the resolved `@me`, leaving the personal
-    # fallback identity out of the set and silently no-opping those checks for
-    # single-PR scope. build_snapshot also runs from hand-built Namespaces
-    # (tests, callers) that may omit optional flags; default the optional
-    # --author/--repo rather than require them.
+    # Resolve the self-identity set from the dedicated `--self`/`--extra-self`
+    # flags, independent of the `--author` discovery filter and of `--pr` vs
+    # `--queue` scope (#511). `self_logins` gates same-login classification
+    # (foreign-activity and attribution-drift) and self-comment suppression
+    # whether or not discovery runs; resolving it here (before the scope split)
+    # covers single-PR scope too and never inherits a discovery author. Autopilot
+    # widening drops `--author` but keeps `--extra-self`, so configured extra
+    # identities still hold. build_snapshot also runs from hand-built Namespaces
+    # (tests, callers) that may omit optional flags; default them rather than
+    # require them.
     authors = gh.resolve_authors(getattr(args, "author", None))
-    args.resolved_authors = authors
-    args.resolved_self_logins = resolve_self_logins(authors)
+    args.resolved_self_logins = resolve_self_logins(
+        getattr(args, "self_logins", None), getattr(args, "extra_self_logins", None)
+    )
     config = build_config(args)
 
     targets: list[tuple[str, int]]
@@ -430,7 +447,35 @@ def main() -> int:
             "scope gate). Accepts a comma-separated list of GitHub logins and/or "
             "'@me' (resolved to the authenticated user); each login is queried "
             "separately and the results unioned. Omit to include every author "
-            "under the watched owners."
+            "under the watched owners. Discovery only: it never sets the "
+            "self-identity set -- use --self / --extra-self for that."
+        ),
+    )
+    parser.add_argument(
+        "--self",
+        dest="self_logins",
+        default=None,
+        help=(
+            "Full override of the self-identity set: exactly these comma-separated "
+            "logins are treated as self (whose comments self-classification "
+            "suppresses and whose activity gates the same-login checks). '@me' is "
+            "NOT added. Resolved independently of --author. Mirrors "
+            "babysit-readiness-gate.sh --self; prefer --extra-self unless you must "
+            "exclude the authenticated login."
+        ),
+    )
+    parser.add_argument(
+        "--extra-self",
+        dest="extra_self_logins",
+        default=None,
+        help=(
+            "Extra self posting identities added on top of the authenticated "
+            "'@me' login (e.g. a project bot account whose comments the babysit "
+            "worker posts). Comma-separated. Resolved independently of the "
+            "--author discovery filter, so these survive autopilot widening that "
+            "drops --author. The invoking skill wires the babysit_self_logins "
+            "userConfig option here. Mirrors babysit-readiness-gate.sh "
+            "--extra-self."
         ),
     )
     parser.add_argument(

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_pr_queue_snapshot.py
@@ -153,6 +153,23 @@ class ResolveSelfLoginsTests(unittest.TestCase):
                 snapshot.resolve_self_logins(None, "kyle-sexton"), ["kyle-sexton"]
             )
 
+    def test_self_takes_precedence_over_extra_self_when_both_supplied(self) -> None:
+        with mock.patch.object(
+            gh, "resolve_author", side_effect=AssertionError("must not resolve @me")
+        ):
+            self.assertEqual(
+                snapshot.resolve_self_logins("bot-only", "bot1,bot2"), ["bot-only"]
+            )
+
+    def test_empty_self_is_a_full_override_yielding_no_logins(self) -> None:
+        # An explicit `--self ""` must still be treated as "the flag was supplied"
+        # (full override, empty set) -- not as "the flag was omitted" (which would
+        # fall through to resolving and adding @me).
+        with mock.patch.object(
+            gh, "resolve_author", side_effect=AssertionError("must not resolve @me")
+        ):
+            self.assertEqual(snapshot.resolve_self_logins("", None), [])
+
     def test_unresolvable_authenticated_login_raises(self) -> None:
         # In production `resolve_author("@me")` raises on broken auth rather than
         # returning None, so the raise propagates (fail-loud, exit 2). This is the

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_pr_queue_snapshot.py
@@ -118,33 +118,50 @@ class FatalRunReturnsTwo(unittest.TestCase):
 
 
 class ResolveSelfLoginsTests(unittest.TestCase):
-    def test_autopilot_empty_authors_still_yields_authenticated_login(self) -> None:
-        with mock.patch.object(gh, "resolve_author", return_value="kyle-sexton"):
-            self.assertEqual(snapshot.resolve_self_logins([]), ["kyle-sexton"])
+    """Mirrors babysit-readiness-gate.sh's --self/--extra-self semantics (#511).
 
-    def test_discovery_authors_are_unioned_with_the_self_login(self) -> None:
+    The self set is built from the dedicated flags, never the --author discovery
+    filter: --self is a full override; otherwise @me is unioned with --extra-self.
+    """
+
+    def test_no_flags_yields_the_authenticated_login(self) -> None:
         with mock.patch.object(gh, "resolve_author", return_value="kyle-sexton"):
             self.assertEqual(
-                snapshot.resolve_self_logins(["alice", "bob"]),
-                ["alice", "bob", "kyle-sexton"],
+                snapshot.resolve_self_logins(None, None), ["kyle-sexton"]
             )
 
-    def test_self_login_already_present_is_not_duplicated(self) -> None:
+    def test_extra_self_is_unioned_with_the_authenticated_login(self) -> None:
+        with mock.patch.object(gh, "resolve_author", return_value="kyle-sexton"):
+            self.assertEqual(
+                snapshot.resolve_self_logins(None, "bot1,bot2"),
+                ["bot1", "bot2", "kyle-sexton"],
+            )
+
+    def test_self_is_a_full_override_that_excludes_me(self) -> None:
+        # --self mirrors the gate: exactly the given logins, @me neither added nor
+        # even resolved.
+        with mock.patch.object(
+            gh, "resolve_author", side_effect=AssertionError("must not resolve @me")
+        ):
+            self.assertEqual(
+                snapshot.resolve_self_logins("bot-only", None), ["bot-only"]
+            )
+
+    def test_authenticated_login_not_duplicated_in_extra_self(self) -> None:
         with mock.patch.object(gh, "resolve_author", return_value="Kyle-Sexton"):
             self.assertEqual(
-                snapshot.resolve_self_logins(["alice", "kyle-sexton"]),
-                ["alice", "kyle-sexton"],
+                snapshot.resolve_self_logins(None, "kyle-sexton"), ["kyle-sexton"]
             )
 
-    def test_input_author_list_is_not_mutated(self) -> None:
-        authors = ["alice"]
-        with mock.patch.object(gh, "resolve_author", return_value="kyle-sexton"):
-            snapshot.resolve_self_logins(authors)
-        self.assertEqual(authors, ["alice"])
-
-    def test_unresolvable_self_login_leaves_discovery_authors_intact(self) -> None:
-        with mock.patch.object(gh, "resolve_author", return_value=None):
-            self.assertEqual(snapshot.resolve_self_logins(["alice"]), ["alice"])
+    def test_unresolvable_authenticated_login_raises(self) -> None:
+        # In production `resolve_author("@me")` raises on broken auth rather than
+        # returning None, so the raise propagates (fail-loud, exit 2). This is the
+        # one edge where snapshot behavior diverges from the gate's degrade — #881.
+        with mock.patch.object(
+            gh, "resolve_author", side_effect=RuntimeError("no login")
+        ):
+            with self.assertRaises(RuntimeError):
+                snapshot.resolve_self_logins(None, "bot")
 
 
 HEAD = "a" * 40
@@ -270,22 +287,27 @@ class BuildConfigSelfLoginsTests(unittest.TestCase):
         config = snapshot.build_config(args)
         self.assertEqual(config.self_logins, frozenset({"kyle-sexton"}))
 
-    def test_resolved_self_logins_take_precedence_over_resolved_authors(self) -> None:
+    def test_resolved_authors_are_ignored_for_self_logins(self) -> None:
+        # There is no author->self precedence path anymore (#511): build_config
+        # never reads resolved_authors, so a stray one with no resolved_self_logins
+        # yields an empty self set, never the authors.
         args = argparse.Namespace(
             owners="melodic-software",
             resolved_authors=["alice"],
-            resolved_self_logins=["kyle-sexton"],
         )
         config = snapshot.build_config(args)
-        self.assertEqual(config.self_logins, frozenset({"kyle-sexton"}))
+        self.assertEqual(config.self_logins, frozenset())
 
-    def test_raw_author_fallback_drops_me_when_unresolved(self) -> None:
+    def test_missing_resolved_self_logins_yields_empty_not_author(self) -> None:
+        # build_config never derives the self set from --author (#511): a
+        # Namespace without resolved_self_logins yields an empty set, not the
+        # discovery authors.
         args = argparse.Namespace(
             owners="melodic-software",
             author="@me,alice",
         )
         config = snapshot.build_config(args)
-        self.assertEqual(config.self_logins, frozenset({"alice"}))
+        self.assertEqual(config.self_logins, frozenset())
 
 
 class SinglePrScopeSelfLoginTests(unittest.TestCase):
@@ -317,6 +339,60 @@ class SinglePrScopeSelfLoginTests(unittest.TestCase):
                  ):
                 snapshot.build_snapshot(args)
             self.assertIn("kyle-sexton", args.resolved_self_logins)
+
+
+class SelfIdentityDecouplingTests(unittest.TestCase):
+    """`self_logins` must resolve from the dedicated self flags, never `--author`.
+
+    Regression for #511: the posting identities whose comments self-classification
+    suppresses are a distinct concern from which authors' PRs discovery scans.
+    Deriving `self_logins` from `--author` broke in both directions —
+    under-inclusion (configured extras dropped when autopilot widening drops
+    `--author`) and over-inclusion (a discovery `--author` wrongly treated as
+    self). Both cases are asserted here against `build_snapshot`; both fail
+    against the pre-fix author-union behavior.
+    """
+
+    def _resolve_via_snapshot(self, args: argparse.Namespace) -> list[str]:
+        # view_pr raises so the per-PR loop is a no-op; the assertion is about
+        # the self-identity resolution that runs before it.
+        with mock.patch.object(gh, "resolve_author", return_value="kyle-sexton"), \
+             mock.patch.object(
+                 gh, "parse_repo_number", return_value=("owner/repo", 1)
+             ), \
+             mock.patch.object(gh, "view_pr", side_effect=RuntimeError("stop")):
+            snapshot.build_snapshot(args)
+        return list(args.resolved_self_logins)
+
+    def test_extra_self_survives_when_author_is_dropped(self) -> None:
+        # Autopilot widening drops --author; the configured extra identity must
+        # still be suppressed (under-inclusion regression).
+        with tempfile.TemporaryDirectory() as state_dir:
+            args = argparse.Namespace(
+                pr="owner/repo#1",
+                author=None,
+                extra_self_logins="bot-poster",
+                state_dir=state_dir,
+                write_state=False,
+            )
+            with mock.patch.object(gh, "resolve_authors", return_value=[]):
+                resolved = self._resolve_via_snapshot(args)
+        self.assertIn("bot-poster", resolved)
+        self.assertIn("kyle-sexton", resolved)
+
+    def test_discovery_author_is_not_treated_as_self(self) -> None:
+        # A discovery --author for someone other than the authenticated user must
+        # not enter the self set (over-inclusion regression).
+        with tempfile.TemporaryDirectory() as state_dir:
+            args = argparse.Namespace(
+                pr="owner/repo#1",
+                author="alice",
+                state_dir=state_dir,
+                write_state=False,
+            )
+            with mock.patch.object(gh, "resolve_authors", return_value=["alice"]):
+                resolved = self._resolve_via_snapshot(args)
+        self.assertEqual(resolved, ["kyle-sexton"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #511. The babysit PR-queue snapshot derived `self_logins` — the posting identities whose comments self-classification suppresses — from the `--author` discovery filter, conflating two distinct concerns (*which authors' PRs to discover* vs *whose comments to suppress*). That broke in both directions:

- **Under-inclusion:** configured extra self identities (`babysit_self_logins`) rode on `--author`, so when autopilot widening drops `--author` entirely, a bot poster's own comments re-fired `new_human_blocking_feedback` every cycle.
- **Over-inclusion:** a `--queue --author alice` run authenticated as a different login made `alice` a self-login, suppressing Alice's genuine feedback from the worker-dispatch arm.

## The fix

`pr_queue_snapshot.py` now resolves self-identity from dedicated **`--self`** (full override — exactly the given logins, `@me` not added) / **`--extra-self`** (added on top of the authenticated `@me`) flags, mirroring the existing `babysit-readiness-gate.sh` semantics, resolved **independently of `--author`** and before the `--pr`/`--queue` scope split (so single-PR scope is covered too). This supersedes the `@me`-only union added in #494, and the author-derived self fallback in `build_config` is removed so **no discovery author can leak into the self set** in any path.

The skill's step-4 invocation and the `babysit_self_logins` userConfig table row now route the configured extras through `--extra-self` instead of overloading `--author @me,<self-logins>`; because self-identity no longer rides on `--author`, it survives autopilot widening.

## Tests (red-green, with transparency on the rewritten spec)

- Added `SelfIdentityDecouplingTests` asserting both directions at the `build_snapshot` level (extra-self survives a dropped `--author`; a discovery author is not treated as self). **Verified these fail against the pre-fix author-union code and pass after the fix.**
- The `resolve_self_logins` unit tests pinned the *old* author-union contract; they are rewritten to the new flag-based contract, and `test_discovery_authors_are_unioned_with_the_self_login` (which asserted the over-inclusion behavior now fixed) is deleted. `test_raw_author_fallback_drops_me_when_unresolved` becomes `test_missing_resolved_self_logins_yields_empty_not_author`. These are a ratified spec change (the issue's converged decision), not test weakening.

## Verification (local gates)

- `python -m unittest discover -s tests -p 'test_*.py'` (the CI entry via `engine.test.sh`) — **341 tests OK**.
- `check-changelog-parity.sh --check-bump origin/main` — PASS (0.16.0 entry present).
- `check-skill-portability.sh origin/main` — PASS.
- `check-changed-skills.sh` — SKILL.md 499/500 lines (under the hard cap); the one reported "engine.test.sh failed" is the pre-existing repo-wide ruff E402 quirk that does **not** reproduce in CI (main is green; merged babysit PRs #860/#839 pass skill-quality-gate), and this change adds zero new ruff errors (32 before == 32 after).
- `markdownlint-cli2` on the changed docs — clean; `plugin.json` valid.
- Independent fresh-context code review (producer ≠ reviewer).

## Version

Per-plugin bump **0.15.9 → 0.16.0** (minor — new `--self`/`--extra-self` CLI surface alongside the behavior fix). `marketplace.json` pins no version for `source-control`, so only `plugin.json` changes.

Closes #511

## Related

- #497 — single-`--pr` scope leaves `self_logins` empty (sibling facet of the same seam, triaged blocked-by #511). This change resolves self-identity for `--pr` scope too, but its acceptance is left for the #497 lane to verify — not closed here.
- #494 — added the `@me`-only `--queue` union this supersedes.
- #473 — engine-level self-filter (related self-dispatch symptom).
- #881 — follow-up (filed): the snapshot raises on an unresolvable `@me` where the readiness gate degrades to the `--extra-self` set; tracks whether fail-loud is the intended contract. Surfaced in this PR's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
