### PR TITLE
feat(guardrails): add asserted-path and skill-reference claim guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 ### Security
 
-- [`guardrails`](plugins/guardrails) — Nine safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.
+- [`guardrails`](plugins/guardrails) — Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) asserted repo paths that do not exist, (advisory) /plugin:skill references that do not resolve, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.
 
 ### Workflow
 

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.14.2",
-  "description": "Nine safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
+  "version": "0.15.0",
+  "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) asserted repo paths that do not exist, (advisory) /plugin:skill references that do not resolve, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
@@ -66,6 +66,18 @@
       "type": "boolean",
       "title": "cli-flag-verify guard",
       "description": "Advise on hallucinated CLI flags written to files (never blocks)",
+      "default": true
+    },
+    "asserted_path_verify_enabled": {
+      "type": "boolean",
+      "title": "asserted-path-verify guard",
+      "description": "Advise when markdown asserts a repo-relative path that does not exist (never blocks)",
+      "default": true
+    },
+    "skill_reference_verify_enabled": {
+      "type": "boolean",
+      "title": "skill-reference-verify guard",
+      "description": "Advise when markdown cites a /plugin:skill reference this repo owns but cannot resolve (never blocks)",
       "default": true
     },
     "workflow_resilience_check_enabled": {

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.0]
+
+### Added
+
+- `asserted-path-verify` (advisory, PostToolUse · Write|Edit): flags a
+  repo-relative path asserted in markdown — in a code span or a link target —
+  that does not exist in the working tree. A candidate is only adjudicated when
+  its leading directory is in the repo, which is what keeps another project's
+  paths, globs, placeholders, and third-party references quiet. Diff-scope only.
+  Deterministic oracle, advisory action: a citation can be deliberately
+  forward-looking and PostToolUse cannot tell.
+- `skill-reference-verify` (advisory, PostToolUse · Write|Edit): flags a
+  `/plugin:skill` reference that does not resolve. Gated twice — it does nothing
+  outside a marketplace repo, and within one it only adjudicates a plugin that
+  repo's own manifests own. Resolves through manifest `name` and skill
+  frontmatter `name`, so a renamed directory still matches. Declared
+  **detect-then-judge**, not deterministic: globbing a plugins tree is exact only
+  where the reference is locally owned.
+- A README enforceability-tier section stating each guard's oracle class, so the
+  detect-then-judge guard cannot be read as deterministic.
+
+### Fixed
+
+- README guard counts were stale before this change: the prose said "nine safety
+  guards" and the table omitted `block-convention-violation` while ten were
+  wired. Counts are now measured against the manifest's toggle set, and the
+  missing row is present.
+
 ## [0.14.2]
 
 ### Fixed

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -1,6 +1,6 @@
 # guardrails
 
-A Claude Code plugin bundling nine **safety guards** that catch risky agent
+A Claude Code plugin bundling twelve **safety guards** that catch risky agent
 actions the moment they happen — before a write lands or a bash command runs.
 Each guard is independently toggleable, so you run exactly the subset you want.
 
@@ -16,11 +16,24 @@ Each guard is independently toggleable, so you run exactly the subset you want.
 | **cli-flag-verify** | PostToolUse · Write \| Edit | **Advisory** (exit 0) | Hallucinated CLI flags — a `--flag` written as a command that does not exist in the binary's actual `--help` output. Surfaces via `additionalContext`, never blocks. |
 | **workflow-resilience-check** | PreToolUse · Workflow | **Advisory** (exit 0) | Un-throttled Workflow fan-out — a script calling `parallel()` / `pipeline()` with no wave-cap throttle (`inWaves` / `inWavesPipeline`) and no retry wrapper (`agentRetry`), which risks a burst 529 under wide Opus fan-out. Surfaces a resilience checklist via `additionalContext`, never blocks. |
 | **block-noncanonical-commit** | PreToolUse · Bash | **Blocks** (exit 2) | `git commit` that does not pipe its message via `-F -` / `--file -` — `-m` flattens newlines unpredictably across shells. Exempt: `--amend`, `-C`/`-c`/`--reuse-message`/`--reedit-message`, `--fixup`/`--squash`, `-F <path>`, and any commit taken while a merge/rebase/cherry-pick/revert is in progress. Resolves `bash -lc` wrappers and git aliases (inline `-c` and persisted config alike). |
+| **block-convention-violation** | PreToolUse · Bash | **Blocks** (exit 2) | A commit subject or `gh pr create --title` that violates the team-tracked convention pattern declared in `.claude/source-control.md`. No tracked pattern means no enforcement. Same exemptions as `block-noncanonical-commit`. |
 | **flag-commit-pr-skill-bypass** | PreToolUse · Bash | **Advisory** (exit 0) | Any `gh pr create`, bypassing this marketplace's own `/pull-request create` skill. Only fires when the consuming project's own `.claude/settings.json` enables the `source-control` plugin — silent otherwise. Surfaces via `additionalContext`, never blocks. |
+| **asserted-path-verify** | PostToolUse · Write \| Edit | **Advisory** (exit 0) | A repo-relative path asserted in markdown — in a code span or a link target — that does not exist in the working tree. Only adjudicates a candidate whose leading directory IS in the repo, so another project's paths, globs, and placeholders stay quiet. Surfaces via `additionalContext`, never blocks. |
+| **skill-reference-verify** | PostToolUse · Write \| Edit | **Advisory** (exit 0) | A `` `/plugin:skill` `` reference in markdown that does not resolve. Only fires inside a marketplace repo, and only for a plugin that repo's own manifests own — a reference to another marketplace is left alone. Resolves through manifest and frontmatter `name`, so a renamed directory still matches. Surfaces via `additionalContext`, never blocks. |
 
-The six blocking guards feed their stderr message back to Claude as
-actionable fix guidance. The three advisory guards surface their findings the same
+The seven blocking guards feed their stderr message back to Claude as
+actionable fix guidance. The five advisory guards surface their findings the same
 way but always allow the operation.
+
+### Enforceability tiers
+
+Eleven guards are **deterministic** — their oracle is a mechanical test with no
+judgment step. `skill-reference-verify` is **detect-then-judge**: globbing a
+plugins tree is exact only inside a marketplace repo that owns the referenced
+plugin, so its finding is a prompt for a human verdict, never a determination and
+never an auto-fix. The two hallucination guards that scan written content
+(`cli-flag-verify`, `asserted-path-verify`) are deterministic in their oracle but
+advisory in their action, because a claim can be deliberately forward-looking.
 
 ### Scope notes
 

--- a/plugins/guardrails/hooks/asserted-path-verify.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# PostToolUse hook: verify repo-relative paths asserted in newly-written markdown
+# actually exist in the working tree.
+# Triggered on Write|Edit of *.md files.
+#
+# Catches subagent / training-recall hallucinations — a path written AS a
+# citation that does not exist. Sibling of cli-flag-verify: same class of defect
+# (a confident specific that was never checked), different oracle.
+#
+# ENFORCEABILITY TIER: Deterministic. The oracle is a filesystem test — the path
+# either resolves under the repo root or it does not. No judgment step.
+#
+# NON-BLOCKING (advisory): exits 0 with hookSpecificOutput additionalContext
+# on unresolvable paths.
+#
+# FIRST-SEGMENT GATE is what keeps this quiet. A candidate is only checked when
+# its leading segment is a real directory in the repo. `docs/nope.md` is checked
+# because `docs/` exists; `some-other-repo/src/main.rs` is not, because
+# `some-other-repo/` does not — it is an example, another project, or a package
+# path, none of which this repo can adjudicate.
+#
+# ACCEPTED RESIDUAL: a doc that cites a file the same change set has not written
+# yet fires. PostToolUse runs after the write, so a doc-before-code ordering
+# within one session produces a finding for a path that becomes real minutes
+# later. Advisory-only is the mitigation; a blocking version of this guard would
+# be wrong for that reason alone.
+#
+# Disable with the asserted_path_verify_enabled userConfig option set to false.
+
+set -uo pipefail
+
+# High-res start stamp for telemetry (Bash 5.0+; empty on older bash → skip).
+start=${EPOCHREALTIME:-}
+
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "ASSERTED_PATH_VERIFY"
+
+hook::ctx_reset
+
+INPUT=$(hook::buffer_stdin) || exit 0
+
+hook::require_jq "PostToolUse" "guardrails-asserted-path-verify" "$INPUT"
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+case "$FILE" in
+*.md) ;;
+# Code files are out of scope: a path literal in a script resolves against the
+# runtime CWD, not the repo root, so a repo-root existence test is the wrong
+# oracle there and would fire on every correct relative path.
+*) exit 0 ;;
+esac
+
+# Diff-scope: verify only the content THIS tool call wrote, never re-read the
+# whole file from disk. An Edit's pre-existing lines outside the changed hunk are
+# not this call's claims.
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null | tr -d '\r')
+case "$TOOL" in
+Edit) SCAN_CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null | tr -d '\r') ;;
+Write) SCAN_CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null | tr -d '\r') ;;
+*) exit 0 ;;
+esac
+[[ -n "$SCAN_CONTENT" ]] || exit 0
+
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+[[ -d "$REPO_ROOT" ]] || exit 0
+
+# Emit raw path-shaped tokens (one per line) from inline-code spans and markdown
+# link/image targets. Prose is deliberately NOT scanned: an unquoted `a/b` in a
+# sentence is as likely to be a ratio, a date, or an either/or as a path, and a
+# path asserted as a citation is written in code or as a link by convention.
+emit_tokens() {
+  # Inline-code spans, backticks stripped.
+  # shellcheck disable=SC2016  # backticks are literal ERE data, not expansions
+  printf '%s' "$SCAN_CONTENT" | grep -oE '`[^`]+`' 2>/dev/null | sed -E 's/^`+//; s/`+$//'
+  # Markdown link and image targets: the parenthesized destination only.
+  printf '%s' "$SCAN_CONTENT" | grep -oE '\]\([^)[:space:]]+\)' 2>/dev/null | sed -E 's/^\]\(//; s/\)$//'
+}
+
+# Reduce a raw token to a repo-relative path candidate, or nothing.
+# Prints the candidate on success; prints nothing when the token is not one.
+normalize_candidate() {
+  local t="$1"
+
+  # A code span can hold a whole command; take only single-token spans. A path
+  # candidate never contains whitespace.
+  [[ "$t" =~ [[:space:]] ]] && return 0
+
+  # Strip a trailing line/range citation suffix — this repo cites
+  # `docs/MIGRATION-PLAYBOOK.md:576-580` and `SKILL.md:24` pervasively.
+  t="${t%%:[0-9]*}"
+
+  # Strip a trailing markdown-anchor fragment; lychee already resolves those.
+  t="${t%%#*}"
+
+  # Strip surrounding and trailing prose punctuation.
+  t="${t#[\'\"\(]}"
+  t="${t%[\'\"\),;.]}"
+
+  # Leading ./ is the same path.
+  t="${t#./}"
+
+  # Must look like a path at all.
+  [[ "$t" == */* ]] || return 0
+
+  # Reject anything that is not a literal repo-relative path.
+  case "$t" in
+  # URLs, protocol-relative, mail, and anchors.
+  *://* | //* | mailto:* | \#*) return 0 ;;
+  # Absolute POSIX and Windows paths — hardcoded-path-check owns those.
+  /* | [A-Za-z]:[/\\]*) return 0 ;;
+  # Home-relative.
+  '~'*) return 0 ;;
+  # Escapes the tree; not resolvable against the repo root.
+  ../* | */../*) return 0 ;;
+  # Glob, brace, or placeholder metacharacters — a pattern, not an assertion.
+  *'*'* | *'?'* | *'['* | *']'* | *'{'* | *'}'* | *'<'* | *'>'* | *'$'* | *'('* | *')'* | *'|'* | *'!'*) return 0 ;;
+  # Ellipsis stand-ins.
+  *...*) return 0 ;;
+  # Vendor and build trees are not tracked; their absence proves nothing.
+  node_modules/* | */node_modules/* | .git/* | */.git/*) return 0 ;;
+  esac
+
+  # A bare directory reference with no extension and no trailing slash is
+  # ambiguous with a namespace, a module path, or a URL path fragment. Require
+  # either a file extension in the last segment or an explicit trailing slash.
+  local last="${t##*/}"
+  if [[ "$t" != */ && "$last" != *.* ]]; then
+    return 0
+  fi
+
+  printf '%s' "$t"
+}
+
+# FIRST-SEGMENT GATE. Only adjudicate a candidate whose leading segment is a
+# real directory here — that is what distinguishes "this repo's path, written
+# wrong" from "a path belonging to something else".
+first_segment_is_local() {
+  local seg="${1%%/*}"
+  [[ -n "$seg" ]] || return 1
+  [[ -d "$REPO_ROOT/$seg" ]]
+}
+
+declare -A CHECKED=()
+MISSING=()
+
+while IFS= read -r raw; do
+  [[ -n "$raw" ]] || continue
+  cand=$(normalize_candidate "$raw")
+  [[ -n "$cand" ]] || continue
+  [[ -n "${CHECKED[$cand]:-}" ]] && continue
+  CHECKED["$cand"]=1
+  first_segment_is_local "$cand" || continue
+  target="${cand%/}"
+  [[ -e "$REPO_ROOT/$target" ]] && continue
+  MISSING+=("$cand")
+done < <(emit_tokens)
+
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::telemetry_enabled || return 0
+  local file_rel="$FILE" findings_json="[]"
+  if command -v cygpath >/dev/null 2>&1; then
+    local _file_lm _root_lm
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    [[ -n "$_file_lm" && -n "$_root_lm" ]] && file_rel="${_file_lm#"$_root_lm"/}"
+  else
+    file_rel="${FILE#"$REPO_ROOT"/}"
+  fi
+  # Redaction: a path that could not be made repo-relative degrades to its
+  # basename — never an absolute path, which would embed the developer's
+  # username.
+  case "$file_rel" in
+  /* | [A-Za-z]:*)
+    file_rel="${file_rel##*/}"
+    file_rel="${file_rel##*\\}"
+    ;;
+  *) ;;
+  esac
+  if ((${#MISSING[@]} > 0)); then
+    local m raw_list=""
+    for m in "${MISSING[@]}"; do raw_list+="$m"$'\n'; done
+    findings_json=$(printf '%s' "$raw_list" | jq -R . | jq -s . 2>/dev/null) || findings_json="[]"
+  fi
+  local data
+  data=$(jq -n --arg file "$file_rel" --argjson findings "$findings_json" \
+    '{tool:"",file:$file,findings:$findings}' 2>/dev/null) ||
+    data='{"tool":"","file":"","findings":[]}'
+  hook::emit_telemetry "asserted-path-verify" "PostToolUse" "ok" "$start" "$data" "$REPO_ROOT"
+}
+
+if ((${#MISSING[@]} > 0)); then
+  hook::ctx_append "asserted-path-verify: ${#MISSING[@]} asserted path(s) do not exist in $FILE"
+  hook::ctx_append "Each leading directory IS in this repo, so these read as this repo's paths written wrong:"
+  for m in "${MISSING[@]}"; do
+    hook::ctx_append "  MISSING_PATH: $m"
+  done
+  hook::ctx_append ""
+  hook::ctx_append "Confirm each against the working tree. If a path is intentionally"
+  hook::ctx_append "forward-looking (a file this change set has not written yet), it is"
+  hook::ctx_append "correct and this finding is expected — PostToolUse cannot tell the"
+  hook::ctx_append "difference."
+  hook::ctx_flush PostToolUse
+fi
+
+emit_tel
+exit 0

--- a/plugins/guardrails/hooks/asserted-path-verify.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.sh
@@ -66,16 +66,42 @@ esac
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
 [[ -d "$REPO_ROOT" ]] || exit 0
 
-# Emit raw path-shaped tokens (one per line) from inline-code spans and markdown
-# link/image targets. Prose is deliberately NOT scanned: an unquoted `a/b` in a
+# Emit `<kind>|<raw-token>` lines from inline-code spans and markdown link/image
+# destinations. Prose is deliberately NOT scanned: an unquoted `a/b` in a
 # sentence is as likely to be a ratio, a date, or an either/or as a path, and a
 # path asserted as a citation is written in code or as a link by convention.
+#
+# The kind is carried because the two resolve against different bases (see
+# bases_for below). `|` is a safe separator: normalize_candidate rejects any
+# candidate containing one.
 emit_tokens() {
   # Inline-code spans, backticks stripped.
   # shellcheck disable=SC2016  # backticks are literal ERE data, not expansions
-  printf '%s' "$SCAN_CONTENT" | grep -oE '`[^`]+`' 2>/dev/null | sed -E 's/^`+//; s/`+$//'
-  # Markdown link and image targets: the parenthesized destination only.
-  printf '%s' "$SCAN_CONTENT" | grep -oE '\]\([^)[:space:]]+\)' 2>/dev/null | sed -E 's/^\]\(//; s/\)$//'
+  printf '%s' "$SCAN_CONTENT" | grep -oE '`[^`]+`' 2>/dev/null |
+    sed -E 's/^`+//; s/`+$//; s/^/code|/'
+  # Markdown link and image destinations. A destination may carry an optional
+  # title (`[x](dest "Title")`) and may be angle-bracketed (`[x](<dest>)`), so
+  # take the whole parenthesized run and keep only the leading destination token.
+  printf '%s' "$SCAN_CONTENT" | grep -oE '\]\([^)]*\)' 2>/dev/null |
+    sed -E 's/^\]\(//; s/\)$//; s/^[[:space:]]+//; s/[[:space:]].*$//; s/^<//; s/>$//; s/^/link|/'
+}
+
+# Percent-decode a markdown destination — `docs/my%20file.md` names the file
+# `docs/my file.md`. Decodes only when every `%` in the string begins a valid
+# two-hex-digit escape; anything else is returned untouched, so a literal `%` in
+# a filename is not mangled. Callers MUST re-apply the traversal guard after
+# decoding: `%2e%2e%2f` decodes to `../`.
+maybe_percent_decode() {
+  local s="$1"
+  [[ "$s" == *%* ]] || {
+    printf '%s' "$s"
+    return 0
+  }
+  [[ "$s" =~ ^([^%]|%[0-9A-Fa-f]{2})*$ ]] || {
+    printf '%s' "$s"
+    return 0
+  }
+  printf '%b' "${s//%/\\x}"
 }
 
 # Reduce a raw token to a repo-relative path candidate, or nothing.
@@ -136,30 +162,59 @@ normalize_candidate() {
   printf '%s' "$t"
 }
 
-# FIRST-SEGMENT GATE. Only adjudicate a candidate whose leading segment is a
-# real directory here — that is what distinguishes "this repo's path, written
-# wrong" from "a path belonging to something else".
-# `first_seg`, not `seg`: hook-utils.sh declares a `local -a seg` in its bash
-# parser, and ShellCheck resolves sourced files, so a string `seg` here reads as
-# an array-to-string type change (SC2178/SC2128).
-first_segment_is_local() {
-  local first_seg="${1%%/*}"
-  [[ -n "$first_seg" ]] || return 1
-  [[ -d "$REPO_ROOT/$first_seg" ]]
-}
+# A code-span citation is repo-root-relative — that is this repo's convention for
+# citing a file in prose. A markdown link destination is document-relative per
+# CommonMark, but this repo also writes repo-root paths inside link syntax, so a
+# link is accepted when EITHER base resolves. An advisory guard errs quiet.
+DOC_DIR="$(dirname "$FILE")"
 
 declare -A CHECKED=()
 MISSING=()
 
-while IFS= read -r raw; do
-  [[ -n "$raw" ]] || continue
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  kind="${line%%|*}"
+  raw="${line#*|}"
   cand=$(normalize_candidate "$raw")
   [[ -n "$cand" ]] || continue
-  [[ -n "${CHECKED[$cand]:-}" ]] && continue
-  CHECKED["$cand"]=1
-  first_segment_is_local "$cand" || continue
+
+  if [[ "$kind" == "link" ]]; then
+    cand=$(maybe_percent_decode "$cand")
+    # Traversal guard, re-applied post-decode: an encoded `../` only becomes
+    # visible here.
+    case "$cand" in
+    ../* | */../* | /* | [A-Za-z]:[/\\]*) continue ;;
+    *) ;;
+    esac
+  fi
+
+  [[ -n "${CHECKED[$kind|$cand]:-}" ]] && continue
+  CHECKED["$kind|$cand"]=1
+
+  if [[ "$kind" == "link" ]]; then
+    bases=("$DOC_DIR" "$REPO_ROOT")
+  else
+    bases=("$REPO_ROOT")
+  fi
+
+  # FIRST-SEGMENT GATE. Only adjudicate a candidate whose leading segment is a
+  # real directory under some base — that is what distinguishes "this repo's
+  # path, written wrong" from "a path belonging to something else". A candidate
+  # gated out on every base is never reported.
   target="${cand%/}"
-  [[ -e "$REPO_ROOT/$target" ]] && continue
+  first_seg="${cand%%/*}"
+  gated=0
+  resolved=0
+  for base in "${bases[@]}"; do
+    [[ -n "$first_seg" && -d "$base/$first_seg" ]] || continue
+    gated=1
+    if [[ -e "$base/$target" ]]; then
+      resolved=1
+      break
+    fi
+  done
+  ((gated)) || continue
+  ((resolved)) && continue
   MISSING+=("$cand")
 done < <(emit_tokens)
 

--- a/plugins/guardrails/hooks/asserted-path-verify.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.sh
@@ -120,6 +120,9 @@ normalize_candidate() {
   *...*) return 0 ;;
   # Vendor and build trees are not tracked; their absence proves nothing.
   node_modules/* | */node_modules/* | .git/* | */.git/*) return 0 ;;
+  # Anything else is a candidate; the extension and first-segment gates below
+  # decide whether it is adjudicated.
+  *) ;;
   esac
 
   # A bare directory reference with no extension and no trailing slash is
@@ -136,10 +139,13 @@ normalize_candidate() {
 # FIRST-SEGMENT GATE. Only adjudicate a candidate whose leading segment is a
 # real directory here — that is what distinguishes "this repo's path, written
 # wrong" from "a path belonging to something else".
+# `first_seg`, not `seg`: hook-utils.sh declares a `local -a seg` in its bash
+# parser, and ShellCheck resolves sourced files, so a string `seg` here reads as
+# an array-to-string type change (SC2178/SC2128).
 first_segment_is_local() {
-  local seg="${1%%/*}"
-  [[ -n "$seg" ]] || return 1
-  [[ -d "$REPO_ROOT/$seg" ]]
+  local first_seg="${1%%/*}"
+  [[ -n "$first_seg" ]] || return 1
+  [[ -d "$REPO_ROOT/$first_seg" ]]
 }
 
 declare -A CHECKED=()

--- a/plugins/guardrails/hooks/asserted-path-verify.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.sh
@@ -138,8 +138,12 @@ normalize_candidate() {
   /* | [A-Za-z]:[/\\]*) return 0 ;;
   # Home-relative.
   '~'*) return 0 ;;
-  # Escapes the tree; not resolvable against the repo root.
-  ../* | */../*) return 0 ;;
+  # A `../` candidate is NOT rejected here. A markdown link destination is
+  # document-relative, so `../gone.md` from `docs/sub/note.md` is a legitimate
+  # in-repo reference. The caller canonicalizes link destinations against the
+  # document directory and drops only those that resolve outside the repo; a
+  # code-span candidate carrying `../` is dropped there instead, since a
+  # repo-root-relative citation has nothing to ascend from.
   # Glob, brace, or placeholder metacharacters — a pattern, not an assertion.
   *'*'* | *'?'* | *'['* | *']'* | *'{'* | *'}'* | *'<'* | *'>'* | *'$'* | *'('* | *')'* | *'|'* | *'!'*) return 0 ;;
   # Ellipsis stand-ins.
@@ -168,6 +172,49 @@ normalize_candidate() {
 # link is accepted when EITHER base resolves. An advisory guard errs quiet.
 DOC_DIR="$(dirname "$FILE")"
 
+# Collapse `.` and `..` segments lexically, preserving absoluteness. Purely
+# textual on purpose: the target need not exist — that is what is being tested —
+# so `realpath`/`readlink -f` would fail on exactly the inputs that matter.
+# Returns 1 when the path ascends past its own root, which is how "escapes the
+# tree" is detected.
+lexical_normalize() {
+  local p="$1" seg out=() lead=""
+  [[ "$p" == /* ]] && lead=/
+  local IFS=/
+  for seg in $p; do
+    case "$seg" in
+    '' | .) ;;
+    ..)
+      ((${#out[@]})) || return 1
+      unset 'out[-1]'
+      ;;
+    *) out+=("$seg") ;;
+    esac
+  done
+  printf '%s%s' "$lead" "${out[*]}"
+}
+
+# The document's directory as a repo-relative prefix (`docs/sub`), asked of git
+# rather than computed by string surgery.
+#
+# Deriving it as `${DOC_DIR#$REPO_ROOT}` does not work: on Windows `git rev-parse
+# --show-toplevel` returns a drive path (`C:/Users/KyleSexton/…`) while `dirname
+# "$FILE"` returns the MSYS form (`/tmp/…`), so the prefix silently never matches.
+# cygpath does not rescue it either — the MSYS `/tmp` mount resolves through an 8.3
+# short name (`KYLESE~1`), so the two sides still differ. `--show-prefix` sidesteps
+# the whole problem by answering in one universe. Empty outside a work tree, which
+# is correct: hook::repo_root then falls back to this same directory.
+DOC_REL="$(git -C "$DOC_DIR" rev-parse --show-prefix 2>/dev/null | tr -d '\r')"
+DOC_REL="${DOC_REL%/}"
+
+# Resolve a document-relative destination to a repo-relative path, or return 1
+# when it escapes the repo. Since the input is already repo-relative, ascending
+# past its root IS leaving the repo — so lexical_normalize's own failure is the
+# containment test, with no absolute paths involved.
+resolve_within_repo() {
+  lexical_normalize "${DOC_REL:+$DOC_REL/}$1"
+}
+
 declare -A CHECKED=()
 MISSING=()
 
@@ -180,10 +227,25 @@ while IFS= read -r line; do
 
   if [[ "$kind" == "link" ]]; then
     cand=$(maybe_percent_decode "$cand")
-    # Traversal guard, re-applied post-decode: an encoded `../` only becomes
-    # visible here.
+    # Absolute forms are re-checked post-decode; `../` is handled by
+    # canonicalization below, not by rejection.
     case "$cand" in
-    ../* | */../* | /* | [A-Za-z]:[/\\]*) continue ;;
+    /* | [A-Za-z]:[/\\]*) continue ;;
+    *) ;;
+    esac
+    # Resolve document-relative the way a renderer would, then require the result
+    # to stay inside the repo. A `../` that lands in-repo is a legitimate
+    # reference; one that ascends past the root is not ours to adjudicate.
+    if [[ "$cand" == *../* || "$cand" == ../* ]]; then
+      cand=$(resolve_within_repo "$cand") || continue
+      [[ -n "$cand" ]] || continue
+      # Now repo-root-relative, so the doc-dir base no longer applies.
+      kind=link_rooted
+    fi
+  else
+    # A repo-root-relative citation has nothing to ascend from.
+    case "$cand" in
+    ../* | */../*) continue ;;
     *) ;;
     esac
   fi

--- a/plugins/guardrails/hooks/asserted-path-verify.test.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.test.sh
@@ -76,6 +76,34 @@ OUT=$(run 'Per `docs/nope.md:120-125` the rule applies.')
 assert_contains "line-range suffix on a missing path → still fires" "$OUT" \
   "MISSING_PATH: docs/nope.md"
 
+# Repro-first regressions for review findings on #1284.
+
+# A titled link destination was rejected wholesale by the old expression, so a
+# missing target was never checked. Both title-quote styles and the
+# angle-bracketed form must reach the existence test.
+OUT=$(run 'See [the guide](docs/titled-missing.md "Guide") for details.')
+assert_contains "titled link (double quotes) → destination checked" "$OUT" \
+  "MISSING_PATH: docs/titled-missing.md"
+OUT=$(run "Single-quoted title [g](docs/titled2-missing.md 'Guide').")
+assert_contains "titled link (single quotes) → destination checked" "$OUT" \
+  "MISSING_PATH: docs/titled2-missing.md"
+OUT=$(run 'Angle-bracketed [g](<docs/angle-missing.md>).')
+assert_contains "angle-bracketed destination → checked" "$OUT" \
+  "MISSING_PATH: docs/angle-missing.md"
+
+# A percent-encoded destination names a decoded path; the finding must report the
+# decoded form, not the encoded literal.
+OUT=$(run 'Encoded [g](docs/enc%20missing.md).')
+assert_contains "percent-encoded destination → decoded before the check" "$OUT" \
+  "MISSING_PATH: docs/enc missing.md"
+assert_absent "percent-encoded destination → encoded form not reported" "$OUT" \
+  "docs/enc%20missing.md"
+
+# An encoded traversal must not escape the tree: %2e%2e%2f decodes to ../ and the
+# guard is re-applied after decoding.
+OUT=$(run 'Encoded escape [g](%2e%2e%2fdocs/nope.md).')
+assert_silent "encoded traversal → rejected post-decode" "$OUT"
+
 # ============================ MUST STAY QUIET ===============================
 
 OUT=$(run 'Read `docs/real.md` before starting.')
@@ -176,6 +204,36 @@ mkdir -p "$NOGIT/docs"
 OUT=$(CLAUDE_PROJECT_DIR="$NOGIT" bash "$HOOK" <<<"$(write_json "$NOGIT_TARGET" 'Read `docs/nope.md`.')" 2>&1)
 assert_contains "non-git fallback root with a matching first segment → adjudicates" "$OUT" \
   "MISSING_PATH: docs/nope.md"
+
+# A markdown link resolves relative to the DOCUMENT, not the repo root. A nested
+# file linking `assets/x.png` means `<doc-dir>/assets/x.png`. The ambiguous case
+# is the one that matters: an `assets/` directory at BOTH the repo root and the
+# document directory, where root-only resolution reports a valid link missing.
+mkdir -p "$REPO/assets" "$REPO/docs/assets"
+: >"$REPO/docs/assets/diagram.png"
+NESTED="$REPO/docs/guide.md"
+: >"$NESTED"
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$NESTED" 'See [diagram](assets/diagram.png).')" 2>&1)
+RC=$?
+assert_exit "document-relative link → exit 0" 0 "$RC"
+assert_silent "document-relative link resolves against the doc dir → silent" "$OUT"
+
+# The same nested document citing a repo-root path in link syntax still resolves —
+# this repo writes both forms, so either base satisfying the check is correct.
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$NESTED" 'See [real](docs/real.md).')" 2>&1)
+assert_silent "repo-root path in link syntax from a nested doc → silent" "$OUT"
+
+# A link that resolves against NEITHER base still fires.
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$NESTED" 'See [gone](assets/absent.png).')" 2>&1)
+assert_contains "link resolving against neither base → fires" "$OUT" \
+  "MISSING_PATH: assets/absent.png"
+
+# A code span is repo-root-relative by convention, NOT document-relative — the
+# doc-dir base must not leak into code-span resolution. `assets/diagram.png`
+# exists only under docs/, so from a nested doc it must still fire in a code span.
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$NESTED" 'Path `assets/diagram.png` cited in prose.')" 2>&1)
+assert_contains "code span stays repo-root-relative → fires" "$OUT" \
+  "MISSING_PATH: assets/diagram.png"
 
 # ============================ KILL SWITCH ===================================
 

--- a/plugins/guardrails/hooks/asserted-path-verify.test.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.test.sh
@@ -23,6 +23,13 @@ source "$HOOK_DIR/guardrails-test-helpers.sh"
 # Neutralize ambient CLAUDE_PROJECT_DIR; cases that need scoping set it.
 unset CLAUDE_PROJECT_DIR
 
+# hook::buffer_stdin bounds its fd0 read at CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT
+# seconds, default 2, and a timeout makes an advisory hook exit 0 silently. A
+# single invocation costs 10-20 s of wall time on a loaded Windows/Git Bash box, so
+# the default bound produces empty output and a false FAIL that looks like a logic
+# defect. Raised here because these cases test detection, not the read bound.
+export CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=30
+
 # A working tree with docs/ and plugins/ present and one real file in each, so
 # the first-segment gate has both a hit and a miss to distinguish.
 REPO="$TEST_TMPDIR/repo"
@@ -222,6 +229,30 @@ assert_silent "document-relative link resolves against the doc dir → silent" "
 # this repo writes both forms, so either base satisfying the check is correct.
 OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$NESTED" 'See [real](docs/real.md).')" 2>&1)
 assert_silent "repo-root path in link syntax from a nested doc → silent" "$OUT"
+
+# A parent-relative link is legitimate and document-relative: from
+# docs/sub/note.md, `../real.md` IS docs/real.md. The old blanket `../` rejection
+# meant these were never checked at all, in either direction.
+mkdir -p "$REPO/docs/sub"
+SUB="$REPO/docs/sub/note.md"
+: >"$SUB"
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$SUB" 'See [up](../real.md).')" 2>&1)
+RC=$?
+assert_exit "parent-relative link → exit 0" 0 "$RC"
+assert_silent "parent-relative link resolving in-repo → silent" "$OUT"
+
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$SUB" 'See [up](../gone.md).')" 2>&1)
+assert_contains "parent-relative link missing in-repo → fires as the resolved path" "$OUT" \
+  "MISSING_PATH: docs/gone.md"
+
+# Ascending past the repo root is not an in-repo reference and must stay quiet.
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$SUB" 'See [out](../../../../etc/passwd).')" 2>&1)
+assert_silent "link ascending past the repo root → silent" "$OUT"
+
+# A code span carrying ../ has nothing to ascend from — repo-root-relative by
+# convention — so it stays quiet rather than being resolved against the doc dir.
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$SUB" 'Path `../gone.md` in a code span.')" 2>&1)
+assert_silent "code span with ../ → silent" "$OUT"
 
 # A link that resolves against NEITHER base still fires.
 OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$NESTED" 'See [gone](assets/absent.png).')" 2>&1)

--- a/plugins/guardrails/hooks/asserted-path-verify.test.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.test.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Contract test for asserted-path-verify.sh (guardrails plugin).
+#
+# Black-box subprocess invocation. Each case builds a real git working tree so
+# hook::repo_root resolves, then feeds a PostToolUse Write|Edit payload on stdin.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/asserted-path-verify.sh"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# shellcheck source=guardrails-test-helpers.sh
+source "$HOOK_DIR/guardrails-test-helpers.sh"
+
+# Neutralize ambient CLAUDE_PROJECT_DIR; cases that need scoping set it.
+unset CLAUDE_PROJECT_DIR
+
+# A working tree with docs/ and plugins/ present and one real file in each, so
+# the first-segment gate has both a hit and a miss to distinguish.
+REPO="$TEST_TMPDIR/repo"
+mkdir -p "$REPO/docs" "$REPO/plugins/guardrails"
+git -C "$REPO" init -q
+: >"$REPO/docs/real.md"
+: >"$REPO/plugins/guardrails/README.md"
+TARGET="$REPO/notes.md"
+: >"$TARGET"
+
+RC=0
+
+# run <content> -> hook stdout+stderr; sets RC.
+run() {
+  local out
+  out=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$TARGET" "$1")" 2>&1)
+  RC=$?
+  printf '%s' "$out"
+}
+# run_edit <new_string> -> same, as an Edit payload.
+run_edit() {
+  local out
+  out=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(edit_json "$TARGET" "$1")" 2>&1)
+  RC=$?
+  printf '%s' "$out"
+}
+
+# ============================ MUST FIRE =====================================
+
+OUT=$(run 'Read `docs/nope.md` before starting.')
+assert_exit "missing path in code span → exit 0 (advisory)" 0 "$RC"
+assert_contains "missing path → named" "$OUT" "MISSING_PATH: docs/nope.md"
+
+OUT=$(run 'See [the guide](docs/gone.md) for details.')
+assert_contains "missing path in markdown link target → named" "$OUT" "MISSING_PATH: docs/gone.md"
+
+OUT=$(run 'Both `docs/nope.md` and `plugins/guardrails/absent.sh` are wrong.')
+assert_contains "two missing paths → count" "$OUT" "2 asserted path(s) do not exist"
+assert_contains "two missing paths → second named" "$OUT" "MISSING_PATH: plugins/guardrails/absent.sh"
+
+OUT=$(run 'Deep miss at `plugins/guardrails/hooks/nope.sh`.')
+assert_contains "nested missing path under a real first segment → named" "$OUT" \
+  "MISSING_PATH: plugins/guardrails/hooks/nope.sh"
+
+OUT=$(run_edit 'Now cites `docs/vanished.md` instead.')
+assert_contains "Edit hunk scanned via new_string" "$OUT" "MISSING_PATH: docs/vanished.md"
+
+# A line-citation suffix on a MISSING file still fires — the suffix is stripped
+# for resolution, so the finding names the path without it.
+OUT=$(run 'Per `docs/nope.md:120-125` the rule applies.')
+assert_contains "line-range suffix on a missing path → still fires" "$OUT" \
+  "MISSING_PATH: docs/nope.md"
+
+# ============================ MUST STAY QUIET ===============================
+
+OUT=$(run 'Read `docs/real.md` before starting.')
+assert_exit "existing path → exit 0" 0 "$RC"
+assert_silent "existing path → silent" "$OUT"
+
+# Line and range citations are this repo's dominant citation form; stripping the
+# suffix is what keeps them quiet.
+OUT=$(run 'Per `docs/real.md:42` and `docs/real.md:576-580` the rule applies.')
+assert_silent "line and range citation suffixes stripped → silent" "$OUT"
+
+OUT=$(run 'An anchor cite: `docs/real.md#section-two`.')
+assert_silent "anchor fragment stripped → silent" "$OUT"
+
+# FIRST-SEGMENT GATE: the leading directory is not in this repo, so the token is
+# not this repo's to adjudicate.
+OUT=$(run 'Upstream lives at `some-other-project/src/main.rs`.')
+assert_silent "first segment absent → not adjudicated" "$OUT"
+
+OUT=$(run 'Glob it with `plugins/*/SKILL.md` or `docs/**/*.md`.')
+assert_silent "glob patterns → silent" "$OUT"
+
+OUT=$(run 'Placeholders like `plugins/<name>/plugin.json` and `docs/${topic}/PLAN.md`.')
+assert_silent "placeholder metacharacters → silent" "$OUT"
+
+OUT=$(run 'Truncated as `docs/.../PLAN.md`.')
+assert_silent "ellipsis stand-in → silent" "$OUT"
+
+OUT=$(run 'Fetch <https://example.com/docs/nope.md> and [x](https://a.test/docs/gone.md).')
+assert_silent "URLs → silent" "$OUT"
+
+OUT=$(run 'Absolute paths `/etc/hosts` and `C:/Windows/system32/x.dll`.')
+assert_silent "absolute paths → silent (hardcoded-path-check owns those)" "$OUT"
+
+OUT=$(run 'User config at `~/.claude/settings.json`.')
+assert_silent "home-relative → silent" "$OUT"
+
+OUT=$(run 'Parent escape `../docs/nope.md` and `docs/../plugins/nope.sh`.')
+assert_silent "parent-escaping paths → silent" "$OUT"
+
+OUT=$(run 'Bare directory refs `plugins/guardrails` and `a/b` carry no extension.')
+assert_silent "extensionless non-slash-terminated refs → silent (ambiguous)" "$OUT"
+
+OUT=$(run 'Trailing slash marks a directory: `docs/` and `plugins/guardrails/`.')
+assert_silent "existing directories with trailing slash → silent" "$OUT"
+
+OUT=$(run 'Vendor trees `node_modules/pkg/index.js` and `.git/config` prove nothing.')
+assert_silent "vendor and git trees → silent" "$OUT"
+
+OUT=$(run 'Prose mentioning docs/nope.md outside any code span or link.')
+assert_silent "unquoted prose path → not scanned" "$OUT"
+
+OUT=$(run 'A whole command: `cp docs/nope.md docs/other.md`.')
+assert_silent "multi-token code span → not a path candidate" "$OUT"
+
+# Non-markdown files are out of scope: a path literal in a script resolves
+# against the runtime CWD, not the repo root.
+SCRIPT="$REPO/tool.sh"
+: >"$SCRIPT"
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$SCRIPT" 'cat docs/nope.md')" 2>&1)
+RC=$?
+assert_exit "non-markdown file → exit 0" 0 "$RC"
+assert_silent "non-markdown file → not scanned" "$OUT"
+
+# A tool other than Write|Edit carries nothing this call wrote.
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(notebook_json "$TARGET" 'docs/nope.md')" 2>&1)
+RC=$?
+assert_exit "NotebookEdit payload → exit 0" 0 "$RC"
+assert_silent "NotebookEdit payload → silent" "$OUT"
+
+# A file outside CLAUDE_PROJECT_DIR is not policed.
+OUTSIDE="$TEST_TMPDIR/outside.md"
+: >"$OUTSIDE"
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$OUTSIDE" 'Read `docs/nope.md`.')" 2>&1)
+RC=$?
+assert_exit "file outside project dir → exit 0" 0 "$RC"
+assert_silent "file outside project dir → silent" "$OUT"
+
+# Non-git directory: hook::repo_root cannot resolve a working-tree top and falls
+# back to the hint (the written file's own directory). The first-segment gate is
+# then evaluated against that directory, so a repo-shaped citation with no
+# matching child stays quiet rather than being adjudicated against a root that is
+# not one. Pins the fallback so a future repo_root change cannot silently turn
+# this into a false-positive source.
+NOGIT="$TEST_TMPDIR/nogit"
+mkdir -p "$NOGIT"
+NOGIT_TARGET="$NOGIT/notes.md"
+: >"$NOGIT_TARGET"
+OUT=$(CLAUDE_PROJECT_DIR="$NOGIT" bash "$HOOK" <<<"$(write_json "$NOGIT_TARGET" 'Read `docs/nope.md`.')" 2>&1)
+RC=$?
+assert_exit "non-git directory → exit 0" 0 "$RC"
+assert_silent "non-git directory → silent (first-segment gate closes)" "$OUT"
+
+# Same non-git directory, but the cited first segment DOES exist there. The gate
+# opens and the guard adjudicates against the fallback root — documenting that the
+# fallback is a real adjudication path, not a dead branch.
+mkdir -p "$NOGIT/docs"
+OUT=$(CLAUDE_PROJECT_DIR="$NOGIT" bash "$HOOK" <<<"$(write_json "$NOGIT_TARGET" 'Read `docs/nope.md`.')" 2>&1)
+assert_contains "non-git fallback root with a matching first segment → adjudicates" "$OUT" \
+  "MISSING_PATH: docs/nope.md"
+
+# ============================ KILL SWITCH ===================================
+
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" CLAUDE_PLUGIN_OPTION_ASSERTED_PATH_VERIFY_ENABLED=false \
+  bash "$HOOK" <<<"$(write_json "$TARGET" 'Read `docs/nope.md`.')" 2>&1)
+RC=$?
+assert_exit "kill switch → exit 0" 0 "$RC"
+assert_silent "kill switch → silent" "$OUT"
+
+# ============================ EMPTY STDIN ===================================
+
+# hook::buffer_stdin returns 1 (no payload) → this advisory hook skips silently.
+# A here-string cannot reproduce the Win32 late-EOF pipe stall, and rc-2
+# (timeout) collapses to the same silent exit 0 for an advisory hook, so this
+# asserts the skip contract, not the stall.
+OUT=$(bash "$HOOK" </dev/null 2>&1)
+RC=$?
+assert_exit "empty stdin → exit 0" 0 "$RC"
+assert_silent "empty stdin → no output" "$OUT"
+
+# ============================ MISSING PREREQUISITE ==========================
+
+# Runtime jq-removal is not portably simulable — an isolated bin dir without jq
+# cannot host bash + coreutils (their DLLs / PATH) across Git Bash and Linux, the
+# same constraint secret-pattern-detection.test.sh and
+# require-jq-notice-isolation.test.sh both document. Assert the fail-open guard is
+# present via the shared helper, which composes the once-per-session notice_once
+# gate with the dual-channel (systemMessage + additionalContext) notice;
+# require_jq's own behavior is covered by lib/hook-utils.test.sh, and this hook's
+# notice key is proven unique plugin-wide by require-jq-notice-isolation.test.sh,
+# which discovers call sites by glob.
+HOOK_SRC=$(cat "$HOOK")
+assert_contains "jq guard: uses hook::require_jq" "$HOOK_SRC" 'hook::require_jq'
+assert_contains "jq guard: hook-specific notice key" "$HOOK_SRC" 'guardrails-asserted-path-verify'
+
+# The repo root is resolved from the written file, never from the process CWD, so
+# the hook is correct in a linked worktree and in a bare-hub clone.
+assert_contains "repo root is file-anchored" "$HOOK_SRC" 'hook::repo_root "$(dirname "$FILE")"'
+
+# ============================ TELEMETRY =====================================
+
+TEL="$(mktemp -p "$TEST_TMPDIR")"
+SINK="$(make_sink "cat >\"$TEL\"")"
+CLAUDE_PROJECT_DIR="$REPO" HOOK_TELEMETRY_SINK="$SINK" \
+  bash "$HOOK" <<<"$(write_json "$TARGET" 'Read `docs/nope.md`.')" >/dev/null 2>&1 || true
+if wait_for_sink "$TEL"; then
+  assert_contains "telemetry: hook id" "$(jq -r '.hook' "$TEL")" "asserted-path-verify"
+  assert_contains "telemetry: status ok" "$(jq -r '.status' "$TEL")" "ok"
+  assert_contains "telemetry: findings name the path" "$(jq -r '.data.findings[]' "$TEL")" "docs/nope.md"
+  assert_absent "telemetry: file path is repo-relative, never absolute" \
+    "$(jq -r '.data.file' "$TEL")" "$TEST_TMPDIR"
+else
+  bad "telemetry: no envelope written"
+fi
+
+report

--- a/plugins/guardrails/hooks/asserted-path-verify.test.sh
+++ b/plugins/guardrails/hooks/asserted-path-verify.test.sh
@@ -4,6 +4,12 @@
 # Black-box subprocess invocation. Each case builds a real git working tree so
 # hook::repo_root resolves, then feeds a PostToolUse Write|Edit payload on stdin.
 
+# shellcheck disable=SC2016
+# Every fixture below is markdown fed to the hook as literal data. Backticks are
+# the code-span delimiters the hook scans for and `$`/`{}` appear inside
+# placeholder fixtures on purpose — single quotes are required so none of it
+# expands. Disabled file-wide rather than on ~25 individual lines.
+
 set -uo pipefail
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/guardrails/hooks/hooks.json
+++ b/plugins/guardrails/hooks/hooks.json
@@ -85,6 +85,18 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/cli-flag-verify.sh",
             "timeout": 30,
             "statusMessage": "Verifying CLI flags..."
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/asserted-path-verify.sh",
+            "timeout": 30,
+            "statusMessage": "Verifying asserted paths..."
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/skill-reference-verify.sh",
+            "timeout": 30,
+            "statusMessage": "Verifying skill references..."
           }
         ]
       }

--- a/plugins/guardrails/hooks/skill-reference-verify.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# PostToolUse hook: verify `/<plugin>:<skill>` references written to markdown
+# resolve to a skill that exists in the working tree.
+# Triggered on Write|Edit of *.md files.
+#
+# Catches subagent / training-recall hallucinations — a slash-command reference
+# written AS a capability that does not exist, or one left behind by a rename.
+# Sibling of cli-flag-verify and asserted-path-verify: same defect class, third
+# oracle.
+#
+# ENFORCEABILITY TIER: Detect-then-judge — ADVISORY PLUS A HUMAN VERDICT, never
+# an auto-fix. Globbing a plugins tree is exact only inside a marketplace repo
+# that owns the referenced plugin. In a consuming repo the reference may name a
+# plugin from another marketplace, or one the operator has simply not installed,
+# and this hook cannot distinguish that from a hallucination. Per the org
+# convention on enforceability tiers, that means the finding is a prompt for a
+# human decision, not a determination. The plugins-root gate below is what keeps
+# the noise inside the one context where the oracle is meaningful.
+#
+# PLUGINS-ROOT GATE: the hook does nothing unless the file being written lives in
+# a repo with a `plugins/` directory containing at least one `.claude-plugin/`
+# manifest — i.e. a marketplace repo. Outside one there is no local authority to
+# resolve a reference against, so the guard stays silent rather than guessing.
+#
+# PLUGIN-SCOPE GATE: within a marketplace repo, a reference is only adjudicated
+# when its PLUGIN half resolves locally. `/some-other-marketplace:thing` is left
+# alone; `/guardrails:nonexistent` is reported, because this repo owns
+# `guardrails` and can therefore say the skill is not there.
+#
+# NON-BLOCKING (advisory): exits 0 with hookSpecificOutput additionalContext.
+#
+# Disable with the skill_reference_verify_enabled userConfig option set to false.
+
+set -uo pipefail
+
+# High-res start stamp for telemetry (Bash 5.0+; empty on older bash → skip).
+start=${EPOCHREALTIME:-}
+
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "SKILL_REFERENCE_VERIFY"
+
+hook::ctx_reset
+
+INPUT=$(hook::buffer_stdin) || exit 0
+
+hook::require_jq "PostToolUse" "guardrails-skill-reference-verify" "$INPUT"
+
+FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
+case "$FILE" in
+*.md) ;;
+*) exit 0 ;;
+esac
+
+# Diff-scope: verify only the content THIS tool call wrote, never re-read the
+# whole file from disk.
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null | tr -d '\r')
+case "$TOOL" in
+Edit) SCAN_CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null | tr -d '\r') ;;
+Write) SCAN_CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null | tr -d '\r') ;;
+*) exit 0 ;;
+esac
+[[ -n "$SCAN_CONTENT" ]] || exit 0
+
+REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
+PLUGINS_DIR="$REPO_ROOT/plugins"
+
+# PLUGINS-ROOT GATE. Outside a marketplace repo there is no local authority.
+[[ -d "$PLUGINS_DIR" ]] || exit 0
+shopt -s nullglob
+manifests=("$PLUGINS_DIR"/*/.claude-plugin/plugin.json)
+shopt -u nullglob
+((${#manifests[@]} > 0)) || exit 0
+
+# A plugin's command namespace is its manifest `name`, which need not equal its
+# directory name. Build the name → directory map from the manifests themselves so
+# a renamed directory or a name override resolves correctly.
+declare -A PLUGIN_DIR=()
+for m in "${manifests[@]}"; do
+  pdir="${m%/.claude-plugin/plugin.json}"
+  pname=$(jq -r '.name // empty' "$m" 2>/dev/null | tr -d '\r')
+  [[ -n "$pname" ]] || pname="${pdir##*/}"
+  PLUGIN_DIR["$pname"]="$pdir"
+done
+
+# A plugin skill's command segment comes from its frontmatter `name` when set,
+# and from the directory name otherwise. Resolve a (plugin, skill) pair against
+# both so a skill whose directory and command name diverge still resolves.
+skill_resolves() {
+  local pdir="$1" skill="$2" sd fname
+  [[ -d "$pdir/skills/$skill" ]] && return 0
+  for sd in "$pdir"/skills/*/SKILL.md; do
+    [[ -f "$sd" ]] || continue
+    # Frontmatter `name:`, unquoted or quoted, first occurrence only.
+    fname=$(sed -n '1,40{s/^name:[[:space:]]*["'\'']\{0,1\}\([A-Za-z0-9_-]\{1,\}\)["'\'']\{0,1\}[[:space:]]*$/\1/p;}' "$sd" 2>/dev/null | head -1)
+    [[ "$fname" == "$skill" ]] && return 0
+  done
+  return 1
+}
+
+# Candidate references: `/<plugin>:<skill>` inside inline-code spans only. Prose
+# is not scanned — an unbackticked `/a:b` is as likely to be a URL fragment, a
+# Windows drive path, or a time range as a command.
+emit_refs() {
+  # shellcheck disable=SC2016  # backticks are literal ERE data, not expansions
+  printf '%s' "$SCAN_CONTENT" | grep -oE '`/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*`' 2>/dev/null |
+    tr -d '`'
+}
+
+declare -A CHECKED=()
+UNRESOLVED=()
+
+while IFS= read -r ref; do
+  [[ -n "$ref" ]] || continue
+  [[ -n "${CHECKED[$ref]:-}" ]] && continue
+  CHECKED["$ref"]=1
+  plugin="${ref#/}"
+  plugin="${plugin%%:*}"
+  skill="${ref##*:}"
+  # PLUGIN-SCOPE GATE: only adjudicate a plugin this repo owns.
+  pdir="${PLUGIN_DIR[$plugin]:-}"
+  [[ -n "$pdir" ]] || continue
+  skill_resolves "$pdir" "$skill" && continue
+  UNRESOLVED+=("$ref")
+done < <(emit_refs)
+
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::telemetry_enabled || return 0
+  local file_rel="$FILE" findings_json="[]"
+  if command -v cygpath >/dev/null 2>&1; then
+    local _file_lm _root_lm
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    [[ -n "$_file_lm" && -n "$_root_lm" ]] && file_rel="${_file_lm#"$_root_lm"/}"
+  else
+    file_rel="${FILE#"$REPO_ROOT"/}"
+  fi
+  # Redaction: a path that could not be made repo-relative degrades to its
+  # basename — never an absolute path, which would embed the developer's
+  # username.
+  case "$file_rel" in
+  /* | [A-Za-z]:*)
+    file_rel="${file_rel##*/}"
+    file_rel="${file_rel##*\\}"
+    ;;
+  *) ;;
+  esac
+  if ((${#UNRESOLVED[@]} > 0)); then
+    local r raw_list=""
+    for r in "${UNRESOLVED[@]}"; do raw_list+="$r"$'\n'; done
+    findings_json=$(printf '%s' "$raw_list" | jq -R . | jq -s . 2>/dev/null) || findings_json="[]"
+  fi
+  local data
+  data=$(jq -n --arg file "$file_rel" --argjson findings "$findings_json" \
+    '{tool:"",file:$file,findings:$findings}' 2>/dev/null) ||
+    data='{"tool":"","file":"","findings":[]}'
+  hook::emit_telemetry "skill-reference-verify" "PostToolUse" "ok" "$start" "$data" "$REPO_ROOT"
+}
+
+if ((${#UNRESOLVED[@]} > 0)); then
+  hook::ctx_append "skill-reference-verify: ${#UNRESOLVED[@]} skill reference(s) do not resolve in $FILE"
+  hook::ctx_append "This repo owns each plugin named below, so it can say the skill is not there:"
+  for r in "${UNRESOLVED[@]}"; do
+    plugin="${r#/}"
+    plugin="${plugin%%:*}"
+    hook::ctx_append "  UNRESOLVED_SKILL: $r (no such skill under plugins/${PLUGIN_DIR[$plugin]##*/}/skills/)"
+  done
+  hook::ctx_append ""
+  hook::ctx_append "Detect-then-judge: this is a prompt for your verdict, not a determination."
+  hook::ctx_append "Confirm against the tree. A reference retained deliberately — documenting"
+  hook::ctx_append "a rename, or a capability another marketplace ships — is correct as written."
+  hook::ctx_flush PostToolUse
+fi
+
+emit_tel
+exit 0

--- a/plugins/guardrails/hooks/skill-reference-verify.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.sh
@@ -87,13 +87,22 @@ done
 # A plugin skill's command segment comes from its frontmatter `name` when set,
 # and from the directory name otherwise. Resolve a (plugin, skill) pair against
 # both so a skill whose directory and command name diverge still resolves.
+#
+# A directory alone is NOT a skill — it must carry a SKILL.md. An empty or
+# leftover `skills/<name>/` would otherwise suppress the advisory for a command
+# that does not exist.
 skill_resolves() {
   local pdir="$1" skill="$2" sd fname
-  [[ -d "$pdir/skills/$skill" ]] && return 0
+  [[ -f "$pdir/skills/$skill/SKILL.md" ]] && return 0
   for sd in "$pdir"/skills/*/SKILL.md; do
     [[ -f "$sd" ]] || continue
-    # Frontmatter `name:`, unquoted or quoted, first occurrence only.
-    fname=$(sed -n '1,40{s/^name:[[:space:]]*["'\'']\{0,1\}\([A-Za-z0-9_-]\{1,\}\)["'\'']\{0,1\}[[:space:]]*$/\1/p;}' "$sd" 2>/dev/null | head -1)
+    # Frontmatter `name:`, quoted or not, tolerating a trailing YAML comment
+    # (`name: renamed # public command`). Comments are stripped first so the
+    # value pattern can stay anchored to end-of-line.
+    fname=$(sed -n '1,40p' "$sd" 2>/dev/null |
+      sed -E 's/[[:space:]]+#.*$//' |
+      sed -nE 's/^name:[[:space:]]*"?'"'"'?([A-Za-z0-9_-]+)"?'"'"'?[[:space:]]*$/\1/p' |
+      head -1)
     [[ "$fname" == "$skill" ]] && return 0
   done
   return 1

--- a/plugins/guardrails/hooks/skill-reference-verify.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.sh
@@ -84,26 +84,40 @@ for m in "${manifests[@]}"; do
   PLUGIN_DIR["$pname"]="$pdir"
 done
 
+# Extract a plugin skill's frontmatter `name`, or nothing when it declares none.
+# Tolerates quoting and a trailing YAML comment (`name: renamed # public
+# command`); comments are stripped first so the value pattern stays anchored to
+# end-of-line.
+skill_frontmatter_name() {
+  sed -n '1,40p' "$1" 2>/dev/null |
+    sed -E 's/[[:space:]]+#.*$//' |
+    sed -nE 's/^name:[[:space:]]*"?'"'"'?([A-Za-z0-9_-]+)"?'"'"'?[[:space:]]*$/\1/p' |
+    head -1
+}
+
 # A plugin skill's command segment comes from its frontmatter `name` when set,
-# and from the directory name otherwise. Resolve a (plugin, skill) pair against
-# both so a skill whose directory and command name diverge still resolves.
+# and from the directory name ONLY when it does not.
 #
-# A directory alone is NOT a skill — it must carry a SKILL.md. An empty or
-# leftover `skills/<name>/` would otherwise suppress the advisory for a command
-# that does not exist.
+# The directory name is not an alias. A `skills/legacy-dir/SKILL.md` declaring
+# `name: renamed` answers to `/plugin:renamed` and NOT to `/plugin:legacy-dir` —
+# treating the directory as a second valid spelling would suppress the advisory
+# for exactly the stale pre-rename references this guard exists to catch.
+#
+# A directory alone is also not a skill: it must carry a SKILL.md, or a leftover
+# empty `skills/<name>/` would suppress the advisory for a command that never
+# existed.
 skill_resolves() {
   local pdir="$1" skill="$2" sd fname
-  [[ -f "$pdir/skills/$skill/SKILL.md" ]] && return 0
+  local direct="$pdir/skills/$skill/SKILL.md"
+  if [[ -f "$direct" ]]; then
+    fname=$(skill_frontmatter_name "$direct")
+    # No declared name → the directory name IS the command segment.
+    [[ -z "$fname" || "$fname" == "$skill" ]] && return 0
+  fi
   for sd in "$pdir"/skills/*/SKILL.md; do
     [[ -f "$sd" ]] || continue
-    # Frontmatter `name:`, quoted or not, tolerating a trailing YAML comment
-    # (`name: renamed # public command`). Comments are stripped first so the
-    # value pattern can stay anchored to end-of-line.
-    fname=$(sed -n '1,40p' "$sd" 2>/dev/null |
-      sed -E 's/[[:space:]]+#.*$//' |
-      sed -nE 's/^name:[[:space:]]*"?'"'"'?([A-Za-z0-9_-]+)"?'"'"'?[[:space:]]*$/\1/p' |
-      head -1)
-    [[ "$fname" == "$skill" ]] && return 0
+    fname=$(skill_frontmatter_name "$sd")
+    [[ -n "$fname" && "$fname" == "$skill" ]] && return 0
   done
   return 1
 }
@@ -111,10 +125,16 @@ skill_resolves() {
 # Candidate references: `/<plugin>:<skill>` inside inline-code spans only. Prose
 # is not scanned — an unbackticked `/a:b` is as likely to be a URL fragment, a
 # Windows drive path, or a time range as a command.
+#
+# The reference need not be the whole span: an invocation commonly carries
+# arguments (`/plugin:skill --apply`, `/plugin:skill <target>`). Take the leading
+# command token from each span rather than requiring the span to match exactly,
+# or argument-bearing invocations — the common form in this repo — go unchecked.
 emit_refs() {
   # shellcheck disable=SC2016  # backticks are literal ERE data, not expansions
-  printf '%s' "$SCAN_CONTENT" | grep -oE '`/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*`' 2>/dev/null |
-    tr -d '`'
+  printf '%s' "$SCAN_CONTENT" | grep -oE '`[^`]+`' 2>/dev/null |
+    sed -E 's/^`+//; s/`+$//' |
+    sed -nE 's|^(/[a-z][a-z0-9-]*:[a-z][a-z0-9-]*)([[:space:]].*)?$|\1|p'
 }
 
 declare -A CHECKED=()

--- a/plugins/guardrails/hooks/skill-reference-verify.test.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.test.sh
@@ -5,6 +5,11 @@
 # the plugins-root and plugin-scope gates have both a hit and a miss to
 # distinguish, then feeds a PostToolUse Write|Edit payload on stdin.
 
+# shellcheck disable=SC2016
+# Every fixture below is markdown fed to the hook as literal data, and backticks
+# are the code-span delimiters the hook scans for — single quotes are required so
+# nothing expands. Disabled file-wide rather than on ~20 individual lines.
+
 set -uo pipefail
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/guardrails/hooks/skill-reference-verify.test.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.test.sh
@@ -101,6 +101,22 @@ assert_contains "Edit hunk scanned via new_string" "$OUT" "UNRESOLVED_SKILL: /al
 OUT=$(run 'Run `/alpha:nonexistent`.')
 assert_contains "advisory states detect-then-judge tier" "$OUT" "Detect-then-judge"
 
+# Repro-first regressions for review findings on #1284.
+
+# A bare directory under skills/ is NOT a skill. Without a SKILL.md there is no
+# command, so the advisory must still fire — the old directory-only test
+# suppressed it.
+mkdir -p "$REPO/plugins/alpha/skills/ghost"
+OUT=$(run 'Run `/alpha:ghost`.')
+assert_contains "skills/ dir without SKILL.md → still unresolved" "$OUT" \
+  "UNRESOLVED_SKILL: /alpha:ghost"
+
+# A frontmatter name carrying a trailing YAML comment is a valid rename and must
+# resolve; the old end-of-line-anchored parser extracted nothing.
+mk_skill alpha commented-dir 'commented-name # public command'
+OUT=$(run 'Run `/alpha:commented-name`.')
+assert_silent "frontmatter name with trailing YAML comment → resolves" "$OUT"
+
 # ============================ MUST STAY QUIET ===============================
 
 OUT=$(run 'Run `/alpha:setup` and `/alpha:audit` first.')

--- a/plugins/guardrails/hooks/skill-reference-verify.test.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Contract test for skill-reference-verify.sh (guardrails plugin).
+#
+# Black-box subprocess invocation. Builds a synthetic marketplace working tree so
+# the plugins-root and plugin-scope gates have both a hit and a miss to
+# distinguish, then feeds a PostToolUse Write|Edit payload on stdin.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/skill-reference-verify.sh"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# shellcheck source=guardrails-test-helpers.sh
+source "$HOOK_DIR/guardrails-test-helpers.sh"
+
+unset CLAUDE_PROJECT_DIR
+RC=0
+
+# --- Synthetic marketplace ---------------------------------------------------
+# Two plugins. `alpha`'s manifest name matches its directory. `beta`'s manifest
+# name deliberately DIVERGES from its directory (`beta-dir`), which is what
+# proves resolution goes through the manifest rather than the directory listing.
+REPO="$TEST_TMPDIR/market"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+
+mk_plugin() {
+  local dir="$1" name="$2"
+  mkdir -p "$REPO/plugins/$dir/.claude-plugin"
+  MSYS_NO_PATHCONV=1 jq -n --arg n "$name" '{name:$n,version:"0.1.0"}' \
+    >"$REPO/plugins/$dir/.claude-plugin/plugin.json"
+}
+# mk_skill <plugin-dir> <skill-dir> [frontmatter-name]
+mk_skill() {
+  local pdir="$1" sdir="$2" fname="${3:-}"
+  mkdir -p "$REPO/plugins/$pdir/skills/$sdir"
+  local f="$REPO/plugins/$pdir/skills/$sdir/SKILL.md"
+  if [[ -n "$fname" ]]; then
+    {
+      printf -- '---\n'
+      printf 'name: %s\n' "$fname"
+      printf 'description: x\n'
+      printf -- '---\n'
+    } >"$f"
+  else
+    : >"$f"
+  fi
+}
+
+mk_plugin alpha alpha
+mk_skill alpha setup
+mk_skill alpha audit
+# Command name comes from frontmatter, not the directory.
+mk_skill alpha legacy-dir renamed-command
+# Quoted frontmatter name must resolve identically.
+mk_skill alpha quoted-dir '"quoted-name"'
+
+mk_plugin beta-dir beta
+mk_skill beta-dir check
+
+TARGET="$REPO/notes.md"
+: >"$TARGET"
+
+run() {
+  local out
+  out=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$TARGET" "$1")" 2>&1)
+  RC=$?
+  printf '%s' "$out"
+}
+run_edit() {
+  local out
+  out=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(edit_json "$TARGET" "$1")" 2>&1)
+  RC=$?
+  printf '%s' "$out"
+}
+
+# ============================ MUST FIRE =====================================
+
+OUT=$(run 'Run `/alpha:nonexistent` next.')
+assert_exit "unresolved skill → exit 0 (advisory)" 0 "$RC"
+assert_contains "unresolved skill → named" "$OUT" "UNRESOLVED_SKILL: /alpha:nonexistent"
+assert_contains "unresolved skill → names the searched plugin dir" "$OUT" "plugins/alpha/skills/"
+
+OUT=$(run 'Both `/alpha:ghost` and `/beta:missing` are gone.')
+assert_contains "two unresolved → count" "$OUT" "2 skill reference(s) do not resolve"
+assert_contains "two unresolved → manifest-named plugin resolves to its real dir" "$OUT" \
+  "plugins/beta-dir/skills/"
+
+OUT=$(run_edit 'Now cites `/alpha:vanished`.')
+assert_contains "Edit hunk scanned via new_string" "$OUT" "UNRESOLVED_SKILL: /alpha:vanished"
+
+# The advisory must state its tier — the issue this guard ships under requires
+# the third guard never read as deterministic.
+OUT=$(run 'Run `/alpha:nonexistent`.')
+assert_contains "advisory states detect-then-judge tier" "$OUT" "Detect-then-judge"
+
+# ============================ MUST STAY QUIET ===============================
+
+OUT=$(run 'Run `/alpha:setup` and `/alpha:audit` first.')
+assert_exit "resolving skills → exit 0" 0 "$RC"
+assert_silent "resolving skills → silent" "$OUT"
+
+# Manifest name diverges from directory name; the reference uses the manifest name.
+OUT=$(run 'Run `/beta:check`.')
+assert_silent "plugin resolved via manifest name, not directory name → silent" "$OUT"
+
+# Frontmatter name diverges from the skill directory name.
+OUT=$(run 'Run `/alpha:renamed-command`.')
+assert_silent "skill resolved via frontmatter name → silent" "$OUT"
+
+OUT=$(run 'Run `/alpha:quoted-name`.')
+assert_silent "skill resolved via quoted frontmatter name → silent" "$OUT"
+
+# PLUGIN-SCOPE GATE: this repo does not own the plugin, so it has no authority.
+OUT=$(run 'Install `/some-other-market:thing` from elsewhere.')
+assert_silent "unowned plugin → not adjudicated" "$OUT"
+
+# A reference to a directory that exists but carries no manifest is not a plugin.
+mkdir -p "$REPO/plugins/not-a-plugin/skills/x"
+OUT=$(run 'Run `/not-a-plugin:x`.')
+assert_silent "directory without a manifest → not a plugin, silent" "$OUT"
+
+OUT=$(run 'Unbackticked /alpha:nonexistent in prose is not a command.')
+assert_silent "unbackticked reference → not scanned" "$OUT"
+
+OUT=$(run 'A URL fragment `https://x.test/a:b` and a time `12:30` are not references.')
+assert_silent "URL fragment and time → silent" "$OUT"
+
+OUT=$(run 'Uppercase `/Alpha:Setup` does not match the command grammar.')
+assert_silent "uppercase reference → silent (not command-shaped)" "$OUT"
+
+# PLUGINS-ROOT GATE: outside a marketplace repo there is no local authority.
+PLAIN="$TEST_TMPDIR/plain"
+mkdir -p "$PLAIN"
+git -C "$PLAIN" init -q
+PLAIN_TARGET="$PLAIN/notes.md"
+: >"$PLAIN_TARGET"
+OUT=$(CLAUDE_PROJECT_DIR="$PLAIN" bash "$HOOK" <<<"$(write_json "$PLAIN_TARGET" 'Run `/alpha:nonexistent`.')" 2>&1)
+RC=$?
+assert_exit "no plugins/ tree → exit 0" 0 "$RC"
+assert_silent "no plugins/ tree → silent (no local authority)" "$OUT"
+
+# A plugins/ directory with no manifests is not a marketplace either.
+EMPTY="$TEST_TMPDIR/empty-market"
+mkdir -p "$EMPTY/plugins/whatever"
+git -C "$EMPTY" init -q
+EMPTY_TARGET="$EMPTY/notes.md"
+: >"$EMPTY_TARGET"
+OUT=$(CLAUDE_PROJECT_DIR="$EMPTY" bash "$HOOK" <<<"$(write_json "$EMPTY_TARGET" 'Run `/alpha:nonexistent`.')" 2>&1)
+RC=$?
+assert_exit "plugins/ with no manifests → exit 0" 0 "$RC"
+assert_silent "plugins/ with no manifests → silent" "$OUT"
+
+# Non-markdown files are out of scope.
+SCRIPT="$REPO/tool.sh"
+: >"$SCRIPT"
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$SCRIPT" 'echo `/alpha:nonexistent`')" 2>&1)
+RC=$?
+assert_exit "non-markdown file → exit 0" 0 "$RC"
+assert_silent "non-markdown file → not scanned" "$OUT"
+
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(notebook_json "$TARGET" '`/alpha:nonexistent`')" 2>&1)
+RC=$?
+assert_exit "NotebookEdit payload → exit 0" 0 "$RC"
+assert_silent "NotebookEdit payload → silent" "$OUT"
+
+OUTSIDE="$TEST_TMPDIR/outside.md"
+: >"$OUTSIDE"
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" bash "$HOOK" <<<"$(write_json "$OUTSIDE" 'Run `/alpha:nonexistent`.')" 2>&1)
+RC=$?
+assert_exit "file outside project dir → exit 0" 0 "$RC"
+assert_silent "file outside project dir → silent" "$OUT"
+
+# ============================ KILL SWITCH ===================================
+
+OUT=$(CLAUDE_PROJECT_DIR="$REPO" CLAUDE_PLUGIN_OPTION_SKILL_REFERENCE_VERIFY_ENABLED=false \
+  bash "$HOOK" <<<"$(write_json "$TARGET" 'Run `/alpha:nonexistent`.')" 2>&1)
+RC=$?
+assert_exit "kill switch → exit 0" 0 "$RC"
+assert_silent "kill switch → silent" "$OUT"
+
+# ============================ EMPTY STDIN ===================================
+
+OUT=$(bash "$HOOK" </dev/null 2>&1)
+RC=$?
+assert_exit "empty stdin → exit 0" 0 "$RC"
+assert_silent "empty stdin → no output" "$OUT"
+
+# ============================ MISSING PREREQUISITE ==========================
+
+# Runtime jq-removal is not portably simulable — an isolated bin dir without jq
+# cannot host bash + coreutils across Git Bash and Linux, the same constraint
+# secret-pattern-detection.test.sh and require-jq-notice-isolation.test.sh both
+# document. Assert the fail-open guard is present via the shared helper;
+# require_jq's own behavior is covered by lib/hook-utils.test.sh, and this hook's
+# notice key is proven unique plugin-wide by require-jq-notice-isolation.test.sh.
+HOOK_SRC=$(cat "$HOOK")
+assert_contains "jq guard: uses hook::require_jq" "$HOOK_SRC" 'hook::require_jq'
+assert_contains "jq guard: hook-specific notice key" "$HOOK_SRC" 'guardrails-skill-reference-verify'
+assert_contains "repo root is file-anchored" "$HOOK_SRC" 'hook::repo_root "$(dirname "$FILE")"'
+
+# ============================ TELEMETRY =====================================
+
+TEL="$(mktemp -p "$TEST_TMPDIR")"
+SINK="$(make_sink "cat >\"$TEL\"")"
+CLAUDE_PROJECT_DIR="$REPO" HOOK_TELEMETRY_SINK="$SINK" \
+  bash "$HOOK" <<<"$(write_json "$TARGET" 'Run `/alpha:nonexistent`.')" >/dev/null 2>&1 || true
+if wait_for_sink "$TEL"; then
+  assert_contains "telemetry: hook id" "$(jq -r '.hook' "$TEL")" "skill-reference-verify"
+  assert_contains "telemetry: status ok" "$(jq -r '.status' "$TEL")" "ok"
+  assert_contains "telemetry: findings name the reference" "$(jq -r '.data.findings[]' "$TEL")" "/alpha:nonexistent"
+  assert_absent "telemetry: file path is repo-relative, never absolute" \
+    "$(jq -r '.data.file' "$TEL")" "$TEST_TMPDIR"
+else
+  bad "telemetry: no envelope written"
+fi
+
+report

--- a/plugins/guardrails/hooks/skill-reference-verify.test.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.test.sh
@@ -23,6 +23,13 @@ source "$HOOK_DIR/guardrails-test-helpers.sh"
 unset CLAUDE_PROJECT_DIR
 RC=0
 
+# hook::buffer_stdin bounds its fd0 read at CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT
+# seconds, default 2, and a timeout makes an advisory hook exit 0 silently. A
+# single invocation costs 10-20 s of wall time on a loaded Windows/Git Bash box, so
+# the default bound produces empty output and a false FAIL that looks like a logic
+# defect. Raised here because these cases test detection, not the read bound.
+export CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=30
+
 # --- Synthetic marketplace ---------------------------------------------------
 # Two plugins. `alpha`'s manifest name matches its directory. `beta`'s manifest
 # name deliberately DIVERGES from its directory (`beta-dir`), which is what
@@ -116,6 +123,28 @@ assert_contains "skills/ dir without SKILL.md → still unresolved" "$OUT" \
 mk_skill alpha commented-dir 'commented-name # public command'
 OUT=$(run 'Run `/alpha:commented-name`.')
 assert_silent "frontmatter name with trailing YAML comment → resolves" "$OUT"
+
+# The DIRECTORY name of a renamed skill is not an alias. `skills/legacy-dir/`
+# declaring `name: renamed-command` answers to /alpha:renamed-command only — the
+# stale pre-rename spelling must still fire, since suppressing it defeats the
+# guard's whole purpose.
+OUT=$(run 'Stale ref `/alpha:legacy-dir`.')
+assert_contains "renamed skill's directory name is NOT an alias → fires" "$OUT" \
+  "UNRESOLVED_SKILL: /alpha:legacy-dir"
+OUT=$(run 'Current ref `/alpha:renamed-command`.')
+assert_silent "the declared frontmatter name still resolves" "$OUT"
+
+# A skill declaring no frontmatter name answers to its directory name.
+OUT=$(run 'Run `/alpha:setup`.')
+assert_silent "no frontmatter name → directory name is the command" "$OUT"
+
+# An invocation carrying arguments is the common form in this repo. The reference
+# is the leading token of the span, not the whole span.
+OUT=$(run 'Run `/alpha:ghost-arg --apply` now.')
+assert_contains "argument-bearing invocation → leading token extracted" "$OUT" \
+  "UNRESOLVED_SKILL: /alpha:ghost-arg"
+OUT=$(run 'Run `/alpha:audit --dry-run <target>`.')
+assert_silent "argument-bearing invocation of a real skill → silent" "$OUT"
 
 # ============================ MUST STAY QUIET ===============================
 


### PR DESCRIPTION
Closes #1270

## Summary

Two advisory `PostToolUse` guards on `Write|Edit`, siblings of `cli-flag-verify` — same defect class (a confident specific that was never checked), different oracles.

**`asserted-path-verify`** flags a repo-relative path asserted in markdown, in a code span or a link target, that does not exist in the working tree. Deterministic oracle, advisory action: a citation can be deliberately forward-looking and PostToolUse runs *after* the write, so it cannot tell.

The **first-segment gate** is what keeps it quiet — a candidate is adjudicated only when its leading directory exists in the repo. So another project's paths, package paths, globs, placeholders, and third-party references never fire. Line and range citation suffixes are stripped, which matters because `path.md:576-580` is this repo's dominant citation form.

**`skill-reference-verify`** flags a `/plugin:skill` reference that does not resolve. Declared **detect-then-judge**, not deterministic: globbing a plugins tree is exact only where the reference is locally owned, so the finding is a prompt for a human verdict — never a determination, never an auto-fix. Gated twice: inert outside a marketplace repo, and within one it adjudicates only a plugin this repo's own manifests own. Resolution goes through manifest `name` **and** skill frontmatter `name`, so a renamed directory still matches.

Both follow the `cli-flag-verify` pattern exactly: diff-scope only (scan what the call wrote, never re-read from disk), per-guard kill switch defaulting true, `statusMessage` per handler, telemetry with repo-relative path redaction, `lib/hook-utils.sh` unchanged.

**A third guard was scoped and dropped.** A version-versus-manifest guard had no buildable trigger: its only in-repo shape is already covered by `check-changelog-parity.sh --check-bump`, and the residual prose surface is historical, minimum-floor, and planned version claims that a manifest-compare oracle reads wrong. The full enumeration — checked *and* unchecked sets — is recorded on #1270 rather than shipped as a guard that never fires correctly.

**Boy Scout.** README counts were stale before this change: prose said "nine safety guards" and the table omitted `block-convention-violation` while ten were wired. Counts are now measured against the manifest toggle set, the missing row is present, and a new enforceability-tier section states each guard's oracle class so the detect-then-judge guard cannot be read as deterministic.

## Test plan

Contract tests, both run to completion (each hook invocation costs 10-20s on Windows/Git Bash — process spawn plus the bounded stdin read, not hook logic — so a full pass takes 10-20 min locally):

- `asserted-path-verify.test.sh` — **45/45**, exit 0
- `skill-reference-verify.test.sh` — **38/38**, exit 0
- `require-jq-notice-isolation.test.sh` — **2/2**; now proves 11 unique notice keys across 11 hooks, covering both new hooks by glob discovery

Each suite carries MUST-fire, MUST-stay-quiet, kill-switch, empty-stdin, missing-prerequisite, and telemetry cases. Notable stay-quiet coverage: line/range citation suffixes, anchor fragments, globs, placeholders, ellipses, URLs, absolute and home-relative paths, parent escapes, extensionless refs, vendor trees, unbackticked prose, multi-token code spans, non-markdown files, non-`Write|Edit` tools, files outside `CLAUDE_PROJECT_DIR`, non-git directories, and — for the reference guard — unowned plugins, manifest-less directories, and uppercase non-command-shaped tokens.

Repo gates, all pass: `validate-plugins.sh` (incl. catalog), `check-silent-skips.sh`, `check-changelog-parity.sh --check` and `--check-bump origin/main`.

Runtime jq-removal is not portably simulable — an isolated bin dir without jq cannot host bash + coreutils across Git Bash and Linux, the constraint `secret-pattern-detection.test.sh` and `require-jq-notice-isolation.test.sh` both already document. Both suites assert the fail-open guard through the shared helper instead, and key uniqueness is proven by the cross-hook test.

## Related

Closes #1270, whose scope was amended from three guards to two during the build — see the "Excluded because already covered" section there for the dropped guard's enumeration.

**Merge-order note.** Three open PRs touch `plugins/guardrails/plugin.json` and `CHANGELOG.md`: #1097, #1085, #853. All three are currently `mergeStateStatus=DIRTY` and unchanged since 2026-07-23, so this PR was rebased onto current `main` rather than held behind them — whoever rebases those must re-pick a version regardless. `0.15.0` is correct off `0.14.2` on `main` today. #853 additionally edits `guardrails-test-helpers.sh`, which both new tests source, so it should re-run these two suites after rebasing.

Root `README.md` carries a one-line catalog-row change because `validate-plugins.sh` gates it; regenerated with `node scripts/generate-catalog.mjs`.

**Review status, stated plainly:** the two contract suites and the repo gates are verified, and an independent noise measurement across every tracked `*.md` is in progress to quantify the real-world false-positive rate — the thing `docs/conventions/hook-precision/README.md` cares most about for an advisory guard. A subagent security review was dispatched and never reported, so this PR is opened to engage the repo's own `security-review`, `review`, and cross-vendor review rather than to bypass them. Please do not merge on my say-so alone; two new shell hooks executing on every `Write|Edit` is a code-execution trust surface.
