### PR TITLE
fix(work-items): expand leading ~ in preflight path normalization

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -11,9 +11,10 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   grant.** `normalize_path` folded backslashes and Windows drive letters but never expanded a
   leading `~`, so a `permissions.additionalDirectories` entry written in `~/…` form never matched
   the absolute worktree root the harness derives from that same home — the preflight wrongly emitted
-  its `(c)` gap even though the grant was live. `normalize_path` now expands a leading `~` (`~` alone
-  or `~/…`) to the user home (`HOME`, then `USERPROFILE`) before folding, so tilde-form entries
-  compare equal to the absolute probed root. A regression case covers the match, the outside-home
+  its `(c)` gap even though the grant was live. `normalize_path` now expands a leading `~` (`~` alone,
+  or `~/…` / `~\…` — both separators, since a Windows entry may use a backslash) to the user home
+  (`HOME`, then `USERPROFILE`) before folding, so tilde-form entries compare equal to the absolute
+  probed root. Regression cases cover the forward- and backslash-separator matches, the outside-home
   non-match, and unchanged non-tilde behavior.
 
 ## [0.22.0]

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -14,8 +14,9 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   its `(c)` gap even though the grant was live. `normalize_path` now expands a leading `~` (`~` alone,
   or `~/…` / `~\…` — both separators, since a Windows entry may use a backslash) to the user home
   (`HOME`, then `USERPROFILE`) before folding, so tilde-form entries compare equal to the absolute
-  probed root. Regression cases cover the forward- and backslash-separator matches, the outside-home
-  non-match, and unchanged non-tilde behavior.
+  probed root. A trailing separator on the home (including `HOME=/`) is stripped before the join so
+  it cannot produce a non-collapsing `//`. Regression cases cover the forward- and backslash-separator
+  matches, the trailing-separator home, the outside-home non-match, and unchanged non-tilde behavior.
 
 ## [0.22.0]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.1]
+
+### Fixed
+
+- **Permission preflight no longer reports a false `additionalDirectories` gap for a tilde-form
+  grant.** `normalize_path` folded backslashes and Windows drive letters but never expanded a
+  leading `~`, so a `permissions.additionalDirectories` entry written in `~/…` form never matched
+  the absolute worktree root the harness derives from that same home — the preflight wrongly emitted
+  its `(c)` gap even though the grant was live. `normalize_path` now expands a leading `~` (`~` alone
+  or `~/…`) to the user home (`HOME`, then `USERPROFILE`) before folding, so tilde-form entries
+  compare equal to the absolute probed root. A regression case covers the match, the outside-home
+  non-match, and unchanged non-tilde behavior.
+
 ## [0.22.0]
 
 ### Added

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -241,6 +241,11 @@ normalize_path() {
   # backslashes, and any in the stripped remainder, are folded by the tr below);
   # neither set leaves ~ literal.
   if [[ -n "$home" ]]; then
+    # Strip one trailing separator (either form — HOME=/, USERPROFILE=…\) so the
+    # join below cannot double it; normalize_path does not collapse an internal
+    # //, so //.worktrees would never match an absolute /.worktrees/… root.
+    home="${home%/}"
+    home="${home%\\}"
     # shellcheck disable=SC2088  # the literal ~ arms are patterns being matched, not paths to expand
     case "$p" in
       "~") p="$home" ;;

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -234,15 +234,17 @@ normalize_path() {
   # Literal only — no symlink resolution, since permission rules match the
   # command string literally.
   local p="$1" drive rest home="${HOME:-${USERPROFILE:-}}"
-  # A leading ~ (~ alone or ~/…) expands to the user home so a tilde-form
+  # A leading ~ (~ alone, or ~/… / ~\… — both separators, since a Windows entry
+  # may be written ~\…) expands to the user home so a tilde-form
   # additionalDirectories entry compares equal to the absolute probed root the
   # harness derives from that same home. HOME first, then USERPROFILE (its
-  # backslashes are folded by the tr below); neither set leaves ~ literal.
+  # backslashes, and any in the stripped remainder, are folded by the tr below);
+  # neither set leaves ~ literal.
   if [[ -n "$home" ]]; then
     # shellcheck disable=SC2088  # the literal ~ arms are patterns being matched, not paths to expand
     case "$p" in
       "~") p="$home" ;;
-      "~/"*) p="$home/${p:2}" ;;
+      "~/"* | "~\\"*) p="$home/${p:2}" ;;
       *) ;;
     esac
   fi

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -228,11 +228,24 @@ verb_denied() { verb_in_rules "$1" "$ALL_DENY" "bare"; }
 verb_bare_exact() { verb_in_rules "$1" "$ALL_ALLOW" "bare-exact-only"; }
 
 normalize_path() {
-  # Fold a path to one comparable form: backslashes → slashes, lower-case and
-  # de-colon a leading Windows drive (D:\repos → /d/repos, matching the git-bash
-  # /d/repos spelling), strip a trailing slash. Literal only — no symlink
-  # resolution, since permission rules match the command string literally.
-  local p="$1" drive rest
+  # Fold a path to one comparable form: expand a leading ~, backslashes →
+  # slashes, lower-case and de-colon a leading Windows drive (D:\repos →
+  # /d/repos, matching the git-bash /d/repos spelling), strip a trailing slash.
+  # Literal only — no symlink resolution, since permission rules match the
+  # command string literally.
+  local p="$1" drive rest home="${HOME:-${USERPROFILE:-}}"
+  # A leading ~ (~ alone or ~/…) expands to the user home so a tilde-form
+  # additionalDirectories entry compares equal to the absolute probed root the
+  # harness derives from that same home. HOME first, then USERPROFILE (its
+  # backslashes are folded by the tr below); neither set leaves ~ literal.
+  if [[ -n "$home" ]]; then
+    # shellcheck disable=SC2088  # the literal ~ arms are patterns being matched, not paths to expand
+    case "$p" in
+      "~") p="$home" ;;
+      "~/"*) p="$home/${p:2}" ;;
+      *) ;;
+    esac
+  fi
   # shellcheck disable=SC1003  # '\\' is tr's escaped backslash (one char), not a quote escape
   p="$(printf '%s' "$p" | tr '\\' '/')"
   case "$p" in

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -327,6 +327,31 @@ CFG18="$TEST_TMPDIR/cfg18"
 MSYS_NO_PATHCONV=1 write_settings "$CFG18" "$FULL_ALLOW" "/"
 assert_eq "root additionalDirectories entry covers any worktree root" "0" "$(run "$REPO" "$CFG18" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Case 19: tilde-form additionalDirectories entry expands to the user home -
+# A ~-form entry (~/.worktrees) must expand to $HOME and cover an absolute probed
+# root beneath it — the grant the harness's own tilde expansion makes live but
+# normalize_path previously left unmatched. HOME is set explicitly so the case is
+# independent of the tester's real home.
+HOME19="$TEST_TMPDIR/home19"
+mkdir -p "$HOME19"
+CFG19="$TEST_TMPDIR/cfg19"
+# shellcheck disable=SC2088  # the literal ~ entry is the input under test, not a path to expand
+write_settings "$CFG19" "$FULL_ALLOW" "~/.worktrees"
+# run_home <home> <fixture-dir> <config-dir> [args...] — like run(), with HOME set
+# so a tilde-form entry expands deterministically. CLAUDE_CONFIG_DIR still points
+# settings at the fixture, so HOME only steers normalize_path's ~ expansion.
+run_home() {
+  local home="$1" fx="$2" cfg="$3"
+  shift 3
+  HOME="$home" PREFLIGHT_FIXTURE_DIR="$fx" CLAUDE_CONFIG_DIR="$cfg" bash "$SCRIPT" "$@"
+}
+OUT=$(run_home "$HOME19" "$REPO" "$CFG19" --worktree-root "$HOME19/.worktrees/999-x")
+assert_not_contains "tilde-form entry covers an absolute child → no (c) gap" "$OUT" "GAP (c)"
+assert_eq "tilde-form entry expands → zero gaps" "0" "$(run_home "$HOME19" "$REPO" "$CFG19" --count --worktree-root "$HOME19/.worktrees/999-x")"
+# The expansion is a real ancestor check, not a blanket pass: a root outside the
+# expanded home is still an uncovered (c) gap, and non-tilde probes are unchanged.
+assert_eq "tilde-form entry does not cover a root outside the home" "1" "$(run_home "$HOME19" "$REPO" "$CFG19" --count --worktree-root "$POSIX_CHILD")"
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"
   exit 0

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -352,6 +352,14 @@ assert_eq "tilde-form entry expands → zero gaps" "0" "$(run_home "$HOME19" "$R
 # expanded home is still an uncovered (c) gap, and non-tilde probes are unchanged.
 assert_eq "tilde-form entry does not cover a root outside the home" "1" "$(run_home "$HOME19" "$REPO" "$CFG19" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Case 19b: backslash-form tilde entry (~\...) also expands ----------------
+# A Windows entry may be written ~\.worktrees; that separator must expand the
+# same as ~/.worktrees (the repo's other portable expanders accept both forms).
+CFG19B="$TEST_TMPDIR/cfg19b"
+# shellcheck disable=SC2088  # the literal ~ entry is the input under test, not a path to expand
+write_settings "$CFG19B" "$FULL_ALLOW" "~${BS}.worktrees"
+assert_eq "backslash-form tilde entry expands → zero gaps" "0" "$(run_home "$HOME19" "$REPO" "$CFG19B" --count --worktree-root "$HOME19/.worktrees/999-x")"
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"
   exit 0

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -360,6 +360,11 @@ CFG19B="$TEST_TMPDIR/cfg19b"
 write_settings "$CFG19B" "$FULL_ALLOW" "~${BS}.worktrees"
 assert_eq "backslash-form tilde entry expands → zero gaps" "0" "$(run_home "$HOME19" "$REPO" "$CFG19B" --count --worktree-root "$HOME19/.worktrees/999-x")"
 
+# --- Case 19c: a trailing separator on the home does not double on the join --
+# HOME ending in / (or \) must not yield //.worktrees, which normalize_path does
+# not collapse and so would not match the absolute probed root.
+assert_eq "trailing-slash home still covers the child → zero gaps" "0" "$(run_home "$HOME19/" "$REPO" "$CFG19" --count --worktree-root "$HOME19/.worktrees/999-x")"
+
 if [[ "$FAILED" -eq 0 ]]; then
   printf '\nAll %d checks passed.\n' "$CASE_NUM"
   exit 0


### PR DESCRIPTION
## Summary

The work/babysit permission preflight's `normalize_path`
(`plugins/work-items/skills/work/scripts/preflight.sh`) folded backslashes and
lower-cased/de-colonned a leading Windows drive letter, but never expanded a
leading `~`. A `permissions.additionalDirectories` entry written in `~/…` form
was therefore compared literally against the **absolute** worktree root the
harness derives from that same home; they never matched, and the preflight
emitted its `(c)` `additionalDirectories` gap even though the grant was live
(the harness expands the tilde, and workers wrote out-of-tree all session with
no prompts).

`normalize_path` now expands a leading `~` (`~` alone or `~/…`) to the user home
— `HOME` first, then `USERPROFILE`, whose backslashes the existing fold handles
— **before** the backslash/drive normalization, so a tilde-form entry compares
equal to the absolute probed root. Report-only behavior, exit codes, and every
other check are unchanged. Bumps `work-items` to 0.22.1 with a CHANGELOG entry
so consumers pick up the fix.

## Test plan

- Added regression **Case 19** to `preflight.test.sh`: a `~/.worktrees` entry
  expands to `$HOME` and covers an absolute child (`no (c) gap`, zero gaps),
  while a root **outside** the expanded home still gaps (proving the expansion
  is a real ancestor check, not a blanket pass, and that non-tilde probes are
  unchanged). `HOME` is set explicitly so the case is independent of the
  tester's real home.
- `bash plugins/work-items/skills/work/scripts/preflight.test.sh` → **all 60
  checks pass**.
- `shellcheck --rcfile=.shellcheckrc` on both scripts → **clean** (the two
  intentional literal-`~` sites carry a scoped `SC2088` disable with rationale).
- Local CI parity: `check-changelog-parity.sh --check` / `--check-bump
  origin/main`, `validate-plugins.sh`, `check-changed-skills.sh origin/main`
  (skill-quality **PASS**, runs the new test), and
  `check-skill-portability.sh origin/main` → **all green**.

## Related

Closes #1206.

Provenance: reported by an autonomous work-loop lane on 2026-07-23 and verified
live by that lane; lane telemetry is recorded in `melodic-software/ci-workflows`
issue #231's wind-down comment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169XBydnqC5S6bkHDz1TDwL
