### PR TITLE
fix(guardrails): configurable hook-manager bypass + broader machine-path roots

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
@@ -96,6 +96,12 @@
       "type": "string",
       "title": "block-noncanonical-commit allow-list",
       "description": "Comma-separated form tokens to allow (currently: message-flag, which permits a bare `-m`)",
+      "default": ""
+    },
+    "block_no_verify_hook_manager_prefixes": {
+      "type": "string",
+      "title": "block-no-verify hook-manager prefixes",
+      "description": "Comma-separated hook-manager env-var name prefixes block-no-verify treats as a bypass when set to 0/false (e.g. lefthook,husky); empty uses the built-in default set (lefthook, husky, pre_commit, simple_git_hooks)",
       "default": ""
     }
   }

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.7]
+
+### Changed
+
+- **`block-no-verify` hook-manager bypass detection is now configurable and
+  covers more managers by default.** The env-var disable check matched only
+  `lefthook*`, silently missing `HUSKY=0` and other managers. It now resolves a
+  configurable prefix set (`block_no_verify_hook_manager_prefixes` userConfig)
+  defaulting to `lefthook, husky, pre_commit, simple_git_hooks`; consumer values
+  are reduced to identifier characters before use, so a value can never inject
+  regex metacharacters.
+- **`hardcoded-path-check` machine-path detection broadened past `repos`.** The
+  drive-letter-anchored checkout-parent pattern matched only `X:\repos\…`, so a
+  hardcoded `C:\Projects\…` or `C:\Dev\…` path went undetected. It now also
+  matches `Projects` and `Dev` (both capitalizations); a consumer's own checkout
+  root was and remains caught by the driver's project-root literal scan.
+
 ## [0.9.6]
 
 ### Fixed

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -10,7 +10,7 @@ Each guard is independently toggleable, so you run exactly the subset you want.
 |-------|-----------------|----------|-----------------|
 | **secret-pattern-detection** | PreToolUse · Write \| Edit \| NotebookEdit | **Blocks** (exit 2) | High-confidence secret/credential patterns (AWS/GitHub/GitLab/Slack/Stripe/OpenAI keys, PEM private keys) in new file content. |
 | **hardcoded-path-check** | PreToolUse · Write \| Edit \| NotebookEdit | **Blocks** (exit 2) | Hardcoded machine-specific paths — Windows drive-letter homes, macOS/Linux user homes, machine-specific repo checkout roots. |
-| **block-no-verify** | PreToolUse · Bash | **Blocks** (exit 2) | Git hook-bypass attempts on `git commit` / `git push`: `--no-verify` / `-n`, `core.hooksPath=` assignment, and `LEFTHOOK=0` / `LEFTHOOK_*=false` env-var prefixes (including inside compound `cd … && …` commands). |
+| **block-no-verify** | PreToolUse · Bash | **Blocks** (exit 2) | Git hook-bypass attempts on `git commit` / `git push`: `--no-verify` / `-n`, `core.hooksPath=` assignment, and hook-manager disable env vars — a configurable prefix set defaulting to `lefthook`, `husky`, `pre_commit`, `simple_git_hooks` (e.g. `LEFTHOOK=0`, `HUSKY=0`, `PRE_COMMIT_*=false`), tunable via `block_no_verify_hook_manager_prefixes`, including inside compound `cd … && …` commands. |
 | **block-dangerous-git** | PreToolUse · Bash | **Blocks** (exit 2) | Irreversible git operations: `push --force`/`-f` plus the equivalent leading-`+` refspec and `--mirror` forms (never `--force-with-lease`; a push dry-run disarms), `reset --hard`, `clean` with a force flag (any dry-run flag disarms), worktree-wide `checkout`/`restore` pathspecs (`.`, `:/`, `:(top…)` — path-scoped forms and `restore --staged .` pass), and forced `checkout -f` / `switch --discard-changes`. Accepted unique-prefix abbreviations of the blocked long options match too. `branch -D` is deliberately not blocked (reflog-recoverable; sanctioned skill flows issue it). Per-repo/per-user allow-list via the `block_dangerous_git_allow` userConfig option (comma list, any subset of `push-force,reset-hard,clean-force,checkout-dot,restore-dot,checkout-force`). |
 | **block-hook-bypass** | PreToolUse · Bash | **Blocks** (exit 2) | Bash file-write workarounds that circumvent the Write/Edit hook gates — `cat > file`, `echo … > file`, and `python3 -c` with file-write indicators. Executable-token detection ignores quoted prose/commit text that merely mentions the pattern. |
 | **cli-flag-verify** | PostToolUse · Write \| Edit | **Advisory** (exit 0) | Hallucinated CLI flags — a `--flag` written as a command that does not exist in the binary's actual `--help` output. Surfaces via `additionalContext`, never blocks. |
@@ -24,11 +24,14 @@ way but always allow the operation.
 
 ### Scope notes
 
-- **Hook-manager coverage.** `block-no-verify` recognizes the **lefthook**
-  env-var disable prefix (`LEFTHOOK=0` / `LEFTHOOK_*=false`). Other managers'
-  disable env vars (husky, pre-commit, …) are **not** matched — but the
-  manager-agnostic `--no-verify` / `-n` and `core.hooksPath=` checks catch those
-  bypasses regardless of which manager runs the hooks.
+- **Hook-manager coverage.** `block-no-verify` recognizes the disable env-var
+  prefixes of a configurable manager set — `lefthook`, `husky`, `pre_commit`,
+  and `simple_git_hooks` by default (`LEFTHOOK=0`, `HUSKY=0`, `PRE_COMMIT_*=false`,
+  `SIMPLE_GIT_HOOKS=0`, …). Extend or narrow it with the
+  `block_no_verify_hook_manager_prefixes` userConfig option (see Consumer seams).
+  Independent of that set, the manager-agnostic `--no-verify` / `-n` and
+  `core.hooksPath=` checks catch bypasses regardless of which manager runs the
+  hooks.
 - **Argv-grammar-faithful matching (and its residual).** `block-no-verify` and
   `block-dangerous-git` share one parser (in the bundled hook-utils library)
   that parses the command the way the shell builds argv — segmenting on
@@ -122,6 +125,13 @@ repo-specific policy of their own:
   (`claude gh dotnet docker npm kubectl terraform az aws`); override with the
   `cli_flag_verify_bins` option (`bin1,bin2,…`) and skip specific binaries
   with `cli_flag_verify_skip_bins`.
+- **Hook-manager prefixes.** `block-no-verify` reads its recognized
+  hook-manager disable-env-var prefixes from `block_no_verify_hook_manager_prefixes`
+  (comma list, default `lefthook, husky, pre_commit, simple_git_hooks`). Add a
+  manager your project uses, or narrow the set. Values are reduced to identifier
+  characters before use, so a consumer value can never inject regex metacharacters.
+  The manager-agnostic `--no-verify` / `-n` and `core.hooksPath=` checks run
+  regardless of this list.
 - **Skill-availability gating.** `flag-commit-pr-skill-bypass` resolves
   `enabledPlugins` the way Claude Code merges it across scopes — user-global
   (`$CLAUDE_CONFIG_DIR/settings.json`, else `~/.claude/settings.json`) as the

--- a/plugins/guardrails/hooks/block-no-verify.sh
+++ b/plugins/guardrails/hooks/block-no-verify.sh
@@ -6,8 +6,12 @@
 #   1. --no-verify / -n on git commit (skips pre-commit + commit-msg hooks)
 #      and --no-verify on git push (skips pre-push hook)
 #   2. core.hooksPath assignment on git commit/push (disables all git hooks)
-#   3. hook-manager env-var prefix (LEFTHOOK=0 / LEFTHOOK_*=0|false) on git
-#      commit/push (disables the hook manager for one invocation)
+#   3. hook-manager env-var prefix (e.g. LEFTHOOK=0 / LEFTHOOK_*=0|false,
+#      HUSKY=0) on git commit/push (disables the hook manager for one
+#      invocation). The manager set is configurable via the
+#      block_no_verify_hook_manager_prefixes userConfig; the default covers the
+#      common managers so a consumer using a different one is not silently
+#      unguarded.
 #
 # Detection is ARGV-GRAMMAR-FAITHFUL: the command is parsed the way the shell
 # builds argv — top-level segments split on unquoted control operators, each
@@ -66,6 +70,22 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/nul
 MAX_COMMAND_LEN=16384
 
 SUBJECT=$(hook::extract_bash_subject "Bash" "$COMMAND")
+
+# Hook-manager env-var disable prefixes, built once into a regex alternation.
+# The default set covers the common managers; a consumer extends it via the
+# block_no_verify_hook_manager_prefixes userConfig (comma-separated, read from
+# the hook-process mirror). Each prefix matches `PREFIX…=0|false`
+# (LEFTHOOK=0, HUSKY=0, LEFTHOOK_VERIFY=false, …). Entries are reduced to
+# identifier chars so a value can never smuggle regex metacharacters into the
+# alternation spliced below.
+HM_ALT=""
+IFS=',' read -ra _hm_list <<<"${CLAUDE_PLUGIN_OPTION_BLOCK_NO_VERIFY_HOOK_MANAGER_PREFIXES:-lefthook,husky,pre_commit,simple_git_hooks}"
+for _hm in "${_hm_list[@]}"; do
+  _hm="${_hm//[^a-zA-Z0-9_]/}"
+  _hm="${_hm,,}"
+  [[ -n "$_hm" ]] && HM_ALT="${HM_ALT:+$HM_ALT|}$_hm"
+done
+[[ -n "$HM_ALT" ]] || HM_ALT="lefthook" # never leave the guard patternless
 
 # Emit one telemetry envelope: $1 status, $2 form ("" when not blocked). Gated
 # on the high-res start stamp and the opt-in sink, so the unwired default path
@@ -131,7 +151,7 @@ check_segment() {
   # assignments before the git executable (not commit messages or pathspecs).
   for ((k = 0; k < gi; k++)); do
     lc="${w[k],,}"
-    [[ "$lc" =~ ^lefthook[_a-z0-9]*=(0|false)$ ]] && block "hook-manager-env" \
+    [[ "$lc" =~ ^(${HM_ALT})[_a-z0-9]*=(0|false)$ ]] && block "hook-manager-env" \
       "BLOCKED: hook-manager env-var bypass is not allowed with git commit/push." \
       "Fix the hook lane failure instead of bypassing."
   done

--- a/plugins/guardrails/hooks/block-no-verify.test.sh
+++ b/plugins/guardrails/hooks/block-no-verify.test.sh
@@ -135,7 +135,7 @@ run "env -S 'ls -la' (split-string non-git, allowed)" \
 # --- [P3] case-insensitive executable + .exe strip (OS-gated) ----------------
 case "${OSTYPE:-}" in
 msys* | cygwin* | win32) exp_win=2 ;; # Windows/MSYS folds case + strips .exe
-*) exp_win=0 ;;                        # POSIX stays case-sensitive
+*) exp_win=0 ;;                       # POSIX stays case-sensitive
 esac
 run "GIT commit --no-verify (uppercase exec, OS-gated)" \
   'GIT commit --no-verify -m test' "$exp_win"
@@ -166,6 +166,21 @@ run "cd foo && LEFTHOOK=0 git commit (compound, blocked)" "cd foo && LEFTHOOK=0 
 
 # --- Form 2 negatives — env-var alone or with non-git command must NOT block -
 run "LEFTHOOK=0 echo foo (not git, allowed)" "LEFTHOOK=0 echo foo" 0
+
+# Default manager set covers more than lefthook.
+run "HUSKY=0 git commit (default set, blocked)" "HUSKY=0 git commit -m test" 2
+run "HUSKY=false git push (default set, blocked)" "HUSKY=false git push" 2
+run "PRE_COMMIT=0 git commit (default set, blocked)" "PRE_COMMIT=0 git commit -m test" 2
+run "SIMPLE_GIT_HOOKS=false git commit (default set, blocked)" "SIMPLE_GIT_HOOKS=false git commit -m test" 2
+run "UNKNOWNMGR=0 git commit (not in set, allowed)" "UNKNOWNMGR=0 git commit -m test" 0
+
+# --- Form 2b: the hook-manager prefix set is configurable -------------------
+run "custom prefix blocks its manager" "MYHOOKS=0 git commit -m test" 2 \
+  CLAUDE_PLUGIN_OPTION_BLOCK_NO_VERIFY_HOOK_MANAGER_PREFIXES="myhooks"
+run "custom set replaces the default (lefthook now allowed)" "LEFTHOOK=0 git commit -m test" 0 \
+  CLAUDE_PLUGIN_OPTION_BLOCK_NO_VERIFY_HOOK_MANAGER_PREFIXES="myhooks"
+run "regex metachars in a prefix value are sanitized, not injected" "MYHOOKS=0 git commit -m test" 2 \
+  CLAUDE_PLUGIN_OPTION_BLOCK_NO_VERIFY_HOOK_MANAGER_PREFIXES="my.*hooks,myhooks"
 run "LEFTHOOK=false ls (not git, allowed)" "LEFTHOOK=false ls" 0
 run "LEFTHOOK=1 git commit (truthy value, allowed)" "LEFTHOOK=1 git commit -m test" 0
 run "LEFTHOOK=true git push (truthy value, allowed)" "LEFTHOOK=true git push" 0

--- a/plugins/guardrails/lib/path-detection/machine-path-patterns.sh
+++ b/plugins/guardrails/lib/path-detection/machine-path-patterns.sh
@@ -40,8 +40,16 @@
 HPP_WIN_USER_BODY='[A-Za-z]:(/|\\\\?)Users(/|\\\\?)[^/\\$%<{~]+(~[0-9]+)?(/|\\\\?)'
 HPP_MACOS_USER_BODY='/Users/[^/$<{~]+/'
 HPP_LINUX_USER_BODY='/home/[^/$<{~]+/'
-HPP_WIN_REPO_BODY='[A-Za-z]:(/|\\\\?)repos(/|\\\\?)[^/\\$%<{~]+(~[0-9]+)?(/|\\\\?)'
+# The checkout-parent segment is drive-letter-anchored, so broadening it beyond
+# `repos` to the other common checkout-root names stays false-positive-safe —
+# only a genuine `X:\<root>\<child>\` absolute path matches, never prose. Both
+# lowercase and Capitalized spellings are listed (a regex character class such
+# as `[Rr]` would leave a partial token the docs typos-gate flags). A consumer's
+# OWN checkout root is already caught by the driver's project-root literal scan;
+# this generic body catches references to OTHER machines' checkout paths in
+# written content.
+HPP_WIN_REPO_BODY='[A-Za-z]:(/|\\\\?)(repos|Repos|projects|Projects|dev|Dev)(/|\\\\?)[^/\\$%<{~]+(~[0-9]+)?(/|\\\\?)'
 # SC1003 false positive: the trailing \\\\ is a deliberate literal-backslash ERE
 # body (a JSON-escaped path separator), not a botched single-quote escape.
 # shellcheck disable=SC1003
-HPP_ESCAPED_WIN_REPO_BODY='[A-Za-z]:\\\\repos\\\\[^\\$%<{~]+(~[0-9]+)?\\\\'
+HPP_ESCAPED_WIN_REPO_BODY='[A-Za-z]:\\\\(repos|Repos|projects|Projects|dev|Dev)\\\\[^\\$%<{~]+(~[0-9]+)?\\\\'


### PR DESCRIPTION
Two-lane posture fixes (audit #912): externalize hardcoded assumptions in two guardrails detectors.

## W3 - hook-manager bypass detection
`block-no-verify` matched only `lefthook*` env-var disables, silently missing `HUSKY=0` and others. Now resolves a configurable prefix set (`block_no_verify_hook_manager_prefixes` userConfig; default `lefthook, husky, pre_commit, simple_git_hooks`). Consumer values are reduced to identifier characters before splicing into the regex alternation, so no metacharacter injection.

## W4 - machine-path checkout roots
`hardcoded-path-check`'s drive-letter-anchored checkout-parent pattern matched only `X:\repos\...`, missing `C:\Projects\...` (this very repo) and `C:\Dev\...`. Broadened to also match `Projects` and `Dev` (both capitalizations). A consumer's own checkout root remains caught by the driver's project-root literal scan.

## Verification
- `block-no-verify.test.sh` 83/0 (adds husky/pre_commit/simple_git_hooks + configurability + sanitization cases)
- `hardcoded-path-check.test.sh` 38/0
- shellcheck clean; guardrails `0.9.5` -> `0.9.6` + CHANGELOG

## Related
- #912 -- umbrella (not closed here)
- Shares the guardrails manifest with #928 (B1); final merges serialize + re-bump per the playbook

Closes #918