### PR TITLE
test(disk-hygiene): mock sys.argv in run_guard* helpers to seal the kill-switch argv seam

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.5]
+
+### Changed
+
+- **Test isolation only — no runtime behavior change.** The `run_guard`, `run_guard_disabled`, and
+  `run_guard_powershell_disabled` helpers in `test_hygiene.py` mocked `os.environ` to exercise the
+  kill switch but left `sys.argv` unpatched. Since the guard reads `--disk-hygiene-enabled` from
+  `sys.argv[1:]` before the environment fallback, a test runner whose real invocation argv happened
+  to carry that flag could override the env-var mock and flip an expected `deny` to `ask`. Each
+  helper now patches `guard.sys.argv` to a clean, flag-free argv alongside its existing environment
+  mock — matching the pattern the `run_guard_enabled_argv` helper already established — so the
+  environment variable stays the sole channel under test. Standard `unittest`/`pytest` invocations
+  never produced such argv, so this seals latent fragility rather than a live failure.
+
 ## [0.4.4]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1064,6 +1064,7 @@ class GuardTests(unittest.TestCase):
         with (
             mock.patch("sys.stdin", stdin),
             redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", [str(SCRIPT_DIR / "destructive_guard.py")]),
             mock.patch.dict(
                 "os.environ", {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "true"}, clear=False
             ),
@@ -1077,6 +1078,7 @@ class GuardTests(unittest.TestCase):
         with (
             mock.patch("sys.stdin", stdin),
             redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", [str(SCRIPT_DIR / "destructive_guard.py")]),
             mock.patch.dict(
                 "os.environ", {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"}, clear=False
             ),
@@ -1319,6 +1321,7 @@ class GuardTests(unittest.TestCase):
         with (
             mock.patch("sys.stdin", stdin),
             redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", [str(SCRIPT_DIR / "destructive_guard.py")]),
             mock.patch.dict(
                 "os.environ",
                 {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "false"},


### PR DESCRIPTION
## Summary

`resolve_disk_hygiene_enabled()` reads `--disk-hygiene-enabled` from `sys.argv[1:]` before the environment fallback (introduced in #382). Three helpers in `plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py` — `run_guard`, `run_guard_disabled`, and `run_guard_powershell_disabled` — patched `os.environ` to drive the kill switch but left `sys.argv` unpatched. If a test runner's real invocation argv happened to carry `--disk-hygiene-enabled <value>`, it would silently override the env-var mock and a `run_guard_powershell_disabled`-based test would observe `ask` where `deny` is expected.

This is test-isolation fragility, not a live failure: standard `unittest`/`pytest` invocations never produce such argv, so CI is unaffected today. The fix seals the latent seam.

## Change

Each of the three helpers now patches `guard.sys.argv` to a clean, flag-free argv (`[str(SCRIPT_DIR / "destructive_guard.py")]`) alongside its existing `os.environ` mock — the exact pattern the newer `run_guard_enabled_argv` helper already established. With no argv flag present, `resolve_disk_hygiene_enabled()` falls through to the environment mock, keeping the env var the sole channel under test. No production logic is touched; the underlying #968 fix is correct and security-reviewed clean.

Version bumped `0.4.4 → 0.4.5` (patch — pure test isolation, no behavior change) with a matching `CHANGELOG.md` entry.

## Verification

- `python -m unittest -v test_hygiene.py` — 81 passed, 4 skipped (platform gates).
- `ruff check` on the touched file — All checks passed.
- `markdownlint-cli2` on `CHANGELOG.md` — 0 errors.
- `check-changelog-parity.sh --check` and `--check-bump origin/main` — pass.
- `scripts/validate-plugins.sh` — manifests + catalog validated.

## Note (out of scope, follow-up candidate)

`run_guard_powershell` (the enabled PowerShell helper) carries the identical env-only seam but is not named in #970, so it is deliberately left untouched here to keep this PR atomic to the issue's stated scope. Worth a follow-up to seal for full consistency.

## Related

- #968 — the security-review SUGGESTION this PR resolves.
- #382 — the argv-reading precedence in `resolve_disk_hygiene_enabled()` that this test change seals against.

Closes #970

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)