### PR TITLE
docs(plugin-audit-port): correct the context: fork rejection rationale

### DIFF
--- a/docs/topics/plugin-audit-port/PLAN.md
+++ b/docs/topics/plugin-audit-port/PLAN.md
@@ -598,7 +598,10 @@ since `$ARGUMENTS` is exactly that channel and
 Each rationale argued from what fork does. The requirement does not depend on that, so it is stated
 positively instead. The deep phase needs two properties:
 
-1. **A context that provably excludes this session's evidence** — the whole point of the gate.
+1. **A context carrying the evidence packet but NOT this session's conversation history or prior
+   reasoning.** The packet is the deliberate channel — `agents/auditor.md`'s procedure opens by
+   reading it as ground truth, and step 1 exists to write it. What must not cross is the reasoning
+   that produced the work under review; that is what a same-context self-check cannot escape.
 2. **A named dispatch target** — the Brief's requirement, and what makes the dispatch site
    auditable: a reader sees which worker runs the deep phase without inferring it from file layout.
 

--- a/docs/topics/plugin-audit-port/PLAN.md
+++ b/docs/topics/plugin-audit-port/PLAN.md
@@ -457,7 +457,7 @@ Create `plugins/context-guard/`:
 |---|---|
 | Extend `rate-limit-guard` with the context tee | Owner decision R2: separate concerns; reuse the pattern, not the plugin |
 | Join `review` / `skill-quality` | Fails the distinct-discovery-intent test (playbook Organization) |
-| `context: fork` for the deep audit | Cannot express the audit's step topology — basis in the `[EXEC-SHAPE]` agent decision below |
+| `context: fork` for the deep audit | Not impossible — rejected on cost. Would require a second skill existing only to be forked, spending shared skill-listing budget for zero user-facing capability. The requirement it must beat is stated as an invariant (fresh context + named dispatch target) in the `[EXEC-SHAPE]` agent decision below, deliberately independent of what any fork inherits |
 | Fixed zone bands as tee-contract constants | Zones are per-consumer judgment knobs; unlike the 90% rate-limit floor there is no writer/reader split-brain risk forcing a constant |
 | `userConfig` for sink/inbox | Per-repo-ish policy → tracked config cascade; `pluginConfigs` is user-settings-only |
 | Verbatim 7-step port | Steps 4–5 overlapped; collapsed to one interactive contract-lock step (owner wants improvement, not a copy) |
@@ -588,14 +588,29 @@ The basis is topological — what the forked unit *is*:
    ([skills](https://code.claude.com/docs/en/skills),
    [sub-agents](https://code.claude.com/docs/en/sub-agents), verified 2026-07-24).
 
-Splitting steps 2–3 into their own `context: fork` sibling skill does not rescue the mechanism
-either: the `auditor` needs a dispatch prompt composed per run (packet path, resolved target, the
-selected component-type lens files), whereas a forked skill's prompt is its static body plus
-`$ARGUMENTS`.
+**Restated as an invariant, after two earlier rationales were defeated in review.** The first
+claimed `context: fork` inherits degraded history — false; a forked skill has no conversation
+access. The second claimed a forked skill is anonymous — false; the `agent` frontmatter field names
+the subagent type. The third claimed a forked sibling could not receive per-run inputs — also false,
+since `$ARGUMENTS` is exactly that channel and
+`plugins/discovery/skills/explore-deep/SKILL.md` ships the pattern.
 
-Recorded caveat, unverified: #1258 reports the Agent tool's `fork` subagent type not inheriting the
-conversation in practice. That report concerns the other mechanism and does not bear on this
-decision; it is carried here so the observation is not lost.
+Each rationale argued from what fork does. The requirement does not depend on that, so it is stated
+positively instead. The deep phase needs two properties:
+
+1. **A context that provably excludes this session's evidence** — the whole point of the gate.
+2. **A named dispatch target** — the Brief's requirement, and what makes the dispatch site
+   auditable: a reader sees which worker runs the deep phase without inferring it from file layout.
+
+`agents/auditor.md` supplies both, and the plugin already ships it. A forked sibling skill could
+satisfy (1) and, via `agent:`, arguably (2) — so it is not rejected as impossible. It is rejected on
+cost: it requires shipping a second skill whose only purpose is to be forked, spending shared
+skill-listing budget (#1271 measures that budget and the silent description drops it causes) for
+zero user-facing capability, and splitting one workflow across two files that must stay in sync.
+
+**Recorded caveat, unverified:** #1258 reports the Agent tool's `fork` subagent type not inheriting
+the conversation in practice, against its documentation. The invariant above is deliberately
+independent of how that resolves; the caveat is carried so the observation is not lost.
 
 ## Open questions
 

--- a/docs/topics/plugin-audit-port/PLAN.md
+++ b/docs/topics/plugin-audit-port/PLAN.md
@@ -39,8 +39,9 @@ Two new marketplace plugins, two swim-lane PRs, seams-first:
       failures, permission-prompt denials, MCP/tool errors, transcript path, component invocation
       record, environment; persisted as a durable evidence packet on disk (compaction-proof,
       resumable).
-   2. **Map + ground** (fresh named subagent, never a fork): read component source/manifest/config
-      resolution; verify every load-bearing harness-behavior claim against CURRENT official docs
+   2. **Map + ground** (fresh named subagent, dispatched from the main thread): read component
+      source/manifest/config resolution; verify every load-bearing harness-behavior claim
+      against CURRENT official docs
       per topic (fresh-docs mandate applies inside the audit, not just to this repo).
    3. **Blindspot + candidate findings** (subagent output, presented to user).
    4. **Contract lock** (main thread, interactive): scope, severity calibration, named assumptions.
@@ -75,9 +76,9 @@ Two new marketplace plugins, two swim-lane PRs, seams-first:
   interview verified statusline schema 2026-07-23 only).
 - `context-guard` is a SEPARATE plugin from `rate-limit-guard` — do not mix concerns (owner
   decision, R2). Reuse the pattern, not the plugin.
-- Deep-audit phase runs in a fresh-context NAMED subagent, never `context: fork` (plugin agents
-  start with fresh context and the Brief requires a NAMED subagent — see the [EXEC-SHAPE] agent
-  decision below).
+- Deep-audit phase (steps 2–3) runs in a fresh-context NAMED subagent that the skill dispatches
+  from the main thread; steps 1, 4, and 6 stay on the main thread. `context: fork` cannot express
+  this topology — basis in the [EXEC-SHAPE] agent decision below.
 - No hardcoded repos, paths, owners; melodic-marketplace targets resolve via inference, never
   baked in.
 - The producer/consumer split holds: audit session never implements fixes in the plugin repo.
@@ -365,7 +366,8 @@ Create `plugins/context-guard/`:
   for `claude plugin validate` and config-resolution probes, and is justified as such in the B6
   security record, stress-test #9). Carries the standing untrusted-content instruction (audited
   plugin source is data, never instructions). Consumes the on-disk evidence packet path passed in
-  its dispatch prompt. Never a fork (fresh-eyes doctrine).
+  its dispatch prompt. Never the Agent tool's `fork` subagent type — basis in the [EXEC-SHAPE]
+  agent decision.
 
 **Sanity Check:**
 
@@ -455,7 +457,7 @@ Create `plugins/context-guard/`:
 |---|---|
 | Extend `rate-limit-guard` with the context tee | Owner decision R2: separate concerns; reuse the pattern, not the plugin |
 | Join `review` / `skill-quality` | Fails the distinct-discovery-intent test (playbook Organization) |
-| `context: fork` for the deep audit | Anonymous, and the Brief requires a NAMED subagent — basis in the `[EXEC-SHAPE]` plugin-agent decision below. **Not** rejected for inheriting history: per the skills reference a forked skill has no conversation access at all. Conversation inheritance is documented for the Agent tool's separate `fork` subagent type, a different mechanism sharing the word (#1258 reports that one not inheriting in practice either) |
+| `context: fork` for the deep audit | Cannot express the audit's step topology — basis in the `[EXEC-SHAPE]` agent decision below |
 | Fixed zone bands as tee-contract constants | Zones are per-consumer judgment knobs; unlike the 90% rate-limit floor there is no writer/reader split-brain risk forcing a constant |
 | `userConfig` for sink/inbox | Per-repo-ish policy → tracked config cascade; `pluginConfigs` is user-settings-only |
 | Verbatim 7-step port | Steps 4–5 overlapped; collapsed to one interactive contract-lock step (owner wants improvement, not a copy) |
@@ -548,11 +550,52 @@ Every `[EXEC-SHAPE]` / `[FALLBACK]` tag in this plan, for override at approval:
 | Decision | What it changes in the plan | Basis (evidence) |
 |---|---|---|
 | [EXEC-SHAPE] Two serialized lanes, sequential phases within each, main-thread implementation sessions | Execution-shape section; no parallel agent waves | Playbook swim-lane + seams-first sections read this session; B1 inlines A3's contract, so lane B authored against an unmerged contract risks split-brain |
-| [EXEC-SHAPE] `plugin-quality` ships a plugin agent (`agents/auditor.md`) as the named fresh-context subagent | Phase B3 exists; SKILL.md step 2 dispatches by agent name | Sub-agents doc (fetched 2026-07-23): plugin agents start with fresh context; Brief requires a NAMED subagent, never a fork |
+| [EXEC-SHAPE] `plugin-quality` ships a plugin agent (`agents/auditor.md`) as the named fresh-context subagent that the main-thread skill dispatches for steps 2–3 | Phase B3 exists; SKILL.md step 2 dispatches by agent name; steps 1, 4, 6 stay main-thread | The audit's step topology is not expressible as `context: fork` — basis in full below |
 | [EXEC-SHAPE] context-guard setup `apply` scoped to seeding/refreshing zones.json only | Phase A4 apply surface; statusline wiring stays print-only | Philosophy setup contract (never mutate user settings) + rate-limit-guard check-only precedent; zones.json is the one machine file whose schema the plugin owns |
 | [FALLBACK — confirm or override] Design gate satisfied by `design/design-resolution.md` early-exit instead of a `/planning:design` pass | No separate design stage before implementation | Interview resolved all design threads (15 branches, owner-confirmed 2026-07-23); artifact maps each design axis to its ledger branch |
 | [FALLBACK — confirm or override] Draft+confirm read as the `audit` verb's "explicit user override" for the `gh issue create` emit | B1 emit design; no `--apply`-style argument gating the sink | Brief B14 locks unconditional draft+confirm; fleet precedent (`github:audit`) uses `--apply` instead — deviation recorded at the coupling site |
 | [FALLBACK — confirm or override] Default zone bands: smart ≤ 50, acceptable 50–75, dumb > 75 | A2 shipped defaults; B1 inlined fallback constants | No documented auto-compact threshold exists (4 doc pages fetched 2026-07-23); judgment values with the A2 empirical-ordering task + zones.json override as correction paths |
+
+### [EXEC-SHAPE] basis — why the deep audit is a dispatched named agent, not `context: fork`
+
+This subsection is the single home for that basis; every other site points here.
+
+Neither "fresh context" nor "named" discriminates, so neither is the reason. A forked skill starts
+blank — "It won't have access to your conversation history" — and the `agent` frontmatter field
+selects the subagent type to run: "Which subagent type to use when `context: fork` is set"
+([skills](https://code.claude.com/docs/en/skills), verified 2026-07-24). So `context: fork` plus
+`agent: auditor` would already be a fresh-context, named-agent-type run; `discovery`'s
+`explore-deep` ships that pairing in this repo. The fresh-eyes doctrine is not the reason either:
+it rules out the Agent tool's separate `fork` subagent type, which "inherits the entire
+conversation so far instead of starting fresh"
+([sub-agents](https://code.claude.com/docs/en/sub-agents), verified 2026-07-24) — a different
+mechanism that shares the word.
+
+The basis is topological — what the forked unit *is*:
+
+1. **`context: fork` forks the whole skill, and only steps 2–3 want a fresh context.** "The skill
+   content becomes the prompt that drives the subagent" — the entire body goes to the subagent, so
+   steps 1, 4, and 6 would go with it. A skill cannot fork one of its own steps.
+2. **Step 1 could not run at all.** Evidence capture reads what was invoked this session, the hook
+   failures and permission denials observed, the anomaly that prompted the audit — that *is*
+   conversation history, the one thing a forked skill is documented not to have. Forking the skill
+   destroys the audit's only input.
+3. **Steps 4 and 6 need user-interactive surfaces a forked skill lacks.** The contract-lock
+   interview and the unconditional egress confirm gate must ask the user. `AskUserQuestion` is
+   removed from every subagent "even when listed in the `tools` field"; forks that inherit the
+   conversation skip that filter, but a forked *skill* does not — "the skill's subagent is a
+   regular agent type, so the exemption for subagents that fork the conversation doesn't cover it"
+   ([skills](https://code.claude.com/docs/en/skills),
+   [sub-agents](https://code.claude.com/docs/en/sub-agents), verified 2026-07-24).
+
+Splitting steps 2–3 into their own `context: fork` sibling skill does not rescue the mechanism
+either: the `auditor` needs a dispatch prompt composed per run (packet path, resolved target, the
+selected component-type lens files), whereas a forked skill's prompt is its static body plus
+`$ARGUMENTS`.
+
+Recorded caveat, unverified: #1258 reports the Agent tool's `fork` subagent type not inheriting the
+conversation in practice. That report concerns the other mechanism and does not bear on this
+decision; it is carried here so the observation is not lost.
 
 ## Open questions
 

--- a/docs/topics/plugin-audit-port/PLAN.md
+++ b/docs/topics/plugin-audit-port/PLAN.md
@@ -455,7 +455,7 @@ Create `plugins/context-guard/`:
 |---|---|
 | Extend `rate-limit-guard` with the context tee | Owner decision R2: separate concerns; reuse the pattern, not the plugin |
 | Join `review` / `skill-quality` | Fails the distinct-discovery-intent test (playbook Organization) |
-| `context: fork` for the deep audit | Brief requires a NAMED subagent; a forked skill is anonymous. Not rejected for inheriting history: the skills reference states a forked skill has no access to the conversation. Conversation inheritance is documented for the Agent tool's separate `fork` subagent type — a different mechanism sharing the word, and one #1258 reports as not inheriting in practice either |
+| `context: fork` for the deep audit | Anonymous, and the Brief requires a NAMED subagent — basis in the `[EXEC-SHAPE]` plugin-agent decision below. **Not** rejected for inheriting history: per the skills reference a forked skill has no conversation access at all. Conversation inheritance is documented for the Agent tool's separate `fork` subagent type, a different mechanism sharing the word (#1258 reports that one not inheriting in practice either) |
 | Fixed zone bands as tee-contract constants | Zones are per-consumer judgment knobs; unlike the 90% rate-limit floor there is no writer/reader split-brain risk forcing a constant |
 | `userConfig` for sink/inbox | Per-repo-ish policy → tracked config cascade; `pluginConfigs` is user-settings-only |
 | Verbatim 7-step port | Steps 4–5 overlapped; collapsed to one interactive contract-lock step (owner wants improvement, not a copy) |

--- a/docs/topics/plugin-audit-port/PLAN.md
+++ b/docs/topics/plugin-audit-port/PLAN.md
@@ -75,8 +75,9 @@ Two new marketplace plugins, two swim-lane PRs, seams-first:
   interview verified statusline schema 2026-07-23 only).
 - `context-guard` is a SEPARATE plugin from `rate-limit-guard` — do not mix concerns (owner
   decision, R2). Reuse the pattern, not the plugin.
-- Deep-audit phase runs in a fresh-context NAMED subagent, never `context: fork` (fork inherits the
-  degraded history — PLUGIN-PHILOSOPHY fresh-eyes doctrine).
+- Deep-audit phase runs in a fresh-context NAMED subagent, never `context: fork` (plugin agents
+  start with fresh context and the Brief requires a NAMED subagent — see the [EXEC-SHAPE] agent
+  decision below).
 - No hardcoded repos, paths, owners; melodic-marketplace targets resolve via inference, never
   baked in.
 - The producer/consumer split holds: audit session never implements fixes in the plugin repo.
@@ -454,7 +455,7 @@ Create `plugins/context-guard/`:
 |---|---|
 | Extend `rate-limit-guard` with the context tee | Owner decision R2: separate concerns; reuse the pattern, not the plugin |
 | Join `review` / `skill-quality` | Fails the distinct-discovery-intent test (playbook Organization) |
-| `context: fork` for the deep audit | Inherits the degraded history the gate exists to escape (fresh-eyes doctrine) |
+| `context: fork` for the deep audit | Brief requires a NAMED subagent; a forked skill is anonymous. Not rejected for inheriting history: the skills reference states a forked skill has no access to the conversation. Conversation inheritance is documented for the Agent tool's separate `fork` subagent type — a different mechanism sharing the word, and one #1258 reports as not inheriting in practice either |
 | Fixed zone bands as tee-contract constants | Zones are per-consumer judgment knobs; unlike the 90% rate-limit floor there is no writer/reader split-brain risk forcing a constant |
 | `userConfig` for sink/inbox | Per-repo-ish policy → tracked config cascade; `pluginConfigs` is user-settings-only |
 | Verbatim 7-step port | Steps 4–5 overlapped; collapsed to one interactive contract-lock step (owner wants improvement, not a copy) |

--- a/docs/topics/plugin-audit-port/PLAN.md
+++ b/docs/topics/plugin-audit-port/PLAN.md
@@ -77,8 +77,9 @@ Two new marketplace plugins, two swim-lane PRs, seams-first:
 - `context-guard` is a SEPARATE plugin from `rate-limit-guard` — do not mix concerns (owner
   decision, R2). Reuse the pattern, not the plugin.
 - Deep-audit phase (steps 2–3) runs in a fresh-context NAMED subagent that the skill dispatches
-  from the main thread; steps 1, 4, and 6 stay on the main thread. `context: fork` cannot express
-  this topology — basis in the [EXEC-SHAPE] agent decision below.
+  from the main thread; steps 1, 4, and 6 stay on the main thread. `context: fork` is not chosen —
+  rejected on listing-budget and synchronization cost, not as inexpressible; basis in the
+  [EXEC-SHAPE] agent decision below.
 - No hardcoded repos, paths, owners; melodic-marketplace targets resolve via inference, never
   baked in.
 - The producer/consumer split holds: audit session never implements fixes in the plugin repo.

--- a/docs/topics/plugin-audit-port/design/design-resolution.md
+++ b/docs/topics/plugin-audit-port/design/design-resolution.md
@@ -22,7 +22,7 @@ surfaced in the plan's decisions table; the owner may still demand a full `/desi
 | Module boundaries | Two standalone plugins (`context-guard`, `plugin-quality`); explicitly NOT an extension of `rate-limit-guard` and NOT joined to `review`/`skill-quality` | B1, B11, B12 |
 | New types/contracts | Snapshot file, zones file, resolver CLI, tracked config file, evidence packet (sketches below) | B12, B15, B8 |
 | Cross-module integration | Soft dependency via documented reader contract (file seam); no manifest `dependencies`; absent/stale → conservative fallback + visible notice | B13 |
-| Execution topology | Two-phase audit: main-thread evidence capture → fresh NAMED subagent (never `context: fork`) | B3, B7 |
+| Execution topology | Two-phase audit: main-thread evidence capture → fresh NAMED subagent (never `context: fork` — the Brief requires a named subagent and a forked skill is anonymous; both start with fresh context) | B3, B7 |
 | Configurability | Tracked `.claude/plugin-quality.md` per config-cascade; user-global `~/.claude/plugin-quality.md`; no `userConfig` v1 | B8 |
 | External integration | Sink = backend-neutral work-item vocabulary; default `gh` issue with draft+confirm egress gate; resolution ladder | B2, B6, B14 |
 | Observability | Zones SSOT readable by both consumers and the operator's statusline (kills display-vs-consumer drift) | B15 |

--- a/docs/topics/plugin-audit-port/design/design-resolution.md
+++ b/docs/topics/plugin-audit-port/design/design-resolution.md
@@ -22,7 +22,7 @@ surfaced in the plan's decisions table; the owner may still demand a full `/desi
 | Module boundaries | Two standalone plugins (`context-guard`, `plugin-quality`); explicitly NOT an extension of `rate-limit-guard` and NOT joined to `review`/`skill-quality` | B1, B11, B12 |
 | New types/contracts | Snapshot file, zones file, resolver CLI, tracked config file, evidence packet (sketches below) | B12, B15, B8 |
 | Cross-module integration | Soft dependency via documented reader contract (file seam); no manifest `dependencies`; absent/stale → conservative fallback + visible notice | B13 |
-| Execution topology | Two-phase audit: main-thread evidence capture → fresh NAMED subagent (never `context: fork`); basis in `PLAN.md`'s `[EXEC-SHAPE]` plugin-agent decision | B3, B7 |
+| Execution topology | Main-thread skill (steps 1, 4, 6) dispatching steps 2–3 to a fresh NAMED subagent; not `context: fork` — basis in `PLAN.md`'s `[EXEC-SHAPE]` agent decision | B3, B7 |
 | Configurability | Tracked `.claude/plugin-quality.md` per config-cascade; user-global `~/.claude/plugin-quality.md`; no `userConfig` v1 | B8 |
 | External integration | Sink = backend-neutral work-item vocabulary; default `gh` issue with draft+confirm egress gate; resolution ladder | B2, B6, B14 |
 | Observability | Zones SSOT readable by both consumers and the operator's statusline (kills display-vs-consumer drift) | B15 |

--- a/docs/topics/plugin-audit-port/design/design-resolution.md
+++ b/docs/topics/plugin-audit-port/design/design-resolution.md
@@ -22,7 +22,7 @@ surfaced in the plan's decisions table; the owner may still demand a full `/desi
 | Module boundaries | Two standalone plugins (`context-guard`, `plugin-quality`); explicitly NOT an extension of `rate-limit-guard` and NOT joined to `review`/`skill-quality` | B1, B11, B12 |
 | New types/contracts | Snapshot file, zones file, resolver CLI, tracked config file, evidence packet (sketches below) | B12, B15, B8 |
 | Cross-module integration | Soft dependency via documented reader contract (file seam); no manifest `dependencies`; absent/stale → conservative fallback + visible notice | B13 |
-| Execution topology | Two-phase audit: main-thread evidence capture → fresh NAMED subagent (never `context: fork` — the Brief requires a named subagent and a forked skill is anonymous; both start with fresh context) | B3, B7 |
+| Execution topology | Two-phase audit: main-thread evidence capture → fresh NAMED subagent (never `context: fork`); basis in `PLAN.md`'s `[EXEC-SHAPE]` plugin-agent decision | B3, B7 |
 | Configurability | Tracked `.claude/plugin-quality.md` per config-cascade; user-global `~/.claude/plugin-quality.md`; no `userConfig` v1 | B8 |
 | External integration | Sink = backend-neutral work-item vocabulary; default `gh` issue with draft+confirm egress gate; resolution ladder | B2, B6, B14 |
 | Observability | Zones SSOT readable by both consumers and the operator's statusline (kills display-vs-consumer drift) | B15 |

--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-07-25
+
+### Changed
+
+- `skills/audit` step 2 no longer justifies its dispatch by what a fork inherits. Three successive
+  rationales for rejecting `context: fork` were each defeated in review, so the requirement is now
+  stated as an invariant the step must satisfy — a context that provably excludes the session's
+  evidence, and a named dispatch target that makes the dispatch site auditable — and the `auditor`
+  agent supplies both. The framing holds either way on #1258, which reports the Agent tool's `fork`
+  subagent type not inheriting the conversation in practice, against its documentation.
+
 ## [0.1.1] - 2026-07-24
 
 ### Fixed

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-07-24
+
+### Fixed
+
+- `skills/audit` step 2 no longer claims a fork "would inherit this session's degraded history".
+  That is false for a skill's `context: fork` frontmatter, which starts the subagent with no
+  conversation history; conversation inheritance belongs to the Agent tool's separate `fork`
+  subagent type. The step now names that type explicitly and also forbids running inline.
+- `skills/audit/references/component-types/skill.md` composition lens no longer asserts that a
+  forked sub-skill "loses history" as a defect; it asks whether the inline-vs-`context: fork`
+  choice matches what the step needs, and names the mechanism.
+
 ## [0.1.0] - 2026-07-24
 
 ### Added

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -11,10 +11,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `skills/audit` step 2 no longer justifies its dispatch by what a fork inherits. Three successive
   rationales for rejecting `context: fork` were each defeated in review, so the requirement is now
-  stated as an invariant the step must satisfy — a context that provably excludes the session's
-  evidence, and a named dispatch target that makes the dispatch site auditable — and the `auditor`
-  agent supplies both. The framing holds either way on #1258, which reports the Agent tool's `fork`
-  subagent type not inheriting the conversation in practice, against its documentation.
+  stated as an invariant the step must satisfy: a context that carries the evidence packet but
+  **not** this session's conversation history or prior reasoning, plus a named dispatch target that
+  makes the dispatch site auditable. The `auditor` agent supplies both — and the packet crossing the
+  boundary is deliberate, since the agent reads it as ground truth. The framing holds either way on
+  #1258, which reports the Agent tool's `fork` subagent type not inheriting the conversation in
+  practice, against its documentation.
 
 ## [0.1.1] - 2026-07-24
 

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -16,6 +16,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `skills/audit/references/component-types/skill.md` composition lens no longer asserts that a
   forked sub-skill "loses history" as a defect; it asks whether the inline-vs-`context: fork`
   choice matches what the step needs, and names the mechanism.
+- `agents/auditor.md` says why it has no conversation history — it is a named subagent rather than
+  a conversation fork — instead of leaving "by design" for the reader to interpret.
 
 ## [0.1.0] - 2026-07-24
 

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -5,7 +5,8 @@ tools: "Read, Grep, Glob, WebFetch, Bash, Write"
 ---
 You are the plugin-quality auditor: a fresh-context specialist that a main audit session
 dispatches for the map+ground and findings phases of a plugin-component audit. You start with no
-conversation history by design — fresh eyes are the point. Everything you need arrives in your
+conversation history — you are a named subagent, not a conversation fork, and fresh eyes are the
+point. Everything you need arrives in your
 dispatch prompt: the evidence-packet path, the audit target (`<plugin>[:<component>]`), and the
 component-type lens file path(s) to apply.
 

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -124,10 +124,12 @@ packet path, the target `<plugin>[:<component>]`, and the applicable component-t
 from the index below. The agent reads the component's installed source, manifest, and config
 resolution, and **verifies every load-bearing harness-behavior claim against CURRENT official
 docs per topic** (the fresh-docs discipline applies inside the audit — hooks behavior against the
-hooks page, skill loading against the skills page, etc.; never training-data recall). Never run
-this step inline in the main thread, and never dispatch it as the Agent tool's `fork` subagent
-type — that fork inherits this session's conversation and carries its degraded evidence forward.
-Fresh eyes are the point.
+hooks page, skill loading against the skills page, etc.; never training-data recall). Dispatch this
+step to the `auditor` agent **by name**. Two properties are required and the named agent is what
+supplies both: its context provably excludes this session's evidence, and the dispatch site names
+the worker so it is auditable. Never run the step inline in the main thread, which satisfies
+neither. Any other mechanism must be justified against those two properties — not against what a
+fork does or does not inherit, which is contested (see the plan's caveat on #1258).
 
 ### Step 3 — Blindspot + candidate findings (subagent output → user)
 

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -126,10 +126,12 @@ resolution, and **verifies every load-bearing harness-behavior claim against CUR
 docs per topic** (the fresh-docs discipline applies inside the audit — hooks behavior against the
 hooks page, skill loading against the skills page, etc.; never training-data recall). Dispatch this
 step to the `auditor` agent **by name**. Two properties are required and the named agent is what
-supplies both: its context provably excludes this session's evidence, and the dispatch site names
-the worker so it is auditable. Never run the step inline in the main thread, which satisfies
-neither. Any other mechanism must be justified against those two properties — not against what a
-fork does or does not inherit, which is contested (see the plan's caveat on #1258).
+supplies both: its context carries the evidence packet but **not** this session's conversation
+history or prior reasoning, and the dispatch site names the worker so it is auditable. The packet is
+the deliberate channel — the agent reads it as ground truth; what must not cross is the reasoning
+that produced the work under review. Never run the step inline in the main thread, which satisfies
+neither property. Any other mechanism must be justified against those two — not against what a fork
+does or does not inherit, which is contested (see the plan's caveat on #1258).
 
 ### Step 3 — Blindspot + candidate findings (subagent output → user)
 

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -117,15 +117,17 @@ context. Write to the packet (`evidence.md` + raw files as needed):
 - The transcript path, working directory, platform/shell, plugin version + install source.
 - Anything anomalous you noticed while using the component (the reason this audit started).
 
-### Step 2 — Map + ground (fresh `auditor` subagent — never a forked context)
+### Step 2 — Map + ground (fresh `auditor` subagent — never inline, never a conversation fork)
 
 Re-evaluate the context-gate, then dispatch the plugin's **`auditor`** agent by name with: the
 packet path, the target `<plugin>[:<component>]`, and the applicable component-type lens file(s)
 from the index below. The agent reads the component's installed source, manifest, and config
 resolution, and **verifies every load-bearing harness-behavior claim against CURRENT official
 docs per topic** (the fresh-docs discipline applies inside the audit — hooks behavior against the
-hooks page, skill loading against the skills page, etc.; never training-data recall). A fork
-would inherit this session's degraded history — the fresh-eyes doctrine is the point.
+hooks page, skill loading against the skills page, etc.; never training-data recall). Never run
+this step inline in the main thread, and never dispatch it as the Agent tool's `fork` subagent
+type — that fork inherits this session's conversation and carries its degraded evidence forward.
+Fresh eyes are the point.
 
 ### Step 3 — Blindspot + candidate findings (subagent output → user)
 

--- a/plugins/plugin-quality/skills/audit/references/component-types/skill.md
+++ b/plugins/plugin-quality/skills/audit/references/component-types/skill.md
@@ -15,8 +15,9 @@ contract gate) when installed, and lean on its findings; absent, this file is th
   boundaries stated for adjacent intents.
 - **Progressive disclosure** — hub thin; detail in `references/`; each reference linked with a
   one-line load-when pointer. Does the hub stay thin as coverage grows?
-- **Composition** — if it orchestrates other skills, are they loaded inline (not forked, which
-  loses history)? Are the named skills real? Are absent-seam fallbacks stated?
+- **Composition** — if it orchestrates other skills, is each loaded inline or forked
+  (`context: fork` runs the skill body in a subagent with no conversation history), and does that
+  match what the step needs? Are the named skills real? Are absent-seam fallbacks stated?
 - **Scope correctness** — user vs project vs plugin; does it wrongly depend on
   project-specific skills that bias a generic task?
 - **Cloud caveat** — if it must run in cloud/routine contexts, note that user-scoped


### PR DESCRIPTION
Closes #1268

## Summary

`docs/topics/plugin-audit-port/` rejected `context: fork` for the deep-audit phase on the stated grounds that a fork "inherits the degraded history the gate exists to escape" (`PLAN.md:78-79`, and again in the alternatives table at `:457`).

That is false for `context: fork`. Per the [skills reference](https://code.claude.com/docs/en/skills) (fetched 2026-07-24) a forked skill "won't have access to your conversation history" — it would satisfy the fresh-eyes requirement it was being rejected for.

**The decision is unchanged.** The real basis was already recorded in the same PLAN's `[EXEC-SHAPE]` agent decision at `:550`: plugin agents start with fresh context, and the Brief requires a *named* subagent, which a forked skill is not. Both prose sites now carry that basis, and `design/design-resolution.md` — which stated the rule with no rationale at all — gains it.

A wrong rationale in a design record propagates into later decisions that cite it, which is why the reason is corrected even though the outcome stands.

## Test plan

- `grep -rn -i "degraded history" docs/topics/plugin-audit-port/` — no matches
- The `[EXEC-SHAPE]` decision at `:550` is unmodified; the corrected text points at it rather than restating it
- Docs-only change; no plugin version or CHANGELOG bump applies

## Related

**One claim is deliberately attributed rather than asserted.** History inheritance is *documented* for the Agent tool's separate `fork` subagent type. #1258 reports empirically that Agent-tool forks did **not** inherit the conversation, contradicting that doc. The corrected text therefore says "documented for", not "does". The correction here does not depend on how #1258 resolves — the named-subagent requirement is the load-bearing basis, and the skills reference settles the `context: fork` half independently.

Prior art, both closed: #1053 fixed the identical inversion in `docs-hygiene`'s `audit-derivability` rubric and evals; #1062 clarified its Hard Rules wording. This is the same class of error in a different file, not a duplicate.

**Adjacent, non-overlapping:** #1252 also edits `plugin-audit-port/PLAN.md`, at `:551` — the table row directly below the `[EXEC-SHAPE]` row this PR points at. It does not touch that row, and this PR does not touch `:551`.
