### PR TITLE
feat(source-control): pr_body_required_sections accepts none (no required sections)

### DIFF
--- a/docs/conventions/pr-body-convention/README.md
+++ b/docs/conventions/pr-body-convention/README.md
@@ -53,6 +53,26 @@ configuration, not in the plugin's shipped default.
 declares `Related` in its own `pr_body_required_sections` list (team-tracked, local overlay, or
 user-global), the same as any other section name. The plugin ships no opinion on it either way.
 
+## `none`: no required sections
+
+The value grammar also accepts the literal keyword `none` — the convention "this repo requires no
+PR-body sections", stated as config rather than left unstatable. A resolved `none` means the
+drafting consumer emits **no** section scaffold and the pre-create gate requires **nothing**; the
+closing-keyword / no-issue-marker mechanism is independent of this key and unaffected.
+
+This exists because "no required sections" is a real team convention, not a hypothetical: consumer
+evidence includes a repo whose merged PRs are 199/200 empty bodies — a deliberate no-body-sections
+practice that previously had no expression in this key (absence yields the portable default, which
+is the opposite of what such a repo wants). `none` parallels the sibling keys `trailer_policy` and
+`pr_body_attribution`, whose `none` values already express "suppress the default" as a resolved
+value.
+
+**`none` is a value, absence is not.** A layer declaring `none` wins the per-key override exactly
+like a list would — it replaces a lower layer's list with zero sections — while a key absent from
+every layer still falls through to the portable default. Layering mechanics live in
+[`config-resolution.md`](../../../plugins/source-control/reference/config-resolution.md); this doc
+only fixes the value's meaning.
+
 ## Resolution semantics
 
 Layering, per-key override, and the value grammar are entirely owned by

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.20.0]
+
+### Added
+
+- **`pr_body_required_sections` accepts the literal keyword `none` — no required sections (#1138).**
+  The key could previously express only a list or absence (absence yields the portable default), so
+  a repo whose team convention is no PR-body sections — real consumer evidence: a repo whose merged
+  PRs are overwhelmingly empty-bodied by design — had no way to state that in config. `none` now
+  resolves to zero required sections, parallel to the sibling keys `trailer_policy` and
+  `pr_body_attribution`: `/pull-request create` drafts no section scaffold and the §2.4.2.2
+  pre-create gate has nothing to require (the §2.4.2.1 closing-keyword check is independent and
+  unchanged; ad hoc `## Related` content from real refs is still never dropped). `none` participates
+  in per-key layering as a **resolved value, not an absence** — a layer declaring `none` overrides a
+  lower layer's list wholesale, while a key unset in every layer still falls through to the portable
+  default (`Summary`, `Test plan`). Documented in `reference/config-resolution.md` and the
+  pr-body-convention seam README (which now owns the value's rationale); `/setup check` renders a
+  resolved `none` as `none (no required sections)` with the winning layer, distinct from the unset
+  row, and the `apply` interview offers `none` for repos whose convention requires no sections. New
+  pull-request evals 19 (team-layer `none` resolves to an empty scaffold) and 20 (`none` wins the
+  per-key override across the three layers) and setup eval 16 (check-report rendering) cover the
+  resolution.
+
 ## [0.19.0]
 
 ### Added

--- a/plugins/source-control/reference/config-resolution.md
+++ b/plugins/source-control/reference/config-resolution.md
@@ -32,14 +32,20 @@ Markdown, one `## <key>` H2 per key, the value as the section body:
   consumer setting `trailer_policy: none` keeps the PR-body line unless they also set this to `none`.
 - `pr_body_required_sections` — the PR-body section scaffold: a flat Markdown bullet list (`- <H2
   heading>` per line, one heading per bullet) naming every `## <heading>` section
-  `/source-control:pull-request create` must both draft and pre-check for before `gh pr create`.
-  Absent everywhere → the bundled portable default, `Summary` and `Test plan` only — see
+  `/source-control:pull-request create` must both draft and pre-check for before `gh pr create`, or
+  the literal keyword `none` — no required sections: the draft emits no section scaffold and the
+  pre-create gate requires nothing. Absent everywhere → the bundled portable default, `Summary` and
+  `Test plan` only — see
   [`docs/conventions/pr-body-convention/README.md`](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/pr-body-convention/README.md)
   for the default's rationale and the seam's full contract. Like `type_list`, and unlike the single
   scalar `subject_pattern`, this key is a **closed list**: a winning layer's list is taken whole,
   never unioned or ordered against an earlier layer's list (per-key override applies to the entire
   value, per "Merge semantics" below) — the same reasoning `type_list` already documents, applied to
-  headings instead of type names.
+  headings instead of type names. `none` participates in that same per-key override as a **resolved
+  value, not an absence** — exactly like its sibling keys `trailer_policy` and `pr_body_attribution`:
+  a layer declaring `none` replaces a lower layer's list (a team file requiring `Summary`/`Test plan`
+  is overridden to zero sections by a local overlay's `none`), while a key absent from every layer
+  still falls through to the portable default.
 
 Absent sections are absent, never empty.
 

--- a/plugins/source-control/skills/pull-request/evals/evals.json
+++ b/plugins/source-control/skills/pull-request/evals/evals.json
@@ -227,6 +227,32 @@
         "A fenced code block's content is preserved even if it contains comment-marker-shaped text (`<!--`), and an HTML comment's content is dropped even if it contains fence-marker-shaped text (```` ``` ````) — each construct's own parsing rules win inside it, never the other's",
         "A heading line carrying a trailing inline comment is still treated as a real section-exit boundary, not swallowed by comment handling"
       ]
+    },
+    {
+      "id": 19,
+      "name": "pr-body-required-sections-none-resolves-empty",
+      "prompt": "/pull-request create from branch feat/512-add-widget. The team's source-control.md config is captured in evals/fixtures/source-control-required-none.md relative to the skill directory (declares pr_body_required_sections: none). No other layer sets the key. Assemble and create the PR.",
+      "expected_output": "The skill resolves pr_body_required_sections to the literal keyword `none` from the team layer: zero required sections. The assembled body carries the `${CLOSES_LINE}` closing-keyword line and the attribution line but NO `## Summary` / `## Test plan` scaffold — `none` is a resolved value, not an absence, so the portable default does not apply. The §2.4.2.2 required-section gate passes with nothing to verify; the §2.4.2.1 closing-keyword check is independent and still runs and must still pass.",
+      "files": ["evals/fixtures/source-control-required-none.md"],
+      "expectations": [
+        "pr_body_required_sections resolving to the literal keyword `none` yields zero required sections — the assembled body carries no `## Summary` / `## Test plan` scaffold",
+        "`none` is treated as a resolved value, not as an unset key — the portable default (Summary, Test plan) is NOT applied",
+        "The §2.4.2.2 required-section gate passes vacuously with an empty required-section list",
+        "The §2.4.2.1 closing-keyword check still runs and is still enforced — `none` does not disable the closing-keyword / no-issue-marker mechanism"
+      ]
+    },
+    {
+      "id": 20,
+      "name": "pr-body-required-sections-none-overrides-lower-layer",
+      "prompt": "/pull-request create from branch feat/512-add-widget. The user-global ~/.claude/source-control.md declares pr_body_required_sections as the bullet list Summary, Test plan, Related. The repo's team-tracked .claude/source-control.md declares pr_body_required_sections as the literal keyword none. The gitignored local overlay .claude/source-control.local.md exists but does not set pr_body_required_sections. Resolve the effective section scaffold.",
+      "expected_output": "Per config-resolution.md's per-key override across the three layers, the team layer's `none` REPLACES the user-global list wholesale — the effective value is zero required sections, and the overlay's silence on the key changes nothing (an absent key in a later layer keeps the earlier winner; it never resets or re-imports a lower layer's list). The skill distinguishes `none` (a resolved value that wins the per-key override like any list would) from absence (which would have fallen through to the user-global list here). A local overlay declaring `none` over a team list would win the same way — the semantics are per-key precedence, identical to trailer_policy / pr_body_attribution.",
+      "files": [],
+      "expectations": [
+        "The team layer's `none` overrides the user-global layer's Summary/Test plan/Related list — the effective resolution is zero required sections",
+        "The local overlay omitting the key does not disturb the team layer's `none` — per-key fallthrough keeps the later layer's resolved value",
+        "`none` wins the per-key override as a resolved value exactly like a list would, with the same precedence semantics as trailer_policy and pr_body_attribution",
+        "Absence and `none` are distinguished: had the team layer omitted the key, the user-global list would have won instead"
+      ]
     }
   ]
 }

--- a/plugins/source-control/skills/pull-request/evals/fixtures/source-control-required-none.md
+++ b/plugins/source-control/skills/pull-request/evals/fixtures/source-control-required-none.md
@@ -1,0 +1,10 @@
+# source-control configuration (eval fixture)
+
+Minimal team-tracked config exercising `pr_body_required_sections: none` — a repo whose convention
+requires no PR-body sections — for eval 19 (`pr-body-required-sections-none-resolves-empty`). Not
+melodic policy — a generic example demonstrating the no-required-sections convention is
+configurable, per the plugin's agnosticity constraint (any repo could declare this).
+
+## pr_body_required_sections
+
+none

--- a/plugins/source-control/skills/pull-request/reference/create.md
+++ b/plugins/source-control/skills/pull-request/reference/create.md
@@ -204,7 +204,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/pull-request/scripts/push-branch.sh" || exit 
 
 Derive PR title from the commit subject, shaped to satisfy the resolved subject/title convention (the ladder in [SKILL.md](../SKILL.md): layered `source-control.md` config → project convention → Conventional Commits default). Build body with `${CLOSES_LINE}` at top, followed by the resolved section scaffold and a config-gated attribution line.
 
-**Resolve the required section scaffold first.** Read `pr_body_required_sections` across the three `source-control.md` layers per [../../../reference/config-resolution.md](../../../reference/config-resolution.md) (per-key override — a winning layer's list is taken whole, never merged with an earlier layer's). Absent everywhere → the bundled portable default, `Summary` and `Test plan` only (no `Related` — see [`docs/conventions/pr-body-convention/README.md`](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/pr-body-convention/README.md) for why the portable default excludes it). Track which file/layer supplied the effective list — the §2.4.2 gate cites it verbatim on failure.
+**Resolve the required section scaffold first.** Read `pr_body_required_sections` across the three `source-control.md` layers per [../../../reference/config-resolution.md](../../../reference/config-resolution.md) (per-key override — a winning layer's list is taken whole, never merged with an earlier layer's). Absent everywhere → the bundled portable default, `Summary` and `Test plan` only (no `Related` — see [`docs/conventions/pr-body-convention/README.md`](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/pr-body-convention/README.md) for why the portable default excludes it). The literal keyword `none` resolves to **zero required sections** — the winning layer's `none` overrides a lower layer's list the same way a list would (a resolved value, never an absence; parallel to `trailer_policy`/`pr_body_attribution`), the template below emits no scaffold blocks, and the §2.4.2.2 gate has nothing to require. Track which file/layer supplied the effective list — the §2.4.2 gate cites it verbatim on failure.
 
 ```bash
 # REQUIRED_SECTIONS: resolved at the model level from the three source-control.md layers'
@@ -216,6 +216,9 @@ REQUIRED_SECTIONS_SOURCE="plugin default (no source-control.md layer sets pr_bod
 # When a layer resolves the key, e.g.:
 #   REQUIRED_SECTIONS=("Summary" "Test plan" "Related")
 #   REQUIRED_SECTIONS_SOURCE="<repo-root>/.claude/source-control.md, ## pr_body_required_sections (team layer)"
+# When the winning layer declares the literal keyword `none` (no required sections):
+#   REQUIRED_SECTIONS=()
+#   REQUIRED_SECTIONS_SOURCE="<repo-root>/.claude/source-control.md, ## pr_body_required_sections (team layer, none)"
 ```
 
 Build one `## <heading>` block per entry in `${REQUIRED_SECTIONS[@]}`, real content in each — never
@@ -229,7 +232,10 @@ the same way `Summary` already does. If `${REFS_LINES}` is non-empty and `Relate
 `${REQUIRED_SECTIONS[@]}`, still append a `## Related` section carrying those lines — real
 user-supplied content is never dropped — but do **not** add it to `${REQUIRED_SECTIONS[@]}`: an ad hoc
 `Related` section is present only because it has real content, and the §2.4.2 gate must never come to
-require a section the resolved config does not list.
+require a section the resolved config does not list. Under a resolved `none` the loop below builds an
+empty `TEMPLATE`, and the assembled body carries only the closing-keyword line, any ad hoc `## Related`
+(the real-refs rule above applies unchanged — `none` suppresses the *required* scaffold, never
+user-supplied content), and the §2.4.3 attribution line.
 
 ```bash
 # One content resolver, reused whether Related is required or ad hoc — the single place
@@ -340,7 +346,7 @@ When user explicitly selected `No related issue: <reason>` in §2.4.0, the gate 
 
 #### 2.4.2.2 Verify required sections (config-driven)
 
-For every heading in `${REQUIRED_SECTIONS[@]}` (resolved in §2.4.1 from `pr_body_required_sections`, or the portable default), confirm a `## <heading>` section exists in `$BODY` **and** its body is non-empty. This is a generic mechanism — it verifies whatever the resolved config lists, never a section name baked into this skill. Deferred beyond presence + non-empty (per [`docs/conventions/pr-body-convention/README.md`](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/pr-body-convention/README.md)): placeholder-text detection (`TBD`/`TODO`/a restated heading) and per-section min-content rules — `standards#173`.
+For every heading in `${REQUIRED_SECTIONS[@]}` (resolved in §2.4.1 from `pr_body_required_sections`, or the portable default), confirm a `## <heading>` section exists in `$BODY` **and** its body is non-empty. This is a generic mechanism — it verifies whatever the resolved config lists, never a section name baked into this skill. A resolved `none` (§2.4.1) leaves `${REQUIRED_SECTIONS[@]}` empty, so this check passes with nothing to verify — the §2.4.2.1 closing-keyword check is independent and still runs. Deferred beyond presence + non-empty (per [`docs/conventions/pr-body-convention/README.md`](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/pr-body-convention/README.md)): placeholder-text detection (`TBD`/`TODO`/a restated heading) and per-section min-content rules — `standards#173`.
 
 ```bash
 MISSING_SECTIONS=()

--- a/plugins/source-control/skills/setup/SKILL.md
+++ b/plugins/source-control/skills/setup/SKILL.md
@@ -61,7 +61,9 @@ above it) — render it comma-joined for this report regardless of how many line
 file spells it across. When every layer leaves it unset, the row still resolves — to the plugin's
 portable default, `Summary` and `Test plan` — so `won by` reads `plugin default` rather than the row
 going blank; this is the one key whose "no layer sets it" state is itself a reportable, named value,
-not a bare absence.
+not a bare absence. A winning layer declaring the literal keyword `none` renders the row's value as
+`none (no required sections)` with that layer in `won by` — a resolved value distinct from the unset
+row above, per config-resolution.md.
 
 Per-layer verdicts:
 
@@ -239,7 +241,10 @@ With no argument in an interactive session, run the interview:
      if it were a universal default; a linked-issue section presumes an issue-tracker convention this
      plugin cannot assume for every repo. Ask what the repo's actual convention requires (a PR
      template, a CI gate like `pr-issue-linkage`, team practice) rather than proposing one, and write
-     only what the repo genuinely needs.
+     only what the repo genuinely needs. A repo whose convention is **no** PR-body sections states
+     that as the literal keyword `none` (a resolved value overriding any lower layer's list, parallel
+     to `trailer_policy`/`pr_body_attribution`) — omitting the section would inherit or fall through
+     to the portable default instead.
      **Omitting this section does NOT always mean "use the portable default"** — per-key fallthrough
      (config-resolution.md's "Merge semantics") means an omitted section keeps whatever an *earlier*
      layer already resolves to. Check the effective merge from step 1 first: omit only when the layers
@@ -295,7 +300,8 @@ With no argument in an interactive session, run the interview:
    (Summary, Test plan) — a flat bullet list, one `- <H2 heading>` per line, e.g.:
    - Summary
    - Test plan
-   - Related>
+   - Related
+   or the literal keyword `none` for a repo whose convention requires no PR-body sections>
    ```
 
    Drop any section with no content rather than leaving it empty. Writing a non-`team` layer, add one

--- a/plugins/source-control/skills/setup/evals/evals.json
+++ b/plugins/source-control/skills/setup/evals/evals.json
@@ -194,6 +194,18 @@
         "States the one-line reason the explicit list is written (overriding the lower layer, not merely restating the default)",
         "Reports the resulting effective merge showing the local overlay's explicit list winning over the team layer's list"
       ]
+    },
+    {
+      "id": 16,
+      "name": "check-reports-none-as-resolved-value",
+      "prompt": "/source-control:setup check\n\nThe team-tracked .claude/source-control.md declares pr_body_required_sections as the literal keyword none. No other layer sets the key.",
+      "expected_output": "The effective-configuration table's pr_body_required_sections row renders `none (no required sections)` with `won by` reading the team layer — a resolved value, reported the same way trailer_policy: none and pr_body_attribution: none are, and clearly distinct from the unset state (which resolves to the portable default with won by 'plugin default'). The row is INFO-class, not FAIL: no required sections is a legitimate, configured convention.",
+      "files": [],
+      "expectations": [
+        "The pr_body_required_sections row renders the resolved value as `none (no required sections)` with the team layer in the won-by column",
+        "A resolved `none` is reported distinctly from the unset state — it does not render as the portable default or as 'plugin default'",
+        "The `none` value is treated as INFO/PASS-class configuration, not a FAIL"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #1138

## Summary

`pr_body_required_sections` now accepts the literal keyword `none` — "this repo requires no PR-body sections" as a stated convention, previously unstatable (absence yields the portable default, the opposite of what a deliberately empty-body repo wants). Parallel to the sibling keys `trailer_policy` and `pr_body_attribution`: a resolved `none` means `/pull-request create` drafts no section scaffold and the §2.4.2.2 pre-create gate requires nothing. The §2.4.2.1 closing-keyword check is independent and unchanged; ad hoc `## Related` content from real refs is still never dropped. `none` participates in per-key layering as a **resolved value, not an absence** — a layer declaring it overrides a lower layer's list wholesale, while a key unset in every layer still falls through to the portable default (`Summary`, `Test plan`).

Surfaces updated: `reference/config-resolution.md` (value grammar + layering semantics), `docs/conventions/pr-body-convention/README.md` (owner doc — new "`none`: no required sections" section with the consumer-evidence rationale), `pull-request/reference/create.md` (§2.4.1 resolve step, template build, §2.4.2.2 vacuous pass), `setup/SKILL.md` (check-report rendering `none (no required sections)`, interview offer, config template). source-control 0.19.0 → 0.20.0 + CHANGELOG.

## Test plan

- `jq -e` validates both edited `evals.json` files and `plugin.json`.
- Both eval files conform to the skill-quality `evals.schema.json` (required `id`+`prompt`, kebab-case `name`, no extra fields).
- New model-graded evals cover the resolution contract: pull-request eval 19 (team-layer `none` → empty scaffold, gate passes vacuously, closing-keyword check still enforced; fixture `source-control-required-none.md`), eval 20 (`none` wins the per-key override across all three layers; absence vs `none` distinguished), setup eval 16 (check report renders resolved `none` distinctly from unset).
- `typos` clean over the touched trees.

## Related

- Sibling `none` precedents: `trailer_policy`, `pr_body_attribution` (config-resolution.md).
- Issue chain: #1138 → #1139 → #1140 → #1141 (source-control convention SSOT series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
