### PR TITLE
fix(guardrails): close interpreter-producer write bypass under the PowerShell tool (#1199)

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Nine safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -16,8 +16,13 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   two-part shape: the **invocation** is detected in a quote-blanked form (`ps::blank_quoted_spans`, so a
   quoted mention stays inert) while the write **indicators** are scanned on the raw command, where they
   legitimately live inside the quoted `-c` payload. PowerShell cmdlet/redirect coverage is unchanged.
-  Four regression fixtures added (real `open(`/`pathlib` writes MUST block; read-only `os.path.normpath`
-  and a quoted mention MUST stay quiet). This was the in-comment "deferred to A2b" gap.
+  Both lanes also recognize a **path-qualified** interpreter (`/usr/bin/python3 -c`,
+  `& 'C:\Python313\python3.exe' -c`, bare `C:\Python313\python3.exe -c`): the command-word boundary
+  admits `/` `\` path separators and an optional `.exe`, and the quoted-call scan admits a path prefix
+  inside the quotes — all anchored on the `python3` basename, so `notpython3` and a non-python quoted exe
+  (`& 'C:\...\app.exe'`) stay inert. Regression fixtures added for real `open(`/`pathlib` writes (MUST
+  block), path-qualified forms in both lanes (MUST block), and read-only `os.path.normpath` / quoted
+  mention / `notpython3` / non-python exe (MUST stay quiet). This was the in-comment "deferred to A2b" gap.
 
 ## [0.14.1]
 

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -31,7 +31,9 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   subexpression (`ps::has_special_constructs`) when no literal `-c` is present, and a computed launcher
   TARGET that hides the interpreter name (`Start-Process -FilePath ('py'+'thon3') …`, `saps $exe …`) fails
   closed via the same computed-launcher clause the git lane uses — while a literal non-python launcher
-  (`Start-Process notepad …`) stays allowed. **Accepted behavior
+  (`Start-Process notepad …`) stays allowed. A `-c` concatenated with an adjacent variable/subexpression
+  (`python3 -c$code`, `python3 -c(…)`), which PowerShell joins into one `-c<source>` argument, is treated
+  as a computed inline-code flag and fails closed (a longer literal flag like `-config` is not `-c`). **Accepted behavior
   change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a
   line/block comment, or a quoted string now **over-blocks** (three prior allow-fixtures flipped to
   expect-block); here-string mentions stay inert (blanked first, like the git lane). **Accepted residual:**

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.14.2]
+
+### Fixed
+
+- **`block-hook-bypass` no longer lets an interpreter-producer write bypass the gate under the PowerShell
+  tool (live-reproduced bypass).** The PowerShell branch classified only PowerShell cmdlet/redirect write
+  forms (`ps::write_bypass`) and then `exit 0`ed **before** the shell-agnostic scans, so
+  `python3 -c "open('x','w')…"` — the identical command the Bash lane blocks — executed unguarded when
+  issued through the PowerShell tool. Reproduced end-to-end: same command, Bash → blocked, PowerShell →
+  file written. The interpreter rule now also runs on the PowerShell lane, mirroring the Bash lane's
+  two-part shape: the **invocation** is detected in a quote-blanked form (`ps::blank_quoted_spans`, so a
+  quoted mention stays inert) while the write **indicators** are scanned on the raw command, where they
+  legitimately live inside the quoted `-c` payload. PowerShell cmdlet/redirect coverage is unchanged.
+  Four regression fixtures added (real `open(`/`pathlib` writes MUST block; read-only `os.path.normpath`
+  and a quoted mention MUST stay quiet). This was the in-comment "deferred to A2b" gap.
+
 ## [0.14.1]
 
 ### Fixed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -30,9 +30,10 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   (`python3 ('-'+'c') …`, `-ArgumentList ('-'+'c'),…`) is caught by fail-closing on a non-tokenizable arg
   subexpression (`ps::has_special_constructs`) when no literal `-c` is present, and a computed launcher
   TARGET that hides the interpreter name (`Start-Process -FilePath ('py'+'thon3') …`, `saps $exe …`) fails
-  closed via the same computed-launcher clause the git lane uses (accepting both whitespace- and
-  colon-bound parameter binding, `-FilePath ('py'+'thon3')` / `-FilePath:$p`) — while a literal non-python
-  launcher (`Start-Process notepad …`) stays allowed. A `-c` concatenated with an adjacent variable/subexpression
+  closed: any launcher present together with an unquoted computed construct (`$`/`(`) blocks, regardless of
+  how the target is bound or how many options precede it (`-FilePath ('py'+'thon3')`, `-FilePath:$p`,
+  `-NoNewWindow -FilePath $exe`) — while a literal non-python launcher (`Start-Process notepad …`) carries
+  no such construct and stays allowed. A `-c` concatenated with an adjacent variable/subexpression
   (`python3 -c$code`, `python3 -c(…)`), which PowerShell joins into one `-c<source>` argument, is treated
   as a computed inline-code flag and fails closed (a longer literal flag like `-config` is not `-c`). **Accepted behavior
   change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -28,7 +28,10 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   is **required** (position-independent), so a legitimate script or module run (`python3 build.py`,
   `python3 -m tool …`) that merely touches an `open(`-like path is **not** blocked; a **computed** flag
   (`python3 ('-'+'c') …`, `-ArgumentList ('-'+'c'),…`) is caught by fail-closing on a non-tokenizable arg
-  subexpression (`ps::has_special_constructs`) when no literal `-c` is present. **Accepted behavior
+  subexpression (`ps::has_special_constructs`) when no literal `-c` is present, and a computed launcher
+  TARGET that hides the interpreter name (`Start-Process -FilePath ('py'+'thon3') …`, `saps $exe …`) fails
+  closed via the same computed-launcher clause the git lane uses — while a literal non-python launcher
+  (`Start-Process notepad …`) stays allowed. **Accepted behavior
   change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a
   line/block comment, or a quoted string now **over-blocks** (three prior allow-fixtures flipped to
   expect-block); here-string mentions stay inert (blanked first, like the git lane). **Accepted residual:**

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -20,9 +20,13 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   `& 'C:\Python313\python3.exe' -c`, bare `C:\Python313\python3.exe -c`): the command-word boundary
   admits `/` `\` path separators and an optional `.exe`, and the quoted-call scan admits a path prefix
   inside the quotes — all anchored on the `python3` basename, so `notpython3` and a non-python quoted exe
-  (`& 'C:\...\app.exe'`) stay inert. Regression fixtures added for real `open(`/`pathlib` writes (MUST
-  block), path-qualified forms in both lanes (MUST block), and read-only `os.path.normpath` / quoted
-  mention / `notpython3` / non-python exe (MUST stay quiet). This was the in-comment "deferred to A2b" gap.
+  (`& 'C:\...\app.exe'`) stay inert. The PowerShell lane also normalizes invoked script blocks (`{`/`}` →
+  space) before the scan, so a compact `&{python3 -c …}`, a spaced `& {python3 …}`, and a quoted name
+  inside the block (`&{'python3' …}`) collapse to the covered `& python3` / `& 'python3'` forms (this is
+  PowerShell-only — `&{cmd}` has no Bash `{ …; }` analogue). Regression fixtures added for real
+  `open(`/`pathlib` writes (MUST block), path-qualified + script-block forms (MUST block), and read-only
+  `os.path.normpath` / quoted mention / `notpython3` / non-python exe / a fully-quoted `&{python3 …}`
+  string (MUST stay quiet). This was the in-comment "deferred to A2b" gap.
 
 ## [0.14.1]
 

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -26,7 +26,9 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   on the quote-intact, backtick-recovered command (`ps::might_write_via_python3`). This uniformly closes
   the quoted / path-qualified / brace-glued / backtick-obfuscated / block-comment / arg-split forms. `-c`
   is **required** (position-independent), so a legitimate script or module run (`python3 build.py`,
-  `python3 -m tool …`) that merely touches an `open(`-like path is **not** blocked. **Accepted behavior
+  `python3 -m tool …`) that merely touches an `open(`-like path is **not** blocked; a **computed** flag
+  (`python3 ('-'+'c') …`, `-ArgumentList ('-'+'c'),…`) is caught by fail-closing on a non-tokenizable arg
+  subexpression (`ps::has_special_constructs`) when no literal `-c` is present. **Accepted behavior
   change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a
   line/block comment, or a quoted string now **over-blocks** (three prior allow-fixtures flipped to
   expect-block); here-string mentions stay inert (blanked first, like the git lane). **Accepted residual:**

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -35,7 +35,10 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   `-NoNewWindow -FilePath $exe`) — while a literal non-python launcher (`Start-Process notepad …`) carries
   no such construct and stays allowed. A `-c` concatenated with an adjacent variable/subexpression
   (`python3 -c$code`, `python3 -c(…)`), which PowerShell joins into one `-c<source>` argument, is treated
-  as a computed inline-code flag and fails closed (a longer literal flag like `-config` is not `-c`). **Accepted behavior
+  as a computed inline-code flag and fails closed (a longer literal flag like `-config` is not `-c`). A call
+  operator / dot-source of a DOUBLE-quoted interpolated target (`& "$env:PYTHON_BIN" …`, `& "$(…)" …`) runs a
+  computed interpreter and fails closed; a SINGLE-quoted target does not interpolate (`& '$x'` is a literal
+  name) and stays allowed. **Accepted behavior
   change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a
   line/block comment, or a quoted string now **over-blocks** (three prior allow-fixtures flipped to
   expect-block); here-string mentions stay inert (blanked first, like the git lane). **Accepted residual:**

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -12,21 +12,29 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   forms (`ps::write_bypass`) and then `exit 0`ed **before** the shell-agnostic scans, so
   `python3 -c "open('x','w')…"` — the identical command the Bash lane blocks — executed unguarded when
   issued through the PowerShell tool. Reproduced end-to-end: same command, Bash → blocked, PowerShell →
-  file written. The interpreter rule now also runs on the PowerShell lane, mirroring the Bash lane's
-  two-part shape: the **invocation** is detected in a quote-blanked form (`ps::blank_quoted_spans`, so a
-  quoted mention stays inert) while the write **indicators** are scanned on the raw command, where they
-  legitimately live inside the quoted `-c` payload. PowerShell cmdlet/redirect coverage is unchanged.
-  Both lanes also recognize a **path-qualified** interpreter (`/usr/bin/python3 -c`,
-  `& 'C:\Python313\python3.exe' -c`, bare `C:\Python313\python3.exe -c`): the command-word boundary
-  admits `/` `\` path separators and an optional `.exe`, and the quoted-call scan admits a path prefix
-  inside the quotes — all anchored on the `python3` basename, so `notpython3` and a non-python quoted exe
-  (`& 'C:\...\app.exe'`) stay inert. The PowerShell lane also normalizes invoked script blocks (`{`/`}` →
-  space) before the scan, so a compact `&{python3 -c …}`, a spaced `& {python3 …}`, and a quoted name
-  inside the block (`&{'python3' …}`) collapse to the covered `& python3` / `& 'python3'` forms (this is
-  PowerShell-only — `&{cmd}` has no Bash `{ …; }` analogue). Regression fixtures added for real
-  `open(`/`pathlib` writes (MUST block), path-qualified + script-block forms (MUST block), and read-only
-  `os.path.normpath` / quoted mention / `notpython3` / non-python exe / a fully-quoted `&{python3 …}`
-  string (MUST stay quiet). This was the in-comment "deferred to A2b" gap.
+  file written. The interpreter rule now also runs on the PowerShell lane. The **Bash** lane keeps its
+  precise `python3 -c` scan (its `strip_literals` is genuinely quote-aware and Bash has no `<# #>` block
+  comments or `&{}` script blocks) and additionally recognizes a **path-qualified** interpreter
+  (`/usr/bin/python3 -c`, `.exe`), anchored on the `python3` basename so `notpython3` stays inert.
+- **The PowerShell lane deliberately DIVERGES from the Bash lane and uses a fail-closed sink instead of a
+  precise scan.** PowerShell is not faithfully bash-tokenizable, and a precise regex/normalize stack could
+  not keep up — successive review rounds each surfaced a fresh evasion (path-qualified target, `&{python3}`
+  script block, quoted-`#` comment truncation, with `<# #>` block comments and `-ArgumentList`
+  arg-splitting still open). Following the repo's SINK DOCTRINE (`ps::classify_git_command` /
+  `ps::might_invoke_git`), the lane now blocks on the mangle-resistant **co-occurrence** of (a) a raw write
+  indicator (`_py_write`) and (b) a python3 interpreter token **plus** a `-c` inline-code flag, both seen
+  on the quote-intact, backtick-recovered command (`ps::might_write_via_python3`). This uniformly closes
+  the quoted / path-qualified / brace-glued / backtick-obfuscated / block-comment / arg-split forms. `-c`
+  is **required** (position-independent), so a legitimate script or module run (`python3 build.py`,
+  `python3 -m tool …`) that merely touches an `open(`-like path is **not** blocked. **Accepted behavior
+  change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a
+  line/block comment, or a quoted string now **over-blocks** (three prior allow-fixtures flipped to
+  expect-block); here-string mentions stay inert (blanked first, like the git lane). **Accepted residual:**
+  a stdin heredoc (`python3 - <<PY … PY`, no `-c`) is uncovered, as it is today. Regression fixtures cover
+  real `open(`/`pathlib` writes, every evasion form (path-qualified, script block, block comment,
+  arg-split — MUST block), the flipped mention cases (MUST block), and script/module runs + read-only
+  `os.path.normpath` + non-python quoted exe + here-string mention (MUST stay quiet). This was the
+  in-comment "deferred to A2b" gap.
 
 ## [0.14.1]
 

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -30,8 +30,9 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   (`python3 ('-'+'c') …`, `-ArgumentList ('-'+'c'),…`) is caught by fail-closing on a non-tokenizable arg
   subexpression (`ps::has_special_constructs`) when no literal `-c` is present, and a computed launcher
   TARGET that hides the interpreter name (`Start-Process -FilePath ('py'+'thon3') …`, `saps $exe …`) fails
-  closed via the same computed-launcher clause the git lane uses — while a literal non-python launcher
-  (`Start-Process notepad …`) stays allowed. A `-c` concatenated with an adjacent variable/subexpression
+  closed via the same computed-launcher clause the git lane uses (accepting both whitespace- and
+  colon-bound parameter binding, `-FilePath ('py'+'thon3')` / `-FilePath:$p`) — while a literal non-python
+  launcher (`Start-Process notepad …`) stays allowed. A `-c` concatenated with an adjacent variable/subexpression
   (`python3 -c$code`, `python3 -c(…)`), which PowerShell joins into one `-c<source>` argument, is treated
   as a computed inline-code flag and fails closed (a longer literal flag like `-config` is not `-c`). **Accepted behavior
   change (fail-closed):** a command that only *mentions* `python3 … -c` + a write indicator in prose, a

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -481,6 +481,16 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   ps::blank_herestrings "$COMMAND"
   _ps_nobt="${PS_BLANKED//\`/}"
   _ps_nobt="$(printf '%s' "$_ps_nobt" | sed 's/#.*$//')"
+  # Invoked script blocks glue the first command straight onto the brace
+  # (`&{python3 -c …}`), so the char before the interpreter is `{` — absent from
+  # the boundary classes below. Normalize `{`/`}` to spaces here, before BOTH
+  # derived forms, so the compact `&{…}`, the spaced `& {…}`, and a quoted name
+  # inside the block (`&{'python3' …}`) all collapse to the already-covered
+  # `& python3` / `& 'python3'` shapes. PowerShell-only: `&{cmd}` is a script-block
+  # invocation with no Bash analogue (a Bash `{ …; }` group needs surrounding
+  # spaces, already covered), so the Bash lane needs no matching change.
+  _ps_nobt="${_ps_nobt//\{/ }"
+  _ps_nobt="${_ps_nobt//\}/ }"
   _ps_lcq="${_ps_nobt,,}"
   _ps_bare="$(ps::blank_quoted_spans "$_ps_nobt")"
   _ps_bare="${_ps_bare,,}"

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -446,58 +446,34 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   if ps::write_bypass "$COMMAND"; then
     block_bypass "powershell-write" "PowerShell file-write cmdlet/redirect bypasses Write/Edit hooks"
   fi
-  # Interpreter-producer writes are shell-AGNOSTIC: `python3 -c '<write>'` bypasses
-  # Write/Edit identically whichever tool launches it, and ps::write_bypass models only
-  # PowerShell cmdlet/redirect forms — so without this the identical command that the
-  # Bash lane blocks sails through under the PowerShell tool. Mirror the Bash lane's
-  # two-part shape: detect the INVOCATION in a quote-blanked form (so a quoted mention
-  # stays inert) and scan the RAW command for the write indicators, which legitimately
-  # live inside the quoted `-c` payload the blanking removes. Accepted floor (identical
-  # to the Bash lane's python-write rule): the indicator scan is raw-command-wide, not
-  # scoped to the `-c` argument, so a real `python3 -c` invocation compounded with an
-  # unrelated later segment that merely mentions an indicator (`python3 -c "print(1)";
-  # Write-Output "open("`) over-blocks. Fail-safe direction (over-block, never
-  # under-block) and structurally unusual for LLM output; kept byte-for-byte in step
-  # with the Bash lane rather than diverging one tool's precision from the other.
-  # Normalize evasions before the INVOCATION scan, mirroring ps::write_bypass:
-  # blank here-strings; DELETE backticks (a `python3<bt><newline>-c` line
-  # continuation then joins under `[[:space:]]+`, and `pyth<bt>on3` escape
-  # obfuscation resolves); drop `#` line comments. Then two invocation scans:
-  #  (1) a call/dot-source of a QUOTED `python3` command word on the quote-INTACT
-  #      text (`& 'python3' -c`) — quote-blanking would erase the command word, so
-  #      it is matched before blanking, exactly as ps::write_bypass catches a
-  #      quoted writer name. A path-qualified quoted target
-  #      (`& 'C:\Python313\python3.exe' -c`) is the same interpreter: the optional
-  #      `[^quote]*[\/]` prefix and `.exe` suffix anchor on the python3 BASENAME.
-  #      Unlike write_bypass's arbitrary-quoted-program residual (cmdlets are not
-  #      invoked by path), python3.exe IS path-invocable, so this is in scope; the
-  #      basename anchor keeps a non-python quoted exe (`& 'C:\...\app.exe'`) inert.
-  #  (2) the bare invocation on the quote-blanked text (`python3 -c`, an unquoted
-  #      `& python3 -c`, a path-qualified `C:\Python313\python3.exe -c` via the `/`
-  #      `\` boundary + optional `.exe`, and the backtick-joined continuation).
-  # The write INDICATOR is still scanned raw (the tokens live in the quoted `-c`
-  # payload) — the accepted-floor note above.
-  _q="\"'"
+  # Interpreter-producer writes (`python3 -c "<inline code that writes>"`) route
+  # around Write/Edit whichever tool launches them, and ps::write_bypass models only
+  # PowerShell cmdlet/redirect forms. On the BASH tool the precise `python3 -c` scan
+  # (further below) is reliable: strip_literals is genuinely quote-aware, and Bash
+  # has no `<# #>` block comments or `&{}` script blocks. PowerShell is NOT
+  # faithfully bash-tokenizable, and successive review rounds proved that a precise
+  # regex/normalize stack cannot keep up — each round exposed a fresh evasion
+  # (path-qualified target, `&{python3}` script block, quoted-`#` comment
+  # truncation, with block comments and `-ArgumentList` arg-splitting still open).
+  # So this lane CONSCIOUSLY DIVERGES from the Bash lane (justified above) and
+  # follows the repo's SINK DOCTRINE (ps::classify_git_command / ps::might_invoke_git):
+  # do not trust a precise negative on a mangled command — block on the
+  # mangle-resistant CO-OCCURRENCE of
+  #   (a) a write INDICATOR in the raw command (_py_write — the tokens live in the
+  #       quoted `-c` payload, so the scan is raw, exactly as the Bash lane), AND
+  #   (b) a python3 interpreter TOKEN plus a `-c` inline-code flag both present
+  #       (ps::might_write_via_python3, quote-INTACT + backtick-recovered).
+  # `-c` is REQUIRED and position-independent, so a legitimate script/module run
+  # (`python3 build.py`, `python3 -m tool …`) that merely touches an `open(`-like
+  # path is NOT blocked — only inline-code writes are. ACCEPTED OVER-BLOCK (the
+  # fail-closed choice the user approved for this lane): a command that only MENTIONS
+  # `python3 … -c` + a write indicator in prose, a line/block comment, or a quoted
+  # string now blocks; here-string mentions stay inert (blanked first, like the git
+  # lane). ACCEPTED RESIDUAL: a stdin heredoc (`python3 - <<PY … PY`, no `-c`) is
+  # uncovered here, as it is today.
   ps::blank_herestrings "$COMMAND"
-  _ps_nobt="${PS_BLANKED//\`/}"
-  _ps_nobt="$(printf '%s' "$_ps_nobt" | sed 's/#.*$//')"
-  # Invoked script blocks glue the first command straight onto the brace
-  # (`&{python3 -c …}`), so the char before the interpreter is `{` — absent from
-  # the boundary classes below. Normalize `{`/`}` to spaces here, before BOTH
-  # derived forms, so the compact `&{…}`, the spaced `& {…}`, and a quoted name
-  # inside the block (`&{'python3' …}`) all collapse to the already-covered
-  # `& python3` / `& 'python3'` shapes. PowerShell-only: `&{cmd}` is a script-block
-  # invocation with no Bash analogue (a Bash `{ …; }` group needs surrounding
-  # spaces, already covered), so the Bash lane needs no matching change.
-  _ps_nobt="${_ps_nobt//\{/ }"
-  _ps_nobt="${_ps_nobt//\}/ }"
-  _ps_lcq="${_ps_nobt,,}"
-  _ps_bare="$(ps::blank_quoted_spans "$_ps_nobt")"
-  _ps_bare="${_ps_bare,,}"
-  if [[ "$COMMAND_LC" =~ $_py_write ]] &&
-    { [[ "$_ps_bare" =~ (^|[[:space:];|&()/\\]+)python3(\.exe)?[[:space:]]+-c ]] ||
-      [[ "$_ps_lcq" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*[$_q]([^$_q]*[\\/])?python3(\.exe)?[$_q][[:space:]]+-c ]]; }; then
-    block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
+  if [[ "$COMMAND_LC" =~ $_py_write ]] && ps::might_write_via_python3 "$PS_BLANKED"; then
+    block_bypass "python-write" "python3 -c inline-code file write bypasses Write/Edit hooks"
   fi
   emit_tel "ok" ""
   exit 0

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -459,7 +459,17 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   # Write-Output "open("`) over-blocks. Fail-safe direction (over-block, never
   # under-block) and structurally unusual for LLM output; kept byte-for-byte in step
   # with the Bash lane rather than diverging one tool's precision from the other.
-  _ps_exec_lc="$(ps::blank_quoted_spans "$COMMAND")"
+  # Blank here-strings and quoted spans, then drop line comments, before the
+  # INVOCATION scan — so an inert `python3 -c` mentioned inside a here-string body
+  # or a `#` comment is not read as a real invocation (parity with the Bash lane's
+  # strip_literals, which drops heredocs and comments). ps::blank_herestrings sets
+  # PS_BLANKED (the RAW command when a here-string is unbalanced — fail-safe toward
+  # over-block, never under-block). The INDICATOR scan below still runs raw (see the
+  # accepted-floor note above): the write tokens legitimately live in the quoted
+  # `-c` payload, exactly as the Bash lane scans them.
+  ps::blank_herestrings "$COMMAND"
+  _ps_exec_lc="$(ps::blank_quoted_spans "$PS_BLANKED")"
+  _ps_exec_lc="$(printf '%s' "$_ps_exec_lc" | sed 's/#.*$//')"
   _ps_exec_lc="${_ps_exec_lc,,}"
   if [[ "$_ps_exec_lc" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] &&
     [[ "$COMMAND_LC" =~ $_py_write ]]; then

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -446,6 +446,19 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   if ps::write_bypass "$COMMAND"; then
     block_bypass "powershell-write" "PowerShell file-write cmdlet/redirect bypasses Write/Edit hooks"
   fi
+  # Interpreter-producer writes are shell-AGNOSTIC: `python3 -c '<write>'` bypasses
+  # Write/Edit identically whichever tool launches it, and ps::write_bypass models only
+  # PowerShell cmdlet/redirect forms — so without this the identical command that the
+  # Bash lane blocks sails through under the PowerShell tool. Mirror the Bash lane's
+  # two-part shape: detect the INVOCATION in a quote-blanked form (so a quoted mention
+  # stays inert) and scan the RAW command for the write indicators, which legitimately
+  # live inside the quoted `-c` payload the blanking removes.
+  _ps_exec_lc="$(ps::blank_quoted_spans "$COMMAND")"
+  _ps_exec_lc="${_ps_exec_lc,,}"
+  if [[ "$_ps_exec_lc" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] &&
+    [[ "$COMMAND_LC" =~ $_py_write ]]; then
+    block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
+  fi
   emit_tel "ok" ""
   exit 0
 fi

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -452,7 +452,13 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   # Bash lane blocks sails through under the PowerShell tool. Mirror the Bash lane's
   # two-part shape: detect the INVOCATION in a quote-blanked form (so a quoted mention
   # stays inert) and scan the RAW command for the write indicators, which legitimately
-  # live inside the quoted `-c` payload the blanking removes.
+  # live inside the quoted `-c` payload the blanking removes. Accepted floor (identical
+  # to the Bash lane's python-write rule): the indicator scan is raw-command-wide, not
+  # scoped to the `-c` argument, so a real `python3 -c` invocation compounded with an
+  # unrelated later segment that merely mentions an indicator (`python3 -c "print(1)";
+  # Write-Output "open("`) over-blocks. Fail-safe direction (over-block, never
+  # under-block) and structurally unusual for LLM output; kept byte-for-byte in step
+  # with the Bash lane rather than diverging one tool's precision from the other.
   _ps_exec_lc="$(ps::blank_quoted_spans "$COMMAND")"
   _ps_exec_lc="${_ps_exec_lc,,}"
   if [[ "$_ps_exec_lc" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] &&

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -462,7 +462,9 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   #   (a) a write INDICATOR in the raw command (_py_write — the tokens live in the
   #       quoted `-c` payload, so the scan is raw, exactly as the Bash lane), AND
   #   (b) a python3 interpreter TOKEN plus a `-c` inline-code flag both present
-  #       (ps::might_write_via_python3, quote-INTACT + backtick-recovered).
+  #       (ps::might_write_via_python3, quote-INTACT + backtick-recovered) — where a
+  #       COMPUTED `-c` (`python3 ('-'+'c') …`) is caught by fail-closing on a
+  #       non-tokenizable arg construct when no literal `-c` is present.
   # `-c` is REQUIRED and position-independent, so a legitimate script/module run
   # (`python3 build.py`, `python3 -m tool …`) that merely touches an `open(`-like
   # path is NOT blocked — only inline-code writes are. ACCEPTED OVER-BLOCK (the

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -466,9 +466,15 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   #  (1) a call/dot-source of a QUOTED `python3` command word on the quote-INTACT
   #      text (`& 'python3' -c`) — quote-blanking would erase the command word, so
   #      it is matched before blanking, exactly as ps::write_bypass catches a
-  #      quoted writer name; and
+  #      quoted writer name. A path-qualified quoted target
+  #      (`& 'C:\Python313\python3.exe' -c`) is the same interpreter: the optional
+  #      `[^quote]*[\/]` prefix and `.exe` suffix anchor on the python3 BASENAME.
+  #      Unlike write_bypass's arbitrary-quoted-program residual (cmdlets are not
+  #      invoked by path), python3.exe IS path-invocable, so this is in scope; the
+  #      basename anchor keeps a non-python quoted exe (`& 'C:\...\app.exe'`) inert.
   #  (2) the bare invocation on the quote-blanked text (`python3 -c`, an unquoted
-  #      `& python3 -c`, and the backtick-joined continuation).
+  #      `& python3 -c`, a path-qualified `C:\Python313\python3.exe -c` via the `/`
+  #      `\` boundary + optional `.exe`, and the backtick-joined continuation).
   # The write INDICATOR is still scanned raw (the tokens live in the quoted `-c`
   # payload) — the accepted-floor note above.
   _q="\"'"
@@ -479,8 +485,8 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   _ps_bare="$(ps::blank_quoted_spans "$_ps_nobt")"
   _ps_bare="${_ps_bare,,}"
   if [[ "$COMMAND_LC" =~ $_py_write ]] &&
-    { [[ "$_ps_bare" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] ||
-      [[ "$_ps_lcq" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*[$_q]python3[$_q][[:space:]]+-c ]]; }; then
+    { [[ "$_ps_bare" =~ (^|[[:space:];|&()/\\]+)python3(\.exe)?[[:space:]]+-c ]] ||
+      [[ "$_ps_lcq" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*[$_q]([^$_q]*[\\/])?python3(\.exe)?[$_q][[:space:]]+-c ]]; }; then
     block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
   fi
   emit_tel "ok" ""
@@ -504,7 +510,11 @@ fi
 # the literal-stripped form (EXEC_LC) so prose/commit text merely mentioning it
 # is not a false positive; scan the RAW command (COMMAND_LC) for the write
 # indicators — they legitimately live inside the quoted `-c` payload the strip removes.
-if [[ "$EXEC_LC" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] &&
+# The command-word boundary admits a leading path (`/` `\` in the class) and an
+# optional `.exe`, so a path-qualified interpreter (`/usr/bin/python3 -c`,
+# `/c/Python313/python3.exe -c`) is the same write — anchored on the python3
+# basename, so `notpython3` (no separator before it) stays inert.
+if [[ "$EXEC_LC" =~ (^|[[:space:];|&()/\\]+)python3(\.exe)?[[:space:]]+-c ]] &&
   [[ "$COMMAND_LC" =~ $_py_write ]]; then
   block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
 fi

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -459,20 +459,28 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   # Write-Output "open("`) over-blocks. Fail-safe direction (over-block, never
   # under-block) and structurally unusual for LLM output; kept byte-for-byte in step
   # with the Bash lane rather than diverging one tool's precision from the other.
-  # Blank here-strings and quoted spans, then drop line comments, before the
-  # INVOCATION scan — so an inert `python3 -c` mentioned inside a here-string body
-  # or a `#` comment is not read as a real invocation (parity with the Bash lane's
-  # strip_literals, which drops heredocs and comments). ps::blank_herestrings sets
-  # PS_BLANKED (the RAW command when a here-string is unbalanced — fail-safe toward
-  # over-block, never under-block). The INDICATOR scan below still runs raw (see the
-  # accepted-floor note above): the write tokens legitimately live in the quoted
-  # `-c` payload, exactly as the Bash lane scans them.
+  # Normalize evasions before the INVOCATION scan, mirroring ps::write_bypass:
+  # blank here-strings; DELETE backticks (a `python3<bt><newline>-c` line
+  # continuation then joins under `[[:space:]]+`, and `pyth<bt>on3` escape
+  # obfuscation resolves); drop `#` line comments. Then two invocation scans:
+  #  (1) a call/dot-source of a QUOTED `python3` command word on the quote-INTACT
+  #      text (`& 'python3' -c`) — quote-blanking would erase the command word, so
+  #      it is matched before blanking, exactly as ps::write_bypass catches a
+  #      quoted writer name; and
+  #  (2) the bare invocation on the quote-blanked text (`python3 -c`, an unquoted
+  #      `& python3 -c`, and the backtick-joined continuation).
+  # The write INDICATOR is still scanned raw (the tokens live in the quoted `-c`
+  # payload) — the accepted-floor note above.
+  _q="\"'"
   ps::blank_herestrings "$COMMAND"
-  _ps_exec_lc="$(ps::blank_quoted_spans "$PS_BLANKED")"
-  _ps_exec_lc="$(printf '%s' "$_ps_exec_lc" | sed 's/#.*$//')"
-  _ps_exec_lc="${_ps_exec_lc,,}"
-  if [[ "$_ps_exec_lc" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] &&
-    [[ "$COMMAND_LC" =~ $_py_write ]]; then
+  _ps_nobt="${PS_BLANKED//\`/}"
+  _ps_nobt="$(printf '%s' "$_ps_nobt" | sed 's/#.*$//')"
+  _ps_lcq="${_ps_nobt,,}"
+  _ps_bare="$(ps::blank_quoted_spans "$_ps_nobt")"
+  _ps_bare="${_ps_bare,,}"
+  if [[ "$COMMAND_LC" =~ $_py_write ]] &&
+    { [[ "$_ps_bare" =~ (^|[[:space:];|&()]+)python3[[:space:]]+-c ]] ||
+      [[ "$_ps_lcq" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*[$_q]python3[$_q][[:space:]]+-c ]]; }; then
     block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
   fi
   emit_tel "ok" ""

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -497,6 +497,12 @@ run_pwsh "PS: python3 -c read-only os.path.normpath (allowed)" \
   "python3 -c \"import os; print(os.path.normpath('a/b'))\"" 0
 run_pwsh "PS: quoted mention of python3 -c open (allowed)" \
   "Write-Output 'run python3 -c open() later'" 0
+# here-string body / line comment mentioning python3 -c + a write indicator is inert
+# text, not an invocation — blanked before the invocation scan (Bash-lane parity).
+run_pwsh "PS: here-string mentions python3 -c open (allowed)" \
+  "$(printf "@'\npython3 -c open(\n'@\nWrite-Output ok")" 0
+run_pwsh "PS: line comment mentions python3 -c open (allowed)" \
+  "Write-Output ok # python3 -c open(" 0
 
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -569,6 +569,10 @@ run_pwsh "PS: Start-Process -FilePath ('py'+'thon3') computed target (blocked)" 
 # whitespace-separated form — both must fail closed.
 run_pwsh "PS: Start-Process -FilePath:\$p colon-bound computed target (blocked)" \
   "\$p = 'py'+'thon3'; Start-Process -FilePath:\$p -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
+# Options before the computed target: any launcher + an unquoted computed construct
+# fails closed regardless of how many options precede -FilePath.
+run_pwsh "PS: Start-Process -NoNewWindow -FilePath \$exe computed target (blocked)" \
+  "\$exe = 'py'+'thon3'; Start-Process -NoNewWindow -FilePath \$exe -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
 run_pwsh "PS: Start-Process notepad (literal non-python launcher, allowed)" \
   "Start-Process notepad -ArgumentList '-c','open(\"x\",\"w\")'" 0
 # `-c` concatenated with a variable/subexpression: PowerShell joins the adjacent

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -565,6 +565,10 @@ run_pwsh "PS: Start-Process -ArgumentList ('-'+'c') computed (blocked)" \
 # might_invoke_git). A LITERAL non-python launcher target stays allowed.
 run_pwsh "PS: Start-Process -FilePath ('py'+'thon3') computed target (blocked)" \
   "Start-Process -FilePath ('py'+'thon3') -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
+# Colon-bound parameter binding (`-FilePath:$p`) is the same computed target as the
+# whitespace-separated form — both must fail closed.
+run_pwsh "PS: Start-Process -FilePath:\$p colon-bound computed target (blocked)" \
+  "\$p = 'py'+'thon3'; Start-Process -FilePath:\$p -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
 run_pwsh "PS: Start-Process notepad (literal non-python launcher, allowed)" \
   "Start-Process notepad -ArgumentList '-c','open(\"x\",\"w\")'" 0
 # `-c` concatenated with a variable/subexpression: PowerShell joins the adjacent

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -559,6 +559,14 @@ run_pwsh "PS: python3 ('-'+'c') computed flag open write (blocked)" \
   "python3 ('-'+'c') \"open('x','w').write('a')\"" 2
 run_pwsh "PS: Start-Process -ArgumentList ('-'+'c') computed (blocked)" \
   "Start-Process python3 -ArgumentList ('-'+'c'),'open(\"x\",\"w\").write(\"a\")'" 2
+# Computed launcher TARGET: `Start-Process -FilePath ('py'+'thon3')` hides the
+# interpreter name itself, so the literal python3-token test cannot see it. A
+# launcher with a computed program arg could be python3 — fail closed (mirrors
+# might_invoke_git). A LITERAL non-python launcher target stays allowed.
+run_pwsh "PS: Start-Process -FilePath ('py'+'thon3') computed target (blocked)" \
+  "Start-Process -FilePath ('py'+'thon3') -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
+run_pwsh "PS: Start-Process notepad (literal non-python launcher, allowed)" \
+  "Start-Process notepad -ArgumentList '-c','open(\"x\",\"w\")'" 0
 # A non-python quoted program with a write indicator stays ALLOWED — no python3
 # token, so the co-occurrence probe does not fire (write_bypass allows quoted progs).
 run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -550,6 +550,15 @@ run_pwsh "PS: block-comment decoy then python3 -c open write (blocked)" \
 # Arg-splitting: `-c` hidden in -ArgumentList is still a `-c` token (quote-bounded).
 run_pwsh "PS: Start-Process python3 -ArgumentList '-c',open (blocked)" \
   "Start-Process python3 -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
+# Computed `-c`: PowerShell evaluates expression-valued arguments before launching,
+# so `('-'+'c')` builds the flag with no literal `-c` token. A python3 write whose
+# args carry a non-tokenizable subexpression construct (`(…)`, via
+# ps::has_special_constructs on the quote-blanked text) cannot be ruled out — fail
+# closed (sink doctrine), the same construct class the git lane refuses to parse.
+run_pwsh "PS: python3 ('-'+'c') computed flag open write (blocked)" \
+  "python3 ('-'+'c') \"open('x','w').write('a')\"" 2
+run_pwsh "PS: Start-Process -ArgumentList ('-'+'c') computed (blocked)" \
+  "Start-Process python3 -ArgumentList ('-'+'c'),'open(\"x\",\"w\").write(\"a\")'" 2
 # A non-python quoted program with a write indicator stays ALLOWED — no python3
 # token, so the co-occurrence probe does not fire (write_bypass allows quoted progs).
 run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -495,60 +495,65 @@ run_pwsh "PS: & { Write-Output secret } > file (blocked)" \
 run_pwsh "PS: & { git diff } > file (tool producer, allowed)" \
   "& { git diff } > out.txt" 0
 
-# Interpreter-producer writes are shell-agnostic: the PowerShell branch must not
-# exit before the python3 -c rule, or the identical command the Bash lane blocks
-# sails through under the PowerShell tool (live-reproduced bypass).
+# Interpreter-producer writes under the PowerShell tool: PowerShell is not
+# faithfully bash-tokenizable, so this lane follows the SINK DOCTRINE — block on
+# the mangle-resistant co-occurrence of a raw write indicator (_py_write) AND a
+# python3 token + `-c` inline-code flag (ps::might_write_via_python3), rather than a
+# precise `python3 -c` scan that review rounds defeated. `-c` is REQUIRED so script
+# and module runs stay allowed; MENTIONS over-block (the accepted fail-closed cost).
 run_pwsh "PS: python3 -c open write (blocked)" \
   "python3 -c \"open('x','w').write('a')\"" 2
 run_pwsh "PS: python3 -c pathlib write_text (blocked)" \
   "python3 -c \"import pathlib; pathlib.Path('x').write_text('a')\"" 2
+# No write indicator (read-only os.path.normpath) — allowed even with python3 -c.
 run_pwsh "PS: python3 -c read-only os.path.normpath (allowed)" \
   "python3 -c \"import os; print(os.path.normpath('a/b'))\"" 0
-run_pwsh "PS: quoted mention of python3 -c open (allowed)" \
-  "Write-Output 'run python3 -c open() later'" 0
-# here-string body / line comment mentioning python3 -c + a write indicator is inert
-# text, not an invocation — blanked before the invocation scan (Bash-lane parity).
+# `-c` REQUIRED: a script run / module run that merely touches an `open(`-like path
+# is NOT an inline-code write — stays allowed (spares legitimate python3 invocations).
+run_pwsh "PS: python3 script run, open( in an arg, no -c (allowed)" \
+  "python3 build.py --path \"open('x','w')\"" 0
+run_pwsh "PS: python3 -m module run, open( in an arg, no -c (allowed)" \
+  "python3 -m mytool \"open('x','w')\"" 0
+# here-string mention stays inert (blanked before the probe, like the git lane).
 run_pwsh "PS: here-string mentions python3 -c open (allowed)" \
   "$(printf "@'\npython3 -c open(\n'@\nWrite-Output ok")" 0
-run_pwsh "PS: line comment mentions python3 -c open (allowed)" \
-  "Write-Output ok # python3 -c open(" 0
-# Evasion parity with ps::write_bypass: a call/dot-source of a QUOTED python3, and a
-# backtick line-continuation between python3 and -c, are the same interpreter write.
+# ACCEPTED OVER-BLOCK (fail-closed): a MENTION of python3 … -c + a write indicator in
+# prose, a line comment, or a quoted string now blocks — the guard cannot prove a
+# non-tokenizable PowerShell command is a mere mention.
+run_pwsh "PS: prose mention of python3 -c open now over-blocks (blocked)" \
+  "Write-Output 'run python3 -c open() later'" 2
+run_pwsh "PS: line-comment mention of python3 -c open now over-blocks (blocked)" \
+  "Write-Output ok # python3 -c open(" 2
+run_pwsh "PS: quoted &{python3 -c open( string now over-blocks (blocked)" \
+  "Write-Output '&{python3 -c open(}'" 2
+# Quoted / path-qualified / brace-glued / backtick-obfuscated python3 with -c: all
+# caught by the token+`-c` probe (quote-intact, backtick-recovered).
 run_pwsh "PS: & 'python3' -c open write (blocked)" \
   "& 'python3' -c \"open('x','w').write('a')\"" 2
 run_pwsh "PS: & \"python3\" -c open write (blocked)" \
   "& \"python3\" -c \"open('x','w').write('a')\"" 2
 run_pwsh "PS: backtick-continuation python3 -c open (blocked)" \
   "$(printf 'python3 `\n-c "open('"'"'x'"'"','"'"'w'"'"').write('"'"'a'"'"')"')" 2
-# Path-qualified call target: `& 'C:\Python313\python3.exe' -c` runs the covered
-# interpreter by absolute path. Unlike the writer-cmdlet residual (cmdlets are not
-# invoked by path), python3.exe IS path-invocable, so the quoted-call scan anchors
-# on the python3 basename inside the quotes. Bare unquoted path-qualified too.
 run_pwsh "PS: & 'C:\\...\\python3.exe' -c open write (blocked)" \
   "& 'C:\\Python313\\python3.exe' -c \"open('x','w').write('a')\"" 2
 run_pwsh "PS: bare C:\\...\\python3.exe -c open write (blocked)" \
   "C:\\Python313\\python3.exe -c \"open('x','w').write('a')\"" 2
-# A quoted call to a NON-python program stays allowed even with a write indicator
-# nearby — the anchor is the python3 basename, not any quoted exe path.
-run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \
-  "& 'C:\\Program Files\\app.exe' -c \"print open(\"" 0
-# Invoked script block: `&{python3 -c ...}` runs the interpreter with the command
-# glued to the opening brace, so the char before python3 is `{`. Braces are
-# normalized to spaces before the scan (both lanes' quote-intact + blanked forms),
-# so the compact `&{...}`, the spaced `& {...}`, AND a quoted name inside the block
-# (`&{'python3' -c}`) all resolve to the already-covered `& python3` / `& 'python3'`
-# forms. This is PowerShell-only: `&{cmd}` is a script-block invocation with no Bash
-# analogue (a Bash `{ …; }` group requires surrounding spaces, already covered).
 run_pwsh "PS: compact &{python3 -c} open write (blocked)" \
   "&{python3 -c \"open('x','w').write('a')\"}" 2
 run_pwsh "PS: spaced & {python3 -c} open write (blocked)" \
   "& {python3 -c \"open('x','w').write('a')\"}" 2
 run_pwsh "PS: &{'python3' -c} quoted-in-block open write (blocked)" \
   "&{'python3' -c \"open('x','w').write('a')\"}" 2
-# A python3 write mention fully INSIDE a quoted string is still inert — brace
-# normalization does not defeat quote-blanking.
-run_pwsh "PS: quoted string containing &{python3 -c open( (allowed)" \
-  "Write-Output '&{python3 -c open(}'" 0
+# Block comment as decoy + real invocation after it: token+`-c` still fires.
+run_pwsh "PS: block-comment decoy then python3 -c open write (blocked)" \
+  "$(printf '<# note #> python3 -c "open('"'"'x'"'"','"'"'w'"'"').write('"'"'a'"'"')"')" 2
+# Arg-splitting: `-c` hidden in -ArgumentList is still a `-c` token (quote-bounded).
+run_pwsh "PS: Start-Process python3 -ArgumentList '-c',open (blocked)" \
+  "Start-Process python3 -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
+# A non-python quoted program with a write indicator stays ALLOWED — no python3
+# token, so the co-occurrence probe does not fire (write_bypass allows quoted progs).
+run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \
+  "& 'C:\\Program Files\\app.exe' -c \"print open(\"" 0
 
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -586,6 +586,13 @@ run_pwsh "PS: python3 -config longer flag, pathlib in arg (allowed)" \
 # token, so the co-occurrence probe does not fire (write_bypass allows quoted progs).
 run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \
   "& 'C:\\Program Files\\app.exe' -c \"print open(\"" 0
+# Call operator with a DOUBLE-QUOTED interpolated target resolves a computed
+# interpreter — fail closed. A SINGLE-quoted target does not interpolate (literal
+# name), so it stays allowed via write_bypass's arbitrary-quoted-program residual.
+run_pwsh "PS: & \"\$env:PYTHON_BIN\" -c interpolated target (blocked)" \
+  "& \"\$env:PYTHON_BIN\" -c \"open('x','w').write('a')\"" 2
+run_pwsh "PS: & '\$x' single-quoted literal target (allowed)" \
+  "& '\$x' -c \"print open(\"" 0
 
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -486,6 +486,18 @@ run_pwsh "PS: & { Write-Output secret } > file (blocked)" \
 run_pwsh "PS: & { git diff } > file (tool producer, allowed)" \
   "& { git diff } > out.txt" 0
 
+# Interpreter-producer writes are shell-agnostic: the PowerShell branch must not
+# exit before the python3 -c rule, or the identical command the Bash lane blocks
+# sails through under the PowerShell tool (live-reproduced bypass).
+run_pwsh "PS: python3 -c open write (blocked)" \
+  "python3 -c \"open('x','w').write('a')\"" 2
+run_pwsh "PS: python3 -c pathlib write_text (blocked)" \
+  "python3 -c \"import pathlib; pathlib.Path('x').write_text('a')\"" 2
+run_pwsh "PS: python3 -c read-only os.path.normpath (allowed)" \
+  "python3 -c \"import os; print(os.path.normpath('a/b'))\"" 0
+run_pwsh "PS: quoted mention of python3 -c open (allowed)" \
+  "Write-Output 'run python3 -c open() later'" 0
+
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \
   "Microsoft.PowerShell.Utility\\Write-Output secret > f.txt" 2

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -57,6 +57,15 @@ run "python3 -c os.path.join producer (allowed)" \
   "python3 -c \"import os; print(os.path.join('a','b'))\"" 0
 run "python3 -c pathlib write_text (blocked)" \
   "python3 -c \"import pathlib; pathlib.Path('x').write_text('a')\"" 2
+# Path-qualified interpreter: an absolute/relative path to python3 is the same
+# write, so the command-word anchor admits a leading path (and a `.exe` suffix).
+run "abs-path python3 -c open write (blocked)" \
+  "/usr/bin/python3 -c \"open('x','w').write('a')\"" 2
+run "path-qualified python3.exe -c open write (blocked)" \
+  "/c/Python313/python3.exe -c \"open('x','w').write('a')\"" 2
+# The basename anchor must NOT match a longer name that merely ends in python3.
+run "notpython3 -c open (allowed)" \
+  "notpython3 -c \"open('x','w').write('a')\"" 0
 
 # --- Redirect false-positive regression -------------------------------------
 # stderr/fd redirects + /dev/null discards are NOT file-write bypasses, even
@@ -511,6 +520,18 @@ run_pwsh "PS: & \"python3\" -c open write (blocked)" \
   "& \"python3\" -c \"open('x','w').write('a')\"" 2
 run_pwsh "PS: backtick-continuation python3 -c open (blocked)" \
   "$(printf 'python3 `\n-c "open('"'"'x'"'"','"'"'w'"'"').write('"'"'a'"'"')"')" 2
+# Path-qualified call target: `& 'C:\Python313\python3.exe' -c` runs the covered
+# interpreter by absolute path. Unlike the writer-cmdlet residual (cmdlets are not
+# invoked by path), python3.exe IS path-invocable, so the quoted-call scan anchors
+# on the python3 basename inside the quotes. Bare unquoted path-qualified too.
+run_pwsh "PS: & 'C:\\...\\python3.exe' -c open write (blocked)" \
+  "& 'C:\\Python313\\python3.exe' -c \"open('x','w').write('a')\"" 2
+run_pwsh "PS: bare C:\\...\\python3.exe -c open write (blocked)" \
+  "C:\\Python313\\python3.exe -c \"open('x','w').write('a')\"" 2
+# A quoted call to a NON-python program stays allowed even with a write indicator
+# nearby — the anchor is the python3 basename, not any quoted exe path.
+run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \
+  "& 'C:\\Program Files\\app.exe' -c \"print open(\"" 0
 
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -567,6 +567,13 @@ run_pwsh "PS: Start-Process -FilePath ('py'+'thon3') computed target (blocked)" 
   "Start-Process -FilePath ('py'+'thon3') -ArgumentList '-c','open(\"x\",\"w\").write(\"a\")'" 2
 run_pwsh "PS: Start-Process notepad (literal non-python launcher, allowed)" \
   "Start-Process notepad -ArgumentList '-c','open(\"x\",\"w\")'" 0
+# `-c` concatenated with a variable/subexpression: PowerShell joins the adjacent
+# expansion into one `-c<source>` arg, so `python3 -c$code` has no whitespace/quote
+# after `-c`. Fail closed. A longer literal flag (`-config`) is NOT `-c` + code.
+run_pwsh "PS: python3 -c\$code concatenated computed flag (blocked)" \
+  "\$code = 'import pathlib; pathlib.Path(\"x\").write_text(\"a\")'; python3 -c\$code" 2
+run_pwsh "PS: python3 -config longer flag, pathlib in arg (allowed)" \
+  "python3 -config \"pathlib.Path\"" 0
 # A non-python quoted program with a write indicator stays ALLOWED — no python3
 # token, so the co-occurrence probe does not fire (write_bypass allows quoted progs).
 run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -532,6 +532,23 @@ run_pwsh "PS: bare C:\\...\\python3.exe -c open write (blocked)" \
 # nearby — the anchor is the python3 basename, not any quoted exe path.
 run_pwsh "PS: & 'C:\\...\\app.exe' with open mention (allowed)" \
   "& 'C:\\Program Files\\app.exe' -c \"print open(\"" 0
+# Invoked script block: `&{python3 -c ...}` runs the interpreter with the command
+# glued to the opening brace, so the char before python3 is `{`. Braces are
+# normalized to spaces before the scan (both lanes' quote-intact + blanked forms),
+# so the compact `&{...}`, the spaced `& {...}`, AND a quoted name inside the block
+# (`&{'python3' -c}`) all resolve to the already-covered `& python3` / `& 'python3'`
+# forms. This is PowerShell-only: `&{cmd}` is a script-block invocation with no Bash
+# analogue (a Bash `{ …; }` group requires surrounding spaces, already covered).
+run_pwsh "PS: compact &{python3 -c} open write (blocked)" \
+  "&{python3 -c \"open('x','w').write('a')\"}" 2
+run_pwsh "PS: spaced & {python3 -c} open write (blocked)" \
+  "& {python3 -c \"open('x','w').write('a')\"}" 2
+run_pwsh "PS: &{'python3' -c} quoted-in-block open write (blocked)" \
+  "&{'python3' -c \"open('x','w').write('a')\"}" 2
+# A python3 write mention fully INSIDE a quoted string is still inert — brace
+# normalization does not defeat quote-blanking.
+run_pwsh "PS: quoted string containing &{python3 -c open( (allowed)" \
+  "Write-Output '&{python3 -c open(}'" 0
 
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -503,6 +503,14 @@ run_pwsh "PS: here-string mentions python3 -c open (allowed)" \
   "$(printf "@'\npython3 -c open(\n'@\nWrite-Output ok")" 0
 run_pwsh "PS: line comment mentions python3 -c open (allowed)" \
   "Write-Output ok # python3 -c open(" 0
+# Evasion parity with ps::write_bypass: a call/dot-source of a QUOTED python3, and a
+# backtick line-continuation between python3 and -c, are the same interpreter write.
+run_pwsh "PS: & 'python3' -c open write (blocked)" \
+  "& 'python3' -c \"open('x','w').write('a')\"" 2
+run_pwsh "PS: & \"python3\" -c open write (blocked)" \
+  "& \"python3\" -c \"open('x','w').write('a')\"" 2
+run_pwsh "PS: backtick-continuation python3 -c open (blocked)" \
+  "$(printf 'python3 `\n-c "open('"'"'x'"'"','"'"'w'"'"').write('"'"'a'"'"')"')" 2
 
 # Review round 8: module-qualified producer heads.
 run_pwsh "PS: module-qualified Write-Output > file (blocked)" \

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -247,6 +247,15 @@ ps::might_write_via_python3() {
   if ps::has_launcher "$recovered" && [[ "$blanked" == *'$'* || "$blanked" == *'('* ]]; then
     return 0
   fi
+  # A call `&` / dot-source `.` of a DOUBLE-QUOTED target that INTERPOLATES a
+  # variable or subexpression (`& "$env:PYTHON_BIN" …`, `& "$(…)" …`) runs a
+  # COMPUTED program that could resolve to python3. blank_quoted_spans erases the
+  # target (so the launcher/token tests miss it) and it is not a launcher, so match
+  # it here on the quote-INTACT text and fail closed. A SINGLE-quoted target does
+  # NOT interpolate in PowerShell (`& '$x'` is the literal name `$x`), so it is not
+  # matched. ps::write_bypass catches only an UNQUOTED `& $`/`& (`; this closes the
+  # quoted-interpolated form for the python-write lane.
+  [[ "$lc" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*\"[^\"]*\$ ]] && return 0
   # Must name a python3 interpreter token at all (quote-intact, backtick-recovered).
   [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
   # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -236,8 +236,12 @@ ps::might_write_via_python3() {
   # computed name, so this runs FIRST and fails closed (the caller still gates on a
   # write indicator). Mirrors ps::might_invoke_git's computed-launcher clause; a
   # LITERAL launcher target (`Start-Process notepad …`) is not matched here and
-  # falls through to the token test, so a non-python launch stays allowed.
-  [[ "$lc" =~ (^|[[:space:]\;\|\&\(])(start-process|saps|start|pwsh|powershell|cmd)(\.exe)?[[:space:]]+(-[a-z]+[[:space:]]+)?[\(\$] ]] && return 0
+  # falls through to the token test, so a non-python launch stays allowed. The
+  # optional parameter name accepts a COLON-bound value (`-FilePath:$p`) as well as
+  # a whitespace-separated one (`-FilePath ('py'+'thon3')`) — PowerShell treats both
+  # as the same argument binding. (ps::might_invoke_git carries the identical clause
+  # and the same whitespace-only gap; a matching fix there is tracked separately.)
+  [[ "$lc" =~ (^|[[:space:]\;\|\&\(])(start-process|saps|start|pwsh|powershell|cmd)(\.exe)?[[:space:]]+(-[a-z]+([[:space:]]+|:))?[\(\$] ]] && return 0
   # Must name a python3 interpreter token at all (quote-intact, backtick-recovered).
   [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
   # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -229,19 +229,24 @@ ps::might_invoke_git() {
 ps::might_write_via_python3() {
   local recovered="${1//\`/}" lc q="\"'" blanked
   lc="${recovered,,}"
-  # A launcher (Start-Process/saps/start/pwsh/powershell/cmd) whose PROGRAM is a
-  # computed expression — `Start-Process -FilePath ('py'+'thon3') …`,
-  # `saps $exe …`, optionally behind one named parameter — could evaluate to
-  # python3 running inline code. The literal python3-token test below cannot see a
-  # computed name, so this runs FIRST and fails closed (the caller still gates on a
-  # write indicator). Mirrors ps::might_invoke_git's computed-launcher clause; a
-  # LITERAL launcher target (`Start-Process notepad …`) is not matched here and
-  # falls through to the token test, so a non-python launch stays allowed. The
-  # optional parameter name accepts a COLON-bound value (`-FilePath:$p`) as well as
-  # a whitespace-separated one (`-FilePath ('py'+'thon3')`) — PowerShell treats both
-  # as the same argument binding. (ps::might_invoke_git carries the identical clause
-  # and the same whitespace-only gap; a matching fix there is tracked separately.)
-  [[ "$lc" =~ (^|[[:space:]\;\|\&\(])(start-process|saps|start|pwsh|powershell|cmd)(\.exe)?[[:space:]]+(-[a-z]+([[:space:]]+|:))?[\(\$] ]] && return 0
+  # The quote-BLANKED command: an `open(` or a quoted mention inside the write
+  # payload is removed, so an UNQUOTED `(` (subexpression) or `$` (variable) that
+  # survives here is a genuine computed construct, not payload text.
+  blanked=$(ps::blank_quoted_spans "$1")
+  # A launcher (Start-Process/saps/start/pwsh/powershell/cmd) whose PROGRAM name is
+  # COMPUTED cannot be proven non-python. Rather than model parameter ordering /
+  # binding with a regex (which successive rounds defeated — one preceding option,
+  # then colon binding, then multiple options), fail closed CONSERVATIVELY: any
+  # launcher present together with an unquoted computed construct (`$` or `(`) →
+  # block (the caller still gates on a write indicator). This runs FIRST because a
+  # computed program has no literal python3 token for the test below to see. A
+  # launcher with only LITERAL args (`Start-Process notepad …`) carries no such
+  # construct and falls through to the token test, so a non-python launch stays
+  # allowed. (ps::might_invoke_git models this with a narrower per-parameter regex;
+  # a matching hardening there is tracked separately, out of this PR's scope.)
+  if ps::has_launcher "$recovered" && [[ "$blanked" == *'$'* || "$blanked" == *'('* ]]; then
+    return 0
+  fi
   # Must name a python3 interpreter token at all (quote-intact, backtick-recovered).
   [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
   # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split
@@ -257,9 +262,7 @@ ps::might_write_via_python3() {
   # so `python3 ('-'+'c') …` / `-ArgumentList ('-'+'c'),…` construct the flag with no
   # literal token. A computed `-c` cannot be ruled out when the args carry a
   # non-tokenizable construct — reuse the git lane's un-parsable test on the
-  # quote-BLANKED text (so an `open(` or a quoted mention inside the write payload
-  # does not count). Fail closed, exactly as the git lane refuses a computed target.
-  blanked=$(ps::blank_quoted_spans "$1")
+  # quote-BLANKED text. Fail closed, exactly as the git lane refuses a computed target.
   ps::has_special_constructs "$blanked" && return 0
   return 1
 }

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -207,6 +207,33 @@ ps::might_invoke_git() {
   return 1
 }
 
+# True (0) when the command both names a python3 interpreter TOKEN and carries a
+# `-c` inline-code flag. Paired with a raw write indicator by the caller, this is
+# the mangle-resistant sink for the interpreter-write lane under the PowerShell
+# tool — the python3 analogue of ps::might_invoke_git, following the same SINK
+# DOCTRINE: PowerShell is not faithfully bash-tokenizable, so rather than trust a
+# precise `python3 -c` scan that successive review rounds defeated (path-qualified
+# target, `&{python3}` script block, quoted-`#` comment truncation, block comments,
+# arg-splitting), ask the weaker question "could an inline-code python3 write be
+# here at all?" and let the caller block on the co-occurrence.
+#
+# `q` carries the two quote characters so neither appears literally in the regex.
+# Both probes run on the quote-INTACT, backtick-recovered text so a quoted
+# (`& 'python3'`), path-qualified (`…\python3.exe`), brace-glued (`&{python3`), or
+# comment-adjacent python3 — and a `-c` split from it or hidden in an arg list
+# (`-ArgumentList '-c',…`) — are all seen; a python3 token inside a here-string is
+# not (the caller blanks here-strings first). The `-c` boundary admits whitespace
+# or a quote on each side, so `'-c'` matches while a longer token (`-Command`,
+# `-Confirm`) does not. python3-ONLY by design: `py -3` / bare `python` and a
+# stdin heredoc (`python3 - <<PY … PY`, no `-c`) stay uncovered, as they are today.
+ps::might_write_via_python3() {
+  local recovered="${1//\`/}" lc q="\"'"
+  lc="${recovered,,}"
+  [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
+  [[ "$lc" =~ (^|[[:space:]$q])-c([[:space:]$q]|$) ]] || return 1
+  return 0
+}
+
 # True (0) when the command uses a dynamic-invocation form that runs an arbitrary
 # string as a command: `iex`/`invoke-expression` (of anything), or a call `&` /
 # dot-source `.` of a STRING LITERAL (`& 'git commit …'`, `. "…"`). These defeat

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -229,6 +229,15 @@ ps::might_invoke_git() {
 ps::might_write_via_python3() {
   local recovered="${1//\`/}" lc q="\"'" blanked
   lc="${recovered,,}"
+  # A launcher (Start-Process/saps/start/pwsh/powershell/cmd) whose PROGRAM is a
+  # computed expression — `Start-Process -FilePath ('py'+'thon3') …`,
+  # `saps $exe …`, optionally behind one named parameter — could evaluate to
+  # python3 running inline code. The literal python3-token test below cannot see a
+  # computed name, so this runs FIRST and fails closed (the caller still gates on a
+  # write indicator). Mirrors ps::might_invoke_git's computed-launcher clause; a
+  # LITERAL launcher target (`Start-Process notepad …`) is not matched here and
+  # falls through to the token test, so a non-python launch stays allowed.
+  [[ "$lc" =~ (^|[[:space:]\;\|\&\(])(start-process|saps|start|pwsh|powershell|cmd)(\.exe)?[[:space:]]+(-[a-z]+[[:space:]]+)?[\(\$] ]] && return 0
   # Must name a python3 interpreter token at all (quote-intact, backtick-recovered).
   [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
   # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -227,11 +227,22 @@ ps::might_invoke_git() {
 # `-Confirm`) does not. python3-ONLY by design: `py -3` / bare `python` and a
 # stdin heredoc (`python3 - <<PY … PY`, no `-c`) stay uncovered, as they are today.
 ps::might_write_via_python3() {
-  local recovered="${1//\`/}" lc q="\"'"
+  local recovered="${1//\`/}" lc q="\"'" blanked
   lc="${recovered,,}"
+  # Must name a python3 interpreter token at all (quote-intact, backtick-recovered).
   [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
-  [[ "$lc" =~ (^|[[:space:]$q])-c([[:space:]$q]|$) ]] || return 1
-  return 0
+  # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split
+  # `-ArgumentList '-c',…` counts; a longer token like `-Command`/`-Confirm` does not).
+  [[ "$lc" =~ (^|[[:space:]$q])-c([[:space:]$q]|$) ]] && return 0
+  # No literal `-c`: PowerShell evaluates expression-valued arguments before launching,
+  # so `python3 ('-'+'c') …` / `-ArgumentList ('-'+'c'),…` construct the flag with no
+  # literal token. A computed `-c` cannot be ruled out when the args carry a
+  # non-tokenizable construct — reuse the git lane's un-parsable test on the
+  # quote-BLANKED text (so an `open(` or a quoted mention inside the write payload
+  # does not count). Fail closed, exactly as the git lane refuses a computed target.
+  blanked=$(ps::blank_quoted_spans "$1")
+  ps::has_special_constructs "$blanked" && return 0
+  return 1
 }
 
 # True (0) when the command uses a dynamic-invocation form that runs an arbitrary

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -243,6 +243,12 @@ ps::might_write_via_python3() {
   # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split
   # `-ArgumentList '-c',…` counts; a longer token like `-Command`/`-Confirm` does not).
   [[ "$lc" =~ (^|[[:space:]$q])-c([[:space:]$q]|$) ]] && return 0
+  # `-c` immediately concatenated with a variable / subexpression is a COMPUTED
+  # inline-code flag: PowerShell joins the adjacent expansion into the same
+  # `-c<source>` argument (`python3 -c$code`, `python3 -c(…)`). The literal check
+  # above requires a whitespace/quote boundary after `-c`, so this adjacency slips
+  # it — fail closed.
+  [[ "$lc" =~ (^|[[:space:]$q])-c[\$\(] ]] && return 0
   # No literal `-c`: PowerShell evaluates expression-valued arguments before launching,
   # so `python3 ('-'+'c') …` / `-ArgumentList ('-'+'c'),…` construct the flag with no
   # literal token. A computed `-c` cannot be ruled out when the args carry a


### PR DESCRIPTION
## Summary

**Closes a live write-gate bypass.** `block-hook-bypass.sh` classified only PowerShell cmdlet/redirect
write forms (`ps::write_bypass`) and then `exit 0`ed **before** the shell-agnostic scans — so an
interpreter-producer write, `python3 -c "open('x','w').write('a')"`, executed **unguarded** through the
PowerShell tool while the identical command through Bash was blocked. Interpreter-producer writes are
shell-**agnostic**: whichever tool launches `python3 -c`, the write bypasses Write/Edit identically.

The interpreter rule now also runs on the PowerShell lane, mirroring the Bash lane's two-part shape:
the **invocation** is detected in a quote-blanked form (`ps::blank_quoted_spans`, so a quoted mention
stays inert) while the write **indicators** are scanned on the raw command, where they legitimately live
inside the quoted `-c` payload. PowerShell cmdlet/redirect coverage is unchanged. guardrails **0.14.2**.

This was the gap the code already acknowledged in-comment as "deferred to A2b".

**Note on provenance:** this is one of the two real causes behind the reported "PowerShell guard bypass".
The other (disk-hygiene's engine gate being dropped when `disk_hygiene_enabled` is unconfigured) is
handled separately. An earlier hypothesis — that PreToolUse hooks don't fire for the PowerShell tool —
was **falsified**: they fire correctly, payload `tool_name` is literally `PowerShell`.

## Test plan

Verified end-to-end through the actual hook (CC 2.1.218):

| command | tool | before | after |
|---|---|---|---|
| `python3 -c "open('x','w').write('a')"` | PowerShell | exit 0 (**bypass**) | exit 2 (blocked ✓) |
| same | Bash | exit 2 | exit 2 (unchanged ✓) |
| `python3 -c "import pathlib; pathlib.Path('x').write_text('a')"` | PowerShell | exit 0 | exit 2 (blocked ✓) |
| `python3 -c "import os; print(os.path.normpath('a/b'))"` | PowerShell | exit 0 | exit 0 (quiet ✓) |
| `Write-Output 'run python3 -c open() later'` | PowerShell | exit 0 | exit 0 (quiet ✓) |
| `Set-Content -Path f.txt -Value 'x'` | PowerShell | exit 2 | exit 2 (unchanged ✓) |

Four regression fixtures added to the PowerShell section of `block-hook-bypass.test.sh` (two MUST-block,
two MUST-stay-quiet). `shellcheck -S error` clean.

Fresh-docs basis (CLAUDE.md mandate): `tools-reference` + `hooks` fetched this session; the PowerShell
tool's hook firing and payload `tool_name` were verified by live payload dump, not recalled.

## Related

Closes #1199.
Sibling cause of the same report: #1195 (disk-hygiene engine gate dropped when the option is unconfigured).
