### PR TITLE
fix(disk-hygiene): reason about volume-root rejection instead of blanket-denying non-OS drives

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Fixed
+
+- **A non-OS volume root (e.g. a Windows Dev Drive) is no longer blanket-rejected (#984).** A
+  whole-volume root was refused purely structurally — on Windows by the mount-point gate (every drive
+  letter is `os.path.ismount` True), backed by a `parent == root` filesystem-root check — with no
+  reasoning about the volume's purpose, blocking a legitimate non-OS volume. Root classification is
+  now reasoned: an OS-managed root (the OS drive holding an existing Windows install / `Program Files`
+  / `ProgramData`, or `/` holding `/bin`, `/etc`, …) is still denied, while a non-OS volume root — a
+  drive root carrying only the per-volume metadata every volume has (`System Volume Information`,
+  `$Recycle.Bin`) and no OS-install marker — is now a valid target. The target-level mount rejection
+  is scoped to non-root mount points, so nested and bind mounts stay hard-blocked; per-entry
+  mount/OS-managed/VCS/identity protections and the preview + per-tier approval gate are unchanged.
+  Scan and preview share one unverified → OS-managed → non-root-mount target-check ordering. A
+  now-valid non-OS volume root composes with the large-target scan gate (0.5.0): it is a known-large
+  root (`large_scan_reasons` reason `non-os-volume-root`), so an unbounded whole-volume walk returns
+  `large-target-confirmation-required` unless bounded with `--max-depth` or confirmed with
+  `--confirmed-large-scan`.
+
 ## [0.5.0]
 
 ### Added

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -22,9 +22,12 @@ filename pattern is a discovery hint, never proof that an entry is junk. Read
 ## Arguments and boundaries
 
 Parse `$ARGUMENTS` as optional `--execute`, optional `--policy <file>`, and one target directory.
-`--execute` means “offer the gated lane”; it is not approval. With no target, ask once. Reject a
-filesystem root, mount target, OS-managed root, protected shell-folder root or descendant, missing
-directory, symlink, or Windows reparse point.
+`--execute` means “offer the gated lane”; it is not approval. With no target, ask once. Reject an
+OS-managed root, a non-root mount target, a protected shell-folder root or descendant, a missing
+directory, a symlink, or a Windows reparse point. A whole-volume root that is not OS-managed (a
+Windows Dev Drive) is no longer rejected outright — it is a valid target, but as a known-large root
+it is gated like a home target (see step 1): the scan returns `large-target-confirmation-required`
+unless bounded with `--max-depth` or confirmed with `--confirmed-large-scan`.
 
 - Use `/repo-hygiene:clean` for one repository's caches, build output, Git metadata, or tree reset.
 - For git worktree checkouts (e.g. under a `.worktrees/` directory), hand off to
@@ -73,10 +76,12 @@ plugin data directory even when the shell environment lacks `CLAUDE_PLUGIN_DATA`
 For a large root (a home directory, anything whose recursive walk could exceed the engine's entry
 cap), start with a bounded pass: add `--max-depth 1` to inventory the target's loose files and
 immediate children, then fan out deeper scans per subtree that the evidence justifies. The engine
-backs this with a deterministic gate: a scan whose target resolves to the user home directory and
-carries neither `--max-depth` nor `--confirmed-large-scan` returns `large-target-confirmation-required`
-(after a cheap top-level probe, not a full walk) instead of the unbounded traversal, so a forgotten
-bound never becomes an accidental whole-home scan. `--max-depth` is the preferred bounded response.
+backs this with a deterministic gate: a scan whose target resolves to the user home directory or a
+non-OS volume root (a Windows Dev Drive — an OS-managed root is denied outright and never reaches
+this gate) and carries neither `--max-depth` nor `--confirmed-large-scan` returns
+`large-target-confirmation-required` (after a cheap top-level probe, not a full walk) instead of the
+unbounded traversal, so a forgotten bound never becomes an accidental whole-volume scan. `--max-depth`
+is the preferred bounded response.
 Reserve `--confirmed-large-scan` for a deliberate full walk the human has confirmed — ask with
 `AskUserQuestion` first, exactly as the apply lane requires before an expensive step; a general
 "clean my home directory" is not that confirmation. Every

--- a/plugins/disk-hygiene/skills/clean/evals/evals.json
+++ b/plugins/disk-hygiene/skills/clean/evals/evals.json
@@ -120,6 +120,18 @@
         "Prefers enabling the OS mechanism over manual cleanup of the OS-owned zone",
         "Still performs the read-only audit and never treats the advisory as deletion authority"
       ]
+    },
+    {
+      "id": 11,
+      "name": "non-os-volume-root-requires-confirmation-not-blanket-rejection",
+      "prompt": "/disk-hygiene:clean D:\\ — it's my Windows Dev Drive, not the OS drive; audit it for junk.",
+      "expected_output": "The whole-volume root is not blanket-rejected: a Dev Drive holds no OS-managed content, so it is a valid target. As a known-large root it hits the large-target gate — the scan returns large-target-confirmation-required (reason non-os-volume-root) unless --max-depth or --confirmed-large-scan is given. The skill confirms the whole-volume scope with the user (AskUserQuestion) and prefers a bounded --max-depth pass before proceeding. An OS-managed root (the OS drive, /) stays denied outright and never reaches the gate.",
+      "files": [],
+      "expectations": [
+        "Does not reject the non-OS volume root outright; treats it as a valid but known-large target",
+        "Honors large-target-confirmation-required (non-os-volume-root): bounds with --max-depth or confirms with --confirmed-large-scan only after asking the user",
+        "Still denies a genuine OS-managed root outright and never fabricates the large-scan confirmation"
+      ]
     }
   ]
 }

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -17,9 +17,17 @@ whether an exact plan is mechanically eligible. Neither layer may weaken the oth
 
 ## Non-overridable checks
 
-- target containment and no filesystem/OS-managed roots;
-- no target root, protected shell-folder root, OS registry/profile hive, VCS metadata or tracked file;
-- no symlink, Windows reparse traversal, target mount, nested mount, or Linux bind mount;
+- target containment; an OS-managed root (per `system_roots()` — the OS drive holding an existing
+  Windows install / `Program Files` / `ProgramData`, or `/` holding `/bin`, `/etc`, …) is denied,
+  while a non-OS volume root (a Windows Dev Drive: a drive root carrying only the per-volume metadata
+  every volume has and no OS-install marker) is a valid target rather than blanket-denied — but as a
+  known-large root it is routed through the large-target scan gate below (bound or confirm), and
+  deletion stays gated by the preview and per-tier approval;
+- the audit root itself is never a removal candidate; no protected shell-folder root, OS
+  registry/profile hive, VCS metadata or tracked file;
+- no symlink, Windows reparse traversal, non-root mount target, nested mount, or Linux bind mount
+  (a volume root is itself a mount point and is governed by the OS-managed/confirmation reasoning
+  above, not this structural mount veto);
 - exact file identity and complete descendant set unchanged since snapshot;
 - repository markers re-discovered from live filesystem state and the Git index queried with
   `git ls-files` at preview and apply; snapshot VCS/protection annotations are never trusted;
@@ -77,11 +85,13 @@ A depth-limited scan records every directory it declined to enter in `truncated_
 directories have no captured descendant set, so the preview blocks them (and anything beneath them)
 as `truncated-not-inventoried`; they are coverage gaps, never candidates.
 
-A scan of a known-large root — the user home directory — is gated before it walks. Absent an explicit
-`--max-depth` bound or a `--confirmed-large-scan` acknowledgement, the engine performs a cheap
-top-level probe and returns `large-target-confirmation-required` instead of the unbounded traversal,
-so an unauthenticated whole-home walk cannot begin by omission. This is scan-cost gating (time and
-resources), distinct from the hard rejection of filesystem and OS-managed roots as invalid targets.
+A scan of a known-large root — the user home directory, or a non-OS volume root (a Windows Dev
+Drive) now that reasoned classification admits it as a valid target — is gated before it walks.
+Absent an explicit `--max-depth` bound or a `--confirmed-large-scan` acknowledgement, the engine
+performs a cheap top-level probe and returns `large-target-confirmation-required` instead of the
+unbounded traversal, so an unauthenticated whole-volume walk cannot begin by omission. This is
+scan-cost gating (time and resources), distinct from the hard rejection of an OS-managed root as an
+invalid target.
 
 Managed state is engine-ineligible. Even current native dry-run evidence is recorded only as a
 report-only handoff because this engine cannot independently authenticate the owning product's state

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -25,15 +25,24 @@ MAX_SNAPSHOT_ENTRIES = 250_000
 TIERS = {"high", "medium", "low"}
 VCS_NAMES = {".git", ".hg", ".svn"}
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
-WINDOWS_VOLUME_SYSTEM_NAMES = {
-    "$Recycle.Bin",
+# Folders whose presence at a drive root identifies that drive as an OS/system
+# drive. A user-provisioned non-OS volume (a Windows Dev Drive) carries none of
+# them, so they are the discriminator for whole-volume-root classification.
+WINDOWS_OS_DRIVE_MARKERS = {
     "Program Files",
     "Program Files (x86)",
     "ProgramData",
     "Recovery",
-    "System Volume Information",
     "Windows",
 }
+# Per-volume filesystem metadata every Windows volume carries, OS drive or not.
+# Protected from deletion on every drive, but never evidence a volume is the OS
+# drive — a Dev Drive has a System Volume Information and $Recycle.Bin too.
+WINDOWS_PER_VOLUME_METADATA = {
+    "$Recycle.Bin",
+    "System Volume Information",
+}
+WINDOWS_VOLUME_SYSTEM_NAMES = WINDOWS_OS_DRIVE_MARKERS | WINDOWS_PER_VOLUME_METADATA
 PLUGIN_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_POLICY = (
     Path(__file__).resolve().parents[1] / "reference" / "baseline-policy.json"
@@ -244,6 +253,78 @@ def system_roots(
     return roots
 
 
+def os_drive_markers(
+    platform_key: str | None = None, windows_roots: list[Path] | None = None
+) -> list[Path]:
+    """Paths whose presence within a volume identifies it as an OS/system drive.
+
+    Distinct from system_roots(): system_roots() lists everything to protect
+    from deletion (including the per-volume metadata every Windows volume
+    carries), whereas this lists only the OS-install markers that make a whole
+    volume the OS drive. The difference is the whole point of the Dev Drive
+    fix: counting per-volume metadata (System Volume Information, $Recycle.Bin)
+    as an OS signal would misclassify every drive root — a provisioned non-OS
+    volume has that metadata too. On POSIX every system root is a genuine OS
+    directory, so the full set applies.
+    """
+    current_platform = platform_key or os_key()
+    if current_platform != "windows":
+        return system_roots(current_platform)
+    markers: list[Path] = []
+    env_roots = (
+        os.environ.get("SystemRoot"),
+        os.environ.get("ProgramFiles"),
+        os.environ.get("ProgramFiles(x86)"),
+        os.environ.get("ProgramData"),
+    )
+    markers.extend(Path(value).absolute() for value in env_roots if value)
+    drive_roots = windows_roots if windows_roots is not None else windows_drive_roots()
+    for drive_root in drive_roots:
+        markers.extend(drive_root / name for name in WINDOWS_OS_DRIVE_MARKERS)
+    return markers
+
+
+def is_volume_root(path: Path) -> bool:
+    """True for a filesystem or drive root — a path that is its own parent."""
+    return path.parent == path
+
+
+def is_os_managed_target(
+    target: Path,
+    roots: list[Path] | None = None,
+    markers: list[Path] | None = None,
+) -> bool:
+    """Reasoned OS-managed classification for a whole-volume audit target.
+
+    Two directions, each with its own root set:
+
+    - the target sits *within* an OS-managed root (system_roots(), the full
+      protect-from-deletion set) — e.g. ``C:\\Windows\\Temp`` or ``/etc/x``;
+    - an OS-install *marker* actually exists *within* the target
+      (os_drive_markers(), the narrow OS-drive discriminator) — e.g. ``C:\\``
+      holds an existing ``C:\\Windows``, ``/`` holds ``/bin``.
+
+    The containing direction deliberately uses the narrow marker set, not
+    system_roots(): every Windows volume — a provisioned non-OS Dev Drive
+    included — carries System Volume Information and $Recycle.Bin, so counting
+    those as an OS signal would deny every drive root and defeat the fix. The
+    existence gate matters because os_drive_markers() synthesizes per-drive
+    marker paths for every drive without checking existence. Result: ``C:\\``
+    (holds an existing Windows install) is denied; a Dev Drive root (holds no
+    OS-install marker) is not — it is confirmation-required, never
+    blanket-denied.
+    """
+    target_abs = target.absolute()
+    for root in roots if roots is not None else system_roots():
+        if is_within(target_abs, root.absolute()):
+            return True
+    for marker in markers if markers is not None else os_drive_markers():
+        marker_abs = marker.absolute()
+        if is_within(marker_abs, target_abs) and marker_abs.exists():
+            return True
+    return False
+
+
 def hard_protection(
     path: Path,
     target: Path,
@@ -251,8 +332,10 @@ def hard_protection(
     known_linux_mounts: set[Path] | None = None,
 ) -> list[str]:
     reasons: list[str] = []
-    if path == target or path.parent == path:
-        reasons.append("target-or-filesystem-root")
+    if path == target:
+        reasons.append("target-root")
+    if is_volume_root(path) and is_os_managed_target(path):
+        reasons.append("os-managed-root")
     current = path
     while is_within(current, target):
         if is_linkish(current):
@@ -549,11 +632,14 @@ def large_scan_reasons(target: Path) -> list[str]:
     """Name deterministically why a target is a known-large scan root.
 
     A known-large root is one whose unbounded recursive walk is expected to be
-    expensive in time and resources — the user home directory today. The engine
-    gates such a walk behind an explicit bound or confirmation, mirroring the
-    apply lane's "ask before it is expensive" posture, moved earlier because the
-    cost here is time, not data loss. Drive-root reasoning is a separate concern
-    owned elsewhere; a filesystem root is already rejected before this runs.
+    expensive in time and resources. Two cases today: the user home directory,
+    and a whole filesystem/volume root that is a valid non-OS target (a Windows
+    Dev Drive). An OS-managed root is denied upstream before this runs, so any
+    volume root reaching the gate is non-OS; the check here is nonetheless
+    self-contained (is_volume_root and not OS-managed) so the reason is honest
+    even called directly. The engine gates such a walk behind an explicit bound
+    or confirmation, mirroring the apply lane's "ask before it is expensive"
+    posture, moved earlier because the cost here is time, not data loss.
 
     The home match is by filesystem identity (device + inode via
     ``os.path.samefile``), not a path-string compare: ``os.path.normcase`` only
@@ -561,6 +647,8 @@ def large_scan_reasons(target: Path) -> list[str]:
     (``/users/alice`` vs ``/Users/alice``) bypass the gate on a case-insensitive
     macOS volume. ``target`` is validated to exist upstream; ``samefile`` raises
     only when a path is missing, so a home that cannot be stat'd is simply no match.
+    The volume-root match is structural (``is_volume_root``: a self-parent path),
+    inherently spelling- and case-robust.
     """
     reasons: list[str] = []
     home = user_home()
@@ -571,6 +659,8 @@ def large_scan_reasons(target: Path) -> list[str]:
             same_home = False
         if same_home:
             reasons.append("user-home")
+    if is_volume_root(target) and not is_os_managed_target(target):
+        reasons.append("non-os-volume-root")
     return sorted(set(reasons))
 
 
@@ -1167,13 +1257,11 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
     target = target_input.resolve(strict=True)
     known_mounts, mount_error = linux_mount_points()
     target_mounted, target_mount_error = mount_state(target, known_mounts)
-    if target.parent == target or any(
-        is_within(target, root.absolute()) for root in system_roots()
-    ):
-        raise HygieneError("snapshot target is now a filesystem or OS-managed root")
     if mount_error or target_mount_error:
         raise HygieneError("snapshot target mount state is unverified")
-    if target_mounted:
+    if is_os_managed_target(target):
+        raise HygieneError("snapshot target is now an OS-managed root")
+    if target_mounted and not is_volume_root(target):
         raise HygieneError("snapshot target is a mount point")
     if has_protected_path_component(target, baseline_exact_names):
         raise HygieneError(
@@ -1590,14 +1678,10 @@ def main(argv: list[str] | None = None) -> int:
             mounted, target_mount_error = mount_state(target, known_mounts)
             if mount_error or target_mount_error:
                 raise HygieneError("target mount state is unverified")
-            if mounted:
+            if is_os_managed_target(target):
+                raise HygieneError("OS-managed roots are not valid audit targets")
+            if mounted and not is_volume_root(target):
                 raise HygieneError("mount points are not valid audit targets")
-            if target.parent == target or any(
-                is_within(target, root.absolute()) for root in system_roots()
-            ):
-                raise HygieneError(
-                    "filesystem and OS-managed roots are not valid audit targets"
-                )
             policy = load_policy(
                 Path(args.policy).expanduser().absolute() if args.policy else None,
                 Path(args.project_dir).expanduser().absolute()

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -345,9 +345,17 @@ def hard_protection(
         if mount_error:
             reasons.append("mount-state-unverified")
         elif mounted:
-            reasons.append(
-                "target-is-mount-point" if current == target else "nested-mount-point"
-            )
+            if current != target:
+                reasons.append("nested-mount-point")
+            elif not is_volume_root(target):
+                # A volume-root target is inherently a mount point and is
+                # admitted as such by the reasoned target-level checks; flagging
+                # it here would mark every descendant target-is-mount-point and
+                # defeat the admitted scan. A non-volume-root target that is a
+                # mount is still blocked (it should never have been admitted, or
+                # became a mount after the snapshot). Nested mounts below the
+                # target stay blocked regardless.
+                reasons.append("target-is-mount-point")
         if current == target:
             break
         if has_protected_name(current, exact_names):

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -162,6 +162,85 @@ class HygieneTests(unittest.TestCase):
         self.assertIn("d:/system volume information", roots)
         self.assertIn("d:/$recycle.bin", roots)
 
+    def test_os_drive_markers_exclude_per_volume_metadata(self) -> None:
+        markers = {
+            str(path).replace("\\", "/").casefold()
+            for path in hygiene.os_drive_markers(
+                platform_key="windows", windows_roots=[Path("C:/"), Path("D:/")]
+            )
+        }
+        # OS-install markers stay; the per-volume metadata every Windows volume
+        # carries — a provisioned non-OS Dev Drive included — must NOT count as
+        # an OS-drive signal, or every drive root would classify OS-managed.
+        self.assertIn("d:/windows", markers)
+        self.assertIn("d:/programdata", markers)
+        self.assertNotIn("d:/system volume information", markers)
+        self.assertNotIn("d:/$recycle.bin", markers)
+
+    def test_os_managed_target_flags_drive_holding_os_install(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            drive = Path(temporary) / "drive"
+            (drive / "Windows").mkdir(parents=True)
+            self.assertTrue(
+                hygiene.is_os_managed_target(
+                    drive, roots=[], markers=[drive / "Windows"]
+                )
+            )
+
+    def test_os_managed_target_ignores_per_volume_metadata_only(self) -> None:
+        # The Dev Drive case: a volume root whose only system-looking folders
+        # are the per-volume metadata every volume carries is NOT OS-managed —
+        # the synthesized OS-install marker does not exist on it.
+        with tempfile.TemporaryDirectory() as temporary:
+            drive = Path(temporary) / "dev-drive"
+            (drive / "System Volume Information").mkdir(parents=True)
+            (drive / "$Recycle.Bin").mkdir()
+            self.assertFalse(
+                hygiene.is_os_managed_target(
+                    drive,
+                    roots=[],
+                    markers=[drive / name for name in ("Windows", "ProgramData")],
+                )
+            )
+
+    def test_os_managed_target_flags_path_within_a_system_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "sysroot"
+            inside = root / "sub"
+            inside.mkdir(parents=True)
+            self.assertTrue(
+                hygiene.is_os_managed_target(inside, roots=[root], markers=[])
+            )
+
+    def test_hard_protection_names_the_target_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "target"
+            target.mkdir()
+            self.assertIn(
+                "target-root", hygiene.hard_protection(target, target, set())
+            )
+
+    def test_hard_protection_reasons_about_volume_root_purpose(self) -> None:
+        # The cited hard_protection branch is now reasoned, not structural: a
+        # volume-root path is flagged os-managed only when reasoned OS-managed.
+        # No live call path reaches it with a root-shaped entry, so exercise it
+        # directly to lock the intent.
+        path, target = Path("X:/"), Path("Y:/")
+        with (
+            mock.patch.object(hygiene, "is_volume_root", return_value=True),
+            mock.patch.object(hygiene, "is_os_managed_target", return_value=True),
+        ):
+            self.assertIn(
+                "os-managed-root", hygiene.hard_protection(path, target, set())
+            )
+        with (
+            mock.patch.object(hygiene, "is_volume_root", return_value=True),
+            mock.patch.object(hygiene, "is_os_managed_target", return_value=False),
+        ):
+            self.assertNotIn(
+                "os-managed-root", hygiene.hard_protection(path, target, set())
+            )
+
     @unittest.skipUnless(
         hygiene.os_key() == "linux", "real mountinfo is available only on Linux"
     )
@@ -304,6 +383,179 @@ class HygieneTests(unittest.TestCase):
             self.assertEqual(2, code)
             self.assertIn("protected shell-folder", output.getvalue())
             self.assertFalse((data_root / "snapshot.json").exists())
+
+    def _scan_target(
+        self,
+        target: Path,
+        data_root: Path,
+        patches: list[object],
+        extra_args: list[str] | None = None,
+    ) -> tuple[int, dict[str, object]]:
+        output = io.StringIO()
+        with (
+            mock.patch.dict(
+                "os.environ", {"CLAUDE_PLUGIN_DATA": str(data_root)}, clear=False
+            ),
+            redirect_stdout(output),
+        ):
+            for patch in patches:
+                self.enterContext(patch)
+            code = hygiene.main(
+                [
+                    "scan",
+                    "--target",
+                    str(target),
+                    "--output",
+                    str(data_root / "snapshot.json"),
+                    *(extra_args or []),
+                ]
+            )
+        return code, json.loads(output.getvalue())
+
+    def _non_os_volume_root_patches(self) -> list[object]:
+        # A drive-letter root is always os.path.ismount True; it holds no
+        # OS-managed content (a Windows Dev Drive), so it is a valid non-OS
+        # volume root rather than a rejected OS root.
+        return [
+            mock.patch.object(hygiene, "is_volume_root", return_value=True),
+            mock.patch.object(hygiene, "is_os_managed_target", return_value=False),
+            mock.patch.object(hygiene, "mount_state", return_value=(True, None)),
+        ]
+
+    def test_non_os_volume_root_without_bound_requires_large_confirmation(self) -> None:
+        # A non-OS volume root is no longer blanket-rejected, but an unbounded
+        # whole-volume walk is gated the same way a home target is (#985's
+        # large-target gate) rather than silently proceeding.
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "dev-drive"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            (target / "scratch.tmp").write_text("x", encoding="utf-8")
+            data_root.mkdir()
+            code, payload = self._scan_target(
+                target, data_root, self._non_os_volume_root_patches()
+            )
+            self.assertEqual(5, code)
+            self.assertEqual("large-target-confirmation-required", payload["status"])
+            self.assertIn("non-os-volume-root", payload["large_target_reasons"])
+            self.assertFalse((data_root / "snapshot.json").exists())
+
+    def test_non_os_volume_root_with_confirmed_flag_scans(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "dev-drive"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            (target / "scratch.tmp").write_text("x", encoding="utf-8")
+            data_root.mkdir()
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                self._non_os_volume_root_patches(),
+                extra_args=["--confirmed-large-scan"],
+            )
+            self.assertEqual(0, code)
+            self.assertEqual("scan-complete", payload["status"])
+            self.assertTrue((data_root / "snapshot.json").exists())
+
+    def test_large_scan_reasons_flags_non_os_volume_root(self) -> None:
+        with (
+            mock.patch.object(hygiene, "is_volume_root", return_value=True),
+            mock.patch.object(hygiene, "is_os_managed_target", return_value=False),
+        ):
+            self.assertEqual(
+                ["non-os-volume-root"], hygiene.large_scan_reasons(Path("X:/"))
+            )
+        # An OS-managed volume root never reaches the gate (denied upstream), and
+        # even called directly it is not named a large target here.
+        with (
+            mock.patch.object(hygiene, "is_volume_root", return_value=True),
+            mock.patch.object(hygiene, "is_os_managed_target", return_value=True),
+        ):
+            self.assertEqual([], hygiene.large_scan_reasons(Path("X:/")))
+
+    def test_scan_denies_os_managed_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "os-root"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                [mock.patch.object(hygiene, "is_os_managed_target", return_value=True)],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("OS-managed roots", payload["error"])
+            self.assertFalse((data_root / "snapshot.json").exists())
+
+    def test_scan_rejects_non_root_mount_point(self) -> None:
+        # A mount point that is not a volume root (a nested or bind mount as the
+        # target) stays hard-blocked — the real cross-boundary danger, unchanged.
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            target = base / "mounted"
+            data_root = base / "plugin-data"
+            target.mkdir()
+            data_root.mkdir()
+            code, payload = self._scan_target(
+                target,
+                data_root,
+                [
+                    mock.patch.object(
+                        hygiene, "is_os_managed_target", return_value=False
+                    ),
+                    mock.patch.object(hygiene, "is_volume_root", return_value=False),
+                    mock.patch.object(
+                        hygiene, "mount_state", return_value=(True, None)
+                    ),
+                ],
+            )
+            self.assertEqual(2, code)
+            self.assertIn("mount points are not valid audit targets", payload["error"])
+            self.assertFalse((data_root / "snapshot.json").exists())
+
+    def test_preview_denies_os_managed_root_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("x", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            with mock.patch.object(hygiene, "is_os_managed_target", return_value=True):
+                with self.assertRaisesRegex(hygiene.HygieneError, "OS-managed root"):
+                    hygiene.preview(snapshot, plan)
+
+    def test_preview_allows_non_os_volume_root_snapshot(self) -> None:
+        # Symmetry with scan: a non-OS volume-root snapshot reaches candidate
+        # evaluation instead of a target-level root/mount veto (the confirmation
+        # gate lived at scan; preview must not re-reject the same root).
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("x", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            with (
+                mock.patch.object(hygiene, "is_volume_root", return_value=True),
+                mock.patch.object(hygiene, "is_os_managed_target", return_value=False),
+                mock.patch.object(hygiene, "mount_state", return_value=(True, None)),
+            ):
+                result = hygiene.preview(snapshot, plan)
+            self.assertEqual("high", result["tier"])
+            self.assertEqual(
+                ["orphan.tmp"], [item["path"] for item in result["candidates"]]
+            )
 
     @unittest.skipUnless(
         shutil.which("git"), "git is required for the VCS regression fixture"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -242,6 +242,36 @@ class HygieneTests(unittest.TestCase):
                 "os-managed-root", hygiene.hard_protection(path, target, set())
             )
 
+    def test_hard_protection_exempts_admitted_volume_root_from_mount_reason(
+        self,
+    ) -> None:
+        # Regression: a descendant of an admitted non-OS volume-root target must
+        # not inherit target-is-mount-point from the ancestor walk reaching the
+        # (mounted) volume root — that blanket-protected every entry and defeated
+        # the admitted scan. A nested mount below the target stays blocked.
+        target, child, nested = Path("X:/"), Path("X:/scratch"), Path("X:/mnt")
+        with (
+            mock.patch.object(
+                hygiene, "is_volume_root", side_effect=lambda p: p == target
+            ),
+            mock.patch.object(hygiene, "is_linkish", return_value=False),
+        ):
+            with mock.patch.object(
+                hygiene, "mount_state", side_effect=lambda p, *a: (p == target, None)
+            ):
+                child_reasons = hygiene.hard_protection(child, target, set())
+            self.assertNotIn("target-is-mount-point", child_reasons)
+            self.assertNotIn("nested-mount-point", child_reasons)
+
+            with mock.patch.object(
+                hygiene,
+                "mount_state",
+                side_effect=lambda p, *a: (p in {target, nested}, None),
+            ):
+                nested_reasons = hygiene.hard_protection(nested, target, set())
+            self.assertIn("nested-mount-point", nested_reasons)
+            self.assertNotIn("target-is-mount-point", nested_reasons)
+
     @unittest.skipUnless(
         hygiene.os_key() == "linux", "real mountinfo is available only on Linux"
     )


### PR DESCRIPTION
## Summary

`disk-hygiene`'s `clean` skill rejected **any** filesystem/volume root as an audit target purely
structurally, with no reasoning about the volume's purpose. This wrongly blocked a legitimate non-OS
volume such as a Windows **Dev Drive** (`D:\`, ReFS, no OS content) with no path to override,
interrogate, or explain. Root classification is now **reasoned**: a genuine OS-managed root stays
denied; a non-OS volume root becomes a valid target that composes with the large-target scan gate.

Fixes #984

## Root cause (corrected from the issue's premise)

The issue cited `hard_protection()` (the `path.parent == path` branch) as the blanket rejection.
Empirically, that branch is **dead code for drive roots** in the live call graph — candidates are
validated non-root descendants of the target, so it never fires on a drive root. The real
user-facing block on Windows was the **mount-point check** in `main()` scan: every Windows drive
letter is `os.path.ismount() == True`, so `D:\` was rejected as a "mount point" *before* the
root check the issue points at (verified live: `os.path.ismount('D:/') == True`; scanning `D:\`
returned `{"error": "mount points are not valid audit targets"}`). Fixing only the cited line would
have left the bug unfixed. `preview()` applied the same checks in a different order, a latent
inconsistency.

## Fix

- **Reasoned OS-managed classification** (`is_os_managed_target`): a root is denied when it is *within*
  an OS-managed root (full `system_roots()` set) or *holds an existing* OS-install marker
  (`os_drive_markers`). The OS-install markers deliberately **exclude the per-volume metadata every
  Windows volume carries** (`System Volume Information`, `$Recycle.Bin`) — a Dev Drive has those too,
  so counting them would misclassify every drive root as OS-managed. `WINDOWS_VOLUME_SYSTEM_NAMES` is
  split into `WINDOWS_OS_DRIVE_MARKERS` ∪ `WINDOWS_PER_VOLUME_METADATA`; the union is unchanged, so
  per-entry protection of those folders on every drive is preserved.
- **Mount rejection scoped to non-root mounts** (`mounted and not is_volume_root(target)`): a
  volume-root target (inherently a mount point) falls through to the reasoned root logic; nested and
  bind mounts stay hard-blocked — the real cross-boundary danger.
- **Scan and preview unified** to one `unverified → OS-managed → non-root-mount` target-check order,
  removing the latent ordering inconsistency.
- **Composes with the large-target gate (#985 / #1010), reusing its vocabulary — no parallel gate.**
  `large_scan_reasons` now names a non-OS volume root a known-large root (reason
  `non-os-volume-root`), so an unbounded whole-volume walk returns `large-target-confirmation-required`
  (exit 5) unless bounded with `--max-depth` or confirmed with `--confirmed-large-scan`. No
  `destructive_guard` change is needed — #1010 already permits that flag.
- `hard_protection`'s (dead-for-drive-roots) branch is made reasoned rather than blanket, for
  faithfulness, and locked with a direct unit test.

Deletion safety is unchanged: per-entry OS-managed / mount / VCS / identity protections, the preview,
and per-tier approval all still gate any removal. The design **degrades safely** — if OS-drive
markers were somehow absent on a real OS drive, the result is confirmation-required plus full
downstream gating, never a silent dangerous delete. A stray non-OS `D:\Windows` folder classifies the
volume as OS-managed (conservative false-positive deny), which is acceptable.

## Test evidence

- `test_hygiene.py`: **101 tests pass** (added classification, `os_drive_markers` metadata-exclusion,
  `hard_protection` reasoning, non-root-mount rejection, OS-managed deny in scan+preview, and
  non-OS-volume-root large-target-gate tests; existing `system_roots` protection test stays green).
- `ruff check` clean; `python -m py_compile` clean.
- Repo gates green: `check-changelog-parity --check-bump`, `check-changed-skills` (skill-quality
  static contract — 0 errors), `validate-plugins` (manifests + catalog), `check-orphaned-fixtures`.
- **Live verification on the audited machine**: `C:\` → denied (`OS-managed roots are not valid audit
  targets`); `D:\` (Dev Drive) with no bound → `large-target-confirmation-required` (reason
  `non-os-volume-root`); `D:\ --max-depth 1 --confirmed-large-scan` → `scan-complete`.

## Independent review

Reviewed by a fresh-context reviewer (rationale withheld, adversarial). Verdict: **classification core
sound** — every branch hand-traced, the pathlib root-identity edge verified empirically, no path where
an OS drive slips through as non-OS or a Dev Drive is wrongly denied, and no deletion-safety
regression. No code changes required. Three low-confidence advisories, noted for transparency (no
action taken):

1. `hard_protection`'s volume-root branch is unreachable on the live call path (candidates are
   validated non-root descendants) — kept as defense-in-depth and locked by a direct unit test.
2. `system_roots()` and `os_drive_markers()` each call `windows_drive_roots()`, so a scan makes a
   couple of redundant `GetLogicalDrives` syscalls per invocation — negligible, not hot-path.
3. Known limitation: a stray `Recovery` (or other OS-install-marker-named) folder on a non-boot drive
   would classify that volume as OS-managed. This fails safe (over-restrictive deny, never an unsafe
   allow) and is the conservative side to err on.

## Fresh-docs note

Per the repo's fresh-docs mandate: this change is Python engine logic that reuses existing status
vocabulary and adds no new plugin component type, manifest field, hook, or skill surface — no official
Claude Code plugin-schema page is load-bearing here, so none is cited. The only external behavior
reused (`--confirmed-large-scan`, `large-target-confirmation-required`) is this plugin's own #1010
contract, referenced directly.

## Related

- #983, #985, #986 — sibling issues from the same disk-hygiene audit, addressed in parallel PRs.
- #985 (PR #1010) — the companion large-target scan gate; this PR builds on its
  `large_scan_reasons` / `--confirmed-large-scan` mechanism rather than adding a parallel gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFq1q99cNeZjKhDzHv2BQw
