### PR TITLE
feat(repo-hygiene): single pruned walk + dry-run manifest + apply summary

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.0]
+
+### Fixed
+
+- **Selective `caches`/`build` tiers now run a single pruned walk per tier instead
+  of ~10 unpruned full-tree `find` walks.** The old `! -path` exclusions filtered
+  output but did not `-prune`, so every per-pattern walk still descended `.git/`,
+  `node_modules/`, and `.venv/`. Enumeration now prunes those three trees once and
+  `-print`s all directory-name and file-glob matches in one walk, then applies
+  per-path protection on the result list. Measured on a large .NET + node repo
+  (Windows/NTFS): one pruned walk incl. `du` sizing ~17s vs a 10-walk unpruned
+  dry-run that exceeded 10 min (killed). (#993)
+
+### Added
+
+- **Dry-run writes a manifest and states reclaimable space; `--apply` consumes it
+  instead of re-walking.** The dry-run emits a session-scoped manifest
+  (`<class>\t<bytes>\t<relpath>` per eligible target), prints its path
+  (`Manifest: <path>`), and a `Summary: planned=N bytes=K` total so the
+  confirmation gate can state reclaimable bytes. `--apply --manifest <path>`
+  removes the manifest's entries with a re-stat + re-classify staleness guard (no
+  second walk); a killed apply resumes by re-running the same command
+  (already-gone entries are idempotent no-ops). `--apply` without a manifest
+  builds one then applies it, preserving the standalone CLI contract. With
+  `--include-caches` the caches tier folds into the same manifest — one walk per
+  tier, no subprocess. (#995)
+- **Apply ends with a machine-parseable summary and fails closed.** Each `--apply`
+  run prints `Summary: removed=N failed=M bytes=K` (bytes actually reclaimed) and
+  exits non-zero when any removal fails, so a fleet sweep no longer requires
+  grepping every per-repo log to confirm success. (#1002)
+
 ## [0.4.6]
 
 ### Fixed

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -34,6 +34,16 @@ All notable changes to the `repo-hygiene` plugin are documented here. Format fol
   exits non-zero when any removal fails, so a fleet sweep no longer requires
   grepping every per-repo log to confirm success. (#1002)
 
+### Removed
+
+- **The `dotnet clean` build-system driver.** `clean-build.sh` no longer runs
+  `dotnet clean <solution>` before removing `bin/`/`obj/`. The universal artifact
+  removal already deletes everything the driver would, so running it first was
+  pure overhead — a full MSBuild evaluation (minutes on a large solution) that
+  also re-created `obj/` evaluation artifacts. One walk + `rm` is strictly faster
+  and equally complete. Removes the `Planned: dotnet clean …` (dry-run) and
+  `DRIVER_FAILED:` (apply) output markers. (#999)
+
 ## [0.4.6]
 
 ### Fixed

--- a/plugins/repo-hygiene/README.md
+++ b/plugins/repo-hygiene/README.md
@@ -17,7 +17,7 @@ the conversation, or presents a menu and falls back to the safe `scan`.
 |--------|--------------|------|
 | `scan` | Read-only inventory of reclaimable caches, build output, and stale git refs | Safe |
 | `caches` | Remove tool / linter caches (`.pytest_cache`, `.ruff_cache`, `__pycache__`, `.turbo`, `.vs`, …) | Low |
-| `build` | Remove build artifacts (`bin`/`obj`/`build`/`dist`/`out`/`target`/`TestResults`, `*.binlog`), includes caches; runs a runtime-detected `dotnet clean` when a `*.slnx`/`*.sln` and `dotnet` are present | Low |
+| `build` | Remove build artifacts (`bin`/`obj`/`build`/`dist`/`out`/`target`/`TestResults`, `*.binlog`), includes caches | Low |
 | `git` | Prune stale worktree/remote metadata and gc; audit branches (merged / PR-merged / stale) and delete only on per-branch opt-in | Low |
 | `tree` | Reset the working tree like a fresh pull — `git reset --hard` + `git clean -fdx` | **Destructive** |
 | `tree-batch` | Run `tree` across many repos (`ghq list`, a glob, or an explicit list) behind one confirmation gate, with a separator-agnostic skip list and a dirty-by-default guard | **Destructive** |

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -96,13 +96,17 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 `bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/preflight.sh` — see [context/preflight.md](context/preflight.md). Interactive: `AskUserQuestion` before `--apply` when non-empty. Autonomous: abort.
 
+#### Dry-run → confirm → apply manifest flow (caches / build)
+
+Both selective mutating tiers pay the filesystem walk **once**. `--dry-run` writes a session-scoped manifest and prints two machine-parseable lines: `Manifest: <path>` and `Summary: planned=N bytes=K` (bytes reclaimable — surface this in the confirmation gate). After the user confirms, apply the **same** manifest with `CLEAN_GUARD_ACK=1 … --apply --manifest <path>` — apply re-stats each entry (staleness guard) and removes it without re-walking, then prints `Summary: removed=N failed=M bytes=K` and exits non-zero if `failed>0`. A killed apply **resumes** by re-running the identical `--apply --manifest <path>` (already-removed entries are idempotent no-ops). Capture `<path>` from the dry-run's `Manifest:` line and thread it through unchanged; the manifest is ephemeral (mktemp default), so pass `--manifest <path>` on the dry-run too if you need a stable location.
+
 ### 2. Caches
 
-`bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/clean-caches.sh` — default `--dry-run`; `--apply` only after confirmation.
+`bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/clean-caches.sh` — default `--dry-run`; apply per the manifest flow above (`--apply --manifest <path>`) only after confirmation.
 
 ### 3. Build (includes caches)
 
-`bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/clean-build.sh --include-caches` — default `--dry-run`; `--apply` after confirmation.
+`bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/clean-build.sh --include-caches` — default `--dry-run`; apply per the manifest flow above only after confirmation. `--include-caches` folds the caches tier into the one build manifest.
 
 ### 4. Git
 

--- a/plugins/repo-hygiene/skills/clean/context/action-router.md
+++ b/plugins/repo-hygiene/skills/clean/context/action-router.md
@@ -53,7 +53,7 @@ Default when still unsure after one question: **`scan`** (safest).
 | Action | Pre-mutation step | User gate |
 | --- | --- | --- |
 | `scan` | Run `scan.sh` | None |
-| `caches`, `build`, `all` | `preflight.sh` + tier scripts `--dry-run` | `AskUserQuestion` when preflight non-empty OR before `--apply` |
+| `caches`, `build`, `all` | `preflight.sh` + tier scripts `--dry-run` (writes a manifest; emits `Manifest:` + `Summary: planned=N bytes=K`) | `AskUserQuestion` when preflight non-empty OR before `--apply` — surface the `bytes` reclaimable total; apply the same manifest (`--apply --manifest <path>`), which emits `Summary: removed=N failed=M bytes=K` and exits non-zero on failure |
 | `git` | `git-prune.sh --dry-run`, `git-branch-audit.sh` | Before `--apply` prune; before any branch deletion |
 | `tree` | `git-tree-reset.sh --dry-run` (always) | **Mandatory** `AskUserQuestion` before `--apply` (surface `PreserveDeps`/`PreserveSecrets`/`AheadCount`); a non-zero `AheadCount` or exit 4 needs explicit unpushed-loss confirmation before `--allow-unpushed`; `--include-secrets` is UNRECOVERABLE — confirm separately; never autonomous |
 | `tree-batch` | `git-tree-reset-batch.sh --dry-run` (always) | **Mandatory** single batch-wide `AskUserQuestion` before `--apply` (surface the per-repo `Outcome`/`Reason`, `Summary`, and `UnmatchedSkip:`); one gate for the whole batch, never per repo; `--include-dirty` re-enables the data-loss vector — confirm separately naming the dirty repos, like `--include-secrets`; never autonomous. Detail: [git-tree-reset-batch.md](git-tree-reset-batch.md) |

--- a/plugins/repo-hygiene/skills/clean/context/action-router.md
+++ b/plugins/repo-hygiene/skills/clean/context/action-router.md
@@ -8,7 +8,7 @@ SKILL.md carries the action table headline; this file carries alias resolution, 
 | --- | --- | --- | --- | --- |
 | `scan` | "Show what's reclaimable" | Read-only inventory | Safe | N/A (no mutation) |
 | `caches` | "Clear tool and linter caches" | `.pytest_cache/`, `.ruff_cache/`, `__pycache__/`, … | Low | **Never** |
-| `build` | "Clear build output and logs" | `bin/`, `obj/`, `dist/`, dotnet clean driver, … | Low | **Never** |
+| `build` | "Clear build output and logs" | `bin/`, `obj/`, `dist/`, `*.binlog`, … | Low | **Never** |
 | `git` | "Prune stale git metadata" | `worktree prune`, `remote prune`, `gc`, branch audit | Low | Prune/gc only after user OK; branch delete always opt-in |
 | `tree` | "Reset working tree like a fresh pull" | `fetch` + `reset --hard` upstream + `clean -fdx` (default-preserve secrets/deps/skill-data; `--include-deps` / `--include-secrets` to widen) | **Destructive** | **Never** |
 | `tree-batch` | "Reset all my repos like a fresh pull" | `tree` across a repo set behind one gate; separator-agnostic skip list; dirty/unpushed skipped unless `--include-dirty` | **Destructive** | **Never** |

--- a/plugins/repo-hygiene/skills/clean/reference/cleanup-config.md
+++ b/plugins/repo-hygiene/skills/clean/reference/cleanup-config.md
@@ -25,9 +25,7 @@ Universal artifact directory globs:
 
 - `**/bin/`, `**/obj/`, `**/build/`, `**/dist/`, `**/out/`, `**/target/`, `**/TestResults/`, `**/*.binlog`
 
-Build-system clean driver (run before the glob removal in Workflow §3):
-
-- .NET: `clean-build.sh` detects a `*.slnx` or `*.sln` at the repo root at runtime and runs `dotnet clean <solution> -v q`. If `dotnet` is unavailable or no solution is present, the driver is skipped; the universal globs still remove `bin/`/`obj/` directly.
+No build-system clean driver (e.g. `dotnet clean`): the universal artifact globs above already remove every output such a driver would delete, so running one first is pure overhead — a full MSBuild evaluation (minutes on a large solution) that also re-creates `obj/` evaluation artifacts. One walk + rm is strictly faster and equally complete.
 
 App-specific runtime output (application logs written outside the universal artifact dirs) is **not** swept generically — no portable path exists. A consumer whose app writes logs to a non-artifact directory reclaims them through the `tree` tier (they are untracked/ignored) or their own gitignore + tooling.
 

--- a/plugins/repo-hygiene/skills/clean/reference/ecosystems.md
+++ b/plugins/repo-hygiene/skills/clean/reference/ecosystems.md
@@ -8,13 +8,13 @@ Per-ecosystem teaching tables for the clean skill. Each entry includes command s
 
 | Target | Tier | Command | Safety | Regen cost |
 |--------|------|---------|--------|-----------|
-| bin/, obj/ | build | `dotnet clean <detected-solution> -v q` then `find . -type d \( -name bin -o -name obj \) -not -path '*/.git/*' -not -path '*/.venv/*' -not -path '*/node_modules/*' -exec rm -rf {} +` | Safe | `dotnet build` (~15s) |
+| bin/, obj/ | build | `find . \( -name .git -o -name node_modules -o -name .venv \) -prune -o -type d \( -name bin -o -name obj \) -print` then `rm -rf` each eligible path | Safe | `dotnet build` (~15s) |
 | TestResults/ | build | `find . -type d -name TestResults -exec rm -rf {} +` | Safe | `dotnet test` |
 | *.binlog | build | `find . -name '*.binlog' -delete` | Safe | Intentional capture only |
 | App log dirs | build | Not swept generically (no portable path) — reclaim via the `tree` action | Safe | App sink creates on next run |
 | `*.csproj.user` / `*.suo` | NEVER | — | Protected | VS / IDE debug profile preference |
 
-The `.NET` solution/project is detected at runtime (`*.slnx` then `*.sln` at repo root); the driver is skipped when `dotnet` or a solution is absent.
+No build-system clean driver runs (e.g. `dotnet clean`): the single pruned walk + `rm -rf` already removes every `bin/`/`obj/` output such a driver would, so invoking one first is pure overhead (#999).
 
 ## Python
 

--- a/plugins/repo-hygiene/skills/clean/reference/ecosystems.md
+++ b/plugins/repo-hygiene/skills/clean/reference/ecosystems.md
@@ -14,7 +14,7 @@ Per-ecosystem teaching tables for the clean skill. Each entry includes command s
 | App log dirs | build | Not swept generically (no portable path) — reclaim via the `tree` action | Safe | App sink creates on next run |
 | `*.csproj.user` / `*.suo` | NEVER | — | Protected | VS / IDE debug profile preference |
 
-No build-system clean driver runs (e.g. `dotnet clean`): the single pruned walk + `rm -rf` already removes every `bin/`/`obj/` output such a driver would, so invoking one first is pure overhead (#999).
+No build-system clean driver runs (e.g. `dotnet clean`): the single pruned walk + `rm -rf` already removes every `bin/`/`obj/` output such a driver would, so invoking one first is pure overhead.
 
 ## Python
 

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -84,6 +84,10 @@ cd "$REPO_ROOT" || exit 1
 
 # --apply with a prebuilt manifest: skip enumeration entirely, just consume it.
 if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
+  if [[ ! -r "$MANIFEST_ARG" ]]; then
+    echo "clean-build.sh: manifest not readable: $MANIFEST_ARG" >&2
+    exit 1
+  fi
   clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG"
   printf 'Summary: removed=%s failed=%s bytes=%s\n' \
     "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -2,7 +2,11 @@
 # shellcheck disable=SC2154
 # Remove build artifacts for the clean build tier (includes caches when --include-caches).
 #
-# Default: --dry-run. --apply mutates. Optional dotnet clean driver when dotnet available.
+# Default: --dry-run (writes a manifest of planned removals + reclaimable bytes).
+# --apply consumes the manifest (re-stat staleness guard) and mutates disk.
+# Optional dotnet clean driver when dotnet available. With --include-caches the
+# caches tier shares this one manifest — a single pruned walk per tier, no
+# subprocess. Enumeration/manifest/apply engine lives in lib/clean-common.sh.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,17 +15,27 @@ source "$SCRIPT_DIR/lib/clean-common.sh"
 
 DRY_RUN=1
 INCLUDE_CACHES=0
+MANIFEST_ARG=""
 
 usage() {
   cat <<'EOF'
 clean-build.sh — remove build artifacts for the clean build tier.
 
 Usage:
-  clean-build.sh [--dry-run] [--apply] [--include-caches] [--help]
+  clean-build.sh [--dry-run] [--apply] [--include-caches] [--manifest PATH] [--help]
 
-Default: --dry-run. --include-caches runs clean-caches.sh first.
+Default: --dry-run — writes a manifest and prints its path + reclaimable total,
+never mutates. --include-caches folds the caches tier into the same manifest.
 
-Exit: 0 success; 1 not a git repo; 2 usage error.
+Manifest flow (single walk paid once):
+  --dry-run              writes a manifest, prints `Manifest: <path>` and
+                         `Summary: planned=N bytes=K`.
+  --apply --manifest P   consumes manifest P (re-stat guard, no re-walk); resume
+                         = re-run the same command (already-gone entries skipped).
+  --apply                without --manifest builds the manifest then applies it.
+  --manifest P           on --dry-run writes to P instead of a mktemp path.
+
+Exit: 0 success; 1 not a git repo OR an apply had rm failures; 2 usage error.
 EOF
 }
 
@@ -38,6 +52,10 @@ while [[ $# -gt 0 ]]; do
   --include-caches)
     INCLUDE_CACHES=1
     shift
+    ;;
+  --manifest)
+    MANIFEST_ARG="${2:-}"
+    shift 2
     ;;
   -h | --help)
     usage
@@ -58,16 +76,11 @@ fi
 
 cd "$REPO_ROOT" || exit 1
 
-CACHE_FLAG=--dry-run
-[[ "$DRY_RUN" -eq 0 ]] && CACHE_FLAG=--apply
-
-if [[ "$INCLUDE_CACHES" -eq 1 ]]; then
-  bash "$SCRIPT_DIR/clean-caches.sh" "$CACHE_FLAG"
-fi
-
 # .NET clean driver — solution/project detected at runtime, never hardcoded.
 # Prefer a *.slnx, then *.sln, at the repo root; skip cleanly when none exists
 # or dotnet is unavailable (universal bin/obj globs below still remove output).
+# Independent of the path manifest (it is an action, not a path): announced on
+# dry-run, run on any --apply.
 DOTNET_SOLUTION=""
 if command -v dotnet >/dev/null 2>&1; then
   for cand in "$REPO_ROOT"/*.slnx "$REPO_ROOT"/*.sln; do
@@ -88,47 +101,35 @@ if [[ -n "$DOTNET_SOLUTION" ]]; then
   fi
 fi
 
-plan_remove() {
-  local abs="$1"
-  [[ -e "$abs" ]] || return 0
-  if clean_path_is_protected "$REPO_ROOT" "$abs"; then
-    printf 'Skip (protected): %s\n' "${abs#"$REPO_ROOT"/}"
-    return 0
-  fi
-  if clean_path_in_submodule "$REPO_ROOT" "$abs"; then
-    printf 'Skip (submodule): %s\n' "${abs#"$REPO_ROOT"/}"
-    return 0
-  fi
-  if [[ -d "$abs" ]] && clean_dir_has_protected_descendant "$REPO_ROOT" "$abs"; then
-    printf 'Skip (protected descendant): %s\n' "${abs#"$REPO_ROOT"/}"
-    return 0
-  fi
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf 'Planned remove: %s\n' "${abs#"$REPO_ROOT"/}"
-  else
-    rm -rf "$abs"
-    printf 'Removed: %s\n' "${abs#"$REPO_ROOT"/}"
-  fi
-}
+# --apply with a prebuilt manifest: skip enumeration entirely, just consume it.
+if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
+  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG"
+  printf 'Summary: removed=%s failed=%s bytes=%s\n' \
+    "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
+  [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
+  exit 0
+fi
 
-for name in "${CLEAN_BUILD_DIR_NAMES[@]}"; do
-  while IFS= read -r abs; do
-    [[ -z "$abs" ]] && continue
-    plan_remove "$abs"
-  done < <(find "$REPO_ROOT" -type d -name "$name" \
-    ! -path "$CLEAN_FIND_EXCLUDE_GIT" \
-    ! -path "$CLEAN_FIND_EXCLUDE_VENV" \
-    ! -path "$CLEAN_FIND_EXCLUDE_NODE_MODULES" 2>/dev/null)
-done
+MANIFEST="$(clean_manifest_path "$MANIFEST_ARG")"
 
-for glob in "${CLEAN_BUILD_FILE_GLOBS[@]}"; do
-  while IFS= read -r abs; do
-    [[ -z "$abs" ]] && continue
-    plan_remove "$abs"
-  done < <(find "$REPO_ROOT" -type f -name "$glob" \
-    ! -path "$CLEAN_FIND_EXCLUDE_GIT" \
-    ! -path "$CLEAN_FIND_EXCLUDE_VENV" \
-    ! -path "$CLEAN_FIND_EXCLUDE_NODE_MODULES" 2>/dev/null)
-done
+if [[ "$INCLUDE_CACHES" -eq 1 ]]; then
+  mapfile -t CACHE_CANDS < <(clean_caches_candidates "$REPO_ROOT")
+  clean_add_candidates caches "${CACHE_CANDS[@]}"
+fi
 
+mapfile -t BUILD_CANDS < <(clean_build_candidates "$REPO_ROOT")
+clean_add_candidates build "${BUILD_CANDS[@]}"
+
+clean_plan "$REPO_ROOT" "$MANIFEST" "$DRY_RUN"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf 'Manifest: %s\n' "$MANIFEST"
+  printf 'Summary: planned=%s bytes=%s\n' "$CLEAN_PLANNED_COUNT" "$CLEAN_PLANNED_BYTES"
+  exit 0
+fi
+
+clean_apply_manifest "$REPO_ROOT" "$MANIFEST"
+printf 'Summary: removed=%s failed=%s bytes=%s\n' \
+  "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
+[[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
 exit 0

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -4,9 +4,9 @@
 #
 # Default: --dry-run (writes a manifest of planned removals + reclaimable bytes).
 # --apply consumes the manifest (re-stat staleness guard) and mutates disk.
-# Optional dotnet clean driver when dotnet available. With --include-caches the
-# caches tier shares this one manifest — a single pruned walk per tier, no
-# subprocess. Enumeration/manifest/apply engine lives in lib/clean-common.sh.
+# With --include-caches the caches tier shares this one manifest — a single
+# pruned walk per tier, no subprocess. Enumeration/manifest/apply engine lives
+# in lib/clean-common.sh.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -76,30 +76,11 @@ fi
 
 cd "$REPO_ROOT" || exit 1
 
-# .NET clean driver — solution/project detected at runtime, never hardcoded.
-# Prefer a *.slnx, then *.sln, at the repo root; skip cleanly when none exists
-# or dotnet is unavailable (universal bin/obj globs below still remove output).
-# Independent of the path manifest (it is an action, not a path): announced on
-# dry-run, run on any --apply.
-DOTNET_SOLUTION=""
-if command -v dotnet >/dev/null 2>&1; then
-  for cand in "$REPO_ROOT"/*.slnx "$REPO_ROOT"/*.sln; do
-    if [[ -f "$cand" ]]; then
-      DOTNET_SOLUTION="$cand"
-      break
-    fi
-  done
-fi
-if [[ -n "$DOTNET_SOLUTION" ]]; then
-  DOTNET_DRIVER="dotnet clean \"$DOTNET_SOLUTION\" -v q"
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf 'Planned: %s\n' "$DOTNET_DRIVER"
-  else
-    if ! dotnet clean "$DOTNET_SOLUTION" -v q 2>/dev/null; then
-      printf 'DRIVER_FAILED: %s\n' "$DOTNET_DRIVER" >&2
-    fi
-  fi
-fi
+# No build-system clean driver (e.g. `dotnet clean`): the universal bin/obj/…
+# removal below already deletes everything such a driver would, and running one
+# first is pure overhead (full MSBuild evaluation, minutes on a large solution)
+# that also re-creates obj/ evaluation artifacts. One walk + rm is strictly
+# faster and equally complete (#999).
 
 # --apply with a prebuilt manifest: skip enumeration entirely, just consume it.
 if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -80,7 +80,7 @@ cd "$REPO_ROOT" || exit 1
 # removal below already deletes everything such a driver would, and running one
 # first is pure overhead (full MSBuild evaluation, minutes on a large solution)
 # that also re-creates obj/ evaluation artifacts. One walk + rm is strictly
-# faster and equally complete (#999).
+# faster and equally complete.
 
 # --apply with a prebuilt manifest: skip enumeration entirely, just consume it.
 if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -88,7 +88,7 @@ if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
     echo "clean-build.sh: manifest not readable: $MANIFEST_ARG" >&2
     exit 1
   fi
-  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG"
+  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG" "build caches"
   printf 'Summary: removed=%s failed=%s bytes=%s\n' \
     "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
   [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
@@ -113,7 +113,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
   exit 0
 fi
 
-clean_apply_manifest "$REPO_ROOT" "$MANIFEST"
+clean_apply_manifest "$REPO_ROOT" "$MANIFEST" "build caches"
 printf 'Summary: removed=%s failed=%s bytes=%s\n' \
   "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
 [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -54,7 +54,11 @@ while [[ $# -gt 0 ]]; do
     shift
     ;;
   --manifest)
-    MANIFEST_ARG="${2:-}"
+    if [[ $# -lt 2 ]]; then
+      echo "clean-build.sh: --manifest requires a value" >&2
+      exit 2
+    fi
+    MANIFEST_ARG="$2"
     shift 2
     ;;
   -h | --help)

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -95,7 +95,7 @@ if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
   exit 0
 fi
 
-MANIFEST="$(clean_manifest_path "$MANIFEST_ARG")"
+MANIFEST="$(clean_manifest_path "$MANIFEST_ARG")" || exit 1
 
 if [[ "$INCLUDE_CACHES" -eq 1 ]]; then
   mapfile -t CACHE_CANDS < <(clean_caches_candidates "$REPO_ROOT")

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.test.sh
@@ -59,26 +59,42 @@ git -C "$TEST_TMPDIR/b2" config user.name "Test"
 mkdir -p "$TEST_TMPDIR/b2/bin/obj"
 echo a >"$TEST_TMPDIR/b2/bin/x.dll"
 echo b >"$TEST_TMPDIR/b2/bin/obj/y.dll"
+# A caches-tier target too, to prove --include-caches folds both classes into
+# the one build manifest (no clean-caches.sh subprocess).
+mkdir -p "$TEST_TMPDIR/b2/.pytest_cache"
+echo c >"$TEST_TMPDIR/b2/.pytest_cache/c"
 MANI="$TEST_TMPDIR/b2.manifest"
 
 run_b2() {
   bash -c "cd '$TEST_TMPDIR/b2' && bash '$BUILD' $*"
 }
 
-out="$(run_b2 --dry-run --manifest "$MANI")"
+out="$(run_b2 --dry-run --include-caches --manifest "$MANI")"
 assert_contains "dry-run prints manifest path" "$out" "Manifest: $MANI"
-assert_contains "nested dir deduped to one plan" "$out" "Summary: planned=1 bytes="
+# bin/ (nested obj/ deduped) + .pytest_cache = 2 planned.
+assert_contains "nested dir deduped, caches folded in" "$out" "Summary: planned=2 bytes="
 mani_body="$(cat "$MANI")"
-assert_contains "manifest carries bin" "$mani_body" "build"
+# Structural pin (consumed contract, #994): exact class<TAB>bytes<TAB>path per tier.
+if grep -qE "^build"$'\t'"[0-9]+"$'\t'"bin$" "$MANI"; then
+  pass "build line is class<TAB>bytes<TAB>path"
+else
+  fail "build manifest line format" "build<TAB><int><TAB>bin" "$mani_body"
+fi
+if grep -qE "^caches"$'\t'"[0-9]+"$'\t'"\.pytest_cache$" "$MANI"; then
+  pass "caches line folded into build manifest"
+else
+  fail "folded caches manifest line" "caches<TAB><int><TAB>.pytest_cache" "$mani_body"
+fi
 assert_not_contains "nested obj not a separate entry" "$mani_body" "bin/obj"
 assert_file_exists "dry-run does not mutate" "$TEST_TMPDIR/b2/bin/obj/y.dll"
 
 out="$(run_b2 --apply --manifest "$MANI")"
 rc=$?
 assert_contains "apply-from-manifest removes bin" "$out" "Removed: bin"
-assert_contains "apply summary shape" "$out" "Summary: removed=1 failed=0 bytes="
+assert_contains "apply summary shape" "$out" "Summary: removed=2 failed=0 bytes="
 assert_exit "apply exit 0" 0 "$rc"
 assert_file_absent "bin gone after apply" "$TEST_TMPDIR/b2/bin/x.dll"
+assert_file_absent "folded cache gone after apply" "$TEST_TMPDIR/b2/.pytest_cache/c"
 
 out="$(run_b2 --apply --manifest "$MANI")"
 rc=$?

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.test.sh
@@ -48,6 +48,43 @@ out="$(run_build --apply)"
 assert_contains "submodule build dir skipped" "$out" "Skip (submodule):"
 assert_file_exists "submodule tracked file preserved" "$TEST_TMPDIR/repo/deps/sub/build/app.js"
 
+# --- manifest / nested-dedup / apply-from-manifest / resume (#993, #995, #1002) ---
+# Fresh repo so progressive mutation above does not bleed into these cases.
+git init "$TEST_TMPDIR/b2" >/dev/null 2>&1
+git -C "$TEST_TMPDIR/b2" config user.email "t@example.com"
+git -C "$TEST_TMPDIR/b2" config user.name "Test"
+# bin/ with a nested obj/ — both are build dir names; the walk returns both but
+# the ancestor (bin/) must collapse the descendant so the byte total is not
+# double-counted and apply does not chase an already-removed path.
+mkdir -p "$TEST_TMPDIR/b2/bin/obj"
+echo a >"$TEST_TMPDIR/b2/bin/x.dll"
+echo b >"$TEST_TMPDIR/b2/bin/obj/y.dll"
+MANI="$TEST_TMPDIR/b2.manifest"
+
+run_b2() {
+  bash -c "cd '$TEST_TMPDIR/b2' && bash '$BUILD' $*"
+}
+
+out="$(run_b2 --dry-run --manifest "$MANI")"
+assert_contains "dry-run prints manifest path" "$out" "Manifest: $MANI"
+assert_contains "nested dir deduped to one plan" "$out" "Summary: planned=1 bytes="
+mani_body="$(cat "$MANI")"
+assert_contains "manifest carries bin" "$mani_body" "build"
+assert_not_contains "nested obj not a separate entry" "$mani_body" "bin/obj"
+assert_file_exists "dry-run does not mutate" "$TEST_TMPDIR/b2/bin/obj/y.dll"
+
+out="$(run_b2 --apply --manifest "$MANI")"
+rc=$?
+assert_contains "apply-from-manifest removes bin" "$out" "Removed: bin"
+assert_contains "apply summary shape" "$out" "Summary: removed=1 failed=0 bytes="
+assert_exit "apply exit 0" 0 "$rc"
+assert_file_absent "bin gone after apply" "$TEST_TMPDIR/b2/bin/x.dll"
+
+out="$(run_b2 --apply --manifest "$MANI")"
+rc=$?
+assert_contains "resume removes nothing" "$out" "Summary: removed=0 failed=0 bytes=0"
+assert_exit "resume exit 0" 0 "$rc"
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.test.sh
@@ -48,7 +48,7 @@ out="$(run_build --apply)"
 assert_contains "submodule build dir skipped" "$out" "Skip (submodule):"
 assert_file_exists "submodule tracked file preserved" "$TEST_TMPDIR/repo/deps/sub/build/app.js"
 
-# --- manifest / nested-dedup / apply-from-manifest / resume (#993, #995, #1002) ---
+# --- manifest / nested-dedup / apply-from-manifest / resume ---
 # Fresh repo so progressive mutation above does not bleed into these cases.
 git init "$TEST_TMPDIR/b2" >/dev/null 2>&1
 git -C "$TEST_TMPDIR/b2" config user.email "t@example.com"
@@ -74,7 +74,7 @@ assert_contains "dry-run prints manifest path" "$out" "Manifest: $MANI"
 # bin/ (nested obj/ deduped) + .pytest_cache = 2 planned.
 assert_contains "nested dir deduped, caches folded in" "$out" "Summary: planned=2 bytes="
 mani_body="$(cat "$MANI")"
-# Structural pin (consumed contract, #994): exact class<TAB>bytes<TAB>path per tier.
+# Structural pin (the manifest is a consumed contract): exact class<TAB>bytes<TAB>path per tier.
 if grep -qE "^build"$'\t'"[0-9]+"$'\t'"bin$" "$MANI"; then
   pass "build line is class<TAB>bytes<TAB>path"
 else

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
@@ -72,6 +72,10 @@ cd "$REPO_ROOT" || exit 1
 
 # --apply with a prebuilt manifest: skip enumeration entirely, just consume it.
 if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
+  if [[ ! -r "$MANIFEST_ARG" ]]; then
+    echo "clean-caches.sh: manifest not readable: $MANIFEST_ARG" >&2
+    exit 1
+  fi
   clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG"
   printf 'Summary: removed=%s failed=%s bytes=%s\n' \
     "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
@@ -76,7 +76,7 @@ if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
     echo "clean-caches.sh: manifest not readable: $MANIFEST_ARG" >&2
     exit 1
   fi
-  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG"
+  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG" "caches"
   printf 'Summary: removed=%s failed=%s bytes=%s\n' \
     "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
   [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
@@ -95,7 +95,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
   exit 0
 fi
 
-clean_apply_manifest "$REPO_ROOT" "$MANIFEST"
+clean_apply_manifest "$REPO_ROOT" "$MANIFEST" "caches"
 printf 'Summary: removed=%s failed=%s bytes=%s\n' \
   "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
 [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
@@ -48,7 +48,11 @@ while [[ $# -gt 0 ]]; do
     shift
     ;;
   --manifest)
-    MANIFEST_ARG="${2:-}"
+    if [[ $# -lt 2 ]]; then
+      echo "clean-caches.sh: --manifest requires a value" >&2
+      exit 2
+    fi
+    MANIFEST_ARG="$2"
     shift 2
     ;;
   -h | --help)

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
@@ -83,7 +83,7 @@ if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
   exit 0
 fi
 
-MANIFEST="$(clean_manifest_path "$MANIFEST_ARG")"
+MANIFEST="$(clean_manifest_path "$MANIFEST_ARG")" || exit 1
 
 mapfile -t CACHE_CANDS < <(clean_caches_candidates "$REPO_ROOT")
 clean_add_candidates caches "${CACHE_CANDS[@]}"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
@@ -2,8 +2,10 @@
 # shellcheck disable=SC2154
 # Remove tool/linter caches for the clean caches tier.
 #
-# Default: --dry-run (print planned removals). --apply mutates disk.
-# Respects protected paths and git-tracked files.
+# Default: --dry-run (writes a manifest of planned removals + reclaimable bytes).
+# --apply consumes the manifest (re-stat staleness guard) and mutates disk.
+# Respects protected paths and git-tracked files. Enumeration/manifest/apply
+# engine is shared with clean-build.sh in lib/clean-common.sh.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,17 +13,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/clean-common.sh"
 
 DRY_RUN=1
+MANIFEST_ARG=""
 
 usage() {
   cat <<'EOF'
 clean-caches.sh — remove tool/linter caches for the clean caches tier.
 
 Usage:
-  clean-caches.sh [--dry-run] [--apply] [--help]
+  clean-caches.sh [--dry-run] [--apply] [--manifest PATH] [--help]
 
-Default: --dry-run. --apply performs rm -rf on eligible targets.
+Default: --dry-run — writes a manifest and prints its path + reclaimable total,
+never mutates. --apply performs rm -rf on eligible targets.
 
-Exit: 0 success; 1 not a git repo; 2 usage error.
+Manifest flow (single walk paid once):
+  --dry-run              writes a manifest, prints `Manifest: <path>` and
+                         `Summary: planned=N bytes=K`.
+  --apply --manifest P   consumes manifest P (re-stat guard, no re-walk); resume
+                         = re-run the same command (already-gone entries skipped).
+  --apply                without --manifest builds the manifest then applies it.
+  --manifest P           on --dry-run writes to P instead of a mktemp path.
+
+Exit: 0 success; 1 not a git repo OR an apply had rm failures; 2 usage error.
 EOF
 }
 
@@ -34,6 +46,10 @@ while [[ $# -gt 0 ]]; do
   --apply)
     DRY_RUN=0
     shift
+    ;;
+  --manifest)
+    MANIFEST_ARG="${2:-}"
+    shift 2
     ;;
   -h | --help)
     usage
@@ -54,55 +70,29 @@ fi
 
 cd "$REPO_ROOT" || exit 1
 
-plan_remove() {
-  local abs="$1"
-  [[ -e "$abs" ]] || return 0
-  if clean_path_is_protected "$REPO_ROOT" "$abs"; then
-    printf 'Skip (protected): %s\n' "${abs#"$REPO_ROOT"/}"
-    return 0
-  fi
-  if clean_path_in_submodule "$REPO_ROOT" "$abs"; then
-    printf 'Skip (submodule): %s\n' "${abs#"$REPO_ROOT"/}"
-    return 0
-  fi
-  if [[ -d "$abs" ]] && clean_dir_has_protected_descendant "$REPO_ROOT" "$abs"; then
-    printf 'Skip (protected descendant): %s\n' "${abs#"$REPO_ROOT"/}"
-    return 0
-  fi
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf 'Planned remove: %s\n' "${abs#"$REPO_ROOT"/}"
-  else
-    rm -rf "$abs"
-    printf 'Removed: %s\n' "${abs#"$REPO_ROOT"/}"
-  fi
-}
+# --apply with a prebuilt manifest: skip enumeration entirely, just consume it.
+if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
+  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG"
+  printf 'Summary: removed=%s failed=%s bytes=%s\n' \
+    "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
+  [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
+  exit 0
+fi
 
-for rel in "${CLEAN_CACHE_EXPLICIT[@]}"; do
-  plan_remove "$REPO_ROOT/$rel"
-done
+MANIFEST="$(clean_manifest_path "$MANIFEST_ARG")"
 
-for rel in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do
-  plan_remove "$REPO_ROOT/$rel"
-done
+mapfile -t CACHE_CANDS < <(clean_caches_candidates "$REPO_ROOT")
+clean_add_candidates caches "${CACHE_CANDS[@]}"
+clean_plan "$REPO_ROOT" "$MANIFEST" "$DRY_RUN"
 
-for name in "${CLEAN_CACHE_FIND_DIR_NAMES[@]}"; do
-  while IFS= read -r abs; do
-    [[ -z "$abs" ]] && continue
-    plan_remove "$abs"
-  done < <(find "$REPO_ROOT" -type d -name "$name" \
-    ! -path "$CLEAN_FIND_EXCLUDE_GIT" \
-    ! -path "$CLEAN_FIND_EXCLUDE_VENV" \
-    ! -path "$CLEAN_FIND_EXCLUDE_NODE_MODULES" 2>/dev/null)
-done
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf 'Manifest: %s\n' "$MANIFEST"
+  printf 'Summary: planned=%s bytes=%s\n' "$CLEAN_PLANNED_COUNT" "$CLEAN_PLANNED_BYTES"
+  exit 0
+fi
 
-for glob in "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"; do
-  while IFS= read -r abs; do
-    [[ -z "$abs" ]] && continue
-    plan_remove "$abs"
-  done < <(find "$REPO_ROOT" -type f -name "$glob" \
-    ! -path "$CLEAN_FIND_EXCLUDE_GIT" \
-    ! -path "$CLEAN_FIND_EXCLUDE_VENV" \
-    ! -path "$CLEAN_FIND_EXCLUDE_NODE_MODULES" 2>/dev/null)
-done
-
+clean_apply_manifest "$REPO_ROOT" "$MANIFEST"
+printf 'Summary: removed=%s failed=%s bytes=%s\n' \
+  "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
+[[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
 exit 0

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -108,7 +108,29 @@ assert_file_absent "arithmetic injection did not execute" "$SENTINEL"
 assert_contains "malformed-byte entry still removes" "$out" "Removed: .ruff_cache"
 assert_exit "inject apply exit 0" 0 "$rc"
 
-# 3. Fail closed on an unreadable/missing manifest — silently doing nothing and
+# 3. Target validation — an entry naming an ordinary untracked dir that is not a
+#    cache target (here `notes/`) is rejected by the tier's candidate rules, never
+#    removed, and counts as a failure. Without this, a tampered manifest could
+#    delete any unprotected untracked path.
+mkdir -p "$TEST_TMPDIR/r2/notes"
+echo n >"$TEST_TMPDIR/r2/notes/keep"
+printf 'caches\t1\tnotes\n' >"$TEST_TMPDIR/r2.bogus.manifest"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.bogus.manifest" 2>&1)"
+rc=$?
+assert_contains "non-target entry rejected" "$out" "Rejected (not a caches target): notes"
+assert_exit "non-target apply exits non-zero" 1 "$rc"
+assert_file_exists "unrelated untracked dir preserved" "$TEST_TMPDIR/r2/notes/keep"
+
+# Wrong-tier entry (a build-class line handed to the caches tier) is rejected too.
+printf 'build\t1\tbin\n' >"$TEST_TMPDIR/r2.wrongtier.manifest"
+mkdir -p "$TEST_TMPDIR/r2/bin"
+echo b >"$TEST_TMPDIR/r2/bin/x"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.wrongtier.manifest" 2>&1)"
+rc=$?
+assert_contains "wrong-tier entry rejected" "$out" "Rejected (wrong tier): bin"
+assert_file_exists "wrong-tier target preserved" "$TEST_TMPDIR/r2/bin/x"
+
+# 4. Fail closed on an unreadable/missing manifest — silently doing nothing and
 #    exiting 0 would let automation treat a mistyped path as a successful sweep.
 out="$(run_r2 --apply --manifest "$TEST_TMPDIR/does-not-exist.manifest" 2>&1)"
 rc=$?
@@ -126,8 +148,10 @@ if rm -rf "$TEST_TMPDIR/r2/.mypy_cache/inner" 2>/dev/null; then
   rm -rf "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
   skip_case "rm-failure accounting — FS does not enforce write-denied parent here"
 else
-  printf 'caches\t4096\t.mypy_cache/inner\n' >"$TEST_TMPDIR/r2.fail.manifest"
-  out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.fail.manifest")"
+  # `.mypy_cache` is a valid explicit cache target; rm cannot empty it while the
+  # dir stays write-denied, so this exercises the genuine Unremovable branch.
+  printf 'caches\t4096\t.mypy_cache\n' >"$TEST_TMPDIR/r2.fail.manifest"
+  out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.fail.manifest" 2>&1)"
   rc=$?
   assert_contains "failure counted" "$out" "Summary: removed=0 failed=1 bytes=0"
   assert_exit "apply exits non-zero on failure" 1 "$rc"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -247,6 +247,23 @@ else
   chmod u+w "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
 fi
 
+# A symlinked ANCESTOR must not let rm follow a manifest path out of the repo:
+# `link/__pycache__` where `link` points outside is rejected, the outside dir
+# preserved. Enumeration never descends a symlinked dir, so this is never planned.
+mkdir -p "$TEST_TMPDIR/escape_victim/__pycache__"
+echo s >"$TEST_TMPDIR/escape_victim/__pycache__/s"
+ln -s "$TEST_TMPDIR/escape_victim" "$TEST_TMPDIR/r2/link" 2>/dev/null || true
+if [[ -L "$TEST_TMPDIR/r2/link" ]]; then
+  printf 'caches\t1\tlink/__pycache__\n' >"$TEST_TMPDIR/r2.ancestor.manifest"
+  out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.ancestor.manifest" 2>&1)"
+  rc=$?
+  assert_contains "symlinked ancestor rejected" "$out" "Rejected (symlinked ancestor): link/__pycache__"
+  assert_exit "symlinked ancestor exits non-zero" 1 "$rc"
+  assert_file_exists "outside dir preserved through symlinked ancestor" "$TEST_TMPDIR/escape_victim/__pycache__/s"
+else
+  skip_case "symlinked ancestor — symlinks not creatable here"
+fi
+
 # --- dry-run/apply consistency + honest byte accounting (fresh repo) ---
 git init "$TEST_TMPDIR/r3" >/dev/null 2>&1
 git -C "$TEST_TMPDIR/r3" config user.email "t@example.com"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -200,6 +200,32 @@ rc=$?
 assert_exit "trailing --manifest is a usage error" 2 "$rc"
 assert_contains "trailing --manifest reported" "$out" "--manifest requires a value"
 
+# 10. A --manifest path that cannot be created (nonexistent parent) must fail
+#     before planning, not print a Manifest:/Summary: line for a file never
+#     written (which would hand apply a bogus path).
+out="$(run_r2 --dry-run --manifest "$TEST_TMPDIR/nonexistent-dir/sub/m" 2>&1)"
+rc=$?
+assert_contains "uncreatable manifest reported" "$out" "cannot create manifest"
+assert_exit "uncreatable manifest exits non-zero" 1 "$rc"
+assert_not_contains "no bogus plan emitted" "$out" "Summary: planned="
+
+# 11. A symlink/reparse point whose basename is a valid target is rejected — the
+#     enumerator uses `find -type d`/`-type f` and never emits a link, but Bash
+#     `[[ -d ]]` follows one. Skips where the FS cannot create a symlink.
+mkdir -p "$TEST_TMPDIR/r2/realcache"
+echo c >"$TEST_TMPDIR/r2/realcache/c"
+ln -s "$TEST_TMPDIR/r2/realcache" "$TEST_TMPDIR/r2/.turbo" 2>/dev/null || true
+if [[ -L "$TEST_TMPDIR/r2/.turbo" ]]; then
+  printf 'caches\t1\t.turbo\n' >"$TEST_TMPDIR/r2.symlink.manifest"
+  out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.symlink.manifest" 2>&1)"
+  rc=$?
+  assert_contains "symlinked dir target rejected" "$out" "Rejected (not a caches target): .turbo"
+  assert_exit "symlink apply exits non-zero" 1 "$rc"
+  assert_file_exists "symlink target contents preserved" "$TEST_TMPDIR/r2/realcache/c"
+else
+  skip_case "symlink dir target — symlinks not creatable here"
+fi
+
 # rm-failure accounting: a manifest entry rm cannot remove must count failed and
 # force a non-zero exit. Deterministic only where the FS enforces a write-denied
 # parent (real POSIX / Linux CI); Cygwin/MSYS ignores it, so probe and skip.

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -53,8 +53,13 @@ assert_contains "dry-run prints manifest path" "$out" "Manifest: $MANI"
 assert_contains "dry-run planned summary" "$out" "Summary: planned=1 bytes="
 assert_file_exists "manifest written" "$MANI"
 mani_body="$(cat "$MANI")"
-assert_contains "manifest tags class+path" "$mani_body" "caches"
-assert_contains "manifest carries the cache path" "$mani_body" ".pytest_cache"
+# Structural pin: the manifest is a consumed contract (#994 parses it), so
+# assert the exact <class>\t<bytes>\t<relpath> shape, not just substrings.
+if grep -qE "^caches"$'\t'"[0-9]+"$'\t'"\.pytest_cache$" "$MANI"; then
+  pass "manifest line is class<TAB>bytes<TAB>path"
+else
+  fail "manifest line format" "caches<TAB><int><TAB>.pytest_cache" "$mani_body"
+fi
 assert_file_exists "dry-run does not mutate" "$TEST_TMPDIR/r2/.pytest_cache/x"
 
 out="$(run_r2 --apply --manifest "$MANI")"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -255,7 +255,7 @@ run_r3() { bash -c "cd '$TEST_TMPDIR/r3' && bash '$CLEAN' $*"; }
 
 # 12. A file (or symlink) whose name matches an explicit cache dir must NOT be
 #     planned: the dry-run only emits what --apply will accept, so a file named
-#     `.pytest_cache` is filtered at planning, keeping the plan applyable.
+#     `.pytest_cache` is filtered at planning, so the plan can still be applied.
 echo f >"$TEST_TMPDIR/r3/.pytest_cache" # a FILE named like a cache DIR
 out="$(run_r3 --dry-run --manifest "$TEST_TMPDIR/r3.m")"
 assert_contains "file-named explicit cache not planned" "$out" "Summary: planned=0"
@@ -274,7 +274,7 @@ assert_not_contains "inflated manifest byte field not trusted" "$out" "bytes=999
 assert_exit "recompute apply exit 0" 0 "$rc"
 
 # 14. A path containing a tab/newline cannot be encoded in the tab-delimited
-#     manifest, so it is skipped with a warning rather than mis-mapped. Skips
+#     manifest, so it is skipped with a warning, not mapped to a wrong path. Skips
 #     where the FS cannot create such a name (NTFS rejects some characters).
 if mkdir -p "$TEST_TMPDIR/r3/od$(printf '\t')d/__pycache__" 2>/dev/null; then
   echo p >"$TEST_TMPDIR/r3/od$(printf '\t')d/__pycache__/p"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -162,6 +162,14 @@ out="$(run_r2 --dry-run --manifest "$MANI" 2>&1)"
 rc=$?
 assert_exit "rewriting a real manifest still works" 0 "$rc"
 
+# 7. A trailing `--manifest` with no value is a usage error, not an infinite loop
+#    (without set -e, `shift 2` on a single remaining arg is a silent no-op). The
+#    timeout fails the case loudly if the guard ever regresses into a hang.
+out="$(timeout 10 bash -c "cd '$TEST_TMPDIR/r2' && bash '$CLEAN' --apply --manifest" 2>&1)"
+rc=$?
+assert_exit "trailing --manifest is a usage error" 2 "$rc"
+assert_contains "trailing --manifest reported" "$out" "--manifest requires a value"
+
 # rm-failure accounting: a manifest entry rm cannot remove must count failed and
 # force a non-zero exit. Deterministic only where the FS enforces a write-denied
 # parent (real POSIX / Linux CI); Cygwin/MSYS ignores it, so probe and skip.

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -219,7 +219,7 @@ if [[ -L "$TEST_TMPDIR/r2/.turbo" ]]; then
   printf 'caches\t1\t.turbo\n' >"$TEST_TMPDIR/r2.symlink.manifest"
   out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.symlink.manifest" 2>&1)"
   rc=$?
-  assert_contains "symlinked dir target rejected" "$out" "Rejected (not a caches target): .turbo"
+  assert_contains "symlinked dir target rejected" "$out" "Rejected (symlinked path): .turbo"
   assert_exit "symlink apply exits non-zero" 1 "$rc"
   assert_file_exists "symlink target contents preserved" "$TEST_TMPDIR/r2/realcache/c"
 else
@@ -257,7 +257,7 @@ if [[ -L "$TEST_TMPDIR/r2/link" ]]; then
   printf 'caches\t1\tlink/__pycache__\n' >"$TEST_TMPDIR/r2.ancestor.manifest"
   out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.ancestor.manifest" 2>&1)"
   rc=$?
-  assert_contains "symlinked ancestor rejected" "$out" "Rejected (symlinked ancestor): link/__pycache__"
+  assert_contains "symlinked ancestor rejected" "$out" "Rejected (symlinked path): link/__pycache__"
   assert_exit "symlinked ancestor exits non-zero" 1 "$rc"
   assert_file_exists "outside dir preserved through symlinked ancestor" "$TEST_TMPDIR/escape_victim/__pycache__/s"
 else

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -76,6 +76,45 @@ rc=$?
 assert_contains "resume removes nothing" "$out" "Summary: removed=0 failed=0 bytes=0"
 assert_exit "resume exit 0" 0 "$rc"
 
+# The manifest is an untrusted --apply surface (a caller supplies it, or a
+# concurrent process alters it). Three hardening guards:
+
+# 1. Containment — an entry escaping the repo (`..`) is rejected, never removed,
+#    and counts as a failure (fail closed). The external victim survives.
+mkdir -p "$TEST_TMPDIR/outside_victim"
+echo v >"$TEST_TMPDIR/outside_victim/keep"
+printf 'caches\t1\t../outside_victim\n' >"$TEST_TMPDIR/r2.escape.manifest"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.escape.manifest" 2>&1)"
+rc=$?
+assert_contains "escaping entry rejected" "$out" "Rejected (outside repo): ../outside_victim"
+assert_contains "rejection counts as failure" "$out" "Summary: removed=0 failed=1 bytes=0"
+assert_exit "escape apply exits non-zero" 1 "$rc"
+assert_file_exists "external victim preserved" "$TEST_TMPDIR/outside_victim/keep"
+
+# 2. Byte field as data — a non-numeric byte field must NOT reach Bash arithmetic
+#    (which evaluates array subscripts recursively). The payload would `touch` a
+#    sentinel if evaluated; the guard coerces it to 0, so the path still removes
+#    and the sentinel never appears.
+mkdir -p "$TEST_TMPDIR/r2/.ruff_cache"
+echo r >"$TEST_TMPDIR/r2/.ruff_cache/r"
+SENTINEL="$TEST_TMPDIR/injected"
+# The `$(...)` MUST stay literal in the manifest — expanding it here would defeat
+# the test. shellcheck disable=SC2016 (intentional single quotes).
+# shellcheck disable=SC2016
+printf 'caches\tx[$(touch %s)]\t.ruff_cache\n' "$SENTINEL" >"$TEST_TMPDIR/r2.inject.manifest"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.inject.manifest")"
+rc=$?
+assert_file_absent "arithmetic injection did not execute" "$SENTINEL"
+assert_contains "malformed-byte entry still removes" "$out" "Removed: .ruff_cache"
+assert_exit "inject apply exit 0" 0 "$rc"
+
+# 3. Fail closed on an unreadable/missing manifest — silently doing nothing and
+#    exiting 0 would let automation treat a mistyped path as a successful sweep.
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/does-not-exist.manifest" 2>&1)"
+rc=$?
+assert_contains "missing manifest reported" "$out" "manifest not readable"
+assert_exit "missing manifest exits non-zero" 1 "$rc"
+
 # rm-failure accounting: a manifest entry rm cannot remove must count failed and
 # force a non-zero exit. Deterministic only where the FS enforces a write-denied
 # parent (real POSIX / Linux CI); Cygwin/MSYS ignores it, so probe and skip.

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -130,6 +130,18 @@ rc=$?
 assert_contains "wrong-tier entry rejected" "$out" "Rejected (wrong tier): bin"
 assert_file_exists "wrong-tier target preserved" "$TEST_TMPDIR/r2/bin/x"
 
+# 3b. Pruned-tree entry — enumeration never descends .git/node_modules/.venv, so
+#     a manifest entry inside one (removing it could corrupt the repo) is rejected
+#     even though its basename is a valid target name.
+mkdir -p "$TEST_TMPDIR/r2/.git/objects/__pycache__"
+echo g >"$TEST_TMPDIR/r2/.git/objects/__pycache__/g"
+printf 'caches\t1\t.git/objects/__pycache__\n' >"$TEST_TMPDIR/r2.pruned.manifest"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.pruned.manifest" 2>&1)"
+rc=$?
+assert_contains "pruned-tree entry rejected" "$out" "Rejected (pruned tree): .git/objects/__pycache__"
+assert_exit "pruned-tree apply exits non-zero" 1 "$rc"
+assert_file_exists "pruned-tree path preserved" "$TEST_TMPDIR/r2/.git/objects/__pycache__/g"
+
 # 4. Type validation — a regular file whose basename matches a dir-name target
 #    (enumeration only emits those under -type d) is rejected, never removed.
 mkdir -p "$TEST_TMPDIR/r2/src"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -247,6 +247,44 @@ else
   chmod u+w "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
 fi
 
+# --- dry-run/apply consistency + honest byte accounting (fresh repo) ---
+git init "$TEST_TMPDIR/r3" >/dev/null 2>&1
+git -C "$TEST_TMPDIR/r3" config user.email "t@example.com"
+git -C "$TEST_TMPDIR/r3" config user.name "Test"
+run_r3() { bash -c "cd '$TEST_TMPDIR/r3' && bash '$CLEAN' $*"; }
+
+# 12. A file (or symlink) whose name matches an explicit cache dir must NOT be
+#     planned: the dry-run only emits what --apply will accept, so a file named
+#     `.pytest_cache` is filtered at planning, keeping the plan applyable.
+echo f >"$TEST_TMPDIR/r3/.pytest_cache" # a FILE named like a cache DIR
+out="$(run_r3 --dry-run --manifest "$TEST_TMPDIR/r3.m")"
+assert_contains "file-named explicit cache not planned" "$out" "Summary: planned=0"
+assert_file_exists "file-named explicit cache untouched by dry-run" "$TEST_TMPDIR/r3/.pytest_cache"
+rm -f "$TEST_TMPDIR/r3/.pytest_cache"
+
+# 13. Reclaimed bytes come from the filesystem at apply, not the manifest's byte
+#     field — a caller-supplied inflated value must not reach the summary.
+mkdir -p "$TEST_TMPDIR/r3/.ruff_cache"
+head -c 4000 /dev/urandom >"$TEST_TMPDIR/r3/.ruff_cache/blob" 2>/dev/null || echo x >"$TEST_TMPDIR/r3/.ruff_cache/blob"
+printf 'caches\t999999999\t.ruff_cache\n' >"$TEST_TMPDIR/r3.inflated.manifest"
+out="$(run_r3 --apply --manifest "$TEST_TMPDIR/r3.inflated.manifest")"
+rc=$?
+assert_contains "target removed" "$out" "Removed: .ruff_cache"
+assert_not_contains "inflated manifest byte field not trusted" "$out" "bytes=999999999"
+assert_exit "recompute apply exit 0" 0 "$rc"
+
+# 14. A path containing a tab/newline cannot be encoded in the tab-delimited
+#     manifest, so it is skipped with a warning rather than mis-mapped. Skips
+#     where the FS cannot create such a name (NTFS rejects some characters).
+if mkdir -p "$TEST_TMPDIR/r3/od$(printf '\t')d/__pycache__" 2>/dev/null; then
+  echo p >"$TEST_TMPDIR/r3/od$(printf '\t')d/__pycache__/p"
+  out="$(run_r3 --dry-run --manifest "$TEST_TMPDIR/r3.tab.manifest" 2>&1)"
+  assert_contains "unencodable path skipped" "$out" "Skip (unencodable path):"
+  assert_not_contains "unencodable path not manifested" "$(cat "$TEST_TMPDIR/r3.tab.manifest")" "__pycache__"
+else
+  skip_case "unencodable path — FS rejects tab in a filename here"
+fi
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -35,6 +35,61 @@ assert_file_absent "cache deleted after apply" "$TEST_TMPDIR/repo/.pytest_cache/
 out="$(run_clean --dry-run)"
 assert_not_contains "node_modules skipped" "$out" "node_modules"
 
+# --- manifest / summary / apply-from-manifest / resume (issues #995, #1002) ---
+# Fresh repo so progressive mutation above does not bleed into these cases.
+git init "$TEST_TMPDIR/r2" >/dev/null 2>&1
+git -C "$TEST_TMPDIR/r2" config user.email "t@example.com"
+git -C "$TEST_TMPDIR/r2" config user.name "Test"
+mkdir -p "$TEST_TMPDIR/r2/.pytest_cache"
+echo x >"$TEST_TMPDIR/r2/.pytest_cache/x"
+MANI="$TEST_TMPDIR/r2.manifest"
+
+run_r2() {
+  bash -c "cd '$TEST_TMPDIR/r2' && bash '$CLEAN' $*"
+}
+
+out="$(run_r2 --dry-run --manifest "$MANI")"
+assert_contains "dry-run prints manifest path" "$out" "Manifest: $MANI"
+assert_contains "dry-run planned summary" "$out" "Summary: planned=1 bytes="
+assert_file_exists "manifest written" "$MANI"
+mani_body="$(cat "$MANI")"
+assert_contains "manifest tags class+path" "$mani_body" "caches"
+assert_contains "manifest carries the cache path" "$mani_body" ".pytest_cache"
+assert_file_exists "dry-run does not mutate" "$TEST_TMPDIR/r2/.pytest_cache/x"
+
+out="$(run_r2 --apply --manifest "$MANI")"
+rc=$?
+assert_contains "apply-from-manifest removes" "$out" "Removed: .pytest_cache"
+assert_contains "apply summary shape" "$out" "Summary: removed=1 failed=0 bytes="
+assert_exit "apply exit 0" 0 "$rc"
+assert_file_absent "cache gone after apply" "$TEST_TMPDIR/r2/.pytest_cache/x"
+
+# Resume: re-applying the spent manifest is idempotent — nothing removed, no
+# failures, clean exit (a killed apply just re-runs the same command).
+out="$(run_r2 --apply --manifest "$MANI")"
+rc=$?
+assert_contains "resume removes nothing" "$out" "Summary: removed=0 failed=0 bytes=0"
+assert_exit "resume exit 0" 0 "$rc"
+
+# rm-failure accounting: a manifest entry rm cannot remove must count failed and
+# force a non-zero exit. Deterministic only where the FS enforces a write-denied
+# parent (real POSIX / Linux CI); Cygwin/MSYS ignores it, so probe and skip.
+mkdir -p "$TEST_TMPDIR/r2/.mypy_cache/inner"
+echo y >"$TEST_TMPDIR/r2/.mypy_cache/inner/y"
+chmod a-w "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
+if rm -rf "$TEST_TMPDIR/r2/.mypy_cache/inner" 2>/dev/null; then
+  chmod u+w "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
+  rm -rf "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
+  skip_case "rm-failure accounting — FS does not enforce write-denied parent here"
+else
+  printf 'caches\t4096\t.mypy_cache/inner\n' >"$TEST_TMPDIR/r2.fail.manifest"
+  out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.fail.manifest")"
+  rc=$?
+  assert_contains "failure counted" "$out" "Summary: removed=0 failed=1 bytes=0"
+  assert_exit "apply exits non-zero on failure" 1 "$rc"
+  chmod u+w "$TEST_TMPDIR/r2/.mypy_cache" 2>/dev/null || true
+fi
+
 if [[ $FAILED -ne 0 ]]; then
   echo "FAILED: $FAILED test(s)"
   exit 1

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -130,12 +130,37 @@ rc=$?
 assert_contains "wrong-tier entry rejected" "$out" "Rejected (wrong tier): bin"
 assert_file_exists "wrong-tier target preserved" "$TEST_TMPDIR/r2/bin/x"
 
-# 4. Fail closed on an unreadable/missing manifest — silently doing nothing and
+# 4. Type validation — a regular file whose basename matches a dir-name target
+#    (enumeration only emits those under -type d) is rejected, never removed.
+mkdir -p "$TEST_TMPDIR/r2/src"
+echo f >"$TEST_TMPDIR/r2/src/__pycache__" # a FILE named like a cache dir
+printf 'caches\t1\tsrc/__pycache__\n' >"$TEST_TMPDIR/r2.type.manifest"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.type.manifest" 2>&1)"
+rc=$?
+assert_contains "file-as-dir target rejected" "$out" "Rejected (not a caches target): src/__pycache__"
+assert_exit "type-mismatch apply exits non-zero" 1 "$rc"
+assert_file_exists "misnamed file preserved" "$TEST_TMPDIR/r2/src/__pycache__"
+
+# 5. Fail closed on an unreadable/missing manifest — silently doing nothing and
 #    exiting 0 would let automation treat a mistyped path as a successful sweep.
 out="$(run_r2 --apply --manifest "$TEST_TMPDIR/does-not-exist.manifest" 2>&1)"
 rc=$?
 assert_contains "missing manifest reported" "$out" "manifest not readable"
 assert_exit "missing manifest exits non-zero" 1 "$rc"
+
+# 6. Dry-run must not truncate an arbitrary --manifest destination: an existing
+#    non-manifest file (a mistyped path) is refused, not erased.
+printf 'important user config\n' >"$TEST_TMPDIR/precious.conf"
+out="$(run_r2 --dry-run --manifest "$TEST_TMPDIR/precious.conf" 2>&1)"
+rc=$?
+assert_contains "non-manifest overwrite refused" "$out" "refusing to overwrite non-manifest file"
+assert_exit "refuse-overwrite exits non-zero" 1 "$rc"
+preserved="$(cat "$TEST_TMPDIR/precious.conf")"
+assert_contains "precious file left intact" "$preserved" "important user config"
+# Re-writing an existing MANIFEST-format file is still allowed (dry-run reuse).
+out="$(run_r2 --dry-run --manifest "$MANI" 2>&1)"
+rc=$?
+assert_exit "rewriting a real manifest still works" 0 "$rc"
 
 # rm-failure accounting: a manifest entry rm cannot remove must count failed and
 # force a non-zero exit. Deterministic only where the FS enforces a write-denied

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -153,14 +153,32 @@ assert_contains "file-as-dir target rejected" "$out" "Rejected (not a caches tar
 assert_exit "type-mismatch apply exits non-zero" 1 "$rc"
 assert_file_exists "misnamed file preserved" "$TEST_TMPDIR/r2/src/__pycache__"
 
-# 5. Fail closed on an unreadable/missing manifest — silently doing nothing and
+# 5. A valid final record without a trailing newline (common in caller-written
+#    files) must still be processed, not silently dropped.
+mkdir -p "$TEST_TMPDIR/r2/.pytest_cache"
+echo x >"$TEST_TMPDIR/r2/.pytest_cache/x"
+printf 'caches\t1\t.pytest_cache' >"$TEST_TMPDIR/r2.nonl.manifest" # no trailing newline
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.nonl.manifest")"
+rc=$?
+assert_contains "newline-less final record processed" "$out" "Removed: .pytest_cache"
+assert_exit "newline-less apply exit 0" 0 "$rc"
+
+# 6. A nonblank but truncated record (missing the path field) is malformed and
+#    fails closed; a genuinely blank line is still ignored.
+printf 'caches\t1\n\n' >"$TEST_TMPDIR/r2.malformed.manifest"
+out="$(run_r2 --apply --manifest "$TEST_TMPDIR/r2.malformed.manifest" 2>&1)"
+rc=$?
+assert_contains "malformed record rejected" "$out" "Rejected (malformed record)"
+assert_exit "malformed record exits non-zero" 1 "$rc"
+
+# 7. Fail closed on an unreadable/missing manifest — silently doing nothing and
 #    exiting 0 would let automation treat a mistyped path as a successful sweep.
 out="$(run_r2 --apply --manifest "$TEST_TMPDIR/does-not-exist.manifest" 2>&1)"
 rc=$?
 assert_contains "missing manifest reported" "$out" "manifest not readable"
 assert_exit "missing manifest exits non-zero" 1 "$rc"
 
-# 6. Dry-run must not truncate an arbitrary --manifest destination: an existing
+# 8. Dry-run must not truncate an arbitrary --manifest destination: an existing
 #    non-manifest file (a mistyped path) is refused, not erased.
 printf 'important user config\n' >"$TEST_TMPDIR/precious.conf"
 out="$(run_r2 --dry-run --manifest "$TEST_TMPDIR/precious.conf" 2>&1)"
@@ -174,7 +192,7 @@ out="$(run_r2 --dry-run --manifest "$MANI" 2>&1)"
 rc=$?
 assert_exit "rewriting a real manifest still works" 0 "$rc"
 
-# 7. A trailing `--manifest` with no value is a usage error, not an infinite loop
+# 9. A trailing `--manifest` with no value is a usage error, not an infinite loop
 #    (without set -e, `shift 2` on a single remaining arg is a silent no-op). The
 #    timeout fails the case loudly if the guard ever regresses into a hang.
 out="$(timeout 10 bash -c "cd '$TEST_TMPDIR/r2' && bash '$CLEAN' --apply --manifest" 2>&1)"

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.test.sh
@@ -35,7 +35,7 @@ assert_file_absent "cache deleted after apply" "$TEST_TMPDIR/repo/.pytest_cache/
 out="$(run_clean --dry-run)"
 assert_not_contains "node_modules skipped" "$out" "node_modules"
 
-# --- manifest / summary / apply-from-manifest / resume (issues #995, #1002) ---
+# --- manifest / summary / apply-from-manifest / resume ---
 # Fresh repo so progressive mutation above does not bleed into these cases.
 git init "$TEST_TMPDIR/r2" >/dev/null 2>&1
 git -C "$TEST_TMPDIR/r2" config user.email "t@example.com"
@@ -53,8 +53,8 @@ assert_contains "dry-run prints manifest path" "$out" "Manifest: $MANI"
 assert_contains "dry-run planned summary" "$out" "Summary: planned=1 bytes="
 assert_file_exists "manifest written" "$MANI"
 mani_body="$(cat "$MANI")"
-# Structural pin: the manifest is a consumed contract (#994 parses it), so
-# assert the exact <class>\t<bytes>\t<relpath> shape, not just substrings.
+# Structural pin: the manifest is a consumed contract downstream tooling parses,
+# so assert the exact <class>\t<bytes>\t<relpath> shape, not just substrings.
 if grep -qE "^caches"$'\t'"[0-9]+"$'\t'"\.pytest_cache$" "$MANI"; then
   pass "manifest line is class<TAB>bytes<TAB>path"
 else

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -434,24 +434,71 @@ clean_manifest_rel_safe() {
   esac
 }
 
+# Return 0 when REL is a legitimate removal target for CLASS — matching the SAME
+# candidate rules enumeration uses to FIND targets (explicit repo-root paths, a
+# recursive dir-name leaf, or a file-glob leaf). The manifest is untrusted, so
+# --apply re-derives target-hood from the rules rather than trusting a listed
+# path was ever a real target: a tampered entry like `caches\t1\tnotes` names an
+# ordinary untracked dir that is not a cache and must never be removed.
+clean_manifest_target_valid() {
+  local class="$1" rel="${2//\\//}" base="${2##*/}" e pat
+  case "$class" in
+  caches)
+    for e in "${CLEAN_CACHE_EXPLICIT[@]}" "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do
+      [[ "$rel" == "$e" ]] && return 0
+    done
+    for e in "${CLEAN_CACHE_FIND_DIR_NAMES[@]}"; do
+      [[ "$base" == "$e" ]] && return 0
+    done
+    for pat in "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"; do
+      # shellcheck disable=SC2053
+      [[ "$base" == $pat ]] && return 0
+    done
+    ;;
+  build)
+    for e in "${CLEAN_BUILD_DIR_NAMES[@]}"; do
+      [[ "$base" == "$e" ]] && return 0
+    done
+    for pat in "${CLEAN_BUILD_FILE_GLOBS[@]}"; do
+      # shellcheck disable=SC2053
+      [[ "$base" == $pat ]] && return 0
+    done
+    ;;
+  *) ;;
+  esac
+  return 1
+}
+
 # Consume a manifest: re-stat + re-run the protection gate per entry (the
 # staleness guard), `rm -rf` survivors, and accumulate outcomes. An entry whose
 # path is already gone is idempotent success (resume) — counted neither removed
 # nor failed. A path that became protected since the dry-run is skipped (its
 # `Skip` line re-emitted), not removed. CLEAN_FAILED_COUNT counts genuine `rm`
-# failures (locked / Unremovable) and rejected entries (a manifest a caller
-# supplied or a concurrent process altered may carry a path that escapes the repo
-# — fail closed on it). The manifest is untrusted input: paths are containment-
-# checked and the byte field is validated as an unsigned decimal before it ever
-# reaches Bash arithmetic (which evaluates array subscripts recursively).
-#   clean_apply_manifest ROOT MANIFEST
+# failures (locked / Unremovable) and rejected entries — fail closed. The
+# manifest is untrusted input (a caller supplies it, or a concurrent process may
+# alter it): every entry is validated before its path is acted on — the class
+# must be one this tier produces (ALLOWED, space-separated), the path must be
+# repo-contained (no `..`/absolute) AND a real target for its class (not an
+# arbitrary untracked dir), and the byte field must be an unsigned decimal before
+# it reaches Bash arithmetic (which evaluates array subscripts recursively).
+#   clean_apply_manifest ROOT MANIFEST ALLOWED_CLASSES
 clean_apply_manifest() {
-  local root="$1" manifest="$2"
+  local root="$1" manifest="$2" allowed="${3:-}"
   local class bytes rel abs skip
   while IFS=$'\t' read -r class bytes rel; do
     [[ -n "$rel" ]] || continue
+    if [[ -n "$allowed" && " $allowed " != *" $class "* ]]; then
+      printf 'Rejected (wrong tier): %s\n' "$rel" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+      continue
+    fi
     if ! clean_manifest_rel_safe "$rel"; then
       printf 'Rejected (outside repo): %s\n' "$rel" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+      continue
+    fi
+    if ! clean_manifest_target_valid "$class" "$rel"; then
+      printf 'Rejected (not a %s target): %s\n' "$class" "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
       continue
     fi

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -462,6 +462,26 @@ clean_manifest_rel_safe() {
   esac
 }
 
+# Return 0 when any component of ROOT/REL (an ancestor directory OR the target)
+# is a symlink or reparse point. `..`-rejection stops textual escapes, but a
+# manifest naming `link/__pycache__` where `link` points outside the repo would
+# otherwise let `rm -rf` follow the ancestor out of the tree. Enumeration uses
+# `find -type d`, which never descends a symlinked dir, so such a path is never
+# one the dry-run emitted — reject it. Junction-aware (fsutil), so it also
+# catches Windows reparse-point ancestors that `realpath`/`-L` miss.
+clean_path_has_reparse_ancestor() {
+  local root="$1" seg
+  local cur="$root"
+  local -a parts
+  IFS=/ read -r -a parts <<<"${2//\\//}"
+  for seg in "${parts[@]}"; do
+    [[ -z "$seg" ]] && continue
+    cur="$cur/$seg"
+    clean_path_is_reparse_point "$cur" && return 0
+  done
+  return 1
+}
+
 # Return 0 when a repo-relative path lies within a pruned tree (a
 # CLEAN_PRUNE_DIRS segment). Enumeration never descends these, so a manifest
 # entry inside one — e.g. `.git/...`, whose removal could corrupt the repo — is
@@ -539,9 +559,10 @@ clean_manifest_target_valid() {
 # manifest is untrusted input (a caller supplies it, or a concurrent process may
 # alter it): every entry is validated before its path is acted on — the class
 # must be one this tier produces (ALLOWED, space-separated), the path must be
-# repo-contained (no `..`/absolute), outside every pruned tree (enumeration never
-# descends CLEAN_PRUNE_DIRS, so a `.git/...` entry is never one it emitted) AND a
-# real target of the right type for its class (not an arbitrary untracked path).
+# repo-contained (no `..`/absolute, no symlinked ancestor that `rm -rf` could
+# follow out of the repo), outside every pruned tree (enumeration never descends
+# CLEAN_PRUNE_DIRS, so a `.git/...` entry is never one it emitted) AND a real
+# target of the right type for its class (not an arbitrary untracked path).
 # The reclaimed-bytes total is re-measured from the filesystem at removal time,
 # so the manifest's byte field never reaches summary arithmetic — a caller value
 # cannot inject (array subscripts evaluate recursively) or overflow it.
@@ -586,6 +607,11 @@ clean_apply_manifest() {
     # failure nor a re-removal — skip before target/type validation (which needs
     # the path to exist).
     [[ -e "$abs" ]] || continue
+    if clean_path_has_reparse_ancestor "$root" "$rel"; then
+      printf 'Rejected (symlinked ancestor): %s\n' "$rel" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+      continue
+    fi
     if ! clean_manifest_target_valid "$class" "$rel" "$abs"; then
       printf 'Rejected (not a %s target): %s\n' "$class" "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -199,7 +199,9 @@ clean_path_is_reparse_point() {
   local path="$1"
   [[ -L "$path" ]] && return 0
   if command -v fsutil >/dev/null 2>&1 && command -v cygpath >/dev/null 2>&1; then
-    fsutil reparsepoint query "$(cygpath -w "$path")" >/dev/null 2>&1 && return 0
+    # `</dev/null`: fsutil drains stdin, which would consume a caller's read loop
+    # fd (e.g. clean_apply_manifest's manifest) if this runs inside one.
+    fsutil reparsepoint query "$(cygpath -w "$path")" </dev/null >/dev/null 2>&1 && return 0
   fi
   return 1
 }
@@ -287,8 +289,13 @@ clean_enumerate() {
 # build-tier's --include-caches path, so the two never drift.
 clean_caches_candidates() {
   local root="$1" rel
-  for rel in "${CLEAN_CACHE_EXPLICIT[@]}"; do printf '%s\n' "$root/$rel"; done
-  for rel in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do printf '%s\n' "$root/$rel"; done
+  # Explicit repo-root paths bypass `find`'s `-type` filter, so apply the same
+  # type check here (explicit dirs must be plain dirs, explicit files plain
+  # files) — otherwise a file or symlink named e.g. `.pytest_cache` would be
+  # planned at dry-run but rejected at --apply, making the advertised plan
+  # unapplyable.
+  for rel in "${CLEAN_CACHE_EXPLICIT[@]}"; do clean_is_plain_dir "$root/$rel" && printf '%s\n' "$root/$rel"; done
+  for rel in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do clean_is_plain_file "$root/$rel" && printf '%s\n' "$root/$rel"; done
   clean_enumerate "$root" "${CLEAN_CACHE_FIND_DIR_NAMES[@]}" -- "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"
 }
 
@@ -375,6 +382,18 @@ clean_plan() {
     abs="${CLEAN_CAND_ABS[$i]}"
     class="${CLEAN_CAND_CLASS[$i]}"
     [[ -e "$abs" ]] || continue
+    # The manifest is tab-delimited and newline-terminated; a path containing
+    # either cannot be encoded unambiguously and would corrupt both the dedup
+    # parse below and the record #994 consumes. Pathological for build/cache
+    # artifacts — skip with a visible warning rather than emit a record that maps
+    # to the wrong path at --apply.
+    case "$abs" in
+    *$'\t'* | *$'\n'*)
+      printf 'Skip (unencodable path): %s\n' "${abs#"$root"/}" >&2
+      continue
+      ;;
+    *) ;;
+    esac
     if skip="$(clean_target_eligible "$root" "$abs")"; then
       elig_abs+=("$abs")
       elig_class+=("$class")
@@ -389,7 +408,9 @@ clean_plan() {
   # path with a trailing '/' key so an ancestor sorts immediately before ALL its
   # descendants and they stay contiguous (the '/' also stops `build` swallowing a
   # sibling `buildstuff` — `buildstuff/` does not start with `build/`), then skip
-  # anything under the last kept ancestor in a single pass.
+  # anything under the last kept ancestor in a single pass. Inputs never carry a
+  # trailing slash (find never emits one; explicit paths are root-joined), so the
+  # single appended '/' is unambiguous.
   local -a surv_abs=() surv_class=()
   local last_key="" key
   while IFS=$'\t' read -r key abs class; do
@@ -520,17 +541,22 @@ clean_manifest_target_valid() {
 # must be one this tier produces (ALLOWED, space-separated), the path must be
 # repo-contained (no `..`/absolute), outside every pruned tree (enumeration never
 # descends CLEAN_PRUNE_DIRS, so a `.git/...` entry is never one it emitted) AND a
-# real target of the right type for its class (not an arbitrary untracked path),
-# and the byte field must be an unsigned decimal before it reaches Bash
-# arithmetic (which evaluates array subscripts recursively).
+# real target of the right type for its class (not an arbitrary untracked path).
+# The reclaimed-bytes total is re-measured from the filesystem at removal time,
+# so the manifest's byte field never reaches summary arithmetic — a caller value
+# cannot inject (array subscripts evaluate recursively) or overflow it.
 #   clean_apply_manifest ROOT MANIFEST ALLOWED_CLASSES
 clean_apply_manifest() {
   local root="$1" manifest="$2" allowed="${3:-}"
   local class bytes rel abs skip
+  # Read the manifest on a dedicated fd (3), not stdin: a per-entry validator can
+  # shell out to a tool that drains stdin (e.g. `fsutil` in the reparse-point
+  # check), which on fd 0 would swallow the rest of the manifest and silently
+  # skip every entry after the first.
   # `|| [[ -n … ]]` processes a final record with no trailing newline (common in
   # caller-written files) instead of dropping it — dropping it would report a
   # cleanup as done while leaving it undone.
-  while IFS=$'\t' read -r class bytes rel || [[ -n "$class$bytes$rel" ]]; do
+  while IFS=$'\t' read -r class bytes rel <&3 || [[ -n "$class$bytes$rel" ]]; do
     if [[ -z "$rel" ]]; then
       # A deliberately blank line is ignored; a nonblank but truncated record
       # (missing the path field, e.g. a partial write by a concurrent process) is
@@ -565,20 +591,26 @@ clean_apply_manifest() {
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
       continue
     fi
-    [[ "$bytes" =~ ^[0-9]+$ ]] || bytes=0
     if ! skip="$(clean_target_eligible "$root" "$abs")"; then
       [[ -n "$skip" ]] && printf '%s\n' "$skip"
       continue
     fi
+    # Reclaimed bytes are re-measured from the filesystem now, not read from the
+    # manifest's dry-run byte field: the target may have grown/shrunk since the
+    # plan, and this also keeps a caller-supplied field out of the summary
+    # arithmetic entirely (no overflow/wrap, no evaluation of untrusted input).
+    local kb
+    kb="$(du -sk "$abs" 2>/dev/null | awk '{print $1}')"
+    [[ "$kb" =~ ^[0-9]+$ ]] || kb=0
     if rm -rf "$abs" 2>/dev/null; then
       printf 'Removed: %s\n' "$rel"
       CLEAN_REMOVED_COUNT=$((CLEAN_REMOVED_COUNT + 1))
-      CLEAN_REMOVED_BYTES=$((CLEAN_REMOVED_BYTES + bytes))
+      CLEAN_REMOVED_BYTES=$((CLEAN_REMOVED_BYTES + kb * 1024))
     else
       printf 'Unremovable: %s\n' "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
     fi
-  done <"$manifest"
+  done 3<"$manifest"
 }
 
 # Return 0 when PATH is safe to (re)write as a manifest: absent, or an existing

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -434,34 +434,42 @@ clean_manifest_rel_safe() {
   esac
 }
 
-# Return 0 when REL is a legitimate removal target for CLASS — matching the SAME
-# candidate rules enumeration uses to FIND targets (explicit repo-root paths, a
-# recursive dir-name leaf, or a file-glob leaf). The manifest is untrusted, so
+# Return 0 when the existing path ABS is a legitimate removal target for CLASS —
+# matching the SAME candidate rules enumeration uses to FIND targets, INCLUDING
+# the filesystem type it emits each under (dir names / explicit dirs are found
+# `-type d`, globs / explicit files `-type f`). The manifest is untrusted, so
 # --apply re-derives target-hood from the rules rather than trusting a listed
-# path was ever a real target: a tampered entry like `caches\t1\tnotes` names an
-# ordinary untracked dir that is not a cache and must never be removed.
+# path was ever a real target: a tampered `caches\t1\tnotes` (an ordinary
+# untracked dir) or `build\t1\timportant/bin` (a regular file merely named `bin`)
+# is one the dry-run could never have planned and must never be removed. Assumes
+# ABS exists (callers `-e`-check first so a resumed, already-gone entry stays an
+# idempotent no-op rather than a rejection).
+#   clean_manifest_target_valid CLASS REL ABS
 clean_manifest_target_valid() {
-  local class="$1" rel="${2//\\//}" base="${2##*/}" e pat
+  local class="$1" rel="${2//\\//}" abs="$3" base="${2##*/}" e pat
   case "$class" in
   caches)
-    for e in "${CLEAN_CACHE_EXPLICIT[@]}" "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do
-      [[ "$rel" == "$e" ]] && return 0
+    for e in "${CLEAN_CACHE_EXPLICIT[@]}"; do
+      [[ "$rel" == "$e" ]] && { [[ -d "$abs" ]] && return 0 || return 1; }
+    done
+    for e in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do
+      [[ "$rel" == "$e" ]] && { [[ -f "$abs" ]] && return 0 || return 1; }
     done
     for e in "${CLEAN_CACHE_FIND_DIR_NAMES[@]}"; do
-      [[ "$base" == "$e" ]] && return 0
+      [[ "$base" == "$e" ]] && { [[ -d "$abs" ]] && return 0 || return 1; }
     done
     for pat in "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"; do
       # shellcheck disable=SC2053
-      [[ "$base" == $pat ]] && return 0
+      [[ "$base" == $pat ]] && { [[ -f "$abs" ]] && return 0 || return 1; }
     done
     ;;
   build)
     for e in "${CLEAN_BUILD_DIR_NAMES[@]}"; do
-      [[ "$base" == "$e" ]] && return 0
+      [[ "$base" == "$e" ]] && { [[ -d "$abs" ]] && return 0 || return 1; }
     done
     for pat in "${CLEAN_BUILD_FILE_GLOBS[@]}"; do
       # shellcheck disable=SC2053
-      [[ "$base" == $pat ]] && return 0
+      [[ "$base" == $pat ]] && { [[ -f "$abs" ]] && return 0 || return 1; }
     done
     ;;
   *) ;;
@@ -497,14 +505,17 @@ clean_apply_manifest() {
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
       continue
     fi
-    if ! clean_manifest_target_valid "$class" "$rel"; then
+    abs="$root/$rel"
+    # Idempotent resume: an entry a prior apply already removed is neither a
+    # failure nor a re-removal — skip before target/type validation (which needs
+    # the path to exist).
+    [[ -e "$abs" ]] || continue
+    if ! clean_manifest_target_valid "$class" "$rel" "$abs"; then
       printf 'Rejected (not a %s target): %s\n' "$class" "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
       continue
     fi
     [[ "$bytes" =~ ^[0-9]+$ ]] || bytes=0
-    abs="$root/$rel"
-    [[ -e "$abs" ]] || continue
     if ! skip="$(clean_target_eligible "$root" "$abs")"; then
       [[ -n "$skip" ]] && printf '%s\n' "$skip"
       continue
@@ -520,13 +531,35 @@ clean_apply_manifest() {
   done <"$manifest"
 }
 
+# Return 0 when PATH is safe to (re)write as a manifest: absent, or an existing
+# regular file that is empty or already in manifest format. `--manifest` is a
+# documented caller-supplied path, so an explicit value that names an existing
+# non-manifest file (e.g. a mistyped `~/.config/app/settings`) must not be
+# truncated — the dry-run build would silently erase it.
+clean_manifest_writable_target() {
+  local path="$1" line
+  [[ -e "$path" ]] || return 0
+  [[ -f "$path" ]] || return 1
+  [[ -s "$path" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" ]] && continue
+    [[ "$line" =~ ^(caches|build)$'\t'[0-9]+$'\t' ]] || return 1
+  done <"$path"
+  return 0
+}
+
 # clean_manifest_path [--manifest VALUE] → resolve/create the session manifest.
 # Honors an explicit path (agent passes dry-run's path back at --apply); else
-# mktemp a session-scoped file. Truncates so a reused path starts clean.
+# mktemp a session-scoped file. Truncates so a reused path starts clean, but
+# refuses (returns 1, prints nothing) to overwrite an existing non-manifest file.
 clean_manifest_path() {
   local explicit="$1" path
   if [[ -n "$explicit" ]]; then
     path="$explicit"
+    if ! clean_manifest_writable_target "$path"; then
+      printf 'clean: refusing to overwrite non-manifest file: %s\n' "$path" >&2
+      return 1
+    fi
   else
     path="$(mktemp 2>/dev/null)" || path="${TMPDIR:-/tmp}/clean-manifest.$$"
   fi

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -608,7 +608,7 @@ clean_apply_manifest() {
     # the path to exist).
     [[ -e "$abs" ]] || continue
     if clean_path_has_reparse_ancestor "$root" "$rel"; then
-      printf 'Rejected (symlinked ancestor): %s\n' "$rel" >&2
+      printf 'Rejected (symlinked path): %s\n' "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
       continue
     fi

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -376,24 +376,28 @@ clean_plan() {
     fi
   done
 
+  # Drop any eligible path nested under an eligible ancestor (`du` of the ancestor
+  # already counts it and `rm -rf` already removes it — otherwise the byte total
+  # double-counts and apply hits a spent path). O(n log n), not O(n²): sort each
+  # path with a trailing '/' key so an ancestor sorts immediately before ALL its
+  # descendants and they stay contiguous (the '/' also stops `build` swallowing a
+  # sibling `buildstuff` — `buildstuff/` does not start with `build/`), then skip
+  # anything under the last kept ancestor in a single pass.
   local -a surv_abs=() surv_class=()
-  local a b nested j
-  for i in "${!elig_abs[@]}"; do
-    a="${elig_abs[$i]}"
-    nested=0
-    for j in "${!elig_abs[@]}"; do
-      [[ "$i" == "$j" ]] && continue
-      b="${elig_abs[$j]}"
-      # Anchor on '/' so `build` never swallows a sibling `buildstuff`.
-      if [[ "$a" == "$b"/* ]]; then
-        nested=1
-        break
-      fi
-    done
-    ((nested)) && continue
-    surv_abs+=("$a")
-    surv_class+=("${elig_class[$i]}")
-  done
+  local last_key="" key
+  while IFS=$'\t' read -r key abs class; do
+    [[ -n "$abs" ]] || continue
+    if [[ -n "$last_key" && "$key" == "$last_key"* ]]; then
+      continue
+    fi
+    surv_abs+=("$abs")
+    surv_class+=("$class")
+    last_key="$key"
+  done < <(
+    for i in "${!elig_abs[@]}"; do
+      printf '%s/\t%s\t%s\n' "${elig_abs[$i]}" "${elig_abs[$i]}" "${elig_class[$i]}"
+    done | LC_ALL=C sort
+  )
   ((${#surv_abs[@]})) || return 0
 
   local -A size_of=()
@@ -415,18 +419,43 @@ clean_plan() {
   done
 }
 
+# Return 0 when a manifest-supplied repo-relative path is safe to act on — below
+# REPO_ROOT, never absolute, never traversing a parent (`..`, either separator).
+# The manifest is a documented `--apply --manifest` surface a caller may supply
+# or a concurrent process may alter, so an entry like `../outside` must never let
+# `rm` escape the repository.
+clean_manifest_rel_safe() {
+  local norm="${1//\\//}"
+  [[ -n "$norm" ]] || return 1
+  [[ "$norm" == /* ]] && return 1
+  case "/$norm/" in
+  */../*) return 1 ;;
+  *) return 0 ;;
+  esac
+}
+
 # Consume a manifest: re-stat + re-run the protection gate per entry (the
 # staleness guard), `rm -rf` survivors, and accumulate outcomes. An entry whose
 # path is already gone is idempotent success (resume) — counted neither removed
 # nor failed. A path that became protected since the dry-run is skipped (its
-# `Skip` line re-emitted), not removed. CLEAN_FAILED_COUNT counts only genuine
-# `rm` failures (locked / Unremovable).
+# `Skip` line re-emitted), not removed. CLEAN_FAILED_COUNT counts genuine `rm`
+# failures (locked / Unremovable) and rejected entries (a manifest a caller
+# supplied or a concurrent process altered may carry a path that escapes the repo
+# — fail closed on it). The manifest is untrusted input: paths are containment-
+# checked and the byte field is validated as an unsigned decimal before it ever
+# reaches Bash arithmetic (which evaluates array subscripts recursively).
 #   clean_apply_manifest ROOT MANIFEST
 clean_apply_manifest() {
   local root="$1" manifest="$2"
   local class bytes rel abs skip
   while IFS=$'\t' read -r class bytes rel; do
     [[ -n "$rel" ]] || continue
+    if ! clean_manifest_rel_safe "$rel"; then
+      printf 'Rejected (outside repo): %s\n' "$rel" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+      continue
+    fi
+    [[ "$bytes" =~ ^[0-9]+$ ]] || bytes=0
     abs="$root/$rel"
     [[ -e "$abs" ]] || continue
     if ! skip="$(clean_target_eligible "$root" "$abs")"; then

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -518,8 +518,19 @@ clean_manifest_target_valid() {
 clean_apply_manifest() {
   local root="$1" manifest="$2" allowed="${3:-}"
   local class bytes rel abs skip
-  while IFS=$'\t' read -r class bytes rel; do
-    [[ -n "$rel" ]] || continue
+  # `|| [[ -n … ]]` processes a final record with no trailing newline (common in
+  # caller-written files) instead of dropping it — dropping it would report a
+  # cleanup as done while leaving it undone.
+  while IFS=$'\t' read -r class bytes rel || [[ -n "$class$bytes$rel" ]]; do
+    if [[ -z "$rel" ]]; then
+      # A deliberately blank line is ignored; a nonblank but truncated record
+      # (missing the path field, e.g. a partial write by a concurrent process) is
+      # malformed — fail closed so automation cannot read it as a successful no-op.
+      [[ -z "$class$bytes" ]] && continue
+      printf 'Rejected (malformed record): %s\n' "$class $bytes" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+      continue
+    fi
     if [[ -n "$allowed" && " $allowed " != *" $class "* ]]; then
       printf 'Rejected (wrong tier): %s\n' "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -384,9 +384,9 @@ clean_plan() {
     [[ -e "$abs" ]] || continue
     # The manifest is tab-delimited and newline-terminated; a path containing
     # either cannot be encoded unambiguously and would corrupt both the dedup
-    # parse below and the record #994 consumes. Pathological for build/cache
-    # artifacts — skip with a visible warning rather than emit a record that maps
-    # to the wrong path at --apply.
+    # parse below and the record a downstream consumer parses. Pathological for
+    # build/cache artifacts — skip with a visible warning rather than emit a
+    # record that maps to the wrong path at --apply.
     case "$abs" in
     *$'\t'* | *$'\n'*)
       printf 'Skip (unencodable path): %s\n' "${abs#"$root"/}" >&2

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -467,32 +467,41 @@ clean_path_has_pruned_segment() {
 # is one the dry-run could never have planned and must never be removed. Assumes
 # ABS exists (callers `-e`-check first so a resumed, already-gone entry stays an
 # idempotent no-op rather than a rejection).
+# A plain directory / regular file that is NOT a symlink or reparse point. The
+# enumerator matches targets with `find -type d`/`-type f`, which never follow a
+# symlink or Windows junction; Bash `[[ -d ]]`/`[[ -f ]]` DO follow them, so a
+# manifest entry naming a link (or a path swapped for one after the dry-run)
+# would otherwise be accepted and its link removed — never a path the dry-run
+# could have emitted.
+clean_is_plain_dir() { [[ -d "$1" ]] && ! clean_path_is_reparse_point "$1"; }
+clean_is_plain_file() { [[ -f "$1" ]] && ! clean_path_is_reparse_point "$1"; }
+
 #   clean_manifest_target_valid CLASS REL ABS
 clean_manifest_target_valid() {
   local class="$1" rel="${2//\\//}" abs="$3" base="${2##*/}" e pat
   case "$class" in
   caches)
     for e in "${CLEAN_CACHE_EXPLICIT[@]}"; do
-      [[ "$rel" == "$e" ]] && { [[ -d "$abs" ]] && return 0 || return 1; }
+      [[ "$rel" == "$e" ]] && { clean_is_plain_dir "$abs" && return 0 || return 1; }
     done
     for e in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do
-      [[ "$rel" == "$e" ]] && { [[ -f "$abs" ]] && return 0 || return 1; }
+      [[ "$rel" == "$e" ]] && { clean_is_plain_file "$abs" && return 0 || return 1; }
     done
     for e in "${CLEAN_CACHE_FIND_DIR_NAMES[@]}"; do
-      [[ "$base" == "$e" ]] && { [[ -d "$abs" ]] && return 0 || return 1; }
+      [[ "$base" == "$e" ]] && { clean_is_plain_dir "$abs" && return 0 || return 1; }
     done
     for pat in "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"; do
       # shellcheck disable=SC2053
-      [[ "$base" == $pat ]] && { [[ -f "$abs" ]] && return 0 || return 1; }
+      [[ "$base" == $pat ]] && { clean_is_plain_file "$abs" && return 0 || return 1; }
     done
     ;;
   build)
     for e in "${CLEAN_BUILD_DIR_NAMES[@]}"; do
-      [[ "$base" == "$e" ]] && { [[ -d "$abs" ]] && return 0 || return 1; }
+      [[ "$base" == "$e" ]] && { clean_is_plain_dir "$abs" && return 0 || return 1; }
     done
     for pat in "${CLEAN_BUILD_FILE_GLOBS[@]}"; do
       # shellcheck disable=SC2053
-      [[ "$base" == $pat ]] && { [[ -f "$abs" ]] && return 0 || return 1; }
+      [[ "$base" == $pat ]] && { clean_is_plain_file "$abs" && return 0 || return 1; }
     done
     ;;
   *) ;;
@@ -591,8 +600,12 @@ clean_manifest_writable_target() {
 
 # clean_manifest_path [--manifest VALUE] → resolve/create the session manifest.
 # Honors an explicit path (agent passes dry-run's path back at --apply); else
-# mktemp a session-scoped file. Truncates so a reused path starts clean, but
-# refuses (returns 1, prints nothing) to overwrite an existing non-manifest file.
+# mktemp a session-scoped file. Truncates so a reused path starts clean; returns
+# 1 (printing nothing on stdout) if it would overwrite an existing non-manifest
+# file OR if the file cannot actually be created/truncated (an unwritable or
+# nonexistent-parent path) — otherwise the dry-run would print a `Manifest:` line
+# and plan removals against a file that was never written, handing the apply step
+# a bogus path.
 clean_manifest_path() {
   local explicit="$1" path
   if [[ -n "$explicit" ]]; then
@@ -604,6 +617,12 @@ clean_manifest_path() {
   else
     path="$(mktemp 2>/dev/null)" || path="${TMPDIR:-/tmp}/clean-manifest.$$"
   fi
-  : >"$path"
+  # Subshell so the redirect's own failure message is captured by 2>/dev/null
+  # (a bare `: >"$path" 2>/dev/null` still prints it — the target redirect is set
+  # up before stderr is redirected).
+  if ! (: >"$path") 2>/dev/null; then
+    printf 'clean: cannot create manifest: %s\n' "$path" >&2
+    return 1
+  fi
   printf '%s' "$path"
 }

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -222,3 +222,241 @@ clean_branch_matches_protected_pattern() {
 
   return 1
 }
+
+# --- enumeration + manifest engine (issues #993 / #995 / #1002) --------------
+#
+# The selective build/caches tiers formerly ran one unpruned full-tree `find`
+# per pattern (~10 walks/repo); the `! -path` exclusions filtered output but did
+# not `-prune`, so every walk still descended `.git/`, `node_modules/`, `.venv/`.
+# The engine below replaces that with ONE pruned walk per tier that never
+# descends those three trees, then classifies, sizes, and manifests the result.
+# Measured on a large .NET + node repo (Windows/NTFS): one pruned walk incl. `du`
+# sizing ~17s vs a 10-walk unpruned dry-run that exceeded 10 min (killed).
+#
+# scan.sh still uses the old per-pattern unpruned walks — TODO(#1011) migrate it
+# onto clean_enumerate (kept out of #993's named scope).
+
+# Single pruned walk. Prunes .git / node_modules / .venv (never descended),
+# then `-print`s directory-name and file-glob matches. Tier-agnostic:
+#   clean_enumerate ROOT dirname… -- fileglob…
+# `du -sk` (POSIX) handles sizing downstream; GNU-only `find -printf` is avoided
+# for BSD/macOS portability.
+clean_enumerate() {
+  local root="$1"
+  shift
+  local -a dir_names=() file_globs=()
+  local bucket=dirs tok
+  for tok in "$@"; do
+    if [[ "$tok" == "--" ]]; then
+      bucket=globs
+      continue
+    fi
+    if [[ "$bucket" == dirs ]]; then dir_names+=("$tok"); else file_globs+=("$tok"); fi
+  done
+
+  local -a args=("$root" '(' -name .git -o -name node_modules -o -name .venv ')' -prune -o '(')
+  local -a match=()
+  local i
+  if ((${#dir_names[@]})); then
+    match+=(-type d '(')
+    for i in "${!dir_names[@]}"; do
+      ((i)) && match+=(-o)
+      match+=(-name "${dir_names[$i]}")
+    done
+    match+=(')')
+  fi
+  if ((${#file_globs[@]})); then
+    ((${#dir_names[@]})) && match+=(-o)
+    match+=(-type f '(')
+    for i in "${!file_globs[@]}"; do
+      ((i)) && match+=(-o)
+      match+=(-name "${file_globs[$i]}")
+    done
+    match+=(')')
+  fi
+  args+=("${match[@]}" ')' -print)
+  find "${args[@]}" 2>/dev/null
+}
+
+# Candidate absolute paths for the caches / build tiers (explicit repo-root
+# paths + one pruned walk). SSOT for both the standalone scripts and the
+# build-tier's --include-caches path, so the two never drift.
+clean_caches_candidates() {
+  local root="$1" rel
+  for rel in "${CLEAN_CACHE_EXPLICIT[@]}"; do printf '%s\n' "$root/$rel"; done
+  for rel in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do printf '%s\n' "$root/$rel"; done
+  clean_enumerate "$root" "${CLEAN_CACHE_FIND_DIR_NAMES[@]}" -- "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"
+}
+
+clean_build_candidates() {
+  local root="$1"
+  clean_enumerate "$root" "${CLEAN_BUILD_DIR_NAMES[@]}" -- "${CLEAN_BUILD_FILE_GLOBS[@]}"
+}
+
+# Return 0 when an existing absolute path is eligible for removal; otherwise
+# print the reason as a `Skip (…)` line on stdout and return 1. This same gate
+# runs at both dry-run (building the manifest) and --apply (the staleness guard:
+# a path that became protected between the two is not removed). Assumes the path
+# exists — callers handle absence (a walk match always exists; an already-removed
+# manifest entry is idempotent-success, handled in clean_apply_manifest).
+clean_target_eligible() {
+  local root="$1" abs="$2" rel="${2#"$1"/}"
+  if clean_path_is_protected "$root" "$abs"; then
+    printf 'Skip (protected): %s\n' "$rel"
+    return 1
+  fi
+  if clean_path_in_submodule "$root" "$abs"; then
+    printf 'Skip (submodule): %s\n' "$rel"
+    return 1
+  fi
+  if [[ -d "$abs" ]] && clean_dir_has_protected_descendant "$root" "$abs"; then
+    printf 'Skip (protected descendant): %s\n' "$rel"
+    return 1
+  fi
+  return 0
+}
+
+# Class-tagged candidate accumulators, consumed by clean_plan. Reset per run.
+CLEAN_CAND_ABS=()
+CLEAN_CAND_CLASS=()
+
+# Dry-run / summary accumulators (bytes are raw bytes — same unit scan.sh reports
+# as `Total reclaimable`).
+CLEAN_PLANNED_COUNT=0
+CLEAN_PLANNED_BYTES=0
+CLEAN_REMOVED_COUNT=0
+CLEAN_FAILED_COUNT=0
+CLEAN_REMOVED_BYTES=0
+
+# clean_add_candidates CLASS abs… — tag each candidate path with its manifest
+# class (caches|build) for the shared dedup + sizing pass.
+clean_add_candidates() {
+  local class="$1" p
+  shift
+  for p in "$@"; do
+    [[ -n "$p" ]] || continue
+    CLEAN_CAND_ABS+=("$p")
+    CLEAN_CAND_CLASS+=("$class")
+  done
+}
+
+clean_human_size() {
+  local b="$1"
+  if ((b >= 1073741824)); then
+    awk -v b="$b" 'BEGIN { printf "%.1f GB", b / 1073741824 }'
+  elif ((b >= 1048576)); then
+    awk -v b="$b" 'BEGIN { printf "%.1f MB", b / 1048576 }'
+  elif ((b >= 1024)); then
+    awk -v b="$b" 'BEGIN { printf "%.1f KB", b / 1024 }'
+  else
+    printf '%s B' "$b"
+  fi
+}
+
+# Classify every accumulated candidate, drop any eligible path nested under an
+# eligible ancestor (`du` of the ancestor already counts it and `rm -rf` already
+# removes it — otherwise the byte total double-counts and apply hits a spent
+# path), size the survivors with a SINGLE batched `du` (one subprocess for the
+# whole set — process creation is slow on Windows/MSYS), append
+# `<class>\t<bytes>\t<relpath>` manifest lines, and — when announce=1 (dry-run)
+# — print `Planned remove:` lines. Accumulates CLEAN_PLANNED_COUNT / _BYTES.
+#   clean_plan ROOT MANIFEST ANNOUNCE
+clean_plan() {
+  local root="$1" manifest="$2" announce="$3"
+  local -a elig_abs=() elig_class=()
+  local i abs class skip
+  # Classify first (a dir skipped for a protected descendant must not shadow a
+  # clean nested target below it), dedup second.
+  for i in "${!CLEAN_CAND_ABS[@]}"; do
+    abs="${CLEAN_CAND_ABS[$i]}"
+    class="${CLEAN_CAND_CLASS[$i]}"
+    [[ -e "$abs" ]] || continue
+    if skip="$(clean_target_eligible "$root" "$abs")"; then
+      elig_abs+=("$abs")
+      elig_class+=("$class")
+    else
+      [[ -n "$skip" ]] && printf '%s\n' "$skip"
+    fi
+  done
+
+  local -a surv_abs=() surv_class=()
+  local a b nested j
+  for i in "${!elig_abs[@]}"; do
+    a="${elig_abs[$i]}"
+    nested=0
+    for j in "${!elig_abs[@]}"; do
+      [[ "$i" == "$j" ]] && continue
+      b="${elig_abs[$j]}"
+      # Anchor on '/' so `build` never swallows a sibling `buildstuff`.
+      if [[ "$a" == "$b"/* ]]; then
+        nested=1
+        break
+      fi
+    done
+    ((nested)) && continue
+    surv_abs+=("$a")
+    surv_class+=("${elig_class[$i]}")
+  done
+  ((${#surv_abs[@]})) || return 0
+
+  local -A size_of=()
+  local kb path
+  while IFS=$'\t' read -r kb path; do
+    [[ -n "$path" ]] || continue
+    size_of["$path"]=$((kb * 1024))
+  done < <(du -sk "${surv_abs[@]}" 2>/dev/null)
+
+  local bytes rel
+  for i in "${!surv_abs[@]}"; do
+    abs="${surv_abs[$i]}"
+    rel="${abs#"$root"/}"
+    bytes="${size_of[$abs]:-0}"
+    printf '%s\t%s\t%s\n' "${surv_class[$i]}" "$bytes" "$rel" >>"$manifest"
+    ((announce)) && printf 'Planned remove: %s (%s)\n' "$rel" "$(clean_human_size "$bytes")"
+    CLEAN_PLANNED_COUNT=$((CLEAN_PLANNED_COUNT + 1))
+    CLEAN_PLANNED_BYTES=$((CLEAN_PLANNED_BYTES + bytes))
+  done
+}
+
+# Consume a manifest: re-stat + re-run the protection gate per entry (the
+# staleness guard), `rm -rf` survivors, and accumulate outcomes. An entry whose
+# path is already gone is idempotent success (resume) — counted neither removed
+# nor failed. A path that became protected since the dry-run is skipped (its
+# `Skip` line re-emitted), not removed. CLEAN_FAILED_COUNT counts only genuine
+# `rm` failures (locked / Unremovable).
+#   clean_apply_manifest ROOT MANIFEST
+clean_apply_manifest() {
+  local root="$1" manifest="$2"
+  local class bytes rel abs skip
+  while IFS=$'\t' read -r class bytes rel; do
+    [[ -n "$rel" ]] || continue
+    abs="$root/$rel"
+    [[ -e "$abs" ]] || continue
+    if ! skip="$(clean_target_eligible "$root" "$abs")"; then
+      [[ -n "$skip" ]] && printf '%s\n' "$skip"
+      continue
+    fi
+    if rm -rf "$abs" 2>/dev/null; then
+      printf 'Removed: %s\n' "$rel"
+      CLEAN_REMOVED_COUNT=$((CLEAN_REMOVED_COUNT + 1))
+      CLEAN_REMOVED_BYTES=$((CLEAN_REMOVED_BYTES + bytes))
+    else
+      printf 'Unremovable: %s\n' "$rel" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+    fi
+  done <"$manifest"
+}
+
+# clean_manifest_path [--manifest VALUE] → resolve/create the session manifest.
+# Honors an explicit path (agent passes dry-run's path back at --apply); else
+# mktemp a session-scoped file. Truncates so a reused path starts clean.
+clean_manifest_path() {
+  local explicit="$1" path
+  if [[ -n "$explicit" ]]; then
+    path="$explicit"
+  else
+    path="$(mktemp 2>/dev/null)" || path="${TMPDIR:-/tmp}/clean-manifest.$$"
+  fi
+  : >"$path"
+  printf '%s' "$path"
+}

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -251,7 +251,14 @@ clean_enumerate() {
     if [[ "$bucket" == dirs ]]; then dir_names+=("$tok"); else file_globs+=("$tok"); fi
   done
 
-  local -a args=("$root" '(' -name .git -o -name node_modules -o -name .venv ')' -prune -o '(')
+  local -a prune=('(')
+  local d
+  for d in "${CLEAN_PRUNE_DIRS[@]}"; do
+    ((${#prune[@]} > 1)) && prune+=(-o)
+    prune+=(-name "$d")
+  done
+  prune+=(')')
+  local -a args=("$root" "${prune[@]}" -prune -o '(')
   local -a match=()
   local i
   if ((${#dir_names[@]})); then
@@ -434,6 +441,22 @@ clean_manifest_rel_safe() {
   esac
 }
 
+# Return 0 when a repo-relative path lies within a pruned tree (a
+# CLEAN_PRUNE_DIRS segment). Enumeration never descends these, so a manifest
+# entry inside one — e.g. `.git/...`, whose removal could corrupt the repo — is
+# one the dry-run could never have emitted. Rejected on --apply, keeping the
+# prune set uniform on the enumerate and apply sides.
+clean_path_has_pruned_segment() {
+  local rel="${1//\\//}" seg
+  for seg in "${CLEAN_PRUNE_DIRS[@]}"; do
+    case "/$rel/" in
+    *"/$seg/"*) return 0 ;;
+    *) ;;
+    esac
+  done
+  return 1
+}
+
 # Return 0 when the existing path ABS is a legitimate removal target for CLASS —
 # matching the SAME candidate rules enumeration uses to FIND targets, INCLUDING
 # the filesystem type it emits each under (dir names / explicit dirs are found
@@ -486,9 +509,11 @@ clean_manifest_target_valid() {
 # manifest is untrusted input (a caller supplies it, or a concurrent process may
 # alter it): every entry is validated before its path is acted on — the class
 # must be one this tier produces (ALLOWED, space-separated), the path must be
-# repo-contained (no `..`/absolute) AND a real target for its class (not an
-# arbitrary untracked dir), and the byte field must be an unsigned decimal before
-# it reaches Bash arithmetic (which evaluates array subscripts recursively).
+# repo-contained (no `..`/absolute), outside every pruned tree (enumeration never
+# descends CLEAN_PRUNE_DIRS, so a `.git/...` entry is never one it emitted) AND a
+# real target of the right type for its class (not an arbitrary untracked path),
+# and the byte field must be an unsigned decimal before it reaches Bash
+# arithmetic (which evaluates array subscripts recursively).
 #   clean_apply_manifest ROOT MANIFEST ALLOWED_CLASSES
 clean_apply_manifest() {
   local root="$1" manifest="$2" allowed="${3:-}"
@@ -502,6 +527,11 @@ clean_apply_manifest() {
     fi
     if ! clean_manifest_rel_safe "$rel"; then
       printf 'Rejected (outside repo): %s\n' "$rel" >&2
+      CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
+      continue
+    fi
+    if clean_path_has_pruned_segment "$rel"; then
+      printf 'Rejected (pruned tree): %s\n' "$rel" >&2
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
       continue
     fi

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -428,12 +428,17 @@ clean_plan() {
   )
   ((${#surv_abs[@]})) || return 0
 
+  # Size via NUL-delimited xargs so a monorepo with thousands of survivors is
+  # chunked under ARG_MAX across multiple `du` execs — a single
+  # `du "${surv_abs[@]}"` would hit E2BIG and, with stderr discarded, silently
+  # size everything at 0. Survivors never contain a tab/newline (skipped at
+  # classification), so the tab-split parse is unambiguous.
   local -A size_of=()
   local kb path
   while IFS=$'\t' read -r kb path; do
     [[ -n "$path" ]] || continue
     size_of["$path"]=$((kb * 1024))
-  done < <(du -sk "${surv_abs[@]}" 2>/dev/null)
+  done < <(printf '%s\0' "${surv_abs[@]}" | xargs -0 du -sk 2>/dev/null)
 
   local bytes rel
   for i in "${!surv_abs[@]}"; do

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -292,8 +292,8 @@ clean_caches_candidates() {
   # Explicit repo-root paths bypass `find`'s `-type` filter, so apply the same
   # type check here (explicit dirs must be plain dirs, explicit files plain
   # files) — otherwise a file or symlink named e.g. `.pytest_cache` would be
-  # planned at dry-run but rejected at --apply, making the advertised plan
-  # unapplyable.
+  # planned at dry-run but rejected at --apply, so the advertised plan could not
+  # be applied.
   for rel in "${CLEAN_CACHE_EXPLICIT[@]}"; do clean_is_plain_dir "$root/$rel" && printf '%s\n' "$root/$rel"; done
   for rel in "${CLEAN_CACHE_EXPLICIT_FILES[@]}"; do clean_is_plain_file "$root/$rel" && printf '%s\n' "$root/$rel"; done
   clean_enumerate "$root" "${CLEAN_CACHE_FIND_DIR_NAMES[@]}" -- "${CLEAN_CACHE_FIND_FILE_GLOBS[@]}"

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -223,7 +223,7 @@ clean_branch_matches_protected_pattern() {
   return 1
 }
 
-# --- enumeration + manifest engine (issues #993 / #995 / #1002) --------------
+# --- enumeration + manifest engine -------------------------------------------
 #
 # The selective build/caches tiers formerly ran one unpruned full-tree `find`
 # per pattern (~10 walks/repo); the `! -path` exclusions filtered output but did
@@ -232,9 +232,6 @@ clean_branch_matches_protected_pattern() {
 # descends those three trees, then classifies, sizes, and manifests the result.
 # Measured on a large .NET + node repo (Windows/NTFS): one pruned walk incl. `du`
 # sizing ~17s vs a 10-walk unpruned dry-run that exceeded 10 min (killed).
-#
-# scan.sh still uses the old per-pattern unpruned walks — TODO(#1011) migrate it
-# onto clean_enumerate (kept out of #993's named scope).
 
 # Single pruned walk. Prunes .git / node_modules / .venv (never descended),
 # then `-print`s directory-name and file-glob matches. Tier-agnostic:

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/cleanup-paths.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/cleanup-paths.sh
@@ -3,6 +3,13 @@
 # SSOT: reference/cleanup-config.md — drift detected by cleanup-paths.test.sh
 # shellcheck disable=SC2034
 
+# Heavy trees that hold no cleanup targets we own — never descended by the
+# single-walk enumeration (`-prune`) and, symmetrically, never accepted from a
+# manifest at `--apply`, so both sides share one prune set. SSOT: the scan tier
+# still uses the per-glob CLEAN_FIND_EXCLUDE_* below (its migration to this walk
+# is deferred).
+CLEAN_PRUNE_DIRS=(.git node_modules .venv)
+
 # Universal find exclusions (cleanup-config.md intro)
 CLEAN_FIND_EXCLUDE_GIT='*/.git/*'
 CLEAN_FIND_EXCLUDE_VENV='*/.venv/*'

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/cleanup-paths.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/cleanup-paths.sh
@@ -47,9 +47,9 @@ CLEAN_BUILD_FILE_GLOBS=(
   '*.binlog'
 )
 
-# build — .NET clean driver. The solution/project file is detected at runtime by
-# clean-build.sh (any *.slnx / *.sln at the repo root), never hardcoded — the
-# universal bin/obj globs above remove output directly when dotnet is absent.
+# build — no build-system clean driver: the universal bin/obj globs above remove
+# every output a driver like `dotnet clean` would, so running one first is pure
+# overhead (#999).
 
 # git — safe prune mutations
 GIT_PRUNE_OPS=(

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/cleanup-paths.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/cleanup-paths.sh
@@ -49,7 +49,7 @@ CLEAN_BUILD_FILE_GLOBS=(
 
 # build — no build-system clean driver: the universal bin/obj globs above remove
 # every output a driver like `dotnet clean` would, so running one first is pure
-# overhead (#999).
+# overhead.
 
 # git — safe prune mutations
 GIT_PRUNE_OPS=(


### PR DESCRIPTION
Reworks the `clean` skill's build/caches enumeration and apply flow as one coherent change, closing four coupled issues.

## What changed, per issue

### #993 — single pruned walk (perf)
The selective `caches`/`build` tiers ran ~10 unpruned full-tree `find` walks per repo (7 build dir-names + 1 build glob + 1 cache dir-name + 1 cache glob); the `! -path` exclusions filtered output but did **not** `-prune`, so every walk re-descended `.git/`, `node_modules/`, and `.venv/`. A new shared `clean_enumerate` runs **one pruned walk per tier** that prunes those three trees once and `-print`s all dir-name and file-glob matches, then classifies protections on the result list.

Field measurement (large .NET + node repo, Windows/NTFS): one pruned walk incl. `du` sizing **~16.7 s** vs a 10-walk unpruned dry-run that **exceeded 10 min** (killed, never finished). Verified locally that the prune excludes a `bin/` nested in `node_modules/` and an `obj/` nested in `.venv/`.

### #995 — dry-run manifest, apply consumes it, resume
- `--dry-run` writes a session-scoped manifest (`<class>\t<bytes>\t<relpath>` per eligible target), prints `Manifest: <path>` and `Summary: planned=N bytes=K` so the confirmation gate can state reclaimable space.
- `--apply --manifest <path>` consumes the manifest with a **re-stat + re-classify staleness guard** (a path that became protected since the dry-run is not removed) instead of re-walking.
- **Resume** = re-run the identical `--apply --manifest <path>`; already-removed entries are idempotent no-ops.
- `--apply` without a manifest builds one then applies it, preserving the standalone CLI contract. `--include-caches` folds the caches tier into the **one** build manifest (no `clean-caches.sh` subprocess).

### #1002 — machine-parseable apply summary, fail-closed
Each `--apply` ends with `Summary: removed=N failed=M bytes=K` (bytes actually reclaimed) and exits non-zero when `failed>0`, so a fleet sweep no longer needs per-log grepping. Reuses the existing `Summary: k=v` + `[[ failed -eq 0 ]] || exit 1` convention (`git-branch-audit.sh`, `git-tree-reset-batch.sh`).

### #999 — drop the `dotnet clean` driver
`clean-build.sh --apply` ran `dotnet clean <solution>` (full MSBuild evaluation, minutes on a large solution) before removing `bin/`/`obj/` wholesale anyway; the driver added **no** removal coverage and re-created `obj/` evaluation artifacts. Removed entirely — one walk + `rm` is strictly faster and equally complete — along with its `Planned: dotnet clean …` (dry-run) and `DRIVER_FAILED:` (apply) output markers and the now-stale driver references in the config/ecosystem/README docs.

## CLI contract changes (both `clean-build.sh` and `clean-caches.sh`)
- **New flag `--manifest <path>`.** On `--dry-run` it writes the manifest to `<path>` instead of a `mktemp` default; on `--apply` it names the manifest to consume (no re-walk).
- **New stdout lines on `--dry-run`:** `Manifest: <path>` and `Summary: planned=N bytes=K`.
- **New stdout line on `--apply`:** `Summary: removed=N failed=M bytes=K`.
- **New exit semantics:** `--apply` now exits `1` when any removal fails (was always `0`); `2` usage error and `1` not-a-git-repo are unchanged.
- **Removed markers (`clean-build.sh` only):** `Planned: dotnet clean …` and `DRIVER_FAILED:` are gone.
- **Unchanged:** `--dry-run` default, `--apply`, `--include-caches`, the protection classes (secrets / runtime deps / skill data preserved by default), and the `Planned remove:` / `Removed:` / `Skip (…)` line prefixes (the dry-run `Planned remove:` line now also carries a human size suffix).

## Design notes
- **Cross-tier nested-target dedup**: any eligible path under an eligible ancestor is dropped before sizing/manifesting, so byte totals never double-count and apply never chases an already-removed path (e.g. a `*.tsbuildinfo` inside a `dist/`, or a nested `obj/` inside `bin/`). Anchored on `/` so `build` never swallows `buildstuff`.
- **Portability**: `du -sk` (POSIX) for sizing; GNU-only `find -printf` intentionally avoided for BSD/macOS. Scripts stay `shell=bash`.
- **Bytes** are block-approximate (du granularity), matching `scan.sh`'s `Total reclaimable`.

## Version
`0.4.6` → `0.5.0` (minor: new `--manifest`/resume surface). Per the official plugin-manifest reference, `version` is an optional semver string and bumping it is how consumers receive the update: https://code.claude.com/docs/en/plugins-reference (§ plugin.json fields — `version`: "Semantic version. Setting this pins the plugin to that version string, so users only receive updates when you bump it.").

## Tests
Extended `clean-caches.test.sh` and `clean-build.test.sh` TDD-style: manifest path + planned summary, exact `class<TAB>bytes<TAB>path` line format (the manifest is a consumed contract), apply summary + exit 0, resume (`removed=0 failed=0`, exit 0), nested-dedup single-count, `--include-caches` folding both classes into one manifest, and a chmod-guarded rm-failure case (`failed=1`, exit 1) that runs on Linux CI and skips on Cygwin where the FS ignores a write-denied parent. All existing repo-hygiene tests remain green; shellcheck, shfmt, markdownlint, editorconfig, changelog-parity, validate-plugins, and check-skill-portability all pass locally.

## Related
- #994 — consumes the dry-run manifest this PR produces (built on top of this batch; not closed here).
- #1011 — `scan.sh` shares the same unpruned-walk pattern; migrating it onto `clean_enumerate` is deferred to this follow-up (not closed here). `scan.sh` is outside #993's named targets.
- #1006 — Batch A (destructive-guard fail-open fix), already merged; this branch was rebased onto `main` after it landed.

Closes #993
Closes #995
Closes #1002
Closes #999