### PR TITLE
feat(conventions): codify hook-config-delivery channel matrix with CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,26 @@ jobs:
       - name: Check for unregistered cross-plugin skill leaf-name collisions
         run: scripts/check-skill-leaf-names.sh --check
 
+  # A ${user_config.*} token in a plugin hook config silently drops the whole
+  # hook entry whenever the key is unset (the declared userConfig `default` is
+  # unimplemented upstream — anthropics/claude-code#46477), so the hook never
+  # fires on a default install. The channel decision matrix
+  # (docs/conventions/hook-config-delivery/) rules argv out for hooks; this
+  # gate pins the exact regression #1242 fixed. Self-test first so a broken
+  # detector cannot mask a regression.
+  userconfig-argv-gate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Test the userconfig-argv gate
+        run: bash scripts/check-hook-userconfig-argv.test.sh
+      - name: Check plugin hook configs for bare userConfig argv tokens
+        run: scripts/check-hook-userconfig-argv.sh
+
   silent-skip-gate:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -690,6 +710,7 @@ jobs:
       - standards-contract-sync
       - cross-plugin-source-drift
       - skill-leaf-name-gate
+      - userconfig-argv-gate
       - silent-skip-gate
       - orphaned-fixture-gate
       - changelog-parity-gate

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -345,6 +345,7 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Hook telemetry | [`docs/conventions/hook-telemetry/`](conventions/hook-telemetry/README.md) |
 | Hook observability (status/failure surfaces) | [`docs/conventions/hook-observability/`](conventions/hook-observability/README.md) |
 | Hook precision (false-positive discipline) | [`docs/conventions/hook-precision/`](conventions/hook-precision/README.md) |
+| Hook config delivery (userConfig→hook channel matrix) | [`docs/conventions/hook-config-delivery/`](conventions/hook-config-delivery/README.md) |
 | Permission-rule hygiene | [`docs/conventions/permission-rule-hygiene/`](conventions/permission-rule-hygiene/README.md) |
 | Repository standards index | [`docs/conventions/standards/`](conventions/standards/README.md) |
 | Skill layout contract and evals schema | `skill-quality` plugin (contract gate + bundled schema) |

--- a/docs/conventions/hook-config-delivery/CHANGELOG.md
+++ b/docs/conventions/hook-config-delivery/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Hook Config Delivery Convention — Changelog
+
+Notable changes to the hook-config-delivery contract. Versioned by `contract_version` (SemVer). A
+change to the decision rule or to a matrix row's verdict is a major bump; adding a channel, a fact,
+or a recheck trigger additively is a minor bump. The version-pinned facts table is evidence, not
+contract — refreshing a pin or recheck date without a verdict change is no bump.
+
+## 1.0 — 2026-07-24
+
+Initial published contract, codifying the channel decision matrix from the userConfig→hook delivery
+program (verification probe of 2026-07-23 on Claude Code 2.1.218; docs re-fetched 2026-07-24).
+Supersedes the proposal draft in issue #1182, which becomes the adoption/tracking pointer.
+
+- Channels A–F characterized, including the shipped direct-settings-read channel (F) that
+  disk-hygiene 0.9.0 (#1242) introduced, superseding the earlier SessionStart-file design for that
+  plugin.
+- Decision rule: skill-hooks → C/F; safety-critical optional-with-default → F (never B — the unset
+  case is repo-tamperable via `env`; never bare argv — the hook drops); non-safety → B with
+  in-script default; sensitive → B/C only.
+- Meta-rule: prefer the most tamper-resistant channel that reliably delivers; argv's exclusion is
+  pinned to the unimplemented upstream `default` (#46477) and carries a recheck trigger, not
+  permanence.
+- Enforcement: `scripts/check-hook-userconfig-argv.sh` CI gate (bare `${user_config.*}` in any
+  plugin hook config fails; allowlist reserved for a proven channel D).
+- Open gap recorded: G-required (channel D's no-unset-case premise, unprobed).

--- a/docs/conventions/hook-config-delivery/README.md
+++ b/docs/conventions/hook-config-delivery/README.md
@@ -1,0 +1,147 @@
+# Hook config delivery — channel decision matrix for plugin userConfig values
+
+Owner doc for **how a plugin delivers a `userConfig` value into a hook's decision logic**. The
+`hook-*` family divides the concern space: [hook-precision](../hook-precision/README.md) owns what a
+hook matches, [hook-observability](../hook-observability/README.md) owns how it surfaces status, and
+[hook-telemetry](../hook-telemetry/README.md) owns what it emits. This doc owns the remaining leg:
+which **channel** carries a user-configured scalar from settings to the hook process, chosen by rule
+instead of ad hoc.
+
+The fleet previously shipped three coexisting approaches with no documented rule — a plugin-hook argv
+substitution (silently broken for unset defaults), a skill-belt env read (skill hooks never receive
+it), and a floated SessionStart-file design (unbuilt). Each was individually plausible; together they
+were the reuse-or-replace fragmentation this doc closes.
+
+## Boundary — composes with config-cascade
+
+[config-cascade](../config-cascade/README.md) owns the layering of **consumer-tracked config files**
+(`.claude/<name>` surfaces: which layers exist and how they merge). This doc owns the delivery path
+of **harness-prompted `userConfig` values** — the options a plugin declares in `plugin.json` and
+Claude Code prompts for at enable time. They are different inputs with different trust properties: a
+cascade layer is repo- or user-authored file content; a `userConfig` value is harness-mediated and
+stored in scopes a repo cannot write. Whether a given knob should be `userConfig` or a tracked
+cascade surface is a design call owned by the [plugin philosophy](../../PLUGIN-PHILOSOPHY.md); once
+it is `userConfig`, this doc owns its route to hook logic. Which keys exist and what they mean stay
+with each plugin's own docs.
+
+## Verified upstream behavior (version-pinned)
+
+Everything below was verified on **Claude Code 2.1.218** — doc-stated facts re-fetched from the live
+official docs on 2026-07-24; behavioral facts proven by a controlled fresh-session probe (isolated
+`claude -p --plugin-dir` runs with positive controls) on 2026-07-23. Latest CC at recheck: 2.1.218.
+Existing state is not evidence of its own correctness: **recheck these facts** (triggers at the end
+of this doc) before extending the matrix or relying on a row in new work.
+
+| # | Fact | Basis |
+|---|---|---|
+| 1 | Plugin `hooks.json` hooks receive `${user_config.KEY}` in **exec form only**, substituted into `command` and each `args` element as a plain string; a shell-form command referencing it fails with an error instead of running (since 2.1.207) | doc-stated ([hooks](https://code.claude.com/docs/en/hooks)) |
+| 2 | Configured values are exported to hook processes as `CLAUDE_PLUGIN_OPTION_<KEY>` (key uppercased) | doc-stated ([plugins-reference](https://code.claude.com/docs/en/plugins-reference#user-configuration)); scope narrowed by fact 4 |
+| 3 | The declared `default` field ("Value used when the user provides nothing") is in the schema but **implemented for neither argv substitution nor env export**. An unset-but-defaulted `${user_config.*}` argv token **silently drops the entire hook entry** — not passed literally, not empty-substituted; the same unset key exports **no** env var | proven (probe T1); upstream [#46477](https://github.com/anthropics/claude-code/issues/46477) closed not-planned, [#39455](https://github.com/anthropics/claude-code/issues/39455) open, [#39827](https://github.com/anthropics/claude-code/issues/39827) closed not-planned; undocumented |
+| 4 | Tamper split on the env channel: for a **configured** key, harness injection overwrites a repo `.claude/settings.json` `env` block (injection wins); for an **unconfigured** key nothing is injected and the repo's `env` block freely populates `CLAUDE_PLUGIN_OPTION_<KEY>` — and env carries no provenance, so a hook cannot tell the two apart | proven (probe T2/T2b); undocumented |
+| 5 | `pluginConfigs` is written to user settings and read back from **user settings, the `--settings` flag, and managed settings only**; entries in a project's `.claude/settings.json` / `.claude/settings.local.json` are ignored (since 2.1.207) | doc-stated ([plugins-reference](https://code.claude.com/docs/en/plugins-reference#user-configuration)) |
+| 6 | Skill- and agent-frontmatter hooks receive **neither** the argv substitution nor `CLAUDE_PLUGIN_OPTION_*` | evidence-strong (probe + field repro); CC docs silent |
+| 7 | Skill/agent **body** `${user_config.KEY}` substitutes into model-visible content, non-sensitive values only | doc-stated ([plugins-reference](https://code.claude.com/docs/en/plugins-reference#user-configuration)) |
+| 8 | Sensitive values are stored in the OS keychain (or `~/.claude/.credentials.json`), never in `settings.json` | doc-stated ([plugins-reference](https://code.claude.com/docs/en/plugins-reference#user-configuration)) |
+
+## The channels
+
+An open list — channels known and characterized today. A newly discovered delivery path extends this
+list and the matrix; it does not fork a private convention.
+
+- **A. Exec-argv substitution** — `${user_config.KEY}` in an exec-form hook's `command`/`args`.
+- **B. Environment** — the hook script reads `CLAUDE_PLUGIN_OPTION_<KEY>`.
+- **C. SessionStart resolver → data file** — a SessionStart plugin hook resolves the value once and
+  persists it under `${CLAUDE_PLUGIN_DATA}`; other surfaces (including skill-frontmatter hooks) read
+  the file.
+- **D. `required:true` + argv** — declare the key required so no unset case exists, then use argv.
+  Premise unproven — see [Open gaps](#open-gaps).
+- **E. Skill/agent body substitution** — `${user_config.KEY}` in model-visible skill/agent content.
+  Reaches the model, never a hook process: advisory only.
+- **F. Direct settings read** — the hook script reads `pluginConfigs["<name>@<marketplace>"].options`
+  itself from the user `settings.json` plus fixed-path managed settings (and `managed-settings.d/`
+  drop-ins), locating the user file **only** from the tamper-resistant `${CLAUDE_PLUGIN_ROOT}` cache
+  anchor — never from an env-derived path (`CLAUDE_CONFIG_DIR`, `HOME`, `%ProgramFiles%`), because a
+  repo `env` block reaches hook subprocesses and env carries no provenance. Shipped exemplar:
+  disk-hygiene's shared kill-switch reader, `plugins/disk-hygiene/lib/killswitch_config.py`
+  (see its `[0.9.0]` [CHANGELOG entry](../../../plugins/disk-hygiene/CHANGELOG.md) for the full
+  trust analysis and residuals).
+
+## The matrix
+
+| Channel | Reaches skill-hook? | Unset-default behavior | Repo-tamper-resistant | Failure mode | Sensitive-safe | Machinery |
+|---|---|---|---|---|---|---|
+| A. Exec argv | no | **BROKEN — whole hook silently dropped (fact 3)** | yes (user/managed scopes) | **unsafe: silent non-enforcement** | on argv | none |
+| B. Env | no | **not delivered (fact 3)** → in-script default required | **only when configured; a repo `env` block owns the unset case (fact 4)** | safe | yes | none |
+| C. SessionStart → data file | **yes** | inherits fact 3 at resolve → in-script default required | yes, if the resolver itself uses a tamper-resistant channel (not bare env — fact 4) | safe | yes (configured values, via the resolver's env) | +hook, +file trust, +session-start timing |
+| D. `required:true` + argv | no | n/a — no unset case | yes | safe | on argv | none (premise unproven) |
+| E. Body substitution | (model, not a hook) | n/a | yes | advisory only | **no** | none |
+| F. Direct settings read | **yes** | in-script default required (declared `default` inert everywhere) | yes (fact 5 + no env-derived paths) | safe — explicit fail direction per plugin | **no — sensitive values are not in `settings.json` (fact 8)** | +settings-file coupling, +managed-path table |
+
+Residual on F (documented, accepted): a value supplied only via a session `--settings` file is honored
+by the harness but invisible to a hook-side read — a runtime CLI flag no hook can observe.
+
+## The decision rule
+
+1. **Skill- or agent-frontmatter hook needs the value** → only **C** or **F** deliver one (fact 6).
+   Otherwise the value reaches the model only (**E**) and the control is advisory.
+2. **Plugin hook, mandatory value (no sensible default)** → **D** once its premise is proven (see
+   Open gaps); until then treat the key as optional-with-default and use the rows below.
+3. **Plugin hook, optional-with-default, safety- or security-critical** → **F** (or **C** with an
+   F-grade resolver). Never **B**: the unset-default case is exactly where a protect-by-default
+   switch lives, and there a repo `env` block owns the value (fact 4). Never bare argv (fact 3).
+4. **Plugin hook, optional-with-default, non-safety** → **B** with an in-script default — acceptable
+   only where a repo supplying its own value for an unset key is tolerable or intended.
+5. **Sensitive value** → **B** or **C**; never argv (visible in process listings), never **E**
+   (model-visible), and **F** cannot read them at all (fact 8).
+
+**Meta-rule — do not enshrine the outage as law.** The standing preference is *the most
+tamper-resistant channel that reliably delivers*. Argv is the most tamper-resistant delivery there
+is; it is excluded today only because fact 3 makes it unreliable for optional-with-default keys.
+If upstream implements `default` substitution, rows A/B/D change and this rule is re-derived — that
+is a recheck trigger, not a rewrite of history.
+
+## Enforcement
+
+Rule "never bare argv" is CI-enforced, not just documented: `scripts/check-hook-userconfig-argv.sh`
+fails the build on any `${user_config.*}` token inside a plugin hook configuration (the default
+`hooks/hooks.json`, manifest-pointed hook files, and inline manifest `hooks` objects alike). MCP and
+LSP server configs are out of scope — substitution there is sanctioned and unaffected by fact 3.
+
+The gate flags **every** hook-config use, including a would-be channel D, because D's premise is
+unproven. A ratified D adoption (after the Open-gaps probe) is recorded in
+`scripts/hook-userconfig-argv-allowlist.txt`; stale allowlist entries fail the gate.
+
+## Open gaps
+
+- **G-required (channel D's premise).** That `required:true` forces a prompt and so removes the
+  unset case is inferred from the schema (`required` — "validation fails when the field is empty")
+  and upstream discussion, not doc-stated and not yet probed: the verification probe declared
+  optional keys only. Cheap to settle — add a `required:true` key to the probe plugin and rerun the
+  unset-key test. Until then D stays in the matrix as unproven and the CI gate has no allowlist
+  entries.
+
+## Adopters
+
+Conformance is tracked as it exists on `main`, per the
+[convention registry](../../PLUGIN-PHILOSOPHY.md#convention-registry) discipline.
+
+| Surface | Channel | Status |
+|---|---|---|
+| disk-hygiene kill switch (`disk_hygiene_enabled`), both guard surfaces | F (shared reader `lib/killswitch_config.py`) | conforms (0.9.0, #1242; closed #1019) |
+| claude-ops + format-hook plugins (`CLAUDE_PLUGIN_OPTION_*` reads via `hook-utils.sh`) | B | non-safety concerns; conformance audit tracked by #1182 |
+
+Issue #1182 is the adoption/tracking pointer for the remaining fleet audit; this doc is the
+authority it points to.
+
+## Recheck triggers
+
+Recheck the facts table (and re-derive the decision rule) when any of these fires:
+
+- A Claude Code CHANGELOG entry touches `userConfig` substitution, the `default` field, or
+  `CLAUDE_PLUGIN_OPTION_*` injection — facts 1–4; rows A/B/D.
+- [#46477](https://github.com/anthropics/claude-code/issues/46477) reopens or `default`
+  substitution ships — fact 3; the meta-rule's exclusion of argv falls away.
+- The documented `pluginConfigs` read scopes change — fact 5; F's tamper claim.
+- The managed-settings paths or precedence change — F's exemplar reader.
+- CC docs begin specifying skill-hook value delivery — fact 6 moves from evidence-strong to
+  doc-stated (or is contradicted).

--- a/docs/conventions/hook-config-delivery/README.md
+++ b/docs/conventions/hook-config-delivery/README.md
@@ -60,8 +60,10 @@ list and the matrix; it does not fork a private convention.
 - **F. Direct settings read** — the hook script reads `pluginConfigs["<name>@<marketplace>"].options`
   itself from the user `settings.json` plus fixed-path managed settings (and `managed-settings.d/`
   drop-ins), locating the user file **only** from the tamper-resistant `${CLAUDE_PLUGIN_ROOT}` cache
-  anchor — never from an env-derived path (`CLAUDE_CONFIG_DIR`, `HOME`, `%ProgramFiles%`), because a
-  repo `env` block reaches hook subprocesses and env carries no provenance. Shipped exemplar:
+  anchor — tamper-resistant because the harness substitutes it from the plugin's install cache under
+  the user's own config dir, a path no repo file can redirect — never from an env-derived path
+  (`CLAUDE_CONFIG_DIR`, `HOME`, `%ProgramFiles%`), because a repo `env` block reaches hook
+  subprocesses and env carries no provenance. Shipped exemplar:
   disk-hygiene's shared kill-switch reader, `plugins/disk-hygiene/lib/killswitch_config.py`
   (see its `[0.9.0]` [CHANGELOG entry](../../../plugins/disk-hygiene/CHANGELOG.md) for the full
   trust analysis and residuals).

--- a/scripts/check-hook-userconfig-argv.sh
+++ b/scripts/check-hook-userconfig-argv.sh
@@ -74,15 +74,22 @@ scan_manifest_path() {
   scan_file "$plugin/${rel#./}"
 }
 
-# scan_file <repo-relative hook config path>
+# scan_file <repo-relative hook config path> — two passes: a raw-text grep for
+# precise file:line reporting, then a decoded pass (jq re-serializes the JSON,
+# resolving \u-escapes such as ${user_config.KEY} that the loader decodes
+# before substitution) so an escaped spelling of the token cannot slip past the
+# raw scan. An unparsable file gets the raw pass only.
 scan_file() {
   local file="$1" hits line
   [[ -f "$file" ]] || return 0
   hits="$(grep -nF "$TOKEN" "$file" || true)"
-  [[ -n "$hits" ]] || return 0
-  while IFS= read -r line; do
-    flag "$file" "${line%%:*}"
-  done <<<"$hits"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r line; do
+      flag "$file" "${line%%:*}"
+    done <<<"$hits"
+  elif jq -c . "$file" 2>/dev/null | grep -qF "$TOKEN"; then
+    flag "$file" "escaped token in decoded JSON"
+  fi
 }
 
 for plugin in plugins/*/; do

--- a/scripts/check-hook-userconfig-argv.sh
+++ b/scripts/check-hook-userconfig-argv.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Gate: no plugin hook configuration may carry a bare ${user_config.*} token.
+#
+#   scripts/check-hook-userconfig-argv.sh    fail on any ${user_config.*} in a
+#                                            plugin hook config
+#
+# Why: the declared userConfig `default` is unimplemented upstream (#46477 —
+# closed not-planned), so an unset-but-defaulted ${user_config.*} argv token
+# silently drops the ENTIRE hook entry instead of substituting. On a default
+# install the hook never fires — the exact regression disk-hygiene shipped
+# through 0.8.x and #1242 fixed. The channel decision matrix
+# (docs/conventions/hook-config-delivery/) rules argv out for hooks until
+# upstream implements `default`; this gate pins that rule.
+#
+# Scope: hook configurations only — the default hooks/hooks.json, any
+# manifest-pointed hook config file (`hooks` as a string or array of paths),
+# and an inline manifest `hooks` object. MCP and LSP server configs are OUT of
+# scope: ${user_config.*} substitution there is sanctioned and does not drop
+# components. A hooks/*.json file the manifest never references is not loaded
+# by Claude Code and is not scanned.
+#
+# Escape hatch: scripts/hook-userconfig-argv-allowlist.txt lists repo-relative
+# file paths permitted to carry the token — reserved for a ratified channel D
+# (`required:true` + argv, no unset case) adoption per the convention's
+# Open-gaps probe. An allowlist entry whose file is missing or clean is stale
+# and fails the gate, so the list can only shrink back to reality.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "check-hook-userconfig-argv: jq is required but not installed" >&2
+  exit 1
+fi
+
+ALLOWLIST="scripts/hook-userconfig-argv-allowlist.txt"
+# shellcheck disable=SC2016  # single quotes are deliberate: the token is matched literally, never expanded
+TOKEN='${user_config.'
+
+# CRLF tolerance: on Windows (Git Bash) jq and text files can carry \r line
+# endings; strip them from every value read, or path tests silently miss.
+allowed() {
+  local path="$1"
+  [[ -f "$ALLOWLIST" ]] || return 1
+  tr -d '\r' <"$ALLOWLIST" | grep -Fxq "$path"
+}
+
+errors=0
+declare -A flagged_or_allowed=()
+
+flag() {
+  local file="$1" where="$2"
+  flagged_or_allowed["$file"]=1
+  # shellcheck disable=SC2310  # allowed only greps a static file; nothing inside it can fail unexpectedly
+  if allowed "$file"; then
+    return 0
+  fi
+  echo "USERCONFIG ARGV: ${file}:${where}: bare \${user_config.*} in plugin hook config" >&2
+  errors=$((errors + 1))
+}
+
+# scan_file <repo-relative hook config path>
+scan_file() {
+  local file="$1" hits line
+  [[ -f "$file" ]] || return 0
+  hits="$(grep -nF "$TOKEN" "$file" || true)"
+  [[ -n "$hits" ]] || return 0
+  while IFS= read -r line; do
+    flag "$file" "${line%%:*}"
+  done <<<"$hits"
+}
+
+for plugin in plugins/*/; do
+  plugin="${plugin%/}"
+  manifest="$plugin/.claude-plugin/plugin.json"
+
+  # Default location, always loaded when present.
+  scan_file "$plugin/hooks/hooks.json"
+
+  [[ -f "$manifest" ]] || continue
+  hooks_type="$(jq -r '.hooks | type' "$manifest" 2>/dev/null | tr -d '\r' || echo invalid)"
+  case "$hooks_type" in
+  string)
+    rel="$(jq -r '.hooks' "$manifest" | tr -d '\r')"
+    scan_file "$plugin/${rel#./}"
+    ;;
+  array)
+    while IFS= read -r rel; do
+      rel="${rel%$'\r'}"
+      [[ -n "$rel" ]] && scan_file "$plugin/${rel#./}"
+    done < <(jq -r '.hooks[] | select(type == "string")' "$manifest" 2>/dev/null || true)
+    ;;
+  object)
+    if jq -c '.hooks' "$manifest" 2>/dev/null | grep -qF "$TOKEN"; then
+      flag "$manifest" "inline hooks object"
+    fi
+    ;;
+  *) ;; # null, absent, or unparsable manifest (manifest validity has its own gate)
+  esac
+done
+
+# Stale-allowlist guard: every entry must name a scanned hook config that still
+# carries the token; anything else is drift the list must shed.
+if [[ -f "$ALLOWLIST" ]]; then
+  while IFS= read -r entry; do
+    entry="${entry%$'\r'}"
+    [[ -z "$entry" || "$entry" == \#* ]] && continue
+    if [[ -z "${flagged_or_allowed[$entry]:-}" ]]; then
+      echo "STALE ALLOWLIST: $ALLOWLIST: '$entry' names no scanned hook config carrying \${user_config.*} — remove it" >&2
+      errors=$((errors + 1))
+    fi
+  done <"$ALLOWLIST"
+fi
+
+if ((errors > 0)); then
+  {
+    echo
+    echo "A \${user_config.*} token in a plugin hook config silently drops the"
+    echo "whole hook entry whenever the key is unset (declared defaults are not"
+    echo "implemented upstream). Deliver the value per the channel decision"
+    echo "matrix instead: docs/conventions/hook-config-delivery/README.md."
+  } >&2
+  exit 1
+fi
+echo "No bare \${user_config.*} tokens in plugin hook configs."

--- a/scripts/check-hook-userconfig-argv.sh
+++ b/scripts/check-hook-userconfig-argv.sh
@@ -59,6 +59,21 @@ flag() {
   errors=$((errors + 1))
 }
 
+# scan_manifest_path <plugin-dir> <manifest> <relative hooks path> — trust
+# boundary: a manifest-pointed hook config must stay inside its own plugin
+# directory. Reject absolute paths and any `..` segment (portable string
+# check — no realpath dependency) with a visible skip, so a crafted manifest
+# cannot point this gate at files outside the tree it claims to scan.
+scan_manifest_path() {
+  local plugin="$1" manifest="$2" rel="$3"
+  [[ -n "$rel" ]] || return 0
+  if [[ "$rel" == /* || "$rel" =~ ^[A-Za-z]: || "/$rel/" == *"/../"* ]]; then
+    echo "check-hook-userconfig-argv: skipping out-of-tree hooks path in $manifest: $rel" >&2
+    return 0
+  fi
+  scan_file "$plugin/${rel#./}"
+}
+
 # scan_file <repo-relative hook config path>
 scan_file() {
   local file="$1" hits line
@@ -82,12 +97,12 @@ for plugin in plugins/*/; do
   case "$hooks_type" in
   string)
     rel="$(jq -r '.hooks' "$manifest" | tr -d '\r')"
-    scan_file "$plugin/${rel#./}"
+    scan_manifest_path "$plugin" "$manifest" "$rel"
     ;;
   array)
     while IFS= read -r rel; do
       rel="${rel%$'\r'}"
-      [[ -n "$rel" ]] && scan_file "$plugin/${rel#./}"
+      scan_manifest_path "$plugin" "$manifest" "$rel"
     done < <(jq -r '.hooks[] | select(type == "string")' "$manifest" 2>/dev/null || true)
     ;;
   object)

--- a/scripts/check-hook-userconfig-argv.test.sh
+++ b/scripts/check-hook-userconfig-argv.test.sh
@@ -211,6 +211,24 @@ else
 fi
 rm -rf "$f"
 
+# --- JSON-escaped token spelling is caught by the decoded pass --------------
+# The fixture spells the underscore as the JSON backslash-u005f escape (built
+# via printf so the literal backslash survives this file's own quoting): raw
+# grep cannot see the token, but the loader-equivalent decoded pass must.
+f="$(new_fixture)"
+ESCAPED_HOOK="$(printf '{"hooks":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","args":["${user\\u005fconfig.some_toggle}"]}]}]}')"
+plugin_file "$f" alpha hooks/hooks.json "$ESCAPED_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "escaped token should fail, got success: $out"
+else
+  if echo "$out" | grep -q 'USERCONFIG ARGV: plugins/alpha/hooks/hooks.json:escaped token in decoded JSON'; then
+    ok "JSON-escaped token spelling fails via the decoded pass"
+  else
+    fail "expected decoded-pass flag, got: $out"
+  fi
+fi
+rm -rf "$f"
+
 # --- manifest with no hooks key passes --------------------------------------
 f="$(new_fixture)"
 plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha"}'

--- a/scripts/check-hook-userconfig-argv.test.sh
+++ b/scripts/check-hook-userconfig-argv.test.sh
@@ -211,6 +211,49 @@ else
 fi
 rm -rf "$f"
 
+# --- manifest with no hooks key passes --------------------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha"}'
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "manifest without a hooks key passes"
+else
+  fail "manifest without a hooks key should pass, got: $out"
+fi
+rm -rf "$f"
+
+# --- out-of-tree manifest hooks path is skipped, visibly --------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha","hooks":"../../outside.json"}'
+printf '%s\n' "$BARE_HOOK" >"$f/outside.json"
+if out="$(run_check "$f" 2>&1)"; then
+  if echo "$out" | grep -q 'skipping out-of-tree hooks path'; then
+    ok "out-of-tree manifest hooks path is skipped with a visible notice"
+  else
+    fail "expected visible out-of-tree skip notice, got: $out"
+  fi
+else
+  fail "out-of-tree path should be skipped (pass), got: $out"
+fi
+rm -rf "$f"
+
+# --- default and manifest-pointed configs both flagged ----------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha","hooks":"./config/extra-hooks.json"}'
+plugin_file "$f" alpha hooks/hooks.json "$BARE_HOOK"
+plugin_file "$f" alpha config/extra-hooks.json "$BARE_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "composite (default + manifest-pointed) should fail, got success: $out"
+else
+  if echo "$out" | grep -q 'USERCONFIG ARGV: plugins/alpha/hooks/hooks.json:' &&
+    echo "$out" | grep -q 'USERCONFIG ARGV: plugins/alpha/config/extra-hooks.json:'; then
+    ok "composite case flags both the default and the manifest-pointed config"
+  else
+    fail "expected both files flagged, got: $out"
+  fi
+fi
+rm -rf "$f"
+
 # --- unparsable manifest does not crash the gate ----------------------------
 f="$(new_fixture)"
 plugin_file "$f" alpha .claude-plugin/plugin.json '{not json'

--- a/scripts/check-hook-userconfig-argv.test.sh
+++ b/scripts/check-hook-userconfig-argv.test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Unit tests for check-hook-userconfig-argv.sh. Builds a tiny synthetic
+# plugins/ tree per scenario in a temp dir and invokes the script against it
+# directly -- the script's own `cd "$(dirname "$0")/.."` makes this work
+# unmodified: copy it to <fixture>/scripts/ and it scans <fixture>/plugins/.
+# shellcheck disable=SC2016  # fixture bodies are literal JSON with ${user_config.*} tokens; expansion is never wanted
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SELF_DIR/check-hook-userconfig-argv.sh"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+new_fixture() {
+  local dir
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/scripts" "$dir/plugins"
+  cp "$SCRIPT" "$dir/scripts/check-hook-userconfig-argv.sh"
+  chmod +x "$dir/scripts/check-hook-userconfig-argv.sh"
+  printf '%s' "$dir"
+}
+
+# plugin_file <fixture> <plugin> <relpath> <content>
+plugin_file() {
+  local fixture="$1" plugin="$2" rel="$3" content="$4"
+  mkdir -p "$fixture/plugins/$plugin/$(dirname "$rel")"
+  printf '%s\n' "$content" >"$fixture/plugins/$plugin/$rel"
+}
+
+run_check() (
+  cd "$1" && bash scripts/check-hook-userconfig-argv.sh
+)
+
+BARE_HOOK='{
+  "hooks": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh",
+          "args": ["--enabled", "${user_config.some_toggle}"]
+        }
+      ]
+    }
+  ]
+}'
+
+CLEAN_HOOK='{
+  "hooks": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh" }
+      ]
+    }
+  ]
+}'
+
+# --- bare token in default hooks/hooks.json fails ---------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$BARE_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "bare token in hooks/hooks.json should fail, got success: $out"
+else
+  if echo "$out" | grep -q 'USERCONFIG ARGV: plugins/alpha/hooks/hooks.json:'; then
+    ok "bare token in default hooks.json fails with file:line"
+  else
+    fail "expected USERCONFIG ARGV with file:line, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- clean hooks.json passes ------------------------------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "clean hooks.json passes"
+else
+  fail "clean hooks.json should pass, got: $out"
+fi
+rm -rf "$f"
+
+# --- token in an MCP config is out of scope ---------------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+plugin_file "$f" alpha .mcp.json '{"mcpServers":{"svc":{"env":{"TOKEN":"${user_config.api_token}"}}}}'
+if out="$(run_check "$f" 2>&1)"; then
+  ok "token in MCP config stays out of scope"
+else
+  fail "MCP config token should not be flagged, got: $out"
+fi
+rm -rf "$f"
+
+# --- manifest string-path hook config with token fails ----------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha","hooks":"./config/extra-hooks.json"}'
+plugin_file "$f" alpha config/extra-hooks.json "$BARE_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "manifest-pointed hook file with token should fail, got success: $out"
+else
+  if echo "$out" | grep -q 'USERCONFIG ARGV: plugins/alpha/config/extra-hooks.json:'; then
+    ok "manifest string-path hook config fails"
+  else
+    fail "expected flag on manifest-pointed file, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- manifest array of hook paths: token in one element fails ---------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha","hooks":["./hooks/hooks.json","./config/extra-hooks.json"]}'
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+plugin_file "$f" alpha config/extra-hooks.json "$BARE_HOOK"
+if run_check "$f" >/dev/null 2>&1; then
+  fail "token in one of the manifest array paths should fail"
+else
+  ok "manifest array hook config fails on the offending element"
+fi
+rm -rf "$f"
+
+# --- inline manifest hooks object with token fails --------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha","hooks":{"hooks":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","args":["${user_config.k}"]}]}]}}'
+if out="$(run_check "$f" 2>&1)"; then
+  fail "inline manifest hooks object with token should fail, got success: $out"
+else
+  if echo "$out" | grep -q 'USERCONFIG ARGV: plugins/alpha/.claude-plugin/plugin.json:inline hooks object'; then
+    ok "inline manifest hooks object fails"
+  else
+    fail "expected inline-object flag, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- token elsewhere in the manifest (not hooks) passes ---------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{"name":"alpha","mcpServers":{"svc":{"env":{"T":"${user_config.api_token}"}}},"hooks":{"hooks":[]}}'
+if out="$(run_check "$f" 2>&1)"; then
+  ok "token in manifest outside the hooks object passes"
+else
+  fail "non-hooks manifest token should pass, got: $out"
+fi
+rm -rf "$f"
+
+# --- unreferenced hooks/*.json sibling is not scanned -----------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+plugin_file "$f" alpha hooks/unreferenced.json "$BARE_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "unreferenced hooks/*.json sibling stays unscanned"
+else
+  fail "unreferenced sibling should not be flagged, got: $out"
+fi
+rm -rf "$f"
+
+# --- allowlisted file with token passes -------------------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$BARE_HOOK"
+printf '%s\n' 'plugins/alpha/hooks/hooks.json' >"$f/scripts/hook-userconfig-argv-allowlist.txt"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "allowlisted hook config passes"
+else
+  fail "allowlisted hook config should pass, got: $out"
+fi
+rm -rf "$f"
+
+# --- stale allowlist entry (file clean) fails -------------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+printf '%s\n' 'plugins/alpha/hooks/hooks.json' >"$f/scripts/hook-userconfig-argv-allowlist.txt"
+if out="$(run_check "$f" 2>&1)"; then
+  fail "stale allowlist entry should fail, got success: $out"
+else
+  if echo "$out" | grep -q 'STALE ALLOWLIST:'; then
+    ok "stale allowlist entry (clean file) fails"
+  else
+    fail "expected STALE ALLOWLIST, got: $out"
+  fi
+fi
+rm -rf "$f"
+
+# --- stale allowlist entry (file missing) fails -----------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+printf '%s\n' 'plugins/gone/hooks/hooks.json' >"$f/scripts/hook-userconfig-argv-allowlist.txt"
+if run_check "$f" >/dev/null 2>&1; then
+  fail "allowlist entry for a missing file should fail"
+else
+  ok "stale allowlist entry (missing file) fails"
+fi
+rm -rf "$f"
+
+# --- allowlist comments and blank lines are inert ---------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+printf '%s\n' '# reserved for a ratified channel D adoption' '' >"$f/scripts/hook-userconfig-argv-allowlist.txt"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "allowlist comments and blank lines are inert"
+else
+  fail "comment-only allowlist should pass, got: $out"
+fi
+rm -rf "$f"
+
+# --- unparsable manifest does not crash the gate ----------------------------
+f="$(new_fixture)"
+plugin_file "$f" alpha .claude-plugin/plugin.json '{not json'
+plugin_file "$f" alpha hooks/hooks.json "$CLEAN_HOOK"
+if out="$(run_check "$f" 2>&1)"; then
+  ok "unparsable manifest is skipped (manifest validity has its own gate)"
+else
+  fail "unparsable manifest should not fail this gate, got: $out"
+fi
+rm -rf "$f"
+
+echo
+echo "passed: $PASS, failed: $FAIL"
+((FAIL == 0)) || exit 1

--- a/scripts/hook-userconfig-argv-allowlist.txt
+++ b/scripts/hook-userconfig-argv-allowlist.txt
@@ -1,0 +1,8 @@
+# Allowlist for scripts/check-hook-userconfig-argv.sh — repo-relative paths of
+# plugin hook configs permitted to carry a ${user_config.*} token.
+#
+# Reserved for a ratified channel D adoption (`required:true` + argv — no unset
+# case, so the upstream default-drop cannot fire). Channel D's premise is
+# unproven (docs/conventions/hook-config-delivery/README.md, Open gaps); do not
+# add an entry before that probe passes and the convention records the result.
+# A stale entry (file missing, or no longer carrying the token) fails the gate.


### PR DESCRIPTION
## Summary

Codifies the userConfig→hook **channel decision matrix** as a new `hook-*` family owner doc,
`docs/conventions/hook-config-delivery/` (README + CHANGELOG, `contract_version` 1.0), registered in
the PLUGIN-PHILOSOPHY convention registry. It composes with `config-cascade` (which owns
consumer-tracked file layering; this owns the harness-prompted userConfig path), characterizes
channels A–F — including the direct-settings-read channel (F) that disk-hygiene 0.9.0 shipped in
#1242 — and version-pins every upstream fact to CC 2.1.218 with explicit recheck triggers
(docs re-fetched 2026-07-24; behavioral facts from the 2026-07-23 fresh-session probe).

Enforces the matrix's "never bare argv" rule with a new **`userconfig-argv-gate`** CI lane:
`scripts/check-hook-userconfig-argv.sh` fails on any `${user_config.*}` token in a plugin hook
config — the default `hooks/hooks.json`, manifest-pointed hook files (string or array), and inline
manifest `hooks` objects. MCP/LSP configs are out of scope (substitution there is sanctioned). A
stale-guarded allowlist (`scripts/hook-userconfig-argv-allowlist.txt`, currently comment-only) is
reserved for a ratified channel D adoption once the G-required probe passes. This pins the exact
regression #1242 fixed: an unset-but-defaulted argv token silently drops the whole hook entry
(upstream `default` unimplemented — anthropics/claude-code#46477, closed not-planned).

## Test plan

- `bash scripts/check-hook-userconfig-argv.test.sh` — 13/13 scenarios green (bare token in default /
  manifest-pointed / array / inline configs fail with file:line; clean, MCP, unreferenced-sibling,
  non-hooks-manifest cases stay quiet; allowlist honored; stale allowlist entries fail; comments
  inert; unparsable manifest skipped). CRLF-tolerant on Windows (jq emits `\r` under Git Bash).
- `bash scripts/check-hook-userconfig-argv.sh` — real tree passes (0.9.0 already removed the last
  bare token).
- `shellcheck --rcfile=.shellcheckrc` clean on both scripts; `actionlint` + YAML parse clean on
  `ci.yml`; `markdownlint-cli2` clean on the new/edited docs.
- CI job runs its self-test first (broken-detector-cannot-mask pattern) and is wired into the
  `ci-status` needs aggregate.

## Related

No related issue: the delivery-channel program is tracked outside this tracker; this PR closes
nothing. Context: supersedes the draft matrix in #1182 (which stays open, demoted to the
adoption/tracking pointer), builds on #1242 (disk-hygiene 0.9.0, closed #1019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
