### PR TITLE
fix(disk-hygiene): validate the target root by object identity

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.2]
+
+### Fixed
+
+- **The anchored target root is validated by object identity, so benign directory churn no longer
+  aborts an approved run (#384).** Preview and apply held the target root to full stat identity
+  (`st_mtime_ns` and `st_size` included), but a directory's mtime and size flip whenever any direct
+  child is added or removed. Human approval sits between scan and apply, so any unrelated write into
+  a live target — a home or an active project root, the common case — flipped the root's mtime and
+  aborted the run with "anchored target changed since the snapshot," forcing a full rescan. Both
+  sites now use the stable device/inode/type identity that directory candidates and `handoff-verify`
+  already use; a replaced root still refuses. The check was never wrong-deleting, only over-refusing.
+
+### Changed
+
+- **`resolve_snapshot_target` no longer takes `strict_root_stat`.** With one root-identity standard
+  across preview, apply, and `handoff-verify`, the parameter that selected between them is gone and
+  the single refusal reads "target root was replaced since the snapshot."
+
 ## [0.9.1]
 
 ### Changed

--- a/plugins/disk-hygiene/skills/clean/reference/safety-model.md
+++ b/plugins/disk-hygiene/skills/clean/reference/safety-model.md
@@ -74,11 +74,10 @@ near-miss recurrence in the manual lane reopens this as a design issue with full
 `handoff-verify` brings snapshot binding to the platforms where apply is unsupported, without
 adding an engine deletion lane. It takes the snapshot plus the human-approved exact path list
 (same containment rules as plan candidates: relative, non-root, no traversal, present in the
-snapshot, non-overlapping), re-validates the target root with preview's link/mount/OS-managed/
-protected-path checks but a deliberately tolerant root-identity check — stable device/inode/type
-(the same object identity apply uses for directories) instead of preview's full stat identity,
-because deleting one approved root-level item changes the root's own mtime and the manual lane
-re-verifies between items; a replaced root still refuses. It then reruns the per-path
+snapshot, non-overlapping), re-validates the target root with the same link/mount/OS-managed/
+protected-path and stable device/inode/type root-identity checks preview and apply use — the root's
+own mtime and size flip whenever any direct child is added or removed, so they are not identity; a
+replaced root still refuses. It then reruns the per-path
 identity/reparse/protection/descendant/VCS/handle checks against live state and emits one
 machine-readable verdict per path. It deliberately does not apply platform execution blockers —
 it exists exactly where `execution-platform-unsupported` blocks the engine lane — and it has no

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -1288,20 +1288,16 @@ def approval_token(snapshot: dict[str, Any], plan: dict[str, Any]) -> str:
     ).hexdigest()[:24]
 
 
-def resolve_snapshot_target(
-    snapshot: dict[str, Any], *, strict_root_stat: bool = True
-) -> tuple[Path, set[Path]]:
+def resolve_snapshot_target(snapshot: dict[str, Any]) -> tuple[Path, set[Path]]:
     """Re-validate the snapshot's target root against live state and return it.
 
     Shared by preview and handoff-verify: both must refuse a snapshot whose
     target root drifted, became a link, a mount point, an OS-managed root, or a
-    protected shell folder since the scan. Preview keeps the full stat identity
-    (size/mtime included) because its approval token binds one immutable state.
-    handoff-verify passes ``strict_root_stat=False`` to tolerate the root
-    directory's own metadata churn — deleting an approved root-level item
-    changes the root's mtime, and the manual lane deletes one item at a time
-    with a re-verify between items — while still refusing a replaced root via
-    the same stable device/inode/type identity apply uses for directories.
+    protected shell folder since the scan. The root is held to the same stable
+    device/inode/type identity as directory candidates, not to stat identity:
+    a directory's mtime and size flip whenever any direct child is added or
+    removed, so any unrelated write into a live target during the approval
+    window would otherwise abort the run.
     """
     if (
         snapshot.get("schema_version") != SCHEMA_VERSION
@@ -1325,16 +1321,12 @@ def resolve_snapshot_target(
             "snapshot target is now a protected shell-folder or profile-hive root"
         )
     identity = snapshot.get("target_identity", {})
-    if strict_root_stat:
-        if not same_identity(target, identity):
-            raise HygieneError("target root changed since the snapshot")
-    else:
-        try:
-            info = target.lstat()
-        except OSError as exc:
-            raise HygieneError(f"target root state is unverified: {exc}")
-        if not same_object_identity(info, identity):
-            raise HygieneError("target root was replaced since the snapshot")
+    try:
+        info = target.lstat()
+    except OSError as exc:
+        raise HygieneError(f"target root state is unverified: {exc}")
+    if not same_object_identity(info, identity):
+        raise HygieneError("target root was replaced since the snapshot")
     return target, known_mounts
 
 
@@ -1461,7 +1453,7 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
     not apply: this subcommand exists exactly for the platforms where the
     engine's own apply lane is unsupported.
     """
-    target, known_mounts = resolve_snapshot_target(snapshot, strict_root_stat=False)
+    target, known_mounts = resolve_snapshot_target(snapshot)
     entries = entry_map(snapshot)
     exact_names = baseline_protected_names() | set(
         snapshot.get("policy", {}).get("protected_exact_names", [])
@@ -1754,9 +1746,9 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
     skipped: list[dict[str, str]] = []
     logical_removed = 0
     target_fd = os.open(target, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
-    if not same_stat_identity(os.fstat(target_fd), snapshot["target_identity"]):
+    if not same_object_identity(os.fstat(target_fd), snapshot["target_identity"]):
         os.close(target_fd)
-        raise HygieneError("anchored target changed since the snapshot")
+        raise HygieneError("anchored target was replaced since the snapshot")
     known_mounts, mount_error = linux_mount_points()
     if mount_error:
         os.close(target_fd)

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 import types
 import unittest
-from contextlib import chdir as chdir_context, redirect_stdout
+from contextlib import ExitStack, chdir as chdir_context, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
@@ -1795,6 +1795,138 @@ class LeastObservableEnginePathTests(unittest.TestCase):
             self.assertIn(
                 f"{nested}: non-Git VCS state is not independently verified", errors
             )
+
+
+class TargetRootIdentityTests(unittest.TestCase):
+    """The anchored target root is object identity, not stat identity (#384)."""
+
+    def setUp(self) -> None:
+        patcher = mock.patch.object(hygiene, "standing_policy_paths", return_value=[])
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    @staticmethod
+    def churned_root_stat(identity: dict[str, object]):
+        """The live root after an unrelated write: same object, new mtime/size."""
+        return types.SimpleNamespace(
+            st_mode=0o040000,
+            st_size=int(identity["stat_size"]) + 4096,
+            st_mtime_ns=int(identity["mtime_ns"]) + 1_000_000,
+            st_dev=identity["device"],
+            st_ino=identity["inode"],
+        )
+
+    def test_preview_survives_benign_root_churn_between_scan_and_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("temporary", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            # An unrelated write into the live target during the approval
+            # window flips the root's own mtime and size.
+            (root / "unrelated.log").write_text("later work", encoding="utf-8")
+            with (
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+                mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+            ):
+                result = hygiene.preview(snapshot, plan)
+            self.assertEqual("ready-for-explicit-approval", result["status"])
+
+    def test_preview_still_refuses_a_replaced_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("temporary", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            snapshot["target_identity"]["inode"] += 1
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            with self.assertRaisesRegex(hygiene.HygieneError, "replaced"):
+                hygiene.preview(snapshot, plan)
+
+    @staticmethod
+    def enter_apply_patches(stack: ExitStack, root_stat) -> None:
+        patches = (
+            mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+            mock.patch.object(
+                hygiene,
+                "preview",
+                return_value={
+                    "status": "ready-for-explicit-approval",
+                    "candidates": [],
+                },
+            ),
+            mock.patch.object(hygiene, "hard_protection", return_value=[]),
+            mock.patch.object(hygiene, "tracked_blocker", return_value=None),
+            mock.patch.object(
+                hygiene, "linux_mount_points", return_value=(set(), None)
+            ),
+            mock.patch.object(hygiene, "handle_state", return_value=("clear", None)),
+            mock.patch.object(hygiene.os, "open", return_value=100),
+            mock.patch.object(hygiene.os, "fstat", return_value=root_stat),
+            mock.patch.object(hygiene.os, "close"),
+            mock.patch.object(hygiene.os, "O_DIRECTORY", 0x10000, create=True),
+            mock.patch.object(hygiene.os, "O_NOFOLLOW", 0x20000, create=True),
+        )
+        for patch in patches:
+            stack.enter_context(patch)
+
+    def test_apply_survives_benign_root_churn_between_scan_and_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("temporary", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            churned = self.churned_root_stat(snapshot["target_identity"])
+            with ExitStack() as stack:
+                self.enter_apply_patches(stack, churned)
+                remove = stack.enter_context(
+                    mock.patch.object(hygiene, "anchored_remove")
+                )
+                report = hygiene.apply_plan(snapshot, plan)
+            remove.assert_called_once()
+            self.assertEqual("completed", report["status"])
+            self.assertEqual(
+                ["orphan.tmp"], [item["path"] for item in report["removed"]]
+            )
+
+    def test_apply_still_refuses_a_replaced_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("temporary", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            replaced = self.churned_root_stat(snapshot["target_identity"])
+            replaced.st_ino = snapshot["target_identity"]["inode"] + 1
+            with ExitStack() as stack:
+                self.enter_apply_patches(stack, replaced)
+                remove = stack.enter_context(
+                    mock.patch.object(hygiene, "anchored_remove")
+                )
+                with self.assertRaisesRegex(hygiene.HygieneError, "replaced"):
+                    hygiene.apply_plan(snapshot, plan)
+            remove.assert_not_called()
 
 
 class HandoffVerifyTests(unittest.TestCase):


### PR DESCRIPTION
*This was generated by AI during autonomous /work-items:work-loop execution.*

Closes #384

## Summary

`disk-hygiene`'s engine held the anchored **target root** to full stat identity — `st_mtime_ns` and
`st_size` included — in both `preview` and `apply`. A directory's mtime and size flip whenever any
direct child is added or removed, and human approval sits between scan and apply, so any unrelated
write into a live target (a home or an active project root — the common case for this skill) aborted
the approved run with `anchored target changed since the snapshot` and forced a full rescan.

Both sites now use the stable device/inode/type object identity that directory candidates
(`same_removal_identity` → `same_object_identity`) and `handoff-verify` already use. A **replaced**
root still refuses — the refusal narrows from "changed" to "was replaced", it does not disappear.
The old check was never wrong-deleting, only over-refusing, so this is a fail-safe → correct-safe
narrowing, not a loosening of the deletion guard.

With one root-identity standard across `preview`, `apply`, and `handoff-verify`,
`resolve_snapshot_target`'s `strict_root_stat` parameter that selected between the two standards is
gone. Plugin version `0.9.1` → `0.9.2`; the CHANGELOG and `safety-model.md` now describe the single
standard.

## Test plan

- `python plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py` — **193 tests, OK (4 skipped)**
  on this branch.
- New `TargetRootIdentityTests` covers all four corners: `preview` and `apply` each survive benign
  root churn (an unrelated sibling write between scan and approval), and each still refuse a
  replaced root (inode changed) — with `anchored_remove` asserted called-once and not-called
  respectively.
- Verified `same_object_identity` (`hygiene.py:1043`) reads only `st_mode`/`st_dev`/`st_ino`, all
  present on a real `os.fstat` result, so the shared helper is valid at the new fd-based
  `apply_plan` call site and not only at the `lstat`-based one.
- Verified no helper became dead: `same_identity` and `same_stat_identity` remain in use for file
  candidates and per-entry revalidation.

## Related

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)