### PR TITLE
docs(skill-quality): check-6 defers to repo markdownlint config; record injection-block decision

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty deterministic checks over a Claude Code skill (frontmatter, listing-budget cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration) and a bundled evals.json schema for validation. Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.1]
+
+### Documentation
+
+- **`check` gotcha: markdownlint (check 6) defers to the consuming repo's markdownlint config —
+  run the checker from inside that repo (`#1153`).** Running the gate from outside the target
+  repo, or against a marketplace-installed skill in the plugin cache (which carries no config),
+  applies markdownlint DEFAULTS, so rules a repo deliberately disables (commonly `MD013`
+  line-length, `MD041` first-line-heading, `MD060` table-pipe) fire as spurious failures on a
+  skill that passes in-repo. This is the usual cause of a "shipped marketplace skill fails the
+  marketplace's own gate" report — a wrong-config artifact, not a regression. The note also
+  records the deliberate decision the report asked for: **injection blocks are not special-cased**
+  — a declared `shell:` block with long lines is `MD013`-subject like any other content, and
+  whether it fails is the consumer's markdownlint config's call (this gate never overrides it) —
+  and documents this marketplace's own CI division of labor (the skill-quality gate skips
+  markdownlint; the hygiene lane lints all repo markdown, SKILL.md included, under the repo
+  config). No behavior change; the CI gate over changed skills already exists.
+
 ## [0.10.0]
 
 ### Changed

--- a/plugins/skill-quality/skills/check/SKILL.md
+++ b/plugins/skill-quality/skills/check/SKILL.md
@@ -104,6 +104,19 @@ that line before editing, since it may be an illustrative example path rather th
   exits 2 (env error).
 - `check-skill.sh` runs `npx markdownlint-cli2` for check 6; when `npx` is absent that check downgrades
   to a WARN rather than failing, so a run on a machine without Node still gates on the other sixteen.
+- **Check 6 defers to the repo's markdownlint config — run it from inside that repo.** `markdownlint-cli2`
+  discovers the nearest `.markdownlint-cli2.jsonc` from its working directory. Run the checker from
+  *outside* the target repo (or against a marketplace-installed skill in the plugin cache, which has no
+  config) and markdownlint applies its DEFAULTS — so rules a repo deliberately disables (commonly
+  `MD013` line-length for injection blocks and tables, `MD041` first-line-heading for a frontmatter/H2
+  start, `MD060` table-pipe style) fire as spurious failures on a skill that passes in-repo. This is the
+  usual cause of a "shipped marketplace skill fails the marketplace's own gate" report: it is a
+  wrong-config artifact, not a real regression. **Injection blocks are not special-cased** — a declared
+  `shell:` block with long lines is MD013-subject like any other content; whether it fails is entirely the
+  consumer's markdownlint config's call (disable `MD013`, or wrap the lines), never something this gate
+  overrides. In this marketplace's own CI the division of labor is explicit: the skill-quality gate skips
+  markdownlint (`CHECK_SKILL_SKIP_MARKDOWNLINT=1` in the repo's `check-changed-skills.sh` gate) and the
+  hygiene lane lints all repo markdown, SKILL.md included, under the repo config.
 - Trigger-keyword preservation compares the working tree against `HEAD` by default, so a brand-new skill
   (no committed version) skips check 3 — that is expected, not a silent pass. For a post-commit audit
   (where `HEAD` == the working tree hides an already-committed change), set `CHECK_SKILL_BASE_REF` to a


### PR DESCRIPTION
## Summary

Resolves the F3 finding from inbox item `20260723-090435-melodic-session-plugins-audit` **as a re-scope: the finding is a measurement artifact, verified three ways.** Reviewers should read the re-scope before the diff.

**F3's premise ("2 of 3 marketplace skills fail the marketplace's own gate → the gate isn't in CI") is false in this repo:**

1. **The CI gate already exists.** `skill-quality-gate` (`.github/workflows/ci.yml`) runs `check-changed-skills.sh origin/$BASE_REF` on every PR, invoking the skill-quality checker over each changed skill. The "run the gate in CI over changed skills" ask was already satisfied.
2. **Skill markdown IS gated in CI — by the hygiene lane, under repo config.** `check-changed-skills.sh` deliberately skips markdownlint (`CHECK_SKILL_SKIP_MARKDOWNLINT=1`, documented division of labor); the hygiene lane lints all repo markdown incl. SKILL.md under `.markdownlint-cli2.jsonc`. (It caught a real MD012 on PR #1167 this session.)
3. **`planning:interview` passes under repo config** — `skill-quality:check interview` with the repo's config → **0 errors, 2 warnings** (264-line hub soft-cap; no `Use when:` phrasing). The producer's MD041/MD013/MD060 FAILs are exactly the rules `.markdownlint-cli2.jsonc` disables — i.e. from linting without repo config.

**What ships (doc-only):** a `check` SKILL.md gotcha that encodes the deliberate decision the report asked for and prevents the recurring false alarm:
- Check 6 (markdownlint) defers to the consuming repo's markdownlint config, discovered from the cwd. Running from outside the repo, or against a plugin-cache install (no config), applies markdownlint DEFAULTS → spurious MD013/MD041/MD060 on skills that pass in-repo. This is the usual "shipped skill fails the gate" report.
- **Injection blocks are not special-cased**: a declared `shell:` block with long lines is MD013-subject like any content; whether it fails is the consumer markdownlint config's call, never overridden by this gate.
- Documents this marketplace's CI division of labor (skill-quality gate skips markdownlint; hygiene lane lints markdown under repo config).

**Deferred (noted, not bundled):** the two advisory WARNs on `planning:interview` (264-line hub → progressive-disclosure split; add `Use when:` phrasing) are real but optional, live in a different plugin, and a description edit risks trigger drift. Left for planning-plugin maintenance; happy to file if wanted.

skill-quality **0.10.1** (doc-only; no behavior change).

## Test plan

- [x] Repro: `CHECK_SKILL_SKILLS_ROOT=plugins/planning/skills check-skill.sh interview` from repo root → PASS (0 errors, 2 warnings) — confirms the producer's FAILs were a wrong-config artifact.
- [x] Self-check: `skill-quality:check check` PASS (0 errors, 0 warnings); SKILL.md 141/500 lines.
- [x] `markdownlint-cli2` (repo config) clean on both changed files.

## Related

- Inbox item `20260723-090435-melodic-session-plugins-audit` finding F3 (falsified — see Summary).
- Companion audit issues: #1151 (merged), #1152 (merged), #1154.
- CI gate already in place: `skill-quality-gate` job in `.github/workflows/ci.yml`.

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
