### PR TITLE
docs(hook-observability): refresh statusMessage adoption (30/31) + define dim-9; cover buffer_stdin timeout & EPOCHREALTIME skip (F4, F3, F2-shared)

### DIFF
--- a/docs/conventions/hook-observability/README.md
+++ b/docs/conventions/hook-observability/README.md
@@ -27,11 +27,13 @@ A static field on a `hooks.json` **handler object**, sibling of `type`/`command`
 ```
 
 Displayed as the UI spinner label while the hook process runs. **A hook script never emits this —
-there is no runtime JSON output field by this name.** **Rollout status: pending.** As of this
-doc's introduction, no `hooks.json` in the fleet declares `statusMessage` yet — all 27 wired
-`type: "command"` handlers across 12 plugins need it added. Tracked as required fleet adoption
-against melodic-software/claude-code-plugins#836 (this doc lands first per the convention-registry
-rule; adoption is the follow-up PR). Wording convention for that rollout: a present-tense gerund
+there is no runtime JSON output field by this name.** **Rollout status: near-complete.** As of
+2026-07-23, 30 of the 31 wired `type: "command"` handlers across the fleet's 15 hook-bearing
+plugins declare `statusMessage`; the sole remaining holdout is
+`plugins/disk-hygiene/hooks/hooks.json`. Tracked against
+melodic-software/claude-code-plugins#836 (this doc landed first per the convention-registry rule;
+adoption was the follow-up wave, now all but one site complete — close #836 once `disk-hygiene`
+declares it or is recorded as a deliberate exception). Wording convention: a present-tense gerund
 phrase naming what the hook is doing, specific to the tool or check
 (`"Formatting Go imports..."`, `"Checking for secrets..."`, `"Recording tool-failure
 telemetry..."`) — not a generic `"Running hook..."`.
@@ -48,6 +50,12 @@ pending notice must compose them there, never `printf` twice.
 file, `jq`) causes the hook to silently no-op instead of performing its check. Doctrine
 (`lib/hook-utils.sh:26-30`): *"a missing runtime prerequisite must surface to BOTH the agent
 (additionalContext) and the user (systemMessage) — a silently skipped feature is a defect."*
+
+This is the doctrine that fleet hook scripts cite in comments as the **"dim-9 doctrine"** — the
+label names *this* visible-skip rule and nothing more, and this section is its authoritative
+definition. (The `dim-N` numbers are an informal fleet-conformance shorthand — e.g. dim-8 = the
+uniform setup-skill wave, dim-11 = seam phrasing — with no central registry defining the numbering;
+giving the whole scheme a documented home is a separate follow-up, tracked outside this doc.)
 
 **Not required** for two situations that are already visible or already correctly agent-scoped:
 

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -813,6 +813,53 @@ else
   fail "git alias (env .command masked): rc=$rc"
 fi
 
+# --- Test 18: hook::buffer_stdin — timeout path (return 2 / BLOCKED) ----------
+# Incomplete JSON on a pipe that stays open past the read timeout must trip the
+# bounded-read timeout branch: return 2 and a `BLOCKED:` diagnostic on stderr
+# (the Win32-pipe late-EOF stall the bounded read exists to survive). Drives the
+# real function: a producer emits a partial payload then sleeps to hold the pipe
+# open, and STDIN_READ_TIMEOUT is shortened so the case is fast. jq present (this
+# host) is what lets the function distinguish a truncated read from a small-but-
+# complete one; without it the branch fails open to return 1, so this asserts the
+# jq-present timeout shape specifically.
+bs_rc_file="$(mktemp)"
+bs_err_file="$(mktemp)"
+{ printf '{"incomplete":'; sleep 1; } | {
+  CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=0.4 hook::buffer_stdin >/dev/null 2>"$bs_err_file"
+  echo "$?" >"$bs_rc_file"
+}
+bs_rc=$(cat "$bs_rc_file")
+if [[ "$bs_rc" == "2" ]] && grep -q 'BLOCKED:' "$bs_err_file"; then
+  ok "buffer_stdin: incomplete JSON past timeout → return 2 + BLOCKED on stderr"
+else
+  fail "buffer_stdin timeout: rc=$bs_rc err=$(cat "$bs_err_file")"
+fi
+rm -f "$bs_rc_file" "$bs_err_file"
+
+# --- Test 19: hook::emit_telemetry — EPOCHREALTIME-absent (Bash < 5.0) skip ---
+# On Bash < 5.0 EPOCHREALTIME is unset, so the caller's `start=${EPOCHREALTIME:-}`
+# snapshot is empty. emit_telemetry must then skip fail-open (return 0, emit no
+# envelope) rather than abort under `set -u` — the same silent-skip the caller's
+# guard intends. Simulated by unsetting EPOCHREALTIME in the command-substitution
+# subshell (its special attribute drops, so references yield empty), which does
+# not leak into the rest of the suite. A wired sink proves nothing is dispatched.
+tel19="$(mktemp)"
+: >"$tel19"
+sink19="$(make_sink "$tel19")"
+rc19=$(
+  unset EPOCHREALTIME
+  start=${EPOCHREALTIME:-}
+  HOOK_TELEMETRY_SINK="$sink19" hook::emit_telemetry "t" "PostToolUse" "ok" "$start" '{"tool":"x","file":"y","findings":[]}'
+  echo $?
+)
+sleep 0.1 # allow any (erroneous) background dispatch to land before asserting empty
+if [[ "$rc19" == "0" && ! -s "$tel19" ]]; then
+  ok "emit_telemetry: EPOCHREALTIME-absent (empty start) → skip fail-open (rc 0, no envelope)"
+else
+  fail "emit_telemetry EPOCHREALTIME-absent: rc=$rc19 sink=[$(cat "$tel19")]"
+fi
+rm -f "$tel19" "$sink19"
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Closes #1169.

Fleet-scope findings surfaced by the `bash-format` consumer audit (handoff-inbox item `20260723-095036`), re-verified and rescoped against current source. **No runtime behavior change** — a fleet-doc correction plus shared-lib test coverage.

## Changes

- **F4 — `statusMessage` adoption doc was badly stale.** The doc claimed "no `hooks.json` in the fleet declares `statusMessage` yet — all 27 wired `type: command` handlers across 12 plugins need it added." Scripted count of current source (jq over every `plugins/*/hooks/hooks.json`): **31 command-type handlers across 15 hook-bearing plugins, 30 declare `statusMessage`; sole holdout `plugins/disk-hygiene`** (a `PreToolUse` destructive-guard). Doc now records near-complete adoption, names the holdout, and states the #836 close condition.
- **F3 — `dim-9 doctrine` defined.** Grounding refuted the "bash-format-local" premise: the label is fleet vocabulary cited in **9 hook scripts** (actionlint, bash-format, biome-format, desktop-notification, eol-normalizer, go-format, powershell-format, ruff-format, typos-format) with **no central glossary** (verified — no dimensions registry exists). Defined it authoritatively in the visible-skip (`systemMessage`) section it names, and noted the broader undefined `dim-N` scheme as a separate follow-up. **Not** stripped from bash-format — that would fragment a fleet-wide convention (`reuse-or-replace`).
- **F2-shared — shared-lib test coverage.** Added `lib/hook-utils.test.sh` cases for `hook::buffer_stdin`'s timeout path (`return 2` / `BLOCKED` on stderr) and `hook::emit_telemetry`'s `EPOCHREALTIME`-absent (Bash < 5.0) skip-fail-open. Shared-lib behavior → tests live centrally, not duplicated into a plugin.

## Verification

- `bash lib/hook-utils.test.sh` → **PASS=85 FAIL=0** (2 new cases green) on bash 5.3.
- `shellcheck -x -S warning lib/hook-utils.test.sh` → clean.
- Only `lib/hook-utils.sh`'s **test** was touched (not the SSOT lib itself), so no `sync-hook-utils.sh` run and no plugin version bumps are needed.

## Notes

- F1's original "add a membership-guard test" was **already satisfied** by `lib/hook-utils.test.sh` Test 12 — see sibling **#1168** (bash-format docs/tests, PR #1171).
- The `disk-hygiene` holdout is left as the documented remaining item; adding its `statusMessage` (or marking it a deliberate exception) would close #836 but pulls a third plugin into this PR, so it is deferred per the group-by-plugin boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Related

- #1171 — sibling PR for the bash-format-local findings (F1, F2-local, F6) from the same audit item.
- #1170 — HITL follow-up (F5, `--config` fresh-install claim), not closed here.
- #836 — statusMessage fleet-adoption tracking issue this PR updates (not closed; one holdout remains).
- Handoff-inbox item `20260723-095036-bash-format-audit-docs-tests-polish` (producer SW2030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)