### PR TITLE
fix(guardrails): hardcoded-path-check skips scanning when no project is active

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Eight safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.1]
+
+### Fixed
+
+- **`hardcoded-path-check` no longer scans when no project is active.** The
+  scope guard previously fell through and scanned unconditionally when
+  `CLAUDE_PROJECT_DIR` was unset — contradicting the README's "only police
+  files under `$CLAUDE_PROJECT_DIR`" contract — and the gitignore escape hatch
+  was gated on the same variable, so in exactly that case the one documented
+  per-file exemption was unreachable (real incident: forced `~/` rewrites onto
+  a machine-local `~/.gitconfig` edited from a no-project session). The hook
+  now skips entirely with no active project: a no-project target is
+  machine-local, not the portable repo artifact this guard protects.
+  Deliberately different from `secret-pattern-detection`, which scans even
+  without a resolvable root — secrets are dangerous anywhere. README "Consumer
+  seams" bullets updated to state the no-project behavior explicitly.
+  (Official hooks reference consulted per the fresh-docs mandate:
+  <https://code.claude.com/docs/en/hooks> — `CLAUDE_PROJECT_DIR` is "the
+  project root", with no guarantee of presence in no-project sessions.)
+
 ## [0.10.0]
 
 ### Added

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -111,12 +111,16 @@ repo-specific policy of their own:
 
 - **Project scoping.** `secret-pattern-detection` and `hardcoded-path-check`
   only police files under `$CLAUDE_PROJECT_DIR`; a write into a sibling repo is
-  that repo's concern. Secret scanning fails **closed** — if the project root
-  cannot be resolved, it scans anyway.
+  that repo's concern. With no active project (`CLAUDE_PROJECT_DIR` unset) the
+  two diverge by threat model: `hardcoded-path-check` skips entirely — a
+  no-project target (a `$HOME` dotfile, say) is machine-local, not a portable
+  repo artifact — while secret scanning fails **closed** and scans anyway
+  (secrets are dangerous anywhere).
 - **Gitignore is the allowlist.** `hardcoded-path-check` skips any file
   `git check-ignore` matches against your `$CLAUDE_PROJECT_DIR` — put
   machine-local files (`settings.local.json`, `.venv/`, …) in your
-  `.gitignore` and they are exempt automatically.
+  `.gitignore` and they are exempt automatically. (Applies within an active
+  project; with none, the hook already skips per the scoping rule above.)
 - **Secret allowlist.** A generic built-in allowlist exempts dependency caches
   (`.venv/`, `node_modules/`), `.env.example` / `.sample` / `.template`
   placeholders, `tests/fixtures` / `tests/testdata` trees, `settings.local.json`,

--- a/plugins/guardrails/hooks/hardcoded-path-check.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.sh
@@ -72,17 +72,21 @@ NORM_FILE="${FILE//\\//}"
 # --- Scope guard: police only files inside THIS project ---
 # A PreToolUse Write|Edit hook fires on every file write regardless of which
 # repo the target lives in. A file outside the project root is not ours to scan
-# — that repo owns its own path policy. Fail OPEN: when CLAUDE_PROJECT_DIR is
-# unset, fall through and scan rather than skip.
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-  _scope_file="$(hook::normalize_path "$FILE")"
-  _scope_project="$(hook::normalize_path "${CLAUDE_PROJECT_DIR}")"
-  _scope_project="${_scope_project%/}"
-  case "$_scope_file" in
-  "$_scope_project"/*) ;; # inside the project — proceed
-  *) exit 0 ;;            # outside the project — not this hook's concern
-  esac
-fi
+# — that repo owns its own path policy. No active project (CLAUDE_PROJECT_DIR
+# unset) → skip entirely: the target is machine-local (a $HOME dotfile, not a
+# portable repo artifact this guard protects), and the gitignore escape hatch
+# below needs a project root, so scanning here would leave no per-file
+# exemption short of the global kill switch. Deliberately different from
+# secret-pattern-detection, which scans even without a resolvable root —
+# secrets are dangerous anywhere; hardcoded paths only harm portable artifacts.
+[[ -n "${CLAUDE_PROJECT_DIR:-}" ]] || exit 0
+_scope_file="$(hook::normalize_path "$FILE")"
+_scope_project="$(hook::normalize_path "${CLAUDE_PROJECT_DIR}")"
+_scope_project="${_scope_project%/}"
+case "$_scope_file" in
+"$_scope_project"/*) ;; # inside the project — proceed
+*) exit 0 ;;            # outside the project — not this hook's concern
+esac
 
 # Skip files that legitimately contain path patterns (regex strings). These
 # cannot rely on the gitignore check below because they are tracked.
@@ -100,8 +104,9 @@ esac
 # Skip gitignored files — designated for machine-specific state (settings.local.json,
 # CLAUDE.local.md, .venv/, node_modules/, etc.). git check-ignore does not require
 # the file to exist on disk, so this works for new Write operations too.
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]] &&
-  git -C "$CLAUDE_PROJECT_DIR" check-ignore -q "$FILE" 2>/dev/null; then
+# CLAUDE_PROJECT_DIR is guaranteed non-empty here — the scope guard above
+# exited on the no-project case.
+if git -C "$CLAUDE_PROJECT_DIR" check-ignore -q "$FILE" 2>/dev/null; then
   exit 0
 fi
 
@@ -118,14 +123,8 @@ esac
 # Resolve current repo root for the machine-specific-path check. Comments are
 # NOT exempt — examples and "do not use" comments still ship as hardcoded paths
 # in fresh clones, get copy-pasted, and rot. Use placeholders in comments too.
-PROJECT_ROOT=""
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-  PROJECT_ROOT=$CLAUDE_PROJECT_DIR
-elif PROJECT_ROOT=$(git -C "$(dirname "$FILE")" rev-parse --show-toplevel 2>/dev/null); then
-  :
-else
-  PROJECT_ROOT=""
-fi
+# The scope guard above guarantees CLAUDE_PROJECT_DIR is set.
+PROJECT_ROOT=$CLAUDE_PROJECT_DIR
 
 # hpp::scan_text's repo-path branch matches PROJECT_ROOT as a
 # literal substring and is never OS-suppressed. That is a valid machine-specific
@@ -151,7 +150,7 @@ if [[ -n "$PROJECT_ROOT" ]]; then
     _tl_norm="${_tl_norm%/}"
     _home_norm="$(hook::normalize_path "${HOME:-${USERPROFILE:-}}")"
     _home_norm="${_home_norm%/}"
-    if [[ -n "$_home_norm" && ( "$_tl_norm" == "$_home_norm" || "$_home_norm" == "$_tl_norm"/* ) ]]; then
+    if [[ -n "$_home_norm" && ("$_tl_norm" == "$_home_norm" || "$_home_norm" == "$_tl_norm"/*) ]]; then
       SCAN_ROOT="" # enclosing checkout is home or an ancestor of home — suppress the branch
     else
       SCAN_ROOT="$PROJECT_ROOT"

--- a/plugins/guardrails/hooks/hardcoded-path-check.test.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.test.sh
@@ -16,7 +16,9 @@ trap 'rm -rf "$TEST_TMPDIR"' EXIT
 # shellcheck source=guardrails-test-helpers.sh
 source "$HOOK_DIR/guardrails-test-helpers.sh"
 
-# Neutralize ambient CLAUDE_PROJECT_DIR so default cases hit the intended path.
+# Neutralize ambient CLAUDE_PROJECT_DIR. Cases that expect scanning set it
+# explicitly — with no active project the hook skips entirely (README
+# "Project scoping": only files under $CLAUDE_PROJECT_DIR are policed).
 unset CLAUDE_PROJECT_DIR
 
 # Runtime-assembled machine paths (no contiguous path literal in source).
@@ -32,27 +34,33 @@ FIXTURE="$TEST_TMPDIR/fixture.txt"
 PS1_FIXTURE="$TEST_TMPDIR/script.ps1"
 
 # ============================ DETECT (exit 2) ================================
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${LINUX_HOME} && ls")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${LINUX_HOME} && ls")" 2>&1)
+RC=$?
 assert_exit "linux home → exit 2" 2 "$RC"
 assert_contains "linux home → message" "$OUT" "Linux user path"
 
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${MAC_HOME} && ls")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${MAC_HOME} && ls")" 2>&1)
+RC=$?
 assert_exit "macos home → exit 2" 2 "$RC"
 assert_contains "macos → message" "$OUT" "macOS user path"
 
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${WIN_HOME} && dir")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${WIN_HOME} && dir")" 2>&1)
+RC=$?
 assert_exit "windows home → exit 2" 2 "$RC"
 assert_contains "windows → message" "$OUT" "Windows user path"
 
 # Cross-OS leak: a Linux path inside a .ps1 still fires (only Windows is suppressed).
-OUT=$(bash "$HOOK" <<<"$(write_json "$PS1_FIXTURE" "Set-Location ${LINUX_HOME}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$PS1_FIXTURE" "Set-Location ${LINUX_HOME}")" 2>&1)
+RC=$?
 assert_exit "Linux leak in .ps1 → exit 2" 2 "$RC"
 assert_contains "cross-OS leak → linux message" "$OUT" "Linux user path"
 
-OUT=$(bash "$HOOK" <<<"$(edit_json "$FIXTURE" "new path ${LINUX_HOME}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(edit_json "$FIXTURE" "new path ${LINUX_HOME}")" 2>&1)
+RC=$?
 assert_exit "Edit new_string → exit 2" 2 "$RC"
 
-OUT=$(bash "$HOOK" <<<"$(notebook_json "$FIXTURE" "cd ${MAC_HOME}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(notebook_json "$FIXTURE" "cd ${MAC_HOME}")" 2>&1)
+RC=$?
 assert_exit "NotebookEdit new_source → exit 2" 2 "$RC"
 
 # Repo-path branch: a genuine (non-home) git checkout root hardcoded in content
@@ -62,7 +70,8 @@ REPO_REAL="$TEST_TMPDIR/realrepo"
 mkdir -p "$REPO_REAL"
 git -C "$REPO_REAL" init -q
 OUT=$(HOME="$TEST_TMPDIR/elsewhere" CLAUDE_PROJECT_DIR="$REPO_REAL" \
-  bash "$HOOK" <<<"$(write_json "$REPO_REAL/notes.txt" "checkout at $REPO_REAL/src")" 2>&1); RC=$?
+  bash "$HOOK" <<<"$(write_json "$REPO_REAL/notes.txt" "checkout at $REPO_REAL/src")" 2>&1)
+RC=$?
 assert_exit "repo root in real non-home checkout → exit 2" 2 "$RC"
 assert_contains "repo root → machine-specific repo message" "$OUT" "Machine-specific repo path"
 
@@ -74,7 +83,8 @@ SUBREPO="$TEST_TMPDIR/subrepo"
 mkdir -p "$SUBREPO/pkg"
 git -C "$SUBREPO" init -q
 OUT=$(HOME="$TEST_TMPDIR/elsewhere2" CLAUDE_PROJECT_DIR="$SUBREPO/pkg" \
-  bash "$HOOK" <<<"$(write_json "$SUBREPO/pkg/notes.txt" "at $SUBREPO/pkg/x")" 2>&1); RC=$?
+  bash "$HOOK" <<<"$(write_json "$SUBREPO/pkg/notes.txt" "at $SUBREPO/pkg/x")" 2>&1)
+RC=$?
 assert_exit "repo subdir of non-home checkout → exit 2" 2 "$RC"
 assert_contains "repo subdir → machine-specific repo message" "$OUT" "Machine-specific repo path"
 
@@ -83,42 +93,71 @@ assert_contains "repo subdir → machine-specific repo message" "$OUT" "Machine-
 # pre-filter gate — which must trip on every root HPP_WIN_REPO_BODY accepts, or
 # the scan early-returns and the leak passes (fail-open).
 WIN_PROJECTS="D:${BS}Projects${BS}acme${BS}src"
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "build from ${WIN_PROJECTS}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "build from ${WIN_PROJECTS}")" 2>&1)
+RC=$?
 assert_exit "windows Projects checkout root → exit 2" 2 "$RC"
 assert_contains "windows Projects root → message" "$OUT" "Windows repo path"
 
+# ============================ NO-PROJECT SKIP ================================
+# No active project (CLAUDE_PROJECT_DIR unset): the hook does not scan at all.
+# A no-project target (e.g. a $HOME dotfile) is machine-local, not a portable
+# repo artifact, and without a project root the gitignore escape hatch below
+# would be unreachable — so the scope guard skips instead of scanning.
+OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "cd ${LINUX_HOME} && ls")" 2>&1)
+RC=$?
+assert_exit "no project + machine path → exit 0 (skip)" 0 "$RC"
+assert_silent "no project → no stderr" "$OUT"
+
+# The reported incident shape: Edit of a $HOME dotfile carrying an absolute
+# user-home path (a machine-local gitconfig include) from a no-project session.
+OUT=$(bash "$HOOK" <<<"$(edit_json "$FIXTURE" "path = ${WIN_HOME}")" 2>&1)
+RC=$?
+assert_exit "no project + Edit dotfile-style path → exit 0 (skip)" 0 "$RC"
+assert_silent "no project Edit → no stderr" "$OUT"
+
 # ============================ ALLOW (exit 0) ================================
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" 'echo "hello world"')" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" 'echo "hello world"')" 2>&1)
+RC=$?
 assert_exit "clean content → exit 0" 0 "$RC"
 assert_silent "clean content → no stderr" "$OUT"
 
 # shellcheck disable=SC2016
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" 'cd $HOME/project && cd ~/dev')" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" 'cd $HOME/project && cd ~/dev')" 2>&1)
+RC=$?
 assert_exit "dynamic \$HOME / ~ → exit 0" 0 "$RC"
 assert_silent "dynamic refs → no stderr" "$OUT"
 
-OUT=$(bash "$HOOK" <<<"$(write_json "$FIXTURE" "cp file ${MAC_SHARED}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "cp file ${MAC_SHARED}")" 2>&1)
+RC=$?
 assert_exit "macos Shared dir → exit 0" 0 "$RC"
 
-OUT=$(bash "$HOOK" <<<"$(write_json "$PS1_FIXTURE" "\$cfg = '${WIN_HOME}'")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$PS1_FIXTURE" "\$cfg = '${WIN_HOME}'")" 2>&1)
+RC=$?
 assert_exit "Windows path in .ps1 → suppressed → exit 0" 0 "$RC"
 
-OUT=$(bash "$HOOK" <<<"$(other_tool_json "Read" "$FIXTURE")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(other_tool_json "Read" "$FIXTURE")" 2>&1)
+RC=$?
 assert_exit "Read tool → exit 0" 0 "$RC"
 
 # Outside CLAUDE_PROJECT_DIR → exit 0 (another repo's concern).
-OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "/tmp/other/file.txt" "$LINUX_HOME")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "/tmp/other/file.txt" "$LINUX_HOME")" 2>&1)
+RC=$?
 assert_exit "outside CLAUDE_PROJECT_DIR → exit 0" 0 "$RC"
 
-OUT=$(bash "$HOOK" <<<"$(write_json "/some/repo/.claude/hooks/foo.sh" "pattern ${LINUX_HOME}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="/some/repo" bash "$HOOK" <<<"$(write_json "/some/repo/.claude/hooks/foo.sh" "pattern ${LINUX_HOME}")" 2>&1)
+RC=$?
 assert_exit ".claude/hooks/ self-exemption → exit 0" 0 "$RC"
 
-OUT=$(bash "$HOOK" <<<"$(write_json "/some/repo/.lefthook/pre-commit/foo.sh" "pattern ${LINUX_HOME}")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="/some/repo" bash "$HOOK" <<<"$(write_json "/some/repo/.lefthook/pre-commit/foo.sh" "pattern ${LINUX_HOME}")" 2>&1)
+RC=$?
 assert_exit ".lefthook/ self-exemption → exit 0" 0 "$RC"
 
-# CC session/workflow state under ~/.claude/projects/ (outside any repo tree).
+# CC session/workflow state under ~/.claude/projects/. Project dir set to the
+# enclosing home so the case-exemption itself is exercised (a no-project run
+# would exit 0 earlier via the scope guard's skip).
 projects_fp="C:${BS}Users${BS}bob${BS}.claude${BS}projects${BS}my-repo${BS}wf.js"
-OUT=$(bash "$HOOK" <<<"$(write_json "$projects_fp" "const out = '${WIN_HOME}'")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="C:${BS}Users${BS}bob" bash "$HOOK" <<<"$(write_json "$projects_fp" "const out = '${WIN_HOME}'")" 2>&1)
+RC=$?
 assert_exit ".claude/projects/ CC-state self-exemption → exit 0" 0 "$RC"
 
 # Gitignored file → exit 0 (consumer seam via .gitignore + git check-ignore).
@@ -126,11 +165,13 @@ GITREPO="$TEST_TMPDIR/gitrepo"
 mkdir -p "$GITREPO"
 git -C "$GITREPO" init -q
 printf 'ignored.txt\n' >"$GITREPO/.gitignore"
-OUT=$(CLAUDE_PROJECT_DIR="$GITREPO" bash "$HOOK" <<<"$(write_json "$GITREPO/ignored.txt" "$LINUX_HOME")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$GITREPO" bash "$HOOK" <<<"$(write_json "$GITREPO/ignored.txt" "$LINUX_HOME")" 2>&1)
+RC=$?
 assert_exit "gitignored file → exit 0 (consumer seam)" 0 "$RC"
 
 # Kill switch — disabled path is a clean no-op even on a real machine path.
-OUT=$(CLAUDE_PLUGIN_OPTION_HARDCODED_PATH_CHECK_ENABLED=false bash "$HOOK" <<<"$(write_json "$FIXTURE" "$LINUX_HOME")" 2>&1); RC=$?
+OUT=$(CLAUDE_PLUGIN_OPTION_HARDCODED_PATH_CHECK_ENABLED=false bash "$HOOK" <<<"$(write_json "$FIXTURE" "$LINUX_HOME")" 2>&1)
+RC=$?
 assert_exit "kill switch off → exit 0" 0 "$RC"
 assert_silent "kill switch off → no stderr" "$OUT"
 
@@ -144,7 +185,8 @@ assert_silent "kill switch off → no stderr" "$OUT"
 HOME_DIR="C:${BS}Users${BS}bob"
 HOME_CMD="${HOME_DIR}${BS}Desktop${BS}run.cmd"
 HOME_UNDER="${HOME_DIR}${BS}AppData${BS}Local${BS}Docker${BS}img.vhdx"
-OUT=$(CLAUDE_PROJECT_DIR="$HOME_DIR" bash "$HOOK" <<<"$(write_json "$HOME_CMD" "copy $HOME_UNDER dst")" 2>&1); RC=$?
+OUT=$(CLAUDE_PROJECT_DIR="$HOME_DIR" bash "$HOOK" <<<"$(write_json "$HOME_CMD" "copy $HOME_UNDER dst")" 2>&1)
+RC=$?
 assert_exit "F1: non-git home project + path under home → exit 0" 0 "$RC"
 assert_silent "F1: non-git home → no stderr" "$OUT"
 
@@ -161,7 +203,8 @@ mkdir -p "$GITHOME"
 git -C "$GITHOME" init -q
 GITHOME_TL="$(git -C "$GITHOME" rev-parse --show-toplevel)"
 OUT=$(HOME="$GITHOME_TL" CLAUDE_PROJECT_DIR="$GITHOME" \
-  bash "$HOOK" <<<"$(write_json "$GITHOME/notes.txt" "path $GITHOME/data/app.bin")" 2>&1); RC=$?
+  bash "$HOOK" <<<"$(write_json "$GITHOME/notes.txt" "path $GITHOME/data/app.bin")" 2>&1)
+RC=$?
 assert_exit "F1: git checkout equal to \$HOME → exit 0" 0 "$RC"
 assert_silent "F1: \$HOME checkout → no stderr" "$OUT"
 
@@ -175,7 +218,8 @@ mkdir -p "$HOMEREPO/Desktop"
 git -C "$HOMEREPO" init -q
 HOMEREPO_TL="$(git -C "$HOMEREPO" rev-parse --show-toplevel)"
 OUT=$(HOME="$HOMEREPO_TL" CLAUDE_PROJECT_DIR="$HOMEREPO/Desktop" \
-  bash "$HOOK" <<<"$(write_json "$HOMEREPO/Desktop/run.txt" "path $HOMEREPO/Desktop/data.bin")" 2>&1); RC=$?
+  bash "$HOOK" <<<"$(write_json "$HOMEREPO/Desktop/run.txt" "path $HOMEREPO/Desktop/data.bin")" 2>&1)
+RC=$?
 assert_exit "F1: home-is-checkout, project = subdir of home → exit 0" 0 "$RC"
 assert_silent "F1: home-checkout subdir → no stderr" "$OUT"
 


### PR DESCRIPTION
## Summary

`hardcoded-path-check.sh` scanned unconditionally when `CLAUDE_PROJECT_DIR` was unset — the scope guard's explicit fail-open branch — contradicting the README "Project scoping" contract ("only police files under `$CLAUDE_PROJECT_DIR`"). The gitignore escape hatch was gated on the same variable, so in exactly that case the one documented per-file exemption was unreachable short of the global kill switch. Real incident (handoff-inbox producer session): forced `~/` rewrites onto a machine-local `~/.gitconfig` edited from a no-project session.

The hook now **skips entirely when no project is active**: a no-project target is machine-local, not the portable repo artifact this guard protects. Deliberately different from `secret-pattern-detection`, which scans even without a resolvable root (secrets are dangerous anywhere; hardcoded paths only harm portable artifacts). Dead downstream no-project branches (gitignore-gate condition, `PROJECT_ROOT` fallback) simplified away. README consumer-seam bullets updated so doc and code agree.

History check: the fail-open dates to the plugin's initial commit (#42) with no recorded rationale beyond the inline comment; CHANGELOG 0.9.8 treated a similar prefilter fail-open as a bug.

## Tests

- Red-first: two new no-project skip cases (Write + Edit, incident shape) failed on the unfixed hook (PASS=40 FAIL=4), green after (PASS=44 FAIL=0).
- Detection/allow cases now set `CLAUDE_PROJECT_DIR` explicitly — scanning is a within-project behavior; exemption-path tests (`.claude/hooks`, `.claude/projects`, gitignore seam) set an enclosing project so each exemption stays exercised rather than masked by the new skip.
- `shellcheck` clean; `check-changelog-parity --check-bump main` and `check-changed-skills` pass.

## Versioning

guardrails 0.10.0 → **0.10.1** (patch — behavior fix, no new mechanism) + CHANGELOG entry.

## Fresh-docs citation

https://code.claude.com/docs/en/hooks — `${CLAUDE_PROJECT_DIR}`: "the project root", exported as an env var on spawned hook processes; no guarantee of presence in no-project sessions.

## Related

- Closes #1038
- Source: handoff-inbox item `20260722-035839-guardrails-hardcoded-path-check-failopen-scope` (F2 of that item recorded as working-as-intended decision note on #1038, no pattern change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)