### PR TITLE
fix(work-items): e2e probe uses declared wayfind: <type> label form

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.24.2]
+
+### Fixed
+
+- **`e2e-probe.sh` now creates and filters the declared `wayfind: research` / `wayfind: task`
+  labels (colon-space), not the colon-no-space `wayfind:research` / `wayfind:task` the probe
+  previously used (`#1256`).** The colon-no-space form is a string that production never emits —
+  it never exercised a label value containing a space, the exact case that makes these labels
+  non-trivial (an unquoted `label:wayfind: research` search qualifier returns zero results
+  silently rather than erroring). A static regression test now guards both the correct literal and
+  the forbidden one directly against the probe's source.
+
 ## [0.24.1]
 
 ### Documentation

--- a/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
@@ -58,8 +58,8 @@ for n in $(gh issue list -R "$REPO" --state open --limit 200 --json number --jq 
   gh issue close "$n" -R "$REPO" --comment "e2e-probe clean-at-start" >/dev/null 2>&1 || true
 done
 gh label create work-map -R "$REPO" --force >/dev/null 2>&1 || true
-gh label create "wayfind:research" -R "$REPO" --force >/dev/null 2>&1 || true
-gh label create "wayfind:task" -R "$REPO" --force >/dev/null 2>&1 || true
+gh label create "wayfind: research" -R "$REPO" --force >/dev/null 2>&1 || true
+gh label create "wayfind: task" -R "$REPO" --force >/dev/null 2>&1 || true
 
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 
@@ -70,10 +70,10 @@ record "create map" "$MAP"
 assert_contains "map id well-formed" "$MAP_ID" "github:"
 
 # 2. Two typed decision items under the map; item2 blocked by item1.
-ITEM1="$(wit create-item --title "e2e research item $TS" --labels "wayfind:research" --parent "$MAP_ID" --repo "$REPO")"
+ITEM1="$(wit create-item --title "e2e research item $TS" --labels "wayfind: research" --parent "$MAP_ID" --repo "$REPO")"
 ITEM1_ID="$(jq -r '.id' <<<"$ITEM1")"
 record "create item1 (research)" "$ITEM1"
-ITEM2="$(wit create-item --title "e2e task item $TS" --labels "wayfind:task" --parent "$MAP_ID" --blocked-by "$ITEM1_ID" --repo "$REPO")"
+ITEM2="$(wit create-item --title "e2e task item $TS" --labels "wayfind: task" --parent "$MAP_ID" --blocked-by "$ITEM1_ID" --repo "$REPO")"
 ITEM2_ID="$(jq -r '.id' <<<"$ITEM2")"
 record "create item2 (task, blocked by item1)" "$ITEM2"
 assert_eq "item2 parent is map" "$MAP_ID" "$(jq -r '.parent_id' <<<"$ITEM2")"

--- a/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.test.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.test.sh
@@ -12,4 +12,18 @@ assert_contains "--help mentions lifecycle" "$out" "lifecycle"
 bash "$S" --nope >/dev/null 2>&1
 assert_eq "unknown flag → usage exit 2" "2" "$?"
 
+# Regression guard: the probe must exercise the wayfind labels' declared,
+# colon-SPACE form (`wayfind: research` / `wayfind: task` — Labels.cs and
+# /planning:wayfind both require it verbatim) and never regress to the
+# colon-no-space form (`wayfind:research` / `wayfind:task`), which a probe run
+# would silently create in the sandbox without ever exercising a label value
+# containing a space. The forbidden needles are built, not written literally,
+# so this file itself never contains the very string it bans.
+SRC="$(cat "$S")"
+WAYFIND_PREFIX="wayfind:"
+assert_contains "probe creates wayfind: research (space)" "$SRC" "${WAYFIND_PREFIX} research"
+assert_contains "probe creates wayfind: task (space)" "$SRC" "${WAYFIND_PREFIX} task"
+assert_not_contains "probe never regresses to wayfind:research (no space)" "$SRC" "${WAYFIND_PREFIX}research"
+assert_not_contains "probe never regresses to wayfind:task (no space)" "$SRC" "${WAYFIND_PREFIX}task"
+
 [[ $FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #1256

## Summary

`e2e-probe.sh` created and filtered the wayfind sub-item labels using the colon-no-space form
`wayfind:research` / `wayfind:task` at four call sites (two `gh label create`, two `--labels`),
not the colon-**space** form `wayfind: research` / `wayfind: task` that `melodic-software/github-iac`'s
`Labels.cs` declares and that `/planning:wayfind` requires verbatim (create + filter). Not a
production-repo risk — the probe only ever targets a required throwaway sandbox — but it cost probe
fidelity: the probe never exercised a label value containing a space, the exact case that makes
these labels non-trivial (an unquoted `label:wayfind: research` search qualifier returns zero
results silently rather than erroring).

Fixed all four call sites to the declared literal and added a static regression test guarding both
the correct string and the forbidden one directly against the probe's source — the forbidden needle
is built from parts rather than written literally so the test file itself never contains the string
it bans.

## Test plan

- `bash -n e2e-probe.sh` — syntax check, passes.
- `shellcheck e2e-probe.sh e2e-probe.test.sh` — no warnings.
- `bash e2e-probe.test.sh` — all 7 cases pass, including the 4 new regression-guard cases (creates
  `wayfind: research`/`wayfind: task`, never regresses to the no-space form).
- `bash run-conformance.test.sh` — unaffected, 4/4 pass (no regression in the broader conformance
  harness).
- `grep -rn "wayfind:research\|wayfind:task" plugins/work-items/` — zero operative call-site
  matches; the only remaining literal mentions are prose (a CHANGELOG entry documenting the fix, and
  the new test's human-readable case labels) — the actual matching needle in the new test is built
  from parts, never written as the literal banned string. This mirrors the existing precedent at
  `plugins/planning/CHANGELOG.md:402`, which already names `wayfind:research` verbatim as
  historical fact.
- Statically verified the GitHub adapter's `create-item.sh` `--labels` handling: it splits only on
  `,` (`IFS=',' read -ra label_list <<<"$labels"`) and forwards each element as one `--label`
  argv entry to `gh` via an array (never re-split), so a single label value containing a space
  reaches `gh` intact as one label, not two.
- **Not performed:** a live run of `e2e-probe.sh` against a real sandbox repo
  (`WIT_CONFORMANCE_GITHUB_REPO`) — this session has no sandbox repo configured. The probe is
  "on-demand only" by design (its own header comment), so acceptance criterion 2 ("the probe still
  passes end-to-end against a sandbox") is unverified by this PR; should be confirmed by whoever
  next runs the probe live, or by the reviewer if a sandbox is available.

## Related

Refs melodic-software/github-iac#179 — the wayfind write-policy resolution that surfaced this defect
Refs melodic-software/claude-code-plugins#1253 — sibling label-string defect (triage routing to
priority: pN-* labels that exist in no repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
