### PR TITLE
fix(claude-memory): implement documented non-repo memory-dir fallback in shared resolver + scope-report

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.3]
+
+### Fixed
+
+- **Non-repo memory-dir resolution implemented (the documented fallback).** The shared
+  `resolve-memory-dir.sh` hard-required a git repo (`exit 1` when `git rev-parse --show-toplevel`
+  was empty) and the `stateless` skill's `scope-report.sh` pre-emptied it with a bail-out telling
+  the user to run from within a repo — but the official memory doc (re-verified 2026-07-22)
+  says "Outside a git repo, the project root is used instead", so a non-repo directory is a
+  fully valid case with a real memory store the skill could neither find nor report. The
+  resolver now derives the project slug from the current directory (same Windows-form
+  normalization as the repo-root path) when no repo is found, `scope-report.sh` calls it
+  unconditionally (with an informational note that the cwd is the project key), and the
+  regression test that had locked the bail-out in as a spec now asserts the resolved
+  cwd-derived path. (#978)
+
 ## [0.3.2]
 
 ### Added

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -17,7 +17,10 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   normalization as the repo-root path) when no repo is found, `scope-report.sh` calls it
   unconditionally (with an informational note that the cwd is the project key), and the
   regression test that had locked the bail-out in as a spec now asserts the resolved
-  cwd-derived path. (#978)
+  cwd-derived path. The `audit` skill's deterministic M2 checker
+  (`memory-index-refs-check.sh`) carried its own now-redundant git-repo guard that would have
+  kept the audit from checking a non-repo store's index integrity — the guard is removed
+  (the shared resolver owns the non-repo case) with a non-repo regression test added. (#978)
 
 ## [0.3.2]
 

--- a/plugins/claude-memory/skills/audit/scripts/memory-index-refs-check.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-index-refs-check.sh
@@ -8,8 +8,9 @@
 #                      orphan direction (a topic file that fell out of the index) is the
 #                      reverse-drift gap this adds.
 #
-# Resolves the CURRENT repo's memory dir via the sibling resolver (NOT a cross-project
-# glob). Orphan opt-out: a topic file containing `<!-- memory-index-orphan-ignore -->`
+# Resolves the CURRENT project's memory dir (repo, or the cwd outside one) via the
+# sibling resolver (NOT a cross-project glob). Orphan opt-out: a topic file containing
+# `<!-- memory-index-orphan-ignore -->`
 # (e.g. an intentional staging file not yet indexed) is skipped.
 #
 # WARN-tier / advisory: prints findings, ALWAYS exits 0. Consumed by the audit
@@ -33,7 +34,8 @@ Usage: memory-index-refs-check.sh [--count|--help]
   --count    print integer finding count (missing + orphan); exit 0
   --help     this message
 
-Resolves the current repo's memory dir via the sibling resolve-memory-dir.sh.
+Resolves the current project's memory dir (repo, or the cwd outside one) via the
+sibling resolve-memory-dir.sh.
 Orphan opt-out: topic file containing `<!-- memory-index-orphan-ignore -->`.
 Advisory — always exits 0.
 EOF
@@ -45,12 +47,8 @@ mode="report"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
-if [[ -z "$repo_root" ]]; then
-  echo "memory-index-refs-check: not inside a git repository" >&2
-  exit 1
-fi
-
+# No repo guard here: the sibling resolver handles the non-repo case itself (outside a
+# git repo the cwd is the project key, per the memory doc).
 memory_dir=$(bash "$SCRIPT_DIR/resolve-memory-dir.sh" 2>/dev/null)
 index="$memory_dir/MEMORY.md"
 

--- a/plugins/claude-memory/skills/audit/scripts/memory-index-refs-check.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-index-refs-check.test.sh
@@ -28,14 +28,14 @@ assert_exit() {
 }
 assert_contains() {
   case "$2" in
-    *"$3"*) pass "$1" ;;
-    *) fail "$1" "expected to contain: $3" ;;
+  *"$3"*) pass "$1" ;;
+  *) fail "$1" "expected to contain: $3" ;;
   esac
 }
 assert_not_contains() {
   case "$2" in
-    *"$3"*) fail "$1" "unexpected substring: $3" ;;
-    *) pass "$1" ;;
+  *"$3"*) fail "$1" "unexpected substring: $3" ;;
+  *) pass "$1" ;;
   esac
 }
 
@@ -48,8 +48,8 @@ make_repo() {
 
 slug_of() {
   local root
-  root=$(cd "$1" && (cygpath -w "$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" 2>/dev/null \
-    || git rev-parse --show-toplevel 2>/dev/null | tr -d '\r'))
+  root=$(cd "$1" && (cygpath -w "$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" 2>/dev/null ||
+    git rev-parse --show-toplevel 2>/dev/null | tr -d '\r'))
   printf '%s' "$root" | sed 's/[:\\/.]/-/g'
 }
 
@@ -120,6 +120,20 @@ rc=0
 OUT=$(run "$H6") || rc=$?
 assert_exit "fresh exits 0" 0 "$rc"
 assert_contains "fresh reports no MEMORY.md" "$OUT" "No MEMORY.md"
+
+# --- Case 7: outside a git repo, the cwd-derived store is still checked (docs:
+# "Outside a git repo, the project root is used instead") ---
+H7="$TEST_TMPDIR/h7"
+NONREPO="$TEST_TMPDIR/plain7"
+mkdir -p "$NONREPO"
+NSLUG=$(cd "$NONREPO" && printf '%s' "$(cygpath -w "$(pwd)" 2>/dev/null || pwd)" | sed 's/[:\\/.]/-/g')
+M7="$H7/.claude/projects/$NSLUG/memory"
+mkdir -p "$M7"
+printf '# Index\n- [gone.md](gone.md)\n' >"$M7/MEMORY.md"
+rc=0
+OUT=$(cd "$NONREPO" && env -u GIT_DIR HOME="$H7" bash "$SCRIPT") || rc=$?
+assert_exit "non-repo exits 0" 0 "$rc"
+assert_contains "non-repo cwd store is checked" "$OUT" "M2-missing"
 
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"

--- a/plugins/claude-memory/skills/audit/scripts/resolve-memory-dir.sh
+++ b/plugins/claude-memory/skills/audit/scripts/resolve-memory-dir.sh
@@ -19,7 +19,8 @@
 #   MEMORY_DIR=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/resolve-memory-dir.sh")
 #
 # Output: absolute path to the memory dir (the dir containing MEMORY.md) on stdout.
-# Exits 1 with a stderr message when not inside a git repo.
+# Outside a git repo the current directory is the project key, per the memory doc:
+# "Outside a git repo, the project root is used instead."
 
 # `set -e` omitted: resolution does explicit error handling via `||` fallbacks and
 # existence checks; must not crash mid-resolve on an optional git sub-command
@@ -35,7 +36,8 @@ Usage:
 
 Derives the Claude Code project-dir slug from the repo root (repo-root absolute path,
 Windows-style on Windows, with `:` `\` `/` `.` -> `-`) and prints the candidate dir that
-holds MEMORY.md (handles bare-clone-hub worktrees). Exits 1 outside a git repository.
+holds MEMORY.md (handles bare-clone-hub worktrees). Outside a git repository the current
+directory is the project key ("Outside a git repo, the project root is used instead").
 EOF
   exit 0
 fi
@@ -46,9 +48,14 @@ fi
 repo_root=$(cygpath -w "$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" 2>/dev/null ||
   git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
 
+# Outside a git repo the cwd IS the project root Claude Code keys the memory dir on
+# (memory doc: "Outside a git repo, the project root is used instead") — same
+# Windows-form normalization as the repo-root path above. No hub-worktree candidates
+# apply without a repo.
+in_repo=1
 if [[ -z "$repo_root" ]]; then
-  echo "resolve-memory-dir: not inside a git repository" >&2
-  exit 1
+  in_repo=0
+  repo_root=$(cygpath -w "$(pwd)" 2>/dev/null || pwd)
 fi
 
 # Config root: CLAUDE_CONFIG_DIR relocates the whole `~/.claude` tree when set.
@@ -61,18 +68,20 @@ session_data_dir="$config_root/projects/$project_slug"
 # Bare-clone-hub worktree: transcripts are keyed by the worktree cwd, but auto-memory
 # is shared at the HUB (keyed by git-common-dir). HUB_SLUG also maps '.' (e.g. a
 # `/.bare` hub dir -> `--bare`). Decide by which candidate actually holds MEMORY.md —
-# never by guessing the slug algorithm.
-git_common=$(cd "$(git rev-parse --git-common-dir 2>/dev/null | tr -d '\r')" 2>/dev/null && pwd)
-hub_raw=$(cygpath -w "$git_common" 2>/dev/null || printf '%s' "$git_common")
-hub_slug=$(printf '%s' "$hub_raw" | sed 's/[:\\/.]/-/g')
-
+# never by guessing the slug algorithm. Hub candidates only exist inside a repo.
 memory_dir=""
-for cand in "$session_data_dir/memory" "$config_root/projects/$hub_slug/memory"; do
-  if [[ -f "$cand/MEMORY.md" ]]; then
-    memory_dir="$cand"
-    break
-  fi
-done
+if [[ "$in_repo" -eq 1 ]]; then
+  git_common=$(cd "$(git rev-parse --git-common-dir 2>/dev/null | tr -d '\r')" 2>/dev/null && pwd)
+  hub_raw=$(cygpath -w "$git_common" 2>/dev/null || printf '%s' "$git_common")
+  hub_slug=$(printf '%s' "$hub_raw" | sed 's/[:\\/.]/-/g')
+
+  for cand in "$session_data_dir/memory" "$config_root/projects/$hub_slug/memory"; do
+    if [[ -f "$cand/MEMORY.md" ]]; then
+      memory_dir="$cand"
+      break
+    fi
+  done
+fi
 
 # Fresh repo with no memory written yet: emit the normal-clone path so callers have a
 # stable target (MEMORY.md absence is handled downstream by the caller).

--- a/plugins/claude-memory/skills/audit/scripts/resolve-memory-dir.sh
+++ b/plugins/claude-memory/skills/audit/scripts/resolve-memory-dir.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Resolve the absolute path to the Claude Code auto-memory dir for the CURRENT repo.
+# Resolve the absolute path to the Claude Code auto-memory dir for the CURRENT project
+# (a git repo, or the current directory outside one).
 #
 # Why this exists: the naive glob `~/.claude/projects/*/memory/` matches EVERY
 # project's memory dir on a multi-project machine and resolves alphabetical-first
@@ -29,7 +30,7 @@ set -uo pipefail
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   cat <<'EOF'
-resolve-memory-dir.sh — emit absolute path to the auto-memory dir for the current repo.
+resolve-memory-dir.sh — emit absolute path to the auto-memory dir for the current project (repo or non-repo cwd).
 
 Usage:
   resolve-memory-dir.sh [--help]

--- a/plugins/claude-memory/skills/stateless/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/stateless/reference/official-guidance.md
@@ -1,6 +1,6 @@
 # Official Claude Code Guidance on Auto Memory State
 
-Last researched: 2026-07-20
+Last researched: 2026-07-22
 Sources: [code.claude.com/docs/en/memory](https://code.claude.com/docs/en/memory),
 [code.claude.com/docs/en/settings](https://code.claude.com/docs/en/settings),
 [code.claude.com/docs/en/env-vars](https://code.claude.com/docs/en/env-vars)

--- a/plugins/claude-memory/skills/stateless/scripts/scope-report.sh
+++ b/plugins/claude-memory/skills/stateless/scripts/scope-report.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Snapshot the auto-memory posture for the CURRENT repo across every settings scope.
+# Snapshot the auto-memory posture for the CURRENT project (a git repo, or the current
+# directory outside one) across every settings scope.
 #
 # Reports two deterministic things so the skill workflow doesn't hand-derive them:
 #   1. Which settings.json files exist at each scope (managed / user / project / local),
@@ -24,12 +25,12 @@ set -uo pipefail
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   cat <<'EOF'
-scope-report.sh — snapshot auto-memory posture across settings scopes for this repo.
+scope-report.sh — snapshot auto-memory posture across settings scopes for this project.
 
 Usage:
   scope-report.sh [--help]
 
-Prints, for the current working directory's repo:
+Prints, for the current working directory's project (repo root, or the cwd outside a repo):
   - existence of each settings.json scope file (managed / user / project / local)
   - the live CLAUDE_CODE_DISABLE_AUTO_MEMORY environment value (if any)
   - the default auto-memory dir, its MEMORY.md line count, and topic-file count
@@ -86,11 +87,10 @@ else
 fi
 
 echo
-echo "=== Default auto-memory directory (this repo) ==="
+echo "=== Default auto-memory directory (this project) ==="
 if [[ -z "$repo_root" ]]; then
-  echo "Not inside a git repository — outside a repo the project root is used as the key."
-  echo "Run the skill from within the target repo, or set autoMemoryDirectory explicitly."
-  exit 0
+  echo "Not inside a git repository — the current directory is the project key"
+  echo "(memory doc: outside a git repo, the project root is used instead)."
 fi
 
 mem_dir=$(bash "$resolver" 2>/dev/null | tr -d '\r')
@@ -105,5 +105,5 @@ if [[ -f "$mem_dir/MEMORY.md" ]]; then
   topics=$(find "$mem_dir" -maxdepth 1 -name '*.md' ! -name 'MEMORY.md' 2>/dev/null | wc -l | tr -d ' \r')
   echo "MEMORY.md: PRESENT (${lines} lines); topic files: ${topics}"
 else
-  echo "MEMORY.md: absent (no auto-memory written to the default location for this repo)"
+  echo "MEMORY.md: absent (no auto-memory written to the default location for this project)"
 fi

--- a/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
+++ b/plugins/claude-memory/skills/stateless/scripts/scope-report.test.sh
@@ -80,14 +80,23 @@ OUT=$(cd "$REPO" && HOME="$ISO_HOME" bash "$SCRIPT")
 assert_contains "MEMORY.md present is reported" "$OUT" "MEMORY.md: PRESENT"
 assert_contains "topic file count reported" "$OUT" "topic files: 1"
 
-# --- Case 5: outside a git repo, exits 0 with a clear note ---
+# --- Case 5: outside a git repo, the cwd is the project key (docs: "Outside a git
+# repo, the project root is used instead") — resolver and report both resolve, no bail-out ---
 
 NONREPO="$TEST_TMPDIR/plain"
 mkdir -p "$NONREPO"
 rc=0
+RES=$(cd "$NONREPO" && env -u GIT_DIR HOME="$ISO_HOME" bash "$RESOLVER" | tr -d '\r') || rc=$?
+assert_exit "resolver exits 0 outside a git repo" 0 "$rc"
+assert_contains "resolver derives the memory dir under the config root" "$RES" "$ISO_HOME/.claude/projects/"
+assert_contains "resolver slug is cwd-derived" "$RES" "plain"
+
+rc=0
 OUT=$(cd "$NONREPO" && env -u GIT_DIR HOME="$ISO_HOME" bash "$SCRIPT") || rc=$?
 assert_exit "non-git dir exits 0" 0 "$rc"
-assert_contains "non-git dir reports it is not a repo" "$OUT" "Not inside a git repository"
+assert_contains "non-git dir notes the cwd is the project key" "$OUT" "current directory"
+assert_contains "non-git dir reports the resolved memory dir" "$OUT" "$ISO_HOME/.claude/projects/"
+assert_contains "non-git dir reports MEMORY.md state" "$OUT" "MEMORY.md: absent"
 
 # --- Case 6: CLAUDE_CONFIG_DIR relocates the config root (user scope + memory tree) ---
 


### PR DESCRIPTION
## Summary

- `resolve-memory-dir.sh` (the plugin's single-source memory-dir resolver, shared by the `audit` and `stateless` skills) hard-required a git repo — `exit 1` when `git rev-parse --show-toplevel` was empty — and `stateless`'s `scope-report.sh` pre-empted it with a bail-out telling the user to "run the skill from within the target repo". The official memory doc (https://code.claude.com/docs/en/memory, re-fetched 2026-07-22) says: *"Outside a git repo, the project root is used instead."* A non-repo cwd is a fully valid, doc-blessed case with a real memory store the skill could neither find nor report (reproduced live: 3 auto-memory files at `~/.claude/projects/C--Users-KyleSexton/memory/` were invisible to `status`/`purge`).
- The resolver now derives the project slug from the current directory (same `cygpath -w` Windows-form normalization as the repo-root path) when no repo is found; bare-clone-hub worktree candidates apply only inside a repo. `scope-report.sh` calls the resolver unconditionally and prints an informational note that the cwd is the project key.
- TDD: `scope-report.test.sh` Case 5 had locked the bail-out in as the expected spec; it now asserts the resolved cwd-derived path for both the resolver and the report (watched fail first, 6 red → 21/21 green).
- Docs refreshed: resolver header/`--help` no longer claim "exits 1 outside a git repository"; `reference/official-guidance.md` last-researched date bumped to 2026-07-22 (quote re-verified current).
- `claude-memory` 0.3.2 → 0.3.3 + CHANGELOG entry.

## Test plan

- [x] `scope-report.test.sh` — 21/21 (new Case 5 assertions watched red first)
- [x] `memory-index-refs-check.test.sh` — 13/13; `orphan-rule-check.test.sh` — 14/14
- [x] shellcheck clean on all touched scripts
- [x] Live repro: non-git cwd now resolves `~/.claude/projects/<cwd-slug>/memory` and reports MEMORY.md state
- [x] `check-changelog-parity.sh --check-bump main` + `check-changed-skills.sh main` pass

## Related

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)
