### PR TITLE
fix(repo-hygiene): destructive-guard fail-open on Windows — shell-form hook launch + jq fail-closed degraded mode

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.6]
+
+### Fixed
+
+- **Destructive-guard hook now launches on Windows — was silently fail-open.** The
+  exec-form hook (`command: "bash"` + `args`) resolves `bash` via PATH, which on
+  Windows finds the WSL relay (`System32\bash.exe`) and fails to launch; Claude Code
+  treats a failed hook launch as non-blocking, so the guard enforced nothing (48
+  errors in one field session). The hook now uses shell form with `shell: bash`,
+  which Claude Code runs via Git Bash on Windows — the guard launches wherever the
+  skill itself can run.
+- **Missing jq now degrades fail-closed instead of fail-open.** Without jq the guard
+  previously announced itself inactive and allowed everything. It now matches the
+  destructive patterns against the raw hook payload and blocks outright (the
+  `CLEAN_GUARD_ACK` acknowledgement is unverifiable without jq); benign commands
+  still pass. Install jq to restore the confirmation-gated flow.
+
 ## [0.4.5]
 
 ### Changed

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -9,9 +9,13 @@ hooks:
   PreToolUse:
     - matcher: "Bash"
       hooks:
+        # Shell form (no `args`) on purpose: exec form resolves `command` via PATH,
+        # which on Windows finds the WSL relay (System32\bash.exe) and the guard
+        # never launches — a silent fail-open. Shell form with `shell: bash` makes
+        # Claude Code itself resolve Git Bash on every platform.
         - type: command
-          command: "bash"
-          args: ["${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive-guard.sh"]
+          command: "bash \"${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive-guard.sh\""
+          shell: bash
 shell: bash
 ---
 

--- a/plugins/repo-hygiene/skills/clean/scripts/destructive-guard.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/destructive-guard.sh
@@ -60,7 +60,9 @@ is_destructive() {
 # coverage is best-effort — but a guard that cannot parse must block what it
 # can see, never go silently inert (cf. #983, #532 fail-open class).
 if ! command -v jq >/dev/null 2>&1; then
-  if is_destructive "$INPUT"; then
+  # Quotes become spaces so the patterns' prefix anchors match a command at the
+  # start of a JSON string value ("command":"rm -rf ..." puts a quote before rm).
+  if is_destructive "${INPUT//\"/ }"; then
     {
       echo "BLOCKED by the clean skill's destructive guard (degraded mode: jq not found)."
       echo "Without jq the guard cannot verify the CLEAN_GUARD_ACK acknowledgement, so destructive commands are blocked outright."

--- a/plugins/repo-hygiene/skills/clean/scripts/destructive-guard.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/destructive-guard.sh
@@ -31,23 +31,6 @@ if [[ "${CLAUDE_PLUGIN_OPTION_CLEAN_DESTRUCTIVE_GUARD_ENABLED:-true}" == "false"
   exit 0
 fi
 
-# jq parses the hook payload. Without it the guard cannot inspect the command,
-# so it goes inactive for this call — announce that on stderr rather than
-# failing open silently (exit 0 keeps the guard non-blocking per its best-effort
-# threat model; install jq to re-enable it).
-if ! command -v jq >/dev/null 2>&1; then
-  echo "clean destructive-guard: jq not found — guard inactive this call (install jq to re-enable)." >&2
-  exit 0
-fi
-
-CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
-[[ -n "$CMD" ]] || exit 0
-
-# Acknowledged path: the skill's confirmation gate prefixes the command.
-if [[ "$CMD" == CLEAN_GUARD_ACK=1\ * ]]; then
-  exit 0
-fi
-
 # rm's recursive (-r/-R/--recursive) and force (-f/--force) flags are matched
 # independently, so separated, reordered, capitalized, and long spellings are
 # caught — not only the adjacent -rf cluster. git's destructive subcommands
@@ -69,6 +52,32 @@ is_destructive() {
   fi
   grep -qE "git[[:space:]]+${gopt}reset[[:space:]]+--hard|git[[:space:]]+${gopt}checkout[[:space:]]+--[[:space:]]|Remove-Item[[:space:]].*-Recurse" <<<"$cmd"
 }
+
+# jq parses the hook payload. Without it the ack prefix cannot be verified, so
+# the guard degrades FAIL-CLOSED: destructive patterns matched against the raw
+# JSON payload block unconditionally (no ack path) until jq is installed. JSON
+# escaping (e.g. tabs as \t) can hide whitespace from the patterns, so degraded
+# coverage is best-effort — but a guard that cannot parse must block what it
+# can see, never go silently inert (cf. #983, #532 fail-open class).
+if ! command -v jq >/dev/null 2>&1; then
+  if is_destructive "$INPUT"; then
+    {
+      echo "BLOCKED by the clean skill's destructive guard (degraded mode: jq not found)."
+      echo "Without jq the guard cannot verify the CLEAN_GUARD_ACK acknowledgement, so destructive commands are blocked outright."
+      echo "Install jq to restore the dry-run -> user-confirmation -> CLEAN_GUARD_ACK=1 flow."
+    } >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[[ -n "$CMD" ]] || exit 0
+
+# Acknowledged path: the skill's confirmation gate prefixes the command.
+if [[ "$CMD" == CLEAN_GUARD_ACK=1\ * ]]; then
+  exit 0
+fi
 
 if is_destructive "$CMD"; then
   {

--- a/plugins/repo-hygiene/skills/clean/scripts/destructive-guard.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/destructive-guard.test.sh
@@ -76,6 +76,33 @@ empty=$(
 )
 assert_exit "empty tool_input exits 0" 0 "$empty"
 
+# --- 8. Degraded mode without jq: fail-closed -------------------------------------
+# Sandbox PATH containing everything the guard needs except jq. Symlinking works
+# on Linux CI; on Windows/MSYS the linked bash cannot load its DLLs, so the
+# sandbox is verified functional first and the cases are skipped when it isn't.
+
+NOJQ_DIR="$(mktemp -d)"
+trap 'rm -rf "$NOJQ_DIR"' EXIT
+for bin in bash cat grep sed; do
+  ln -s "$(command -v "$bin")" "$NOJQ_DIR/$bin" 2>/dev/null || true
+done
+
+nojq_exit() {
+  printf '{"tool_input":{"command":"%s"}}' "$1" | PATH="$NOJQ_DIR" "$NOJQ_DIR/bash" "$SCRIPT" >/dev/null 2>&1
+  echo $?
+}
+
+if [[ "$(PATH="$NOJQ_DIR" "$NOJQ_DIR/bash" -c 'command -v jq >/dev/null 2>&1 && echo have-jq; echo ok' 2>/dev/null)" == "ok" ]]; then
+  assert_exit "no jq: blocks raw destructive payload" 2 "$(nojq_exit "git clean -fdx")"
+  assert_exit "no jq: blocks rm -rf payload" 2 "$(nojq_exit "rm -rf build/")"
+  assert_exit "no jq: benign payload passes" 0 "$(nojq_exit "git status")"
+  assert_exit "no jq: ack prefix does NOT bypass (unverifiable)" 2 "$(nojq_exit "CLEAN_GUARD_ACK=1 git clean -fdx")"
+  reason=$(printf '{"tool_input":{"command":"git clean -fdx"}}' | PATH="$NOJQ_DIR" "$NOJQ_DIR/bash" "$SCRIPT" 2>&1 >/dev/null)
+  assert_contains "no jq: block reason names degraded mode" "$reason" "degraded mode: jq not found"
+else
+  skip_case "degraded-mode cases: PATH sandbox not functional on this platform"
+fi
+
 # --- Final report -----------------------------------------------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Problem

The clean skill's session-scoped destructive guard (SKILL.md frontmatter PreToolUse hook) never launched on Windows. The hook used **exec form** (`command: "bash"` + `args`), and per the hooks reference, exec form resolves `command` as an executable on PATH — on Windows that finds the WSL relay (`System32\bash.exe`), which fails with `execvpe(/bin/bash) failed`. A failed hook launch is a **non-blocking** error, so the guard silently enforced nothing: 48 hook errors in one 82-repo fleet session (fee18cc2), with bulk `rm -rf` applies running ungated.

## Fix

1. **Shell-form hook with `shell: bash`.** Per the [hooks reference](https://code.claude.com/docs/en/hooks), shell form runs the command string via Git Bash on Windows, resolved by Claude Code itself instead of PATH lookup. The guard now launches wherever the skill itself can run (the skill already requires Git Bash via `allowed-tools: Bash(bash …)` and `shell: bash` precompute).
2. **jq-missing path now fails closed.** Previously the guard announced itself inactive and exited 0 — a second fail-open within the script itself. Without jq the `CLEAN_GUARD_ACK` acknowledgement is unverifiable, so the guard now matches its destructive patterns against the raw hook payload and blocks outright, telling the agent to install jq. Benign commands still pass. Same fail-open class as #983 / the #532 umbrella.

Platform note: a hook that fails to *launch* can never block (documented, non-blocking by design), so true fail-closed at the harness layer is impossible — the achievable posture is making launch succeed in every environment the skill runs in, plus fail-closed behavior for every failure mode inside the script's control. Cross-linked in #983, which hits the same class via a different vector.

## Tests

- New degraded-mode section in `destructive-guard.test.sh`: PATH sandbox without jq — destructive payloads block (exit 2), benign pass, ack prefix does NOT bypass, block reason names degraded mode. Sandbox self-verifies and skips on platforms where symlinked bash can't run (Windows/MSYS); executes on Linux CI.
- Full clean-skill suite green locally (30 guard checks + 11 sibling suites); `skill-quality:check` PASS (0 errors).

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D1oCPX8LaUKnLUi3TXmih

## Related

- #983 — disk-hygiene guard fail-open via a different vector (unsupported ${CLAUDE_PLUGIN_DATA} substitution); same class, still open
- #532 — false-green umbrella covering silent fail-open patterns
- #1003 — fleet-sweep field-report umbrella this fix belongs to
- #464 — same-plugin PR serialization constraint governing this batch series