### PR TITLE
docs(permission-rule-hygiene): record the undelivered plugin bin/-on-PATH capability

### DIFF
--- a/docs/conventions/permission-rule-hygiene/CHANGELOG.md
+++ b/docs/conventions/permission-rule-hygiene/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes to the permission-rule-hygiene convention. The convention states
 anti-patterns; it is enforced by the `claude-config` plugin's `permission-hygiene` skill (checks
 P1/P2/P3), whose detector and criteria version independently of this document.
 
+## 1.1 — 2026-07-24
+
+- Added "Known gap — step 1's plugin `bin/` is not delivered on Windows / Git Bash": the measured
+  behavior, its harness-wide scope, the two consequences for helper authors, and why a `~/.local/bin`
+  shim is not a substitute.
+
 ## 1.0 — 2026-07-14
 
 Initial published convention.

--- a/docs/conventions/permission-rule-hygiene/CHANGELOG.md
+++ b/docs/conventions/permission-rule-hygiene/CHANGELOG.md
@@ -9,7 +9,7 @@ P1/P2/P3), whose detector and criteria version independently of this document.
 - Added "Known gap — step 1's plugin `bin/` is not delivered on Windows / Git Bash": the measured
   behavior, its harness-wide scope, the two consequences for helper authors, why a `~/.local/bin`
   shim and an `env.PATH` settings entry are not substitutes, and the one untested candidate
-  (leading-wildcard rule) with the specific unknown that gates it.
+  (leading-wildcard rule) with the two specific unknowns that gate it.
 
 ## 1.0 — 2026-07-14
 

--- a/docs/conventions/permission-rule-hygiene/CHANGELOG.md
+++ b/docs/conventions/permission-rule-hygiene/CHANGELOG.md
@@ -7,8 +7,9 @@ P1/P2/P3), whose detector and criteria version independently of this document.
 ## 1.1 — 2026-07-24
 
 - Added "Known gap — step 1's plugin `bin/` is not delivered on Windows / Git Bash": the measured
-  behavior, its harness-wide scope, the two consequences for helper authors, and why a `~/.local/bin`
-  shim is not a substitute.
+  behavior, its harness-wide scope, the two consequences for helper authors, why a `~/.local/bin`
+  shim and an `env.PATH` settings entry are not substitutes, and the one untested candidate
+  (leading-wildcard rule) with the specific unknown that gates it.
 
 ## 1.0 — 2026-07-14
 

--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -149,15 +149,28 @@ Two consequences for anyone writing a guarded helper today:
   but it is *not* exported to the Bash tool's own environment, so a raw shell expansion yields an
   empty string ([plugins-reference](https://code.claude.com/docs/en/plugins-reference), Environment
   variables).
-- **Expect no allow rule to cover it.** `bash` is not one of the wrappers Claude Code strips before
-  matching, so a `bash <path> …` command can only be matched by an interpreter-led rule — which is
-  anti-pattern 1, dropped on entering auto mode. The call therefore reaches the classifier on every
-  invocation. Do not design a helper on the assumption that the operator can pre-approve it.
+- **Expect the call to reach the classifier on every invocation.** `bash` is not one of the wrappers
+  Claude Code strips before matching, so a rule for a `bash <path> …` command has to name `bash` —
+  making it interpreter-led, i.e. anti-pattern 1, dropped on entering auto mode. Do not assume the
+  operator can pre-approve the helper.
 
 Until the gap closes upstream, treat step 1's plugin-`bin/` bullet as the intended end state rather
-than a capability to build on, on this platform. A `~/.local/bin` shim is **not** a substitute: a
-static shim pins a version-numbered install path that changes on every plugin update, and a shim that
-resolves the newest directory under the install cache can select an unvetted staging clone.
+than a capability to build on, on this platform. Two substitutes look attractive and are not:
+
+- A **`~/.local/bin` shim**: a static shim pins a version-numbered install path that changes on every
+  plugin update, and a shim that resolves the newest directory under the install cache can select an
+  unvetted staging clone.
+- **`env.PATH` in user settings**, which does reach the Bash tool's shell (`env` is applied "to
+  subprocesses Claude Code spawns", [settings](https://code.claude.com/docs/en/settings)): it carries
+  the same version-pinned-path rot, and overriding `PATH` wholesale in settings is its own hazard.
+
+One candidate is untested rather than rejected. Bash rules accept a wildcard in any position,
+including leading, so a rule anchored on the wrapper's own name — `Bash(*<wrapper-name> *)` — would
+syntactically match the bundled-path invocation without naming an interpreter. **Whether that shape
+survives auto mode is unverified**: the documented drop list enumerates blanket rules, wildcarded
+interpreters, package-manager runners, and `Agent` rules, and says nothing about a leading wildcard
+in the command position. Establish that before building on it, and weigh that such a rule matches the
+name at *any* path, including an unvetted copy.
 
 ## Sources
 

--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -122,6 +122,43 @@ name narrowly:
    the operator to add the bare-name rule once to `~/.claude/settings.json`, and never relies on
    interpreter-wildcard `allowed-tools` for auto-mode-gated actions.
 
+## Known gap — step 1's plugin `bin/` is not delivered on Windows / Git Bash
+
+The plugin `bin/` half of step 1 is documented but does not hold on this platform, so a helper whose
+only permission story is bin/-on-PATH has **no** operative allow rule there. Measured on Windows 11 /
+Git Bash, Claude Code **v2.1.219**, with the owning plugin installed at user scope and reported
+`enabled` by `claude plugin list`:
+
+```console
+$ which source-control-babysit-merge ; echo $?
+which: no source-control-babysit-merge in (...)
+1
+$ echo "$PATH" | tr ':' '\n' | grep -i plugins
+                          # no plugin directory of any kind is on PATH
+```
+
+The absence is **harness-wide, not a packaging defect in one plugin**: a second, unrelated installed
+plugin that also ships a `bin/` is equally absent from `PATH`. The files themselves are fine —
+committed `100755`, present in the install cache, correct shebangs. The feature also is not
+version-gated away: it predates the measured harness.
+
+Two consequences for anyone writing a guarded helper today:
+
+- **Invoke it by its bundled path**, the same form the sibling `scripts/` use. That is deterministic
+  and works now. Resolve `${CLAUDE_PLUGIN_ROOT}` in skill or agent content — it is substituted there,
+  but it is *not* exported to the Bash tool's own environment, so a raw shell expansion yields an
+  empty string ([plugins-reference](https://code.claude.com/docs/en/plugins-reference), Environment
+  variables).
+- **Expect no allow rule to cover it.** `bash` is not one of the wrappers Claude Code strips before
+  matching, so a `bash <path> …` command can only be matched by an interpreter-led rule — which is
+  anti-pattern 1, dropped on entering auto mode. The call therefore reaches the classifier on every
+  invocation. Do not design a helper on the assumption that the operator can pre-approve it.
+
+Until the gap closes upstream, treat step 1's plugin-`bin/` bullet as the intended end state rather
+than a capability to build on, on this platform. A `~/.local/bin` shim is **not** a substitute: a
+static shim pins a version-numbered install path that changes on every plugin update, and a shim that
+resolves the newest directory under the install cache can select an unvetted staging clone.
+
 ## Sources
 
 - Auto-mode drop behavior and decision order — [permission-modes](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode)

--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -125,9 +125,10 @@ name narrowly:
 ## Known gap — step 1's plugin `bin/` is not delivered on Windows / Git Bash
 
 The plugin `bin/` half of step 1 is documented but does not hold on this platform, so a helper whose
-only permission story is bin/-on-PATH has **no** operative allow rule there. Measured on Windows 11 /
-Git Bash, Claude Code **v2.1.219**, with the owning plugin installed at user scope and reported
-`enabled` by `claude plugin list`:
+only permission story is bin/-on-PATH has **no** operative allow rule there. Behavior on macOS and
+Linux is unverified — probe there rather than reading a Windows-scoped heading as a clearance.
+Measured on Windows 11 / Git Bash, Claude Code **v2.1.219**, with the owning plugin installed at user
+scope and reported `enabled` by `claude plugin list`:
 
 ```console
 $ which source-control-babysit-merge ; echo $?
@@ -151,26 +152,36 @@ Two consequences for anyone writing a guarded helper today:
   variables).
 - **Expect the call to reach the classifier on every invocation.** `bash` is not one of the wrappers
   Claude Code strips before matching, so a rule for a `bash <path> …` command has to name `bash` —
-  making it interpreter-led, i.e. anti-pattern 1, dropped on entering auto mode. Do not assume the
-  operator can pre-approve the helper.
+  making it interpreter-led, i.e. anti-pattern 1. The documented drop categories clearly reach the
+  wildcarded-target form (`Bash(bash <path>*)`); whether they reach a fixed-path form
+  (`Bash(bash <fixed-path>:*)`) is not stated, so that shape is an anti-pattern on convention grounds
+  rather than a confirmed drop. Either way, treat the call as reaching the classifier — do not assume
+  the operator can pre-approve the helper.
 
 Until the gap closes upstream, treat step 1's plugin-`bin/` bullet as the intended end state rather
 than a capability to build on, on this platform. Two substitutes look attractive and are not:
 
 - A **`~/.local/bin` shim**: a static shim pins a version-numbered install path that changes on every
-  plugin update, and a shim that resolves the newest directory under the install cache can select an
-  unvetted staging clone.
+  plugin update.
 - **`env.PATH` in user settings**, which does reach the Bash tool's shell (`env` is applied "to
   subprocesses Claude Code spawns", [settings](https://code.claude.com/docs/en/settings)): it carries
   the same version-pinned-path rot, and overriding `PATH` wholesale in settings is its own hazard.
 
 One candidate is untested rather than rejected. Bash rules accept a wildcard in any position,
-including leading, so a rule anchored on the wrapper's own name — `Bash(*<wrapper-name> *)` — would
-syntactically match the bundled-path invocation without naming an interpreter. **Whether that shape
-survives auto mode is unverified**: the documented drop list enumerates blanket rules, wildcarded
-interpreters, package-manager runners, and `Agent` rules, and says nothing about a leading wildcard
-in the command position. Establish that before building on it, and weigh that such a rule matches the
-name at *any* path, including an unvetted copy.
+including leading, so a rule anchored on the wrapper's own name rather than on the interpreter could
+reach the bundled-path invocation without naming one. Two things have to be established before
+building on it.
+
+- **It has to match the invocation as actually written.** The documented bundled-path form quotes the
+  path, so the character following the wrapper name is a closing quote, not a space — a candidate
+  shaped `Bash(*<wrapper-name> *)` does not match it, and fails before the auto-mode question is even
+  reached. Derive the candidate from the exact command string operators are told to run.
+- **Whether a leading-wildcard rule survives auto mode is unverified.** The documented drop list
+  enumerates blanket rules, wildcarded interpreters, package-manager runners, and `Agent` rules, and
+  says nothing about a leading wildcard in the command position.
+
+Weigh too that a rule anchored on a bare wrapper name matches that name at *any* path, including an
+unvetted copy.
 
 ## Sources
 


### PR DESCRIPTION
No linked issue

## Summary

The permission-rule-hygiene convention's *correct pattern* tells helper authors to expose a guarded
code-execution helper as a bare command on the Bash tool's `PATH`, and names a plugin's `bin/`
directory as the way to do that after plugin migration. Upstream documents that behavior. It does not
happen. This PR records the gap in the convention that depends on it, so no future helper is designed
around a capability that is not there.

This is a docs-only change under `docs/conventions/`. It ships no code, touches no plugin, and does
**not** close #843 — the capability itself is upstream.

## Fix

`docs/conventions/permission-rule-hygiene/README.md` gains a *Known gap* section after the correct
pattern, recording:

- The measured behavior — `which <wrapper>` exits 1 and no plugin directory of any kind appears on
  `PATH`, on Windows 11 / Git Bash, Claude Code v2.1.219, with the owning plugin installed at user
  scope and reported `enabled`.
- Its scope: **harness-wide, not a packaging defect in one plugin.** A second, unrelated installed
  plugin that also ships a `bin/` is equally absent from `PATH`. The files are committed `100755`,
  present in the install cache, with correct shebangs, and the feature predates the measured harness.
- The two consequences for a helper author: invoke by bundled path (resolving `${CLAUDE_PLUGIN_ROOT}`
  in skill/agent content, which is *not* exported to the Bash tool's own environment), and expect the
  call to reach the classifier every time — `bash` is not one of the wrappers Claude Code strips
  before matching, so a rule for a `bash <path> …` command has to name `bash`, making it
  interpreter-led, which is the document's own anti-pattern 1. The section is deliberately asymmetric
  about what follows from that: the documented drop categories reach the wildcarded-target form
  (`Bash(bash <path>*)`), while whether they reach a fixed-path form (`Bash(bash <fixed-path>:*)`) is
  **not stated upstream**, so that shape is an anti-pattern on convention grounds rather than a
  confirmed drop.
- Why the two attractive substitutes are not substitutes: a `~/.local/bin` shim pins a
  version-numbered install path that changes on every plugin update; an `env.PATH` entry in user
  settings does reach the Bash tool's shell but carries the same version-pinned rot, plus the hazard
  of overriding `PATH` wholesale.
- One candidate recorded as **untested rather than rejected**: Bash rules accept a wildcard in any
  position, including leading, so a rule anchored on the wrapper's own name rather than on the
  interpreter could reach the bundled-path invocation without naming one. The section then states the
  two things that must be established first — and the first of them **disqualifies the obvious
  spelling**: the documented bundled-path form quotes the path, so the character following the
  wrapper name is a closing quote rather than a space, and a candidate shaped `Bash(*<wrapper-name> *)`
  does **not** match it. The candidate has to be derived from the exact command string operators are
  told to run. The second is that whether a leading-wildcard rule survives auto mode is undocumented —
  the drop list enumerates blanket rules, wildcarded interpreters, package-manager runners, and
  `Agent` rules, and is silent on a leading wildcard in the command position.

`CHANGELOG.md` for the convention records this as 1.1. The convention versions independently of any
plugin, so this carries no `plugin.json` bump.

## Verification

Every claim in the new section is either a command run in this environment or a quote from a doc
fetched this session — no recall.

- **`which` / `PATH` probe**, Git Bash, this machine:

  ```console
  $ which source-control-babysit-merge ; echo $?
  which: no source-control-babysit-merge in (...)
  1
  $ echo "$PATH" | tr ':' '\n' | grep -i plugins   # no output
  ```

- **Harness-wide scope:** the same probe against the `caveman` plugin's `bin/` (a different
  marketplace, unrelated author) is equally absent, so this is not a `source-control` packaging
  defect.
- **Plugin state:** `claude plugin list` reports `source-control@melodic-software` v0.26.0, scope
  user, `✔ enabled`; `bin/` is present in the install cache; `git ls-files -s` shows both wrappers at
  mode `100755`.
- **Harness version:** `claude --version` → `2.1.219`, well past the release that introduced
  `bin/`-on-PATH.
- **Not a one-off reading:** #843 carries three independent reproductions of the same `which` failure
  from separate sessions on separate dates (the #484 origin, the triage lane's empirical check, and a
  later babysit cycle). This PR's probe is the fourth. All are the same machine and platform, so the
  record is *repeated over time*, not *cross-platform* — the section states the platform it was
  measured on and claims nothing beyond it.
- **`env.PATH` lever confirmed, then rejected on durability, not capability:** a nested
  `claude -p --settings '{"env":{"ZZ_PATH_PROBE":"REACHED"}}'` run echoed `[REACHED]` from its Bash
  tool, so settings `env` does reach that shell. It is recorded as a non-substitute because of the
  version-pinned path, not because it doesn't work.
- **Upstream docs re-fetched this session**, all still asserting the capability or bounding it:
  [plugins-reference](https://code.claude.com/docs/en/plugins-reference) (Executables row; the
  `agent`/`subagentStatusLine`-only plugin `settings.json`; `${CLAUDE_PLUGIN_ROOT}` exported to hook,
  MCP, and LSP subprocesses only),
  [permissions](https://code.claude.com/docs/en/permissions#process-wrappers) (the stripped-wrapper
  list, which does not include `bash`), and
  [permission-modes](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode)
  (the auto-mode drop list).
- **Gates:** `markdownlint-cli2 --config .markdownlint-cli2.jsonc` over both changed files —
  `Summary: 0 error(s)`. `typos --config _typos.toml` over the convention directory — exit 0.
- **Independent re-verification** (fresh context, this branch's pushed head `afa0356ed3`, rationale
  withheld): every claim in the section re-tested against this machine and against the docs re-fetched
  again. The gap reproduces on harness **2.1.220** — one release past the version the section names,
  which strengthens the record rather than staling it. The bundled-path workaround was executed rather
  than asserted: `bash "<cache>/0.26.2/bin/source-control-babysit-merge"` reaches `babysit_merge.py`'s
  argparse and exits 2 on the missing positional, proving the path resolves and the wrapper runs.
  plugins-reference still carries the Executables row verbatim, and `anthropics/claude-code#42872`
  quotes the **v2.1.91** changelog introducing the feature. Full report in the PR comments.

## Related

- Refs #843 — the tracking issue. Deliberately **not** closed: this PR records the gap and its
  consequences, but delivering `bin/`-on-`PATH` is an upstream Claude Code capability that cannot be
  implemented here.
- Refs #484 — origin of the `${CLAUDE_PLUGIN_ROOT}/bin/` path-form workaround this section points at
  as the invocation that works today.
