### PR TITLE
fix(disk-hygiene): enforce disk_hygiene_enabled kill switch on PowerShell lane + via hook argv

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.4]
+
+### Fixed
+
+- **The `disk_hygiene_enabled` kill switch now actually blocks deletions in audit-only mode.**
+  Setting `disk_hygiene_enabled=false` (audit-only mode) failed to prevent deletions in two
+  independent ways, both fixed here.
+  - The PowerShell lane never consulted the kill switch: `destructive_guard.py` routed `PowerShell`
+    calls to `powershell_decision` and returned before the enabled gate was computed, so flagged
+    deletion spellings (`Remove-Item`, `rm`, `del`, `::Delete`, recycle-bin calls) still returned
+    `ask` — and could be approved — even with execution disabled. The enabled gate is now resolved
+    before the tool-name branch and threaded into `powershell_decision`, which denies flagged
+    deletions in audit-only mode and only prompts (`ask`) when execution is enabled.
+  - The kill switch was inert under the env-injection failure: the guard read
+    `CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED` from the hook process environment and defaulted to
+    enabled when absent, but the runtime does not inject plugin env vars into a skill-frontmatter
+    hook's environment, so a configured `false` was silently overridden to enabled. The `clean`
+    skill's hook now passes the configured value as a runtime-substituted
+    `--disk-hygiene-enabled ${user_config.disk_hygiene_enabled}` argument — inline placeholder
+    substitution resolves in exec-form hook `args` where environment injection does not — and the
+    guard reads the kill switch from that argument, honoring the environment variable only as a
+    fallback. When no channel supplies a value the guard still fails safe to enabled (guard active,
+    every mutation gated behind the final human prompt). This mirrors the `--authorized-data-root`
+    argv mechanism.
+
 ## [0.4.3]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -10,7 +10,7 @@ hooks:
       hooks:
         - type: command
           command: "python3"
-          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}"]
+          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py", "--authorized-data-root", "${CLAUDE_PLUGIN_DATA}", "--disk-hygiene-enabled", "${user_config.disk_hygiene_enabled}"]
 ---
 
 # Disk hygiene
@@ -34,7 +34,12 @@ directory, symlink, or Windows reparse point.
   retention mechanism. Report `needs-elevation` or `handle-state-unverified` and stop that tier.
 - If the `disk_hygiene_enabled` userConfig option is `false` (its value here is
   `${user_config.disk_hygiene_enabled}`; a literal unexpanded token means unset = enabled), audit
-  only and explain why execution is disabled. The hook
+  only and explain why execution is disabled. In this audit-only mode the guard denies every
+  deletion lane, including the flagged PowerShell mutation spellings, not only the Bash engine
+  apply. The kill-switch value reaches the guard as a runtime-substituted hook argument
+  (`--disk-hygiene-enabled ${user_config.disk_hygiene_enabled}`), so a configured `false` is
+  honored even where the runtime does not inject the `CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED`
+  environment variable; the environment variable is only a fallback. The hook
   runs in shell-free exec form and reports its absolute Python interpreter and the authorized
   `--data-root` value in denial guidance. Use that exact interpreter path as `<hook-python>` for
   every engine call; bare `python`/`python3` is rejected because Bash aliases and functions can

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -61,10 +61,16 @@ only a bare positive-integer literal.
 
 The same guard also covers the PowerShell tool with the inverse tradeoff: PowerShell stays open for
 read-only support work, while engine invocations are hard-denied (Bash is the only engine lane) and
-known deletion spellings and .NET Delete calls are downgraded to a final human permission prompt —
-the same bar as the engine apply prompt. That lane is a raised bar, not fail-closed: an unknown
-mutation spelling passes it, so the engine's own containment, revalidation, and platform gates remain
-the deletion authority.
+known deletion spellings and .NET Delete calls resolve against the `disk_hygiene_enabled` kill
+switch — the same bar as the engine apply lane. When execution is enabled they are downgraded to a
+final human permission prompt; in audit-only mode (`disk_hygiene_enabled` is `false`) they are
+denied outright, so the kill switch blocks deletions on the PowerShell lane too and not only the
+Bash engine apply. The kill-switch value reaches the guard as a runtime-substituted hook argument
+(`--disk-hygiene-enabled ${user_config.disk_hygiene_enabled}`), so a configured `false` holds even
+where the runtime does not inject `CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED` into the hook
+environment (the environment variable is only a fallback). That lane is a raised bar, not
+fail-closed: an unknown mutation spelling passes it, so the engine's own containment, revalidation,
+and platform gates remain the deletion authority.
 
 A depth-limited scan records every directory it declined to enter in `truncated_paths`. Truncated
 directories have no captured descendant set, so the preview blocks them (and anything beneath them)

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -112,22 +112,31 @@ _AUTHORIZED_DATA_ROOT_FLAG = "--authorized-data-root"
 _CLAUDE_PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA"
 _AUTHORIZED_DATA_ROOT_PLACEHOLDER = f"${{{_CLAUDE_PLUGIN_DATA_ENV}}}"
 
+_DISK_HYGIENE_ENABLED_FLAG = "--disk-hygiene-enabled"
+_DISK_HYGIENE_ENABLED_ENV = "CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED"
+_DISK_HYGIENE_ENABLED_PLACEHOLDER = "${user_config.disk_hygiene_enabled}"
 
-def _argv_authorized_data_root(argv: list[str]) -> str | None:
-    """Read the authorized data root the runtime substituted into the hook argv.
 
-    The skill-frontmatter hook passes ``--authorized-data-root ${CLAUDE_PLUGIN_DATA}``;
-    inline placeholder substitution resolves in hook arguments even where
+def _argv_flag_value(argv: list[str], flag: str) -> str | None:
+    """Read the runtime-substituted value the frontmatter hook passed for ``flag``.
+
+    Inline placeholder substitution resolves in hook ``args`` even where
     environment injection does not, so the guard's own argv is the authoritative,
-    model-unforgeable channel for the data root.
+    model-unforgeable channel for a value the harness controls. Accepts both the
+    space-separated (``--flag value``) and ``--flag=value`` spellings.
     """
     for index, token in enumerate(argv):
-        if token == _AUTHORIZED_DATA_ROOT_FLAG and index + 1 < len(argv):
+        if token == flag and index + 1 < len(argv):
             return argv[index + 1]
-        prefix = f"{_AUTHORIZED_DATA_ROOT_FLAG}="
+        prefix = f"{flag}="
         if token.startswith(prefix):
             return token[len(prefix) :]
     return None
+
+
+def _argv_authorized_data_root(argv: list[str]) -> str | None:
+    """Read the authorized data root the runtime substituted into the hook argv."""
+    return _argv_flag_value(argv, _AUTHORIZED_DATA_ROOT_FLAG)
 
 
 def resolve_authorized_data_root() -> str | None:
@@ -140,6 +149,25 @@ def resolve_authorized_data_root() -> str | None:
     if from_argv and from_argv != _AUTHORIZED_DATA_ROOT_PLACEHOLDER:
         return from_argv
     return os.environ.get(_CLAUDE_PLUGIN_DATA_ENV)
+
+
+def resolve_disk_hygiene_enabled() -> bool:
+    """Resolve the execution kill switch from the hook argv, then the environment.
+
+    The kill switch is a safety control: ``false`` is audit-only mode and must
+    prevent every deletion lane. The runtime does not inject
+    ``CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED`` into a skill-frontmatter hook's
+    process environment, so the configured value reaches the guard through the
+    hook argv (``--disk-hygiene-enabled ${user_config.disk_hygiene_enabled}``);
+    the environment variable is honored only as a fallback. A literal,
+    unsubstituted placeholder or an empty value is treated as absent. When no
+    channel supplies a value the guard fails safe to enabled — the guard stays
+    active and still gates every mutation behind the final human prompt.
+    """
+    from_argv = _argv_flag_value(sys.argv[1:], _DISK_HYGIENE_ENABLED_FLAG)
+    if from_argv and from_argv != _DISK_HYGIENE_ENABLED_PLACEHOLDER:
+        return from_argv.strip().lower() != "false"
+    return os.environ.get(_DISK_HYGIENE_ENABLED_ENV, "true").strip().lower() != "false"
 
 
 def _is_authorized_data_root(value: str, authority: str | None) -> bool:
@@ -262,15 +290,18 @@ _POWERSHELL_MUTATION_WORDS = re.compile(
 _POWERSHELL_DOTNET_DELETE = re.compile(r"(?i)::\s*delete")
 
 
-def powershell_decision(command: str) -> tuple[str, str] | None:
+def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
     """Return a (decision, reason) pair for a PowerShell command, or None to defer.
 
     PowerShell stays available for read-only support work (git, gh, metadata
     inspection), so this lane gates known filesystem-mutation spellings and any
     engine invocation rather than denying unknown commands. Engine calls stay on
-    the Bash lane's fail-closed deny-unknown guard; mutation spellings surface
-    the same final human permission prompt as the engine apply lane, so the
-    unsupported-platform manual handoff remains possible but never silent.
+    the Bash lane's fail-closed deny-unknown guard. A flagged mutation spelling
+    resolves against the ``disk_hygiene_enabled`` kill switch: when execution is
+    enabled it surfaces the final human permission prompt (``ask``), preserving
+    the unsupported-platform manual handoff; in audit-only mode (``enabled`` is
+    false) it is denied outright, so the kill switch blocks every deletion lane
+    and not only the Bash engine lane.
     """
     if "hygiene.py" in command.casefold():
         return (
@@ -280,20 +311,30 @@ def powershell_decision(command: str) -> tuple[str, str] | None:
         )
     match = _POWERSHELL_MUTATION_WORDS.search(command)
     if match:
-        return (
-            "ask",
-            f'disk-hygiene flagged the deletion spelling "{match.group(0)}". '
-            "Confirm only if this is the explicitly approved manual handoff and "
-            "the command touches exactly the paths you approved.",
+        return _powershell_mutation_verdict(
+            enabled,
+            f'disk-hygiene flagged the deletion spelling "{match.group(0)}".',
         )
     if _POWERSHELL_DOTNET_DELETE.search(command):
-        return (
-            "ask",
-            "disk-hygiene flagged a .NET Delete call. Confirm only if this is "
-            "the explicitly approved manual handoff and the command touches "
-            "exactly the paths you approved.",
+        return _powershell_mutation_verdict(
+            enabled, "disk-hygiene flagged a .NET Delete call."
         )
     return None
+
+
+def _powershell_mutation_verdict(enabled: bool, flagged: str) -> tuple[str, str]:
+    """Deny a flagged PowerShell deletion in audit-only mode; otherwise prompt."""
+    if not enabled:
+        return (
+            "deny",
+            f"{flagged} Disk-hygiene execution is disabled (audit-only mode), so "
+            "deletions are blocked on every lane.",
+        )
+    return (
+        "ask",
+        f"{flagged} Confirm only if this is the explicitly approved manual "
+        "handoff and the command touches exactly the paths you approved.",
+    )
 
 
 def _bash_denial_guidance(authority: str | None) -> str:
@@ -333,15 +374,16 @@ def main() -> int:
         )
         return 0
 
+    enabled = resolve_disk_hygiene_enabled()
+
     if tool_name == "PowerShell":
-        verdict = powershell_decision(command)
+        verdict = powershell_decision(command, enabled)
         if verdict:
             print(json.dumps(decision(*verdict)))
         return 0
 
     authority = resolve_authorized_data_root()
     command_kind = classify_exact_engine_command(command, authority)
-    enabled = os.environ.get("CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED", "true").lower() != "false"
     if command_kind in {"scan", "preview"}:
         print(
             json.dumps(

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1084,6 +1084,41 @@ class GuardTests(unittest.TestCase):
             self.assertEqual(0, guard.main())
         return json.loads(stdout.getvalue())
 
+    def run_guard_enabled_argv(
+        self, command: str, tool_name: str, enabled_arg: str
+    ) -> dict[str, object] | None:
+        """Drive the guard with the kill switch supplied via hook argv, not the env.
+
+        Mirrors the skill-frontmatter hook, which substitutes
+        ``--disk-hygiene-enabled ${user_config.disk_hygiene_enabled}`` into the
+        guard's own argv while CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED is absent
+        from the hook process environment — the exact env-injection failure this
+        fix addresses.
+        """
+        argv = [
+            str(SCRIPT_DIR / "destructive_guard.py"),
+            "--disk-hygiene-enabled",
+            enabled_arg,
+        ]
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key != "CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED"
+        }
+        stdin = io.StringIO(
+            json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+        )
+        stdout = io.StringIO()
+        with (
+            mock.patch("sys.stdin", stdin),
+            redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", argv),
+            mock.patch.dict("os.environ", environment, clear=True),
+        ):
+            self.assertEqual(0, guard.main())
+        value = stdout.getvalue()
+        return json.loads(value) if value.strip() else None
+
     def test_guard_denies_direct_recursive_delete(self) -> None:
         result = self.run_guard("rm -rf /tmp/example")
         self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
@@ -1268,6 +1303,26 @@ class GuardTests(unittest.TestCase):
             redirect_stdout(stdout),
             mock.patch.dict(
                 "os.environ", {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "true"}, clear=False
+            ),
+        ):
+            self.assertEqual(0, guard.main())
+        value = stdout.getvalue()
+        return json.loads(value) if value.strip() else None
+
+    def run_guard_powershell_disabled(
+        self, command: str
+    ) -> dict[str, object] | None:
+        stdin = io.StringIO(
+            json.dumps({"tool_name": "PowerShell", "tool_input": {"command": command}})
+        )
+        stdout = io.StringIO()
+        with (
+            mock.patch("sys.stdin", stdin),
+            redirect_stdout(stdout),
+            mock.patch.dict(
+                "os.environ",
+                {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"},
+                clear=False,
             ),
         ):
             self.assertEqual(0, guard.main())
@@ -1478,6 +1533,101 @@ class GuardTests(unittest.TestCase):
                     "contains ${ must be preserved as the argv authority",
                 )
 
+    def test_argv_flag_value_parses_both_arg_spellings(self) -> None:
+        self.assertEqual(
+            "false",
+            guard._argv_flag_value(["--disk-hygiene-enabled", "false"], "--disk-hygiene-enabled"),
+        )
+        self.assertEqual(
+            "false",
+            guard._argv_flag_value(["--disk-hygiene-enabled=false"], "--disk-hygiene-enabled"),
+        )
+        self.assertIsNone(
+            guard._argv_flag_value(["--other", "false"], "--disk-hygiene-enabled")
+        )
+        self.assertIsNone(
+            guard._argv_flag_value(["--disk-hygiene-enabled"], "--disk-hygiene-enabled")
+        )
+
+    def test_resolve_disk_hygiene_enabled_precedence(self) -> None:
+        script = str(SCRIPT_DIR / "destructive_guard.py")
+
+        def drive(argv_tail: list[str], env: dict[str, str]) -> bool:
+            with (
+                mock.patch.object(guard.sys, "argv", [script, *argv_tail]),
+                mock.patch.dict("os.environ", env, clear=True),
+            ):
+                return guard.resolve_disk_hygiene_enabled()
+
+        # Argv is authoritative over the environment, both directions.
+        self.assertFalse(
+            drive(
+                ["--disk-hygiene-enabled", "false"],
+                {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "true"},
+            ),
+            "a configured false in argv must disable even when the env says true",
+        )
+        self.assertTrue(
+            drive(
+                ["--disk-hygiene-enabled", "true"],
+                {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"},
+            )
+        )
+        # Case-insensitive, whitespace-tolerant false.
+        self.assertFalse(drive(["--disk-hygiene-enabled", " FALSE "], {}))
+        # A literal, unsubstituted placeholder falls back to the environment.
+        self.assertFalse(
+            drive(
+                ["--disk-hygiene-enabled", "${user_config.disk_hygiene_enabled}"],
+                {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"},
+            ),
+            "an unsubstituted placeholder must fall back to the environment",
+        )
+        # An empty substituted value falls back to the environment.
+        self.assertFalse(
+            drive(
+                ["--disk-hygiene-enabled", ""],
+                {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"},
+            )
+        )
+        # No argv, env supplies the value.
+        self.assertFalse(
+            drive([], {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"})
+        )
+        # No channel supplies a value: fail safe to enabled (guard active).
+        self.assertTrue(drive([], {}))
+
+    def test_skill_hook_passes_disk_hygiene_enabled_flag_matching_constant(
+        self,
+    ) -> None:
+        """Lock the config<->code seam the kill switch depends on.
+
+        The frontmatter hook must pass the exact flag literal the guard parses,
+        immediately followed by the ${user_config.disk_hygiene_enabled} token. If
+        either side is renamed without the other, the guard silently loses the
+        configured value and falls back to the (absent) env var — defaulting to
+        enabled and defeating the kill switch, the regression this test guards.
+        """
+        skill = SCRIPT_DIR.parent / "SKILL.md"
+        text = skill.read_text(encoding="utf-8")
+        args_line = next(
+            (
+                line
+                for line in text.splitlines()
+                if "destructive_guard.py" in line and "args:" in line
+            ),
+            None,
+        )
+        self.assertIsNotNone(args_line, "frontmatter hook args line not found")
+        assert args_line is not None
+        array_text = args_line[args_line.index("[") : args_line.rindex("]") + 1]
+        args = json.loads(array_text)
+        self.assertIn(guard._DISK_HYGIENE_ENABLED_FLAG, args)
+        flag_index = args.index(guard._DISK_HYGIENE_ENABLED_FLAG)
+        self.assertEqual(
+            guard._DISK_HYGIENE_ENABLED_PLACEHOLDER, args[flag_index + 1]
+        )
+
     def test_skill_hook_passes_authorized_data_root_flag_matching_constant(
         self,
     ) -> None:
@@ -1638,6 +1788,56 @@ class GuardTests(unittest.TestCase):
             "Get-Item C:/tmp/example | Select-Object Length",
         ):
             self.assertIsNone(self.run_guard_powershell(command), command)
+
+    def test_powershell_deletion_spellings_denied_in_audit_only_mode(self) -> None:
+        """Kill switch (B2): audit-only mode must deny PowerShell deletions, not ask."""
+        for command in (
+            "Remove-Item -Recurse -Force C:/tmp/example",
+            "rm C:/tmp/example",
+            "del C:/tmp/example",
+            "[IO.File]::Delete('C:/tmp/example')",
+            "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
+        ):
+            result = self.run_guard_powershell_disabled(command)
+            assert result is not None, command
+            self.assertEqual(
+                "deny",
+                result["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+
+    def test_kill_switch_blocks_every_lane_via_argv_without_env(self) -> None:
+        """Acceptance (B2+D3 together): a configured ``false`` reaching the guard
+        only through the hook argv — the env var UNSET, the exact env-injection
+        failure — must block deletions on both the PowerShell and Bash lanes."""
+        script = SCRIPT_DIR / "hygiene.py"
+        powershell = self.run_guard_enabled_argv(
+            "Remove-Item -Recurse -Force C:/tmp/example", "PowerShell", "false"
+        )
+        assert powershell is not None
+        self.assertEqual(
+            "deny", powershell["hookSpecificOutput"]["permissionDecision"]
+        )
+        apply_command = (
+            f'"{self.python_command()}" "{script}" apply --execute --snapshot s '
+            f'--plan p --confirm-tier high --approval-token {"a" * 24} --report r'
+        )
+        bash = self.run_guard_enabled_argv(apply_command, "Bash", "false")
+        assert bash is not None
+        self.assertEqual("deny", bash["hookSpecificOutput"]["permissionDecision"])
+
+    def test_kill_switch_enabled_via_argv_without_env_still_gates(self) -> None:
+        """The argv channel with the env var unset also carries an enabling value:
+        an ``apply`` is gated (``ask``) rather than denied, confirming the argv
+        value — not a hardcoded default — drives the decision."""
+        script = SCRIPT_DIR / "hygiene.py"
+        apply_command = (
+            f'"{self.python_command()}" "{script}" apply --execute --snapshot s '
+            f'--plan p --confirm-tier high --approval-token {"a" * 24} --report r'
+        )
+        result = self.run_guard_enabled_argv(apply_command, "Bash", "true")
+        assert result is not None
+        self.assertEqual("ask", result["hookSpecificOutput"]["permissionDecision"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The `disk_hygiene_enabled=false` kill switch ("audit-only mode") did not actually prevent deletions, for **two independent reasons**. Both are fixed here.

- **B2** — the enabled flag never gated the PowerShell lane, so flagged deletion spellings still returned `ask` (and could be approved) with execution disabled.
- **D3** — the kill switch was inert under the env-injection failure: the guard read the value from the hook process environment, which the runtime does not populate for a skill-frontmatter hook, so a configured `false` was silently overridden to enabled.

## Fix

**B2 — gate the PowerShell lane** (`skills/clean/scripts/destructive_guard.py`). `main()` routed `tool_name == "PowerShell"` to `powershell_decision()` and returned *before* the `enabled` gate was computed (that computation was only reached on the Bash branch). The gate is now resolved once, before the tool-name branch, and threaded into `powershell_decision(command, enabled)`. A flagged mutation spelling (`Remove-Item`/`rm`/`del`/`::Delete`/recycle-bin) resolves against the kill switch via new helper `_powershell_mutation_verdict`: `ask` when enabled (preserves the manual-handoff prompt), **`deny` in audit-only mode**. Engine (`hygiene.py`) calls stay hard-denied regardless.

**D3 — deliver the value through the hook argv** (`skills/clean/SKILL.md` + `destructive_guard.py`), mirroring the `--authorized-data-root ${CLAUDE_PLUGIN_DATA}` mechanism landed in #742 / #376. The frontmatter exec-form hook now passes `--disk-hygiene-enabled ${user_config.disk_hygiene_enabled}` in its `args` array. New `resolve_disk_hygiene_enabled()` reads the kill switch from that argv (generic `_argv_flag_value` extracted from `_argv_authorized_data_root`), treats a literal/unsubstituted placeholder or empty value as absent, and honors `CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED` **only as a fallback**. Absent every channel, the guard fails safe to `enabled=true` (guard active, every mutation still gated behind the final human prompt) — the pre-existing fail-safe default is preserved; the change is that a user who *set* `false` now has that value honored.

Per the [plugins reference](https://code.claude.com/docs/en/plugins-reference), `${user_config.KEY}` is rejected only in *shell-form* fields; the sanctioned channel for exec-form hooks is `args` (or the env var) — exactly our hook shape.

Docs updated to match: `SKILL.md` audit-only note, `reference/safety-model.md` PowerShell paragraph (previously stated deletions are always `ask`), `CHANGELOG.md`, and `plugin.json` `0.4.3 → 0.4.4`.

## Verification

`python -m unittest test_hygiene` — **77 passed, 4 skipped** (Linux-only platform gates). New tests:

- **B2**: `test_powershell_deletion_spellings_denied_in_audit_only_mode` — the five mutation spellings + `::Delete` return `deny` when disabled. The pre-existing `test_powershell_deletion_spellings_force_final_prompt` (enabled → `ask`) still passes, proving the enabled path is unchanged.
- **D3 / acceptance**: `test_kill_switch_blocks_every_lane_via_argv_without_env` — the centerpiece: a configured `false` reaching the guard **only via argv, with the env var UNSET** (the exact env-injection failure) denies both a PowerShell `Remove-Item` **and** a Bash `apply`. `test_kill_switch_enabled_via_argv_without_env_still_gates` confirms an argv `true` (env unset) yields `ask`, proving the argv value — not a hardcoded default — drives the decision.
- Precedence/seam: `test_resolve_disk_hygiene_enabled_precedence` (argv-over-env both directions, case/whitespace-tolerant `false`, placeholder/empty → env fallback, no-channel → fail-safe enabled), `test_argv_flag_value_parses_both_arg_spellings`, and `test_skill_hook_passes_disk_hygiene_enabled_flag_matching_constant` (locks the frontmatter-args ↔ guard-constant seam).

Linters: `ruff check` — **All checks passed**; `markdownlint-cli2` on the 3 changed markdown files — **0 errors**; `check-changelog-parity.sh --check` and `--check-bump origin/main` — **pass** (`0.4.4` entry present). (`ruff format` is not the repo's gate — `origin/main` is not `ruff format`-clean either, so it is not run to avoid unrelated churn.)

**Caveat (inherited, unverifiable without the live harness):** the `!= "false"` comparison assumes a boolean userConfig serializes to the string `"false"`. This is the *same assumption the pre-existing env-var gate already made* (`CLAUDE_PLUGIN_OPTION_...` was parsed identically), so it is no new regression; and live-harness substitution of `${user_config.disk_hygiene_enabled}` into exec-form `args` rests on the plugins-reference guarantee (same substitution pass as `${CLAUDE_PLUGIN_DATA}`, already proven to resolve in this exact position) and cannot be exercised without the running harness.

Closes #382

## Related

- Source: #382.
- #376 & #742 — the env-injection root cause and the `--authorized-data-root` argv precedent this builds on.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
