### PR TITLE
feat(claude-memory): route model-era instruction findings to audit-instructions (0.3.2)

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.2]
+
+### Added
+
+- **`audit` skill: reciprocal scope-boundary note.** Model-era instruction-content findings
+  (prior-model workarounds, over-prescriptive scaffolding, bare prohibitions, reasoning-echo
+  directives, stale example scaffolding) now route to the `claude-config` plugin's
+  `audit-instructions` skill when that plugin is installed; absent it, such observations stay
+  in the audit report criteria-free rather than being judged against this checklist or
+  silently dropped. Completes the partition that skill declared toward this one.
+
 ## [0.3.1]
 
 ### Changed

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -33,6 +33,18 @@ the `audit` and `automation-gaps` skills in the `claude-config` plugin).
 | Auto-memory | `~/.claude/projects/<project>/memory/` | First 200 lines of MEMORY.md | Yes |
 | Settings, hooks, MCP, agents, skills | Various | Various | No — use `claude-config`'s `audit` / `automation-gaps` |
 
+## Scope boundary (route out)
+
+This audit owns instruction-layer **health**: structure, size, placement, and index integrity of
+the memory files against the codified checklist. Whether an instruction's *content* is still
+needed by the current model — prior-model workarounds, over-prescriptive scaffolding, bare
+prohibitions without rationale, reasoning-echo directives, stale example scaffolding — is the
+model-era fit question, owned by the `claude-config` plugin's `audit-instructions` skill. When
+that plugin is installed, route such findings to `/claude-config:audit-instructions` rather than
+judging them against this checklist; when it is not installed, keep each as a criteria-free
+observation in this audit's report (never a checklist finding, never silently dropped) so the
+operator can weigh it against current official prompting guidance.
+
 ## Argument parsing
 
 | Argument | Action |


### PR DESCRIPTION
Adds the reciprocal scope-boundary note to `claude-memory:audit`: model-era instruction-content findings now route to `claude-config:audit-instructions`, completing the one-way partition that skill declared toward claude-memory in #800. Deliberately split out of the #800 PR to keep each PR single-plugin.

Closes #868

## What ships

- **`audit` SKILL.md — new "Scope boundary (route out)" section**: claude-memory owns instruction-layer health (structure, size, placement, index integrity); model-era content fit (prior-model workarounds, over-prescriptive scaffolding, bare prohibitions without rationale, reasoning-echo directives, stale example scaffolding) routes to `/claude-config:audit-instructions`. Seam-phrased per `docs/conventions/seam-phrasing/README.md`: install gate ("when that plugin is installed"), stated fallback (observations stay in the report criteria-free — never a checklist finding, never silently dropped), ownership framing on both sides.
- **claude-memory 0.3.2** + CHANGELOG entry per changelog-parity.

## Verification

- Local gates green: check-changed-skills (check-skill PASS, 0 errors; 1 pre-existing no-Gotchas warning), changelog-parity `--check` + `--check-bump`, generate-catalog `--check`, validate-plugin-contracts, skill-portability lint, markdownlint.
- Fresh-context acceptance verifier: 5/5 criteria PASS — seam-phrasing shape (gate + fallback + ownership) confirmed against the convention doc; zero literal trigger-phrase collisions with audit-instructions' description and no check-ID enumeration; partition texts mirror without contradiction.

## Related

- #800 / #870 — the audit-instructions skill and the PR that declared the one-way partition this completes.
- `docs/conventions/seam-phrasing/README.md` — phrasing shape followed at the reference site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
