### PR TITLE
fix(disk-hygiene): PowerShell guard covers .Delete() instance calls and robocopy purge flags

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.1]
+
+### Fixed
+
+- **PowerShell mutation guard covers instance-method `.Delete()`, and robocopy mirror/purge/move
+  (#1111).** The .NET-delete pattern required `::` before `delete`, so `$item.Delete()` executed
+  with no guard flag (live-observed in the 0.6.4 consumer audit, F4); it now also matches
+  `.Delete(`. `robocopy` with `/MIR`, `/PURGE`, `/MOV`, or `/MOVE` (mass deletion via mirroring)
+  now raises the final ask prompt and is denied in audit-only mode; plain `robocopy /E` copies
+  stay untouched. The truncation family (`Set-Content`, `Out-File`, `New-Item -Force`) is
+  DECLINED with reason: those spellings are ordinary file-writing work, and an ask-tier belt that
+  fires on every write during a cleanup session trades too much friction for a raised bar the
+  engine's own containment already backs — design stays raised-bar-not-fail-closed.
+
 ## [0.7.0]
 
 ### Added

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -562,7 +562,10 @@ _POWERSHELL_MUTATION_WORDS = re.compile(
     r"|sendtorecyclebin|deletefile|deletedirectory|removedirectory"
     r")(?![\w-])"
 )
-_POWERSHELL_DOTNET_DELETE = re.compile(r"(?i)::\s*delete")
+_POWERSHELL_DOTNET_DELETE = re.compile(r"(?i)(::\s*delete|\.\s*delete\s*\()")
+_POWERSHELL_ROBOCOPY_PURGE = re.compile(
+    r"(?i)(?<![\w./\\-])robocopy(?![\w-]).*(/mir|/purge|/mov|/move)(?![\w-])"
+)
 # Module-qualified cmdlet invocations (Module\Cmdlet) put a backslash before the
 # cmdlet name, which the word pattern's lookbehind rejects; cover the deletion
 # cmdlets explicitly (aliases like rm/del cannot be module-qualified).
@@ -606,6 +609,12 @@ def powershell_decision(command: str, enabled: bool) -> tuple[str, str] | None:
             enabled,
             "disk-hygiene flagged the module-qualified deletion spelling "
             f'"{qualified.group(0)}".',
+        )
+    if _POWERSHELL_ROBOCOPY_PURGE.search(command):
+        return _powershell_mutation_verdict(
+            enabled,
+            "disk-hygiene flagged a robocopy mirror/purge/move invocation "
+            "(mass deletion via mirroring).",
         )
     return None
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -563,8 +563,11 @@ _POWERSHELL_MUTATION_WORDS = re.compile(
     r")(?![\w-])"
 )
 _POWERSHELL_DOTNET_DELETE = re.compile(r"(?i)(::\s*delete|\.\s*delete\s*\()")
+# robocopy is an executable normally invocable by full path
+# (C:\Windows\System32\robocopy.exe), so unlike the cmdlet word list its
+# lookbehind must permit path separators before the name.
 _POWERSHELL_ROBOCOPY_PURGE = re.compile(
-    r"(?i)(?<![\w./\\-])robocopy(?![\w-]).*(/mir|/purge|/mov|/move)(?![\w-])"
+    r"(?i)(?<![\w-])robocopy(\.exe)?(?![\w-]).*(/mir|/purge|/mov|/move)(?![\w-])"
 )
 # Module-qualified cmdlet invocations (Module\Cmdlet) put a backslash before the
 # cmdlet name, which the word pattern's lookbehind rejects; cover the deletion

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -2687,6 +2687,8 @@ class GuardTests(unittest.TestCase):
             "robocopy C:/src C:/dst /MIR",
             "robocopy C:/src C:/dst /E /PURGE",
             "robocopy C:/src C:/dst /MOV",
+            "C:\\Windows\\System32\\robocopy.exe C:\\src C:\\dst /MIR",
+            "& 'C:/Windows/System32/robocopy.exe' C:/src C:/dst /PURGE",
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
         ):
             result = self.run_guard_powershell(command)
@@ -2704,6 +2706,7 @@ class GuardTests(unittest.TestCase):
             "Get-ChildItem -Force C:/tmp",
             "Get-Item C:/tmp/example | Select-Object Length",
             "robocopy C:/src C:/dst /E",
+            "C:\\Windows\\System32\\robocopy.exe C:\\src C:\\dst /E",
             "Get-Item C:/tmp/example | Select-Object IsDeleted",
         ):
             self.assertIsNone(self.run_guard_powershell(command), command)

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -2682,6 +2682,11 @@ class GuardTests(unittest.TestCase):
             "Microsoft.PowerShell.Management\\Clear-RecycleBin -Force",
             "Microsoft.PowerShell.Management\\Remove-Item -Recurse C:/tmp/example",
             "[IO.File]::Delete('C:/tmp/example')",
+            "$item.Delete()",
+            "(Get-Item C:/tmp/example).Delete()",
+            "robocopy C:/src C:/dst /MIR",
+            "robocopy C:/src C:/dst /E /PURGE",
+            "robocopy C:/src C:/dst /MOV",
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
         ):
             result = self.run_guard_powershell(command)
@@ -2698,6 +2703,8 @@ class GuardTests(unittest.TestCase):
             "gh pr list --repo owner/repo",
             "Get-ChildItem -Force C:/tmp",
             "Get-Item C:/tmp/example | Select-Object Length",
+            "robocopy C:/src C:/dst /E",
+            "Get-Item C:/tmp/example | Select-Object IsDeleted",
         ):
             self.assertIsNone(self.run_guard_powershell(command), command)
 
@@ -2710,6 +2717,8 @@ class GuardTests(unittest.TestCase):
             "Clear-RecycleBin -Force",
             "Microsoft.PowerShell.Management\\Clear-RecycleBin -Force",
             "[IO.File]::Delete('C:/tmp/example')",
+            "$item.Delete()",
+            "robocopy C:/src C:/dst /MIR",
             "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('x', 'OnlyErrorDialogs', 'SendToRecycleBin')",
         ):
             result = self.run_guard_powershell_disabled(command)


### PR DESCRIPTION
## Summary

Closes #1111 (handoff-inbox item `20260723-021058-disk-hygiene-0-6-4-consumer-audit`, finding F4 remainder — `Clear-RecycleBin` and module-qualified cmdlets already landed via #1118's review rounds).

- Instance-method `.Delete()` now raises the guard's final ask prompt (the .NET pattern required `::` before `delete`, so `$item.Delete()` executed unflagged — live-observed in the producer audit); denied in audit-only mode.
- `robocopy` with `/MIR`, `/PURGE`, `/MOV`, `/MOVE` (mass deletion via mirroring) gated the same way; plain `robocopy /E` copies stay untouched.
- Truncation family (`Set-Content`, `Out-File`, `New-Item -Force`) **declined with recorded reason** (CHANGELOG): ordinary file-writing spellings — ask-tier friction on every write outweighs the raised bar; design stays raised-bar-not-fail-closed per the guard's documented philosophy.

disk-hygiene 0.7.0 → 0.7.1.

## Test plan

- [x] Ask-grid + audit-only-deny-grid entries for `.Delete()` (two spellings), `/MIR`, `/E /PURGE`, `/MOV`
- [x] Negative cases: `robocopy /E` and `Select-Object IsDeleted` defer
- [x] Suite 128 OK

## Related

- #1118 (F4 first tranche via review rounds), #1112 (substring-deny narrowing, separate)
- Handoff-inbox item: `20260723-021058-disk-hygiene-0-6-4-consumer-audit` (F4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
