### PR TITLE
fix(actionlint): align emitted telemetry hook id with schema (#959)

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.1]
+
+### Fixed
+
+- **Emitted telemetry `hook` id now matches the published schema.** The hook emitted
+  `"actionlint"` on all three paths (skipped / findings / clean), but the envelope
+  `hook` value is the hook-script basename and its schema is discovered at
+  `data/<hook>.schema.json`. It now emits `"actionlint-check"`, matching
+  `docs/conventions/hook-telemetry/data/actionlint-check.schema.json` and the
+  README Implementers table. Producer-conformance fix only — the published
+  envelope/data contract is unchanged.
+
 ## [0.5.0]
 
 ### Added

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -102,7 +102,7 @@ build_data_json() {
 # status so a consumer sink can observe the coverage gap.
 if ! command -v actionlint >/dev/null 2>&1; then
   data_json=$(build_data_json '[]')
-  emit_tel "actionlint" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "actionlint-check" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
   if hook::notice_once "actionlint-missing" "$INPUT"; then
     hook::emit_skip_notice PostToolUse "actionlint: 'actionlint' not found on PATH — workflow lint skipped for this session. Install: https://github.com/rhysd/actionlint/blob/main/docs/install.md"
   fi
@@ -133,11 +133,11 @@ if [[ -n "$AL_OUTPUT" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
   data_json=$(build_data_json "$FINDINGS_JSON")
-  emit_tel "actionlint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "actionlint-check" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
   exit 0
 fi
 
 # Clean workflow.
 data_json=$(build_data_json '[]')
-emit_tel "actionlint" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "actionlint-check" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
 exit 0

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -201,7 +201,7 @@ if [[ -s "$TEL" ]]; then
       fail "envelope: $field missing ($(cat "$TEL"))"
     fi
   done
-  if [[ "$(jq -r '.hook' "$TEL")" == "actionlint" ]]; then ok "envelope: hook is actionlint"; else fail "envelope: hook=$(jq -r '.hook' "$TEL")"; fi
+  if [[ "$(jq -r '.hook' "$TEL")" == "actionlint-check" ]]; then ok "envelope: hook is actionlint-check"; else fail "envelope: hook=$(jq -r '.hook' "$TEL")"; fi
   if [[ "$(jq -r '.status' "$TEL")" == "ok" ]]; then ok "envelope: status ok"; else fail "envelope: status=$(jq -r '.status' "$TEL")"; fi
   if [[ "$(jq -r '.schema_version' "$TEL")" == "1.0" ]]; then ok "envelope: schema_version 1.0"; else fail "envelope: schema_version=$(jq -r '.schema_version' "$TEL")"; fi
   if [[ "$(jq '.data.findings | length' "$TEL")" -ge 1 ]]; then ok "envelope: findings populated"; else fail "envelope: findings empty ($(jq '.data.findings' "$TEL"))"; fi


### PR DESCRIPTION
## Summary

The `actionlint-check` hook emitted a telemetry envelope whose `hook` id was `"actionlint"`, but the published schema and discovery convention key on the **hook-script basename**, `actionlint-check`. A consumer sink resolving `data/<hook>.schema.json` from the envelope's `hook` value would look up `data/actionlint.schema.json` (which does not exist) instead of the real `data/actionlint-check.schema.json`. This is a producer-conformance bug: three authoritative artifacts (the schema file, the README Implementers table, and the schema's own `title`/`description`) already agree on `actionlint-check`; only the producer and its own test diverged.

## Fix

Producer-side only — 4 lines across 2 files:

- `plugins/actionlint/hooks/actionlint-check.sh` — `"actionlint"` → `"actionlint-check"` at all three `emit_tel` sites (skipped / findings / clean paths).
- `plugins/actionlint/hooks/actionlint-check.test.sh` — flipped the `.hook` assertion and its success-message string to expect `"actionlint-check"`.

No change to `docs/conventions/hook-telemetry/` schema or README — they are already canonical. No `schema_version` bump (the published envelope/data contract is unchanged). The plugin's own version is bumped `0.5.0` → `0.5.1` (patch, producer-conformance bugfix) with a matching CHANGELOG entry.

## Verification

Acceptance grep (expect empty):

```
$ git grep 'emit_tel "actionlint"' plugins/actionlint/
$ echo $?
1        # no match — all three sites converted
```

Test suite (`actionlint` was on PATH, so it ran fully — not skipped):

```
$ bash plugins/actionlint/hooks/actionlint-check.test.sh
...
ok: envelope: hook is actionlint-check
...
PASS=35 FAIL=0
```

Closes #959

## Related

Implementation follows the triage-lane planning comment on #959 (posted 2026-07-22T07:00:13Z), "Implementation plan — #959: align actionlint telemetry `hook` id", which resolved the canonical-direction fork from evidence (envelope `hook` id is the hook-script basename, proven by the `guardrails` plugin shipping many hooks each emitting its own basename).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
