### PR TITLE
feat(disk-hygiene): gate unbounded scans of known-large targets at the engine

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.0]
+
+### Added
+
+- **Engine-level large-target scan gate.** A `scan` whose target resolves to the user home directory
+  now returns `large-target-confirmation-required` (after a cheap top-level probe, no full walk)
+  unless it carries `--max-depth` or the new `--confirmed-large-scan` flag, backing the former
+  prompt-only `--max-depth 1` convention with a deterministic backstop so a forgotten bound cannot
+  become an accidental unbounded whole-home walk. The Bash guard accepts the valueless
+  `--confirmed-large-scan` in the exact scan shape.
+
 ## [0.4.7]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -62,7 +62,8 @@ stay there, never in the target or `${CLAUDE_PLUGIN_ROOT}`. Run:
 ```text
 "<hook-python>" "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py" scan \
   --target "<target>" --output "<run-dir>/snapshot.json" [--policy "<policy.json>"] \
-  --project-dir "${CLAUDE_PROJECT_DIR}" --data-root "${CLAUDE_PLUGIN_DATA}"
+  --project-dir "${CLAUDE_PROJECT_DIR}" --data-root "${CLAUDE_PLUGIN_DATA}" \
+  [--max-depth <N>] [--confirmed-large-scan]
 ```
 
 The guard validates `--data-root` against the authorized data root it receives as a
@@ -71,7 +72,14 @@ plugin data directory even when the shell environment lacks `CLAUDE_PLUGIN_DATA`
 
 For a large root (a home directory, anything whose recursive walk could exceed the engine's entry
 cap), start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and
-immediate children, then fan out deeper scans per subtree that the evidence justifies. Every
+immediate children, then fan out deeper scans per subtree that the evidence justifies. The engine
+backs this with a deterministic gate: a scan whose target resolves to the user home directory and
+carries neither `--max-depth` nor `--confirmed-large-scan` returns `large-target-confirmation-required`
+(after a cheap top-level probe, not a full walk) instead of the unbounded traversal, so a forgotten
+bound never becomes an accidental whole-home scan. `--max-depth` is the preferred bounded response.
+Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed — ask with
+`AskUserQuestion` first, exactly as the apply lane requires before an expensive step; a general
+"clean my home directory" is not that confirmation. Every
 directory whose descendants were not walked — cut off by `--max-depth`, a protected root, or a VCS
 boundary — is recorded in `truncated_paths`; report them as coverage gaps, never as clean, and
 never plan them for removal (the preview blocks them as `truncated-not-inventoried` and skips the

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -57,7 +57,8 @@ the host platform's path case rules; POSIX path identity is never case-folded. A
 is accepted only when it matches the authorized data root the guard receives as a runtime-substituted
 hook argument (`${CLAUDE_PLUGIN_DATA}`) — the shell environment is never trusted for it (an env var is
 honored only as a fallback), and absent that authority the flag fails closed. `--max-depth` accepts
-only a bare positive-integer literal.
+only a bare positive-integer literal. `--confirmed-large-scan` is the one valueless scan flag; the
+guard permits at most one and rejects any trailing value, so the scan grammar stays exact.
 
 The same guard also covers the PowerShell tool with the inverse tradeoff: PowerShell stays open for
 read-only support work, while engine invocations are hard-denied (Bash is the only engine lane) and
@@ -75,6 +76,12 @@ and platform gates remain the deletion authority.
 A depth-limited scan records every directory it declined to enter in `truncated_paths`. Truncated
 directories have no captured descendant set, so the preview blocks them (and anything beneath them)
 as `truncated-not-inventoried`; they are coverage gaps, never candidates.
+
+A scan of a known-large root — the user home directory — is gated before it walks. Absent an explicit
+`--max-depth` bound or a `--confirmed-large-scan` acknowledgement, the engine performs a cheap
+top-level probe and returns `large-target-confirmation-required` instead of the unbounded traversal,
+so an unauthenticated whole-home walk cannot begin by omission. This is scan-cost gating (time and
+resources), distinct from the hard rejection of filesystem and OS-managed roots as invalid targets.
 
 Managed state is engine-ineligible. Even current native dry-run evidence is recorded only as a
 report-only handoff because this engine cannot independently authenticate the owning product's state

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -226,15 +226,24 @@ def classify_exact_engine_command(command: str, authority: str | None) -> str | 
 
     if tokens[2] == "scan":
         if (
-            len(tokens) not in {7, 9, 11, 13, 15}
+            len(tokens) < 7
             or tokens[3] != "--target"
             or not _argument(tokens[4])
             or tokens[5] != "--output"
             or not _argument(tokens[6])
         ):
             return None
-        if not _consume_optional_pairs(
-            tokens[7:],
+        # --confirmed-large-scan is the sole valueless scan flag; strip at most
+        # one so the remainder is the pure flag/value-pair grammar every other
+        # optional follows.
+        optionals = list(tokens[7:])
+        confirmed = optionals.count("--confirmed-large-scan")
+        if confirmed > 1:
+            return None
+        if confirmed:
+            optionals.remove("--confirmed-large-scan")
+        if len(optionals) not in {0, 2, 4, 6, 8} or not _consume_optional_pairs(
+            optionals,
             frozenset({"--policy", "--project-dir", "--data-root", "--max-depth"}),
             authority,
         ):

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -538,6 +538,46 @@ def os_autoclean_advisory(target: Path) -> dict[str, Any] | None:
     }
 
 
+def user_home() -> Path | None:
+    try:
+        return Path.home()
+    except RuntimeError:
+        return None
+
+
+def large_scan_reasons(target: Path) -> list[str]:
+    """Name deterministically why a target is a known-large scan root.
+
+    A known-large root is one whose unbounded recursive walk is expected to be
+    expensive in time and resources — the user home directory today. The engine
+    gates such a walk behind an explicit bound or confirmation, mirroring the
+    apply lane's "ask before it is expensive" posture, moved earlier because the
+    cost here is time, not data loss. Drive-root reasoning is a separate concern
+    owned elsewhere; a filesystem root is already rejected before this runs.
+    """
+    reasons: list[str] = []
+    home = user_home()
+    if home is not None:
+        try:
+            resolved_home = home.resolve(strict=False)
+        except OSError:
+            resolved_home = home
+        if os.path.normcase(os.fspath(target)) == os.path.normcase(
+            os.fspath(resolved_home)
+        ):
+            reasons.append("user-home")
+    return sorted(set(reasons))
+
+
+def top_level_entry_count(target: Path) -> tuple[int | None, str | None]:
+    """Count immediate children only — a cheap probe that never recurses."""
+    try:
+        with os.scandir(target) as iterator:
+            return sum(1 for _ in iterator), None
+    except OSError as exc:
+        return None, str(exc)
+
+
 def scan_tree(
     target: Path, policy: dict[str, Any], max_depth: int | None = None
 ) -> dict[str, Any]:
@@ -1509,6 +1549,7 @@ def build_parser() -> argparse.ArgumentParser:
     scan.add_argument("--project-dir")
     scan.add_argument("--data-root")
     scan.add_argument("--max-depth", type=int)
+    scan.add_argument("--confirmed-large-scan", action="store_true")
     for name in ("preview", "apply"):
         command = subparsers.add_parser(name)
         command.add_argument("--snapshot", required=True)
@@ -1568,6 +1609,31 @@ def main(argv: list[str] | None = None) -> int:
                 raise HygieneError("--max-depth must be a positive integer")
             output_path = state_output_path(Path(args.output))
             advisory = os_autoclean_advisory(target)
+            large_reasons = large_scan_reasons(target)
+            if (
+                large_reasons
+                and args.max_depth is None
+                and not args.confirmed_large_scan
+            ):
+                immediate_entries, probe_error = top_level_entry_count(target)
+                return emit(
+                    {
+                        "status": "large-target-confirmation-required",
+                        "target": str(target),
+                        "large_target_reasons": large_reasons,
+                        "immediate_entries": immediate_entries,
+                        "probe_error": probe_error,
+                        "os_autoclean": advisory,
+                        "note": (
+                            "This is a known-large scan root; an unbounded "
+                            "recursive walk is gated at the engine. Re-run with "
+                            "--max-depth N for a bounded pass (start with "
+                            "--max-depth 1), or, only after the human confirms a "
+                            "full walk, add --confirmed-large-scan."
+                        ),
+                    },
+                    5,
+                )
             try:
                 snapshot = scan_tree(target, policy, args.max_depth)
             except HygieneError as exc:

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -554,17 +554,22 @@ def large_scan_reasons(target: Path) -> list[str]:
     apply lane's "ask before it is expensive" posture, moved earlier because the
     cost here is time, not data loss. Drive-root reasoning is a separate concern
     owned elsewhere; a filesystem root is already rejected before this runs.
+
+    The home match is by filesystem identity (device + inode via
+    ``os.path.samefile``), not a path-string compare: ``os.path.normcase`` only
+    folds case on Windows, so a string compare would let a case-variant spelling
+    (``/users/alice`` vs ``/Users/alice``) bypass the gate on a case-insensitive
+    macOS volume. ``target`` is validated to exist upstream; ``samefile`` raises
+    only when a path is missing, so a home that cannot be stat'd is simply no match.
     """
     reasons: list[str] = []
     home = user_home()
     if home is not None:
         try:
-            resolved_home = home.resolve(strict=False)
+            same_home = os.path.samefile(target, home)
         except OSError:
-            resolved_home = home
-        if os.path.normcase(os.fspath(target)) == os.path.normcase(
-            os.fspath(resolved_home)
-        ):
+            same_home = False
+        if same_home:
             reasons.append("user-home")
     return sorted(set(reasons))
 

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -963,15 +963,15 @@ class HygieneTests(unittest.TestCase):
             root = base / "target"
             root.mkdir()
             (root / "junk.tmp").write_text("x", encoding="utf-8")
+            home = base / "home"
+            home.mkdir()
             data_root = base / "plugin-data"
             data_root.mkdir()
             output = data_root / "run" / "snapshot.json"
             stdout_io = io.StringIO()
             with (
-                # Home is a different directory, so the target is not known-large.
-                mock.patch.object(
-                    hygiene.Path, "home", return_value=(base / "home").resolve()
-                ),
+                # Home is a different real directory, so identity does not match.
+                mock.patch.object(hygiene.Path, "home", return_value=home.resolve()),
                 redirect_stdout(stdout_io),
             ):
                 code = hygiene.main(
@@ -988,6 +988,36 @@ class HygieneTests(unittest.TestCase):
             payload = json.loads(stdout_io.getvalue())
             self.assertEqual(0, code)
             self.assertEqual("scan-complete", payload["status"])
+
+    def test_home_match_is_by_filesystem_identity_not_case_folded_string(
+        self,
+    ) -> None:
+        # A case-variant spelling resolves to the same directory on a
+        # case-insensitive macOS volume, but os.path.normcase folds case only on
+        # Windows — a string compare would let it bypass the gate. The match is
+        # by filesystem identity, simulated here (CI is case-sensitive Linux) by
+        # having samefile report the two distinct spellings as one file.
+        target = Path("/users/alice")
+        home = Path("/Users/alice")
+        self.assertNotEqual(os.fspath(target), os.fspath(home))
+        with (
+            mock.patch.object(hygiene, "user_home", return_value=home),
+            mock.patch("os.path.samefile", return_value=True) as samefile,
+        ):
+            reasons = hygiene.large_scan_reasons(target)
+        self.assertEqual(["user-home"], reasons)
+        samefile.assert_called_once_with(target, home)
+
+    def test_home_match_treats_unstattable_home_as_no_match(self) -> None:
+        # samefile raises when a path is missing; a home that cannot be stat'd
+        # must be no match, never a crash.
+        with (
+            mock.patch.object(
+                hygiene, "user_home", return_value=Path("/home/missing")
+            ),
+            mock.patch("os.path.samefile", side_effect=FileNotFoundError),
+        ):
+            self.assertEqual([], hygiene.large_scan_reasons(Path("/home/target")))
 
 
 class StandingPolicyTests(unittest.TestCase):

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -880,6 +880,115 @@ class HygieneTests(unittest.TestCase):
             self.assertIn("--max-depth", payload["error"])
             self.assertIn("os_autoclean", payload)
 
+    def _home_target_fixture(self) -> tuple[Path, Path, Path]:
+        """A directory tree standing in for the user home target."""
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, base, ignore_errors=True)
+        root = base / "home"
+        root.mkdir()
+        (root / "loose.tmp").write_text("x", encoding="utf-8")
+        (root / "nested").mkdir()
+        (root / "nested" / "leaf.txt").write_text("y", encoding="utf-8")
+        data_root = base / "plugin-data"
+        data_root.mkdir()
+        return root, data_root, data_root / "run" / "snapshot.json"
+
+    def _run_home_scan(
+        self, extra_args: list[str]
+    ) -> tuple[int, dict[str, object], Path]:
+        root, data_root, output = self._home_target_fixture()
+        stdout_io = io.StringIO()
+        with (
+            mock.patch.object(hygiene.Path, "home", return_value=root.resolve()),
+            redirect_stdout(stdout_io),
+        ):
+            code = hygiene.main(
+                [
+                    "scan",
+                    "--target",
+                    str(root),
+                    "--output",
+                    str(output),
+                    "--data-root",
+                    str(data_root),
+                    *extra_args,
+                ]
+            )
+        return code, json.loads(stdout_io.getvalue()), output
+
+    def test_home_target_without_bound_requires_confirmation_and_never_walks(
+        self,
+    ) -> None:
+        root, data_root, output = self._home_target_fixture()
+        stdout_io = io.StringIO()
+        with (
+            mock.patch.object(hygiene.Path, "home", return_value=root.resolve()),
+            refuse_call("scan_tree"),
+            redirect_stdout(stdout_io),
+        ):
+            code = hygiene.main(
+                [
+                    "scan",
+                    "--target",
+                    str(root),
+                    "--output",
+                    str(output),
+                    "--data-root",
+                    str(data_root),
+                ]
+            )
+        payload = json.loads(stdout_io.getvalue())
+        self.assertEqual(5, code)
+        self.assertEqual("large-target-confirmation-required", payload["status"])
+        self.assertEqual(["user-home"], payload["large_target_reasons"])
+        self.assertEqual(2, payload["immediate_entries"])
+        self.assertIn("os_autoclean", payload)
+        self.assertFalse(output.exists())
+
+    def test_home_target_with_max_depth_proceeds(self) -> None:
+        code, payload, output = self._run_home_scan(["--max-depth", "1"])
+        self.assertEqual(0, code)
+        self.assertEqual("scan-complete", payload["status"])
+        self.assertTrue(output.exists())
+
+    def test_home_target_with_confirmed_flag_proceeds(self) -> None:
+        code, payload, output = self._run_home_scan(["--confirmed-large-scan"])
+        self.assertEqual(0, code)
+        self.assertEqual("scan-complete", payload["status"])
+        self.assertTrue(output.exists())
+
+    def test_ordinary_subdirectory_is_not_gated(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            root = base / "target"
+            root.mkdir()
+            (root / "junk.tmp").write_text("x", encoding="utf-8")
+            data_root = base / "plugin-data"
+            data_root.mkdir()
+            output = data_root / "run" / "snapshot.json"
+            stdout_io = io.StringIO()
+            with (
+                # Home is a different directory, so the target is not known-large.
+                mock.patch.object(
+                    hygiene.Path, "home", return_value=(base / "home").resolve()
+                ),
+                redirect_stdout(stdout_io),
+            ):
+                code = hygiene.main(
+                    [
+                        "scan",
+                        "--target",
+                        str(root),
+                        "--output",
+                        str(output),
+                        "--data-root",
+                        str(data_root),
+                    ]
+                )
+            payload = json.loads(stdout_io.getvalue())
+            self.assertEqual(0, code)
+            self.assertEqual("scan-complete", payload["status"])
+
 
 class StandingPolicyTests(unittest.TestCase):
     @staticmethod
@@ -1721,6 +1830,32 @@ class GuardTests(unittest.TestCase):
                     "permissionDecision"
                 ],
                 value,
+            )
+
+    def test_guard_scan_accepts_single_confirmed_large_scan_flag(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        base = f'"{self.python_command()}" "{script}" scan --target t --output s'
+        allowed = (
+            f"{base} --confirmed-large-scan",
+            f"{base} --confirmed-large-scan --max-depth 1",
+            f"{base} --max-depth 1 --confirmed-large-scan",
+            f"{base} --confirmed-large-scan --policy p",
+        )
+        denied = (
+            f"{base} --confirmed-large-scan --confirmed-large-scan",
+            f"{base} --confirmed-large-scan v",
+        )
+        for command in allowed:
+            self.assertEqual(
+                "allow",
+                self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+                command,
+            )
+        for command in denied:
+            self.assertEqual(
+                "deny",
+                self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+                command,
             )
 
     def test_guard_preview_accepts_optional_authorized_data_root(self) -> None:


### PR DESCRIPTION
## Root cause

The `scan` lane had no engine-level backstop for known-large targets. `SKILL.md`
only asked the invoking agent to add `--max-depth 1` on a large root — a
prompt-level convention. If the agent forgets, skips it, or a differently-tuned
future agent weights that instruction differently, an unbounded recursive walk of
`$HOME`/`%USERPROFILE%` runs unconfirmed. Only the destructive `apply` lane was
gated; the scan's own time/resource cost was not. The home directory is a valid
target today (its basename — the username — is not a protected shell-folder name),
so nothing stopped the full walk.

## Fix

Detect the user home directory deterministically in the engine (`large_scan_reasons`,
exact resolved-path equality — descendants like `~/projects` stay ungated). A scan
of that target carrying neither `--max-depth` nor the new `--confirmed-large-scan`
flag now does a cheap top-level `os.scandir` probe and returns
`large-target-confirmation-required` (exit 5) **instead of walking**, mirroring the
apply lane's "ask before it is expensive" posture — moved earlier because the cost
here is time, not data loss. `--max-depth` is the preferred bounded response;
`--confirmed-large-scan` is the explicit, human-confirmed override (SKILL.md directs
the agent to `AskUserQuestion` first).

The change is an **engine backstop reached through the Bash guard**, so the guard's
strict scan grammar had to accept it: `destructive_guard.py` now strips at most one
valueless `--confirmed-large-scan` from the scan optionals and validates the
remainder as the existing flag/value-pair grammar, keeping the shape exact
(duplicate flag or a trailing value is denied).

Docs updated: `SKILL.md` section 1 (engine gate + the two flags, command block),
`safety-model.md` (scan-cost gate paragraph + the new guard flag). The prompt-level
`--max-depth 1` guidance stays, now backed by the engine.

## Tests

`test_hygiene.py` (86 tests pass, 4 platform-skips):
- `test_home_target_without_bound_requires_confirmation_and_never_walks` — asserts
  `large-target-confirmation-required`, exit 5, `refuse_call("scan_tree")` proves no
  walk, and no snapshot file is written.
- `test_home_target_with_max_depth_proceeds` / `test_home_target_with_confirmed_flag_proceeds`
  — both reach `scan-complete` and write the snapshot.
- `test_ordinary_subdirectory_is_not_gated` — a non-home target is unaffected.
- `test_guard_scan_accepts_single_confirmed_large_scan_flag` — guard allows the flag
  (alone, with `--max-depth`, with `--policy`) and denies a doubled flag or a
  trailing value.

## Verification

- `bash plugins/disk-hygiene/skills/clean/scripts/hygiene.test.sh` → 86 pass / 4 skip.
- `ruff check` (0.15.20) → all checks pass on the three scripts.
- `bash scripts/validate-plugins.sh` → all manifests + catalog validate.
- `markdownlint-cli2` on the three changed docs → 0 errors.
- Pre-existing `ruff format` drift on lines this PR does not touch (a 0.15.20-vs-pinned-0.15.21
  quirk; disk-hygiene's `.test.sh` runs unittest only) is intentionally left alone; my added
  lines are ruff-canonical.

## Scope / residual risks

- **Companion #984 (drive-root reasoning) is out of scope.** `hard_protection` root-rejection
  is untouched. `large_scan_reasons` covers only `user-home`; drive roots are rejected upstream
  today, so coverage is complete now. **Deferred trigger:** if #984 makes a reasoned drive root
  a valid scan target, extend `large_scan_reasons` to cover it, or an unbounded drive-root walk
  would bypass this gate.
- Version/CHANGELOG conflicts with sibling lanes are expected; entries kept minimal and mergeable.

## Fresh-docs mandate

No official docs fetched: the change is internal Python engine/guard logic plus skill/reference
prose, touching no documented plugin/hook/manifest **schema** (the semver `version` bump is not a
schema change). The fresh-docs mandate targets schema/behavior changes against upstream docs, which
this PR does not make.

## Related

- #984 - companion drive-root-reasoning fix, concurrent sibling lane; this PR deliberately does not touch `hard_protection` root-rejection (see Scope above).
- #983, #986 - sibling issues surfaced by the same disk-hygiene audit session, addressed in parallel PRs; not closed by this PR.

Fixes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFq1q99cNeZjKhDzHv2BQw
