### PR TITLE
docs(ignition): restart the acceptance clock at the 15-min schedule flip

### DIFF
--- a/docs/topics/autonomy-ignition/PLAN.md
+++ b/docs/topics/autonomy-ignition/PLAN.md
@@ -338,7 +338,9 @@ accumulation window or the first eligibility claim is hollow and the window re-a
    (`TODO(#778)` in verify-join) — the predicate's "0 human-reverted merges" input cannot
    fail until this lands.
 
-**Sanity Check:** at day 7: predicate stub shows ≥1 week of scheduled fires with zero manual
+**Sanity Check:** at day 7 of the acceptance clock — seven days after the recorded timestamp at
+which the Desktop task's schedule actually flipped to the 15-min grid, NOT day 7 of the original
+accumulation window: predicate stub shows ≥1 week of scheduled fires with zero manual
 INITIATIONS (run history: no manual entries post-warm-up; human merges expected and fine);
 gaps named as dated scope notes in the roadmap PLAN.
 

--- a/docs/topics/autonomy-ignition/PLAN.md
+++ b/docs/topics/autonomy-ignition/PLAN.md
@@ -286,7 +286,13 @@ in telemetry = Sonnet; live checkout clean; any fire-without-row = Phase 1 defec
 > missed-fire detector is still specced against the hourly cadence (its wiring was already
 > deferred to Phase 4) — re-spec + revalidation against the 15-min slot grid filed as
 > scratch#66; until it lands, individual missed 15-min slots have no automated signal
-> beyond failure tracker items and run history.
+> beyond failure tracker items and run history. Same consequence split as the 2026-07-21
+> pause incident: the C2 PREDICATE window is unaffected by the cadence flip (its span
+> measures mature completions, not slot coverage), but the roadmap ACCEPTANCE clock
+> ("fires on schedule with zero manual kicks for ≥1 week") RESTARTS at the timestamp the
+> Desktop task's schedule actually flips to the 15-min grid — the prior hourly stretch
+> misses three of every four slots under the new grid and cannot count toward a week of
+> on-schedule 15-min operation.
 >
 > **Delegated-merge amendment (recorded 2026-07-22):** during accumulation the de facto
 > merge path has been operator-DELEGATED main-session merges — the interactive main


### PR DESCRIPTION
Follow-up to #1052, which merged while its final review thread (PLAN.md L285, restart the acceptance window after the cadence flip) was still open. This lands the fix that thread asked for: the roadmap's >=1-week fires-on-schedule acceptance stretch cannot carry the hourly portion across the cadence flip — hourly fires miss three of every four slots under the 15-min grid — so the acceptance clock restarts at the actual Desktop schedule-flip timestamp. Recorded as the same predicate-vs-acceptance consequence split the 2026-07-21 pause incident established (predicate window unaffected; it measures mature completions, not slot coverage).

## Related

- #1052 (merged; thread https://github.com/melodic-software/claude-code-plugins/pull/1052#discussion_r3650534473 remains the source finding). No linked issue — status-note documentation; nothing in this repo closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017P1vVA8iViUTfQWjA9tgZG
