### PR TITLE
feat(claude-memory): dotfile-manager backfill detection beyond chezmoi (yadm, stow, fingerprints)

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   to be repo-agnostic but only checked chezmoi, with a hand-wave to "check any other dotfile
   manager". It now carries concrete detectors for chezmoi (managed-output check — the previous
   bare `&&` chain reported TRACKED whenever the binary existed), yadm
-  (`ls-files --error-unmatch`), and GNU stow / symlink managers (settings file is a symlink),
-  plus a fingerprint fallback (`.chezmoiroot`, `~/.local/share/chezmoi`, `~/.local/share/yadm`,
-  `.stow-local-ignore`, `.dotbot`/`install.conf.yaml`) that reports "manager fingerprint
+  (`ls-files --error-unmatch`), and GNU stow / symlink managers (settings file is a symlink,
+  or its parent dir is — the stow tree-folded layout), plus a fingerprint fallback
+  (`.chezmoiroot`, `~/.local/share/chezmoi`, `~/.local/share/yadm`, `.stow-global-ignore`,
+  `~/.dotbot`) that reports "manager fingerprint
   present but unconfirmed" instead of silently concluding the file is unmanaged when a
   manager's artifacts exist without its binary on PATH. Backfill routing now names each
   manager's own flow and warns against any `apply`/`restow` from the live session. (#980)

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.5]
+
+### Changed
+
+- **`stateless` disable: dotfile-manager backfill detection beyond chezmoi.** Step 3 claimed
+  to be repo-agnostic but only checked chezmoi, with a hand-wave to "check any other dotfile
+  manager". It now carries concrete detectors for chezmoi (managed-output check — the previous
+  bare `&&` chain reported TRACKED whenever the binary existed), yadm
+  (`ls-files --error-unmatch`), and GNU stow / symlink managers (settings file is a symlink),
+  plus a fingerprint fallback (`.chezmoiroot`, `~/.local/share/chezmoi`, `~/.local/share/yadm`,
+  `.stow-local-ignore`, `.dotbot`/`install.conf.yaml`) that reports "manager fingerprint
+  present but unconfirmed" instead of silently concluding the file is unmanaged when a
+  manager's artifacts exist without its binary on PATH. Backfill routing now names each
+  manager's own flow and warns against any `apply`/`restow` from the live session. (#980)
+
 ## [0.3.4]
 
 ### Added

--- a/plugins/claude-memory/skills/stateless/context/disable.md
+++ b/plugins/claude-memory/skills/stateless/context/disable.md
@@ -76,14 +76,18 @@ command -v chezmoi >/dev/null 2>&1 &&
   yadm ls-files --error-unmatch "$settings" >/dev/null 2>&1 && tracked="yadm"
 [[ -z "$tracked" && -L "$settings" ]] &&
   tracked="symlink -> $(readlink "$settings") (GNU stow or a similar symlink manager)"
+# Stow tree-folding: the parent dir (e.g. ~/.claude) may be the symlink while the
+# settings file inside it is a regular file reached through it — check the dir too.
+[[ -z "$tracked" && -L "$(dirname -- "$settings")" ]] &&
+  tracked="parent-dir symlink -> $(readlink "$(dirname -- "$settings")") (GNU stow tree-folded, or similar)"
 if [[ -n "$tracked" ]]; then
   echo "TRACKED by $tracked — backfill to the dotfiles source"
 else
   fp=""
   [[ -e "$HOME/.chezmoiroot" || -d "$HOME/.local/share/chezmoi" ]] && fp="$fp chezmoi"
   [[ -d "$HOME/.local/share/yadm" ]] && fp="$fp yadm"
-  [[ -e "$HOME/.stow-local-ignore" ]] && fp="$fp stow"
-  [[ -d "$HOME/.dotbot" || -e "$HOME/install.conf.yaml" ]] && fp="$fp dotbot"
+  [[ -e "$HOME/.stow-global-ignore" ]] && fp="$fp stow"
+  [[ -d "$HOME/.dotbot" ]] && fp="$fp dotbot"
   if [[ -n "$fp" ]]; then
     echo "manager fingerprint present but binary/tracking not confirmed:$fp — verify manually before editing"
   else

--- a/plugins/claude-memory/skills/stateless/context/disable.md
+++ b/plugins/claude-memory/skills/stateless/context/disable.md
@@ -63,17 +63,42 @@ A user-scope `settings.json` is often tracked by a dotfile manager. If it is, a 
 must be backfilled to the source of truth — do not leave the tracked file drifted, and never
 run an `apply` that could revert your edit.
 
-Detect and route generically (repo-agnostic — do not assume a specific manager):
+Detect and route generically (repo-agnostic — no single manager assumed). Three concrete
+detectors — chezmoi and yadm track real files and answer path queries; GNU stow (and
+similar) manages via symlinks, so a symlinked settings file is the discriminator:
 
 ```bash
-command -v chezmoi >/dev/null 2>&1 && chezmoi managed "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json" 2>/dev/null \
-  && echo "TRACKED by chezmoi — backfill to the dotfiles source" \
-  || echo "not chezmoi-tracked (check any other dotfile manager)"
+settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+tracked=""
+command -v chezmoi >/dev/null 2>&1 &&
+  [[ -n "$(chezmoi managed "$settings" 2>/dev/null)" ]] && tracked="chezmoi"
+[[ -z "$tracked" ]] && command -v yadm >/dev/null 2>&1 &&
+  yadm ls-files --error-unmatch "$settings" >/dev/null 2>&1 && tracked="yadm"
+[[ -z "$tracked" && -L "$settings" ]] &&
+  tracked="symlink -> $(readlink "$settings") (GNU stow or a similar symlink manager)"
+if [[ -n "$tracked" ]]; then
+  echo "TRACKED by $tracked — backfill to the dotfiles source"
+else
+  fp=""
+  [[ -e "$HOME/.chezmoiroot" || -d "$HOME/.local/share/chezmoi" ]] && fp="$fp chezmoi"
+  [[ -d "$HOME/.local/share/yadm" ]] && fp="$fp yadm"
+  [[ -e "$HOME/.stow-local-ignore" ]] && fp="$fp stow"
+  [[ -d "$HOME/.dotbot" || -e "$HOME/install.conf.yaml" ]] && fp="$fp dotbot"
+  if [[ -n "$fp" ]]; then
+    echo "manager fingerprint present but binary/tracking not confirmed:$fp — verify manually before editing"
+  else
+    echo "no dotfile manager detected — manually managed settings file, no backfill needed"
+  fi
+fi
 ```
 
-If tracked, tell the user to backfill through their dotfiles repo's own flow (for chezmoi:
-its `add-dotfile` / drift-reconcile path), not `chezmoi apply` from this session. If no
-manager is detected, note that a manually managed settings file needs no backfill.
+The fingerprint fallback matters when a manager's artifacts exist but its binary is not on
+PATH (fresh shell, partial install): report it as unconfirmed rather than silently
+concluding the file is unmanaged. If tracked, tell the user to backfill through their
+dotfiles repo's own flow (chezmoi: its `add-dotfile` / drift-reconcile path; yadm:
+`yadm add` + commit; stow: edit the file inside the stow package — the symlink already
+points there), never an `apply`/`restow` from this session that could revert the live
+edit. If nothing is detected, note that a manually managed settings file needs no backfill.
 
 ## Step 4: Confirm effect
 


### PR DESCRIPTION
## Summary

`disable.md` Step 3 claimed its dotfile-manager backfill detection was "repo-agnostic — do not assume a specific manager" but only checked chezmoi, with a prose hand-wave to "check any other dotfile manager" and no concrete mechanism (handoff-inbox Finding 5, `claude-memory@0.3.2` audit).

- **Three concrete detectors, checked in order:** chezmoi (output-nonempty check on `chezmoi managed <settings>` — the previous bare `&&` chain reported TRACKED whenever the chezmoi binary existed, regardless of whether the file was actually managed), yadm (`yadm ls-files --error-unmatch`), and GNU stow / symlink managers (a symlinked settings file is the discriminator; the target is reported).
- **Fingerprint fallback:** when no manager binary/tracking confirms, `$HOME` artifacts (`.chezmoiroot`, `~/.local/share/chezmoi`, `~/.local/share/yadm`, `.stow-local-ignore`, `.dotbot`/`install.conf.yaml`) are reported as "manager fingerprint present but binary/tracking not confirmed — verify manually" instead of silently concluding the file is unmanaged.
- **Backfill routing** names each manager's own flow (chezmoi `add-dotfile`/drift-reconcile; yadm `add` + commit; stow: edit inside the package — the symlink already points there) and keeps the existing never-run-`apply`/`restow` rule.
- `claude-memory` 0.3.4 → 0.3.5 + CHANGELOG.

## Test plan

- [x] Docs-only change (workflow context file); snippet validated with `bash -n`
- [x] `check-changelog-parity.sh --check-bump main` + `check-changed-skills.sh main` pass

## Related

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
