### PR TITLE
docs(config-cascade): rename consumer-config-layering seam → config-cascade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ Thumbs.db
 .claude/settings.local.json
 .claude/observability/
 .claude/worktrees/
-# source-control convention personal overlay (docs/conventions/consumer-config-layering/README.md
+# source-control convention personal overlay (docs/conventions/config-cascade/README.md
 # "Overlay naming" — the recursive form covers a flat .claude/source-control.local.md and any
 # future folder-form overlay in one line; the plugin's own docs still show the narrower
 # .claude/*.local.* form, tracked separately as "overlay spelling drift")

--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -241,7 +241,7 @@ one increment past the precedent). Behavioral gaps the docs leave open are resol
      (profile axis) — the two compose (`.claude/<concern>/<profile-name>/`). Reference adopter:
      [`ai-briefing`](ai-briefing-design.md).
    - **Resolution + override semantics, overlay naming, and the recommended consumer `.gitignore`
-     line** are owned by [`docs/conventions/consumer-config-layering/`](conventions/consumer-config-layering/README.md)
+     line** are owned by [`docs/conventions/config-cascade/`](conventions/config-cascade/README.md)
      — the layering axis is cross-cutting, so it is contracted once there rather than restated per
      seam. A surface declares its own keys and schema here or in its own owner doc, and points there
      for how its layers merge.

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -338,7 +338,7 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Lifecycle artifact protocol | [`docs/PLUGIN-ARTIFACT-PROTOCOL.md`](PLUGIN-ARTIFACT-PROTOCOL.md) |
 | Shared hook utility library | `lib/hook-utils.sh`, synced by `scripts/sync-hook-utils.sh` |
 | Cross-plugin shared-source clusters | `scripts/cross-plugin-source-registry.txt` |
-| Consumer-config layering and precedence | [`docs/conventions/consumer-config-layering/`](conventions/consumer-config-layering/README.md) |
+| Config cascade — consumer-config layering and precedence | [`docs/conventions/config-cascade/`](conventions/config-cascade/README.md) |
 | Commit-convention enforcement seam | [`docs/conventions/commit-convention/`](conventions/commit-convention/README.md) |
 | PR-body required-sections convention | [`docs/conventions/pr-body-convention/`](conventions/pr-body-convention/README.md) |
 | Ecosystem command resolution | [`docs/conventions/ecosystem-commands/`](conventions/ecosystem-commands/README.md) |

--- a/docs/conventions/config-cascade/CHANGELOG.md
+++ b/docs/conventions/config-cascade/CHANGELOG.md
@@ -1,10 +1,18 @@
-# Consumer-Config Layering Convention — Changelog
+# Config Cascade Convention — Changelog
 
-Notable changes to the consumer-config layering contract. The contract is versioned by
+Notable changes to the config-cascade contract. The contract is versioned by
 `contract_version` (SemVer) and governs the layering axis only — layer set, precedence, override
 semantics, and overlay naming. Per-concern keys and schema are versioned by their own owner docs and
 change independently. A change to the precedence order or the meaning of a layer is a major bump;
 adding an optional layer or relaxing a rule additively is a minor bump.
+
+## Renamed — 2026-07-23
+
+Folder + concept renamed `consumer-config-layering` → `config-cascade` (#1188). No contract change:
+`contract_version` and every layer/precedence rule are unchanged — this is a name/path rename only,
+so no version bump. The former clunky three-noun label is replaced by "cascade" (the established
+CSS-cascade term for precedence-ordered resolution with override + ratified inversion). All live
+references updated; historical topic docs and CHANGELOGs retain the former name as frozen record.
 
 ## 1.1 — 2026-07-20
 

--- a/docs/conventions/config-cascade/README.md
+++ b/docs/conventions/config-cascade/README.md
@@ -1,4 +1,8 @@
-# Consumer-Config Layering Convention
+# Config Cascade Convention
+
+> Formerly `consumer-config-layering` (renamed #1188). "Cascade" (CSS `@layer`/`!important`) is the
+> established term that natively carries both per-key override and a ratified precedence-inversion —
+> matching this seam's user→team→local + policy-floor model.
 
 A versioned, marketplace-wide contract for **how** a plugin's consumer-tracked configuration layers —
 which layers exist, what order they resolve in, and what a later layer may do to an earlier one. Every

--- a/docs/conventions/consumer-config-layering/README.md
+++ b/docs/conventions/consumer-config-layering/README.md
@@ -1,0 +1,12 @@
+# Moved → `config-cascade`
+
+This convention was renamed **`consumer-config-layering` → `config-cascade`** (#1188).
+
+The contract now lives at
+[`docs/conventions/config-cascade/README.md`](../config-cascade/README.md). Its raw URL:
+`https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md`.
+
+This stub is a **compatibility tombstone**: earlier cached `code-tidying` (≤0.7.1) and `testing`
+(≤0.3.1) plugin copies still fetch the old path, so it is preserved to avoid a 404 until those
+installs update. New references must point at `config-cascade`; this file may be removed once the old
+plugin versions are no longer in circulation.

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -45,7 +45,7 @@ tracked seam config. A repository adopts it through its own reviewable lane-enab
 binding/config PR that turns a lane on in that repo — which is the recorded, human-ratified act for
 the baseline rung, so no lane ever auto-merges without a reviewed change having enabled it. Raising
 any higher rung — including any C3-autonomous merge — is a config change on the tracked, layered
-config seam ([consumer-config layering](../consumer-config-layering/README.md)), which makes it
+config seam ([config-cascade](../config-cascade/README.md)), which makes it
 exactly the autonomy matrix's required **human-ratified knob flip recorded on the governance
 surface**
 ([`work-classes.md`](../../../plugins/autonomy/reference/guardrails/work-classes.md#promotion-and-demotion)).

--- a/plugins/code-tidying/.claude-plugin/plugin.json
+++ b/plugins/code-tidying/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "code-tidying",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Code tidying and comment hygiene: /code-tidying:tidy proactively hunts a rotated, glob-scoped lane for Beck-style tidyings under a research-backed scope budget and ships one tight PR; /code-tidying:batch-simplify sweeps recently changed files through grouped, dependency-ordered simplification waves with a never-drop deferred-items contract; /code-tidying:audit-comment-residue is a read-only classifier that flags history, plan, conversational, and ticket/PR residue in code comments for author-applied deletion. Project-specific tidy lanes are scaffolded into a tracked .claude/tidy-lanes/ config folder by a re-runnable setup skill.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/code-tidying/CHANGELOG.md
+++ b/plugins/code-tidying/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `code-tidying` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.2]
+
+### Changed
+
+- **Doc reference updated for the `config-cascade` seam rename (#1188).** The layering-contract link in
+  `tidy/SKILL.md` and `tidy/lanes/docs-prose.md` now points at `docs/conventions/config-cascade/`
+  (formerly `consumer-config-layering`). No behavior change.
+
 ## [0.7.1]
 
 ### Changed

--- a/plugins/code-tidying/skills/tidy/SKILL.md
+++ b/plugins/code-tidying/skills/tidy/SKILL.md
@@ -59,7 +59,7 @@ A lane is a discrete glob-scoped slice of the repo, defined in a lane file that 
 1. `${CLAUDE_PROJECT_DIR}/.claude/tidy-lanes/<lane>.md` — the consuming project's own lane definition, if present
 2. `${CLAUDE_PLUGIN_ROOT}/skills/tidy/lanes/<lane>.md` — the bundled generic lane
 
-When the project layer is absent, resolution is the bundled lane alone. When it is present, how the two layers combine is governed by the **project layer's own `## Merge semantics` section** (per the [consumer-config layering contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/consumer-config-layering/README.md)):
+When the project layer is absent, resolution is the bundled lane alone. When it is present, how the two layers combine is governed by the **project layer's own `## Merge semantics` section** (per the [config-cascade contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md)):
 
 - The project layer declares a `## Merge semantics` section → **read both layers and merge per that declaration** (typically: `Scope` and most sections per-section override, watch-for patterns additive). A section absent from the project layer keeps the bundled value; the bundled generic patterns are never frozen out. The bundled `docs-prose` lane declares this shape.
 - The project layer declares no such section → it resolves **project-only** (the bundled lane is not read). This is the legacy first-match path; lanes still on it are migrated one at a time.

--- a/plugins/code-tidying/skills/tidy/lanes/docs-prose.md
+++ b/plugins/code-tidying/skills/tidy/lanes/docs-prose.md
@@ -17,7 +17,7 @@ Retarget this to the consuming project's actual documentation layout with a proj
 
 ## Merge semantics
 
-This lane is layered per the [consumer-config layering contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/consumer-config-layering/README.md) ("Merge semantics"). A project lane at `.claude/tidy-lanes/docs-prose.md` does **not** replace this file wholesale — it merges with the bundled lane **per section**, so bundled improvements to sections the project does not touch keep reaching the repo:
+This lane is layered per the [config-cascade contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md) ("Merge semantics"). A project lane at `.claude/tidy-lanes/docs-prose.md` does **not** replace this file wholesale — it merges with the bundled lane **per section**, so bundled improvements to sections the project does not touch keep reaching the repo:
 
 - **`Scope`** — **per-section override.** A project `Scope` block replaces the bundled globs entirely; retargeting doc layout is the whole reason a project writes a lane, and two glob sets do not meaningfully concatenate. A project lane that omits `Scope` keeps the bundled globs.
 - **`Watch-for patterns`** — **additive (concatenate).** A project's watch-for entries are **appended** to the bundled P-1..P-6; the generic patterns are never frozen out, and new bundled patterns flow to the project on upgrade. A project adds repo-specific patterns here; it does not restate or replace the bundled ones.

--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Test-stage discipline across all ecosystems: coverage-gap analysis and test planning (`/testing:plan`), TDD test authoring and placement (`/testing:write`), live E2E plus non-UI smoke verification (`/testing:run-e2e`), and failing-test root-cause diagnosis with the reproduce → isolate → fix → retest loop (`/testing:diagnose`).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/testing/CHANGELOG.md
+++ b/plugins/testing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `testing` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.2]
+
+### Changed
+
+- **Doc reference updated for the `config-cascade` seam rename (#1188).** The layering-contract links in
+  `README.md`, `run-e2e/SKILL.md`, and `run-e2e/context/e2e-config.md` now point at
+  `docs/conventions/config-cascade/` (formerly `consumer-config-layering`). No behavior change.
+
 ## [0.3.1]
 
 ### Changed

--- a/plugins/testing/README.md
+++ b/plugins/testing/README.md
@@ -46,7 +46,7 @@ This plugin declares no userConfig options.
 `browser_mode` (`headed | headless`, default `headless`). Both defaults preserve current
 behavior, so the file is optional. Its keys, defaults, and precedence are documented in
 the skill's bundled `run-e2e/context/e2e-config.md`; it layers per the marketplace
-consumer-config-layering convention.
+config-cascade convention.
 
 ## License
 

--- a/plugins/testing/skills/run-e2e/SKILL.md
+++ b/plugins/testing/skills/run-e2e/SKILL.md
@@ -39,7 +39,7 @@ On a hard-fail, STOP **and** write a structured verification-environment gap rep
 
 Two keys govern this run: `recording` (`video | gif | off`) and `browser_mode` (`headed | headless`). They live in the consumer-tracked surface `.claude/testing/e2e.md`; [context/e2e-config.md](context/e2e-config.md) owns their definitions, defaults, and precedence. Resolve them before driving:
 
-- Anchor at the repo root, then read every layer of the surface that exists — user-global, team, and local overlay — and merge `recording` and `browser_mode` per key. Report which layer supplied each effective value. The generic layer mechanics (anchoring, reading every layer, provenance, soft-degrade) are the layering contract's — see the [consumer-config layering contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/consumer-config-layering/README.md); this step only names the surface path, the keys, and the per-key merge.
+- Anchor at the repo root, then read every layer of the surface that exists — user-global, team, and local overlay — and merge `recording` and `browser_mode` per key. Report which layer supplied each effective value. The generic layer mechanics (anchoring, reading every layer, provenance, soft-degrade) are the layering contract's — see the [config-cascade contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md); this step only names the surface path, the keys, and the per-key merge.
 - An explicit instruction in the session prompt overrides the file layers for that run — the keys are defaults only. The precedence ladder is in [context/e2e-config.md](context/e2e-config.md).
 
 ## Step 3: Drive the run (subagent-isolated)

--- a/plugins/testing/skills/run-e2e/context/e2e-config.md
+++ b/plugins/testing/skills/run-e2e/context/e2e-config.md
@@ -2,7 +2,7 @@
 
 The consumer-tracked config surface for `/testing:run-e2e`. It carries two per-operator / per-repo preferences: how a run captures evidence, and whether the browser is visible. The surface identity is its whole path relative to `.claude/` — `testing/e2e.md` — so its layers live at `~/.claude/testing/e2e.md` (user-global), `${CLAUDE_PROJECT_DIR}/.claude/testing/e2e.md` (team), and `${CLAUDE_PROJECT_DIR}/.claude/testing/e2e.local.md` (local overlay).
 
-This file owns the keys — their meaning, allowed values, defaults, and precedence. How the layers merge is owned by the layering contract; see the [consumer-config layering contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/consumer-config-layering/README.md). The two compose: this doc declares the keys and points there for layer mechanics.
+This file owns the keys — their meaning, allowed values, defaults, and precedence. How the layers merge is owned by the layering contract; see the [config-cascade contract](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/config-cascade/README.md). The two compose: this doc declares the keys and points there for layer mechanics.
 
 ## Keys
 


### PR DESCRIPTION
## Summary

Renames the marketplace-wide consumer-config layering seam from the clunky three-noun
`consumer-config-layering` to **`config-cascade`**.

Name chosen via `/naming:name-it-better` (blind 3-lens fan-out): "cascade" (CSS `@layer`/`!important`)
is the one established term of art that natively carries **both** per-key override **and** a ratified
precedence-inversion — matching the seam's user→team→local + policy-floor model. Runner-ups:
`config-layering`, `layer-cascade`, `config-precedence`.

- `git mv docs/conventions/consumer-config-layering → config-cascade`.
- All **live** references updated (name + path): MIGRATION-PLAYBOOK, PLUGIN-PHILOSOPHY, loop-lane seam,
  code-tidying (SKILL + docs-prose lane), testing (README + run-e2e SKILL/context), `.gitignore`.
- Seam README records the former name (discoverability); CHANGELOG records the rename with **no
  `contract_version` bump** — name/path only, contract unchanged.
- code-tidying `0.7.1→0.7.2`, testing `0.3.1→0.3.2` (patch) so consumers receive the corrected doc-URL.
- **Historical** topic docs / CHANGELOGs retain the former name as frozen record (bare-text mentions,
  not links).

**Provenance context:** the rename was gated (issue #1187) on whether the seam was legitimately
ratified. Finding: all 12 `docs/conventions/*` seams are PR-introduced across the repo's whole history;
`consumer-config-layering` (#692) is unremarkable. The shared `kyle-sexton` identity (human + agents)
makes metadata-level "human-ratified vs agent-accreted" undecidable — a **repo-wide** property, not a
disqualifier for this seam. The operator's direct direction this session is the ratification.

## Test plan

- `lychee --offline './**/*.md'` — **0 errors** (2754 links checked); no dead relative link to the old path.
- `grep -rn '](.*conventions/consumer-config-layering' .` — none (no dead relative links).
- `scripts/check-changelog-parity.sh --check-bump origin/main` — both bumped plugins have entries.
- Remaining `consumer-config-layering` mentions are historical bare-text only (topic PLANs, CHANGELOGs, `.work/`).

## Related

- Closes #1188
- Provenance context: #1187 (audit finding recorded above)
- Follows #1185 (well-known path, which dogfoods the `docs/conventions/<concern>/` location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)