### PR TITLE
fix(disk-hygiene): hand off VCS worktree checkouts to /source-control:worktree

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.7]
+
+### Fixed
+
+- **The `clean` skill now hands off VCS worktree checkouts to `/source-control:worktree`.** A repos
+  root containing a `.worktrees/` tree surfaces as a VCS-boundary `truncated_paths` coverage gap, but
+  the skill named no next step — leaving the operator at an unexplained truncated-path entry. The
+  boundary list (and the README relationship list) now point at `/source-control:worktree
+  status`/`cleanup` (if installed) as the owner of worktree lifecycle, extending the existing
+  managed-state → named-handoff pattern. Discoverability only — no engine or safety behavior change;
+  VCS-tracked content was already engine-ineligible. (#986)
+
 ## [0.4.6]
 
 ### Changed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -7,13 +7,14 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 
 ### Fixed
 
-- **The `clean` skill now hands off VCS worktree checkouts to `/source-control:worktree`.** A repos
-  root containing a `.worktrees/` tree surfaces as a VCS-boundary `truncated_paths` coverage gap, but
-  the skill named no next step — leaving the operator at an unexplained truncated-path entry. The
-  boundary list (and the README relationship list) now point at `/source-control:worktree
-  status`/`cleanup` (if installed) as the owner of worktree lifecycle, extending the existing
-  managed-state → named-handoff pattern. Discoverability only — no engine or safety behavior change;
-  VCS-tracked content was already engine-ineligible. (#986)
+- **The `clean` skill now hands off git worktree checkouts to `/source-control:worktree`.** An audit
+  of a repos root containing worktree checkouts (e.g. under `.worktrees/`) inventories each checkout
+  and protects its tracked content and `.git` metadata, but the skill named no next step for the
+  worktree lifecycle it does not own. The boundary list (and the README relationship list) now point
+  at `/source-control:worktree status`/`cleanup` (if installed) — run from the checkout's own main
+  repository, since those actions manage the current repository's worktrees and take no target —
+  extending the existing managed-state → named-handoff pattern. Discoverability only; no engine or
+  safety behavior change. (#986)
 
 ## [0.4.6]
 

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -109,6 +109,9 @@ hand-cleaning the zone.
 
 - Use `/repo-hygiene:clean` for deterministic caches, build outputs, Git metadata, or a fresh-pull reset
   inside one repository. `disk-hygiene` does not duplicate those mechanisms.
+- Use `/source-control:worktree status`/`cleanup` (if installed) for git worktree checkouts such as a
+  `.worktrees/` tree. `disk-hygiene` records them as a VCS-boundary coverage gap and hands off; it never
+  plans a worktree's tracked contents.
 - Use a product's own prune/GC/uninstall command for state it owns. This skill reports the handoff and
   records the native result but never makes managed state eligible for engine execution.
 - `git clean` remains the authority for ignored/untracked repository files. This plugin protects every

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -110,8 +110,9 @@ hand-cleaning the zone.
 - Use `/repo-hygiene:clean` for deterministic caches, build outputs, Git metadata, or a fresh-pull reset
   inside one repository. `disk-hygiene` does not duplicate those mechanisms.
 - Use `/source-control:worktree status`/`cleanup` (if installed) for git worktree checkouts such as a
-  `.worktrees/` tree. `disk-hygiene` records them as a VCS-boundary coverage gap and hands off; it never
-  plans a worktree's tracked contents.
+  `.worktrees/` tree — run those actions from the checkout's own main repository, as they manage the
+  current repository's worktrees and take no target. `disk-hygiene` protects tracked content and `.git`
+  metadata but does not manage worktree lifecycle.
 - Use a product's own prune/GC/uninstall command for state it owns. This skill reports the handoff and
   records the native result but never makes managed state eligible for engine execution.
 - `git clean` remains the authority for ignored/untracked repository files. This plugin protects every

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -27,6 +27,9 @@ filesystem root, mount target, OS-managed root, protected shell-folder root or d
 directory, symlink, or Windows reparse point.
 
 - Use `/repo-hygiene:clean` for one repository's caches, build output, Git metadata, or tree reset.
+- Use `/source-control:worktree status`/`cleanup` (if installed) for VCS worktree checkouts; a
+  `.worktrees/` tree the walk reaches as a Git boundary surfaces as a `truncated_paths` coverage gap,
+  and that plugin owns worktree lifecycle. The engine never plans a worktree's tracked contents.
 - For state owned by a package manager, plugin manager, browser, IDE, cloud-sync client, or similar
   product, research its documented dry-run/prune/GC command and report the handoff. Managed state is
   never eligible for this engine, even when a native dry-run calls it eligible.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -27,9 +27,10 @@ filesystem root, mount target, OS-managed root, protected shell-folder root or d
 directory, symlink, or Windows reparse point.
 
 - Use `/repo-hygiene:clean` for one repository's caches, build output, Git metadata, or tree reset.
-- Use `/source-control:worktree status`/`cleanup` (if installed) for VCS worktree checkouts; a
-  `.worktrees/` tree the walk reaches as a Git boundary surfaces as a `truncated_paths` coverage gap,
-  and that plugin owns worktree lifecycle. The engine never plans a worktree's tracked contents.
+- For git worktree checkouts (e.g. under a `.worktrees/` directory), hand off to
+  `/source-control:worktree status`/`cleanup` (if installed), run from the checkout's own main
+  repository — those actions manage the current repository's worktrees and take no target path. The
+  engine already protects tracked content and `.git` metadata, but owns no worktree lifecycle.
 - For state owned by a package manager, plugin manager, browser, IDE, cloud-sync client, or similar
   product, research its documented dry-run/prune/GC command and report the handoff. Managed state is
   never eligible for this engine, even when a native dry-run calls it eligible.


### PR DESCRIPTION
## What

The `clean` skill's boundary list already routes state it does not own to the owning tool (`/repo-hygiene:clean` for one repo; a product's native prune/GC for managed state). VCS worktree checkouts had no such pointer.

A repos root containing a `.worktrees/` tree is reached by the walk as a Git boundary and surfaces as a `truncated_paths` coverage gap — correctly out of scope for the junk engine (VCS-tracked content is already engine-ineligible), but the skill named no next step, leaving the operator at an unexplained truncated-path entry.

## Change

Extend the existing *managed-state → named-handoff* pattern to worktree directories, pointing at `/source-control:worktree status`/`cleanup` (the plugin that owns worktree lifecycle):

- `skills/clean/SKILL.md` — one boundary bullet, tied to the `truncated_paths` / Git-boundary mechanism already documented in the snapshot step.
- `README.md` — the parallel "Relationship to other tools" bullet, kept in sync.
- `plugin.json` — version `0.4.6` → `0.4.7`.
- `CHANGELOG.md` — `### Fixed` entry.

The `/source-control:worktree` reference is qualified with **"if installed"** — disk-hygiene declares no dependency on source-control, matching the repo's dominant cross-plugin-reference convention.

Discoverability only: **no engine or safety behavior changes.**

## Verification

- markdownlint-cli2: 0 errors
- typos: clean
- lychee: 19/19 links OK

Docs-only skill-text change; no official Claude Code doc fetch was needed (no schema, manifest, or hook-contract surface touched), per the repo's fresh-docs mandate.

## Related

- #983, #984, #985 — sibling issues from the same disk-hygiene audit session, fixed in parallel PRs; #984/#985 also bump the disk-hygiene version/CHANGELOG (reconciled at merge).
- #547 — umbrella for the path-hygiene false-positive class surfaced in the same audit.

Fixes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFq1q99cNeZjKhDzHv2BQw
