### PR TITLE
feat(repo-fleet-hygiene): drift push-state evidence, gh account in header, explicit clean-repo marker

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -8,11 +8,14 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 ### Added
 
 - **Drift findings name the push state (#1120).** `merged-pr-tip-drift` evidence now states whether
-  the local tip exists on the same-named remote-tracking ref — the fact that flips the cleanup risk
-  profile (pushed drift is recoverable from the remote after deletion; unpushed drift is data
-  loss). Computed from the remote-ref OIDs the enumeration already collected and previously
-  discarded; purely local, no network. When the remote-tracking inventory is unavailable the
-  evidence says "push state unknown" instead of guessing.
+  the local tip matches the last-fetched remote-tracking ref — the fact that changes the cleanup
+  risk profile. The wording is deliberately cached-observation, not current-reachability: a
+  tracking ref only records what the remote advertised at the last fetch (the branch may have been
+  deleted or force-pushed since), so a match reads "pushed as of the last fetch; verify current
+  remote state before relying on recoverability". Computed from the remote-ref OIDs the
+  enumeration already collected and previously discarded; purely local, no network. When the
+  remote-tracking inventory is unavailable the evidence says "push state unknown" instead of
+  guessing.
 - **Report header names the authenticated gh account (#1120).** `GitHub evidence: available
   (account: <login>)` — a dozen `HTTP 404` UNKNOWNNs read very differently under the wrong login
   than under the right one. Probed via a narrowly allowlisted `gh api user` GET with a fixed

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.0]
+
+### Added
+
+- **Drift findings name the push state (#1120).** `merged-pr-tip-drift` evidence now states whether
+  the local tip exists on the same-named remote-tracking ref — the fact that flips the cleanup risk
+  profile (pushed drift is recoverable from the remote after deletion; unpushed drift is data
+  loss). Computed from the remote-ref OIDs the enumeration already collected and previously
+  discarded; purely local, no network. When the remote-tracking inventory is unavailable the
+  evidence says "push state unknown" instead of guessing.
+- **Report header names the authenticated gh account (#1120).** `GitHub evidence: available
+  (account: <login>)` — a dozen `HTTP 404` UNKNOWNNs read very differently under the wrong login
+  than under the right one. Probed via a narrowly allowlisted `gh api user` GET with a fixed
+  template (mirroring the `repos/{slug}` allowlist shape); any probe failure keeps the plain
+  header line. This is the cheap subset of the tracked per-domain-gh-auth request.
+- **Clean repositories say so (#1120).** A finding-less repository section now ends with an
+  explicit `Findings: none` line and the same `---` terminator finding blocks use — clean output
+  is distinguishable from truncated output.
+
 ## [0.5.0]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -142,9 +142,14 @@ gh_probe_allowed() {
     [[ $# -eq 4 && "$2" == "status" && "$3" == "--hostname" && "$4" == "github.com" ]]
     ;;
   api)
+    # Exactly two read-only endpoints: the repository identity probe and the authenticated-login
+    # probe for the report header. Both are GET with a fixed template; nothing else is admitted.
     [[ $# -eq 8 && "$2" =~ ^repos/[^/[:cntrl:][:space:]]+/[^/[:cntrl:][:space:]]+$ &&
       "$3" == "--hostname" && "$4" == "github.com" && "$5" == "--method" && "$6" == "GET" &&
-      "$7" == "--template" && "$8" == '{{printf "%s\t%s" .full_name .default_branch}}' ]]
+      "$7" == "--template" && "$8" == '{{printf "%s\t%s" .full_name .default_branch}}' ]] ||
+      [[ $# -eq 8 && "$2" == "user" &&
+        "$3" == "--hostname" && "$4" == "github.com" && "$5" == "--method" && "$6" == "GET" &&
+        "$7" == "--template" && "$8" == '{{.login}}' ]]
     ;;
   pr)
     [[ "${2:-}" == "list" && "${3:-}" == "--repo" &&
@@ -444,6 +449,15 @@ if command -v gh >/dev/null 2>&1 && run_bounded_gh auth status --hostname github
   GH_READY=true
 fi
 
+# Which gh account produced the GitHub evidence changes how UNKNOWNs read (a dozen HTTP 404s under
+# the wrong login is expected, under the right one it is a real signal), so the header names it.
+# Best-effort: any probe failure keeps the plain header line. This is the cheap subset of the
+# tracked per-domain-gh-auth request (multiple accounts per host) — see the plugin backlog.
+GH_ACCOUNT=""
+if [[ "$GH_READY" == "true" ]]; then
+  GH_ACCOUNT="$(run_bounded_gh api user --hostname github.com --method GET --template '{{.login}}' 2>/dev/null | tr -d '\r\n')" || GH_ACCOUNT=""
+fi
+
 select_remote() {
   local repo="$1" remotes count
   if run_git_probe -C "$repo" remote get-url origin >/dev/null 2>&1; then
@@ -559,9 +573,13 @@ FINDINGS_LOW=0
 FINDINGS_UNKNOWN=0
 FINDINGS_ACKED=0
 REPOS_AUDITED=0
+# Per-repository finding tally, reset by analyze_repo: a section that ends with zero findings
+# emits an explicit "Findings: none" marker so clean output is distinguishable from truncation.
+REPO_FINDING_COUNT=0
 
 emit_finding() {
   local confidence="$1" kind="$2" target="$3" evidence="$4" disposition="$5" handoff="$6"
+  REPO_FINDING_COUNT=$((REPO_FINDING_COUNT + 1))
   case "$confidence" in
   HIGH) FINDINGS_HIGH=$((FINDINGS_HIGH + 1)) ;;
   MEDIUM) FINDINGS_MEDIUM=$((FINDINGS_MEDIUM + 1)) ;;
@@ -590,7 +608,10 @@ analyze_repo() {
   local repo_pr_rows="" exact_pr_rows="" repo_pr_available=false protected=false
   local remote_inventory_failed=false
   local -a WT_PATHS=() WT_BRANCHES=() WT_PRUNABLE=() WT_LOCKED=()
-  local -a BRANCH_NAMES=() BRANCH_TIPS=() REMOTE_BRANCH_NAMES=() PRIVACY_GATED_BRANCHES=()
+  local -a BRANCH_NAMES=() BRANCH_TIPS=() REMOTE_BRANCH_NAMES=() REMOTE_BRANCH_TIPS=()
+  local -a PRIVACY_GATED_BRANCHES=()
+  local remote_tip push_state ri
+  REPO_FINDING_COUNT=0
 
   select_remote "$discovered" && {
     discovered_remote="$SELECTED_REMOTE"
@@ -842,12 +863,16 @@ analyze_repo() {
       fi
       [[ "$remote_ref_record" == *$'\t'* ]] || continue
       remote_branch_short="${remote_ref_record%%$'\t'*}"
+      remote_tip="${remote_ref_record#*$'\t'}"
       # refs/remotes/<remote>/ also yields a bare "<remote>" entry (the symbolic HEAD pointer to
       # the remote's default branch, e.g. refs/remotes/origin/HEAD -> refname:short "origin") --
       # require the literal "<remote>/" prefix so that entry is excluded, not misread as a branch.
       if [[ "$remote_branch_short" == "$canonical_remote/"* ]]; then
         remote_branch_short="${remote_branch_short#"$canonical_remote"/}"
-        [[ -n "$remote_branch_short" ]] && REMOTE_BRANCH_NAMES+=("$remote_branch_short")
+        if [[ -n "$remote_branch_short" ]]; then
+          REMOTE_BRANCH_NAMES+=("$remote_branch_short")
+          REMOTE_BRANCH_TIPS+=("$remote_tip")
+        fi
       fi
     done < <(
       run_git_probe -C "$canonical" for-each-ref \
@@ -861,6 +886,7 @@ analyze_repo() {
       # flag keeps the per-branch privacy-gap aggregate quiet: this repo-wide finding already says
       # every exact lookup is skipped, so repeating it per branch would double-report.
       REMOTE_BRANCH_NAMES=()
+      REMOTE_BRANCH_TIPS=()
       remote_inventory_failed=true
       emit_finding UNKNOWN remote-branch-inventory-unavailable "$canonical" \
         "git for-each-ref for refs/remotes/$canonical_remote/ failed" \
@@ -972,8 +998,23 @@ analyze_repo() {
       fi
     elif [[ -n "$pr_any" && "$branch" != "$default_branch" ]]; then
       IFS='|' read -r pr_num pr_oid pr_merged pr_url <<<"$pr_any"
+      # Whether the drift commits were ever pushed flips the risk profile of cleanup (pushed
+      # drift is recoverable from the remote after deletion; unpushed drift is data loss), so the
+      # evidence names the push state from the already-collected remote-tracking inventory --
+      # purely local, no network.
+      if [[ "$remote_inventory_failed" == "true" || -z "$canonical_remote" ]]; then
+        push_state="remote-tracking inventory unavailable, push state unknown"
+      else
+        push_state="local tip absent from the same-named remote-tracking ref (drift commits may be unpushed)"
+        for ((ri = 0; ri < ${#REMOTE_BRANCH_NAMES[@]}; ri++)); do
+          if [[ "${REMOTE_BRANCH_NAMES[$ri]}" == "$branch" && "${REMOTE_BRANCH_TIPS[$ri]}" == "$tip" ]]; then
+            push_state="local tip present on the same-named remote-tracking ref (drift commits pushed)"
+            break
+          fi
+        done
+      fi
       emit_finding MEDIUM merged-pr-tip-drift "$canonical :: $branch" \
-        "GitHub PR #$pr_num MERGED at headRefOid $pr_oid, but current local tip is $tip" \
+        "GitHub PR #$pr_num MERGED at headRefOid $pr_oid, but current local tip is $tip; $push_state" \
         "Manual review; not a cleanup candidate" "Inspect commits added after PR #$pr_num"
     elif [[ "$protected" == "false" && "$attached" == "false" && -n "$canonical_remote" && -n "$default_branch" ]]; then
       run_git_probe -C "$canonical" merge-base --is-ancestor "$tip" \
@@ -1001,6 +1042,13 @@ analyze_repo() {
       "Push or re-fetch the branch to restore remote evidence, or verify manually on GitHub, then rerun"
   fi
 
+  # A clean section previously ended after its header fields with no marker -- indistinguishable
+  # from truncated output. Say so explicitly, with the same terminator finding blocks use.
+  if [[ "$REPO_FINDING_COUNT" -eq 0 ]]; then
+    printf 'Findings: none\n'
+    printf '%s\n' '---'
+  fi
+
   REPOS_AUDITED=$((REPOS_AUDITED + 1))
 }
 
@@ -1011,7 +1059,13 @@ if [[ -n "$CONFIG_FILE" ]]; then
 else
   print_field Config "none (no explicit, project, or user-global config; current-project scope)"
 fi
-printf 'GitHub evidence: %s\n' "$([[ "$GH_READY" == "true" ]] && echo available || echo unavailable)"
+if [[ "$GH_READY" == "true" && -n "$GH_ACCOUNT" ]]; then
+  printf 'GitHub evidence: available (account: '
+  display_value "$GH_ACCOUNT"
+  printf ')\n'
+else
+  printf 'GitHub evidence: %s\n' "$([[ "$GH_READY" == "true" ]] && echo available || echo unavailable)"
+fi
 printf 'Repositories discovered: %s\n' "${#TARGETS[@]}"
 for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   printf 'Root '

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -999,17 +999,18 @@ analyze_repo() {
       fi
     elif [[ -n "$pr_any" && "$branch" != "$default_branch" ]]; then
       IFS='|' read -r pr_num pr_oid pr_merged pr_url <<<"$pr_any"
-      # Whether the drift commits were ever pushed flips the risk profile of cleanup (pushed
-      # drift is recoverable from the remote after deletion; unpushed drift is data loss), so the
+      # Whether the drift commits were ever pushed changes the risk profile of cleanup, so the
       # evidence names the push state from the already-collected remote-tracking inventory --
-      # purely local, no network.
+      # purely local, no network. A remote-tracking ref only records what the remote advertised
+      # at the LAST FETCH (the branch may have been deleted or force-pushed since), so the
+      # evidence is framed as cached local observation, never as current remote reachability.
       if [[ "$remote_inventory_failed" == "true" || -z "$canonical_remote" ]]; then
         push_state="remote-tracking inventory unavailable, push state unknown"
       else
-        push_state="local tip absent from the same-named remote-tracking ref (drift commits may be unpushed)"
+        push_state="local tip not on the last-fetched remote-tracking ref (drift commits may never have been pushed)"
         for ((ri = 0; ri < ${#REMOTE_BRANCH_NAMES[@]}; ri++)); do
           if [[ "${REMOTE_BRANCH_NAMES[$ri]}" == "$branch" && "${REMOTE_BRANCH_TIPS[$ri]}" == "$tip" ]]; then
-            push_state="local tip present on the same-named remote-tracking ref (drift commits pushed)"
+            push_state="local tip matches the last-fetched remote-tracking ref (pushed as of the last fetch; verify current remote state before relying on recoverability)"
             break
           fi
         done

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -449,7 +449,8 @@ if command -v gh >/dev/null 2>&1 && run_bounded_gh auth status --hostname github
   GH_READY=true
 fi
 
-# Which gh account produced the GitHub evidence changes how UNKNOWNs read (a dozen HTTP 404s under
+# Which gh account produced the GitHub evidence changes how UNKNOWN findings read (a dozen HTTP
+# 404s under
 # the wrong login is expected, under the right one it is a real signal), so the header names it.
 # Best-effort: any probe failure keeps the plain header line. This is the cheap subset of the
 # tracked per-domain-gh-auth request (multiple accounts per host) — see the plugin backlog.

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -353,9 +353,9 @@ fi
 # Drift push-state evidence: stale/changed has a same-named remote-tracking ref at the SAME OID
 # (pushed); stale/gone has a drift-batch row but NO remote-tracking ref (may be unpushed).
 assert_contains "pushed drift named in evidence" \
-  "current local tip is drift-tip; local tip present on the same-named remote-tracking ref (drift commits pushed)"
+  "current local tip is drift-tip; local tip matches the last-fetched remote-tracking ref (pushed as of the last fetch; verify current remote state before relying on recoverability)"
 assert_contains "unpushed drift named in evidence" \
-  "current local tip is gone-tip; local tip absent from the same-named remote-tracking ref (drift commits may be unpushed)"
+  "current local tip is gone-tip; local tip not on the last-fetched remote-tracking ref (drift commits may never have been pushed)"
 
 # Header names the authenticated gh account; a failed login probe degrades to the plain line.
 assert_contains "header names gh account" "GitHub evidence: available (account: test-login)"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -168,7 +168,9 @@ for-each-ref)
   fi
   case "$base" in
   canonical-a)
-    printf 'main\tmain-a\0\nfeature/shared\tsha-a\0\nstale/changed\tdrift-tip\0\nfeature/mismatch\tmismatch\0\n'
+    # stale/gone: merged-PR batch row exists at a different OID (drift) but the branch has no
+    # remote-tracking ref -- the drift finding must state the local tip is absent (unpushed).
+    printf 'main\tmain-a\0\nfeature/shared\tsha-a\0\nstale/changed\tdrift-tip\0\nfeature/mismatch\tmismatch\0\nstale/gone\tgone-tip\0\n'
     ;;
   repo-b)
     printf 'main\tmain-b\0\nfeature/shared\tsha-b\0\n'
@@ -206,6 +208,10 @@ auth) exit 0 ;;
 api)
   endpoint="${2:-}"
   case "$endpoint" in
+  user)
+    [[ "${MOCK_GH_USER_FAIL:-}" == "1" ]] && exit 1
+    printf 'test-login'
+    ;;
   repos/acme/repo-a) printf 'acme/repo-a\tmain' ;;
   repos/acme/repo-b) printf 'acme/repo-b\tmain' ;;
   repos/acme/root-repo) printf 'acme/root-repo\tmain' ;;
@@ -228,6 +234,7 @@ pr)
   github.com/acme/repo-a)
     printf '18\tfeature/shared\tsha-a\t2026-07-01T00:00:00Z\thttps://github.com/acme/repo-a/pull/18\n'
     printf '42\tstale/changed\tmerged-tip\t2026-07-02T00:00:00Z\thttps://github.com/acme/repo-a/pull/42\n'
+    printf '43\tstale/gone\tother-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/repo-a/pull/43\n'
     ;;
   github.com/acme/repo-b | github.com/acme/root-repo | github.com/new/repo | github.com/acme/repo-c) ;;
   github.com/acme/rref-fail) ;;
@@ -343,6 +350,30 @@ else
   printf 'PASS: failed remote inventory not double-reported as privacy gap\n'
 fi
 
+# Drift push-state evidence: stale/changed has a same-named remote-tracking ref at the SAME OID
+# (pushed); stale/gone has a drift-batch row but NO remote-tracking ref (may be unpushed).
+assert_contains "pushed drift named in evidence" \
+  "current local tip is drift-tip; local tip present on the same-named remote-tracking ref (drift commits pushed)"
+assert_contains "unpushed drift named in evidence" \
+  "current local tip is gone-tip; local tip absent from the same-named remote-tracking ref (drift commits may be unpushed)"
+
+# Header names the authenticated gh account; a failed login probe degrades to the plain line.
+assert_contains "header names gh account" "GitHub evidence: available (account: test-login)"
+
+# Clean repos say so explicitly instead of ending the section without a marker.
+if grep -A6 -F "Repo: $TMP/root/acme/root-repo" "$output" | grep -Fq "Findings: none"; then
+  printf 'PASS: clean repo emits explicit Findings: none marker\n'
+else
+  printf 'FAIL: clean repo emits explicit Findings: none marker\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -A6 -F "Repo: $TMP/discovered-a" "$output" | grep -Fq "Findings: none"; then
+  printf 'FAIL: finding-bearing repo wrongly emitted Findings: none\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS: finding-bearing repo does not emit Findings: none\n'
+fi
+
 # fleet.ackUnavailable: 404 on an acked identity (mixed-case config entry) is
 # demoted to ACKNOWLEDGED; an unacked 404 stays UNKNOWN; a non-404 failure on
 # an acked identity stays UNKNOWN with its real reason.
@@ -423,6 +454,16 @@ if grep -Fq -- "Config: none" "$ladder_out"; then
   printf 'PASS: no-config run states none was consumed\n'
 else
   printf 'FAIL: no-config run states none was consumed\n' >&2
+  failures=$((failures + 1))
+fi
+
+# A failed authenticated-login probe must degrade the header to the plain line, never block.
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 MOCK_GH_USER_FAIL=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" >"$ladder_out"
+if grep -Fq -- "GitHub evidence: available" "$ladder_out" && ! grep -Fq -- "(account:" "$ladder_out"; then
+  printf 'PASS: failed account probe degrades to plain header line\n'
+else
+  printf 'FAIL: failed account probe degrades to plain header line\n' >&2
   failures=$((failures + 1))
 fi
 


### PR DESCRIPTION
## Summary

Three report-evidence improvements from a live 25-repo triage (rfh 0.6.0):

- **Drift push state (F3):** `merged-pr-tip-drift` Evidence now states whether the local tip exists on the same-named remote-tracking ref — pushed drift is recoverable after deletion, unpushed is data loss. Uses the remote-ref `%(objectname)` the enumeration already collected and previously discarded; purely local, no network. Remote inventory unavailable → "push state unknown", never a guess.
- **Header names the gh identity (F4):** `GitHub evidence: available (account: <login>)` via a narrowly allowlisted `gh api user` GET with a fixed template, mirroring the existing `repos/{slug}` allowlist shape. Any probe failure keeps the current plain line. Cheap subset of the tracked per-domain-gh-auth request (cross-linked in the code comment).
- **Clean repos say so (F6):** finding-less repository sections end with an explicit `Findings: none` line + the same `---` terminator finding blocks use — clean output distinguishable from truncation.

## Test plan

- [x] Pushed drift (`stale/changed`, remote ref at same OID) → "drift commits pushed"; unpushed drift (new `stale/gone` fixture: batch row at different OID, no remote ref) → "drift commits may be unpushed"
- [x] Header account assert + degradation run (`MOCK_GH_USER_FAIL=1` → plain line, no `(account:`)
- [x] Clean repo (`root-repo`) emits `Findings: none`; finding-bearing repo does not
- [x] Full suite: 44 asserts pass; shellcheck clean on both files

Closes #1120

## Related

- #1125 — merged predecessor in the serial chain (#1119); this PR builds on its privacy-gate/guard changes
- #1121 — final serial follow-up (blocked on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
