### PR TITLE
chore(actionlint): declare stdin_read_timeout, verify --config claim against docs, setup Gotchas

### DIFF
--- a/plugins/actionlint/.claude-plugin/plugin.json
+++ b/plugins/actionlint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "actionlint",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Lint GitHub Actions workflow files on edit via actionlint, surfacing findings as advisory context.",
   "author": {
     "name": "Melodic Software",
@@ -22,6 +22,13 @@
       "title": "actionlint-check hook",
       "description": "Lint GitHub Actions workflow files on edit via actionlint",
       "default": true
+    },
+    "stdin_read_timeout": {
+      "type": "number",
+      "title": "Hook stdin read timeout (seconds)",
+      "description": "Bound on reading the hook payload from stdin before failing open",
+      "default": 2,
+      "min": 1
     }
   }
 }

--- a/plugins/actionlint/CHANGELOG.md
+++ b/plugins/actionlint/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to the `actionlint` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.0]
+
+### Added
+
+- **`stdin_read_timeout` declared in userConfig (#1134).** The shared hook lib reads
+  `CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT`, but per current docs `--config <key=value>` sets
+  only options "declared in the plugin's manifest" and `/plugin configure` offers declared
+  options — so the knob was unreachable through native config surfaces for this plugin. Declared
+  now (type/default/floor mirroring the claude-ops precedent); other hook plugins reusing the
+  shared lib should declare it the same way. Decision recorded in the setup skill's new Gotchas.
+- **`skills/setup` Gotchas surface (#1134).** Records the manifest-declaration requirement, the
+  undocumented post-install `--config` behavior, and attributes the `-shellcheck=` deadlock
+  rationale as the hook author's own observation (no matching upstream rhysd/actionlint issue as
+  of 2026-07-23; the edit-time latency rationale stands on its own). Clears the skill-quality
+  no-Gotchas WARN.
+
+### Changed
+
+- **Setup skill no longer asserts the undocumented `--config` fresh-install claim (#1134).**
+  "only applies on a fresh install (ignored once installed)" appears nowhere in current official
+  docs; the guidance now cites what the docs do say (`--config` is a `claude plugin install`
+  flag for manifest-declared options), marks post-install behavior undocumented, and keeps the
+  verified uninstall-then-install headless path.
+
 ## [0.6.0]
 
 ### Fixed

--- a/plugins/actionlint/README.md
+++ b/plugins/actionlint/README.md
@@ -50,10 +50,12 @@ Then verify prerequisites with `/actionlint:setup check`.
 ## Configuration
 
 actionlint auto-discovers its own `.github/actionlint.yaml` config from your
-repository when present. One `userConfig` option tunes the hook itself:
+repository when present. Two `userConfig` options tune the hook itself:
 
 - **`actionlint_enabled`** (boolean, default `true`) — kill switch for the
   actionlint-check hook.
+- **`stdin_read_timeout`** (number, default `2`, minimum `1`) — bound in
+  seconds on reading the hook payload from stdin before failing open.
 
 Configure interactively with `/plugin configure actionlint` or headless at
 install time:

--- a/plugins/actionlint/skills/setup/SKILL.md
+++ b/plugins/actionlint/skills/setup/SKILL.md
@@ -55,14 +55,36 @@ Run `check`, then for each FAIL point at the resolution — this skill installs 
   (the [actionlint install guide](https://github.com/rhysd/actionlint/blob/main/docs/install.md)).
 - missing `jq` / Bash: platform install instructions from the README Requirements section.
 - toggle off: direct to `/plugin configure actionlint` (interactive, any
-  time). Headless: `--config` only applies on a fresh install (ignored once installed), so reconfigure via `claude plugin uninstall actionlint` then
-  `claude plugin install actionlint@<marketplace> --config actionlint_enabled=true`;
+  time). Headless: current official docs document `--config` only as a
+  `claude plugin install` flag that sets manifest-declared options; its
+  behavior against an already-installed plugin is undocumented, and in
+  practice the reliable headless path is `claude plugin uninstall actionlint`
+  then `claude plugin install actionlint@<marketplace> --config actionlint_enabled=true`;
   this skill never writes user settings or `pluginConfigs`.
 
 After pointing at a remediation, re-run the relevant `check` probe and report its actual
 result — never claim resolved on the reader's report that they installed something.
 
 Re-running `apply` after everything passes changes nothing and reports "already configured".
+
+## Gotchas
+
+- **A userConfig knob is reachable natively only if the manifest declares it.** Per current
+  docs, `claude plugin install --config <key=value>` sets options "declared in the plugin's
+  manifest" — an undeclared key silently cannot be set through native config surfaces (a raw
+  settings `env` block still works). That is why `stdin_read_timeout` is declared in this
+  plugin's manifest even though the shared hook lib supplies its default; hook plugins reusing
+  the shared lib should declare it too (claude-ops set the precedent).
+- **`--config` post-install behavior is undocumented.** The docs describe it only as an
+  install-time flag; do not assume re-running install re-applies config on an installed
+  plugin — the verified headless path is uninstall-then-install (see `apply` above).
+- **`-shellcheck=` / `-pyflakes=` are deliberate, and the deadlock claim is a local
+  observation.** The hook disables actionlint's external run-block linters primarily for
+  edit-time latency; the additional "ShellCheck deadlocks on large blocks under the Windows
+  subprocess IPC path in actionlint 1.7.x" rationale is the hook author's own reproduction —
+  no matching upstream rhysd/actionlint issue as of 2026-07-23. The latency rationale alone
+  justifies the flags for an advisory edit-time hook; deep run-block linting belongs in a
+  commit hook or CI.
 
 ## What this skill does NOT do
 

--- a/plugins/actionlint/skills/setup/SKILL.md
+++ b/plugins/actionlint/skills/setup/SKILL.md
@@ -10,8 +10,9 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform contract: `check` inspects and reports, `apply`
 resolves. This plugin owns no consumer-project configuration — actionlint auto-discovers its
-own optional config from the repository, and the only tunable is the native `userConfig`
-toggle. Every prerequisite is a `PATH` binary the plugin never bundles, and the plugin never
+own optional config from the repository, and the tunables are the native `userConfig`
+options (the `actionlint_enabled` toggle and `stdin_read_timeout`). Every prerequisite is a
+`PATH` binary the plugin never bundles, and the plugin never
 installs system packages, so `apply` is guidance-only with **no write path** — it never
 modifies the repository, user settings, or the plugin cache.
 
@@ -44,6 +45,9 @@ restores the FAIL semantics.
 5. **Hook toggle** — report the effective `actionlint_enabled` value:
    `${user_config.actionlint_enabled}` (unexpanded or empty means default `true`; any value
    other than `true` disables the hook).
+5b. **Stdin read timeout** — INFO: report the effective `stdin_read_timeout` value:
+   `${user_config.stdin_read_timeout}` (unexpanded or empty means default `2` seconds,
+   minimum `1`; bounds reading the hook payload before failing open).
 6. **Hook registration** — INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 


### PR DESCRIPTION
## Summary

Config/doc follow-ups from the actionlint audit (actionlint 0.7.0), serialized behind #1136:

- **`stdin_read_timeout` declared in userConfig.** The shared hook lib reads `CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT`, but per current official docs (plugins-reference, fetched 2026-07-23) `--config <key=value>` sets only options "declared in the plugin's manifest" — the knob was unreachable through native config surfaces for this plugin. Declaration mirrors the claude-ops precedent (type/default/floor); the decision is recorded in the setup skill's Gotchas so other hook plugins follow consistently.
- **Undocumented fresh-install claim removed.** The setup skill asserted `--config` "only applies on a fresh install (ignored once installed)" — present nowhere in current docs. Reworded to cite what the docs do say (install-time flag for manifest-declared options), mark post-install behavior undocumented, keep the verified uninstall-then-install headless path.
- **`skills/setup` Gotchas surface added** (clears the skill-quality no-Gotchas WARN): manifest-declaration requirement, undocumented post-install `--config` behavior, and attribution of the `-shellcheck=` deadlock rationale as the hook author's own observation (no matching upstream rhysd/actionlint issue as of 2026-07-23; latency rationale stands alone).

## Test plan

- [x] plugin.json parses (validated); manifest shape mirrors claude-ops
- [x] Full hook suite still 41/41 after rebase; shellcheck clean
- [x] Markdown/manifest-only otherwise — CI skill-quality-gate + changelog-parity-gate validate

Closes #1134

## Related

- #1136 (#1133) — merged predecessor in this serial pair
- #1135 — hook-utils.sh split proposal (needs-decision, parked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
