### PR TITLE
fix(claude-ops): resolve default marketplace across version skew; generalize CRLF gotcha; correct install_new render doc (F1-F3)

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.1]
+
+### Fixed
+
+- **`plugins` skill: the default (no-`--marketplace`) path no longer breaks after a mid-session
+  version bump of claude-ops itself (`#1176`, audit finding F1).** `fleet-state.sh`'s
+  `resolve_default_marketplace` exact-matched the running plugin root against the version-pinned
+  `installPath` in `installed_plugins.json`; any time the session's loaded version differed from the
+  installed one — a marketplace `autoUpdate` shortly after session start, or `sync`'s own Step-3
+  self-update — the join found nothing and the skill's primary invocation form failed with "could not
+  resolve the default marketplace". Added a version-agnostic fallback that matches the version-stripped
+  `…/cache/<marketplace>/<plugin>` prefix (exact match still tried first; marketplace stays
+  distinguishable), plus a clearer error that prints the searched root and names the version-skew cause.
+  Covered by a new version-skew case in `fleet-state.test.sh`.
+
+### Changed
+
+- **`context/gotchas.md`: generalized the CRLF gotcha (audit finding F2).** The trailing-`\r` hazard
+  is not `jq`-only — any captured Windows value (`python` `print`, PowerShell interop, `git config`,
+  a CRLF file read) can corrupt a constructed `claude plugin` id so the CLI reports
+  `Plugin "<name>" not found` with the full id passed (marketplace suffix silently corrupted). Rescoped
+  the entry to "any captured value", documented the collision with the bare-name symptom, and
+  cross-referenced the two.
+- **`plugins` SKILL.md: corrected the `install_new` render contract (audit finding F3).** An unset
+  `${user_config.install_new}` renders the literal placeholder (the manifest `default` is not
+  substituted for an unset key; verified against CC 2.1.218) — the common default-config case. The doc
+  now reads that literal placeholder as the expected unset state → use the default `ask` without
+  flagging it as an invalid value; only an explicitly-set unsupported value is the invalid case.
+
 ## [0.19.0]
 
 ### Added

--- a/plugins/claude-ops/skills/plugins/SKILL.md
+++ b/plugins/claude-ops/skills/plugins/SKILL.md
@@ -125,13 +125,23 @@ schema has no `enum` type — verified against the published schema), default `"
 - `all` — install every not-yet-installed catalog plugin automatically
 - `none` — report them in "Action needed" only, never install
 
-Any other value is invalid; treat it as `ask` and note the invalid value in the report.
+Any explicitly-set value other than these three is invalid; treat it as `ask` and note the invalid
+value in the report.
 
-**Configured value: `${user_config.install_new}`** — a `userConfig` value only reaches this skill's
-own content through this literal `${user_config.KEY}` substitution (Claude Code text-substitutes it
-before the model sees the rendered skill); declaring the option in `plugin.json` alone does not make
-its value readable here. Sync's Step 4 branches on this line's rendered value, not on the option's
-name or description above.
+**Configured value: `${user_config.install_new}`** — Claude Code text-substitutes a `userConfig`
+value into this skill's content before the model sees the rendered skill, but **only when the key is
+explicitly set** in some `pluginConfigs` scope; declaring the option in `plugin.json` alone does not
+make its value readable here. Crucially, the manifest's `"default": "ask"` is **not** substituted for
+an unset key (verified 2026-07-23 against CC 2.1.218: an unset key renders the literal placeholder,
+while a sibling `${CLAUDE_PLUGIN_ROOT}` substitutes in the same render). So for the common
+default-config user — no `pluginConfigs` set anywhere — this line renders as the **literal
+placeholder text** `${user_config.install_new}`, unchanged.
+
+Read that literal placeholder as the **expected unset state → use the default `ask`**, and do NOT
+report it as an invalid value. Only a rendered value that is a real word other than
+`ask`/`all`/`none` (i.e. the key *was* set, to something unsupported) is the invalid-value case worth
+flagging. Sync's Step 4 branches on this line's rendered value — or on the `ask` default when the
+render is the literal placeholder — not on the option's name or description above.
 
 ## Cross-references
 

--- a/plugins/claude-ops/skills/plugins/context/gotchas.md
+++ b/plugins/claude-ops/skills/plugins/context/gotchas.md
@@ -14,6 +14,12 @@ and `catalog`-joined ids already are. `sync.md`'s Step 3 and `converge.md`'s CLI
 the fully-qualified form for this reason — never shorten an id to the bare name when constructing an
 actual `claude plugin update|install|uninstall|enable` command, even for readability in a report.
 
+Caveat — same symptom, different cause: a `Plugin "<name>" not found` failure with the
+**fully-qualified** `<name>@<marketplace>` id passed is NOT this gotcha. On Windows that is almost
+always a trailing `\r` silently corrupting the marketplace suffix (`<marketplace>\r`) — see
+"[Captured values on Windows carry `\r`](#captured-values-on-windows-carry-r--strip-it-before-embedding-in-any-command-or-json)"
+below. Check the id for a trailing CR before concluding the id form is wrong.
+
 ## Trusting `plugin list` / `plugin details` for "what's loaded here"
 
 Both show the highest installed version across every scope, not the cwd-effective one. Reporting a
@@ -60,12 +66,24 @@ changes this shape, that exit-2 failure is the signal to re-verify against a liv
 training-data recall) and update the parser — never widen the shape check to "whatever doesn't
 crash the script."
 
-## This host's `jq` build CRLF-terminates its output
+## Captured values on Windows carry `\r` — strip it before embedding in any command or JSON
 
 Discovered empirically while implementing `fleet-state.sh` (Windows/MSYS `jq`): even single-line
-compact JSON output ends `\r\n`, not just `\n`. `$(...)` command substitution strips only the
-trailing `\n`, so a stray `\r` survives at the end of a captured value and corrupts it once
-re-embedded in another `--argjson` argument (`jq: invalid JSON text passed to --argjson`). Any new
-script in this skill that shells out to `jq` and captures its output should route every call through
-the same `jq() { command jq "$@" | tr -d '\r'; }`-style wrapper `fleet-state.sh` already uses —
-don't rediscover this the hard way in a second script.
+compact JSON output ends `\r\n`, not just `\n`. But this is **not a `jq`-only hazard** — *any* value
+captured on Windows/MSYS (a native `python` `print(...)`, a PowerShell interop line, `git config`
+output, a CRLF-terminated file read) can arrive with a trailing `\r`. `$(...)` command substitution
+strips only the trailing `\n`, so the `\r` survives at the end of the captured value and corrupts it
+once it is either:
+
+- re-embedded in another `jq --argjson` argument (`jq: invalid JSON text passed to --argjson`), or
+- **embedded in a constructed `claude plugin` id.** A `<name>@<marketplace>\r` id is passed with the
+  full id present, yet the CLI reports `Plugin "<name>" not found` — the marketplace suffix is
+  silently corrupted. The symptom is byte-identical to the bare-name gotcha above and actively
+  misdirects diagnosis (the full id *was* passed). Observed live: extracting ids via
+  `python -c "print(...)"` on Windows gave every id but the last a trailing `\r`, and 57/58
+  `claude plugin update` calls failed this way.
+
+Route every `jq` call through the `jq() { command jq "$@" | tr -d '\r'; }`-style wrapper
+`fleet-state.sh` already uses, **and** strip `\r` (`tr -d '\r'`, or `${var%$'\r'}`) from every value
+captured from any other source before embedding it in a `claude plugin` command or a JSON argument.
+Don't rediscover this the hard way in a second script.

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
@@ -202,16 +202,41 @@ msys* | cygwin* | win32) case_insensitive_os="true" ;;
 esac
 
 # --- Resolve default marketplace: the one this plugin was installed from ---
+# Two-stage match against installed_plugins.json's version-pinned installPath:
+#   1. exact — installPath == this plugin's normalized root (the precise case).
+#   2. version-agnostic fallback — installPath and the running root differ ONLY
+#      by their trailing `/<version>` segment. This is common, not an edge case:
+#      marketplace autoUpdate bumps the install shortly after session start while
+#      the session keeps rendering the old version's skill, and `sync`'s own
+#      Step 3 updates claude-ops itself — so every subsequent same-session call of
+#      the bare (no --marketplace) default path would otherwise fail. The fallback
+#      matches the version-stripped `…/cache/<marketplace>/<plugin>` prefix, which
+#      still carries the marketplace (so two marketplaces shipping the same plugin
+#      stay distinguishable). Takes the caller's already-normalized root as $1 so
+#      the caller can reuse it in the error message (a var set here would be lost
+#      across the `$(...)` the caller wraps this in).
 resolve_default_marketplace() {
-  local plugin_root norm_root
-  plugin_root="${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT_DEFAULT}"
-  norm_root=$(hook::normalize_path "$(hook::physical_path "$plugin_root")")
-  norm_root="${norm_root%/}"
-  jq -r --arg root "$norm_root" --argjson ci "$case_insensitive_os" '
+  local norm_root="$1" norm_root_parent result
+  # Stage 1: exact installPath match.
+  result=$(jq -r --arg root "$norm_root" --argjson ci "$case_insensitive_os" '
     .plugins
     | to_entries[]
     | select(.value[] | (.installPath // "" | gsub("\\\\";"/")) as $p |
              if $ci then ($p | ascii_downcase) == ($root | ascii_downcase) else $p == $root end)
+    | .key
+  ' "$INSTALLED_JSON" | head -1 | sed 's/.*@//')
+  if [[ -n "$result" ]]; then
+    printf '%s' "$result"
+    return 0
+  fi
+  # Stage 2: version-agnostic parent-prefix match (survives mid-session skew).
+  norm_root_parent="${norm_root%/*}"
+  [[ -n "$norm_root_parent" && "$norm_root_parent" != "$norm_root" ]] || return 0
+  jq -r --arg parent "$norm_root_parent" --argjson ci "$case_insensitive_os" '
+    .plugins
+    | to_entries[]
+    | select(.value[] | (.installPath // "" | gsub("\\\\";"/") | rtrimstr("/") | sub("/[^/]*$";"")) as $pp |
+             if $ci then ($pp | ascii_downcase) == ($parent | ascii_downcase) else $pp == $parent end)
     | .key
   ' "$INSTALLED_JSON" | head -1 | sed 's/.*@//'
 }
@@ -417,9 +442,18 @@ done
 
 case "$MODE" in
 default)
-  TARGET=$(resolve_default_marketplace)
+  plugin_root="${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT_DEFAULT}"
+  norm_root=$(hook::normalize_path "$(hook::physical_path "$plugin_root")")
+  norm_root="${norm_root%/}"
+  TARGET=$(resolve_default_marketplace "$norm_root")
   if [[ -z "$TARGET" ]]; then
-    echo "ERROR: could not resolve the default marketplace (this plugin's CLAUDE_PLUGIN_ROOT was not found in installed_plugins.json). Pass --marketplace <name> explicitly." >&2
+    echo "ERROR: could not resolve the default marketplace. This plugin's install dir" >&2
+    echo "  ${norm_root:-<unresolved>}" >&2
+    echo "matched no installed_plugins.json entry — searched by exact installPath and by" >&2
+    echo "version-agnostic .../cache/<marketplace>/<plugin> prefix. This usually means the" >&2
+    echo "session's loaded version differs from the installed one AND the cache layout is" >&2
+    echo "not the expected .../cache/<marketplace>/<plugin>/<version> shape. Pass" >&2
+    echo "--marketplace <name> explicitly." >&2
     exit 1
   fi
   emit_marketplace "$TARGET" || exit 1

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
@@ -444,6 +444,35 @@ out=$(run_state "$case_dir" CLAUDE_PLUGIN_ROOT="$case_dir/nowhere-installed")
 rc=$?
 assert_exit "default marketplace: unresolvable root fails loud, doesn't guess" 1 "$rc"
 assert_contains "default marketplace: names the fallback" "$out" "--marketplace"
+assert_contains "default marketplace: error names the searched root" "$out" "nowhere-installed"
+
+# ============================================================================
+# Case: version skew — session's loaded version != installed version.
+# installPath is version-pinned; a mid-session autoUpdate (or sync's own Step-3
+# self-update) makes the running root's version segment differ, so the exact
+# installPath match misses. The version-agnostic parent-prefix fallback must
+# still resolve the marketplace so the bare (no --marketplace) default path
+# keeps working. Real dirs so realpath resolves both consistently.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+skew_parent="$case_dir/cache/market1/this-plugin"
+mkdir -p "$skew_parent/0.18.3" "$skew_parent/0.19.0"
+installed_ver_path="$skew_parent/0.18.3" # the version recorded in installed_plugins.json
+session_ver_path="$skew_parent/0.19.0"   # the version the session actually loaded
+native_installed="$(cygpath -w "$installed_ver_path" 2>/dev/null || echo "$installed_ver_path")"
+write "$case_dir/installed_plugins.json" "$(
+  jq -cn --arg root "$native_installed" \
+    '{version: 1, plugins: {"this-plugin@market1": [{scope: "user", installPath: $root, version: "0.18.3"}]}}'
+)"
+write "$case_dir/known_marketplaces.json" '{"market1": {"source": {"source": "github", "repo": "example/market1"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+write "$case_dir/catalog/market1.json" '{"plugins": [{"name": "this-plugin"}]}'
+ARGS=()
+out=$(run_state "$case_dir" CLAUDE_PLUGIN_ROOT="$session_ver_path")
+rc=$?
+assert_exit "version skew: resolves via version-agnostic parent-prefix fallback" 0 "$rc"
+resolved_name=$(jq -r '.marketplace.name' <<<"$out" 2>/dev/null)
+assert_eq "version skew: correct marketplace despite version mismatch" "market1" "$resolved_name"
 
 # ============================================================================
 # Case: jq missing — clear notice, not a bare command-not-found


### PR DESCRIPTION
Closes #1176.

Consumer-audit fixes for the claude-ops `plugins` sync skill (handoff-inbox item `20260723-155027`), re-verified against current source (0.19.0). Version `0.19.0` → `0.19.1`.

## Changes

- **F1 (bug).** `fleet-state.sh`'s `resolve_default_marketplace` exact-matched the running plugin root against the version-pinned `installPath`, so any skew between the session's loaded version and the installed one — a marketplace `autoUpdate` after session start, or `sync`'s own Step-3 self-update of claude-ops — broke the primary no-`--marketplace` path with "could not resolve the default marketplace". Added a **version-agnostic fallback** matching the version-stripped `…/cache/<marketplace>/<plugin>` prefix (exact match still tried first; the marketplace stays distinguishable via the path), plus a clearer error that prints the searched root and names the skew cause.
- **F2a (doc).** Generalized `context/gotchas.md`'s CRLF entry from "this host's `jq` build" to **any captured Windows value** (`python` print, PowerShell interop, `git config`, CRLF file read): a trailing `\r` on a constructed `claude plugin` id makes the CLI report `Plugin "<name>" not found` with the full id passed (marketplace suffix corrupted), colliding with the bare-name symptom — documented and cross-referenced both ways.
- **F3a (doc).** `plugins/SKILL.md` now reads an unset `${user_config.install_new}` — which renders the literal placeholder, since the manifest `default` is not substituted for an unset key (verified vs CC 2.1.218) — as the **expected unset state → default `ask`**, not an invalid value; only an explicitly-set unsupported value is flagged.

## Verification

- `bash plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh` → **28 cases, 0 failed** (new version-skew case green).
- `shellcheck -x -S warning fleet-state.sh` → clean.
- `scripts/check-changed-skills.sh origin/main` → PASS for the `plugins` skill (runs the fleet-state test).

## Deferred (noted on #1176, not in this PR)

- **F2b:** ship a `sync-sweep.sh` sibling owning the Step 2+3 update loop (CR-stripping, fail-loud, structured per-id JSON) so `sync.md` shrinks to "run this, report from its output". Bigger net-new surface with its own test.
- **F3b:** verify upstream whether a declared `userConfig` default is *intended* to substitute for an unset key; file a CC docs issue if docs and behavior disagree. F3a is correct regardless.

## Related

- Handoff-inbox item `20260723-155027-claude-ops-plugins-sync-audit` (producer: KyleSexton workstation, CC 2.1.218).
- Prior inbox items landed this session: #1171 (bash-format), #1172 (hook-observability + hook-utils).

🤖 Generated with [Claude Code](https://claude.com/claude-code)