### PR TITLE
fix(guardrails): skip hardcoded-path-check when project dir is not a git work tree

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Nine safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.12.3]
+
+### Fixed
+
+- **`hardcoded-path-check` skips when the project dir is not a git working
+  tree (#1094, residual of #1038).** Claude Code sets `CLAUDE_PROJECT_DIR` for
+  any directory — a home-directory session being the common case — and there
+  the scope guard passed while every per-file exemption rung was unreachable:
+  the `.claude` carve-outs don't cover machine-local plugin config
+  (`~/.claude/<plugin>.conf`), and `git check-ignore` errors outside a work
+  tree, leaving only the global kill switch. The scope guard now also skips
+  when `git rev-parse --is-inside-work-tree` does not report a working tree
+  (same rationale as the #1039 no-project skip: hardcoded paths only harm
+  portable repo artifacts, and a non-worktree project dir has none). Bare
+  repos skip too. README scoping bullet updated; tests pin the skip, the
+  unchanged real-work-tree behavior, and the carve-outs now exercised inside
+  real work trees.
+
 ## [0.12.2]
 
 ### Fixed

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -111,11 +111,14 @@ repo-specific policy of their own:
 
 - **Project scoping.** `secret-pattern-detection` and `hardcoded-path-check`
   only police files under `$CLAUDE_PROJECT_DIR`; a write into a sibling repo is
-  that repo's concern. With no active project (`CLAUDE_PROJECT_DIR` unset) the
-  two diverge by threat model: `hardcoded-path-check` skips entirely — a
-  no-project target (a `$HOME` dotfile, say) is machine-local, not a portable
-  repo artifact — while secret scanning fails **closed** and scans anyway
-  (secrets are dangerous anywhere).
+  that repo's concern. With no active project (`CLAUDE_PROJECT_DIR` unset) —
+  or a project dir that is **not a git working tree** (a home-directory
+  session, say; Claude Code sets the project dir for any directory) — the two
+  diverge by threat model: `hardcoded-path-check` skips entirely — such a
+  target (a `$HOME` dotfile, a machine-local `.claude/*.conf`) is
+  machine-local, not a portable repo artifact, and outside a work tree the
+  gitignore allowlist below could never exempt it — while secret scanning
+  fails **closed** and scans anyway (secrets are dangerous anywhere).
 - **Gitignore is the allowlist.** `hardcoded-path-check` skips any file
   `git check-ignore` matches against your `$CLAUDE_PROJECT_DIR` — put
   machine-local files (`settings.local.json`, `.venv/`, …) in your

--- a/plugins/guardrails/hooks/hardcoded-path-check.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.sh
@@ -80,6 +80,15 @@ NORM_FILE="${FILE//\\//}"
 # secret-pattern-detection, which scans even without a resolvable root —
 # secrets are dangerous anywhere; hardcoded paths only harm portable artifacts.
 [[ -n "${CLAUDE_PROJECT_DIR:-}" ]] || exit 0
+# Same rationale when the project dir resolves but is NOT a git working tree
+# (Claude Code sets CLAUDE_PROJECT_DIR for any directory — a home-directory
+# session is the common case): the target is not a portable repo artifact, and
+# every per-file exemption rung below is unreachable there — the .claude
+# carve-outs don't cover machine-local plugin config, and git check-ignore
+# errors outside a work tree — leaving only the global kill switch. A bare
+# repo also skips (no working tree means no tracked portable artifacts to
+# protect at this path).
+[[ "$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]] || exit 0
 _scope_file="$(hook::normalize_path "$FILE")"
 _scope_project="$(hook::normalize_path "${CLAUDE_PROJECT_DIR}")"
 _scope_project="${_scope_project%/}"

--- a/plugins/guardrails/hooks/hardcoded-path-check.test.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.test.sh
@@ -12,6 +12,9 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="$HOOK_DIR/hardcoded-path-check.sh"
 TEST_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
+# The scope guard skips any project dir that is not a git working tree, so
+# the default active-project fixture root must BE one for scan cases to run.
+git -C "$TEST_TMPDIR" init -q
 
 # shellcheck source=guardrails-test-helpers.sh
 source "$HOOK_DIR/guardrails-test-helpers.sh"
@@ -165,6 +168,34 @@ RC=$?
 assert_exit "no project + Edit dotfile-style path → exit 0 (skip)" 0 "$RC"
 assert_silent "no project Edit → no stderr" "$OUT"
 
+# ======================= NON-WORKTREE PROJECT SKIP ==========================
+# CLAUDE_PROJECT_DIR set but NOT a git working tree (home-directory sessions —
+# the harness sets a project dir for any directory): skip entirely. The target
+# is machine-local, and no exemption rung is reachable there (the .claude
+# carve-outs don't cover machine-local plugin config; git check-ignore errors
+# outside a work tree), so scanning would leave only the global kill switch.
+# The reported incident shape: Write of ~/.claude/<plugin>.conf naming
+# absolute machine roots.
+# Own tmpdir — $TEST_TMPDIR is itself a work tree now, so a subdir of it
+# would not exercise the non-worktree path.
+NONREPO="$(mktemp -d)"
+mkdir -p "$NONREPO/.claude"
+OUT=$(CLAUDE_PROJECT_DIR="$NONREPO" bash "$HOOK" <<<"$(write_json "$NONREPO/.claude/tool.conf" "root = ${LINUX_HOME}")" 2>&1)
+RC=$?
+assert_exit "non-worktree project + machine-local conf → exit 0 (skip)" 0 "$RC"
+assert_silent "non-worktree project → no stderr" "$OUT"
+rm -rf "$NONREPO"
+
+# Same content under a REAL work tree still fires — the skip keys on the
+# work-tree probe, not on path shape.
+WT="$TEST_TMPDIR/realwt"
+mkdir -p "$WT"
+git -C "$WT" init -q
+OUT=$(CLAUDE_PROJECT_DIR="$WT" bash "$HOOK" <<<"$(write_json "$WT/notes.txt" "root = ${LINUX_HOME}")" 2>&1)
+RC=$?
+assert_exit "same content in real work tree → exit 2" 2 "$RC"
+assert_contains "real work tree → linux message" "$OUT" "Linux user path"
+
 # ============================ ALLOW (exit 0) ================================
 OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" 'echo "hello world"')" 2>&1)
 RC=$?
@@ -239,19 +270,24 @@ OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "/tmp/othe
 RC=$?
 assert_exit "outside CLAUDE_PROJECT_DIR → exit 0" 0 "$RC"
 
-OUT=$(CLAUDE_PROJECT_DIR="/some/repo" bash "$HOOK" <<<"$(write_json "/some/repo/.claude/hooks/foo.sh" "pattern ${LINUX_HOME}")" 2>&1)
+# Case-exemption pins run inside a REAL work tree — the scope guard's
+# non-worktree skip would otherwise exit before the carve-outs and leave them
+# unpinned.
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$TEST_TMPDIR/.claude/hooks/foo.sh" "pattern ${LINUX_HOME}")" 2>&1)
 RC=$?
 assert_exit ".claude/hooks/ self-exemption → exit 0" 0 "$RC"
 
-OUT=$(CLAUDE_PROJECT_DIR="/some/repo" bash "$HOOK" <<<"$(write_json "/some/repo/.lefthook/pre-commit/foo.sh" "pattern ${LINUX_HOME}")" 2>&1)
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$TEST_TMPDIR/.lefthook/pre-commit/foo.sh" "pattern ${LINUX_HOME}")" 2>&1)
 RC=$?
 assert_exit ".lefthook/ self-exemption → exit 0" 0 "$RC"
 
-# CC session/workflow state under ~/.claude/projects/. Project dir set to the
-# enclosing home so the case-exemption itself is exercised (a no-project run
-# would exit 0 earlier via the scope guard's skip).
-projects_fp="C:${BS}Users${BS}bob${BS}.claude${BS}projects${BS}my-repo${BS}wf.js"
-OUT=$(CLAUDE_PROJECT_DIR="C:${BS}Users${BS}bob" bash "$HOOK" <<<"$(write_json "$projects_fp" "const out = '${WIN_HOME}'")" 2>&1)
+# CC session/workflow state under ~/.claude/projects/, with home itself a
+# checkout (dotfiles-as-home) so the run reaches the case-exemption rather
+# than exiting at the non-worktree skip.
+HOMECO="$TEST_TMPDIR/homeco"
+mkdir -p "$HOMECO"
+git -C "$HOMECO" init -q
+OUT=$(CLAUDE_PROJECT_DIR="$HOMECO" bash "$HOOK" <<<"$(write_json "$HOMECO/.claude/projects/my-repo/wf.js" "const out = '${WIN_HOME}'")" 2>&1)
 RC=$?
 assert_exit ".claude/projects/ CC-state self-exemption → exit 0" 0 "$RC"
 


### PR DESCRIPTION
## Summary

The #1039 fix skips `hardcoded-path-check` when `CLAUDE_PROJECT_DIR` is unset — but Claude Code sets a project dir for **any** directory (per current official hooks docs), home-directory sessions being the common case. There the scope guard passed while every per-file exemption rung was unreachable:

- the `*.claude/hooks/*` / `*.claude/projects/*` carve-outs don't cover machine-local plugin config (`~/.claude/<plugin>.conf`);
- `git check-ignore` errors outside a work tree, so the gitignore allowlist can never fire;
- the only remaining escape was the global `hardcoded_path_check_enabled=false` kill switch.

Reproduced live (producer incident): a `Write` of `~/.claude/repo-fleet-hygiene.conf` — a machine-local gitconfig-format file whose entire purpose is naming machine paths — was blocked with no per-file exemption.

Fix: the scope guard also skips when `git -C "$CLAUDE_PROJECT_DIR" rev-parse --is-inside-work-tree` doesn't report a working tree — the same rationale as #1039 and the hook's stated philosophy: hardcoded paths only harm portable repo artifacts, and a non-worktree project dir has none. Bare repos skip too (no working tree, no tracked portable artifacts at that path).

## Test restructure

The fixture root (`$TEST_TMPDIR`) is now git-initialized so active-project scan cases still run under the new guard, and the carve-out pins were re-pointed at **real** work trees — previously they used nonexistent project dirs (`/some/repo`, a fake home), which the new skip would have turned into trivially-passing tests that no longer exercised the carve-outs. New pins: non-worktree skip (machine-local `.claude/*.conf` shape) and same-content-in-real-work-tree still blocks.

## Verification

- `hardcoded-path-check.test.sh` **72/0**; shellcheck clean
- guardrails `0.12.2` → `0.12.3` + CHANGELOG; README scoping bullet updated

## Related

- Producer finding: handoff-inbox item `20260723-014618-guardrails-hpp-win-repo-pattern-gaps` (Finding 2)
- Prior art: #1038 / #1039 (no-project skip); sibling finding #1093 (merged as #1095)

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)