### PR TITLE
feat(architecture): ADR discovery ladder, Gotchas surface, exemplar validation (deepening F5/F6)

### DIFF
--- a/plugins/architecture/.claude-plugin/plugin.json
+++ b/plugins/architecture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "architecture",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Scans an existing codebase for module-level architecture friction — shallow modules, seam leaks, and locality gaps — using Ousterhout's deep-module lens, presents candidates as a self-contained HTML report, and runs an interview loop on the selected candidate before handing off for planning.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/architecture/CHANGELOG.md
+++ b/plugins/architecture/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `architecture` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.1]
+
+### Added
+
+- Deepening lens: ADRs now get the same discovery discipline as the domain
+  glossary — honor a project-declared decisions location, else walk a short
+  ladder of common homes (`docs/adr/`, `docs/decisions/`, `.adr/`, …) from the
+  examined directory up to the repo root, instead of one shallow glob that
+  missed most layouts (F6).
+- Phase 3 interview loop: validate an exemplar call site by reading it before
+  locking the deepened shape around it — an exemplar chosen from memory can turn
+  out not to fit; search for one that does rather than shaping the interface
+  around the wrong site (audit appendix).
+- `improve` skill: a `## Gotchas` surface recording the observed failure history
+  — the `${CLAUDE_PLUGIN_DATA}` artifact-path trap (F1) and the unverified
+  scan-claim shipping risk that Phase 1.5 now guards (F2) (F5).
+
+Declined (F5, with evidence): the audit's markdownlint failures (MD041/MD013/
+MD060) do not reproduce under this repo's `.markdownlint-cli2.jsonc` — all three
+are disabled there, and `markdownlint-cli2` over the skill reports 0 issues.
+Docs-only + discovery guidance; no behavior change to the scan/verify/report
+pipeline. Follow-up to the SW2030 consumer audit of 0.3.5 (#1158).
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/architecture/skills/improve/SKILL.md
+++ b/plugins/architecture/skills/improve/SKILL.md
@@ -61,3 +61,10 @@ Graceful degradation — where a named step below is not available in the consum
 | A candidate shape is agreed | Hand off to a planning skill if the project has one; else summarize the agreed shape for planning | Consumes the `agreed-shape` entry from the candidate artifact (see `actions/deepening.md`) |
 | During the interview loop | Maintain resolved project vocabulary | Invoke `/domain-driven-design:curate-language` when available in the current session; otherwise update an existing consumer-declared glossary in its own shape |
 | Post-improvement | Review the implemented changes with the project's review tool | Standard diff review |
+
+## Gotchas
+
+Observed failure history — patterns that have actually bitten. Add here when a new one surfaces.
+
+- **The durable candidate artifact is a per-project memory-tier file, never `${CLAUDE_PLUGIN_DATA}`.** That token does not substitute in skill markdown content (it is a hook/monitor/MCP path substitution only), and even resolved it points at a plugin-global dir that collides candidates across projects. The artifact resolves through the marketplace topic-docs convention (the plugin's topic-docs [binding](../../reference/topic-docs.md)) — memory tier, default `.work/<topic-slug>/`. A `${CLAUDE_PROJECT_DIR}/.claude/...` path is also wrong: `.claude/` generated output is reserved for observability, and an unignored artifact there leaks scan output into git.
+- **Scan-agent claims are shipped only after Phase 1.5 reproduction.** Explore agents have a demonstrated error rate: a real run reported a service "registered but never composed — a bug in the seam" that one grep disproved (it *is* consumed, via a different consumer, with tests). Any candidate headed for a `Strong` badge and any runtime-bug / dead-code claim is reproduced against the actual code before it reaches the user-facing report — the report lends every claim its authority, so an unreproduced overstatement is cheap to make and expensive to reputation.

--- a/plugins/architecture/skills/improve/actions/deepening.md
+++ b/plugins/architecture/skills/improve/actions/deepening.md
@@ -6,7 +6,9 @@ Three phases, with a verification gate (Phase 1.5) between the scan and the repo
 
 ## Phase 1 — Explore for friction
 
-Read the project's domain glossary if it maintains one — the nearest `UBIQUITOUS-LANGUAGE.md` (or equivalent), found by walking UP from the directory being examined toward the repo root and stopping at the first match (the same way `.editorconfig` / `.gitignore` resolve). Also read any architecture decision records in the area being examined.
+Read the project's domain glossary if it maintains one — the nearest `UBIQUITOUS-LANGUAGE.md` (or equivalent), found by walking UP from the directory being examined toward the repo root and stopping at the first match (the same way `.editorconfig` / `.gitignore` resolve).
+
+Also read any architecture decision records (ADRs) in the area being examined — give them the same discovery discipline as the glossary rather than one shallow glob. If the consuming project declares where its decisions live (a path in its `CLAUDE.md` / rules, or a documented convention), honor that. Otherwise walk a short ladder of the common homes, from the examined directory up to the repo root: `docs/adr/`, `docs/decisions/`, `doc/adr/`, `.adr/`, `adr/`, plus any `*.md` whose name matches `adr-*` / `*-decision*`. ADR placement varies widely; a single default glob misses most of them.
 
 Use the Agent tool with `subagent_type=Explore` (or any read-only exploration subagent available) to walk the codebase. Brief each scan subagent with the canonical template in [../research/deepening/scan-briefing.md](../research/deepening/scan-briefing.md) — vocabulary primer, friction checklist, dependency categories, the two badge-acceptance heuristics, and the per-candidate return schema — so scan quality does not vary run-to-run and confidence is calibrated against the heuristics at scan time (not left to Phase 2). Explore organically — note where friction appears:
 
@@ -85,6 +87,7 @@ Side effects inline as decisions crystallize:
   in its own shape. If no convention exists, offer discovery-first lazy creation without prescribing
   a filename.
 - **User rejects a candidate with a load-bearing reason?** Offer to record it as an architecture decision — only when the reason would help a future explorer avoid re-suggesting it.
+- **Naming an exemplar call site to anchor the shape?** Read it before locking the shape around it. An exemplar chosen from memory or a candidate's file list can turn out not to fit once actually read; validate the fit first, and if it does not hold, search for a call site that does rather than shaping the interface around the wrong one.
 
 ### Design-It-Twice exploration mode
 


### PR DESCRIPTION
Closes #1158

## Summary

Final tranche of the SW2030 consumer audit of architecture@0.3.5 — F5 + F6 plus one appendix item (architecture 0.4.0 → **0.4.1**, additive):

- **F6 — ADR discovery ladder.** Phase 1 gave ADRs one shallow glob while the glossary got a precise walk-up rule; in the audit run the ADR check found nothing despite the repo having an ADR convention. ADRs now honor a project-declared decisions location, else walk a short ladder of common homes (`docs/adr/`, `docs/decisions/`, `.adr/`, `adr-*`/`*-decision*`) from the examined directory up to the repo root.
- **Appendix — exemplar validation.** Phase 3's decision tree now validates an exemplar call site by reading it before locking the deepened shape around it (the audit hit an exemplar named before reading that turned out not to fit).
- **F5 — Gotchas surface.** Added `## Gotchas` recording the real failure history: the `${CLAUDE_PLUGIN_DATA}` artifact-path trap (F1) and the unverified scan-claim shipping risk Phase 1.5 guards (F2). `check-changed-skills.sh` now passes with **0 warnings** (was 1).

## Test plan

- `scripts/check-changed-skills.sh origin/main` — **PASS, 0 errors 0 warnings** (Gotchas surface now present).
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass (0.4.1 entry).
- `markdownlint-cli2 'plugins/architecture/**/*.md'` — 0 issues.

## Related

Refs #1156, #1157 (both merged — the F1 and F2/F3/F4 predecessors this was serialized behind).

**F5 markdownlint half declined, with evidence:** the audit's MD041/MD013/MD060 failures do not reproduce under this repo's `.markdownlint-cli2.jsonc` — all three are disabled there and `markdownlint-cli2` reports 0 issues on the skill. The audit ran under the consuming repo's config; under the plugin repo's own config there is nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)