### PR TITLE
fix(claude-ops): route large jq payloads via --slurpfile, not argv

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.3]
+
+### Fixed
+
+- **`plugins` skill: `fleet-state.sh` no longer crashes with `Argument list too long` against a
+  large-catalog marketplace (`#1336`).** Every `jq --argjson <name> "$value"` call site carrying a
+  catalog/installed/enabled-scale JSON payload embedded that value as a literal command-line
+  argument; for a marketplace catalog large enough (confirmed against a real 273-plugin catalog,
+  reproduced here with a synthetic 500-plugin fixture), the serialized JSON exceeded the
+  platform/shell's argv-length ceiling and `jq` failed before emitting anything — silently dropping
+  that marketplace from `sync`/`audit`/`converge`. Confirmed on Windows Git Bash/MSYS `jq`, but the
+  underlying argv-length ceiling is a real limit on every platform, just reached sooner there.
+  Every affected call site now routes its payload through a temp file via `jq --slurpfile` instead
+  of `--argjson`, so catalog size never determines whether a marketplace can be synced. Only the
+  fixed-size boolean `--argjson` uses (`au`/`ci`/`autoUpdate`) remain untouched. Covered by a new
+  large-catalog case in `fleet-state.test.sh` (asserts no argv-length crash and full,
+  non-truncated output) plus a static guard locking the remaining `--argjson` count to booleans
+  only.
+  - Temp files created for `--slurpfile` routing live in one per-run directory removed by an EXIT
+    trap; each call site invokes the writer inside a `$(...)` subshell, so files are not tracked in
+    an array (a subshell-local append would vanish on return) — the whole directory is the cleanup
+    unit instead.
+  - A malformed source file (e.g. `settings.json`) used to make the affected `--argjson` fail loud
+    immediately; `--slurpfile` instead tolerates a genuinely empty payload as "zero JSON values"
+    and would have silently degraded the report to `null` fields. The writer now emits a
+    deliberately-invalid token for an empty payload so jq's own parser still errors at the call
+    site, preserving the prior fail-loud behavior. Covered by a new malformed-`user_settings.json`
+    case in `fleet-state.test.sh`.
+
 ## [0.19.2]
 
 ### Documentation

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
@@ -104,6 +104,59 @@ fi
 # instead of calling jq directly so no call site has to remember this.
 jq() { command jq "$@" | tr -d '\r'; }
 
+# --- Large-JSON routing: temp file instead of argv (#1336) ------------------
+# `jq --argjson name "$value"` embeds $value as a literal command-line
+# argument. Several call sites below carry a full marketplace catalog or the
+# composed per-marketplace report; for a large enough marketplace (confirmed
+# against a 273-plugin catalog) the serialized JSON exceeds this
+# platform/shell's argv-length ceiling and jq fails with "Argument list too
+# long" (confirmed on Windows Git Bash/MSYS jq) — a real OS ARG_MAX ceiling
+# everywhere, just reached sooner here. jq_slurp_tmpfile writes a JSON value
+# to a fresh temp file and prints its path so a call site can pass
+# `--slurpfile name "$(jq_slurp_tmpfile "$value")"` instead of
+# `--argjson name "$value"`; payload then travels through the filesystem,
+# never argv, so its size never determines whether jq can be invoked.
+# --slurpfile always yields a one-element array bound to $name, so a
+# converted jq program reads `$name[0]` where it used to read `$name`.
+# Process substitution (`<(...)`) was considered instead of a real temp file,
+# but a native-Windows jq binary does not reliably read the /dev/fd-style
+# paths Git Bash's process substitution produces, so a real file backed by
+# `mktemp` is the portable choice. Every call site invokes jq_slurp_tmpfile
+# inside a `$(...)` command substitution (to capture the printed path), which
+# runs the function in a SUBSHELL — an array append inside it would mutate
+# only the subshell's copy and vanish on return (the same pitfall
+# fleet-state.test.sh's own new_case_dir doc comment calls out for CASE_NUM),
+# so temp files are NOT individually tracked in an array. Instead every one
+# of them is created inside a single per-run temp directory, and the EXIT
+# trap removes that whole directory — a subshell-safe cleanup that needs no
+# shared mutable state, on every exit path (normal completion, `exit`, or an
+# unhandled error under `set -u`).
+_FLEET_STATE_TMPDIR="$(mktemp -d)" || {
+  echo "ERROR: could not create a temp directory for large-JSON routing" >&2
+  exit 2
+}
+trap 'rm -rf "$_FLEET_STATE_TMPDIR"' EXIT
+
+jq_slurp_tmpfile() {
+  local f
+  f=$(mktemp "$_FLEET_STATE_TMPDIR/payload.XXXXXX") || return 1
+  if [[ -z "$1" ]]; then
+    # An empty value only happens when an earlier `jq` read of a source file
+    # (e.g. user/project/local settings.json) already failed — malformed
+    # JSON captures no stdout. `--argjson name ""` used to fail this loud
+    # immediately ("invalid JSON text passed to --argjson"); `--slurpfile`
+    # tolerates a genuinely EMPTY file as "zero JSON values" instead of
+    # erroring, which would silently degrade the report (a null/empty field
+    # instead of the script failing) rather than reproducing the prior
+    # fail-loud behavior. Write a deliberately-invalid token so the
+    # consuming jq call's own parser still errors at this call site.
+    printf '%s' 'FLEET_STATE_INVALID_EMPTY_PAYLOAD' >"$f"
+  else
+    printf '%s' "$1" >"$f"
+  fi
+  printf '%s' "$f"
+}
+
 INSTALLED_JSON="${FLEET_STATE_INSTALLED_JSON:-$HOME/.claude/plugins/installed_plugins.json}"
 MARKETPLACES_JSON="${FLEET_STATE_MARKETPLACES_JSON:-$HOME/.claude/plugins/known_marketplaces.json}"
 USER_SETTINGS="${FLEET_STATE_USER_SETTINGS:-$HOME/.claude/settings.json}"
@@ -168,19 +221,28 @@ fi
 # Union of every id ever mentioned in any scope (raw, unmerged) — used to
 # distinguish "never mentioned anywhere" (missing_from_enabled) from
 # "explicitly false somewhere" (deliberate opt-out, never flipped by sync).
-known_ids=$(jq -cn --argjson u "$user_map" --argjson p "$project_map" --argjson l "$local_map" \
-  '($u + $p + $l) | keys')
+known_ids=$(jq -cn \
+  --slurpfile u "$(jq_slurp_tmpfile "$user_map")" \
+  --slurpfile p "$(jq_slurp_tmpfile "$project_map")" \
+  --slurpfile l "$(jq_slurp_tmpfile "$local_map")" \
+  '($u[0] + $p[0] + $l[0]) | keys')
 
 # Effective value per id: local > project > user.
-effective_map=$(jq -cn --argjson u "$user_map" --argjson p "$project_map" --argjson l "$local_map" \
-  '$u + $p + $l')
+effective_map=$(jq -cn \
+  --slurpfile u "$(jq_slurp_tmpfile "$user_map")" \
+  --slurpfile p "$(jq_slurp_tmpfile "$project_map")" \
+  --slurpfile l "$(jq_slurp_tmpfile "$local_map")" \
+  '$u[0] + $p[0] + $l[0]')
 
 # ids explicitly set to false in ANY scope — a deliberate opt-out, even for a
 # plugin never installed at all (e.g. a team pre-declares "we're not using
 # this" in project settings before anyone runs install). "Missing" (needing
 # an install prompt) excludes these; sync never installs over an opt-out.
-explicit_false_ids=$(jq -cn --argjson u "$user_map" --argjson p "$project_map" --argjson l "$local_map" \
-  '[($u, $p, $l) | to_entries[] | select(.value == false) | .key] | unique')
+explicit_false_ids=$(jq -cn \
+  --slurpfile u "$(jq_slurp_tmpfile "$user_map")" \
+  --slurpfile p "$(jq_slurp_tmpfile "$project_map")" \
+  --slurpfile l "$(jq_slurp_tmpfile "$local_map")" \
+  '[($u[0], $p[0], $l[0]) | to_entries[] | select(.value == false) | .key] | unique')
 
 # --- Normalized current-project root, for the `currentProject` install flag
 current_project_norm=""
@@ -330,10 +392,10 @@ emit_marketplace() {
   # scope, even one never installed at all.
   local missing_from_install
   missing_from_install=$(jq -cn \
-    --argjson catalog "$catalog_ids" \
-    --argjson installed "$installed_ids" \
-    --argjson falseIds "$explicit_false_ids" \
-    '($catalog - $installed) - $falseIds')
+    --slurpfile catalog "$(jq_slurp_tmpfile "$catalog_ids")" \
+    --slurpfile installed "$(jq_slurp_tmpfile "$installed_ids")" \
+    --slurpfile falseIds "$(jq_slurp_tmpfile "$explicit_false_ids")" \
+    '($catalog[0] - $installed[0]) - $falseIds[0]')
 
   # User-scope completeness, distinct from all-scope missing_from_install: a
   # plugin installed only at project/local scope is present all-scope but not
@@ -345,10 +407,10 @@ emit_marketplace() {
 
   local missing_from_user_install
   missing_from_user_install=$(jq -cn \
-    --argjson catalog "$catalog_ids" \
-    --argjson userInstalled "$user_installed_ids" \
-    --argjson falseIds "$explicit_false_ids" \
-    '($catalog - $userInstalled) - $falseIds')
+    --slurpfile catalog "$(jq_slurp_tmpfile "$catalog_ids")" \
+    --slurpfile userInstalled "$(jq_slurp_tmpfile "$user_installed_ids")" \
+    --slurpfile falseIds "$(jq_slurp_tmpfile "$explicit_false_ids")" \
+    '($catalog[0] - $userInstalled[0]) - $falseIds[0]')
 
   local known_at_mp
   known_at_mp=$(jq -c --arg suffix "@$name" '[.[] | select(endswith($suffix))]' <<<"$known_ids")
@@ -365,13 +427,17 @@ emit_marketplace() {
   verifiable_ids=$(jq -c '[.[] | select(.scope == "user" or .currentProject == true) | .id] | unique' <<<"$installed")
 
   local missing_from_enabled
-  missing_from_enabled=$(jq -cn --argjson verifiable_ids "$verifiable_ids" --argjson known "$known_at_mp" \
-    --argjson defaultDisabled "$default_disabled_ids" \
-    '($verifiable_ids - $known) - $defaultDisabled')
+  missing_from_enabled=$(jq -cn \
+    --slurpfile verifiable_ids "$(jq_slurp_tmpfile "$verifiable_ids")" \
+    --slurpfile known "$(jq_slurp_tmpfile "$known_at_mp")" \
+    --slurpfile defaultDisabled "$(jq_slurp_tmpfile "$default_disabled_ids")" \
+    '($verifiable_ids[0] - $known[0]) - $defaultDisabled[0]')
 
   local enabled_at_mp
-  enabled_at_mp=$(jq -cn --argjson known "$known_at_mp" --argjson eff "$effective_map" \
-    'reduce $known[] as $id ({}; . + {($id): $eff[$id]})')
+  enabled_at_mp=$(jq -cn \
+    --slurpfile known "$(jq_slurp_tmpfile "$known_at_mp")" \
+    --slurpfile eff "$(jq_slurp_tmpfile "$effective_map")" \
+    'reduce $known[0][] as $id ({}; . + {($id): $eff[0][$id]})')
 
   # `versionsMatch` separates a benign multi-scope install (project and user
   # scope both pinned to the same version — normal, not actionable) from a
@@ -392,22 +458,22 @@ emit_marketplace() {
     --arg name "$name" \
     --argjson autoUpdate "$([[ "$auto_update" == "true" ]] && echo true || echo false)" \
     --arg lastUpdated "$last_updated" \
-    --argjson catalog "$catalog" \
-    --argjson installed "$installed" \
-    --argjson enabled "$enabled_at_mp" \
-    --argjson missingInstall "$missing_from_install" \
-    --argjson missingUserInstall "$missing_from_user_install" \
-    --argjson missingEnabled "$missing_from_enabled" \
-    --argjson divergences "$divergences" \
+    --slurpfile catalog "$(jq_slurp_tmpfile "$catalog")" \
+    --slurpfile installed "$(jq_slurp_tmpfile "$installed")" \
+    --slurpfile enabled "$(jq_slurp_tmpfile "$enabled_at_mp")" \
+    --slurpfile missingInstall "$(jq_slurp_tmpfile "$missing_from_install")" \
+    --slurpfile missingUserInstall "$(jq_slurp_tmpfile "$missing_from_user_install")" \
+    --slurpfile missingEnabled "$(jq_slurp_tmpfile "$missing_from_enabled")" \
+    --slurpfile divergences "$(jq_slurp_tmpfile "$divergences")" \
     '{
       marketplace: {name: $name, autoUpdate: $autoUpdate, lastUpdated: $lastUpdated},
-      catalog: $catalog,
-      installed: $installed,
-      enabled: $enabled,
-      missing_from_install: $missingInstall,
-      missing_from_user_install: $missingUserInstall,
-      missing_from_enabled: $missingEnabled,
-      divergences: $divergences
+      catalog: $catalog[0],
+      installed: $installed[0],
+      enabled: $enabled[0],
+      missing_from_install: $missingInstall[0],
+      missing_from_user_install: $missingUserInstall[0],
+      missing_from_enabled: $missingEnabled[0],
+      divergences: $divergences[0]
     }'
 }
 
@@ -467,9 +533,9 @@ all)
   while IFS= read -r n; do
     [[ -z "$n" ]] && continue
     block=$(emit_marketplace "$n" || true)
-    result=$(jq -c --arg n "$n" --argjson b "$block" '. + {($n): $b}' <<<"$result")
+    result=$(jq -c --arg n "$n" --slurpfile b "$(jq_slurp_tmpfile "$block")" '. + {($n): $b[0]}' <<<"$result")
   done <<<"$names"
-  jq -cn --argjson m "$result" '{marketplaces: $m}'
+  jq -cn --slurpfile m "$(jq_slurp_tmpfile "$result")" '{marketplaces: $m[0]}'
   ;;
 *)
   echo "ERROR: unreachable mode: $MODE" >&2

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
@@ -701,6 +701,103 @@ case "$out" in
 *) pass "exported source shadow ignored: real hook-utils sourced via builtin" ;;
 esac
 
+# ============================================================================
+# Case: large-catalog marketplace does not crash with "Argument list too
+# long" (#1336). fleet-state.sh used to embed full catalog/installed/enabled
+# JSON blobs as literal `jq --argjson` command-line arguments; once a
+# marketplace catalog got large enough (confirmed against a real 273-plugin
+# catalog), the serialized JSON exceeded the platform/shell's argv-length
+# ceiling and jq crashed before emitting anything. Uses a synthetic 500-plugin
+# catalog — well past the 273-plugin real-world repro — fully installed and
+# enabled, so every array in the composed report (catalog, installed, enabled,
+# and all three missing_from_* arrays) carries the full payload through the
+# same code path that used to crash. Asserts the run completes AND produces
+# the same-shaped, semantically-correct output a small catalog would (no
+# silent truncation or partial report — the acceptance criteria's second
+# bullet), not merely that it exits 0.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+big_n=500
+write "$case_dir/known_marketplaces.json" '{"bigmarket": {"source": {"source": "github", "repo": "example/bigmarket"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+# Realistic-length ids (not bare "plugin-0") so the serialized payload's
+# per-entry size is closer to the real-world repro, not an artificially
+# compact worst case.
+jq -cn --argjson n "$big_n" \
+  '{plugins: [range(0;$n) | {name: ("large-catalog-synthetic-plugin-\(.)"), description: "synthetic fixture entry for issue #1336 large-catalog argv-length regression test"}]}' \
+  >"$case_dir/catalog/bigmarket.json"
+jq -cn --argjson n "$big_n" \
+  '{version: 1, plugins: (reduce range(0;$n) as $i ({};
+    . + {("large-catalog-synthetic-plugin-\($i)@bigmarket"): [{scope: "user", installPath: "y", version: "0.1.0"}]}))}' \
+  >"$case_dir/installed_plugins.json"
+jq -cn --argjson n "$big_n" \
+  '{enabledPlugins: (reduce range(0;$n) as $i ({}; . + {("large-catalog-synthetic-plugin-\($i)@bigmarket"): true}))}' \
+  >"$case_dir/user_settings.json"
+ARGS=(--marketplace bigmarket)
+out=$(run_state "$case_dir")
+rc=$?
+assert_exit "large catalog (500 plugins): exit 0, no argv-length crash" 0 "$rc"
+case "$out" in
+*"Argument list too long"*) fail "large catalog: no 'Argument list too long'" "found in output: $out" ;;
+*) pass "large catalog: no 'Argument list too long'" ;;
+esac
+catalog_len=$(jq '.catalog | length' <<<"$out" 2>/dev/null)
+assert_eq "large catalog: full 500-entry catalog reported, not truncated" "$big_n" "$catalog_len"
+installed_len=$(jq '.installed | length' <<<"$out" 2>/dev/null)
+assert_eq "large catalog: full 500-entry installed list reported" "$big_n" "$installed_len"
+missing_install_len=$(jq '.missing_from_install | length' <<<"$out" 2>/dev/null)
+assert_eq "large catalog: every plugin installed, so missing_from_install empty" "0" "$missing_install_len"
+missing_user_install_len=$(jq '.missing_from_user_install | length' <<<"$out" 2>/dev/null)
+assert_eq "large catalog: every plugin user-installed, so missing_from_user_install empty" "0" "$missing_user_install_len"
+missing_enabled_len=$(jq '.missing_from_enabled | length' <<<"$out" 2>/dev/null)
+assert_eq "large catalog: every plugin enabled, so missing_from_enabled empty" "0" "$missing_enabled_len"
+sample_enabled=$(jq -r '.enabled["large-catalog-synthetic-plugin-499@bigmarket"]' <<<"$out" 2>/dev/null)
+assert_eq "large catalog: a spot-checked entry has correct effective-enabled value, not a placeholder" "true" "$sample_enabled"
+
+# ============================================================================
+# Case: malformed user_settings.json still fails loud after the --argjson ->
+# --slurpfile conversion (#1336 fail-loud parity). --slurpfile tolerates a
+# genuinely EMPTY file as "zero JSON values" (yielding null) rather than
+# erroring the way `--argjson name ""` used to when a prior `jq -c
+# '.enabledPlugins // {}'` read failed on malformed source JSON and captured
+# no stdout — so a naive conversion would turn a loud crash into a silent
+# `null`-degraded report. jq_slurp_tmpfile guards this by writing a
+# deliberately-invalid token for an empty value, forcing jq's own parser to
+# still error at the --slurpfile call site. Confirmed against the actual
+# pre-fix script (git history) that this exact fixture already failed loud
+# (nonzero exit) before this issue's change, so this case is locking in
+# existing behavior, not inventing a new contract.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+write "$case_dir/known_marketplaces.json" '{"market1": {"source": {"source": "github", "repo": "example/market1"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+write "$case_dir/catalog/market1.json" '{"plugins": [{"name": "alpha"}]}'
+write "$case_dir/installed_plugins.json" '{"version":1,"plugins":{}}'
+write "$case_dir/user_settings.json" '{bad json'
+ARGS=(--marketplace market1)
+out=$(run_state "$case_dir")
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  fail "malformed user_settings.json: fails loud, not silently degraded" "expected nonzero exit, got 0 with output: $out"
+else
+  pass "malformed user_settings.json: fails loud, not silently degraded"
+fi
+
+# ============================================================================
+# Case: static guard — no large-payload `--argjson` call site regresses back
+# into fleet-state.sh (#1336). The runtime case above proves the CURRENT
+# script doesn't crash; this guards against a future edit silently
+# reintroducing `--argjson catalog|installed|missing*` (the exact pattern
+# that crashed) alongside the harmless small-boolean `--argjson au|ci` uses
+# this script legitimately keeps (a fixed literal `true`/`false`, never
+# proportional to catalog size). Counts every `--argjson` occurrence in the
+# script body (source lines only, comments excluded) and asserts it matches
+# the fixed count of boolean-only remaining uses.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+argjson_code_count=$(grep -v '^\s*#' "$SCRIPT" | grep -c -- '--argjson' || true)
+assert_eq "static guard: --argjson remains only on fixed-size booleans (au/ci/autoUpdate), not catalog-sized payloads" "7" "$argjson_code_count"
+
 # --- Summary -------------------------------------------------------------
 printf '\n%d cases, %d failed\n' "$CASE_NUM" "$FAILED"
 [[ "$FAILED" -eq 0 ]] && exit 0


### PR DESCRIPTION
Closes #1336

## Summary

- `fleet-state.sh` (claude-ops `plugins` skill) embedded catalog/installed/enabled JSON blobs as
  literal `jq --argjson` command-line arguments; a large enough marketplace catalog (confirmed
  against a real 273-plugin catalog) exceeded the platform/shell's argv-length ceiling and jq
  crashed with `Argument list too long` before emitting anything, silently dropping that
  marketplace from `sync`/`audit`/`converge`. Confirmed on Windows Git Bash/MSYS jq, but the
  underlying ceiling is a real OS `ARG_MAX` limit everywhere, just reached sooner there.
- Every affected call site now writes its payload to a temp file and passes `--slurpfile` instead
  of `--argjson`, so catalog size never determines whether a marketplace can be synced. Only the
  fixed-size boolean `--argjson` uses (`au`/`ci`/`autoUpdate`) remain untouched.
- Two follow-on defects surfaced during verification, both fixed in the same change:
  - Temp files are cleaned up via one per-run directory removed by an `EXIT` trap, not an array —
    each writer call runs inside a `$(...)` subshell, so an array append there would silently
    vanish on return.
  - A malformed source file (e.g. `settings.json`) used to make the affected `--argjson` fail loud
    immediately; `--slurpfile` instead tolerates a genuinely empty payload as "zero JSON values"
    and would have silently degraded the report to `null` fields. The writer now emits a
    deliberately-invalid sentinel for an empty payload so jq's own parser still errors at the call
    site, preserving the pre-fix fail-loud behavior.
- Bumped `claude-ops` to `0.19.3` with a matching `CHANGELOG.md` entry.

## Test plan

- `fleet-state.test.sh` (31 cases, 0 failed), including two new cases added by this PR:
  - A synthetic 500-plugin catalog case (past the real 273-plugin repro) — asserts no
    `Argument list too long`, exit 0, and full non-truncated output (catalog/installed/missing_*
    arrays all correctly sized, a spot-checked `enabled` entry correct).
  - A malformed `user_settings.json` case — asserts the fix still fails loud (nonzero exit), not
    silently degraded.
  - A static guard asserting the remaining `--argjson` count stays at the fixed booleans-only
    total, so a future edit can't silently reintroduce a large-payload `--argjson` call site.
- Reproduced the actual pre-fix crash: extracted the pre-fix script from `HEAD` via `git archive`
  and ran it against the same synthetic 500-plugin fixture — confirmed `Argument list too long`
  before this fix, confirmed clean success after.
- Verified the EXIT-trap temp-directory cleanup empirically (temp-dir count identical before and
  after a normal run — no leaked files).
- `shellcheck` clean on `fleet-state.sh`.

## Related

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
