### PR TITLE
feat(source-control): neutral tool-agnostic convention SSOT via convention_source

### DIFF
--- a/docs/conventions/commit-convention/README.md
+++ b/docs/conventions/commit-convention/README.md
@@ -49,6 +49,76 @@ The two reads are deliberately not identical:
    *drafting* side may still author PCRE-shaped patterns, but a team that wants a pattern *enforced*
    writes it in ERE.
 
+## The neutral convention SSOT (`convention_source`)
+
+Reopen of #913's "no YAML / no path rename" decision, author-directed (#1141 carries the four
+reopen grounds: author directive, an observed three-copy drift surface on a real consuming machine,
+the ecosystem's move to prose-only AGENTS.md pointers with no machine format, and the audit
+checklist's own recurring-concerns memory contradicting the decline).
+
+The team-tracked `.claude/source-control.md` MAY declare one additional H2 key:
+
+```markdown
+## convention_source
+
+docs/conventions/commits.yml
+```
+
+— a **repo-relative, forward-slash** path to a neutral flat-scalar YAML file, the tool-agnostic
+SSOT any consumer (this seam's resolver, a commit-msg hook, CI, another agent) reads with one sed:
+
+```yaml
+# Commit-subject / PR-title convention — single source of truth.
+# Consumed by the source-control plugin, commit hooks, and CI alike.
+dialect: posix-ere
+subject_pattern: '^[A-Z]+-[0-9]+: .+'
+pr_title_pattern: Same as `subject_pattern`.
+```
+
+Contract points:
+
+- **The pointer is optional and team-only.** Absent → today's markdown-H2 grammar, unchanged —
+  full back-compat, zero action for existing consumers. The pointer is honored from the
+  team-tracked file only (same policy floor: a gitignored overlay must not redirect the gate).
+  The path is ALWAYS repo-declared; the plugin hardcodes no doc-root convention and ships no
+  well-known search list in V1 (recorded decision: a search list is discoverable sugar that adds
+  probe order and shadowing questions with no consumer demanding it yet — the pointer alone keeps
+  every path choice in the consuming repo's hands).
+- **Value grammar (one-sed contract).** A key's value is everything after `^<key>:` on the first
+  matching column-0 line — whitespace-trimmed, one pair of matching surrounding quotes removed, no
+  YAML escape processing. `sed -n 's/^subject_pattern:[[:space:]]*//p'` (plus quote-strip) is the
+  reference extraction. Write patterns that need no quote escaping (prefer single quotes; a pattern
+  containing a single quote goes unquoted or double-quoted). Full-line `#` comments are inert;
+  trailing `#` is NOT comment-stripped — a regex may contain `#`.
+- **The `Conventional Commits` keyword and the `` Same as `subject_pattern`. `` deferral marker
+  work identically on both surfaces** — one literal each, owned here, no per-surface variants.
+- **`dialect:`** (optional, default `posix-ere`) declares the regex dialect for NON-enforcement
+  consumers (a JS CI runner, a PCRE hook) so they know what they are reading instead of silently
+  misreading it. Enforcement itself stays POSIX-ERE-only: a declared non-`posix-ere` dialect
+  disables this seam's enforcement with a diagnostic, exactly like a PCRE-ism in the pattern.
+- **Per-key precedence, fail-closed pointer.** When the pointer is declared, the neutral file is
+  authoritative for the machine keys it carries; a key it omits falls back to the team markdown H2
+  (plugin-only keys — `trailer_policy`, `pr_body_attribution` — stay `.claude/`-side; the drafting
+  side may also read a flat `pr_body_required_sections:` list from the neutral file). A
+  declared-but-broken pointer — absolute, backslash, or `..` path; missing file — disables
+  enforcement with a diagnostic rather than falling back: a silent markdown fallback could enforce
+  a stale pattern the migration retired. User-global and `*.local.md` overlay layers are unchanged.
+- **Monorepo per-directory scoping is out of scope for V1** (recorded, not designed for).
+
+**Incumbent steelman, walked before replacing.** Markdown-H2 was chosen (#913) so the config file
+doubles as human-readable documentation: a self-describing preamble, prose beside values, one file
+readable with no schema knowledge. Those purposes survive the move: YAML `#` comments carry the
+preamble and per-value prose (the example above is self-describing), and the human document proper
+lives in CONTRIBUTING/AGENTS.md pointing at the YAML — prose and machine values no longer share a
+grammar, which is the very coupling that produced three hand-synced copies. What markdown-H2 could
+not offer any non-plugin consumer is a parse it doesn't have to reimplement: the H2 grammar
+(first-non-empty-body-line, preamble inertness, deferral literals) exists only in this repo,
+while flat-scalar YAML is extractable by sed, yq, any YAML loader, and any agent. The
+frontmatter-hybrid compromise (YAML frontmatter + markdown body in one file) was re-examined and
+declined for V1: it splits parsing across two grammars in one file — the exact brittleness
+recurring-concerns #4 records — and the two-file shape (YAML + prose pointer) covers the same
+purposes without it.
+
 ## Two load-bearing contracts
 
 - **Unresolved = no enforcement.** No team-tracked pattern (or a non-enforceable one) → the gate does

--- a/docs/conventions/commit-convention/README.md
+++ b/docs/conventions/commit-convention/README.md
@@ -100,9 +100,11 @@ Contract points:
   authoritative for the machine keys it carries; a key it omits falls back to the team markdown H2
   (plugin-only keys — `trailer_policy`, `pr_body_attribution` — stay `.claude/`-side; the drafting
   side may also read a flat `pr_body_required_sections:` list from the neutral file). A
-  declared-but-broken pointer — absolute, backslash, or `..` path; missing file — disables
-  enforcement with a diagnostic rather than falling back: a silent markdown fallback could enforce
-  a stale pattern the migration retired. User-global and `*.local.md` overlay layers are unchanged.
+  declared-but-broken pointer — absolute, backslash, or `..` path; missing file; a symlinked file
+  or a symlinked path segment whose physical target leaves the repository root (the target must be
+  a regular file physically under the repo) — disables enforcement with a diagnostic rather than
+  falling back: a silent markdown fallback could enforce a stale pattern the migration retired,
+  and a symlink escape would let untracked external content steer the gate. User-global and `*.local.md` overlay layers are unchanged.
 - **Monorepo per-directory scoping is out of scope for V1** (recorded, not designed for).
 
 **Incumbent steelman, walked before replacing.** Markdown-H2 was chosen (#913) so the config file

--- a/docs/conventions/pr-body-convention/README.md
+++ b/docs/conventions/pr-body-convention/README.md
@@ -14,6 +14,10 @@ plugin". An owner doc lands before the second consumer adopts the key, not after
 markdown), resolved across the same three layers as every other key on that surface —
 user-global, team-tracked, and a gitignored personal overlay — per
 [`source-control/reference/config-resolution.md`](../../../plugins/source-control/reference/config-resolution.md).
+When the team layer declares a `convention_source` neutral file (the
+[commit-convention seam](../commit-convention/README.md)'s tool-agnostic SSOT), that file may carry
+this key as a flat YAML list (or the keyword `none`) and is then authoritative for the team layer,
+same per-key semantics.
 That document owns the **resolution mechanics**: the value grammar, the three-layer read order, and
 the per-key (whole-list) override semantics. This doc never restates them — it owns the concern's
 *shape* and *rationale*, and points there for *how* a value resolves.

--- a/lib/resolve-convention-pattern.sh
+++ b/lib/resolve-convention-pattern.sh
@@ -150,6 +150,23 @@ if [[ -n "$ptr" ]]; then
     printf '%s\n' "resolve-convention-pattern: convention_source declares '$ptr' but no such file exists under the repo root; enforcement disabled (fix the pointer or restore the file)." >&2
     exit 1
   fi
+  # The lexical checks above don't stop a symlink escape: a repo-relative
+  # pointer can name a symlink (or sit under a symlinked directory) whose
+  # physical target is outside the repository, letting untracked external
+  # content steer the gate. Require a REGULAR file whose physical directory
+  # (pwd -P canonicalizes every symlinked path segment) stays under the
+  # physical repo root. Pure-bash on purpose — the vendored hook copy cannot
+  # assume realpath exists on every consumer machine.
+  if [[ -L "$NEUTRAL_FILE" ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source '$ptr' is a symlink; the neutral file must be a regular tracked file — enforcement disabled." >&2
+    exit 1
+  fi
+  canon_root="$(cd "$repo_root" 2>/dev/null && pwd -P)"
+  canon_dir="$(cd "$(dirname "$NEUTRAL_FILE")" 2>/dev/null && pwd -P)"
+  if [[ -z "$canon_root" || -z "$canon_dir" || "$canon_dir/" != "$canon_root/"* ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source '$ptr' resolves outside the repository root (symlinked path segment); enforcement disabled." >&2
+    exit 1
+  fi
   dialect="$(yaml_value "$NEUTRAL_FILE" dialect)"
   if [[ -n "$dialect" && "$dialect" != "posix-ere" ]]; then
     printf '%s\n' "resolve-convention-pattern: convention_source file declares dialect '$dialect'; enforcement consumes posix-ere only — enforcement disabled." >&2

--- a/lib/resolve-convention-pattern.sh
+++ b/lib/resolve-convention-pattern.sh
@@ -174,6 +174,20 @@ if [[ -n "$ptr" ]]; then
   fi
 fi
 
+# A key the neutral file CARRIES must hold a value. Present-but-empty
+# (`subject_pattern:` or `subject_pattern: ''`) is a configuration error, not
+# an omission — silently falling back to the markdown H2 would enforce a stale
+# pattern the migration meant to retire. Runs at top level (not inside a
+# command substitution) so the exit reaches the caller.
+check_neutral_key() {
+  local k="$1"
+  [[ -n "$NEUTRAL_FILE" ]] || return 0
+  grep -q -E "^${k}:" "$NEUTRAL_FILE" || return 0
+  [[ -n "$(yaml_value "$NEUTRAL_FILE" "$k")" ]] && return 0
+  printf '%s\n' "resolve-convention-pattern: convention_source file carries '$k' with an empty value; a carried key must hold a value (delete the line to fall back to the markdown H2) — enforcement disabled." >&2
+  exit 1
+}
+
 # Team-layer value for a machine key: the neutral file when the pointer is
 # declared AND that file carries the key; the team markdown H2 otherwise.
 team_value() {
@@ -223,6 +237,12 @@ raw_value() {
     printf '%s' "$v"
   fi
 }
+
+# Present-but-empty neutral keys fail closed BEFORE resolution (top-level so
+# the exit propagates; both keys checked for pr_title_pattern since its
+# deferral marker re-reads subject_pattern).
+check_neutral_key "$key"
+[[ "$key" == "pr_title_pattern" ]] && check_neutral_key "subject_pattern"
 
 value="$(raw_value "$key")"
 

--- a/lib/resolve-convention-pattern.sh
+++ b/lib/resolve-convention-pattern.sh
@@ -74,6 +74,16 @@ esac
 # Team-tracked layer only — the enforcement authority (see header).
 readonly TEAM_FILE="$repo_root/.claude/source-control.md"
 
+# --- Neutral convention SSOT (docs/conventions/commit-convention/, #1141) ---
+# The team file MAY declare `## convention_source` naming a repo-relative
+# flat-scalar YAML file (the tool-agnostic SSOT other consumers — commit-msg
+# hooks, CI — read with one sed). When declared, that file is authoritative for
+# the machine keys it carries; a key it omits falls back to the team markdown
+# H2. The pointer is honored from the TEAM file only (same policy floor — a
+# gitignored overlay must not redirect the gate), and a declared-but-broken
+# pointer FAILS CLOSED to no-enforcement with a diagnostic rather than silently
+# re-reading markdown values migration may have retired.
+
 # First non-empty body line under `## <key>`, CR-stripped. Empty when the
 # section is absent or bodyless. Awk over sed: needs section-state, not a line
 # match.
@@ -97,6 +107,70 @@ h2_value() {
   ' "$file"
 }
 
+# First matching flat-scalar value for a key from the neutral YAML file:
+# `^<key>:` at column 0, CR-stripped, surrounding whitespace trimmed, ONE pair
+# of matching surrounding quotes ('…' or "…") removed. No YAML quote-escape
+# processing — the one-sed extraction contract other consumers rely on can't
+# either, so the seam doc tells authors to write patterns that need no escaping.
+# Full-line `#` comments never match the key anchor; trailing `#` text is NOT
+# stripped (a regex may legitimately contain `#`).
+yaml_value() {
+  local file="$1" k="$2" line v
+  [[ -f "$file" ]] || return 0
+  line="$(grep -m1 -E "^${k}:" "$file" | tr -d '\r')"
+  [[ -n "$line" ]] || return 0
+  v="${line#"${k}":}"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  if [[ ${#v} -ge 2 && ("$v" == \'*\' || "$v" == \"*\") && "${v:0:1}" == "${v: -1}" ]]; then
+    v="${v:1:${#v}-2}"
+  fi
+  printf '%s' "$v"
+}
+
+# Resolve the optional neutral-file pointer. Sets NEUTRAL_FILE (empty when no
+# pointer is declared). A declared pointer that cannot be honored — absolute or
+# traversal path, missing file, or a dialect other than posix-ere — disables
+# enforcement (exit 1) with a diagnostic: fail closed, never fall back.
+NEUTRAL_FILE=""
+ptr="$(h2_value "$TEAM_FILE" "convention_source")"
+if [[ -n "$ptr" ]]; then
+  case "$ptr" in
+  /* | [A-Za-z]:* | *\\* | *..*)
+    # Repo-relative forward-slash paths only: no absolute paths (POSIX or
+    # drive-lettered), no backslash separators, no `..` traversal — a tracked
+    # pointer must not read outside the repository the gate governs.
+    printf '%s\n' "resolve-convention-pattern: convention_source '$ptr' is not a plain repo-relative path (absolute, backslash, or '..' segment); enforcement disabled." >&2
+    exit 1
+    ;;
+  *) ;; # plain repo-relative path — proceed
+  esac
+  NEUTRAL_FILE="$repo_root/$ptr"
+  if [[ ! -f "$NEUTRAL_FILE" ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source declares '$ptr' but no such file exists under the repo root; enforcement disabled (fix the pointer or restore the file)." >&2
+    exit 1
+  fi
+  dialect="$(yaml_value "$NEUTRAL_FILE" dialect)"
+  if [[ -n "$dialect" && "$dialect" != "posix-ere" ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source file declares dialect '$dialect'; enforcement consumes posix-ere only — enforcement disabled." >&2
+    exit 1
+  fi
+fi
+
+# Team-layer value for a machine key: the neutral file when the pointer is
+# declared AND that file carries the key; the team markdown H2 otherwise.
+team_value() {
+  local k="$1" v
+  if [[ -n "$NEUTRAL_FILE" ]]; then
+    v="$(yaml_value "$NEUTRAL_FILE" "$k")"
+    if [[ -n "$v" ]]; then
+      printf '%s' "$v"
+      return 0
+    fi
+  fi
+  h2_value "$TEAM_FILE" "$k"
+}
+
 # Enforcement patterns are POSIX ERE, NOT PCRE. The resolver does not translate
 # a pattern (translating PCRE->ERE by string rewriting is unsound — bracket
 # expressions, POSIX classes, and escaped backslashes all break naive
@@ -118,10 +192,13 @@ is_non_ere() {
   return 1
 }
 
-# Resolve one key's raw value from the team layer, expanding the CC keyword.
+# Resolve one key's raw value from the team layer (neutral file first when the
+# pointer is declared — team_value), expanding the CC keyword. The keyword and
+# the deferral marker work identically on both surfaces: one literal each, no
+# per-surface variants to drift.
 raw_value() {
   local k="$1" v
-  v="$(h2_value "$TEAM_FILE" "$k")"
+  v="$(team_value "$k")"
   [[ -n "$v" ]] || return 0
   if [[ "$v" == "Conventional Commits" ]]; then
     printf '%s' "$CC_ERE"
@@ -135,7 +212,7 @@ value="$(raw_value "$key")"
 # pr_title_pattern deferral: `Same as `subject_pattern`.` enforces the effective
 # subject pattern. Resolve against the raw (pre-expansion) pr_title value.
 if [[ "$key" == "pr_title_pattern" ]]; then
-  raw_pr="$(h2_value "$TEAM_FILE" "pr_title_pattern")"
+  raw_pr="$(team_value "pr_title_pattern")"
   if [[ "$raw_pr" == "$PR_DEFERRAL" ]]; then
     value="$(raw_value "subject_pattern")"
   fi

--- a/lib/resolve-convention-pattern.test.sh
+++ b/lib/resolve-convention-pattern.test.sh
@@ -243,6 +243,27 @@ addneutral "$r" "conventions.yml" $'subject_pattern: \047^evil: .+\047'
 run "$r" >/dev/null 2>&1
 assert_exit "neutral: overlay pointer ignored (team-only)" 1 $?
 
+# --- symlink escapes are rejected (skipped where ln -s can't make symlinks) ---
+outside="$TEST_TMPDIR/outside.yml"
+printf '%s\n' "subject_pattern: '^outside: .+'" >"$outside"
+r="$(newrepo $'## convention_source\nlink.yml')"
+ln -s "$outside" "$r/link.yml" 2>/dev/null
+if [[ -L "$r/link.yml" ]]; then
+  run "$r" >/dev/null 2>&1
+  assert_exit "neutral: symlinked file rejected" 1 $?
+  # A symlinked DIRECTORY segment escaping the repo is rejected too.
+  mkdir -p "$TEST_TMPDIR/outdir"
+  printf '%s\n' "subject_pattern: '^outdir: .+'" >"$TEST_TMPDIR/outdir/c.yml"
+  r="$(newrepo $'## convention_source\nsub/c.yml')"
+  ln -s "$TEST_TMPDIR/outdir" "$r/sub" 2>/dev/null
+  if [[ -L "$r/sub" ]]; then
+    run "$r" >/dev/null 2>&1
+    assert_exit "neutral: symlinked dir segment rejected" 1 $?
+  fi
+else
+  echo "SKIP: symlink cases (ln -s unavailable on this filesystem)"
+fi
+
 # --- usage / invalid key ---
 bash "$SCRIPT" >/dev/null 2>&1
 assert_exit "no args -> exit 2" 2 $?

--- a/lib/resolve-convention-pattern.test.sh
+++ b/lib/resolve-convention-pattern.test.sh
@@ -243,6 +243,18 @@ addneutral "$r" "conventions.yml" $'subject_pattern: \047^evil: .+\047'
 run "$r" >/dev/null 2>&1
 assert_exit "neutral: overlay pointer ignored (team-only)" 1 $?
 
+# --- a present-but-EMPTY neutral key fails closed (never stale markdown) ---
+r="$(newrepo $'## convention_source\nconventions.yml\n\n## subject_pattern\n^stale-md: .+')"
+addneutral "$r" "conventions.yml" $'subject_pattern: \047\047'
+out="$(run "$r")"
+rc=$?
+assert_exit "neutral: empty quoted key -> exit 1" 1 "$rc"
+assert_eq "neutral: empty quoted key -> empty stdout (no stale fallback)" "" "$out"
+r="$(newrepo $'## convention_source\nconventions.yml\n\n## subject_pattern\n^stale-md: .+')"
+addneutral "$r" "conventions.yml" $'subject_pattern:'
+run "$r" >/dev/null 2>&1
+assert_exit "neutral: bare empty key -> exit 1" 1 $?
+
 # --- symlink escapes are rejected (skipped where ln -s can't make symlinks) ---
 outside="$TEST_TMPDIR/outside.yml"
 printf '%s\n' "subject_pattern: '^outside: .+'" >"$outside"

--- a/lib/resolve-convention-pattern.test.sh
+++ b/lib/resolve-convention-pattern.test.sh
@@ -158,6 +158,91 @@ assert_eq "pr explicit value" '^PR: .+' "$(run "$r" pr_title_pattern)"
 r="$(newrepo $'## subject_pattern\n\n^spaced: .+')"
 assert_eq "blank line before value skipped" '^spaced: .+' "$(run "$r")"
 
+# =====================================================================
+# Neutral convention SSOT (convention_source pointer + flat-scalar YAML)
+# =====================================================================
+
+# Write a neutral YAML file at a repo-relative path inside repo $1.
+addneutral() {
+  local d="$1" path="$2" body="$3"
+  mkdir -p "$d/$(dirname "$path")"
+  printf '%s\n' "$body" >"$d/$path"
+}
+
+# --- pointer + single-quoted YAML value resolves ---
+r="$(newrepo $'## convention_source\ndocs/conventions/commits.yml')"
+addneutral "$r" "docs/conventions/commits.yml" $'# team commit convention\nsubject_pattern: \047^SW2-[0-9]+: .+\047'
+assert_eq "neutral: quoted YAML subject" '^SW2-[0-9]+: .+' "$(run "$r")"
+
+# --- double-quoted YAML value strips its quotes too ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'subject_pattern: "^DQ-[0-9]+: .+"'
+assert_eq "neutral: double-quoted value" '^DQ-[0-9]+: .+' "$(run "$r")"
+
+# --- unquoted YAML value passes through ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'subject_pattern: ^plain: .+'
+assert_eq "neutral: unquoted value" '^plain: .+' "$(run "$r")"
+
+# --- CC keyword works in the neutral file exactly as in markdown ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'subject_pattern: Conventional Commits'
+assert_eq "neutral: CC keyword -> CC_ERE" "$CC_ERE" "$(run "$r")"
+
+# --- pr_title deferral marker works in the neutral file ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'subject_pattern: \047^N-[0-9]+: .+\047\npr_title_pattern: Same as `subject_pattern`.'
+assert_eq "neutral: pr deferral -> subject" '^N-[0-9]+: .+' "$(run "$r" pr_title_pattern)"
+
+# --- dialect: posix-ere (explicit) still resolves ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'dialect: posix-ere\nsubject_pattern: \047^D-[0-9]+: .+\047'
+assert_eq "neutral: dialect posix-ere ok" '^D-[0-9]+: .+' "$(run "$r")"
+
+# --- dialect other than posix-ere -> no enforcement ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'dialect: pcre\nsubject_pattern: \047^\\d+: .+\047'
+out="$(run "$r")"
+rc=$?
+assert_exit "neutral: dialect pcre -> exit 1" 1 "$rc"
+assert_eq "neutral: dialect pcre -> empty stdout" "" "$out"
+
+# --- declared pointer, missing file -> FAIL CLOSED (never markdown fallback) ---
+r="$(newrepo $'## convention_source\nmissing.yml\n\n## subject_pattern\n^stale: .+')"
+out="$(run "$r")"
+rc=$?
+assert_exit "neutral: missing file -> exit 1" 1 "$rc"
+assert_eq "neutral: missing file -> empty (no stale markdown fallback)" "" "$out"
+
+# --- absolute and traversal pointers are rejected ---
+r="$(newrepo $'## convention_source\n/etc/conventions.yml')"
+run "$r" >/dev/null 2>&1
+assert_exit "neutral: absolute pointer -> exit 1" 1 $?
+r="$(newrepo $'## convention_source\n../outside.yml')"
+run "$r" >/dev/null 2>&1
+assert_exit "neutral: traversal pointer -> exit 1" 1 $?
+
+# --- a key the neutral file omits falls back to the team markdown H2 ---
+r="$(newrepo $'## convention_source\nconventions.yml\n\n## pr_title_pattern\n^MD: .+')"
+addneutral "$r" "conventions.yml" $'subject_pattern: \047^Y-[0-9]+: .+\047'
+assert_eq "neutral: omitted key -> markdown fallback" '^MD: .+' "$(run "$r" pr_title_pattern)"
+
+# --- neutral value WINS over a not-yet-retired markdown duplicate ---
+r="$(newrepo $'## convention_source\nconventions.yml\n\n## subject_pattern\n^old-md: .+')"
+addneutral "$r" "conventions.yml" $'subject_pattern: \047^new-yaml: .+\047'
+assert_eq "neutral: YAML wins over markdown duplicate" '^new-yaml: .+' "$(run "$r")"
+
+# --- comment and blank lines in the neutral file are inert ---
+r="$(newrepo $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'# convention SSOT\n\n# see CONTRIBUTING.md\nsubject_pattern: \047^C-[0-9]+: .+\047'
+assert_eq "neutral: comments/blanks inert" '^C-[0-9]+: .+' "$(run "$r")"
+
+# --- pointer in the LOCAL overlay only is ignored (team-only policy floor) ---
+r="$(newrepo "" $'## convention_source\nconventions.yml')"
+addneutral "$r" "conventions.yml" $'subject_pattern: \047^evil: .+\047'
+run "$r" >/dev/null 2>&1
+assert_exit "neutral: overlay pointer ignored (team-only)" 1 $?
+
 # --- usage / invalid key ---
 bash "$SCRIPT" >/dev/null 2>&1
 assert_exit "no args -> exit 2" 2 $?

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "description": "Nine safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.13.0]
+
+### Added
+
+- **Vendored convention resolver understands the neutral convention SSOT (#1141).** The synced copy
+  of `lib/resolve-convention-pattern.sh` now honors a team-tracked `## convention_source` pointer to
+  a repo-relative flat-scalar YAML file: machine keys resolve from that file when it declares them
+  (markdown-H2 fallback per key), the `Conventional Commits` keyword and the `pr_title_pattern`
+  deferral marker work identically on both surfaces, a non-`posix-ere` `dialect:` declaration
+  disables enforcement with a diagnostic, and a declared-but-broken pointer (absolute/backslash/`..`
+  path, missing file) fails closed to no-enforcement rather than silently re-reading markdown values
+  a migration may have retired. Policy floor unchanged: the pointer is honored from the team file
+  only. Seam contract: `docs/conventions/commit-convention/README.md`.
+
 ## [0.12.3]
 
 ### Fixed

--- a/plugins/guardrails/hooks/resolve-convention-pattern.sh
+++ b/plugins/guardrails/hooks/resolve-convention-pattern.sh
@@ -150,6 +150,23 @@ if [[ -n "$ptr" ]]; then
     printf '%s\n' "resolve-convention-pattern: convention_source declares '$ptr' but no such file exists under the repo root; enforcement disabled (fix the pointer or restore the file)." >&2
     exit 1
   fi
+  # The lexical checks above don't stop a symlink escape: a repo-relative
+  # pointer can name a symlink (or sit under a symlinked directory) whose
+  # physical target is outside the repository, letting untracked external
+  # content steer the gate. Require a REGULAR file whose physical directory
+  # (pwd -P canonicalizes every symlinked path segment) stays under the
+  # physical repo root. Pure-bash on purpose — the vendored hook copy cannot
+  # assume realpath exists on every consumer machine.
+  if [[ -L "$NEUTRAL_FILE" ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source '$ptr' is a symlink; the neutral file must be a regular tracked file — enforcement disabled." >&2
+    exit 1
+  fi
+  canon_root="$(cd "$repo_root" 2>/dev/null && pwd -P)"
+  canon_dir="$(cd "$(dirname "$NEUTRAL_FILE")" 2>/dev/null && pwd -P)"
+  if [[ -z "$canon_root" || -z "$canon_dir" || "$canon_dir/" != "$canon_root/"* ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source '$ptr' resolves outside the repository root (symlinked path segment); enforcement disabled." >&2
+    exit 1
+  fi
   dialect="$(yaml_value "$NEUTRAL_FILE" dialect)"
   if [[ -n "$dialect" && "$dialect" != "posix-ere" ]]; then
     printf '%s\n' "resolve-convention-pattern: convention_source file declares dialect '$dialect'; enforcement consumes posix-ere only — enforcement disabled." >&2

--- a/plugins/guardrails/hooks/resolve-convention-pattern.sh
+++ b/plugins/guardrails/hooks/resolve-convention-pattern.sh
@@ -174,6 +174,20 @@ if [[ -n "$ptr" ]]; then
   fi
 fi
 
+# A key the neutral file CARRIES must hold a value. Present-but-empty
+# (`subject_pattern:` or `subject_pattern: ''`) is a configuration error, not
+# an omission — silently falling back to the markdown H2 would enforce a stale
+# pattern the migration meant to retire. Runs at top level (not inside a
+# command substitution) so the exit reaches the caller.
+check_neutral_key() {
+  local k="$1"
+  [[ -n "$NEUTRAL_FILE" ]] || return 0
+  grep -q -E "^${k}:" "$NEUTRAL_FILE" || return 0
+  [[ -n "$(yaml_value "$NEUTRAL_FILE" "$k")" ]] && return 0
+  printf '%s\n' "resolve-convention-pattern: convention_source file carries '$k' with an empty value; a carried key must hold a value (delete the line to fall back to the markdown H2) — enforcement disabled." >&2
+  exit 1
+}
+
 # Team-layer value for a machine key: the neutral file when the pointer is
 # declared AND that file carries the key; the team markdown H2 otherwise.
 team_value() {
@@ -223,6 +237,12 @@ raw_value() {
     printf '%s' "$v"
   fi
 }
+
+# Present-but-empty neutral keys fail closed BEFORE resolution (top-level so
+# the exit propagates; both keys checked for pr_title_pattern since its
+# deferral marker re-reads subject_pattern).
+check_neutral_key "$key"
+[[ "$key" == "pr_title_pattern" ]] && check_neutral_key "subject_pattern"
 
 value="$(raw_value "$key")"
 

--- a/plugins/guardrails/hooks/resolve-convention-pattern.sh
+++ b/plugins/guardrails/hooks/resolve-convention-pattern.sh
@@ -74,6 +74,16 @@ esac
 # Team-tracked layer only — the enforcement authority (see header).
 readonly TEAM_FILE="$repo_root/.claude/source-control.md"
 
+# --- Neutral convention SSOT (docs/conventions/commit-convention/, #1141) ---
+# The team file MAY declare `## convention_source` naming a repo-relative
+# flat-scalar YAML file (the tool-agnostic SSOT other consumers — commit-msg
+# hooks, CI — read with one sed). When declared, that file is authoritative for
+# the machine keys it carries; a key it omits falls back to the team markdown
+# H2. The pointer is honored from the TEAM file only (same policy floor — a
+# gitignored overlay must not redirect the gate), and a declared-but-broken
+# pointer FAILS CLOSED to no-enforcement with a diagnostic rather than silently
+# re-reading markdown values migration may have retired.
+
 # First non-empty body line under `## <key>`, CR-stripped. Empty when the
 # section is absent or bodyless. Awk over sed: needs section-state, not a line
 # match.
@@ -97,6 +107,70 @@ h2_value() {
   ' "$file"
 }
 
+# First matching flat-scalar value for a key from the neutral YAML file:
+# `^<key>:` at column 0, CR-stripped, surrounding whitespace trimmed, ONE pair
+# of matching surrounding quotes ('…' or "…") removed. No YAML quote-escape
+# processing — the one-sed extraction contract other consumers rely on can't
+# either, so the seam doc tells authors to write patterns that need no escaping.
+# Full-line `#` comments never match the key anchor; trailing `#` text is NOT
+# stripped (a regex may legitimately contain `#`).
+yaml_value() {
+  local file="$1" k="$2" line v
+  [[ -f "$file" ]] || return 0
+  line="$(grep -m1 -E "^${k}:" "$file" | tr -d '\r')"
+  [[ -n "$line" ]] || return 0
+  v="${line#"${k}":}"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  if [[ ${#v} -ge 2 && ("$v" == \'*\' || "$v" == \"*\") && "${v:0:1}" == "${v: -1}" ]]; then
+    v="${v:1:${#v}-2}"
+  fi
+  printf '%s' "$v"
+}
+
+# Resolve the optional neutral-file pointer. Sets NEUTRAL_FILE (empty when no
+# pointer is declared). A declared pointer that cannot be honored — absolute or
+# traversal path, missing file, or a dialect other than posix-ere — disables
+# enforcement (exit 1) with a diagnostic: fail closed, never fall back.
+NEUTRAL_FILE=""
+ptr="$(h2_value "$TEAM_FILE" "convention_source")"
+if [[ -n "$ptr" ]]; then
+  case "$ptr" in
+  /* | [A-Za-z]:* | *\\* | *..*)
+    # Repo-relative forward-slash paths only: no absolute paths (POSIX or
+    # drive-lettered), no backslash separators, no `..` traversal — a tracked
+    # pointer must not read outside the repository the gate governs.
+    printf '%s\n' "resolve-convention-pattern: convention_source '$ptr' is not a plain repo-relative path (absolute, backslash, or '..' segment); enforcement disabled." >&2
+    exit 1
+    ;;
+  *) ;; # plain repo-relative path — proceed
+  esac
+  NEUTRAL_FILE="$repo_root/$ptr"
+  if [[ ! -f "$NEUTRAL_FILE" ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source declares '$ptr' but no such file exists under the repo root; enforcement disabled (fix the pointer or restore the file)." >&2
+    exit 1
+  fi
+  dialect="$(yaml_value "$NEUTRAL_FILE" dialect)"
+  if [[ -n "$dialect" && "$dialect" != "posix-ere" ]]; then
+    printf '%s\n' "resolve-convention-pattern: convention_source file declares dialect '$dialect'; enforcement consumes posix-ere only — enforcement disabled." >&2
+    exit 1
+  fi
+fi
+
+# Team-layer value for a machine key: the neutral file when the pointer is
+# declared AND that file carries the key; the team markdown H2 otherwise.
+team_value() {
+  local k="$1" v
+  if [[ -n "$NEUTRAL_FILE" ]]; then
+    v="$(yaml_value "$NEUTRAL_FILE" "$k")"
+    if [[ -n "$v" ]]; then
+      printf '%s' "$v"
+      return 0
+    fi
+  fi
+  h2_value "$TEAM_FILE" "$k"
+}
+
 # Enforcement patterns are POSIX ERE, NOT PCRE. The resolver does not translate
 # a pattern (translating PCRE->ERE by string rewriting is unsound — bracket
 # expressions, POSIX classes, and escaped backslashes all break naive
@@ -118,10 +192,13 @@ is_non_ere() {
   return 1
 }
 
-# Resolve one key's raw value from the team layer, expanding the CC keyword.
+# Resolve one key's raw value from the team layer (neutral file first when the
+# pointer is declared — team_value), expanding the CC keyword. The keyword and
+# the deferral marker work identically on both surfaces: one literal each, no
+# per-surface variants to drift.
 raw_value() {
   local k="$1" v
-  v="$(h2_value "$TEAM_FILE" "$k")"
+  v="$(team_value "$k")"
   [[ -n "$v" ]] || return 0
   if [[ "$v" == "Conventional Commits" ]]; then
     printf '%s' "$CC_ERE"
@@ -135,7 +212,7 @@ value="$(raw_value "$key")"
 # pr_title_pattern deferral: `Same as `subject_pattern`.` enforces the effective
 # subject pattern. Resolve against the raw (pre-expansion) pr_title value.
 if [[ "$key" == "pr_title_pattern" ]]; then
-  raw_pr="$(h2_value "$TEAM_FILE" "pr_title_pattern")"
+  raw_pr="$(team_value "pr_title_pattern")"
   if [[ "$raw_pr" == "$PR_DEFERRAL" ]]; then
     value="$(raw_value "subject_pattern")"
   fi

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.0]
+
+### Added
+
+- **Neutral tool-agnostic convention SSOT — `convention_source` (#1141, author-directed reopen of
+  #913).** The team-tracked `.claude/source-control.md` may now declare `## convention_source`: a
+  repo-relative flat-scalar YAML file (`subject_pattern`, `pr_title_pattern`, optional
+  `pr_body_required_sections` list or `none`, optional `dialect:` defaulting `posix-ere`) that
+  enforcement (commit-msg hooks, CI) and drafting (any agent) consume as ONE source — decoupling
+  the convention values from the markdown-H2 grammar that previously left consuming machines
+  hand-syncing byte-identical regex copies. Absent pointer → today's behavior, zero action for
+  existing consumers; the path is always repo-declared (no hardcoded doc root, no well-known
+  search list in V1 — recorded decision); the `Conventional Commits` keyword and the pr-title
+  deferral marker work identically on both surfaces; the neutral file is authoritative per key with
+  markdown-H2 fallback, plugin-only keys stay `.claude/`-side, and user/local overlay layers are
+  unchanged. Enforcement contract unchanged (POSIX ERE only, unresolved = no enforcement,
+  team-only policy floor — the pointer too is honored from the team file only); a
+  declared-but-broken pointer or non-`posix-ere` dialect fails closed with a diagnostic.
+  `lib/resolve-convention-pattern.sh` extended (guardrails vendored copy synced byte-identical,
+  guardrails 0.13.0); 14 new resolver test cases (44 total). The incumbent markdown-H2 steelman and
+  the format decision walk-through are recorded in `docs/conventions/commit-convention/README.md`;
+  `setup apply` gains the offer-and-migrate path (spoke section, eval 18) that retires duplicated
+  keys rather than leaving both surfaces authoritative. Monorepo per-directory scoping: out of
+  scope V1, recorded.
+
 ## [0.22.0]
 
 ### Changed

--- a/plugins/source-control/reference/config-resolution.md
+++ b/plugins/source-control/reference/config-resolution.md
@@ -49,6 +49,20 @@ Markdown, one `## <key>` H2 per key, the value as the section body:
 
 Absent sections are absent, never empty.
 
+- `convention_source` — optional, **honored in the team-tracked layer only**: a repo-relative
+  forward-slash path to a neutral flat-scalar YAML file, the tool-agnostic convention SSOT other
+  consumers (commit-msg hooks, CI, other agents) read too. When declared, the neutral file is
+  authoritative for the machine keys it carries (`subject_pattern`, `pr_title_pattern`, optionally
+  a flat `pr_body_required_sections:` list and `dialect:`); a key it omits falls back to the team
+  file's own H2 sections, and plugin-only keys (`trailer_policy`, `pr_body_attribution`) stay in
+  the markdown surface. The `Conventional Commits` keyword and the pr-title deferral marker work
+  identically in the neutral file. User-global and local-overlay layers are unchanged and still
+  merge per key on top. Value grammar, pointer safety rules, and the fail-closed
+  broken-pointer contract are owned by the
+  [commit-convention seam](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/commit-convention/README.md)
+  — drafting honors the same contract (a declared-but-broken pointer is surfaced as a config error,
+  never silently re-read from markdown values a migration may have retired).
+
 ## The three layers
 
 Resolve every read from the repo root — `${CLAUDE_PROJECT_DIR}` when set, otherwise

--- a/plugins/source-control/skills/setup/SKILL.md
+++ b/plugins/source-control/skills/setup/SKILL.md
@@ -141,6 +141,11 @@ In brief:
   layer (team = tracked and staged; local = ignored and untracked, two independent probes; user =
   no git command at all), and report the new **effective merge**, not just what was written.
 
+- **Neutral SSOT (optional):** a `team` write may declare `## convention_source` pointing at a
+  repo-relative flat-scalar YAML file other tools consume too — offered when another consumer
+  exists, with migration retiring keys the neutral file takes over (spoke section "Neutral
+  convention SSOT").
+
 Every step's exact contract — the interview steps, the written-file template, the per-layer
 verification scripts, and the failure remediations — lives in the spoke; this summary never
 overrides it.
@@ -197,6 +202,9 @@ Skill-behavior failure patterns hit in real runs. Add to this section when new o
   the window silently — probe `git rev-parse --is-shallow-repository` and report the actual span.
 - **Same-session `userConfig` reads are stale.** Reconfigured babysit values become visible only
   in a fresh session — re-running `check` in the same session reports a false failure.
+- **A broken `convention_source` pointer fails closed.** Enforcement and drafting surface it as a
+  config error rather than silently falling back to markdown values a migration may have retired —
+  verify the pointer round-trips through the resolver at write time.
 
 ## What this skill does NOT do
 

--- a/plugins/source-control/skills/setup/evals/evals.json
+++ b/plugins/source-control/skills/setup/evals/evals.json
@@ -219,6 +219,19 @@
         "Merge, Revert, fixup!, and squash! auto-subjects are excluded before classification",
         "The report shows bucketed volume-weighted percentages with a recent-vs-older recency split and names the source, and the user picks from the evidence — the winning bucket is not silently promoted into config"
       ]
+    },
+    {
+      "id": 18,
+      "name": "apply-neutral-ssot-migration-retires-duplicates",
+      "prompt": "/source-control:setup apply\n\nThe team .claude/source-control.md already declares subject_pattern as a ticket-prefix regex. The user says: our commit-msg hook and CI also need to read this convention — move it to a tool-agnostic single source of truth.",
+      "expected_output": "The skill offers the neutral convention SSOT: it asks the repo's own path preference (never hardcoding a doc root), writes a flat-scalar YAML file (subject_pattern, pr_title_pattern, dialect: posix-ere, self-describing # comments), declares `## convention_source` with that repo-relative path in .claude/source-control.md, and — critically — RETIRES the now-duplicated subject_pattern from the markdown file in the same apply rather than leaving both authoritative. Verification round-trips the pointer through the enforcement resolver and reports the effective merge. Plugin-only keys (trailer_policy, pr_body_attribution) stay in the markdown file.",
+      "files": [],
+      "expectations": [
+        "Asks the repo's path preference for the neutral file instead of hardcoding a doc-root convention; the pointer written is repo-relative with forward slashes",
+        "Writes flat-scalar YAML with the machine keys and declares convention_source in the team .claude/source-control.md",
+        "Retires the duplicated subject_pattern from the markdown file in the same apply — both surfaces are never left authoritative for the same key",
+        "Verifies the pointer round-trips through the enforcement resolver (broken pointer fails closed) and keeps plugin-only keys markdown-side"
+      ]
     }
   ]
 }

--- a/plugins/source-control/skills/setup/reference/apply-convention.md
+++ b/plugins/source-control/skills/setup/reference/apply-convention.md
@@ -330,3 +330,29 @@ With no argument in an interactive session, run the interview:
    NOT team-wide enforcement. Committers without the plugin are bound only by a commit-msg hook or CI
    check; when the team wants that, point at the guardrails plugin's opt-in commit-msg hook or the
    repo's own hook manager rather than implying this file enforces anything by itself.
+
+## Neutral convention SSOT (`convention_source`)
+
+For a `team` write, offer (never require) the neutral-file shape — one tool-agnostic flat-scalar
+YAML file other consumers (commit-msg hooks, CI, other agents) read alongside this plugin. Contract
+and value grammar are owned by the
+[commit-convention seam](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/commit-convention/README.md);
+this skill's part:
+
+- **Offer it when it earns its keep** — the user says another tool consumes the convention (a hook,
+  CI, another agent), or asks for a tool-agnostic/SSOT shape. A repo where only this plugin reads
+  the convention loses nothing by staying markdown-only; say so rather than upselling the split.
+- **Writing it:** ask the repo's own path preference (the plugin ships no doc-root convention —
+  `docs/conventions/…`, `.github/…`, a root dotfile are all the repo's call; repo-relative,
+  forward slashes, no `..`), write the YAML with machine keys (`subject_pattern`,
+  `pr_title_pattern`, optionally `pr_body_required_sections`, `dialect: posix-ere`) plus `#`
+  comments carrying the self-describing preamble, and declare `## convention_source` with that path
+  in `.claude/source-control.md`.
+- **Migration retires duplicates.** When the team markdown file already carries a key the neutral
+  file now declares, REMOVE it from the markdown in the same apply — the resolver would prefer the
+  neutral value anyway, but leaving both invites hand-edit drift, which is the disease this shape
+  cures. Plugin-only keys (`trailer_policy`, `pr_body_attribution`) stay in the markdown file.
+- **Verification adds one probe:** the pointer's target exists, is repo-relative, and round-trips
+  through the enforcement resolver (`lib/resolve-convention-pattern.sh <repo_root>
+  subject_pattern` emits the expected pattern). A broken pointer fails closed to no-enforcement by
+  contract — surface it at write time, not at the team's first blocked commit.

--- a/plugins/source-control/skills/setup/reference/apply-convention.md
+++ b/plugins/source-control/skills/setup/reference/apply-convention.md
@@ -352,7 +352,13 @@ this skill's part:
   file now declares, REMOVE it from the markdown in the same apply — the resolver would prefer the
   neutral value anyway, but leaving both invites hand-edit drift, which is the disease this shape
   cures. Plugin-only keys (`trailer_policy`, `pr_body_attribution`) stay in the markdown file.
-- **Verification adds one probe:** the pointer's target exists, is repo-relative, and round-trips
-  through the enforcement resolver (`lib/resolve-convention-pattern.sh <repo_root>
-  subject_pattern` emits the expected pattern). A broken pointer fails closed to no-enforcement by
-  contract — surface it at write time, not at the team's first blocked commit.
+- **Verification adds two probes.** (1) The pointer's target exists, is repo-relative, and
+  round-trips through the enforcement resolver (`lib/resolve-convention-pattern.sh <repo_root>
+  subject_pattern` emits the expected pattern) — a broken pointer fails closed to no-enforcement by
+  contract, so surface it at write time, not at the team's first blocked commit. (2) The neutral
+  file is **staged together with the pointer**, by explicit path, in the same team-write
+  verification (step 6's team guard covers only `.claude/source-control.md`) — a commit carrying
+  `convention_source` without its tracked YAML target would hand every fresh checkout the
+  missing-file fail-closed path and silently disable enforcement repo-wide. Run the same
+  ignore-check + stage + `git diff --quiet` sequence against the neutral file's path, and treat an
+  ignore-rule match on it as the same hard STOP as an ignored team file.


### PR DESCRIPTION
Closes #1141

## Summary

Author-directed reopen of #913's recorded "no YAML / no path rename" decision — the four reopen grounds (author directive, a real consuming machine hand-syncing three byte-identical regex copies, the ecosystem's prose-only AGENTS.md pointer standard with no machine format, and the plugin-audit recurring-concerns memory contradicting the decline) are recorded in #1141; a comment recording the outcome goes on #913 at merge.

The team-tracked `.claude/source-control.md` may now declare `## convention_source`: a **repo-relative flat-scalar YAML file** (`subject_pattern`, `pr_title_pattern`, optional `pr_body_required_sections` list or `none`, optional `dialect:` defaulting `posix-ere`) that enforcement (commit-msg hooks, CI) and drafting (any agent) consume as one source. Key contract points, all recorded in the commit-convention seam README:

- **Back-compat absolute:** no pointer → today's markdown-H2 behavior, zero action for existing consumers.
- **Everything repo-declared:** the path is the consuming repo's call (no hardcoded doc root; no well-known search list in V1 — recorded decision with rationale). The `Conventional Commits` keyword and the pr-title deferral marker work identically on both surfaces.
- **Per-key precedence:** the neutral file is authoritative for keys it carries; omitted keys fall back to the markdown H2; plugin-only keys (`trailer_policy`, `pr_body_attribution`) stay `.claude/`-side; user/local overlay layers unchanged.
- **Enforcement contract unchanged:** POSIX ERE only, unresolved = no enforcement, team-only policy floor — including the pointer itself (an overlay cannot redirect the gate). A declared-but-broken pointer (absolute/backslash/`..` path, missing file) or a non-`posix-ere` dialect **fails closed** with a diagnostic, never a silent markdown fallback that could enforce a migration-retired pattern.
- **Incumbent steelman documented:** markdown-H2's doubles-as-documentation purposes tested against the move (YAML `#` comments + prose pointer doc); frontmatter-hybrid re-examined and declined for V1 with rationale.
- **`setup apply`** gains the offer-and-migrate path: repo-chosen path, YAML write, pointer declaration, and retiring duplicated markdown keys so both surfaces are never authoritative for the same key. Monorepo per-directory scoping: out of scope V1, recorded.

`lib/resolve-convention-pattern.sh` extended; the guardrails vendored copy synced byte-identical via `scripts/sync-resolve-convention-pattern.sh` (gate: resolve-convention-pattern-sync), with guardrails 0.12.3 → 0.13.0 + CHANGELOG per the bump gate. source-control 0.22.0 → 0.23.0 + CHANGELOG.

## Test plan

- `bash lib/resolve-convention-pattern.test.sh`: **44 cases, 0 failed** — 14 new neutral-SSOT cases: quoted/double-quoted/unquoted YAML values, CC keyword and deferral marker in YAML, explicit `posix-ere` dialect, non-ERE dialect → fail closed, missing-file pointer → fail closed with no stale markdown fallback, absolute/traversal pointer rejection, omitted-key markdown fallback, YAML-wins-over-unretired-duplicate, comment/blank inertness, overlay-pointer ignored (team-only floor).
- `scripts/sync-resolve-convention-pattern.sh --check`: guardrails copy byte-identical.
- `skill-quality:check` on `setup`: PASS, 0 errors.
- `jq -e` validates both manifests and the evals file; new setup eval 18 covers the apply migration path.

## Related

- #913 — the reopened decision (outcome comment lands there on merge).
- Issue chain: #1138 (PR #1142) → #1139 (PR #1144) → #1140 (PR #1146) → #1141 (this), all merged in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
