### PR TITLE
feat(source-control): add machine-readable commit-convention enforcement seam

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,26 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/sync-parse-concern-value.sh --check-bump "origin/$BASE_REF"
 
+  resolve-convention-pattern-sync:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the PR base ref is resolvable for the bump gate.
+          fetch-depth: 0
+      - name: Verify plugin copies match the shared resolver
+        run: scripts/sync-resolve-convention-pattern.sh --check
+      - name: Run shared resolver tests
+        run: bash lib/resolve-convention-pattern.test.sh
+      - name: Verify consuming plugins bumped when the lib changed
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/sync-resolve-convention-pattern.sh --check-bump "origin/$BASE_REF"
+
   standards-contract-sync:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -661,6 +681,7 @@ jobs:
       - hygiene
       - hook-utils-sync
       - parse-concern-value-sync
+      - resolve-convention-pattern-sync
       - standards-contract-sync
       - cross-plugin-source-drift
       - skill-leaf-name-gate

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -629,6 +629,17 @@ migration gate and the plugin-acceptance security review below — before it shi
 degradation). Defer risky units (hard external dependencies, no graceful degradation) and any
 license-gated units to per-item triage rather than a blanket hold. The ordering is reversible.
 
+**Swim-lane execution (orchestrated fan-out).** When an orchestrator drives several units to merge in
+one effort, each unit is a **swim lane**: a dedicated worktree (created under the same
+identity-scoped directory root as the primary checkout, so the repo's commit/push identity applies —
+never a sibling path outside it), a feature branch named `<type>/<issue>-<slug>`, its own atomic PR
+that closes exactly one issue, driven independently through CI to a clean merge, then post-merge
+cleanup (delete the branch, remove the worktree). A **seams-first** unit whose contract binds
+downstream lanes lands and merges **before** the dependent lanes open, so they build on the merged
+contract rather than rediscovering it. Independent lanes run concurrently; lanes sharing a
+contract-blocking dependency wait on its merge. The shared-file conflicts above are still resolved by
+serializing the final merges, not authorship.
+
 ## Plugin-acceptance security review
 
 A plugin runs code on the consumer's machine and can wire Claude to external systems. **Every plugin accepted

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -280,6 +280,7 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Shared hook utility library | `lib/hook-utils.sh`, synced by `scripts/sync-hook-utils.sh` |
 | Cross-plugin shared-source clusters | `scripts/cross-plugin-source-registry.txt` |
 | Consumer-config layering and precedence | [`docs/conventions/consumer-config-layering/`](conventions/consumer-config-layering/README.md) |
+| Commit-convention enforcement seam | [`docs/conventions/commit-convention/`](conventions/commit-convention/README.md) |
 | Ecosystem command resolution | [`docs/conventions/ecosystem-commands/`](conventions/ecosystem-commands/README.md) |
 | Hook telemetry | [`docs/conventions/hook-telemetry/`](conventions/hook-telemetry/README.md) |
 | Hook precision (false-positive discipline) | [`docs/conventions/hook-precision/`](conventions/hook-precision/README.md) |

--- a/docs/conventions/commit-convention/README.md
+++ b/docs/conventions/commit-convention/README.md
@@ -1,0 +1,75 @@
+# Commit-convention enforcement seam
+
+Owner doc for the machine-readable **enforcement** read of a consumer's commit-subject /
+PR-title convention. This concern is consumed by **more than one plugin** — `source-control`
+authors and drafts against the convention, `guardrails` gates against it — so its ownership lives
+here at marketplace level, not inside either plugin, per
+[`docs/MIGRATION-PLAYBOOK.md`](../../MIGRATION-PLAYBOOK.md) "concern-named config consumed by >1
+plugin". A guardrails hook cites **this** doc, never `plugins/source-control/reference/`.
+
+## Two reads of one file
+
+The convention lives in the consumer's tracked `.claude/source-control.md` (H2-per-key markdown),
+resolved across three layers by the model per
+[`source-control/reference/config-resolution.md`](../../../plugins/source-control/reference/config-resolution.md).
+That document owns **drafting** resolution — how `/source-control:commit` and `/pull-request`
+compose a compliant subject/title. This seam owns the **enforcement** resolution — how a
+zero-dependency hook decides whether an *already-formed* subject/title is allowed.
+
+The two reads are deliberately not identical:
+
+| | Drafting (config-resolution.md) | Enforcement (this seam) |
+|---|---|---|
+| Reader | the model | a bash hook (`[[ =~ ]]` / `grep -E`) |
+| Layers read | all three (user-global, team, local), per-key merge | **team-tracked only** (`${REPO_ROOT}/.claude/source-control.md`) |
+| Fallthrough | CLAUDE.md/rules/hook, then bundled CC default | **none** — unresolved means no enforcement |
+| Dialect | any (the model interprets PCRE) | POSIX ERE only (normalized/rejected) |
+
+## The parse contract
+
+`lib/resolve-convention-pattern.sh` is the single source of truth. Given a repo root and a key
+(`subject_pattern` or `pr_title_pattern`) it emits an ERE regex on stdout, or nothing.
+
+1. **Value grammar.** The value is the **first non-empty body line** under the `## <key>` H2 in the
+   team-tracked file. (The surface already constrains machine-relevant keys to exactly one value —
+   never a list.)
+2. **`Conventional Commits` keyword** expands to the one canonical ERE the resolver owns —
+   `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+` — so the model's
+   interpretation and every hook's regex cannot drift.
+3. **`pr_title_pattern` deferral** — the literal `` Same as `subject_pattern`. `` resolves the
+   effective subject pattern instead.
+4. **Regex dialect = POSIX ERE — accepted or rejected, never translated.** The enforcement value
+   must already be POSIX ERE (write `[0-9]`, not `\d`). Translating PCRE→ERE by string rewriting is
+   unsound — bracket expressions, POSIX classes, and escaped backslashes all break naive
+   substitution — so the resolver does not attempt it. Any PCRE-only construct — a `(?...)` group
+   (non-capturing, lookaround, named), or any backslash-letter/digit escape (`\d \w \s \D \A \t \1`
+   …) — makes the pattern **non-enforceable**: the resolver emits nothing, writes a one-line
+   diagnostic to stderr, and the gate no-ops. A value that does not compile as ERE is likewise
+   non-enforceable. This keeps enforcement predictable and impossible to mistranslate; the model's
+   *drafting* side may still author PCRE-shaped patterns, but a team that wants a pattern *enforced*
+   writes it in ERE.
+
+## Two load-bearing contracts
+
+- **Unresolved = no enforcement.** No team-tracked pattern (or a non-enforceable one) → the gate does
+  nothing. A gate never blocks against the bundled Conventional Commits default: CC is not a
+  lane-1-eligible default (see [`docs/PLUGIN-PHILOSOPHY.md`](../../PLUGIN-PHILOSOPHY.md) "Two-lane
+  convention posture"), so gating an un-opted-in repo against it would impose a convention the
+  consumer never chose. **Enforcement strength = strength of explicit team config.**
+- **Policy-floor via team-only reads.** Enforcement reads the **tracked** team layer only; the
+  user-global and gitignored `*.local.md` overlays are drafting inputs a blocking gate never
+  consults. This is the floor *by construction* — a personal/gitignored file cannot weaken what the
+  gate enforces because the gate never looks at it, and "is regex A stricter than B" is undecidable,
+  so no merge could honor a "tighten-only" rule anyway. A user wanting a stricter personal gate
+  tightens team policy via PR; a looser personal preference is a drafting choice, never an
+  enforcement bypass.
+
+## Consumers
+
+- `guardrails` CC-layer content gate (#914) and opt-in `commit-msg` hook (#919) source the vendored
+  copy of the resolver; each registers its path in `scripts/sync-resolve-convention-pattern.sh` and
+  bumps the guardrails manifest so consumers receive the change.
+
+Naming coincidence recorded per the seam rules: the convention file is `.claude/source-control.md`
+after the concern (delivery workflow), not the plugin. The plugin-name collision is incidental; the
+file is not renamed.

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -200,7 +200,7 @@ open.
 
 | Surface | Consumer config path | Layers | Conformance |
 |---|---|---|---|
-| `source-control` | `.claude/source-control.md` | team only | single-layer; migration to all three in flight (#647) |
+| `source-control` | `.claude/source-control.md` | all three | conforms (per-key override, #660); enforcement reads team-tracked only per [`commit-convention`](../commit-convention/README.md) |
 | `toolchain` / `ecosystem-commands` | `.claude/ecosystems/<ecosystem>.yaml` | all three | conforms |
 | `codebase-health` | `.claude/codebase-health.md` | all three | conforms (concatenating, with a declared empty-list opt-out) |
 | `github` | `.claude/github/` (`routing.yaml` per-key override, `conventions.md` concatenating) | all three | conforms; policy-floor inversion on write-posture routing keys, declared in the plugin's `change-routing.md` |

--- a/lib/resolve-convention-pattern.sh
+++ b/lib/resolve-convention-pattern.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Resolve the ENFORCEMENT pattern for a source-control convention key
+# (`subject_pattern` / `pr_title_pattern`) to a POSIX-ERE regex a hook can hand
+# straight to `[[ =~ ]]` or `grep -E`, cross-platform.
+#
+# WHY THIS EXISTS: the convention surface (`.claude/source-control.md`, one
+# `## <key>` H2 per key) is authored for a MODEL to read — its `subject_pattern`
+# value may be the keyword `Conventional Commits` or a regex in PCRE dialect
+# (`(?:…)`, `\d`). A blocking hook cannot evaluate that: `grep -E` chokes on
+# `(?:`, and neither ERE engine knows `\d`. This centralizes the read + the
+# dialect normalization once, so `block-noncanonical-commit`, the CC-layer
+# content gate, and the opt-in `commit-msg` hook all enforce the SAME pattern
+# the SAME way — no per-hook re-fork, no drift.
+#
+# ENFORCEMENT ≠ DRAFTING — the policy-floor contract:
+#   Enforcement reads the TEAM-TRACKED layer ONLY:
+#   `${REPO_ROOT}/.claude/source-control.md`. The user-global
+#   (`~/.claude/source-control.md`) and gitignored local
+#   (`.claude/source-control.local.md`) overlays are DRAFTING inputs the model
+#   merges per `reference/config-resolution.md`; a blocking gate never reads
+#   them. That is the floor by construction: a personal/gitignored file cannot
+#   weaken what the gate enforces because the gate never looks at it, and
+#   "is regex A stricter than B" is undecidable so no merge could honor "tighten
+#   only" anyway. A team with no tracked pattern gets NO enforcement (never the
+#   bundled Conventional Commits default — that default is not lane-1-eligible,
+#   so gating an un-opted-in repo against it violates the two-lane posture).
+#
+# SINGLE SOURCE OF TRUTH: lib/resolve-convention-pattern.sh at the marketplace
+# repo root. Copies materialized into consuming plugins exist only because
+# installed plugins are cache-isolated and must be self-contained — never edit a
+# copy. Edit the source and run scripts/sync-resolve-convention-pattern.sh; CI
+# rejects drifted copies. Owner contract: docs/conventions/commit-convention/.
+#
+# Usage:
+#   resolve-convention-pattern.sh <repo_root> <subject_pattern|pr_title_pattern>
+#
+# Output: the resolved ERE regex on stdout (no trailing newline sensitivity), or
+#   NOTHING when the key is unresolved OR resolves to a pattern that cannot be
+#   expressed in ERE. A non-enforceable pattern additionally writes a one-line
+#   diagnostic to stderr. Exit status:
+#     0  a pattern was emitted (enforce it)
+#     1  no enforcement (unresolved, or non-ERE-expressible — stdout empty)
+#     2  usage error
+set -uo pipefail
+
+# The bundled Conventional Commits pattern — the ONE place the `Conventional
+# Commits` keyword expands, so the model's interpretation and every hook's regex
+# cannot drift. Mirrors /source-control:commit's documented expansion and is
+# already pure ERE (capturing groups, no `\d`).
+readonly CC_ERE='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+# shellcheck disable=SC2016  # backticks are a literal part of the deferral marker, not a substitution
+readonly PR_DEFERRAL='Same as `subject_pattern`.'
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit 0
+fi
+
+repo_root="${1:-}"
+key="${2:-}"
+
+if [[ -z "$repo_root" || -z "$key" ]]; then
+  echo "resolve-convention-pattern: usage: resolve-convention-pattern.sh <repo_root> <subject_pattern|pr_title_pattern>" >&2
+  exit 2
+fi
+case "$key" in
+subject_pattern | pr_title_pattern) ;;
+*)
+  echo "resolve-convention-pattern: key must be subject_pattern or pr_title_pattern, got '$key'" >&2
+  exit 2
+  ;;
+esac
+
+# Team-tracked layer only — the enforcement authority (see header).
+readonly TEAM_FILE="$repo_root/.claude/source-control.md"
+
+# First non-empty body line under `## <key>`, CR-stripped. Empty when the
+# section is absent or bodyless. Awk over sed: needs section-state, not a line
+# match.
+h2_value() {
+  local file="$1" k="$2"
+  [[ -f "$file" ]] || return 0
+  awk -v key="$k" '
+    BEGIN { in_section = 0 }
+    /^##[[:space:]]/ {
+      # A new H2 ends the target section.
+      hdr = $0; sub(/^##[[:space:]]+/, "", hdr); sub(/[[:space:]]+$/, "", hdr)
+      in_section = (hdr == key) ? 1 : 0
+      next
+    }
+    in_section {
+      line = $0; gsub(/\r/, "", line)
+      if (line ~ /^[[:space:]]*$/) next          # skip blank lines before the value
+      sub(/^[[:space:]]+/, "", line); sub(/[[:space:]]+$/, "", line)
+      print line; exit                            # first non-empty body line wins
+    }
+  ' "$file"
+}
+
+# Enforcement patterns are POSIX ERE, NOT PCRE. The resolver does not translate
+# a pattern (translating PCRE->ERE by string rewriting is unsound — bracket
+# expressions, POSIX classes, and escaped backslashes all break naive
+# substitution); it accepts a value that is already ERE and rejects one that
+# uses a PCRE-only construct, so a pattern the ERE engines would misread takes
+# the documented no-enforcement path instead of silently enforcing the wrong
+# thing. A team wanting a digit class writes `[0-9]`, not `\d`.
+is_non_ere() {
+  local p="$1"
+  # Any `(?...)` group — non-capturing `(?:`, lookaround `(?=`/`(?!`, named
+  # `(?<`/`(?P<`. POSIX ERE has none of these.
+  [[ "$p" == *'(?'* ]] && return 0
+  # Any backslash followed by a letter or digit: the shorthand classes
+  # \d \w \s \D \S \W, the anchors \A \Z \z \b \B, control escapes \t \n \r …,
+  # and backreferences \1..\9. POSIX ERE reads each as the literal character.
+  # A backslash before a metacharacter (`\.`, `\(`, `\+`) is valid ERE and stays
+  # allowed.
+  [[ "$p" =~ \\[a-zA-Z0-9] ]] && return 0
+  return 1
+}
+
+# Resolve one key's raw value from the team layer, expanding the CC keyword.
+raw_value() {
+  local k="$1" v
+  v="$(h2_value "$TEAM_FILE" "$k")"
+  [[ -n "$v" ]] || return 0
+  if [[ "$v" == "Conventional Commits" ]]; then
+    printf '%s' "$CC_ERE"
+  else
+    printf '%s' "$v"
+  fi
+}
+
+value="$(raw_value "$key")"
+
+# pr_title_pattern deferral: `Same as `subject_pattern`.` enforces the effective
+# subject pattern. Resolve against the raw (pre-expansion) pr_title value.
+if [[ "$key" == "pr_title_pattern" ]]; then
+  raw_pr="$(h2_value "$TEAM_FILE" "pr_title_pattern")"
+  if [[ "$raw_pr" == "$PR_DEFERRAL" ]]; then
+    value="$(raw_value "subject_pattern")"
+  fi
+fi
+
+# Unresolved -> no enforcement (exit 1, stdout empty). Never fall back to CC_ERE.
+[[ -n "$value" ]] || exit 1
+
+if is_non_ere "$value"; then
+  printf '%s\n' "resolve-convention-pattern: $key is not POSIX ERE (a PCRE-only construct: a (?...) group, or a backslash-letter/backslash-digit escape such as \\d \\A \\t \\1); enforcement disabled -- author the pattern in POSIX ERE (e.g. [0-9] not \\d) to enable the gate." >&2
+  exit 1
+fi
+
+# Safety net: reject anything that still does not compile as POSIX ERE (e.g. an
+# unbalanced `^[$`) so a bad config takes the no-enforcement path, never a hook
+# that would then error or wrongly block on it. grep -E exits >=2 on an invalid
+# expression, 0/1 on a valid one.
+grep -E -- "$value" </dev/null >/dev/null 2>&1
+if (($? >= 2)); then
+  printf '%s\n' "resolve-convention-pattern: $key does not compile as POSIX ERE; enforcement disabled." >&2
+  exit 1
+fi
+
+printf '%s\n' "$value"
+exit 0

--- a/lib/resolve-convention-pattern.test.sh
+++ b/lib/resolve-convention-pattern.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Regression tests for lib/resolve-convention-pattern.sh — the shared commit/PR
+# convention ENFORCEMENT-pattern resolver. Run: bash lib/resolve-convention-pattern.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/resolve-convention-pattern.sh"
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+FAILED=0
+CASE_NUM=0
+
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  detail: %s\n' "$1" "$2" >&2
+}
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected: [$2], actual: [$3]"; fi
+}
+assert_exit() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected exit $2, got $3"; fi
+}
+
+# The canonical Conventional Commits ERE — kept in lockstep with the SUT header.
+CC_ERE='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?: .+'
+
+# Make an isolated repo root whose TEAM layer holds the given markdown body.
+# Extra positional args after the first write additional overlay files:
+#   newrepo "<team body>" [local-body] [does NOT create user-global — see note]
+newrepo() {
+  local d
+  d="$(mktemp -d "$TEST_TMPDIR/repo.XXXXXX")"
+  mkdir -p "$d/.claude"
+  [[ -n "${1:-}" ]] && printf '%s\n' "$1" >"$d/.claude/source-control.md"
+  [[ -n "${2:-}" ]] && printf '%s\n' "$2" >"$d/.claude/source-control.local.md"
+  printf '%s' "$d"
+}
+run() { bash "$SCRIPT" "$1" "${2:-subject_pattern}"; }
+
+# --- --help ---
+out="$(bash "$SCRIPT" --help)"
+assert_exit "--help exits 0" 0 $?
+
+# --- Conventional Commits keyword expands to the canonical ERE ---
+r="$(newrepo $'## subject_pattern\nConventional Commits')"
+assert_eq "CC keyword -> CC_ERE" "$CC_ERE" "$(run "$r")"
+
+# --- a custom ERE passes through unchanged ---
+r="$(newrepo $'## subject_pattern\n^[A-Z]+-[0-9]+: .+')"
+assert_eq "plain ERE unchanged" '^[A-Z]+-[0-9]+: .+' "$(run "$r")"
+
+# --- an already-alternated ERE passes through unchanged ---
+r="$(newrepo $'## subject_pattern\n^(feat|fix): .+')"
+assert_eq "ERE alternation unchanged" '^(feat|fix): .+' "$(run "$r")"
+
+# --- PCRE-only constructs are NOT translated -> no enforcement ---
+# The resolver accepts POSIX ERE and rejects PCRE; a team writes [0-9] not \d.
+r="$(newrepo $'## subject_pattern\n^(?:feat|fix): .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "(?: non-capturing group -> exit 1" 1 $?
+r="$(newrepo $'## subject_pattern\n^[A-Z]+-\\d+: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "\\d -> exit 1 (use [0-9])" 1 $?
+r="$(newrepo $'## subject_pattern\n^\\w+\\s: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "\\w \\s -> exit 1" 1 $?
+
+# --- lookahead has no ERE equivalent -> no enforcement, exit 1, empty stdout ---
+r="$(newrepo $'## subject_pattern\n^(?=.{1,50}$)\\w+: .+')"
+out="$(run "$r")"
+rc=$?
+assert_exit "lookaround -> exit 1" 1 "$rc"
+assert_eq "lookaround -> empty stdout" "" "$out"
+
+# --- word-boundary \b is non-ERE -> no enforcement ---
+r="$(newrepo $'## subject_pattern\n^\\bfeat: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "\\b -> exit 1" 1 $?
+
+# --- backreference is non-ERE -> no enforcement ---
+r="$(newrepo $'## subject_pattern\n^(\\w+): \\1')"
+run "$r" >/dev/null 2>&1
+assert_exit "backref -> exit 1" 1 $?
+
+# --- negated shorthand classes (\D \S \W) have no ERE spelling -> no enforce ---
+r="$(newrepo $'## subject_pattern\n^\\D+: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "\\D -> exit 1" 1 $?
+
+# --- absolute anchors (\A \z \Z) are non-ERE -> no enforcement ---
+r="$(newrepo $'## subject_pattern\n\\Afeat: .+\\z')"
+run "$r" >/dev/null 2>&1
+assert_exit "\\A \\z -> exit 1" 1 $?
+
+# --- control-char escapes (\t \n ...) are non-ERE -> no enforcement ---
+r="$(newrepo $'## subject_pattern\n^\\tJIRA-[0-9]+: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "\\t -> exit 1" 1 $?
+
+# --- an escaped backslash (\\d = literal, not the class) -> no enforcement ---
+r="$(newrepo $'## subject_pattern\n^foo\\\\d: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "escaped backslash -> exit 1" 1 $?
+
+# --- a \d/\w/\s shorthand INSIDE a bracket expression -> no enforcement ---
+r="$(newrepo $'## subject_pattern\n^[\\w-]+: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "shorthand inside bracket -> exit 1" 1 $?
+
+# --- a pattern that does not compile as POSIX ERE -> no enforcement (net) ---
+r="$(newrepo $'## subject_pattern\n^[: .+')"
+out="$(run "$r")"
+rc=$?
+assert_exit "uncompilable ERE -> exit 1" 1 "$rc"
+assert_eq "uncompilable ERE -> empty stdout" "" "$out"
+
+# --- unresolved: no team file at all -> exit 1, NEVER the CC default ---
+r="$(newrepo "")"
+out="$(run "$r")"
+rc=$?
+assert_exit "no team file -> exit 1" 1 "$rc"
+assert_eq "no team file -> empty (no CC fallback)" "" "$out"
+
+# --- unresolved: file exists but key absent -> exit 1 ---
+r="$(newrepo $'## trailer_policy\nnone')"
+run "$r" >/dev/null 2>&1
+assert_exit "key absent -> exit 1" 1 $?
+
+# --- policy-floor: a LOCAL overlay pattern is IGNORED by enforcement ---
+# team file absent, overlay present -> still no enforcement (gate is team-only).
+r="$(newrepo "" $'## subject_pattern\n^anything: .+')"
+run "$r" >/dev/null 2>&1
+assert_exit "local overlay never enforces (team-only)" 1 $?
+
+# --- pr_title_pattern deferral resolves the effective subject pattern ---
+r="$(newrepo $'## subject_pattern\n^ABC-[0-9]+: .+\n\n## pr_title_pattern\nSame as `subject_pattern`.')"
+assert_eq "pr deferral -> subject" '^ABC-[0-9]+: .+' "$(run "$r" pr_title_pattern)"
+
+# --- pr_title_pattern with its own value stands alone ---
+r="$(newrepo $'## subject_pattern\n^X: .+\n\n## pr_title_pattern\n^PR: .+')"
+assert_eq "pr explicit value" '^PR: .+' "$(run "$r" pr_title_pattern)"
+
+# --- first non-empty body line wins; leading blank lines skipped ---
+r="$(newrepo $'## subject_pattern\n\n^spaced: .+')"
+assert_eq "blank line before value skipped" '^spaced: .+' "$(run "$r")"
+
+# --- usage / invalid key ---
+bash "$SCRIPT" >/dev/null 2>&1
+assert_exit "no args -> exit 2" 2 $?
+bash "$SCRIPT" "$TEST_TMPDIR" bogus_key >/dev/null 2>&1
+assert_exit "invalid key -> exit 2" 2 $?
+
+echo ""
+echo "ran $CASE_NUM cases, $FAILED failed"
+[[ "$FAILED" -eq 0 ]]

--- a/plugins/source-control/reference/config-resolution.md
+++ b/plugins/source-control/reference/config-resolution.md
@@ -81,6 +81,18 @@ no `type_list` in any layer resolves to the bundled 11-type list.
 `pr_title_pattern` resolving to `Same as \`subject_pattern\`.` expands against the **effective**
 `subject_pattern` after all three layers merge, not against the pattern in its own layer.
 
+## Drafting vs enforcement
+
+This document owns **drafting** resolution — how `/source-control:commit` and `/pull-request`
+compose a compliant subject/title, reading all three layers with the per-key merge above. A separate
+concern owns **enforcement** — how a zero-dependency guardrails hook decides whether an
+*already-formed* subject/title is allowed. The two read the same `.claude/source-control.md` file but
+differ deliberately: enforcement reads the **team-tracked layer only** (a gitignored `*.local.md`
+must never weaken a blocking gate), resolves to **POSIX ERE only**, and treats an unresolved key as
+**no enforcement** — never the bundled Conventional Commits default. That contract, the regex-dialect
+normalization, and the resolver (`lib/resolve-convention-pattern.sh`) live in the
+[commit-convention enforcement seam](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/commit-convention/README.md).
+
 ## Consumer `.gitignore`
 
 The overlay convention needs one line in the consuming repo:

--- a/scripts/sync-resolve-convention-pattern.sh
+++ b/scripts/sync-resolve-convention-pattern.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Sync or verify the plugin copies of the shared commit/PR convention
+# ENFORCEMENT-pattern resolver (lib/resolve-convention-pattern.sh).
+#
+#   scripts/sync-resolve-convention-pattern.sh                     copy the lib into each consuming plugin
+#   scripts/sync-resolve-convention-pattern.sh --check             fail if any plugin copy differs from the source
+#   scripts/sync-resolve-convention-pattern.sh --check-bump <ref>  fail if the lib changed vs <ref> but a consuming
+#                                                                  plugin's manifest version did not — the plugin
+#                                                                  version is the update cache key, so an unbumped
+#                                                                  plugin never delivers the change to consumers
+#
+# Like sync-parse-concern-value.sh, the copies are consumed at DIFFERENT paths,
+# so the destinations are an explicit list. The list is intentionally EMPTY
+# until the first consumer vendors the resolver: the guardrails CC-layer content
+# gate (#914) and the opt-in commit-msg hook (#919) each add their copy path here
+# and bump the guardrails manifest in the same change. Until then the resolver is
+# the seam's source of truth with no cache-isolated copies to keep in step.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+src="lib/resolve-convention-pattern.sh"
+
+copies=(
+  # plugins/guardrails/hooks/resolve-convention-pattern.sh   # added by #914
+)
+
+mode="${1:-sync}"
+case "$mode" in
+sync)
+  for copy in ${copies[@]+"${copies[@]}"}; do
+    cp "$src" "$copy"
+    echo "synced: $copy"
+  done
+  echo "synced ${#copies[@]} copies of $src."
+  ;;
+--check)
+  drifted=0
+  for copy in ${copies[@]+"${copies[@]}"}; do
+    if ! cmp -s "$src" "$copy"; then
+      echo "DRIFT: $copy differs from $src" >&2
+      drifted=1
+    fi
+  done
+  if [[ "$drifted" -ne 0 ]]; then
+    echo "Run scripts/sync-resolve-convention-pattern.sh and commit the result." >&2
+    exit 1
+  fi
+  echo "All ${#copies[@]} plugin copies match $src."
+  ;;
+--check-bump)
+  base="${2:?usage: sync-resolve-convention-pattern.sh --check-bump <base-ref>}"
+  if git diff --quiet "$base" -- "$src"; then
+    echo "Lib unchanged vs $base; no version bumps required."
+    exit 0
+  fi
+  stale=0
+  for copy in ${copies[@]+"${copies[@]}"}; do
+    manifest="${copy%%/hooks/*}/.claude-plugin/plugin.json"
+    base_version=$(git show "$base:$manifest" 2>/dev/null | jq -r '.version // empty' || true)
+    if [[ -z "$base_version" ]]; then
+      continue
+    fi
+    head_version=$(jq -r '.version // empty' "$manifest")
+    if [[ "$head_version" == "$base_version" ]]; then
+      echo "STALE VERSION: $src changed vs $base but $manifest is still $head_version" >&2
+      stale=1
+    fi
+  done
+  if [[ "$stale" -ne 0 ]]; then
+    echo "Bump the version of every consuming plugin so consumers receive the lib change." >&2
+    exit 1
+  fi
+  echo "Lib changed vs $base and every consuming plugin bumped its version."
+  ;;
+*)
+  echo "usage: sync-resolve-convention-pattern.sh [--check | --check-bump <base-ref>]" >&2
+  exit 2
+  ;;
+esac


### PR DESCRIPTION
Seams-first foundation (#912) for hard-gating commit subjects and PR titles. Gives a zero-dependency guardrails hook a machine-readable path to the effective enforcement pattern **without changing the consumer-facing markdown surface** (which just landed in #660).

## What lands
- **`lib/resolve-convention-pattern.sh` + 19 tests** — the single artifact every enforcement hook sources. Reads the effective `subject_pattern`/`pr_title_pattern` and emits a POSIX-ERE regex.
- **`scripts/sync-resolve-convention-pattern.sh` + CI job** — the sync scaffold the guardrails consumers (#914, #919) register into (copies list intentionally empty until then).
- **`docs/conventions/commit-convention/`** — concern owner-doc (enforcement vs drafting), registered in the PLUGIN-PHILOSOPHY convention registry.
- **`config-resolution.md`** — drafting-vs-enforcement reconciliation section.
- **`consumer-config-layering`** — correct the stale `source-control` row (all-three layering landed in #660; drop the in-flight #647 note).
- **`MIGRATION-PLAYBOOK`** — codify swim-lane execution.

## Locked contract (binds #914/#919)
1. **Dialect** = POSIX ERE; normalizes `(?:`->`(`, `\d`->`[0-9]`, `\w`/`\s`; rejects un-expressible PCRE (lookaround/backref/`\b`) -> no enforcement + visible note.
2. **Unresolved -> no enforcement** (never the bundled CC default -- CC is not lane-1-eligible).
3. **Policy-floor via team-only reads** -- enforcement reads the tracked `.claude/source-control.md` only; gitignored/user-global overlays are drafting-only and can never weaken a gate.

## Verification
- `bash lib/resolve-convention-pattern.test.sh` -> 19/19 pass
- `shellcheck --rcfile=.shellcheckrc` clean on all three scripts
- `scripts/sync-resolve-convention-pattern.sh --check` passes

## Related
- #912 -- umbrella tracking issue (not closed here)
- Unblocks #914 (CC-layer content gate) and #919 (opt-in commit-msg hook), which vendor this resolver

Closes #913