### PR TITLE
docs(bash-format): document project scope + setup gotchas; add opt-in/shfmt-fallback test coverage (F1, F2, F6)

### DIFF
--- a/plugins/bash-format/.claude-plugin/plugin.json
+++ b/plugins/bash-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "bash-format",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Auto-format and lint shell scripts on edit via shfmt + ShellCheck, using the consuming repo's own .editorconfig and .shellcheckrc.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `bash-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.6.2]
+
+### Changed
+
+- **Documented the in-project-only scope.** The hook acts only on shell files under
+  `CLAUDE_PROJECT_DIR` (symlink-resolved membership guard in the shared library); a `.sh`/`.bash`
+  file written outside the project is silently skipped. README gains a "Scope" note and the setup
+  skill's `check` gains a project-scope probe (and no longer reports "fully operational" without the
+  caveat) so an advisory linter's out-of-project no-op is not a surprise (`#1168`, finding F1).
+- Setup skill: added a `## Gotchas` section (cache-path `ENAMETOOLONG`, `check`-PASS-≠-full-coverage,
+  opt-in-conditional `shfmt` FAIL) (`#1168`, finding F6).
+
+### Tests
+
+- `bash-format.test.sh`: added coverage for the `[*.{sh,bash}]` brace-list and `[**/*.sh]`
+  path-prefixed `.editorconfig` opt-in forms, and for the `shfmt < 3.8` `--apply-ignore` fallback
+  (`|| shfmt -w`) via a stub shfmt (`#1168`, finding F2). No runtime behavior change.
+
 ## [0.6.1]
 
 ### Changed

--- a/plugins/bash-format/CHANGELOG.md
+++ b/plugins/bash-format/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to the `bash-format` plugin are documented here. Format foll
 
 ### Changed
 
-- **Documented the in-project-only scope.** The hook acts only on shell files under
-  `CLAUDE_PROJECT_DIR` (symlink-resolved membership guard in the shared library); a `.sh`/`.bash`
-  file written outside the project is silently skipped. README gains a "Scope" note and the setup
-  skill's `check` gains a project-scope probe (and no longer reports "fully operational" without the
-  caveat) so an advisory linter's out-of-project no-op is not a surprise (`#1168`, finding F1).
+- **Documented the project scope.** When `CLAUDE_PROJECT_DIR` is set, the hook acts only on shell
+  files under it (symlink-resolved membership guard in the shared library); a `.sh`/`.bash` file
+  written outside the project is silently skipped. When `CLAUDE_PROJECT_DIR` is unset (e.g. some
+  headless `-p` sessions) the guard is skipped and any existing edited file is processed. README
+  gains a "Scope" note and the setup skill's `check` gains a project-scope probe (and no longer
+  reports "fully operational" without the caveat) so an advisory linter's out-of-project no-op is
+  not a surprise (`#1168`, finding F1; scope-qualification per PR review).
 - Setup skill: added a `## Gotchas` section (cache-path `ENAMETOOLONG`, `check`-PASS-≠-full-coverage,
   opt-in-conditional `shfmt` FAIL) (`#1168`, finding F6).
 

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -30,12 +30,14 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 - **Config from the consumer.** ShellCheck discovers `.shellcheckrc` by walking
   up from the file's directory; shfmt reads `.editorconfig` the same way. No
   working-directory assumptions — the tools are anchored to the edited file.
-- **Scope: files inside the current project only.** The hook acts on shell files
-  under `CLAUDE_PROJECT_DIR` (symlink-resolved). A `.sh`/`.bash` file written
-  *outside* the project — e.g. to a temp or scratchpad directory — is silently
-  skipped: no lint, no format, no notice. This is deliberate defense-in-depth
-  scoping inherited from the shared hook library; if you need such a file linted,
-  run `shellcheck` on it directly.
+- **Scope: files inside the current project — when `CLAUDE_PROJECT_DIR` is set.**
+  With `CLAUDE_PROJECT_DIR` set, the hook acts only on shell files under it
+  (symlink-resolved): a `.sh`/`.bash` file written *outside* the project — e.g. to
+  a temp or scratchpad directory — is silently skipped (no lint, no format, no
+  notice), deliberate defense-in-depth scoping inherited from the shared hook
+  library. If `CLAUDE_PROJECT_DIR` is **unset** (e.g. some headless `-p` sessions),
+  the membership check is skipped and any existing edited file is processed. Either
+  way, to lint a file the hook skipped, run `shellcheck` on it directly.
 
 ## Requirements
 

--- a/plugins/bash-format/README.md
+++ b/plugins/bash-format/README.md
@@ -30,6 +30,12 @@ and `.editorconfig` for formatting. It ships no rules of its own.
 - **Config from the consumer.** ShellCheck discovers `.shellcheckrc` by walking
   up from the file's directory; shfmt reads `.editorconfig` the same way. No
   working-directory assumptions — the tools are anchored to the edited file.
+- **Scope: files inside the current project only.** The hook acts on shell files
+  under `CLAUDE_PROJECT_DIR` (symlink-resolved). A `.sh`/`.bash` file written
+  *outside* the project — e.g. to a temp or scratchpad directory — is silently
+  skipped: no lint, no format, no notice. This is deliberate defense-in-depth
+  scoping inherited from the shared hook library; if you need such a file linted,
+  run `shellcheck` on it directly.
 
 ## Requirements
 

--- a/plugins/bash-format/hooks/bash-format.test.sh
+++ b/plugins/bash-format/hooks/bash-format.test.sh
@@ -245,8 +245,73 @@ EOF
   else
     fail "[*] catch-all -> shell file not formatted: $(cat "$REPO_STAR/x.sh")"
   fi
+
+  # A brace-list section naming sh (`[*.{sh,bash}]`) governs shell files:
+  # section_applies_to_shell matches the `{,sh,}` / `{sh,` / `,sh}` shapes, so
+  # formatting opts in. Regression guard for the documented brace-list form,
+  # previously exercised only via section_applies_to_shell's implementation.
+  REPO_BRACE="$WORK/brace-config"
+  new_repo "$REPO_BRACE"
+  printf 'root = true\n[*.{sh,bash}]\nindent_style = space\nindent_size = 2\n' >"$REPO_BRACE/.editorconfig"
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_BRACE/x.sh"
+  run_hook "$REPO_BRACE/x.sh" >/dev/null
+  if grep -q '^  echo hi$' "$REPO_BRACE/x.sh"; then
+    ok "[*.{sh,bash}] brace-list .editorconfig -> shell file formatted"
+  else
+    fail "[*.{sh,bash}] brace-list -> shell file not formatted: $(cat "$REPO_BRACE/x.sh")"
+  fi
+
+  # A path-prefixed shell glob (`[**/*.sh]`) governs shell files:
+  # section_applies_to_shell keys on the `*.sh` suffix regardless of a leading
+  # path component. Regression guard for the documented path-prefixed form.
+  REPO_PATHGLOB="$WORK/pathglob-config"
+  new_repo "$REPO_PATHGLOB"
+  printf 'root = true\n[**/*.sh]\nindent_style = space\nindent_size = 2\n' >"$REPO_PATHGLOB/.editorconfig"
+  mkdir -p "$REPO_PATHGLOB/src"
+  printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_PATHGLOB/src/x.sh"
+  run_hook "$REPO_PATHGLOB/src/x.sh" >/dev/null
+  if grep -q '^  echo hi$' "$REPO_PATHGLOB/src/x.sh"; then
+    ok "[**/*.sh] path-prefixed .editorconfig -> shell file formatted"
+  else
+    fail "[**/*.sh] path-prefixed -> shell file not formatted: $(cat "$REPO_PATHGLOB/src/x.sh")"
+  fi
 else
   echo "  (shfmt absent -- gate cases skipped)"
+fi
+
+# --- shfmt < 3.8 --apply-ignore fallback (`|| shfmt -w`) --------------------
+# The format pass calls `shfmt --apply-ignore -w FILE || shfmt -w FILE`: shfmt
+# 3.8+ honors --apply-ignore, older shfmt does not know the flag and fails, so
+# the plain-`-w` fallback must still format. A stub shfmt that REJECTS
+# --apply-ignore (simulating < 3.8) but formats on plain -w proves the fallback
+# runs. Independent of the host's real shfmt: the stub is prepended to PATH.
+STUBDIR="$(mktemp -d -p "$WORK" shfmtstub.XXXXXX)"
+cat >"$STUBDIR/shfmt" <<'STUB'
+#!/usr/bin/env bash
+# Simulate shfmt < 3.8: --apply-ignore is an unknown flag -> fail, no format.
+for a in "$@"; do
+  [[ "$a" == "--apply-ignore" ]] && exit 2
+done
+# Plain `-w FILE` path: rewrite the (last-arg) file to a formatted shape so the
+# caller's fallback branch is observable.
+f="${*: -1}"
+printf '#!/usr/bin/env bash\nif true; then\n  echo hi\nfi\n' >"$f"
+STUB
+chmod +x "$STUBDIR/shfmt"
+REPO_OLDSHFMT="$WORK/old-shfmt"
+new_repo "$REPO_OLDSHFMT"
+printf 'root = true\n[*.sh]\nindent_style = space\nindent_size = 2\n' >"$REPO_OLDSHFMT/.editorconfig"
+printf '#!/usr/bin/env bash\nif true; then\necho hi\nfi\n' >"$REPO_OLDSHFMT/x.sh"
+(
+  cd "$UNRELATED" || exit 1
+  printf '{"tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$REPO_OLDSHFMT/x.sh" |
+    env -u CLAUDE_PROJECT_DIR PATH="$STUBDIR:$PATH" \
+      CLAUDE_PLUGIN_OPTION_BASH_FORMAT_ENABLED=true bash "$HOOK" >/dev/null
+)
+if grep -q '^  echo hi$' "$REPO_OLDSHFMT/x.sh"; then
+  ok "shfmt<3.8 (--apply-ignore rejected) -> plain -w fallback still formats"
+else
+  fail "shfmt<3.8 fallback did not format: $(cat "$REPO_OLDSHFMT/x.sh")"
 fi
 
 # ============================================================================

--- a/plugins/bash-format/skills/setup/SKILL.md
+++ b/plugins/bash-format/skills/setup/SKILL.md
@@ -63,6 +63,15 @@ restores the FAIL semantics.
    other than `true` disables the hook).
 8. **Hook registration** — INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
+9. **Project scope** — INFO: the hook acts only on shell files inside
+   `CLAUDE_PROJECT_DIR` (symlink-resolved membership guard in the shared hook
+   library). A `.sh`/`.bash` file written *outside* the project (temp/scratchpad
+   dirs) is silently skipped — no lint, no format, no notice. Report this so a
+   green `check` is not read as "every shell edit anywhere is covered"; it is not.
+
+When every probe passes, report the result **with the scope caveat** (item 9) —
+never an unqualified "fully operational", which would imply out-of-project shell
+edits are covered when they are deliberately skipped.
 
 ## `apply` (idempotent)
 
@@ -96,3 +105,18 @@ Re-running `apply` after everything passes changes nothing and reports "already 
   Code user settings, not `pluginConfigs`, not the plugin cache. Every prerequisite is a `PATH`
   binary or the native toggle, so remediation is guidance only.
 - Download or execute tools during `check` beyond the read-only `command -v` presence probes.
+
+## Gotchas
+
+- **`ENAMETOOLONG` when grepping the plugin cache.** Installed plugins run from a
+  deeply nested, cache-isolated path. Piping a `grep`/`rg` over the long absolute
+  path to `hooks/hook-utils.sh` (or another bundled file) can spawn-fail with
+  `ENAMETOOLONG` on some hosts. Read the file directly (or `cd` into the plugin
+  hooks dir first and grep a short relative path) rather than passing the full
+  cache path on the command line.
+- **`check` PASS ≠ every shell edit is covered.** The hook is project-scoped
+  (probe 9): shell files written outside `CLAUDE_PROJECT_DIR` are silently
+  skipped. A fully green `check` still does not cover out-of-project edits — say so.
+- **`shfmt` FAIL is opt-in-conditional.** A missing `shfmt` is only a FAIL when an
+  `.editorconfig` section governs shell files; without that opt-in it is INFO, not
+  a defect. Resolve the `.editorconfig` opt-in state before calling `shfmt` a failure.

--- a/plugins/bash-format/skills/setup/SKILL.md
+++ b/plugins/bash-format/skills/setup/SKILL.md
@@ -63,11 +63,13 @@ restores the FAIL semantics.
    other than `true` disables the hook).
 8. **Hook registration** — INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
-9. **Project scope** — INFO: the hook acts only on shell files inside
-   `CLAUDE_PROJECT_DIR` (symlink-resolved membership guard in the shared hook
-   library). A `.sh`/`.bash` file written *outside* the project (temp/scratchpad
-   dirs) is silently skipped — no lint, no format, no notice. Report this so a
-   green `check` is not read as "every shell edit anywhere is covered"; it is not.
+9. **Project scope** — INFO: when `CLAUDE_PROJECT_DIR` is set, the hook acts only
+   on shell files inside it (symlink-resolved membership guard in the shared hook
+   library); a `.sh`/`.bash` file written *outside* the project (temp/scratchpad
+   dirs) is silently skipped — no lint, no format, no notice. When
+   `CLAUDE_PROJECT_DIR` is **unset** (e.g. some headless `-p` sessions) the guard
+   is skipped and any existing edited file is processed. Report this so a green
+   `check` is not read as "every shell edit anywhere is covered".
 
 When every probe passes, report the result **with the scope caveat** (item 9) —
 never an unqualified "fully operational", which would imply out-of-project shell
@@ -114,9 +116,10 @@ Re-running `apply` after everything passes changes nothing and reports "already 
   `ENAMETOOLONG` on some hosts. Read the file directly (or `cd` into the plugin
   hooks dir first and grep a short relative path) rather than passing the full
   cache path on the command line.
-- **`check` PASS ≠ every shell edit is covered.** The hook is project-scoped
-  (probe 9): shell files written outside `CLAUDE_PROJECT_DIR` are silently
-  skipped. A fully green `check` still does not cover out-of-project edits — say so.
+- **`check` PASS ≠ every shell edit is covered.** When `CLAUDE_PROJECT_DIR` is set
+  the hook is project-scoped (probe 9): shell files written outside it are silently
+  skipped, so a fully green `check` still does not cover out-of-project edits. (When
+  `CLAUDE_PROJECT_DIR` is unset the scoping does not apply — see probe 9.)
 - **`shfmt` FAIL is opt-in-conditional.** A missing `shfmt` is only a FAIL when an
   `.editorconfig` section governs shell files; without that opt-in it is INFO, not
   a defect. Resolve the `.editorconfig` opt-in state before calling `shfmt` a failure.


### PR DESCRIPTION
Closes #1168.

Consumer-side audit polish for `bash-format@0.6.1` (handoff-inbox item `20260723-095036`), findings **F1, F2 (bash-format-local), F6**. **No behavioral change** — docs + tests only. Version `0.6.2`.

## Changes

- **F1 (docs).** Documented the in-project-only scope: the hook acts only on shell files under `CLAUDE_PROJECT_DIR` (symlink-resolved membership guard in the shared library); files written outside the project are silently skipped. Added a README "Scope" note and a project-scope probe to the setup skill's `check` (which no longer reports "fully operational" without the caveat).
  - **Grounding note:** F1's original "add a membership-guard test" sub-item is **already satisfied** — `lib/hook-utils.test.sh` Test 12 thoroughly tests the guard (in-project accept, prefix-sibling reject, escaping-symlink reject, symlinked-root). The producer only read `bash-format.test.sh` (which deliberately unsets `CLAUDE_PROJECT_DIR`). So F1 reduces to docs.
- **F2 (bash-format-local tests).** Added `bash-format.test.sh` coverage for the `[*.{sh,bash}]` brace-list and `[**/*.sh]` path-prefixed `.editorconfig` opt-in forms, and the `shfmt < 3.8` `--apply-ignore` fallback (`|| shfmt -w`) via a stub shfmt.
- **F6.** Added a `## Gotchas` section to the setup skill (cache-path `ENAMETOOLONG`, `check`-PASS-≠-full-coverage, opt-in-conditional `shfmt` FAIL).

## Verification

- `bash plugins/bash-format/hooks/bash-format.test.sh` → **PASS=42 FAIL=0** (3 new cases green).
- `shellcheck -x -S warning` on the test file → clean.
- `plugin.json` valid; version bumped `0.6.1` → `0.6.2`; CHANGELOG updated.

## Scope moved out of this PR

- **F3** (`dim-9 doctrine` label) → **#1169**. Grounding refuted the "bash-format-local" premise: the label is fleet vocabulary cited in 9 hook scripts with no shared glossary. Stripping it from bash-format alone would fragment the convention; the fix is a shared-doc definition (fleet-scope).
- **Shared-lib F2 gaps** (`buffer_stdin` timeout, `EPOCHREALTIME` degradation) → **#1169** (belong in `lib/hook-utils.test.sh`).
- **F5** (`--config` fresh-install claim) → **#1170** (HITL — verifying mutates shared machine install state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Related

- #1172 — sibling PR for the fleet-scope findings (F2-shared, F3, F4) from the same audit item.
- #1170 — HITL follow-up (F5, `--config` fresh-install claim), not closed here.
- Handoff-inbox item `20260723-095036-bash-format-audit-docs-tests-polish` (producer SW2030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)