### PR TITLE
feat(babysit-lane): adopt the merge lane with drain mode at worker tier

### DIFF
--- a/docs/topics/ci-workflows-work-loop/PLAN.md
+++ b/docs/topics/ci-workflows-work-loop/PLAN.md
@@ -367,7 +367,7 @@ Cross-cutting work items (both skills, reviewer findings):
 - **Sanity Check:** `grep -c "conventions/loop-lane" plugins/work-items/skills/work-loop/SKILL.md` ≥ 1 and same for `attend-queue` (convention cited, not restated).
 - **Sanity Check:** `grep -En "claude-(opus|sonnet|haiku|fable)-[0-9]" plugins/work-items/skills/{work-loop,attend-queue}/SKILL.md` returns empty (no hard-coded model IDs; tiers only).
 
-### Phase 5: ci-workflows tracker binding [TODO]
+### Phase 5: ci-workflows tracker binding [DONE]
 
 One PR to ci-workflows. Pre-flight consumer check (contract surface = new tracked file): grep
 ci-workflows workflows/scripts for `.work-item-tracker.json` readers — none expected (file is
@@ -394,7 +394,7 @@ outside the ruleset's ref scope. Retain a one-command build-time confirmation as
   listing propagation window — consequence is a duplicate PR, recoverable, caught by
   babysit/HITL; a jittered delay before the lease re-read shrinks it cheaply).
 
-### Phase 6: standards lease-activation PR draft [TODO]
+### Phase 6: standards lease-activation PR draft [DONE]
 
 Prepare (never file) the standards change editing `conventions/process/issue-tracker.md` L37
 block: record activation of assignee+lease claiming (trigger met: autonomous multi-worker


### PR DESCRIPTION
## Summary

Adds the team-tracked `.claude/source-control.md` layer with the babysit-loop lane keys (`drain` stop mode, `worker` tier, `c2-mechanical` merge rung, 30-minute grace window). Per the loop-lane convention's baseline-activation rule, this reviewed PR is the recorded human-ratified lane adoption for ci-workflows — the act that activates the baseline merge rung (gate-proven C2-mechanical PRs only; everything else stays human merge). Without this file, the lane runs with every merge human-only.

Phase B3 pre-requisite of the work-loop plan (claude-code-plugins `docs/topics/ci-workflows-work-loop/babysit-PLAN.md`).

## Test plan

- markdownlint clean
- Key names match the seam's key table (`plugins/source-control/reference/config-resolution.md`)

## Related

No linked issue.