### PR TITLE
docs(docs-hygiene): clarify audit-derivability Hard Rules line 111 fork-mechanism reference

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Documentation-hygiene toolkit of six skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — docs-hygiene plugin
 
+## [0.8.6]
+
+### Fixed
+
+- `audit-derivability` Hard Rules "never by a fork" now names the Agent tool's `fork` subagent
+  type inline and distinguishes it from a skill's own `context: fork` frontmatter (which starts
+  blank), matching the disambiguation already in the spot-test bullet — the Hard Rules section is
+  now self-contained for a reader landing there first.
+
 ## [0.8.5]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-derivability/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-derivability/SKILL.md
@@ -108,7 +108,7 @@ After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointe
 - **Read-only.** No `Edit`, no `Write`, no mutating `Bash`. The author applies every deletion and rewrite. Deletion is the highest-stakes doc edit; the classifier only recommends.
 - **Never derivability alone.** A `delete` verdict requires all of: derivable, low re-derivation cost, no owned facts. Any owned non-derivable fact forces `keep-owns-facts`.
 - **Cache verdicts carry a drift-control condition or they demote.** No regeneration path and no recheck trigger → not a cache, demote to pointer/delete.
-- **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by a fork.
+- **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by the Agent tool's `fork` subagent type (a skill's own `context: fork` frontmatter is unrelated — it starts blank).
 - **Audience named in every verdict.** Agent-facing and human-facing docs clear different deletion bars.
 - **Owned facts are salvaged before anything is deleted.** When a doc is mostly derivable but owns a fact, the verdict is keep + route-the-remainder, never delete-and-lose.
 - **Output deterministic.** Filenames sort lexically; no timestamps in output.


### PR DESCRIPTION
## Summary

The `audit-derivability` Hard Rules bullet read "…never confirmed from this (contaminated) context, **never by a fork**." That bare "a fork" was technically correct — it means the Agent tool's `fork` subagent type — but a reader landing in the Hard Rules section first (via search or a partial read) had no local disambiguation and could wonder whether it also bans a skill's own `context: fork` frontmatter. This makes the bullet self-contained.

## Fix

Name the mechanism inline and distinguish it from skill-level `context: fork`, matching the phrasing already established in the spot-test bullet (added in #1058), so the two clarifications read as one consistent voice:

> …never by the Agent tool's `fork` subagent type (a skill's own `context: fork` frontmatter is unrelated — it starts blank).

## Verification

Before:
> - **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by a fork.

After:
> - **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by the Agent tool's `fork` subagent type (a skill's own `context: fork` frontmatter is unrelated — it starts blank).

The Hard Rules bullet now carries the same Agent-tool-fork-vs-`context: fork` disambiguation as the spot-test bullet, so it no longer depends on the reader having reached that earlier line. Patch version bump (`0.8.5` → `0.8.6`) with a matching CHANGELOG entry.

Closes #1062

## Related

- #1062 — the deferred follow-up this addresses.
- #1053 — the original inverted-fork-mechanism issue.
- #1058 — the fix that added the spot-test bullet's disambiguation this now mirrors in the Hard Rules section.
- #1082 — deferred follow-up (SUGGESTION, non-blocking): "opposite" vs "unrelated" wording drift between line 56 and line 111, plus the Gotchas bullet (~line 119) still lacking disambiguation.

---

Authored by Claude Code (Claude Opus 4.8). Session: https://claude.ai/code/session_01Mu8bLN896ia5AeWmGPqAUv
