### PR TITLE
fix(actionlint): remove silent-skip membership guard, error telemetry on failed lint, no abs-path leak

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.0]
+
+### Fixed
+
+- **Membership guard removed — 8.3 short-form paths no longer silently skip the lint (#1133).**
+  The hook parsed `file_path` through the shared lib's `hook::read_file_path`, whose
+  `CLAUDE_PROJECT_DIR` membership guard compares realpath-normalized forms; GNU `realpath` under
+  Git Bash does not expand Windows 8.3 short names, so a short-form `file_path` (the shape Claude
+  Code's own scratchpad paths take) failed the prefix match and the hook exited silently — no
+  lint, no notice, no telemetry. For an advisory PostToolUse linter the guard protects nothing
+  (the tool already ran; the hook cannot block), so every false-negative is pure coverage loss.
+  The hook now parses the path itself (existence check retained; the workflow-location filters
+  still bound what gets linted); the synced shared lib is untouched for consumers that need the
+  guard. Regression tests: a deliberately mismatched `CLAUDE_PROJECT_DIR` still lints, and a
+  short-prefix 8.3 path still lints where the volume generates short names.
+- **A failed `cd`/actionlint launch no longer reads as a clean pass (#1133).** The lint invocation
+  discarded its exit status; a failed `cd` (or an actionlint exit ≥ 2 — invalid CLI, fatal, launch
+  failure) produced empty output and fell through to the clean-workflow branch, emitting telemetry
+  `status:"ok", findings:[]` indistinguishable from a real pass. Both now emit `status:"error"`
+  (captured output as `data.findings`) and stay silent on the advisory channels. Covered by a
+  stubbed exit-3 actionlint test.
+- **`data.file` can no longer leak an absolute path (#1133).** When the repo-root prefix strip did
+  not match (mount/symlink mismatch), the telemetry `data.file` silently carried the absolute
+  path, violating the schema's repo-relative contract; it now degrades to the basename.
+- **Test gap closed: `-pyflakes=` regression fixture (#1133).** Only `-shellcheck=` was exercised;
+  a `shell: python` run-block fixture now pins the pyflakes integration off.
+
 ## [0.5.2]
 
 ### Fixed

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -51,7 +51,19 @@ esac
 # notice instead of a silent no-op (dim-9 doctrine).
 hook::require_jq PostToolUse actionlint "$INPUT"
 
-FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+# Deliberately NOT hook::read_file_path: its CLAUDE_PROJECT_DIR membership
+# guard is wrong for an advisory PostToolUse linter. PostToolUse cannot block
+# or undo the write (the tool already ran), so the guard protects nothing --
+# every guard false-negative is a silent coverage loss. The concrete one: GNU
+# realpath under Git Bash does not expand Windows 8.3 short names, so a
+# short-form file_path (<drive>:\...\SOMEDIR~1\... form) fails the prefix
+# match against a long-form project dir and the lint silently never runs,
+# violating the prerequisite-visibility doctrine (a silently skipped feature
+# is a defect). The workflow-location filters above and below bound what gets
+# linted; membership adds nothing. Parse + existence check only (the shared
+# lib is synced fleet-wide and other consumers keep the guard).
+FILE=$(printf '%s' "$INPUT" | jq -r '(.tool_input.file_path // empty) | gsub("\r";"")' 2>/dev/null)
+[[ -n "$FILE" && -f "$FILE" ]] || exit 0
 # Only GitHub Actions workflow files. actionlint recognizes both .yml and .yaml
 # under .github/workflows/; other YAML is not a workflow and must be skipped.
 FILE_NORM="$(hook::normalize_path "$FILE")"
@@ -81,6 +93,14 @@ if command -v cygpath >/dev/null 2>&1; then
 else
   FILE_REL="${FILE#"$REPO_ROOT"/}"
 fi
+# The schema's data.file contract is repo-relative. When the prefix strip did
+# not match (mount/symlink mismatch, cygpath disagreement), FILE_REL is still
+# an absolute path -- degrade to the basename rather than leaking the absolute
+# path into telemetry.
+case "$FILE_REL" in
+[A-Za-z]:* | /* | \\\\*) FILE_REL="$(basename "$FILE")" ;;
+*) ;;
+esac
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
 # findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
@@ -115,7 +135,30 @@ fi
 # subprocess IPC path in actionlint 1.7.x, and either adds latency unsuited to
 # an edit-time advisory hook. Native workflow diagnostics (the value of this
 # hook) are unaffected; deep run-block linting belongs in a commit hook or CI.
-AL_OUTPUT=$(cd "$REPO_ROOT" && actionlint -shellcheck= -pyflakes= -- "$FILE_REL" 2>&1) || true
+# A failed cd (repo root vanished, permission) must never read as a clean
+# pass: without this branch an empty AL_OUTPUT would fall through to the
+# clean-workflow telemetry (status ok, findings []), indistinguishable from a
+# real pass. Changing this process's cwd is safe -- the hook exits below.
+if ! cd "$REPO_ROOT" 2>/dev/null; then
+  data_json=$(build_data_json '[]')
+  emit_tel "actionlint-check" "PostToolUse" "error" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+fi
+AL_OUTPUT=$(actionlint -shellcheck= -pyflakes= -- "$FILE_REL" 2>&1)
+AL_STATUS=$?
+
+# actionlint exits 0 (clean) or 1 (problems found); anything else -- 2 invalid
+# CLI, 3 fatal, 126/127 launch failure -- means the lint DID NOT run. Report it
+# as an error (output captured as findings for the sink), never as clean.
+if [[ "$AL_STATUS" -ge 2 ]]; then
+  FINDINGS_JSON='[]'
+  if [[ -n "$AL_OUTPUT" ]]; then
+    FINDINGS_JSON=$(printf '%s' "$AL_OUTPUT" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
+  fi
+  data_json=$(build_data_json "$FINDINGS_JSON")
+  emit_tel "actionlint-check" "PostToolUse" "error" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+fi
 
 if [[ -n "$AL_OUTPUT" ]]; then
   hook::ctx_reset

--- a/plugins/actionlint/hooks/actionlint-check.test.sh
+++ b/plugins/actionlint/hooks/actionlint-check.test.sh
@@ -174,6 +174,106 @@ else
   ok "no shellcheck finding surfaced (SC2086)"
 fi
 
+# --- Case 8: -pyflakes= disabled -> no pyflakes finding (regression) ---------
+# `print(undefined_name)` in a `shell: python` run block is a pyflakes-only
+# finding ("undefined name") with no native actionlint diagnostic. With the
+# integration off, no finding surfaces; when pyflakes is absent actionlint
+# skips the integration regardless, so this never false-fails.
+printf 'name: pyrun\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: print(undefined_name)\n        shell: python\n' \
+  >"$REPO/.github/workflows/pyrun.yml"
+OUT=$(run_hook "$REPO/.github/workflows/pyrun.yml")
+RC=$?
+if [[ $RC -eq 0 ]]; then ok "python run: block -> exit 0"; else fail "pyrun exit $RC"; fi
+if printf '%s' "$OUT" | grep -qi 'undefined name'; then
+  fail "pyflakes finding surfaced -- -pyflakes= regressed: $OUT"
+else
+  ok "no pyflakes finding surfaced (-pyflakes= holds)"
+fi
+
+# --- Case 9: NO membership guard -- mismatched CLAUDE_PROJECT_DIR still lints
+# Regression for the silent-skip bug: the old hook::read_file_path membership
+# guard silently exited when the file path did not prefix-match
+# CLAUDE_PROJECT_DIR (its concrete trigger: Windows 8.3 short-form paths that
+# GNU realpath does not expand). An advisory PostToolUse linter must lint
+# regardless of project membership -- prove it with a deliberately unrelated
+# CLAUDE_PROJECT_DIR.
+OUT=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/violation.yml" |
+    env CLAUDE_PROJECT_DIR="$UNRELATED" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
+)
+RC=$?
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext | contains("missing")' >/dev/null 2>&1; then
+  ok "mismatched CLAUDE_PROJECT_DIR -> still lints (no membership guard)"
+else
+  fail "mismatched CLAUDE_PROJECT_DIR silently skipped lint (rc=$RC out=$OUT)"
+fi
+
+# --- Case 9b: Windows 8.3 short-form path still lints (where available) ------
+# The real-world shape is a SHORT-form prefix (the user/temp dir Claude Code
+# hands out) with a long-form tail -- .github/workflows components are 8.3-safe
+# and arrive unmangled, so the location filter still matches while the old
+# membership guard's realpath comparison did not. cygpath -ms yields the short
+# form with forward slashes (JSON-safe). Only meaningful where cygpath exists
+# AND the volume generates short names; skip silently otherwise.
+if command -v cygpath >/dev/null 2>&1; then
+  SHORT_REPO=$(cygpath -ms "$REPO" 2>/dev/null || true)
+  SHORT="${SHORT_REPO:+$SHORT_REPO/.github/workflows/violation.yml}"
+  if [[ -n "$SHORT" && -f "$SHORT" && "$SHORT_REPO" != "$(cygpath -m "$REPO" 2>/dev/null)" ]]; then
+    OUT=$(
+      cd "$UNRELATED" || exit 1
+      printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$SHORT" |
+        env CLAUDE_PROJECT_DIR="$REPO" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true bash "$HOOK"
+    )
+    RC=$?
+    if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.hookSpecificOutput.additionalContext | contains("missing")' >/dev/null 2>&1; then
+      ok "8.3 short-form path -> still lints"
+    else
+      fail "8.3 short-form path silently skipped (rc=$RC out=$OUT)"
+    fi
+  else
+    echo "note: 8.3 short-name case skipped (no distinct short form on this volume)"
+  fi
+fi
+
+# --- Case 10: actionlint hard failure -> telemetry status error, never ok ----
+# Stub actionlint exits 3 (fatal) -- the lint DID NOT run; the old code read
+# empty-output-as-clean. PATH keeps real tools via exec wrappers.
+ERRBIN="$(mktemp -d -p "$WORK" errbin.XXXXXX)"
+for t in bash jq git dirname basename cat env printf mktemp mkdir find tr awk grep sed uname sleep cygpath realpath readlink; do
+  real_t="$(command -v "$t" 2>/dev/null)" || continue
+  [[ -n "$real_t" ]] || continue
+  printf '#!/bin/sh\nexec "%s" "$@"\n' "$real_t" >"$ERRBIN/$t"
+  chmod +x "$ERRBIN/$t"
+done
+printf '#!/bin/sh\necho "fatal: simulated actionlint failure" >&2\nexit 3\n' >"$ERRBIN/actionlint"
+chmod +x "$ERRBIN/actionlint"
+ERR_TEL="$(mktemp)"
+ERR_SINK="$(make_sink "cat >\"$ERR_TEL\"")"
+OUT_ERR=$(
+  cd "$UNRELATED" || exit 1
+  printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO/.github/workflows/clean.yml" |
+    env -u CLAUDE_PROJECT_DIR PATH="$ERRBIN" CLAUDE_PLUGIN_OPTION_ACTIONLINT_ENABLED=true \
+      HOOK_TELEMETRY_SINK="$ERR_SINK" bash "$HOOK"
+)
+RC_ERR=$?
+if [[ $RC_ERR -eq 0 && -z "$OUT_ERR" ]]; then
+  ok "actionlint hard failure -> exit 0, silent on channels (advisory; sink carries the error)"
+else
+  fail "hard-failure (rc=$RC_ERR out=$OUT_ERR)"
+fi
+wait_for_sink "$ERR_TEL"
+if [[ -s "$ERR_TEL" ]]; then
+  if [[ "$(jq -r '.status' "$ERR_TEL")" == "error" ]]; then
+    ok "actionlint hard failure -> telemetry status error (not ok)"
+  else
+    fail "hard-failure telemetry status=$(jq -r '.status' "$ERR_TEL") (must be error)"
+  fi
+else
+  fail "hard-failure: no telemetry envelope written"
+fi
+rm -f "$ERR_TEL"
+
 # ============================================================================
 # Telemetry
 # ============================================================================


### PR DESCRIPTION
## Summary

Silent-failure cluster from the actionlint plugin audit (actionlint 0.6.0):

- **F1 (the driver):** the shared-lib `hook::read_file_path` membership guard silently skipped the lint on Windows 8.3 short-form paths — GNU `realpath` under Git Bash does not expand short names, so the prefix match against a long-form `CLAUDE_PROJECT_DIR` failed and the hook exited with no lint, no notice, no telemetry (reproduced Tier-0 by the producer in both path forms). For an advisory PostToolUse linter the guard protects nothing (the tool already ran; hooks docs: PostToolUse cannot block) — every false-negative is pure coverage loss. Adopted the producer's primary recommendation: the hook parses `file_path` itself (existence check retained; workflow-location filters unchanged bound what gets linted). **The synced shared lib is untouched** — other consumers keep the guard.
- **F2:** a failed `cd` or actionlint exit ≥ 2 (invalid CLI, fatal, launch failure) fell through to the clean-workflow branch as `status:"ok", findings:[]`. Now a distinct `status:"error"` envelope (captured output as `data.findings`, per the telemetry convention's documented value set), silent on the advisory channels.
- **F3:** `data.file` degrades to the basename when the repo-root prefix strip does not match, never leaking an absolute path into the schema's repo-relative field.
- **F6 (test gaps):** `-pyflakes=` regression fixture added (only `-shellcheck=` was pinned); membership-guard behavior now covered.

## Test plan

- [x] Mismatched `CLAUDE_PROJECT_DIR` still lints (guard-removal regression)
- [x] 8.3 short-prefix path still lints (conditional — runs where the volume generates short names; ran and passed on the dev machine)
- [x] Stubbed exit-3 actionlint → telemetry `status:"error"`, advisory channels silent
- [x] `shell: python` pyflakes fixture pins `-pyflakes=` off
- [x] Full suite 41/41; shellcheck clean on both files

Closes #1133

## Related

- #1134 — config/doc follow-ups from the same audit (serialized behind this PR)
- #1135 — hook-utils.sh split proposal (needs-decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
