### PR TITLE
refactor(disk-hygiene): derive the Python version floor from one origin

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.1]
+
+### Changed
+
+- **The Python version floor now has one origin.** The "3.11+" floor was hand-maintained in at
+  least five places — `hygiene.py`'s runtime check (the real enforcement), both `.test.sh`
+  wrappers, both SKILL.md files, and the README — while the setup skill told itself to "probe
+  what they actually require, don't recite this file"; a future bump would drift the copies
+  silently. The floor is now the module-level `MIN_PYTHON` constant in `hygiene.py`: the runtime
+  check and its error message derive from it, a regression test locks the constant's greppable
+  line shape and proves enforcement uses it, both test wrappers parse it instead of restating
+  the number (failing loudly if the parse breaks), `setup check` step 1 derives the probed floor
+  from the constant, and the remaining prose mentions are annotated as pointers or convenience
+  copies of that origin.
+
 ## [0.6.0]
 
 ### Added

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -45,9 +45,11 @@ at preview. Backups remain the recovery boundary for user data.
 ## Requirements and platform support
 
 - Python 3.11+ available on `PATH` is required for scanning, validation, the skill-scoped guard, and
-  cleanup. Claude Code launches the guard in shell-free exec form; guarded engine calls must use the
-  same absolute interpreter reported by that guard, so Bash aliases and functions cannot replace it.
-  The plugin never downloads a runtime.
+  cleanup (the floor's single origin is the `MIN_PYTHON` constant in
+  `skills/clean/scripts/hygiene.py`; `/disk-hygiene:setup check` derives the enforced value from
+  there, so treat the number printed here as a convenience copy). Claude Code launches the guard in
+  shell-free exec form; guarded engine calls must use the same absolute interpreter reported by that
+  guard, so Bash aliases and functions cannot replace it. The plugin never downloads a runtime.
 - Git is optional for ordinary trees. If a target contains or sits inside a Git worktree, Git becomes
   required so tracked content can be proven safe; otherwise cleanup for that subtree is blocked.
 - Windows uses Python 3.11's `lstat` reparse metadata plus Win32 APIs exposed by the OS. It never

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -54,7 +54,8 @@ directory, symlink, or Windows reparse point.
   replace them. If either value is not known yet, submit the otherwise exact scan shape once with
   bare `python`: the guard must deny it and report both, after which retry the scan with the
   absolute interpreter and the reported `--data-root`. If the reported interpreter is older than
-  Python 3.11, stop with the declared prerequisite instead of improvising a different scanner or
+  the engine's declared floor (the `MIN_PYTHON` constant in `hygiene.py`, the floor's single
+  origin), stop with the declared prerequisite instead of improvising a different scanner or
   deletion path.
 - Automated, scheduled, remote, unattended, or no-human-in-loop sessions always audit and stop.
 
@@ -250,7 +251,8 @@ sparse files, hard links, compression, and delayed allocation affect it.
 - The guard hook launches in exec form via `python3`, resolved on `PATH` with no shell (`python3`,
   not bare `python`, because stock macOS and many Linux distros ship only `python3` and a legacy
   `python` 2.x would crash the guard on modern syntax). Enforcement is therefore only as strong as
-  that resolution: on a host where `python3` does not resolve to a 3.11+ interpreter the PreToolUse
+  that resolution: on a host where `python3` does not resolve to an interpreter meeting the
+  engine's `MIN_PYTHON` floor the PreToolUse
   launch fails, and Claude Code treats a failed hook launch as a non-blocking error, so the guard
   does not intercept there. Concretely, the exposure is the manual PowerShell deletion lane: engine
   `apply` is unsupported on Windows and macOS and elsewhere runs only behind the guard's own `ask`,

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -20,6 +20,7 @@ import tempfile
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+MIN_PYTHON = (3, 11)
 SCHEMA_VERSION = 1
 MAX_SNAPSHOT_ENTRIES = 250_000
 TIERS = {"high", "medium", "low"}
@@ -1573,8 +1574,9 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     DATA_ROOT_OVERRIDE = args.data_root
     try:
-        if sys.version_info < (3, 11):
-            raise HygieneError("disk-hygiene requires Python 3.11 or newer")
+        if sys.version_info < MIN_PYTHON:
+            floor = ".".join(str(part) for part in MIN_PYTHON)
+            raise HygieneError(f"disk-hygiene requires Python {floor} or newer")
         if args.command == "scan":
             target_input = Path(args.target).expanduser().absolute()
             if (

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.test.sh
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.test.sh
@@ -4,17 +4,25 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# The Python floor has one origin: MIN_PYTHON in hygiene.py. Parse it rather
+# than restating the number here.
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$SCRIPT_DIR/hygiene.py")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from hygiene.py" >&2
+  exit 1
+fi
+
 if command -v python >/dev/null 2>&1; then
   PYTHON=python
 elif command -v python3 >/dev/null 2>&1; then
   PYTHON=python3
 else
-  echo "SKIP: Python 3.11+ not found" >&2
+  echo "SKIP: Python ${FLOOR}+ not found" >&2
   exit 0
 fi
 
-"$PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' || {
-  echo "SKIP: Python 3.11+ required" >&2
+"$PYTHON" -c "import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)" || {
+  echo "SKIP: Python ${FLOOR}+ required" >&2
   exit 0
 }
 "$PYTHON" -m unittest -v "$SCRIPT_DIR/test_hygiene.py"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -7,6 +7,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -1018,6 +1019,45 @@ class HygieneTests(unittest.TestCase):
             mock.patch("os.path.samefile", side_effect=FileNotFoundError),
         ):
             self.assertEqual([], hygiene.large_scan_reasons(Path("/home/target")))
+
+
+class VersionFloorTests(unittest.TestCase):
+    """The Python floor has one origin: hygiene.MIN_PYTHON."""
+
+    def test_min_python_line_keeps_its_greppable_shape(self) -> None:
+        # setup check and the .test.sh wrappers derive the floor by parsing
+        # this exact line shape out of hygiene.py.
+        source = (SCRIPT_DIR / "hygiene.py").read_text(encoding="utf-8")
+        matches = re.findall(
+            r"^MIN_PYTHON = \((\d+), (\d+)\)$", source, flags=re.MULTILINE
+        )
+        self.assertEqual(1, len(matches))
+        self.assertEqual(tuple(map(int, matches[0])), hygiene.MIN_PYTHON)
+
+    def test_engine_enforces_the_constant_and_names_it_in_the_error(self) -> None:
+        below = (hygiene.MIN_PYTHON[0], hygiene.MIN_PYTHON[1] - 1, 0)
+        with (
+            mock.patch.object(hygiene.sys, "version_info", below),
+            redirect_stdout(io.StringIO()),
+        ):
+            code = hygiene.main(
+                ["scan", "--target", "irrelevant", "--output", "irrelevant"]
+            )
+        self.assertNotEqual(0, code)
+
+    def test_error_message_derives_from_the_constant(self) -> None:
+        floor = ".".join(str(part) for part in hygiene.MIN_PYTHON)
+        below = (hygiene.MIN_PYTHON[0], hygiene.MIN_PYTHON[1] - 1, 0)
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(hygiene.sys, "version_info", below),
+            redirect_stdout(stdout),
+        ):
+            hygiene.main(
+                ["scan", "--target", "irrelevant", "--output", "irrelevant"]
+            )
+        payload = json.loads(stdout.getvalue())
+        self.assertIn(floor, payload["error"])
 
 
 class StandingPolicyTests(unittest.TestCase):

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -27,11 +27,14 @@ When the plugin's toggle is disabled, every prerequisite absence downgrades from
 INFO — a deliberately disabled plugin is not broken. Report the probes informationally and
 note that re-enabling restores the FAIL semantics.
 
-1. **Python 3.11+ on `PATH`** — the interpreter used by scanning, validation, the
-   skill-scoped guard, and cleanup. FAIL if absent or older, with the README's requirement
-   as the remediation; the plugin never downloads a runtime. Report the absolute
-   interpreter path (guarded engine calls must use the same absolute interpreter the guard
-   reports — Bash aliases and functions cannot substitute).
+1. **Python floor on `PATH`** — the interpreter used by scanning, validation, the
+   skill-scoped guard, and cleanup. The required version has one origin: the `MIN_PYTHON`
+   constant in `${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py` — parse it from
+   there (`grep -m1 '^MIN_PYTHON' …`) and probe the interpreter against that value; do not
+   recite a version number from this file or the README. FAIL if absent or older, naming
+   the parsed floor in the remediation; the plugin never downloads a runtime. Report the
+   absolute interpreter path (guarded engine calls must use the same absolute interpreter
+   the guard reports — Bash aliases and functions cannot substitute).
 2. **Git** — `command -v git`. Conditional per the README: optional for ordinary trees,
    required when a target contains or sits inside a Git worktree. Report presence as INFO
    with that conditionality stated; absence is only a FAIL for worktree-containing targets.
@@ -59,8 +62,8 @@ note that re-enabling restores the FAIL semantics.
 Run `check`, then for each FAIL point at the resolution. Every prerequisite is a system
 tool or an OS capability, so `apply` installs nothing and writes nothing — it only points:
 
-- missing/old Python: the platform's own Python 3.11+ install channel; never a plugin
-  download.
+- missing/old Python: the platform's own install channel for the floor `check` parsed from
+  the engine's `MIN_PYTHON`; never a plugin download.
 - missing git (worktree targets): platform install instructions.
 - toggle off: direct to `/plugin configure disk-hygiene` (interactive, any time).
   Headless: `--config` only applies on a fresh install (ignored once installed), so

--- a/plugins/disk-hygiene/skills/setup/scripts/kill_switch_probe.test.sh
+++ b/plugins/disk-hygiene/skills/setup/scripts/kill_switch_probe.test.sh
@@ -4,17 +4,26 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# The Python floor has one origin: MIN_PYTHON in the clean engine. Parse it
+# rather than restating the number here.
+ENGINE="$SCRIPT_DIR/../../clean/scripts/hygiene.py"
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$ENGINE")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from $ENGINE" >&2
+  exit 1
+fi
+
 if command -v python >/dev/null 2>&1; then
   PYTHON=python
 elif command -v python3 >/dev/null 2>&1; then
   PYTHON=python3
 else
-  echo "SKIP: Python 3.11+ not found" >&2
+  echo "SKIP: Python ${FLOOR}+ not found" >&2
   exit 0
 fi
 
-"$PYTHON" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' || {
-  echo "SKIP: Python 3.11+ required" >&2
+"$PYTHON" -c "import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)" || {
+  echo "SKIP: Python ${FLOOR}+ required" >&2
   exit 0
 }
 "$PYTHON" -m unittest -v "$SCRIPT_DIR/test_kill_switch_probe.py"


### PR DESCRIPTION
## Summary

Fixes finding 3 (SSOT drift) from handoff-inbox item `20260722-004536-disk-hygiene-setup-audit`: the "Python 3.11+" floor was hand-maintained in ≥5 places — `hygiene.py`'s `sys.version_info < (3, 11)` runtime check (the real enforcement), both `.test.sh` wrappers, `setup/SKILL.md` (twice), `clean/SKILL.md`, and the README — while the setup skill told itself "probe what they actually require, don't recite this file". A future floor bump would drift the copies silently.

- `hygiene.py` gains a module-level `MIN_PYTHON = (3, 11)` constant; the runtime check and its error message derive from it.
- New `VersionFloorTests` lock the constant's greppable line shape (`^MIN_PYTHON = (\d+, \d+)$`) and prove enforcement + error text use it (red-first).
- Both `.test.sh` wrappers parse the constant via `sed` instead of restating the number, and fail loudly if the parse breaks.
- `setup check` step 1 now derives the probed floor from the constant; `apply` guidance points at the parsed floor.
- Remaining prose (`clean/SKILL.md` gotchas, README requirements) reworded to pointers or explicitly-annotated convenience copies. API-fact mentions of Python 3.11 (e.g. "3.11 has no `os.path.isjunction`") are left alone — they are not floor copies.
- Version 0.6.0 → 0.6.1 + CHANGELOG.

## Testing

- `test_hygiene.py`: 95 tests OK (4 platform skips), including the 3 new floor tests.
- Both wrappers run green with the parsed floor; parse-failure path exits 1 with a named FAIL.
- `check-changed-skills.sh` PASS, `check-changelog-parity.sh --check-bump` PASS, shellcheck clean on both wrappers.

## Related

- Closes #1008
- Handoff-inbox item: `20260722-004536-disk-hygiene-setup-audit` (F3, MED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)