### PR TITLE
fix(work-items): reconcile the telemetry comment creation race in both lanes

### DIFF
--- a/plugins/work-items/skills/attend-queue/SKILL.md
+++ b/plugins/work-items/skills/attend-queue/SKILL.md
@@ -107,6 +107,14 @@ else
 fi
 ```
 
+**Creation race reconcile.** Two sessions racing the first-ever upsert can both see an empty
+lookup and both POST, forking the singleton. After any POST, re-list the sentinel comments: when
+more than one exists, the LOWEST comment id is canonical — every session converges on it
+deterministically. A session whose own POST lost the race PATCHes its state into the canonical
+comment and edits its duplicate's body to a one-line tombstone pointing at the canonical id
+(sentinel line removed, so the duplicate never matches the lookup again). Later cycles read only
+the canonical comment; nothing is deleted.
+
 When the bound provider is not `github`, this upsert is unavailable: carry the same telemetry
 content in the lane's pass report/log instead, with a notice that the comment surface is absent.
 

--- a/plugins/work-items/skills/work-loop/SKILL.md
+++ b/plugins/work-items/skills/work-loop/SKILL.md
@@ -73,6 +73,14 @@ else
 fi
 ```
 
+**Creation race reconcile.** Two sessions racing the first-ever upsert can both see an empty
+lookup and both POST, forking the singleton. After any POST, re-list the sentinel comments: when
+more than one exists, the LOWEST comment id is canonical — every session converges on it
+deterministically. A session whose own POST lost the race PATCHes its state into the canonical
+comment and edits its duplicate's body to a one-line tombstone pointing at the canonical id
+(sentinel line removed, so the duplicate never matches the lookup again). Later cycles read only
+the canonical comment; nothing is deleted.
+
 When the bound provider is not `github`, this upsert is unavailable: carry the same telemetry
 content — including the machine-readable state block — in the lane's cycle report/log instead,
 with a notice that the comment surface is absent.


### PR DESCRIPTION
## Summary

Ports the creation-race reconcile that review surfaced on the babysit lane (#1175) to the two merged work-items lanes, which share the same first-upsert POST race: after any POST, re-list the sentinel comments; the lowest comment id is canonical; a losing session PATCHes its state into the canonical comment and tombstones its duplicate (sentinel line removed). No deletions; deterministic convergence.

## Test plan

- markdownlint clean on both changed skill bodies
- Prose-only change to the upsert contract paragraph; no script changes

## Related

No linked issue — follow-up to #1175 review findings.