### PR TITLE
feat(docs-hygiene): add container-position pattern forms to rename-references

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "Documentation-hygiene toolkit of six skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog — docs-hygiene plugin
 
+## [0.9.0]
+
+### Added
+
+- **`rename-references` gains three container-position pattern forms (13–15), closing the gap
+  that let six stale references survive three sweep passes (`#1283`).** Forms 1–12 assume the
+  renamed token is a skill/mode identifier. When a CONTAINER renames — a plugin, a marketplace
+  entry — the token also appears in positions none of them reach: as the argument to a
+  management command (`/plugin install <old>@marketplace`, `/plugin configure <old>`), as a
+  document title that IS the token (`# <old>`), and in possessive or appositive prose
+  (`<old>'s effective configuration`, `the <old> plugin`). Form 1 cannot fire on the first
+  shape because the slash anchors `plugin`, not `<old>`.
+
+  Each new form is high-precision because the SURROUNDING SYNTAX admits only the naming sense:
+  a management verb before the token, a `$`-anchored heading, the possessive clitic. That is
+  what lets them stay Certain where bare-token Form 2 cannot be. Measured on the real fixture
+  (the `re-anchor` → `discipline` rename, over that plugin's own tree): Form 2 matched **134**
+  lines for **8** real defects; Forms 13–15 matched **9** — the 8 defects plus one frozen
+  CHANGELOG-history line the existing "Frozen historical records" rule already excludes.
+
+  Command-argument hits are called out as FUNCTIONAL breaks, not cosmetic ones: a reader
+  following `/plugin install <old>@marketplace` gets `plugin-not-found`.
+
+### Changed
+
+- **`triage.md` records the collision class the English-verb blocklist cannot serve.** The
+  blocklist holds tokens that are English verbs in general; it cannot cover a token that is a
+  verb *in the consuming codebase*. Both branches fail there — omitted, every bare-token hit is
+  rated Certain and the sweep proposes rewriting the verb uses; added, every hit lands ambiguous
+  and the per-match confirmation rule turns a handful of defects into hundreds of prompts.
+  Extending the blocklist swaps one unusable bucket for another; the remedy is position. The
+  section routes to Forms 13–15 and carries the measured figures.
+- **`patterns.md` Phase 6 now requires validating a new form on BOTH axes.** Recall alone is not
+  evidence — Form 2 already has perfect recall on every form in the library and is still
+  unusable when the token is a verb. A candidate is measured against the commit that FIXED the
+  missed references (its removed lines are the defect set) for recall, and against the whole
+  pre-fix tree for precision, reporting its hit count beside Form 2's on that same tree.
+- **`audit.md`'s pattern-form breakdown** lists Forms 13–15 so an audit report accounts for
+  every form the sweep runs.
+
 ## [0.8.6]
 
 ### Fixed

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -23,6 +23,27 @@
   Command-argument hits are called out as FUNCTIONAL breaks, not cosmetic ones: a reader
   following `/plugin install <old>@marketplace` gets `plugin-not-found`.
 
+- **Container-rename mode (`patterns.md` Phase 0b) — the rule that actually removes the prompt
+  flood.** Precedence (below) resolves only lines the container forms ALSO matched: 8 of Form 2's
+  134 on the measured fixture. The other 126 are ordinary verb uses no container form touches,
+  and they fall through to Form 2's Certain default. The sweep now declares a MODE at Phase 0
+  from what is being renamed. For a container — a plugin, a marketplace entry, a package — the
+  renamed thing is a proper name, so a bare-token occurrence is evidence of nothing; the residue
+  is excluded from Certain **regardless of blocklist membership** and reported as one aggregate
+  count, surfaced only behind an explicit widen and then as Ambiguous. Mode is a property of what
+  is being renamed, which is why it works where the static blocklist cannot: it does not depend
+  on anyone having listed the token in advance. Fixture result with mode + precedence: 8 Certain
+  findings, 126 reported-not-proposed, 0 confirmation prompts.
+
+- **Form 14 is scoped to container-owned documents.** "A heading that IS the token can only be
+  naming it" holds for a coined or hyphenated name and FAILS for an ordinary-word one — verified
+  against this repository: renaming a `testing` plugin matches `README.md:86` (`### Testing`, a
+  marketplace category heading) and renaming `architecture` matches `plugins/miro/README.md:39`
+  (`## Architecture`, an unrelated design section). Under precedence a false Certain there is
+  worse than a plain Form 2 hit, because it discards the safer classification. A title match is
+  Certain only in plausibly container-owned files, and always Ambiguous when the token is a
+  common English word.
+
 - **Container-position precedence, without which the new forms only ADD hits.** Forms 13–15 are
   strictly more specific than Form 2 — every line they match, Form 2 matches too. The sweep now
   deduplicates by `(file, line)` after collecting and before triage: a container-position match

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -23,6 +23,15 @@
   Command-argument hits are called out as FUNCTIONAL breaks, not cosmetic ones: a reader
   following `/plugin install <old>@marketplace` gets `plugin-not-found`.
 
+- **Container-position precedence, without which the new forms only ADD hits.** Forms 13–15 are
+  strictly more specific than Form 2 — every line they match, Form 2 matches too. The sweep now
+  deduplicates by `(file, line)` after collecting and before triage: a container-position match
+  takes the Certain path and its bare-token duplicate for that line is dropped as the same
+  reference seen through a weaker lens, not a second finding. Only lines the container forms did
+  NOT match fall through to Form 2's blocklist rule. The audit report carries the superseded
+  count so the suppression is visible rather than inferred. This is what makes position an actual
+  remedy for the verb collision instead of an additional lens over an unchanged prompt flood.
+
 ### Changed
 
 - **`triage.md` records the collision class the English-verb blocklist cannot serve.** The
@@ -37,8 +46,13 @@
   unusable when the token is a verb. A candidate is measured against the commit that FIXED the
   missed references (its removed lines are the defect set) for recall, and against the whole
   pre-fix tree for precision, reporting its hit count beside Form 2's on that same tree.
-- **`audit.md`'s pattern-form breakdown** lists Forms 13–15 so an audit report accounts for
-  every form the sweep runs.
+- **`audit.md`'s pattern-form breakdown** lists Forms 13–15 and the superseded-hit count, and its
+  Survey phase applies the precedence dedup before triage runs.
+- **Form 14 accepts single-quoted YAML** (`name: '<old>'`) alongside bare and double-quoted
+  values, with the quotes required to PAIR — a naive `["']?` would match the invalid `"<old>'`.
+- **Form 15 allows the token to be inline code** before the possessive clitic, which in markdown
+  is the common case rather than the exception: the literal `<old>'s` sequence never appears when
+  the token is a code span, so without this the form missed its own motivating example.
 
 ## [0.8.6]
 

--- a/plugins/docs-hygiene/skills/rename-references/context/audit.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/audit.md
@@ -77,6 +77,9 @@ Pattern-form breakdown:
 - Form 10 (cross-skill):    <count>
 - Form 11 (line-number-citation): <count>
 - Form 12 (dot-form sub-identifier): <count>
+- Form 13 (command-argument):  <count>
+- Form 14 (document title):    <count>
+- Form 15 (possessive/appositive): <count>
 
 Next: invoke `/rename-references <old> to <new>` to apply, or `/rename-references preview <old> to <new>` to dry-run.
 ```

--- a/plugins/docs-hygiene/skills/rename-references/context/audit.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/audit.md
@@ -35,10 +35,18 @@ Run all patterns from [patterns.md](patterns.md) in parallel via Grep tool. For 
 - Apply auto-exclusions per `../SKILL.md` "Auto-exclusions" via `glob` filter or post-filter
 
 Aggregate matches into a flat list of `{file, line, pattern_form, snippet}` tuples, then apply
-the container-position precedence rule in `patterns.md` "Phase 0" — deduplicate by
-`(file, line)` so a line matched by Forms 13–15 is attributed to that form and its weaker
-Form 2 / chain-form duplicates are dropped. Carry the dropped count into the report's
-"superseded" row. Deduplicate BEFORE Phase 3, or triage will bucket the same reference twice.
+BOTH rules from `patterns.md`, in this order:
+
+1. **Precedence** ("Phase 0") — deduplicate by `(file, line)` so a line matched by Forms 13–15
+   is attributed to that form and its weaker Form 2 / chain-form duplicates are dropped. Carry
+   the dropped count into the report's "superseded" row.
+2. **Container-rename mode** ("Phase 0b") — when the renamed thing is a container, exclude the
+   remaining bare-token residue from Certain entirely and report it as one aggregate count.
+   Precedence alone leaves that residue at Form 2's Certain default; the mode rule is what
+   removes it.
+
+Both run BEFORE Phase 3, or triage will bucket the same reference twice and re-admit the
+residue the mode rule excluded.
 
 ### Phase 3: Triage
 
@@ -85,6 +93,7 @@ Pattern-form breakdown:
 - Form 14 (document title):    <count>
 - Form 15 (possessive/appositive): <count>
 - Form-2 hits superseded by container-position matches: <count>
+- Bare-token occurrences outside container position (container-rename mode; NOT proposed): <count>
 
 Next: invoke `/rename-references <old> to <new>` to apply, or `/rename-references preview <old> to <new>` to dry-run.
 ```

--- a/plugins/docs-hygiene/skills/rename-references/context/audit.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/audit.md
@@ -34,7 +34,11 @@ Run all patterns from [patterns.md](patterns.md) in parallel via Grep tool. For 
 - Use `multiline: true` for Form 7 (frontmatter chain string)
 - Apply auto-exclusions per `../SKILL.md` "Auto-exclusions" via `glob` filter or post-filter
 
-Aggregate matches into a flat list of `{file, line, pattern_form, snippet}` tuples.
+Aggregate matches into a flat list of `{file, line, pattern_form, snippet}` tuples, then apply
+the container-position precedence rule in `patterns.md` "Phase 0" — deduplicate by
+`(file, line)` so a line matched by Forms 13–15 is attributed to that form and its weaker
+Form 2 / chain-form duplicates are dropped. Carry the dropped count into the report's
+"superseded" row. Deduplicate BEFORE Phase 3, or triage will bucket the same reference twice.
 
 ### Phase 3: Triage
 
@@ -80,6 +84,7 @@ Pattern-form breakdown:
 - Form 13 (command-argument):  <count>
 - Form 14 (document title):    <count>
 - Form 15 (possessive/appositive): <count>
+- Form-2 hits superseded by container-position matches: <count>
 
 Next: invoke `/rename-references <old> to <new>` to apply, or `/rename-references preview <old> to <new>` to dry-run.
 ```

--- a/plugins/docs-hygiene/skills/rename-references/context/patterns.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/patterns.md
@@ -156,6 +156,87 @@ invokes?\s+`?/<other-skill>\s+<old>\b
 - **False-positives:** rare — `<old>.` followed by a word char is specific. Sentence-end prose (`verify. Then…`) is excluded because `[\w-]+` requires a word char immediately after the dot (the space after the dot breaks it).
 - **Coupled-rename note:** dot-form is one face of coupled-sibling renames. When a skill renames, ALSO enumerate its internal mode names and content-file basenames that changed in lockstep (`quality` mode, `context/quality.md`) and sweep EACH as its own rename pair — they carry no primary token, so a sweep keyed only on `<old>` never reaches them. See SKILL.md "Gotchas" coupled-rename entry.
 
+## Container-position forms (13–15)
+
+Forms 1–12 assume `<old>` is a skill/mode identifier. When the renamed thing is a
+**container** — a plugin, a marketplace entry, anything a user names as an argument or
+titles a document after — three positions carry it that none of the earlier forms reach.
+Each is high-precision because the SURROUNDING SYNTAX proves the token is a proper name,
+not a verb.
+
+Why this matters more than coverage: when `<old>` is also an English verb *in the consuming
+codebase*, Form 2 cannot separate the two senses at any triage setting. Measured on the
+`re-anchor` → `discipline` rename, over the plugin's own tree: Form 2 matched **134** lines;
+Forms 13–15 matched **9** — the 8 real defects plus one frozen CHANGELOG-history line the
+existing "Frozen historical records" rule already excludes. See `triage.md`
+"Verb-sense collision the blocklist cannot serve".
+
+## Form 13: Command-argument position
+
+```regex
+(^|[^\w/])/plugins?\s+(install|uninstall|configure|enable|disable|update|add|remove)\s+`?<old>\b
+\b<old>@[\w.-]+
+```
+
+- **Triage default:** Certain
+- **Catches:** `<old>` as the ARGUMENT to a management command rather than as the command
+  itself — `/plugin install <old>@marketplace`, `/plugin configure <old>`,
+  `/plugin enable <old>` — plus the `<old>@<marketplace>` qualified-id form wherever it
+  appears (settings examples, install snippets, `enabledPlugins` / `pluginConfigs` keys).
+- **Why Form 1 misses it:** Form 1 anchors on `/<old>`. Here the slash belongs to `plugin`,
+  and `<old>` sits one-to-several words downstream with no slash of its own.
+- **Why the leading `[^\w/]` alternation:** keeps `.../plugin install x` (a path) from
+  matching while still allowing a line start, a space, or a backtick before the slash.
+- **Optional backtick before `<old>`:** these appear inside inline code spans constantly
+  (`` `/plugin configure <old>` ``); without `` `? `` the pattern misses the most common
+  rendering.
+- **False-positives:** rare. The enclosing management verb is what supplies the
+  disambiguation bare-token position lacks — prose does not accidentally say
+  "/plugin configure" before an English verb.
+- **Severity note:** these are FUNCTIONAL breaks, not cosmetic. A reader following
+  `/plugin install <old>@marketplace` gets `plugin-not-found`. Rank them above title hits
+  when reporting.
+
+## Form 14: Document title / declared name
+
+```regex
+^#{1,6}\s+`?<old>`?\s*$
+^(name|title):\s*"?<old>"?\s*$
+```
+
+- **Triage default:** Certain
+- **Catches:** an ATX heading whose ENTIRE content is the renamed token — the README H1 that
+  names the thing — and frontmatter `name:` / `title:` declaring it.
+- **Why the `$` anchor is load-bearing:** it is what makes this Certain rather than
+  ambiguous. A heading that merely *contains* the token (`## How re-anchor works`) may well
+  be verb usage and belongs in Form 2's ambiguous bucket; a heading that IS the token can
+  only be naming it.
+- **False-positives:** effectively none. A heading consisting solely of a bare English verb
+  is not a shape real documents use.
+- **Note:** a plugin/skill README H1 is the landing surface every consumer sees first, and
+  it is the single most-missed reference in practice — the rename moves the directory, so
+  the path-form patterns all pass, and nothing looks at line 1.
+
+## Form 15: Possessive and appositive container reference
+
+```regex
+\b<old>'s\b
+\bthe <old> (plugin|skill|marketplace entry|package|module)\b
+```
+
+- **Triage default:** Certain
+- **Catches:** prose where `<old>` stands in for the CONTAINER — "Report `<old>`'s effective
+  configuration", "the `<old>` plugin ships…".
+- **Why it is Certain even when `<old>` is a blocklisted verb:** English verbs do not take
+  the possessive clitic, and a noun-class appositive (`the X plugin`) forces the naming
+  reading. Both shapes are grammatically incompatible with the verb sense, so this is safe
+  where Form 2 is not.
+- **False-positives:** a token that is a noun in ordinary use ("the review plugin" vs a
+  review) can still collide; when `<old>` is a common NOUN rather than a verb, demote this
+  form to ambiguous.
+- **Extend the appositive noun class** to whatever the consuming repository calls its
+  containers.
+
 ## Phase 0 — pre-sweep blocklist load
 
 Before running any pattern, load the English-verb blocklist from `triage.md`. Any bare-token (Form 2) or chain-context match (Forms 4, 5, 6, 9) where the token is in the blocklist is forced into ambiguous bucket regardless of regex precision.
@@ -167,6 +248,13 @@ When the skill's re-sweep finds a NEW syntactic form not covered above:
 1. STOP — do not silently mangle. Report the new form to user.
 2. Document the pattern in this file with all 5 fields (form name, regex, triage default, example, false-positives)
 3. Re-run sweep with extended pattern library
+
+**Validate a new form on BOTH axes before adding it.** Recall alone is not evidence — Form 2
+already has perfect recall on every form here and is still unusable when the token is a verb.
+Measure the candidate against a real fixture: the reference commit that FIXED the missed
+references (its removed lines are the defect set) for recall, and the whole pre-fix tree for
+precision, reporting the new form's hit count beside bare-token Form 2's on that same tree.
+A form that does not beat Form 2 on precision is not carrying its weight.
 
 ## Cross-platform note
 

--- a/plugins/docs-hygiene/skills/rename-references/context/patterns.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/patterns.md
@@ -201,7 +201,7 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
 
 ```regex
 ^#{1,6}\s+`?<old>`?\s*$
-^(name|title):\s*"?<old>"?\s*$
+^(name|title):\s*("<old>"|'<old>'|<old>)\s*$
 ```
 
 - **Triage default:** Certain
@@ -211,6 +211,9 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
   ambiguous. A heading that merely *contains* the token (`## How re-anchor works`) may well
   be verb usage and belongs in Form 2's ambiguous bucket; a heading that IS the token can
   only be naming it.
+- **Quote handling:** the alternation accepts a bare, double-quoted, or single-quoted value
+  and requires the quotes to PAIR — `"<old>"` and `'<old>'`, never `"<old>'`. A naive
+  `["']?<old>["']?` would match the mismatched form, which is not valid YAML.
 - **False-positives:** effectively none. A heading consisting solely of a bare English verb
   is not a shape real documents use.
 - **Note:** a plugin/skill README H1 is the landing surface every consumer sees first, and
@@ -220,13 +223,18 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
 ## Form 15: Possessive and appositive container reference
 
 ```regex
-\b<old>'s\b
-\bthe <old> (plugin|skill|marketplace entry|package|module)\b
+`?\b<old>\b`?'s\b
+\bthe `?<old>`? (plugin|skill|marketplace entry|package|module)\b
 ```
 
 - **Triage default:** Certain
 - **Catches:** prose where `<old>` stands in for the CONTAINER — "Report `<old>`'s effective
   configuration", "the `<old>` plugin ships…".
+- **Inline-code wrapping is the common case, not the exception:** in markdown the token is
+  usually a code span, so the literal `<old>'s` sequence never appears — it is
+  `` `<old>` `` followed by `'s`. The optional backticks are what make this form fire on
+  real documentation; without them it silently misses its own motivating example. Form 13
+  carries the same allowance for the same reason.
 - **Why it is Certain even when `<old>` is a blocklisted verb:** English verbs do not take
   the possessive clitic, and a noun-class appositive (`the X plugin`) forces the naming
   reading. Both shapes are grammatically incompatible with the verb sense, so this is safe
@@ -240,6 +248,28 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
 ## Phase 0 — pre-sweep blocklist load
 
 Before running any pattern, load the English-verb blocklist from `triage.md`. Any bare-token (Form 2) or chain-context match (Forms 4, 5, 6, 9) where the token is in the blocklist is forced into ambiguous bucket regardless of regex precision.
+
+**Precedence: a container-position match wins its line outright.** Forms 13–15 are strictly
+more specific than Form 2 — every line they match, Form 2 also matches. Without precedence the
+new forms would only ADD hits, leaving the Form 2 flood they exist to avoid fully intact.
+
+Deduplicate by `(file, line)` AFTER the sweep and BEFORE triage:
+
+1. A `(file, line)` matched by any of Forms 13–15 is attributed to that form and enters the
+   **Certain** bucket. Drop the Form 2 (and any chain-form) match for that same line — it is
+   the same reference seen through a weaker lens, not a second finding.
+2. Only lines Forms 13–15 did NOT match fall through to Form 2's blocklist rule above.
+
+The Phase 0 rule is therefore scoped to what actually reaches Form 2: it forces a
+blocklisted token's bare-token matches ambiguous, and container-position matches never
+become bare-token matches. Report the deduplication in the audit output — "N Form-2 hits
+superseded by container-position matches" — so a reader can see the suppression happened
+rather than inferring it from a smaller number.
+
+**This precedence is what makes the remedy real.** On the measured fixture the sweep still
+RUNS Form 2 and still collects its 134 lines; precedence is what turns those into 8
+Certain container-position findings plus 126 ordinary verb uses that were never candidates,
+instead of 134 confirmation prompts.
 
 ## Phase 6 — pattern library evolution
 

--- a/plugins/docs-hygiene/skills/rename-references/context/patterns.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/patterns.md
@@ -214,11 +214,22 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
 - **Quote handling:** the alternation accepts a bare, double-quoted, or single-quoted value
   and requires the quotes to PAIR — `"<old>"` and `'<old>'`, never `"<old>'`. A naive
   `["']?<old>["']?` would match the mismatched form, which is not valid YAML.
-- **False-positives:** effectively none. A heading consisting solely of a bare English verb
-  is not a shape real documents use.
+- **False-positives — real, and the reason for the scope rule below.** "A heading that IS the
+  token can only be naming it" holds when the token is coined or hyphenated. It FAILS when the
+  container has an ordinary-word name: renaming a `testing` plugin matches this repository's own
+  `README.md:86` (`### Testing`, a marketplace category heading), and renaming an `architecture`
+  plugin matches `plugins/miro/README.md:39` (`## Architecture`, an unrelated design section).
+  Both were verified against the tree. Under precedence, a false Certain here is worse than a
+  Form 2 hit, because it DISCARDS the safer classification.
+- **Scope rule (required):** rate a title match Certain only when the file is plausibly
+  container-owned — the container's own README/SKILL/manifest, or a path under its directory.
+  A heading match in a file the container does not own is **Ambiguous**, whatever the token
+  looks like. When the token is a common English word, demote every title match to Ambiguous
+  regardless of path.
 - **Note:** a plugin/skill README H1 is the landing surface every consumer sees first, and
   it is the single most-missed reference in practice — the rename moves the directory, so
-  the path-form patterns all pass, and nothing looks at line 1.
+  the path-form patterns all pass, and nothing looks at line 1. That is why the form exists;
+  the scope rule is what keeps it from over-reaching to every document in the tree.
 
 ## Form 15: Possessive and appositive container reference
 
@@ -266,10 +277,38 @@ become bare-token matches. Report the deduplication in the audit output — "N F
 superseded by container-position matches" — so a reader can see the suppression happened
 rather than inferring it from a smaller number.
 
-**This precedence is what makes the remedy real.** On the measured fixture the sweep still
-RUNS Form 2 and still collects its 134 lines; precedence is what turns those into 8
-Certain container-position findings plus 126 ordinary verb uses that were never candidates,
-instead of 134 confirmation prompts.
+**Precedence alone is NOT sufficient — it only resolves lines the container forms also
+matched.** On the measured fixture that is 8 lines out of Form 2's 134. The other 126 are
+ordinary verb uses that no container form touches, so they fall through to Form 2 and, when
+the token is absent from the static blocklist, take its **Certain** default. Deduplicating
+overlaps does nothing for them.
+
+## Phase 0b — container-rename mode
+
+Declare the sweep's MODE at Phase 0, from what is being renamed:
+
+- **Identifier rename** (a skill, a mode, a dotted ID) — every form applies as before. Nothing
+  below changes.
+- **Container rename** (a plugin, a marketplace entry, a package) — the thing being renamed is
+  a proper name, so a bare-token occurrence is EVIDENCE OF NOTHING: it is as likely to be the
+  word used ordinarily as the container referenced. In this mode:
+  1. Forms 13–15 (plus Forms 1 and 3, which are already position-anchored) produce the
+     **Certain** bucket.
+  2. Form 2's residue — every bare-token line NOT matched by a position-anchored form — is
+     **excluded from Certain entirely**, regardless of blocklist membership. Report it as a
+     single aggregate count ("126 bare-token occurrences not in container position, not
+     proposed"), never as per-match prompts.
+  3. Surface the residue only if the user explicitly asks to widen (`--include-bare-token`),
+     and then as Ambiguous, never Certain.
+
+Container renames are exactly the case where bare-token position carries no signal, so
+spending the user's attention on it is a cost with no corresponding catch. The static
+blocklist is irrelevant here — mode is a property of what is being renamed, not of whether
+someone remembered to list the token.
+
+**With mode + precedence together**, the measured fixture resolves as: 8 Certain
+container-position findings, 126 bare-token occurrences reported as an aggregate and not
+proposed, and 0 confirmation prompts — against Form 2's unaided 134.
 
 ## Phase 6 — pattern library evolution
 

--- a/plugins/docs-hygiene/skills/rename-references/context/triage.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/triage.md
@@ -60,6 +60,25 @@ load, save, copy, move, write, read, parse, render, print, format,
 
 (Extend as new collisions surface.)
 
+**Verb-sense collision the blocklist cannot serve.** The blocklist is a static list of tokens
+that are English verbs *in general*. It cannot cover a token that is a verb **in the consuming
+codebase** — a coined or hyphenated term the project uses verbally hundreds of times. Both
+branches fail for such a token:
+
+- **Absent from the blocklist** → every bare-token hit is rated Certain, so the sweep proposes
+  rewriting the verb uses.
+- **Added to the blocklist** → every hit lands ambiguous, and the per-match rule below turns a
+  handful of real defects into hundreds of confirmation prompts.
+
+Extending the blocklist is therefore the WRONG remedy here; it swaps one unusable bucket for
+another. The remedy is position: `patterns.md` Forms 13–15 anchor on syntax that only the
+container sense can occupy (argument-to-a-management-command, a heading that IS the token, the
+possessive clitic), so they stay Certain regardless of blocklist membership.
+
+Measured on the `re-anchor` → `discipline` rename, over that plugin's own tree: Form 2 matched
+134 lines for 8 real defects; Forms 13–15 matched 9. Reach for a position-anchored form before
+reaching for the blocklist.
+
 **User flow:** present each match individually via `AskUserQuestion` with 3 lines of surrounding context. Three options per match: "rename this", "skip this", "skip remaining ambiguous". Always one-by-one — batched confirmation defeats the safety purpose.
 
 **Why per-match:** "the user just renamed the `confirm` skill" does NOT mean every English use of "confirm" should be replaced. The incident that motivated this skill contained dozens of legitimate "confirm" verb uses (research vocabulary, user-confirmation prompts, domain logic) that MUST be preserved. Per-match confirmation lets the user catch each.

--- a/plugins/docs-hygiene/skills/rename-references/context/triage.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/triage.md
@@ -79,6 +79,14 @@ Measured on the `re-anchor` → `discipline` rename, over that plugin's own tree
 134 lines for 8 real defects; Forms 13–15 matched 9. Reach for a position-anchored form before
 reaching for the blocklist.
 
+**Position-anchoring alone does not finish the job.** Forms 13–15 resolve only the lines they
+match; the remaining bare-token lines still reach Form 2 and take its Certain default. What
+removes them is `patterns.md` "Phase 0b — container-rename mode": when the renamed thing is a
+container, bare-token position carries no signal at all, so the residue is excluded from Certain
+and reported as an aggregate rather than as prompts. Mode is decided by WHAT is being renamed,
+which is why it works where the blocklist cannot — it does not depend on anyone having listed
+the token in advance.
+
 **User flow:** present each match individually via `AskUserQuestion` with 3 lines of surrounding context. Three options per match: "rename this", "skip this", "skip remaining ambiguous". Always one-by-one — batched confirmation defeats the safety purpose.
 
 **Why per-match:** "the user just renamed the `confirm` skill" does NOT mean every English use of "confirm" should be replaced. The incident that motivated this skill contained dozens of legitimate "confirm" verb uses (research vocabulary, user-confirmation prompts, domain logic) that MUST be preserved. Per-match confirmation lets the user catch each.

--- a/plugins/docs-hygiene/skills/rename-references/evals/evals.json
+++ b/plugins/docs-hygiene/skills/rename-references/evals/evals.json
@@ -72,6 +72,31 @@
         "Output explains both names appear in the plan doc by design (self-reference)",
         "Output does not rewrite the plan doc's occurrences of the old name"
       ]
+    },
+    {
+      "id": 7,
+      "name": "container-rename-catches-command-argument-and-title",
+      "prompt": "I renamed the plugin `re-anchor` to `discipline`. The directory moved and every /re-anchor: invocation is updated. Audit for anything still stale.",
+      "expected_output": "The sweep runs the container-position forms (13-15) in addition to Forms 1-12, so it reports the plugin name in command-argument position (`/plugin install re-anchor@melodic-software`, `/plugin configure re-anchor`), a document title that is the bare token (`# re-anchor`), and possessive container prose (\"re-anchor's effective configuration\") as Certain. It does NOT report the English-verb uses (\"each skill re-anchors ONE discipline\") as Certain, and it flags command-argument hits as functional breaks rather than cosmetic ones.",
+      "files": [],
+      "expectations": [
+        "Forms 13-15 are run, not only the slash-token and path forms that a directory move already satisfies",
+        "`/plugin install <old>@marketplace` and `/plugin configure <old>` are reported as Certain and identified as functional breaks",
+        "A heading whose entire content is the bare token is reported as Certain",
+        "Verb-sense uses of the token are not swept into the Certain bucket"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "verb-collision-not-fixed-by-blocklist-extension",
+      "prompt": "The token I'm renaming is also used as a verb hundreds of times in this repo. Should I add it to the English-verb blocklist so the sweep stops proposing bad rewrites?",
+      "expected_output": "Explains that blocklist extension is the wrong remedy for a token that is a verb in the consuming codebase: leaving it off rates every bare-token hit Certain, and adding it forces every hit into the ambiguous bucket where the per-match confirmation rule turns a handful of real defects into hundreds of prompts. Routes to the position-anchored forms 13-15 instead, which stay Certain regardless of blocklist membership because their surrounding syntax admits only the container sense.",
+      "files": [],
+      "expectations": [
+        "Identifies that BOTH blocklist branches fail for a codebase-specific verb, not just the omit branch",
+        "Recommends position-anchored forms rather than extending the blocklist",
+        "Does not propose per-match confirmation over the full bare-token hit set as the answer"
+      ]
     }
   ]
 }

--- a/plugins/docs-hygiene/skills/rename-references/evals/evals.json
+++ b/plugins/docs-hygiene/skills/rename-references/evals/evals.json
@@ -110,6 +110,31 @@
         "The report includes the count of Form-2 hits superseded by container-position matches",
         "Ordinary verb uses are not surfaced as rename candidates or as mandatory confirmation prompts"
       ]
+    },
+    {
+      "id": 10,
+      "name": "container-mode-excludes-bare-token-residue-from-certain",
+      "prompt": "Audit the rename of the `re-anchor` plugin to `discipline`. The token is used as an English verb about 130 times across the plugin and it is not in the blocklist.",
+      "expected_output": "Declares container-rename mode at Phase 0. Position-anchored forms produce the Certain bucket; the bare-token residue -- every Form 2 line NOT matched by a position-anchored form -- is excluded from Certain entirely regardless of blocklist membership, and reported as a single aggregate count rather than as per-match confirmation prompts. It does not propose rewriting the verb uses, and it does not ask the user to confirm them one by one.",
+      "files": [],
+      "expectations": [
+        "Container-rename mode is declared and drives the bucketing",
+        "Bare-token residue is excluded from Certain WITHOUT relying on the blocklist",
+        "Residue is reported as an aggregate count, not as per-match prompts",
+        "Deduplication of overlapping lines is not presented as sufficient on its own"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "title-form-scoped-to-container-owned-documents",
+      "prompt": "Rename the `testing` plugin to `test-suite`. Audit for stale references.",
+      "expected_output": "Recognizes that `testing` is an ordinary English word, so Form 14 title matches are demoted to Ambiguous rather than Certain. A heading like `### Testing` in the repository root README (a marketplace category heading, not the container's own document) is NOT auto-applied; only headings in plausibly container-owned files -- the plugin's own README/SKILL/manifest or paths under its directory -- are eligible for Certain, and even those are demoted when the token is a common word.",
+      "files": [],
+      "expectations": [
+        "A title match outside container-owned files is not rated Certain",
+        "An ordinary-word container name demotes title matches regardless of path",
+        "Precedence does not discard the safer classification for an out-of-scope title match"
+      ]
     }
   ]
 }

--- a/plugins/docs-hygiene/skills/rename-references/evals/evals.json
+++ b/plugins/docs-hygiene/skills/rename-references/evals/evals.json
@@ -76,7 +76,7 @@
     {
       "id": 7,
       "name": "container-rename-catches-command-argument-and-title",
-      "prompt": "I renamed the plugin `re-anchor` to `discipline`. The directory moved and every /re-anchor: invocation is updated. Audit for anything still stale.",
+      "prompt": "I renamed the plugin `re-anchor` to `discipline`. The directory moved and every qualified `/re-anchor:<skill>` invocation is already updated. Audit for anything still stale.",
       "expected_output": "The sweep runs the container-position forms (13-15) in addition to Forms 1-12, so it reports the plugin name in command-argument position (`/plugin install re-anchor@melodic-software`, `/plugin configure re-anchor`), a document title that is the bare token (`# re-anchor`), and possessive container prose (\"re-anchor's effective configuration\") as Certain. It does NOT report the English-verb uses (\"each skill re-anchors ONE discipline\") as Certain, and it flags command-argument hits as functional breaks rather than cosmetic ones.",
       "files": [],
       "expectations": [
@@ -96,6 +96,19 @@
         "Identifies that BOTH blocklist branches fail for a codebase-specific verb, not just the omit branch",
         "Recommends position-anchored forms rather than extending the blocklist",
         "Does not propose per-match confirmation over the full bare-token hit set as the answer"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "container-position-match-supersedes-bare-token-on-same-line",
+      "prompt": "Audit the rename of `re-anchor` to `discipline`. The token is also used as an English verb throughout the plugin, so I expect a lot of noise.",
+      "expected_output": "The sweep runs Form 2 and the container-position forms, then deduplicates by (file, line) before triage: each line matched by Forms 13-15 is attributed to that form and enters Certain, and its Form 2 duplicate is dropped rather than raised as a second finding. Lines Form 2 matched alone are the ordinary verb uses and are not presented as rename candidates. The report states how many Form-2 hits were superseded, so the suppression is visible rather than inferred.",
+      "files": [],
+      "expectations": [
+        "Deduplication by (file, line) happens after the sweep and BEFORE triage",
+        "A container-position match takes the Certain path and its bare-token duplicate for the same line is dropped",
+        "The report includes the count of Form-2 hits superseded by container-position matches",
+        "Ordinary verb uses are not surfaced as rename candidates or as mandatory confirmation prompts"
       ]
     }
   ]


### PR DESCRIPTION
Closes #1283

## Summary

Six stale references survived three sweep passes during the `re-anchor` → `discipline` plugin rename (#1276). All six were two syntactic shapes `rename-references`' pattern library did not cover, and the gap is structural rather than incidental: **Forms 1–12 all assume the renamed token is a skill or mode identifier.**

When a CONTAINER renames — a plugin, a marketplace entry — the token occupies positions none of them reach:

- **Form 1** anchors on `/<old>`, so it cannot fire on `/plugin configure <old>`: the slash belongs to `plugin`, and the token sits downstream in argument position.
- **Form 3** needs a path; none of these are paths.
- **Form 2** (bare token) matches, but cannot separate the container sense from the verb sense at any triage setting when the token is also a verb in the consuming codebase.

Forms 13–15 anchor on syntax that admits **only** the naming sense:

| Form | Position | Why it is Certain |
|---|---|---|
| 13 | Command argument — `/plugin install <old>@mkt`, `/plugin configure <old>` | A management verb immediately precedes the token; prose does not say "/plugin configure" before an English verb |
| 14 | Document title — `# <old>`, frontmatter `name:` | The `$` anchor: a heading that *contains* the token may be verb usage, but one that IS the token can only be naming it |
| 15 | Possessive / appositive — `<old>'s`, `the <old> plugin` | English verbs do not take the possessive clitic; the noun-class appositive forces the naming reading |

Command-argument hits are flagged as **functional breaks**, not cosmetic: a reader following `/plugin install <old>@marketplace` gets `plugin-not-found`. Four of the six missed references were this shape, including the README's own install block.

## Fix

- `context/patterns.md` — Forms 13–15, each with the five documented fields the existing forms carry, under a short section explaining why container position is its own class.
- `context/triage.md` — records the collision class the English-verb blocklist **cannot** serve. The blocklist holds tokens that are verbs *in general*; a token that is a verb *in the consuming codebase* fails both ways: omitted → every bare-token hit is rated Certain and the sweep proposes rewriting the verb uses; added → every hit lands ambiguous, where the per-match confirmation rule turns a handful of real defects into hundreds of prompts. Extending the blocklist swaps one unusable bucket for another. The remedy is position.
- `context/patterns.md` Phase 6 — now requires validating any new form on **both** axes. Recall alone is not evidence: Form 2 already has perfect recall on every form in the library and is still unusable.
- `context/audit.md` — pattern-form breakdown lists 13–15, so an audit report accounts for every form the sweep runs.
- Two eval cases (7, 8): the container-rename sweep, and the blocklist-extension trap.

## Verification

Validated on **both** axes against the real fixture rather than asserted. Recall came from the removed lines of `930c97a4` (the commit that fixed the references — its deletions *are* the defect set); precision from the whole pre-fix tree at `930c97a4^`.

| Pattern | Hits on `930c97a4^` under `plugins/discipline` | Real defects among them |
|---|--:|--:|
| Form 2 (bare token) | **134** | 8 |
| Forms 13–15 combined | **9** | 8 |

The 9th hit is a frozen CHANGELOG-history line, which the existing "Frozen historical records" auto-exclusion already handles. The one defect line Forms 13–15 do *not* match is the frontmatter `description` trigger-phrase block — deliberately kept in that rename, so matching it would have been a false positive.

Gates run locally:

- `claude plugin validate .` — passes
- `markdownlint-cli2` on all four changed markdown files — 0 errors
- `scripts/check-changelog-parity.sh --check-bump origin/main` — passes (`docs-hygiene` 0.8.6 → 0.9.0 with a matching entry)
- `scripts/check-changelog-parity.sh --check` — passes
- `evals.json` parses; diff is additive only (25 insertions, 0 deletions to existing cases)

## Related

- Refs #1276 — the rename whose six missed references are this PR's fixture; `930c97a4` is the reference commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSXnCLnmzk8y4cKv2y1z9f
