### PR TITLE
feat(claude-ops): scope-selectable skill-usage store + machine-local git exclude

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",
@@ -31,8 +31,20 @@
     },
     "skill_usage_dir": {
       "type": "string",
-      "title": "Skill-usage log directory (project-relative)",
-      "description": "Optional contained project-relative directory where the skill-usage-audit hook writes skill-usage.jsonl. Absolute, drive, UNC, traversal, and escaping-symlink paths are invalid. Leave unset to use .claude/observability."
+      "title": "Skill-usage log directory (relative subpath under the scope root)",
+      "description": "Optional contained relative directory where the skill-usage-audit hooks write skill-usage.jsonl, resolved under the skill_usage_scope root (repo scope: the project root; user scope: $HOME). Absolute, drive, UNC, traversal, and escaping-symlink paths are invalid in every scope. Ignored by the data-dir scope (plugin-owned layout). Leave unset to use .claude/observability."
+    },
+    "skill_usage_scope": {
+      "type": "string",
+      "title": "Skill-usage log scope",
+      "description": "Where the skill-usage store lives. Valid values: \"repo\" (default — project tree under the repo root, kept out of git status via a machine-local .git/info/exclude entry), \"user\" (the skill_usage_dir subpath under $HOME, one cross-repo store; rows carry a project field), \"data-dir\" (${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>, plugin-owned and update-safe). The manifest schema has no enum type, so this validates in prose; any other value is treated as \"repo\" with a one-time advisory.",
+      "default": "repo"
+    },
+    "skill_usage_git_exclude": {
+      "type": "boolean",
+      "title": "Machine-local git exclude for the repo-scope store",
+      "description": "When the repo-scope store sits inside a git work tree, idempotently add its directory to .git/info/exclude (machine-local; never touches .gitignore or tracked files) so git status stays clean. Set false if your team deliberately commits the telemetry.",
+      "default": true
     },
     "install_new": {
       "type": "string",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -24,7 +24,9 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   `project` (project-root basename, display) and `project_id` (basename + 8-char digest of
   the physical path — same-basename checkouts stay distinguishable) so cross-repo scopes
   keep repo identity; the data-dir key uses the same collision-resistant slug, and the
-  exclude line is segment-normalized so a configured `./x` or `x//y` still matches.
+  exclude line is segment-normalized (a configured `./x` or `x//y` still matches) and
+  glob-escaped (`*` `?` `[` in a configured dir write a literal exclude pattern, not a
+  glob that over-matches sibling dirs).
   **Default-flip decision (recorded):** the default deliberately stays `repo` — the store
   sits beside `hook-events.jsonl` per the observability skill's project-local posture (that
   skill reads only `hook-events.jsonl` and the OTEL store, so colocation is convention, not

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   keep repo identity; the data-dir key uses the same collision-resistant slug, and the
   exclude line is segment-normalized (a configured `./x` or `x//y` still matches) and
   glob-escaped (`*` `?` `[` in a configured dir write a literal exclude pattern, not a
-  glob that over-matches sibling dirs).
+  glob that over-matches sibling dirs). A `skill_usage_dir=.` (repo-root) store excludes
+  the store file (`/skill-usage.jsonl`) rather than the whole tree.
   **Default-flip decision (recorded):** the default deliberately stays `repo` — the store
   sits beside `hook-events.jsonl` per the observability skill's project-local posture (that
   skill reads only `hook-events.jsonl` and the OTEL store, so colocation is convention, not

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.0]
+
+### Added
+
+- **`skill_usage_scope` userConfig — the skill-usage store's home is now scope-selectable
+  (`repo` | `user` | `data-dir`), and the repo scope keeps `git status` clean via a
+  machine-local `.git/info/exclude` entry (`#1151`).** Previously the store was forced into
+  every consuming repo's tree (`.claude/observability/skill-usage.jsonl` as untracked
+  `git status` noise) and the `skill_usage_dir` containment validation made user/machine
+  scope unreachable by config — containment as a ceiling instead of a default. Now: `repo`
+  (default, unchanged location) resolves the contained `skill_usage_dir` subpath under the
+  repo root and idempotently adds the store dir to `.git/info/exclude` (machine-local; never
+  `.gitignore` or tracked files; tracked content is unaffected by ignore semantics; opt out
+  with the new `skill_usage_git_exclude=false` for teams that deliberately commit the
+  telemetry); `user` resolves the same contained subpath under `$HOME` — one cross-repo
+  operator store; `data-dir` writes `${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>` —
+  plugin-owned, update-safe, keyed by repo. Unknown scope values fall back to `repo` with a
+  one-time advisory (prose-validated; the manifest schema has no enum type). Store rows gain
+  a `project` field (project-root basename) so cross-repo scopes keep repo identity.
+  **Default-flip decision (recorded):** the default deliberately stays `repo` — the store
+  sits beside `hook-events.jsonl` per the observability skill's project-local posture (that
+  skill reads only `hook-events.jsonl` and the OTEL store, so colocation is convention, not
+  a read dependency), the exclude entry removes the status noise that motivated the change,
+  and flipping would silently relocate existing consumers' data.
+
 ## [0.18.3]
 
 ### Security

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -21,7 +21,10 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   operator store; `data-dir` writes `${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>` —
   plugin-owned, update-safe, keyed by repo. Unknown scope values fall back to `repo` with a
   one-time advisory (prose-validated; the manifest schema has no enum type). Store rows gain
-  a `project` field (project-root basename) so cross-repo scopes keep repo identity.
+  `project` (project-root basename, display) and `project_id` (basename + 8-char digest of
+  the physical path — same-basename checkouts stay distinguishable) so cross-repo scopes
+  keep repo identity; the data-dir key uses the same collision-resistant slug, and the
+  exclude line is segment-normalized so a configured `./x` or `x//y` still matches.
   **Default-flip decision (recorded):** the default deliberately stays `repo` — the store
   sits beside `hook-events.jsonl` per the observability skill's project-local posture (that
   skill reads only `hook-events.jsonl` and the OTEL store, so colocation is convention, not

--- a/plugins/claude-ops/README.md
+++ b/plugins/claude-ops/README.md
@@ -187,7 +187,8 @@ options tune the skills:
   second store lives. `repo` (default) keeps it in the project tree, with a
   machine-local `.git/info/exclude` entry so `git status` stays clean; `user`
   resolves the same `skill_usage_dir` subpath under `$HOME` for one cross-repo
-  operator store (rows carry a `project` field); `data-dir` writes
+  operator store (rows carry `project` + collision-resistant `project_id`
+  fields); `data-dir` writes
   `${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>` — plugin-owned, update-safe,
   never in any repo tree. Prose-validated (no `enum` in the manifest schema);
   an unknown value falls back to `repo` with a one-time advisory. The default

--- a/plugins/claude-ops/README.md
+++ b/plugins/claude-ops/README.md
@@ -34,8 +34,10 @@ boolean (default **on**; see [Per-hook kill switches](#per-hook-kill-switches)).
 The six pure emitters are a no-op until a consumer wires a sink (below);
 `skill-usage-audit` is the exception — both its producers also write the shared
 `skill-usage.jsonl` second store unconditionally (disable the whole feature with
-`skill_usage_audit_enabled=false`, or relocate the store with the
-`skill_usage_dir` option).
+`skill_usage_audit_enabled=false`; pick the store's home with `skill_usage_scope`
+and `skill_usage_dir`). In the default repo scope the store dir is kept out of
+`git status` via an idempotent machine-local `.git/info/exclude` entry
+(`skill_usage_git_exclude=false` opts out for teams that commit the telemetry).
 
 `skill-usage-audit` is captured by two disjoint producers so both invocation
 paths are measured: the model-invoked `Skill` tool (`PostToolUse`) and the
@@ -181,10 +183,27 @@ options tune the skills:
   Absolute, drive-qualified, UNC, traversal, and escaping-symlink paths are
   invalid; known-issues operations must stop and direct you to reconfigure
   rather than write outside the project.
-- **`skill_usage_dir`** (string, optional) — project-relative directory where
-  `skill-usage-audit` writes its `skill-usage.jsonl` second store (the
+- **`skill_usage_scope`** (string, optional) — where the `skill-usage-audit`
+  second store lives. `repo` (default) keeps it in the project tree, with a
+  machine-local `.git/info/exclude` entry so `git status` stays clean; `user`
+  resolves the same `skill_usage_dir` subpath under `$HOME` for one cross-repo
+  operator store (rows carry a `project` field); `data-dir` writes
+  `${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>` — plugin-owned, update-safe,
+  never in any repo tree. Prose-validated (no `enum` in the manifest schema);
+  an unknown value falls back to `repo` with a one-time advisory. The default
+  stays `repo` deliberately: the store sits beside `hook-events.jsonl`, matching
+  the observability posture that telemetry is project-local, and the exclude
+  entry removes the status noise that motivated the scope knob.
+- **`skill_usage_git_exclude`** (boolean, default `true`) — repo scope only:
+  idempotently exclude the store dir via `.git/info/exclude` (never touches
+  `.gitignore` or tracked files). Set `false` when your team deliberately
+  commits the telemetry.
+- **`skill_usage_dir`** (string, optional) — contained relative directory,
+  resolved under the scope root (repo scope: repo root; user scope: `$HOME`),
+  where `skill-usage-audit` writes its `skill-usage.jsonl` second store (the
   "measuring skills" record, separate from the telemetry envelope); leave unset
-  to use `.claude/observability`. The same containment rules apply. An invalid
+  to use `.claude/observability`. The same containment rules apply in every
+  scope; the `data-dir` scope ignores it. An invalid
   value produces a visible advisory and skips the second-store write; telemetry
   through an independently configured sink can still proceed.
 

--- a/plugins/claude-ops/hooks/claude-ops-paths.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.sh
@@ -41,3 +41,64 @@ claude_ops::resolve_project_relative_dir() {
 
   printf '%s' "$candidate"
 }
+
+# Stable slug for a project directory, used to key per-repo stores under
+# machine-level bases (${CLAUDE_PLUGIN_DATA}). Physical path, separators and
+# reserved bytes folded to '-'.
+claude_ops::repo_slug() {
+  local p
+  p=$(hook::normalize_path "$(hook::physical_path "$1")")
+  p="${p//[^A-Za-z0-9._-]/-}"
+  printf '%s' "${p:-project}"
+}
+
+# Resolve the skill-usage store directory for a scope:
+#   repo (default) — skill_usage_dir (default .claude/observability) as a
+#     contained project-relative path under the project root.
+#   user — the same contained subpath, resolved under $HOME instead
+#     (default ~/.claude/observability).
+#   data-dir — ${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>; skill_usage_dir
+#     does not apply (the data dir is plugin-owned, keyed by repo).
+# Prints the destination on success. Returns 1 on an invalid configured dir,
+# 2 when the scope's base directory is unavailable.
+claude_ops::resolve_skill_usage_dir() {
+  local scope="$1" project_dir="$2" rel_dir="$3"
+  case "$scope" in
+  user)
+    [[ -n "${HOME:-}" && -d "${HOME:-}" ]] || return 2
+    claude_ops::resolve_project_relative_dir "$HOME" "$rel_dir" || return 1
+    ;;
+  data-dir)
+    [[ -n "${CLAUDE_PLUGIN_DATA:-}" ]] || return 2
+    printf '%s' "${CLAUDE_PLUGIN_DATA%/}/skill-usage/$(claude_ops::repo_slug "$project_dir")"
+    ;;
+  *)
+    claude_ops::resolve_project_relative_dir "$project_dir" "$rel_dir" || return 1
+    ;;
+  esac
+}
+
+# Keep `git status` clean when the store lives inside a repo work tree: append
+# a root-anchored ignore line for the store dir to the repo's machine-local
+# exclude file (git rev-parse --git-path info/exclude — correct in linked
+# worktrees too). Idempotent; never touches tracked files or .gitignore; only
+# ignore semantics change, so tracked content under the dir is unaffected.
+# Disable with skill_usage_git_exclude=false. Best-effort: every failure is a
+# silent no-op (the write path must never break on ignore hygiene).
+claude_ops::ensure_git_exclude() {
+  local project_dir="$1" rel_dir="$2" exclude_file line
+  [[ "${CLAUDE_PLUGIN_OPTION_SKILL_USAGE_GIT_EXCLUDE:-true}" == "true" ]] || return 0
+  exclude_file=$(git -C "$project_dir" rev-parse --git-path info/exclude 2>/dev/null | tr -d '\r')
+  [[ -n "$exclude_file" ]] || return 0
+  case "$exclude_file" in
+  /* | [A-Za-z]:*) ;;
+  *) exclude_file="${project_dir%/}/$exclude_file" ;;
+  esac
+  line="${rel_dir//\\//}"
+  line="/${line%/}/"
+  if [[ -f "$exclude_file" ]] && grep -qxF -- "$line" "$exclude_file" 2>/dev/null; then
+    return 0
+  fi
+  mkdir -p "$(dirname -- "$exclude_file")" 2>/dev/null || return 0
+  printf '%s\n' "$line" >>"$exclude_file" 2>/dev/null || true
+}

--- a/plugins/claude-ops/hooks/claude-ops-paths.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.sh
@@ -119,14 +119,17 @@ claude_ops::resolve_skill_usage_dir() {
 }
 
 # Keep `git status` clean when the store lives inside a repo work tree: append
-# a root-anchored ignore line for the store dir to the repo's machine-local
-# exclude file (git rev-parse --git-path info/exclude — correct in linked
-# worktrees too). Idempotent; never touches tracked files or .gitignore; only
-# ignore semantics change, so tracked content under the dir is unaffected.
-# Disable with skill_usage_git_exclude=false. Best-effort: every failure is a
-# silent no-op (the write path must never break on ignore hygiene).
+# a root-anchored ignore line to the repo's machine-local exclude file (git
+# rev-parse --git-path info/exclude — correct in linked worktrees too).
+# Normally ignores the store DIR (`/<dir>/`); when the configured dir resolves
+# to the repo root itself (e.g. skill_usage_dir=.), the store is a bare file at
+# the root, so ignore just that FILE (`/<store_file>`) rather than the whole
+# repo. Idempotent; never touches tracked files or .gitignore; only ignore
+# semantics change, so tracked content is unaffected. Disable with
+# skill_usage_git_exclude=false. Best-effort: every failure is a silent no-op
+# (the write path must never break on ignore hygiene).
 claude_ops::ensure_git_exclude() {
-  local project_dir="$1" rel_dir="$2" exclude_file line
+  local project_dir="$1" rel_dir="$2" store_file="${3:-skill-usage.jsonl}" exclude_file dir line
   [[ "${CLAUDE_PLUGIN_OPTION_SKILL_USAGE_GIT_EXCLUDE:-true}" == "true" ]] || return 0
   exclude_file=$(git -C "$project_dir" rev-parse --git-path info/exclude 2>/dev/null | tr -d '\r')
   [[ -n "$exclude_file" ]] || return 0
@@ -134,9 +137,13 @@ claude_ops::ensure_git_exclude() {
   /* | [A-Za-z]:*) ;;
   *) exclude_file="${project_dir%/}/$exclude_file" ;;
   esac
-  line="$(claude_ops::normalize_rel_segments "$rel_dir")"
-  [[ -n "$line" ]] || return 0
-  line="/$(claude_ops::gitignore_escape "$line")/"
+  dir="$(claude_ops::normalize_rel_segments "$rel_dir")"
+  if [[ -n "$dir" ]]; then
+    line="/$(claude_ops::gitignore_escape "$dir")/"
+  else
+    # Store dir IS the repo root — ignore the specific store file, not the tree.
+    line="/$(claude_ops::gitignore_escape "$store_file")"
+  fi
   if [[ -f "$exclude_file" ]] && grep -qxF -- "$line" "$exclude_file" 2>/dev/null; then
     return 0
   fi

--- a/plugins/claude-ops/hooks/claude-ops-paths.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.sh
@@ -42,14 +42,35 @@ claude_ops::resolve_project_relative_dir() {
   printf '%s' "$candidate"
 }
 
-# Stable slug for a project directory, used to key per-repo stores under
-# machine-level bases (${CLAUDE_PLUGIN_DATA}). Physical path, separators and
-# reserved bytes folded to '-'.
+# Stable, collision-resistant slug for a project directory, used to key
+# per-repo stores under machine-level bases (${CLAUDE_PLUGIN_DATA}) and to
+# identify the repo in cross-repo store rows. Readable basename + an 8-char
+# digest of the full physical path — folding alone is lossy (/tmp/a-b and
+# /tmp/a/b would collide), so the digest carries the uniqueness. sha1sum ships
+# with Git Bash and Linux; cksum is the POSIX fallback.
 claude_ops::repo_slug() {
-  local p
+  local p base hash
   p=$(hook::normalize_path "$(hook::physical_path "$1")")
-  p="${p//[^A-Za-z0-9._-]/-}"
-  printf '%s' "${p:-project}"
+  base="${p##*/}"
+  base="${base//[^A-Za-z0-9._-]/-}"
+  hash=$(printf '%s' "$p" | sha1sum 2>/dev/null | cut -c1-8)
+  [[ -n "$hash" ]] || hash=$(printf '%s' "$p" | cksum 2>/dev/null | cut -d' ' -f1)
+  printf '%s' "${base:-project}${hash:+-$hash}"
+}
+
+# Collapse a configured relative dir to clean segments: both separators to '/',
+# empty and '.' segments dropped. The resolver tolerates ./x and x//y when
+# writing (mkdir normalizes), but a git ignore pattern is matched literally, so
+# the exclude line must be canonical.
+claude_ops::normalize_rel_segments() {
+  local raw="${1//\\//}" out="" seg
+  local -a segs
+  IFS='/' read -r -a segs <<<"$raw"
+  for seg in "${segs[@]}"; do
+    [[ -z "$seg" || "$seg" == "." ]] && continue
+    out+="${seg}/"
+  done
+  printf '%s' "${out%/}"
 }
 
 # Resolve the skill-usage store directory for a scope:
@@ -94,8 +115,9 @@ claude_ops::ensure_git_exclude() {
   /* | [A-Za-z]:*) ;;
   *) exclude_file="${project_dir%/}/$exclude_file" ;;
   esac
-  line="${rel_dir//\\//}"
-  line="/${line%/}/"
+  line="$(claude_ops::normalize_rel_segments "$rel_dir")"
+  [[ -n "$line" ]] || return 0
+  line="/${line}/"
   if [[ -f "$exclude_file" ]] && grep -qxF -- "$line" "$exclude_file" 2>/dev/null; then
     return 0
   fi

--- a/plugins/claude-ops/hooks/claude-ops-paths.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.sh
@@ -73,6 +73,25 @@ claude_ops::normalize_rel_segments() {
   printf '%s' "${out%/}"
 }
 
+# Backslash-escape gitignore glob metacharacters (* ? [) and a literal
+# backslash so a configured dir like `telemetry*` writes a LITERAL exclude
+# pattern, not a glob that over-matches sibling dirs. Leading #/! need no
+# handling: the exclude line always begins with the root anchor `/`, so the
+# comment/negation meaning (first-char-only) never applies.
+claude_ops::gitignore_escape() {
+  local s="$1" out="" ch i
+  for ((i = 0; i < ${#s}; i++)); do
+    ch="${s:i:1}"
+    # shellcheck disable=SC1003  # '\' is a literal single-backslash case pattern, not a botched quote escape
+    case "$ch" in
+    '*' | '?' | '[' | '\') out+='\' ;;
+    *) ;;
+    esac
+    out+="$ch"
+  done
+  printf '%s' "$out"
+}
+
 # Resolve the skill-usage store directory for a scope:
 #   repo (default) — skill_usage_dir (default .claude/observability) as a
 #     contained project-relative path under the project root.
@@ -117,7 +136,7 @@ claude_ops::ensure_git_exclude() {
   esac
   line="$(claude_ops::normalize_rel_segments "$rel_dir")"
   [[ -n "$line" ]] || return 0
-  line="/${line}/"
+  line="/$(claude_ops::gitignore_escape "$line")/"
   if [[ -f "$exclude_file" ]] && grep -qxF -- "$line" "$exclude_file" 2>/dev/null; then
     return 0
   fi

--- a/plugins/claude-ops/hooks/claude-ops-paths.test.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.test.sh
@@ -70,6 +70,18 @@ case "$slug" in
 '') bad "repo_slug non-empty" ;;
 *) ok "repo_slug emits only safe bytes" ;;
 esac
+mkdir -p "$TEST_TMPDIR/a-b" "$TEST_TMPDIR/a/b"
+if [[ "$(claude_ops::repo_slug "$TEST_TMPDIR/a-b")" != "$(claude_ops::repo_slug "$TEST_TMPDIR/a/b")" ]]; then
+  ok "repo_slug distinguishes fold-colliding paths"
+else
+  bad "repo_slug distinguishes fold-colliding paths"
+fi
+assert_eq "repo_slug is stable across calls" "$slug" "$(claude_ops::repo_slug "$PROJECT")"
+
+assert_eq "normalize_rel_segments drops ./ and //" ".claude/observability" \
+  "$(claude_ops::normalize_rel_segments './.claude//observability/')"
+assert_eq "normalize_rel_segments folds backslashes" "telemetry/skills" \
+  "$(claude_ops::normalize_rel_segments 'telemetry\skills')"
 assert_eq "data-dir scope keys by repo slug" "$DATA_DIR/skill-usage/$slug" \
   "$(CLAUDE_PLUGIN_DATA="$DATA_DIR" claude_ops::resolve_skill_usage_dir data-dir "$PROJECT" '.claude/observability')"
 if CLAUDE_PLUGIN_DATA="" claude_ops::resolve_skill_usage_dir data-dir "$PROJECT" '.claude/observability' >/dev/null; then
@@ -99,6 +111,22 @@ if git -C "$REPO" init -q 2>/dev/null; then
     ok "store dir invisible to git status"
   else
     bad "store dir invisible to git status"
+  fi
+  REPO3="$TEST_TMPDIR/repo3"
+  mkdir -p "$REPO3"
+  git -C "$REPO3" init -q 2>/dev/null
+  claude_ops::ensure_git_exclude "$REPO3" './.claude//observability/'
+  if grep -qxF -- '/.claude/observability/' "$REPO3/.git/info/exclude" 2>/dev/null; then
+    ok "denormalized configured dir yields canonical exclude line"
+  else
+    bad "denormalized configured dir yields canonical exclude line"
+  fi
+  mkdir -p "$REPO3/.claude/observability"
+  : >"$REPO3/.claude/observability/skill-usage.jsonl"
+  if [[ -z "$(git -C "$REPO3" status --porcelain 2>/dev/null)" ]]; then
+    ok "status clean under denormalized configured dir"
+  else
+    bad "status clean under denormalized configured dir"
   fi
   REPO2="$TEST_TMPDIR/repo2"
   mkdir -p "$REPO2"

--- a/plugins/claude-ops/hooks/claude-ops-paths.test.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.test.sh
@@ -27,7 +27,10 @@ for case_name in posix_absolute windows_drive windows_drive_relative unc travers
   unc) value='\\\\server\\share\\skills' ;;
   traversal) value='../outside' ;;
   backslash_traversal) value='..\\outside' ;;
-  *) bad "unknown path test case: $case_name"; continue ;;
+  *)
+    bad "unknown path test case: $case_name"
+    continue
+    ;;
   esac
   if claude_ops::resolve_project_relative_dir "$PROJECT" "$value" >/dev/null; then
     bad "$case_name path rejected"
@@ -45,5 +48,72 @@ if ln -s "$OUTSIDE" "$PROJECT/escape" 2>/dev/null && [[ -L "$PROJECT/escape" ]];
     ok "escaping symlink ancestor rejected"
   fi
 fi
+
+# --- Scope-selected skill-usage destination ---------------------------------
+FAKE_HOME="$TEST_TMPDIR/home"
+mkdir -p "$FAKE_HOME"
+assert_eq "repo scope resolves under project" "$PROJECT/.claude/observability" \
+  "$(claude_ops::resolve_skill_usage_dir repo "$PROJECT" '.claude/observability')"
+assert_eq "user scope resolves under HOME" "$FAKE_HOME/.claude/observability" \
+  "$(HOME="$FAKE_HOME" claude_ops::resolve_skill_usage_dir user "$PROJECT" '.claude/observability')"
+if HOME="$FAKE_HOME" claude_ops::resolve_skill_usage_dir user "$PROJECT" '../outside' >/dev/null; then
+  bad "user scope traversal rejected"
+else
+  ok "user scope traversal rejected"
+fi
+
+DATA_DIR="$TEST_TMPDIR/plugin-data"
+mkdir -p "$DATA_DIR"
+slug=$(claude_ops::repo_slug "$PROJECT")
+case "$slug" in
+*[!A-Za-z0-9._-]*) bad "repo_slug emits only safe bytes" ;;
+'') bad "repo_slug non-empty" ;;
+*) ok "repo_slug emits only safe bytes" ;;
+esac
+assert_eq "data-dir scope keys by repo slug" "$DATA_DIR/skill-usage/$slug" \
+  "$(CLAUDE_PLUGIN_DATA="$DATA_DIR" claude_ops::resolve_skill_usage_dir data-dir "$PROJECT" '.claude/observability')"
+if CLAUDE_PLUGIN_DATA="" claude_ops::resolve_skill_usage_dir data-dir "$PROJECT" '.claude/observability' >/dev/null; then
+  bad "data-dir scope without CLAUDE_PLUGIN_DATA fails"
+else
+  ok "data-dir scope without CLAUDE_PLUGIN_DATA fails"
+fi
+
+# --- Machine-local git exclude hygiene --------------------------------------
+REPO="$TEST_TMPDIR/repo"
+mkdir -p "$REPO"
+if git -C "$REPO" init -q 2>/dev/null; then
+  claude_ops::ensure_git_exclude "$REPO" '.claude/observability'
+  EXCL="$REPO/.git/info/exclude"
+  if grep -qxF -- '/.claude/observability/' "$EXCL" 2>/dev/null; then
+    ok "exclude line added to .git/info/exclude"
+  else
+    bad "exclude line added to .git/info/exclude"
+  fi
+  before=$(grep -cxF -- '/.claude/observability/' "$EXCL")
+  claude_ops::ensure_git_exclude "$REPO" '.claude/observability'
+  assert_eq "exclude append is idempotent" "$before" \
+    "$(grep -cxF -- '/.claude/observability/' "$EXCL")"
+  mkdir -p "$REPO/.claude/observability"
+  : >"$REPO/.claude/observability/skill-usage.jsonl"
+  if [[ -z "$(git -C "$REPO" status --porcelain -- .claude/observability 2>/dev/null)" ]]; then
+    ok "store dir invisible to git status"
+  else
+    bad "store dir invisible to git status"
+  fi
+  REPO2="$TEST_TMPDIR/repo2"
+  mkdir -p "$REPO2"
+  git -C "$REPO2" init -q 2>/dev/null
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_GIT_EXCLUDE=false \
+    claude_ops::ensure_git_exclude "$REPO2" '.claude/observability'
+  if grep -qxF -- '/.claude/observability/' "$REPO2/.git/info/exclude" 2>/dev/null; then
+    bad "skill_usage_git_exclude=false suppresses the exclude write"
+  else
+    ok "skill_usage_git_exclude=false suppresses the exclude write"
+  fi
+fi
+NONREPO="$TEST_TMPDIR/nonrepo"
+mkdir -p "$NONREPO"
+claude_ops::ensure_git_exclude "$NONREPO" '.claude/observability'
+ok "non-repo project is a silent no-op for exclude hygiene"
 
 report

--- a/plugins/claude-ops/hooks/claude-ops-paths.test.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.test.sh
@@ -155,6 +155,22 @@ if git -C "$REPO" init -q 2>/dev/null; then
   else
     bad "glob-metachar configured dir written as literal exclude pattern"
   fi
+  # skill_usage_dir=. → store is a bare file at the repo root; exclude the FILE.
+  REPO5="$TEST_TMPDIR/repo5"
+  mkdir -p "$REPO5"
+  git -C "$REPO5" init -q 2>/dev/null
+  claude_ops::ensure_git_exclude "$REPO5" '.'
+  if grep -qxF -- '/skill-usage.jsonl' "$REPO5/.git/info/exclude" 2>/dev/null; then
+    ok "repo-root store excludes the store file, not the tree"
+  else
+    bad "repo-root store excludes the store file, not the tree"
+  fi
+  : >"$REPO5/skill-usage.jsonl"
+  if [[ -z "$(git -C "$REPO5" status --porcelain 2>/dev/null)" ]]; then
+    ok "repo-root store file invisible to git status"
+  else
+    bad "repo-root store file invisible to git status"
+  fi
 fi
 NONREPO="$TEST_TMPDIR/nonrepo"
 mkdir -p "$NONREPO"

--- a/plugins/claude-ops/hooks/claude-ops-paths.test.sh
+++ b/plugins/claude-ops/hooks/claude-ops-paths.test.sh
@@ -82,6 +82,11 @@ assert_eq "normalize_rel_segments drops ./ and //" ".claude/observability" \
   "$(claude_ops::normalize_rel_segments './.claude//observability/')"
 assert_eq "normalize_rel_segments folds backslashes" "telemetry/skills" \
   "$(claude_ops::normalize_rel_segments 'telemetry\skills')"
+
+assert_eq "gitignore_escape escapes glob metachars" 'telemetry\*/a\?b/\[x]' \
+  "$(claude_ops::gitignore_escape 'telemetry*/a?b/[x]')"
+assert_eq "gitignore_escape leaves ordinary paths intact" '.claude/observability' \
+  "$(claude_ops::gitignore_escape '.claude/observability')"
 assert_eq "data-dir scope keys by repo slug" "$DATA_DIR/skill-usage/$slug" \
   "$(CLAUDE_PLUGIN_DATA="$DATA_DIR" claude_ops::resolve_skill_usage_dir data-dir "$PROJECT" '.claude/observability')"
 if CLAUDE_PLUGIN_DATA="" claude_ops::resolve_skill_usage_dir data-dir "$PROJECT" '.claude/observability' >/dev/null; then
@@ -137,6 +142,18 @@ if git -C "$REPO" init -q 2>/dev/null; then
     bad "skill_usage_git_exclude=false suppresses the exclude write"
   else
     ok "skill_usage_git_exclude=false suppresses the exclude write"
+  fi
+  # Glob-metachar configured dir writes a LITERAL exclude pattern (no dir
+  # created — * is illegal in a filename on Windows; the string path is the
+  # subject here).
+  REPO4="$TEST_TMPDIR/repo4"
+  mkdir -p "$REPO4"
+  git -C "$REPO4" init -q 2>/dev/null
+  claude_ops::ensure_git_exclude "$REPO4" 'telemetry*'
+  if grep -qxF -- '/telemetry\*/' "$REPO4/.git/info/exclude" 2>/dev/null; then
+    ok "glob-metachar configured dir written as literal exclude pattern"
+  else
+    bad "glob-metachar configured dir written as literal exclude pattern"
   fi
 fi
 NONREPO="$TEST_TMPDIR/nonrepo"

--- a/plugins/claude-ops/hooks/skill-usage-audit.sh
+++ b/plugins/claude-ops/hooks/skill-usage-audit.sh
@@ -2,9 +2,12 @@
 # PostToolUse/Skill hook: record Skill tool invocations for the "measuring
 # skills" pattern. Two independent outputs:
 #   1. A bespoke second store, skill-usage.jsonl (SkillUse events), written
-#      UNCONDITIONALLY. Its directory is project-relative and defaults to
-#      .claude/observability; override with the skill_usage_dir userConfig
-#      (exported to this hook as CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR).
+#      UNCONDITIONALLY. Destination is scope-selected by the skill_usage_scope
+#      userConfig (repo — default, project-relative skill_usage_dir under the
+#      repo root, git-status-clean via a machine-local .git/info/exclude entry;
+#      user — the same subpath under $HOME; data-dir —
+#      ${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>). skill_usage_dir defaults
+#      to .claude/observability (options arrive as CLAUDE_PLUGIN_OPTION_*).
 #   2. A telemetry envelope, emitted only when a consumer wires
 #      HOOK_TELEMETRY_SINK (the shared, generic seam).
 #
@@ -28,24 +31,36 @@ TOOL=$(hook::jq_field "$INPUT" '.tool_name') || exit 0
 [[ "$TOOL" == "Skill" ]] || exit 0
 
 SKILL=$(
-  hook::jq_field "$INPUT" '.tool_input.skill' \
-    || hook::jq_field "$INPUT" '.tool_input.command' \
-    || hook::jq_field "$INPUT" '.tool_input.name'
+  hook::jq_field "$INPUT" '.tool_input.skill' ||
+    hook::jq_field "$INPUT" '.tool_input.command' ||
+    hook::jq_field "$INPUT" '.tool_input.name'
 ) || exit 0
 SKILL="${SKILL#/}"
 
 # --- Second store: skill-usage.jsonl (unconditional) ------------------------
 project_dir=$(hook::repo_root "${CLAUDE_PROJECT_DIR:-.}")
 rel_dir="${CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR:-.claude/observability}"
+scope="${CLAUDE_PLUGIN_OPTION_SKILL_USAGE_SCOPE:-repo}"
+case "$scope" in
+repo | user | data-dir) ;;
+*)
+  if hook::notice_once "skill-usage-audit-badscope" "$INPUT"; then
+    hook::emit_skip_notice "PostToolUse" \
+      "claude-ops skill-usage logging: unknown skill_usage_scope \"${scope}\" (valid: repo, user, data-dir) — using the default repo scope."
+  fi
+  scope="repo"
+  ;;
+esac
 log_dir=""
-if ! log_dir=$(claude_ops::resolve_project_relative_dir "$project_dir" "$rel_dir"); then
+if ! log_dir=$(claude_ops::resolve_skill_usage_dir "$scope" "$project_dir" "$rel_dir"); then
   if hook::notice_once "skill-usage-audit-badconfig" "$INPUT"; then
     hook::emit_skip_notice "PostToolUse" \
-      "claude-ops skipped skill-usage logging: skill_usage_dir must be a contained project-relative path (no absolute, drive, UNC, traversal, or escaping symlink path)."
+      "claude-ops skipped skill-usage logging: the skill-usage destination is invalid for scope \"${scope}\" (repo/user scopes need a contained relative skill_usage_dir — no absolute, drive, UNC, traversal, or escaping symlink path; data-dir needs CLAUDE_PLUGIN_DATA)."
   fi
-elif mkdir -p "$log_dir" 2>/dev/null \
-  && verified_log_dir=$(claude_ops::resolve_project_relative_dir "$project_dir" "$rel_dir") \
-  && [[ "$verified_log_dir" == "$log_dir" ]]; then
+elif mkdir -p "$log_dir" 2>/dev/null &&
+  verified_log_dir=$(claude_ops::resolve_skill_usage_dir "$scope" "$project_dir" "$rel_dir") &&
+  [[ "$verified_log_dir" == "$log_dir" ]]; then
+  [[ "$scope" == "repo" ]] && claude_ops::ensure_git_exclude "$project_dir" "$rel_dir"
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%S)
   branch=$(git -C "$project_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   line=$(
@@ -53,13 +68,14 @@ elif mkdir -p "$log_dir" 2>/dev/null \
       --arg ts "$ts" \
       --arg skill "$SKILL" \
       --arg branch "$branch" \
+      --arg project "$(basename -- "$project_dir")" \
       --arg hook "skill-usage-audit" \
-      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, hook: $hook, source: "tool"}'
+      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, project: $project, hook: $hook, source: "tool"}'
   ) && hook::append_jsonl "${log_dir}/skill-usage.jsonl" "$line"
 else
   if hook::notice_once "skill-usage-audit-nodest" "$INPUT"; then
     hook::emit_skip_notice "PostToolUse" \
-      "claude-ops skipped skill-usage logging: the configured project-relative destination could not be created safely."
+      "claude-ops skipped skill-usage logging: the configured destination could not be created safely."
   fi
 fi
 

--- a/plugins/claude-ops/hooks/skill-usage-audit.sh
+++ b/plugins/claude-ops/hooks/skill-usage-audit.sh
@@ -69,8 +69,9 @@ elif mkdir -p "$log_dir" 2>/dev/null &&
       --arg skill "$SKILL" \
       --arg branch "$branch" \
       --arg project "$(basename -- "$project_dir")" \
+      --arg project_id "$(claude_ops::repo_slug "$project_dir")" \
       --arg hook "skill-usage-audit" \
-      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, project: $project, hook: $hook, source: "tool"}'
+      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, project: $project, project_id: $project_id, hook: $hook, source: "tool"}'
   ) && hook::append_jsonl "${log_dir}/skill-usage.jsonl" "$line"
 else
   if hook::notice_once "skill-usage-audit-nodest" "$INPUT"; then

--- a/plugins/claude-ops/hooks/skill-usage-audit.test.sh
+++ b/plugins/claude-ops/hooks/skill-usage-audit.test.sh
@@ -16,7 +16,8 @@ source "$HOOK_DIR/claude-ops-test-helpers.sh"
 INPUT='{"tool_name":"Skill","tool_input":{"skill":"/research"}}'
 
 # --- Second store: written unconditionally, default .claude/observability ---
-PROJ="$TEST_TMPDIR/proj"; mkdir -p "$PROJ"
+PROJ="$TEST_TMPDIR/proj"
+mkdir -p "$PROJ"
 env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJ" \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 STORE="$PROJ/.claude/observability/skill-usage.jsonl"
@@ -30,7 +31,8 @@ else
 fi
 
 # --- skill_usage_dir userConfig override -----------------------------------
-PROJ2="$TEST_TMPDIR/proj2"; mkdir -p "$PROJ2"
+PROJ2="$TEST_TMPDIR/proj2"
+mkdir -p "$PROJ2"
 env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJ2" \
   CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR="telemetry/skills" \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
@@ -42,9 +44,11 @@ assert_eq "override dir used" "research" \
 # goes through hook::notice_once (once-per-session gate), which persists a
 # marker file under CLAUDE_PLUGIN_DATA — an unisolated real machine path would
 # make this assertion pass only on the first-ever run.
-PROJB="$TEST_TMPDIR/projb"; mkdir -p "$PROJB"
+PROJB="$TEST_TMPDIR/projb"
+mkdir -p "$PROJB"
 OUTSIDE="$TEST_TMPDIR/outside"
-BADCFG_DATA="$TEST_TMPDIR/badcfg-data"; mkdir -p "$BADCFG_DATA"
+BADCFG_DATA="$TEST_TMPDIR/badcfg-data"
+mkdir -p "$BADCFG_DATA"
 INVALID_OUTPUT=$(env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJB" \
   CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR="../outside" \
   CLAUDE_PLUGIN_DATA="$BADCFG_DATA" \
@@ -59,8 +63,10 @@ assert_contains "invalid override advisory is user-visible (systemMessage)" \
   "claude-ops skipped skill-usage logging"
 
 # --- Envelope emitted when a sink is wired ---------------------------------
-PROJ3="$TEST_TMPDIR/proj3"; mkdir -p "$PROJ3"
-TEL="$TEST_TMPDIR/tel.json"; SINK="$(make_sink "$TEL")"
+PROJ3="$TEST_TMPDIR/proj3"
+mkdir -p "$PROJ3"
+TEL="$TEST_TMPDIR/tel.json"
+SINK="$(make_sink "$TEL")"
 env HOOK_TELEMETRY_SINK="$SINK" CLAUDE_PROJECT_DIR="$PROJ3" \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 if wait_for_sink "$TEL"; then
@@ -75,16 +81,87 @@ else
 fi
 
 # --- Non-Skill tool is skipped (no store, no envelope) ---------------------
-PROJ4="$TEST_TMPDIR/proj4"; mkdir -p "$PROJ4"
-TELN="$TEST_TMPDIR/teln.json"; SINKN="$(make_sink "$TELN")"
+PROJ4="$TEST_TMPDIR/proj4"
+mkdir -p "$PROJ4"
+TELN="$TEST_TMPDIR/teln.json"
+SINKN="$(make_sink "$TELN")"
 env HOOK_TELEMETRY_SINK="$SINKN" CLAUDE_PROJECT_DIR="$PROJ4" \
   bash "$HOOK" <<<'{"tool_name":"Bash","tool_input":{"command":"ls"}}' >/dev/null 2>&1
 assert_file_absent "non-Skill → no second store" "$PROJ4/.claude/observability/skill-usage.jsonl"
 assert_file_absent "non-Skill → no envelope" "$TELN"
 
+# --- Repo scope in a git work tree: machine-local exclude hygiene ----------
+PROJG="$TEST_TMPDIR/projg"
+mkdir -p "$PROJG"
+if git -C "$PROJG" init -q 2>/dev/null; then
+  env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJG" \
+    bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
+  assert_eq "repo-scope store written in git repo" "research" \
+    "$(jq -r '.skill' "$PROJG/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+  assert_eq "row carries project field" "projg" \
+    "$(jq -r '.project' "$PROJG/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+  if grep -qxF -- '/.claude/observability/' "$PROJG/.git/info/exclude" 2>/dev/null; then
+    ok "exclude entry keeps git status clean"
+  else
+    bad "exclude entry keeps git status clean"
+  fi
+  if [[ -z "$(git -C "$PROJG" status --porcelain 2>/dev/null)" ]]; then
+    ok "git status clean after hook write"
+  else
+    bad "git status clean after hook write"
+  fi
+fi
+
+# --- user scope writes under HOME ------------------------------------------
+PROJU="$TEST_TMPDIR/proju"
+mkdir -p "$PROJU"
+HOMEU="$TEST_TMPDIR/homeu"
+mkdir -p "$HOMEU"
+env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJU" HOME="$HOMEU" \
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_SCOPE="user" \
+  bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
+assert_eq "user scope writes under HOME" "research" \
+  "$(jq -r '.skill' "$HOMEU/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+assert_file_absent "user scope leaves the project tree untouched" \
+  "$PROJU/.claude/observability/skill-usage.jsonl"
+
+# --- data-dir scope writes under CLAUDE_PLUGIN_DATA, keyed by repo slug -----
+PROJD="$TEST_TMPDIR/projd"
+mkdir -p "$PROJD"
+DATAD="$TEST_TMPDIR/datad"
+mkdir -p "$DATAD"
+env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJD" \
+  CLAUDE_PLUGIN_DATA="$DATAD" \
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_SCOPE="data-dir" \
+  bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
+DATAD_STORE=$(find "$DATAD/skill-usage" -name skill-usage.jsonl 2>/dev/null | head -n1)
+if [[ -n "$DATAD_STORE" ]]; then
+  assert_eq "data-dir scope writes keyed store" "research" "$(jq -r '.skill' "$DATAD_STORE")"
+else
+  bad "data-dir scope writes keyed store"
+fi
+assert_file_absent "data-dir scope leaves the project tree untouched" \
+  "$PROJD/.claude/observability/skill-usage.jsonl"
+
+# --- Unknown scope: visible advisory, falls back to repo --------------------
+PROJS="$TEST_TMPDIR/projs"
+mkdir -p "$PROJS"
+BADSCOPE_DATA="$TEST_TMPDIR/badscope-data"
+mkdir -p "$BADSCOPE_DATA"
+BADSCOPE_OUTPUT=$(env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJS" \
+  CLAUDE_PLUGIN_DATA="$BADSCOPE_DATA" \
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_SCOPE="machine" \
+  bash "$HOOK" <<<"$INPUT" 2>/dev/null)
+assert_contains "unknown scope emits visible advisory" "$BADSCOPE_OUTPUT" \
+  "unknown skill_usage_scope"
+assert_eq "unknown scope falls back to repo store" "research" \
+  "$(jq -r '.skill' "$PROJS/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+
 # --- Kill switch suppresses both outputs -----------------------------------
-PROJ5="$TEST_TMPDIR/proj5"; mkdir -p "$PROJ5"
-TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
+PROJ5="$TEST_TMPDIR/proj5"
+mkdir -p "$PROJ5"
+TELK="$TEST_TMPDIR/telk.json"
+SINKK="$(make_sink "$TELK")"
 env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PROJECT_DIR="$PROJ5" \
   CLAUDE_PLUGIN_OPTION_SKILL_USAGE_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1

--- a/plugins/claude-ops/hooks/skill-usage-audit.test.sh
+++ b/plugins/claude-ops/hooks/skill-usage-audit.test.sh
@@ -100,6 +100,11 @@ if git -C "$PROJG" init -q 2>/dev/null; then
     "$(jq -r '.skill' "$PROJG/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
   assert_eq "row carries project field" "projg" \
     "$(jq -r '.project' "$PROJG/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+  PROJG_ID="$(jq -r '.project_id // empty' "$PROJG/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+  case "$PROJG_ID" in
+  projg-*) ok "row carries collision-resistant project_id ($PROJG_ID)" ;;
+  *) bad "row carries collision-resistant project_id (got '$PROJG_ID')" ;;
+  esac
   if grep -qxF -- '/.claude/observability/' "$PROJG/.git/info/exclude" 2>/dev/null; then
     ok "exclude entry keeps git status clean"
   else

--- a/plugins/claude-ops/hooks/skill-usage-expansion-audit.sh
+++ b/plugins/claude-ops/hooks/skill-usage-expansion-audit.sh
@@ -10,8 +10,9 @@
 #
 # Same two outputs as the tool-path producer:
 #   1. The bespoke second store, skill-usage.jsonl (SkillUse events), written
-#      UNCONDITIONALLY, at the same project-relative destination (the
-#      skill_usage_dir userConfig, else .claude/observability).
+#      UNCONDITIONALLY, at the same scope-selected destination as the tool-path
+#      producer (skill_usage_scope: repo | user | data-dir; skill_usage_dir,
+#      else .claude/observability, for the repo/user scopes).
 #   2. The unified skill-usage-audit telemetry envelope, emitted only when a
 #      consumer wires HOOK_TELEMETRY_SINK. Keeps the same `hook` id and data
 #      schema so the store stays unified across both producers.
@@ -48,15 +49,27 @@ EXP_TYPE=$(jq -r '(.expansion_type // empty) | gsub("\r";"")' <<<"$INPUT" 2>/dev
 # --- Second store: skill-usage.jsonl (unconditional) ------------------------
 project_dir=$(hook::repo_root "${CLAUDE_PROJECT_DIR:-.}")
 rel_dir="${CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR:-.claude/observability}"
+scope="${CLAUDE_PLUGIN_OPTION_SKILL_USAGE_SCOPE:-repo}"
+case "$scope" in
+repo | user | data-dir) ;;
+*)
+  if hook::notice_once "skill-usage-expansion-audit-badscope" "$INPUT"; then
+    hook::emit_skip_notice "UserPromptExpansion" \
+      "claude-ops skill-usage logging: unknown skill_usage_scope \"${scope}\" (valid: repo, user, data-dir) — using the default repo scope."
+  fi
+  scope="repo"
+  ;;
+esac
 log_dir=""
-if ! log_dir=$(claude_ops::resolve_project_relative_dir "$project_dir" "$rel_dir"); then
+if ! log_dir=$(claude_ops::resolve_skill_usage_dir "$scope" "$project_dir" "$rel_dir"); then
   if hook::notice_once "skill-usage-expansion-audit-badconfig" "$INPUT"; then
     hook::emit_skip_notice "UserPromptExpansion" \
-      "claude-ops skipped skill-usage logging: skill_usage_dir must be a contained project-relative path (no absolute, drive, UNC, traversal, or escaping symlink path)."
+      "claude-ops skipped skill-usage logging: the skill-usage destination is invalid for scope \"${scope}\" (repo/user scopes need a contained relative skill_usage_dir — no absolute, drive, UNC, traversal, or escaping symlink path; data-dir needs CLAUDE_PLUGIN_DATA)."
   fi
-elif mkdir -p "$log_dir" 2>/dev/null \
-  && verified_log_dir=$(claude_ops::resolve_project_relative_dir "$project_dir" "$rel_dir") \
-  && [[ "$verified_log_dir" == "$log_dir" ]]; then
+elif mkdir -p "$log_dir" 2>/dev/null &&
+  verified_log_dir=$(claude_ops::resolve_skill_usage_dir "$scope" "$project_dir" "$rel_dir") &&
+  [[ "$verified_log_dir" == "$log_dir" ]]; then
+  [[ "$scope" == "repo" ]] && claude_ops::ensure_git_exclude "$project_dir" "$rel_dir"
   ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%S)
   branch=$(git -C "$project_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   line=$(
@@ -64,15 +77,16 @@ elif mkdir -p "$log_dir" 2>/dev/null \
       --arg ts "$ts" \
       --arg skill "$SKILL" \
       --arg branch "$branch" \
+      --arg project "$(basename -- "$project_dir")" \
       --arg hook "skill-usage-audit" \
       --arg exp "$EXP_TYPE" \
-      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, hook: $hook, source: "expansion"}
+      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, project: $project, hook: $hook, source: "expansion"}
        + (if $exp != "" then {expansion_type: $exp} else {} end)'
   ) && hook::append_jsonl "${log_dir}/skill-usage.jsonl" "$line"
 else
   if hook::notice_once "skill-usage-expansion-audit-nodest" "$INPUT"; then
     hook::emit_skip_notice "UserPromptExpansion" \
-      "claude-ops skipped skill-usage logging: the configured project-relative destination could not be created safely."
+      "claude-ops skipped skill-usage logging: the configured destination could not be created safely."
   fi
 fi
 

--- a/plugins/claude-ops/hooks/skill-usage-expansion-audit.sh
+++ b/plugins/claude-ops/hooks/skill-usage-expansion-audit.sh
@@ -78,9 +78,10 @@ elif mkdir -p "$log_dir" 2>/dev/null &&
       --arg skill "$SKILL" \
       --arg branch "$branch" \
       --arg project "$(basename -- "$project_dir")" \
+      --arg project_id "$(claude_ops::repo_slug "$project_dir")" \
       --arg hook "skill-usage-audit" \
       --arg exp "$EXP_TYPE" \
-      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, project: $project, hook: $hook, source: "expansion"}
+      '{ts: $ts, event: "SkillUse", skill: $skill, branch: $branch, project: $project, project_id: $project_id, hook: $hook, source: "expansion"}
        + (if $exp != "" then {expansion_type: $exp} else {} end)'
   ) && hook::append_jsonl "${log_dir}/skill-usage.jsonl" "$line"
 else

--- a/plugins/claude-ops/hooks/skill-usage-expansion-audit.test.sh
+++ b/plugins/claude-ops/hooks/skill-usage-expansion-audit.test.sh
@@ -17,7 +17,8 @@ source "$HOOK_DIR/claude-ops-test-helpers.sh"
 INPUT='{"command_name":"/research","expansion_type":"slash_command"}'
 
 # --- Second store: written unconditionally, default .claude/observability ---
-PROJ="$TEST_TMPDIR/proj"; mkdir -p "$PROJ"
+PROJ="$TEST_TMPDIR/proj"
+mkdir -p "$PROJ"
 env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJ" \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 STORE="$PROJ/.claude/observability/skill-usage.jsonl"
@@ -32,7 +33,8 @@ else
 fi
 
 # --- expansion_type omitted → line still emitted, no expansion_type key ------
-PROJX="$TEST_TMPDIR/projx"; mkdir -p "$PROJX"
+PROJX="$TEST_TMPDIR/projx"
+mkdir -p "$PROJX"
 env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJX" \
   bash "$HOOK" <<<'{"command_name":"deploy"}' >/dev/null 2>&1
 STOREX="$PROJX/.claude/observability/skill-usage.jsonl"
@@ -45,7 +47,8 @@ else
 fi
 
 # --- mcp_prompt is also recorded (all commands, no filter) ------------------
-PROJM="$TEST_TMPDIR/projm"; mkdir -p "$PROJM"
+PROJM="$TEST_TMPDIR/projm"
+mkdir -p "$PROJM"
 env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJM" \
   bash "$HOOK" <<<'{"command_name":"ask","expansion_type":"mcp_prompt"}' >/dev/null 2>&1
 STOREM="$PROJM/.claude/observability/skill-usage.jsonl"
@@ -53,7 +56,8 @@ assert_eq "mcp_prompt recorded" "mcp_prompt" \
   "$(jq -r '.expansion_type' "$STOREM" 2>/dev/null)"
 
 # --- skill_usage_dir userConfig override -----------------------------------
-PROJ2="$TEST_TMPDIR/proj2"; mkdir -p "$PROJ2"
+PROJ2="$TEST_TMPDIR/proj2"
+mkdir -p "$PROJ2"
 env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJ2" \
   CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR="telemetry/skills" \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
@@ -61,12 +65,14 @@ assert_eq "override dir used" "research" \
   "$(jq -r '.skill' "$PROJ2/telemetry/skills/skill-usage.jsonl" 2>/dev/null)"
 
 # --- Invalid override is visible and cannot escape the project -------------
-PROJB="$TEST_TMPDIR/projb"; mkdir -p "$PROJB"
+PROJB="$TEST_TMPDIR/projb"
+mkdir -p "$PROJB"
 # CLAUDE_PLUGIN_DATA isolated to a fresh dir: the config-invalid branch now
 # goes through hook::notice_once (once-per-session gate), which persists a
 # marker file under CLAUDE_PLUGIN_DATA — an unisolated real machine path would
 # make this assertion pass only on the first-ever run.
-BADCFG_DATA="$TEST_TMPDIR/badcfg-data"; mkdir -p "$BADCFG_DATA"
+BADCFG_DATA="$TEST_TMPDIR/badcfg-data"
+mkdir -p "$BADCFG_DATA"
 INVALID_OUTPUT=$(env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJB" \
   CLAUDE_PLUGIN_OPTION_SKILL_USAGE_DIR="../outside" \
   CLAUDE_PLUGIN_DATA="$BADCFG_DATA" \
@@ -82,8 +88,10 @@ assert_contains "invalid override advisory is user-visible (systemMessage)" \
   "claude-ops skipped skill-usage logging"
 
 # --- Envelope emitted when a sink is wired ---------------------------------
-PROJ3="$TEST_TMPDIR/proj3"; mkdir -p "$PROJ3"
-TEL="$TEST_TMPDIR/tel.json"; SINK="$(make_sink "$TEL")"
+PROJ3="$TEST_TMPDIR/proj3"
+mkdir -p "$PROJ3"
+TEL="$TEST_TMPDIR/tel.json"
+SINK="$(make_sink "$TEL")"
 env HOOK_TELEMETRY_SINK="$SINK" CLAUDE_PROJECT_DIR="$PROJ3" \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
 if wait_for_sink "$TEL"; then
@@ -99,16 +107,35 @@ else
 fi
 
 # --- Missing command_name is skipped (no store, no envelope) ---------------
-PROJ4="$TEST_TMPDIR/proj4"; mkdir -p "$PROJ4"
-TELN="$TEST_TMPDIR/teln.json"; SINKN="$(make_sink "$TELN")"
+PROJ4="$TEST_TMPDIR/proj4"
+mkdir -p "$PROJ4"
+TELN="$TEST_TMPDIR/teln.json"
+SINKN="$(make_sink "$TELN")"
 env HOOK_TELEMETRY_SINK="$SINKN" CLAUDE_PROJECT_DIR="$PROJ4" \
   bash "$HOOK" <<<'{"expansion_type":"slash_command"}' >/dev/null 2>&1
 assert_file_absent "no command_name → no second store" "$PROJ4/.claude/observability/skill-usage.jsonl"
 assert_file_absent "no command_name → no envelope" "$TELN"
 
+# --- user scope writes under HOME (scope shared with tool producer) --------
+PROJU="$TEST_TMPDIR/proju"
+mkdir -p "$PROJU"
+HOMEU="$TEST_TMPDIR/homeu"
+mkdir -p "$HOMEU"
+env -u HOOK_TELEMETRY_SINK CLAUDE_PROJECT_DIR="$PROJU" HOME="$HOMEU" \
+  CLAUDE_PLUGIN_OPTION_SKILL_USAGE_SCOPE="user" \
+  bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1
+assert_eq "user scope writes under HOME" "research" \
+  "$(jq -r '.skill' "$HOMEU/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+assert_eq "user-scope row carries project field" "proju" \
+  "$(jq -r '.project' "$HOMEU/.claude/observability/skill-usage.jsonl" 2>/dev/null)"
+assert_file_absent "user scope leaves the project tree untouched" \
+  "$PROJU/.claude/observability/skill-usage.jsonl"
+
 # --- Kill switch (shared) suppresses both outputs --------------------------
-PROJ5="$TEST_TMPDIR/proj5"; mkdir -p "$PROJ5"
-TELK="$TEST_TMPDIR/telk.json"; SINKK="$(make_sink "$TELK")"
+PROJ5="$TEST_TMPDIR/proj5"
+mkdir -p "$PROJ5"
+TELK="$TEST_TMPDIR/telk.json"
+SINKK="$(make_sink "$TELK")"
 env HOOK_TELEMETRY_SINK="$SINKK" CLAUDE_PROJECT_DIR="$PROJ5" \
   CLAUDE_PLUGIN_OPTION_SKILL_USAGE_AUDIT_ENABLED=false \
   bash "$HOOK" <<<"$INPUT" >/dev/null 2>&1

--- a/plugins/claude-ops/skills/setup/SKILL.md
+++ b/plugins/claude-ops/skills/setup/SKILL.md
@@ -31,12 +31,24 @@ table, one remediation line per FAIL. Do not modify anything.
    - empty or unexpanded: INFO — the registry uses `${CLAUDE_PLUGIN_DATA}` (the zero-config default).
    - a configured value: validate containment (below). PASS when contained — it resolves from the
      project root. FAIL when uncontained.
-2. **`skill_usage_dir`** — report the effective skill-usage-log destination:
-   - empty or unexpanded: INFO — the log uses `.claude/observability` (the zero-config default).
-   - a configured value: validate containment. PASS when contained; FAIL when uncontained.
-3. **Containment** — a configured value must be a contained, project-relative path. FAIL any
+2. **`skill_usage_dir` + `skill_usage_scope`** — report the effective skill-usage-log destination:
+   - scope empty, unexpanded, or `repo`: the store resolves under the project root; empty
+     `skill_usage_dir` is INFO — the log uses `.claude/observability` (the zero-config default), kept
+     out of `git status` by a machine-local `.git/info/exclude` entry unless
+     `${user_config.skill_usage_git_exclude}` renders `false`.
+   - scope `user`: INFO — the same contained subpath resolves under `$HOME` (default
+     `~/.claude/observability`), one cross-repo store.
+   - scope `data-dir`: INFO — the store is plugin-owned at
+     `${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>`; `skill_usage_dir` is ignored.
+   - any other scope value: FAIL — the hooks fall back to `repo` with a one-time advisory; remediate
+     to a valid value (`repo` | `user` | `data-dir`).
+   - a configured `skill_usage_dir` (repo/user scopes): validate containment under the scope root.
+     PASS when contained; FAIL when uncontained.
+3. **Containment** — a configured value must be a contained relative path under its base (the project
+   root for `registry_dir` and repo-scope `skill_usage_dir`; `$HOME` for user-scope
+   `skill_usage_dir`). FAIL any
    POSIX/rooted path, Windows drive-qualified or drive-relative path, UNC path, any `..` segment with
-   either separator, and any existing symlink path that resolves outside the project. Do not normalize
+   either separator, and any existing symlink path that resolves outside that base. Do not normalize
    an invalid value into acceptance, and do not run any operation that would use an invalid destination.
 4. **Personal-vs-project** — INFO: both options are personal, user-scoped preferences, not tracked team
    policy. Note the per-machine-vs-repository-resident tradeoff so the reader can choose in `apply`.


### PR DESCRIPTION
## Summary

Fixes the F1 finding from inbox item `20260723-090435-melodic-session-plugins-audit`: the claude-ops skill-usage second store was forced into every consuming repo's tree as untracked `git status` noise, and `skill_usage_dir` containment validation made user/machine scope unreachable by config.

- **`skill_usage_scope` userConfig** (`repo` default | `user` | `data-dir`): `repo` keeps the current project-tree location; `user` resolves the same contained `skill_usage_dir` subpath under `$HOME` (one cross-repo operator store); `data-dir` writes `${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>` (plugin-owned, update-safe). Unknown values fall back to `repo` with a one-time advisory (prose-validated — the manifest schema has no enum type). Containment is now a per-scope default, not a ceiling.
- **Machine-local git-status hygiene**: repo scope idempotently adds a root-anchored entry to `.git/info/exclude` (`git rev-parse --git-path`, worktree-correct; never touches `.gitignore` or tracked files — ignore semantics leave tracked content unaffected). Opt out with `skill_usage_git_exclude=false` for teams that deliberately commit telemetry.
- **`project` field** added to store rows (project-root basename) so cross-repo scopes keep repo identity.
- **Default-flip decision recorded** (CHANGELOG + issue): default stays `repo` — verified the `/claude-ops:observability` skill reads only `hook-events.jsonl` + the OTEL store (colocation is convention, not a read dependency); the exclude entry removes the status noise that motivated a flip; flipping would silently relocate existing consumers' data.
- Shared resolvers (`claude_ops::resolve_skill_usage_dir`, `repo_slug`, `ensure_git_exclude`) in `claude-ops-paths.sh`; both producers (tool + expansion) updated symmetrically; setup skill `check` covers scope reporting; README + CHANGELOG updated. claude-ops **0.19.0**.

Fresh-docs verified this session: hooks env contract (`CLAUDE_PLUGIN_DATA`, `CLAUDE_PLUGIN_OPTION_<KEY>`) per <https://code.claude.com/docs/en/hooks>; userConfig schema (no enum type) per <https://code.claude.com/docs/en/plugins-reference>.

## Test plan

- [x] `claude-ops-paths.test.sh` 18/18 — scope resolution (repo/user/data-dir), user-scope traversal rejection, missing `CLAUDE_PLUGIN_DATA` failure, repo-slug safety, exclude add + idempotency + opt-out + non-repo no-op, `git status` clean.
- [x] `skill-usage-audit.test.sh` 29/29 — git-repo repo-scope write + exclude entry + clean status, user scope under `$HOME` (project tree untouched), data-dir keyed store, unknown-scope advisory + repo fallback, `project` field, existing containment/kill-switch/envelope suite.
- [x] `skill-usage-expansion-audit.test.sh` 28/28 — user-scope parity + `project` field + full existing suite.
- [x] Full hook suite (10 files) green; `shellcheck -x` clean on all six touched scripts; `skill-quality:check setup` PASS (0 errors).

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Related

- Inbox item `20260723-090435-melodic-session-plugins-audit` (finding F1); companion issues from the same decomposition: #1152, #1153, #1154.
