### PR TITLE
fix(adhd): audit fixes — conflict visibility, escape hatches, precedence, off-switch, evals (0.3.0)

### DIFF
--- a/plugins/adhd/.claude-plugin/plugin.json
+++ b/plugins/adhd/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "adhd",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Shape and restructure the assistant's output for a reader with ADHD — action-first, low-friction, and digestible. adhd:shape is a standing session posture: lead with the concrete next action, number multi-step work, restate state across turns, cap and rank lists, give concrete time estimates, make wins visible, and cut preamble, recap, and closers. adhd:clarify is a one-shot reshape of a dense, decision-heavy artifact already on screen — chunk it one-decision-at-a-time, define the session's own jargon, and surface exactly what you must decide, faithfully (operative terms quoted verbatim, no altitude loss), rendered as an HTML decision table for big content. Reauthored in part from ayghri/i-have-adhd (MIT). Deliberately mutually exclusive with terse-for-tokens output shapers like caveman — opposite objectives.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/adhd/CHANGELOG.md
+++ b/plugins/adhd/CHANGELOG.md
@@ -3,6 +3,53 @@
 All notable changes to the `adhd` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.0]
+
+Fixes every finding from the 2026-07-23 live audit (handoff item
+`20260723-082358-adhd-shape-clarify-audit`, #1130).
+
+### Added
+
+- **Conflicting-shaper check at the enforcing layer (H1, L4).** The
+  caveman-style mutual-exclusion warning lived only in README/plugin.json —
+  layers the model never reads at invocation time; reproduced live as a silent
+  contradictory mix. Both SKILL.md bodies now surface an active
+  terse-for-tokens shaper before applying, name the source found in session
+  context, and ask the user to pick one. Advisory by necessity: no documented
+  skill-to-hook detection mechanism exists.
+- **`clarify` trivial-target escape hatch (M1).** A resolved target with fewer
+  than ~2 decisions gets a one-line "nothing dense here" + a question for the
+  intended target instead of the full table/glossary apparatus.
+- **`shape` off-switch (L1).** "stop shaping" / "normal output" ends the
+  standing posture; documented in SKILL.md and README.
+- **`shape` Gotchas section (L6, audit trail).** Records the audit's observed
+  failures, the compaction-durability caveat, and the explicit rules-5-vs-10
+  boundary test (last-completed step + next step only; never a running
+  done-list). Clears the skill-quality no-Gotchas WARN.
+- **Evals for every observed failure mode (M4).** shape: conflicting-shaper-
+  active, off-switch. clarify: trivial target, cold start (no prior message).
+
+### Changed
+
+- **`clarify` local-file rung writes to an OS temp path (M2).** The previous
+  destination leaned on a plugin-data substitution variable that is not
+  documented for skill-body substitution and substituted unpredictably in live
+  use (including to the wrong plugin's data dir when the token traveled through
+  another skill's arguments). OS temp/scratchpad is now the primary local-file
+  destination and the variable is gone from the skill body.
+- **Sibling precedence made explicit (M3, L3).** clarify's decision table is
+  exempt from shape's five-item list cap (fidelity wins over shaping) — stated
+  in both skills; clarify on already-shape-formatted output is declared a
+  no-op.
+- **`clarify` fidelity rule 2 fallback (L5).** An original with no identifiers
+  gets a declared synthesized locator (sequential marker or quoted opening
+  phrase) — never a chunk with no way back to its source passage.
+- **README compaction caveat (L2).** The standing posture is content-based
+  persistence; re-invoke after a context compaction if shaping stops.
+
+Out of scope by design: description-length trimming (marketplace-level gate
+decision, recorded in the audit's policy note).
+
 ## [0.2.0]
 
 ### Added

--- a/plugins/adhd/README.md
+++ b/plugins/adhd/README.md
@@ -56,7 +56,12 @@ you invoke `/adhd:shape` directly.
 Once invoked, `shape`'s rules persist as a **standing instruction for the rest of
 the session** — invoke it once at the start of a session and every following
 response is shaped, no need to repeat it. Invoke it whenever you want that
-output shape; skip it when you don't.
+output shape; skip it when you don't. Turn it off mid-session with **"stop
+shaping"** or **"normal output"**.
+
+One durability caveat: the standing posture is content-based persistence, so
+context compaction/summarization in a long session can erode it. If responses
+stop being shaped after a compaction, re-invoke `/adhd:shape`.
 
 `clarify` is on-demand too, but **one-shot, not session-standing**: it surfaces on
 a plain-language cue ("make this clear", "clarify this", "help me digest this",

--- a/plugins/adhd/skills/clarify/SKILL.md
+++ b/plugins/adhd/skills/clarify/SKILL.md
@@ -40,6 +40,19 @@ re-read that prior message and clarify it. When there is **no prior assistant
 message** — a cold start where the reader opens with "make this clear" and
 nothing has been said — do not invent a target: ask what to clarify.
 
+**Trivial-target escape hatch.** When the resolved target holds fewer than ~2
+decisions — a short answer, a status line, anything with nothing to untangle —
+do **not** run the full table/glossary apparatus on it. Say in one line that
+the target has nothing dense to clarify, and ask what the reader actually
+wanted clarified. A three-line response restructured into a one-row decision
+table is ceremony, not clarity.
+
+**Conflicting-shaper note.** If a terse-for-tokens output shaper (e.g. caveman
+hooks) is active in the session context, say so before rendering: this skill's
+faithful, structure-adding output directly contradicts a strip-words directive,
+and the two cannot both govern the same response. Advisory only — name the
+source and let the user pick.
+
 ## Fidelity rules (hard)
 
 A clarification is a **lens on the original, not a replacement for it.** These
@@ -56,6 +69,10 @@ defeats the purpose:
    original item's own identifier (Q9, Round 4 · P15b, §3) so the reader can jump
    back to the source. This is separate from any numbering this skill adds for
    itself (see [Rendering](#rendering-artifact-forward)) — never collapse the two.
+   When the original carries **no identifiers** (a dense prose memo with no Q-numbers
+   or section marks), synthesize a locator and say you did: a sequential marker
+   ("¶2", "Para 3") or the chunk's quoted opening phrase — never leave a chunk
+   with no way back to its source passage.
 3. **List omissions explicitly.** Anything in the original you did not carry
    forward — a caveat, a fifth option, a dependency — is named in a short "Left
    out" note, not silently dropped. The reader decides whether an omission
@@ -107,11 +124,16 @@ sessions and absent in others. Detect it: if the Artifact tool is available, tha
 is the top rung; otherwise degrade down the ladder. Never claim a decision table
 was rendered when only prose was produced.
 
-Write any local HTML file to the plugin's own data directory
-(`${CLAUDE_PLUGIN_DATA}`) or an OS temp path and hand back that path — a
-clarified view is transient generated state, so it never lands in the consumer's
-repository tree. If neither a writable location nor the Artifact surface is
-available, drop to the terminal-markdown rung rather than writing into the repo.
+Write any local HTML file to an **OS temp path** (the session's scratchpad
+directory when the harness provides one, else the platform temp dir) and hand
+back that path — a clarified view is transient generated state, so it never
+lands in the consumer's repository tree. Do not rely on a plugin-data
+substitution variable for this location: skill-body substitution is documented
+only for a fixed set of variables, and an undocumented token can substitute
+unpredictably (including to the wrong plugin's directory when the token
+travels through another skill's arguments). If no writable temp location nor
+the Artifact surface is available, drop to the terminal-markdown rung rather
+than writing into the repo.
 
 The fidelity rules hold in **every** medium — verbatim terms, original-number
 back-links, omissions, lens line — table or prose.
@@ -172,7 +194,11 @@ job.
 invoke it once and every response for the rest of the session is shaped. This is
 a **one-shot** reshape of **one** artifact already on screen — it does not change
 how future responses are written. Use `shape` to set the house style; use this to
-rescue a specific wall of text.
+rescue a specific wall of text. Two interaction rules when both are active:
+the decision table is **exempt from shape's five-item list cap** (fidelity
+forbids dropping decisions, and fidelity wins over shaping); and shape-formatted
+output is already restructured, so running clarify on it is usually a no-op —
+say so instead of re-rendering it.
 
 ## Gotchas
 

--- a/plugins/adhd/skills/clarify/SKILL.md
+++ b/plugins/adhd/skills/clarify/SKILL.md
@@ -196,9 +196,13 @@ a **one-shot** reshape of **one** artifact already on screen — it does not cha
 how future responses are written. Use `shape` to set the house style; use this to
 rescue a specific wall of text. Two interaction rules when both are active:
 the decision table is **exempt from shape's five-item list cap** (fidelity
-forbids dropping decisions, and fidelity wins over shaping); and shape-formatted
-output is already restructured, so running clarify on it is usually a no-op —
-say so instead of re-rendering it.
+forbids dropping decisions, and fidelity wins over shaping); and when the
+target is shape-formatted output, judge by the target's **actual decision
+density, never its provenance** — an already action-shaped, low-density
+response has nothing left to restructure (take the trivial-target escape
+hatch), but a dense multi-decision artifact still gets the full faithful
+restructure even though shape produced it (shape's explain override emits
+long, decision-heavy responses with no glossary, locators, or table).
 
 ## Gotchas
 

--- a/plugins/adhd/skills/clarify/evals/evals.json
+++ b/plugins/adhd/skills/clarify/evals/evals.json
@@ -64,6 +64,29 @@
         "Includes a glossary defining session-local jargon in plain words",
         "Defines the shorthand without lowering the altitude of the underlying concept"
       ]
+    },
+    {
+      "id": 6,
+      "name": "trivial-target-escape-hatch-instead-of-full-apparatus",
+      "prompt": "[The previous assistant response was three short lines confirming a file was saved, with no decisions in it.] /adhd:clarify",
+      "expected_output": "Recognizes the resolved target holds fewer than ~2 decisions and takes the escape hatch: one line saying there is nothing dense to clarify in that message, plus a question asking what the reader actually wanted clarified. Does not render a decision table, glossary, or omissions note for a trivial target.",
+      "files": [],
+      "expectations": [
+        "Does not run the full table/glossary/omissions apparatus on a trivial target",
+        "States in one line that the target has nothing dense to clarify",
+        "Asks what the reader actually intended to clarify"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "cold-start-asks-for-target-instead-of-inventing-one",
+      "prompt": "make this clear",
+      "expected_output": "With no prior assistant message in the session, does not invent a target or clarify the user's own three-word request: asks what to clarify.",
+      "files": [],
+      "expectations": [
+        "Does not invent or guess a target artifact",
+        "Asks the user what to clarify"
+      ]
     }
   ]
 }

--- a/plugins/adhd/skills/shape/SKILL.md
+++ b/plugins/adhd/skills/shape/SKILL.md
@@ -12,6 +12,26 @@ rest of this session in the form below, not just the next one. The reader has
 ADHD. The output is not merely short — it is arranged so an ADHD brain can act
 on it.
 
+## Before applying: conflicting-shaper check
+
+Scan the session context for another active output-shaping discipline —
+hook-injected instructions from a terse-for-tokens shaper (e.g. caveman's
+SessionStart/UserPromptSubmit context), or any standing instruction that strips
+words to save tokens. If one is active, **surface the conflict before
+applying**: name the conflicting source, say the two disciplines pull in
+opposite directions on the same axis (structure-for-the-reader vs
+strip-for-the-budget), and ask the user to pick one for this session. Do not
+silently apply both — the mix is contradictory and unpredictable. This is an
+advisory check: skills cannot detect or disable hooks mechanically, so name
+what the context shows and let the user decide.
+
+## Turning it off
+
+The posture ends when the user says so — "stop shaping" or "normal output"
+reverts to unshaped responses for the rest of the session (re-invoke
+`/adhd:shape` to turn it back on). Treat close variants ("drop the ADHD
+format") the same way.
+
 ## Five facts that drive every rule
 
 1. **Working memory is small.** Anything off-screen is gone. Never ask the
@@ -75,6 +95,11 @@ The reader cannot carry "we're on step 3 of 5" between messages. Say it again.
 - Strong: "Step 3 of 5 done: schema updated. Next: backfill the new column —
   run the script?"
 
+The boundary against rule 10's "no recap": restating state is the
+**last-completed step plus the next step, once** — never a running list of
+everything done so far. "Step 3 of 5 done: X. Next: Y" passes; "I've now done
+X, Y, and Z" is the forbidden recap.
+
 ### 6. Give concrete time estimates
 
 Ballpark in real units, not feelings.
@@ -103,6 +128,10 @@ the fix.
 
 Past five, split into "do now" vs "later," or "must" vs "nice to have." Five
 ranked items beat ten unranked.
+
+Exception: a `/adhd:clarify` decision table is **exempt** from this cap — its
+fidelity rules forbid dropping or compressing any decision, and fidelity wins
+over shaping. A 7-decision table renders all 7 rows.
 
 ### 10. No preamble, no recap, no closers
 
@@ -141,6 +170,25 @@ Before sending, delete:
 
 Then check: reading only the first line and the last line, does the reader know
 (a) what to do next and (b) what just happened? If yes, send.
+
+## Gotchas
+
+Observed failures from a live audit of this skill (adhd@0.2.0, 2026-07-23):
+
+- **Applied silently alongside an active conflicting shaper.** With caveman's
+  hooks injecting terse-for-tokens instructions, invoking this skill produced
+  the exact "contradictory, unpredictable mix" the README warns about, with no
+  conflict flagged — the warning lived only in README/plugin.json, layers the
+  model never reads at invocation time. The conflicting-shaper check above is
+  the fix; it is advisory by necessity (no documented skill-to-hook detection
+  mechanism exists).
+- **The standing posture erodes across context compaction.** "Applies for the
+  rest of the session" is content-based persistence: when the conversation is
+  summarized/compacted, the rules can drop out of context. Re-invoke
+  `/adhd:shape` after a compaction if responses stop being shaped.
+- **Rules 5 vs 10 read as contradictory without the boundary test.** "Restate
+  state every turn" vs "no recap" — the explicit test now lives in rule 5
+  (last-completed step + next step only; never a running done-list).
 
 ## Attribution
 

--- a/plugins/adhd/skills/shape/evals/evals.json
+++ b/plugins/adhd/skills/shape/evals/evals.json
@@ -60,6 +60,31 @@
         "No forbidden preamble opener",
         "No forbidden closing pleasantry or post-answer recap"
       ]
+    },
+    {
+      "id": 6,
+      "name": "conflicting-shaper-active-surfaces-conflict-before-applying",
+      "prompt": "[Session context contains a hook-injected standing instruction: 'CAVEMAN MODE ACTIVE — drop articles and filler to save tokens; respond terse like smart caveman.'] /adhd:shape",
+      "expected_output": "Detects the active terse-for-tokens output shaper in session context and surfaces the conflict before applying: names the conflicting source (caveman), states the two disciplines pull in opposite directions on the same output-shape axis, and asks the user to pick one for the session instead of silently applying both.",
+      "files": [],
+      "expectations": [
+        "Surfaces the conflict before applying the shaping rules, rather than silently activating alongside the terse shaper",
+        "Names the conflicting source found in session context",
+        "Asks the user to choose one discipline for the session",
+        "Does not claim it can mechanically disable the other shaper (advisory only)"
+      ]
+    },
+    {
+      "id": 7,
+      "name": "off-switch-stops-the-standing-posture",
+      "prompt": "[Earlier this session /adhd:shape was invoked and responses have been shaped since.] stop shaping. Now, what does the N+1 query problem mean for our ORM setup?",
+      "expected_output": "Treats 'stop shaping' as the documented off-switch: reverts to normal unshaped output for the rest of the session and answers the ORM question as an ordinary full response, without applying the action-first/numbered/capped-list rules, and without demanding a re-invocation ritual beyond the plain phrase.",
+      "files": [],
+      "expectations": [
+        "Recognizes 'stop shaping' (or 'normal output') as ending the standing posture",
+        "The subsequent answer is ordinary unshaped prose, not the shaped format",
+        "Does not continue applying the shaping rules after the off-switch"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes every finding from the 2026-07-23 live audit of adhd@0.2.0 (handoff item `20260723-082358-adhd-shape-clarify-audit`; both skills exercised live with caveman hooks simultaneously active). Markdown-only, version 0.3.0.

- **H1/L4:** conflicting-shaper check now lives in BOTH SKILL.md bodies (the mutual-exclusion warning existed only in README/plugin.json — layers the model never reads at invocation; reproduced live as a silent contradictory mix). Advisory: name the source found in session context, ask the user to pick one; no skill-to-hook detection mechanism exists to hard-enforce.
- **M1:** clarify trivial-target escape hatch — fewer than ~2 decisions → one line + ask, not the full table/glossary apparatus.
- **M2:** clarify local-file rung targets an OS temp path; the undocumented plugin-data substitution variable is removed from the body (substituted unpredictably in live use, including cross-plugin through another skill's arguments).
- **M3/L3:** precedence explicit — clarify's decision table exempt from shape's five-item cap (fidelity wins); clarify on shape-formatted output declared a no-op.
- **L1:** shape off-switch: "stop shaping" / "normal output" (SKILL.md + README).
- **L2:** README compaction-durability caveat.
- **L5:** fidelity rule 2 fallback for unlabeled sources (declared synthesized locator).
- **L6 + Gotchas:** rules 5-vs-10 boundary test explicit; shape gains a Gotchas section recording the audit's observed failures (clears the skill-quality no-Gotchas WARN).
- **M4:** evals for every observed failure mode — shape: conflicting-shaper-active, off-switch; clarify: trivial target, cold start.

Out of scope by design: description-length trimming (marketplace-level gate decision per the audit's policy note).

## Test plan

- [x] Markdown/JSON only — no scripts; CI skill-quality-gate + changelog-parity-gate validate structure
- [x] Both evals.json extended in the existing sibling schema (ids 6-7 each)
- [x] Trigger keywords in both descriptions unchanged (skill-quality trigger-drop protection)

Closes #1130

## Related

- Producer audit: handoff-inbox item `20260723-082358-adhd-shape-clarify-audit` (resolution recorded there on completion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
