### PR TITLE
feat(skill-quality): actionable guidance for gating a marketplace-installed skill

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty deterministic checks over a Claude Code skill (frontmatter, listing-budget cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration) and a bundled evals.json schema for validation. Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -27,7 +27,9 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   name; the target root stays operator-provided. First-class installed-skill resolution is left
   as a tracked follow-up.
 
+## [0.9.0]
 
+### Changed
 
 - **Check 3 (trigger-keyword preservation) — move exception.** A quoted trigger phrase
   dropped from a skill's listing text but present verbatim in a SIBLING skill's

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,9 +3,31 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [0.9.0]
+## [0.10.0]
 
 ### Changed
+
+- **`check` gives actionable guidance for a marketplace-installed skill instead of a bare
+  "not found" (`#1152`).** A `plugin:skill` argument (e.g. `source-control:setup`) — the common
+  case when gating an installed skill — now prints exactly how to run the gate against the
+  install: point `CHECK_SKILL_SKILLS_ROOT` at the cache skills dir, with the note that the cache
+  is a **copy, not a git checkout**, so the git-backed checks (3 trigger-preservation, 8 vendor,
+  9 stale-metadata) correctly no-op there (a "new skill / skipped" result is expected). A missing
+  bare name now names the `CHECK_SKILL_SKILLS_ROOT` remedy too. SKILL.md documents the
+  installed-skill resolution path.
+
+  **Scope note — the originating report (`#1152`) is partly falsified.** It claimed the plugin
+  cache "IS a git checkout of the marketplace repo, so HEAD exists" and asked to wire check 3 to
+  it. Primary-source evidence contradicts this: Claude Code *copies* marketplace plugins into
+  `~/.claude/plugins/cache` (docs: "rather than using them in-place"), and the on-disk cache
+  carries no `.git`. Check 3's "new skill / skipped" on a cache path is therefore **correct
+  behavior, not a bug** — there is no rewrite baseline in a copy — and is not "fixed." The cache
+  sub-layout (`<marketplace>/<plugin>/<version>`) is also undocumented and version-dir-churning,
+  so the checker deliberately does **not** reverse-engineer it to auto-resolve a `plugin:skill`
+  name; the target root stays operator-provided. First-class installed-skill resolution is left
+  as a tracked follow-up.
+
+
 
 - **Check 3 (trigger-keyword preservation) — move exception.** A quoted trigger phrase
   dropped from a skill's listing text but present verbatim in a SIBLING skill's

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -152,7 +152,26 @@ note() {
 }
 
 if [[ ! -d "$SKILL_DIR" ]]; then
-  err "Skill not found: $SKILL_DIR"
+  # A `plugin:skill` argument is a common miss: the operator wants to gate a
+  # marketplace-INSTALLED skill, but this checker resolves a bare skill name
+  # under one skills root — it deliberately does NOT reverse-engineer Claude
+  # Code's plugin-cache layout to find it. The cache path
+  # (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills`) is an
+  # internal detail: only the cache's existence is documented, the
+  # `<mp>/<plugin>/<version>` nesting is not, and the version dir changes on
+  # every update (code.claude.com/docs/en/plugins-reference). Point the root at
+  # it explicitly instead. Note the cache is a COPY, not a git checkout, so the
+  # git-backed checks (3 trigger-preservation, 8 vendor, 9 stale-metadata)
+  # correctly no-op there — a "new skill / skipped" result is expected, not a
+  # defect (this is why check 3 cannot compare an installed skill against HEAD).
+  if [[ "$SKILL_NAME" == *:* ]]; then
+    leaf="${SKILL_NAME##*:}"
+    err "Skill not found: '$SKILL_NAME'. This looks like a plugin:skill name — the checker resolves a bare skill name under one skills root, not Claude Code's internal plugin-cache layout. To gate a marketplace-installed skill, point the root at its installed skills dir:
+    CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills bash check-skill.sh $leaf
+  The cache is a copy, not a git checkout, so the git-backed checks (3/8/9) no-op there (a 'new skill / skipped' result is expected)."
+  else
+    err "Skill not found: $SKILL_DIR. Set CHECK_SKILL_SKILLS_ROOT (or skill-quality's skills_root) to the directory that CONTAINS '$SKILL_NAME' as a subdirectory."
+  fi
   exit 1
 fi
 if [[ ! -f "$SKILL_MD" ]]; then

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -165,9 +165,12 @@ if [[ ! -d "$SKILL_DIR" ]]; then
   # correctly no-op there — a "new skill / skipped" result is expected, not a
   # defect (this is why check 3 cannot compare an installed skill against HEAD).
   if [[ "$SKILL_NAME" == *:* ]]; then
-    leaf="${SKILL_NAME##*:}"
+    # %q makes the leaf a paste-safe shell token — a malformed name whose leaf
+    # carries shell syntax must not become an executable substitution when the
+    # operator copies the suggested command.
+    q_leaf=$(printf '%q' "${SKILL_NAME##*:}")
     err "Skill not found: '$SKILL_NAME'. This looks like a plugin:skill name — the checker resolves a bare skill name under one skills root, not Claude Code's internal plugin-cache layout. To gate a marketplace-installed skill, point the root at its installed skills dir:
-    CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills bash check-skill.sh $leaf
+    CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills bash \"\${CLAUDE_PLUGIN_ROOT}/scripts/check-skill.sh\" $q_leaf
   The cache is a copy, not a git checkout, so the git-backed checks (3/8/9) no-op there (a 'new skill / skipped' result is expected)."
   else
     err "Skill not found: $SKILL_DIR. Set CHECK_SKILL_SKILLS_ROOT (or skill-quality's skills_root) to the directory that CONTAINS '$SKILL_NAME' as a subdirectory."

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -113,11 +113,27 @@ rc=$?
 if [[ $rc -eq 1 ]] &&
   grep -q 'plugin:skill name' <<<"$out" &&
   grep -q 'CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache' <<<"$out" &&
+  grep -qF '${CLAUDE_PLUGIN_ROOT}/scripts/check-skill.sh' <<<"$out" &&
   grep -q 'setup' <<<"$out"; then
   pass "plugin:skill name gets installed-skill resolution guidance"
 else
   fail "plugin:skill name should get installed-skill guidance (rc=$rc): $out"
 fi
+
+# 4c. A leaf carrying shell syntax is escaped in the pasteable command (paste
+#     safety — a copied command must not execute a substitution). Scope the
+#     check to the rerun-command line: the diagnostic prefix echoes the raw
+#     name (single-quoted, not pasteable) and that echo is fine.
+out="$(run 'x:$(touch pwn)' 2>&1)"
+cmd_line="$(grep 'check-skill.sh' <<<"$out")"
+if grep -qF '$(touch pwn)' <<<"$cmd_line"; then
+  fail "leaf with shell syntax should be escaped in the rerun command, not left bare: $cmd_line"
+elif grep -qF 'touch' <<<"$cmd_line"; then
+  pass "leaf with shell syntax is shell-escaped in the suggested command"
+else
+  fail "leaf-escape assertion did not find the escaped leaf: $cmd_line"
+fi
+[[ -e "$TMP/pwn" ]] && fail "escaping test must not create a file"
 
 # 5. Dropping a committed single-quoted trigger phrase fails (check 3, the
 #    regression-critical path — exercises the git-backed SKILL_REL resolution).

--- a/plugins/skill-quality/scripts/check-skill.test.sh
+++ b/plugins/skill-quality/scripts/check-skill.test.sh
@@ -58,8 +58,8 @@ just a heading
 
 run() {
   # Run from inside the fixture repo so `git rev-parse` resolves to it.
-  (cd "$TMP" \
-    && CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+  (cd "$TMP" &&
+    CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
       bash "$SUT" "$@")
 }
 
@@ -95,6 +95,28 @@ if [[ $rc -eq 1 ]]; then
   pass "missing skill exits 1"
 else
   fail "missing skill should exit 1 (rc=$rc)"
+fi
+
+# 4a. Missing bare-name skill hints at CHECK_SKILL_SKILLS_ROOT.
+out="$(run does-not-exist 2>&1)"
+if grep -q 'CHECK_SKILL_SKILLS_ROOT' <<<"$out"; then
+  pass "missing bare-name skill hints at CHECK_SKILL_SKILLS_ROOT"
+else
+  fail "missing bare-name skill should hint at CHECK_SKILL_SKILLS_ROOT: $out"
+fi
+
+# 4b. A plugin:skill name gets targeted installed-skill guidance (exit 1, no
+#     cache-layout reverse-engineering — the checker points the operator at the
+#     root instead).
+out="$(run source-control:setup 2>&1)"
+rc=$?
+if [[ $rc -eq 1 ]] &&
+  grep -q 'plugin:skill name' <<<"$out" &&
+  grep -q 'CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache' <<<"$out" &&
+  grep -q 'setup' <<<"$out"; then
+  pass "plugin:skill name gets installed-skill resolution guidance"
+else
+  fail "plugin:skill name should get installed-skill guidance (rc=$rc): $out"
 fi
 
 # 5. Dropping a committed single-quoted trigger phrase fails (check 3, the
@@ -221,8 +243,8 @@ fi
 # 6. A relative skills root resolves against CLAUDE_PROJECT_DIR, not the cwd,
 #    even when invoked from a subdirectory.
 mkdir -p "$TMP/subdir"
-out="$(cd "$TMP/subdir" \
-  && CLAUDE_PROJECT_DIR="$TMP" CHECK_SKILL_SKILLS_ROOT=".claude/skills" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
+out="$(cd "$TMP/subdir" &&
+  CLAUDE_PROJECT_DIR="$TMP" CHECK_SKILL_SKILLS_ROOT=".claude/skills" CHECK_SKILL_SKIP_MARKDOWNLINT=1 \
     bash "$SUT" good-skill 2>&1)"
 rc=$?
 if [[ $rc -eq 0 ]] && grep -q 'PASS' <<<"$out"; then
@@ -330,8 +352,8 @@ git -C "$TMP" add -A
 git -C "$TMP" commit -qm 'baseref v2 drops beta'
 run baseref-skill >/dev/null 2>&1
 rc_head=$?
-out_base="$(cd "$TMP" \
-  && CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 CHECK_SKILL_BASE_REF=HEAD^ \
+out_base="$(cd "$TMP" &&
+  CHECK_SKILL_SKILLS_ROOT="$SKILLS" CHECK_SKILL_SKIP_MARKDOWNLINT=1 CHECK_SKILL_BASE_REF=HEAD^ \
     bash "$SUT" baseref-skill 2>&1)"
 rc_base=$?
 if [[ $rc_head -eq 0 ]] && [[ $rc_base -eq 1 ]] && grep -q 'ref beta' <<<"$out_base"; then

--- a/plugins/skill-quality/skills/check/SKILL.md
+++ b/plugins/skill-quality/skills/check/SKILL.md
@@ -34,6 +34,23 @@ CHECK_SKILL_SKILLS_ROOT="${user_config.skills_root}" \
 
 When it is unset, invoke the script plain — it falls back to `${CLAUDE_PROJECT_DIR}/.claude/skills`.
 
+**Gating a marketplace-installed skill.** A `plugin:skill` name (e.g. `source-control:setup`) is
+NOT auto-resolved: the checker resolves a bare skill name under one root and deliberately does not
+reverse-engineer Claude Code's plugin-cache layout to locate an install. That layout is internal —
+only the cache's existence is documented, the `<marketplace>/<plugin>/<version>` nesting is not, and
+the version dir changes on every update
+([plugins-reference](https://code.claude.com/docs/en/plugins-reference)). To gate an installed skill,
+point the root at its installed skills dir explicitly:
+
+```shell
+CHECK_SKILL_SKILLS_ROOT=~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills \
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-skill.sh" <skill-leaf-name>
+```
+
+The cache is a **copy, not a git checkout**, so the git-backed checks (3 trigger-preservation, 8
+vendor byte-identity, 9 stale-metadata) no-op against it — a "new skill / skipped" result is
+expected there, not a defect. Passing a `plugin:skill` name unresolved prints this exact guidance.
+
 ## Arguments
 
 Parse `$ARGUMENTS`:


### PR DESCRIPTION
## Summary

Resolves the F2 finding from inbox item `20260723-090435-melodic-session-plugins-audit` — **as a deliberate re-scope, because primary-source evidence falsifies half the report. Reviewers should read the re-scope before the diff.**

**What the report got right (fixed here):** `skill-quality:check` had no path for a marketplace-INSTALLED skill. `check plugin:skill` (or any name that lives only in the plugin cache) fell back to the project's `.claude/skills` and printed a bare "Skill not found", so the operator had to already know to set `CHECK_SKILL_SKILLS_ROOT`. Now:
- A `plugin:skill` argument prints exactly how to gate the install — point `CHECK_SKILL_SKILLS_ROOT` at the cache skills dir — plus the note that the cache is a **copy, not a git checkout**, so the git-backed checks (3 trigger-preservation, 8 vendor, 9 stale-metadata) no-op there (a "new skill / skipped" result is expected).
- A missing bare name now names the `CHECK_SKILL_SKILLS_ROOT` remedy.
- `SKILL.md` documents the installed-skill resolution path. Tests cover both messages.

**What the report got wrong (NOT fixed — falsified):** it claimed the plugin cache "IS a git checkout of the marketplace repo, so HEAD exists" and asked to wire check 3's HEAD comparison to it. Evidence:
- **Docs** (<https://code.claude.com/docs/en/plugins-reference>): *"Claude Code copies marketplace plugins to the user's local plugin cache (`~/.claude/plugins/cache`) rather than using them in-place."*
- **On disk**: `git -C ~/.claude/plugins/cache/melodic-software/skill-quality/0.9.0 rev-parse` → `fatal: not a git repository`. The cache is a copy with no `.git`.
- Therefore check 3's "new skill / skipped" on a cache path is **correct behavior, not a bug** (there is no rewrite baseline in a copy), and is left as-is.

**What is deliberately NOT built (anti-coupling):** auto-resolving `plugin:skill` against the cache. The sub-layout `<marketplace>/<plugin>/<version>/skills` is undocumented (only the cache's existence is), and the version dir changes every update. skill-quality is a repo-agnostic marketplace plugin — reverse-engineering an internal path is exactly the coupling the repo's portability gate guards against. The target root stays operator-provided; first-class installed-skill resolution is deferred to #1166 (open design question: no documented cross-plugin install-path lookup exists today).

skill-quality **0.10.0**.

## Test plan

- [x] `check-skill.test.sh` — full suite green, incl. new assertions: missing bare name hints `CHECK_SKILL_SKILLS_ROOT`; `plugin:skill` name gets the installed-skill guidance (leaf name echoed, cache path shown, no cache-layout resolution attempted).
- [x] `shellcheck -x check-skill.sh` clean.
- [x] Self-check: `skill-quality:check check` PASS (0 errors, 0 warnings); SKILL.md 128/500 lines, markdownlint clean.
- [x] Spot-check: `check source-control:setup` prints the actionable guidance and exits 1.

## Related

- Inbox item `20260723-090435-melodic-session-plugins-audit` finding F2 (partly falsified — see Summary).
- #1166 — deferred: first-class installed-skill resolution (needs a documented-contract decision).
- Companion audit issues from the same decomposition: #1153, #1154.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
