### PR TITLE
docs(docs-hygiene): unify audit-derivability fork-mechanism wording

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Documentation-hygiene toolkit of six skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — docs-hygiene plugin
 
+## [0.8.7]
+
+### Fixed
+
+- `audit-derivability` fork-mechanism disambiguation now reads in one voice: the Hard Rules bullet
+  adopts the "is the opposite" phrasing already used by the spot-test bullet, `context/rubric.md`,
+  and `evals/evals.json`, replacing its divergent "is unrelated". The Gotchas self-grade bullet,
+  previously the one bare "non-fork subagent" site, now names the Agent tool's `fork` subagent type
+  as the forbidden mechanism — matching what `evals/evals.json` already grades on — without
+  repeating the full `context: fork` explanation.
+
 ## [0.8.6]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-derivability/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-derivability/SKILL.md
@@ -108,7 +108,7 @@ After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointe
 - **Read-only.** No `Edit`, no `Write`, no mutating `Bash`. The author applies every deletion and rewrite. Deletion is the highest-stakes doc edit; the classifier only recommends.
 - **Never derivability alone.** A `delete` verdict requires all of: derivable, low re-derivation cost, no owned facts. Any owned non-derivable fact forces `keep-owns-facts`.
 - **Cache verdicts carry a drift-control condition or they demote.** No regeneration path and no recheck trigger → not a cache, demote to pointer/delete.
-- **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by the Agent tool's `fork` subagent type (a skill's own `context: fork` frontmatter is unrelated — it starts blank).
+- **Load-bearing or contested deletions are spot-tested by a fresh, non-fork subagent** — never confirmed from this (contaminated) context, never by the Agent tool's `fork` subagent type (a skill's own `context: fork` frontmatter is the opposite: it starts blank).
 - **Audience named in every verdict.** Agent-facing and human-facing docs clear different deletion bars.
 - **Owned facts are salvaged before anything is deleted.** When a doc is mostly derivable but owns a fact, the verdict is keep + route-the-remainder, never delete-and-lose.
 - **Output deterministic.** Filenames sort lexically; no timestamps in output.
@@ -116,7 +116,7 @@ After the ledger, OFFER to route actionable verdicts (delete / convert-to-pointe
 ## Gotchas
 
 - **Derivable is not a verdict.** "An agent could re-derive this" alone never justifies `delete` — check re-derivation cost, drift risk, and fact ownership first. The most common misfire is deleting a mostly-derivable doc that owned one buried rationale line.
-- **The self-grade trap.** After reading a doc you know its answers, so it always *looks* re-derivable. Never confirm a load-bearing deletion from this context — delegate to a fresh, non-fork subagent that has not seen the doc.
+- **The self-grade trap.** After reading a doc you know its answers, so it always *looks* re-derivable. Never confirm a load-bearing deletion from this context — delegate to a fresh, non-fork subagent that has not seen the doc, never the Agent tool's `fork` subagent type.
 - **Cache without drift control is not a cache.** `keep-as-derivation-cache` with no regeneration path and no recheck trigger is an unmaintained copy; demote it.
 - **Code-derivable ≠ duplicates-another-doc.** A doc restating *another doc* is `/docs-hygiene:extract-ssot`, not a `delete` here. Derivability is re-derivation from code/config/structure.
 - **Audience changes the verdict.** The same restatement can be dead weight on an agent surface and worth keeping for humans. Do not carry one surface's verdict to the other.


### PR DESCRIPTION
Closes #1082

## Summary

The `audit-derivability` skill warns against confirming a deletion with a contaminated context, and
names the fork mechanism at three sites in `SKILL.md`. Those three sites had drifted apart: two gave
the same fact in two different voices, and the third named none of it.

- **Hard Rules bullet (was line 111):** `is unrelated` → `is the opposite`. The spot-test bullet
  (line 56), `context/rubric.md:134`, and `evals/evals.json:84` already used "the opposite," so this
  bullet was the sole outlier of four sites — aligning it required no change to the other three.
- **Gotchas self-grade bullet (was line ~119):** previously the one bare `non-fork subagent`
  mention. It now names the Agent tool's `fork` subagent type as the forbidden mechanism, which
  `evals/evals.json:88` already grades on. It does **not** repeat the `context: fork` explanation —
  a Gotchas summary restating the full disambiguation a third time would be duplication on an
  agent-facing surface, exactly what this plugin exists to remove.

"Opposite" is also the more accurate word, verified against current official docs this session:

- Agent-tool fork — "A fork inherits the full parent conversation instead of starting fresh"
  ([tools reference](https://code.claude.com/docs/en/tools-reference))
- Skill `context: fork` — "It won't have access to your conversation history"
  ([skills](https://code.claude.com/docs/en/skills))

Same word, inverse context behavior. "Unrelated" understated precisely the trap the disambiguation
exists to prevent.

`docs-hygiene` bumped 0.8.6 → 0.8.7 with the matching CHANGELOG entry.

## Test plan

Run from the PR worktree against `origin/main`:

- `scripts/check-changed-skills.sh origin/main` — PASS, 0 errors, 0 warnings; confirms all 8
  base-ref trigger phrases preserved (the frontmatter `description` is untouched) and SKILL.md at
  142/500 lines.
- `scripts/check-skill-portability.sh origin/main` — no unexcused coupling tokens.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — the version bump has its
  `## [0.8.7]` entry.
- `scripts/validate-plugins.sh` — all plugin manifests and the catalog validate.
- `markdownlint-cli2 --config .markdownlint-cli2.jsonc "plugins/docs-hygiene/**/*.md"` — 36 files,
  0 errors.
- `scripts/check-silent-skips.sh`, `scripts/check-skill-leaf-names.sh` — clean.

No behavioral surface changes: prose only, plus the version/CHANGELOG pair.

## Related

- #1082 — the item this closes; a review-deferral from PR #1067, itself a follow-up to #1062 /
  #1058 / #1053, which is the lineage that produced the two-voice drift.
- #1268 — touches a related "fork inherits degraded history" claim in a **different** plugin.
  Deliberately out of scope here; this PR stays inside
  `plugins/docs-hygiene/skills/audit-derivability/`.
- #1317 — deferred review finding from this PR (Codex, P2), classified VALID (defer). #1258 reports
  the Agent tool's `fork` subagent type NOT inheriting the conversation at runtime, against its
  documentation, which would make "the opposite" an overclaim at all four sites. Deferred because a
  partial hedge reintroduces exactly the drift #1082 removes, one of the four sites is a graded
  `evals.json` criterion rather than prose, and #1258 is itself unreduced and `needs-human`. The
  Hard Rule is unaffected — "never fork for the spot-test" holds under either branch.
- `context/rubric.md` and `evals/evals.json` were read as the tie-breaker for which phrasing is
  canonical, and are intentionally **not** modified — they already carry the winning wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NE8W4XPPVfZVCGBW2GYgyH

