### PR TITLE
fix(ci): portability-lint: anchor is_comment to block-level HTML comments

### DIFF
--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -143,7 +143,12 @@ scan_file() {
   fi
   awk '
     function is_annotated(l) { return l ~ /portability-ok:/ }
-    function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /<!--/ }
+    # Block-level only: a content line that merely happens to carry an inline
+    # HTML comment marker (e.g. prose with `<!-- note -->` mid-line) must NOT
+    # count as a comment line for pending_annot carry-forward purposes — only a
+    # line whose `<!--` opens at the start (after optional whitespace) is a
+    # genuine dedicated comment line. See #611.
+    function is_comment(l) { return l ~ /^[[:space:]]*#/ || l ~ /^[[:space:]]*<!--/ }
     # Guard markers for the active branch class: branch-detection evidence ONLY
     # — a symbolic-ref / merge-base / origin/HEAD / PR-baseRefName resolution
     # command (or a `-> origin/` symbolic-ref target) co-located on the hit line.

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -142,6 +142,26 @@ else
 fi
 rm -f "$f"
 
+# --- a content line with an inline HTML comment does not act as a comment --
+# line for pending_annot carry-forward purposes (#611): only a genuine
+# block-level `<!--` comment line (opening at start-of-line, modulo leading
+# whitespace) may extend an annotation to the next line. Line 2 below has a
+# hardcoded token AND an inline `<!--` marker that is NOT itself a
+# portability-ok annotation — under the pre-fix bug this made is_comment()
+# true for line 2, which left pending_annot carried over from line 1 instead
+# of resetting it, wrongly excusing line 3's unannotated hit too.
+f="$(tmpfile '<!-- portability-ok: covers only line 2 -->
+diff against origin/main here <!-- unrelated inline note, not an annotation -->
+diff against origin/main again, unannotated')"
+if out="$(scan_paths "$f" 2>&1)"; then
+  fail "content line with inline HTML comment must not carry annotation to line 3, got success: $out"
+elif echo "$out" | grep -q ":3:" && ! echo "$out" | grep -q ":2:"; then
+  ok "content line with inline HTML comment does not extend pending_annot to the next line"
+else
+  fail "expected line 3 flagged and line 2 excused (annotated above), got: $out"
+fi
+rm -f "$f"
+
 # --- whole-file portability-scope declaration passes -----------------------
 f="$(tmpfile '<!-- portability-scope: forge=github — inherent, declared boundary -->
 This skill diffs origin/main and pushes with origin/master.')"


### PR DESCRIPTION
## Summary

- `scan_file`'s awk block (`scripts/check-skill-portability.sh`) treated any line
  containing an HTML comment-open marker (`<!` followed by `--`) as a comment
  line for `pending_annot` carry-forward purposes — including a CONTENT line
  that merely happens to carry an inline comment marker mid-line (e.g.
  `diff against origin/main <!-- some other note -->`) and is not itself
  annotated with `portability-ok:`.
- Because a non-annotated "comment" line left `pending_annot` unchanged instead
  of resetting it to 0, such a content line could silently extend a prior
  genuine annotation's coverage past itself to a later, unannotated line — a
  false-negative risk in the fail-closed gate.
- Fix: anchor the HTML-comment branch of `is_comment()` to require the marker
  at the start of the line (modulo leading whitespace) — block-level only —
  per the reviewer's suggested fix recorded on #611, so only a genuine
  dedicated comment line can set or carry `pending_annot`.

## Test plan

- Added a regression case to `scripts/check-skill-portability.test.sh`
  reproducing the reported scenario: an annotated comment line, followed by a
  content line with a hardcoded token *and* an unrelated inline comment marker
  mid-line (`diff against origin/main here <!-- unrelated inline note, not an
  annotation -->`), followed by a third unannotated content line with the same
  hardcoded token. Confirmed the new case fails against the pre-fix script
  (line 3 wrongly excused) and passes after the fix (line 3 correctly flagged,
  line 2 still excused via `annotated_above`).
- Full self-test suite: `PASS=17 FAIL=0` (was `PASS=16` before this change; the
  16 pre-existing cases still pass unchanged).
- `shellcheck` (repo `.shellcheckrc`) and `shfmt -d` clean on both modified
  files.

Closes #611

## Related

- #609 — the portability-lint gate this fix hardens (post-green review
  deferred this finding out of that PR's scope to keep its diff scoped to the
  gate's initial ship).
- #1342 — follow-up filed from this PR's own post-green review (Codex bot):
  the `^[[:space:]]*<!--` anchor doesn't recognize a block comment nested
  inside a Markdown list/blockquote container (e.g. `- <!-- portability-ok:
  ... -->`). Verified not a live regression (no `portability-ok:` usage
  exists in the corpus today); deferred as new scope beyond #611's literal
  acceptance criteria.
- #624 — sibling escape-hatch grammar rigor pair from PR #609's re-review
  (same file/area, also deferred, `needs-human`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

