### PR TITLE
docs(prompts): record the C3 rung decision — stay at c2-mechanical

### DIFF
--- a/prompts/loops/loop-lane-prompts.md
+++ b/prompts/loops/loop-lane-prompts.md
@@ -768,14 +768,16 @@ overnight without me":
 
 - **Tier `autopilot`** — in the prompt below. Already maximal.
 - **Merge rung** — one line in `.claude/source-control.md` on `main`.
-  Currently `c2-mechanical`. Changing it to `c3-autonomous` takes the
-  eligible set from the `mechanical` handful to nearly the whole open
-  `agent-ready` backlog — run the union command for the live figures rather
-  than trusting a number written here. Whether that raise is
-  *authorized* is a separate question from whether the seam supports it: the
-  guardrail matrix sets C3 merge policy to `human merge` and lists no C3
-  auto-merge promotion cell, so the flip is filed as an operator decision
-  rather than a ready edit.
+  Currently `c2-mechanical`, and **staying there: the operator decided
+  against raising it on 2026-07-25** (#1388). Changing it to `c3-autonomous`
+  would take the eligible set from the `mechanical` handful to nearly the
+  whole open `agent-ready` backlog, but throughput was not the binding
+  constraint — authorization was. The guardrail matrix sets C3 merge policy
+  to a flat `human merge` and lists **no C3 auto-merge promotion cell**, so
+  no evidence predicate exists that a raise could satisfy; and the C2 rung
+  already in force has not met its own predicate either, with zero autonomous
+  merges recorded here to date. Reopen the question only by amending the
+  guardrail contract first, never by flipping the seam alone.
 
 `full-autonomy` as a rung adds only C4 `structural` and C5
 `untrusted-provenance` on top of `c3-autonomous` — refactors, migrations,
@@ -783,14 +785,17 @@ contract changes, and fork PRs. That is the category least suited to
 landing unattended, for near-zero throughput gain over c3, so `full-autonomy`
 is never the answer here.
 
-**But that ranking is not a recommendation to raise.** The governing policy
-is `plugins/autonomy/reference/guardrails.md`'s matrix, which sets C3 merge
-policy to `human merge`, and its promotion table, which defines an auto-merge
-evidence predicate for C2 only — C3 has no auto-merge promotion cell at all.
-Until that policy defines a C3 promotion path, **stay at `c2-mechanical`**:
-the eligible-count arithmetic above says what the seam would do, not what
-the contract permits. Raising the rung anyway is an operator decision to
-override the matrix, and it belongs in a change to the policy first.
+**But that ranking is not a recommendation to raise, and the question is
+settled.** The governing policy is `plugins/autonomy/reference/guardrails.md`'s
+matrix, which sets C3 merge policy to `human merge`, and its promotion table,
+which defines an auto-merge evidence predicate for C2 only — C3 has no
+auto-merge promotion cell at all. The eligible-count arithmetic above says
+what the seam *would* do, not what the contract *permits*.
+
+**Decided 2026-07-25 (#1388): stay at `c2-mechanical`.** Raising the rung
+would be an operator override of the matrix, and it belongs in a change to
+the policy first — add a C3 auto-merge cell with an evidence predicate, then
+flip the seam. Not the reverse.
 
 Neither rung bypasses classification: an item with **no recorded class in
 either source** — no `Work-class: C<n>` body trailer and no `work-class:`


### PR DESCRIPTION
## Summary

The loop-lane prompts document described the `babysit_loop_merge` rung raise as "filed as an operator decision rather than a ready edit". That was accurate when #1320 landed and is now stale — the operator decided on 2026-07-25 (#1388) **not** to raise it.

This records the outcome and the reasoning. The reasoning is the part worth keeping: throughput was never the binding constraint, authorization was.

- The guardrail matrix (`plugins/autonomy/reference/guardrails.md`) sets C3 merge policy to a flat `human merge`.
- `work-classes.md`'s promotable-cell table lists exactly three rows — C2 auto-merge, C3 *AI review advisory→blocking*, and C4/C5 (never promotes). **There is no C3 auto-merge cell**, so no evidence predicate exists that a raise could satisfy.
- The C2 rung already in force has not met its own predicate either (≥20 autonomous C2 completions over ≥14 days): this repository has recorded **zero autonomous merges to date**.

Without this, a future reader finds the eligible-count arithmetic — which says a raise would take the eligible set from a handful to nearly the whole backlog — and no record of why that was declined. The document now also states the only legitimate path to reopening it: amend the guardrail contract to define a C3 promotion cell first, *then* flip the seam. Never the reverse.

## Test plan

- `markdownlint-cli2 --config .markdownlint-cli2.jsonc "prompts/**/*.md"` — `Summary: 0 error(s)`
- `typos --config _typos.toml prompts/loops/loop-lane-prompts.md` — exit 0
- Grepped for other stale pending-decision phrasing; the only remaining `pending` is an unrelated `work-class: pending` example string illustrating a label the classification count must reject.

Prose-only; no command, threshold, or behavioral guidance changed.

## Related

No related issue: this records the resolution of #1388, which stays open until the operator closes it. Follows #1320, which introduced the document.
