### PR TITLE
docs(repo-fleet-hygiene): relative-path setup guidance, per-root discovery counts, gotchas, quoted triggers

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.1]
+
+### Added
+
+- **Per-root discovery counts in the audit report header (#1101).** The header printed only the total
+  `Repositories discovered: N`; a discovery root that walked to zero repositories left no trace, so a
+  directory the user expected to be a repo had to be diffed against memory. Each `--root`/config `root`
+  now prints `Root <path>: <k> repositories`, keeping a zero-contribution root visible without any
+  per-directory noise. Covered by `audit-fleet.test.sh`.
+- **`## Gotchas` surfaces on both skills (#1101).** The `audit` and `setup` skills now document the
+  real first-contact gotchas: a project-scoped config is consumed only from its own project (fleet
+  configs belong at the user-global path), and absolute paths in tracked config can trip a consumer's
+  write-time path-portability guard where the relative form passes and resolves identically.
+
+### Changed
+
+- **`setup apply` prefers relative-to-config-dir paths (#1101).** `apply` now writes any
+  root/repository/canonical target relative to the config file's directory when expressible that way —
+  the two forms audit identically, and the relative form avoids consumer write-time path guards that
+  reject absolute paths in tracked config.
+- **`audit` skill trigger phrases are single-quoted (#1101).** The `Use when:` triggers are now
+  single-quoted so the skill-quality checker's trigger-drop regression protection tracks them; every
+  existing trigger keyword is preserved.
+
 ## [0.3.0]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit
-description: "Audit Git/GitHub hygiene across a fleet of local repositories: find GitHub-merged local branches, merged/missing/prunable/mislinked worktree registrations, and remotes that resolve to a moved or renamed GitHub repository. Read-only and confidence-tiered; emits exact handoffs to repo-hygiene/source-control but never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: audit repositories, repo fleet hygiene, stale branches across repos, orphaned worktrees across repos, moved repos, renamed GitHub owner, cross-repo git cleanup report."
+description: "Audit Git/GitHub hygiene across a fleet of local repositories: find GitHub-merged local branches, merged/missing/prunable/mislinked worktree registrations, and remotes that resolve to a moved or renamed GitHub repository. Read-only and confidence-tiered; emits exact handoffs to repo-hygiene/source-control but never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
 user-invocable: true
 argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]..."
 allowed-tools:
@@ -119,3 +119,15 @@ do not turn "no verified finding" into "fleet is clean".
 
 This plugin remains useful if those optional collaborators are absent: the report names the local
 Git/GitHub evidence and target so another tool or human can act.
+
+## Gotchas
+
+- **Which config is consumed depends on where the audit runs.** Config resolution follows the ladder in
+  the Input resolution section: explicit `--config`, else the project-scoped
+  `.claude/repo-fleet-hygiene.conf`, else the user-global one. A project-scoped config is invisible when
+  the audit runs from a different project, so confirm the consumed config named in the report header
+  before trusting a run's scope.
+- **Config paths resolve relative to the config file's directory.** A relative `root`/`repo`/canonical
+  path is anchored at the config directory, not the audit's working directory. Absolute paths work but
+  are what a consumer's write-time path guard flags, so author config via
+  `/repo-fleet-hygiene:setup apply`, which prefers the portable relative form.

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -398,10 +398,18 @@ discover_repositories() {
   done
 }
 
+ROOT_LABELS=()
+ROOT_COUNTS=()
 for root in "${ROOT_ARGS[@]:-}"; do
   [[ -n "$root" ]] || continue
   [[ -d "$root" ]] || fail "discovery root not found: $root"
+  # Per-root visibility: attribute newly discovered repositories to this root so a root that
+  # contributed none is still reported. Deduplication credits a repo shared by nested/overlapping
+  # roots to the first root that reaches it, keeping sum(root counts) + explicit --repo == discovered.
+  root_before=${#TARGETS[@]}
   discover_repositories "$root" 0
+  ROOT_LABELS+=("$root")
+  ROOT_COUNTS+=($((${#TARGETS[@]} - root_before)))
 done
 
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "no Git working trees found in the requested scope"
@@ -940,6 +948,11 @@ else
 fi
 printf 'GitHub evidence: %s\n' "$([[ "$GH_READY" == "true" ]] && echo available || echo unavailable)"
 printf 'Repositories discovered: %s\n' "${#TARGETS[@]}"
+for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
+  printf 'Root '
+  display_value "${ROOT_LABELS[$root_index]}"
+  printf ': %s repositories\n' "${ROOT_COUNTS[$root_index]}"
+done
 
 for target in "${TARGETS[@]}"; do
   analyze_repo "$target"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -11,6 +11,7 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/bad-discovered" "$TMP/bad-canonical" "$TMP/wt-fail" \
   "$TMP/ref-fail" \
   "$TMP/root/acme/root-repo/.git" \
+  "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
   "$TMP/discovered-c" "$TMP/canonical-c"
 : >"$TMP/calls.log"
@@ -216,6 +217,7 @@ export EVIL_PATH
 cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
 [fleet]
     root = ../root
+    root = ../emptyroot
     repo = ../discovered-a
     repo = ../repo-b
     repo = ../old-repo
@@ -274,6 +276,8 @@ assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
 assert_contains "failed repositories not counted successful" "Summary: repositories=5"
+assert_contains "per-root discovered count for a contributing root" "../root: 1 repositories"
+assert_contains "zero-contribution root stays visible in the header" "../emptyroot: 0 repositories"
 
 if grep -Fq -- '--head feature/mismatch' "$CALL_LOG"; then
   printf 'FAIL: local-only branch name was sent to GitHub via --head\n' >&2

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -68,7 +68,11 @@ Run `check`, then create or update the config from the supplied arguments.
 
    (`..` is relative to `.claude/` and therefore names `${CLAUDE_PROJECT_DIR}`.)
 4. Write/update with an ordinary file edit, not `git config --file ... --add`: the file may be tracked
-   and the user must see a deterministic diff. Preserve comments and unrelated sections.
+   and the user must see a deterministic diff. Preserve comments and unrelated sections. Prefer a
+   path relative to the config file's directory for any root/repository/canonical target expressible
+   that way — the grammar resolves relative paths from that directory and both forms audit
+   identically, while some consumer environments run a write-time path-portability guard that rejects
+   absolute paths in tracked config.
 5. Verify after remediation — re-run the `check` probes against the written file (never claim success on
    the edit alone):
 
@@ -105,3 +109,14 @@ similar; verify the normalized GitHub remote identity on both sides first.
 - Write Claude Code settings, `pluginConfigs`, the plugin cache, or any machine-local state — the
   config is the consumer's own tracked file.
 - Touch Git remotes, branches, or worktrees.
+
+## Gotchas
+
+- **Absolute paths in tracked config can be rejected by consumer write guards.** A root, repository, or
+  canonical target written as an absolute path may trip a consumer's write-time path-portability guard;
+  the same target written relative to the config file's directory passes and resolves identically, so
+  `apply` prefers the relative form.
+- **A project-scoped config is consumed only from its own project.** Per the Scoping rule above, a
+  config meant to apply from every project belongs at the user-global
+  `~/.claude/repo-fleet-hygiene.conf`, not a per-project path — otherwise the audit silently narrows to
+  the project it was authored in.


### PR DESCRIPTION
## Summary

Three batched first-contact quality improvements for `repo-fleet-hygiene` (issue #1101, handoff-inbox
findings 2, 4, and residual 5). Same plugin, one PATCH bump `0.3.0 → 0.3.1`.

> **Serialized behind #1104 — do not merge yet.** PR #1104 (issue #1100, `fleet.ackUnavailable`) is
> open against this same plugin and touches the **exact same six files** (`plugin.json`, `CHANGELOG.md`,
> both `SKILL.md`, `audit-fleet.sh`, `audit-fleet.test.sh`). Per the same-plugin collision protocol this
> PR is a DRAFT labeled `do-not-merge` and must land **after** #1104. Once #1104 merges, this branch
> needs `origin/main` merged in, the version re-bumped (0.3.1 → 0.3.2, since #1104 will have taken
> 0.3.1), and the CHANGELOG section reconciled.

## Fix

**F2 — `setup apply` prefers relative-to-config-dir paths.** The grammar already resolves relative
paths from the config directory, but nothing steered `apply` toward writing them. `apply` now prefers
a config-dir-relative path for any root/repository/canonical target expressible that way, and documents
that absolute paths in tracked config can trip a consumer's write-time path-portability guard while the
relative form passes and resolves identically.

**F4 — per-root discovery counts.** The header printed only the total `Repositories discovered: N`; a
root that walked to zero repositories left no trace. Each `--root`/config `root` now prints
`Root <path>: <k> repositories`, keeping a zero-contribution root visible with no per-directory noise.
Deduplication credits a repo shared by nested/overlapping roots to the first root that reaches it,
preserving `sum(root counts) + explicit --repo == discovered`.

**F5 — skill-quality residuals.** Both skills gain a `## Gotchas` surface capturing the real known
gotchas (project-scoped config is consumed only from its own project — fleet configs belong at the
user-global path; absolute paths vs consumer write guards). The `audit` skill's `Use when:` trigger
phrases are now single-quoted so the skill-quality checker's trigger-drop regression protection tracks
them, with every existing trigger keyword preserved. Producer's MD041/MD013 findings were discarded —
the repo's `.markdownlint-cli2.jsonc` disables both and the files lint clean under the real config.

## Verification

All run under Git Bash in the worktree:

- `audit-fleet.test.sh` — **all tests pass**, including two new assertions covering the per-root count
  line (a contributing root shows `1 repositories`; an empty root shows `0 repositories`).
- `skill-quality check audit` and `check setup` — **PASS, 0 errors, 0 warnings** each (gotchas surface
  detected; audit triggers now quoted; setup preserves all 5 base-ref trigger phrases; audit
  description 568/1536 chars).
- `markdownlint-cli2` with the repo's `.markdownlint-cli2.jsonc` on both `SKILL.md` and `CHANGELOG.md`
  — **0 errors**.

Version bump `0.3.0 → 0.3.1` in `plugin.json` with a matching `## [0.3.1]` CHANGELOG entry.

Closes #1101

## Related

- #1104 (issue #1100, `fleet.ackUnavailable`) — same-plugin PR this one serializes behind.
- Handoff-inbox source item `20260723-014618-repo-fleet-hygiene-setup-audit-findings`.
- Config-scoping gotcha wording aligned with #1099/#1102 (already merged) `0.3.0` behavior.
