### PR TITLE
fix(disk-hygiene): launch clean guard via resolvable python3 interpreter

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -7,34 +7,19 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 
 ### Fixed
 
-- **The `clean` skill's destructive-safety guard now launches under both `python3` and `python`.**
-  The PreToolUse hook ran in exec form via the single unqualified interpreter `python`, which stock
-  macOS and many Linux distros do not ship (only `python3`). Because Claude Code treats a failed
-  hook launch as a non-blocking error, an unresolvable name fails the guard open — `rm -rf`, engine
-  `apply`, and other destructive shapes stop being intercepted. The guard now registers two launch
-  entries, `python3` and `python`; all matching hooks run in parallel, so a host exposing a 3.11+
-  runtime under either name is guarded — closing the fail-open both on macOS/Linux (only `python3`)
-  and on a POSIX layout exposing only bare `python` (no `python3`). This is fail-closed in every
-  direction: an unresolvable name contributes nothing, and a legacy `python` 2.x entry crashes on
-  modern syntax (also non-blocking); the sibling entry still guards. A regression test
-  (`test_skill_hook_interpreters_cover_python3_and_python_and_resolve`) locks both names and probes
-  that a resolving Python 3 name reports a 3.11+ interpreter. Residual: on a host where neither name
-  resolves to a runnable 3.11+ interpreter (e.g. a python.org-only Windows install exposing only
-  `py`) the launch still fails open on the manual PowerShell deletion lane — engine `apply` is
-  already unsupported on Windows/macOS, so the per-path human approval that lane already requires
-  and the consumer's baseline permission policy stay the backstop, and `/disk-hygiene:setup check`
-  reports interpreter resolution. (#380)
-- **Each guard instance now authorizes an engine call spelled with either registered interpreter.**
-  The dual registration above launches one guard under `python3` and one under `python`; each
-  previously trusted only its own launch runtime. Where the two names resolve to different 3.11+
-  interpreters (e.g. a virtualenv `python` beside a system `python3`), every engine call uses one
-  absolute interpreter, so the sibling instance denied it — and deny winning over allow across
-  parallel hooks blocked the whole engine lane on that common mixed-interpreter layout. The guard
-  now trusts any path resolving to this process's runtime or either `PATH`-resolved hook name
-  (`python3`/`python`); bare names stay rejected, and trusting a resolved hook name adds no new
-  trust because that name already launches the guard. A regression test
-  (`test_engine_call_allowed_under_sibling_registered_interpreter`) locks the sibling-interpreter
-  path. (#380)
+- **The `clean` skill's destructive-safety guard now launches via a resolvable `python3`.** The
+  PreToolUse hook ran in exec form via the unqualified interpreter `python`, which stock macOS and
+  many Linux distros do not ship (only `python3`). Because Claude Code treats a failed hook launch
+  as a non-blocking error, an unresolvable `python` fails the guard open — `rm -rf`, engine `apply`,
+  and other destructive shapes stop being intercepted on the very POSIX hosts the safety model
+  relies on — and a legacy `python` 2.x resolving first would crash the guard on modern syntax. The
+  hook now names `python3`. A new regression test (`test_skill_hook_interpreter_is_python3_and_resolves`)
+  locks the config at `python3` and probes that a runnable `python3` reports a 3.11+ interpreter.
+  Enforcement remains bounded by resolution: on a host without a resolvable `python3` the launch
+  still fails open on the manual PowerShell deletion lane (engine `apply` is already unsupported on
+  Windows/macOS), so the per-path human approval that lane already requires and the consumer's
+  baseline permission policy stay the backstop, and `/disk-hygiene:setup check` reports interpreter
+  resolution. (#380)
 
 ## [0.4.2]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.3]
+
+### Fixed
+
+- **The `clean` skill's destructive-safety guard now launches via a resolvable `python3`.** The
+  PreToolUse hook ran in exec form via the unqualified interpreter `python`, which stock macOS and
+  many Linux distros do not ship (only `python3`). Because Claude Code treats a failed hook launch
+  as a non-blocking error, an unresolvable `python` fails the guard open — `rm -rf`, engine `apply`,
+  and other destructive shapes stop being intercepted on the very POSIX hosts the safety model
+  relies on — and a legacy `python` 2.x resolving first would crash the guard on modern syntax. The
+  hook now names `python3`. A new regression test (`test_skill_hook_interpreter_is_python3_and_resolves`)
+  locks the config at `python3` and probes that it resolves to a 3.11+ interpreter. Enforcement
+  remains bounded by resolution: on a host without a resolvable `python3` the launch still fails
+  open, so the manual-handoff human approval and the consumer's baseline permission policy stay the
+  backstop, and `/disk-hygiene:setup check` reports interpreter resolution. (#380)
+
 ## [0.4.2]
 
 ### Fixed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -7,19 +7,23 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 
 ### Fixed
 
-- **The `clean` skill's destructive-safety guard now launches via a resolvable `python3`.** The
-  PreToolUse hook ran in exec form via the unqualified interpreter `python`, which stock macOS and
-  many Linux distros do not ship (only `python3`). Because Claude Code treats a failed hook launch
-  as a non-blocking error, an unresolvable `python` fails the guard open — `rm -rf`, engine `apply`,
-  and other destructive shapes stop being intercepted on the very POSIX hosts the safety model
-  relies on — and a legacy `python` 2.x resolving first would crash the guard on modern syntax. The
-  hook now names `python3`. A new regression test (`test_skill_hook_interpreter_is_python3_and_resolves`)
-  locks the config at `python3` and probes that a runnable `python3` reports a 3.11+ interpreter.
-  Enforcement remains bounded by resolution: on a host without a resolvable `python3` the launch
-  still fails open on the manual PowerShell deletion lane (engine `apply` is already unsupported on
-  Windows/macOS), so the per-path human approval that lane already requires and the consumer's
-  baseline permission policy stay the backstop, and `/disk-hygiene:setup check` reports interpreter
-  resolution. (#380)
+- **The `clean` skill's destructive-safety guard now launches under both `python3` and `python`.**
+  The PreToolUse hook ran in exec form via the single unqualified interpreter `python`, which stock
+  macOS and many Linux distros do not ship (only `python3`). Because Claude Code treats a failed
+  hook launch as a non-blocking error, an unresolvable name fails the guard open — `rm -rf`, engine
+  `apply`, and other destructive shapes stop being intercepted. The guard now registers two launch
+  entries, `python3` and `python`; all matching hooks run in parallel, so a host exposing a 3.11+
+  runtime under either name is guarded — closing the fail-open both on macOS/Linux (only `python3`)
+  and on a POSIX layout exposing only bare `python` (no `python3`). This is fail-closed in every
+  direction: an unresolvable name contributes nothing, and a legacy `python` 2.x entry crashes on
+  modern syntax (also non-blocking); the sibling entry still guards. A regression test
+  (`test_skill_hook_interpreters_cover_python3_and_python_and_resolve`) locks both names and probes
+  that a resolving Python 3 name reports a 3.11+ interpreter. Residual: on a host where neither name
+  resolves to a runnable 3.11+ interpreter (e.g. a python.org-only Windows install exposing only
+  `py`) the launch still fails open on the manual PowerShell deletion lane — engine `apply` is
+  already unsupported on Windows/macOS, so the per-path human approval that lane already requires
+  and the consumer's baseline permission policy stay the backstop, and `/disk-hygiene:setup check`
+  reports interpreter resolution. (#380)
 
 ## [0.4.2]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -14,10 +14,12 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   and other destructive shapes stop being intercepted on the very POSIX hosts the safety model
   relies on — and a legacy `python` 2.x resolving first would crash the guard on modern syntax. The
   hook now names `python3`. A new regression test (`test_skill_hook_interpreter_is_python3_and_resolves`)
-  locks the config at `python3` and probes that it resolves to a 3.11+ interpreter. Enforcement
-  remains bounded by resolution: on a host without a resolvable `python3` the launch still fails
-  open, so the manual-handoff human approval and the consumer's baseline permission policy stay the
-  backstop, and `/disk-hygiene:setup check` reports interpreter resolution. (#380)
+  locks the config at `python3` and probes that a runnable `python3` reports a 3.11+ interpreter.
+  Enforcement remains bounded by resolution: on a host without a resolvable `python3` the launch
+  still fails open on the manual PowerShell deletion lane (engine `apply` is already unsupported on
+  Windows/macOS), so the per-path human approval that lane already requires and the consumer's
+  baseline permission policy stay the backstop, and `/disk-hygiene:setup check` reports interpreter
+  resolution. (#380)
 
 ## [0.4.2]
 

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -24,6 +24,17 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   already unsupported on Windows/macOS, so the per-path human approval that lane already requires
   and the consumer's baseline permission policy stay the backstop, and `/disk-hygiene:setup check`
   reports interpreter resolution. (#380)
+- **Each guard instance now authorizes an engine call spelled with either registered interpreter.**
+  The dual registration above launches one guard under `python3` and one under `python`; each
+  previously trusted only its own launch runtime. Where the two names resolve to different 3.11+
+  interpreters (e.g. a virtualenv `python` beside a system `python3`), every engine call uses one
+  absolute interpreter, so the sibling instance denied it — and deny winning over allow across
+  parallel hooks blocked the whole engine lane on that common mixed-interpreter layout. The guard
+  now trusts any path resolving to this process's runtime or either `PATH`-resolved hook name
+  (`python3`/`python`); bare names stay rejected, and trusting a resolved hook name adds no new
+  trust because that name already launches the guard. A regression test
+  (`test_engine_call_allowed_under_sibling_registered_interpreter`) locks the sibling-interpreter
+  path. (#380)
 
 ## [0.4.2]
 

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -247,6 +247,10 @@ sparse files, hard links, compression, and delayed allocation affect it.
   - Where both names resolve to the same interpreter (the common POSIX layout, including a
     `python` → `python3` symlink, which resolves identically), the guard runs twice per call —
     redundant, never weaker.
+  - Where the two names resolve to different 3.11+ interpreters (e.g. a virtualenv `python` beside a
+    system `python3`), each guard instance trusts both registered interpreters, so an engine call
+    spelled with either absolute path passes; without that, the sibling instance would deny every
+    engine call — deny winning over allow across parallel hooks — and make the lane unusable.
   - Where a legacy `python` 2.x resolves, each guarded call emits a Python 2 traceback to the
     transcript — harmless noise; the `python3` entry still enforces.
   `/disk-hygiene:setup check` reports which interpreters resolve on this machine.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -231,11 +231,13 @@ sparse files, hard links, compression, and delayed allocation affect it.
   `python` 2.x would crash the guard on modern syntax). Enforcement is therefore only as strong as
   that resolution: on a host where `python3` does not resolve to a 3.11+ interpreter the PreToolUse
   launch fails, and Claude Code treats a failed hook launch as a non-blocking error, so the guard
-  does not intercept there. This does not open a silent auto-delete path — the engine's own apply
-  lane runs only after the guard's `ask` prompt, is unsupported on Windows and macOS entirely, and
-  the manual-handoff lane plus the consumer's baseline permission policy still gate every deletion —
-  but it is defense-in-depth lost, not preserved. `/disk-hygiene:setup check` reports whether the
-  interpreter resolves on this machine.
+  does not intercept there. Concretely, the exposure is the manual PowerShell deletion lane: engine
+  `apply` is unsupported on Windows and macOS and elsewhere runs only behind the guard's own `ask`,
+  so no silent auto-delete path opens, but the guard's PowerShell belt that turns a deletion spelling
+  into a final human prompt is lost. The backstops that remain are the per-path human approval the
+  manual-handoff lane already requires and the consumer's baseline permission policy — defense-in-depth
+  lost, not preserved. `/disk-hygiene:setup check` reports whether the interpreter resolves on this
+  machine.
 - The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
   metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
   into a final human permission prompt. It is a raised bar, not a fail-closed lane; the engine's

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -11,9 +11,6 @@ hooks:
         - type: command
           command: "python3"
           args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
-        - type: command
-          command: "python"
-          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
 ---
 
 # Disk hygiene
@@ -229,31 +226,18 @@ sparse files, hard links, compression, and delayed allocation affect it.
   research uses non-Bash read-only tools; only literal-word bundled scan, preview, and apply shapes
   using the hook runtime's same absolute executable pass. Shell expansions, globs, splitting/escape
   forms, operators, redirections, aliases, and exported functions fail closed.
-- The guard registers two PreToolUse launch entries running the same guard, one under `command:
-  "python3"` and one under `command: "python"`, each resolved on `PATH` in exec form with no shell.
-  All matching hooks run in parallel, so whichever name resolves to a 3.11+ runtime enforces — a
-  host exposing the runtime under either name is covered, which closes the earlier fail-open on a
-  layout that ships only bare `python` (no `python3`). Every failure mode of one entry is
-  fail-closed against the other: an unresolvable name is a non-blocking launch error that
-  contributes nothing, and a legacy `python` 2.x entry crashes on modern syntax (also non-blocking)
-  — in both cases the sibling entry still guards. Residual exposures, all disclosed:
-  - If NEITHER name resolves to a runnable 3.11+ interpreter (e.g. a python.org-only Windows install
-    exposing only `py`), both launches fail and the guard does not intercept. The exposure is the
-    manual PowerShell deletion lane — engine `apply` is unsupported on Windows and macOS and
-    elsewhere runs only behind the guard's own `ask`, so no silent auto-delete path opens; what is
-    lost is the PowerShell belt that turns a deletion spelling into a final human prompt. The
-    remaining backstops are the per-path human approval the manual-handoff lane already requires and
-    the consumer's baseline permission policy.
-  - Where both names resolve to the same interpreter (the common POSIX layout, including a
-    `python` → `python3` symlink, which resolves identically), the guard runs twice per call —
-    redundant, never weaker.
-  - Where the two names resolve to different 3.11+ interpreters (e.g. a virtualenv `python` beside a
-    system `python3`), each guard instance trusts both registered interpreters, so an engine call
-    spelled with either absolute path passes; without that, the sibling instance would deny every
-    engine call — deny winning over allow across parallel hooks — and make the lane unusable.
-  - Where a legacy `python` 2.x resolves, each guarded call emits a Python 2 traceback to the
-    transcript — harmless noise; the `python3` entry still enforces.
-  `/disk-hygiene:setup check` reports which interpreters resolve on this machine.
+- The guard hook launches in exec form via `python3`, resolved on `PATH` with no shell (`python3`,
+  not bare `python`, because stock macOS and many Linux distros ship only `python3` and a legacy
+  `python` 2.x would crash the guard on modern syntax). Enforcement is therefore only as strong as
+  that resolution: on a host where `python3` does not resolve to a 3.11+ interpreter the PreToolUse
+  launch fails, and Claude Code treats a failed hook launch as a non-blocking error, so the guard
+  does not intercept there. Concretely, the exposure is the manual PowerShell deletion lane: engine
+  `apply` is unsupported on Windows and macOS and elsewhere runs only behind the guard's own `ask`,
+  so no silent auto-delete path opens, but the guard's PowerShell belt that turns a deletion spelling
+  into a final human prompt is lost. The backstops that remain are the per-path human approval the
+  manual-handoff lane already requires and the consumer's baseline permission policy — defense-in-depth
+  lost, not preserved. `/disk-hygiene:setup check` reports whether the interpreter resolves on this
+  machine.
 - The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
   metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
   into a final human permission prompt. It is a raised bar, not a fail-closed lane; the engine's

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -11,6 +11,9 @@ hooks:
         - type: command
           command: "python3"
           args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
+        - type: command
+          command: "python"
+          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
 ---
 
 # Disk hygiene
@@ -226,18 +229,27 @@ sparse files, hard links, compression, and delayed allocation affect it.
   research uses non-Bash read-only tools; only literal-word bundled scan, preview, and apply shapes
   using the hook runtime's same absolute executable pass. Shell expansions, globs, splitting/escape
   forms, operators, redirections, aliases, and exported functions fail closed.
-- The guard hook launches in exec form via `python3`, resolved on `PATH` with no shell (`python3`,
-  not bare `python`, because stock macOS and many Linux distros ship only `python3` and a legacy
-  `python` 2.x would crash the guard on modern syntax). Enforcement is therefore only as strong as
-  that resolution: on a host where `python3` does not resolve to a 3.11+ interpreter the PreToolUse
-  launch fails, and Claude Code treats a failed hook launch as a non-blocking error, so the guard
-  does not intercept there. Concretely, the exposure is the manual PowerShell deletion lane: engine
-  `apply` is unsupported on Windows and macOS and elsewhere runs only behind the guard's own `ask`,
-  so no silent auto-delete path opens, but the guard's PowerShell belt that turns a deletion spelling
-  into a final human prompt is lost. The backstops that remain are the per-path human approval the
-  manual-handoff lane already requires and the consumer's baseline permission policy — defense-in-depth
-  lost, not preserved. `/disk-hygiene:setup check` reports whether the interpreter resolves on this
-  machine.
+- The guard registers two PreToolUse launch entries running the same guard, one under `command:
+  "python3"` and one under `command: "python"`, each resolved on `PATH` in exec form with no shell.
+  All matching hooks run in parallel, so whichever name resolves to a 3.11+ runtime enforces — a
+  host exposing the runtime under either name is covered, which closes the earlier fail-open on a
+  layout that ships only bare `python` (no `python3`). Every failure mode of one entry is
+  fail-closed against the other: an unresolvable name is a non-blocking launch error that
+  contributes nothing, and a legacy `python` 2.x entry crashes on modern syntax (also non-blocking)
+  — in both cases the sibling entry still guards. Residual exposures, all disclosed:
+  - If NEITHER name resolves to a runnable 3.11+ interpreter (e.g. a python.org-only Windows install
+    exposing only `py`), both launches fail and the guard does not intercept. The exposure is the
+    manual PowerShell deletion lane — engine `apply` is unsupported on Windows and macOS and
+    elsewhere runs only behind the guard's own `ask`, so no silent auto-delete path opens; what is
+    lost is the PowerShell belt that turns a deletion spelling into a final human prompt. The
+    remaining backstops are the per-path human approval the manual-handoff lane already requires and
+    the consumer's baseline permission policy.
+  - Where both names resolve to the same interpreter (the common POSIX layout, including a
+    `python` → `python3` symlink, which resolves identically), the guard runs twice per call —
+    redundant, never weaker.
+  - Where a legacy `python` 2.x resolves, each guarded call emits a Python 2 traceback to the
+    transcript — harmless noise; the `python3` entry still enforces.
+  `/disk-hygiene:setup check` reports which interpreters resolve on this machine.
 - The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
   metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
   into a final human permission prompt. It is a raised bar, not a fail-closed lane; the engine's

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -9,7 +9,7 @@ hooks:
     - matcher: "Bash|PowerShell"
       hooks:
         - type: command
-          command: "python"
+          command: "python3"
           args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
 ---
 
@@ -226,6 +226,16 @@ sparse files, hard links, compression, and delayed allocation affect it.
   research uses non-Bash read-only tools; only literal-word bundled scan, preview, and apply shapes
   using the hook runtime's same absolute executable pass. Shell expansions, globs, splitting/escape
   forms, operators, redirections, aliases, and exported functions fail closed.
+- The guard hook launches in exec form via `python3`, resolved on `PATH` with no shell (`python3`,
+  not bare `python`, because stock macOS and many Linux distros ship only `python3` and a legacy
+  `python` 2.x would crash the guard on modern syntax). Enforcement is therefore only as strong as
+  that resolution: on a host where `python3` does not resolve to a 3.11+ interpreter the PreToolUse
+  launch fails, and Claude Code treats a failed hook launch as a non-blocking error, so the guard
+  does not intercept there. This does not open a silent auto-delete path — the engine's own apply
+  lane runs only after the guard's `ask` prompt, is unsupported on Windows and macOS entirely, and
+  the manual-handoff lane plus the consumer's baseline permission policy still gate every deletion —
+  but it is defense-in-depth lost, not preserved. `/disk-hygiene:setup check` reports whether the
+  interpreter resolves on this machine.
 - The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
   metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
   into a final human permission prompt. It is a raised bar, not a fail-closed lane; the engine's

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
 import sys
 from pathlib import Path
 
@@ -24,11 +23,11 @@ def decision(value: str, reason: str) -> dict[str, object]:
     }
 
 
-def _same_interpreter(value: str, source: str | None) -> bool:
-    if not source:
+def _is_current_python(value: str) -> bool:
+    if not os.path.isabs(value):
         return False
     try:
-        runtime = Path(source).resolve(strict=True)
+        runtime = Path(sys.executable).resolve(strict=True)
         candidate = Path(value).absolute()
         return (
             os.path.normcase(os.fspath(candidate))
@@ -37,26 +36,6 @@ def _same_interpreter(value: str, source: str | None) -> bool:
         )
     except OSError:
         return False
-
-
-def _is_trusted_engine_interpreter(value: str) -> bool:
-    """Accept an absolute path resolving to any interpreter Claude Code launches
-    this guard under: this process's runtime or either registered hook command
-    (``python3`` / ``python``). When those names resolve to different executables
-    (e.g. a virtualenv ``python`` beside a system ``python3``), each of the two
-    parallel guard instances must still accept a call spelled with the other's
-    interpreter, or the sibling instance denies every engine call and — deny
-    winning over allow across hooks — makes the lane unusable. Bare names stay
-    rejected so a Bash alias or exported function cannot substitute for the
-    interpreter; trusting a resolved hook name adds no new trust because that name
-    already launches this guard.
-    """
-    if not os.path.isabs(value):
-        return False
-    return any(
-        _same_interpreter(value, source)
-        for source in (sys.executable, shutil.which("python3"), shutil.which("python"))
-    )
 
 
 def _display_python() -> str:
@@ -211,7 +190,7 @@ def classify_exact_engine_command(command: str, authority: str | None) -> str | 
     tokens = _literal_shell_words(command)
     if tokens is None:
         return None
-    if len(tokens) < 3 or not _is_trusted_engine_interpreter(tokens[0]):
+    if len(tokens) < 3 or not _is_current_python(tokens[0]):
         return None
     expected_script = str(Path(__file__).resolve().with_name("hygiene.py"))
     if _script_path_key(tokens[1]) != _script_path_key(expected_script):

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -23,11 +24,11 @@ def decision(value: str, reason: str) -> dict[str, object]:
     }
 
 
-def _is_current_python(value: str) -> bool:
-    if not os.path.isabs(value):
+def _same_interpreter(value: str, source: str | None) -> bool:
+    if not source:
         return False
     try:
-        runtime = Path(sys.executable).resolve(strict=True)
+        runtime = Path(source).resolve(strict=True)
         candidate = Path(value).absolute()
         return (
             os.path.normcase(os.fspath(candidate))
@@ -36,6 +37,26 @@ def _is_current_python(value: str) -> bool:
         )
     except OSError:
         return False
+
+
+def _is_trusted_engine_interpreter(value: str) -> bool:
+    """Accept an absolute path resolving to any interpreter Claude Code launches
+    this guard under: this process's runtime or either registered hook command
+    (``python3`` / ``python``). When those names resolve to different executables
+    (e.g. a virtualenv ``python`` beside a system ``python3``), each of the two
+    parallel guard instances must still accept a call spelled with the other's
+    interpreter, or the sibling instance denies every engine call and — deny
+    winning over allow across hooks — makes the lane unusable. Bare names stay
+    rejected so a Bash alias or exported function cannot substitute for the
+    interpreter; trusting a resolved hook name adds no new trust because that name
+    already launches this guard.
+    """
+    if not os.path.isabs(value):
+        return False
+    return any(
+        _same_interpreter(value, source)
+        for source in (sys.executable, shutil.which("python3"), shutil.which("python"))
+    )
 
 
 def _display_python() -> str:
@@ -190,7 +211,7 @@ def classify_exact_engine_command(command: str, authority: str | None) -> str | 
     tokens = _literal_shell_words(command)
     if tokens is None:
         return None
-    if len(tokens) < 3 or not _is_current_python(tokens[0]):
+    if len(tokens) < 3 or not _is_trusted_engine_interpreter(tokens[0]):
         return None
     expected_script = str(Path(__file__).resolve().with_name("hygiene.py"))
     if _script_path_key(tokens[1]) != _script_path_key(expected_script):

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1135,22 +1135,6 @@ class GuardTests(unittest.TestCase):
             result["hookSpecificOutput"]["permissionDecisionReason"],
         )
 
-    def test_engine_call_allowed_under_sibling_registered_interpreter(self) -> None:
-        real = self.python_command()
-        script = SCRIPT_DIR / "hygiene.py"
-        command = f'"{real}" "{script}" scan --target t --output s'
-        original_which = guard.shutil.which
-
-        def fake_which(name: str) -> str | None:
-            return real if name in {"python", "python3"} else original_which(name)
-
-        with (
-            mock.patch.object(guard.sys, "executable", os.fspath(script)),
-            mock.patch.object(guard.shutil, "which", side_effect=fake_which),
-        ):
-            result = self.run_guard(command)
-        self.assertEqual("allow", result["hookSpecificOutput"]["permissionDecision"])
-
     @unittest.skipUnless(os.name == "posix", "exported Bash functions are POSIX-only")
     def test_absolute_python_bypasses_exported_same_name_function(self) -> None:
         completed = subprocess.run(
@@ -1523,55 +1507,49 @@ class GuardTests(unittest.TestCase):
         flag_index = args.index(guard._AUTHORIZED_DATA_ROOT_FLAG)
         self.assertEqual("${CLAUDE_PLUGIN_DATA}", args[flag_index + 1])
 
-    def test_skill_hook_interpreters_cover_python3_and_python_and_resolve(self) -> None:
-        """Lock the guard's launch interpreters and prove a Python 3 name resolves.
+    def test_skill_hook_interpreter_is_python3_and_resolves(self) -> None:
+        """Lock the guard's launch interpreter and prove it resolves.
 
-        The PreToolUse hook runs in exec form, so each `command` resolves on PATH
-        with no shell. The guard registers two launch entries — `python3` and
-        `python` — so a host exposing a 3.11+ runtime under either name is
-        guarded; a name that is unresolvable, or a legacy 2.x that crashes on
-        modern syntax, is a non-blocking launch error the sibling entry
-        backstops. The static half locks that both names are present, anchoring
-        on each entry's destructive_guard.py args line so an unrelated future
-        `command:` key elsewhere in SKILL.md cannot be matched by accident. The
-        runtime half asserts every Python 3 name that resolves is 3.11+,
-        tolerates a legacy 2.x `python` (its py3 sibling enforces), and skips
-        only where no name yields a runnable 3.11+ interpreter — the documented
-        residual host gap, not a regression.
+        The PreToolUse hook runs in exec form, so `command` is resolved on PATH
+        with no shell. Bare `python` is absent on stock macOS and many Linux
+        distros (and a legacy 2.x would crash the guard), which fails the launch
+        open — the guard never intercepts. The static half locks the config at
+        `python3`. The runtime half is the "interpreter actually resolves" probe:
+        it skips where `python3` cannot run — absent from PATH, or resolved to a
+        name that will not execute (a Windows App Execution Alias stub resolves
+        to a real path yet exits non-zero) — because that is the documented
+        residual host gap, not a regression; only a runnable `python3` is
+        asserted to be 3.11+.
         """
         skill = SCRIPT_DIR.parent / "SKILL.md"
-        lines = skill.read_text(encoding="utf-8").splitlines()
-        interpreters = [
-            line.split(":", 1)[1].strip().strip('"')
-            for index, line in enumerate(lines)
-            if line.strip().startswith("command:")
-            and index + 1 < len(lines)
-            and "destructive_guard.py" in lines[index + 1]
-            and "args:" in lines[index + 1]
-        ]
-        self.assertEqual(["python", "python3"], sorted(interpreters), interpreters)
+        command_line = next(
+            (
+                line
+                for line in skill.read_text(encoding="utf-8").splitlines()
+                if line.strip().startswith("command:")
+            ),
+            None,
+        )
+        self.assertIsNotNone(command_line, "frontmatter hook command line not found")
+        assert command_line is not None
+        interpreter = command_line.split(":", 1)[1].strip().strip('"')
+        self.assertEqual("python3", interpreter)
 
-        covered_by_py3 = False
-        for interpreter in interpreters:
-            resolved = shutil.which(interpreter)
-            if resolved is None:
-                continue
-            probe = subprocess.run(
-                [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
-                capture_output=True,
-                text=True,
-            )
-            if probe.returncode != 0 or not probe.stdout.strip():
-                continue
-            major, minor = (int(part) for part in probe.stdout.strip().split("."))
-            if major < 3:
-                continue
-            self.assertGreaterEqual((major, minor), (3, 11), f"{interpreter}: {probe.stdout}")
-            covered_by_py3 = True
-        if not covered_by_py3:
+        resolved = shutil.which(interpreter)
+        if resolved is None:
+            self.skipTest(f"{interpreter} does not resolve on this host")
+        probe = subprocess.run(
+            [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0 or not probe.stdout.strip():
             self.skipTest(
-                "neither python3 nor python resolves to a runnable 3.11+ interpreter on this host"
+                f"{interpreter} resolved to a non-runnable interpreter "
+                f"({(probe.stderr or probe.stdout).strip()})"
             )
+        major, minor = (int(part) for part in probe.stdout.strip().split("."))
+        self.assertGreaterEqual((major, minor), (3, 11), probe.stdout)
 
     def test_guard_scan_max_depth_accepts_only_positive_integer_literal(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1507,6 +1507,43 @@ class GuardTests(unittest.TestCase):
         flag_index = args.index(guard._AUTHORIZED_DATA_ROOT_FLAG)
         self.assertEqual("${CLAUDE_PLUGIN_DATA}", args[flag_index + 1])
 
+    def test_skill_hook_interpreter_is_python3_and_resolves(self) -> None:
+        """Lock the guard's launch interpreter and prove it resolves.
+
+        The PreToolUse hook runs in exec form, so `command` is resolved on PATH
+        with no shell. Bare `python` is absent on stock macOS and many Linux
+        distros (and a legacy 2.x would crash the guard), which fails the launch
+        open — the guard never intercepts. The static half locks the config at
+        `python3`; the runtime half is the "interpreter actually resolves" probe,
+        skipped only where no `python3` exists at all so it never false-fails a
+        host that simply lacks the runtime the plugin already requires elsewhere.
+        """
+        skill = SCRIPT_DIR.parent / "SKILL.md"
+        command_line = next(
+            (
+                line
+                for line in skill.read_text(encoding="utf-8").splitlines()
+                if line.strip().startswith("command:")
+            ),
+            None,
+        )
+        self.assertIsNotNone(command_line, "frontmatter hook command line not found")
+        assert command_line is not None
+        interpreter = command_line.split(":", 1)[1].strip().strip('"')
+        self.assertEqual("python3", interpreter)
+
+        resolved = shutil.which(interpreter)
+        if resolved is None:
+            self.skipTest(f"{interpreter} not resolvable on this host")
+        version = subprocess.run(
+            [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, version.returncode, version.stderr)
+        major, minor = (int(part) for part in version.stdout.strip().split("."))
+        self.assertGreaterEqual((major, minor), (3, 11), version.stdout)
+
     def test_guard_scan_max_depth_accepts_only_positive_integer_literal(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"
         base = f'"{self.python_command()}" "{script}" scan --target t --output s'

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1514,9 +1514,12 @@ class GuardTests(unittest.TestCase):
         with no shell. Bare `python` is absent on stock macOS and many Linux
         distros (and a legacy 2.x would crash the guard), which fails the launch
         open — the guard never intercepts. The static half locks the config at
-        `python3`; the runtime half is the "interpreter actually resolves" probe,
-        skipped only where no `python3` exists at all so it never false-fails a
-        host that simply lacks the runtime the plugin already requires elsewhere.
+        `python3`. The runtime half is the "interpreter actually resolves" probe:
+        it skips where `python3` cannot run — absent from PATH, or resolved to a
+        name that will not execute (a Windows App Execution Alias stub resolves
+        to a real path yet exits non-zero) — because that is the documented
+        residual host gap, not a regression; only a runnable `python3` is
+        asserted to be 3.11+.
         """
         skill = SCRIPT_DIR.parent / "SKILL.md"
         command_line = next(
@@ -1534,15 +1537,19 @@ class GuardTests(unittest.TestCase):
 
         resolved = shutil.which(interpreter)
         if resolved is None:
-            self.skipTest(f"{interpreter} not resolvable on this host")
-        version = subprocess.run(
+            self.skipTest(f"{interpreter} does not resolve on this host")
+        probe = subprocess.run(
             [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
             capture_output=True,
             text=True,
         )
-        self.assertEqual(0, version.returncode, version.stderr)
-        major, minor = (int(part) for part in version.stdout.strip().split("."))
-        self.assertGreaterEqual((major, minor), (3, 11), version.stdout)
+        if probe.returncode != 0 or not probe.stdout.strip():
+            self.skipTest(
+                f"{interpreter} resolved to a non-runnable interpreter "
+                f"({(probe.stderr or probe.stdout).strip()})"
+            )
+        major, minor = (int(part) for part in probe.stdout.strip().split("."))
+        self.assertGreaterEqual((major, minor), (3, 11), probe.stdout)
 
     def test_guard_scan_max_depth_accepts_only_positive_integer_literal(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1135,6 +1135,22 @@ class GuardTests(unittest.TestCase):
             result["hookSpecificOutput"]["permissionDecisionReason"],
         )
 
+    def test_engine_call_allowed_under_sibling_registered_interpreter(self) -> None:
+        real = self.python_command()
+        script = SCRIPT_DIR / "hygiene.py"
+        command = f'"{real}" "{script}" scan --target t --output s'
+        original_which = guard.shutil.which
+
+        def fake_which(name: str) -> str | None:
+            return real if name in {"python", "python3"} else original_which(name)
+
+        with (
+            mock.patch.object(guard.sys, "executable", os.fspath(script)),
+            mock.patch.object(guard.shutil, "which", side_effect=fake_which),
+        ):
+            result = self.run_guard(command)
+        self.assertEqual("allow", result["hookSpecificOutput"]["permissionDecision"])
+
     @unittest.skipUnless(os.name == "posix", "exported Bash functions are POSIX-only")
     def test_absolute_python_bypasses_exported_same_name_function(self) -> None:
         completed = subprocess.run(

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1507,49 +1507,55 @@ class GuardTests(unittest.TestCase):
         flag_index = args.index(guard._AUTHORIZED_DATA_ROOT_FLAG)
         self.assertEqual("${CLAUDE_PLUGIN_DATA}", args[flag_index + 1])
 
-    def test_skill_hook_interpreter_is_python3_and_resolves(self) -> None:
-        """Lock the guard's launch interpreter and prove it resolves.
+    def test_skill_hook_interpreters_cover_python3_and_python_and_resolve(self) -> None:
+        """Lock the guard's launch interpreters and prove a Python 3 name resolves.
 
-        The PreToolUse hook runs in exec form, so `command` is resolved on PATH
-        with no shell. Bare `python` is absent on stock macOS and many Linux
-        distros (and a legacy 2.x would crash the guard), which fails the launch
-        open — the guard never intercepts. The static half locks the config at
-        `python3`. The runtime half is the "interpreter actually resolves" probe:
-        it skips where `python3` cannot run — absent from PATH, or resolved to a
-        name that will not execute (a Windows App Execution Alias stub resolves
-        to a real path yet exits non-zero) — because that is the documented
-        residual host gap, not a regression; only a runnable `python3` is
-        asserted to be 3.11+.
+        The PreToolUse hook runs in exec form, so each `command` resolves on PATH
+        with no shell. The guard registers two launch entries — `python3` and
+        `python` — so a host exposing a 3.11+ runtime under either name is
+        guarded; a name that is unresolvable, or a legacy 2.x that crashes on
+        modern syntax, is a non-blocking launch error the sibling entry
+        backstops. The static half locks that both names are present, anchoring
+        on each entry's destructive_guard.py args line so an unrelated future
+        `command:` key elsewhere in SKILL.md cannot be matched by accident. The
+        runtime half asserts every Python 3 name that resolves is 3.11+,
+        tolerates a legacy 2.x `python` (its py3 sibling enforces), and skips
+        only where no name yields a runnable 3.11+ interpreter — the documented
+        residual host gap, not a regression.
         """
         skill = SCRIPT_DIR.parent / "SKILL.md"
-        command_line = next(
-            (
-                line
-                for line in skill.read_text(encoding="utf-8").splitlines()
-                if line.strip().startswith("command:")
-            ),
-            None,
-        )
-        self.assertIsNotNone(command_line, "frontmatter hook command line not found")
-        assert command_line is not None
-        interpreter = command_line.split(":", 1)[1].strip().strip('"')
-        self.assertEqual("python3", interpreter)
+        lines = skill.read_text(encoding="utf-8").splitlines()
+        interpreters = [
+            line.split(":", 1)[1].strip().strip('"')
+            for index, line in enumerate(lines)
+            if line.strip().startswith("command:")
+            and index + 1 < len(lines)
+            and "destructive_guard.py" in lines[index + 1]
+            and "args:" in lines[index + 1]
+        ]
+        self.assertEqual(["python", "python3"], sorted(interpreters), interpreters)
 
-        resolved = shutil.which(interpreter)
-        if resolved is None:
-            self.skipTest(f"{interpreter} does not resolve on this host")
-        probe = subprocess.run(
-            [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
-            capture_output=True,
-            text=True,
-        )
-        if probe.returncode != 0 or not probe.stdout.strip():
-            self.skipTest(
-                f"{interpreter} resolved to a non-runnable interpreter "
-                f"({(probe.stderr or probe.stdout).strip()})"
+        covered_by_py3 = False
+        for interpreter in interpreters:
+            resolved = shutil.which(interpreter)
+            if resolved is None:
+                continue
+            probe = subprocess.run(
+                [resolved, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+                capture_output=True,
+                text=True,
             )
-        major, minor = (int(part) for part in probe.stdout.strip().split("."))
-        self.assertGreaterEqual((major, minor), (3, 11), probe.stdout)
+            if probe.returncode != 0 or not probe.stdout.strip():
+                continue
+            major, minor = (int(part) for part in probe.stdout.strip().split("."))
+            if major < 3:
+                continue
+            self.assertGreaterEqual((major, minor), (3, 11), f"{interpreter}: {probe.stdout}")
+            covered_by_py3 = True
+        if not covered_by_py3:
+            self.skipTest(
+                "neither python3 nor python resolves to a runnable 3.11+ interpreter on this host"
+            )
 
     def test_guard_scan_max_depth_accepts_only_positive_integer_literal(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"


### PR DESCRIPTION
## Summary

The `disk-hygiene` `clean` skill's PreToolUse destructive-safety guard launched in **exec form** via a single unqualified interpreter. Per the [hooks reference](https://code.claude.com/docs/en/hooks), exec form (an `args` array is present) resolves `command` on `PATH` with **no shell**, "all matching hooks run in parallel", and any non-zero exit that is not exit-2 is "a non-blocking error … Execution continues." A hook that cannot launch therefore produces no exit-2, so the tool call **proceeds** — a **fail-open of a security guard**.

The original guard named `python`, which stock macOS and many Linux distros do not ship (only `python3`) — a fail-open on the very POSIX hosts the safety model relies on. Naming `python3` alone closes that, but reopens the symmetric hole flagged by the Codex **P1** review: a POSIX layout that exposes the supported 3.11+ runtime as bare `python` with **no** `python3` regresses back to an unresolvable launch — the guard silently stops intercepting, and `hygiene.py apply` is no longer forced through the guard's final `ask`.

## Fix

- **`plugins/disk-hygiene/skills/clean/SKILL.md`** — the guard now registers **two** PreToolUse launch entries under the same matcher, `command: "python3"` and `command: "python"`, each running the same `destructive_guard.py`. All matching hooks run in parallel, so whichever name resolves to a 3.11+ runtime enforces — a host exposing the runtime under **either** name is guarded. This is fail-closed in every direction: an unresolvable name is a non-blocking launch error contributing nothing, and a legacy `python` 2.x entry crashes on modern syntax (also non-blocking); the sibling entry still guards. It cannot introduce a new fail-open — worst case it over-*denies* (fail-closed) on a pathological host where the two names resolve to genuinely distinct real interpreters (`resolve(strict=True)` collapses the common `python`→`python3` symlink to one path, so both `allow` the same engine call there).
- **Regression probe** — `test_skill_hook_interpreters_cover_python3_and_python_and_resolve` in `test_hygiene.py`, modeled on the sibling `test_skill_hook_passes_authorized_data_root_flag_matching_constant` seam test. It statically locks the frontmatter launch names to exactly `{python3, python}`, anchored on each entry's `destructive_guard.py` args line so an unrelated future `command:` key elsewhere in SKILL.md cannot be matched by accident (closing the parser-fragility advisory from the `claude[bot]` reviews). The runtime half asserts every Python 3 name that resolves is 3.11+, tolerates a legacy 2.x `python` (its py3 sibling enforces), and skips only where no name yields a runnable 3.11+ interpreter — the documented residual host gap, not a regression.
- **rule 6e — no false guarantee** — the `## Gotchas` bullet and CHANGELOG entry caveat that enforcement is only as strong as interpreter resolution. Residual: on a host where **neither** name resolves to a runnable 3.11+ interpreter (e.g. a python.org-only Windows install exposing only `py`) the launch still fails open on the manual PowerShell deletion lane. That does **not** open a silent auto-delete path — engine `apply` is unsupported on Windows and macOS, runs only after the guard's `ask`, and the manual-handoff human approval plus the consumer's baseline permission policy still gate every deletion — but it is defense-in-depth lost, not preserved. `/disk-hygiene:setup check` reports which interpreters resolve.
- **Version** — `disk-hygiene` `0.4.2` → `0.4.3`, with a top-inserted CHANGELOG entry.

### Why two entries, not a launcher script or shell form

Exec form already runs without a shell, so the guard needs no Git Bash/PowerShell — switching to shell form to do `python3 || python` resolution would *newly* depend on a shell and regress the PowerShell-only-Windows case. A "tiny launcher" must itself be launched by some interpreter name (same bootstrap problem), and exec form on Windows requires `command` to resolve to a real executable such as a `.exe` — a `.sh` launcher cannot be the `command`.

Two hook entries were **initially rejected** here citing double-run on machines with both names. That call is now reversed: it optimized against redundant execution, but the Codex P1 confirmed a real fail-*open* on a supported runtime layout, which is the dominating concern for a safety guard. Double-run of a fail-closed guard is safe redundancy (both entries run the identical decision function; the common `python`→`python3` symlink resolves to one path, so they agree); a silently unguarded host is not. Registering both names is the minimal change that guards every host exposing the runtime under either name, with no new fail-open.

## Verification

All commands run in the worktree.

**Full suite (75 tests) via the plugin's cross-platform wrapper — pass:**
```
$ bash hygiene.test.sh
...
Ran 75 tests in 2.910s
OK (skipped=4)
```

**New regression test runs (not skipped) and passes:**
```
$ python3 -m unittest -v test_hygiene.GuardTests.test_skill_hook_interpreters_cover_python3_and_python_and_resolve
Lock the guard's launch interpreters and prove a Python 3 name resolves. ... ok
Ran 1 test in 0.091s
OK
```

**Proof the guard launches under BOTH names and denies `rm -rf` (fail-closed):**
```
$ for i in python3 python; do echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/example"}}' \
    | "$i" destructive_guard.py --authorized-data-root /tmp/data | jq -r .hookSpecificOutput.permissionDecision; done
deny
deny
```

**Linters/format on changed files:**
```
$ markdownlint-cli2 plugins/disk-hygiene/skills/clean/SKILL.md plugins/disk-hygiene/CHANGELOG.md
Summary: 0 error(s)

$ ruff check plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
All checks passed!
```

Closes #380

## Related

- Source issue: #380 (priority: high, area: security).
- Sibling: merged PR #742 touched this same guard's argv (authorized-data-root resolution); this change is orthogonal (launch interpreter).
- **Decision revised:** the earlier `python3`-only choice (`## Decision (Option A)` on #380) was re-derived after the Codex P1 review demonstrated it reopened a fail-open on a bare-`python`-only POSIX layout. Multi-name launch (both `python3` and `python`) is the corrected approach; the launcher / shell-form alternatives remain rejected as documented above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
