### PR TITLE
docs: cite shareable-artifact-design as the generalized upstream doctrine

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -10,7 +10,11 @@ lifecycle plugins.
 A plugin is a reusable, independently useful vertical slice of one cohesive capability. It must work
 outside the repository and organization that produced it. Publisher metadata may identify its source;
 runtime behavior must not depend on publisher names, organization-specific environment variables,
-repository names, absolute machine paths, or an undocumented consumer layout.
+repository names, absolute machine paths, or an undocumented consumer layout. The artifact-agnostic
+form of this doctrine — consumer-agnostic behavior, externalized consumer-varying configuration,
+consumer tiers, explicit adoption — is owned by `melodic-software/standards`
+`conventions/engineering/shareable-artifact-design.md`; this document specializes it for Claude Code
+plugins and adds only what is plugin-specific.
 
 Keep plugins horizontally decoupled:
 
@@ -384,6 +388,9 @@ authoritative self-updating master list. Pages load-bearing for this document, v
   tags, bundles.
 - [Claude Code settings](https://code.claude.com/docs/en/settings) — settings scopes, precedence, and
   the special storage and read scopes of `pluginConfigs`.
+- `melodic-software/standards` `conventions/engineering/shareable-artifact-design.md` — the
+  artifact-agnostic consumer-facing design doctrine the design boundary, configuration ownership,
+  and setup contract above specialize for plugins.
 - `melodic-software/standards` engineering philosophy and cross-platform review criteria — repository
   design and verification policy.
 


### PR DESCRIPTION
## Summary

PLUGIN-PHILOSOPHY's design boundary is the plugin specialization of the org-wide convention now owned by `melodic-software/standards` `conventions/engineering/shareable-artifact-design.md` (standards #237, merged in standards PR #238). The design boundary states the specialization relationship; the authoritative references gain the explicit entry. Completes the follow-up promised in #933's companion work.

No linked issue: the tracked items (#933, standards#237) are already closed by their own PRs; this is their promised follow-up citation.

## Related

- melodic-software/standards#237 — the convention doc this cites (closed by standards PR #238; not closed by this PR).
- #933 — the advisor-escalation work this citation follow-up was sequenced after (already closed by #934).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
