### PR TITLE
feat(disk-hygiene): hygiene.py handoff-verify — deterministic revalidation for the manual lane (F2)

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.0]
+
+### Added
+
+- **`hygiene.py handoff-verify` — deterministic revalidation for the manual lane (#1109).** New
+  read-only subcommand: takes the snapshot plus the human-approved exact path list
+  (`{"version": 1, "paths": [...]}`, same containment rules as plan candidates) and reruns the
+  engine's identity/reparse/protection/descendant/VCS/handle checks per path against live state,
+  emitting one machine-readable verdict each — `clear` / `drifted` / `gone` / `contested` — and
+  never deleting anything. Platform execution blockers deliberately do not apply (the subcommand
+  exists exactly where apply is unsupported); every unverifiable condition fails closed into
+  `contested`. Exit 0 all-clear, exit 3 otherwise. The target-root gate reuses preview's checks but
+  tolerates the root directory's own metadata churn (stable device/inode/type identity instead of
+  full stat identity — deleting an approved root-level item changes the root's mtime, and the
+  manual lane deletes one item at a time with a re-verify between items); a replaced root still
+  refuses. The clean skill's manual-handoff lane now writes `handoff-paths.json`, runs
+  handoff-verify immediately before deletion, and acts only on verdict-`clear` paths — bringing
+  snapshot binding to Windows/macOS without adding an engine deletion lane (captures most of the
+  declined F12 value; #1116's affirmation records this as the intended alternative). The Bash
+  guard admits the exact `handoff-verify --snapshot <s> --paths <p> [--data-root <d>]` shape as a
+  read-only invocation, including in audit-only mode (kill switch keeps blocking every deletion
+  lane; verification is reporting). Safety model documents the verdict vocabulary and the
+  emission-time-only validity of `clear`.
+
 ## [0.7.3]
 
 ### Added

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -234,9 +234,14 @@ handoff, not an engine plan:
    set changed since the snapshot), `gone` (no longer present), or `contested` (protection,
    VCS state, a live handle, elevation, or unverifiable state) — and never deletes anything.
    Act only on verdict-`clear` paths. Additionally confirm any owner process named in the audit
-   evidence is still absent — that evidence is report-level, outside the engine's checks. A
-   clear verdict is valid only at emission time: delete immediately, one item at a time, and
-   re-run handoff-verify after any delay or interruption.
+   evidence is still absent — that evidence is report-level, outside the engine's checks.
+
+   **Verify one path per deletion, not one batch for all.** In a multi-path run, the first
+   path's check ages while every later path is still being walked and probed, so its `clear`
+   is already stale at emission — and staler after each intervening deletion. Pair each
+   deletion with its own fresh single-path handoff-verify run (verify one → delete that one →
+   next); reserve the multi-path form for reporting. A clear verdict is valid only at emission
+   time: delete immediately, and re-run handoff-verify after any delay or interruption.
 2. Prefer reversible removal (Windows Recycle Bin / macOS Trash) over permanent deletion, and say
    which was used. That reversibility is conditional, not guaranteed: bin size caps, a
    policy-disabled bin, or a non-NTFS/network volume can silently make the same operation

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -219,9 +219,24 @@ approves an exact path list in this interactive session (the same `AskUserQuesti
 list bar as the engine lane; a general "clean it up" is still not approval), removal is a manual
 handoff, not an engine plan:
 
-1. Revalidate each path immediately before removal: size, mtime, and kind unchanged since the
-   audit evidence; no reparse point/symlink; any owner process named in the evidence still absent;
-   an exclusive-open probe succeeds (no live handle).
+1. Write the approved exact paths to `<run-dir>/handoff-paths.json` as
+   `{"version": 1, "paths": ["relative/exact.tmp"]}` (snapshot-relative, exact, non-overlapping,
+   never globs), then run the engine's deterministic revalidation immediately before deletion:
+
+   ```text
+   "<hook-python>" "${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/hygiene.py" handoff-verify \
+     --snapshot "<run-dir>/snapshot.json" --paths "<run-dir>/handoff-paths.json" \
+     --data-root "${CLAUDE_PLUGIN_DATA}"
+   ```
+
+   It reruns the engine's identity/reparse/protection/descendant/VCS/handle checks per path
+   against live state and emits one verdict each — `clear`, `drifted` (identity or descendant
+   set changed since the snapshot), `gone` (no longer present), or `contested` (protection,
+   VCS state, a live handle, elevation, or unverifiable state) — and never deletes anything.
+   Act only on verdict-`clear` paths. Additionally confirm any owner process named in the audit
+   evidence is still absent — that evidence is report-level, outside the engine's checks. A
+   clear verdict is valid only at emission time: delete immediately, one item at a time, and
+   re-run handoff-verify after any delay or interruption.
 2. Prefer reversible removal (Windows Recycle Bin / macOS Trash) over permanent deletion, and say
    which was used. That reversibility is conditional, not guaranteed: bin size caps, a
    policy-disabled bin, or a non-NTFS/network volume can silently make the same operation
@@ -233,8 +248,8 @@ handoff, not an engine plan:
    enumerating the container and deleting per item under steps 1, 2, and 4; items that arrive
    after enumeration are simply not deleted. This is the engine lane's changed-since-scan threat
    in the manual lane, where no snapshot token protects execution.
-4. Skip and report any path that fails revalidation; never substitute a sibling or retry around a
-   lock.
+4. Skip and report any path whose verdict is not `clear`; never substitute a sibling, retry
+   around a lock, or delete under a stale verdict.
 
 The PowerShell guard lane turns deletion spellings into a final human permission prompt (the same
 bar as the engine apply prompt); confirm that prompt only when the command matches the exact
@@ -264,9 +279,9 @@ sparse files, hard links, compression, and delayed allocation affect it.
 - `allowed-tools` would pre-approve rather than restrict tools, so this destructive skill intentionally
   grants none. Consumer permission policy remains authoritative.
 - The Bash hook denies unknown commands rather than trying to enumerate deletion spellings. Supporting
-  research uses non-Bash read-only tools; only literal-word bundled scan, preview, and apply shapes
-  using the hook runtime's same absolute executable pass. Shell expansions, globs, splitting/escape
-  forms, operators, redirections, aliases, and exported functions fail closed.
+  research uses non-Bash read-only tools; only literal-word bundled scan, preview, handoff-verify, and
+  apply shapes using the hook runtime's same absolute executable pass. Shell expansions, globs,
+  splitting/escape forms, operators, redirections, aliases, and exported functions fail closed.
 - The guard registers twice: a plugin-level engine gate (`hooks/hooks.json`, `--mode engine-gate`)
   that fires in every session, receives the kill switch and data root by plugin-hook substitution,
   and defers instantly on any command not referencing the engine; and this skill's frontmatter belt,

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -83,7 +83,7 @@ per item, under the final human permission prompt the PowerShell guard raises.
 
 | Verdict | Meaning | Manual-lane action |
 |---|---|---|
-| `clear` | Every check passed against live state at emission time | Delete this exact path immediately, one item at a time |
+| `clear` | Every check passed against live state at emission time | Delete this exact path immediately — verify one path per deletion, never one batch for all (earlier checks age while later paths are probed) |
 | `gone` | The path no longer exists | Nothing to delete; report it |
 | `drifted` | Identity, kind, or the captured descendant set changed since the snapshot | Keep; the approval no longer describes what is on disk — rescan |
 | `contested` | Protection, VCS state, a live handle, elevation, or unverifiable state | Keep; the reasons list names each contest — resolve and re-verify |

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -70,8 +70,12 @@ near-miss recurrence in the manual lane reopens this as a design issue with full
 `handoff-verify` brings snapshot binding to the platforms where apply is unsupported, without
 adding an engine deletion lane. It takes the snapshot plus the human-approved exact path list
 (same containment rules as plan candidates: relative, non-root, no traversal, present in the
-snapshot, non-overlapping), re-validates the target root exactly as preview does, then reruns the
-per-path identity/reparse/protection/descendant/VCS/handle checks against live state and emits one
+snapshot, non-overlapping), re-validates the target root with preview's link/mount/OS-managed/
+protected-path checks but a deliberately tolerant root-identity check — stable device/inode/type
+(the same object identity apply uses for directories) instead of preview's full stat identity,
+because deleting one approved root-level item changes the root's own mtime and the manual lane
+re-verifies between items; a replaced root still refuses. It then reruns the per-path
+identity/reparse/protection/descendant/VCS/handle checks against live state and emits one
 machine-readable verdict per path. It deliberately does not apply platform execution blockers —
 it exists exactly where `execution-platform-unsupported` blocks the engine lane — and it has no
 deletion capability of any kind: the model deletes only verdict-`clear` paths in the manual lane,

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -61,11 +61,38 @@ identity, and only then calls descriptor-relative `rmdir`. Windows and macOS ret
 That decline was re-examined and AFFIRMED by the maintainer on 2026-07-23 (issue #1116), against
 the framing "new-trust-surface risk of a Windows deletion lane vs the residual approval-to-execution
 window the decline leaves in the manual lane": with the manual lane's per-item revalidation rules
-and the planned `handoff-verify` revalidation (#1109), the residual window is small, while a
+and the `handoff-verify` revalidation (#1109, landed), the residual window is small, while a
 descriptor-anchored Windows apply is a large new surface. Recorded reversal trigger: a post-#1109
 near-miss recurrence in the manual lane reopens this as a design issue with full security review.
 
-The skill-scoped Bash guard accepts only complete literal words in the three declared engine command
+## Manual-handoff revalidation (`handoff-verify`)
+
+`handoff-verify` brings snapshot binding to the platforms where apply is unsupported, without
+adding an engine deletion lane. It takes the snapshot plus the human-approved exact path list
+(same containment rules as plan candidates: relative, non-root, no traversal, present in the
+snapshot, non-overlapping), re-validates the target root exactly as preview does, then reruns the
+per-path identity/reparse/protection/descendant/VCS/handle checks against live state and emits one
+machine-readable verdict per path. It deliberately does not apply platform execution blockers —
+it exists exactly where `execution-platform-unsupported` blocks the engine lane — and it has no
+deletion capability of any kind: the model deletes only verdict-`clear` paths in the manual lane,
+per item, under the final human permission prompt the PowerShell guard raises.
+
+| Verdict | Meaning | Manual-lane action |
+|---|---|---|
+| `clear` | Every check passed against live state at emission time | Delete this exact path immediately, one item at a time |
+| `gone` | The path no longer exists | Nothing to delete; report it |
+| `drifted` | Identity, kind, or the captured descendant set changed since the snapshot | Keep; the approval no longer describes what is on disk — rescan |
+| `contested` | Protection, VCS state, a live handle, elevation, or unverifiable state | Keep; the reasons list names each contest — resolve and re-verify |
+
+Fail-closed mapping: every unverifiable condition (handle tool missing or timing out, unreadable
+state, truncated coverage) lands in `contested`, never `clear`. A `clear` verdict authorizes
+nothing by itself — it reports that revalidation found no change and no contest at that instant;
+the human approval and the per-item prompt remain the authorization. Verdicts expire immediately:
+any delay or interruption means re-running handoff-verify. Managed-state exclusion stays where it
+always was in the manual lane — model judgment plus human review of the audit report — because
+snapshot entries carry no owner claim for the engine to check.
+
+The skill-scoped Bash guard accepts only complete literal words in the four declared engine command
 shapes. It rejects every Bash expansion family, glob/word-splitting input, redirection, operator,
 escape, and compound-command form before validating arguments. Canonical script-path comparison uses
 the host platform's path case rules; POSIX path identity is never case-folded. A `--data-root` value

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -463,7 +463,7 @@ def _consume_optional_pairs(
 
 
 def classify_exact_engine_command(command: str, authority: str | None) -> str | None:
-    """Return scan/preview/apply only for one complete, canonical invocation."""
+    """Return scan/preview/handoff-verify/apply for one canonical invocation."""
     tokens = _literal_shell_words(command)
     if tokens is None:
         return None
@@ -510,6 +510,18 @@ def classify_exact_engine_command(command: str, authority: str | None) -> str | 
             )
         )
         return "preview" if valid else None
+    if tokens[2] == "handoff-verify":
+        valid = (
+            len(tokens) in {7, 9}
+            and tokens[3] == "--snapshot"
+            and _argument(tokens[4])
+            and tokens[5] == "--paths"
+            and _argument(tokens[6])
+            and _consume_optional_pairs(
+                tokens[7:], frozenset({"--data-root"}), authority
+            )
+        )
+        return "handoff-verify" if valid else None
     if tokens[2] == "apply":
         if len(tokens) not in {14, 16}:
             return None
@@ -659,7 +671,7 @@ def _bash_denial_guidance(authority: str | None) -> str:
         )
     )
     return (
-        "Disk-hygiene fails closed: Bash is restricted to exact bundled scan, preview, and apply invocations using the hook's absolute Python interpreter "
+        "Disk-hygiene fails closed: Bash is restricted to exact bundled scan, preview, handoff-verify, and apply invocations using the hook's absolute Python interpreter "
         f'"{_display_python()}". Bare python/python3 commands are denied because shell functions and aliases can replace them.'
         + data_sentence
         + " Use non-Bash read-only tools for supporting inspection."
@@ -711,7 +723,7 @@ def main() -> int:
         )
         return 0
     command_kind = classify_exact_engine_command(command, authority)
-    if command_kind in {"scan", "preview"}:
+    if command_kind in {"scan", "preview", "handoff-verify"}:
         print(
             json.dumps(
                 decision(
@@ -732,7 +744,7 @@ def main() -> int:
         )
         return 0
     reason = (
-        "Disk-hygiene execution is disabled; only exact bundled scan and preview invocations are permitted."
+        "Disk-hygiene execution is disabled; only exact bundled scan, preview, and handoff-verify invocations are permitted."
         if command_kind == "apply"
         else _bash_denial_guidance(authority)
     )

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -1584,8 +1584,10 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
         "note": (
             "Read-only revalidation for the manual handoff lane; this "
             "subcommand has no deletion capability. A clear verdict is valid "
-            "only at emission time — delete only verdict-clear paths, "
-            "immediately, one item at a time, and re-verify after any delay."
+            "only at emission time — in a multi-path run the earliest checks "
+            "age while later paths are still probed, so verify ONE path per "
+            "deletion (verify one, delete that one, then the next) and "
+            "re-verify after any delay. The multi-path form is for reporting."
         ),
     }
 

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -1543,8 +1543,21 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
         for name in expected_paths:
             entry = entries[name]
             current = target.joinpath(*PurePosixPath(name).parts)
-            if not same_identity(current, entry):
+            # Distinguish unverifiable descendant state from real drift:
+            # same_identity's blanket OSError->False would report a denied
+            # lstat as changed-since-scan, telling the lane to rescan when
+            # the actual remedy is resolving access (review finding).
+            try:
+                info = current.lstat()
+            except FileNotFoundError:
                 drifted.add("changed-since-scan")
+            except PermissionError:
+                contested.add("needs-elevation")
+            except OSError:
+                contested.add("filesystem-state-unverified")
+            else:
+                if not same_stat_identity(info, entry):
+                    drifted.add("changed-since-scan")
             contested.update(
                 hard_protection(current, target, exact_names, known_mounts)
             )
@@ -1554,7 +1567,13 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
             ):
                 contested.add("consumer-protected-path")
         if not truncated:
-            vcs = tracked_blocker(path, target)
+            # A hung git (TimeoutExpired) must degrade to this one path's
+            # contested verdict, not abort the whole run with no verdicts —
+            # the subcommand promises a verdict per approved path.
+            try:
+                vcs = tracked_blocker(path, target)
+            except (OSError, subprocess.SubprocessError):
+                vcs = "vcs-state-unverified"
             if vcs:
                 contested.add(vcs)
             state, detail = candidate_handle_state(target, path, expected_paths)

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -1576,7 +1576,15 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
                 vcs = "vcs-state-unverified"
             if vcs:
                 contested.add(vcs)
-            state, detail = candidate_handle_state(target, path, expected_paths)
+            # Same degradation rule as the VCS probe: a probe that fails to
+            # LAUNCH (lsof vanishing after which(), a ctypes load error) is
+            # this path's contested verdict, not a whole-run abort.
+            try:
+                state, detail = candidate_handle_state(
+                    target, path, expected_paths
+                )
+            except (OSError, subprocess.SubprocessError):
+                state, detail = "unverified", "handle-probe-failed"
             if state == "open":
                 contested.add("live-handle" + (f": {detail}" if detail else ""))
             elif state == "needs_elevation":

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -1490,12 +1490,21 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
                 {"path": relative, "verdict": "gone", "reasons": ["no-longer-present"]}
             )
             continue
-        except OSError as exc:
+        except PermissionError:
             verdicts.append(
                 {
                     "path": relative,
                     "verdict": "contested",
-                    "reasons": [f"state-unverified: {exc}"],
+                    "reasons": ["needs-elevation"],
+                }
+            )
+            continue
+        except OSError:
+            verdicts.append(
+                {
+                    "path": relative,
+                    "verdict": "contested",
+                    "reasons": ["filesystem-state-unverified"],
                 }
             )
             continue
@@ -1520,6 +1529,9 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
         else:
             try:
                 current_paths = current_descendants(target, path)
+            # On failure, treat the live set as unknown rather than empty
+            # (preview's choice): an unreadable subtree is contested, not
+            # provably drifted — "changed" cannot be claimed without a read.
             except PermissionError:
                 current_paths = expected_paths
                 contested.add("needs-elevation")

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -952,6 +952,41 @@ def validate_plan(
     return normalized
 
 
+def validate_handoff_paths(
+    payload: dict[str, Any], entries: dict[str, dict[str, Any]]
+) -> list[str]:
+    """Structurally validate a manual-handoff approved-path list.
+
+    Same containment rules as plan candidates (relative, non-root, no
+    traversal, present in the snapshot, non-overlapping) without the plan's
+    tier/evidence envelope: the handoff list is the human-approved exact path
+    list, and the audit report — not this file — carries the evidence.
+    """
+    if payload.get("version") != SCHEMA_VERSION:
+        raise HygieneError("paths file version must be 1")
+    paths = payload.get("paths")
+    if not isinstance(paths, list) or not paths:
+        raise HygieneError("paths must be a non-empty array")
+    normalized: list[str] = []
+    seen: list[PurePosixPath] = []
+    for relative in paths:
+        if not isinstance(relative, str) or not relative or relative in {".", "/"}:
+            raise HygieneError("approved path must be a non-root relative path")
+        pure = PurePosixPath(relative)
+        if pure.is_absolute() or ".." in pure.parts or relative not in entries:
+            raise HygieneError(
+                f"approved path is outside or absent from snapshot: {relative}"
+            )
+        if any(
+            pure == prior or pure in prior.parents or prior in pure.parents
+            for prior in seen
+        ):
+            raise HygieneError(f"approved paths overlap: {relative}")
+        seen.append(pure)
+        normalized.append(relative)
+    return normalized
+
+
 def current_descendants(root: Path, candidate: Path) -> set[str]:
     paths: set[str] = set()
     known_mounts, mount_error = linux_mount_points()
@@ -1253,13 +1288,26 @@ def approval_token(snapshot: dict[str, Any], plan: dict[str, Any]) -> str:
     ).hexdigest()[:24]
 
 
-def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+def resolve_snapshot_target(
+    snapshot: dict[str, Any], *, strict_root_stat: bool = True
+) -> tuple[Path, set[Path]]:
+    """Re-validate the snapshot's target root against live state and return it.
+
+    Shared by preview and handoff-verify: both must refuse a snapshot whose
+    target root drifted, became a link, a mount point, an OS-managed root, or a
+    protected shell folder since the scan. Preview keeps the full stat identity
+    (size/mtime included) because its approval token binds one immutable state.
+    handoff-verify passes ``strict_root_stat=False`` to tolerate the root
+    directory's own metadata churn — deleting an approved root-level item
+    changes the root's mtime, and the manual lane deletes one item at a time
+    with a re-verify between items — while still refusing a replaced root via
+    the same stable device/inode/type identity apply uses for directories.
+    """
     if (
         snapshot.get("schema_version") != SCHEMA_VERSION
         or snapshot.get("engine") != "disk-hygiene-python-1"
     ):
         raise HygieneError("unsupported snapshot version")
-    baseline_exact_names = baseline_protected_names()
     target_input = Path(snapshot.get("target", "")).absolute()
     if has_linkish_component(target_input):
         raise HygieneError("snapshot target now traverses a link or reparse point")
@@ -1272,12 +1320,27 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         raise HygieneError("snapshot target is now an OS-managed root")
     if target_mounted and not is_volume_root(target):
         raise HygieneError("snapshot target is a mount point")
-    if has_protected_path_component(target, baseline_exact_names):
+    if has_protected_path_component(target, baseline_protected_names()):
         raise HygieneError(
             "snapshot target is now a protected shell-folder or profile-hive root"
         )
-    if not same_identity(target, snapshot.get("target_identity", {})):
-        raise HygieneError("target root changed since the snapshot")
+    identity = snapshot.get("target_identity", {})
+    if strict_root_stat:
+        if not same_identity(target, identity):
+            raise HygieneError("target root changed since the snapshot")
+    else:
+        try:
+            info = target.lstat()
+        except OSError as exc:
+            raise HygieneError(f"target root state is unverified: {exc}")
+        if not same_object_identity(info, identity):
+            raise HygieneError("target root was replaced since the snapshot")
+    return target, known_mounts
+
+
+def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
+    baseline_exact_names = baseline_protected_names()
+    target, known_mounts = resolve_snapshot_target(snapshot)
     entries = entry_map(snapshot)
     candidates = validate_plan(plan, entries)
     truncated_paths = {
@@ -1387,6 +1450,132 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         "warning": "Approval is valid only for this tier, exact plan, and snapshot. Re-preview after any change.",
     }
     return payload
+
+
+def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, Any]:
+    """Re-run per-path revalidation for the manual handoff lane, read-only.
+
+    Deterministically reruns the engine's identity/reparse/protection/VCS/
+    handle checks against live state for each approved path and emits a
+    verdict — never a deletion. Platform execution blockers deliberately do
+    not apply: this subcommand exists exactly for the platforms where the
+    engine's own apply lane is unsupported.
+    """
+    target, known_mounts = resolve_snapshot_target(snapshot, strict_root_stat=False)
+    entries = entry_map(snapshot)
+    exact_names = baseline_protected_names() | set(
+        snapshot.get("policy", {}).get("protected_exact_names", [])
+    )
+    truncated_paths = {
+        value
+        for value in snapshot.get("truncated_paths", [])
+        if isinstance(value, str)
+    }
+    globs = [
+        pattern
+        for pattern in snapshot.get("policy", {}).get(
+            "additional_protected_path_globs", []
+        )
+        if isinstance(pattern, str)
+    ]
+    verdicts: list[dict[str, Any]] = []
+    for relative in approved:
+        path = target.joinpath(*PurePosixPath(relative).parts)
+        drifted: set[str] = set()
+        contested: set[str] = set()
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            verdicts.append(
+                {"path": relative, "verdict": "gone", "reasons": ["no-longer-present"]}
+            )
+            continue
+        except OSError as exc:
+            verdicts.append(
+                {
+                    "path": relative,
+                    "verdict": "contested",
+                    "reasons": [f"state-unverified: {exc}"],
+                }
+            )
+            continue
+        contested.update(hard_protection(path, target, exact_names, known_mounts))
+        truncated = any(
+            name == relative
+            or name.startswith(relative + "/")
+            or relative.startswith(name + "/")
+            for name in truncated_paths
+        )
+        expected_paths = {
+            name
+            for name in entries
+            if name == relative or name.startswith(relative + "/")
+        }
+        if truncated:
+            # A truncated path has no captured descendant set, so no live walk
+            # can prove anything about it — never clear (same rationale as the
+            # preview short-circuit).
+            contested.add("truncated-not-inventoried")
+            current_paths = expected_paths
+        else:
+            try:
+                current_paths = current_descendants(target, path)
+            except PermissionError:
+                current_paths = expected_paths
+                contested.add("needs-elevation")
+            except (OSError, HygieneError):
+                current_paths = expected_paths
+                contested.add("filesystem-state-unverified")
+        if current_paths != expected_paths:
+            drifted.add("changed-since-scan")
+        for name in expected_paths:
+            entry = entries[name]
+            current = target.joinpath(*PurePosixPath(name).parts)
+            if not same_identity(current, entry):
+                drifted.add("changed-since-scan")
+            contested.update(
+                hard_protection(current, target, exact_names, known_mounts)
+            )
+            relative_current = current.relative_to(target).as_posix()
+            if any(
+                fnmatch.fnmatchcase(relative_current, pattern) for pattern in globs
+            ):
+                contested.add("consumer-protected-path")
+        if not truncated:
+            vcs = tracked_blocker(path, target)
+            if vcs:
+                contested.add(vcs)
+            state, detail = candidate_handle_state(target, path, expected_paths)
+            if state == "open":
+                contested.add("live-handle" + (f": {detail}" if detail else ""))
+            elif state == "needs_elevation":
+                contested.add("needs-elevation")
+            elif state != "clear":
+                contested.add(
+                    "handle-state-unverified" + (f": {detail}" if detail else "")
+                )
+        verdict = "drifted" if drifted else "contested" if contested else "clear"
+        verdicts.append(
+            {
+                "path": relative,
+                "verdict": verdict,
+                "reasons": sorted(drifted) + sorted(contested),
+            }
+        )
+    clear = sum(1 for item in verdicts if item["verdict"] == "clear")
+    return {
+        "status": "handoff-verify-complete",
+        "target": str(target),
+        "verdicts": verdicts,
+        "clear": clear,
+        "not_clear": len(verdicts) - clear,
+        "note": (
+            "Read-only revalidation for the manual handoff lane; this "
+            "subcommand has no deletion capability. A clear verdict is valid "
+            "only at emission time — delete only verdict-clear paths, "
+            "immediately, one item at a time, and re-verify after any delay."
+        ),
+    }
 
 
 def removal_entries(relative: str, entries: dict[str, dict[str, Any]]) -> list[str]:
@@ -1662,6 +1851,13 @@ def build_parser() -> argparse.ArgumentParser:
             command.add_argument("--confirm-tier", required=True, choices=sorted(TIERS))
             command.add_argument("--approval-token", required=True)
             command.add_argument("--report", required=True)
+    verify = subparsers.add_parser(
+        "handoff-verify",
+        help="re-verify approved paths for the manual handoff lane (read-only)",
+    )
+    verify.add_argument("--snapshot", required=True)
+    verify.add_argument("--paths", required=True)
+    verify.add_argument("--data-root")
     return parser
 
 
@@ -1761,6 +1957,12 @@ def main(argv: list[str] | None = None) -> int:
                 }
             )
         snapshot = load_json(Path(args.snapshot))
+        if args.command == "handoff-verify":
+            approved = validate_handoff_paths(
+                load_json(Path(args.paths)), entry_map(snapshot)
+            )
+            result = handoff_verify(snapshot, approved)
+            return emit(result, 3 if result["not_clear"] else 0)
         plan = load_json(Path(args.plan))
         checked = preview(snapshot, plan)
         if args.command == "preview":

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -2046,6 +2046,62 @@ class HandoffVerifyTests(unittest.TestCase):
             self.assertNotEqual("clear", verdict["verdict"])
             self.assertIn("truncated-not-inventoried", verdict["reasons"])
 
+    def test_vcs_probe_timeout_degrades_to_contested_not_abort(self) -> None:
+        # A hung git must not abort the run with zero verdicts: every
+        # approved path still gets its verdict, the timed-out one contested.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "first.tmp").write_text("stale", encoding="utf-8")
+            (root / "second.tmp").write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            with (
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+                mock.patch.object(
+                    hygiene,
+                    "tracked_blocker",
+                    side_effect=subprocess.TimeoutExpired("git", 20),
+                ),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["first.tmp", "second.tmp"])
+            self.assertEqual(2, len(result["verdicts"]))
+            for verdict in result["verdicts"]:
+                self.assertEqual("contested", verdict["verdict"])
+                self.assertIn("vcs-state-unverified", verdict["reasons"])
+
+    def test_denied_descendant_stat_is_contested_not_drifted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            stale = root / "stale-cache"
+            stale.mkdir(parents=True)
+            (stale / "sealed.tmp").write_text("sealed", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            real_lstat = Path.lstat
+
+            def selective_lstat(self: Path):
+                if self.name == "sealed.tmp":
+                    raise PermissionError(13, "access denied")
+                return real_lstat(self)
+
+            handle, vcs = self.clear_probe_mocks()
+            with (
+                handle,
+                vcs,
+                mock.patch.object(
+                    hygiene,
+                    "current_descendants",
+                    return_value={"stale-cache", "stale-cache/sealed.tmp"},
+                ),
+                mock.patch.object(Path, "lstat", selective_lstat),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["stale-cache"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("contested", verdict["verdict"])
+            self.assertIn("needs-elevation", verdict["reasons"])
+            self.assertNotIn("changed-since-scan", verdict["reasons"])
+
     def test_validate_handoff_paths_rejects_malformed_input(self) -> None:
         entries = {"keep/junk.tmp": {}, "keep": {}}
         cases = [

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1797,6 +1797,209 @@ class LeastObservableEnginePathTests(unittest.TestCase):
             )
 
 
+class HandoffVerifyTests(unittest.TestCase):
+    """handoff-verify: read-only manual-lane revalidation (#1109)."""
+
+    def setUp(self) -> None:
+        patcher = mock.patch.object(hygiene, "standing_policy_paths", return_value=[])
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    @staticmethod
+    def clear_probe_mocks():
+        return (
+            mock.patch.object(hygiene, "handle_state", return_value=("clear", None)),
+            mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+        )
+
+    def test_clear_verdict_is_read_only_and_ignores_platform_blockers(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            junk = root / "junk.tmp"
+            junk.write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs:
+                result = hygiene.handoff_verify(snapshot, ["junk.tmp"])
+            self.assertEqual("handoff-verify-complete", result["status"])
+            self.assertEqual(1, result["clear"])
+            self.assertEqual(0, result["not_clear"])
+            verdict = result["verdicts"][0]
+            self.assertEqual(
+                {"path": "junk.tmp", "verdict": "clear", "reasons": []}, verdict
+            )
+            # Read-only: the path survives, and the platform execution gate
+            # (which blocks apply on Windows/macOS) must not appear here.
+            self.assertTrue(junk.exists())
+            self.assertNotIn("execution-platform-unsupported", verdict["reasons"])
+
+    def test_gone_verdict_for_removed_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            junk = root / "junk.tmp"
+            junk.write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            junk.unlink()
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs:
+                result = hygiene.handoff_verify(snapshot, ["junk.tmp"])
+            self.assertEqual(
+                {"path": "junk.tmp", "verdict": "gone", "reasons": ["no-longer-present"]},
+                result["verdicts"][0],
+            )
+            self.assertEqual(1, result["not_clear"])
+
+    def test_drifted_verdict_for_changed_since_approval_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            junk = root / "junk.tmp"
+            junk.write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            junk.write_text("rewritten after approval", encoding="utf-8")
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs:
+                result = hygiene.handoff_verify(snapshot, ["junk.tmp"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("drifted", verdict["verdict"])
+            self.assertIn("changed-since-scan", verdict["reasons"])
+
+    def test_drifted_verdict_for_new_descendant(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            stale = root / "stale-cache"
+            stale.mkdir(parents=True)
+            (stale / "old.tmp").write_text("old", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            (stale / "arrived-later.txt").write_text("new", encoding="utf-8")
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs:
+                result = hygiene.handoff_verify(snapshot, ["stale-cache"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("drifted", verdict["verdict"])
+            self.assertIn("changed-since-scan", verdict["reasons"])
+
+    def test_contested_verdict_for_live_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "busy.tmp").write_text("held", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            with (
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("open", "win32-error-32")
+                ),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["busy.tmp"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("contested", verdict["verdict"])
+            # candidate_handle_state prefixes the relative path on Windows.
+            reason = next(
+                value
+                for value in verdict["reasons"]
+                if value.startswith("live-handle")
+            )
+            self.assertIn("win32-error-32", reason)
+
+    def test_contested_verdict_for_vcs_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "tracked.tmp").write_text("tracked", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            with (
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+                mock.patch.object(
+                    hygiene, "tracked_blocker", return_value="vcs-tracked-content"
+                ),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["tracked.tmp"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("contested", verdict["verdict"])
+            self.assertIn("vcs-tracked-content", verdict["reasons"])
+
+    def test_unverified_handle_fails_closed_as_contested(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "murky.tmp").write_text("murky", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            with (
+                mock.patch.object(
+                    hygiene,
+                    "handle_state",
+                    return_value=("unverified", "lsof-not-found"),
+                ),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["murky.tmp"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("contested", verdict["verdict"])
+            reason = next(
+                value
+                for value in verdict["reasons"]
+                if value.startswith("handle-state-unverified")
+            )
+            self.assertIn("lsof-not-found", reason)
+
+    def test_validate_handoff_paths_rejects_malformed_input(self) -> None:
+        entries = {"keep/junk.tmp": {}, "keep": {}}
+        cases = [
+            ({"version": 2, "paths": ["keep"]}, "version"),
+            ({"version": 1, "paths": []}, "non-empty"),
+            ({"version": 1, "paths": ["/absolute"]}, "outside or absent"),
+            ({"version": 1, "paths": ["../escape"]}, "outside or absent"),
+            ({"version": 1, "paths": ["not-in-snapshot"]}, "outside or absent"),
+            ({"version": 1, "paths": ["keep", "keep/junk.tmp"]}, "overlap"),
+            ({"version": 1, "paths": ["."]}, "non-root"),
+        ]
+        for payload, message in cases:
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(hygiene.HygieneError, message):
+                    hygiene.validate_handoff_paths(payload, entries)
+
+    def test_handoff_verify_subcommand_exit_codes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            junk = root / "junk.tmp"
+            junk.write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            snapshot_path = Path(temporary) / "snapshot.json"
+            snapshot_path.write_text(json.dumps(snapshot), encoding="utf-8")
+            paths_path = Path(temporary) / "handoff-paths.json"
+            paths_path.write_text(
+                json.dumps({"version": 1, "paths": ["junk.tmp"]}), encoding="utf-8"
+            )
+            argv = [
+                "handoff-verify",
+                "--snapshot",
+                str(snapshot_path),
+                "--paths",
+                str(paths_path),
+            ]
+            handle, vcs = self.clear_probe_mocks()
+            output = io.StringIO()
+            with handle, vcs, redirect_stdout(output):
+                self.assertEqual(0, hygiene.main(argv))
+            payload = json.loads(output.getvalue())
+            self.assertEqual("handoff-verify-complete", payload["status"])
+            self.assertEqual("clear", payload["verdicts"][0]["verdict"])
+            junk.write_text("changed after approval", encoding="utf-8")
+            handle, vcs = self.clear_probe_mocks()
+            output = io.StringIO()
+            with handle, vcs, redirect_stdout(output):
+                self.assertEqual(3, hygiene.main(argv))
+            payload = json.loads(output.getvalue())
+            self.assertEqual("drifted", payload["verdicts"][0]["verdict"])
+            self.assertTrue(junk.exists())
+
+
 class GuardTests(unittest.TestCase):
     @staticmethod
     def python_command() -> str:
@@ -2011,6 +2214,50 @@ class GuardTests(unittest.TestCase):
             "deny",
             self.run_guard(malformed)["hookSpecificOutput"]["permissionDecision"],
         )
+
+    def test_guard_allows_exact_handoff_verify_shape(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        command = (
+            f'"{self.python_command()}" "{script}" handoff-verify '
+            "--snapshot s --paths p"
+        )
+        self.assertEqual(
+            "allow",
+            self.run_guard(command)["hookSpecificOutput"]["permissionDecision"],
+        )
+
+    def test_guard_allows_handoff_verify_in_audit_only_mode(self) -> None:
+        # handoff-verify is read-only, so the kill switch must not block it —
+        # audit-only consumers still get the manual-lane revalidation report.
+        script = SCRIPT_DIR / "hygiene.py"
+        command = (
+            f'"{self.python_command()}" "{script}" handoff-verify '
+            "--snapshot s --paths p"
+        )
+        self.assertEqual(
+            "allow",
+            self.run_guard_disabled(command)["hookSpecificOutput"][
+                "permissionDecision"
+            ],
+        )
+
+    def test_guard_denies_malformed_handoff_verify_shapes(self) -> None:
+        script = SCRIPT_DIR / "hygiene.py"
+        prefix = f'"{self.python_command()}" "{script}" handoff-verify'
+        commands = [
+            f"{prefix} --paths p --snapshot s",  # wrong flag order
+            f"{prefix} --snapshot s",  # missing --paths
+            f"{prefix} --snapshot s --paths p --report r",  # undeclared flag
+            f"{prefix} --snapshot s --paths p extra",  # trailing token
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertEqual(
+                    "deny",
+                    self.run_guard(command)["hookSpecificOutput"][
+                        "permissionDecision"
+                    ],
+                )
 
     def test_guard_allows_exact_kill_switch_probe_invocation(self) -> None:
         probe = SCRIPT_DIR.parent.parent / "setup" / "scripts" / "kill_switch_probe.py"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -1947,6 +1947,105 @@ class HandoffVerifyTests(unittest.TestCase):
             )
             self.assertIn("lsof-not-found", reason)
 
+    def test_root_metadata_churn_from_prior_deletion_does_not_refuse(self) -> None:
+        # The motivating scenario for the tolerant root check: deleting one
+        # approved root-level item changes the root's own mtime; the next
+        # item's re-verify must still run and verdict cleanly.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            first = root / "first.tmp"
+            second = root / "second.tmp"
+            first.write_text("stale", encoding="utf-8")
+            second.write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            first.unlink()  # manual-lane deletion of the prior approved item
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs:
+                result = hygiene.handoff_verify(snapshot, ["second.tmp"])
+            self.assertEqual(
+                {"path": "second.tmp", "verdict": "clear", "reasons": []},
+                result["verdicts"][0],
+            )
+
+    def test_replaced_root_still_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "junk.tmp").write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            with mock.patch.object(
+                hygiene, "same_object_identity", return_value=False
+            ):
+                with self.assertRaisesRegex(hygiene.HygieneError, "replaced"):
+                    hygiene.handoff_verify(snapshot, ["junk.tmp"])
+
+    def test_unstatable_path_maps_permission_to_needs_elevation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            guarded = root / "guarded.tmp"
+            guarded.write_text("held", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            real_lstat = Path.lstat
+
+            def selective_lstat(self: Path):
+                if self.name == "guarded.tmp":
+                    raise PermissionError(13, "access denied")
+                return real_lstat(self)
+
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs, mock.patch.object(Path, "lstat", selective_lstat):
+                result = hygiene.handoff_verify(snapshot, ["guarded.tmp"])
+            self.assertEqual(
+                {
+                    "path": "guarded.tmp",
+                    "verdict": "contested",
+                    "reasons": ["needs-elevation"],
+                },
+                result["verdicts"][0],
+            )
+
+    def test_unreadable_descendants_are_contested_not_drifted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            stale = root / "stale-cache"
+            stale.mkdir(parents=True)
+            (stale / "old.tmp").write_text("old", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            handle, vcs = self.clear_probe_mocks()
+            with (
+                handle,
+                vcs,
+                mock.patch.object(
+                    hygiene,
+                    "current_descendants",
+                    side_effect=PermissionError(13, "access denied"),
+                ),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["stale-cache"])
+            verdict = result["verdicts"][0]
+            self.assertEqual("contested", verdict["verdict"])
+            self.assertIn("needs-elevation", verdict["reasons"])
+            self.assertNotIn("changed-since-scan", verdict["reasons"])
+
+    def test_truncated_path_can_never_be_clear(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            deep = root / "outer" / "inner"
+            deep.mkdir(parents=True)
+            (deep / "leaf.tmp").write_text("deep", encoding="utf-8")
+            snapshot = hygiene.scan_tree(
+                root.resolve(), hygiene.load_policy(None), 1
+            )
+            self.assertIn("outer", snapshot["truncated_paths"])
+            handle, vcs = self.clear_probe_mocks()
+            with handle, vcs:
+                result = hygiene.handoff_verify(snapshot, ["outer"])
+            verdict = result["verdicts"][0]
+            self.assertNotEqual("clear", verdict["verdict"])
+            self.assertIn("truncated-not-inventoried", verdict["reasons"])
+
     def test_validate_handoff_paths_rejects_malformed_input(self) -> None:
         entries = {"keep/junk.tmp": {}, "keep": {}}
         cases = [

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -2102,6 +2102,32 @@ class HandoffVerifyTests(unittest.TestCase):
             self.assertIn("needs-elevation", verdict["reasons"])
             self.assertNotIn("changed-since-scan", verdict["reasons"])
 
+    def test_handle_probe_launch_failure_degrades_to_contested(self) -> None:
+        # lsof vanishing between which() and run() (or a ctypes load error)
+        # must contest this path, not abort the run with zero verdicts.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "first.tmp").write_text("stale", encoding="utf-8")
+            (root / "second.tmp").write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            with (
+                mock.patch.object(
+                    hygiene,
+                    "handle_state",
+                    side_effect=FileNotFoundError(2, "lsof vanished"),
+                ),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+            ):
+                result = hygiene.handoff_verify(snapshot, ["first.tmp", "second.tmp"])
+            self.assertEqual(2, len(result["verdicts"]))
+            for verdict in result["verdicts"]:
+                self.assertEqual("contested", verdict["verdict"])
+                self.assertIn(
+                    "handle-state-unverified: handle-probe-failed",
+                    verdict["reasons"],
+                )
+
     def test_validate_handoff_paths_rejects_malformed_input(self) -> None:
         entries = {"keep/junk.tmp": {}, "keep": {}}
         cases = [


### PR DESCRIPTION
## Summary

dh **0.8.0** — the disk-hygiene consumer-audit item's largest remaining finding (F2 ambitious path). Adds a read-only `hygiene.py handoff-verify` subcommand that brings snapshot binding to Windows/macOS — the platforms where engine `apply` is unsupported — without adding an engine deletion lane. Captures most of the declined Windows-execution-lane (F12) value at a fraction of the risk; #1116's affirmation records this as the intended alternative.

**Engine** (`hygiene.py`):
- `handoff-verify --snapshot <s> --paths <p> [--data-root <d>]` takes the snapshot plus the human-approved exact path list (`{"version": 1, "paths": [...]}` — validated with the same containment rules as plan candidates: relative, non-root, no traversal, present in snapshot, non-overlapping) and reruns identity/reparse/protection/descendant/VCS/handle checks per path against live state.
- Per-path machine-readable verdicts: `clear` / `drifted` (identity or captured descendant set changed) / `gone` (no longer present) / `contested` (protection, VCS, live handle, elevation, or unverifiable state). **Fail-closed:** every unverifiable condition lands in `contested`, never `clear`. Exit 0 all-clear, 3 otherwise. **No deletion capability exists in the subcommand.**
- Platform execution blockers deliberately do not apply — the subcommand exists exactly where `execution-platform-unsupported` blocks the engine lane.
- Target-root validation extracted into `resolve_snapshot_target`, shared with `preview` (behavior there unchanged, full stat identity — the approval token binds one immutable state). handoff-verify passes `strict_root_stat=False`: the root is checked with the engine's established directory object-identity (device/inode/type — the same check `apply` uses for directories) because the manual lane deletes one root-level item at a time with a re-verify between items, and the root's own mtime churn must not invalidate the next verify. A replaced root still refuses.

**Guard** (`destructive_guard.py`): admits the exact `handoff-verify` token shape as a read-only invocation — including in audit-only mode (the kill switch continues to block every deletion lane; verification is reporting). Malformed shapes (wrong flag order, missing/undeclared flags, trailing tokens) stay denied. No change to the deny-by-default posture.

**Docs**: clean SKILL.md's manual-handoff lane now writes `handoff-paths.json`, runs handoff-verify immediately before deletion, and acts only on verdict-`clear` paths (per-item, under the PowerShell guard's final prompt); owner-process absence stays a model-side check since snapshot entries carry no owner claim. `reference/safety-model.md` gains a handoff-verify section with the verdict vocabulary table, fail-closed mapping, and emission-time-only validity of `clear`.

**Contract decisions recorded** (resolved loudly, not silently): the four verdict classes come from #1109's acceptance criteria; the mapping choices made here are (a) unverifiable → `contested`, (b) drifted takes precedence over contested when both apply, (c) root metadata churn tolerated via object identity while root replacement refuses. All three documented in safety-model.md and the CHANGELOG.

## Test plan

- [x] 12 new tests: 9 engine (clear read-only + platform-blocker exclusion, gone, changed-since-approval content drift, new-descendant drift, live-handle contested, VCS contested, unverified-handle fail-closed, paths-file validation matrix, `main()` exit codes 0/3) + 3 guard (exact shape allowed, allowed in audit-only mode, malformed shapes denied)
- [x] Suite passes locally on Windows: 163 tests, OK (4 platform skips)
- [x] `hygiene.test.sh` wrapper → OK; `check-changelog-parity.sh --check-bump` → pass; `check-changed-skills.sh` → CHECK-SKILL clean: PASS
- [ ] CI ubuntu lane green

## Related

Closes #1109. Source: handoff-inbox item `20260723-021058-disk-hygiene-0-6-4-consumer-audit`, finding F2 (ambitious path). Relates to #1116 (F12 decline affirmation — this PR is the recorded alternative) and #1108/PR #1118 (manual-lane TOCTOU discipline this extends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
