### PR TITLE
fix(repo-fleet-hygiene): guard empty remote-ref array, surface privacy-gated merged-branch gap

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.0]
+
+### Fixed
+
+- **One repository with zero remote-tracking refs no longer aborts the whole fleet report (#1119).**
+  The merged-PR exact-fallback gate expanded `REMOTE_BRANCH_NAMES` unguarded — the script's only
+  value-expansion of a possibly-empty array without the `:-` idiom its siblings use. Under `set -u`
+  on bash ≤ 4.3 (macOS system bash is 3.2.57; bash 4.4 removed the behavior) that expansion is a
+  fatal unbound-variable error, and `analyze_repo` runs in the main shell — a never-fetched clone,
+  a fully-pruned repo, or the partial-failure reset killed the entire run mid-report. Guarded with
+  the sibling idiom plus an empty-string skip; repo-b in the test suite is documented as the
+  empty-remote-inventory regression fixture.
+
+### Added
+
+- **Privacy-gated merged-branch misses are now visible (#1119).** The exact `--head` fallback stays
+  fail-closed (a branch name never observed on the remote is never transmitted to GitHub), but the
+  skip is no longer silent: branches with no batch evidence that the gate blocks from exact lookup
+  are reported once per repository as an `UNKNOWN merge-evidence-privacy-gated` aggregate finding —
+  the merged-then-auto-deleted-then-pruned branch now surfaces as a reportable evidence gap instead
+  of vanishing. A repo-wide failed remote-ref scan keeps the aggregate quiet (the existing
+  `remote-branch-inventory-unavailable` finding already covers every branch; new `rref-fail`
+  fixture proves no double-report). The misleading fallback comment ("prevents a false negative" —
+  untrue after head auto-delete + prune) is corrected, and the deferred widenings
+  (`branch.<name>.merge`/`.remote` proof of prior push; batch-window pagination) are recorded there.
+
 ## [0.4.1]
 
 ### Added

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -588,8 +588,9 @@ analyze_repo() {
   local ref_record branch_status=1 branch_inventory_valid=true
   local remote_ref_record remote_branch_status=1 remote_branch_short remote_branch_known
   local repo_pr_rows="" exact_pr_rows="" repo_pr_available=false protected=false
+  local remote_inventory_failed=false
   local -a WT_PATHS=() WT_BRANCHES=() WT_PRUNABLE=() WT_LOCKED=()
-  local -a BRANCH_NAMES=() BRANCH_TIPS=() REMOTE_BRANCH_NAMES=()
+  local -a BRANCH_NAMES=() BRANCH_TIPS=() REMOTE_BRANCH_NAMES=() PRIVACY_GATED_BRANCHES=()
 
   select_remote "$discovered" && {
     discovered_remote="$SELECTED_REMOTE"
@@ -856,8 +857,11 @@ analyze_repo() {
     if [[ "$remote_branch_status" != "0" ]]; then
       # The producer may have emitted and appended some records before failing partway through;
       # discard them so a partial remote-ref inventory can never make remote_branch_known true
-      # below and drive the exact --head fallback query on stale/incomplete evidence.
+      # below and drive the exact --head fallback query on stale/incomplete evidence. The failure
+      # flag keeps the per-branch privacy-gap aggregate quiet: this repo-wide finding already says
+      # every exact lookup is skipped, so repeating it per branch would double-report.
       REMOTE_BRANCH_NAMES=()
+      remote_inventory_failed=true
       emit_finding UNKNOWN remote-branch-inventory-unavailable "$canonical" \
         "git for-each-ref for refs/remotes/$canonical_remote/ failed" \
         "Exact per-branch GitHub lookups are skipped for every branch in this repository" \
@@ -905,13 +909,23 @@ analyze_repo() {
           break
         fi
       done <<<"$repo_pr_rows"
-      # The batch is an optimization, not an evidence boundary. An exact repository+head fallback
-      # prevents an older local branch from becoming a false negative outside the recent-PR window.
-      # Only send a branch name GitHub can already see: --head transmits it verbatim to github.com,
-      # so a purely local branch (never pushed) must never reach this query at all.
+      # The batch is an optimization, not an evidence boundary: an exact repository+head fallback
+      # catches a merged PR outside the recent-created batch window -- but only for a branch still
+      # present in the local remote-tracking inventory. After the common merge flow (head branch
+      # auto-deleted by GitHub, then a prune fetch) that ref is gone and the privacy gate below
+      # skips this lookup, so the gap is reported as merge-evidence-privacy-gated rather than
+      # passing silently. Only send a branch name GitHub can already see: --head transmits it
+      # verbatim to github.com, so a purely local branch (never pushed) must never reach this
+      # query at all. Deferred (revisit if the gap keeps biting): widening proof-of-prior-push
+      # via branch.<name>.merge/.remote config, and paginating the batch window.
       if [[ -z "$pr_match" ]]; then
         remote_branch_known=false
-        for remote_branch_short in "${REMOTE_BRANCH_NAMES[@]}"; do
+        # ":-" guard: expanding an empty array under set -u is a fatal unbound-variable error on
+        # bash <= 4.3 (fixed in 4.4; macOS system bash is 3.2), and analyze_repo runs in the main
+        # shell -- one
+        # repo with zero remote-tracking refs would abort the whole fleet report without it.
+        for remote_branch_short in "${REMOTE_BRANCH_NAMES[@]:-}"; do
+          [[ -n "$remote_branch_short" ]] || continue
           [[ "$remote_branch_short" == "$branch" ]] && {
             remote_branch_known=true
             break
@@ -934,6 +948,12 @@ analyze_repo() {
               "exact repository-and-head merged-PR query failed" "Do not infer branch merge state" \
               "Restore GitHub access/authentication and rerun"
           fi
+        elif [[ "$protected" == "false" && -z "$pr_any" && "$remote_inventory_failed" == "false" ]]; then
+          # Privacy gate engaged with zero batch evidence: this branch cannot be checked against
+          # GitHub without transmitting a name the remote may not carry. Collect it so the gap is
+          # reported once per repository below -- a silent miss here is exactly the merged-then-
+          # auto-deleted-then-pruned branch disappearing from the report.
+          PRIVACY_GATED_BRANCHES+=("$branch")
         fi
       fi
     fi
@@ -970,6 +990,16 @@ analyze_repo() {
       fi
     fi
   done
+
+  # One aggregate line per repository (not per branch) keeps a fleet full of local-only branches
+  # from drowning the report while still honoring the no-silent-caps ethos: every skipped exact
+  # lookup is named. The branch names appear only in this local report, never in a GitHub query.
+  if [[ "${#PRIVACY_GATED_BRANCHES[@]}" -gt 0 ]]; then
+    emit_finding UNKNOWN merge-evidence-privacy-gated "$canonical" \
+      "exact merged-PR lookup skipped for ${#PRIVACY_GATED_BRANCHES[@]} branch(es) absent from the local remote-tracking inventory: ${PRIVACY_GATED_BRANCHES[*]}" \
+      "Merged state unverified; a merged branch whose remote ref was auto-deleted and pruned reports no merged finding" \
+      "Push or re-fetch the branch to restore remote evidence, or verify manually on GitHub, then rerun"
+  fi
 
   REPOS_AUDITED=$((REPOS_AUDITED + 1))
 }

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$TMP"' EXIT
 MOCK_BIN="$TMP/bin"
 mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/repo-b" "$TMP/old-repo" \
   "$TMP/bad-discovered" "$TMP/bad-canonical" "$TMP/wt-fail" \
-  "$TMP/ref-fail" \
+  "$TMP/ref-fail" "$TMP/rref-fail" \
   "$TMP/root/acme/root-repo/.git" \
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
@@ -48,6 +48,7 @@ rev-parse)
     bad-canonical) printf '%s\n' "$TEST_ROOT/bad-canonical" ;;
     wt-fail) printf '%s\n' "$TEST_ROOT/wt-fail" ;;
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail" ;;
+    rref-fail) printf '%s\n' "$TEST_ROOT/rref-fail" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
@@ -66,6 +67,7 @@ rev-parse)
     bad-canonical) printf '%s\n' "$TEST_ROOT/bad-canonical/.git" ;;
     wt-fail) printf '%s\n' "$TEST_ROOT/wt-fail/.git" ;;
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail/.git" ;;
+    rref-fail) printf '%s\n' "$TEST_ROOT/rref-fail/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
@@ -87,6 +89,7 @@ remote)
     bad-canonical) printf '%s\n' 'https://gitlab.com/other/unrelated.git' ;;
     wt-fail) printf '%s\n' 'https://github.com/acme/wt-fail.git' ;;
     ref-fail) printf '%s\n' 'https://github.com/acme/ref-fail.git' ;;
+    rref-fail) printf '%s\n' 'https://github.com/acme/rref-fail.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
@@ -117,6 +120,9 @@ worktree)
   ref-fail)
     printf 'worktree %s\0HEAD ref-main\0branch refs/heads/main\0\0' "$TEST_ROOT/ref-fail"
     ;;
+  rref-fail)
+    printf 'worktree %s\0HEAD rr-main\0branch refs/heads/main\0\0' "$TEST_ROOT/rref-fail"
+    ;;
   root-repo)
     printf 'worktree %s\0HEAD root-main\0branch refs/heads/main\0\0' "$TEST_ROOT/root/acme/root-repo"
     ;;
@@ -140,17 +146,23 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | wt-fail | ref-fail | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
   # refs/remotes/<remote>/ scans (case-branch below) prove a local-only branch never becomes a
   # --head argument to gh: canonical-a's remote mirror deliberately omits feature/mismatch.
+  # repo-b deliberately matches NO case here (empty output, exit 0): it is the empty-remote-
+  # inventory regression fixture for #1119 -- its non-default feature/shared branch has no PR-batch
+  # row, so the exact-fallback gate loop must run over an empty REMOTE_BRANCH_NAMES without
+  # aborting the fleet (unguarded expansion is fatal under set -u on bash <= 4.3) and must report
+  # the skipped lookup as a visible privacy gap.
   if [[ "${3:-}" == refs/remotes/*/ ]]; then
     case "$base" in
     canonical-a)
       printf 'origin\thead-a\0\norigin/main\tmain-a\0\norigin/feature/shared\tsha-a\0\norigin/stale/changed\tdrift-tip\0\n'
       ;;
+    rref-fail) exit 9 ;;
     esac
     exit 0
   fi
@@ -164,6 +176,7 @@ for-each-ref)
   old-repo) printf 'main\told-main\0\n' ;;
   wt-fail) printf 'main\twt-main\0\nfeature/fail\tfail-tip\0\n' ;;
   ref-fail) printf 'main\tref-main\0\nfeature/partial\tpartial-tip\0'; exit 9 ;;
+  rref-fail) printf 'main\trr-main\0\nfeature/gated\trr-tip\0\n' ;;
   root-repo) printf 'main\troot-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
   gone-repo) printf 'main\tgone-main\0\n' ;;
@@ -199,6 +212,7 @@ api)
   repos/acme/bad) printf 'acme/bad\tmain' ;;
   repos/acme/wt-fail) printf 'acme/wt-fail\tmain' ;;
   repos/acme/ref-fail) printf 'acme/ref-fail\tmain' ;;
+  repos/acme/rref-fail) printf 'acme/rref-fail\tmain' ;;
   repos/old/repo) printf 'new/repo\tmain' ;;
   repos/acme/repo-c) printf 'acme/repo-c\tmain' ;;
   repos/gone/net) printf 'gh: connection reset by peer\n' >&2; exit 1 ;;
@@ -216,6 +230,7 @@ pr)
     printf '42\tstale/changed\tmerged-tip\t2026-07-02T00:00:00Z\thttps://github.com/acme/repo-a/pull/42\n'
     ;;
   github.com/acme/repo-b | github.com/acme/root-repo | github.com/new/repo | github.com/acme/repo-c) ;;
+  github.com/acme/rref-fail) ;;
   github.com/acme/wt-fail)
     printf '88\tfeature/fail\tfail-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/wt-fail/pull/88\n'
     ;;
@@ -246,6 +261,7 @@ cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
     repo = ../bad-discovered
     repo = ../wt-fail
     repo = ../ref-fail
+    repo = ../rref-fail
     repo = ../discovered-c
     repo = ../gone-repo
     repo = ../lost-repo
@@ -302,9 +318,30 @@ assert_not_contains "repo B branch did not inherit repo A merge" "Target: $TMP/r
 assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad-canonical ::"
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
-assert_contains "failed repositories not counted successful" "Summary: repositories=8"
+assert_contains "failed repositories not counted successful" "Summary: repositories=9"
 assert_contains "per-root discovered count for a contributing root" "../root: 1 repositories"
 assert_contains "zero-contribution root stays visible in the header" "../emptyroot: 0 repositories"
+
+# Empty remote-ref inventory (repo-b: refs/remotes scan returns nothing with exit 0) must reach
+# and survive the exact-fallback gate loop -- on bash <= 4.3 an unguarded empty-array expansion
+# under set -u aborts the whole fleet -- and the privacy-gated skip must be visible, never silent.
+if grep -A3 -F "Finding: merge-evidence-privacy-gated" "$output" | grep -Fq "Target: $TMP/repo-b"; then
+  printf 'PASS: empty remote inventory survives gate loop and reports privacy gap\n'
+else
+  printf 'FAIL: empty remote inventory survives gate loop and reports privacy gap\n' >&2
+  failures=$((failures + 1))
+fi
+assert_contains "local-only branch named in aggregate privacy gap" \
+  "absent from the local remote-tracking inventory: feature/mismatch"
+# A FAILED remote-ref scan (rref-fail) already reports remote-branch-inventory-unavailable
+# repo-wide; the per-repo privacy-gap aggregate must stay quiet there, not double-report.
+assert_contains "failed remote-ref scan reported repo-wide" "Finding: remote-branch-inventory-unavailable"
+if grep -A3 -F "Finding: merge-evidence-privacy-gated" "$output" | grep -Fq "Target: $TMP/rref-fail"; then
+  printf 'FAIL: failed remote inventory double-reported as privacy gap\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS: failed remote inventory not double-reported as privacy gap\n'
+fi
 
 # fleet.ackUnavailable: 404 on an acked identity (mixed-case config entry) is
 # demoted to ACKNOWLEDGED; an unacked 404 stays UNKNOWN; a non-404 failure on


### PR DESCRIPTION
## Summary

- **F1 (crash):** the merged-PR exact-fallback gate expanded `REMOTE_BRANCH_NAMES` unguarded — the script's only value-expansion of a possibly-empty array without the `:-` idiom its siblings use (`ACK_KEYS`, `REPO_ARGS`, `ROOT_ARGS`, `TARGET_COMMON_KEYS`). Under `set -u` on bash ≤ 4.3 (macOS system bash 3.2.57; bash 4.4 CHANGES 3.a removed the behavior) one repo with zero remote-tracking refs aborted the ENTIRE fleet report, since `analyze_repo` runs in the main shell. Fixed with the sibling guard idiom + empty-string skip — no version gate, per the issue's direction.
- **F2 (silent miss made visible):** the privacy gate on the exact `--head` fallback stays fail-closed, but a skipped lookup now emits one per-repo aggregate `UNKNOWN merge-evidence-privacy-gated` finding listing the gated branches — the merged→auto-deleted→pruned branch surfaces as a reportable evidence gap instead of vanishing. Branch names appear only in the local report, never in a GitHub query. The misleading comment ("prevents a false negative" — untrue post auto-delete + prune) is corrected; deferred widenings (`branch.<name>.merge`/`.remote` proof-of-prior-push, batch-window pagination) recorded in the comment.
- A repo-wide failed remote-ref scan suppresses the aggregate (existing `remote-branch-inventory-unavailable` finding already covers every branch — no double-report).
- Version 0.5.0 + CHANGELOG.

## Test plan

- [x] repo-b documented as the empty-remote-inventory regression fixture (remote-ref scan returns empty with exit 0; non-default `feature/shared` absent from the PR batch) — gate loop executes on the empty array and reports the gap
- [x] New `rref-fail` fixture: FAILED remote-ref scan → `remote-branch-inventory-unavailable` repo-wide, NO privacy-gap double-report
- [x] `feature/mismatch` (local-only) named in canonical-a's aggregate privacy gap; still never sent via `--head`
- [x] Full suite: 40 asserts pass; shellcheck clean on both files

Closes #1119

## Related

- #1117 — merged base this PR serializes behind (same plugin; version/CHANGELOG)
- #1120, #1121 — serial follow-ups from the same audit handoff item (blocked on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
