### PR TITLE
docs(disk-hygiene): scope PowerShell-belt claims to preview + recheck (#1195)

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.2]
+
+### Fixed
+
+- **Docs no longer promise PowerShell-tool deletion protection that does not fire on current builds
+  (inbox `173656`).** `skills/clean/SKILL.md` and `reference/safety-model.md` asserted the PowerShell
+  guard belt "turns deletion spellings into a final human permission prompt" and that a configured
+  `disk_hygiene_enabled=false` blocks the PowerShell lane. On Claude Code 2.1.218 (Windows, reproduced)
+  a `Bash|PowerShell` PreToolUse hook fires for the Bash tool but does **not** intercept
+  PowerShell-*tool* commands — the PowerShell tool is a documented *preview* feature
+  ([tools-reference](https://code.claude.com/docs/en/tools-reference)) and PreToolUse interception of it
+  is not a listed preview limitation, so the belt and the kill switch's reach into the manual PowerShell
+  lane are inert there. The claims are now scoped as the guard's *intended* design with an explicit
+  version-pinned preview caveat + recheck trigger; on Windows the protections that actually hold are the
+  manual lane's per-path `handoff-verify` approval and the consumer's baseline permission policy.
+  Observed effect only — the mechanism (matcher firing vs Windows payload delivery vs `tool_name`) is not
+  yet isolated; a fresh-session hook-firing probe is bundled for the maintainer, and the upstream
+  docs-vs-behavior divergence is held for a report once isolated.
+
 ## [0.8.1]
 
 ### Changed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -19,8 +19,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   version-pinned preview caveat + recheck trigger; on Windows the protections that actually hold are the
   manual lane's per-path `handoff-verify` approval and the consumer's baseline permission policy.
   Observed effect only — the mechanism (matcher firing vs Windows payload delivery vs `tool_name`) is not
-  yet isolated; a fresh-session hook-firing probe is bundled for the maintainer, and the upstream
-  docs-vs-behavior divergence is held for a report once isolated.
+  yet isolated (recheck by adding a logging `PreToolUse` `matcher: "PowerShell"` hook in a fresh session
+  and confirming it fires for a PowerShell-tool command); the upstream docs-vs-behavior divergence is
+  held for a report once isolated.
 
 ## [0.8.1]
 

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -263,8 +263,10 @@ handoff, not an engine plan:
 
 The PowerShell guard lane is *designed* to turn deletion spellings into a final human permission prompt
 (the same bar as the engine apply prompt); confirm that prompt only when the command matches the exact
-approved list. Engine invocations from PowerShell stay hard-denied. **Caveat (Claude Code 2.1.218,
-Windows): this belt does not fire for the PowerShell tool** — the PowerShell tool is in preview and
+approved list. Engine invocations from PowerShell are *designed* to stay hard-denied (also subject to
+the caveat below). **Caveat (Claude Code 2.1.218, Windows): none of this PowerShell interception fires
+for the PowerShell tool** — the deletion-spelling prompt AND the engine-invocation deny are both inert;
+the PowerShell tool is in preview and
 PreToolUse hooks were reproduced not to intercept PowerShell-tool commands, so on Windows do not rely on
 this prompt; the manual lane's per-path `handoff-verify` approval and the baseline permission policy are
 the protections that actually hold. See the PowerShell-preview gotcha below and `reference/safety-model.md`.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -261,9 +261,13 @@ handoff, not an engine plan:
 4. Skip and report any path whose verdict is not `clear`; never substitute a sibling, retry
    around a lock, or delete under a stale verdict.
 
-The PowerShell guard lane turns deletion spellings into a final human permission prompt (the same
-bar as the engine apply prompt); confirm that prompt only when the command matches the exact
-approved list. Engine invocations from PowerShell stay hard-denied.
+The PowerShell guard lane is *designed* to turn deletion spellings into a final human permission prompt
+(the same bar as the engine apply prompt); confirm that prompt only when the command matches the exact
+approved list. Engine invocations from PowerShell stay hard-denied. **Caveat (Claude Code 2.1.218,
+Windows): this belt does not fire for the PowerShell tool** — the PowerShell tool is in preview and
+PreToolUse hooks were reproduced not to intercept PowerShell-tool commands, so on Windows do not rely on
+this prompt; the manual lane's per-path `handoff-verify` approval and the baseline permission policy are
+the protections that actually hold. See the PowerShell-preview gotcha below and `reference/safety-model.md`.
 
 Summarize removed paths, logical bytes removed, observed free-space delta, and every skip grouped by
 `locked`, `changed-or-link`, `protected`, `needs-elevation`, `handle-state-unverified`, or
@@ -310,9 +314,21 @@ sparse files, hard links, compression, and delayed allocation affect it.
   manual-handoff lane already requires and the consumer's baseline permission policy — defense-in-depth
   lost, not preserved. `/disk-hygiene:setup check` reports whether the interpreter resolves on this
   machine.
+- **The PowerShell deletion belt does not fire for the PowerShell *tool* on current builds (Claude Code
+  2.1.218, Windows) — distinct from the `python3`-resolution loss above.** Even with `python3` resolving,
+  a `Bash|PowerShell` PreToolUse hook was reproduced to fire for the Bash tool but NOT intercept
+  PowerShell-*tool* commands. The PowerShell tool is a documented *preview* feature
+  ([tools-reference](https://code.claude.com/docs/en/tools-reference)); PreToolUse interception of it is
+  not a listed preview limitation, so this is an observed docs-vs-behavior gap (mechanism not yet
+  isolated — matcher firing vs Windows payload delivery vs the tool's `tool_name`). Consequence on
+  Windows: the PowerShell deletion belt AND the `disk_hygiene_enabled` kill switch's reach into the
+  manual PowerShell lane are both inert; the protections that hold are the manual lane's per-path
+  `handoff-verify` approval and the consumer's baseline permission policy. Recheck when the PowerShell
+  tool exits preview or when interception is verified directly.
 - The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
   metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
-  into a final human permission prompt. It is a raised bar, not a fail-closed lane; the engine's
+  into a final human permission prompt (**subject to the preview caveat above — this does not fire for
+  the PowerShell tool on 2.1.218**). It is a raised bar, not a fail-closed lane; the engine's
   own containment and the Bash lane remain the deletion authority.
 - The guard rejects `~` anywhere in a Bash command as a shell-expansion character, which includes
   Windows 8.3 short names (`SOMEUS~1`). Always pass long-form paths; the guard's own disclosures

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -155,8 +155,9 @@ observed effect; the mechanism (matcher firing vs Windows payload delivery vs th
 is not yet isolated. Treat every "prompt"/"deny" claim in this section as the guard's *intended* design,
 **not a protection in force on Windows**: on Windows the only deletion protection that actually holds is
 the manual lane's per-path human `handoff-verify` approval plus the consumer's baseline permission
-policy. **Recheck** when the PowerShell tool exits preview, or verify firing directly with the plugin's
-fresh-session hook-firing probe before relying on the lane.
+policy. **Recheck** when the PowerShell tool exits preview, or verify firing directly: in a fresh session
+add a logging `PreToolUse` hook with `matcher: "PowerShell"` and confirm it runs for a PowerShell-*tool*
+command (or check whether a known deletion spelling is actually prompted), before relying on the lane.
 
 Kill-switch enforcement is only as reachable as the value is, and the guard now registers on two
 surfaces with different reach. The **plugin-level engine gate** (`hooks/hooks.json`, exec form,

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -144,6 +144,20 @@ switch. When the guard sees execution enabled they are downgraded to a final hum
 when it sees a configured `false` (audit-only mode) they are denied outright, so the kill switch would
 block deletions on the PowerShell lane too and not only the Bash engine apply.
 
+**Preview caveat — PowerShell-tool interception does NOT fire on current builds (verified on Claude
+Code 2.1.218, Windows).** The PowerShell tool is a documented *preview* feature
+([tools-reference](https://code.claude.com/docs/en/tools-reference)); on 2.1.218 a `Bash|PowerShell`
+PreToolUse hook was reproduced to fire for the Bash tool but **not** intercept PowerShell-*tool*
+commands. So the entire PowerShell paragraph above — the deletion-spelling belt, the `ask` downgrade,
+and the audit-only `deny` — **does not take effect for the PowerShell tool on this build**, and the
+`disk_hygiene_enabled` kill switch does not reach the PowerShell manual-deletion lane. This is an
+observed effect; the mechanism (matcher firing vs Windows payload delivery vs the tool's `tool_name`)
+is not yet isolated. Treat every "prompt"/"deny" claim in this section as the guard's *intended* design,
+**not a protection in force on Windows**: on Windows the only deletion protection that actually holds is
+the manual lane's per-path human `handoff-verify` approval plus the consumer's baseline permission
+policy. **Recheck** when the PowerShell tool exits preview, or verify firing directly with the plugin's
+fresh-session hook-firing probe before relying on the lane.
+
 Kill-switch enforcement is only as reachable as the value is, and the guard now registers on two
 surfaces with different reach. The **plugin-level engine gate** (`hooks/hooks.json`, exec form,
 `--mode engine-gate`) receives `${user_config.disk_hygiene_enabled}` and `${CLAUDE_PLUGIN_DATA}`


### PR DESCRIPTION
## Summary

disk-hygiene's docs promised a PowerShell deletion guard that **does not fire on current builds**. On
Claude Code 2.1.218 (Windows, reproduced) a `Bash|PowerShell` PreToolUse hook fires for the Bash tool
but does **not** intercept **PowerShell-tool** commands, so the documented PowerShell deletion belt and
the `disk_hygiene_enabled` kill switch's reach into the manual PowerShell lane are inert there.

`skills/clean/SKILL.md` and `reference/safety-model.md` now scope every PowerShell-lane "prompt"/"deny"
claim as the guard's **intended** design behind an explicit version-pinned **preview caveat + recheck
trigger** ("as of 2.1.218 the PowerShell tool is in preview and PreToolUse guards don't intercept it").
The protections stated to actually hold on Windows are the manual lane's per-path `handoff-verify`
approval and the consumer's baseline permission policy. disk-hygiene **0.8.2**.

This is the **observed-effect** half. The matcher name `PowerShell` is doc-correct
([tools-reference](https://code.claude.com/docs/en/tools-reference)) — so this is NOT a matcher code
fix; it's a docs-vs-behavior divergence whose **upstream raise is deferred** until the mechanism is
isolated (a fresh-session logging-hook probe is bundled at `.work/handoff-inbox-batch-3/verification/`).

## Test plan

- **Reproduced (2.1.218, Windows):** identical `python3 -c "open(<path>,'w')…"` write — via the Bash tool
  → BLOCKED by a `Bash|PowerShell` PreToolUse hook; via the PowerShell tool → executed (not intercepted).
  The guard's own logic is correct (`destructive_guard.py` returns `ask` on PowerShell deletion spellings
  when run by hand) — it just never fires for PowerShell-tool commands on this build.
- `skill-quality:check disk-hygiene/clean` → **PASS** (0 errors; all 6 trigger phrases preserved;
  markdownlint clean).
- **Security posture:** docs-only change that *narrows* a false protection claim — it documents an
  existing gap rather than adding a trust surface, so the plugin's actual security posture is unchanged;
  the docs are now accurate about it. No code, hook, or manifest-behavior change.
- Fresh-docs basis (CLAUDE.md mandate): `tools-reference` + `hooks` fetched this session; the
  interception failure is empirically reproduced, not recalled.

## Related

Closes #1195.
Related: #1019 (skill-belt kill-switch value channel — Finding 2 dup); the ecosystem-wide guardrails
PowerShell-guard inertness (tracked separately).
