### PR TITLE
feat(source-control): setup writes a self-describing team convention file

### DIFF
--- a/lib/resolve-convention-pattern.test.sh
+++ b/lib/resolve-convention-pattern.test.sh
@@ -52,6 +52,13 @@ assert_exit "--help exits 0" 0 $?
 r="$(newrepo $'## subject_pattern\nConventional Commits')"
 assert_eq "CC keyword -> CC_ERE" "$CC_ERE" "$(run "$r")"
 
+# --- self-describing preamble above the first H2 is inert (setup template) ---
+# /source-control:setup apply writes a prose header for non-plugin readers; the
+# parse contract reads only the first non-empty body line under the `## <key>`
+# H2, so a file with the preamble must resolve identically to one without.
+r="$(newrepo $'# source-control configuration\n\nRead by the source-control Claude Code plugin (and, where installed, the\nguardrails commit-convention gate). Without those plugins this file is inert.\nIt is a drafting aid, not team-wide enforcement.\n\n## subject_pattern\nConventional Commits')"
+assert_eq "preamble above first H2 is inert" "$CC_ERE" "$(run "$r")"
+
 # --- a custom ERE passes through unchanged ---
 r="$(newrepo $'## subject_pattern\n^[A-Z]+-[0-9]+: .+')"
 assert_eq "plain ERE unchanged" '^[A-Z]+-[0-9]+: .+' "$(run "$r")"

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.17.1]
+
+### Changed
+
+- **The team convention file `/source-control:setup apply` writes is now self-describing
+  (#1046, audit f6).** The template's header states, for the reader who does NOT run these
+  plugins, that the file is read by the source-control plugin (and the guardrails
+  commit-convention gate where installed), is inert without them, and is a drafting aid —
+  not team-wide enforcement, which is a commit-msg hook or CI check. The header is part of
+  the template (a reconfiguration run rewrites it in place, never appends a second copy),
+  and prose above the first `##` heading is inert to every consumer by construction: the
+  enforcement resolver reads only the first non-empty body line under a `## <key>` H2 — a
+  regression test in `lib/resolve-convention-pattern.test.sh` now proves a preambled file
+  resolves identically to a bare one. The `apply` report for a team write states the same
+  draft-aid vs enforcement distinction instead of implying the file enforces anything by
+  itself.
+
 ## [0.17.0]
 
 ### Added

--- a/plugins/source-control/skills/setup/SKILL.md
+++ b/plugins/source-control/skills/setup/SKILL.md
@@ -227,6 +227,11 @@ With no argument in an interactive session, run the interview:
    ```markdown
    # source-control configuration
 
+   Read by the source-control Claude Code plugin (and, where installed, the guardrails
+   commit-convention gate). Without those plugins this file is inert — safe to ignore.
+   It is a drafting aid for plugin users, not team-wide enforcement: tool-agnostic
+   enforcement for every committer (plugin or not) is a commit-msg hook or CI check.
+
    Commit-subject / PR-title convention for the source-control plugin, resolved by
    `/source-control:commit` and `/source-control:pull-request` before they infer from the repo's own
    CLAUDE.md/rules/commit-msg hook or fall back to the bundled Conventional Commits default.
@@ -259,6 +264,14 @@ With no argument in an interactive session, run the interview:
    Drop any section with no content rather than leaving it empty. Writing a non-`team` layer, add one
    line under the heading naming which layer this file is and that it overrides per key — the file
    sits next to (or looks identical to) the team file, and the next reader has no other signal.
+
+   The self-describing preamble above the first `##` heading exists for the reader who does NOT run
+   these plugins — the team file lands in shared history, and a teammate opening it deserves to know
+   it binds nothing on its own. It is part of the template, not an append: a reconfiguration run
+   rewrites the whole header block in place, never stacks a second copy. Prose above the first H2 is
+   inert to every consumer by construction — the enforcement resolver reads only the first non-empty
+   body line under a `## <key>` heading (`lib/resolve-convention-pattern.sh` parse contract), and the
+   drafting read is per-H2-key — so the preamble can never change a resolved value.
 
 6. **Verify the write, per layer.** The post-write check inverts between layers and there is no
    shared shortcut: the team file must be tracked, the local overlay must be ignored, and the
@@ -357,6 +370,12 @@ With no argument in an interactive session, run the interview:
    overridden by an existing team file, and a `layer=team` write can be overridden by an existing
    local overlay — a user who is told only "wrote `subject_pattern`" and then sees `/commit` use a
    different pattern has been misled by the success message.
+
+   For a `team` write, the report also states plainly what the file is and is not: a drafting aid
+   (plus CC-layer enforcement input) for teammates who run these plugins, inert for everyone else —
+   NOT team-wide enforcement. Committers without the plugin are bound only by a commit-msg hook or CI
+   check; when the team wants that, point at the guardrails plugin's opt-in commit-msg hook or the
+   repo's own hook manager rather than implying this file enforces anything by itself.
 
 ### Babysit config
 


### PR DESCRIPTION
## Summary

The team-tracked `.claude/source-control.md` that `/source-control:setup apply` writes lands in shared history with no signal for a teammate who does not run these plugins — audit finding f6 on #912, declared folded into #913 but never delivered by PR #925 (its file list contains no setup-skill change).

- The `apply` template now opens with a self-describing preamble: read by the source-control plugin (and the guardrails commit-convention gate where installed), inert without them, and a **drafting aid, not team-wide enforcement** — tool-agnostic enforcement for every committer is a commit-msg hook or CI check.
- The `apply` report for a team write states the same draft-aid vs enforcement distinction.
- The header is template-owned: a reconfiguration run rewrites it in place, never appends a second copy.
- Preamble safety proven, not assumed: a new regression case in `lib/resolve-convention-pattern.test.sh` shows a preambled file resolves identically to a bare one (the parse contract reads only the first non-empty body line under a `## <key>` H2).

source-control `0.17.0` → `0.17.1` with CHANGELOG entry.

## Test plan

- [x] `bash lib/resolve-convention-pattern.test.sh` — 28 cases, 0 failed (new preamble case included)
- [x] `bash scripts/check-changelog-parity.sh --check-bump main` — pass
- [x] `bash scripts/check-changed-skills.sh main` — setup: PASS (0 errors)

## Related

- Closes #1046
- Refs #912 (audit umbrella, finding f6), #913 (claimed the fold), #925 (seam PR that shipped without it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
