### PR TITLE
docs(claude-md): narrow the fresh-docs scope, cut the duplicated URL table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@AGENTS.md
+
 # Operating rules — AI agents working in this repo
 
 This repository is a private Claude Code plugin marketplace. Plugins here must still be reusable,
@@ -5,29 +7,15 @@ repo-agnostic, configurable by consumers, and safe in plugin form.
 
 ## Fresh-docs mandate (non-negotiable)
 
-Operate only off current official documentation — never training-data recall, never a stale summary.
-Before ANY change to this repo (a new plugin, a manifest edit, a structure change), WebFetch the
-relevant page(s) below for current schema and behavior, and cite the URL. If a fact is not confirmed
-from a fetched page this session, treat it as unverified and say so.
+**Scope** — a change touching a plugin manifest, a marketplace schema, a hook contract, or documented
+harness behavior. Prose edits, formatting, and mechanical edits are out.
 
-| Topic | Canonical URL |
-|---|---|
-| Create plugins | https://code.claude.com/docs/en/plugins |
-| Plugins reference (schemas, variables, CLI) | https://code.claude.com/docs/en/plugins-reference |
-| Plugin dependencies (version constraints) | https://code.claude.com/docs/en/plugin-dependencies |
-| Create & distribute a marketplace | https://code.claude.com/docs/en/plugin-marketplaces |
-| Discover & install plugins | https://code.claude.com/docs/en/discover-plugins |
-| Skills | https://code.claude.com/docs/en/skills |
-| Slash commands | https://code.claude.com/docs/en/commands |
-| Hooks reference | https://code.claude.com/docs/en/hooks |
-| Subagents | https://code.claude.com/docs/en/sub-agents |
-| Settings | https://code.claude.com/docs/en/settings |
-| Memory — CLAUDE.md, `.claude/rules/`, auto memory | https://code.claude.com/docs/en/memory |
-| The `.claude` directory | https://code.claude.com/docs/en/claude-directory |
-| MCP | https://code.claude.com/docs/en/mcp |
-| Tools reference (monitors) | https://code.claude.com/docs/en/tools-reference |
-| Docs index (discover any other page) | https://code.claude.com/docs/llms.txt |
-| Official-doc index (all plugin-relevant pages) | docs/OFFICIAL-DOCS.md |
+Inside that scope, operate only off current official documentation — never training-data recall,
+never a stale summary. Before the change, open [`docs/OFFICIAL-DOCS.md`](docs/OFFICIAL-DOCS.md) — the
+canonical index of every plugin-relevant official page, plus the self-updating `llms.txt` master list
+for anything it omits — WebFetch the page(s) it points to for current schema and behavior, and cite
+the URL. If a fact is not confirmed from a page fetched this session, treat it as unverified and say
+so. Non-negotiable.
 
 Machine-readable JSON Schemas (editor validation for the JSON in this repo; Claude Code ignores the
 `$schema` field at load time): `marketplace.json` →
@@ -58,6 +46,6 @@ migration.
 
 ## Branching & PRs
 
-PRs required; squash merge; branch `<type>/<description>`. PR title follows Conventional Commits,
-enforced here by `.github/workflows/pr-title.yml` (squash merge sets the commit subject to the PR
-title). Org convention home: `melodic-software/standards` `conventions/`.
+PRs required; squash merge; branch `<type>/<description>`. `.github/workflows/pr-title.yml` enforces
+the PR-title convention (squash merge sets the commit subject to the PR title). Org convention home:
+`melodic-software/standards` `conventions/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,15 +7,19 @@ repo-agnostic, configurable by consumers, and safe in plugin form.
 
 ## Fresh-docs mandate (non-negotiable)
 
+[`docs/OFFICIAL-DOCS.md`](docs/OFFICIAL-DOCS.md) is the canonical index of every plugin-relevant
+official page, plus the self-updating `llms.txt` master list for anything it omits.
+
 **Scope** — a change touching a plugin manifest, a marketplace schema, a hook contract, or documented
-harness behavior. Prose edits, formatting, and mechanical edits are out.
+harness behavior, which includes the contract surface of every plugin component that index covers.
+The discriminator is the surface, not the file: a skill's frontmatter, a subagent's fields, or an
+`.mcp.json` entry is a contract change and is in; that same skill's prose body is a prose edit and is
+out. Formatting and mechanical edits are out.
 
 Inside that scope, operate only off current official documentation — never training-data recall,
-never a stale summary. Before the change, open [`docs/OFFICIAL-DOCS.md`](docs/OFFICIAL-DOCS.md) — the
-canonical index of every plugin-relevant official page, plus the self-updating `llms.txt` master list
-for anything it omits — WebFetch the page(s) it points to for current schema and behavior, and cite
-the URL. If a fact is not confirmed from a page fetched this session, treat it as unverified and say
-so. Non-negotiable.
+never a stale summary. Before the change, open the index, WebFetch the page(s) it points to for
+current schema and behavior, and cite the URL. If a fact is not confirmed from a page fetched this
+session, treat it as unverified and say so. Non-negotiable.
 
 Machine-readable JSON Schemas (editor validation for the JSON in this repo; Claude Code ignores the
 `$schema` field at load time): `marketplace.json` →

--- a/README.md
+++ b/README.md
@@ -171,7 +171,8 @@ Install one: `/plugin install <plugin-name>@melodic-software`.
 - `docs/hook-migration-audit.md` — point-in-time audit of medley's general-purpose hooks for extraction into `guardrails`/`claude-ops`.
 - `docs/ai-briefing-design.md` — engine/profile/personal split design record for the `ai-briefing` migration (reference adopter of the profiled-folder convention).
 - `docs/CI-RUNNER-ROUTING.md` — local-runner selection, hosted boundaries, and failure recovery.
-- `CLAUDE.md` — operating rules for AI agents working in this repo (fresh-docs mandate + canonical links).
+- `CLAUDE.md` — operating rules for AI agents working in this repo (fresh-docs mandate + plugin design rules).
+- `docs/OFFICIAL-DOCS.md` — canonical index of the official Claude Code doc pages the mandate sends you to.
 
 ## Official documentation
 


### PR DESCRIPTION
No linked issue

## Summary

Rightsizes the repo `CLAUDE.md` — loaded in full into every session in this repository — under three
locked decisions from the context-engineering rightsizing effort: D-18 (cut the duplicated doc-URL
table to a pointer), D-16 (narrow the fresh-docs mandate in scope, not substance), and the
`@AGENTS.md` import.

`CLAUDE.md`: **63 → 55 lines, 3,972 → 3,357 characters (-15.5%)**. Measured by script against
`origin/main`, not by eye.

One number worth stating plainly rather than burying: the `@AGENTS.md` import is a net **context
increase**. Cutting the table saves 615 chars; importing `AGENTS.md` costs 1,259. The effective
loaded surface (`CLAUDE.md` + the imported file) goes 3,972 → 4,616 chars, **+16.2%**. The official
memory doc says so directly — "Splitting into `@path` imports helps organization but doesn't reduce
context, since imported files load at launch." The import is justified on single-source-of-truth
grounds (one instruction set for both agent toolchains), not on budget grounds. The D-18 cut is the
rightsizing win; the import is a correctness/de-duplication win that costs context.

## Fix

### 1. Narrow the fresh-docs mandate's scope (D-16)

Old scope clause, verbatim:

> Before ANY change to this repo (a new plugin, a manifest edit, a structure change), WebFetch the
> relevant page(s) below for current schema and behavior, and cite the URL.

New scope clause, verbatim:

> **Scope** — a change touching a plugin manifest, a marketplace schema, a hook contract, or
> documented harness behavior, which includes the contract surface of every plugin component that
> index covers. The discriminator is the surface, not the file: a skill's frontmatter, a subagent's
> fields, or an `.mcp.json` entry is a contract change and is in; that same skill's prose body is a
> prose edit and is out. Formatting and mechanical edits are out.

Nothing inside the scope weakens. "Non-negotiable" stays in the heading and is restated in the body;
the citation requirement stays; the "treat as unverified and say so" fallback stays. The out-of-scope
side is stated explicitly so it is not re-litigated in a future session.

The component-contract sentence came from review (commit `81bd02ec`). Both Codex (P2 on
`CLAUDE.md:11`) and the Claude review job independently found the same hole in the first draft:
naming only manifests, marketplace schemas, and hook contracts left skills, subagents, `.mcp.json`,
settings, and output styles outside the mandate, which would have permitted shipping an invalid
plugin artifact off stale recall. The surface-not-file discriminator closes it without re-widening to
"ANY change" — D-16's prose/formatting/mechanical carve-out is intact.

### 2. Cut the doc-URL table to a pointer (D-18)

Removed `CLAUDE.md:13-30` (18 lines — the table header, separator, and 16 rows).

**Strict-subset re-verification, scripted, before cutting.** Extracted every URL from the table and
every URL from `docs/OFFICIAL-DOCS.md` and diffed the sets:

- 15 URLs in the table
- 41 URLs in `docs/OFFICIAL-DOCS.md`
- **0 URLs in the table absent from `docs/OFFICIAL-DOCS.md`** — strict subset confirmed, no
  pre-cut backfill needed

The table's own last row (`| Official-doc index (all plugin-relevant pages) | docs/OFFICIAL-DOCS.md |`)
already pointed at the superset, so the fifteen rows above it were a duplicate index that drifts
against the one it points to.

**The accepted risk is honored in the rule text.** Because the URLs stop being pre-loaded, the
mandate now instructs the agent to *go open the index and fetch from it*, not merely that an index
exists: "open `docs/OFFICIAL-DOCS.md` … WebFetch the page(s) it points to for current schema and
behavior, and cite the URL." The `llms.txt` master list is named as the fallback for anything the
index omits.

### 3. Import `AGENTS.md`

`@AGENTS.md` added as the first line. Syntax verified against the current official memory doc,
<https://code.claude.com/docs/en/memory> (fetched 2026-07-24), which prescribes exactly this for a
repository that already has an `AGENTS.md`:

> Claude Code reads `CLAUDE.md`, not `AGENTS.md`. If your repository already uses `AGENTS.md` for
> other coding agents, create a `CLAUDE.md` that imports it so both tools read the same instructions
> without duplicating them. You can also add Claude-specific instructions below the import.

Same page confirms: `@path/to/import`, relative paths resolve against the file containing the import,
imports may appear anywhere in the file, max depth four hops, and code spans/fences are skipped by
the import parser. The symlink alternative the doc also offers is explicitly ruled out for this repo
— it "requires Administrator privileges or Developer Mode" on Windows, and contributors here work on
Windows.

**Duplication assessment before importing.** The two files do not overlap:

| File | Owns |
|---|---|
| `AGENTS.md` | Synced-standards handling (fix upstream, never patch the materialization), explicit-path staging (never `git add -A`), PR-thread resolution, Conventional Commits PR titles |
| `CLAUDE.md` | The fresh-docs mandate, the plugin design rules, the process pointers, branching mechanics |

One adjacent statement existed on both surfaces: PR titles follow Conventional Commits. `AGENTS.md`
keeps it (it is the agent-agnostic convention); `CLAUDE.md` keeps only the non-duplicated part —
which workflow enforces it, and why squash merge makes the title load-bearing. This is the one place
the import would otherwise have doubled the instruction surface, and it is resolved rather than
imported blindly.

### 4. `README.md` pointer correction (one line)

`README.md:174` described `CLAUDE.md` as "fresh-docs mandate + canonical links". The canonical links
are no longer there, so the description was made accurate and `docs/OFFICIAL-DOCS.md` — now the
mandate's actual destination — was added to the same file inventory. Without this the README would
have pointed readers at a table that no longer exists.

## D-15 justifications — rationale, and why it no longer holds

D-15 requires every removal to state the constraint's original rationale and why it no longer holds.

**Removal 1 — the 18-line doc-URL table.**

- *Rationale.* Pre-loading the canonical URLs into every session guaranteed an agent could not invent
  a plausible-looking docs URL, and removed the excuse of not knowing where to look.
- *Why it no longer holds.* `docs/OFFICIAL-DOCS.md` exists and is a strict superset (verified above:
  41 URLs vs 15, zero missing). The anti-invention guarantee is fully preserved by one pointer to a
  richer index; what the table added over the pointer was drift risk, since two indexes of the same
  URLs must be hand-synced. The rule now names the index and orders the agent to fetch from it, so
  the force comes from the rule rather than from the URLs happening to be in context.

**Removal 2 — "Before ANY change to this repo" as the mandate's scope.**

- *Rationale.* A blanket trigger admits no argument about whether a given change "counts", so no
  agent can reason its way out of verifying.
- *Why it no longer holds.* The blanket trigger is not actually obeyed — it demands a WebFetch for a
  typo fix — and a rule routinely violated in its cheap cases loses authority in its expensive ones.
  The named triggers cover every case where stale recall can actually produce a broken or wrong
  artifact: the contract surface of every plugin component `docs/OFFICIAL-DOCS.md` indexes, plus
  documented harness behavior. Naming the out-of-scope side removes the same interpretive wiggle room
  the blanket phrasing was protecting against. The safety rationale is retained where it has teeth
  and dropped only where it had none.
- *Residual risk, stated rather than hidden.* The prose/contract line is a judgment call the agent
  now makes, where before there was none to make. The surface-not-file discriminator is what makes it
  decidable, and the failure mode is bounded: a misjudged prose edit skips a fetch that would have
  changed nothing, while every artifact-breaking surface is named. Worth revisiting if a real
  under-trigger shows up in practice.

**Removal 3 — "PR title follows Conventional Commits" from `CLAUDE.md`.**

- *Rationale.* Stating the convention where an agent reads it before opening a PR.
- *Why it no longer holds.* `AGENTS.md:26` already states it, and that file is now imported into
  `CLAUDE.md` — so the statement is still loaded into every session, just once instead of twice.
  This is a de-duplication, not a deletion of the constraint.

## Verification

All gates run locally in the worktree:

| Gate | Command | Result |
|---|---|---|
| markdownlint | `npx markdownlint-cli2@0.23.0 --config .markdownlint-cli2.jsonc CLAUDE.md README.md docs/OFFICIAL-DOCS.md AGENTS.md` | 4 files, **0 errors** |
| typos | `typos --config _typos.toml CLAUDE.md README.md` | exit 0 |
| editorconfig | `editorconfig-checker -config .editorconfig-checker.json CLAUDE.md README.md` | exit 0 |
| lychee (offline) | `lychee --config lychee.toml --offline CLAUDE.md README.md` | 68 unique, **65 OK, 0 errors**, 4 excluded |

All re-run after the review fix. Nothing was suppressed and no lint rule was disabled. CI on the
first commit was **26/26 green**.

**Sequencing (D-8).** `gh pr diff 1096 --name-only` confirms PR #1096 touches `README.md`,
`docs/PLUGIN-PHILOSOPHY.md`, `docs/topics/fresh-eyes-checkpoint-audit/design/design-resolution.md`,
and eight files under `plugins/skill-quality/`. It does **not** touch `CLAUDE.md`. This PR does not
touch `docs/PLUGIN-PHILOSOPHY.md` or `check-skill.sh`. The one shared file is `README.md`; #1096's
hunks there are at lines 117, 350, 386, and 427, while this PR's single-line change is at line 174 —
no overlap, so no textual conflict, though whichever merges second still rebases normally.

## Related

- Follow-up, deliberately **not** swept here (D-3 forbids bulk sweeps of `plugins/**`): several files
  restate or reference the fresh-docs mandate and should point at repo `CLAUDE.md` rather than
  paraphrase its scope. None of them restate the old "ANY change" scope, so none contradicts the
  narrowed version today — this is pointer-hygiene, not a correctness fix:
  - `docs/MIGRATION-PLAYBOOK.md:16`, `docs/MIGRATION-PLAYBOOK.md:649`, `docs/MIGRATION-PLAYBOOK.md:1127`
  - `docs/extensibility-contract-smoke-tests.md:9`
  - `plugins/autonomy/skills/setup/context/trigger-dispatch-slice.md:14`
  - `plugins/plugin-quality/skills/audit/SKILL.md:126`
  - `plugins/guardrails/CHANGELOG.md:147`, `plugins/guardrails/CHANGELOG.md:386`,
    `plugins/plugin-quality/CHANGELOG.md:14` (changelog entries — historical record, leave as-is)
  - `docs/topics/**/PLAN.md` (9 files) — point-in-time planning records, leave as-is
- Sequencing checked against PR #1096 per D-8; no file claimed by it is edited here.
