### PR TITLE
docs(claude-ops): state that /loop never resets context; relaunch is the reset

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   itself, so the "restart at ~N% context" discipline has no in-session
   enforcement; the skill's `restart` (fresh session from the canonical prompt) is
   the actual reset, and it is operator- or launcher-initiated, not automatic. The
-  SKILL.md now states this so a lane prompt does not mis-assume per-cycle
+  SKILL.md now states this so a lane prompt does not wrongly assume per-cycle
   freshness. Interim documentation ahead of an automatic relaunch trigger. (#551)
 
 ## [0.18.0]

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.1]
+
+### Changed
+
+- **`lanes` skill — document that a relaunch is the only context reset a loop
+  lane gets.** A `/loop` lane re-invokes in the same session and cannot `/clear`
+  itself, so the "restart at ~N% context" discipline has no in-session
+  enforcement; the skill's `restart` (fresh session from the canonical prompt) is
+  the actual reset, and it is operator- or launcher-initiated, not automatic. The
+  SKILL.md now states this so a lane prompt does not mis-assume per-cycle
+  freshness. Interim documentation ahead of an automatic relaunch trigger. (#551)
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -35,21 +35,31 @@ name is a lane in the resolved config — a hand-started session (e.g. an intera
 ## A relaunch is the only context reset a loop lane gets
 
 `/loop` re-invokes its prompt in the **same** session (it self-paces via
-`ScheduleWakeup`), so a lane's context accumulates monotonically across every cycle,
-subagent return, and operator turn — nothing inside the loop ever resets it. A
-running loop **cannot** reset its own context: a built-in like `/clear` issued from a
+`ScheduleWakeup`), so a lane's context carries forward across every cycle, subagent
+return, and operator turn — the loop never starts a fresh one. A running loop
+**cannot** reset its own context on demand: a built-in like `/clear` issued from a
 loop re-run reaches the model as plain text, not an executed command, so the model
 cannot `/clear` itself. Any "restart the loop when context passes ~N%" discipline is
 therefore an admonition with no in-session enforcement — the lane has no reliable way
 to measure its own context usage and no way to act on the threshold if it could.
 
-`restart` (stop the session, relaunch from the canonical prompt) is what actually
-resets the context: the relaunched lane starts a **fresh** session seeded from the
-prompt file. That reset is **operator- or launcher-initiated**, not automatic — there
-is no per-cycle or threshold trigger that runs `restart` for you today. Until such a
-trigger exists, treat the periodic `restart` (e.g. the morning refresh) as the
-mechanism that keeps long-running lanes out of the compaction/degradation zone, and
-do not let a lane prompt assume each `/loop` cycle begins with fresh context.
+The context change that *does* happen automatically in-session is Claude Code's
+**auto-compaction**: when the conversation nears the model's input limit, older
+history is summarized in place to free space. That is not a reset — the session
+continues on a lossy summary of what came before, not a fresh context — so a lane that
+runs long enough will lose earlier context to compaction well before any operator
+relaunch, not keep every turn until then.
+
+`restart` (stop the session, relaunch from the canonical prompt) is the only
+*fresh-session* reset: the relaunched lane starts a **fresh** session seeded from the
+prompt file, carrying none of the prior conversation. That reset is **operator- or
+launcher-initiated**, not automatic — there is no per-cycle or threshold trigger that
+runs `restart` for you today. Auto-compaction can still fire between restarts, but it
+only summarizes; it does not clear the accumulated, increasingly degraded context.
+Until an automatic relaunch trigger exists, treat the periodic `restart` (e.g. the
+morning refresh) as the mechanism that keeps long-running lanes off a stale,
+repeatedly-compacted context, and do not let a lane prompt assume each `/loop` cycle
+begins with fresh context.
 
 ## Run it
 

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -32,6 +32,25 @@ background-session surface.
 name is a lane in the resolved config — a hand-started session (e.g. an interactive
 `work` window, or an unrelated `PR Babysit`) is never stopped by this skill.
 
+## A relaunch is the only context reset a loop lane gets
+
+`/loop` re-invokes its prompt in the **same** session (it self-paces via
+`ScheduleWakeup`), so a lane's context accumulates monotonically across every cycle,
+subagent return, and operator turn — nothing inside the loop ever resets it. A
+running loop **cannot** reset its own context: a built-in like `/clear` issued from a
+loop re-run reaches the model as plain text, not an executed command, so the model
+cannot `/clear` itself. Any "restart the loop when context passes ~N%" discipline is
+therefore an admonition with no in-session enforcement — the lane has no reliable way
+to measure its own context usage and no way to act on the threshold if it could.
+
+`restart` (stop the session, relaunch from the canonical prompt) is what actually
+resets the context: the relaunched lane starts a **fresh** session seeded from the
+prompt file. That reset is **operator- or launcher-initiated**, not automatic — there
+is no per-cycle or threshold trigger that runs `restart` for you today. Until such a
+trigger exists, treat the periodic `restart` (e.g. the morning refresh) as the
+mechanism that keeps long-running lanes out of the compaction/degradation zone, and
+do not let a lane prompt assume each `/loop` cycle begins with fresh context.
+
 ## Run it
 
 ```bash


### PR DESCRIPTION
## Summary

Doc-only interim caveat to `claude-ops:lanes` SKILL.md: `/loop` never resets context — a running loop cannot `/clear` itself; an external fresh-session relaunch is the only reset. Patch bump + changelog entry.

Staged on `fix/551-loop-context-reset` and approved to ship as a standalone PR by operator ruling (ratification interview, 2026-07-22 ~03:05Z, recorded on #551). The full mechanism — per-cycle-fresh relaunch + externalized cadence handoff — continues under #551; this caveat stops readers from relying on the unenforceable "restart at ~50%" admonition in the meantime.

No linked issue (interim caveat; #551 stays open for the full mechanism).

## Related

- #551 — /loop context-reset: trigger model + cadence contract (operator ruling recorded there)
- #500 — work-state-driven cadence (tie-breaker sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
