### PR TITLE
feat(disk-hygiene): split guard registration — plugin-level engine gate delivers kill switch + data-root

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.0]
+
+### Added
+
+- **Split guard registration — plugin-level engine gate delivers the kill switch and data-root
+  authority (#1105, #1106, #1107).** The destructive guard now registers on two surfaces. A NEW
+  plugin-level `hooks/hooks.json` PreToolUse hook runs `destructive_guard.py --mode engine-gate`
+  with `${user_config.disk_hygiene_enabled}` and `${CLAUDE_PLUGIN_DATA}` substituted in exec form
+  (both channels docs-verified) — so a configured `false` (audit-only mode) is guard-enforced
+  against engine invocations in every session, and `--data-root` authority no longer depends on
+  reconstruction from the plugin root. In engine-gate mode the guard defers instantly with no
+  output for any command that does not reference the engine, so unrelated work is never taxed. The
+  skill-scoped belt (deny-by-default Bash + deletion-spelling PowerShell discipline) is unchanged
+  and remains scoped to active cleanup. GuardTests now exercise the exact channel set the shipped
+  plugin-level registration receives (`run_guard_engine_gate` grid), closing the
+  tests-prove-undelivered-channels gap. Trust-surface delta recorded in the README's
+  plugin-acceptance security review section. Docs record the observed-vs-documented hook-lifetime
+  discrepancy (session-long belt firing, producer-reported — #1105 tracks the interactive repro)
+  and that PreToolUse hooks fire inside subagents. The maintainer's re-affirmation of the
+  Windows-engine-execution decline (#1116) is recorded in the safety model with its reversal
+  trigger.
+
 ## [0.6.5]
 
 ### Fixed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   reconstruction from the plugin root. In engine-gate mode the guard defers instantly with no
   output for any command that does not reference the engine, so unrelated work is never taxed. The
   skill-scoped belt (deny-by-default Bash + deletion-spelling PowerShell discipline) is unchanged
-  and remains scoped to active cleanup. GuardTests now exercise the exact channel set the shipped
+  and remains scoped to active cleanup. The gate acts on parsed engine INVOCATIONS, not mentions —
+  `git diff -- hygiene.py`, `rg hygiene.py`, or `echo hygiene.py` defer; unparsable
+  marker-carrying commands fail closed into the gate (review finding on the implementation PR). GuardTests now exercise the exact channel set the shipped
   plugin-level registration receives (`run_guard_engine_gate` grid), closing the
   tests-prove-undelivered-channels gap. Trust-surface delta recorded in the README's
   plugin-acceptance security review section. Docs record the observed-vs-documented hook-lifetime

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -17,7 +17,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   output for any command that does not reference the engine, so unrelated work is never taxed. The
   skill-scoped belt (deny-by-default Bash + deletion-spelling PowerShell discipline) is unchanged
   and remains scoped to active cleanup. The gate acts on parsed engine INVOCATIONS, not mentions —
-  `git diff -- hygiene.py`, `rg hygiene.py`, or `echo hygiene.py` defer; unparsable
+  `git diff -- hygiene.py`, `rg hygiene.py`, or `echo hygiene.py` defer, a word resolving to a
+  DIFFERENT existing file named `hygiene.py` (a consumer's own tool) defers, and interpreter
+  options before the script (`python3 -B`) cannot slip the gate; unparsable
   marker-carrying commands fail closed into the gate (review finding on the implementation PR). GuardTests now exercise the exact channel set the shipped
   plugin-level registration receives (`run_guard_engine_gate` grid), closing the
   tests-prove-undelivered-channels gap. Trust-surface delta recorded in the README's

--- a/plugins/disk-hygiene/README.md
+++ b/plugins/disk-hygiene/README.md
@@ -49,10 +49,17 @@ at preview. Backups remain the recovery boundary for user data.
   `skills/clean/scripts/hygiene.py`; `/disk-hygiene:setup check` derives the enforced value from
   there, so treat the number printed here as a convenience copy). Claude Code launches the guard in
   shell-free exec form; guarded engine calls must use the same absolute interpreter reported by that
-  guard, so Bash aliases and functions cannot replace it. The guard is skill-scoped — it fires only
-  within the `clean` skill's context, so driving `hygiene.py` directly outside that skill relies on
-  the engine's built-in containment and preview gate, not the hook. The plugin never downloads a
-  runtime.
+  guard, so Bash aliases and functions cannot replace it. The guard registers on two surfaces: a
+  plugin-level **engine gate** (`hooks/hooks.json`) that fires in every session but acts only on
+  commands referencing the engine — deferring everything else instantly — and enforces the
+  configured kill switch and data-root authority through plugin-hook substitution; and the
+  skill-scoped **belt** inside the `clean` skill's context, which adds the deny-by-default Bash and
+  deletion-spelling PowerShell discipline during active cleanup work. Hook-lifetime caveat: docs
+  scope a skill hook to the component's lifetime, but session-long firing of the belt has been
+  observed on at least one Claude Code build (producer-reported; see issue #1105) — if unrelated
+  commands are denied after a clean run ends, start a new session and see that issue. PreToolUse
+  hooks also fire inside subagents, so fanned-out workers run under the same guards. The plugin
+  never downloads a runtime.
 - Git is optional for ordinary trees. If a target contains or sits inside a Git worktree, Git becomes
   required so tracked content can be proven safe; otherwise cleanup for that subtree is blocked.
 - Windows has the full **audit** lane (Python 3.11's `lstat` reparse metadata plus Win32 APIs
@@ -137,11 +144,22 @@ hand-cleaning the zone.
 - **MCP / external trust:** no MCP server, agent, dependency, or third-party service is shipped.
 - **Configuration:** one non-sensitive `userConfig` boolean (`disk_hygiene_enabled`, default
   `true`) gating the execution tiers — setting it `false` puts `/disk-hygiene:clean` in audit-only
-  mode. That mode is enforced by the skill, which resolves the toggle through the bundled kill-switch
-  probe and self-enforces; the skill-scoped guard cannot independently enforce it, because a
-  skill-frontmatter hook reaches the guard with neither the `${user_config.*}` substitution nor the
-  `CLAUDE_PLUGIN_OPTION_*` environment variable, though the guard still forces a human prompt before
-  every mutation. A direct `hygiene.py` invocation outside that skill does not read the toggle and
+  mode. That mode is now guard-enforced: the plugin-level engine gate receives the configured value
+  by exec-form substitution and denies engine invocations outright when it is `false`, in every
+  session. The skill self-enforcement (kill-switch probe + skill-content value) and the skill-scoped
+  belt remain as redundant layers; the belt still cannot receive the value (skill-frontmatter hooks
+  get neither `${user_config.*}` substitution nor `CLAUDE_PLUGIN_OPTION_*`), and still forces a
+  human prompt before every mutation.
+- **Trust-surface record (0.7.0):** the plugin-level `hooks/hooks.json` PreToolUse registration is a
+  NEW trust surface (a hook that launches in every consumer session), added deliberately for
+  guard-enforced audit-only mode and data-root authority (#1106 decision, Option E — split
+  registration). Its blast radius is bounded by design: exec form (no shell), bundled
+  standard-library script only, instant no-output deferral for any command not referencing the
+  engine, and no new capability beyond what the skill-scoped deployment already did during active
+  cleanup. Known costs, accepted: one `python3` launch per Bash/PowerShell call, and on a machine
+  where `python3` resolves to the Windows Store alias stub the launch fails on every call (tracked
+  with remediation detection in #1110). This entry is the plugin-acceptance review delta for the
+  change. A direct `hygiene.py` invocation outside that skill does not read the toggle and
   answers only to the engine's own preview/approval-token gate. The toggle can only narrow the
   destructive surface, never widen it (see [the safety model](skills/clean/reference/safety-model.md)
   for the degraded-mode detail). No credentials. Policy comes from an explicit invocation

--- a/plugins/disk-hygiene/hooks/hooks.json
+++ b/plugins/disk-hygiene/hooks/hooks.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3",
+            "args": [
+              "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/destructive_guard.py",
+              "--mode",
+              "engine-gate",
+              "--plugin-root",
+              "${CLAUDE_PLUGIN_ROOT}",
+              "--authorized-data-root",
+              "${CLAUDE_PLUGIN_DATA}",
+              "--disk-hygiene-enabled",
+              "${user_config.disk_hygiene_enabled}"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -267,6 +267,11 @@ sparse files, hard links, compression, and delayed allocation affect it.
   research uses non-Bash read-only tools; only literal-word bundled scan, preview, and apply shapes
   using the hook runtime's same absolute executable pass. Shell expansions, globs, splitting/escape
   forms, operators, redirections, aliases, and exported functions fail closed.
+- The guard registers twice: a plugin-level engine gate (`hooks/hooks.json`, `--mode engine-gate`)
+  that fires in every session, receives the kill switch and data root by plugin-hook substitution,
+  and defers instantly on any command not referencing the engine; and this skill's frontmatter belt,
+  which adds the deny-by-default Bash and deletion-spelling PowerShell discipline while cleanup is
+  the active work. Verdicts are idempotent where both fire.
 - The guard hook launches in exec form via `python3`, resolved on `PATH` with no shell (`python3`,
   not bare `python`, because stock macOS and many Linux distros ship only `python3` and a legacy
   `python` 2.x would crash the guard on modern syntax). Enforcement is therefore only as strong as

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -58,6 +58,13 @@ device/inode/type identity, proves it empty through that descriptor, rechecks th
 identity, and only then calls descriptor-relative `rmdir`. Windows and macOS return
 `execution-platform-unsupported`; their audit and report behavior is unchanged.
 
+That decline was re-examined and AFFIRMED by the maintainer on 2026-07-23 (issue #1116), against
+the framing "new-trust-surface risk of a Windows deletion lane vs the residual approval-to-execution
+window the decline leaves in the manual lane": with the manual lane's per-item revalidation rules
+and the planned `handoff-verify` revalidation (#1109), the residual window is small, while a
+descriptor-anchored Windows apply is a large new surface. Recorded reversal trigger: a post-#1109
+near-miss recurrence in the manual lane reopens this as a design issue with full security review.
+
 The skill-scoped Bash guard accepts only complete literal words in the three declared engine command
 shapes. It rejects every Bash expansion family, glob/word-splitting input, redirection, operator,
 escape, and compound-command form before validating arguments. Canonical script-path comparison uses
@@ -102,18 +109,22 @@ switch. When the guard sees execution enabled they are downgraded to a final hum
 when it sees a configured `false` (audit-only mode) they are denied outright, so the kill switch would
 block deletions on the PowerShell lane too and not only the Bash engine apply.
 
-That kill-switch enforcement is, however, only as reachable as the value is. The guard reads it from a
-`--disk-hygiene-enabled` argv flag or the `CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED` environment
-variable, but a skill-frontmatter hook receives neither — Claude Code substitutes only
-`${CLAUDE_PLUGIN_ROOT}` into a skill hook's args and does not inject `CLAUDE_PLUGIN_OPTION_*` into its
-environment. So in the bundled skill deployment the guard defaults to enabled and cannot honor a
-configured `false` by denying; it still forces a human prompt before every mutation, and the model
-itself reads the substituted `disk_hygiene_enabled` value from the skill content and self-enforces
-audit-only. Enforcing the kill switch in the guard needs a delivery channel skill hooks do not yet
-have (a plugin-scoped hook or MCP server that can carry the value, or Claude Code adding
-`${user_config.*}` substitution for skill hooks). Even when the switch is reachable, the PowerShell
-lane is a raised bar, not fail-closed: an unknown mutation spelling passes it, so the engine's own
-containment, revalidation, and platform gates remain the deletion authority.
+Kill-switch enforcement is only as reachable as the value is, and the guard now registers on two
+surfaces with different reach. The **plugin-level engine gate** (`hooks/hooks.json`, exec form,
+`--mode engine-gate`) receives `${user_config.disk_hygiene_enabled}` and `${CLAUDE_PLUGIN_DATA}`
+by substitution — channels Claude Code documents for plugin hooks — so a configured `false` is
+guard-enforced against every engine invocation in every session, whether or not the clean skill is
+active. The gate defers instantly (no output) for any command that does not reference the engine,
+so it never taxes unrelated work; its coverage marker is the engine script name, a belt against
+casual invocation, not an authority (renaming the script evades the gate but not the engine's own
+preview/approval-token containment). The **skill-scoped belt** (the clean skill's frontmatter
+hook) still receives neither the substitution nor the `CLAUDE_PLUGIN_OPTION_*` environment
+variable, so on its surface the guard defaults to enabled; that is now a defense-in-depth
+redundancy rather than the only enforcement, and the model additionally reads the substituted
+`disk_hygiene_enabled` value from the skill content and self-enforces audit-only. Even when the
+switch is reachable, the PowerShell lane is a raised bar, not fail-closed: an unknown mutation
+spelling passes it, so the engine's own containment, revalidation, and platform gates remain the
+deletion authority.
 
 A depth-limited scan records every directory it declined to enter in `truncated_paths`. Truncated
 directories have no captured descendant set, so the preview blocks them (and anything beneath them)

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -51,8 +51,15 @@ def _argument(value: str) -> bool:
     return bool(value) and not value.startswith("-")
 
 
-def _literal_shell_words(command: str) -> list[str] | None:
-    """Parse only space-delimited literal words with optional whole-word quotes."""
+def _literal_shell_words(
+    command: str, *, allow_backslash: bool = False
+) -> list[str] | None:
+    """Parse only space-delimited literal words with optional whole-word quotes.
+
+    ``allow_backslash`` permits ``\\`` inside words for surfaces where it is a
+    path separator rather than an escape character (PowerShell commands); the
+    Bash default keeps rejecting it.
+    """
     if not command or any(
         value in _SHELL_EXPANSION_OR_OPERATOR_CHARS for value in command
     ):
@@ -71,7 +78,7 @@ def _literal_shell_words(command: str) -> list[str] | None:
             word = command[index + 1 : end]
             if not word or "'" in word or '"' in word:
                 return None
-            if quote == '"' and "\\\\" in word:
+            if quote == '"' and "\\\\" in word and not allow_backslash:
                 return None
             index = end + 1
             if index < len(command) and command[index] != " ":
@@ -83,7 +90,7 @@ def _literal_shell_words(command: str) -> list[str] | None:
             word = command[index:end]
             if (
                 not word
-                or "\\" in word
+                or ("\\" in word and not allow_backslash)
                 or "'" in word
                 or '"' in word
                 or any(value.isspace() for value in word)
@@ -164,7 +171,7 @@ _MODE_ENGINE_GATE = "engine-gate"
 _ENGINE_MARKER = "hygiene.py"
 
 
-def _engine_gate_relevant(command: str) -> bool:
+def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
     """Decide whether the plugin-level engine gate should act on ``command``.
 
     A plugin-level hook fires on every shell call in every session, so a bare
@@ -217,16 +224,22 @@ def _engine_gate_relevant(command: str) -> bool:
             return False
         return _samefile(word)
 
+    allow_backslash = tool_name == "PowerShell"
     lowered = command.casefold()
     if _ENGINE_MARKER not in lowered:
         # No marker: the only relevant shape is a linked alias of the bundled
-        # engine invoked by path. Unparsable marker-less commands defer —
-        # failing closed here would gate every command with an operator.
-        words = _literal_shell_words(command)
+        # engine invoked by path. Unparsable marker-free commands cannot fail
+        # closed (that would gate every command with an operator), so scan
+        # their whitespace tokens for separator-carrying words and identity-
+        # check those — a literal alias path gates even beside an operator.
+        words = _literal_shell_words(command, allow_backslash=allow_backslash)
         if words is None:
-            return False
+            return any(
+                _same_file_as_bundled(token.strip("'\""))
+                for token in command.split()
+            )
         return any(_same_file_as_bundled(word) for word in words)
-    words = _literal_shell_words(command)
+    words = _literal_shell_words(command, allow_backslash=allow_backslash)
     if words is None:
         return True
     for index, word in enumerate(words):
@@ -599,7 +612,9 @@ def main() -> int:
         )
         return 0
 
-    if resolve_mode() == _MODE_ENGINE_GATE and not _engine_gate_relevant(command):
+    if resolve_mode() == _MODE_ENGINE_GATE and not _engine_gate_relevant(
+        command, tool_name
+    ):
         # Plugin-level gate: no engine invocation in the command — defer with no
         # output so unrelated work in every consumer session is untouched.
         return 0

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -273,14 +273,11 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
         "exec",
         "command",
     }
-    effective_index = None
-    for index, word in enumerate(words):
-        folded = word.casefold()
-        base = Path(folded).name
-        if base in _WRAPPERS or "=" in word or word.startswith("-"):
-            continue
-        effective_index = index
-        break
+    wrapper_indices = [
+        index
+        for index, word in enumerate(words)
+        if Path(word.casefold()).name in _WRAPPERS
+    ]
     for index, word in enumerate(words):
         folded = word.casefold()
         if Path(folded).name == _ENGINE_MARKER:
@@ -292,14 +289,19 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
                 continue
             if (
                 index == 0
-                or index == effective_index
                 or os.path.isabs(word)
                 or any(_is_interpreter(w) for w in words[:index])
+                or any(w_index < index for w_index in wrapper_indices)
             ):
                 # An absolute engine path is an invocation target whatever the
-                # launcher (env, a wrapper) — mentions use bare relative names
-                # in ARGUMENT position (`git diff -- hygiene.py`), never as the
-                # effective command.
+                # launcher, and a bare marker word ANYWHERE after a known
+                # launcher wrapper gates conservatively (wrapper option
+                # operands like `nice -n 10` defeat effective-command
+                # inference, and PATH injection can make the bare name the
+                # command). A deliberate overbreadth: a mere MENTION after a
+                # wrapper (`sudo grep x hygiene.py`) gates too — rare, and the
+                # kill-switch bypass risk outweighs it. Plain-command mentions
+                # (`git diff -- hygiene.py`) still defer.
                 return True
             continue
         if _ENGINE_MARKER in folded and " " in word:

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -218,9 +218,23 @@ def _engine_gate_relevant(command: str) -> bool:
                 # Provably a different existing file — a consumer's own
                 # hygiene.py, not this engine.
                 continue
-            if index == 0 or any(_is_interpreter(w) for w in words[:index]):
+            if (
+                index == 0
+                or os.path.isabs(word)
+                or any(_is_interpreter(w) for w in words[:index])
+            ):
+                # An absolute engine path is an invocation target whatever the
+                # launcher (env, a wrapper) — mentions use bare relative names.
                 return True
             continue
+        if _ENGINE_MARKER in folded and " " in word:
+            first_token = folded.split()[0]
+            if Path(first_token).name == _ENGINE_MARKER or _is_interpreter(
+                first_token
+            ):
+                # A quoted compound payload (sh -c / pwsh -Command) whose first
+                # token is the engine or an interpreter is an invocation.
+                return True
         if _ENGINE_MARKER in folded and "python" in folded:
             return True
     return False

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -281,11 +281,18 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
     for index, word in enumerate(words):
         folded = word.casefold()
         if Path(folded).name == _ENGINE_MARKER:
+            if _samefile(word):
+                # The word IS the bundled engine — gate regardless of launcher
+                # (pypy3, an unknown interpreter, anything). Identity beats
+                # launcher enumeration. Accepted overbreadth: a MENTION of the
+                # bundled engine by a resolving path gates too; real-world
+                # mentions use names that resolve to nothing (deferred below)
+                # or to consumer files (deferred below).
+                return True
             resolved_key = _script_path_key(word)
-            if resolved_key is not None and not _samefile(word):
+            if resolved_key is not None:
                 # Provably a different existing file — a consumer's own
-                # hygiene.py, not this engine. (A link to the bundled engine
-                # named hygiene.py is the engine and stays in play.)
+                # hygiene.py, not this engine.
                 continue
             if (
                 index == 0

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -173,8 +173,15 @@ def _engine_gate_relevant(command: str) -> bool:
     mentions into the belt's fail-closed parser would block ordinary work
     session-wide. The gate acts only on what parses as an INVOCATION:
 
-    - a literal word whose basename is the engine script, either as the command
-      itself or preceded by an interpreter token (``python*``/``py``);
+    - a literal word carrying the engine's filename that is not provably a
+      DIFFERENT file: a word that resolves to an existing file other than the
+      bundled ``hygiene.py`` (a consumer's own ``tools/hygiene.py``) is not this
+      engine and defers; the bundled script itself, or an unresolvable word,
+      stays in play;
+    - such a word counts as an INVOCATION when it is the command itself or ANY
+      earlier word is an interpreter token (``python*``/``py``) — "immediately
+      preceding" is not required, so interpreter options
+      (``python3 -B .../hygiene.py``) cannot slip the gate;
     - a quoted compound word (e.g. a ``bash -c``/``pwsh -Command`` payload) that
       carries both the engine marker and an interpreter token;
     - any command carrying the marker that the literal parser cannot prove is a
@@ -191,13 +198,27 @@ def _engine_gate_relevant(command: str) -> bool:
     words = _literal_shell_words(command)
     if words is None:
         return True
+
+    def _is_interpreter(word: str) -> bool:
+        base = Path(word.casefold()).name
+        return base.startswith("python") or base in {"py", "py.exe"}
+
+    bundled_key = _script_path_key(
+        str(Path(__file__).resolve().with_name("hygiene.py"))
+    )
     for index, word in enumerate(words):
         folded = word.casefold()
         if Path(folded).name == _ENGINE_MARKER:
-            if index == 0:
-                return True
-            previous = Path(words[index - 1].casefold()).name
-            if previous.startswith("python") or previous in {"py", "py.exe"}:
+            resolved_key = _script_path_key(word)
+            if (
+                resolved_key is not None
+                and bundled_key is not None
+                and resolved_key != bundled_key
+            ):
+                # Provably a different existing file — a consumer's own
+                # hygiene.py, not this engine.
+                continue
+            if index == 0 or any(_is_interpreter(w) for w in words[:index]):
                 return True
             continue
         if _ENGINE_MARKER in folded and "python" in folded:

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -241,6 +241,21 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
         return any(_same_file_as_bundled(word) for word in words)
     words = _literal_shell_words(command, allow_backslash=allow_backslash)
     if words is None:
+        # Marker present but not literally parseable (operators, compounds).
+        # Fail closed UNLESS every marker-carrying token is provably a
+        # DIFFERENT existing file (a consumer's own hygiene.py in a compound
+        # command) and no token is the bundled engine under any name.
+        tokens = [token.strip("'\"") for token in command.split()]
+        if any(_same_file_as_bundled(token) for token in tokens):
+            return True
+        marker_tokens = [
+            token for token in tokens if _ENGINE_MARKER in token.casefold()
+        ]
+        if marker_tokens and all(
+            _script_path_key(token) is not None and not _samefile(token)
+            for token in marker_tokens
+        ):
+            return False
         return True
     for index, word in enumerate(words):
         folded = word.casefold()

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -158,6 +158,27 @@ def _plugin_data_root_from_root(plugin_root: str) -> str | None:
     return None
 
 
+_MODE_FLAG = "--mode"
+_MODE_BELT = "belt"
+_MODE_ENGINE_GATE = "engine-gate"
+_ENGINE_MARKER = "hygiene.py"
+
+
+def resolve_mode() -> str:
+    """Resolve which registration surface launched this guard.
+
+    ``belt`` (default) is the skill-scoped deployment: deny-by-default Bash and
+    deletion-spelling PowerShell discipline, tolerable only while the clean skill
+    is the active work. ``engine-gate`` is the plugin-level deployment: it cares
+    ONLY about engine invocations (kill switch + data-root authority must hold in
+    every session), so any command that does not reference the engine defers
+    instantly — a plugin-level hook must never tax unrelated work. An
+    unrecognized or absent value falls back to ``belt``, the stricter mode.
+    """
+    value = _argv_flag_value(sys.argv[1:], _MODE_FLAG)
+    return value if value in {_MODE_BELT, _MODE_ENGINE_GATE} else _MODE_BELT
+
+
 _DISK_HYGIENE_ENABLED_FLAG = "--disk-hygiene-enabled"
 _DISK_HYGIENE_ENABLED_ENV = "CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED"
 _DISK_HYGIENE_ENABLED_PLACEHOLDER = "${user_config.disk_hygiene_enabled}"
@@ -480,6 +501,14 @@ def main() -> int:
                 )
             )
         )
+        return 0
+
+    if (
+        resolve_mode() == _MODE_ENGINE_GATE
+        and _ENGINE_MARKER not in command.casefold()
+    ):
+        # Plugin-level gate: nothing engine-shaped in the command — defer with no
+        # output so unrelated work in every consumer session is untouched.
         return 0
 
     enabled = resolve_disk_hygiene_enabled()

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -164,6 +164,47 @@ _MODE_ENGINE_GATE = "engine-gate"
 _ENGINE_MARKER = "hygiene.py"
 
 
+def _engine_gate_relevant(command: str) -> bool:
+    """Decide whether the plugin-level engine gate should act on ``command``.
+
+    A plugin-level hook fires on every shell call in every session, so a bare
+    mention of the engine's filename (``git diff -- hygiene.py``,
+    ``rg hygiene.py README.md``, ``echo hygiene.py``) must defer — routing
+    mentions into the belt's fail-closed parser would block ordinary work
+    session-wide. The gate acts only on what parses as an INVOCATION:
+
+    - a literal word whose basename is the engine script, either as the command
+      itself or preceded by an interpreter token (``python*``/``py``);
+    - a quoted compound word (e.g. a ``bash -c``/``pwsh -Command`` payload) that
+      carries both the engine marker and an interpreter token;
+    - any command carrying the marker that the literal parser cannot prove is a
+      mere mention (expansions, operators, unparsable quoting) — fail closed
+      into the gate; the belt's own rules then decide.
+
+    This is a belt, not the authority: an invocation smuggled past it still
+    answers to the engine's own preview/approval-token containment (and to the
+    skill-scoped belt during active cleanup).
+    """
+    lowered = command.casefold()
+    if _ENGINE_MARKER not in lowered:
+        return False
+    words = _literal_shell_words(command)
+    if words is None:
+        return True
+    for index, word in enumerate(words):
+        folded = word.casefold()
+        if Path(folded).name == _ENGINE_MARKER:
+            if index == 0:
+                return True
+            previous = Path(words[index - 1].casefold()).name
+            if previous.startswith("python") or previous in {"py", "py.exe"}:
+                return True
+            continue
+        if _ENGINE_MARKER in folded and "python" in folded:
+            return True
+    return False
+
+
 def resolve_mode() -> str:
     """Resolve which registration surface launched this guard.
 
@@ -503,11 +544,8 @@ def main() -> int:
         )
         return 0
 
-    if (
-        resolve_mode() == _MODE_ENGINE_GATE
-        and _ENGINE_MARKER not in command.casefold()
-    ):
-        # Plugin-level gate: nothing engine-shaped in the command — defer with no
+    if resolve_mode() == _MODE_ENGINE_GATE and not _engine_gate_relevant(command):
+        # Plugin-level gate: no engine invocation in the command — defer with no
         # output so unrelated work in every consumer session is untouched.
         return 0
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -257,6 +257,30 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
         ):
             return False
         return True
+    # The effective command word: skip launcher wrappers, VAR=value
+    # assignments, and option words — `env PATH=... hygiene.py apply` makes the
+    # bare marker word the command even though it is not word 0.
+    _WRAPPERS = {
+        "env",
+        "nohup",
+        "nice",
+        "time",
+        "timeout",
+        "setsid",
+        "stdbuf",
+        "sudo",
+        "doas",
+        "exec",
+        "command",
+    }
+    effective_index = None
+    for index, word in enumerate(words):
+        folded = word.casefold()
+        base = Path(folded).name
+        if base in _WRAPPERS or "=" in word or word.startswith("-"):
+            continue
+        effective_index = index
+        break
     for index, word in enumerate(words):
         folded = word.casefold()
         if Path(folded).name == _ENGINE_MARKER:
@@ -268,11 +292,14 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
                 continue
             if (
                 index == 0
+                or index == effective_index
                 or os.path.isabs(word)
                 or any(_is_interpreter(w) for w in words[:index])
             ):
                 # An absolute engine path is an invocation target whatever the
-                # launcher (env, a wrapper) — mentions use bare relative names.
+                # launcher (env, a wrapper) — mentions use bare relative names
+                # in ARGUMENT position (`git diff -- hygiene.py`), never as the
+                # effective command.
                 return True
             continue
         if _ENGINE_MARKER in folded and " " in word:

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -188,35 +188,55 @@ def _engine_gate_relevant(command: str) -> bool:
       mere mention (expansions, operators, unparsable quoting) — fail closed
       into the gate; the belt's own rules then decide.
 
-    This is a belt, not the authority: an invocation smuggled past it still
-    answers to the engine's own preview/approval-token containment (and to the
-    skill-scoped belt during active cleanup).
+    A path-like word (containing a separator) that is the SAME FILE as the
+    bundled engine — a symlink or hard link under any name — gates regardless
+    of its filename. Accepted residuals, all of the copy-evasion class the gate
+    can never close (a byte copy is a different file): a PATH-installed alias
+    with no separator, an alias inside a command the literal parser rejects
+    when the marker is absent, and a copied engine. This is a belt, not the
+    authority: an invocation smuggled past it still answers to the engine's own
+    preview/approval-token containment (and to the skill-scoped belt during
+    active cleanup).
     """
-    lowered = command.casefold()
-    if _ENGINE_MARKER not in lowered:
-        return False
-    words = _literal_shell_words(command)
-    if words is None:
-        return True
 
     def _is_interpreter(word: str) -> bool:
         base = Path(word.casefold()).name
         return base.startswith("python") or base in {"py", "py.exe"}
 
-    bundled_key = _script_path_key(
-        str(Path(__file__).resolve().with_name("hygiene.py"))
-    )
+    bundled = Path(__file__).resolve().with_name("hygiene.py")
+
+    def _samefile(word: str) -> bool:
+        try:
+            return os.path.samefile(word, bundled)
+        except OSError:
+            return False
+
+    def _same_file_as_bundled(word: str) -> bool:
+        # Separator requirement bounds the no-marker scan to path-like words.
+        if "/" not in word and "\\" not in word:
+            return False
+        return _samefile(word)
+
+    lowered = command.casefold()
+    if _ENGINE_MARKER not in lowered:
+        # No marker: the only relevant shape is a linked alias of the bundled
+        # engine invoked by path. Unparsable marker-less commands defer —
+        # failing closed here would gate every command with an operator.
+        words = _literal_shell_words(command)
+        if words is None:
+            return False
+        return any(_same_file_as_bundled(word) for word in words)
+    words = _literal_shell_words(command)
+    if words is None:
+        return True
     for index, word in enumerate(words):
         folded = word.casefold()
         if Path(folded).name == _ENGINE_MARKER:
             resolved_key = _script_path_key(word)
-            if (
-                resolved_key is not None
-                and bundled_key is not None
-                and resolved_key != bundled_key
-            ):
+            if resolved_key is not None and not _samefile(word):
                 # Provably a different existing file — a consumer's own
-                # hygiene.py, not this engine.
+                # hygiene.py, not this engine. (A link to the bundled engine
+                # named hygiene.py is the engine and stays in play.)
                 continue
             if (
                 index == 0

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 import types
 import unittest
-from contextlib import redirect_stdout
+from contextlib import chdir as chdir_context, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -1839,16 +1839,24 @@ class GuardTests(unittest.TestCase):
             )
 
     def test_engine_gate_defers_mere_mentions_of_the_engine(self) -> None:
-        """Read-only commands that merely NAME the script must defer (P2 review)."""
-        for tool_name, command in (
-            ("Bash", "git diff -- hygiene.py"),
-            ("Bash", "rg hygiene.py README.md"),
-            ("Bash", "echo hygiene.py"),
-            ("PowerShell", "Select-String -Pattern guard hygiene.py"),
-        ):
-            self.assertIsNone(
-                self.run_guard_engine_gate(command, tool_name), (tool_name, command)
-            )
+        """Read-only commands that merely NAME the script must defer (P2 review).
+
+        Runs from a neutral cwd: a bare `hygiene.py` mention in a real consumer
+        session resolves to nothing (or to the consumer's own file) — resolving
+        to the BUNDLED engine (cwd inside the plugin scripts dir) gates by
+        identity, deliberately.
+        """
+        with tempfile.TemporaryDirectory() as tmp, chdir_context(tmp):
+            for tool_name, command in (
+                ("Bash", "git diff -- hygiene.py"),
+                ("Bash", "rg hygiene.py README.md"),
+                ("Bash", "echo hygiene.py"),
+                ("PowerShell", "Select-String -Pattern guard hygiene.py"),
+            ):
+                self.assertIsNone(
+                    self.run_guard_engine_gate(command, tool_name),
+                    (tool_name, command),
+                )
 
     def test_engine_gate_catches_interpreter_options_before_the_script(self) -> None:
         """Interpreter options must not slip the kill switch (P1 review)."""
@@ -1986,6 +1994,15 @@ class GuardTests(unittest.TestCase):
             "Bash",
             "false",
         )
+        assert result is not None
+        self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
+
+    def test_engine_gate_catches_non_cpython_launch_of_bundled_engine(self) -> None:
+        """A relative bundled-engine path gates under ANY launcher (P1 r10)."""
+        with chdir_context(SCRIPT_DIR):
+            result = self.run_guard_engine_gate(
+                "pypy3 ./hygiene.py apply --plan p --token t", "Bash", "false"
+            )
         assert result is not None
         self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
 

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1885,6 +1885,25 @@ class GuardTests(unittest.TestCase):
         assert compound is not None
         self.assertEqual("deny", compound["hookSpecificOutput"]["permissionDecision"])
 
+    def test_engine_gate_catches_linked_aliases_of_the_bundled_engine(self) -> None:
+        """A link to the engine under another name must gate by identity (P1 review)."""
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR) as tmp:
+            alias = Path(tmp) / "clean-engine"
+            try:
+                os.link(script, alias)
+            except OSError as exc:  # pragma: no cover - filesystem-dependent
+                self.skipTest(f"hard links unavailable here: {exc}")
+            posix_alias = str(alias).replace("\\", "/")
+            result = self.run_guard_engine_gate(
+                f'"{posix_alias}" apply --plan p --token t', "Bash", "false"
+            )
+            assert result is not None
+            self.assertEqual(
+                "deny", result["hookSpecificOutput"]["permissionDecision"]
+            )
+            os.unlink(alias)
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1979,6 +1979,16 @@ class GuardTests(unittest.TestCase):
         assert result is not None
         self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
 
+    def test_engine_gate_catches_engine_after_wrapper_with_option_operands(self) -> None:
+        """Wrapper option operands must not hide the bare engine name (P1 r9)."""
+        result = self.run_guard_engine_gate(
+            f"env -i PATH=/usr/bin nice -n 10 hygiene.py apply --plan p --token t",
+            "Bash",
+            "false",
+        )
+        assert result is not None
+        self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1904,6 +1904,39 @@ class GuardTests(unittest.TestCase):
             )
             os.unlink(alias)
 
+    def test_engine_gate_catches_alias_beside_shell_operator(self) -> None:
+        """A literal alias path gates even in an operator-carrying command (P1 r6)."""
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR) as tmp:
+            alias = Path(tmp) / "clean-engine"
+            try:
+                os.link(script, alias)
+            except OSError as exc:  # pragma: no cover - filesystem-dependent
+                self.skipTest(f"hard links unavailable here: {exc}")
+            posix_alias = str(alias).replace("\\", "/")
+            result = self.run_guard_engine_gate(
+                f'"{posix_alias}" apply --plan p --token t && true', "Bash", "false"
+            )
+            assert result is not None
+            self.assertEqual(
+                "deny", result["hookSpecificOutput"]["permissionDecision"]
+            )
+            os.unlink(alias)
+
+    def test_engine_gate_defers_consumer_windows_path_on_powershell(self) -> None:
+        """Backslash consumer paths must defer on PowerShell, not fail closed (P2 r6)."""
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR) as tmp:
+            consumer = Path(tmp) / "hygiene.py"
+            consumer.write_text("print('consumer tool')\n", encoding="utf-8")
+            windows_path = str(consumer)  # native backslashes on Windows
+            if "\\" not in windows_path:
+                windows_path = windows_path.replace("/", "\\")
+            self.assertIsNone(
+                self.run_guard_engine_gate(
+                    f"python {windows_path} --help", "PowerShell"
+                )
+            )
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1838,6 +1838,27 @@ class GuardTests(unittest.TestCase):
                 self.run_guard_engine_gate(command, tool_name), (tool_name, command)
             )
 
+    def test_engine_gate_defers_mere_mentions_of_the_engine(self) -> None:
+        """Read-only commands that merely NAME the script must defer (P2 review)."""
+        for tool_name, command in (
+            ("Bash", "git diff -- hygiene.py"),
+            ("Bash", "rg hygiene.py README.md"),
+            ("Bash", "echo hygiene.py"),
+            ("PowerShell", "Select-String -Pattern guard hygiene.py"),
+        ):
+            self.assertIsNone(
+                self.run_guard_engine_gate(command, tool_name), (tool_name, command)
+            )
+
+    def test_engine_gate_fails_closed_on_unparseable_marker_commands(self) -> None:
+        """Marker + shell operators/expansions the literal parser rejects → gate."""
+        result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")
+        assert result is not None
+        self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
+        embedded = self.run_guard_engine_gate('bash -c "python3 hygiene.py scan --target t --output s"')
+        assert embedded is not None
+        self.assertEqual("deny", embedded["hookSpecificOutput"]["permissionDecision"])
+
     def test_engine_gate_gates_engine_invocations(self) -> None:
         script = SCRIPT_DIR / "hygiene.py"
         powershell = self.run_guard_engine_gate(

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1785,6 +1785,89 @@ class GuardTests(unittest.TestCase):
                 command,
             )
 
+    def run_guard_engine_gate(
+        self, command: str, tool_name: str = "Bash", enabled_arg: str = "true"
+    ) -> dict[str, object] | None:
+        """Drive the guard as the plugin-level engine-gate deployment would.
+
+        Supplies ``--mode engine-gate`` plus both plugin-level substitution
+        channels (``--disk-hygiene-enabled`` and ``--authorized-data-root``) on
+        argv, with the env channel absent — mirroring the shipped
+        ``hooks/hooks.json`` exec-form registration. Returns None when the guard
+        deferred with no output.
+        """
+        argv = [
+            str(SCRIPT_DIR / "destructive_guard.py"),
+            "--mode",
+            "engine-gate",
+            "--plugin-root",
+            str(SCRIPT_DIR.parent.parent.parent),
+            "--authorized-data-root",
+            str(SCRIPT_DIR / "data-root"),
+            "--disk-hygiene-enabled",
+            enabled_arg,
+        ]
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key != "CLAUDE_PLUGIN_OPTION_DISK_HYGIENE_ENABLED"
+        }
+        stdin = io.StringIO(
+            json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+        )
+        stdout = io.StringIO()
+        with (
+            mock.patch("sys.stdin", stdin),
+            redirect_stdout(stdout),
+            mock.patch.object(guard.sys, "argv", argv),
+            mock.patch.dict("os.environ", environment, clear=True),
+        ):
+            self.assertEqual(0, guard.main())
+        text = stdout.getvalue().strip()
+        return json.loads(text) if text else None
+
+    def test_engine_gate_defers_all_non_engine_commands(self) -> None:
+        """Plugin-level deployment must never tax unrelated work in a session."""
+        for tool_name, command in (
+            ("Bash", "git --version"),
+            ("Bash", "rm -rf /tmp/unrelated"),
+            ("PowerShell", "Remove-Item -Recurse C:/tmp/unrelated"),
+            ("PowerShell", "git status --short"),
+        ):
+            self.assertIsNone(
+                self.run_guard_engine_gate(command, tool_name), (tool_name, command)
+            )
+
+    def test_engine_gate_gates_engine_invocations(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        powershell = self.run_guard_engine_gate(
+            f'& python "{script}" scan --target t --output s', "PowerShell"
+        )
+        assert powershell is not None
+        self.assertEqual(
+            "deny", powershell["hookSpecificOutput"]["permissionDecision"]
+        )
+        malformed = self.run_guard_engine_gate(f'python3 "{script}" apply --oops')
+        assert malformed is not None
+        self.assertEqual(
+            "deny", malformed["hookSpecificOutput"]["permissionDecision"]
+        )
+
+    def test_engine_gate_fails_closed_on_engine_when_disabled(self) -> None:
+        """Engine-referencing Bash under audit-only mode must deny, never defer.
+
+        The argv kill-switch decision logic itself is proven by
+        ``test_kill_switch_blocks_every_lane_via_argv``; this asserts the
+        engine-gate mode routes an engine-referencing command into that logic
+        instead of deferring past it.
+        """
+        script = SCRIPT_DIR / "hygiene.py"
+        result = self.run_guard_engine_gate(
+            f'python3 "{script}" scan --target t --output s', "Bash", "false"
+        )
+        assert result is not None
+        self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
+
     def run_guard_powershell(self, command: str) -> dict[str, object] | None:
         stdin = io.StringIO(
             json.dumps({"tool_name": "PowerShell", "tool_input": {"command": command}})

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1937,6 +1937,38 @@ class GuardTests(unittest.TestCase):
                 )
             )
 
+    def test_engine_gate_defers_consumer_script_in_compound_commands(self) -> None:
+        """A provably-different hygiene.py defers even beside operators (P2 r7)."""
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR) as tmp:
+            consumer = Path(tmp) / "hygiene.py"
+            consumer.write_text("print('consumer tool')\n", encoding="utf-8")
+            posix = str(consumer).replace("\\", "/")
+            self.assertIsNone(
+                self.run_guard_engine_gate(f"python3 {posix} --help && echo done")
+            )
+            self.assertIsNone(
+                self.run_guard_engine_gate(
+                    f"python {posix} --help; echo done", "PowerShell"
+                )
+            )
+
+    def test_engine_gate_still_gates_engine_beside_consumer_decoy(self) -> None:
+        """A decoy consumer file must not launder a real engine invocation (r7)."""
+        script = SCRIPT_DIR / "hygiene.py"
+        with tempfile.TemporaryDirectory(dir=SCRIPT_DIR) as tmp:
+            consumer = Path(tmp) / "hygiene.py"
+            consumer.write_text("print('consumer tool')\n", encoding="utf-8")
+            posix = str(consumer).replace("\\", "/")
+            result = self.run_guard_engine_gate(
+                f'python3 {posix} --help && python3 "{script}" apply --plan p --token t',
+                "Bash",
+                "false",
+            )
+            assert result is not None
+            self.assertEqual(
+                "deny", result["hookSpecificOutput"]["permissionDecision"]
+            )
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1850,6 +1850,27 @@ class GuardTests(unittest.TestCase):
                 self.run_guard_engine_gate(command, tool_name), (tool_name, command)
             )
 
+    def test_engine_gate_catches_interpreter_options_before_the_script(self) -> None:
+        """Interpreter options must not slip the kill switch (P1 review)."""
+        script = SCRIPT_DIR / "hygiene.py"
+        result = self.run_guard_engine_gate(
+            f'/usr/bin/python3 -B "{script}" apply --plan p --token t', "Bash", "false"
+        )
+        assert result is not None
+        self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
+
+    def test_engine_gate_defers_consumer_owned_hygiene_scripts(self) -> None:
+        """A different existing file named hygiene.py is not this engine (P2 review)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            # realpath expands Windows 8.3 short segments (KYLESE~1): the guard
+            # rejects `~` anywhere in a Bash command as a shell-expansion
+            # character, and this test needs a parseable consumer path.
+            consumer = Path(os.path.realpath(tmp)) / "hygiene.py"
+            consumer.write_text("print('consumer tool')\n", encoding="utf-8")
+            self.assertIsNone(
+                self.run_guard_engine_gate(f'python3 "{consumer}" --help')
+            )
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1969,6 +1969,16 @@ class GuardTests(unittest.TestCase):
                 "deny", result["hookSpecificOutput"]["permissionDecision"]
             )
 
+    def test_engine_gate_catches_path_resolved_engine_after_env_wrapper(self) -> None:
+        """env VAR=... hygiene.py must gate as the effective command (P1 r8)."""
+        result = self.run_guard_engine_gate(
+            f"env PATH={SCRIPT_DIR}:/usr/bin hygiene.py apply --plan p --token t",
+            "Bash",
+            "false",
+        )
+        assert result is not None
+        self.assertEqual("deny", result["hookSpecificOutput"]["permissionDecision"])
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1850,7 +1850,7 @@ class GuardTests(unittest.TestCase):
                 self.run_guard_engine_gate(command, tool_name), (tool_name, command)
             )
 
-    def test_engine_gate_fails_closed_on_unparseable_marker_commands(self) -> None:
+    def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")
         assert result is not None

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1871,6 +1871,20 @@ class GuardTests(unittest.TestCase):
                 self.run_guard_engine_gate(f'python3 "{consumer}" --help')
             )
 
+    def test_engine_gate_catches_wrapper_launchers_of_the_bundled_engine(self) -> None:
+        """env / sh -c wrappers around the absolute engine path must gate (P1 review)."""
+        script = SCRIPT_DIR / "hygiene.py"
+        wrapped = self.run_guard_engine_gate(
+            f'/usr/bin/env "{script}" apply --plan p --token t', "Bash", "false"
+        )
+        assert wrapped is not None
+        self.assertEqual("deny", wrapped["hookSpecificOutput"]["permissionDecision"])
+        compound = self.run_guard_engine_gate(
+            f'sh -c "{script} apply --plan p --token t"', "Bash", "false"
+        )
+        assert compound is not None
+        self.assertEqual("deny", compound["hookSpecificOutput"]["permissionDecision"])
+
     def test_engine_gate_fails_closed_on_unparsable_marker_commands(self) -> None:
         """Marker + shell operators/expansions the literal parser rejects → gate."""
         result = self.run_guard_engine_gate("python3 hygiene.py scan && echo done")

--- a/plugins/disk-hygiene/skills/setup/SKILL.md
+++ b/plugins/disk-hygiene/skills/setup/SKILL.md
@@ -28,10 +28,11 @@ INFO — a deliberately disabled plugin is not broken. Report the probes informa
 note that re-enabling restores the FAIL semantics.
 
 1. **Python floor on `PATH`** — the interpreter used by scanning, validation, the
-   skill-scoped guard, and cleanup. (The guard is skill-scoped: its PreToolUse hook fires
-   only within the `clean` skill's context, so this skill's own probes — and any direct
-   `hygiene.py` invocation outside `clean` — rely on the engine's built-in containment,
-   not the hook.) The required version has one origin: the `MIN_PYTHON`
+   guard, and cleanup. (The guard registers on two surfaces: a plugin-level engine gate
+   that fires in every session but acts only on engine-referencing commands, and the
+   skill-scoped belt inside the `clean` skill's context. This skill's own probes — and
+   any direct `hygiene.py` invocation — meet the engine gate; the deny-by-default belt
+   applies only during `clean`.) The required version has one origin: the `MIN_PYTHON`
    constant in `${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py` — parse it from
    there (`grep -m1 '^MIN_PYTHON' …`) and probe the interpreter against that value; do not
    recite a version number from this file or the README. FAIL if absent or older, naming


### PR DESCRIPTION
## Summary

Closes #1107. Implements the #1106 maintainer decision (Option E — split registration), from handoff-inbox item `20260723-021058-disk-hygiene-0-6-4-consumer-audit` findings F1/F5.

- **New plugin-level engine gate** (`hooks/hooks.json`, exec form): runs `destructive_guard.py --mode engine-gate` with `${user_config.disk_hygiene_enabled}` + `${CLAUDE_PLUGIN_DATA}` substituted (both channels verified against code.claude.com/docs/en/hooks and /plugins-reference, fetched this session — details in the #1105 findings comment). A configured `false` is now guard-enforced against engine invocations in every session; data-root authority arrives directly instead of by reconstruction.
- **Instant deferral outside the engine:** engine-gate mode exits with no output for any command not referencing the engine — unrelated work is never taxed (the review-established deny-by-default Bash lane stays skill-scoped).
- **Belt unchanged:** the clean skill's frontmatter hook keeps the deny-by-default Bash + deletion-spelling PowerShell discipline during active cleanup.
- **GuardTests honesty gap closed:** new `run_guard_engine_gate` grid proves defer/deny/kill-switch behavior over the exact channel set the shipped plugin-level registration receives.
- **Docs:** split-registration architecture (README, clean + setup SKILL.md, safety model); observed-vs-documented hook-lifetime discrepancy recorded with pointer to #1105's pending interactive repro; subagent hook firing noted; #1116's decline affirmation recorded in the safety model with its reversal trigger.

**Security review (new trust surface):** the plugin-level PreToolUse hook fires in every consumer session — deliberate, per the #1106 decision. Review delta recorded in README's plugin-acceptance section: exec form only, bundled stdlib script, instant no-output deferral for non-engine commands, no new capability beyond the skill-scoped deployment's; accepted costs (per-call `python3` launch; Store-stub interaction) named, with #1110 tracking stub detection.

disk-hygiene 0.6.5 → 0.7.0 (minor: new registration surface + capability).

## Test plan

- [x] `hygiene.test.sh` — 115 tests OK (3 new: engine-gate defers all non-engine commands on both tools; gates engine invocations incl. PowerShell deny + malformed-shape deny; fails closed on engine commands in audit-only mode)
- [x] `skill-quality:check` PASS on clean and setup skills
- [x] CI gates (hygiene, plugin-gate, changelog-parity, security-review) verify

## Related

- #1106 (decision record, closed), #1105 (verification findings; interactive repro still open), #1116 (affirmation recorded here), #1110 (Store-stub detection), #1122 (automated-review infra failure — reviews on this PR may infra-fail again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
