### PR TITLE
feat(review): route deep-scan asks to the official Claude Security plugin

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.14.11",
+  "version": "0.15.0",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.0]
+
+### Added
+
+- Deep-scan escalation routing to the official Claude Security plugin (`/claude-security`) from
+  quality-gate security mode and the fanout leaf roster — presence-gated, pointer-only
+  (contract stays upstream at <https://code.claude.com/docs/en/claude-security>), and explicitly
+  not a fan-out leaf.
+
 ## [0.14.11]
 
 ### Changed

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to the `review` plugin are documented here. Format follows
 - Deep-scan escalation routing to the official Claude Security plugin (`/claude-security`) from
   quality-gate security mode and the fanout leaf roster — presence-gated, pointer-only
   (contract stays upstream at <https://code.claude.com/docs/en/claude-security>), and explicitly
-  not a fan-out leaf.
+  not a fan-out leaf. The fanout pre-flight gate checks ask shape before diff resolution, so a
+  whole-repo security-audit ask escalates regardless of diff state.
 
 ## [0.14.11]
 

--- a/plugins/review/skills/fanout/SKILL.md
+++ b/plugins/review/skills/fanout/SKILL.md
@@ -52,10 +52,12 @@ Both review modes share the roster ([context/leaf-roster.md](context/leaf-roster
 
 ## Pre-flight gate (both review modes)
 
-Resolve the review diff base ("Shared inputs") and confirm it yields a non-empty diff BEFORE any surface is spawned:
+**Ask-shape check first, before any diff resolution:** when the ask is a whole-repository security audit rather than a change review, emit the deep-scan escalation from [context/leaf-roster.md](context/leaf-roster.md) "Deep-scan escalation" and STOP — regardless of diff state. A tracked diff or open PR does not convert that ask into a change review; a diff-scoped fan-out would answer a question the user did not ask.
+
+Otherwise resolve the review diff base ("Shared inputs") and confirm it yields a non-empty diff BEFORE any surface is spawned:
 
 - **Unresolvable base** — an open PR's `origin/<baseRefName>` fails `git rev-parse --verify` even after a fetch (do NOT silently substitute a different base — that reviews the wrong diff), or no ladder ref resolves at all → report which ref failed and STOP.
-- **Nothing to review** — truly clean tree, or untracked-only changes → emit the matching diagnostic (full logic: [context/default-mode.md](context/default-mode.md) "Clean-tree short-circuit + untracked-only diagnostic") and STOP; never stage files. When the ask was a whole-repository security audit rather than a change review, the STOP diagnostic also carries the deep-scan escalation from [context/leaf-roster.md](context/leaf-roster.md) "Deep-scan escalation" — a clean tree is the common shape of that ask, and stopping silently would bury the intended route.
+- **Nothing to review** — truly clean tree, or untracked-only changes → emit the matching diagnostic (full logic: [context/default-mode.md](context/default-mode.md) "Clean-tree short-circuit + untracked-only diagnostic") and STOP; never stage files.
 
 Either outcome spawns ZERO reviewers — a fan-out against an empty or wrong change set burns the whole roster to produce noise. The `fix` action is exempt: it consumes persisted findings and spawns no reviewers.
 

--- a/plugins/review/skills/fanout/SKILL.md
+++ b/plugins/review/skills/fanout/SKILL.md
@@ -55,7 +55,7 @@ Both review modes share the roster ([context/leaf-roster.md](context/leaf-roster
 Resolve the review diff base ("Shared inputs") and confirm it yields a non-empty diff BEFORE any surface is spawned:
 
 - **Unresolvable base** — an open PR's `origin/<baseRefName>` fails `git rev-parse --verify` even after a fetch (do NOT silently substitute a different base — that reviews the wrong diff), or no ladder ref resolves at all → report which ref failed and STOP.
-- **Nothing to review** — truly clean tree, or untracked-only changes → emit the matching diagnostic (full logic: [context/default-mode.md](context/default-mode.md) "Clean-tree short-circuit + untracked-only diagnostic") and STOP; never stage files.
+- **Nothing to review** — truly clean tree, or untracked-only changes → emit the matching diagnostic (full logic: [context/default-mode.md](context/default-mode.md) "Clean-tree short-circuit + untracked-only diagnostic") and STOP; never stage files. When the ask was a whole-repository security audit rather than a change review, the STOP diagnostic also carries the deep-scan escalation from [context/leaf-roster.md](context/leaf-roster.md) "Deep-scan escalation" — a clean tree is the common shape of that ask, and stopping silently would bury the intended route.
 
 Either outcome spawns ZERO reviewers — a fan-out against an empty or wrong change set burns the whole roster to produce noise. The `fix` action is exempt: it consumes persisted findings and spawns no reviewers.
 

--- a/plugins/review/skills/fanout/context/leaf-roster.md
+++ b/plugins/review/skills/fanout/context/leaf-roster.md
@@ -31,3 +31,12 @@ When the project ships per-concern review criteria documents, each one becomes a
 ## Total roster
 
 4 agents + N discovered ownerless slices (N varies by project). Report the resolved roster in the tier-transparency line before dispatch.
+
+## Deep-scan escalation (not a leaf)
+
+The official Claude Security plugin's `/claude-security` scan is a self-orchestrating multi-agent
+workflow, not a dispatchable leaf — never add it to the fan-out. When the request is a whole-repo
+security audit rather than a change-set review, recommend it (presence-gated: only when its command
+appears in the skill listing; otherwise suggest installing
+`claude-security@claude-plugins-official`). Contract:
+<https://code.claude.com/docs/en/claude-security>.

--- a/plugins/review/skills/fanout/context/run-everything-mode.md
+++ b/plugins/review/skills/fanout/context/run-everything-mode.md
@@ -14,7 +14,7 @@ Trigger: `$ARGUMENTS` is `run-everything` / `everything` / `all`. Distinct from 
 6. **Normalize main-thread** — gather the Workflow's extracted leaf records + the raw orchestrator outputs; run Stage 0 on the orchestrator outputs (the Workflow only extracted the leaf branch), then Stages 1–4 of `findings-normalization.md` over the combined record set. Reconcile per surface against the Workflow's `raw` array: any surface whose raw output is non-empty but yielded zero extracted records gets Stage 0 re-run main-thread on that raw text; whatever still fails to parse goes verbatim into `## Unparsed` — partial extraction never silently drops a surface.
 7. **Persist** per `default-mode.md` "Findings-writer contract"; prepend the DEGRADED block when the fallback was taken.
 
-**Pre-flight gate first:** SKILL.md's pre-flight gate applies to this mode too — an unresolvable base ref or an empty change set (including untracked-only) reports and stops before step 1; with nothing diffable, every leaf would diff an empty tree and return nothing. Do NOT stage files. A whole-repo security-audit ask stopping here gets the `leaf-roster.md` "Deep-scan escalation" recommendation in the STOP diagnostic (per SKILL.md's gate) — that ask is diff-less by nature and `/claude-security` is its intended route.
+**Pre-flight gate first:** SKILL.md's pre-flight gate applies to this mode too — the ask-shape check routes a whole-repo security-audit ask to the `leaf-roster.md` "Deep-scan escalation" before any diff resolution, and an unresolvable base ref or an empty change set (including untracked-only) reports and stops before step 1; with nothing diffable, every leaf would diff an empty tree and return nothing. Do NOT stage files.
 
 ## Pre-launch availability gate
 

--- a/plugins/review/skills/fanout/context/run-everything-mode.md
+++ b/plugins/review/skills/fanout/context/run-everything-mode.md
@@ -14,7 +14,7 @@ Trigger: `$ARGUMENTS` is `run-everything` / `everything` / `all`. Distinct from 
 6. **Normalize main-thread** — gather the Workflow's extracted leaf records + the raw orchestrator outputs; run Stage 0 on the orchestrator outputs (the Workflow only extracted the leaf branch), then Stages 1–4 of `findings-normalization.md` over the combined record set. Reconcile per surface against the Workflow's `raw` array: any surface whose raw output is non-empty but yielded zero extracted records gets Stage 0 re-run main-thread on that raw text; whatever still fails to parse goes verbatim into `## Unparsed` — partial extraction never silently drops a surface.
 7. **Persist** per `default-mode.md` "Findings-writer contract"; prepend the DEGRADED block when the fallback was taken.
 
-**Pre-flight gate first:** SKILL.md's pre-flight gate applies to this mode too — an unresolvable base ref or an empty change set (including untracked-only) reports and stops before step 1; with nothing diffable, every leaf would diff an empty tree and return nothing. Do NOT stage files.
+**Pre-flight gate first:** SKILL.md's pre-flight gate applies to this mode too — an unresolvable base ref or an empty change set (including untracked-only) reports and stops before step 1; with nothing diffable, every leaf would diff an empty tree and return nothing. Do NOT stage files. A whole-repo security-audit ask stopping here gets the `leaf-roster.md` "Deep-scan escalation" recommendation in the STOP diagnostic (per SKILL.md's gate) — that ask is diff-less by nature and `/claude-security` is its intended route.
 
 ## Pre-launch availability gate
 

--- a/plugins/review/skills/quality-gate/context/security.md
+++ b/plugins/review/skills/quality-gate/context/security.md
@@ -24,6 +24,16 @@ Launch the `security-reviewer` agent with:
 
 The agent covers per-ecosystem injection/XSS/deserialization/path-traversal checks, the OWASP Top 10, security headers, and auth-specific checks (see the agent definition for the full baseline).
 
+## Deep-scan escalation
+
+When the ask outgrows a diff-scoped agent pass — a whole-repository audit, threat-model depth, or
+independently verified findings with patch suggestions — recommend the official Claude Security
+plugin's `/claude-security` command instead of widening this mode. Presence-gated: route to it only
+when its command appears in the skill listing; otherwise suggest installing
+`claude-security@claude-plugins-official`. Jobs, prerequisites, and output contract are
+upstream-owned — do not restate them; see
+<https://code.claude.com/docs/en/claude-security>.
+
 ## After the review
 
 - **CRITICAL findings** — fix immediately, no exceptions


### PR DESCRIPTION
No related issue: adopting the official Claude Security plugin stack — session-scoped integration work with no tracked issue.

## Summary

Quality-gate security mode and the fanout leaf roster now escalate whole-repository audits and threat-model-depth asks to the official Claude Security plugin's `/claude-security` command:

- Presence-gated — routes only when the command appears in the skill listing; otherwise suggests installing `claude-security@claude-plugins-official`.
- Pointer-only — jobs, prerequisites, and output contract stay upstream at https://code.claude.com/docs/en/claude-security (no restated content to drift).
- Explicitly NOT a fan-out leaf — the scan is a self-orchestrating multi-agent workflow; the roster records the exclusion.
- `review` plugin 0.14.11 → 0.15.0, CHANGELOG entry added.

Fresh-docs mandate satisfied: https://code.claude.com/docs/en/claude-security and https://code.claude.com/docs/en/plugins-reference fetched this session.

## Test plan

- [x] plugin.json parses; semver minor bump (new guidance, no breaking change)
- [x] Docs-only + manifest change — no executable surface touched
- [ ] CI markdown/lint gates on this PR

## Related

Refs melodic-software/dotfiles#294 — same adoption: seeds `claude-security` + `security-guidance` (user scope) and the official marketplace into the dotfiles settings seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MJkgbx6eFYyCHveAeTADd