### PR TITLE
docs(topics): land two topic plans that existed only in a local stash

### DIFF
--- a/docs/topics/interview-batch-rounds/PLAN.md
+++ b/docs/topics/interview-batch-rounds/PLAN.md
@@ -1,0 +1,55 @@
+# interview-batch-rounds
+
+## Brief
+
+### TLDR
+
+- `/planning:interview` Step 2 moves from one-question-at-a-time to **frontier-rounds**: each round asks every question whose prerequisites are settled, numbered, each with a recommendation; answers recompute the frontier; done when frontier is empty.
+- Prose is the default question surface; `AskUserQuestion` becomes opt-in via a new planning-plugin `userConfig` scalar (`question_surface`, default prose).
+- Fact-finding goes non-blocking: facts are dispatched to background sub-agents; only questions downstream of a running lookup wait for it.
+- Upstream sharpenings absorbed: facts-vs-decisions split (facts looked up, decisions always put to the user) and an explicit confirmation gate before the Brief locks.
+- Question-budget guidance added (depth scales down as upstream artifacts scale up; ballooning frontier routes to `/planning:wayfind`); planning plugin bumps to 0.13.0.
+
+### Goal
+
+An interview session resolves the same decision tree in far fewer round-trips: the user answers a whole frontier of independent questions in one reply (dictation-friendly), dependent questions arrive only after their prerequisites settle, and the terminal "agree, agree, agree" tail collapses into a single round. The skill never asks the user for a fact it can look up, never decides a design choice on the user's behalf, and never acts before the user confirms shared understanding.
+
+### Constraints
+
+- Vocabulary stays "interview" — no "grill/grilling" terminology anywhere in the skill or docs.
+- Scope is the interview skill only; other planning skills (prd, design, architect, brainstorm, wayfind) are untouched this change.
+- Repo plugin philosophy holds: repo-agnostic, configurable without editing the plugin (`userConfig` for the personal surface preference), plugin-form-safe.
+- Cross-skill references stay intra-plugin (wayfind escape valve is a sibling skill in the planning plugin); no new cross-plugin coupling.
+- Fresh-docs mandate: the `userConfig` schema is verified from the current plugins docs before the manifest edit lands, not from recall.
+- One discipline, not two: rounds everywhere in the skill (`me` and `auto` Q&A); a frontier of one question degenerates to the old behavior, so no per-mode fork.
+
+### Acceptance criteria
+
+- SKILL.md and context/loop.md describe the rounds loop: compute the frontier (all decisions whose prerequisites are settled), ask it as one numbered set in prose with a recommendation per question, wait, recompute; a question dependent on an open question in the same round is deferred to a later round.
+- The canonical `me`-mode framing carries the facts-vs-decisions split: facts are resolved from the environment (non-blocking sub-agent dispatch when slow), decisions are always put to the user; the blanket "explore the environment instead of asking" line is gone.
+- The stop condition requires an empty frontier AND explicit user confirmation of shared understanding before persistence/handoff.
+- `plugins/planning/.claude-plugin/plugin.json` (or the manifest's documented userConfig location) declares `question_surface` with default `prose`; the skill reads it and only uses `AskUserQuestion` when the user opted in.
+- gotchas.md, templates/checklist.md, and evals/evals.json are updated — no remaining assertion that questions must be asked one at a time or that batching is a failure mode; evals assert rounds behavior instead.
+- Question-budget guidance present: interviews invoked after research/exploration/PRD treat those artifacts as settled prerequisites; a ballooning frontier is named as a `/planning:wayfind` signal; no numeric question cap.
+- Planning plugin version is 0.13.0 and CHANGELOG.md carries a behavioral-change note (rounds default, new `question_surface` userConfig).
+
+### Captured assumptions
+
+- Plugin `userConfig` supports a per-user enum/string scalar readable as `${user_config.question_surface}` as the docs described at last full review — revisit (and re-verify from the fetched plugins-reference page) at implementation time before the manifest edit.
+- Upstream `batch-grill-me` is still `in-progress/` and may drift after we ship — acceptable; we own the fork and re-audit upstream opportunistically.
+
+### Out-of-scope
+
+- Rewriting the one-question-at-a-time echoes in prd, design, architect (INTERVIEW tag), and brainstorm — deferred pattern-consistency audit.
+- All other upstream ports surfaced by the gap scan (Fowler review baseline, to-questionnaire, skill-quality negation/negative-space, tdd top-up, wayfind task-type verify, git-guardrails, wizard, router) — tracked on the session's deferred agenda, each its own effort.
+- A setup action for the surface preference — `userConfig` suffices for V1; setup sugar may follow later.
+
+### Deferred questions
+
+- Exact `question_surface` value set and any additional interview userConfig keys — defer until implementation; **arbiter: /architect**
+- How an opted-in `AskUserQuestion` surface renders a frontier larger than the tool's 4-question cap (chunking vs prose fallback) — defer until implementation; **arbiter: /architect**
+- Whether the confirmation gate also applies to `lock`-mode direct synthesis (no Q&A ran) — defer until implementation; **arbiter: USER-RESERVED** (could change the stop-condition contract)
+
+## Plan
+
+<!-- empty — populated by /architect -->

--- a/docs/topics/shadowed-skill-renames/PLAN.md
+++ b/docs/topics/shadowed-skill-renames/PLAN.md
@@ -1,0 +1,87 @@
+# Shadowed skill renames
+
+## Brief
+
+**TLDR:** Undo the pre-migration shadow-compromise skill names (namespacing removed the constraint), fix audit-surfaced semantic misfits, extract a `domain-driven-design` plugin, and codify the naming grammar + cross-plugin reference rules in `docs/PLUGIN-PHILOSOPHY.md` — as a sequenced set of breaking-change PRs with no renames-map entries.
+
+### Goal
+
+Every skill and plugin name in the marketplace denotes what it actually does, follows one codified grammar, and the conventions that produced this state are written down so future names are predictable.
+
+### Locked decisions
+
+**Naming grammar (codify in PLUGIN-PHILOSOPHY, PR 1):**
+
+- Imperative verbs; namespace supplies the object. Documented deviation from the official gerund preference (cite the page, copy nothing) — rationale: sentence-composability ("/explore X, then /research, then /interview me") and collection-consistency (itself official guidance).
+- Verb meanings: `audit`/`scan` = read-only report; `check` = deterministic pass/fail gate; `clean`/`tidy`/`fix` = mutates; `setup` = plugin config; `update` = vendor refresh.
+- `audit` mutation: read-only by default; mutation only behind an explicit user override (flag/argument), safety qualifiers permitted. Bare invocation never mutates.
+- Sanctioned exceptions: nouns for knowledge routers (`principles`, `methodology`) and lifecycle-object routers (`worktree`, `pull-request`); vendor-wrapper stutter (`firecrawl:firecrawl`); `-deep` suffix = heavier isolated execution tier.
+- Cross-plugin references: required-for-contract → declared plugin dependency (native auto-install; link the official doc); optional enhancement → "if installed" soft reference with graceful degradation; bare unguarded references forbidden.
+
+**Skill renames** (dir + frontmatter `name` move together; description sharpened third-person what+when):
+
+| From | To |
+|---|---|
+| `planning:architect` | `planning:plan` |
+| `debugging:diagnose` | `debugging:debug` |
+| `docs-hygiene:declutter` | `docs-hygiene:audit-noise` |
+| `work-items:scan` | `work-items:scan-todos` |
+| `toolchain:build` | `toolchain:check` |
+| `machine-health:check` | `machine-health:audit` |
+| `claude-ops:troubleshoot` | `claude-ops:known-issues` |
+| `knowledge:youtube` | `knowledge:youtube-digest` |
+| `playbooks:thariq` | `playbooks:skill-authoring` (vendor/, upstream metadata, and `/playbooks:update` mechanics move intact) |
+| `session-flow:orchestration-brief` | `session-flow:orchestrate` (finish mid-flight rename) |
+
+**Plugin changes:**
+
+- New `domain-driven-design` plugin housing `ubiquitous-language` (from `planning:domain-modeling`). `planning` declares a hard dependency on it (auto-install). `ubiquitous-language` soft-routes discovery to `event-storming`.
+- `event-storming` stays standalone — multi-purpose per eventstorming.com (business health, startup viability, service design, software architecture; DDD is one application).
+- Plugin renames as hard breaks: `markdown-formatter` → `markdown-format`, `bash-lint` → `bash-format`.
+- Keep: `testing:e2e` (cover non-UI smoke in description), `verification:confirm`, `discovery:research-deep`/`explore-deep`, `review:quality-gate` (add /code-review boundary note), plugin names `codebase-health`, `tdd`.
+
+**Execution (approved package):**
+
+1. PR 1 — codify conventions in PLUGIN-PHILOSOPHY; no renames.
+2. One PR per affected plugin for skill renames; each PR carries ALL repo-wide reference updates for that rename atomically (cross-plugin doc references included); minor version bump per plugin (0.x breaking-by-minor precedent); `/docs-hygiene:rename-references` sweep before merge.
+3. PR — domain-driven-design extraction + planning dependency + planning bump.
+4. PR — plugin renames (markdown-format, bash-format): marketplace.json entry rename, hard break.
+5. PR — finish orchestration-brief → orchestrate.
+6. Tier D deferred items filed on the work-item tracker, not executed here.
+
+### Constraints
+
+- NO `renames`-map entries while the marketplace is settling — every rename is a clean breaking change with a version bump.
+- Never hand-copy external documentation into convention docs; state the rule, link the source.
+- Skill `name` must match its directory (agentskills.io spec); 1–64 chars, lowercase alnum + hyphens.
+- Plugin skills have no bare command form — `/planning:plan` is the full command; built-in `/plan` (plan-mode toggle) is unaffected.
+- Repo process: PRs required, squash merge, Conventional Commits titles, branch `<type>/<description>`; fresh-docs mandate applies to every manifest/schema edit.
+
+### Acceptance criteria
+
+- PLUGIN-PHILOSOPHY contains grammar, audit-mutation rule, cross-plugin reference rule, and sanctioned exceptions, citing official sources without copying them.
+- All renamed skills load under their new names; no file in the repo references a dead skill/plugin name (rename-references sweep clean).
+- `claude plugin install planning` auto-installs `domain-driven-design`.
+- marketplace.json `renames` map unchanged (no new entries).
+- Every touched plugin has a version bump and CHANGELOG note marking the breaking rename.
+
+### Captured assumptions
+
+- planning→domain-driven-design dependency declared as bare name (marketplace-latest), no version constraint / release tags — monorepo marketplace keeps them consistent. Revisit if plugins gain independent release cadence.
+- `domain-driven-design` plugin starts at 0.1.0.
+- Private-marketplace consumers tolerate hard plugin renames by reinstalling (dev-phase posture).
+
+### Out-of-scope
+
+- Tier D restructurings (filed as tracker items): songwriting split (keep `object-writing`; extract `metaphor`, `cliche`, `point-of-view`), `discovery:explore` blindspot split, `source-control:pull-request` babysit split, `firecrawl` update-pipeline extraction, `codebase-health:audit` fix-phase delegation to implementation/verification lanes, `toolchain:setup` step-6 relocation, `testing:plan` as test-type SSOT, `planning:plan` Step-2 design-axes leak, `review:quality-gate` /code-review boundary note.
+- Gerund migration (rejected), plugin renames for `codebase-health`/`tdd` (kept).
+
+### Deferred questions
+
+- [arbiter: implementation] Exact sharpened description wording per renamed skill (third-person, what+when, key triggers preserved — e.g. "troubleshoot" stays a trigger word for `known-issues`).
+- [arbiter: USER-RESERVED] Reserved-word exposure: if any skill ever ships to the API Skills surface, `claude-*` plugin names need re-checking against platform-side validation (trigger recorded; no action now).
+- [arbiter: USER-RESERVED] Songwriting split details (which content moves to `metaphor`/`cliche`/`point-of-view`) — own interview when picked up.
+
+## Plan
+
+(To be filled by /planning:plan — or proceed directly; the PR sequence above is execution-ready.)


### PR DESCRIPTION
No linked issue

## Summary

Two `docs/topics/*/PLAN.md` files were reachable from nothing but a git stash's untracked component in a single clone, on a branch that never reached the remote. Stash entries are invisible to `git status`, are never pushed, and die with the disk — so this content had no recovery path at all.

Found during a "is anything at risk of being lost locally" audit. This PR is the recovery.

## What was stranded and why it was unrecoverable

| File | Lines | Where it lived |
|---|---|---|
| `docs/topics/interview-batch-rounds/PLAN.md` | 55 | `stash@{...}^3`, untracked component |
| `docs/topics/shadowed-skill-renames/PLAN.md` | 87 | same stash |

The stash was created `On main: stale pre-776 topic drafts` / `WIP on fix/wayfind-label-grammar`. `fix/wayfind-label-grammar` does not exist on the remote (`git ls-remote --heads origin` returns nothing). Neither file exists on `origin/main`. Three sibling files in the same stash pair — `fresh-eyes-checkpoint-audit/PLAN.md` and its `design/design-resolution.md`, `underspecification/PLAN.md`, `plugin-fleet-sync-skill/PLAN.md` and its `design/design-resolution.md` — **are** on `main`, which is what makes these two the outliers rather than the rule.

## These are records, not proposals

Both describe work that has since shipped. Verified against this branch's tree rather than assumed:

- **`interview-batch-rounds`** — `/planning:interview` moving to frontier rounds, the prose-vs-`AskUserQuestion` surface toggle, non-blocking fact dispatch, the facts-vs-decisions split. `plugins/planning/skills/interview/SKILL.md` now mentions `frontier` 14 times; the skill implements it.
- **`shadowed-skill-renames`** — undoing the pre-migration shadow-compromise names, extracting a `domain-driven-design` plugin, and codifying the naming grammar in `docs/PLUGIN-PHILOSOPHY.md`. `plugins/domain-driven-design/` exists, `plugins/discipline/` exists (the `re-anchor` rename), and the grammar is written.

So what is being recovered is the **locked decisions and their rationale** — the part a future reader needs when asking why a name or a question-surface default is what it is, and the part that was one `git stash drop` away from gone.

`docs/topics/` already holds completed plans for comparable efforts (`autonomy-ignition`, `boris-video-absorption`, `plugin-fleet-sync-skill`, and others), so these belong beside them rather than in a separate archive.

## Deliberately unedited

Content is byte-for-byte as stashed. No reconciliation against what actually shipped, no status banners, no tidying. A record that was quietly rewritten to match the outcome is worth less than one that shows what was decided at the time — the divergences, where they exist, are themselves the useful signal.

## Verification

- `markdownlint-cli2 --config .markdownlint-cli2.jsonc` over both files — `Summary: 0 error(s)`.
- Both paths confirmed absent from `origin/main` before extraction (`git cat-file -e origin/main:<path>` non-zero).
- Extraction was `git show 'stash@{N}^3:<path>'` — read-only against the stash; the stash entry is untouched and still present.
- No plugin touched, so no `plugin.json` bump and no CHANGELOG entry: `check-changelog-parity.sh` is scoped to `plugins/<name>/`, and `docs/topics/` changes on `main` do not carry one.

## Related

Not linked to an issue — this is recovery of stranded content found during a local-loss audit, not the execution of a tracked work item.

The audit's other findings are separate: a third stash entry holds a `resolve-conflicts/evals/evals.json` variant on another never-pushed branch (`absorb/pocock-mechanisms`) whose 83 lines differ from `main`'s 83 in ways that need a human call, and is deliberately **not** included here.