### PR TITLE
feat(architecture): scan-briefing template + verification gate (deepening F2/F3/F4)

### DIFF
--- a/plugins/architecture/.claude-plugin/plugin.json
+++ b/plugins/architecture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "architecture",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Scans an existing codebase for module-level architecture friction — shallow modules, seam leaks, and locality gaps — using Ousterhout's deep-module lens, presents candidates as a self-contained HTML report, and runs an interview loop on the selected candidate before handing off for planning.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/architecture/CHANGELOG.md
+++ b/plugins/architecture/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to the `architecture` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.0]
+
+### Added
+
+- Deepening lens: canonical scan-subagent briefing template
+  (`research/deepening/scan-briefing.md`) — vocabulary primer, friction checklist,
+  dependency categories, both badge-acceptance heuristics, and a per-candidate
+  return schema (incl. `shallow-signal` and `runtime-claim` fields). Phase 1 now
+  briefs every scan agent from it, so scan quality no longer varies run-to-run and
+  confidence is calibrated against the acceptance heuristics at scan time rather
+  than arriving only at report time (F3, F4).
+- Deepening lens: a verification gate (Phase 1.5) between the scan and the HTML
+  report. Every `Strong`-badge candidate has its `shallow-signal` reproduced, and
+  every runtime-bug / dead-code claim is checked against the actual code, before it
+  reaches the user-facing report — closing the gap where an overstated scan claim
+  shipped with the report's authority (F2). Phase 2 opens with an explicit re-badge
+  against the two acceptance heuristics plus the verification result. The durable
+  candidate artifact gains a `shallow-signal` field so the verified evidence
+  survives the handoff.
+
+Pure-ADD extension: existing phase contracts and vocabulary discipline are
+unchanged. Minor version bump — new capability, no behavior removed. Follow-up to
+the SW2030 consumer audit of 0.3.5 (#1157).
+
 ## [0.3.6]
 
 ### Fixed

--- a/plugins/architecture/skills/improve/actions/deepening.md
+++ b/plugins/architecture/skills/improve/actions/deepening.md
@@ -23,16 +23,16 @@ Classify each candidate's dependencies per [../research/deepening/dependencies.m
 
 ## Phase 1.5 — Verify before publishing
 
-Hard gate between the scan and the report. Scan-agent accuracy is mixed, and the HTML report is a user-facing artifact that lends every claim its authority — an overstated claim there is cheap to make and expensive to reputation. Before rendering Phase 2, adversarially verify:
+Hard gate between the scan and the report. Scan-agent accuracy is mixed, and the HTML report is a user-facing artifact that lends every claim its authority — an overstated claim there is cheap to make and expensive to reputation. The scan output carries a `confidence` field (`strong` / `worth-exploring` / `speculative`) but no badge yet — the `recommendation` badge is assigned in Phase 2. Gate on the scan field that exists here. Before rendering Phase 2, adversarially verify:
 
-- **Every candidate that will carry a `Strong` badge** — reproduce its `shallow-signal` (the concrete observation from the scan-briefing return schema). If the signal does not reproduce, the candidate is not `Strong`; downgrade or drop it.
+- **Every candidate the scan returned with `confidence: strong`** (the ones headed for a `Strong` badge) — reproduce its `shallow-signal` (the concrete observation from the scan-briefing return schema). If the signal does not reproduce, drop the candidate's confidence below `strong`.
 - **Every `runtime-claim`** — any candidate asserting a live bug or dead code. These are grep-cheap to check and the most damaging to get wrong (the worked failure: a scan reporting a service "registered but never composed" that a single grep showed *is* consumed, via a different consumer, with tests). Reproduce the claim against the actual code before it reaches the report; correct or drop it if it does not hold.
 
-Verification can be a second cheap read-only subagent pass or inline reproduction — the bar is that no `Strong` badge and no runtime-bug/dead-code claim reaches Phase 2 unreproduced. Record what changed (downgraded, dropped, corrected) so the candidate artifact reflects the verified state, not the raw scan.
+Verification can be a second cheap read-only subagent pass or inline reproduction — the bar is that no `confidence: strong` candidate and no runtime-bug/dead-code claim reaches Phase 2 unreproduced. Record what changed (downgraded, dropped, corrected) so the candidate artifact reflects the verified state, not the raw scan.
 
 ## Phase 2 — Present candidates as HTML report
 
-**Re-badge first.** Before rendering, re-badge each surviving candidate against the two acceptance heuristics below (deletion-test acceptance form, two-adapter rule) and the Phase 1.5 verification result — scan-time confidence is an input, not the final badge. A candidate whose `shallow-signal` failed to reproduce, or whose value rests on a one-adapter abstraction, cannot carry `Strong`.
+**Re-badge first.** Before rendering, map each surviving candidate's scan `confidence` to its `recommendation` badge (`strong` → `Strong`, `worth-exploring` → `Worth exploring`, `speculative` → `Speculative`), then re-badge against the two acceptance heuristics below (deletion-test acceptance form, two-adapter rule) and the Phase 1.5 verification result — scan-time confidence is an input, not the final badge. A candidate whose `shallow-signal` failed to reproduce, or whose value rests on a one-adapter abstraction, cannot carry `Strong`.
 
 Write a self-contained HTML file via a secure temp-file primitive so the path is unpredictable and permissions are restrictive. On Unix/Linux, create it with `mktemp` (e.g. `mktemp --tmpdir deepening-review-XXXXXX.html` or `mktemp -t deepening-review.XXXXXX.html`); on Windows, use a user-scoped temp under `%LOCALAPPDATA%\Temp` or equivalent. Open for user: `start <path>` on Windows, `open <path>` on macOS, `xdg-open <path>` on Linux. Report the absolute path.
 
@@ -59,8 +59,8 @@ Use the project's domain glossary vocabulary for the domain, and [../research/de
 - dependency-category: in-process | local-substitutable | ports-and-adapters | mock
 - recommendation: Strong | Worth exploring | Speculative
 - problem: <one sentence>
-- deepening: <one sentence — the shallow-module friction signal, not an interface proposal>
-- shallow-signal: <the concrete observation reproduced in Phase 1.5 — the verified evidence for shallowness, not a bare assertion>
+- deepening: <one sentence, narrative — the shallow-module friction, not an interface proposal; e.g. "three modules wrap a single call each, adding no behavior">
+- shallow-signal: <the concrete, verified observation reproduced in Phase 1.5 — evidence, not narrative; e.g. "OrderHandler/OrderValidator/OrderRepo each forward their one argument unmodified (confirmed by reading all three)">
 - agreed-shape: <empty until Phase 3 — filled when the user picks and the shape is grilled: interface entry points, what sits behind the seam, tests that survive>
 - rejected-reason: <only if status is rejected and the reason is load-bearing>
 ```

--- a/plugins/architecture/skills/improve/actions/deepening.md
+++ b/plugins/architecture/skills/improve/actions/deepening.md
@@ -60,8 +60,8 @@ Use the project's domain glossary vocabulary for the domain, and [../research/de
 - recommendation: Strong | Worth exploring | Speculative
 - problem: <one sentence>
 - deepening: <one sentence, narrative — the shallow-module friction, not an interface proposal; e.g. "three modules wrap a single call each, adding no behavior">
-- shallow-signal: <the concrete observation — evidence, not narrative; e.g. "OrderHandler/OrderValidator/OrderRepo each forward their one argument unmodified (confirmed by reading all three)". Reproduced in Phase 1.5 for every `Strong` candidate and every runtime-claim; for a candidate left below `Strong` with no runtime-claim it is the scan's as-reported signal, not yet reproduced>
-- signal-verified: <true once Phase 1.5 reproduced this candidate's shallow-signal (all `Strong` candidates, all runtime-claims); false for a candidate that never passed the gate — so the planning handoff never reads an unverified signal as verified>
+- shallow-signal: <the concrete observation — evidence, not narrative; e.g. "OrderHandler/OrderValidator/OrderRepo each forward their one argument unmodified (confirmed by reading all three)". Reproduced in Phase 1.5 for every `Strong` candidate; a runtime-claim candidate has its *claim* reproduced, not this signal, so unless it is also `Strong` the signal here is the scan's as-reported observation, not yet reproduced>
+- signal-verified: <true only once Phase 1.5 reproduced *this signal* — i.e. every `Strong` candidate. A runtime-claim reproduction verifies the claim, not the shallow-signal, so a runtime-claim candidate left below `Strong` keeps `signal-verified: false`. This keeps the planning handoff from ever reading an unverified shallowness observation as verified>
 - agreed-shape: <empty until Phase 3 — filled when the user picks and the shape is grilled: interface entry points, what sits behind the seam, tests that survive>
 - rejected-reason: <only if status is rejected and the reason is load-bearing>
 ```

--- a/plugins/architecture/skills/improve/actions/deepening.md
+++ b/plugins/architecture/skills/improve/actions/deepening.md
@@ -2,13 +2,13 @@
 
 The `deepening` action implements Ousterhout's "deepening" concept — finding shallow modules (interface nearly as complex as implementation) and proposing how to deepen them (small interface, large behavior behind it).
 
-Three phases. Each has a hard gate before the next.
+Three phases, with a verification gate (Phase 1.5) between the scan and the report. Each has a hard gate before the next.
 
 ## Phase 1 — Explore for friction
 
 Read the project's domain glossary if it maintains one — the nearest `UBIQUITOUS-LANGUAGE.md` (or equivalent), found by walking UP from the directory being examined toward the repo root and stopping at the first match (the same way `.editorconfig` / `.gitignore` resolve). Also read any architecture decision records in the area being examined.
 
-Use the Agent tool with `subagent_type=Explore` (or any read-only exploration subagent available) to walk the codebase. Explore organically — note where friction appears:
+Use the Agent tool with `subagent_type=Explore` (or any read-only exploration subagent available) to walk the codebase. Brief each scan subagent with the canonical template in [../research/deepening/scan-briefing.md](../research/deepening/scan-briefing.md) — vocabulary primer, friction checklist, dependency categories, the two badge-acceptance heuristics, and the per-candidate return schema — so scan quality does not vary run-to-run and confidence is calibrated against the heuristics at scan time (not left to Phase 2). Explore organically — note where friction appears:
 
 - Where does understanding one concept require bouncing between many small modules?
 - Where are modules **shallow** — interface nearly as complex as implementation?
@@ -21,7 +21,18 @@ Apply the **deletion test** to anything suspected shallow: would deleting it con
 
 Classify each candidate's dependencies per [../research/deepening/dependencies.md](../research/deepening/dependencies.md) — the category determines testing strategy.
 
+## Phase 1.5 — Verify before publishing
+
+Hard gate between the scan and the report. Scan-agent accuracy is mixed, and the HTML report is a user-facing artifact that lends every claim its authority — an overstated claim there is cheap to make and expensive to reputation. Before rendering Phase 2, adversarially verify:
+
+- **Every candidate that will carry a `Strong` badge** — reproduce its `shallow-signal` (the concrete observation from the scan-briefing return schema). If the signal does not reproduce, the candidate is not `Strong`; downgrade or drop it.
+- **Every `runtime-claim`** — any candidate asserting a live bug or dead code. These are grep-cheap to check and the most damaging to get wrong (the worked failure: a scan reporting a service "registered but never composed" that a single grep showed *is* consumed, via a different consumer, with tests). Reproduce the claim against the actual code before it reaches the report; correct or drop it if it does not hold.
+
+Verification can be a second cheap read-only subagent pass or inline reproduction — the bar is that no `Strong` badge and no runtime-bug/dead-code claim reaches Phase 2 unreproduced. Record what changed (downgraded, dropped, corrected) so the candidate artifact reflects the verified state, not the raw scan.
+
 ## Phase 2 — Present candidates as HTML report
+
+**Re-badge first.** Before rendering, re-badge each surviving candidate against the two acceptance heuristics below (deletion-test acceptance form, two-adapter rule) and the Phase 1.5 verification result — scan-time confidence is an input, not the final badge. A candidate whose `shallow-signal` failed to reproduce, or whose value rests on a one-adapter abstraction, cannot carry `Strong`.
 
 Write a self-contained HTML file via a secure temp-file primitive so the path is unpredictable and permissions are restrictive. On Unix/Linux, create it with `mktemp` (e.g. `mktemp --tmpdir deepening-review-XXXXXX.html` or `mktemp -t deepening-review.XXXXXX.html`); on Windows, use a user-scoped temp under `%LOCALAPPDATA%\Temp` or equivalent. Open for user: `start <path>` on Windows, `open <path>` on macOS, `xdg-open <path>` on Linux. Report the absolute path.
 
@@ -49,6 +60,7 @@ Use the project's domain glossary vocabulary for the domain, and [../research/de
 - recommendation: Strong | Worth exploring | Speculative
 - problem: <one sentence>
 - deepening: <one sentence — the shallow-module friction signal, not an interface proposal>
+- shallow-signal: <the concrete observation reproduced in Phase 1.5 — the verified evidence for shallowness, not a bare assertion>
 - agreed-shape: <empty until Phase 3 — filled when the user picks and the shape is grilled: interface entry points, what sits behind the seam, tests that survive>
 - rejected-reason: <only if status is rejected and the reason is load-bearing>
 ```

--- a/plugins/architecture/skills/improve/actions/deepening.md
+++ b/plugins/architecture/skills/improve/actions/deepening.md
@@ -32,7 +32,7 @@ Verification can be a second cheap read-only subagent pass or inline reproductio
 
 ## Phase 2 — Present candidates as HTML report
 
-**Re-badge first.** Before rendering, map each surviving candidate's scan `confidence` to its `recommendation` badge (`strong` → `Strong`, `worth-exploring` → `Worth exploring`, `speculative` → `Speculative`), then re-badge against the two acceptance heuristics below (deletion-test acceptance form, two-adapter rule) and the Phase 1.5 verification result — scan-time confidence is an input, not the final badge. A candidate whose `shallow-signal` failed to reproduce, or whose value rests on a one-adapter abstraction, cannot carry `Strong`.
+**Re-badge first.** Before rendering, map each surviving candidate's scan `confidence` to its `recommendation` badge (`strong` → `Strong`, `worth-exploring` → `Worth exploring`, `speculative` → `Speculative`), then re-badge against the two acceptance heuristics below (deletion-test acceptance form, two-adapter rule) and the Phase 1.5 verification result — scan-time confidence is an input, not the final badge. A candidate whose `shallow-signal` failed to reproduce, or whose value rests on a one-adapter abstraction, cannot carry `Strong`. **Promotion closes the same gate:** if re-badging lifts a candidate the scan rated below `strong` up to `Strong`, apply the Phase 1.5 reproduction to its `shallow-signal` *before* it carries the badge — a `Strong` claim reaches the report reproduced no matter which way the badge was reached, so the Phase 1.5 guarantee holds across both the original strong set and any promotions.
 
 Write a self-contained HTML file via a secure temp-file primitive so the path is unpredictable and permissions are restrictive. On Unix/Linux, create it with `mktemp` (e.g. `mktemp --tmpdir deepening-review-XXXXXX.html` or `mktemp -t deepening-review.XXXXXX.html`); on Windows, use a user-scoped temp under `%LOCALAPPDATA%\Temp` or equivalent. Open for user: `start <path>` on Windows, `open <path>` on macOS, `xdg-open <path>` on Linux. Report the absolute path.
 
@@ -60,7 +60,8 @@ Use the project's domain glossary vocabulary for the domain, and [../research/de
 - recommendation: Strong | Worth exploring | Speculative
 - problem: <one sentence>
 - deepening: <one sentence, narrative — the shallow-module friction, not an interface proposal; e.g. "three modules wrap a single call each, adding no behavior">
-- shallow-signal: <the concrete, verified observation reproduced in Phase 1.5 — evidence, not narrative; e.g. "OrderHandler/OrderValidator/OrderRepo each forward their one argument unmodified (confirmed by reading all three)">
+- shallow-signal: <the concrete observation — evidence, not narrative; e.g. "OrderHandler/OrderValidator/OrderRepo each forward their one argument unmodified (confirmed by reading all three)". Reproduced in Phase 1.5 for every `Strong` candidate and every runtime-claim; for a candidate left below `Strong` with no runtime-claim it is the scan's as-reported signal, not yet reproduced>
+- signal-verified: <true once Phase 1.5 reproduced this candidate's shallow-signal (all `Strong` candidates, all runtime-claims); false for a candidate that never passed the gate — so the planning handoff never reads an unverified signal as verified>
 - agreed-shape: <empty until Phase 3 — filled when the user picks and the shape is grilled: interface entry points, what sits behind the seam, tests that survive>
 - rejected-reason: <only if status is rejected and the reason is load-bearing>
 ```

--- a/plugins/architecture/skills/improve/research/deepening/scan-briefing.md
+++ b/plugins/architecture/skills/improve/research/deepening/scan-briefing.md
@@ -1,0 +1,73 @@
+# Scan Briefing — canonical subagent prompt for Phase 1
+
+The friction scan fans out read-only exploration subagents. Brief every scan subagent with the
+structure below, the same way [interface-design.md](interface-design.md) briefs the Design-It-Twice
+agents — so scan quality does not vary run-to-run and the badge-acceptance heuristics reach the
+agents at scan time instead of arriving only in Phase 2.
+
+Assemble one briefing per subagent. Each briefing has four parts: vocabulary primer, friction
+checklist, dependency categories, and the per-candidate return schema. Include the project's own
+glossary terms (if it maintains one) alongside the architecture vocabulary so every agent names
+things the same way.
+
+## 1. Vocabulary primer
+
+Give each agent the deepening terms it must use — **module, interface, implementation, depth, seam,
+adapter, leverage, locality** — from [vocabulary.md](vocabulary.md), and the rejected framings
+(never *component*, *service*, *boundary*, or depth-as-line-ratio). Consistent language is the
+point: a report assembled from agents that each named things differently is not comparable.
+
+## 2. Friction checklist
+
+The agent walks its assigned area of the codebase and notes where friction appears, against the same
+questions Phase 1 asks:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as implementation?
+- Where have pure functions been extracted for testability, but real bugs hide in how they're
+  called (no **locality**)?
+- Where do tightly-coupled modules leak across their **seams**?
+- Where do bugs recur *at the seams between* several owned subsystems rather than inside any one?
+- Which parts are untested, or hard to test through their current **interface**?
+
+Apply the **deletion test** to anything suspected shallow: would deleting it *concentrate*
+complexity (the signal — earning its keep) or merely *move* it (a pass-through)?
+
+## 3. Dependency categories
+
+The agent classifies each candidate's dependencies per [dependencies.md](dependencies.md) —
+in-process, local-substitutable, ports-and-adapters (remote-but-owned), or mock (true external) —
+because the category determines the testing strategy the eventual recommendation names.
+
+## 4. Badge-acceptance heuristics (calibrate confidence at scan time)
+
+Have the agent rate its own confidence **against the two acceptance heuristics**, not on gut feel —
+this is what F4 fixes: heuristics applied at scan time instead of arriving only in Phase 2.
+
+- **Deletion test (acceptance form)** — would a future maintainer, finding this module gone, rebuild
+  it substantially the same way? If not, the boundary is arbitrary and the candidate is weak.
+- **Two-adapter rule** — an abstraction or port earns its existence only with two real
+  consumers/adapters (typically production + test). A candidate whose value hinges on a one-adapter
+  abstraction is speculative indirection — `speculative` confidence at best.
+
+## 5. Per-candidate return schema
+
+Every agent returns each candidate in this exact shape, so Phase 1.5 can verify and Phase 2 can
+render without re-deriving structure:
+
+```markdown
+- title: <short candidate name>
+- files: <comma-separated paths>
+- problem: <one sentence — the friction, in vocabulary terms>
+- shallow-signal: <the concrete observation — the evidence for shallowness, e.g. "three one-method
+  wrappers each forwarding their argument"; this is what Phase 1.5 reproduces>
+- category: in-process | local-substitutable | ports-and-adapters | mock
+- deletion-verdict: concentrates | moves
+- test-surface: <what a test at the deepened interface would assert>
+- confidence: strong | worth-exploring | speculative   # calibrated against §4, not gut feel
+- runtime-claim: <only if the candidate asserts a live bug or dead code — state it explicitly so
+  Phase 1.5 knows to reproduce it; omit otherwise>
+```
+
+The `shallow-signal` and `runtime-claim` fields exist specifically so the verification gate
+(Phase 1.5) has something concrete to reproduce rather than a bare assertion.

--- a/plugins/architecture/skills/improve/research/deepening/scan-briefing.md
+++ b/plugins/architecture/skills/improve/research/deepening/scan-briefing.md
@@ -5,10 +5,10 @@ structure below, the same way [interface-design.md](interface-design.md) briefs 
 agents — so scan quality does not vary run-to-run and the badge-acceptance heuristics reach the
 agents at scan time instead of arriving only in Phase 2.
 
-Assemble one briefing per subagent. Each briefing has four parts: vocabulary primer, friction
-checklist, dependency categories, and the per-candidate return schema. Include the project's own
-glossary terms (if it maintains one) alongside the architecture vocabulary so every agent names
-things the same way.
+Assemble one briefing per subagent. Each briefing has five parts: vocabulary primer, friction
+checklist, dependency categories, badge-acceptance heuristics, and the per-candidate return schema.
+Include the project's own glossary terms (if it maintains one) alongside the architecture vocabulary
+so every agent names things the same way.
 
 ## 1. Vocabulary primer
 


### PR DESCRIPTION
Closes #1157

## Summary

Three coupled gaps in the deepening lens's scan→report path, all from the SW2030 consumer audit of architecture@0.3.5. F3's briefing template is the natural carrier for F2's verify instruction and F4's heuristics, so they land as one coherent change (architecture 0.3.6 → **0.4.0**, pure-ADD).

- **F3 — canonical scan-subagent briefing.** New `research/deepening/scan-briefing.md`: vocabulary primer, friction checklist, dependency categories, both badge-acceptance heuristics, and a per-candidate return schema (with `shallow-signal` and `runtime-claim` fields). Phase 1 now briefs every scan agent from it, the same way `interface-design.md` briefs the Design-It-Twice agents — so scan quality no longer varies run-to-run.
- **F2 — verification gate.** New **Phase 1.5** between scan and report: reproduce every `Strong`-badge candidate's `shallow-signal`, and check every runtime-bug / dead-code claim against the actual code, before the user-facing HTML report lends them its authority. The worked failure the audit caught: a scan reporting a service "registered but never composed" that a single grep refuted (the service *is* consumed, via a different consumer, with tests).
- **F4 — heuristics at scan time.** Confidence is now calibrated against the two acceptance heuristics in the briefing (scan time), and Phase 2 opens with an explicit re-badge against them plus the Phase 1.5 result.

The durable candidate artifact gains a `shallow-signal` field so the verified evidence survives the planning handoff.

## Test plan

- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass (0.4.0 entry present).
- `scripts/check-changed-skills.sh origin/main` — PASS, 0 errors (1 pre-existing Gotchas warning, scoped to #1158).
- `markdownlint-cli2 'plugins/architecture/**/*.md'` — 0 issues.
- Relative link `../research/deepening/scan-briefing.md` resolves from `actions/` (verified: sibling `research/deepening/` dir).

## Related

Refs #1156 (merged — the F1 predecessor this was serialized behind), #1158 (F5/F6, blocked on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)