### PR TITLE
docs(ruff-format): add hook-telemetry data schema + registry row

### DIFF
--- a/docs/conventions/hook-telemetry/README.md
+++ b/docs/conventions/hook-telemetry/README.md
@@ -154,6 +154,7 @@ producers without coordinating with them or each other.
 |----------|--------------|-------------|
 | `markdown-format` plugin | `markdown-format` | `data/markdown-format.schema.json` |
 | `typos-format` plugin | `typos-format` | `data/typos-format.schema.json` |
+| `ruff-format` plugin | `ruff-format` | `data/ruff-format.schema.json` |
 | `bash-format` plugin | `bash-format` | `data/bash-format.schema.json` |
 | `desktop-notification` plugin | `desktop-notification` | `data/desktop-notification.schema.json` |
 | `guardrails` plugin | `secret-pattern-detection` | `data/secret-pattern-detection.schema.json` |

--- a/docs/conventions/hook-telemetry/data/ruff-format.schema.json
+++ b/docs/conventions/hook-telemetry/data/ruff-format.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/hook-telemetry/data/ruff-format.schema.json",
+  "title": "ruff-format telemetry data",
+  "description": "Per-hook `data` payload for the ruff-format hook. Discovered from the envelope `hook` value \"ruff-format\". Evolves additive-only.",
+  "type": "object",
+  "required": ["tool", "file", "findings"],
+  "additionalProperties": true,
+  "properties": {
+    "tool": {
+      "type": "string",
+      "description": "Claude Code tool that triggered the hook (Write or Edit)."
+    },
+    "file": {
+      "type": "string",
+      "description": "Path of the formatted Python file, relative to the consuming repo root."
+    },
+    "findings": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Residual Ruff diagnostics remaining after check --fix and format, one concise line per diagnostic. Empty array = clean."
+    }
+  }
+}

--- a/plugins/ruff-format/.claude-plugin/plugin.json
+++ b/plugins/ruff-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "ruff-format",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Auto-format and lint Python on edit via Ruff, only when a Ruff config governs the repo — using the consuming repo's own Ruff config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/ruff-format/CHANGELOG.md
+++ b/plugins/ruff-format/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `ruff-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Fixed
+
+- Published `data/ruff-format.schema.json` in the hook-telemetry convention and
+  registered `ruff-format` in its Implementers table, closing the gap where the
+  hook's `hook::emit_telemetry("ruff-format", ...)` envelope had no per-hook
+  `data` schema for a consuming sink to validate against — unlike the sibling
+  `markdown-format` and `typos-format` producers. No hook behavior change.
+
 ## [0.4.2]
 
 ### Changed


### PR DESCRIPTION
## Summary

`plugins/ruff-format/hooks/ruff-format.sh` emits telemetry via `hook::emit_telemetry("ruff-format", ...)` but never shipped the hook-telemetry convention's per-hook data schema or Implementers table row, unlike the `markdown-format` and `typos-format` producers. Consumer sinks discovering the `ruff-format` `hook` value had no published `data` schema to validate against.

## Fix

- Added `docs/conventions/hook-telemetry/data/ruff-format.schema.json`, mirroring `markdown-format.schema.json`'s shape (`tool`, `file`, `findings: string[]`) — `ruff-format.sh` builds `data.findings` as an array of concise diagnostic lines from `ruff check --no-fix --output-format concise`, the same shape as markdown-format's lint-line findings (not typos-format's structured `{typo, corrections}` objects).
- Added the `ruff-format` row to the Implementers table in `docs/conventions/hook-telemetry/README.md`.
- Bumped `plugins/ruff-format/.claude-plugin/plugin.json` to `0.4.3` (patch — conformance fix, no hook behavior change) with a matching `CHANGELOG.md` entry.

Followed the same pattern as `typos-format`'s schema+registry-row addition (#872): no `hook-telemetry/CHANGELOG.md` entry, since per-hook `data` schemas are not separately version-stamped (README "Versioning").

## Verification

- `jq . docs/conventions/hook-telemetry/data/ruff-format.schema.json` and `jq . plugins/ruff-format/.claude-plugin/plugin.json` — both valid JSON.
- Re-fetched `origin/main` immediately before opening this PR and confirmed `plugins/ruff-format/.claude-plugin/plugin.json` was still at `0.4.2` (no collision with the version bump).
- Searched `scripts/run-plugin-tests.sh` and `scripts/aggregate-hygiene-results.sh` for an automated Implementers-table/schema-file consistency check — none exists; this gap is exactly what issue #874 is about, so verification here is manual: diffed against `markdown-format.schema.json` and `typos-format.schema.json` field-by-field, and cross-checked `data.findings`'s shape against the actual `jq` construction in `ruff-format.sh`'s `build_data_json`.
- `gh pr list --state open` showed no other open PR touching `plugins/ruff-format/` or `docs/conventions/hook-telemetry/` — no collision risk.

## Related

- Reference templates: `markdown-format` plugin's `data/markdown-format.schema.json` + registry row, and `typos-format` plugin's `data/typos-format.schema.json` + registry row (#872).
- Epic: #830 (`docs/topics/lint-static-analysis-gaps/PLAN.md`).

Closes #874