### PR TITLE
docs(ignition): acceleration ruling — front-load count, parallel Phase IV, flip pre-build

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -10,7 +10,11 @@ lifecycle plugins.
 A plugin is a reusable, independently useful vertical slice of one cohesive capability. It must work
 outside the repository and organization that produced it. Publisher metadata may identify its source;
 runtime behavior must not depend on publisher names, organization-specific environment variables,
-repository names, absolute machine paths, or an undocumented consumer layout.
+repository names, absolute machine paths, or an undocumented consumer layout. The artifact-agnostic
+form of this doctrine — consumer-agnostic behavior, externalized consumer-varying configuration,
+consumer tiers, explicit adoption — is owned by `melodic-software/standards`
+`conventions/engineering/shareable-artifact-design.md`; this document specializes it for Claude Code
+plugins and adds only what is plugin-specific.
 
 Keep plugins horizontally decoupled:
 
@@ -384,6 +388,9 @@ authoritative self-updating master list. Pages load-bearing for this document, v
   tags, bundles.
 - [Claude Code settings](https://code.claude.com/docs/en/settings) — settings scopes, precedence, and
   the special storage and read scopes of `pluginConfigs`.
+- `melodic-software/standards` `conventions/engineering/shareable-artifact-design.md` — the
+  artifact-agnostic consumer-facing design doctrine the design boundary, configuration ownership,
+  and setup contract above specialize for plugins.
 - `melodic-software/standards` engineering philosophy and cross-platform review criteria — repository
   design and verification policy.
 


### PR DESCRIPTION
Dated Phase-4 note: operator ruling (2026-07-22) to move at maximum speed within the predicate's intent. Calendar gates stay binding; sanctioned levers are front-loaded seeding (genuine items only), parallel Phase IV ignition (gate already met), and pre-built Phase III flip machinery. Records same-day watch activity: drain PRs #23/#24/#26 + Dependabot #25 merged, queue reseeded (scratch#27–#31), predicate completions=6.

## Related

- kyle-sexton/autonomy-demo-scratch#27–#31. No linked issue — status-note documentation; nothing in this repo closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)