### PR TITLE
docs(work-items): sync triage SKILL attention-view + state machine with live labels

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, and raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states). The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.1]
+
+### Fixed
+
+- **Triage SKILL state machine + attention view reconciled with live labels (`#817`).** The
+  attention view's bucket list named only `status:needs-triage`, leaving a repo that files raw
+  intake on the priority axis (`priority:needs-triage`, per `#802`'s dual-axis Scope wording)
+  invisible to the no-arg attention view; the bucket now names both axes. Separately,
+  `status:needs-decision` was already referenced by the closing invariant as a routing outcome
+  that clears the raw marker, but was never introduced as a side exit in the state machine itself
+  (unlike `needs-info`, human-gated, and close) — it is now documented alongside them in the
+  side-exits sentence and the state diagram. Doc-only; no routing logic changed.
+
 ## [0.21.0]
 
 ### Added

--- a/plugins/work-items/skills/triage/SKILL.md
+++ b/plugins/work-items/skills/triage/SKILL.md
@@ -50,7 +50,7 @@ State names follow the plugin's vocabulary and the canonical roles ([`${CLAUDE_P
 | **briefed** | brief posted + `status:ready` | Fully specified as a behavioral contract (per [`${CLAUDE_PLUGIN_ROOT}/reference/agent-brief.md`](${CLAUDE_PLUGIN_ROOT}/reference/agent-brief.md)) |
 | **autonomous-eligible** | role label (default `agent-ready`) | Briefed AND delegable — eligible for autonomous pickup from the frontier |
 
-Side exits from any state: `status:needs-info` (returns to raw when the reporter replies), the human-gated role label (default `needs-human`), or close (wontfix / duplicate / already implemented).
+Side exits from any state: `status:needs-info` (returns to raw when the reporter replies), `status:needs-decision` (awaiting a human or maintainer judgment call), the human-gated role label (default `needs-human`), or close (wontfix / duplicate / already implemented).
 
 **A briefed item takes one of three exits**, distinguished by the decision its brief carries:
 
@@ -64,6 +64,7 @@ raw → verified → briefed
  |        |          ├→ decision-defaulted → autonomous-eligible + status:ready + "Decision defaulted: … — veto before merge"
  |        |          └→ human-gated (role label, default needs-human) — briefed for a human
  |        └→ status:needs-info → raw (on reporter reply)
+ ├→ status:needs-decision: awaiting a human or maintainer judgment call
  └→ close: wontfix | duplicate | already implemented
 ```
 
@@ -74,7 +75,7 @@ Claiming stays coordination state, not a label — assignee + lease via the seam
 Show three buckets (oldest first, one-line summaries):
 
 1. **Unlabeled** — never triaged
-2. **`status:needs-triage`** — explicitly tagged for evaluation
+2. **Raw marker** — `status:needs-triage` / `priority:needs-triage`, whichever axis the repo files it under — explicitly tagged for evaluation
 3. **`status:needs-info` with reporter activity** — reporter replied since last triage note; ready for re-evaluation
 
 List open items and filter into buckets programmatically (adapter: "List items", bare read). When the repo treats external PRs as a request surface, include them and tag each line `[PR]` or `[issue]` — but surface only *external* PRs (a collaborator's in-flight PR is not triage work; this filter is discovery-only, and an explicitly named PR is always triaged regardless of author). Present as a compact table.


### PR DESCRIPTION
## Summary

`plugins/work-items/skills/triage/SKILL.md` had two docs-match-reality gaps against shipped state:

- The "Attention view (no number)" bucket list named only the status-axis raw marker (`status:needs-triage`), leaving a repo that files raw intake on the priority axis (`priority:needs-triage`, per PR #802's already-merged dual-axis Scope wording) invisible to the no-arg attention view.
- `status:needs-decision` is a live, actively-used label (e.g. issue #505, per CHANGELOG `[0.16.1]`/`#562`), and the closing invariant already referenced it as a routing outcome that clears the raw marker — but the state machine itself never introduced it as a side exit, unlike `needs-info`, human-gated, and close.

## Fix

- Attention-view bucket 2 now reads "Raw marker — `status:needs-triage` / `priority:needs-triage`, whichever axis the repo files it under", mirroring the Scope section's exact dual-axis wording (SKILL.md line 35).
- The "Side exits from any state" sentence and the state-machine ASCII diagram now name `status:needs-decision` ("awaiting a human or maintainer judgment call" — the label's live GitHub description) alongside the existing side exits.
- Version-bumped `work-items` 0.21.0 → 0.21.1 (patch, matching the `#562` precedent for the same doc-only shape) with a matching CHANGELOG entry.

Scope note: the raw-state table row (line 48, `unlabeled or status:needs-triage`) is intentionally left single-axis — broader raw-marker axis canonicalization across that table, evals, and reference docs is issue #818's job, not this one. Also intentionally out of scope: adding `needs-decision` to step 2's "Target state" list or step 5's outcome table — doing so would require defining when triage applies it vs. the human-gated role, which the label's live usage does not settle (it appears both with and without `needs-human` across open issues) and which this issue scoped as pure docs-match-reality, not a design decision.

## Verification

- Confirmed PR #802's merged Scope-section wording verbatim (`gh pr view 802`): "carrying the raw marker (`status:needs-triage` / `priority:needs-triage`, whichever axis the repo files it under)" — the attention-view bucket now mirrors this exactly.
- Confirmed `status:needs-decision` is a live label via `gh issue list --label "status: needs-decision"` (21+ open/closed issues, e.g. #881, #718, #664, #551) and confirmed its GitHub description ("Awaiting a human or maintainer judgment call") used verbatim in the new SKILL.md text.
- Confirmed issue #505's prior routing to `status:needs-decision` via the plugin's own CHANGELOG `[0.16.1]` entry (`#562`), which already treated `needs-decision` as a routing outcome in the closing invariant — this PR closes the gap between that reference and the state machine's own introduction of the label.
- Traced the ASCII diagram's pipe/branch alignment by hand to confirm the new `status:needs-decision` line reads correctly as a side exit at the same indentation level as `close`.

Closes #817

## Related

- #817 (this fix)
- #802 (source of the dual-axis raw-marker wording mirrored here)
- #505 (live example of `status:needs-decision` usage; see also CHANGELOG `#562`)
- #818 — separate, unopened-PR item covering raw-marker axis canonicalization across the state table, evals, and reference docs; deliberately not touched here to avoid overlap. Re-checked immediately before opening this PR: no PR exists yet for #818.
- #853 — open draft PR (labeled `do-not-merge`, stale at plugin version 0.19.0) also touches `plugins/work-items/.claude-plugin/plugin.json` and `CHANGELOG.md` for an unrelated shell-test-helper doc change. Re-checked immediately before opening this PR: no version-bump collision — #853 is stale relative to current `main` (0.21.0) and will need to rebase regardless of this PR.

Claude-Session: https://claude.ai/code/session_01K1V3gkrfSf75isB8MiDy3o