### PR TITLE
docs(go-format): document generated-file guard's known bash-vs-ast.IsGenerated gaps

### DIFF
--- a/plugins/go-format/.claude-plugin/plugin.json
+++ b/plugins/go-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "go-format",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Auto-fix Go formatting and import management on edit via goimports — runs unconditionally (no consumer-config gate), skipping generated files.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/go-format/CHANGELOG.md
+++ b/plugins/go-format/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `go-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.1]
+
+### Added
+
+- Documented the generated-file guard's known limitation in
+  `hooks/go-format.sh`: the leading-block scan is a deliberate string-match
+  approximation of Go's own `ast.IsGenerated` (a parsed-AST classifier), the
+  gap between the two is structural rather than a fixable bug, and no further
+  pattern patches are planned unless a real-world generated file is observed
+  defeating the scan — at which point the structural fix is a `go`-toolchain
+  shell-out, not another pattern. Documentation-only; no behavior change.
+
 ## [0.1.0]
 
 ### Added

--- a/plugins/go-format/hooks/go-format.sh
+++ b/plugins/go-format/hooks/go-format.sh
@@ -134,6 +134,22 @@ emit_skipped() {
 # matches. (The marker itself can only ever appear on a `//`-prefixed line —
 # `^// Code generated .* DO NOT EDIT\.$` — never inside a `/* */` block, so
 # block-comment lines are only ever scanned-through, not matched against.)
+#
+# APPROXIMATION: this string-match scan is a deliberate stand-in for Go's own
+# `ast.IsGenerated`, which classifies a *parsed* `*ast.File` (via `go/parser`).
+# The two cannot be made equal by adding patterns — the gap is structural, so
+# exotic shapes (unusual build-tag/comment interleavings, nested block
+# comments, atypical Unicode whitespace) can keep surfacing indefinitely. That
+# is tolerable because the guard is advisory (see ADVISORY, top of file): an
+# unhandled shape only means goimports reformats a generated file — visible in
+# the diff, no gate broken. So no further pattern patches are planned unless a
+# *real-world* generated file is observed defeating this scan; a synthetic
+# counter-example alone is not enough. The actual structural fix, should a real
+# case ever warrant it, is to shell out to the `go` toolchain (`go/parser` plus
+# the real `ast.IsGenerated` logic) instead of extending this matcher — not
+# done here because it would add per-edit latency and a hard `go`-toolchain
+# dependency this hook otherwise keeps optional (only `-local` grouping needs
+# `go`).
 GENERATED=0
 IN_BLOCK=0
 while IFS= read -r _line || [[ -n "$_line" ]]; do


### PR DESCRIPTION
## Summary

`plugins/go-format/hooks/go-format.sh`'s generated-file guard is a bash
string-match approximation of Go's own `ast.IsGenerated` (a parsed-AST
classifier via `go/parser`). Across PR #910's review, an automated Codex pass
progressively surfaced — and each time got a real fix for — a bare marker, a
`//`-header before the marker, a `/* */` block-comment header, an *indented*
block-comment header, and a tab-only blank separator (now covered by regression
cases 5–5h in `go-format.test.sh`).

That is the expected shape of chasing string-match parity with an AST-based
detector: the gap is **structural, not a single fixable bug**, so further narrow
edge cases can keep surfacing indefinitely. The guard is advisory only — the
hook never blocks an edit; the worst case for an unhandled shape is goimports
reformatting a generated file, visible in the diff, no gate broken. This PR
documents that deliberate scope boundary at the guard's location so the
known-limitation is explicit rather than implicit, and re-litigating the
tradeoff isn't needed each time a bot or human surfaces a new exotic shape.

## Fix

Documentation-only. No behavior change, no logic change, no test change.

- **`plugins/go-format/hooks/go-format.sh`** — extended the existing
  `GENERATED-FILE GUARD` inline comment block (at the guard's scan logic) with
  an `APPROXIMATION:` note capturing: (1) the scan is a deliberate string-match
  stand-in for `ast.IsGenerated`, which can't be made equal by adding patterns
  because the gap is structural; (2) that's tolerable because the guard is
  advisory (worst case = a generated file gets reformatted, visible in the
  diff); (3) no further pattern patches unless a **real-world** generated file
  is observed defeating it (a synthetic counter-example is not enough); (4) the
  actual structural fix — a `go`-toolchain shell-out (`go/parser` + real
  `ast.IsGenerated`) — is deliberately not taken, to avoid per-edit latency and
  a hard `go` dependency this hook otherwise keeps optional. Placed as a
  maintainer-facing code comment (single home) rather than duplicated into the
  user-facing README, whose "Skips generated files" bullet already covers the
  behavior. The comment references no issue/PR number — it stands on its own.
- **`plugins/go-format/CHANGELOG.md`** — new `## [0.1.1]` `### Added` entry.
- **`plugins/go-format/.claude-plugin/plugin.json`** — patch bump `0.1.0` → `0.1.1`.

## Verification

Docs-only: verification is "no code/behavior change; existing suite still
passes." Ran the full go-format hook test suite (a real `goimports` v0.48.0 on
PATH) before and after the comment edit:

```
$ GOIMPORTS_TEST_BIN="$HOME/go/bin/goimports.exe" bash plugins/go-format/hooks/go-format.test.sh
...
PASS=45 FAIL=0
```

`shellcheck plugins/go-format/hooks/go-format.sh` → clean.

Closes #927

## Related

- #910 — the PR whose review (a progressive Codex edge-case pass) produced this
  issue and the 5a–5h regression cases.