### PR TITLE
fix(guardrails): restore path-detection prefilter fail-open fix (0.9.8)

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
@@ -35,7 +35,7 @@
     "block_no_verify_enabled": {
       "type": "boolean",
       "title": "block-no-verify guard",
-      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, lefthook disables)",
+      "description": "Block git hook-bypass attempts (--no-verify, core.hooksPath=, hook-manager env-var disables for a configurable set — lefthook/husky/pre-commit/simple-git-hooks by default)",
       "default": true
     },
     "block_dangerous_git_enabled": {

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.8]
+
+### Fixed
+
+- **`hardcoded-path-check` pre-filter no longer fails open on the broadened
+  checkout roots.** 0.9.7 widened the detailed drive-letter bodies to accept
+  `Projects` and `Dev` (both capitalizations), but the cheap `scan_text`
+  pre-filter gate still tripped only on `Users|/home/|repos`. Content whose
+  sole machine path used a widened root (e.g. `C:\Projects\…`, `C:\Dev\…`)
+  early-returned before the detailed scan ever ran — a fail-open in a security
+  gate. The gate now lists every root token the detailed bodies accept, keeping
+  it a strict superset; a `Projects`-root regression test guards it.
+
+### Changed
+
+- **`block-no-verify` guard description broadened to match shipped behavior.**
+  The `block_no_verify_enabled` userConfig description still enumerated
+  "lefthook disables" only; it now states the actual configurable default set
+  (lefthook, husky, pre-commit, simple-git-hooks).
+
 ## [0.9.7]
 
 ### Changed

--- a/plugins/guardrails/hooks/hardcoded-path-check.test.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.test.sh
@@ -78,6 +78,15 @@ OUT=$(HOME="$TEST_TMPDIR/elsewhere2" CLAUDE_PROJECT_DIR="$SUBREPO/pkg" \
 assert_exit "repo subdir of non-home checkout → exit 2" 2 "$RC"
 assert_contains "repo subdir → machine-specific repo message" "$OUT" "Machine-specific repo path"
 
+# Generic Windows checkout root under a widened root name (Projects/Dev/Repos):
+# content carries no "Users"/"repos" literal, so it exercises the cheap
+# pre-filter gate — which must trip on every root HPP_WIN_REPO_BODY accepts, or
+# the scan early-returns and the leak passes (fail-open).
+WIN_PROJECTS="D:${BS}Projects${BS}acme${BS}src"
+OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "build from ${WIN_PROJECTS}")" 2>&1); RC=$?
+assert_exit "windows Projects checkout root → exit 2" 2 "$RC"
+assert_contains "windows Projects root → message" "$OUT" "Windows repo path"
+
 # ============================ ALLOW (exit 0) ================================
 OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" 'echo "hello world"')" 2>&1); RC=$?
 assert_exit "clean content → exit 0" 0 "$RC"

--- a/plugins/guardrails/lib/path-detection/hardcoded-path-patterns.sh
+++ b/plugins/guardrails/lib/path-detection/hardcoded-path-patterns.sh
@@ -59,7 +59,9 @@ hpp::scan_text() {
   # of every detailed pattern's invariant literal:
   #   Users   ⊇ Windows-user + macOS-user  (both forms contain "Users")
   #   /home/  ⊇ Linux-user
-  #   repos   ⊇ Windows-repo + escaped-Windows-repo
+  #   checkout-root literals ⊇ Windows-repo + escaped-Windows-repo — the gate
+  #     lists every root token HPP_WIN_REPO_BODY / HPP_ESCAPED_WIN_REPO_BODY
+  #     accept (both spellings), so a widened body must widen this list too.
   # The project-root branch keys on the root's final path segment, which is
   # present identically in the slash, backslash, and escaped forms. When NONE of
   # these triggers fire, no detailed pattern below can match, so early-returning
@@ -71,7 +73,7 @@ hpp::scan_text() {
   # Uses a here-string, NOT `printf | grep -q`: a pipe + `grep -q` early-exit
   # would SIGPIPE printf, and under `pipefail` the pipeline would report printf's
   # failure and invert the result.
-  if ! grep -qE 'Users|/home/|repos' <<<"$content" 2>/dev/null; then
+  if ! grep -qE 'Users|/home/|repos|Repos|projects|Projects|dev|Dev' <<<"$content" 2>/dev/null; then
     local gate_root=""
     if [[ -n "$project_root" ]]; then
       gate_root="${project_root//\\//}"


### PR DESCRIPTION
## Summary

The `hardcoded-path-check` guard's cheap `scan_text` pre-filter had narrowed on `main`: it gated only on `Users|/home/|repos`, while the detailed drive-letter bodies (`HPP_WIN_REPO_BODY` / `HPP_ESCAPED_WIN_REPO_BODY`) accept the broadened `repos|Repos|projects|Projects|dev|Dev` roots shipped in 0.9.7. Content whose only machine path used a widened root (e.g. `C:\Projects\…`, `C:\Dev\…`) therefore early-returned `0` before the detailed scan ever ran — a fail-open in a security gate. This re-widens the pre-filter gate to a strict superset of every root token the detailed bodies accept, adds a `Projects`-root regression test, folds in the stale `block_no_verify_enabled` description sync (it still read "lefthook disables" only, now the full configurable default set), and bumps the plugin to `0.9.8`.

All 40 `hardcoded-path-check` tests pass; shellcheck clean.

Closes #944

## Related

- #932 — the merged PR whose landed fail-open fix (`9a33e665`) was dropped by a concurrent force-push, landing this regression on `main`; this PR restores it fix-forward.
- #918 — the original broadened-machine-roots issue #932 addressed.
