### PR TITLE
docs(conventions): add loop-lane convention with ci-workflows-work-loop contract slice

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -350,6 +350,7 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Skill layout contract and evals schema | `skill-quality` plugin (contract gate + bundled schema) |
 | Review severity vocabulary | `review` plugin (`context/severity.md`) |
 | Seam phrasing (presence-gated fallbacks) | [`docs/conventions/seam-phrasing/`](conventions/seam-phrasing/README.md) |
+| Loop-lane topology, escalation, capability tiers, loop invariants | [`docs/conventions/loop-lane/`](conventions/loop-lane/README.md) |
 
 ## Cross-platform contract
 

--- a/docs/conventions/loop-lane/CHANGELOG.md
+++ b/docs/conventions/loop-lane/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Loop-lane convention — changelog
+
+Notable changes to the loop-lane contract. The contract is versioned by SemVer; a change to the
+topology, the escalation contract, the capability-tier vocabulary, or any loop-layer invariant is a
+major bump, and additive guidance is a minor bump. A new model release re-audits the capability-tier
+table (§3) and is recorded here.
+
+## 1.0.0 — 2026-07-23
+
+Initial published contract. Lands before the second adopter, per the convention-registry rule: the
+`work-items` `work-loop` / `attend-queue` skills and the `source-control` `babysit-loop` skill share
+these concerns across two plugins.
+
+- **Three-session topology** — worker loop authors PRs (never merges), babysit lane owns merges
+  within the autonomy matrix's merge-policy column, attended queue holds judgment.
+- **Autonomy ladder** — human merge is the shipped default for all but gate-proven bot and
+  C2-mechanical PRs; higher rungs are opt-in per repo, and raising one is the matrix's recorded
+  human-ratified config flip.
+- **Escalation contract** — `needs-human` role label resolved via `config.role_labels` plus a
+  machine-marked discriminator comment; event classes owned by the autonomy guardrails.
+- **Capability tiers** — order-defined (frontier / strong / fast), never family names; runtime
+  resolution by model alias only, Models API as the build/audit-time path; security-surface work
+  routes to frontier always; weekly-cap specifics linked to the official support article, never
+  restated.
+- **Loop-layer invariants** — stop shapes with a drain-terminal state; `#691` cycle budget restarts
+  the session, never the loop; `#502` single edit-in-place telemetry comment with durable loop state;
+  headless-config floor; seam exit 8 backoff-as-dirty; snapshot drain exit; subagent discipline
+  preamble.
+- **Launch surfaces** — `/loop` primary and dependency-free; `claude-ops` `lanes` a one-directional
+  supporting launcher (#480), presence-gated with a `/loop` fallback.
+- **Rate-limit guard binding** — each lane inlines the operable pause floor and cites the guard
+  reader contract for provenance; single-account-per-machine invariant; per-cycle guard-mode
+  telemetry.
+
+Live Claude Code surfaces (model aliases, `ScheduleWakeup` bounds, `/loop` self-pacing) verified
+against current official documentation on 2026-07-23.

--- a/docs/conventions/loop-lane/CHANGELOG.md
+++ b/docs/conventions/loop-lane/CHANGELOG.md
@@ -13,9 +13,10 @@ these concerns across two plugins.
 
 - **Three-session topology** — worker loop authors PRs (never merges), babysit lane owns merges
   within the autonomy matrix's merge-policy column, attended queue holds judgment.
-- **Autonomy ladder** — human merge is the shipped default for all but gate-proven bot and
-  C2-mechanical PRs; higher rungs are opt-in per repo, and raising one is the matrix's recorded
-  human-ratified config flip.
+- **Autonomy ladder** — human merge is the shipped default for all but gate-proven C2-mechanical
+  PRs (a work-class test, not an authorship one: bot authorship alone never qualifies, and C3/C4/C5/
+  unclassified stay human-gated); this default is the recorded baseline rung, and every higher rung
+  is opt-in per repo through the matrix's recorded human-ratified config flip.
 - **Escalation contract** — `needs-human` role label resolved via `config.role_labels` plus a
   machine-marked discriminator comment; event classes owned by the autonomy guardrails.
 - **Capability tiers** — order-defined (frontier / strong / fast), never family names; runtime

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -112,6 +112,15 @@ state**: when every remaining open item is human-gated or escalated and no PR is
 reports and stops cleanly rather than idling forever — without it, an overnight drain deadlocks on
 the first unanswered escalation.
 
+A standing lane is additionally bounded by the `/loop` launch surface's **seven-day expiry**: a
+self-paced `/loop` ends automatically seven days after it starts, idle backoff notwithstanding
+(<https://code.claude.com/docs/en/scheduled-tasks#seven-day-expiry>, verified 2026-07-23). A standing
+lane therefore requires a relaunch owner — the operator while attended, or a launcher that relaunches
+lanes (`claude-ops` `lanes` after the migration). The lane records its loop-started timestamp in the
+lane's #502 telemetry block so the approaching expiry is visible ahead of time, and an expiry hit is
+handled exactly like the cycle-budget hit below: a restart-request into the #502 block, then a clean
+stop.
+
 **Self-pacing.** A lane paces itself through `/loop` with the interval omitted; Claude schedules the
 next iteration with `ScheduleWakeup`, whose delay is clamped between one minute and one hour.
 `ScheduleWakeup` is called at the end of each iteration and is not operator-callable (verified

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -1,0 +1,194 @@
+# Loop-lane convention
+
+Owner doc for the concerns shared by every **loop lane** — a session that wraps a single-pass
+mechanic in a self-paced drain loop over a repository's backlog. Three lanes adopt it: the
+`work-items` `work-loop` and `attend-queue` skills and the `source-control` `babysit-loop` skill.
+Because those live in two different plugins, the topology, escalation contract, capability-tier
+vocabulary, and loop-layer invariants they share cannot live inside either plugin — a
+sibling-plugin file import is a defect
+([`PLUGIN-PHILOSOPHY.md`](../../PLUGIN-PHILOSOPHY.md#design-boundary)), and a cross-plugin convention
+lands in an owner doc before the second plugin adopts it
+([convention registry](../../PLUGIN-PHILOSOPHY.md#convention-registry)). This is that owner doc.
+
+**Pointer-not-copy.** Each mechanic below is owned by a plugin or a sibling convention; this doc
+fixes the *contract* every lane holds to and points at the owner for the *mechanism*. It never
+restates a mechanics block. The `autonomy` plugin remains the governing-policy pointer (the
+guardrail matrix), and the loop lanes are the interim executor for the not-yet-built autonomy runner
+([`runner.md`](../../../plugins/autonomy/reference/runner.md)); this convention is the loop-layer
+contract that operates within that policy.
+
+## 1. Three-session topology
+
+A drained repository runs three cooperating sessions, each with exactly one authority:
+
+| Session | Authority | Never does |
+|---|---|---|
+| Worker loop (`work-loop`) | Claims items, authors PRs | Merges |
+| Babysit lane (`babysit-loop`) | Advances and merges PRs within the matrix's merge-policy column | Decides operator-owned questions |
+| Attended queue (`attend-queue`) | Human-in-the-loop triage and escalation answers | Runs unattended |
+
+The worker loop is PR-only; merge authority belongs to the babysit lane; judgment belongs to the
+attended queue. No lane crosses into another's authority.
+
+### Autonomy ladder (merge authority)
+
+Merge authority is a configurable ladder with the safest rung shipped by default: **human merge for
+every PR except gate-proven bot and C2-mechanical PRs**. Higher rungs — up to full autonomy, where
+frontier-tier subagents resolve conflicts, answer review comments, and drive a PR to merge — are
+opt-in per repository.
+
+Raising a rung is a config change on the tracked, layered config seam
+([consumer-config layering](../consumer-config-layering/README.md)), which makes it exactly the
+autonomy matrix's required **human-ratified knob flip recorded on the governance surface**
+([`work-classes.md`](../../../plugins/autonomy/reference/guardrails/work-classes.md#promotion-and-demotion)).
+C3-autonomous merge is therefore reachable only through a recorded, reviewable flip, never by
+default — the matrix's promotion contract honored by construction. Demotion stays automatic and
+fail-closed, per the same owner doc.
+
+## 2. Escalation contract
+
+A lane escalates by creating or labeling a tracker item that carries the **`needs-human` role
+label**, resolved through the consumer's `.work-item-tracker.json` `config.role_labels` map and
+never compared as a string literal
+([`label-taxonomy.md`](../../../plugins/work-items/reference/label-taxonomy.md#canonical-roles) owns
+the canonical roles and the resolution). A machine-marked bot comment discriminates a
+worker-*escalated* item from an operator-*parked* one — both wear the same role label, so the marker,
+not a second label, carries the distinction. No lane creates labels; the label set is IaC-owned.
+
+The event classes that oblige escalation are governing policy owned by
+[`guardrails.md`](../../../plugins/autonomy/reference/guardrails.md#escalation) (gate failure,
+verification divergence, admission rejection, demotion, structural-plan approval, and
+untrusted-provenance). This convention adds no second escalation channel; the telemetry comment (§4)
+is the report surface, never the sole path when human action is required.
+
+## 3. Capability tiers
+
+Model selection is expressed as **capability tiers defined by order, never by family name** —
+capability does not track family across generations (a current mid-tier model can equal a prior
+top-tier one), so a tier named for a family silently rots. Three ordered tiers:
+
+| Tier | Role |
+|---|---|
+| frontier | Complex-stamped items; every security-surface work class, always |
+| strong | Default implementer / worker |
+| fast | Orchestrator and mechanical items; never weaker than the implementer it reviews |
+
+Fixed rules: an advisor or reviewer is **at least as capable** as the main model it checks (equal
+pairings are valid, and a fast orchestrator paired with an advisor at or above the main tier is the
+recommended shape); a reviewer or verifier is never weaker than the implementer; a security-surface
+work class routes to the frontier tier unconditionally.
+
+**Runtime resolution is by model alias only.** The bare family-word aliases
+(`fable` / `opus` / `sonnet` / `haiku`) are the live-updating handles that resolve to the current
+recommended model for the provider and update over time; a dated model name is a pinned snapshot and
+is never written into a lane body. Aliases are the only handle guaranteed under subscription OAuth,
+so they are the runtime path; the Models API list endpoint is the **build/audit-time** verification
+path, since it may require an API key a loop session lacks. No lane hard-codes a model ID. (Alias
+semantics verified against <https://code.claude.com/docs/en/model-config> on 2026-07-23.)
+
+Tier tables are built from a live official-docs fetch at authoring time, never from recall. Any new
+model release re-audits the tier table — the trigger is recorded in this convention's
+[`CHANGELOG.md`](CHANGELOG.md).
+
+### Rate-limit windows
+
+Subscription (Pro/Max) usage is bounded by a rolling five-hour window and a weekly cap. The weekly
+cap's exact model scoping and numeric limits are volatile and are **not** restated here — see the
+official [Anthropic support article](https://support.claude.com/en/articles/11049741-what-is-the-max-plan)
+(verified 2026-07-23). The operable pause floor lives in the rate-limit guard binding (§6).
+
+## 4. Loop-layer invariants
+
+Every loop lane holds these, whatever single-pass mechanic it wraps.
+
+**Stop shapes.** A lane runs in one of two shapes: *standing* (idle backs off toward longer wakeups;
+no activity-timeout stop) or *drain* (stops when its backlog is empty). Drain carries a **terminal
+state**: when every remaining open item is human-gated or escalated and no PR is in flight, the lane
+reports and stops cleanly rather than idling forever — without it, an overnight drain deadlocks on
+the first unanswered escalation.
+
+**Self-pacing.** A lane paces itself through `/loop` with the interval omitted; Claude schedules the
+next iteration with `ScheduleWakeup`, whose delay is clamped between one minute and one hour.
+`ScheduleWakeup` is called at the end of each iteration and is not operator-callable (verified
+against <https://code.claude.com/docs/en/tools-reference> and
+<https://code.claude.com/docs/en/scheduled-tasks> on 2026-07-23). Idle raises the delay toward the
+ceiling. The `source-control` babysit lane's own self-pacing section
+([`babysit-prs` loop reference](../../../plugins/source-control/skills/babysit-prs/reference/loop.md))
+is the worked precedent.
+
+**Cycle budget (#691).** A per-session cycle budget restarts the **session**, never ends the
+**loop**. A running loop cannot `/clear` or relaunch itself — a relaunch is the only context reset a
+lane gets ([`claude-ops` lanes](../../../plugins/claude-ops/skills/lanes/SKILL.md), section "A
+relaunch is the only context reset a loop lane gets") — so a budget hit emits a restart-request
+through telemetry and stops the loop cleanly, leaving the relaunch to the launcher or operator.
+
+**Telemetry comment (#502).** Each lane maintains exactly **one** status comment on a tracking item,
+identified by a machine sentinel marker and **edited in place** every cycle — never a second comment.
+`claude-ops`'s `telemetry-upsert.sh` is the interim home of this contract and a compatible reader
+(`morning-brief` reads the same surface); an installed plugin cannot invoke a sibling plugin's
+script, so each lane **inlines** the small `gh api` upsert and the coupling to `claude-ops` stays
+one-directional.
+
+**Durable loop state.** Conversation context is lossy across compaction, so a lane persists its
+adaptive-cap streak counter, its rate-limit-warning latch, and its cycle count in a machine-readable
+block of that same #502 telemetry comment, and re-reads them at each cycle start.
+
+**Headless-config floor.** A headless lane launch never blocks on an interview: it takes explicit or
+persisted config, or tier defaults, and logs the assumption. The interactive path may run a
+mini-interview and offer to persist the answer; the headless path never waits on one.
+
+**Provider backoff (seam exit 8).** A tracker-seam exit 8 — provider unavailable, or secondary forge
+limits under one credential — is handled as backoff-and-retry and counted as a **dirty** signal for
+the adaptive cap.
+
+**Snapshot drain exit.** The drain-exit condition is evaluated against a snapshot taken at cycle
+start; new automated intake arriving mid-cycle is **reported, never chased**, so an item-producing
+bot cannot hold a drain open indefinitely.
+
+**Subagent discipline preamble.** Every subagent a lane dispatches runs the re-anchor discipline
+sweep — sweep-all-disciplines, use-your-skills, do-your-research.
+
+## 5. Consumers and launch surfaces
+
+| Consumer | Plugin | Lane |
+|---|---|---|
+| `work-loop` | `work-items` | worker (PR-authoring drain) |
+| `attend-queue` | `work-items` | attended triage / escalation queue |
+| `babysit-loop` | `source-control` | merge lane over [`babysit-prs`](../../../plugins/source-control/skills/babysit-prs/SKILL.md) |
+
+The skill paths `plugins/work-items/skills/work-loop/`, `plugins/work-items/skills/attend-queue/`,
+and `plugins/source-control/skills/babysit-loop/` are introduced by later phases; they are named
+here as the adopters this owner doc lands ahead of.
+
+**Launch surfaces.** A lane launches interactively via `/loop` — the primary surface, built-in and
+dependency-free — or headless via the `claude-ops` `lanes` launcher, which stores the one-line lane
+prompt through its `prompt_dir` seam (#480). `lanes` is a **supporting, strictly one-directional**
+launcher: it launches the lane; no lane body ever requires, imports, or degrades without
+`claude-ops`. Every mention of `lanes` in a lane body is presence-gated with the `/loop` fallback
+documented at the site, per the [seam-phrasing convention](../seam-phrasing/README.md).
+
+## 6. Rate-limit guard binding
+
+All three lanes consume the shared subscription rate-limit windows (§3). An installed plugin cannot
+read a sibling plugin's files or this repo's `docs/` at runtime, so each consuming lane body
+**inlines the operable floor** — the fixed tee-file path, the 90%-of-either-window pause threshold,
+the staleness rule, and drain-then-pause — and cites the guard's reader contract for provenance only.
+That reader contract is `plugins/rate-limit-guard/reference/reader-contract.md`, introduced with the
+`rate-limit-guard` plugin in a later phase. This convention records the inline-floor rule so the
+values stay byte-identical across lanes; fleet audits check conformance per consumer.
+
+**Single-account-per-machine invariant.** The tee file is last-writer-wins and carries no account
+identifier, so a mid-drain switch to a second account feeds one account's healthy windows to lanes
+running on the exhausted one. The guard cannot detect this; operation assumes one account per
+machine.
+
+**Guard-mode telemetry.** Each lane records the guard's mode — proactive, reactive, or unknown — in
+its #502 telemetry block every cycle, so a silent degradation to reactive-only stays visible on the
+tracking surface.
+
+## Versioning
+
+This contract is versioned in [`CHANGELOG.md`](CHANGELOG.md). A change to the topology, the
+escalation contract, the tier vocabulary, or any loop-layer invariant is a major bump; additive
+guidance is a minor bump. **Re-derivation trigger:** any new model release re-audits the
+capability-tier table (§3), recorded as a changelog entry.

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -33,11 +33,16 @@ attended queue. No lane crosses into another's authority.
 ### Autonomy ladder (merge authority)
 
 Merge authority is a configurable ladder with the safest rung shipped by default: **human merge for
-every PR except gate-proven bot and C2-mechanical PRs**. Higher rungs — up to full autonomy, where
+every PR except gate-proven C2-mechanical ones**. The exception is a *work-class* test, not an
+authorship test — a PR qualifies only when the item classifies C2 (mechanical), whether a bot, a
+human, or a worker authored it; bot authorship alone is never sufficient. C3, C4, C5, and
+unclassified items stay human-gated regardless of author. Higher rungs — up to full autonomy, where
 frontier-tier subagents resolve conflicts, answer review comments, and drive a PR to merge — are
 opt-in per repository.
 
-Raising a rung is a config change on the tracked, layered config seam
+This shipped default is itself the recorded baseline rung, versioned in this convention and in the
+tracked seam config. Raising any higher rung — including any C3-autonomous merge — is a config change
+on the tracked, layered config seam
 ([consumer-config layering](../consumer-config-layering/README.md)), which makes it exactly the
 autonomy matrix's required **human-ratified knob flip recorded on the governance surface**
 ([`work-classes.md`](../../../plugins/autonomy/reference/guardrails/work-classes.md#promotion-and-demotion)).
@@ -116,11 +121,15 @@ ceiling. The `source-control` babysit lane's own self-pacing section
 ([`babysit-prs` loop reference](../../../plugins/source-control/skills/babysit-prs/reference/loop.md))
 is the worked precedent.
 
-**Cycle budget (#691).** A per-session cycle budget restarts the **session**, never ends the
-**loop**. A running loop cannot `/clear` or relaunch itself — a relaunch is the only context reset a
-lane gets ([`claude-ops` lanes](../../../plugins/claude-ops/skills/lanes/SKILL.md), section "A
-relaunch is the only context reset a loop lane gets") — so a budget hit emits a restart-request
-through telemetry and stops the loop cleanly, leaving the relaunch to the launcher or operator.
+**Cycle budget (#691).** A per-session cycle budget bounds one session; a budget hit **always**
+emits a restart-request into the #502 telemetry block and stops the loop cleanly — a running loop
+cannot `/clear` or relaunch itself, since a relaunch is the only context reset a lane gets
+([`claude-ops` lanes](../../../plugins/claude-ops/skills/lanes/SKILL.md), section "A relaunch is the
+only context reset a loop lane gets"). What happens next is launcher-relative. Under a launcher that
+acts on restart-requests (for example `claude-ops` `lanes`), the lane is relaunched and the loop
+continues — the budget restarts the **session**, never ends the **loop**. Under a bare interactive
+`/loop` with no launcher, the same budget hit is a **terminal** manual-restart state: the stop is
+reported in lane telemetry, and the operator — or a migration to a launcher — owns the restart.
 
 **Telemetry comment (#502).** Each lane maintains exactly **one** status comment on a tracking item,
 identified by a machine sentinel marker and **edited in place** every cycle — never a second comment.

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -124,8 +124,9 @@ the first unanswered escalation.
 A standing lane is additionally bounded by the `/loop` launch surface's **seven-day expiry**: a
 self-paced `/loop` ends automatically seven days after it starts, idle backoff notwithstanding
 (<https://code.claude.com/docs/en/scheduled-tasks#seven-day-expiry>, verified 2026-07-23). A standing
-lane therefore requires a relaunch owner — the operator while attended, or a launcher that relaunches
-lanes (`claude-ops` `lanes` after the migration). The lane records its loop-started timestamp in the
+lane therefore requires a relaunch owner — today always the operator, for whom `claude-ops` `lanes`
+`restart` is a one-command path (operator-initiated by contract; see the cycle-budget paragraph
+below). The lane records its loop-started timestamp in the
 lane's #502 telemetry block so the approaching expiry is visible ahead of time, and an expiry hit is
 handled exactly like the cycle-budget hit below: a restart-request into the #502 block, then a clean
 stop.
@@ -144,10 +145,14 @@ emits a restart-request into the #502 telemetry block and stops the loop cleanly
 cannot `/clear` or relaunch itself, since a relaunch is the only context reset a lane gets
 ([`claude-ops` lanes](../../../plugins/claude-ops/skills/lanes/SKILL.md), section "A relaunch is the
 only context reset a loop lane gets"). What happens next is launcher-relative. Under a launcher that
-acts on restart-requests (for example `claude-ops` `lanes`), the lane is relaunched and the loop
-continues — the budget restarts the **session**, never ends the **loop**. Under a bare interactive
-`/loop` with no launcher, the same budget hit is a **terminal** manual-restart state: the stop is
-reported in lane telemetry, and the operator — or a migration to a launcher — owns the restart.
+acts on restart-requests, the lane is relaunched and the loop continues — the budget restarts the
+**session**, never ends the **loop**. **No such automatic launcher exists today**: `claude-ops`
+`lanes` is operator-initiated by contract ("no scheduler runs `restart` for you today", per its
+SKILL.md), so until an automatic relaunch trigger exists, *every* budget hit — under `lanes` or a
+bare interactive `/loop` alike — is a **terminal** manual-restart state: the stop is reported in
+lane telemetry, and the operator owns the restart (`lanes` `restart` is the operator's one-command
+path). The restart-request in the #502 block is written so that the operator today, and an
+automatic trigger when one exists, can act on the same surface.
 
 **Telemetry comment (#502).** Each lane maintains exactly **one** status comment on a tracking item,
 identified by a machine sentinel marker and **edited in place** every cycle — never a second comment.

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -41,14 +41,23 @@ frontier-tier subagents resolve conflicts, answer review comments, and drive a P
 opt-in per repository.
 
 This shipped default is itself the recorded baseline rung, versioned in this convention and in the
-tracked seam config. Raising any higher rung — including any C3-autonomous merge — is a config change
-on the tracked, layered config seam
-([consumer-config layering](../consumer-config-layering/README.md)), which makes it exactly the
-autonomy matrix's required **human-ratified knob flip recorded on the governance surface**
+tracked seam config. A repository adopts it through its own reviewable lane-enabling change — the
+binding/config PR that turns a lane on in that repo — which is the recorded, human-ratified act for
+the baseline rung, so no lane ever auto-merges without a reviewed change having enabled it. Raising
+any higher rung — including any C3-autonomous merge — is a config change on the tracked, layered
+config seam ([consumer-config layering](../consumer-config-layering/README.md)), which makes it
+exactly the autonomy matrix's required **human-ratified knob flip recorded on the governance
+surface**
 ([`work-classes.md`](../../../plugins/autonomy/reference/guardrails/work-classes.md#promotion-and-demotion)).
 C3-autonomous merge is therefore reachable only through a recorded, reviewable flip, never by
 default — the matrix's promotion contract honored by construction. Demotion stays automatic and
 fail-closed, per the same owner doc.
+
+**Merge-rung raises are seam-only.** Invocation arguments never raise the merge rung: a raise binds
+only from the tracked seam config layer, so every increase in merge authority is the recorded,
+reviewable act above. An argument may select a *lower* (safer) rung for a single run, never a higher
+one — argument precedence, which wins for other lane dimensions, is floored at the seam-config rung
+for merge authority.
 
 ## 2. Escalation contract
 

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -177,8 +177,13 @@ the adaptive cap.
 start; new automated intake arriving mid-cycle is **reported, never chased**, so an item-producing
 bot cannot hold a drain open indefinitely.
 
-**Subagent discipline preamble.** Every subagent a lane dispatches runs the re-anchor discipline
-sweep — sweep-all-disciplines, use-your-skills, do-your-research.
+**Subagent discipline preamble.** Every subagent a lane dispatches carries a standing discipline
+preamble. When the `re-anchor` plugin is installed, the dispatch prompt invokes its sweep —
+sweep-all-disciplines, use-your-skills, do-your-research; when it is absent, the dispatch prompt
+inlines the equivalent standing instructions (verify claims against authoritative sources before
+acting, prefer installed skills over ad-hoc approaches, and re-check work against the active
+conventions). The reference is presence-gated with this inline fallback per the
+[seam-phrasing convention](../seam-phrasing/README.md) — `re-anchor` is never a hard dependency.
 
 ## 5. Consumers and launch surfaces
 

--- a/docs/topics/ci-workflows-work-loop/PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/PLAN.md
@@ -202,8 +202,9 @@ README.md contract sections (pointer-not-copy — cite owners, never restate):
 1. **3-session topology** — worker loop authors PRs (never merges); babysit lane owns merges
    WITHIN the autonomy guardrail matrix's merge-policy column; HITL decides. Merge authority
    (operator-resolved 2026-07-23): a configurable AUTONOMY LADDER with the safest default —
-   **human merge is the shipped default for everything except gate-proven bot/C2 mechanical
-   PRs** (dependabot/small/easy/safe candidates); higher rungs up to full autonomy (frontier
+   **human merge is the shipped default for everything except gate-proven C2-mechanical
+   PRs** (dependabot/small/easy/safe candidates; a work-class test irrespective of author — bot
+   authorship alone never qualifies, per the loop-lane convention); higher rungs up to full autonomy (frontier
    subagents resolving conflicts, responding to comments, making changes, driving to merge)
    are opt-in per repo. The ratification mechanism: raising a merge rung is a config change on
    the TRACKED layered seam (reviewable, versioned) — exactly the matrix's required
@@ -511,7 +512,8 @@ None — all seven approval-round decisions resolved by the operator 2026-07-23:
    supporting, one-directional launcher; loop skills never depend on claude-ops (guarded
    if-installed, `/loop` fallback documented).
 5. Merge authority → configurable autonomy ladder; shipped default = human merge for all but
-   gate-proven bot/C2 mechanical PRs; higher rungs (through full autonomy with frontier
+   gate-proven C2-mechanical PRs (any author; bot authorship alone never qualifies, per the
+   loop-lane convention); higher rungs (through full autonomy with frontier
    subagents driving to merge) opt-in via tracked-config flip = the matrix's recorded
    human-ratified promotion.
 6. Babysit tier for ci-workflows → WORKER (autopilot premise invalidated post-launch).

--- a/docs/topics/ci-workflows-work-loop/PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/PLAN.md
@@ -413,7 +413,9 @@ means: the session pushes the branch + prepares the PR body file and notifies th
 2. Launch three lanes: `work-loop` + `attend-queue` + babysit (babysit-PLAN Phase B3). Launch
    surface `[FALLBACK — confirm or override]`: FIRST cycle attended via interactive `/loop`
    (observability); unattended operation then moves to `claude-ops:lanes` (background named
-   sessions) so budget-hit restart-requests have a launcher to act on them — reviewer finding:
+   sessions) so budget-hit restart-requests reach the operator's one-command relaunch surface
+   (`lanes restart` — operator-invoked by its contract; no automatic trigger consumes
+   restart-requests today, per the loop-lane convention) — reviewer finding:
    an interactive `/loop` with nobody watching turns a #691 budget-hit into a silent drain
    stall. Until lanes-managed, the stall risk is documented in the lane report.
    PHASE-ENTRY GATE before any lanes migration (stress-test finding: statusline is verified

--- a/docs/topics/ci-workflows-work-loop/PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/PLAN.md
@@ -1,0 +1,549 @@
+# ci-workflows-work-loop
+
+## Brief
+
+**TLDR**: Drain repo issue backlogs autonomously via a 3-session-per-repo topology — worker loop
+authors PRs (never merges), babysit lane owns merges at a merge-capable tier (worker minimum;
+autopilot where only bot PRs are in scope), HITL decides — built as reusable org-scope plugin
+lanes; ci-workflows (21 open issues) is the first instantiation. Sibling deliverable with its own
+Brief: `/source-control:babysit-loop` (`babysit-PLAN.md`, same directory — succession from the
+terminated babysit session).
+
+### Goal
+
+1. Two new skills in the `work-items` plugin (`melodic-software/claude-code-plugins`):
+   `work-loop` (dynamic self-paced drain: mechanical-triage intake sweep, adaptive parallel
+   dispatch, escalation, heartbeat, exit-condition evaluation) and `hitl-queue` (attended lane:
+   polls escalations + untriaged intake, composes `/work-items:triage` + `/planning:interview`,
+   writes answers back, flips items to agent-ready). Work-lane-specific mechanics ONLY — shared
+   cross-lane concerns live in the convention doc (goal 1b), which both plugins cite.
+   Interim-executor rationale cites `plugins/autonomy/reference/runner.md`.
+1b. New repo-level convention `docs/conventions/loop-lane/` + registry row
+   (per `docs/PLUGIN-PHILOSOPHY.md`: sibling-plugin imports are defects; a cross-plugin
+   convention lands in an owner doc before a second plugin adopts it — the babysit lane in
+   `source-control` is that second adopter). Owns: 3-session topology, escalation contract,
+   model-routing capability tiers (IDs live-resolved), and the loop-layer invariants — stop
+   shapes (standing vs drain), `#691` cycle-budget semantics (resolution (a): budget restarts the
+   SESSION, never ends the LOOP), idle backoff, `#502` per-lane edited status comment,
+   headless-config floor (a headless lane launch never blocks on an interview: explicit/persisted
+   config or tier defaults + log), and the subagent discipline preamble. `autonomy` remains the
+   governing-policy pointer (guardrail matrix), not a mechanics home.
+2. New small `rate-limit-guard` plugin: statusline tee wrapper (writes `rate_limits` + timestamp to
+   fixed path), reader contract (pause ≥90% of either window until later `resets_at`; Monitor
+   watches tee file so account switches wake the pause early — MANDATORY, not optional: the
+   statusline schema carries no account-identifier field, verified live), `StopFailure` matcher
+   `"rate_limit"` reactive fallback (side-effect-only detection — hook output/exit ignored,
+   payload carries no reset/quota data; resume timing comes from the tee file or parsed error
+   text, verified live), capability-detect fail-open (absence/absurd values = unknown,
+   reactive-only — covers enterprise/API-key auth, where limits may exist but are unobservable).
+   Implementation notes: shell-run fields reject `${user_config.*}` (use exec-form args/env/config
+   file); plugin `experimental.monitors` auto-start is a candidate watcher surface; babysit-loop
+   and hitl sessions are consumers two and three of the shared windows.
+3. ci-workflows instantiation: `.work-item-tracker.json` (github provider) via PR; initial triage
+   pass over the 14 unlabeled issues (attended, this session); loop run to exit condition.
+4. `standards` doc PR: record activation of the deferred assignee+lease claiming mechanism
+   (`conventions/process/issue-tracker.md` status axis).
+
+### Constraints
+
+- Worker loop is PR-only; merging belongs to babysit worker tier; judgment belongs to HITL.
+- Exit condition: every open issue closed OR has an active non-draft PR (native closing-keyword
+  linkage; the seam's in-flight-PR exclusion is the drain signal).
+- Label set is github-iac-owned: no ad-hoc label creation; role labels resolved via
+  `.work-item-tracker.json` `config.role_labels`, never compared as literals. Worker-escalated vs
+  parked discriminated by machine-marked bot comment, not a new label.
+- Skill bodies are thin delta only — invoke owned mechanics (`/work-items:work`,
+  `/implementation:implement-dispatch`, `/source-control:worktree`, `/work-items:triage`,
+  `/planning:interview`); never restate selection/claim/lease/dispatch/triage machinery.
+- Worker dispatch prompts enumerate required skills per phase; subagent authority is an open-ended
+  duty ("escalate decisions that are the operator's — e.g. contract, security-posture,
+  enforcement-scope, issue-goal changes"), not a closed list.
+- Work-class gate, in autonomy contract terms (`reference/guardrails/work-classes.md` +
+  `admission-policy.md`, read this session): `C2` mechanical → autonomous-eligible; `C3` scoped →
+  autonomous for bug-fix-shaped items, human-gated for feature-shaped (operator tightening —
+  permitted without justification); `C4` structural/contract and `C5` untrusted-provenance →
+  human-gated / per-contract floors; unclassified → fail-closed human-gated (contract rule).
+- Model routing: capability TIERS in the convention doc, defined by capability ORDER, never by
+  family name (verified: family ≠ capability across generations — the advisor matrix ranks
+  Sonnet 5 equal to Opus 4.6). Live resolution: model aliases (`fable`/`opus`/`sonnet`/`haiku` —
+  the only live-updating handles; dateless IDs are pinned snapshots) + the Models API list
+  endpoint; account for provider-dependent alias resolution and org `availableModels` overrides.
+  Advisor rule as documented: "at least as capable" as main (equal pairings valid); fast-main +
+  strong-advisor pairing is officially recommended (advisor docs + blog, cited in
+  scratchpad model-routing-verification/RESEARCH.md). Defaults: fast-tier orchestrator +
+  advisor ≥ main; strong-tier workers;
+  frontier tier for complex-stamped items; fast tier for mechanical; reviewer/verifier never
+  weaker than implementer; tier signal from triage briefing (issue body, not a label);
+  security-surface work-class → frontier tier, ALWAYS (operator directive). Windows: 5-hour
+  ROLLING + weekly FIXED-ANCHOR (not rolling — verified); the per-model weekly cap's family is
+  mid-transition in official docs (Sonnet vs Opus conflict) — LINK the support article, never
+  hard-code the family; Fable's 50%-of-weekly allowance on Max is documented.
+- Adaptive item-level cap: start 2, +1 after 3 consecutive clean items (ceiling 3), −1 on any dirty
+  item (floor 1); no ramp-up while a rate-limit warning is live; composed budget with
+  implement-dispatch's per-item wave cap stated explicitly.
+- Rate limits: drain-then-pause default (finish in-flight, stop claiming, ScheduleWakeup/Monitor
+  until reset, report); hard stop only by user request; model downshift only as explicit opt-in.
+- Org-agnostic throughout; no machine-/user-specific paths in skill bodies.
+- ci-workflows `CLAUDE.md` security ground rules are inviolable by workers (escalate, never edit).
+- Authoring governed by `playbooks:skill-authoring` + `skill-quality:check`; WebFetch current
+  official plugin/skills docs during build (claude-code-plugins CLAUDE.md mandate); hook wiring
+  (StopFailure) via `update-config`; model-routing tier tables built from a live official-docs
+  fetch at build time, never recall.
+- Prep before build: pull ci-workflows (behind 11) + standards (behind 19); claude-code-plugins →
+  main + pull (current branch's upstream deleted).
+
+### Acceptance criteria
+
+- Loop runs unattended on ci-workflows until the exit condition; final report lists items closed,
+  PR'd, and escalated.
+- Escalated items carry `needs-human` (role-resolved) + machine-marked question comment; attend-queue
+  surfaces them and untriaged intake in one attention view.
+- Two parallel workers never hold the same item (seam lease race observed working).
+- Guard pauses claiming at ≥90% of either window and resumes after reset without operator action
+  (subscription auth); on non-subscription auth it declares reactive-only and never throttles.
+- Both lanes + guard plugin pass `skill-quality:check`.
+- Second-repo adoption = one binding PR + three sessions; zero plugin edits.
+
+### Captured assumptions
+
+- Subscription (Pro/Max) auth in loop sessions for proactive throttle; anything else fail-opens to
+  reactive.
+- work-items `#572` (autonomous branch/worktree provisioning seam) worked around in-template via
+  explicit provisioning before dispatch; upstream fix optional follow-up.
+- Statusline runs (and tees) in interactive sessions; headless `claude -p` unverified and unused.
+- `/login` multi-account rotation is undocumented community practice — manual operator action
+  only; the design never automates or depends on it.
+
+### Out of scope
+
+- The autonomy runner build (stays charter-gated; this loop is the interim executor earning its
+  triggers — cited, not built).
+- Routine-catalog graduation of heartbeat/triage sweeps (trigger recorded: loop proves stable).
+- Babysit plugin lane (owned by the user's separate session).
+- Worker-loop merging; new labels; the unofficial `api/oauth/usage` endpoint.
+
+### Deferred questions
+
+- Multi-repo scale-out shape (per-repo loops vs round-robin worker) — trigger: second repo adopts.
+  Arbiter: USER-RESERVED.
+- Upstream work-items PR for `#572` once the in-template workaround proves out. Arbiter:
+  /planning:plan.
+- Build-time verifications: StopFailure `rate_limit`
+  matcher behavior on API-key auth; implement-dispatch per-worker model override wiring (substrate
+  confirmed: agent frontmatter supports `model`, `effort`, `skills` preload, `isolation:
+  worktree`); worker
+  commit signing vs merge strategy against the `signing` ruleset (`required_signatures` on main —
+  verified live); machine-readable surfacing of Q18's quality signals (design intent; check
+  pipeline-shape.md). Arbiter: /planning:plan.
+
+## Plan
+
+> Scope-change note (2026-07-23, approval round): three Brief statements superseded by
+> operator decision — (1) "babysit merges at worker tier minimum / autopilot for bot-only
+> repos" → autonomy ladder with human-merge default (Phase 2 item 1; babysit-PLAN B3 tier =
+> worker); (2) skill name `hitl-queue` → `attend-queue` (naming-grammar rule); (3) exit
+> condition gains the drain-terminal state. Brief text above is historical; this Plan is
+> authoritative for the deltas.
+
+### Standards grounding
+
+No standards index (`docs/standards/README.md` with `standards-contract` frontmatter) exists in
+claude-code-plugins, ci-workflows, or standards — resolution ladder rung 4/6 (inference; assumption
+surfaced). Grounding sources read this session:
+
+| Surface | Source | Provenance |
+|---|---|---|
+| Plugin/skill design | claude-code-plugins `CLAUDE.md` (fresh-docs mandate L6-11, design rules L37-50); `docs/PLUGIN-PHILOSOPHY.md` (seam rules L22-33, convention registry L329-353, hook contract L326-328, Windows exec-form L128, Monitors stance "Wait" L134) | team (repo) |
+| Work-items seam | `plugins/work-items/reference/tracker-seam.md`, `label-taxonomy.md`, `tools/work-item-tracker/CONTRACT.md` (lease protocol L207-231) | team (repo) |
+| Autonomy contracts | `plugins/autonomy/reference/guardrails.md` (matrix, escalation L68-94), `guardrails/work-classes.md`, `admission-policy.md`, `runner.md` (interim-executor L8-51) | team (repo) |
+| Source-control | `plugins/source-control/skills/babysit-prs/SKILL.md` + `reference/loop.md`, `reference/config-resolution.md` | team (repo) |
+| Lane ops | `plugins/claude-ops/skills/lanes/SKILL.md` (launcher, `telemetry-upsert.sh` #502 interim, #480 prompt seam) | team (repo) |
+| Security | ci-workflows `CLAUDE.md` L7-50 (inviolable ground rules) | team (repo) |
+| Tracker process | standards `conventions/process/issue-tracker.md` (L37 deferred lease, L52-58 label IaC governance) | team (repo) |
+
+### Build-technique note
+
+No viability unknown remains (interview + research resolved design); risk is integration. Kept
+tracer-bullet slice = Phase 5+7 head: bind the tracker seam and run ONE work-loop cycle
+end-to-end on ci-workflows before declaring the lane operational. Phases 2–4 are the
+convention/plugin substrate that slice consumes.
+
+### Phase 1: Topic-contract move + branches [DONE]
+
+Move both Briefs to the tracked contract slice in claude-code-plugins (operator-confirmed
+placement; topic-docs convention `contract_tier: branch`):
+
+| File | Action | What |
+|---|---|---|
+| `claude-code-plugins/docs/topics/ci-workflows-work-loop/PLAN.md` | Create | this file (Brief + Plan) |
+| `claude-code-plugins/docs/topics/ci-workflows-work-loop/babysit-PLAN.md` | Create | babysit Brief + Plan |
+| `claude-code-plugins/docs/topics/ci-workflows-work-loop/design/design-resolution.md` | Create | design gate file — a contract kind per topic-docs convention (README tier table), moves with the slice |
+| `.work/ci-workflows-work-loop/*` | KEEP | working state; research + ledgers stay memory-slice |
+
+Branch per PR-phase (`feat/loop-lane-convention`, `feat/rate-limit-guard`,
+`feat/work-items-loop-lanes`, …) — topic docs ride the first build branch and each later branch
+carries its own phase-status updates.
+
+- **Sanity Check:** `git -C <claude-code-plugins> ls-files docs/topics/ci-workflows-work-loop/` lists both PLAN files + `design/design-resolution.md` (exit 0, 3 lines).
+
+### Phase 2: `docs/conventions/loop-lane/` convention + registry row [DONE]
+
+Owner doc for every shared cross-lane concern (PLUGIN-PHILOSOPHY L331-333: owner doc lands BEFORE
+the second adopter). One PR to claude-code-plugins.
+
+| File | Action | What |
+|---|---|---|
+| `docs/conventions/loop-lane/README.md` | Create | full contract (content below) |
+| `docs/conventions/loop-lane/CHANGELOG.md` | Create | `## 1.0.0 — <date>` |
+| `docs/PLUGIN-PHILOSOPHY.md` | Modify | one registry row: `\| Loop-lane topology, escalation, capability tiers, loop invariants \| [docs/conventions/loop-lane/](conventions/loop-lane/README.md) \|` |
+
+README.md contract sections (pointer-not-copy — cite owners, never restate):
+
+1. **3-session topology** — worker loop authors PRs (never merges); babysit lane owns merges
+   WITHIN the autonomy guardrail matrix's merge-policy column; HITL decides. Merge authority
+   (operator-resolved 2026-07-23): a configurable AUTONOMY LADDER with the safest default —
+   **human merge is the shipped default for everything except gate-proven bot/C2 mechanical
+   PRs** (dependabot/small/easy/safe candidates); higher rungs up to full autonomy (frontier
+   subagents resolving conflicts, responding to comments, making changes, driving to merge)
+   are opt-in per repo. The ratification mechanism: raising a merge rung is a config change on
+   the TRACKED layered seam (reviewable, versioned) — exactly the matrix's required
+   "human-ratified knob flip recorded on the governance surface" (`work-classes.md` Promotion
+   L57-59), so C3 autonomous merge is reachable only through a recorded flip, never by
+   default. Operator may adjust rungs on the fly; each adjustment is a tracked config edit.
+2. **Escalation contract** — `needs-human` role label resolved via `.work-item-tracker.json`
+   `config.role_labels` (cite `plugins/work-items/reference/label-taxonomy.md` canonical roles)
+   \+ machine-marked bot comment discriminator (worker-escalated vs parked). Cites autonomy
+   `reference/guardrails.md#escalation` event classes as governing policy; no second channel.
+3. **Capability tiers** — order-defined tiers (never family names); RUNTIME resolution via
+   aliases ONLY (the only handles guaranteed under subscription OAuth — stress-test finding:
+   the Models API list endpoint needs API-key auth loop sessions may lack); Models API is the
+   build/audit-time verification path; re-derivation trigger recorded in the convention
+   CHANGELOG: any new model release re-audits the tier table. Advisor "at least as capable";
+   security-surface class → frontier ALWAYS; weekly-cap family LINKED to the support article,
+   never hard-coded. Tier tables built from live official-docs fetch at build time (fresh-docs
+   mandate).
+4. **Loop-layer invariants** — stop shapes (standing vs drain, PLUS the drain-terminal state
+   `[FALLBACK — confirm or override]`: when every remaining open item is human-gated/escalated
+   and no PR is in flight, drain reports + stops cleanly instead of idling forever — reviewer
+   finding: without it an overnight drain deadlocks on the first unanswered escalation);
+   #691 resolution (a): cycle budget restarts the SESSION, never ends the LOOP — restart is
+   launcher/operator-initiated (a running loop cannot `/clear` itself; cite `claude-ops` lanes
+   SKILL.md "A relaunch is the only context reset"), so budget-hit = emit restart-request
+   telemetry + stop loop cleanly; idle backoff; #502 per-lane edited status comment — the
+   convention FIXES the comment contract (machine sentinel marker, edit-in-place, one comment
+   per lane, per #502) and each lane INLINES the small `gh api` upsert (operator coupling
+   directive 2026-07-23 + philosophy: an installed plugin cannot invoke a sibling plugin's
+   scripts; `claude-ops` `telemetry-upsert.sh` is cited as the interim #502 home and a
+   compatible consumer — `morning-brief` reads the same surface — coupling stays
+   one-directional);
+   **durable loop state across compaction** — adaptive-cap streak counter, rate-limit-warning
+   latch, and cycle count persist in a machine-readable block of the lane's #502 telemetry
+   comment, re-read at each cycle start (conversation context alone is compaction-lossy);
+   headless-config floor (headless launch never blocks on interview: explicit/persisted config
+   or tier defaults + logged notice); subagent discipline preamble (sweep-all-disciplines +
+   use-your-skills + do-your-research); seam exit 8 (provider unavailable / secondary GitHub
+   limits under one credential) → backoff-and-retry, counted as a dirty signal for the adaptive
+   cap; drain exit evaluated against a cycle-start snapshot — new automated intake is REPORTED,
+   never chased.
+5. **Consumers + launch surfaces** — work-items `work-loop`/`attend-queue`, source-control
+   `babysit-loop`; launchable interactively via `/loop` (primary, dependency-free) or headless
+   via `claude-ops:lanes` (`prompt_dir` seam, #480 forward dependency) — lanes is a SUPPORTING
+   launcher, strictly one-directional (operator coupling directive 2026-07-23): lanes launches
+   the skills; no loop skill ever references, requires, or degrades without `claude-ops`; every
+   mention in skill bodies is guarded if-installed with the `/loop` fallback documented.
+   `autonomy` remains governing-policy pointer.
+6. **Rate-limit guard binding** — all three lanes are consumers of the shared subscription
+   windows. Operability rule (reviewer finding): an installed plugin cannot read sibling-plugin
+   files or this repo's `docs/` at runtime — each consuming skill body INLINES the operable
+   floor (tee-file path, 90% threshold, staleness rule, drain-then-pause) and cites the guard
+   reader contract for provenance only. The convention records this inline-floor rule so the
+   values stay byte-identical across consumers (fleet audit checks conformance per row).
+   Single-account-per-machine invariant (stress-test finding: tee file is last-writer-wins with
+   no account id — a mid-drain `/login` to another account feeds healthy windows to lanes on
+   the exhausted one; the guard cannot detect this, the convention says so); lane telemetry
+   records guard mode (proactive/reactive/unknown) each cycle so silent degradation is visible
+   in the #502 surface.
+
+- **Sanity Check:** `grep -c "loop-lane" docs/PLUGIN-PHILOSOPHY.md` ≥ 1 (registry row present).
+- **Sanity Check:** `test -f docs/conventions/loop-lane/README.md && test -f docs/conventions/loop-lane/CHANGELOG.md` exit 0.
+- **Sanity Check:** repo CI green on the PR (`ci-status` required check).
+- **Sanity Check:** `grep -En "plugins/(work-items|source-control|claude-ops|autonomy)/" docs/conventions/loop-lane/README.md` returns citations only in pointer form (reviewed: no restated mechanics blocks >3 lines quoting a plugin file).
+
+### Phase 3: `rate-limit-guard` plugin [TODO]
+
+Review: security
+New small plugin in claude-code-plugins. One PR. Pre-flight consumer check N/A (new surface, no
+existing consumers). Fresh-docs mandate: WebFetch statusline + hooks reference pages before
+authoring; cite URLs in the PR.
+
+| File | Action | What |
+|---|---|---|
+| `plugins/rate-limit-guard/.claude-plugin/plugin.json` | Create | manifest, semver 0.1.0, `userConfig`: hook kill switch ONLY (reviewer finding: threshold/tee-path overrides are dead config — `${user_config.*}` is plugin-scoped and cross-plugin consumers read the documented fixed values; contract path + 90% are FIXED) |
+| `plugins/rate-limit-guard/hooks/hooks.json` | Create | `StopFailure` matcher `"rate_limit"` → `record-rate-limit-stop.sh` |
+| `plugins/rate-limit-guard/hooks/record-rate-limit-stop.sh` + `.test.sh` | Create | side-effect-only detection record (hook output/exit ignored by harness — verified); test-first |
+| `plugins/rate-limit-guard/hooks/hook-utils.sh` | Create | synced copy via `scripts/sync-hook-utils.sh` (CI byte-parity gate) |
+| `plugins/rate-limit-guard/scripts/statusline-tee.sh` + `.test.sh` | Create | wraps the user's statusline command; tees stdin JSON `rate_limits` + ISO timestamp to the contract path via ATOMIC write (temp file + rename — 3+ concurrent sessions write one path; readers must never see torn JSON; Windows: rename-over-open-target can EACCES without FILE_SHARE_DELETE — retry-then-skip, and a tee failure NEVER propagates into the statusline pipeline; `.test.sh` covers the locked-target case); tees any session-distinguishing field present so a future account-id field is adopted automatically; defined no-statusline path (installs as standalone minimal statusline when none configured); Windows/Git Bash shell requirement stated in the script header and verified live (first instantiation is the operator's Windows machine); test-first |
+| `plugins/rate-limit-guard/skills/setup/SKILL.md` | Create | CHECK-ONLY setup (PLUGIN-PHILOSOPHY L270: setup must NOT mutate Claude Code user settings): `check` verifies jq, probes tee freshness (distinguishing "no statusline configured" from "wrapper missing"), and PRINTS the exact `settings.json` statusline edit for the operator to apply; surfaces the chezmoi/dotfiles tracking proposal for the operator-changed user-scope file |
+| `plugins/rate-limit-guard/reference/reader-contract.md` | Create | pause when EITHER window ≥90%, until the TRIPPED window's `resets_at` (the later `resets_at` applies only when BOTH windows trip — reviewer finding: the earlier phrasing over-pauses a 5-hour trip until the weekly reset); staleness rule (no account-id field — consumers MUST arm a session Monitor on the tee file; plugin ships no monitor config, fleet Monitors stance is "Wait" per PLUGIN-PHILOSOPHY L134); capability-detect fail-open (absent/absurd = unknown = reactive-only); drain-then-pause; fixed tee path + threshold as the operable constants consumers inline; consumer list (3 lanes) |
+| `plugins/rate-limit-guard/README.md`, `CHANGELOG.md` | Create | per repo norms |
+| `.claude-plugin/marketplace.json` | Modify | plugin entry (no version field) |
+| `scripts/skill-leaf-name-registry.txt` | Modify | register `setup` leaf if registry requires per-plugin entries (verify gate script semantics at build) |
+
+Build-time verifications (Brief "Deferred questions", arbiter: this plan): StopFailure
+`rate_limit` matcher behavior on API-key auth (empirical: forced-failure probe); statusline
+stdin schema fields present on this CLI version (live probe); shell-run fields reject
+`${user_config.*}` → exec-form args/env only (already verified; re-verify against current docs).
+
+- **Sanity Check:** `bash scripts/validate-plugins.sh` exit 0.
+- **Sanity Check:** `bash scripts/run-plugin-tests.sh` exit 0 (includes new `.test.sh` files).
+- **Sanity Check:** `bash scripts/sync-hook-utils.sh --check` exit 0.
+- **Sanity Check:** live probe — with wrapper wired, `jq -e '.rate_limits and .captured_at' <tee-file>` exit 0 after one statusline refresh.
+- **Sanity Check:** `/skill-quality:check setup` PASS.
+
+### Phase 4: work-items `work-loop` + `attend-queue` skills [TODO]
+
+Review: architecture
+Two thin-delta skills in `plugins/work-items/skills/`. One PR. Bodies invoke owned mechanics —
+never restate selection/claim/lease/dispatch/triage machinery (constraint; the seam hub
+`reference/tracker-seam.md` is read at invocation start per plugin norm).
+
+| File | Action | What |
+|---|---|---|
+| `plugins/work-items/skills/work-loop/SKILL.md` | Create | loop layer (content below) |
+| `plugins/work-items/skills/work-loop/evals/evals.json` | Create | per evals schema |
+| `plugins/work-items/skills/attend-queue/SKILL.md` | Create | attended lane (content below) |
+| `plugins/work-items/skills/attend-queue/evals/evals.json` | Create | per evals schema |
+| `plugins/work-items/CHANGELOG.md` + `.claude-plugin/plugin.json` | Modify | version bump + any new `userConfig` keys (adaptive-cap bounds) |
+| `scripts/skill-leaf-name-registry.txt` | Modify | register new leaf names (gate) |
+
+`work-loop` delta only: per-cycle intake sweep (mechanical triage via `/work-items:triage`
+autonomous lane — #459 CLOSED, autonomous mode exists); work-class gate in autonomy contract
+terms (C2 → autonomous; C3 bug-fix-shaped → autonomous, feature-shaped → human-gated (operator
+tightening, no justification needed per `admission-policy.md` L38-40); C4/C5/unclassified →
+human-gated fail-closed); adaptive item cap (start 2, +1 after 3 consecutive clean, ceiling 3,
+−1 on dirty, floor 1; no ramp while rate-limit warning live; QUOTA GUARD (operator-resolved
+2026-07-23): frontier-tier items run at concurrency 1 with adaptive ceiling 2 — the general
+ceiling 3 applies to non-frontier tiers only; composed-budget statement with
+implement-dispatch per-item wave cap — note #573: userConfig cap enforcement not yet wired,
+loop-body arithmetic is the interim enforcement); #572 workaround in-template (explicit
+`/source-control:worktree` provisioning before dispatch); escalation + telemetry + stop shapes +
+budget semantics BY CITATION to `docs/conventions/loop-lane/`; guard integration by citation to
+reader contract; exit condition = seam frontier empty ∧ every open issue closed or has active
+non-draft PR (GraphQL close-linkage per `adapters/github/README.md` L183-192); dynamic `/loop`
+pacing via ScheduleWakeup. Q18 quality-signal surfacing: verify design intent against
+`reference/pipeline-shape.md` at build (deferred-question arbiter: this plan).
+
+`attend-queue` delta only: attended poll of (a) `needs-human` role-labeled items with
+machine-marked comments, (b) untriaged intake via `/work-items:triage` attention view;
+composes `/work-items:triage` + `/planning:interview`; writes answers back as issue comments;
+flips items to `agent-ready` role label (resolved, never literal).
+
+Cross-cutting work items (both skills, reviewer findings):
+
+- Inline the guard operable floor (fixed tee path, 90% threshold, staleness rule,
+  drain-then-pause) per the convention's inline-floor rule; cite reader contract for provenance.
+- Every cross-plugin invocation (`/implementation:implement-dispatch`,
+  `/source-control:worktree`, `/planning:interview`) follows the declared-or-guarded rule +
+  seam-phrasing convention (gate + documented fallback per site) — same phrasing
+  `plugins/work-items/skills/work/SKILL.md` already uses for the same targets.
+- Naming (operator-resolved 2026-07-23): the Brief's `hitl-queue` violated the repo
+  imperative-verb rule (PLUGIN-PHILOSOPHY L41); renamed to `attend-queue` (verb-first)
+  throughout this Plan. `work-loop` is verb-first and passes.
+- Exit-condition includes the drain-terminal state (all remaining open items human-gated →
+  report + clean stop) per the Phase 2 invariant `[FALLBACK]`.
+- Admission hardening (stress-test findings — the C3 classifier is the loop that benefits from
+  admitting the item): (a) instantiation-level path/topic HARD GATE — any item touching SHA
+  pins, checksums, or ci-workflows CLAUDE.md ground-rule surfaces is human-gated regardless of
+  classification (the tool-version-drift advisories surface-read as C2 dep bumps but are
+  trust-on-first-download checksum recomputation on security-critical pins, operator-owned per
+  ci-workflows CLAUDE.md L52-58); (b) triage author-rule: workflow-bot-authored advisory issues
+  → `needs-human` by default (also makes drain exits terminate against automated intake);
+  (c) HITL ratifies every C3-autonomous admission for the first full drain (operator-adopted
+  2026-07-23; earn-trust posture).
+
+- **Sanity Check:** `/skill-quality:check work-loop` PASS and `/skill-quality:check attend-queue` PASS.
+- **Sanity Check:** `bash scripts/validate-plugins.sh` exit 0 (evals schema, leaf-name, catalog gates).
+- **Sanity Check:** `grep -c "conventions/loop-lane" plugins/work-items/skills/work-loop/SKILL.md` ≥ 1 and same for `attend-queue` (convention cited, not restated).
+- **Sanity Check:** `grep -En "claude-(opus|sonnet|haiku|fable)-[0-9]" plugins/work-items/skills/{work-loop,attend-queue}/SKILL.md` returns empty (no hard-coded model IDs; tiers only).
+
+### Phase 5: ci-workflows tracker binding [TODO]
+
+One PR to ci-workflows. Pre-flight consumer check (contract surface = new tracked file): grep
+ci-workflows workflows/scripts for `.work-item-tracker.json` readers — none expected (file is
+new; seam tooling is the only reader).
+
+| File | Action | What |
+|---|---|---|
+| `ci-workflows/.work-item-tracker.json` | Create | `{"schema_version":"1.0","provider":"github","config":{"lease_ttl_hours":24}}` (role_labels omitted → canonical defaults `agent-ready`/`needs-human`/`recurring` with loud warning; defaults match the org label taxonomy) |
+
+Phase-entry checks: (a) `gh label list -R melodic-software/ci-workflows --limit 100` — confirm
+`agent-ready`, `needs-human`, `recurring` exist; any missing label → STOP, route a `github-iac`
+Pulumi PR first (label set is IaC-owned; never `gh label create`). (b) worker commit signing vs
+`required_signatures` ruleset: RESOLVED by live verification during the stress-test — the
+`signing` ruleset targets the default branch only, `base` allows squash as the sole merge
+method, and GitHub web-flow signs API-created squash commits; worker feature-branch commits sit
+outside the ruleset's ref scope. Retain a one-command build-time confirmation as a formality.
+
+- **Sanity Check:** seam `capabilities` verb exit 0 in the ci-workflows checkout, and
+  `list-frontier --autonomous` exit 0 returning a JSON envelope (the `health` verb does not
+  exist — verified against `CONTRACT.md` verb table).
+- **Sanity Check:** two-session claim race — CONCURRENT, not sequential (stress-test finding:
+  sequential A-then-B passes even with a wide race window): fire both `claim <id>` calls in
+  parallel; exactly one exits 0 and one exits 7, OR the residual is documented (GitHub comment
+  listing propagation window — consequence is a duplicate PR, recoverable, caught by
+  babysit/HITL; a jittered delay before the lease re-read shrinks it cheaply).
+
+### Phase 6: standards lease-activation PR draft [TODO]
+
+Prepare (never file) the standards change editing `conventions/process/issue-tracker.md` L37
+block: record activation of assignee+lease claiming (trigger met: autonomous multi-worker
+contention is now real), point at work-items `tools/work-item-tracker/CONTRACT.md` lease
+protocol as the mechanism, retire the interim 🔒 marker text. "Never auto-filed" (Brief goal 4)
+means: the session pushes the branch + prepares the PR body file and notifies the operator; NO
+`gh pr create` is executed by the session or any lane — the operator files and merges.
+
+- **Sanity Check:** branch exists on origin (`git ls-remote --heads origin <branch>` non-empty),
+  PR body file present in the topic slice, operator notified in the session report;
+  `gh pr list -R melodic-software/standards --head <branch>` returns EMPTY (nothing auto-filed).
+
+### Phase 7: attended triage + launch + drain [TODO]
+
+1. Attended triage pass (operator present) over live untriaged intake via `/work-items:triage`
+   attention view — 10 zero-label issues at plan time (Brief said 14; count drifted, use live).
+2. Launch three lanes: `work-loop` + `attend-queue` + babysit (babysit-PLAN Phase B3). Launch
+   surface `[FALLBACK — confirm or override]`: FIRST cycle attended via interactive `/loop`
+   (observability); unattended operation then moves to `claude-ops:lanes` (background named
+   sessions) so budget-hit restart-requests have a launcher to act on them — reviewer finding:
+   an interactive `/loop` with nobody watching turns a #691 budget-hit into a silent drain
+   stall. Until lanes-managed, the stall risk is documented in the lane report.
+   PHASE-ENTRY GATE before any lanes migration (stress-test finding: statusline is verified
+   interactive-only): verify statusline execution + tee freshness under ONE `--bg`
+   lanes-launched probe session. If `--bg` sessions do not tee, either keep one attended anchor
+   session alive (one machine, one tee file serves all readers) or defer the migration and
+   document unattended operation as reactive-only.
+3. Drain to exit condition; final report lists items closed / PR'd / escalated (acceptance
+   criterion).
+
+- **Sanity Check:** `gh issue list -R melodic-software/ci-workflows --state open --json number,labels` — zero items lacking triage outcome (every open item labeled or role-labeled).
+- **Sanity Check:** exit-condition query — seam `list-frontier --autonomous` returns empty AND
+  every remaining open issue has an OPEN close-linked PR (GraphQL probe) OR carries the
+  `needs-human` role label (drain-terminal state, per the Phase 2 `[FALLBACK]` invariant).
+- **Sanity Check:** guard behavior observed once: pause log entry at ≥90% or explicit
+  reactive-only declaration on non-subscription auth; AND one resume observed without operator
+  action after a `resets_at` passes (acceptance criterion covers resume, not just pause — if no
+  window trips during the drain, record a synthetic tee-file probe: back-dated `resets_at`
+  unpauses the loop).
+- **Sanity Check:** one live `attend-queue` exercise: attention view lists ≥1 escalated +
+  untriaged item in ONE view during the attended pass (acceptance criterion), captured in the
+  session report.
+
+Deferred acceptance criterion (explicit, with trigger): "second-repo adoption = one binding PR
+\+ three sessions; zero plugin edits" is verifiable only when a second repo adopts — deferred to
+that trigger (Brief "Deferred questions": multi-repo scale-out, USER-RESERVED).
+
+## Blast radius
+
+HIGH — new org-wide convention constraining all future lanes; new plugin with hooks + user-scope
+statusline wiring (affects every session on the machine); autonomous PR authorship + (via babysit)
+merges in an org repo with an org credential; multiple stress-test triggers match (infrastructure,
+new conventions/enforcement, cross-plugin architecture, security-sensitive). Formal stress-test
+REQUIRED.
+
+## Stress-test summary
+
+Two independent fresh-context rounds (2026-07-23):
+
+- **Plan reviewer** (Step 3): 1 CRITICAL / 11 IMPORTANT / 5 SUGGESTION — all verified against
+  sources and fixed in place. Clusters: rate-limit-guard seam doctrine (setup must not mutate
+  user settings; operable floors must be inlined, not cited; dead userConfig; atomic tee;
+  pause-window semantics) and unattended-termination realism (drain-terminal state, restart
+  owner, compaction-durable loop state). Also: `health` verb didn't exist (→ `capabilities`),
+  topic-docs contract kinds, naming grammar, Phase 6 filing ambiguity.
+- **/devils-advocate** (Step 4): 2 CRITICAL / 3 HIGH / 6 MEDIUM / 2 LOW. Must-fix all applied
+  or routed to operator: merge-authority contradiction with the autonomy matrix (→ Open
+  Decision 5); babysit autopilot premise invalidated post-launch (→ Open Decision 6, babysit
+  PLAN); `--bg` statusline tee verification gate (Phase 7); C3 self-classification hardening
+  (Phase 4 path/topic gate + bot-author triage rule + HITL ratification period); quota
+  economics surfaced (Open Decision 7). MEDIUMs absorbed as documentation-pass items across
+  Phases 2/3/5. LOW #12 (squash-merge satisfies `required_signatures`) was VERIFIED LIVE
+  during the stress-test — signing ruleset targets the default branch only, squash is the only
+  allowed merge method, GitHub web-flow signs API squash commits; Phase 5's build-time
+  confirmation retained as a formality.
+- One research-iterate round sufficed; no unresolved CRITICAL/HIGH remains outside the three
+  operator decisions.
+
+## Execution shape
+
+Phases are PR-boundary-sequential on the critical path; one genuine parallel opportunity:
+
+| Phase | Surface | Basis |
+|---|---|---|
+| 1 | main-session | mechanical move + branch setup, trivial |
+| 2 | main-session | judgment-heavy convention authoring; playbook-governed |
+| 3 | main-session (+ fresh-context review sub-agents) | security-sensitive plugin; test-first scripts |
+| 4 | main-session (+ fresh-context review sub-agents) | skill authoring, playbook-governed |
+| 5 | main-session | small config PR + live race test needs two sessions (second is a sub-agent/worktree session) |
+| 6 | main-session | operator-routed draft |
+| 7 | main-session, operator present | attended triage + launch |
+
+Dependency graph: 1 → 2 → {3, 4} → 5 → 7; 6 independent after 5's lease mechanism proves out;
+babysit-PLAN B1/B2 parallel-safe with Phase 4 (disjoint plugin dirs), B3 joins at 7.
+Wave option after Phase 2 merges: Phase 3 ∥ Phase 4 ∥ babysit B1+B2 (file-disjoint across
+`plugins/rate-limit-guard/`, `plugins/work-items/`, `plugins/source-control/`) — material saving
+if run as parallel sessions/agents; cost: 3 concurrent build agents multiply tokens. Default
+recommendation: sequential 3 → 4 in one session (shared fresh-docs fetches amortize), babysit
+B1/B2 in the operator's parallel session per succession note. Sequential fallback: if any
+parallel build session reports scope-fence violation or cross-plugin edit, abort it and fold the
+work into the main session sequentially.
+
+## Open questions
+
+None — all seven approval-round decisions resolved by the operator 2026-07-23:
+
+1. Telemetry comment home → per-lane tracking issue in the TARGET repo (ci-workflows);
+   convention doc records it at Phase 2. (Operator: "rest makes sense".)
+2. Naming → renamed `hitl-queue` to `attend-queue` (verb-first) throughout the Plan.
+3. Drain-terminal stop shape → adopted (modifies briefed exit condition).
+4. Unattended launch surface → adopted: attended `/loop` first cycle, then `claude-ops:lanes`
+   gated on the `--bg` tee probe — with the operator's coupling caveat encoded: lanes is a
+   supporting, one-directional launcher; loop skills never depend on claude-ops (guarded
+   if-installed, `/loop` fallback documented).
+5. Merge authority → configurable autonomy ladder; shipped default = human merge for all but
+   gate-proven bot/C2 mechanical PRs; higher rungs (through full autonomy with frontier
+   subagents driving to merge) opt-in via tracked-config flip = the matrix's recorded
+   human-ratified promotion.
+6. Babysit tier for ci-workflows → WORKER (autopilot premise invalidated post-launch).
+7. Quota economics → frontier concurrency 1 + adaptive ceiling 2 for frontier items (general
+   ceiling 3 for other tiers).
+
+## Handoff to implementation
+
+### User-approval gates
+
+- Phase 5 phase-entry (a): any missing role label → STOP; github-iac Pulumi PR is operator work.
+- Phase 6: draft PR routed to operator; no lane files or merges it.
+- Phase 7 launch: operator present for triage; lane launch is operator-initiated.
+- `[FALLBACK]` rows in the decisions table (presentation) — confirm or override before the
+  affected phase starts.
+
+### Execution shape ([EXEC-SHAPE] tagged)
+
+- [EXEC-SHAPE] Sub-topic promotion DECLINED: PR-boundary phases already give independent commit
+  boundaries; the two-track split (two PLAN files) is the operative decomposition; a third level
+  would scatter the contract. Evidence: topic-docs convention supports multi-file slices.
+- [EXEC-SHAPE] #691 implementation shape: budget-hit emits restart-request telemetry + clean loop
+  stop; restart is launcher/operator-initiated. Evidence: `claude-ops` lanes SKILL.md verified
+  behavior — a running loop cannot `/clear` or restart itself.
+- [EXEC-SHAPE] Lane prompts are one-line skill invocations stored via the `claude-ops` lanes
+  `prompt_dir` seam (`.work`, #480 forward dependency) — no new prompt storage built.
+- [EXEC-SHAPE] Phase ordering 3 → 4 sequential in one session; babysit track parallel per
+  succession note. Scope fences = plugin directory boundaries listed per phase.
+
+### Mechanical work
+
+- One PR per phase (2, 3, 4, 5, 6); commit convention per claude-code-plugins norms; topic docs
+  ride build branches; phase tags advanced in PLAN.md as each completes.
+- Verification checkpoints: repo CI (`ci-status`) green per PR; `skill-quality:check` per new
+  skill; fresh-context review sub-agent before each PR (producer ≠ critic).
+- Close-out at final PR: `/planning:plan close-out` (publish PLAN to PR, graduate ADR candidates
+  — the loop-lane convention itself is the durable doc; prune the contract slice).

--- a/docs/topics/ci-workflows-work-loop/babysit-PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/babysit-PLAN.md
@@ -1,0 +1,289 @@
+# babysit-loop (source-control lane) — Brief (partial)
+
+Authored by the BABYSIT session, now terminated. SUCCESSION: the
+work-loop session owns this track — absorb the alignment notes,
+drive the open questions to decisions with the operator (done:
+Q13–Q15 + HITL probe locked below; the interim
+`babysit-open-questions.md` was folded in and deleted), finalize
+this Brief, and carry it into planning alongside the work-loop
+Brief. Ledger with all grounding facts:
+`babysit-interview-checklist.md` (same dir). The babysit skill build
+(`/source-control:babysit-loop`) then proceeds wherever the operator
+runs it; nothing else lives only in the dead session.
+
+## Brief
+
+**TLDR**: Reusable `/source-control:babysit-loop <owner/repo> [flags]`
+skill in the source-control plugin — the babysit lane of the
+3-session topology. Wraps `/source-control:babysit-prs` in a
+standing/drain loop with configurable autonomy dimensions;
+ci-workflows (drain mode, autopilot) is the first instantiation.
+
+### Goal
+
+1. New skill `/source-control:babysit-loop` in the source-control
+   plugin (`melodic-software/claude-code-plugins`): loop layer over
+   babysit-prs — stop conditions, self-paced cadence with idle
+   backoff, cycle-budget restart semantics, lane telemetry, subagent
+   discipline preamble, autonomy-dimension configuration.
+2. Shared cross-plugin loop-lane convention (see Placement below).
+3. ci-workflows instantiation: `--drain` autopilot loop scoped to
+   `melodic-software/ci-workflows`.
+
+### Decisions locked (babysit interview Q1–Q12)
+
+- Tier for ci-workflows: **autopilot** (only open PRs are
+  bot-authored; safe/worker find zero). Draft elevation + barrier
+  clearing in scope; fable subagents for conflicts/blockers; every
+  subagent runs /re-anchor:sweep-all-disciplines +
+  /re-anchor:use-your-skills + /re-anchor:do-your-research.
+- Scope: repo-only per invocation (repo is the skill's required arg).
+- do-not-merge label: respected by default; strip only behind
+  explicit override flag.
+- Stop modes: default **standing** (idle backs off toward 1h
+  wakeups; no activity-timeout stop); `--drain` stops at 0 open PRs
+  AND 0 open issues. ci-workflows uses `--drain`.
+- Pacing: dynamic self-paced /loop (matches work-loop Q1).
+- Sequencing: build skill first, then launch the lane through it.
+- Concurrency safety (3-session topology): activity grace window
+  (default 30 min) — never elevate/resolve/merge a PR whose head
+  moved or received comments inside the window; never elevate a
+  draft carrying a WIP signal (title marker, do-not-merge label,
+  non-green checks). Existing babysit-prs yield-on-head-move +
+  foreign_activity discipline retained.
+- Cycle budget: adopt #691 resolution (a) — budget restarts the
+  SESSION, never ends the LOOP.
+- Telemetry: lane edits its one #502-style status comment per cycle
+  (convention material, see Placement).
+
+### Decisions locked (rounds Q13–Q15 + probe, operator-confirmed 2026-07-23)
+
+- Q13 config model: tier presets + per-dimension overrides. Interactive session with
+  ambiguous/absent config → AskUserQuestion mini-interview, then offer to persist. Headless
+  launch never blocks: resolved config (args or persisted) or tier defaults + logged notice.
+- Q14 persistence: new keys on the layered `source-control.md` seam (user-global → repo tracked →
+  local overlay; per-key merge per `reference/config-resolution.md`); invocation args win. Both
+  loop lanes cite the same consumer-config-layering registry row.
+- Q15 autonomy-dimension contract: dimensions 1–7 (discovery scope, fixing, thread resolution,
+  draft elevation, barrier overrides, merge, escalation) + always-on safety knobs (grace window,
+  yield-on-head-move, no-monitor clause, watched-owner boundary) + loop knobs (standing vs drain,
+  #691 cycle budget, #502 telemetry). Tiers = named presets over the dimensions. Per-bot
+  allowlists / per-check policies deferred post-V1.
+- HITL escalation (dimension 7 default): reuse the loop-lane escalation contract — tracker item
+  with `needs-human` role label + machine-marked comment (HITL session polls that surface);
+  telemetry remains the report channel, never the sole escalation path when human action is
+  required.
+
+### Placement finding — RECONCILED (work-loop session, 2026-07-23)
+
+Work-loop session AGREES: shared concerns move to `docs/conventions/loop-lane/` + registry row;
+work-loop Brief goal 1b now owns that deliverable; the in-plugin reference-doc plan is retracted.
+Alignment notes below are absorbed into the work-loop Brief. Remaining open here: Q13–Q15 + HITL
+probe (put to operator as work-loop interview round 6).
+
+### Original finding (babysit session)
+
+`docs/PLUGIN-PHILOSOPHY.md`: sibling-plugin file imports are
+defects; "a new cross-plugin convention lands in an owner doc
+before a second plugin adopts it" (convention registry,
+`docs/conventions/<concern>/`).
+
+Work-loop Brief currently puts the shared reference doc (escalation
+contract, 3-session topology, model-routing capability tiers) INSIDE
+the work-items plugin. The babysit lane lives in source-control and
+cannot read work-items files — the moment source-control adopts the
+topology/escalation/tier language, those concerns are cross-plugin
+and must move to a repo-level convention owner doc (e.g.
+`docs/conventions/loop-lane/`) with a registry row. Proposed split:
+
+- `docs/conventions/loop-lane/` — 3-session topology, escalation
+  contract, capability tiers (IDs live-resolved), loop-layer
+  invariants: stop shapes, cycle-budget/#691 semantics, idle
+  backoff, #502 telemetry comment, headless-config floor, subagent
+  discipline preamble.
+- work-items keeps only work-lane-specific mechanics; source-control
+  keeps only babysit-specific mechanics; both cite the convention.
+- autonomy plugin: governing policy pointer (guardrail matrix), not
+  a mechanics home. Compatible with runner.md interim-executor
+  framing and future #480 consumption.
+
+### Alignment notes for absorption
+
+- Topology tier wording: work-loop Brief says "babysit (worker
+  tier) merges". Correct the topology doc to: worker-loop never
+  merges; babysit lane owns merges at a merge-capable tier — worker
+  minimum, autopilot where bot PRs are in scope (ci-workflows case).
+- rate-limit-guard: babysit-loop is a third consumer of the shared
+  subscription windows — it must integrate the same guard contract
+  (pause new work ≥90%, drain-then-pause). Add source-control lane
+  to the guard's consumer list.
+- Exit-condition composition: babysit `--drain` (0 PRs AND 0 issues)
+  intentionally outlives work-loop's exit (all issues closed or
+  PR'd) — babysit finishes merging the tail.
+- Model routing: babysit subagent defaults (fable for
+  conflict/blocker resolution per operator directive) should be
+  expressed in the shared capability-tier vocabulary, not hardcoded
+  model names.
+- #502 telemetry + #691 cycle-budget semantics absent from work-loop
+  Brief — both lanes need them; convention doc is the home.
+
+## Plan
+
+### Standards grounding
+
+Same resolution as the sibling work-loop PLAN (no standards index anywhere; rung 4/6 inference —
+see `PLAN.md` "Standards grounding" table; additional surfaces below):
+
+| Surface | Source | Provenance |
+|---|---|---|
+| Babysit mechanics | `plugins/source-control/skills/babysit-prs/SKILL.md` (tier matrix L98-107, guarded wrappers L185-238, userConfig surface L281-316), `reference/loop.md` (cadence L426-454, HEAD gates L132-176) | team (repo) |
+| Config seam | `plugins/source-control/reference/config-resolution.md` (layered `source-control.md`, per-key merge L68-93); `docs/conventions/consumer-config-layering/README.md` (implementers row L203) | team (repo) |
+
+### Dependencies
+
+- Consumes work-loop PLAN Phase 2 (`docs/conventions/loop-lane/` — topology, escalation,
+  tiers, stop shapes, #691/#502 semantics, headless-config floor) and Phase 3
+  (`rate-limit-guard` reader contract). B1/B2 start after Phase 2 merges; B3 additionally
+  after Phase 3 and work-loop Phase 5 (tracker binding, for the escalation surface).
+- Grounding fact shaping B1: existing babysit-prs config is NATIVE plugin `userConfig`
+  (`${user_config.babysit_*}`, user-settings-scoped) — it cannot express repo-scoped lane
+  config (drain vs standing is a property of the target repo). Q14's layered
+  `source-control.md` seam is therefore the correct home for LOOP keys; per-user babysit_*
+  keys stay where they are. The two surfaces coexist; B1 documents the split.
+
+### Phase B1: loop config keys on the layered seam [TODO]
+
+One PR to claude-code-plugins (may share a branch with B2).
+
+| File | Action | What |
+|---|---|---|
+| `plugins/source-control/reference/config-resolution.md` | Modify | widen scope statement beyond the commit-subject convention; add loop-lane key table: `babysit_loop_stop_mode` (standing\|drain), `babysit_loop_tier_preset`, per-dimension override keys (dimensions 1–7), `babysit_loop_grace_window_minutes` (default 30), `babysit_loop_cycle_budget`; precedence: invocation args win over all layers; per-key merge unchanged |
+| `docs/conventions/consumer-config-layering/README.md` | Modify | update source-control implementers row: both loop lanes cite the row (Q14) |
+
+Key-name shapes above are working names — final names follow the seam's existing conventions at
+build time.
+
+- **Sanity Check:** `grep -ci "stop.mode\|standing\|drain" plugins/source-control/reference/config-resolution.md` ≥ 2 (loop-key table present — concept-level check; literal key names are working names subject to seam conventions).
+- **Sanity Check:** `grep -c "loop" docs/conventions/consumer-config-layering/README.md` ≥ 1 (row updated).
+- **Sanity Check:** repo CI green.
+
+### Phase B2: `/source-control:babysit-loop` skill [TODO]
+
+Review: architecture
+One PR (or same PR as B1). Thin loop layer over `/source-control:babysit-prs` — never restates
+its tier matrix, guarded wrappers, or safety discipline; invokes it per cycle with the resolved
+tier + scope.
+
+| File | Action | What |
+|---|---|---|
+| `plugins/source-control/skills/babysit-loop/SKILL.md` | Create | loop layer (content below) |
+| `plugins/source-control/skills/babysit-loop/evals/evals.json` | Create | per evals schema |
+| `plugins/source-control/CHANGELOG.md` + `.claude-plugin/plugin.json` | Modify | version bump |
+| `scripts/skill-leaf-name-registry.txt` | Modify | register `babysit-loop` leaf (gate) |
+
+SKILL.md delta only: required arg `<owner/repo>`; config resolution per B1 (args → layered seam
+→ tier defaults; interactive ambiguity → AskUserQuestion mini-interview + offer to persist;
+headless never blocks — resolved config or tier defaults + logged notice, per convention
+headless-config floor); stop modes (default standing with idle backoff toward 1h wakeups;
+`--drain` stops at 0 open PRs AND 0 open issues — intentionally outlives work-loop's exit);
+autonomy-dimension contract (dimensions 1–7 + always-on safety knobs + loop knobs; tiers =
+named presets; dimension 6 (merge) shipped default = human merge for everything except
+gate-proven bot/C2 mechanical PRs, higher rungs opt-in per the autonomy ladder — a
+tracked-seam config edit is the recorded human-ratified promotion (work-loop PLAN Phase 2
+item 1); per-bot allowlists deferred post-V1); concurrency safety (30-min activity grace
+window — never elevate/resolve/merge a PR whose head moved or received comments inside it;
+never elevate a draft carrying WIP signals; babysit-prs yield-on-head-move + foreign-activity
+discipline retained by citation); #691 (a) + #502 telemetry + escalation (dimension 7 default:
+tracker item with `needs-human` role label + machine-marked comment) BY CITATION to
+`docs/conventions/loop-lane/`; guard reader-contract integration (third consumer);
+do-not-merge respected by default, strip only behind explicit override flag; subagent
+discipline preamble + capability-tier vocabulary for conflict/blocker subagents (frontier tier
+per operator directive — expressed as tier, never model name); dynamic `/loop` pacing via
+ScheduleWakeup within [60,3600]s clamp (cite loop.md cadence table; `/schedule` for daily-scale
+cadence).
+
+Cross-cutting work items (reviewer findings, mirrors work-loop Phase 4): inline the guard
+operable floor (fixed tee path, 90% threshold, staleness, drain-then-pause) — cite reader
+contract for provenance only (installed plugins cannot read sibling-plugin or repo docs at
+runtime); `--drain` exit includes the drain-terminal state (0 open PRs AND 0 open issues OR all
+remaining open items human-gated → report + clean stop) per the loop-lane convention
+`[FALLBACK]` invariant; durable loop state (cycle count, backoff level) persists in the #502
+telemetry block; every cross-plugin reference (guard, loop-lane vocabulary) declared-or-guarded
+per seam phrasing. Naming: `babysit-loop` is verb-first — passes the grammar rule.
+
+- **Sanity Check:** `/skill-quality:check babysit-loop` PASS.
+- **Sanity Check:** `bash scripts/validate-plugins.sh` exit 0.
+- **Sanity Check:** `grep -c "conventions/loop-lane" plugins/source-control/skills/babysit-loop/SKILL.md` ≥ 1 and `grep -c "babysit-prs" ...` ≥ 1 (cites both owners).
+- **Sanity Check:** `grep -En "claude-(opus|sonnet|haiku|fable)-[0-9]" plugins/source-control/skills/babysit-loop/SKILL.md` returns empty (tier vocabulary only).
+
+### Phase B3: ci-workflows drain instantiation [TODO]
+
+Launch through the skill (sequencing decision: build first, then launch through it):
+`/source-control:babysit-loop melodic-software/ci-workflows --drain` at **WORKER tier**
+(operator-resolved 2026-07-23, superseding the interview-time autopilot pick: that premise —
+"only open PRs are bot-authored" — is invalidated the moment work-loop ships PRs, and the bot
+case (standards-sync) is already covered by native armed auto-merge, #213). The lane's
+justification is barrier clearing + draft elevation + gate-proven merges of own/bot PRs;
+security/posture blockers stay hard escalations. Higher rungs up to full autonomy (frontier
+subagents resolving conflicts/comments and driving to merge) are reachable via the
+autonomy-ladder config on the tracked seam (work-loop PLAN Phase 2 item 1) — each raise is a
+recorded human-ratified flip; merge scope bounded by the matrix reconciliation (C3 → human
+merge unless flipped). First cycle observed attended; telemetry comment = per-lane tracking
+issue in ci-workflows (operator-resolved).
+
+- **Sanity Check:** first-cycle report shows tier=worker, mode=drain, grace-window active;
+  no merge performed on any PR with head activity inside the grace window (report assertion).
+- **Sanity Check:** lane telemetry comment exists and is EDITED (not duplicated) on second
+  cycle — `gh api` comment count for the marker returns 1.
+- **Sanity Check:** drain exit observed or standing correctly backing off (ScheduleWakeup
+  delays growing toward 3600s in the report) when queue empty.
+
+## Blast radius
+
+HIGH — autonomous merge authority (autopilot) in an org repo; shares the org-wide loop-lane
+convention; config-seam widening touches a cross-plugin registry row. Rides the work-loop
+PLAN's formal stress-test (single Step 4 run covers both tracks; findings recorded in both).
+
+## Stress-test summary
+
+Shared Step 3/4 run with the work-loop PLAN (see its "Stress-test summary" for the full
+ledger). Babysit-specific outcomes: tier re-opened (B3 — autopilot → recommended worker, Open
+Decision 6); merge scope bounded by the autonomy matrix reconciliation (Open Decision 5);
+drain exit hardened (snapshot semantics + drain-terminal state + bot-author triage rule make
+exit reachable against automated intake); guard floors inlined; `--bg` tee verification gates
+any unattended migration.
+
+## Execution shape
+
+| Phase | Surface | Basis |
+|---|---|---|
+| B1 | main-session | small doc/config PR, judgment on seam wording |
+| B2 | main-session (+ fresh-context review sub-agent) | skill authoring, playbook-governed |
+| B3 | main-session, operator present first cycle | launch + observation |
+
+Sequential B1 → B2 → B3; parallel-safe with work-loop Phases 3–4 (disjoint plugin dirs) per the
+work-loop PLAN execution shape. Scope fence: `plugins/source-control/` +
+`docs/conventions/consumer-config-layering/README.md` only.
+
+## Open questions
+
+(none beyond the shared telemetry-home question — work-loop PLAN "Open questions" 1)
+
+## Handoff to implementation
+
+### User-approval gates
+
+- B3 launch is operator-initiated; autopilot tier confirmed per interview but the FIRST cycle
+  runs attended.
+- Any strip of a do-not-merge label requires the explicit override flag — never default.
+
+### Execution shape ([EXEC-SHAPE] tagged)
+
+- [EXEC-SHAPE] B1+B2 may share one PR/branch (same plugin, one reviewable unit). Evidence:
+  plugin norms — config seam + consuming skill land together elsewhere in the plugin's history.
+- [EXEC-SHAPE] Working key names in B1 subject to seam naming conventions at build.
+
+### Mechanical work
+
+- Commit convention per repo norms; CI green per PR; fresh-context review before the PR;
+  phase tags advanced here as work completes; close-out shared with work-loop PLAN.

--- a/docs/topics/ci-workflows-work-loop/babysit-PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/babysit-PLAN.md
@@ -157,7 +157,7 @@ One PR to claude-code-plugins (may share a branch with B2).
 
 | File | Action | What |
 |---|---|---|
-| `plugins/source-control/reference/config-resolution.md` | Modify | widen scope statement beyond the commit-subject convention; add loop-lane key table: `babysit_loop_stop_mode` (standing\|drain), `babysit_loop_tier_preset`, per-dimension override keys (dimensions 1–7), `babysit_loop_grace_window_minutes` (default 30), `babysit_loop_cycle_budget`; precedence: invocation args win over all layers; per-key merge unchanged |
+| `plugins/source-control/reference/config-resolution.md` | Modify | widen scope statement beyond the commit-subject convention; add loop-lane key table: `babysit_loop_stop_mode` (standing\|drain), `babysit_loop_tier_preset`, per-dimension override keys (dimensions 1–7), `babysit_loop_grace_window_minutes` (default 30), `babysit_loop_cycle_budget`; precedence: invocation args win over all layers, EXCEPT dimension 6 (merge) where an argument may only select a lower rung — merge-rung raises bind only from the tracked seam config, per the loop-lane convention's "Merge-rung raises are seam-only" rule; per-key merge unchanged |
 | `docs/conventions/consumer-config-layering/README.md` | Modify | update source-control implementers row: both loop lanes cite the row (Q14) |
 
 Key-name shapes above are working names — final names follow the seam's existing conventions at

--- a/docs/topics/ci-workflows-work-loop/babysit-PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/babysit-PLAN.md
@@ -188,7 +188,9 @@ headless-config floor); stop modes (default standing with idle backoff toward 1h
 `--drain` stops at 0 open PRs AND 0 open issues — intentionally outlives work-loop's exit);
 autonomy-dimension contract (dimensions 1–7 + always-on safety knobs + loop knobs; tiers =
 named presets; dimension 6 (merge) shipped default = human merge for everything except
-gate-proven bot/C2 mechanical PRs, higher rungs opt-in per the autonomy ladder — a
+gate-proven C2-mechanical PRs (a work-class test irrespective of author; bot authorship
+alone never qualifies, per the loop-lane convention), higher rungs opt-in per the autonomy
+ladder — a
 tracked-seam config edit is the recorded human-ratified promotion (work-loop PLAN Phase 2
 item 1); per-bot allowlists deferred post-V1); concurrency safety (30-min activity grace
 window — never elevate/resolve/merge a PR whose head moved or received comments inside it;

--- a/docs/topics/ci-workflows-work-loop/design/design-resolution.md
+++ b/docs/topics/ci-workflows-work-loop/design/design-resolution.md
@@ -17,7 +17,11 @@ Design threads and their resolutions live in:
 
 - `../PLAN.md` Brief (goals 1/1b/2/3/4, constraints, deferred questions with arbiters)
 - `../babysit-PLAN.md` Brief (Q1–Q15 + HITL probe, placement reconciliation)
-- Rationale ledgers: `../interview-checklist.md`, `../babysit-interview-checklist.md`
+
+The full rationale ledgers (`interview-checklist.md`, `babysit-interview-checklist.md`) are
+session-local working state in the gitignored `.work` memory slice, deliberately not part of this
+tracked contract slice. The durable do-not-relitigate record travels with the slice instead: the
+"Stress-test summary" and "Open questions" sections of `../PLAN.md` and `../babysit-PLAN.md`.
 
 A separate `/planning:design` pass would re-derive contracts the operator already confirmed
 (handoff marks them do-not-relitigate). The handoff's operator-confirmed next step routes

--- a/docs/topics/ci-workflows-work-loop/design/design-resolution.md
+++ b/docs/topics/ci-workflows-work-loop/design/design-resolution.md
@@ -1,0 +1,24 @@
+---
+outcome: early-exit
+date: 2026-07-23
+topic: ci-workflows-work-loop (work-loop + babysit tracks)
+---
+
+# Design resolution — early exit
+
+Tier assessment: deliverables are skill bodies (markdown), a repo-level convention doc + registry
+row, one small hook/statusline plugin (`rate-limit-guard`), and a repo config file
+(`.work-item-tracker.json`). No new programmatic types or package topology; the cross-plugin
+contracts (escalation contract, capability-tier vocabulary, loop-layer invariants, guard
+reader contract, `source-control.md` config keys) were resolved as interview threads across 6
+rounds + 2 discipline sweeps and are locked in the two Briefs.
+
+Design threads and their resolutions live in:
+
+- `../PLAN.md` Brief (goals 1/1b/2/3/4, constraints, deferred questions with arbiters)
+- `../babysit-PLAN.md` Brief (Q1–Q15 + HITL probe, placement reconciliation)
+- Rationale ledgers: `../interview-checklist.md`, `../babysit-interview-checklist.md`
+
+A separate `/planning:design` pass would re-derive contracts the operator already confirmed
+(handoff marks them do-not-relitigate). The handoff's operator-confirmed next step routes
+directly to `/planning:plan` over both Briefs — that instruction is the accepted skip.


### PR DESCRIPTION
## Summary

Phases 1 and 2 of the ci-workflows-work-loop plan: land the shared loop-lane convention before its
second adopter, and move the plan's Briefs into the tracked topic-docs contract slice.

- `docs/conventions/loop-lane/` (new owner doc + CHANGELOG 1.0.0) fixes the contract shared by every
  loop lane across two plugins — the `work-items` `work-loop`/`attend-queue` skills and the
  `source-control` `babysit-loop` skill — so those cross-plugin concerns live in a marketplace-level
  owner doc rather than a sibling-plugin import, per the PLUGIN-PHILOSOPHY convention-registry rule
  (the owner doc lands before the second adopter). Six contract sections: three-session topology with
  a human-merge-default autonomy ladder; the `needs-human` escalation contract; order-defined
  capability tiers (frontier/strong/fast) resolved by model alias only; loop-layer invariants (stop
  shapes with a drain-terminal state, #691 session-restart budget, #502 single edit-in-place
  telemetry comment with compaction-durable loop state, headless-config floor, seam exit 8, snapshot
  drain exit); consumers and launch surfaces (`/loop` primary and dependency-free, `claude-ops`
  `lanes` a one-directional supporting launcher); and the rate-limit-guard inline-floor binding with
  the single-account-per-machine invariant.
- One registry row added to `docs/PLUGIN-PHILOSOPHY.md` — names and points, does not restate.
- `docs/topics/ci-workflows-work-loop/` (contract slice, `contract_tier: branch`) carries faithful
  copies of the plan's two Briefs and the design-resolution gate file; the Phase 1 and Phase 2 status
  tags are advanced to DONE. These files are pruned before the plan's final merge, per the topic-docs
  lifecycle.

Pointer-not-copy throughout: each cited mechanic is a link plus a short summary, never a restated
mechanics block. No hard-coded model IDs — capability tiers are order-defined and resolved at runtime
by model alias; the weekly-usage-cap specifics are linked to the official support article, never
named as fact. Live Claude Code surfaces (model aliases, `ScheduleWakeup` bounds, `/loop`
self-pacing) were verified against current official documentation on 2026-07-23, per the repo
fresh-docs mandate.

No linked issue — the plan is tracked in the topic slice, and the `#NNN` references in the docs are
ci-workflows issues, not this repo's.

## Test plan

- markdownlint-cli2 (repo `.markdownlint-cli2.jsonc`): 0 issues across all changed docs. Five
  pre-existing markdown defects in the copied `PLAN.md` (never linted while it lived in gitignored
  `.work`) were fixed by escaping markdown-significant characters and stripping one trailing space —
  content preserved.
- Two sanctioned divergences from a byte-faithful Phase 1 copy (both `.work` originals untouched):
  (a) the `PLAN.md` markdown escaping + trailing-space trim above; (b) the copied
  `design/design-resolution.md` rationale-ledger reference was rewritten to point at the durable
  in-slice record (the two PLAN files' Stress-test summary / Open questions), because those ledgers
  deliberately stay in the gitignored `.work` memory slice and would otherwise dangle in the tracked
  copy.
- crate-ci/typos against the repo `_typos.toml`: clean.
- Sanity checks: `git ls-files docs/topics/ci-workflows-work-loop/` lists exactly 3 files;
  `grep -c "loop-lane" docs/PLUGIN-PHILOSOPHY.md` = 1; both `docs/conventions/loop-lane/README.md`
  and `CHANGELOG.md` exist; the plugin-citation grep returns pointer-form links/paths only.
- No hard-coded model IDs (`grep -E "claude-(opus|sonnet|haiku|fable)-[0-9]"` empty); no
  machine-specific paths; no trailing whitespace; LF endings.
- Every anchored cross-doc link verified against an existing heading; forward-reference paths (the
  not-yet-created `rate-limit-guard` reader contract and the loop skill directories) are inline-code
  literals, not live links.
- Independent fresh-context review of the diff against the plan's Phase 1/2 acceptance criteria
  (producer != critic).

## Related

- Full contract and sibling track: the topic slice in this PR
  (`docs/topics/ci-workflows-work-loop/PLAN.md` and `babysit-PLAN.md`) — Phases 1-2 of a multi-PR
  plan. Phase 3 (the `rate-limit-guard` plugin) introduces the reader contract this convention
  forward-references; Phase 4 introduces the `work-loop`/`attend-queue` skills; the babysit track
  introduces `babysit-loop`. Those three are the adopters this owner doc lands ahead of.
- Registry: `docs/PLUGIN-PHILOSOPHY.md` "Convention registry".
- No linked issue.
