### PR TITLE
docs(disk-hygiene): split Windows audit/execution lanes, scope the guard wording, fix stale no-userConfig claim

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.2]
+
+### Fixed
+
+- **Windows platform posture no longer reads as if the engine deletes there.** `setup check`'s
+  platform-posture step said "Windows (full, `lstat` reparse + Win32, never UAC)", but "full"
+  described only the audit lane — `clean`'s preview returns `execution-platform-unsupported` on
+  Windows and removal is a manual Recycle-Bin handoff. The posture line (and the README's Windows
+  bullet) now keeps the lanes visibly separate: full **audit**; engine **execution unsupported**;
+  manual, per-path Recycle-Bin handoff after explicit approval. macOS gains the matching manual
+  Trash note.
+- **"Skill-scoped guard" wording now says what the scope means.** The `destructive_guard.py`
+  PreToolUse hook is registered in the `clean` skill's frontmatter and fires only within that
+  skill's context; setup's own probes and any direct `hygiene.py` invocation rely on the engine's
+  built-in containment, not the hook. One clause in `setup check` step 1 and the README
+  requirements bullet now states this instead of implying always-on protection.
+- **The security review's Configuration bullet no longer claims "no `userConfig`".** That claim
+  has been stale since 0.3.0 introduced the `disk_hygiene_enabled` toggle; the bullet now
+  describes the actual surface (one non-sensitive boolean that can only narrow the destructive
+  surface) with the review conclusion unchanged.
+
 ## [0.6.1]
 
 ### Changed

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -136,8 +136,11 @@ hand-cleaning the zone.
   quoted CLI arguments.
 - **MCP / external trust:** no MCP server, agent, dependency, or third-party service is shipped.
 - **Configuration:** one non-sensitive `userConfig` boolean (`disk_hygiene_enabled`, default
-  `true`) gating the execution tiers — setting it `false` is audit-only mode; it can only narrow
-  the destructive surface, never widen it. No credentials. Policy comes from an explicit invocation
+  `true`) gating the execution tiers — setting it `false` puts `/disk-hygiene:clean` in audit-only
+  mode (enforced by the skill-scoped guard, which denies every deletion lane there; a direct
+  `hygiene.py` invocation outside that skill does not read the toggle and answers only to the
+  engine's own preview/approval-token gate). The toggle can only narrow the destructive surface,
+  never widen it. No credentials. Policy comes from an explicit invocation
   argument or standing `disk-hygiene.json` files under `~/.claude/` and the consumer project's
   `.claude/`. All policy input is pattern-only and additive: it can add protections and discovery
   hints or disable hints, and cannot weaken hard guards or authorize removal, so ambient config

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -49,11 +49,16 @@ at preview. Backups remain the recovery boundary for user data.
   `skills/clean/scripts/hygiene.py`; `/disk-hygiene:setup check` derives the enforced value from
   there, so treat the number printed here as a convenience copy). Claude Code launches the guard in
   shell-free exec form; guarded engine calls must use the same absolute interpreter reported by that
-  guard, so Bash aliases and functions cannot replace it. The plugin never downloads a runtime.
+  guard, so Bash aliases and functions cannot replace it. The guard is skill-scoped — it fires only
+  within the `clean` skill's context, so driving `hygiene.py` directly outside that skill relies on
+  the engine's built-in containment and preview gate, not the hook. The plugin never downloads a
+  runtime.
 - Git is optional for ordinary trees. If a target contains or sits inside a Git worktree, Git becomes
   required so tracked content can be proven safe; otherwise cleanup for that subtree is blocked.
-- Windows uses Python 3.11's `lstat` reparse metadata plus Win32 APIs exposed by the OS. It never
-  invokes UAC and never enters the execution lane.
+- Windows has the full **audit** lane (Python 3.11's `lstat` reparse metadata plus Win32 APIs
+  exposed by the OS; never invokes UAC) but engine **execution is unsupported**: `preview` returns
+  `execution-platform-unsupported`, and removal is a manual, per-path Recycle-Bin handoff after
+  explicit approval.
 - Linux requires readable `/proc/self/mountinfo`, descriptor-relative filesystem APIs, and `lsof` for
   the optional execution lane. Absence, diagnostics, or authority gaps block cleanup.
 - macOS supports audit/report only because this implementation has no authoritative bind-mount and
@@ -130,7 +135,9 @@ hand-cleaning the zone.
   construction, or downloads are used. Paths cross the process boundary as JSON or individually
   quoted CLI arguments.
 - **MCP / external trust:** no MCP server, agent, dependency, or third-party service is shipped.
-- **Configuration:** no `userConfig` and no credentials. Policy comes from an explicit invocation
+- **Configuration:** one non-sensitive `userConfig` boolean (`disk_hygiene_enabled`, default
+  `true`) gating the execution tiers — setting it `false` is audit-only mode; it can only narrow
+  the destructive surface, never widen it. No credentials. Policy comes from an explicit invocation
   argument or standing `disk-hygiene.json` files under `~/.claude/` and the consumer project's
   `.claude/`. All policy input is pattern-only and additive: it can add protections and discovery
   hints or disable hints, and cannot weaken hard guards or authorize removal, so ambient config

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -28,7 +28,10 @@ INFO — a deliberately disabled plugin is not broken. Report the probes informa
 note that re-enabling restores the FAIL semantics.
 
 1. **Python floor on `PATH`** — the interpreter used by scanning, validation, the
-   skill-scoped guard, and cleanup. The required version has one origin: the `MIN_PYTHON`
+   skill-scoped guard, and cleanup. (The guard is skill-scoped: its PreToolUse hook fires
+   only within the `clean` skill's context, so this skill's own probes — and any direct
+   `hygiene.py` invocation outside `clean` — rely on the engine's built-in containment,
+   not the hook.) The required version has one origin: the `MIN_PYTHON`
    constant in `${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py` — parse it from
    there (`grep -m1 '^MIN_PYTHON' …`) and probe the interpreter against that value; do not
    recite a version number from this file or the README. FAIL if absent or older, naming
@@ -39,10 +42,13 @@ note that re-enabling restores the FAIL semantics.
    required when a target contains or sits inside a Git worktree. Report presence as INFO
    with that conditionality stated; absence is only a FAIL for worktree-containing targets.
 3. **Platform posture** — detect the current OS family and report its documented lane per
-   the README: Windows (full, `lstat` reparse + Win32, never UAC), Linux (full when
-   `/proc/self/mountinfo` is readable; `lsof` needed only for the optional execution
-   lane — absent `lsof` is INFO with the reduced-capability note), macOS (audit/report
-   only by design — INFO, not a defect).
+   the README, keeping the audit and execution lanes visibly separate: Windows (full
+   **audit** — `lstat` reparse + Win32, never UAC; engine **execution unsupported** —
+   `preview` returns `execution-platform-unsupported`, removal is a manual, per-path
+   Recycle-Bin handoff after explicit approval), Linux (full audit; execution when
+   `/proc/self/mountinfo` is readable — `lsof` needed only for that optional execution
+   lane, absent `lsof` is INFO with the reduced-capability note), macOS (audit/report
+   only by design; manual Trash handoff — INFO, not a defect).
 4. **Execution kill switch** — resolve the effective `disk_hygiene_enabled` value
    deterministically; never present an assumed value as the configured one. Run the bundled
    probe with the step-1 interpreter:


### PR DESCRIPTION
## Summary

Fixes findings 2 + 4 (plus one stale claim found while reproducing) from handoff-inbox item `20260722-004536-disk-hygiene-setup-audit` — all declarative wording/accuracy fixes:

- **Windows lanes split** (F2, MED): `setup check`'s platform posture reported "Windows (full, `lstat` reparse + Win32, never UAC)" while `clean`'s preview returns `execution-platform-unsupported` on Windows. The posture line and the README Windows bullet now separate the lanes: full **audit**; engine **execution unsupported**; manual, per-path Recycle-Bin handoff after explicit approval. macOS gains the matching manual-Trash note.
- **Guard scope stated** (F4, LOW): `destructive_guard.py`'s PreToolUse hook is registered in the `clean` skill's frontmatter and fires only within that skill's context. One clause in `setup check` step 1 and the README requirements bullet now says setup's own probes and direct `hygiene.py` invocation rely on the engine's built-in containment, not the hook.
- **Stale security-review claim**: the plugin-acceptance review's Configuration bullet said "no `userConfig`" — false since 0.3.0 introduced `disk_hygiene_enabled`. It now describes the actual surface (one non-sensitive boolean, only able to narrow the destructive surface); review conclusion unchanged.
- Version 0.6.1 → 0.6.2 + CHANGELOG.

## Testing

Docs-only (SKILL.md prose + README + manifest/CHANGELOG). `check-changed-skills.sh` PASS, `check-changelog-parity.sh --check-bump` PASS.

## Related

- Closes #1009
- Handoff-inbox item: `20260722-004536-disk-hygiene-setup-audit` (F2 MED, F4 LOW, + stale README claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)