### PR TITLE
ci(security): enforce zizmor findings via fail-on-findings (#510 Phase 0+1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,13 @@ updates:
       # dependency intentionally tracks the latest Claude Code release.
       interval: daily
     open-pull-requests-limit: 5
+    cooldown:
+      # Biome waits out the supply-chain settle window like every other locked
+      # dependency. Claude Code is excluded so it keeps tracking the latest
+      # release immediately, matching this root's daily schedule.
+      default-days: 7
+      exclude:
+        - "@anthropic-ai/claude-code"
     # Batch minor + patch bumps into one reviewed PR; majors stay individual.
     groups:
       npm-minor-patch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,11 +225,11 @@ jobs:
     permissions:
       contents: read
     # Actions security lint; any regular-persona finding blocks the merge gate.
-    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
+    uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@31a5b76c4a0b663023dc1c944e2bcfc01d6f6c46 # 31a5b76 2026-07-21
     with:
       runner: ubuntu-24.04
       paths: .
-      fail-on-findings: true
+      fail-on-severity: low
 
   hook-utils-sync:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,11 +224,12 @@ jobs:
   zizmor:
     permissions:
       contents: read
-    # Advisory Actions security lint; findings annotate without blocking.
+    # Actions security lint; any regular-persona finding blocks the merge gate.
     uses: melodic-software/ci-workflows/.github/workflows/zizmor.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
     with:
       runner: ubuntu-24.04
       paths: .
+      fail-on-findings: true
 
   hook-utils-sync:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

The `zizmor` Actions-security lane ran **advisory** — it exited non-zero on findings but the reusable workflow swallowed that (default no-block), so findings only appeared as transient check-run annotations and never blocked a merge. This PR moves the lane from advisory to **enforced**: any finding the `regular` persona emits now red-lines the required `ci-status` merge gate.

Because flipping the gate red-lines every open PR on any unresolved finding, the default branch had to be finding-free first — so this PR also fixes the one live finding at `main` HEAD (Phase 0) before enforcing (Phase 1).

## Fix

**Phase 0 — fix the live finding set.** Confirmed the current finding set two ways: locally (`zizmor --persona=regular .`, no `--min-severity` floor, matching the lane) and against the actual `zizmor` CI job on `main` HEAD (run `29890319770`, commit `c52e30a`) via its check-run annotations. Both agree on exactly **one** actionable finding:

- `dependabot-cooldown` (medium) — `.github/dependabot.yml:43`, the root `npm` update block had no `cooldown:`.

Fix (`.github/dependabot.yml`): add `cooldown: default-days: 7` to that block, with `exclude: ["@anthropic-ai/claude-code"]`. `default-days: 7` clears the audit (anything lower re-triggers the medium); the `exclude` is invisible to the audit and preserves the block's documented intent — Claude Code keeps tracking the latest release immediately on its daily schedule. **Behavior change to name:** `@biomejs/biome` (the other dep in that block) now waits out the 7-day settle window where it previously updated immediately — consistent with every other update block in the file.

**Phase 1 — enforce the gate** (`.github/workflows/ci.yml`): bump the zizmor reusable-workflow pin `90f1c54` → `31a5b76` and set **`fail-on-severity: low`** (replacing the initially-attempted `fail-on-findings: true`).

Why `fail-on-severity` and a pin bump rather than `fail-on-findings` at the old pin: the required `Runner policy` lane enforces a per-call `allowedInputs` contract that lives in `.github/standards/runner-policy/policy.json`, which is **upstream-managed** (synced from `melodic-software/standards`; editing the materialization here is forbidden and would drift). That managed contract does **not** bless `fail-on-findings` for the zizmor call at pin `90f1c54`, and the repository-local overlay (`.github/runner-policy.json`) exposes **no seam** to add an input (verified empirically — the engine rejects any contract override: `additionalProperties` violation). Upstream ci-workflows has since superseded the boolean: at `zizmor.yml@31a5b76` (2026-07-21), `fail-on-severity` (never/low/medium/high) is the **preferred** blocking input and `fail-on-findings` is a legacy alias. The managed contract **already blesses** `fail-on-severity` for that newer pin, so bumping to it is a fully in-repo path with no managed-file edit and no cross-repo change. `low` blocks on any finding at note-level and above — byte-for-byte the same "any finding, no floor" behavior the boolean would have given.

## Verification

- **Confirmed live-finding set:** 1 finding (`dependabot-cooldown` @ `.github/dependabot.yml:43`), cross-checked local run + `main` CI annotations.
- **Fix clears it:** re-ran `zizmor --persona=regular .` after the fix on **zizmor 1.27.0** (the exact version the reusable workflow pins) → `No findings to report`, exit 0.
- **Runner policy passes:** ran the managed engine locally — `node .github/standards/runner-policy/runner-policy.mjs --root .` → `Runner policy passed.` `actionlint .github/workflows/ci.yml` → clean.
- **Gate proof:** this PR's own `zizmor` lane runs with `fail-on-severity: low` active — a green lane / green `ci-status` is the definitive proof Phase 0 is complete. See the CI status on this PR.

## Caveats (no false guarantees)

- This enforcement adds a merge gate on the required `ci-status` check with **no severity floor** — `fail-on-severity: low` blocks on any finding zizmor's `regular` persona emits (note and above), not just warnings.
- It interacts with the #476 autopilot merge tier: a blocking `zizmor` conclusion becomes part of what that tier must clear before an automated merge.
- This makes findings **NOTICED (red conclusion) and ENFORCED** — not readable-in-content. The durable code-scanning surface (SARIF → code scanning) is **deferred upstream** (see Related); findings are not "fully surfaced" here.

Closes #510

## Related

- Source issue: #510 (Phase 0 + Phase 1 — the in-repo scope).
- Operator ruling 2026-07-22T03:17Z: compose Option 3 then Option 2; defer Option 1 to #509; defer Phase 2 upstream.
- Decision (Option A — pin bump + `fail-on-severity: low`): ratified by Opus-consensus review after the `Runner policy` contract blocker surfaced; recorded on #510.
- Phase 2 (SARIF / code-scanning surface): deferred to `melodic-software/ci-workflows#154`.
- Option 1: deferred to #509.
- Merge-tier interaction: #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
