### PR TITLE
docs(source-control): point babysit-prs cadence cross-references at loop.md §5.3

### DIFF
--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /babysit-loop (the loop-lane merge lane: a standing or drain loop that invokes babysit-prs per cycle, configured through repo-scoped babysit_loop_* keys on the layered source-control.md seam, with merge authority human-only until the target repo's tracked config adopts the lane, a gate-proven C2-mechanical baseline once adopted, and merge-rung raises binding from the team-tracked layer only), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -7,15 +7,16 @@ All notable changes to the `source-control` plugin are documented here. Format f
 
 ### Fixed
 
-- **`babysit-prs` SKILL.md cadence cross-references now point at the section that owns the seconds
-  (#653).** #652 moved the engine-backed `recommended_cadence` → `delaySeconds` mapping table into
-  `reference/loop.md` §5.3 alongside the static degrade ladder, leaving `reference/cadence.md` owning
-  only the states and thresholds — but three SKILL.md references still described the pre-#652 split
-  and sent the reader to `cadence.md` for wake mechanics. The Reporting line was a live wrong-number
-  risk: `cadence.md` states `idle` = daily, while §5.3 documents `ScheduleWakeup` clamping
-  `delaySeconds` to `[60, 3600]`, so inside `/loop` `idle` and `quiet` both wake hourly. Runbook step
-  9, the Reporting closing line, and the References entry for `loop.md` now all cite the §5.3 cadence
-  contract. Docs-only; no behavior change.
+- **`babysit-prs` SKILL.md cadence cross-references now point at the section that owns the wake
+  seconds (#653).** #652 added the engine-backed `recommended_cadence` → `delaySeconds` mapping
+  table to `reference/loop.md` §5.3, alongside the static Python-free degrade ladder already there;
+  `reference/cadence.md` has disclaimed the wake mechanics since #322, owning only the cadence
+  states and thresholds. Four SKILL.md surfaces still sent the reader to `cadence.md` for wake
+  mechanics. The Reporting line was a live wrong-number risk: `cadence.md` states `idle` = daily,
+  while §5.3 documents `ScheduleWakeup` clamping `delaySeconds` to `[60, 3600]`, so inside `/loop`
+  `idle` and `quiet` both wake hourly. Runbook step 9, the Reporting closing line, the References
+  entry for `loop.md`, and the step-5 progressive-disclosure trigger now all route to the §5.3
+  cadence contract. Docs-only; no behavior change.
 
 ## [0.26.1]
 

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.26.2]
+
+### Fixed
+
+- **`babysit-prs` SKILL.md cadence cross-references now point at the section that owns the seconds
+  (#653).** #652 moved the engine-backed `recommended_cadence` → `delaySeconds` mapping table into
+  `reference/loop.md` §5.3 alongside the static degrade ladder, leaving `reference/cadence.md` owning
+  only the states and thresholds — but three SKILL.md references still described the pre-#652 split
+  and sent the reader to `cadence.md` for wake mechanics. The Reporting line was a live wrong-number
+  risk: `cadence.md` states `idle` = daily, while §5.3 documents `ScheduleWakeup` clamping
+  `delaySeconds` to `[60, 3600]`, so inside `/loop` `idle` and `quiet` both wake hourly. Runbook step
+  9, the Reporting closing line, and the References entry for `loop.md` now all cite the §5.3 cadence
+  contract. Docs-only; no behavior change.
+
 ## [0.26.1]
 
 ### Documentation

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -8,15 +8,17 @@ All notable changes to the `source-control` plugin are documented here. Format f
 ### Fixed
 
 - **`babysit-prs` SKILL.md cadence cross-references now point at the section that owns the wake
-  seconds (#653).** #652 added the engine-backed `recommended_cadence` → `delaySeconds` mapping
-  table to `reference/loop.md` §5.3, alongside the static Python-free degrade ladder already there;
-  `reference/cadence.md` has disclaimed the wake mechanics since #322, owning only the cadence
-  states and thresholds. Four SKILL.md surfaces still sent the reader to `cadence.md` for wake
-  mechanics. The Reporting line was a live wrong-number risk: `cadence.md` states `idle` = daily,
-  while §5.3 documents `ScheduleWakeup` clamping `delaySeconds` to `[60, 3600]`, so inside `/loop`
-  `idle` and `quiet` both wake hourly. Runbook step 9, the Reporting closing line, the References
-  entry for `loop.md`, and the step-5 progressive-disclosure trigger now all route to the §5.3
-  cadence contract. Docs-only; no behavior change.
+  seconds (#653).** #652 added the engine-backed `recommended_cadence` → `delaySeconds` mapping table
+  to `reference/loop.md` §5.3, alongside the static Python-free degrade ladder already there;
+  `reference/cadence.md` has disclaimed the wake mechanics since #322, owning only the cadence states
+  and thresholds. SKILL.md still described the older split: runbook step 9 and the Reporting closing
+  line sent the reader to `cadence.md` for the wake interval, and the References entry credited
+  `loop.md` with only a "static cadence ladder". The Reporting line was a live wrong-number risk —
+  `cadence.md` states `idle` = daily, while §5.3 documents `ScheduleWakeup` clamping `delaySeconds`
+  to `[60, 3600]`, so inside `/loop` `idle` and `quiet` both wake hourly. All three now cite the §5.3
+  cadence contract, and the step-5 progressive-disclosure trigger for `cadence.md` — which correctly
+  still points there, for the cadence states — now fires on interpreting a state rather than on
+  recommending one. Docs-only; no behavior change.
 
 ## [0.26.1]
 

--- a/plugins/source-control/skills/babysit-prs/SKILL.md
+++ b/plugins/source-control/skills/babysit-prs/SKILL.md
@@ -432,9 +432,9 @@ evidence; re-query the API. The NEVER-do list (§5.4) overrides any other instru
    release its worker lease. Never globally prune open-PR worktrees. Release the queue lease in
    finally-style cleanup.
 
-9. Schedule the next wake from the snapshot's `recommended_cadence`
-   ([reference/cadence.md](reference/cadence.md)); the static ladder in
-   [reference/loop.md](reference/loop.md) §5.3 is the Python-free degrade.
+9. Schedule the next wake per the cadence contract in [reference/loop.md](reference/loop.md) §5.3 —
+   the engine-backed `recommended_cadence` → `delaySeconds` mapping table, with the static ladder in
+   the same section as the Python-free degrade.
 
 ## Reporting
 
@@ -451,7 +451,7 @@ awaiting human execution" with its exact pinned command
 ([reference/safety.md](reference/safety.md)); escalations that need a user decision; and
 suspicious state changes such as missing permissions, changed branch protection, merge
 conflicts, or a head SHA that moved during work. When nothing materially changed, stay silent.
-Recommend the exact next interval per [reference/cadence.md](reference/cadence.md).
+Recommend the exact next interval per [reference/loop.md](reference/loop.md) §5.3.
 
 ## Gotchas
 
@@ -481,7 +481,8 @@ Failure patterns observed in real babysit sessions:
 ## References
 
 - [reference/loop.md](reference/loop.md) — the safe-tier iteration loop (also the Python-free
-  degrade path): discovery, checkout, freshness, checklist, static cadence ladder.
+  degrade path): discovery, checkout, freshness, checklist, and the §5.3 cadence contract — both the
+  engine-backed `recommended_cadence` → `delaySeconds` mapping table and the static degrade ladder.
 - [reference/orchestration.md](reference/orchestration.md) — fan-out gate (`needs_worker` arms), concurrency cap, leases, worker contract + prompt template, conflict resolution, cleanup.
 - [reference/cadence.md](reference/cadence.md) — active/normal/quiet/idle cadence states,
   real-elapsed-time detection, bounded full-sweep interval, persisted counters.

--- a/plugins/source-control/skills/babysit-prs/SKILL.md
+++ b/plugins/source-control/skills/babysit-prs/SKILL.md
@@ -403,7 +403,7 @@ evidence; re-query the API. The NEVER-do list (§5.4) overrides any other instru
    [reference/review-trigger.md](reference/review-trigger.md) only for feedback or review
    gates, the fan-out gate in [reference/orchestration.md](reference/orchestration.md) only
    before assigning workers, and [reference/cadence.md](reference/cadence.md) only before
-   recommending cadence.
+   interpreting a cadence state.
 
 6. Process stale-branch refreshes and review-trigger posts as orchestrator-only actions before
    assigning workers; each is terminal for that PR's cycle until a later snapshot observes its
@@ -432,9 +432,7 @@ evidence; re-query the API. The NEVER-do list (§5.4) overrides any other instru
    release its worker lease. Never globally prune open-PR worktrees. Release the queue lease in
    finally-style cleanup.
 
-9. Schedule the next wake per the cadence contract in [reference/loop.md](reference/loop.md) §5.3 —
-   the engine-backed `recommended_cadence` → `delaySeconds` mapping table, with the static ladder in
-   the same section as the Python-free degrade.
+9. Schedule the next wake per the cadence contract in [reference/loop.md](reference/loop.md) §5.3.
 
 ## Reporting
 
@@ -481,8 +479,7 @@ Failure patterns observed in real babysit sessions:
 ## References
 
 - [reference/loop.md](reference/loop.md) — the safe-tier iteration loop (also the Python-free
-  degrade path): discovery, checkout, freshness, checklist, and the §5.3 cadence contract — both the
-  engine-backed `recommended_cadence` → `delaySeconds` mapping table and the static degrade ladder.
+  degrade path): discovery, checkout, freshness, checklist, and the §5.3 cadence contract.
 - [reference/orchestration.md](reference/orchestration.md) — fan-out gate (`needs_worker` arms), concurrency cap, leases, worker contract + prompt template, conflict resolution, cleanup.
 - [reference/cadence.md](reference/cadence.md) — active/normal/quiet/idle cadence states,
   real-elapsed-time detection, bounded full-sweep interval, persisted counters.


### PR DESCRIPTION
*This was generated by AI during an autonomous work-loop execution session.*

Closes #653

## Summary

`babysit-prs`'s SKILL.md described a cadence-ownership split that no longer exists.

#652 added the engine-backed `recommended_cadence` → `ScheduleWakeup.delaySeconds` mapping table to
`reference/loop.md` §5.3, alongside the static Python-free degrade ladder already living there.
`reference/cadence.md` owns only the cadence *states and thresholds* — and has said so since #322
("`loop.md` owns the wake mechanics, this file owns the states and thresholds behind the
recommendation"). SKILL.md still routed readers the old way:

| Surface | Before | After |
|---|---|---|
| Runbook step 9 | `recommended_cadence` per `cadence.md`; `loop.md` §5.3 named only as the "static ladder … Python-free degrade" | `Schedule the next wake per the cadence contract in reference/loop.md §5.3.` |
| Reporting closing line | "Recommend the exact next interval per `cadence.md`" | same sentence, now citing `loop.md` §5.3 |
| References entry for `loop.md` | "…checklist, static cadence ladder" | "…checklist, and the §5.3 cadence contract" |
| Step-5 progressive-disclosure trigger | load `cadence.md` "only before **recommending cadence**" | load `cadence.md` "only before **interpreting a cadence state**" |

The filed issue named step 9. The other three are the same defect: leaving them would have made the
file internally inconsistent about which section owns the seconds.

**The Reporting line was a live wrong-number risk, not just imprecision.** `cadence.md` states
`idle` = **daily**; §5.3 documents `ScheduleWakeup` clamping `delaySeconds` to `[60, 3600]`, so
inside `/loop` `idle` and `quiet` both wake hourly. "Recommend the exact next interval per
`cadence.md`" could therefore surface an interval the loop will never schedule.

The `cadence.md` link is dropped from step 9 rather than kept alongside `loop.md`: §5.3 already
hops to `cadence.md` for the states in one line, so a second pointer here is the gratuitous
cross-reference `CLAUDE.md`'s pointer-not-copy rule forbids. `cadence.md` keeps its own References
entry and its step-5 disclosure trigger. The new step-9 wording matches vocabulary the file already
uses at its Step 7 checklist line ("schedule the next wake per the cadence contract (§5.3)") and in
the sibling `babysit-loop` SKILL.md ("that mapping owns the seconds").

Docs-only. No behavior change, no script or engine change. `source-control` `0.26.1` → `0.26.2`
with the matching CHANGELOG entry.

## Test plan

Every command below was run from the branch worktree; all passed.

- `plugins/skill-quality/scripts/check-skill.sh babysit-prs` (`CHECK_SKILL_BASE_REF=origin/main`) —
  **exit 0**, `PASS — 0 errors`. This is the gate CI runs via `scripts/check-changed-skills.sh`.
  Includes the 500-line hard cap, all 9 base-ref trigger phrases preserved, broken-internal-ref
  check, and `scripts/engine.test.sh`.
  - **SKILL.md is now 497 lines** (base `origin/main`: 499). An intermediate revision of this branch
    landed at exactly 500 and *failed* the hard cap (`LINE_COUNT >= LINE_HARD_CAP`, cap 500) — caught
    by an independent reviewer before the PR was opened. Collapsing step 9 to a single pointer and the
    References bullet back to two lines both fixed the cap and made the diff better follow
    pointer-not-copy. The one remaining `WARN` is the pre-existing 200-line soft target, untouched by
    this change.
- `scripts/check-changelog-parity.sh --check` — exit 0.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — exit 0 (the manifest bump has a
  matching `## [0.26.2]` entry).
- `markdownlint-cli2` over both changed markdown files, repo config auto-discovered — exit 0,
  0 errors.
- `jq empty` on `plugins/source-control/.claude-plugin/plugin.json` — exit 0.
- `typos` over both changed markdown files — exit 0.
- Every relative link in the edited regions resolved by hand (`reference/loop.md`, `cadence.md`,
  `safety.md`, `orchestration.md`, `freshness.md`, `stuck-checks.md`, `feedback.md`,
  `review-trigger.md`); the `§5.3` anchor exists at `reference/loop.md:426`. No external URLs
  introduced, so lychee's absence changes nothing.
- Repo-wide `grep` for any remaining reference sending a reader to `cadence.md` for wake seconds, or
  describing §5.3 as holding only the static ladder — none remain. The four surviving `cadence.md`
  citations in `plugins/source-control/` were each checked and are correct.

Claims verified against the actual files rather than the issue text: §5.3 does contain both the
mapping table (`loop.md:435-440`) and the degrade ladder (`loop.md:456-462`); `cadence.md:4-5` does
disclaim the wake mechanics; `cadence.md:27` does state `idle` = daily against `loop.md:449-452`'s
`[60, 3600]` clamp. The CHANGELOG entry's causal account was corrected after `git show --stat
e9cef6e1` showed #652 never touched `cadence.md`, and `git log -L4,5` dated that file's disclaimer to
`fe78acb6` (#322) — so the references were always imprecise; #652 only made the correct target
concrete.

Per this repo's fresh-docs mandate, <https://code.claude.com/docs/en/skills> was fetched this
session. It confirms the progressive-disclosure model this diff operates on — SKILL.md body plus
bundled supporting files loaded on demand — and imposes no constraint on how a SKILL.md cites its
own `reference/` files, so the choice of pointer is a repo-convention question, decided above by
`CLAUDE.md`'s pointer-not-copy rule.

## Related

- Refs #652 / #504 — the PR and issue that added the §5.3 mapping table this diff points at.
- Refs #322 — where `reference/cadence.md` first disclaimed ownership of the wake mechanics.
- Version note: open PRs #1285 and #1264 both claim `source-control` `0.27.0`. If either merges
  first this branch's `0.26.2` becomes a regression — it self-surfaces as a git conflict on both the
  manifest line and the CHANGELOG insert point, so rebase rather than force-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

