### PR TITLE
feat(repo-fleet-hygiene): per-entry stale-config degradation, duplicate-checkout finding, deletion-triage pointer

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.0]
+
+### Changed
+
+- **Stale config entries degrade per-entry, not per-run (#1121).** A config-sourced
+  `fleet.repo`/`fleet.root` path that is missing or no longer a Git working tree becomes an
+  `UNKNOWN stale-config-entry` finding (naming the path, the reason, and the config source) and the
+  rest of the fleet is still audited — deleting five repositories right after an audit no longer
+  aborts every subsequent run until the config is edited. CLI-supplied `--repo`/`--root` paths still
+  hard-fail (a typo should stop the run), as does invalid config syntax. SKILL.md graceful
+  degradation updated to match.
+
+### Added
+
+- **Duplicate checkouts surfaced (#1121).** Multiple audited checkouts resolving to the same
+  normalized GitHub identity are still audited independently (correct — same-identity clones have
+  independent local state), but the coincidence now yields one LOW informational
+  `duplicate-checkout` finding per identity listing the checkout paths. Guaranteed LOW-only.
+- **README names the deletion-triage owner (#1121).** "Can I delete this repository safely?" is
+  disposability analysis owned by `/repo-hygiene:clean` (scan/stash/git tiers); the README's new
+  "What this does not answer" section points there. The deletion-triage inventory itself was
+  declined by design for this read-only report — recorded in the source handoff item's resolution.
+
 ## [0.6.0]
 
 ### Added

--- a/plugins/repo-fleet-hygiene/README.md
+++ b/plugins/repo-fleet-hygiene/README.md
@@ -96,6 +96,13 @@ accepts only its documented command, option, operand, and environment shapes. A 
 branch inventory becomes `UNKNOWN`; partial output is discarded and the repository is not counted as
 successfully audited.
 
+## What this does not answer
+
+"Can I delete this repository safely?" is deletion triage — an inventory of dirty files, stashes,
+and unpushed branches — and belongs to `/repo-hygiene:clean` (its scan/stash/git tiers), which owns
+per-repository disposability analysis. This audit is a read-only cross-repository evidence REPORT;
+it names candidates and hands off, and deliberately does not judge whether a checkout is disposable.
+
 ## Requirements
 
 - Git with `git worktree list --porcelain -z` and `git rev-parse --path-format=absolute` support.

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -100,7 +100,12 @@ do not turn "no verified finding" into "fleet is clean".
 ## Graceful degradation
 
 - Git missing or too old: stop before scanning and give the prerequisite error.
-- Invalid config/override/path: report the exact invalid input and stop; never silently fall back.
+- Invalid config SYNTAX, invalid override, or an invalid CLI-supplied `--repo`/`--root` path: report
+  the exact invalid input and stop; never silently fall back.
+- A config-sourced `fleet.repo`/`fleet.root` path that is missing or not a Git working tree degrades
+  per-entry, not per-run: the entry becomes an `UNKNOWN` `stale-config-entry` finding and the rest of
+  the fleet is still audited (deleting repositories right after an audit must not abort every
+  subsequent run until the config is edited).
 - `gh` missing/unauthenticated or API/timeout failure: continue Git/worktree checks, report GitHub
   evidence as `UNKNOWN`, and make no merged/migration claim. Compatible `timeout`/`gtimeout` is
   preferred; otherwise use the collector's finite TERM-to-KILL Bash watchdog.

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -383,6 +383,11 @@ is_acked() {
 
 if [[ ${#ROOT_ARGS[@]} -eq 0 && ${#REPO_ARGS[@]} -eq 0 ]]; then
   REPO_ARGS+=("${CLAUDE_PROJECT_DIR:-$PWD}")
+  # The implicit current-project default is CLI-equivalent, not config-sourced: it is appended
+  # after CLI_REPO_COUNT was captured, so count it there or the zero-configuration audit from a
+  # non-Git directory would degrade to a stale-config-entry (with an empty source) instead of
+  # hard-failing like the explicit-path case it stands in for.
+  CLI_REPO_COUNT=$((CLI_REPO_COUNT + 1))
 fi
 
 path_key() {

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -489,7 +489,12 @@ for root in "${ROOT_ARGS[@]:-}"; do
   ROOT_COUNTS+=($((${#TARGETS[@]} - root_before)))
 done
 
-[[ ${#TARGETS[@]} -gt 0 ]] || fail "no Git working trees found in the requested scope"
+# An all-stale config (every entry deleted since the last run) must still produce a report whose
+# stale-config-entry findings tell the user what to remediate -- hard-fail only when there is
+# neither a target to audit nor a stale entry to report.
+if [[ ${#TARGETS[@]} -eq 0 && ${#STALE_CONFIG_PATHS[@]} -eq 0 ]]; then
+  fail "no Git working trees found in the requested scope"
+fi
 
 GH_READY=false
 if command -v gh >/dev/null 2>&1 && run_bounded_gh auth status --hostname github.com >/dev/null 2>&1; then
@@ -707,10 +712,6 @@ analyze_repo() {
   print_field Canonical "$canonical"
   print_field 'Canonical resolution' "$override_source"
   print_field Remote "${discovered_key:-unknown}"
-  if [[ -n "$discovered_key" ]]; then
-    IDENT_KEYS+=("$(lower "$discovered_key")")
-    IDENT_PATHS+=("$discovered")
-  fi
 
   if [[ -z "$discovered_key" ]]; then
     emit_finding UNKNOWN github-identity-unavailable "$discovered" \
@@ -740,6 +741,17 @@ analyze_repo() {
       emit_finding UNKNOWN github-identity-unavailable "$discovered_key" "$expected_reason" \
         "Do not infer moved, deleted, or clean" "Restore GitHub access/authentication and rerun"
     fi
+  fi
+
+  # Duplicate-checkout keys use the GitHub-canonicalized identity when resolution succeeded, so an
+  # old checkout whose remote still says old/repo pairs with a fresh clone of new/repo; the parsed
+  # remote is only the fallback when canonical resolution is unavailable.
+  if [[ -n "$github_repo" ]]; then
+    IDENT_KEYS+=("github.com/$(lower "$github_repo")")
+    IDENT_PATHS+=("$discovered")
+  elif [[ -n "$discovered_key" ]]; then
+    IDENT_KEYS+=("$(lower "$discovered_key")")
+    IDENT_PATHS+=("$discovered")
   fi
 
   if [[ "$canonical" != "$discovered" ]]; then

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -341,6 +341,12 @@ resolve_input_path() {
   fi
 }
 
+# Entries before these counts came from the command line; entries appended from config below sit
+# at or past them. The failure unit differs by origin: a CLI typo should stop the run, but a
+# config-sourced path that has since been deleted degrades per-entry (stale-config-entry UNKNOWN)
+# so removing five repos right after an audit cannot abort every subsequent fleet run.
+CLI_ROOT_COUNT=${#ROOT_ARGS[@]}
+CLI_REPO_COUNT=${#REPO_ARGS[@]}
 if [[ -n "$CONFIG_FILE" ]]; then
   while IFS= read -r -d '' value; do
     [[ -n "$value" ]] && ROOT_ARGS+=("$(resolve_input_path "$value" "$CONFIG_DIR")")
@@ -391,13 +397,33 @@ path_key() {
 
 TARGETS=()
 TARGET_COMMON_KEYS=()
+# Stale config-sourced entries collected during argument processing; the report header has not
+# printed yet, so they are emitted as per-entry UNKNOWN findings once it has.
+STALE_CONFIG_PATHS=()
+STALE_CONFIG_REASONS=()
+# add_target <path> <origin>: origin "cli" hard-fails on an invalid path (a typo should stop the
+# run); origin "config" records a stale-config-entry and continues (the entry, not the run, is
+# the failure unit for a tracked fleet config). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
-  local candidate="$1" top common common_key existing
-  [[ -d "$candidate" ]] || fail "repository directory not found: $candidate"
-  top="$(run_git_probe -C "$candidate" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" ||
-    fail "not a Git working tree: $candidate"
-  common="$(run_git_probe -C "$candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')" ||
-    fail "cannot resolve Git common directory: $candidate"
+  local candidate="$1" origin="${2:-cli}" top common common_key existing
+  if [[ ! -d "$candidate" ]]; then
+    [[ "$origin" == "config" ]] || fail "repository directory not found: $candidate"
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("configured fleet.repo path is not a directory")
+    return 0
+  fi
+  top="$(run_git_probe -C "$candidate" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" || {
+    [[ "$origin" == "config" ]] || fail "not a Git working tree: $candidate"
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("configured fleet.repo path is not a Git working tree")
+    return 0
+  }
+  common="$(run_git_probe -C "$candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')" || {
+    [[ "$origin" == "config" ]] || fail "cannot resolve Git common directory: $candidate"
+    STALE_CONFIG_PATHS+=("$candidate")
+    STALE_CONFIG_REASONS+=("cannot resolve the Git common directory for the configured path")
+    return 0
+  }
   common_key="$(path_key "$common")"
   for existing in "${TARGET_COMMON_KEYS[@]:-}"; do
     [[ "$existing" == "$common_key" ]] && return 0
@@ -406,8 +432,16 @@ add_target() {
   TARGET_COMMON_KEYS+=("$common_key")
 }
 
+repo_index=0
 for repo in "${REPO_ARGS[@]:-}"; do
-  [[ -n "$repo" ]] && add_target "$repo"
+  if [[ -n "$repo" ]]; then
+    if [[ "$repo_index" -lt "$CLI_REPO_COUNT" ]]; then
+      add_target "$repo" cli
+    else
+      add_target "$repo" config
+    fi
+  fi
+  repo_index=$((repo_index + 1))
 done
 
 discover_repositories() {
@@ -430,9 +464,22 @@ discover_repositories() {
 
 ROOT_LABELS=()
 ROOT_COUNTS=()
+root_index=0
 for root in "${ROOT_ARGS[@]:-}"; do
-  [[ -n "$root" ]] || continue
-  [[ -d "$root" ]] || fail "discovery root not found: $root"
+  [[ -n "$root" ]] || {
+    root_index=$((root_index + 1))
+    continue
+  }
+  if [[ ! -d "$root" ]]; then
+    # Same per-entry degradation as add_target: a configured root that has since been deleted
+    # is a stale-config-entry finding, not a run abort; a CLI --root typo still stops the run.
+    [[ "$root_index" -ge "$CLI_ROOT_COUNT" ]] || fail "discovery root not found: $root"
+    STALE_CONFIG_PATHS+=("$root")
+    STALE_CONFIG_REASONS+=("configured fleet.root path is not a directory")
+    root_index=$((root_index + 1))
+    continue
+  fi
+  root_index=$((root_index + 1))
   # Per-root visibility: attribute newly discovered repositories to this root so a root that
   # contributed none is still reported. Deduplication credits a repo shared by nested/overlapping
   # roots to the first root that reaches it, keeping sum(root counts) + explicit --repo == discovered.
@@ -574,6 +621,9 @@ FINDINGS_LOW=0
 FINDINGS_UNKNOWN=0
 FINDINGS_ACKED=0
 REPOS_AUDITED=0
+# Per-repo GitHub identity observations for the cross-repo duplicate-checkout pass after the loop.
+IDENT_KEYS=()
+IDENT_PATHS=()
 # Per-repository finding tally, reset by analyze_repo: a section that ends with zero findings
 # emits an explicit "Findings: none" marker so clean output is distinguishable from truncation.
 REPO_FINDING_COUNT=0
@@ -657,6 +707,10 @@ analyze_repo() {
   print_field Canonical "$canonical"
   print_field 'Canonical resolution' "$override_source"
   print_field Remote "${discovered_key:-unknown}"
+  if [[ -n "$discovered_key" ]]; then
+    IDENT_KEYS+=("$(lower "$discovered_key")")
+    IDENT_PATHS+=("$discovered")
+  fi
 
   if [[ -z "$discovered_key" ]]; then
     emit_finding UNKNOWN github-identity-unavailable "$discovered" \
@@ -1075,8 +1129,46 @@ for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   printf ': %s repositories\n' "${ROOT_COUNTS[$root_index]}"
 done
 
+# Config-sourced entries that failed per-entry validation during argument processing (the header
+# had not printed yet); each is a visible finding, never a silent skip.
+for ((stale_index = 0; stale_index < ${#STALE_CONFIG_PATHS[@]}; stale_index++)); do
+  printf '\n'
+  emit_finding UNKNOWN stale-config-entry "${STALE_CONFIG_PATHS[$stale_index]}" \
+    "${STALE_CONFIG_REASONS[$stale_index]} (source: $CONFIG_FILE)" \
+    "Entry skipped; the rest of the fleet was audited" \
+    "Remove or correct the entry via /repo-fleet-hygiene:setup apply, or restore the path, then rerun"
+done
+
 for target in "${TARGETS[@]}"; do
   analyze_repo "$target"
+done
+
+# Cross-repository view: multiple independent checkouts of the same normalized GitHub identity are
+# each audited on their own local state (correct), but the coincidence itself gets one LOW
+# informational line per identity -- never more, since same-identity clones legitimately diverge.
+DUP_REPORTED=()
+for ((di = 0; di < ${#IDENT_KEYS[@]}; di++)); do
+  dup_key="${IDENT_KEYS[$di]}"
+  dup_seen=false
+  for dup_prev in "${DUP_REPORTED[@]:-}"; do
+    [[ -n "$dup_prev" && "$dup_prev" == "$dup_key" ]] && {
+      dup_seen=true
+      break
+    }
+  done
+  [[ "$dup_seen" == "true" ]] && continue
+  DUP_REPORTED+=("$dup_key")
+  DUP_PATHS=()
+  for ((dj = 0; dj < ${#IDENT_KEYS[@]}; dj++)); do
+    [[ "${IDENT_KEYS[$dj]}" == "$dup_key" ]] && DUP_PATHS+=("${IDENT_PATHS[$dj]}")
+  done
+  if [[ "${#DUP_PATHS[@]}" -ge 2 ]]; then
+    printf '\n'
+    emit_finding LOW duplicate-checkout "$dup_key" \
+      "${#DUP_PATHS[@]} distinct checkouts resolve to the same GitHub identity: ${DUP_PATHS[*]}" \
+      "Informational only; same-identity clones have independent local state" \
+      "Consolidate manually if unintended; no automated action"
+  fi
 done
 
 printf '\nSummary: repositories=%s high=%s medium=%s low=%s unknown=%s acknowledged=%s\n' \

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$TMP"' EXIT
 MOCK_BIN="$TMP/bin"
 mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/repo-b" "$TMP/old-repo" \
   "$TMP/bad-discovered" "$TMP/bad-canonical" "$TMP/wt-fail" \
-  "$TMP/ref-fail" "$TMP/rref-fail" "$TMP/dup-a" \
+  "$TMP/ref-fail" "$TMP/rref-fail" "$TMP/dup-a" "$TMP/new-clone" \
   "$TMP/root/acme/root-repo/.git" \
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
@@ -50,6 +50,7 @@ rev-parse)
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail" ;;
     rref-fail) printf '%s\n' "$TEST_ROOT/rref-fail" ;;
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a" ;;
+    new-clone) printf '%s\n' "$TEST_ROOT/new-clone" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
@@ -70,6 +71,7 @@ rev-parse)
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail/.git" ;;
     rref-fail) printf '%s\n' "$TEST_ROOT/rref-fail/.git" ;;
     dup-a) printf '%s\n' "$TEST_ROOT/dup-a/.git" ;;
+    new-clone) printf '%s\n' "$TEST_ROOT/new-clone/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
@@ -93,6 +95,7 @@ remote)
     ref-fail) printf '%s\n' 'https://github.com/acme/ref-fail.git' ;;
     rref-fail) printf '%s\n' 'https://github.com/acme/rref-fail.git' ;;
     dup-a) printf '%s\n' 'https://github.com/acme/repo-b.git' ;;
+    new-clone) printf '%s\n' 'https://github.com/new/repo.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
@@ -129,6 +132,9 @@ worktree)
   dup-a)
     printf 'worktree %s\0HEAD dup-main\0branch refs/heads/main\0\0' "$TEST_ROOT/dup-a"
     ;;
+  new-clone)
+    printf 'worktree %s\0HEAD nc-main\0branch refs/heads/main\0\0' "$TEST_ROOT/new-clone"
+    ;;
   root-repo)
     printf 'worktree %s\0HEAD root-main\0branch refs/heads/main\0\0' "$TEST_ROOT/root/acme/root-repo"
     ;;
@@ -152,7 +158,7 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
@@ -186,6 +192,7 @@ for-each-ref)
   ref-fail) printf 'main\tref-main\0\nfeature/partial\tpartial-tip\0'; exit 9 ;;
   rref-fail) printf 'main\trr-main\0\nfeature/gated\trr-tip\0\n' ;;
   dup-a) printf 'main\tdup-main\0\n' ;;
+  new-clone) printf 'main\tnc-main\0\n' ;;
   root-repo) printf 'main\troot-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
   gone-repo) printf 'main\tgone-main\0\n' ;;
@@ -227,6 +234,7 @@ api)
   repos/acme/ref-fail) printf 'acme/ref-fail\tmain' ;;
   repos/acme/rref-fail) printf 'acme/rref-fail\tmain' ;;
   repos/old/repo) printf 'new/repo\tmain' ;;
+  repos/new/repo) printf 'new/repo\tmain' ;;
   repos/acme/repo-c) printf 'acme/repo-c\tmain' ;;
   repos/gone/net) printf 'gh: connection reset by peer\n' >&2; exit 1 ;;
   *) printf 'gh: Not Found (HTTP 404)\n' >&2; exit 1 ;;
@@ -277,6 +285,7 @@ cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
     repo = ../ref-fail
     repo = ../rref-fail
     repo = ../dup-a
+    repo = ../new-clone
     repo = ../deleted-repo
     root = ../gone-root
     repo = ../discovered-c
@@ -335,7 +344,17 @@ assert_not_contains "repo B branch did not inherit repo A merge" "Target: $TMP/r
 assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad-canonical ::"
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
-assert_contains "failed repositories not counted successful" "Summary: repositories=10"
+assert_contains "failed repositories not counted successful" "Summary: repositories=11"
+
+# Duplicate detection keys on the CANONICALIZED identity: old-repo (remote still says old/repo,
+# resolved to new/repo) must pair with new-clone (cloned from new/repo directly).
+if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/old-repo" &&
+  grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/new-clone"; then
+  printf 'PASS: moved-remote checkout pairs with fresh clone via canonical identity\n'
+else
+  printf 'FAIL: moved-remote checkout pairs with fresh clone via canonical identity\n' >&2
+  failures=$((failures + 1))
+fi
 
 # Stale CONFIG-sourced entries degrade per-entry (deleted-repo, gone-root) and the run continues;
 # a CLI-supplied bad path must still hard-fail (checked in a separate run below).
@@ -495,6 +514,21 @@ if grep -Fq -- "Config: none" "$ladder_out"; then
   printf 'PASS: no-config run states none was consumed\n'
 else
   printf 'FAIL: no-config run states none was consumed\n' >&2
+  failures=$((failures + 1))
+fi
+
+# An ALL-stale config must still complete and render its stale-config-entry findings -- the
+# remediation detail matters most exactly when every entry is gone.
+cat >"$TMP/stale-only.conf" <<'STALEONLY'
+[fleet]
+    repo = ./no-such-dir-anywhere
+STALEONLY
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/stale-only.conf" >"$ladder_out" 2>&1 &&
+  grep -Fq "Finding: stale-config-entry" "$ladder_out" &&
+  grep -Fq "Repositories discovered: 0" "$ladder_out"; then
+  printf 'PASS: all-stale config completes with stale findings instead of hard-failing\n'
+else
+  printf 'FAIL: all-stale config completes with stale findings instead of hard-failing\n' >&2
   failures=$((failures + 1))
 fi
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -340,8 +340,10 @@ assert_contains "failed repositories not counted successful" "Summary: repositor
 # Stale CONFIG-sourced entries degrade per-entry (deleted-repo, gone-root) and the run continues;
 # a CLI-supplied bad path must still hard-fail (checked in a separate run below).
 assert_contains "stale config repo degrades per-entry" "Finding: stale-config-entry"
-assert_contains "stale config repo names the path" "Target: $TMP/deleted-repo"
-assert_contains "stale config root names the path" "Target: $TMP/gone-root"
+# The script may canonicalize CONFIG_DIR (e.g. /tmp -> its symlink target on Git Bash), so match
+# the stable config-relative suffix rather than the $TMP prefix.
+assert_contains "stale config repo names the path" "config/../deleted-repo"
+assert_contains "stale config root names the path" "config/../gone-root"
 assert_contains "stale root reason names fleet.root" "configured fleet.root path is not a directory"
 
 # Duplicate checkouts of one identity (repo-b + dup-a) get ONE LOW informational finding listing

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "$TMP"' EXIT
 MOCK_BIN="$TMP/bin"
 mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/repo-b" "$TMP/old-repo" \
   "$TMP/bad-discovered" "$TMP/bad-canonical" "$TMP/wt-fail" \
-  "$TMP/ref-fail" "$TMP/rref-fail" \
+  "$TMP/ref-fail" "$TMP/rref-fail" "$TMP/dup-a" \
   "$TMP/root/acme/root-repo/.git" \
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
@@ -49,6 +49,7 @@ rev-parse)
     wt-fail) printf '%s\n' "$TEST_ROOT/wt-fail" ;;
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail" ;;
     rref-fail) printf '%s\n' "$TEST_ROOT/rref-fail" ;;
+    dup-a) printf '%s\n' "$TEST_ROOT/dup-a" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
@@ -68,6 +69,7 @@ rev-parse)
     wt-fail) printf '%s\n' "$TEST_ROOT/wt-fail/.git" ;;
     ref-fail) printf '%s\n' "$TEST_ROOT/ref-fail/.git" ;;
     rref-fail) printf '%s\n' "$TEST_ROOT/rref-fail/.git" ;;
+    dup-a) printf '%s\n' "$TEST_ROOT/dup-a/.git" ;;
     root-repo) printf '%s\n' "$TEST_ROOT/root/acme/root-repo/.git" ;;
     discovered-c | canonical-c) printf '%s\n' "$TEST_ROOT/canonical-c/.git" ;;
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
@@ -90,6 +92,7 @@ remote)
     wt-fail) printf '%s\n' 'https://github.com/acme/wt-fail.git' ;;
     ref-fail) printf '%s\n' 'https://github.com/acme/ref-fail.git' ;;
     rref-fail) printf '%s\n' 'https://github.com/acme/rref-fail.git' ;;
+    dup-a) printf '%s\n' 'https://github.com/acme/repo-b.git' ;;
     root-repo) printf '%s\n' 'https://github.com/acme/root-repo.git' ;;
     discovered-c | canonical-c) printf '%s\n' 'https://github.com/acme/repo-c.git' ;;
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
@@ -123,6 +126,9 @@ worktree)
   rref-fail)
     printf 'worktree %s\0HEAD rr-main\0branch refs/heads/main\0\0' "$TEST_ROOT/rref-fail"
     ;;
+  dup-a)
+    printf 'worktree %s\0HEAD dup-main\0branch refs/heads/main\0\0' "$TEST_ROOT/dup-a"
+    ;;
   root-repo)
     printf 'worktree %s\0HEAD root-main\0branch refs/heads/main\0\0' "$TEST_ROOT/root/acme/root-repo"
     ;;
@@ -146,7 +152,7 @@ symbolic-ref)
 branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
-  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
+  repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
@@ -179,6 +185,7 @@ for-each-ref)
   wt-fail) printf 'main\twt-main\0\nfeature/fail\tfail-tip\0\n' ;;
   ref-fail) printf 'main\tref-main\0\nfeature/partial\tpartial-tip\0'; exit 9 ;;
   rref-fail) printf 'main\trr-main\0\nfeature/gated\trr-tip\0\n' ;;
+  dup-a) printf 'main\tdup-main\0\n' ;;
   root-repo) printf 'main\troot-main\0\n' ;;
   canonical-c) printf 'main\tmain-c\0\n' ;;
   gone-repo) printf 'main\tgone-main\0\n' ;;
@@ -269,6 +276,9 @@ cat >"$TMP/config/repo-fleet-hygiene.conf" <<'EOF'
     repo = ../wt-fail
     repo = ../ref-fail
     repo = ../rref-fail
+    repo = ../dup-a
+    repo = ../deleted-repo
+    root = ../gone-root
     repo = ../discovered-c
     repo = ../gone-repo
     repo = ../lost-repo
@@ -325,7 +335,36 @@ assert_not_contains "repo B branch did not inherit repo A merge" "Target: $TMP/r
 assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad-canonical ::"
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
-assert_contains "failed repositories not counted successful" "Summary: repositories=9"
+assert_contains "failed repositories not counted successful" "Summary: repositories=10"
+
+# Stale CONFIG-sourced entries degrade per-entry (deleted-repo, gone-root) and the run continues;
+# a CLI-supplied bad path must still hard-fail (checked in a separate run below).
+assert_contains "stale config repo degrades per-entry" "Finding: stale-config-entry"
+assert_contains "stale config repo names the path" "Target: $TMP/deleted-repo"
+assert_contains "stale config root names the path" "Target: $TMP/gone-root"
+assert_contains "stale root reason names fleet.root" "configured fleet.root path is not a directory"
+
+# Duplicate checkouts of one identity (repo-b + dup-a) get ONE LOW informational finding listing
+# both paths; a single-checkout identity gets none.
+if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -Fq "Confidence: LOW"; then
+  printf 'PASS: duplicate-checkout stays LOW\n'
+else
+  printf 'FAIL: duplicate-checkout stays LOW\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/repo-b" &&
+  grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -F "Evidence:" | grep -Fq "$TMP/dup-a"; then
+  printf 'PASS: duplicate-checkout lists both checkout paths\n'
+else
+  printf 'FAIL: duplicate-checkout lists both checkout paths\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -A3 -F "Finding: duplicate-checkout" "$output" | grep -Fq "Target: github.com/acme/repo-a"; then
+  printf 'FAIL: single-checkout identity wrongly reported as duplicate\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS: single-checkout identity not reported as duplicate\n'
+fi
 assert_contains "per-root discovered count for a contributing root" "../root: 1 repositories"
 assert_contains "zero-contribution root stays visible in the header" "../emptyroot: 0 repositories"
 
@@ -454,6 +493,17 @@ if grep -Fq -- "Config: none" "$ladder_out"; then
   printf 'PASS: no-config run states none was consumed\n'
 else
   printf 'FAIL: no-config run states none was consumed\n' >&2
+  failures=$((failures + 1))
+fi
+
+# A CLI-supplied bad path is a typo, not config drift: the run must still hard-fail.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/never-existed" >"$ladder_out" 2>&1; then
+  printf 'FAIL: CLI-supplied missing repo did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "repository directory not found" "$ladder_out"; then
+  printf 'PASS: CLI-supplied missing repo hard-fails\n'
+else
+  printf 'FAIL: CLI-supplied missing repo hard-fails (wrong error)\n' >&2
   failures=$((failures + 1))
 fi
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -532,6 +532,20 @@ else
   failures=$((failures + 1))
 fi
 
+# The implicit current-project default (no CLI paths, no config) is CLI-equivalent: running the
+# zero-configuration audit from a non-Git directory must still hard-fail, never degrade to a
+# stale-config-entry with an empty source.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/noconf" HOME="$TMP/nohome" \
+  bash "$SCRIPT" >"$ladder_out" 2>&1; then
+  printf 'FAIL: zero-config non-Git project dir did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "not a Git working tree" "$ladder_out" && ! grep -Fq "stale-config-entry" "$ladder_out"; then
+  printf 'PASS: zero-config non-Git project dir hard-fails without stale-config degradation\n'
+else
+  printf 'FAIL: zero-config non-Git project dir hard-fails without stale-config degradation (wrong output)\n' >&2
+  failures=$((failures + 1))
+fi
+
 # A CLI-supplied bad path is a typo, not config drift: the run must still hard-fail.
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/never-existed" >"$ladder_out" 2>&1; then
   printf 'FAIL: CLI-supplied missing repo did not hard-fail\n' >&2


### PR DESCRIPTION
## Summary

Final slice of the live-audit findings series (rfh 0.7.0):

- **F7 — stale config entries degrade per-entry, not per-run.** A config-sourced `fleet.repo`/`fleet.root` path that is missing or no longer a Git working tree becomes an `UNKNOWN stale-config-entry` finding (naming path, reason, config source) and the run continues; CLI-supplied `--repo`/`--root` still hard-fail (typo = stop), as does invalid config syntax. SKILL.md graceful degradation updated.
- **F8 — duplicate checkouts surfaced.** After the per-repo loop, identities with 2+ audited checkouts get ONE LOW informational `duplicate-checkout` finding listing the paths. LOW-only guaranteed — same-identity clones have independent local state and are still audited independently.
- **F5 — deletion triage declined by design; README points at the owner.** New "What this does not answer" README section names `/repo-hygiene:clean` (scan/stash/git tiers) for disposability analysis; the inventory block stays out of this read-only report.

## Test plan

- [x] Stale config repo (`deleted-repo`) + stale config root (`gone-root`) produce per-entry `stale-config-entry` findings naming path/reason and the run still audits 10 repositories
- [x] CLI-supplied missing `--repo` hard-fails with "repository directory not found" (separate run)
- [x] Duplicate identity (repo-b + new `dup-a` fixture, both acme/repo-b) → one LOW `duplicate-checkout` listing both paths; single-checkout identity (acme/repo-a) yields nothing; Confidence stays LOW
- [x] Full suite: 50 asserts pass; shellcheck clean on both files

Closes #1121

## Related

- #1125 (#1119), #1127 (#1120) — merged predecessors in this serial series
- Parent handoff item `20260723-065037-repo-fleet-hygiene-audit-live-run-findings` — F5 decline rationale recorded in its resolution on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
