### PR TITLE
fix(claude-memory): purge safety — bundled-consent gate note + opt-in backup-before-purge

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.4]
+
+### Added
+
+- **`stateless` purge: opt-in backup-before-purge escape hatch.** The confirmation gate now
+  offers to snapshot the manifest's exact files to a sibling `<memory_dir>.bak-<UTC>/`
+  directory before deleting ("yes, with backup"). The copy follows the same
+  manifest-exact/no-re-glob discipline as the delete, verifies the copy count before any
+  deletion, and Step 5 reports the snapshot path. (#979)
+
+### Changed
+
+- **`stateless` purge: bundled-consent does not satisfy the confirmation gate.** Step 3 now
+  states explicitly that consent gathered earlier via a bundled or multi-option answer — an
+  upstream `/interview` round, a numbered menu selection whose option happened to include the
+  purge, or a "purge" given before the manifest was known — does not satisfy the gate; it must
+  restate the concrete now-known scope (file count, directories) and receive a fresh,
+  scope-referencing confirmation. A worked anti-pattern example is included. (#979)
+
 ## [0.3.3]
 
 ### Fixed

--- a/plugins/claude-memory/skills/stateless/SKILL.md
+++ b/plugins/claude-memory/skills/stateless/SKILL.md
@@ -40,7 +40,7 @@ re-fetch the two source pages if a fact is load-bearing before you act.
 |----------|--------|
 | *(none)* or `status` | Report the auto-memory posture: effective enabled/disabled state, where the store lives, what it holds. Read-only. |
 | `disable` | Turn auto memory off durably (`autoMemoryEnabled: false` + `CLAUDE_CODE_DISABLE_AUTO_MEMORY`). Edits settings — confirm scope first. |
-| `purge` | **Destructive.** Delete the auto-memory files. Reads `autoMemoryDirectory` at every scope first, shows a manifest, and deletes only after explicit confirmation. |
+| `purge` | **Destructive.** Delete the auto-memory files. Reads `autoMemoryDirectory` at every scope first, shows a manifest, offers an opt-in pre-delete backup, and deletes only after explicit confirmation. |
 
 ## Precedence (documented)
 

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -85,13 +85,21 @@ recursively. Each source directory gets its own sibling snapshot `<dir>.bak-<UTC
 ts=$(date -u +%Y%m%dT%H%M%SZ)
 total=$(grep -c . "$manifest")
 copied=0
+declare -A made=()
 while IFS= read -r file; do
   [[ -n "$file" ]] || continue
   # Re-check the entry is still a regular non-symlink file: a symlink swapped in after
   # the Step 2 capture must not be dereferenced into the backup (cp would follow it).
   [[ -f "$file" && ! -L "$file" ]] || { echo "BACKUP FAILED (no longer a regular file): $file" >&2; break; }
   dest="$(dirname -- "$file").bak-$ts"
-  mkdir -p -- "$dest" || { echo "BACKUP FAILED (mkdir): $dest" >&2; break; }
+  # Create each snapshot dir exactly once, and refuse a pre-existing destination
+  # (concurrent same-second purge, or a planted symlink that would redirect the
+  # backup): plain mkdir — never -p — fails on anything already there.
+  if [[ -z "${made[$dest]:-}" ]]; then
+    [[ -e "$dest" || -L "$dest" ]] && { echo "BACKUP FAILED (destination already exists): $dest" >&2; break; }
+    mkdir -- "$dest" || { echo "BACKUP FAILED (mkdir): $dest" >&2; break; }
+    made[$dest]=1
+  fi
   cp -- "$file" "$dest/" || { echo "BACKUP FAILED (cp): $file" >&2; break; }
   copied=$((copied + 1))
 done <"$manifest"

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -47,21 +47,57 @@ Present to the user:
 - That this deletes auto-memory notes only — **not** CLAUDE.md, rules, transcripts, or history.
 - If `$manifest` is empty, report that there is nothing to purge and stop (no-op).
 
-## Step 3: Confirmation gate
+## Step 3: Confirmation gate (with backup offer)
 
 Ask for explicit confirmation, quoting the concrete manifest (and any `UNEXPECTED RELOCATION`
-paths), e.g.:
+paths), and offer an opt-in backup in the same question, e.g.:
 
 > This will permanently delete N auto-memory file(s): `<abs path>/MEMORY.md`,
-> `<abs path>/debugging.md`, … This cannot be undone. Type "yes" to proceed.
+> `<abs path>/debugging.md`, … This cannot be undone. I can first copy these exact files to
+> `<memory_dir>.bak-<UTC-timestamp>/` as a snapshot. Type "yes" to delete, or
+> "yes, with backup" to snapshot first.
 
 Proceed only on an unambiguous yes. Anything else — abort and change nothing. Never infer
 consent from the original request; the gate is a separate, explicit step.
 
-## Step 4: Delete the captured manifest
+**A bundled or earlier multi-option answer does NOT satisfy this gate.** Consent that rode
+along in an upstream flow — an `/interview` round where "purge" was one bullet of a bundled
+answer, a numbered menu selection (`"1"`) whose option happened to include the purge, or a
+"go stateless and purge" given before the manifest existed — is materially weaker than this
+gate's bar. The gate must restate the concrete, now-known scope (file count, directories)
+and receive a fresh confirmation that references that scope specifically.
 
-After confirmation, delete exactly the paths captured in `$manifest` in Step 2 — do not
-re-enumerate, do not `find ... -delete`, do not `rm -rf` any directory:
+Worked anti-pattern: the user answers "go stateless and purge" in an early interview round;
+later the manifest turns out to be 198 files. A follow-up menu offers "1) purge all 198
+2) keep topic files", and the user replies `"1"`. That `"1"` is a menu selection made while
+weighing other bundled concerns — not a scope-referencing confirmation of an irreversible
+delete. Correct handling: raise this gate anyway, quote the 198 files and their directories,
+and require a fresh "yes" (or "yes, with backup") before deleting anything.
+
+## Step 4: Optional backup, then delete the captured manifest
+
+**Backup first when the user opted in** ("yes, with backup"). Copy exactly the files
+captured in `$manifest` — same no-re-glob discipline as the delete; never copy a directory
+recursively. Each source directory gets its own sibling snapshot `<dir>.bak-<UTC>/`:
+
+```bash
+ts=$(date -u +%Y%m%dT%H%M%SZ)
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  dest="$(dirname -- "$file").bak-$ts"
+  mkdir -p -- "$dest"
+  cp -- "$file" "$dest/"
+done <"$manifest"
+```
+
+`cp -- "$file"` on a manifest entry copies a regular file only (the Step 2 capture was
+`-type f`); the backup lives beside the memory dir, outside it, so it is never re-matched
+by a future purge's `-maxdepth 1` enumeration of the memory dir itself. Verify the copy
+count equals the manifest count before deleting; on any copy failure, stop — do not delete.
+
+After confirmation (and the backup, when requested), delete exactly the paths captured in
+`$manifest` in Step 2 — do not re-enumerate, do not `find ... -delete`, do not `rm -rf`
+any directory:
 
 ```bash
 while IFS= read -r file; do
@@ -78,6 +114,8 @@ otherwise leaving the empty directory is harmless.
 ## Step 5: Report and offer follow-through
 
 - Confirm what was deleted (files, directories).
+- If a backup was taken, report its absolute path(s) (`<dir>.bak-<UTC>/`) and note the
+  snapshot is the user's to keep or delete — the skill never auto-prunes it.
 - Purge removes existing notes but does **not** stop new ones. If the user wants to stay
   stateless, point to `disable` (or run it now if they ask) so Claude doesn't immediately
   re-accumulate memory.

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -54,7 +54,8 @@ paths), and offer an opt-in backup in the same question, e.g.:
 
 > This will permanently delete N auto-memory file(s): `<abs path>/MEMORY.md`,
 > `<abs path>/debugging.md`, … This cannot be undone. I can first copy these exact files to
-> `<memory_dir>.bak-<UTC-timestamp>/` as a snapshot. Type "yes" to delete, or
+> `<memory_dir>.bak-<UTC-timestamp>/` as a snapshot. If the backup fails, the deletion is
+> cancelled too (you can re-confirm a plain delete afterwards). Type "yes" to delete, or
 > "yes, with backup" to snapshot first.
 
 Proceed only on an unambiguous yes. Anything else — abort and change nothing. Never infer
@@ -82,18 +83,26 @@ recursively. Each source directory gets its own sibling snapshot `<dir>.bak-<UTC
 
 ```bash
 ts=$(date -u +%Y%m%dT%H%M%SZ)
+total=$(grep -c . "$manifest")
+copied=0
 while IFS= read -r file; do
   [[ -n "$file" ]] || continue
   dest="$(dirname -- "$file").bak-$ts"
-  mkdir -p -- "$dest"
-  cp -- "$file" "$dest/"
+  mkdir -p -- "$dest" || { echo "BACKUP FAILED (mkdir): $dest" >&2; break; }
+  cp -- "$file" "$dest/" || { echo "BACKUP FAILED (cp): $file" >&2; break; }
+  copied=$((copied + 1))
 done <"$manifest"
+if [[ "$copied" -ne "$total" ]]; then
+  echo "Backup incomplete ($copied/$total) — ABORTING: delete nothing." >&2
+fi
 ```
 
+Proceed to the delete ONLY when `copied == total`. On any shortfall (full disk,
+permissions), abort the purge, report the partial snapshot's path, and change nothing —
+the user can re-confirm a plain no-backup delete afterwards if they still want it.
 `cp -- "$file"` on a manifest entry copies a regular file only (the Step 2 capture was
 `-type f`); the backup lives beside the memory dir, outside it, so it is never re-matched
-by a future purge's `-maxdepth 1` enumeration of the memory dir itself. Verify the copy
-count equals the manifest count before deleting; on any copy failure, stop — do not delete.
+by a future purge's `-maxdepth 1` enumeration of the memory dir itself.
 
 After confirmation (and the backup, when requested), delete exactly the paths captured in
 `$manifest` in Step 2 — do not re-enumerate, do not `find ... -delete`, do not `rm -rf`

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -87,6 +87,9 @@ total=$(grep -c . "$manifest")
 copied=0
 while IFS= read -r file; do
   [[ -n "$file" ]] || continue
+  # Re-check the entry is still a regular non-symlink file: a symlink swapped in after
+  # the Step 2 capture must not be dereferenced into the backup (cp would follow it).
+  [[ -f "$file" && ! -L "$file" ]] || { echo "BACKUP FAILED (no longer a regular file): $file" >&2; break; }
   dest="$(dirname -- "$file").bak-$ts"
   mkdir -p -- "$dest" || { echo "BACKUP FAILED (mkdir): $dest" >&2; break; }
   cp -- "$file" "$dest/" || { echo "BACKUP FAILED (cp): $file" >&2; break; }
@@ -94,6 +97,7 @@ while IFS= read -r file; do
 done <"$manifest"
 if [[ "$copied" -ne "$total" ]]; then
   echo "Backup incomplete ($copied/$total) — ABORTING: delete nothing." >&2
+  exit 1
 fi
 ```
 


### PR DESCRIPTION
## Summary

Two purge-safety hardenings in the `stateless` skill's purge workflow, from a live `/plugin-audit` run where an irreversible 198-file purge was confirmed via a `"1"` menu-select bundled into an unrelated follow-up — materially weaker than the gate's stated "type 'yes'" bar — and where the audit spent heavy triage effort specifically because deletion had no safety net.

- **Bundled-consent gate note (advisory tier).** `context/purge.md` Step 3 now states that consent gathered earlier via a bundled/multi-option answer (an upstream `/interview` round, a numbered menu selection whose option happened to include the purge, or a "purge" given before the manifest was known) does NOT satisfy the gate — it must restate the concrete now-known scope (file count, directories) and receive a fresh scope-referencing confirmation. A worked anti-pattern example is included. Advisory is the ceiling: there is no command signature to gate mechanically.
- **Opt-in backup-before-purge.** The gate now offers "yes, with backup": the manifest's exact files are copied to a sibling `<dir>.bak-<UTC>/` per source directory (same manifest-exact/no-re-glob discipline as the delete), copy count verified before any deletion, and Step 5 reports the snapshot path. The backup lives beside — not inside — the memory dir, so a future purge's `-maxdepth 1` enumeration never re-matches it.
- SKILL.md purge argument row mentions the backup offer; `claude-memory` 0.3.3 → 0.3.4 + CHANGELOG.

## Test plan

- [x] Docs-only change (workflow context files); no scripts touched — `scope-report.test.sh` 21/21 still green
- [x] `check-changelog-parity.sh --check-bump main` + `check-changed-skills.sh main` (skill-quality incl. 500-line cap) pass

## Related

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
