### PR TITLE
docs(work-items): force UTF-8 wherever a body edit leaves the gh pipeline

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `work-items` plugin are documented here. Format follo
 
 ### Documentation
 
-- **GitHub adapter: force UTF-8 wherever a body edit leaves the byte-faithful pipeline (`#1037`).**
+- **GitHub adapter: force UTF-8 wherever a body edit leaves the UTF-8-safe pipeline (`#1037`).**
   A new cross-cutting gotcha in `tools/work-item-tracker/adapters/github/README.md` records that the
   `gh` transports do not transcode, and requires an explicit UTF-8 encoding on both sides of any
   ad-hoc read or write of a fetched body. No behavior change.

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.24.4]
+
+### Documentation
+
+- **GitHub adapter: force UTF-8 wherever a body edit leaves the byte-faithful pipeline (`#1037`).**
+  A new cross-cutting gotcha in `tools/work-item-tracker/adapters/github/README.md` records that the
+  `gh` transports do not transcode, and requires an explicit UTF-8 encoding on both sides of any
+  ad-hoc read or write of a fetched body. No behavior change.
+
 ## [0.24.3]
 
 ### Fixed

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
@@ -323,9 +323,12 @@ items", the `--add-label`-vs-`--label` rule under "Edit labels / assignees"). Cr
 
 - **Windows `\r`.** Git Bash adds `\r` to `gh` output through `jq`/`--jq`; end every parsing
   pipeline with `| tr -d '\r'`.
-- **Keep body edits inside the byte-faithful pipeline; force UTF-8 anywhere they leave it.**
-  `--json`/`--jq`, `gh api`, the bash `>` redirect, and `--body-file` only move bytes, so the
-  read-modify-write shapes above never transcode. Corruption enters when an **ad-hoc** step decodes
+- **Keep body edits inside the UTF-8-safe pipeline; force UTF-8 anywhere they leave it.**
+  `--json`/`--jq`, `gh api`, the bash `>` redirect, and `--body-file` pass the encoding through
+  untouched, so the read-modify-write shapes above never transcode. That is an encoding guarantee,
+  not a byte-for-byte one: the shapes above normalize line endings and trailing whitespace on
+  purpose (`tr -d '\r'` drops CRs; `$(cat …)` strips trailing newlines, and the `printf '%s\n'`
+  puts exactly one back). Corruption enters when an **ad-hoc** step decodes
   those bytes with a tool whose default is a legacy code page: the body's UTF-8 is read as Windows
   ANSI and re-encoded, putting every non-ASCII character at risk — the observed case is em-dash
   U+2014 arriving back as U+00E2 U+20AC U+201D — and that corrupted copy is then written over the

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
@@ -323,6 +323,21 @@ items", the `--add-label`-vs-`--label` rule under "Edit labels / assignees"). Cr
 
 - **Windows `\r`.** Git Bash adds `\r` to `gh` output through `jq`/`--jq`; end every parsing
   pipeline with `| tr -d '\r'`.
+- **Keep body edits inside the byte-faithful pipeline; force UTF-8 anywhere they leave it.**
+  `--json`/`--jq`, `gh api`, the bash `>` redirect, and `--body-file` only move bytes, so the
+  read-modify-write shapes above never transcode. Corruption enters when an **ad-hoc** step decodes
+  those bytes with a tool whose default is a legacy code page: the body's UTF-8 is read as Windows
+  ANSI and re-encoded, putting every non-ASCII character at risk — the observed case is em-dash
+  U+2014 arriving back as U+00E2 U+20AC U+201D — and that corrupted copy is then written over the
+  good one. Nothing reports it; every command still exits 0. Two Windows defaults decode this way:
+  Python's `open()` with no `encoding=` (the locale encoding, i.e. the ANSI code page —
+  [PEP 686](https://peps.python.org/pep-0686/) makes UTF-8 the default only in 3.15+) and Windows
+  PowerShell 5.1's `Get-Content` (PowerShell 6+ already defaults to `utf8NoBOM`). Do not reason
+  from the version you happen to be on — state the encoding on both sides of any ad-hoc step:
+  `open(path, encoding='utf-8')` or `.read().decode('utf-8')` (or run under `PYTHONUTF8=1`);
+  PowerShell `Get-Content -Encoding utf8`. Writing back from Windows PowerShell 5.1 needs
+  `[IO.File]::WriteAllText($p, $s, (New-Object Text.UTF8Encoding $false))` — there
+  `-Encoding utf8` prepends a BOM and `utf8NoBOM` does not exist (PowerShell 6+ has both).
 - **Rate limits** (verify current values via GitHub REST docs): batch bulk creates to respect
   the secondary content-generation limit — e.g. 30 items per batch with short pauses.
 - **Issue Forms auto-labeling** fires only on web-form creation, not `gh issue create` — apply

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
@@ -333,10 +333,13 @@ items", the `--add-label`-vs-`--label` rule under "Edit labels / assignees"). Cr
   Python's `open()` with no `encoding=` (the locale encoding, i.e. the ANSI code page —
   [PEP 686](https://peps.python.org/pep-0686/) makes UTF-8 the default only in 3.15+) and Windows
   PowerShell 5.1's `Get-Content` (PowerShell 6+ already defaults to `utf8NoBOM`). Do not reason
-  from the version you happen to be on — state the encoding on both sides of any ad-hoc step:
-  `open(path, encoding='utf-8')` or `open(path, 'rb').read().decode('utf-8')` (or run under
-  `PYTHONUTF8=1`); PowerShell `Get-Content -Encoding utf8`. Writing back from Windows PowerShell 5.1 needs
-  `[IO.File]::WriteAllText($p, $s, (New-Object Text.UTF8Encoding $false))` — there
+  from the version you happen to be on — state the encoding on both sides of any ad-hoc step,
+  read *and* write. Python reads with `open(path, encoding='utf-8')` or
+  `open(path, 'rb').read().decode('utf-8')` and writes back with
+  `open(path, 'w', encoding='utf-8')` (or run under `PYTHONUTF8=1`, which covers both sides).
+  Windows PowerShell 5.1 reads with `Get-Content -Raw -Encoding utf8` — without `-Raw` you get a
+  line array, not the one string the write below takes — and writes back with
+  `[IO.File]::WriteAllText($p, $s, (New-Object Text.UTF8Encoding $false))`, because there
   `-Encoding utf8` prepends a BOM and `utf8NoBOM` does not exist (PowerShell 6+ has both).
 - **Rate limits** (verify current values via GitHub REST docs): batch bulk creates to respect
   the secondary content-generation limit — e.g. 30 items per batch with short pauses.

--- a/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
+++ b/plugins/work-items/tools/work-item-tracker/adapters/github/README.md
@@ -334,8 +334,8 @@ items", the `--add-label`-vs-`--label` rule under "Edit labels / assignees"). Cr
   [PEP 686](https://peps.python.org/pep-0686/) makes UTF-8 the default only in 3.15+) and Windows
   PowerShell 5.1's `Get-Content` (PowerShell 6+ already defaults to `utf8NoBOM`). Do not reason
   from the version you happen to be on — state the encoding on both sides of any ad-hoc step:
-  `open(path, encoding='utf-8')` or `.read().decode('utf-8')` (or run under `PYTHONUTF8=1`);
-  PowerShell `Get-Content -Encoding utf8`. Writing back from Windows PowerShell 5.1 needs
+  `open(path, encoding='utf-8')` or `open(path, 'rb').read().decode('utf-8')` (or run under
+  `PYTHONUTF8=1`); PowerShell `Get-Content -Encoding utf8`. Writing back from Windows PowerShell 5.1 needs
   `[IO.File]::WriteAllText($p, $s, (New-Object Text.UTF8Encoding $false))` — there
   `-Encoding utf8` prepends a BOM and `utf8NoBOM` does not exist (PowerShell 6+ has both).
 - **Rate limits** (verify current values via GitHub REST docs): batch bulk creates to respect


### PR DESCRIPTION
Closes #1037

## Summary

The GitHub adapter documents read-modify-write shapes that fetch an issue/comment body, edit it,
and write it back. #1037 filed those as a corruption vector: em-dashes (U+2014) coming back as
`U+00E2 U+20AC U+201D`, silently, with every command exiting 0.

The issue's own investigation comment disproved the filed diagnosis, and this PR ships the
corrected convention rather than the one the issue body suggests. Both halves were re-verified
empirically on this machine before writing (see Test plan):

- **The `gh` transports are byte-faithful.** `--json`/`--jq`, `gh api`, the bash `>` redirect, and
  `--body-file` only move bytes. A real em-dash pushed through a full comment round-trip
  (`-F body=@file` -> `--jq '.body' > file` -> `-F body=@file` -> refetch) came back byte-identical
  to the source. The pipelines in the adapter README need no encoding flag and are unchanged.
- **The corruption is a downstream decode.** It enters when an ad-hoc step decodes those bytes with
  a tool whose default is a legacy code page — the body's UTF-8 read as Windows ANSI and re-encoded,
  then written back over the good copy.

So the new gotcha is transport-agnostic: keep body edits inside the byte-faithful pipeline, and
where an ad-hoc step is unavoidable, state the encoding on **both** sides of it.

Two Windows defaults decode this way, both named with their version scope so the note does not rot:

| Surface | Default | Remedy |
|---|---|---|
| Python `open()`, no `encoding=` | locale encoding (ANSI code page) through 3.14 | `encoding='utf-8'`, `.decode('utf-8')`, or `PYTHONUTF8=1` |
| Windows PowerShell 5.1 `Get-Content` | ANSI code page | `-Encoding utf8` |

[PEP 686](https://peps.python.org/pep-0686/) (Final, Python 3.15) flips the Python default to UTF-8,
and PowerShell 6+ already defaults to `utf8NoBOM` — which is exactly why the guidance is "state it
explicitly" rather than "check your version".

The write half is version-split deliberately. On Windows PowerShell 5.1, `Set-Content -Encoding utf8`
prepends a BOM and `utf8NoBOM` does not exist as a value — and by the byte-faithfulness established
above, `--body-file` would carry that `U+FEFF` straight into the stored body. That path gets
`[IO.File]::WriteAllText($p, $s, (New-Object Text.UTF8Encoding $false))` instead. This was a review
finding on the first draft of this PR, caught and verified before it shipped.

No behavior change: documentation plus the version/CHANGELOG bump the repo's parity gate requires.
No committed code in this repo instantiates the footgun — every `--body-file` read-modify-write here
is bash/jq with no decode step, which the diff asserts rather than assumes.

## Test plan

Every claim in the new gotcha was reproduced on this machine (Windows 11, Git Bash, `gh` 2.95.0,
Python 3.14.6 with `locale.getencoding()` -> `cp1252`, pwsh 7.6.3, Windows PowerShell 5.1.26100),
byte-inspected with `od -tx1` rather than eyeballed:

- **Corruption mechanism.** Clean UTF-8 `e2 80 94` read with Python's default `open()` and
  re-encoded -> `c3 a2 e2 82 ac e2 80 9d` — the exact byte sequence #1037 documents. Clean under
  `encoding='utf-8'`, under `.decode('utf-8')`, and under `PYTHONUTF8=1`.
- **PowerShell version split.** Windows PowerShell 5.1 `Get-Content` (no `-Encoding`) reproduced the
  same mojibake; pwsh 7.6.3 was clean by default. This is why the note is version-scoped instead of
  blanket "PowerShell corrupts".
- **PS 5.1 write-side BOM.** `Set-Content -Encoding utf8` emitted `ef bb bf ...`; `utf8NoBOM` was
  rejected outright (not a valid enum value in 5.1); `WriteAllText` with `UTF8Encoding $false` was
  clean. Confirms the version-split remedy above.
- **Transport round-trip (end-to-end, live).** Posted a scratch comment on #1037 containing a real
  em-dash via `-F body=@file`, fetched it back through the accused path
  (`gh api ... --jq '.body' > file`), wrote it back via `-F body=@file`, and refetched: 1 em-dash,
  0 mojibake, byte-identical to source (`md5` match after trailing-newline normalization). The
  scratch comment was tombstoned afterward.
- **This PR's own bytes.** The diff is about encoding corruption, so the committed blobs were
  checked directly, not by inspection: 0 mojibake sequences, 0 CR bytes, no BOM, valid UTF-8
  (`iconv -f UTF-8 -t UTF-8`) in the git index.
- **Repo gates, locally:** `markdownlint-cli2` 0 issues, `typos` exit 0, `editorconfig-checker`
  exit 0, `check-changelog-parity.sh --check` and `--check-bump origin/main` both exit 0.

## Related

- Sources verified this session against primary docs, not recall: [PEP 686](https://peps.python.org/pep-0686/)
  (Final, Python 3.15), [`locale.getencoding()`](https://docs.python.org/3/library/locale.html#locale.getencoding)
  ("On Windows, return the ANSI code page"),
  [`Get-Content` 5.1](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-content?view=powershell-5.1)
  (default `Default` = active code page) vs
  [`Get-Content` 7.x](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-content)
  (default `utf8NoBOM`), and
  [`gh issue edit`](https://cli.github.com/manual/gh_issue_edit) for `--body-file`.
- #1037's body still carries the disproven fix direction (it recommends avoiding the fetch shape and
  using `json.load(open(path))`, which is itself the footgun on Windows). The correction lives in
  that issue's investigation comment and now in the adapter README; the body is left as filed since
  the thread supersedes it.

*This PR was authored by AI (autonomous work-loop lane).*
