### PR TITLE
docs(review): reconcile stale code-review framing in quality-gate pr.md and README

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.1]
+
+### Fixed
+
+- Reconciled stale `code-review` framing in `quality-gate`'s `pr.md` and the plugin README: it
+  described `code-review` as an optional `claude-plugins-official` marketplace plugin invoked as
+  `/code-review:code-review`. Per current official docs, `/code-review` is a bundled built-in
+  command (invoked bare) and the "parallel agents / posts PR comments" behavior actually
+  describes the separate managed Code Review GitHub App service — neither is an installable
+  marketplace plugin. `pr.md` now documents both surfaces distinctly under a Boundary section,
+  mirroring the pattern `code.md` already uses for its own built-in boundary (#266/#735).
+
 ## [0.15.0]
 
 ### Added

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -13,7 +13,10 @@ All notable changes to the `review` plugin are documented here. Format follows
   command (invoked bare) and the "parallel agents / posts PR comments" behavior actually
   describes the separate managed Code Review GitHub App service — neither is an installable
   marketplace plugin. `pr.md` now documents both surfaces distinctly under a Boundary section,
-  mirroring the pattern `code.md` already uses for its own built-in boundary (#266/#735).
+  mirroring the pattern `code.md` already uses for its own built-in boundary (#266/#735). The
+  section's mutation gate covers only the surfaces that actually write — `--comment` (posts to the
+  PR), `--fix` (mutates the working tree), and the managed service — leaving bare
+  `/code-review <target>` ungated as a read-only option.
 
 ## [0.15.0]
 

--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -61,8 +61,9 @@ Invoke via `@review:<agent>` or let Claude delegate.
 - **Graceful degrade.** The optional `pr-review-toolkit` orchestrator plugin (from the official
   marketplace) adds adversarial breadth when installed; every path works without it. Claude
   Code's bundled `/code-review` command and the managed Code Review GitHub App service are
-  separate built-in/managed surfaces, not marketplace plugins — see `context/pr.md`'s Boundary
-  section for how the `pr` mode relates to them.
+  separate built-in/managed surfaces, not marketplace plugins — see the Boundary section of
+  [`skills/quality-gate/context/pr.md`](skills/quality-gate/context/pr.md) for how the `pr` mode
+  relates to them.
 - **Self-contained.** The severity baseline and all mode guidance ship inside the plugin
   and are referenced via `${CLAUDE_PLUGIN_ROOT}`.
 

--- a/plugins/review/README.md
+++ b/plugins/review/README.md
@@ -58,9 +58,11 @@ Invoke via `@review:<agent>` or let Claude delegate.
   files when present (the marketplace-wide ecosystem-commands contract,
   `docs/conventions/ecosystem-commands/README.md`), falling back to your documented conventions,
   then its own bundled generic defaults as a last resort.
-- **Graceful degrade.** Optional orchestrator plugins (`pr-review-toolkit`, `code-review`
-  from the official marketplace) add adversarial breadth when installed; every path works
-  without them.
+- **Graceful degrade.** The optional `pr-review-toolkit` orchestrator plugin (from the official
+  marketplace) adds adversarial breadth when installed; every path works without it. Claude
+  Code's bundled `/code-review` command and the managed Code Review GitHub App service are
+  separate built-in/managed surfaces, not marketplace plugins — see `context/pr.md`'s Boundary
+  section for how the `pr` mode relates to them.
 - **Self-contained.** The severity baseline and all mode guidance ship inside the plugin
   and are referenced via `${CLAUDE_PLUGIN_ROOT}`.
 

--- a/plugins/review/skills/quality-gate/context/pr.md
+++ b/plugins/review/skills/quality-gate/context/pr.md
@@ -18,14 +18,19 @@ Two Claude Code surfaces overlap this mode's job on an open PR. Neither is an in
   inline PR comments tagged by severity. It triggers automatically on PR open/push per the
   repo's configured behavior, or on demand by commenting `@claude review` on the PR.
 
-**PR-mutation gate:** `/code-review --comment` and triggering the managed service both post to
-the PR, which violates the review modes' report-only contract; when the branch has an open PR,
-dispatch either only on explicit user opt-in ("post the review comment"), otherwise skip and
-name the skip in the review report — fall to the read-only manual path below.
+**Mutation gate — flags and the managed service, not the bare command:** `/code-review --comment`
+posts inline comments to the PR and triggering the managed service posts a full review; both
+violate the review modes' report-only contract. `--fix` mutates the working tree. Dispatch any of
+those three only on explicit user opt-in ("post the review comment", "apply the fixes"), otherwise
+skip and name the skip in the review report.
+
+Bare `/code-review <target>` is **not** gated: it reports into the session and writes nothing to
+the PR or the working tree, so it stays available as a read-only option alongside the manual path
+below.
 
 ## Manual PR review (default read-only path)
 
-Used by default, or when the opt-in above is withheld:
+Used by default, or alongside a bare `/code-review <target>` pass:
 
 1. `gh pr diff` for the change set (page it — large PRs flood context)
 2. Apply the project's review criteria (or `${CLAUDE_PLUGIN_ROOT}/context/severity.md` baseline) manually, or dispatch this plugin's `code-reviewer` agent against the PR's merge-base diff

--- a/plugins/review/skills/quality-gate/context/pr.md
+++ b/plugins/review/skills/quality-gate/context/pr.md
@@ -2,19 +2,34 @@
 
 Reviews an existing GitHub PR with git-history context.
 
-## `code-review` orchestrator plugin (when installed)
+## Boundary — two built-in/managed surfaces, neither a marketplace plugin
 
-When the `code-review` plugin (from the `claude-plugins-official` marketplace) is available, `/code-review:code-review` detects the current branch's PR and runs parallel review agents with confidence scoring against it.
+Two Claude Code surfaces overlap this mode's job on an open PR. Neither is an installable
+`claude-plugins-official` marketplace plugin — both ship with Claude Code itself:
 
-**PR-mutation gate:** its PR mode posts findings as a PR comment, which violates the review modes' report-only contract; when the branch has an open PR, dispatch it only on explicit user opt-in ("post the review comment"), otherwise skip it and name the skip in the review report — fall to the read-only manual path below.
+- **Bundled `/code-review` command** — invoked bare (no plugin namespace), always available,
+  no install required. Pass a PR number as its target (`/code-review 123`) to review that PR
+  locally; it reports correctness bugs plus reuse/simplification/efficiency cleanups. `--fix`
+  applies edits to the working tree and `--comment` posts the findings as inline PR comments —
+  both mutate.
+- **Managed Code Review GitHub App service** — a separate org-level service (Team/Enterprise,
+  enabled once by an Owner in admin settings) that runs multiple review agents in parallel
+  against the PR diff, verifies candidates to filter false positives, and posts the results as
+  inline PR comments tagged by severity. It triggers automatically on PR open/push per the
+  repo's configured behavior, or on demand by commenting `@claude review` on the PR.
+
+**PR-mutation gate:** `/code-review --comment` and triggering the managed service both post to
+the PR, which violates the review modes' report-only contract; when the branch has an open PR,
+dispatch either only on explicit user opt-in ("post the review comment"), otherwise skip and
+name the skip in the review report — fall to the read-only manual path below.
 
 ## Manual PR review (default read-only path)
 
-Used when the plugin is absent, or when the opt-in above is withheld:
+Used by default, or when the opt-in above is withheld:
 
 1. `gh pr diff` for the change set (page it — large PRs flood context)
 2. Apply the project's review criteria (or `${CLAUDE_PLUGIN_ROOT}/context/severity.md` baseline) manually, or dispatch this plugin's `code-reviewer` agent against the PR's merge-base diff
-3. When the repository runs its own CI review bot on PR open/sync, note that its coverage still arrives independently
+3. When the repository runs its own CI review bot (e.g. the managed Code Review service) on PR open/sync, note that its coverage still arrives independently
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes #732

## Summary

- `plugins/review/skills/quality-gate/context/pr.md` described `code-review` as an optional
  `claude-plugins-official` marketplace plugin invoked as `/code-review:code-review`, running
  "parallel review agents with confidence scoring" and posting PR comments. Per current official
  docs (https://code.claude.com/docs/en/code-review, fetched fresh this session), that's actually
  two distinct built-in/managed surfaces, neither an installable plugin: the bundled `/code-review`
  command (invoked bare, no namespace) and the separate managed Code Review GitHub App service
  (org-enabled, posts inline PR comments via `@claude review` or automatic triggers).
- Reworded `pr.md`'s opening section into a **Boundary** naming both surfaces distinctly, mirroring
  the pattern `context/code.md` already uses for its own built-in boundary (added in #266/#735).
- Updated `plugins/review/README.md`'s "Graceful degrade" bullet: `pr-review-toolkit` stays a real
  optional marketplace plugin; `code-review` is removed from that list and pointed at `pr.md`'s new
  Boundary section instead.
- Bumped `review` `0.15.0` -> `0.15.1` (docs-only patch) with a matching CHANGELOG entry.

## Test plan

```
$ python -c "import json; d=json.load(open('plugins/review/.claude-plugin/plugin.json')); print(d['version'])"
0.15.1

$ npx markdownlint-cli2@0.23.0 plugins/review/skills/quality-gate/context/pr.md plugins/review/README.md plugins/review/CHANGELOG.md
markdownlint-cli2 v0.23.0 (markdownlint v0.41.0)
Summary: 0 error(s)
```

Docs-only change; no code/build/test surface affected.

## Related

- Refs #266 — the sibling fix (`code.md`'s built-in `/code-review` boundary) whose PR deferred this
  reconciliation to #732.
- Refs #1325 — follow-up filed during this work: the same stale `code-review`-as-marketplace-plugin
  framing also appears in `fanout/SKILL.md` and `fanout/context/findings-normalization.md`, out of
  #732's scope (README + `pr.md` only); left for that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)