### PR TITLE
test(disk-hygiene): mock sys.argv in run_guard_powershell to seal the kill-switch argv seam

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.6]
+
+### Changed
+
+- **Test isolation only — no runtime behavior change.** The `run_guard_powershell` helper in
+  `test_hygiene.py` — the enabled-PowerShell sibling of the three helpers sealed in 0.4.5 — carried
+  the identical unsealed seam: it mocked `os.environ` to drive the kill switch but left `sys.argv`
+  unpatched, so an ambient `--disk-hygiene-enabled` flag in the real test-runner invocation could
+  override the env-var mock the test intends to exercise. It now patches `guard.sys.argv` to a
+  clean, flag-free argv alongside its existing environment mock — matching the pattern the other
+  four `run_guard*` helpers use — so the environment variable stays the sole channel under test.
+  This completes the seam-sealing left out of 0.4.5 for scope; standard `unittest`/`pytest`
+  invocations never produced such argv, so it seals latent fragility rather than a live failure.
+
 ## [0.4.5]
 
 ### Changed

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1303,6 +1303,7 @@ class GuardTests(unittest.TestCase):
         with (
             mock.patch("sys.stdin", stdin),
             redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", [str(SCRIPT_DIR / "destructive_guard.py")]),
             mock.patch.dict(
                 "os.environ", {"CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED": "true"}, clear=False
             ),


### PR DESCRIPTION
## Summary

`resolve_disk_hygiene_enabled()` reads `--disk-hygiene-enabled` from `sys.argv[1:]` before the environment fallback (introduced in #382). The `run_guard_powershell` helper in `plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py` — the enabled-PowerShell sibling of the three helpers sealed in #971 — patched `os.environ` to drive the kill switch but left `sys.argv` unpatched. If a test runner's real invocation argv happened to carry `--disk-hygiene-enabled <value>`, it would silently override the env-var mock the test intends to exercise.

This is test-isolation fragility, not a live failure: standard `unittest`/`pytest` invocations never produce such argv, so CI is unaffected today. The fix seals the one latent seam #971 deliberately left out of scope, bringing all five `run_guard*` helpers to parity.

## Change

`run_guard_powershell` now patches `guard.sys.argv` to a clean, flag-free argv (`[str(SCRIPT_DIR / "destructive_guard.py")]`) alongside its existing `os.environ` mock — the exact pattern the four now-fixed helpers (`run_guard`, `run_guard_disabled`, `run_guard_powershell_disabled`, `run_guard_enabled_argv`) already use. With no argv flag present, `resolve_disk_hygiene_enabled()` falls through to the environment mock, keeping the env var the sole channel under test. No production logic is touched.

Version bumped `0.4.5 → 0.4.6` (patch — pure test isolation, no behavior change) with a matching `CHANGELOG.md` entry.

## Verification

- `python -m unittest -v test_hygiene.py` — 81 passed, 4 skipped (platform gates).
- `ruff check` on the touched file — All checks passed.
- `markdownlint-cli2` on `CHANGELOG.md` — 0 errors.
- `check-changelog-parity.sh --check` and `--check-bump origin/main` — pass.
- `scripts/validate-plugins.sh` — manifests + catalog validated.

## Related

- #970 / #971 — the sibling fix this completes; #971 sealed the same seam in the other four `run_guard*` helpers and its own body flagged this enabled PowerShell helper as a deliberately out-of-scope follow-up.
- The Codex P2 review thread on #971 that formally raised this (non-blocking, deferred to keep #971 landing clean) and filed it here as #973.
- #382 — the argv-reading precedence in `resolve_disk_hygiene_enabled()` that this test change seals against.

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)
