### PR TITLE
docs(philosophy): lock setup-lifecycle convention

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -254,14 +254,17 @@ setup skill aggregates and reports it per skill.
 The verb set is deliberately closed at `check` and `apply` — no standalone `remove`, `reset`, or
 `migrate` verb joins the mandatory contract (teardown, where genuinely needed, rides as a `remove`
 argument to `apply`, per the teardown rule below). `apply` is *state-assessing*: it reads current
-state and converges, which is what idempotent-and-preserve-unrelated-content already requires, named
-as a verb contract rather than a new bar. This subsumes forward schema evolution — an `apply` that
-meets prior-shape config fills absent keys at current defaults, preserves keys it does not
-recognize, and reports (never silently rewrites) values it cannot reconcile, so an obsolete or
-renamed key surfaces on re-run instead of sitting silently inert. It does not translate renamed or
-removed keys: the fleet's clean-break stance (no compatibility shims, no migration tooling) extends
-to setup config, and reconcile-and-report is what stands in for a migration verb. `reset` decomposes
-to teardown plus `apply`.
+state and converges, which the idempotency and preserve-unrelated-content requirements above already
+demand, named as a verb contract rather than a new bar. It reconciles conservatively — fill absent
+keys at current defaults, preserve keys it does not recognize, and report (never silently rewrite)
+values it cannot reconcile, so an obsolete or renamed key surfaces on re-run instead of sitting
+silently inert. Schema evolution is handled this way, without a separate `migrate` verb: a plugin
+that versions its own config contract may carry a forward, directional, user-confirmed upgrade of a
+recognized older version — still under `apply`, never a separate verb and never a silent write (the
+versioned standards index is the fleet example) — while a plugin that instead takes topic-docs'
+clean-break path relocates by hand with no compatibility tooling. What the clean-break stance rules
+out for either is silent backward-compatibility shims and dual-read windows that translate a changed
+shape behind the user's back. `reset` decomposes to teardown plus `apply`.
 
 Setup may inspect the repository and create or update the plugin's tracked project configuration. It
 must not write into the installed plugin cache, mutate Claude Code user settings, or write
@@ -280,7 +283,8 @@ project config the plugin owns and never to `pluginConfigs` — whose reconfigur
 the `/plugin configure` flow the check-only carve-out above routes to. Teardown stays off the
 mandatory contract because it is destructive and, across the fleet today, unexercised — grounds to
 defer it with a trigger, not proof it is never needed: a second plugin needing teardown graduates a
-shared teardown shape into an owner doc before that second adopter. The distinction is config versus
+shared teardown shape into an owner doc before that second adopter — a step the fleet conformance
+audit checks, the same enforcement every convention-registry row rides. The distinction is config versus
 data: removing the plugin's own tracked setup config is teardown, whereas an apply-scoped operation
 that mutates a managed inventory the plugin maintains (a status change over existing entries, say)
 is ordinary `apply` surface, not teardown, and does not trip that trigger.
@@ -297,9 +301,9 @@ honored either way. The skill is the interactive, discoverable consumer-configur
 (check/apply over tracked project config) — a need no native hook exposes, so the skill is not a
 redundant custom mechanism. The `Setup` hook event and `SessionStart` install hook are the
 unattended faces the same plugin may also carry, and unattended init routes to them rather than a
-custom channel. Where both exist they converge to one idempotent state. The `setup`-skill
-requirement above is satisfied in the interactive dimension by the skill and may be complemented —
-never replaced — in the headless dimension by these idioms.
+custom channel. Where both exist they converge to one idempotent state. The `setup` skill fulfills
+the `setup`-skill requirement above; the headless dimension may be complemented — never replaced —
+by these native idioms.
 
 ## Prerequisites and failure behavior
 

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -233,15 +233,35 @@ conformance audit tracks the gap.
 
 The uniform contract: the skill is named `setup`, sets `disable-model-invocation: true`, and offers
 `check` (read-only inspect and verify) and `apply` (idempotent configure) actions. This is a
-normative target — setup skills that predate this contract are nonconforming until migrated, and
-the fleet conformance audit tracks the gap rather than the doctrine pretending it is closed. Setup
-must be:
+normative target — setup skills that predate this contract are nonconforming until brought into
+conformance, and the fleet conformance audit tracks the gap rather than the doctrine pretending it
+is closed. Setup must be:
 
 - idempotent and safe to rerun;
 - transparent about what it inferred, changed, skipped, or could not verify;
 - limited to configuration the plugin owns;
 - safe for existing files, preserving unrelated user content; and
 - non-interactive when complete arguments are supplied, so automation and headless use remain possible.
+
+Setup is one **plugin-level** `setup` skill, never a per-skill setup action. Setup granularity
+follows install granularity: a plugin installs and is configured as a unit, and its configuration
+surface — tracked project files, external prerequisites, `userConfig` — is plugin-scoped and
+routinely shared across skills, so one `setup` skill is the single discoverable entry point
+(`/<plugin>:setup`) and the one place `disable-model-invocation` is set for configuration, not a
+flag fragmented across per-skill actions. Where distinct skills carry distinct readiness, the one
+setup skill aggregates and reports it per skill.
+
+The verb set is deliberately closed at `check` and `apply` — no standalone `remove`, `reset`, or
+`migrate` verb joins the mandatory contract (teardown, where genuinely needed, rides as a `remove`
+argument to `apply`, per the teardown rule below). `apply` is *state-assessing*: it reads current
+state and converges, which is what idempotent-and-preserve-unrelated-content already requires, named
+as a verb contract rather than a new bar. This subsumes forward schema evolution — an `apply` that
+meets prior-shape config fills absent keys at current defaults, preserves keys it does not
+recognize, and reports (never silently rewrites) values it cannot reconcile, so an obsolete or
+renamed key surfaces on re-run instead of sitting silently inert. It does not translate renamed or
+removed keys: the fleet's clean-break stance (no compatibility shims, no migration tooling) extends
+to setup config, and reconcile-and-report is what stands in for a migration verb. `reset` decomposes
+to teardown plus `apply`.
 
 Setup may inspect the repository and create or update the plugin's tracked project configuration. It
 must not write into the installed plugin cache, mutate Claude Code user settings, or write
@@ -252,12 +272,34 @@ setup is conforming: `check` verifies and reports, reconfiguration routes throug
 (`/plugin configure <plugin>` — see above), and no `apply` is offered, because the only thing it
 could write is the `pluginConfigs` this contract forbids.
 
+Bare `apply` converges to the configured state and never removes; genuine teardown — converging to
+the *absence* of the plugin's own tracked project config — is the one thing `apply` will not do
+unasked. A plugin that genuinely needs it exposes it as an optional apply-scoped operation (an
+`apply remove`, under the same never-blind, preserve-unrelated discipline), bounded to the tracked
+project config the plugin owns and never to `pluginConfigs` — whose reconfigure-or-clear path stays
+the `/plugin configure` flow the check-only carve-out above routes to. Teardown stays off the
+mandatory contract because it is destructive and, across the fleet today, unexercised — grounds to
+defer it with a trigger, not proof it is never needed: a second plugin needing teardown graduates a
+shared teardown shape into an owner doc before that second adopter. The distinction is config versus
+data: removing the plugin's own tracked setup config is teardown, whereas an apply-scoped operation
+that mutates a managed inventory the plugin maintains (a status change over existing entries, say)
+is ordinary `apply` surface, not teardown, and does not trip that trigger.
+
 Two native idioms are the sanctioned initialization surfaces (verified 2026-07-17 against the
 [hooks reference](https://code.claude.com/docs/en/hooks) and
 [plugins reference](https://code.claude.com/docs/en/plugins-reference)): the `Setup` hook event
 (`--init-only`, or `--init`/`--maintenance` in `-p` mode) for headless and CI preparation, and a
 `SessionStart` hook comparing a bundled manifest against its `${CLAUDE_PLUGIN_DATA}` copy for
 runtime-dependency installation.
+
+These native idioms complement the `setup` skill; they do not compete with it, and native-first is
+honored either way. The skill is the interactive, discoverable consumer-configuration face
+(check/apply over tracked project config) — a need no native hook exposes, so the skill is not a
+redundant custom mechanism. The `Setup` hook event and `SessionStart` install hook are the
+unattended faces the same plugin may also carry, and unattended init routes to them rather than a
+custom channel. Where both exist they converge to one idempotent state. The `setup`-skill
+requirement above is satisfied in the interactive dimension by the skill and may be complemented —
+never replaced — in the headless dimension by these idioms.
 
 ## Prerequisites and failure behavior
 


### PR DESCRIPTION
## Summary

Own design session for the **setup-lifecycle convention** (epic #830). Resolves the four threads in #837's body and encodes the outcome in the "Setup is explicit and repeatable" section of `docs/PLUGIN-PHILOSOPHY.md`. Doc-only change (+45/−3 lines); no skill edits — see Verification.

## The four threads (locked)

**1. Verb set — `remove`/`reset`/`migrate` vs state-assessing `apply`.** The mandatory contract stays **closed at `check` and `apply`**. `apply` is **state-assessing**: it reads current state and converges — naming the existing idempotent-and-preserve-unrelated requirement as a verb contract, not a new bar. That subsumes the forward direction of "migrate": an `apply` meeting prior-shape config fills absent keys at defaults, preserves unrecognized keys, and **reports** (never silently rewrites) values it cannot reconcile, so an obsolete/renamed key surfaces on re-run instead of sitting silently inert. It does **not** translate renamed/removed keys — the fleet's clean-break stance (no shims, no migration tooling) extends to setup config; reconcile-and-report replaces a `migrate` verb. `reset` = teardown + `apply`. Genuine **teardown** is an *optional* apply-scoped operation (`apply remove`), bounded to the plugin's own **tracked project config** — never `pluginConfigs` (reconfigure/clear stays `/plugin configure`) — deferred with a **second-adopter → owner-doc** trigger.

**2. Per-skill setup action vs plugin setup skill.** Setup is **one plugin-level `setup` skill**, never a per-skill action. Primary rationale: **setup granularity follows install granularity** — a plugin installs and configures as a unit, and there is no native per-skill install anchor. One discoverable entry (`/<plugin>:setup`), one place `disable-model-invocation` is set for configuration, one owner of a config surface that is routinely shared across skills; the setup skill aggregates per-skill readiness rather than fragmenting.

**3. Philosophy-doc update.** Encoded in `PLUGIN-PHILOSOPHY.md` — **not** a new `docs/conventions/setup-lifecycle/` owner doc. Re-derived reasoning (not incumbency): the convention **registry** hosts *inter-plugin coordination* concerns whose rules are self-contained enough for one separate owner doc; the setup contract is an *intra-plugin uniform contract* — like Naming and Cross-platform, which also live in the philosophy doc and carry no registry row — and its rules are **distributed across and dependent on** three neighboring sections (Configuration ownership = what setup may write; Prerequisites = what it declares; Two-lane = the discover-via-setup lane), so extraction would duplicate or fragment them. Honest limitation (not resolved here, out of #837's scope): the registry's inclusion criterion is fuzzy at the edges (`permission-rule-hygiene`, skill-layout are per-plugin contracts that *did* get rows — distinguished by a separate enforcement mechanism needing its own home; setup's conformance rides the general fleet audit). The conclusion holds regardless.

**4. Fleet conformance.** A fresh-context fleet audit found **zero nonconformers** among the 38 setup skills (all have `disable-model-invocation: true` + a `check` action; 35 offer `apply`; the 3 check-only — bug-report, dometrain, miro — are the sanctioned userConfig-only carve-out). Where teardown-like operations exist they are already apply-scoped arguments (`songwriting: apply remove`; `machine-health: apply disable=/deprecate=/demote=/approve=`), never separate lifecycle verbs — direct support for thread 1. The sharpened wording adds **no requirement any existing skill violates**, so this is doc-only. The lint-gap plugins (`typos-format`, `go-format`) already ship conforming check/apply setups. The only debt is **two pre-existing missing-setup gaps** (`education` userConfig-only; `repo-hygiene` single kill-switch) that predate #837's decisions and are a distinct concern → tracked in **#988**.

## Fix

`docs/PLUGIN-PHILOSOPHY.md` "Setup is explicit and repeatable": adds the plugin-level decision, the closed verb set with the state-assessing/reconcile-and-report `apply` and the optional bounded teardown, and a paragraph reconciling the setup skill with the native `Setup`/`SessionStart` hook idioms the same section sanctions (complementary faces, native-first honored).

## Verification

- **Design independence:** first-principles derivation → cross-vendor advisor pass → fresh-context adversarial stress-test (attacked all four threads; verdict "safe with specific fixes, no thread reopened"; C1/I1/I4/M1 folded into the doc text, I2/I5/M2/M3 into this rationale, I6 = ticket #988 filed) → fresh-context independent review of the committed diff (rationale withheld).
- **Fleet conformance (behavior, not just presence):** spot-checked that no shipped `apply` overwrites blind — config-writing setups carry read-first/reconcile/preserve language; the thin formatter setups are check-centric (verify tool presence, report "already configured" on rerun, write no user-owned config). Zero conformance debt confirmed.
- **Gate:** `markdownlint-cli2 docs/PLUGIN-PHILOSOPHY.md` → 0 errors. No new links added. Emphasis/heading/list style conform (MD013 disabled repo-wide).

<details>
<summary>Locked design threads (memory-tier artifact, pasted for the durable record)</summary>

### Empirical grounding (verified 2026-07-22, live fleet)

- 56 plugins; 38 ship a `setup` skill; 18 do not (all 18 are zero-config/zero-prereq knowledge/methodology plugins — contract-exempt).
- All 38 setup skills: `name: setup` + `disable-model-invocation: true`. 35 offer check+apply; 3 are check-only (bug-report, dometrain, miro) — all userConfig-only, the sanctioned carve-out.
- ZERO of 38 expose any top-level lifecycle verb beyond check/apply.
- Where teardown-like operations DO exist they are apply-scoped arguments, never separate verbs: `songwriting: apply scaffold|remove`, `machine-health: apply disable=|deprecate=|demote=|approve=`.
- No `Setup` or `SessionStart` hook event exists anywhere in the fleet today.
- True nonconformers to the check/apply + disable-model-invocation contract: NONE.

Source: fresh-context fleet audit (independent subagent) + direct grep verification.

### Thread resolutions

**Thread 1 (verbs).** Contract stays two verbs, check + apply. `apply` state-assessing/reconciling; `reset` decomposes to teardown + apply; `migrate` rejected — clean-break (topic-docs "Adoption") generalized to setup config, a deliberately-named generalization. Teardown = optional apply-scoped `apply remove`, off the mandatory contract (rare, destructive, hand-reversible), with a second-adopter → owner-doc trigger.

**Thread 2 (plugin-level).** Re-derived from install-granularity (a plugin installs/configures as a unit; no native per-skill install anchor), single discoverable entry, shared cross-skill config surface, verb-per-skill naming grammar. The setup skill aggregates per-skill readiness.

**Thread 3 (philosophy-doc).** Kept in PLUGIN-PHILOSOPHY.md, not a new owner doc: setup is an intra-plugin uniform contract (like Naming/Cross-platform, also non-registry) whose rules are distributed across three neighboring sections; extraction would fragment them. Registry inclusion criterion is genuinely fuzzy at the edges (acknowledged, not redrawn here — out of scope).

**Thread 4 (conformance).** Zero nonconformers among 38; sharpened wording adds no requirement any existing skill violates → doc-only. Lint-gap plugins (typos-format, go-format) already conform. Two pre-existing missing-setup gaps (education, repo-hygiene) predate these decisions → tracked in #988.

### Adversarial stress-test ledger (fresh-context; verdict: safe with specific fixes, no thread reopened)

- **C1** (native Setup/SessionStart hooks vs mandated setup skill): complementary, not competing — skill = interactive consumer-config face no native hook exposes; hooks = unattended faces; native-first honored. Folded into the doc.
- **I1** (unspecified "upgrade old shapes"): narrowed to preserve-unknown + fill-defaults + report-incompatible; no key translation. Folded into the doc.
- **I2** (teardown trigger already fired?): songwriting `apply remove` is teardown-ish (ONE); machine-health `apply disable=…` is domain-data mutation, not teardown. Second-adopter trigger NOT yet met. Config-vs-data distinction folded into the doc.
- **I3** (behavior audit, not presence): PASS — spot-checked no shipped `apply` overwrites blind (config-writers reconcile/preserve; formatter setups are check-centric).
- **I4** (reversibility overgeneralized; `apply remove` vs pluginConfigs): teardown bounded to tracked project config, never pluginConfigs. Folded into the doc.
- **I5** (thread-3 reasoning incumbency-flavored): re-derived on intra-plugin-contract vs inter-plugin-coordination; registry fuzziness acknowledged.
- **I6** (follow-up must be filed): ticket #988 filed with audit evidence.
- **M1/M2/M3**: teardown wording ("bare apply never removes"); install-granularity as thread-2's lead defense; "0/38 = grounds to defer with a trigger, not proof never needed."

### Independent review (fresh-context, rationale withheld; verdict: ready with specific fixes)

Folded: #1 scope `disable-model-invocation` to setup (not plugin-wide absolute); #2 split the dense verb paragraph and move the `pluginConfigs` write-boundary/carve-out ahead of the teardown rule that leans on it; #3 disambiguate "no `remove` verb" vs `apply remove` at first mention; plus cheap in-section wins #4 (migrate-token collision), #6 (config-vs-data criterion stated before the example), #7 (trim mid-sentence bold). markdownlint: 0 errors.

</details>

## Related

- #830 — parent epic (lint/static-analysis gap closure); #837 was flagged there for its own design session.
- #829 — the epic Brief / PLAN that named this setup-lifecycle thread.
- #988 — follow-up filed by this work: add setup skills for `education` + `repo-hygiene` (pre-existing missing-setup gaps, not closed here).

Closes #837.
