### PR TITLE
docs(disk-hygiene): disclose the PowerShell lane's uncovered mutation spellings

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -12,8 +12,9 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   "known deletion spellings" without stating that destructive non-deletion spellings — `Move-Item`,
   `Rename-Item`, overwriting writers (`Set-Content`/`Out-File`/`>`/`New-Item -Force`), and
   `Format-Volume`/`Clear-Disk` — reach the tool with no guard verdict, audit-only mode included. The
-  gap is now disclosed where the security model is stated, with the per-path human approval and the
-  consumer's permission policy named as its only backstops. Docs only; the guard's behavior is
+  gap is now disclosed where the security model is stated, naming the consumer's permission policy as
+  its only backstop — the manual handoff's per-path approval covers the paths selected for removal, so
+  it does not reach what these spellings collaterally destroy. Docs only; the guard's behavior is
   unchanged and closing the gap is tracked in #387.
 
 ## [0.9.0]

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.1]
+
+### Changed
+
+- **The PowerShell lane's documented coverage now names what it does not flag (#386).**
+  `reference/safety-model.md` and the clean skill's PowerShell gotcha described the lane as gating
+  "known deletion spellings" without stating that destructive non-deletion spellings — `Move-Item`,
+  `Rename-Item`, overwriting writers (`Set-Content`/`Out-File`/`>`/`New-Item -Force`), and
+  `Format-Volume`/`Clear-Disk` — reach the tool with no guard verdict, audit-only mode included. The
+  gap is now disclosed where the security model is stated, with the per-path human approval and the
+  consumer's permission policy named as its only backstops. Docs only; the guard's behavior is
+  unchanged and closing the gap is tracked in #387.
+
 ## [0.9.0]
 
 ### Fixed

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -336,8 +336,9 @@ sparse files, hard links, compression, and delayed allocation affect it.
   (`CLAUDE_TOOL_NAME` does not exist).
 - The PowerShell lane is the inverse tradeoff: it stays open for read-only support work (git, gh,
   metadata probes) and instead hard-denies engine invocations and turns known deletion spellings
-  into a final human permission prompt. It is a raised bar, not a fail-closed lane; the engine's
-  own containment and the Bash lane remain the deletion authority.
+  into a final human permission prompt. It is a raised bar, not a fail-closed lane — move, rename,
+  overwrite, and volume-format spellings are not flagged at all (`reference/safety-model.md`); the
+  engine's own containment and the Bash lane remain the deletion authority.
 - The guard rejects `~` anywhere in a Bash command as a shell-expansion character, which includes
   Windows 8.3 short names (`SOMEUS~1`). Always pass long-form paths; the guard's own disclosures
   are already long-form.

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -51,8 +51,8 @@ unless bounded with `--max-depth` or confirmed with `--confirmed-large-scan`.
   value could not be read. The guard now enforces this independently: it resolves the same
   `disk_hygiene_enabled` toggle by reading it straight from your user `settings.json` (the read is
   shared with this probe, and the settings file is located from the tamper-resistant
-  `${CLAUDE_PLUGIN_ROOT}` — not the environment), so in audit-only mode it denies every mutation lane
-  outright — the Bash engine `apply` and the PowerShell deletion belt alike. Running the probe still
+  `${CLAUDE_PLUGIN_ROOT}` — not the environment), so in audit-only mode it denies both mutation lanes
+  it gates outright — the Bash engine `apply` and the PowerShell deletion belt alike. Running the probe still
   matters so you can state the configured value accurately and stop before proposing work the guard
   would deny; the guard is the backstop, not the sole enforcer. The hook runs in shell-free exec form and reports its absolute Python
   interpreter and the authorized `--data-root` value in denial guidance. Use that exact interpreter

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -149,8 +149,10 @@ knowingly partial: the flagged set is deletion- and recycle-shaped (plus `roboco
 and .NET `Delete`), so destructive **non-deletion** spellings — `Move-Item`/`mv`, `Rename-Item`,
 overwriting writers (`Set-Content`, `Out-File`, `>`, `New-Item -Force`), and volume operations
 (`Format-Volume`, `Clear-Disk`) — reach the tool with no guard verdict at all, in audit-only mode
-included. Data loss through those spellings is held only by the per-path human approval the manual
-handoff already requires and the consumer's own permission policy, never by this guard.
+included. The only thing standing between them and the filesystem is the consumer's own permission
+policy, never this guard: the manual handoff's per-path approval covers the paths selected for
+removal, so it does not reach what such a command collaterally destroys — a `Move-Item -Force`
+destination, a truncated `Out-File` target, or an entire volume.
 
 TODO(#387): extend the flagged set to those spellings.
 

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -151,6 +151,7 @@ overwriting writers (`Set-Content`, `Out-File`, `>`, `New-Item -Force`), and vol
 (`Format-Volume`, `Clear-Disk`) — reach the tool with no guard verdict at all, in audit-only mode
 included. Data loss through those spellings is held only by the per-path human approval the manual
 handoff already requires and the consumer's own permission policy, never by this guard.
+
 TODO(#387): extend the flagged set to those spellings.
 
 **Kill-switch enforcement (since 0.9.0): both surfaces resolve it by reading user settings.** The guard
@@ -177,8 +178,9 @@ engine invocation **whether or not the clean skill is active**; it defers (no ou
 does not reference the engine, so it does **not** see PowerShell deletion spellings. Those are enforced by
 the **skill-scoped belt** (`powershell_decision`) — denied outright in audit-only — only **while the clean
 skill is active**. An absent, unreadable, or ambiguous read fails **closed to enabled**: the guard stays
-active and forces a human prompt before every mutation, so an unreadable toggle never silently disables
-the guard.
+active and forces a human prompt before every mutation **it sees** — every Bash engine `apply`, and on
+PowerShell only the flagged spellings above — so an unreadable toggle never silently disables the
+guard.
 
 This replaces the earlier delivery, where the gate carried a bare `${user_config.disk_hygiene_enabled}`
 argument. Because the declared userConfig `default` is not implemented upstream

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -144,6 +144,15 @@ switch. When the guard sees execution enabled they are downgraded to a final hum
 when it sees a configured `false` (audit-only mode) they are denied outright, so the kill switch would
 block deletions on the PowerShell lane too and not only the Bash engine apply.
 
+Because this lane enumerates spellings instead of denying unknown commands, its coverage is
+knowingly partial: the flagged set is deletion- and recycle-shaped (plus `robocopy` mirror/purge/move
+and .NET `Delete`), so destructive **non-deletion** spellings — `Move-Item`/`mv`, `Rename-Item`,
+overwriting writers (`Set-Content`, `Out-File`, `>`, `New-Item -Force`), and volume operations
+(`Format-Volume`, `Clear-Disk`) — reach the tool with no guard verdict at all, in audit-only mode
+included. Data loss through those spellings is held only by the per-path human approval the manual
+handoff already requires and the consumer's own permission policy, never by this guard.
+TODO(#387): extend the flagged set to those spellings.
+
 **Kill-switch enforcement (since 0.9.0): both surfaces resolve it by reading user settings.** The guard
 registers on two surfaces — the **plugin-level engine gate** (`hooks/hooks.json`, exec form,
 `--mode engine-gate`) and the **skill-scoped belt** (the clean skill's frontmatter hook) — and both


### PR DESCRIPTION
Closes #386

## Summary

#386 grouped three disk-hygiene doc corrections (D1, D2, D4 — the body has no D3). Re-verified each
against current `main` before implementing: **two of the three were already fixed by later work**, so
this PR lands only the one that is still live.

**D1 — Windows mislabeled "full": already fixed.** `skills/setup/SKILL.md` now splits the lanes
explicitly ("Windows (full **audit** … engine **execution unsupported**"), matching
`execution_blockers` in `hygiene.py`. `README.md` says the same. No change needed.

**D2 — false "hook process receives `CLAUDE_PLUGIN_DATA`" premise: already fixed.** Both cited sites
now describe the real mechanism — `clean/SKILL.md` ("validates `--data-root` against the plugin data
directory it derives from `${CLAUDE_PLUGIN_ROOT}`") and `reference/safety-model.md` (derivation +
`--authorized-data-root` + env fallback, with the fail-closed consequence stated). No change needed.
The 0.3.0 CHANGELOG entry still carries the original wording and is **deliberately left alone**: it is
a released historical record, the issue scoped it out ("Beyond the already-known CHANGELOG 0.3.0
line"), and later entries (0.4.x, 0.9.0) already record the correction.

**D4 — PowerShell-lane gaps: half fixed, half live.** Sub-gap (a), the kill switch not closing the
lane, was fixed by #382 — the guard now denies flagged spellings outright in audit-only mode, and the
docs say so. Sub-gap (b) is still real: the lane enumerates spellings, and `Move-Item`/`mv`,
`Rename-Item`, overwriting writers (`Set-Content`, `Out-File`, `>`, `New-Item -Force`), and
`Format-Volume`/`Clear-Disk` are absent from `_POWERSHELL_MUTATION_WORDS`, so they reach the tool with
**no guard verdict at all**. The docs described the lane's coverage without naming that hole, which
reads as broader protection than the regex delivers.

This PR discloses that hole once, where the security model is stated
(`reference/safety-model.md`), names the consumer permission policy as its only backstop, and carries
`TODO(#387)`. `clean/SKILL.md`'s existing "raised bar, not a fail-closed lane" gotcha gains one clause
pointing at that paragraph rather than restating it.

Review-driven follow-ups (Codex, both accepted) tightened two adjacent over-promises the disclosure
exposed: the fail-closed paragraph's "a human prompt before every mutation" is now bounded to what the
guard sees, the audit-only "denies every mutation lane" to the two lanes it gates, and the manual
handoff's per-path approval is no longer offered as a backstop here — it approves the paths selected
for removal, so it cannot cover what an unflagged spelling collaterally destroys (a `Move-Item -Force`
destination, a truncated `Out-File` target, a whole volume).

Docs only — **no guard behavior changes**. Extending the flagged set is #387's job, not this issue's.

## Test plan

- `markdownlint-cli2` over `plugins/disk-hygiene/**/*.md` — 0 errors.
- `scripts/check-changed-skills.sh origin/main` — `clean` PASS, 0 errors (344/500 lines, all 6 base-ref
  trigger phrases preserved).
- `scripts/check-skill-portability.sh origin/main` — no unexcused coupling tokens.
- `scripts/validate-plugins.sh` — all manifests + catalog valid.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — version bump 0.9.0 → 0.9.1 has its
  matching CHANGELOG entry.

Fresh-docs mandate discharged for the harness-behavior claims sitting at the edit site:
[plugins-reference](https://code.claude.com/docs/en/plugins-reference) (environment variables +
persistent data directory) and [hooks](https://code.claude.com/docs/en/hooks) (skill-frontmatter
hooks). Result: the reference documents all three path variables as exported to hook processes and
substituted in "hook and monitor commands", but **neither page carves out skill-frontmatter hooks**,
so the existing safety-model text — which already attributes the non-export to an observed Claude Code
build rather than to the docs — is still accurate and was left unchanged.

## Related

- #387 — extend the PowerShell mutation-spelling set (the gap this PR documents).
- #382 — kill switch on the PowerShell lane (closed; D4 sub-gap (a)).
- #376 — the `CLAUDE_PLUGIN_DATA` env premise (closed; D2's root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

