### PR TITLE
fix(source-control): state well-known rung git-tracked requirement on both surfaces

### DIFF
--- a/docs/conventions/commit-convention/README.md
+++ b/docs/conventions/commit-convention/README.md
@@ -86,13 +86,19 @@ Contract points:
   1. an **explicit `convention_source` pointer** — the relocation override; the path stays
      repo-owned, so a repo that keeps its convention elsewhere is unaffected;
   2. absent a pointer, the **well-known default path**
-     `docs/conventions/source-control/commit-convention.yml` when that file exists — the marketplace's
-     own dogfooded `docs/conventions/<concern>/` layout, so the common case reads ONE tool-agnostic
-     file with no markdown pointer-parse and no pointer to sever;
+     `docs/conventions/source-control/commit-convention.yml` **when that file is git-tracked** — the
+     marketplace's own dogfooded `docs/conventions/<concern>/` layout, so the common case reads ONE
+     tool-agnostic file with no markdown pointer-parse and no pointer to sever;
   3. absent both, the **team markdown-H2** sections (legacy).
 
-  Once a neutral file resolves via rung 1 or 2 it is authoritative and the fail-closed broken-file
-  contract applies; a key it omits still falls back per key to the markdown H2.
+  **Rung 2 requires the file to be git-TRACKED — a policy floor both surfaces enforce identically.**
+  An untracked or gitignored file at the default path is a generated/local artifact, not team
+  convention; honoring it would let a personal/local file drive the gate (the same floor the team-only
+  reads protect) and would let drafting diverge from enforcement. Enforcement checks this with
+  `git ls-files --error-unmatch` (git-absent or untracked → skip rung 2, fall through to the markdown
+  H2); the drafting read (`config-resolution.md`) applies the identical requirement, so both surfaces
+  resolve the same file. Once a neutral file resolves via rung 1 or 2 it is authoritative and the
+  fail-closed broken-file contract applies; a key it omits still falls back per key to the markdown H2.
 
   **Both V1 reasons for shipping no well-known search are engaged, not overridden by fiat** (#163434
   is the demanding consumer; design: `docs/topics/commit-convention-well-known-path/`). V1 recorded

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /babysit-loop (the loop-lane merge lane: a standing or drain loop that invokes babysit-prs per cycle, configured through repo-scoped babysit_loop_* keys on the layered source-control.md seam, with merge authority human-only until the target repo's tracked config adopts the lane, a gate-proven C2-mechanical baseline once adopted, and merge-rung raises binding from the team-tracked layer only), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.25.1]
+
+### Fixed
+
+- **Well-known rung's git-tracked requirement now stated on both resolution surfaces.** #1185's review
+  hardening (an untracked/gitignored file at the well-known path must not drive resolution) landed only
+  in the enforcement resolver. `config-resolution.md` (drafting) and the commit-convention seam README
+  still described rung 2 as firing "when that file exists" while claiming the surfaces were "identical"
+  — false after the fix, and a real divergence risk (drafting would use an untracked file the gate
+  skips). Both specs now require rung 2 to be **git-tracked** and tell the drafting reader how to check
+  it (`git ls-files --error-unmatch`), so drafting and enforcement resolve the same file. Docs-only;
+  the resolver already enforced this.
+
 ## [0.25.0]
 
 ### Added

--- a/plugins/source-control/reference/config-resolution.md
+++ b/plugins/source-control/reference/config-resolution.md
@@ -62,11 +62,16 @@ Absent sections are absent, never empty.
   merge per key on top. **The neutral file is resolved by a three-rung precedence, identical on the
   drafting and enforcement surfaces:** (1) an explicit `convention_source` pointer (the relocation
   override — path stays repo-owned); absent one, (2) the **well-known default path**
-  `docs/conventions/source-control/commit-convention.yml` when that file exists (the common case —
-  read ONE tool-agnostic file, no pointer needed); absent both, (3) the team markdown H2 sections
-  (legacy / back-compat). Once a neutral file is resolved via rung 1 or 2 it is authoritative and
-  the fail-closed broken-file contract applies; a key it omits still falls back per key to the
-  markdown H2. Value grammar, pointer safety rules, and the fail-closed
+  `docs/conventions/source-control/commit-convention.yml` **when that file is git-tracked** (the
+  common case — read ONE tool-agnostic file, no pointer needed); absent both, (3) the team markdown
+  H2 sections (legacy / back-compat). The rung-2 **git-tracked requirement is a policy floor shared by
+  both surfaces**: an untracked or gitignored file at the default path must NOT drive resolution — it
+  is a generated/local artifact, not team convention, and honoring it would let drafting diverge from
+  the enforcement gate (which enforces the same floor). Verify with
+  `git ls-files --error-unmatch docs/conventions/source-control/commit-convention.yml`; if it is
+  untracked (or git is unavailable), skip rung 2 and fall through to the markdown H2. Once a neutral
+  file is resolved via rung 1 or 2 it is authoritative and the fail-closed broken-file contract
+  applies; a key it omits still falls back per key to the markdown H2. Value grammar, pointer safety rules, and the fail-closed
   broken-pointer contract are owned by the
   [commit-convention seam](https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/commit-convention/README.md)
   — drafting honors the same contract (a declared-but-broken pointer is surfaced as a config error,

--- a/plugins/source-control/skills/setup/SKILL.md
+++ b/plugins/source-control/skills/setup/SKILL.md
@@ -225,8 +225,9 @@ Skill-behavior failure patterns hit in real runs. Add to this section when new o
   surface it as a config error rather than silently falling back to markdown values a migration may
   have retired — verify the neutral file round-trips through the resolver at write time. The neutral
   file resolves by a fixed 3-rung precedence (explicit pointer > well-known
-  `docs/conventions/source-control/commit-convention.yml` > markdown-H2); `check` warns when a
-  resolved neutral file shadows a stale markdown-H2 duplicate.
+  `docs/conventions/source-control/commit-convention.yml` **when git-tracked** > markdown-H2); an
+  untracked/gitignored file at the well-known path is skipped on both surfaces (policy floor), and
+  `check` warns when a resolved neutral file shadows a stale markdown-H2 duplicate.
 
 ## What this skill does NOT do
 


### PR DESCRIPTION
## Summary

#1185's P1 review hardening — the well-known convention-file rung activates only when the file is
**git-tracked** — landed only in the enforcement resolver bash. The drafting spec
(`config-resolution.md`) and the commit-convention seam README still said rung 2 fires "when that
file exists", and config-resolution.md claimed the surfaces were "identical" — false after the fix.

**The drift it created:** a repo with an untracked/gitignored well-known file + a different markdown-H2
`subject_pattern` → drafting resolves the untracked file, enforcement skips it → the plugin drafts
commits its own gate rejects. Exactly the two-surface divergence the design exists to prevent.

Adds the git-tracked requirement + how the drafting reader checks it (`git ls-files --error-unmatch`)
to config-resolution.md, the seam README, and the setup SKILL.md gotcha. **Docs-only** — the resolver
already enforced tracked; this makes the specs match and "identical on both surfaces" true again.

source-control `0.25.0 → 0.25.1`.

## Test plan

- `lychee --offline` clean on the three edited docs.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — bump has an entry.
- No code change (resolver + its 58 tests unchanged); the resolver already required tracked.

## Related

- Closes #1191
- Follow-up to #1185 / #163434 (well-known default path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)