### PR TITLE
fix(guardrails): raise PreToolUse blocking-guard timeouts from 10/15s to 60s

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Eleven safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.1]
+
+### Fixed
+
+- **PreToolUse blocking guards were declared with `timeout: 10`/`15` — 40-60x below the platform's
+  own documented `command`-hook default of 600s for `PreToolUse` (only `UserPromptSubmit` (30) and
+  `MessageDisplay` (10) lower it; `PreToolUse` does not — <https://code.claude.com/docs/en/hooks>,
+  fetched 2026-07-25) — causing the harness to kill them before completion under real machine load
+  and let the guarded tool call proceed with no `permissionDecision` from that guard.** Measured at
+  86.1% of PreToolUse runs killed at the declared timeout across 3,923 runs on one machine
+  (melodic-software/claude-code-plugins#1345). Confirmed against this session's own local
+  `~/.claude/projects/*/*.jsonl` transcript: a `hook_cancelled` attachment for
+  `block-convention-violation.sh` (`timedOut: true`, `durationMs: 10184` against `timeoutMs: 10000`)
+  was immediately followed by the guarded Bash tool call executing and returning a real result — the
+  guard's verdict was silently lost, not merely slow. Standalone timing of all seven affected guards
+  in this repo (no concurrent hook load) completed in well under 1.5s each, and the source contains no
+  network calls or unbounded loops — confirming the guards are not inherently slow; the declared
+  timeout was simply provisioned far below what the platform allows and below what real (contended)
+  runs need. `timeout` raised from 10/15 to **60** (10-40x more headroom over the every real duration
+  sample this investigation captured, while staying well short of the 600s platform default so a
+  genuinely hung process is still bounded) for the seven **blocking** PreToolUse guards:
+  `secret-pattern-detection`, `hardcoded-path-check`, `block-no-verify`, `block-dangerous-git`,
+  `block-hook-bypass`, `block-noncanonical-commit`, `block-convention-violation`. The two **advisory**
+  PreToolUse hooks (`flag-commit-pr-skill-bypass`, `workflow-resilience-check`, which never block
+  regardless of outcome) and the PostToolUse hooks are unchanged — a missed advisory notice is not the
+  fail-open security defect this fix addresses. This mitigation narrows the timeout-driven fail-open
+  window; it does not remove it — a harness-killed hook process cannot itself report a decision, and
+  what should happen to the guarded tool call when a *blocking* guard is killed (deny by default vs.
+  today's silent fallback) is a harness-level policy question outside a plugin's control, tracked
+  separately.
+
 ## [0.15.0]
 
 ### Added

--- a/plugins/guardrails/hooks/hooks.json
+++ b/plugins/guardrails/hooks/hooks.json
@@ -7,13 +7,13 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/secret-pattern-detection.sh",
-            "timeout": 15,
+            "timeout": 60,
             "statusMessage": "Checking for secrets..."
           },
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/hardcoded-path-check.sh",
-            "timeout": 15,
+            "timeout": 60,
             "statusMessage": "Checking for hardcoded paths..."
           }
         ]
@@ -24,19 +24,19 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-no-verify.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking for --no-verify bypass..."
           },
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-dangerous-git.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking for dangerous git commands..."
           },
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-hook-bypass.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking for hook-bypass attempts..."
           },
           {
@@ -53,13 +53,13 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-noncanonical-commit.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking commit-message convention..."
           },
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/block-convention-violation.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking commit subject / PR title against the team convention..."
           }
         ]


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

## Summary

- The seven **blocking** PreToolUse guards in `plugins/guardrails/hooks/hooks.json` declared
  `timeout: 10`/`15` — 40-60x below the platform's documented 600s default for `PreToolUse` command
  hooks (only `UserPromptSubmit` (30) and `MessageDisplay` (10) lower it; confirmed via WebFetch of
  <https://code.claude.com/docs/en/hooks>, fetched 2026-07-25). The harness kills a hook that exceeds
  its declared timeout, and a killed hook contributes no `permissionDecision`, so the guarded tool
  call proceeds without that guard's verdict — measured at 86.1% of PreToolUse runs on one machine
  (#1345).
- Raised `timeout` to **60** for the seven blocking guards: `secret-pattern-detection`,
  `hardcoded-path-check`, `block-no-verify`, `block-dangerous-git`, `block-hook-bypass`,
  `block-noncanonical-commit`, `block-convention-violation`. The two advisory PreToolUse hooks
  (`flag-commit-pr-skill-bypass`, `workflow-resilience-check` — never block regardless of outcome)
  and the PostToolUse hooks are unchanged: a missed advisory notice is not the security defect this
  fix addresses.
- Version bump `0.15.0` → `0.15.1` (patch, Fixed) and a CHANGELOG entry recording the evidence.

## Verification performed (per the item's "verify it genuinely closes the fail-open window" instruction)

- **Reproduced the reported failure from primary source**, not just the issue's own claim: this
  session's local `~/.claude/projects/*/*.jsonl` contains a `hook_cancelled` attachment for
  `block-convention-violation.sh` (`timedOut: true`, `durationMs: 10184`, `timeoutMs: 10000`)
  immediately followed by the guarded Bash tool call executing and returning a real result — the
  guard's verdict was silently dropped, confirmed empirically, not inferred from documentation (the
  official docs do not specify cancel/timeout behavior — confirmed by the same WebFetch above).
- **Checked whether the guards are inherently slow before changing the number.** Read all affected
  guard scripts (`hook-utils.sh`, `block-convention-violation.sh`, `block-hook-bypass.sh`, etc.): pure
  bash string parsing plus a bounded handful of external process spawns (`jq`, `git`, one `bash`
  subshell for the convention resolver) — no network calls, no unbounded loops. Then **timed all seven
  standalone** (no concurrent hook load) with representative PreToolUse payloads against this repo:
  every guard completed in under 1.5s. This rules out "the script itself hangs" and confirms the
  bottleneck is process-spawn/contention overhead under real harness load, consistent with the issue's
  own root-cause data (median 3.0 concurrent hook starts on killed runs vs. 1.0 on completed ones).
- **Checked for a more structural cause (double hook registration)** before accepting a config-only
  fix: no duplicate `guardrails` registration in `~/.claude/settings.json` or the plugin cache, and no
  toolUseID in the sampled transcript fired the same guard command twice.
- Ran all seven affected guards' existing contract test suites — untouched by this change since it
  only edits `hooks.json`, not any `.sh` script, but run for regression confidence: `block-no-verify`
  112/112, `block-dangerous-git` 251/251, `block-hook-bypass` 203/203, `block-noncanonical-commit`
  90/90, `block-convention-violation` 31/31, `hardcoded-path-check` 72/72, `secret-pattern-detection`
  42/42 — all passing, 0 failures.
- Validated both edited JSON files (`hooks.json`, `plugin.json`) parse cleanly.

## Scope boundary (why this is a mitigation, not a closure)

Raising the timeout **narrows** the fail-open window measured in #1345; it does not remove it. A
harness-killed hook process cannot itself report a decision — that is a harness-level property no
plugin can change. What *should* happen to a guarded tool call when a blocking guard is genuinely
killed (deny-by-default vs. today's silent fallback) is a policy decision outside this plugin's
control and outside this item's `work-class: scoped` brief. Filed as its own item rather than folded
into this fix: #1378.

## Test plan

- [x] `plugins/guardrails/hooks/*.test.sh` for all seven touched guards — 701/701 passing (0 failures)
- [x] `jq empty` on `hooks.json` and `plugin.json`
- [x] Standalone timing of all seven guards confirms sub-1.5s completion absent contention
- [x] Primary-source jsonl confirms the fail-open mechanism this PR mitigates

Closes #1345

## Related

- #1378 — deferred policy decision: what should happen when a blocking guard is killed (harness-level, out of scope here)