### PR TITLE
feat(source-control): setup skill supports pr_body_required_sections (#1032)

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.0]
+
+### Added
+
+- **`/source-control:setup` now covers `pr_body_required_sections` (#1032, completing #975's
+  adoption path).** `check` reports the key's effective value across all three layers — a
+  `pr_body_required_sections` row on the effective-configuration table, resolving to the plugin's
+  portable default (`Summary`, `Test plan`) with `won by: plugin default` when no layer sets it,
+  rather than a blank row. `apply`'s interview offers setting it and the written-config template
+  gains the matching `## pr_body_required_sections` section, at parity with every other per-key
+  surface (`subject_pattern`, `pr_title_pattern`, `trailer_policy`, `pr_body_attribution`). The
+  interview deliberately recommends only the plugin's own portable default and never proposes a
+  `Related`/linked-issue section or any other organization-specific list — asking what the repo's
+  actual convention requires, never inventing one, per the plugin's Two-lane convention posture.
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -16,7 +16,25 @@ All notable changes to the `source-control` plugin are documented here. Format f
   surface (`subject_pattern`, `pr_title_pattern`, `trailer_policy`, `pr_body_attribution`). The
   interview deliberately recommends only the plugin's own portable default and never proposes a
   `Related`/linked-issue section or any other organization-specific list — asking what the repo's
-  actual convention requires, never inventing one, per the plugin's Two-lane convention posture.
+  actual convention requires, never inventing one, per the plugin's Two-lane convention posture. The
+  interview also states, per-key-fallthrough-aware, when resetting to the portable default over a
+  lower layer that already sets the key requires writing the explicit default list rather than
+  omitting the section — an omission only inherits, it never overrides (review-caught during #1032).
+
+### Fixed
+
+- **`## Related` pre-create gate no longer drops visible text sharing a line with an inline HTML
+  comment (#975/#1029 follow-up, review-caught during #1032).** The comment-aware heading scan
+  previously treated an entire line as comment text once it saw `<!--`, dropping content like
+  `Ran smoke tests <!-- details omitted -->` before the section's non-empty check — a false-fail,
+  since GitHub still renders the visible text outside the comment. The scan now strips only the
+  comment SPAN (single- or multi-line), preserving visible text before, between, and after spans on
+  the same line; a genuinely comment-only line, or a fully-hidden middle line of a multi-line span,
+  still contributes nothing. Defensive pass over the fence/comment interaction: a fence's content is
+  never comment-parsed (comment-marker-shaped text inside a fence stays literal) and a comment's
+  content is never fence-parsed (fence-marker-shaped text inside a comment stays literal), and a
+  heading line carrying a trailing inline comment is still correctly read as a real exit boundary.
+  New eval 18 covers the regression.
 
 ## [0.18.0]
 

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -213,6 +213,20 @@
         "Comment text is never counted as non-empty content, even inside a genuinely matched section — unlike a fenced code block, which is rendered and does count",
         "The behavior matches what GitHub itself renders (nothing) and what a comment-stripping PR-body validator would see (nothing)"
       ]
+    },
+    {
+      "id": 18,
+      "name": "pr-body-required-sections-gate-preserves-visible-text-around-inline-comments",
+      "prompt": "/pull-request create. pr_body_required_sections requires Test plan. The drafted `## Test plan` section's only content line is `Ran smoke tests <!-- details omitted -->` — real visible text sharing a line with a trailing HTML comment.",
+      "expected_output": "The §2.4.2.2 gate passes for `## Test plan` — 'Ran smoke tests ' is real content GitHub renders, so the section is not empty. The scan strips only the comment SPAN (`<!-- details omitted -->`), not the whole line, so visible text before, between, or after a comment span on the same line (including a multi-line span whose opening or closing line also carries visible text) is preserved and counted; only a genuinely comment-only line (eval 17) or a fully-hidden middle line of a multi-line span contributes nothing. A fence still takes priority over a comment inside it (fence content is literal, never comment-parsed) and vice versa (comment content is literal, never fence-parsed), and a heading line carrying a trailing inline comment is still correctly read as a real exit boundary rather than misrouted into comment handling.",
+      "files": [],
+      "expectations": [
+        "Visible text sharing a line with an inline HTML comment is preserved and counted as real content — the gate does not block on a section whose only issue is a trailing/leading inline comment",
+        "Only the comment span itself is removed, not the whole line — text before the span, after the span, or between two spans on the same line is all kept",
+        "A multi-line comment span's opening line keeps its pre-comment visible text and its closing line keeps its post-comment visible text; only a fully-hidden middle line contributes nothing",
+        "A fenced code block's content is preserved even if it contains comment-marker-shaped text (`<!--`), and an HTML comment's content is dropped even if it contains fence-marker-shaped text (```` ``` ````) — each construct's own parsing rules win inside it, never the other's",
+        "A heading line carrying a trailing inline comment is still treated as a real section-exit boundary, not swallowed by comment handling"
+      ]
     }
   ]
 }

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -350,20 +350,43 @@ for section in "${REQUIRED_SECTIONS[@]}"; do
   # ("```"/"~~~") AND outside an HTML comment (<!-- ... -->, single- or multi-line) —
   # a Summary that documents a template containing a literal "## Related" inside a
   # code sample, or a body carrying a commented-out draft section, must never
-  # satisfy the Related requirement GitHub itself renders as absent. A single
-  # action block (not separate pattern-action rules) keeps exactly one branch
-  # firing per line — awk otherwise runs every matching rule for a line, which
-  # would double-toggle state on a line matching more than one pattern.
+  # satisfy the Related requirement GitHub itself renders as absent.
   #
   # Fences and comments are NOT symmetric once inside the found section: a fence
-  # delimiter encountered there is real, RENDERED content and stays in the
-  # captured body (a section whose own genuine content includes a code block is
-  # still captured correctly) — but a comment is never rendered at all, in or out
-  # of a found section, so comment text is never printed into SECTION_BODY. A
-  # required section whose entire body is an unfilled `<!-- ... -->` template
-  # placeholder must read as empty, the same as GitHub's own render and this
-  # repo's PR-body validator (which strips comments before checking) would.
+  # delimiter there is real, RENDERED content and stays in the captured body (a
+  # section whose own genuine content includes a code block is still captured
+  # correctly) — but a comment is never rendered at all, so comment text is
+  # never counted as content, even inside a found section. An *inline* comment
+  # is stripped as a SPAN, not a whole line, though: "Ran smoke tests <!-- done
+  # --><!-- todo -->" keeps "Ran smoke tests " (GitHub still renders the text
+  # outside the comment) rather than dropping the entire line the way a
+  # comment-only line correctly does. A fence or comment already open when a
+  # line starts consumes that line's meaning entirely before any NEW fence or
+  # comment on the same line is considered — GFM parses both literally with no
+  # nested markup, so a "<!--" inside an open fence, or a "```" inside an open
+  # comment, is never a real comment/fence start.
   SECTION_BODY=$(printf '%s\n' "$BODY" | awk -v h="## ${section}" '
+  function strip_comment_span(line,    out, idx) {
+    # Removes every "<!-- ... -->" span from `line`, keeping visible text
+    # before/after/between spans on the same line; updates the global
+    # in_comment state when a span does not close on this line (a multi-line
+    # comment). A comment-only line returns "".
+    out = ""
+    while (1) {
+      if (in_comment) {
+        idx = index(line, "-->")
+        if (idx == 0) { return out }
+        line = substr(line, idx + 3)
+        in_comment = 0
+      } else {
+        idx = index(line, "<!--")
+        if (idx == 0) { return out line }
+        out = out substr(line, 1, idx - 1)
+        line = substr(line, idx + 4)
+        in_comment = 1
+      }
+    }
+  }
   {
     # Fence detection matches GFM (https://github.github.com/gfm/#fenced-code-blocks):
     # up to 3 leading spaces, then 3+ of the SAME fence character (backtick or
@@ -378,23 +401,37 @@ for section in "${REQUIRED_SECTIONS[@]}"; do
     if (stripped ~ /^```/) fence_char = "`"
     else if (stripped ~ /^~~~/) fence_char = "~"
 
-    if (!in_fence && fence_char != "") { in_fence = 1; open_char = fence_char; if (found) print; next }
+    # An already-open fence or comment takes absolute priority (see the block
+    # comment above) — checked before anything else, including the heading and
+    # exit-boundary tests below.
     if (in_fence) {
       if (fence_char == open_char) in_fence = 0
       if (found) print
       next
     }
-    if ($0 ~ /<!--/) {
-      in_comment = 1
-      if ($0 ~ /-->/) in_comment = 0
-      next
-    }
     if (in_comment) {
-      if ($0 ~ /-->/) in_comment = 0
+      visible = strip_comment_span($0)
+      if (found && visible != "") print visible
       next
     }
+
+    # Heading and exit-boundary checks run on the RAW line, never a
+    # comment-stripped one: a real ATX heading (or the next one, ending this
+    # section) must start the line itself, so a "##"-shaped fragment freed by
+    # stripping a same-line comment could never be a real heading GitHub would
+    # render as one. Checking the raw line here also means a heading carrying
+    # a trailing inline comment ("## Related <!-- draft -->") is still
+    # correctly read as a real exit boundary, not misrouted into the
+    # comment-open branch below.
     if (!found && $0 == h) { found = 1; next }
     if (found && $0 ~ /^## /) { exit }
+
+    if (fence_char != "") { in_fence = 1; open_char = fence_char; if (found) print; next }
+    if ($0 ~ /<!--/) {
+      visible = strip_comment_span($0)
+      if (found && visible != "") print visible
+      next
+    }
     if (found) print
   }
   ')

--- a/plugins/source-control/skills/setup/SKILL.md
+++ b/plugins/source-control/skills/setup/SKILL.md
@@ -239,7 +239,18 @@ With no argument in an interactive session, run the interview:
      if it were a universal default; a linked-issue section presumes an issue-tracker convention this
      plugin cannot assume for every repo. Ask what the repo's actual convention requires (a PR
      template, a CI gate like `pr-issue-linkage`, team practice) rather than proposing one, and write
-     only what the repo genuinely needs. Omit this section entirely to keep the portable default.
+     only what the repo genuinely needs.
+     **Omitting this section does NOT always mean "use the portable default"** — per-key fallthrough
+     (config-resolution.md's "Merge semantics") means an omitted section keeps whatever an *earlier*
+     layer already resolves to. Check the effective merge from step 1 first: omit only when the layers
+     *below* the one being written already resolve to the portable default (or the key is unset
+     everywhere) — writing the explicit default there would just add redundant noise. When the intent
+     is genuinely to reset back to the portable default *over* a lower layer that sets something else
+     (a team config requiring `Related`, and this write is a personal overlay or a team rewrite meant
+     to drop it), the portable default must be written out explicitly as the bullet list (`- Summary`,
+     `- Test plan`) — an omitted section would silently keep inheriting the lower layer's list instead.
+     State the one-line reason when this applies ("written explicitly to override the team layer's
+     list, not merely to restate the default").
 5. **Write the config.** Materialize the target layer's path with these sections:
 
    ```markdown

--- a/plugins/source-control/skills/setup/SKILL.md
+++ b/plugins/source-control/skills/setup/SKILL.md
@@ -48,12 +48,20 @@ single layer's value as the effective convention; a reader who cannot see which 
 tell why `/commit` behaves as it does.
 
 ```text
-key                 value                       won by
-subject_pattern     ^[A-Z]+-\d+: .+             team
-pr_title_pattern    Same as subject_pattern      team
-trailer_policy      none                         local overlay
-pr_body_attribution none                         local overlay
+key                        value                       won by
+subject_pattern            ^[A-Z]+-\d+: .+             team
+pr_title_pattern           Same as subject_pattern      team
+trailer_policy             none                         local overlay
+pr_body_attribution        none                         local overlay
+pr_body_required_sections  Summary, Test plan           plugin default
 ```
+
+`pr_body_required_sections` is a **list**-valued key (like `type_list`, and unlike every scalar row
+above it) — render it comma-joined for this report regardless of how many lines the winning layer's
+file spells it across. When every layer leaves it unset, the row still resolves — to the plugin's
+portable default, `Summary` and `Test plan` — so `won by` reads `plugin default` rather than the row
+going blank; this is the one key whose "no layer sets it" state is itself a reportable, named value,
+not a bare absence.
 
 Per-layer verdicts:
 
@@ -222,6 +230,16 @@ With no argument in an interactive session, run the interview:
      `trailer_policy: none` still keeps the PR-body line unless this is also set). Recommend keeping the
      default `🤖 Generated with [Claude Code]…` line unless the user wants a custom line or `none` to
      omit it. Omit this section entirely to keep the default.
+   - **`pr_body_required_sections`** (optional) — the required `## <heading>` section scaffold
+     `/pull-request create` drafts and pre-checks before opening a PR (one bullet per heading; see
+     [config-resolution.md](../../reference/config-resolution.md) and
+     [`docs/conventions/pr-body-convention/README.md`](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/pr-body-convention/README.md)).
+     **RECOMMENDED: keep the plugin's own portable default** (`Summary`, `Test plan`) — this interview
+     must not suggest a `Related`/linked-issue section, or any other specific organization's list, as
+     if it were a universal default; a linked-issue section presumes an issue-tracker convention this
+     plugin cannot assume for every repo. Ask what the repo's actual convention requires (a PR
+     template, a CI gate like `pr-issue-linkage`, team practice) rather than proposing one, and write
+     only what the repo genuinely needs. Omit this section entirely to keep the portable default.
 5. **Write the config.** Materialize the target layer's path with these sections:
 
    ```markdown
@@ -259,6 +277,14 @@ With no argument in an interactive session, run the interview:
 
    <only present if the repo overrides the default PR-body attribution line — a custom line, or
    `none` to omit it>
+
+   ## pr_body_required_sections
+
+   <only present if the repo's required-section scaffold differs from the plugin's portable default
+   (Summary, Test plan) — a flat bullet list, one `- <H2 heading>` per line, e.g.:
+   - Summary
+   - Test plan
+   - Related>
    ```
 
    Drop any section with no content rather than leaving it empty. Writing a non-`team` layer, add one

--- a/plugins/source-control/skills/setup/evals/evals.json
+++ b/plugins/source-control/skills/setup/evals/evals.json
@@ -181,6 +181,19 @@
         "Asks about the repo's actual convention rather than proposing one the repo gave no signal for",
         "Omits the pr_body_required_sections section from the written config when the portable default is accepted"
       ]
+    },
+    {
+      "id": 15,
+      "name": "reset-to-default-writes-explicit-list-over-lower-layer",
+      "prompt": "/source-control:setup apply layer=local\n\nThe tracked team .claude/source-control.md already declares pr_body_required_sections as Summary, Test plan, Related. I personally don't want to bother with Related on this machine — go back to just Summary and Test plan.",
+      "expected_output": "Because pr_body_required_sections falls through per key, an omitted section in the local overlay would keep inheriting the team layer's Summary/Test plan/Related list, not reset to the portable default. The skill recognizes the intent as an explicit override and writes pr_body_required_sections in the local overlay as the literal bullet list (Summary, Test plan) rather than leaving the section out, stating in one line that it is written explicitly to override the team layer's list, not merely to restate the portable default. It then reports the resulting effective merge (the local overlay's explicit list winning over the team layer).",
+      "files": [],
+      "expectations": [
+        "Recognizes that omitting the section would NOT reset to the portable default, because the team layer already sets pr_body_required_sections",
+        "Writes the explicit portable-default bullet list (Summary, Test plan) into the local overlay rather than omitting the section",
+        "States the one-line reason the explicit list is written (overriding the lower layer, not merely restating the default)",
+        "Reports the resulting effective merge showing the local overlay's explicit list winning over the team layer's list"
+      ]
     }
   ]
 }

--- a/plugins/source-control/skills/setup/evals/evals.json
+++ b/plugins/source-control/skills/setup/evals/evals.json
@@ -155,6 +155,32 @@
         "Still carries through independent keys such as trailer_policy that the invocation did not name",
         "Leaves no config in which type_list coexists with a custom subject_pattern"
       ]
+    },
+    {
+      "id": 13,
+      "name": "check-reports-pr-body-required-sections-plugin-default",
+      "prompt": "/source-control:setup check\n\nNo layer sets pr_body_required_sections.",
+      "expected_output": "The effective-configuration table includes a pr_body_required_sections row resolving to Summary, Test plan (the plugin's portable default) with won by reading 'plugin default' — the row is present and named, not blank or omitted, even though no layer sets the key. This mirrors how the report treats other unset optional keys as INFO rather than FAIL, but pr_body_required_sections additionally names the resolved default value since 'unset' is itself a meaningful, reportable state for this key.",
+      "files": [],
+      "expectations": [
+        "The check table includes a pr_body_required_sections row even when no layer sets it",
+        "The row's value is the plugin's portable default (Summary, Test plan), not blank",
+        "The row's won-by column reads 'plugin default' rather than naming a layer that never set it",
+        "An unset pr_body_required_sections is reported as INFO, not FAIL"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "apply-interview-recommends-portable-default-not-org-specific-list",
+      "prompt": "/source-control:setup apply\n\nRun the interactive interview for a repo with no existing source-control.md and no inferable convention signal.",
+      "expected_output": "When the interview reaches pr_body_required_sections, it recommends keeping the plugin's portable default (Summary, Test plan) and does NOT propose adding a Related/linked-issue section, or any other specific organization's convention, as if it were a universal default. It asks what the repo's actual convention requires (a PR template, a CI gate such as pr-issue-linkage, team practice) rather than inventing one, and omits the section from the written config when the user accepts the portable default.",
+      "files": [],
+      "expectations": [
+        "Recommends the plugin's portable default (Summary, Test plan) for pr_body_required_sections",
+        "Does not suggest a Related/linked-issue section, or any other org-specific list, as a default recommendation",
+        "Asks about the repo's actual convention rather than proposing one the repo gave no signal for",
+        "Omits the pr_body_required_sections section from the written config when the portable default is accepted"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #1032

## Summary

Completes #975's adoption path: `/source-control:setup` was the last mechanism-owning surface that
didn't know about `pr_body_required_sections` (added in #1029), so a team using the sanctioned
guided setup flow couldn't configure the required-section scaffold or see which layer supplies it —
the only path was hand-editing `.claude/source-control.md` directly.

- **`check` reports a `pr_body_required_sections` row** on the effective-configuration table,
  resolving to the plugin's portable default (`Summary`, `Test plan`) with `won by: plugin default`
  when no layer sets it — a named, reportable value rather than a blank row, since "unset" is itself
  a meaningful state for this key.
- **`apply`'s interview offers setting it**, deliberately recommending only the plugin's own portable
  default and never proposing a `Related`/linked-issue section (or any other org-specific list) as a
  universal default — it asks what the repo's actual convention requires (a PR template, a CI gate
  like `pr-issue-linkage`, team practice) rather than inventing one, per the plugin's Two-lane
  convention posture.
- **The written-config template** gains the matching `## pr_body_required_sections` section, at
  parity with every other per-key surface (`subject_pattern`, `pr_title_pattern`, `trailer_policy`,
  `pr_body_attribution`).
- New evals 13-14 cover the check-report default and the agnostic-interview behavior.
- Plugin version bumped `0.18.0` → `0.19.0` with a matching `CHANGELOG.md` entry.

This branch was rebased onto `feat/975-required-body-sections` (then onto `main` after #1029 merged)
so it includes #1029's `pr_body_required_sections` key and #1055's setup-template preamble together —
verified both coexist correctly in the write template (preamble header, then the per-key section
list ending with the new `## pr_body_required_sections` section).

## Test plan

- `npx markdownlint-cli2` over the changed skill doc and CHANGELOG: 0 errors.
- `node -e "JSON.parse(...)"` over the updated `evals/evals.json`: valid JSON.
- `bash scripts/check-changelog-parity.sh --check-bump origin/main`: PASS.
- `bash scripts/validate-plugins.sh`: every plugin manifest and the marketplace catalog validate.
- Manually verified the merged write template renders correctly end to end (preamble +
  `pr_body_required_sections` section both present, no duplication) after rebasing onto `main`.

## Related

- #975 / #1029 — the mechanism and portable-default key this PR completes the adoption path for.
- #1055 — the setup-template self-describing-preamble change this branch was rebased across; both
  changes touch the same "Write the config" template step and coexist without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
