### PR TITLE
fix(repo-fleet-hygiene): config resolution ladder + consumed-config visibility

### DIFF
--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -210,7 +210,7 @@ open.
 | `ai-briefing` | `.claude/ai-briefing/` | team only | undeclared: overlay recommended, never resolved |
 | `code-tidying` | `.claude/tidy-lanes/<lane>.md` | team only | team layer over a bundled default. A project lane declaring `## Merge semantics` merges per-section with its bundled lane (`docs-prose` decomposed: `Scope` per-section override, watch-for patterns additive — #701); lanes without the declaration still resolve project-only wholesale (`shell-tooling` — #724). No user-global or `*.local.*` overlay (#723) |
 | `topic-docs` | `.claude/topic-docs.yaml` | team only | single-layer |
-| `repo-fleet-hygiene` | `.claude/repo-fleet-hygiene.conf` | team only | single-layer |
+| `repo-fleet-hygiene` | `.claude/repo-fleet-hygiene.conf` | user-global + team | declared deviation; whole-file precedence (explicit `--config` > team > user-global fallback), no per-key merge, no overlay layer (#1099) |
 | `work-items` | `.work-item-tracker.json` | team only | single-layer; resolves by CWD-to-root climb rather than anchoring at the repo root |
 | `testing` (`run-e2e`) | `.claude/testing/e2e.md` | all three | conforms; per-key override on `recording` / `browser_mode`, keys owned by `run-e2e/context/e2e-config.md` |
 

--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+### Fixed
+
+- **Fleet config is no longer silently ignored outside the project that wrote it (#1099).**
+  The audit consumed config only from `${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf`,
+  so a machine-scoped fleet config authored in one directory vanished the moment the audit ran
+  from any real project — silently narrowing to that single project with no mention of the
+  existing file. The collector now owns a resolution ladder: explicit `--config`, else the
+  project-scoped file, else the user-global `~/.claude/repo-fleet-hygiene.conf` (a file placed
+  there is recorded user intent, not a guessed machine root; `$HOME` with `%USERPROFILE%`
+  fallback). The report header names the consumed config and its source — or states that none
+  was consumed — so silent non-consumption cannot recur. An invalid auto-probed config fails
+  loud rather than falling back to a narrower scope. Setup's `check`/`apply` output states the
+  scoping rule and the user-global placement option. Ladder covered by four new test cases.
+
 ## [0.2.0]
 
 ### Changed

--- a/plugins/repo-fleet-hygiene/README.md
+++ b/plugins/repo-fleet-hygiene/README.md
@@ -41,8 +41,11 @@ Audit exact repositories without recursive discovery:
 /repo-fleet-hygiene:audit --repo <repo-root>/github.com/acme/api --repo <repo-root>/github.com/acme/web
 ```
 
-The skill automatically uses `.claude/repo-fleet-hygiene.conf` in the consumer project when present,
-or accepts `--config <path>` explicitly. Explicit CLI roots/repos are additive.
+Config resolution is a whole-file precedence ladder: explicit `--config <path>`, else
+`.claude/repo-fleet-hygiene.conf` in the consumer project, else the user-global
+`~/.claude/repo-fleet-hygiene.conf` (a machine-scoped fleet config that applies from every
+project). The audit report header names which config was consumed. Explicit CLI roots/repos are
+additive.
 
 ## Configuration
 

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -30,9 +30,14 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
   (repeatable; explicit wins over config).
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 
-If neither `--root` nor `--repo` is present, the script uses `${CLAUDE_PROJECT_DIR}`. If `--config`
-is absent and `${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf` exists, pass that file. Never
-guess a broader machine root from the current path.
+If neither `--root` nor `--repo` is present, the script uses `${CLAUDE_PROJECT_DIR}`. Config
+resolution is the script's own ladder — do not pre-resolve or pass a probed path yourself:
+explicit `--config` wins, else the script probes
+`${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf` (project-scoped), else
+`~/.claude/repo-fleet-hygiene.conf` (user-global — a machine-scoped fleet config placed there is
+recorded user intent, not a guessed root). The report header names the consumed config and its
+source, or states that none was consumed. Never guess a broader machine root from the current
+path beyond that ladder.
 
 Before execution, reject any arguments outside this grammar. Pass every path/override as a quoted
 argument; never assemble a shell fragment from config, repository, remote, or branch text.

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -288,9 +288,32 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Config resolution ladder: explicit --config, then the project-scoped file,
+# then the user-global one. A fleet config is inherently machine-scoped, so a
+# user-global ~/.claude file is honored when the current project carries none —
+# that file is recorded user intent, not a guessed broader machine root. The
+# consumed source is named in the report header so silent non-consumption
+# cannot happen.
+CONFIG_SOURCE="none"
 if [[ -n "$CONFIG_FILE" ]]; then
   [[ -f "$CONFIG_FILE" ]] || fail "config file not found: $CONFIG_FILE"
+  CONFIG_SOURCE="explicit --config"
+else
+  if [[ -n "${CLAUDE_PROJECT_DIR:-}" && -f "${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf" ]]; then
+    CONFIG_FILE="${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf"
+    CONFIG_SOURCE="project"
+  else
+    home_dir="${HOME:-${USERPROFILE:-}}"
+    if [[ -n "$home_dir" && -f "$home_dir/.claude/repo-fleet-hygiene.conf" ]]; then
+      CONFIG_FILE="$home_dir/.claude/repo-fleet-hygiene.conf"
+      CONFIG_SOURCE="user-global"
+    fi
+  fi
+fi
+if [[ -n "$CONFIG_FILE" ]]; then
   CONFIG_FILE="$(cd "$(dirname "$CONFIG_FILE")" 2>/dev/null && pwd -P)/$(basename "$CONFIG_FILE")"
+  # An invalid config fails loud regardless of how it was found — an
+  # auto-probed file never silently falls back to a narrower scope.
   run_git_probe config --file "$CONFIG_FILE" --list >/dev/null 2>&1 || fail "invalid Git config: $CONFIG_FILE"
   CONFIG_DIR="$(dirname "$CONFIG_FILE")"
 else
@@ -910,6 +933,11 @@ analyze_repo() {
 
 printf 'Repo Fleet Hygiene Audit\n'
 printf 'Mode: read-only (no fetch, prune, repair, delete, checkout, or remote update)\n'
+if [[ -n "$CONFIG_FILE" ]]; then
+  print_field Config "$CONFIG_FILE ($CONFIG_SOURCE)"
+else
+  print_field Config "none (no explicit, project, or user-global config; current-project scope)"
+fi
 printf 'GitHub evidence: %s\n' "$([[ "$GH_READY" == "true" ]] && echo available || echo unavailable)"
 printf 'Repositories discovered: %s\n' "${#TARGETS[@]}"
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -295,6 +295,45 @@ else
   printf 'PASS: control-bearing path stayed within one encoded field\n'
 fi
 
+# Config resolution ladder: explicit --config > project-scoped > user-global > none,
+# with the consumed source named in the report header.
+assert_contains "explicit config named in header" "(explicit --config)"
+
+mkdir -p "$TMP/proj/.claude" "$TMP/noconf" "$TMP/homeg/.claude" "$TMP/nohome"
+cat >"$TMP/proj/.claude/repo-fleet-hygiene.conf" <<'LADDER'
+[fleet]
+    repo = ../../discovered-a
+LADDER
+cp "$TMP/proj/.claude/repo-fleet-hygiene.conf" "$TMP/homeg/.claude/repo-fleet-hygiene.conf"
+ladder_out="$TMP/ladder.txt"
+
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/proj" HOME="$TMP/nohome" \
+  bash "$SCRIPT" >"$ladder_out"
+if grep -Fq -- "repo-fleet-hygiene.conf (project)" "$ladder_out"; then
+  printf 'PASS: project config auto-probed and named\n'
+else
+  printf 'FAIL: project config auto-probed and named\n' >&2
+  failures=$((failures + 1))
+fi
+
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/noconf" HOME="$TMP/homeg" \
+  bash "$SCRIPT" >"$ladder_out"
+if grep -Fq -- "repo-fleet-hygiene.conf (user-global)" "$ladder_out"; then
+  printf 'PASS: user-global config fallback consumed and named\n'
+else
+  printf 'FAIL: user-global config fallback consumed and named\n' >&2
+  failures=$((failures + 1))
+fi
+
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" >"$ladder_out"
+if grep -Fq -- "Config: none" "$ladder_out"; then
+  printf 'PASS: no-config run states none was consumed\n'
+else
+  printf 'FAIL: no-config run states none was consumed\n' >&2
+  failures=$((failures + 1))
+fi
+
 # Exercise the collector's own fail-closed command gate, rather than relying on a denylist that can
 # miss a new mutation spelling. None of these forbidden vectors may reach the fake executables.
 calls_before="$(wc -l <"$CALL_LOG")"

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -20,6 +20,13 @@ prompting.
 Default config path: `${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf`. An explicit `--config`
 may choose another path. Resolve relative roots/repos/canonical paths from the config file directory.
 
+**Scoping rule (state it in `check`/`apply` output):** the audit consumes config through a ladder —
+explicit `--config`, else the project-scoped default above, else the user-global
+`~/.claude/repo-fleet-hygiene.conf`. A project-scoped config is therefore consumed only when the
+audit runs with that same project directory; a fleet config meant to apply from every project
+belongs at the user-global path (`apply --config ~/.claude/repo-fleet-hygiene.conf`). The audit
+report header names which config (if any) was consumed.
+
 ## `check` (read-only)
 
 The audit script (`${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/audit-fleet.sh`) and the config file are
@@ -27,9 +34,10 @@ the source of truth. Probe, report a PASS/FAIL/INFO table with one remediation l
 modify nothing. Do NOT run the fleet walk itself — that is `/repo-fleet-hygiene:audit`; `check` only
 validates the configuration the audit would consume.
 
-1. **Config presence** — resolve the config path (`--config` or the default). Absent → INFO: the audit
-   defaults to the current project; `apply` scaffolds a config only if the user wants bounded roots or
-   overrides.
+1. **Config presence** — resolve the config path (`--config` or the default). Absent → INFO naming
+   the full ladder: the audit next probes the user-global `~/.claude/repo-fleet-hygiene.conf` (report
+   whether one exists there) and otherwise defaults to the current project; `apply` scaffolds a
+   config only if the user wants bounded roots or overrides.
 2. **Parse validity** — present config: `git config --file "<path>" --list >/dev/null`. A non-zero exit
    is FAIL with the parse error in the remediation line. Never `source` the file.
 3. **Entry resolution** — for each `[fleet] root`/`repo` and each `[canonical …] path`, resolve it from


### PR DESCRIPTION
## Summary

The audit consumed config only from `${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf`, so a machine-scoped fleet config authored in one directory silently vanished when the audit ran from any real project — narrowing to that single project (the exact pre-config default the config was built to escape), with nothing in `setup check`, `setup apply`, or the report saying so. Reproduced per the producer handoff item.

Changes (#1099's three coordinated fixes):

1. **Resolution ladder owned by the collector**: explicit `--config` → project-scoped `.claude/repo-fleet-hygiene.conf` → user-global `~/.claude/repo-fleet-hygiene.conf` (`$HOME`, `%USERPROFILE%` fallback). A user-global fleet config is recorded user intent, not a guessed machine root — the "never guess a broader machine root" rule survives intact beyond the ladder. An invalid auto-probed config fails loud; it never silently falls back to a narrower scope.
2. **Report visibility**: header prints `Config: <path> (<source>)` or `Config: none (…)` — silent non-consumption cannot recur. Rendered via the control-safe field printer.
3. **Docs**: audit SKILL.md defers config resolution to the script's ladder; setup SKILL.md states the scoping rule in `check`/`apply` output and documents user-global placement (`apply --config ~/.claude/repo-fleet-hygiene.conf`).

## Verification

- `audit-fleet.test.sh` **27/0** — 4 new cases: explicit-config header naming, project auto-probe, user-global fallback, none-consumed statement
- shellcheck clean on script + test
- repo-fleet-hygiene `0.2.0` → `0.3.0` + CHANGELOG

## Related

- Producer finding: handoff-inbox item `20260723-014618-repo-fleet-hygiene-setup-audit-findings` (Finding 1, primary)
- Siblings from the same item: #1100 (ackUnavailable), #1101 (polish batch) — separate PRs

Closes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)