### PR TITLE
fix(guardrails): enablement probe honors local-only plugin scope

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Nine safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.1]
+
+### Fixed
+
+- **`flag-commit-pr-skill-bypass` honors local-only plugin enablement (audit f2
+  residual, follow-up to 0.9.9's user-global fix).** `source_control_enabled()`
+  counted a `settings.local.json` value only when the project `settings.json`
+  already declared the same key, so a plugin enabled ONLY at local scope
+  (`claude plugin install --scope local` — a first-class state per the official
+  plugins reference) resolved as disabled and the `gh pr create` advisory never
+  fired. A local value now participates in per-key resolution unconditionally
+  (settings precedence Local > Project > User); the two tests that encoded the
+  old "local-only key is ignored" model are inverted, plus a new
+  local-only-enable-with-no-other-scope case.
+  (Docs consulted per the fresh-docs mandate:
+  <https://code.claude.com/docs/en/settings> scope precedence;
+  <https://code.claude.com/docs/en/plugins-reference> `--scope local`.)
+
 ## [0.12.0]
 
 ### Added

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
@@ -9,9 +9,10 @@
 # resolved across user-global (`~/.claude/settings.json`), project
 # (`<repo>/.claude/settings.json`), and local (`.claude/settings.local.json`) in
 # precedence order (user-global is the base, project overrides it, local
-# overrides that) — a plugin enabled ONLY at user-global (a common install) is
-# active in every project, so a probe reading the project file alone
-# false-negatives and this advisory never fires. Uncertain state (no jq, no
+# overrides that — unconditionally; `claude plugin install --scope local` makes
+# a local-only key a first-class state) — a plugin enabled ONLY at user-global
+# (a common install) or ONLY at local scope is active here, so a probe reading
+# the project file alone false-negatives and this advisory never fires. Uncertain state (no jq, no
 # value at any scope) never flags a `gh pr create` call — an advisory firing on
 # unknown state is noise, not signal. A missing jq specifically still surfaces a
 # one-time systemMessage that the guard is disabled
@@ -179,8 +180,11 @@ source_control_enabled() {
     lval=$(sc_key_value "$local_settings" "$key")
     effective="$uval"
     [[ -n "$bval" ]] && effective="$bval"
-    # A local override counts only for a key the project settings already declare.
-    [[ -n "$bval" && -n "$lval" ]] && effective="$lval"
+    # Local participates unconditionally: settings precedence is Local >
+    # Project > User, and `claude plugin install --scope local` writes
+    # enabledPlugins to settings.local.json as a first-class standalone state
+    # — a local-only key is real enablement, not noise to ignore.
+    [[ -n "$lval" ]] && effective="$lval"
     [[ "$effective" == "true" ]] && return 0 # any enabled key -> skill available
   done <<<"$keys"
   return 1

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.test.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.test.sh
@@ -139,15 +139,20 @@ assert_silent "project false overrides user-global true" "$out"
 out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$ENABLED_PROJECT" HOME="$HOME_DISABLED")
 assert_contains "project true overrides user-global false" "$out" "gh pr create"
 
-# A local key the project settings.json does NOT declare is ignored by Claude
-# Code, so it must not override — only the project+user-global values apply.
+# Local scope stands alone (settings precedence Local > Project > User;
+# `claude plugin install --scope local` writes enabledPlugins to
+# settings.local.json as a first-class state) — a local value participates in
+# per-key resolution whether or not the project settings.json declares the key.
 LOCAL_ONLY_OFF="$(make_project '' false)" # project {} (no key), local=false
 out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$LOCAL_ONLY_OFF" HOME="$HOME_ENABLED")
-assert_contains "local-only false ignored (no project key) -> user-global fires" "$out" "gh pr create"
+assert_silent "local-only false overrides user-global true (no project key)" "$out"
 
 LOCAL_ONLY_ON="$(make_project '' true)" # project {} (no key), local=true
 out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$LOCAL_ONLY_ON" HOME="$HOME_DISABLED")
-assert_silent "local-only true ignored (no project key) -> user-global disabled stays silent" "$out"
+assert_contains "local-only true overrides user-global false (no project key)" "$out" "gh pr create"
+
+out=$(run_hook "$(command_json 'gh pr create --title x --body y')" "$LOCAL_ONLY_ON")
+assert_contains "local-only enablement fires with no other scope set" "$out" "gh pr create"
 
 # user-global via a relocated CLAUDE_CONFIG_DIR (not ~/.claude) is honored.
 CFG_ENABLED="$(make_config_dir true)"


### PR DESCRIPTION
## Summary

Audit f2 residual (#912; follow-up to #916 / PR #928): `source_control_enabled()` in `flag-commit-pr-skill-bypass.sh` counted a `settings.local.json` value only when the project `settings.json` already declared the same key. A plugin enabled ONLY at local scope — `claude plugin install --scope local`, a first-class state per the official plugins reference — therefore resolved as disabled, and the `gh pr create` advisory never fired (same silent false-negative class #916 fixed for user-global).

A local value now participates in per-key resolution unconditionally, matching the documented scope precedence (Local > Project > User). The two tests that encoded the old "a local-only key is ignored" model are inverted, plus a new local-only-enable-with-no-other-scope case.

Docs consulted per the fresh-docs mandate: [settings scope precedence](https://code.claude.com/docs/en/settings), [`--scope local`](https://code.claude.com/docs/en/plugins-reference).

guardrails `0.12.0` → `0.12.1` with CHANGELOG entry.

## Test plan

- [x] `flag-commit-pr-skill-bypass.test.sh` — 28/0 (red-first: 3 new/inverted local-scope cases)
- [x] `scripts/check-changelog-parity.sh --check-bump main` — pass
- [x] shellcheck clean

## Related

- Closes #1045
- Refs #912 (audit umbrella, f2), #916 / #928 (user-global fix this completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
