### PR TITLE
feat(repo-fleet-hygiene): fleet.ackUnavailable — acknowledge known-inaccessible identities

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.0]
+
+### Added
+
+- **`fleet.ackUnavailable` — acknowledge known-inaccessible GitHub identities (#1100).** In real
+  fleets, many `github-identity-unavailable` UNKNOWNNs are foreseeable 404s (upstream repos made
+  private/deleted; repos owned by a different GitHub account than the authenticated `gh` login) and
+  re-reported at full prominence every run. The repeatable `ackUnavailable = github.com/owner/repo`
+  config key demotes a 404/403 identity failure for that identity to a new `ACKNOWLEDGED`
+  confidence — still reported with its real HTTP reason and the ack source, never suppressed, and
+  counted separately in the summary (`acknowledged=N`). Acks never touch non-404/403 failures
+  (network errors keep UNKNOWN prominence even for acked identities) or successful-response
+  evidence (a rename still reports HIGH). The read-probe allowlist is extended narrowly
+  (`--null --get-all fleet.ackUnavailable`); malformed ack values fail loud. Documented in the
+  setup grammar and `check` (INFO listing); covered by ack-hit, unacked-404, and
+  non-404-on-acked-identity test cases.
+
 ## [0.3.0]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -61,6 +61,8 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
 2. **GitHub identity:** read the selected fetch remote with `git remote get-url`; accept only
    `github.com/owner/repo`; query `GET /repos/{owner}/{repo}`. If returned `full_name` differs, report
    `HIGH` transfer/rename evidence. A 404/403/network error is `UNKNOWN`, never "deleted" or "moved".
+   A 404/403 on an identity listed in `fleet.ackUnavailable` is demoted to `ACKNOWLEDGED` — still
+   reported, never suppressed; acks never touch non-404/403 failures or successful-response evidence.
 3. **Merged branch:** query `gh pr list --repo <this-repo> --state merged --head <this-branch>` for
    each local branch in each repository. Identical branch names in another repository are unrelated.
    `HIGH` requires the PR `headRefOid` to equal the current local tip. Tip drift is `MEDIUM` manual
@@ -80,12 +82,14 @@ Full tier/disposition table: [reference/confidence-model.md](reference/confidenc
 
 ## Presentation
 
-Return the script's repository sections and finish with four grouped lists:
+Return the script's repository sections and finish with five grouped lists:
 
 1. `HIGH — candidate handoffs`
 2. `MEDIUM — manual review`
 3. `LOW — informational only`
 4. `UNKNOWN — evidence gaps`
+5. `ACKNOWLEDGED — configured known-inaccessible identities` (`fleet.ackUnavailable` demotions;
+   present the group only when non-empty)
 
 For each candidate, keep repository, canonical path, exact branch/worktree/remote target, PR/API
 evidence, and handoff. Never collapse same-named branches across repositories.

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -63,7 +63,7 @@ git_probe_allowed() {
       return
     fi
     if [[ $# -eq 6 && "$4" == "--null" && "$5" == "--get-all" ]]; then
-      [[ "$6" == "fleet.root" || "$6" == "fleet.repo" ]]
+      [[ "$6" == "fleet.root" || "$6" == "fleet.repo" || "$6" == "fleet.ackUnavailable" ]]
       return
     fi
     if [[ $# -eq 6 && "$4" == "--get-regexp" && "$5" == "-z" ]]; then
@@ -345,6 +345,31 @@ if [[ -n "$CONFIG_FILE" ]]; then
   done < <(run_git_probe config --file "$CONFIG_FILE" --null --get-all fleet.repo 2>/dev/null || true)
 fi
 
+# Acknowledged known-inaccessible GitHub identities (fleet.ackUnavailable,
+# repeatable). An acknowledgment only demotes a 404/403
+# github-identity-unavailable finding to ACKNOWLEDGED prominence — it never
+# suppresses the finding, never touches non-404/403 failures, and never
+# affects evidence from a successful API response.
+ACK_KEYS=()
+if [[ -n "$CONFIG_FILE" ]]; then
+  while IFS= read -r -d '' value; do
+    [[ -n "$value" ]] || continue
+    ack_key="$(lower "$value")"
+    [[ "$ack_key" =~ ^github\.com/[^/[:cntrl:][:space:]]+/[^/[:cntrl:][:space:]]+$ ]] ||
+      fail "invalid fleet.ackUnavailable value (expected github.com/owner/repository): $value"
+    ACK_KEYS+=("$ack_key")
+  done < <(run_git_probe config --file "$CONFIG_FILE" --null --get-all fleet.ackUnavailable 2>/dev/null || true)
+fi
+
+is_acked() {
+  local key a
+  key="$(lower "$1")"
+  for a in "${ACK_KEYS[@]:-}"; do
+    [[ -n "$a" && "$a" == "$key" ]] && return 0
+  done
+  return 1
+}
+
 if [[ ${#ROOT_ARGS[@]} -eq 0 && ${#REPO_ARGS[@]} -eq 0 ]]; then
   REPO_ARGS+=("${CLAUDE_PROJECT_DIR:-$PWD}")
 fi
@@ -524,6 +549,7 @@ FINDINGS_HIGH=0
 FINDINGS_MEDIUM=0
 FINDINGS_LOW=0
 FINDINGS_UNKNOWN=0
+FINDINGS_ACKED=0
 REPOS_AUDITED=0
 
 emit_finding() {
@@ -532,6 +558,7 @@ emit_finding() {
   HIGH) FINDINGS_HIGH=$((FINDINGS_HIGH + 1)) ;;
   MEDIUM) FINDINGS_MEDIUM=$((FINDINGS_MEDIUM + 1)) ;;
   LOW) FINDINGS_LOW=$((FINDINGS_LOW + 1)) ;;
+  ACKNOWLEDGED) FINDINGS_ACKED=$((FINDINGS_ACKED + 1)) ;;
   *) FINDINGS_UNKNOWN=$((FINDINGS_UNKNOWN + 1)) ;;
   esac
   print_field Finding "$kind"
@@ -616,6 +643,14 @@ analyze_repo() {
           "GitHub REST resolved the configured remote identity to canonical full_name $expected_actual" \
           "Human-reviewed remote update" "Review git remote set-url for $discovered_remote in $discovered"
       fi
+    elif [[ "$expected_reason" == *"HTTP 404"* || "$expected_reason" == *"HTTP 403"* ]] && is_acked "$discovered_key"; then
+      # Acked demotion applies ONLY to the foreseeable-inaccessible statuses;
+      # any other failure (network, timeout, malformed response) keeps full
+      # UNKNOWN prominence with its real reason even for an acked identity.
+      emit_finding ACKNOWLEDGED github-identity-unavailable "$discovered_key" \
+        "$expected_reason; acknowledged known-inaccessible via fleet.ackUnavailable" \
+        "Acknowledged; no GitHub evidence combined" \
+        "Remove the fleet.ackUnavailable entry to restore UNKNOWN prominence"
     else
       emit_finding UNKNOWN github-identity-unavailable "$discovered_key" "$expected_reason" \
         "Do not infer moved, deleted, or clean" "Restore GitHub access/authentication and rerun"
@@ -945,6 +980,6 @@ for target in "${TARGETS[@]}"; do
   analyze_repo "$target"
 done
 
-printf '\nSummary: repositories=%s high=%s medium=%s low=%s unknown=%s\n' \
-  "$REPOS_AUDITED" "$FINDINGS_HIGH" "$FINDINGS_MEDIUM" "$FINDINGS_LOW" "$FINDINGS_UNKNOWN"
+printf '\nSummary: repositories=%s high=%s medium=%s low=%s unknown=%s acknowledged=%s\n' \
+  "$REPOS_AUDITED" "$FINDINGS_HIGH" "$FINDINGS_MEDIUM" "$FINDINGS_LOW" "$FINDINGS_UNKNOWN" "$FINDINGS_ACKED"
 printf 'Mutation count: 0\n'

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -12,7 +12,7 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/ref-fail" \
   "$TMP/root/acme/root-repo/.git" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
-  "$TMP/discovered-c" "$TMP/canonical-c"
+  "$TMP/discovered-c" "$TMP/canonical-c" "$TMP/gone-repo" "$TMP/lost-repo" "$TMP/net-repo"
 : >"$TMP/calls.log"
 
 cat >"$MOCK_BIN/git" <<'EOF'
@@ -49,6 +49,9 @@ rev-parse)
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
+    gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
+    lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo" ;;
+    net-repo) printf '%s\n' "$TEST_ROOT/net-repo" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -64,6 +67,9 @@ rev-parse)
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
+    gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
+    lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
+    net-repo) printf '%s\n' "$TEST_ROOT/net-repo/.git" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -82,6 +88,9 @@ remote)
     ref-fail) printf '%s\n' 'https://github.com/acme/ref-fail.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
+    gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
+    lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
+    net-repo) printf '%s\n' 'https://github.com/gone/net.git' ;;
     *) exit 1 ;;
     esac
   else
@@ -113,6 +122,15 @@ worktree)
   canonical-c)
     printf 'worktree %s\0HEAD main-c\0branch refs/heads/main\0\0' "$TEST_ROOT/canonical-c"
     ;;
+  gone-repo)
+    printf 'worktree %s\0HEAD gone-main\0branch refs/heads/main\0\0' "$TEST_ROOT/gone-repo"
+    ;;
+  lost-repo)
+    printf 'worktree %s\0HEAD lost-main\0branch refs/heads/main\0\0' "$TEST_ROOT/lost-repo"
+    ;;
+  net-repo)
+    printf 'worktree %s\0HEAD net-main\0branch refs/heads/main\0\0' "$TEST_ROOT/net-repo"
+    ;;
   esac
   ;;
 symbolic-ref)
@@ -121,7 +139,7 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | wt-fail | ref-fail | canonical-c) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | wt-fail | ref-fail | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
@@ -147,6 +165,9 @@ for-each-ref)
   ref-fail) printf 'main\tref-main\0\nfeature/partial\tpartial-tip\0'; exit 9 ;;
   root-repo) printf 'main\troot-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
+  gone-repo) printf 'main\tgone-main\0\n' ;;
+  lost-repo) printf 'main\tlost-main\0\n' ;;
+  net-repo) printf 'main\tnet-main\0\n' ;;
   esac
   ;;
 merge-base) exit 1 ;;
@@ -179,6 +200,7 @@ api)
   repos/acme/ref-fail) printf 'acme/ref-fail\tmain' ;;
   repos/old/repo) printf 'new/repo\tmain' ;;
   repos/acme/repo-c) printf 'acme/repo-c\tmain' ;;
+  repos/gone/net) printf 'gh: connection reset by peer\n' >&2; exit 1 ;;
   *) printf 'gh: Not Found (HTTP 404)\n' >&2; exit 1 ;;
   esac
   ;;
@@ -223,7 +245,12 @@ cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
     repo = ../wt-fail
     repo = ../ref-fail
     repo = ../discovered-c
+    repo = ../gone-repo
+    repo = ../lost-repo
+    repo = ../net-repo
     maxDepth = 5
+    ackUnavailable = github.com/Gone/Away
+    ackUnavailable = github.com/gone/net
 [canonical "github.com/acme/repo-a"]
     path = ../canonical-a
 [canonical "github.com/acme/bad"]
@@ -273,7 +300,31 @@ assert_not_contains "repo B branch did not inherit repo A merge" "Target: $TMP/r
 assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad-canonical ::"
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
-assert_contains "failed repositories not counted successful" "Summary: repositories=5"
+assert_contains "failed repositories not counted successful" "Summary: repositories=8"
+
+# fleet.ackUnavailable: 404 on an acked identity (mixed-case config entry) is
+# demoted to ACKNOWLEDGED; an unacked 404 stays UNKNOWN; a non-404 failure on
+# an acked identity stays UNKNOWN with its real reason.
+if grep -B2 -F "Target: github.com/gone/away" "$output" | grep -Fq "Confidence: ACKNOWLEDGED"; then
+  printf 'PASS: acked 404 demoted to ACKNOWLEDGED\n'
+else
+  printf 'FAIL: acked 404 demoted to ACKNOWLEDGED\n' >&2
+  failures=$((failures + 1))
+fi
+assert_contains "acked finding names its ack source" "acknowledged known-inaccessible via fleet.ackUnavailable"
+if grep -B2 -F "Target: github.com/lost/cause" "$output" | grep -Fq "Confidence: UNKNOWN"; then
+  printf 'PASS: unacked 404 stays UNKNOWN\n'
+else
+  printf 'FAIL: unacked 404 stays UNKNOWN\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -B2 -F "Target: github.com/gone/net" "$output" | grep -Fq "Confidence: UNKNOWN"; then
+  printf 'PASS: non-404 failure on acked identity stays UNKNOWN\n'
+else
+  printf 'FAIL: non-404 failure on acked identity stays UNKNOWN\n' >&2
+  failures=$((failures + 1))
+fi
+assert_contains "summary counts acknowledged separately" "acknowledged=1"
 
 if grep -Fq -- '--head feature/mismatch' "$CALL_LOG"; then
   printf 'FAIL: local-only branch name was sent to GitHub via --head\n' >&2

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -3,7 +3,7 @@ name: setup
 description: "Verify and configure repo-fleet-hygiene for a consumer project. check inspects the optional .claude/repo-fleet-hygiene.conf read-only (presence, parse validity, path resolution); apply creates or updates it — adding bounded fleet roots, exact repositories, and remote-keyed canonical checkout overrides — preserving unrelated entries. Use when: 'set up repo fleet audit', 'is repo-fleet-hygiene configured', 'configure fleet roots', 'canonical repo override', 'dotfiles-manager checkout'. Re-runnable and safe."
 user-invocable: true
 disable-model-invocation: true
-argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]... [--canonical <github.com/owner/repo=path>]..."
+argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]... [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]..."
 ---
 
 ## Purpose
@@ -56,6 +56,11 @@ Run `check`, then create or update the config from the supplied arguments.
 1. Parse only the declared argument grammar. Validate every root/repository/canonical path with
    read-only filesystem and `git rev-parse` checks. Normalize canonical keys to
    `github.com/owner/repository` (lowercase host, case-preserving owner/name is acceptable).
+   Validate each `--ack-unavailable` value as a normalizable `github.com/owner/repository`
+   (no filesystem probe — the identity is expected to be inaccessible); write it as a repeatable
+   `[fleet] ackUnavailable` entry, deduplicating case-insensitively against entries already
+   present. Like roots/repos, apply is additive — removing an acknowledgment is a manual edit of
+   the consumer's own config file.
 2. If the config exists, read it with `git config --file <path> --list --show-origin`. Preserve every
    unrelated entry. Never source it.
 3. State the proposed additions/updates before writing. With complete arguments, proceed

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -46,6 +46,8 @@ validates the configuration the audit would consume.
 4. **`maxDepth`** — present and outside `1..12` is FAIL; absent is INFO (the audit's own default applies).
 5. **Canonical identity** — INFO for each `[canonical "github.com/owner/repository"]` entry: report the
    normalized key. Flag as FAIL only a key that is not a normalizable `github.com/owner/repository`.
+6. **Acknowledged identities** — INFO listing each `fleet.ackUnavailable` entry (normalized). FAIL any
+   value that is not a normalizable `github.com/owner/repository`.
 
 ## `apply` (idempotent)
 
@@ -89,10 +91,17 @@ Re-running `apply` with the same arguments after everything resolves changes not
     root = ../../repos/github.com   # repeatable discovery root
     repo = ../../special/repo      # repeatable exact target
     maxDepth = 5                   # integer 1..12
+    ackUnavailable = github.com/owner/repository   # repeatable; acknowledge a known-inaccessible identity
 
 [canonical "github.com/owner/repository"]
     path = ../../../canonical-checkout
 ```
+
+`ackUnavailable` demotes a 404/403 `github-identity-unavailable` finding for that identity from
+`UNKNOWN` to `ACKNOWLEDGED` in the audit report — still reported, never suppressed, and never
+affecting non-404/403 failures or successful-response evidence. Use it for foreseeable 404s:
+upstream repositories made private or deleted, or repositories owned by a different GitHub account
+than the authenticated `gh` login.
 
 Resolution priority is explicit audit CLI override, canonical config entry, then discovered checkout's
 `git rev-parse --show-toplevel`. Never add a canonical override merely because two directory names look


### PR DESCRIPTION
## Summary

In the producer's 25-repo fleet run, 12 findings were UNKNOWN `github-identity-unavailable` — all foreseeable 404s (upstream repos made private/deleted; repos owned by a different GitHub account than the authenticated `gh` login), re-reported at full prominence every run. The script's refusal to infer anything from a 404 is correct and stays; what was missing was a mechanism to record "this identity is known-inaccessible from this machine".

New repeatable config key:

```gitconfig
[fleet]
    ackUnavailable = github.com/owner/repo
```

Semantics (deliberately narrow):

- A **404/403** identity failure for an acked identity is demoted from `UNKNOWN` to a new `ACKNOWLEDGED` confidence — still reported with its real HTTP reason plus the ack source, never suppressed, counted separately (`Summary: … acknowledged=N`).
- **Non-404/403 failures keep UNKNOWN prominence** even for acked identities (a network error on an acked repo reports its real reason).
- **Successful-response evidence is untouched** — a rename on an acked identity still reports `HIGH github-remote-moved`.
- Keys compare lowercase (mixed-case config entries match); malformed values fail loud; the fail-closed read-probe allowlist is extended narrowly (`--null --get-all fleet.ackUnavailable` only).

Docs: setup grammar + new `check` step (INFO listing acked identities, FAIL on non-normalizable values); audit SKILL.md evidence rule + `ACKNOWLEDGED` presentation group. Multi-account `gh` support remains explicitly out of scope.

## Verification

- `audit-fleet.test.sh` **32/0** — new cases: acked 404 (mixed-case entry) → ACKNOWLEDGED; unacked 404 → UNKNOWN; non-404 failure on acked identity → UNKNOWN; summary `acknowledged=1`
- shellcheck clean; repo-fleet-hygiene `0.3.0` → `0.4.0` + CHANGELOG

## Related

- Producer finding: handoff-inbox item `20260723-014618-repo-fleet-hygiene-setup-audit-findings` (Finding 3)
- Siblings: #1099 (merged as #1102), #1101 (polish batch, next)

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)