### PR TITLE
test(claude-config): add step-list-culling eval case to audit-instructions (0.9.1)

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Four audit skills for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), and audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.1]
+
+### Added
+
+- **`audit-instructions` eval: `step-list-culled-not-preserved`.** Exercises check I8's
+  step-list nuance: a mechanical numbered procedure is culled to intent plus hard constraints
+  (genuine ordering, safety gates, external contracts kept) rather than preserved verbatim.
+  Absorbed from the superseded `audit-model-fit` suite (its C2 analog), per the follow-up
+  material recorded when 0.9.0 removed that skill.
+
 ## [0.9.0]
 
 ### Added

--- a/plugins/claude-config/skills/audit-instructions/evals/evals.json
+++ b/plugins/claude-config/skills/audit-instructions/evals/evals.json
@@ -65,12 +65,13 @@
       "id": 6,
       "name": "step-list-culled-not-preserved",
       "prompt": "/claude-config:audit-instructions one of my skills spells out a 9-step numbered procedure for opening a PR — 'run git status, then git add, then write the message, then...'. Should a capable model keep all the steps?",
-      "expected_output": "Flags the mechanical numbered procedure as an I8 model-era finding (over-prescriptive step list) and proposes culling it to the intent plus the hard constraints — ordering that genuinely matters, safety gates, external contracts — removing steps that only narrate a procedure a current model already sequences correctly. It does not preserve all 9 steps verbatim, and it keeps any step that encodes a real ordering, safety, or contract requirement.",
+      "expected_output": "Flags the mechanical numbered procedure as an I8 model-era finding (over-prescriptive step list) and proposes culling it to the intent plus the hard constraints — ordering that genuinely matters, safety gates, external contracts — removing steps that only narrate a procedure a current model already sequences correctly. It does not preserve all 9 steps verbatim, and it keeps any step that encodes a real ordering, safety, or contract requirement. Because I8 is behavioral-tier, the cull reaches the report as a verify-pass-vetted behavioral proposal, not an unverified confident removal.",
       "files": [],
       "expectations": [
         "Identifies the numbered step list as an I8 over-prescriptive finding",
         "Proposes culling to intent plus hard constraints rather than keeping all steps verbatim",
-        "Keeps steps that encode a genuine ordering, safety-gate, or external-contract requirement"
+        "Keeps steps that encode a genuine ordering, safety-gate, or external-contract requirement",
+        "Surfaces the cull as a behavioral proposal that passed the fresh-context verify pass, not an unverified confident removal"
       ]
     }
   ]

--- a/plugins/claude-config/skills/audit-instructions/evals/evals.json
+++ b/plugins/claude-config/skills/audit-instructions/evals/evals.json
@@ -64,13 +64,14 @@
     {
       "id": 6,
       "name": "step-list-culled-not-preserved",
-      "prompt": "/claude-config:audit-instructions one of my skills spells out a 9-step numbered procedure for opening a PR — 'run git status, then git add, then write the message, then...'. Should a capable model keep all the steps?",
-      "expected_output": "Flags the mechanical numbered procedure as an I8 model-era finding (over-prescriptive step list) and proposes culling it to the intent plus the hard constraints — ordering that genuinely matters, safety gates, external contracts — removing steps that only narrate a procedure a current model already sequences correctly. It does not preserve all 9 steps verbatim, and it keeps any step that encodes a real ordering, safety, or contract requirement. Because I8 is behavioral-tier, the cull reaches the report as a verify-pass-vetted behavioral proposal, not an unverified confident removal.",
+      "prompt": "/claude-config:audit-instructions one of my skills spells out a 9-step numbered procedure for opening a PR: 1. run git status to see what changed; 2. run git diff to review the changes; 3. stage the files with git add; 4. write a commit message; 5. run the test suite and stop if it fails; 6. commit; 7. push the branch; 8. title the PR per Conventional Commits (CI rejects other titles); 9. open the PR with gh pr create. Should a capable model keep all the steps?",
+      "expected_output": "Flags the mechanical numbered procedure as an I8 model-era finding (over-prescriptive step list) and proposes culling it to the intent plus the hard constraints, removing the narration steps (status/diff/add/message/commit/push — a procedure a current model already sequences correctly) while keeping the steps that encode a real safety gate or external contract: run-tests-and-stop-on-failure (step 5) and the Conventional Commits PR-title requirement CI enforces (step 8). It does not preserve all 9 steps verbatim. Because I8 is behavioral-tier, the cull reaches the report as a verify-pass-vetted behavioral proposal, not an unverified confident removal.",
       "files": [],
       "expectations": [
         "Identifies the numbered step list as an I8 over-prescriptive finding",
-        "Proposes culling to intent plus hard constraints rather than keeping all steps verbatim",
-        "Keeps steps that encode a genuine ordering, safety-gate, or external-contract requirement",
+        "Proposes culling to intent plus hard constraints rather than keeping all 9 steps verbatim",
+        "Keeps the test-gate step (run tests, stop on failure) and the CI-enforced Conventional Commits PR-title step as load-bearing",
+        "Culls narration steps (git status/diff/add/commit/push) that a current model sequences correctly from intent",
         "Surfaces the cull as a behavioral proposal that passed the fresh-context verify pass, not an unverified confident removal"
       ]
     }

--- a/plugins/claude-config/skills/audit-instructions/evals/evals.json
+++ b/plugins/claude-config/skills/audit-instructions/evals/evals.json
@@ -60,6 +60,18 @@
         "Demotes a proposal the verifier defends to info or drops it, rather than presenting it as a confident removal",
         "Does not present a refuted or behavioral-tier removal as an error or an applied change"
       ]
+    },
+    {
+      "id": 6,
+      "name": "step-list-culled-not-preserved",
+      "prompt": "/claude-config:audit-instructions one of my skills spells out a 9-step numbered procedure for opening a PR — 'run git status, then git add, then write the message, then...'. Should a capable model keep all the steps?",
+      "expected_output": "Flags the mechanical numbered procedure as an I8 model-era finding (over-prescriptive step list) and proposes culling it to the intent plus the hard constraints — ordering that genuinely matters, safety gates, external contracts — removing steps that only narrate a procedure a current model already sequences correctly. It does not preserve all 9 steps verbatim, and it keeps any step that encodes a real ordering, safety, or contract requirement.",
+      "files": [],
+      "expectations": [
+        "Identifies the numbered step list as an I8 over-prescriptive finding",
+        "Proposes culling to intent plus hard constraints rather than keeping all steps verbatim",
+        "Keeps steps that encode a genuine ordering, safety-gate, or external-contract requirement"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds the step-list-culling eval case to `claude-config:audit-instructions` — the second of two absorb candidates recorded in #870 when `audit-model-fit` was superseded.

Closes #889

## What ships

- **New eval case `step-list-culled-not-preserved`** (`evals/evals.json`, id 6): a mechanical 9-step numbered procedure must be flagged as an I8 (Model-era re-audit) over-prescriptive finding and culled to intent plus hard constraints — steps encoding genuine ordering, safety gates, or external contracts kept — never preserved verbatim. Modeled on the superseded suite's C2 analog, re-phrased against the I8 catalog.
- **claude-config 0.9.1** + CHANGELOG entry per changelog-parity.

## Verification

- `check-jsonschema` against `plugins/skill-quality/reference/evals.schema.json`: ok.
- Local gates green: check-changed-skills (check-skill PASS, 0 errors), changelog-parity `--check` + `--check-bump`, generate-catalog `--check`, validate-plugin-contracts, markdownlint.
- Fresh-context acceptance verifier: 5/5 criteria PASS (case shape/uniqueness, I8 mapping confirmed against `reference/criteria.md`, no mojibake from the historical source, bump + CHANGELOG parity, commit subject).

## Related

- #870 — supersede PR that recorded this absorb candidate as follow-up material.
- #888 — sibling absorb candidate (`!`-injected surface inventory), tracked separately.
- #800 / #809 — originating issue and the superseded `audit-model-fit` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
