### PR TITLE
docs(ecosystem-commands): worked run-from: repo-root example + multi-root gate failure format

### DIFF
--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -4,16 +4,20 @@
 
 Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented illustrative gate
 (`proto-gen-freshness`) demonstrating the `run-from: repo-root` shape added in 1.2.0 — no bundled
-default or example repo needs it yet, so it is documentation, not a functioning gate. Its
-`trigger-globs` (`*.proto`, `buf.gen.yaml`) are also added to the file's own `globs`, per the 1.1.1
-reachability rule, so the worked example is actually reachable under auto-targeting rather than
-silently unfired. Its freshness `cmd` runs `buf generate --clean` and pairs `git diff HEAD
---exit-code` with `git ls-files --others --exclude-standard`, so the example demonstrates a gate that
-actually catches stale generated code: a bare `git diff` compares only against the index (a staged
-regeneration reports clean) and never reports untracked paths at all (a newly generated output
-false-passes), and without `--clean` — whose `buf.gen.yaml` counterpart
-[defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — a `.pb.go` orphaned by
-a deleted `.proto` is left in place and passes both git checks.
+default or example repo needs it yet, so it is documentation, not a functioning gate. `*.proto` and
+`buf.gen.yaml` are also added to the file's own `globs`, per the 1.1.1 reachability rule, so the
+worked example is actually reachable under auto-targeting rather than silently unfired. Its
+`trigger-globs` (`*.proto`, `buf.gen.yaml`, `*.pb.go`, `*.pb.gw.go`) additionally list the plugins'
+own generated-output patterns, so a hand-edit that drifts a generated file from what `buf generate`
+would produce still fires the gate — those two need no separate `globs` entry since they already end
+in `.go`. Its freshness `cmd` runs `buf generate --clean` and pairs `git diff HEAD --exit-code` with
+`git ls-files --others --exclude-standard` scoped to every buf.gen.yaml-configured plugin's output
+(`*.pb.go` and grpc-gateway's `*.pb.gw.go` in this example, extended per additional plugin), so the
+example demonstrates a gate that actually catches stale generated code: a bare `git diff` compares
+only against the index (a staged regeneration reports clean) and never reports untracked paths at all
+(a newly generated output false-passes), and without `--clean` — whose `buf.gen.yaml` counterpart
+[defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — an output orphaned by a
+deleted `.proto` is left in place and passes both git checks.
 Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
 documentation-depth finding from #1460's review): a worked `run-from: repo-root` example was still
 missing.

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — ecosystem-commands convention
 
+## 1.2.1 — 2026-07-25
+
+Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented illustrative gate
+(`proto-gen-freshness`) demonstrating the `run-from: repo-root` shape added in 1.2.0 — no bundled
+default or example repo needs it yet, so it is documentation, not a functioning gate. Its
+`trigger-globs` (`*.proto`, `buf.gen.yaml`) are also added to the file's own `globs`, per the 1.1.1
+reachability rule, so the worked example is actually reachable under auto-targeting rather than
+silently unfired. Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
+documentation-depth finding from #1460's review): a worked `run-from: repo-root` example was still
+missing.
+
 ## 1.2.0 — 2026-07-25
 
 Additive: optional `gates[].run-from` key (`"ecosystem"` default | `"repo-root"`) — lets a gate

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -22,7 +22,9 @@ whose working-tree copy `--clean` has since overwritten; and without `--clean` â
 counterpart [defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) â€” an output
 orphaned by a deleted `.proto` is left in place and passes every git check. The comment also records
 what no regenerate-and-diff gate can catch: an unstaged hand-edit to a generated file is overwritten
-by `--clean` before any check reads it.
+by `--clean` before any check reads it. The example's `install-hint` gains the Buf CLI alongside
+golangci-lint and the Go toolchain: `install-hint` is per-ecosystem, so a tool-presence skip on the
+new gate would otherwise reuse a hint that cannot install the executable it is missing.
 Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
 documentation-depth finding from #1460's review): a worked `run-from: repo-root` example was still
 missing.

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -7,11 +7,14 @@ Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented 
 default or example repo needs it yet, so it is documentation, not a functioning gate. Its
 `trigger-globs` (`*.proto`, `buf.gen.yaml`) are also added to the file's own `globs`, per the 1.1.1
 reachability rule, so the worked example is actually reachable under auto-targeting rather than
-silently unfired. Its freshness `cmd` pairs `git diff HEAD --exit-code` with
-`git ls-files --others --exclude-standard`: a bare `git diff` compares only against the index (a
-staged regeneration reports clean) and never reports untracked paths at all (a newly generated
-output false-passes), so both forms are needed for the example to demonstrate a gate that actually
-catches stale generated code. Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
+silently unfired. Its freshness `cmd` runs `buf generate --clean` and pairs `git diff HEAD
+--exit-code` with `git ls-files --others --exclude-standard`, so the example demonstrates a gate that
+actually catches stale generated code: a bare `git diff` compares only against the index (a staged
+regeneration reports clean) and never reports untracked paths at all (a newly generated output
+false-passes), and without `--clean` — whose `buf.gen.yaml` counterpart
+[defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — a `.pb.go` orphaned by
+a deleted `.proto` is left in place and passes both git checks.
+Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
 documentation-depth finding from #1460's review): a worked `run-from: repo-root` example was still
 missing.
 

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented illustrative gate
 (`proto-gen-freshness`) demonstrating the `run-from: repo-root` shape added in 1.2.0 — no bundled
-default or example repo needs it yet, so it is documentation, not a functioning gate. `*.proto` and
-`buf.gen.yaml` are also added to the file's own `globs`, per the 1.1.1 reachability rule, so the
-worked example is actually reachable under auto-targeting rather than silently unfired. Its
-`trigger-globs` (`*.proto`, `buf.gen.yaml`, `*.pb.go`, `*.pb.gw.go`) additionally list the plugins'
+default or example repo needs it yet, so it is documentation, not a functioning gate. Every input
+that can change what `buf generate` produces is also added to the file's own `globs`, per the 1.1.1
+reachability rule, so the worked example is actually reachable under auto-targeting rather than
+silently unfired: `*.proto` and `buf.gen.yaml`, plus `buf.yaml` and v1's `buf.work.yaml`, whose
+workspace `modules`/`includes`/`excludes` decide which Protobuf files generation discovers at all.
+Its `trigger-globs` (those four, plus `*.pb.go` and `*.pb.gw.go`) additionally list the plugins'
 own generated-output patterns, so a hand-edit that drifts a generated file from what `buf generate`
 would produce still fires the gate — those two need no separate `globs` entry since they already end
 in `.go`. Its freshness `cmd` runs `buf generate --clean` and chains `git diff HEAD --exit-code`,

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -10,14 +10,19 @@ worked example is actually reachable under auto-targeting rather than silently u
 `trigger-globs` (`*.proto`, `buf.gen.yaml`, `*.pb.go`, `*.pb.gw.go`) additionally list the plugins'
 own generated-output patterns, so a hand-edit that drifts a generated file from what `buf generate`
 would produce still fires the gate — those two need no separate `globs` entry since they already end
-in `.go`. Its freshness `cmd` runs `buf generate --clean` and pairs `git diff HEAD --exit-code` with
-`git ls-files --others --exclude-standard` scoped to every buf.gen.yaml-configured plugin's output
-(`*.pb.go` and grpc-gateway's `*.pb.gw.go` in this example, extended per additional plugin), so the
-example demonstrates a gate that actually catches stale generated code: a bare `git diff` compares
-only against the index (a staged regeneration reports clean) and never reports untracked paths at all
-(a newly generated output false-passes), and without `--clean` — whose `buf.gen.yaml` counterpart
-[defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — an output orphaned by a
-deleted `.proto` is left in place and passes both git checks.
+in `.go`. Its freshness `cmd` runs `buf generate --clean` and chains `git diff HEAD --exit-code`,
+`git diff --cached --exit-code`, and `git ls-files --others --exclude-standard`, each scoped to every
+buf.gen.yaml-configured plugin's output (`*.pb.go` and grpc-gateway's `*.pb.gw.go` in this example,
+extended per additional plugin), so the example demonstrates a gate that actually catches stale
+generated code: a bare `git diff` compares only against the index (a staged regeneration reports
+clean) and never reports untracked paths at all (a newly generated output false-passes); `git diff
+HEAD` compares the working tree to the last commit and never inspects the index, so it closes the
+staged-regeneration case but needs the `--cached` companion to catch a hand-edit staged in the index
+whose working-tree copy `--clean` has since overwritten; and without `--clean` — whose `buf.gen.yaml`
+counterpart [defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — an output
+orphaned by a deleted `.proto` is left in place and passes every git check. The comment also records
+what no regenerate-and-diff gate can catch: an unstaged hand-edit to a generated file is overwritten
+by `--clean` before any check reads it.
 Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
 documentation-depth finding from #1460's review): a worked `run-from: repo-root` example was still
 missing.

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -15,19 +15,22 @@ change imported descriptors and options with no local `.proto` edit at all).
 Its `trigger-globs` (those five, plus `*.pb.go` and `*.pb.gw.go`) additionally list the plugins'
 own generated-output patterns, so a hand-edit that drifts a generated file from what `buf generate`
 would produce still fires the gate — those two need no separate `globs` entry since they already end
-in `.go`. Its freshness `cmd` runs `buf generate --clean` and chains `git diff HEAD --exit-code`,
-`git diff --cached --exit-code`, and `git ls-files --others --exclude-standard`, each scoped to every
-buf.gen.yaml-configured plugin's output (`*.pb.go` and grpc-gateway's `*.pb.gw.go` in this example,
-extended per additional plugin), so the example demonstrates a gate that actually catches stale
-generated code: a bare `git diff` compares only against the index (a staged regeneration reports
-clean) and never reports untracked paths at all (a newly generated output false-passes); `git diff
-HEAD` compares the working tree to the last commit and never inspects the index, so it closes the
-staged-regeneration case but needs the `--cached` companion to catch a hand-edit staged in the index
-whose working-tree copy `--clean` has since overwritten; and without `--clean` — whose `buf.gen.yaml`
-counterpart [defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — an output
-orphaned by a deleted `.proto` is left in place and passes every git check. The comment also records
-what no regenerate-and-diff gate can catch: an unstaged hand-edit to a generated file is overwritten
-by `--clean` before any check reads it. The example's `install-hint` gains the Buf CLI alongside
+in `.go`. Its freshness `cmd` brackets `buf generate --clean` with one `git status --porcelain`
+scoped to every buf.gen.yaml-configured plugin's output (`*.pb.go` and grpc-gateway's `*.pb.gw.go`
+in this example, extended per additional plugin), so the example demonstrates a gate that actually
+catches stale generated code without destroying any. The post-generation check reports modified,
+newly generated, and orphaned output in one command, staged or not — a bare `git diff` compares only
+against the index (a staged regeneration reports clean) and never reports untracked paths at all,
+and without `--clean` — whose `buf.gen.yaml` counterpart
+[defaults to `false`](https://buf.build/docs/configuration/v2/buf-gen-yaml/) — an output orphaned by
+a deleted `.proto` is left in place and passes every git check. The pre-generation check (`-uno`,
+tracked paths only) is the guard: `--clean` deletes the plugins' output directories, so generation
+would otherwise overwrite an uncommitted hand-edit, and once regeneration has reverted one the
+worktree matches HEAD while the staged entry survives — [`git diff <commit>` compares the working
+tree, never the index](https://git-scm.com/docs/git-diff) — a false pass no post-generation diff
+form can reach. Untracked output stays outside the guard, since regeneration reproduces it
+identically, so the ordinary "forgot to regenerate" flow still fails at the post-generation check
+rather than the guard. The example's `install-hint` gains the Buf CLI alongside
 golangci-lint and the Go toolchain: `install-hint` is per-ecosystem, so a tool-presence skip on the
 new gate would otherwise reuse a hint that cannot install the executable it is missing.
 Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -7,11 +7,14 @@ Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented 
 default or example repo needs it yet, so it is documentation, not a functioning gate. Every input
 that can change what `buf generate` produces is also added to the file's own `globs`, per the 1.1.1
 reachability rule, so the worked example is actually reachable under auto-targeting rather than
-silently unfired — buf's whole documented input surface rather than a subset: `*.proto` (the
-sources), `buf.gen.yaml` (which plugins run and where they write), `buf.yaml` and v1's
-`buf.work.yaml` (the workspace `modules`/`includes`/`excludes` that decide which Protobuf files
-generation discovers at all), and `buf.lock` (the resolved dependency pins — `buf dep update` can
-change imported descriptors and options with no local `.proto` edit at all).
+silently unfired: `*.proto` (the sources), `buf.gen.yaml` (which plugins run and where they write),
+`buf.yaml` and v1's `buf.work.yaml` (the workspace `modules`/`includes`/`excludes` that decide which
+Protobuf files generation discovers at all), and `buf.lock` (the resolved dependency pins — `buf dep
+update` can change imported descriptors and options with no local `.proto` edit at all). That is
+buf's own configuration surface, which is what an example can know; the comment states the rule the
+list applies and tells a consuming repo to extend it with the generation inputs no example can
+enumerate — most commonly a `local:` plugin built from sources in the same repo, whose `*.go` files
+change the output while matching none of the globs.
 Its `trigger-globs` (those five, plus `*.pb.go` and `*.pb.gw.go`) additionally list the plugins'
 own generated-output patterns, so a hand-edit that drifts a generated file from what `buf generate`
 would produce still fires the gate — those two need no separate `globs` entry since they already end

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -7,9 +7,12 @@ Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented 
 default or example repo needs it yet, so it is documentation, not a functioning gate. Every input
 that can change what `buf generate` produces is also added to the file's own `globs`, per the 1.1.1
 reachability rule, so the worked example is actually reachable under auto-targeting rather than
-silently unfired: `*.proto` and `buf.gen.yaml`, plus `buf.yaml` and v1's `buf.work.yaml`, whose
-workspace `modules`/`includes`/`excludes` decide which Protobuf files generation discovers at all.
-Its `trigger-globs` (those four, plus `*.pb.go` and `*.pb.gw.go`) additionally list the plugins'
+silently unfired — buf's whole documented input surface rather than a subset: `*.proto` (the
+sources), `buf.gen.yaml` (which plugins run and where they write), `buf.yaml` and v1's
+`buf.work.yaml` (the workspace `modules`/`includes`/`excludes` that decide which Protobuf files
+generation discovers at all), and `buf.lock` (the resolved dependency pins — `buf dep update` can
+change imported descriptors and options with no local `.proto` edit at all).
+Its `trigger-globs` (those five, plus `*.pb.go` and `*.pb.gw.go`) additionally list the plugins'
 own generated-output patterns, so a hand-edit that drifts a generated file from what `buf generate`
 would produce still fires the gate — those two need no separate `globs` entry since they already end
 in `.go`. Its freshness `cmd` runs `buf generate --clean` and chains `git diff HEAD --exit-code`,

--- a/docs/conventions/ecosystem-commands/CHANGELOG.md
+++ b/docs/conventions/ecosystem-commands/CHANGELOG.md
@@ -7,7 +7,11 @@ Docs-only, no schema shape change: `examples/go.yaml` gains a clearly-commented 
 default or example repo needs it yet, so it is documentation, not a functioning gate. Its
 `trigger-globs` (`*.proto`, `buf.gen.yaml`) are also added to the file's own `globs`, per the 1.1.1
 reachability rule, so the worked example is actually reachable under auto-targeting rather than
-silently unfired. Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
+silently unfired. Its freshness `cmd` pairs `git diff HEAD --exit-code` with
+`git ls-files --others --exclude-standard`: a bare `git diff` compares only against the index (a
+staged regeneration reports clean) and never reports untracked paths at all (a newly generated
+output false-passes), so both forms are needed for the example to demonstrate a gate that actually
+catches stale generated code. Deferred from melodic-software/claude-code-plugins#1361 via #1462 (a
 documentation-depth finding from #1460's review): a worked `run-from: repo-root` example was still
 missing.
 

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -1,6 +1,6 @@
 # Example .claude/ecosystems/go.yaml — a consuming repo's Go command surface.
 # Contract: docs/conventions/ecosystem-commands/README.md (schema: ecosystem.schema.json).
-globs: ["*.go", "go.mod", "go.sum", "*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml"]
+globs: ["*.go", "go.mod", "go.sum", "*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml", "buf.lock"]
 project-discovery: ["go.mod"]
 build-cmd: "go build ./..."
 test-cmd: "go test ./..."
@@ -24,12 +24,18 @@ gates:
   # above (not just this gate's `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs
   # alone never selects an ecosystem under auto-targeting, so without a `globs` entry a change
   # touching only that file would never reach this gate outside `/toolchain:check go` or
-  # `check all`. That is `*.proto` and `buf.gen.yaml` (which plugins run and where they write),
-  # plus `buf.yaml` and v1's `buf.work.yaml`: those define the workspace modules, `includes`, and
-  # `excludes` that decide which Protobuf files generation discovers at all, so editing one alone
-  # can strand or orphan generated output. Refs:
-  # https://buf.build/docs/configuration/v2/buf-yaml/ and
-  # https://buf.build/docs/configuration/v1/buf-work-yaml/. The gate's
+  # `check all`. Apply that rule to buf's whole documented input surface, not a favourite subset —
+  # the sources plus every file that changes what generation sees or emits:
+  #   - `*.proto` — the sources themselves.
+  #   - `buf.gen.yaml` — which plugins run and where they write.
+  #   - `buf.yaml` (v1 also `buf.work.yaml`) — the workspace `modules`/`includes`/`excludes` that
+  #     decide which Protobuf files generation discovers at all.
+  #   - `buf.lock` — the resolved external-dependency pins; `buf dep update` can change imported
+  #     descriptors and options with no local `.proto` edit at all.
+  # Editing any one of them alone can strand or orphan generated output, so each needs its own
+  # `globs` entry. Refs: https://buf.build/docs/configuration/v2/buf-yaml/,
+  # https://buf.build/docs/configuration/v1/buf-work-yaml/, and
+  # https://buf.build/docs/configuration/v2/buf-lock/. The gate's
   # `trigger-globs` below also lists the plugins' own generated-output patterns (`*.pb.go`,
   # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would
   # produce still fires this gate — unlike the buf inputs above, they need no separate `globs`
@@ -78,7 +84,7 @@ gates:
   # (which the gate reports on FAIL) names the listing command.
   - name: proto-gen-freshness
     cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' '*.pb.gw.go' && git diff --cached --exit-code -- '*.pb.go' '*.pb.gw.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go' '*.pb.gw.go')\""
-    trigger-globs: ["*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml", "*.pb.go", "*.pb.gw.go"]
+    trigger-globs: ["*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml", "buf.lock", "*.pb.go", "*.pb.gw.go"]
     run-from: repo-root
     remediation: "Run buf generate --clean from the repo root, then stage and commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins) — modified, newly generated, and deleted (an output whose .proto is gone). The gate fails until the regenerated output is committed, whether the drift sits in the working tree, the index, or both. `git status --short -- '*.pb.go' '*.pb.gw.go'` lists all three, its first column reporting the index and its second the working tree (extend the same way)."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -7,7 +7,7 @@ test-cmd: "go test ./..."
 check-cmd: "golangci-lint run ./..."
 fix-cmd: "golangci-lint run --fix ./..."
 opt-in: ".golangci.yml, .golangci.yaml, .golangci.toml, or .golangci.json present (walked from the changed file up to the repo root) — otherwise golangci-lint applies its own unconfigured \"standard\" linter preset unconditionally"
-install-hint: "Install golangci-lint: https://golangci-lint.run/docs/welcome/install/ | Go toolchain: https://go.dev/dl/"
+install-hint: "Install golangci-lint: https://golangci-lint.run/docs/welcome/install/ | Go toolchain: https://go.dev/dl/ | Buf CLI (needed by the proto-gen-freshness gate below): https://buf.build/docs/cli/installation/"
 gates:
   - name: go-mod-tidy-drift
     cmd: "go mod tidy -diff"

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -28,33 +28,48 @@ gates:
   # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would
   # produce still fires this gate — unlike `*.proto`/`buf.gen.yaml`, they need no separate `globs`
   # entry: both already end in `.go`, so the ecosystem's own `*.go` glob already selects them.
-  # Every part of the `cmd` closes one way stale generated code slips past a naive freshness check —
-  # a bare `buf generate && git diff --exit-code` false-passes all three:
+  # Every part of the `cmd` closes one way stale generated code slips past a naive freshness check.
+  # Three are ways a bare `buf generate && git diff --exit-code` false-passes; the fourth is a gap
+  # `git diff HEAD` itself introduces, covered in the paragraph below the list:
   #   1. Staged regeneration. `git diff` with no commit argument compares the working tree to the
   #      *index*, so output the consumer already staged reports clean. `git diff HEAD` compares the
-  #      worktree AND the index against the last commit.
+  #      working tree to the last commit — it never inspects the index — so a regeneration that is
+  #      staged but not yet committed still differs from the stale commit and the gate fires.
   #   2. Newly generated output. `git diff` never reports untracked paths, so a brand-new `.proto`'s
-  #      generated output false-passes either diff form. `git ls-files --others --exclude-standard`
+  #      generated output false-passes every diff form. `git ls-files --others --exclude-standard`
   #      catches it, honoring .gitignore so a repo that deliberately ignores generated code passes.
   #   3. Orphaned output. When a `.proto` is deleted or renamed, generation writes nothing over the
-  #      now-sourceless output, so both git checks pass a file that should no longer exist. The
+  #      now-sourceless output, so every git check passes a file that should no longer exist. The
   #      `clean` field in buf.gen.yaml "defaults to false", and `--clean` deletes "the directories,
   #      jar files, or zip files that the plugins will write to" before generating, so the orphan
   #      surfaces as a deletion `git diff HEAD` reports. Passing the flag keeps the gate correct
   #      regardless of the consumer's buf.gen.yaml. Refs:
   #      https://buf.build/docs/reference/cli/buf/generate/ and
   #      https://buf.build/docs/configuration/v2/buf-gen-yaml/
+  # Swapping bare `git diff` for `git diff HEAD` closes case 1 but opens a gap the bare form did not
+  # have: a hand-edit staged in the index, whose worktree copy `buf generate --clean` then overwrites
+  # with correct output. The worktree now matches HEAD, so `git diff HEAD --exit-code` exits 0 while
+  # the bad entry sits in the index, still committable — the very drift the gate exists to stop.
+  # `git diff --cached` compares the *index* to the last commit, so it sees the staged entry that
+  # `git diff HEAD` cannot. Neither form subsumes the other — `--cached` alone would miss drift that
+  # is only in the working tree — so the `cmd` chains both rather than substituting one for the other.
+  # Known property of any regenerate-and-diff gate, not a defect of this one: `buf generate --clean`
+  # deletes and rewrites the plugins' output directories before any check reads them, so a hand-edit
+  # to a generated file that was never staged or committed is destroyed by running the gate rather
+  # than reported by it. Only staged or committed drift survives to be caught — treat generated
+  # output as read-only rather than a place to hold in-progress edits.
   # The pathspec after `--` must cover every plugin buf.gen.yaml configures, not just protoc-gen-go's
   # `*.pb.go` — a repo that also runs grpc-gateway writes `*.pb.gw.go`, and every other configured
   # plugin writes its own extension again, so scoping to one plugin's output would leave --clean's
   # deletion of the others undetected. This example covers `*.pb.go` and grpc-gateway's `*.pb.gw.go`;
   # add one pathspec per additional plugin this repo's buf.gen.yaml configures.
-  # The two git checks leave the index untouched — `git add --intent-to-add` would fold case 2 into
-  # the diff, but it leaves index residue in the consumer's worktree. Neither prints filenames on
-  # failure, so the `remediation` (which the gate reports on FAIL) names the listing command.
+  # The three git checks leave the index untouched (`git diff --cached` reads the index, never writes
+  # it) — `git add --intent-to-add` would fold case 2 into the diff, but it leaves index residue in
+  # the consumer's worktree. None of the three prints filenames on failure, so the `remediation`
+  # (which the gate reports on FAIL) names the listing command.
   - name: proto-gen-freshness
-    cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' '*.pb.gw.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go' '*.pb.gw.go')\""
+    cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' '*.pb.gw.go' && git diff --cached --exit-code -- '*.pb.go' '*.pb.gw.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go' '*.pb.gw.go')\""
     trigger-globs: ["*.proto", "buf.gen.yaml", "*.pb.go", "*.pb.gw.go"]
     run-from: repo-root
-    remediation: "Run buf generate --clean from the repo root, then commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins) — modified, newly generated, and deleted (an output whose .proto is gone). `git status --short -- '*.pb.go' '*.pb.gw.go'` lists all three (extend the same way)."
+    remediation: "Run buf generate --clean from the repo root, then stage and commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins) — modified, newly generated, and deleted (an output whose .proto is gone). The gate fails until the regenerated output is committed, whether the drift sits in the working tree, the index, or both. `git status --short -- '*.pb.go' '*.pb.gw.go'` lists all three, its first column reporting the index and its second the working tree (extend the same way)."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -1,6 +1,6 @@
 # Example .claude/ecosystems/go.yaml — a consuming repo's Go command surface.
 # Contract: docs/conventions/ecosystem-commands/README.md (schema: ecosystem.schema.json).
-globs: ["*.go", "go.mod", "go.sum", "*.proto", "buf.gen.yaml"]
+globs: ["*.go", "go.mod", "go.sum", "*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml"]
 project-discovery: ["go.mod"]
 build-cmd: "go build ./..."
 test-cmd: "go test ./..."
@@ -20,13 +20,19 @@ gates:
   # `project-discovery: ["go.mod"]`, so without `run-from: repo-root` a repo-wide check like
   # protobuf-generated-code freshness would run once per discovered go.mod root instead of once
   # from $REPO_ROOT — redundant at best, failing in roots that lack a buf.gen.yaml at worst.
-  # `*.proto`/`buf.gen.yaml` are added to this file's own `globs` above (not just this gate's
-  # `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs alone never selects an
-  # ecosystem under auto-targeting, so without that `globs` entry a change touching only `.proto`
-  # files would never reach this gate outside `/toolchain:check go` or `check all`. The gate's
+  # Every input that can change what `buf generate` produces is added to this file's own `globs`
+  # above (not just this gate's `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs
+  # alone never selects an ecosystem under auto-targeting, so without a `globs` entry a change
+  # touching only that file would never reach this gate outside `/toolchain:check go` or
+  # `check all`. That is `*.proto` and `buf.gen.yaml` (which plugins run and where they write),
+  # plus `buf.yaml` and v1's `buf.work.yaml`: those define the workspace modules, `includes`, and
+  # `excludes` that decide which Protobuf files generation discovers at all, so editing one alone
+  # can strand or orphan generated output. Refs:
+  # https://buf.build/docs/configuration/v2/buf-yaml/ and
+  # https://buf.build/docs/configuration/v1/buf-work-yaml/. The gate's
   # `trigger-globs` below also lists the plugins' own generated-output patterns (`*.pb.go`,
   # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would
-  # produce still fires this gate — unlike `*.proto`/`buf.gen.yaml`, they need no separate `globs`
+  # produce still fires this gate — unlike the buf inputs above, they need no separate `globs`
   # entry: both already end in `.go`, so the ecosystem's own `*.go` glob already selects them.
   # Every part of the `cmd` closes one way stale generated code slips past a naive freshness check.
   # Three are ways a bare `buf generate && git diff --exit-code` false-passes; the fourth is a gap
@@ -72,7 +78,7 @@ gates:
   # (which the gate reports on FAIL) names the listing command.
   - name: proto-gen-freshness
     cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' '*.pb.gw.go' && git diff --cached --exit-code -- '*.pb.go' '*.pb.gw.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go' '*.pb.gw.go')\""
-    trigger-globs: ["*.proto", "buf.gen.yaml", "*.pb.go", "*.pb.gw.go"]
+    trigger-globs: ["*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml", "*.pb.go", "*.pb.gw.go"]
     run-from: repo-root
     remediation: "Run buf generate --clean from the repo root, then stage and commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins) — modified, newly generated, and deleted (an output whose .proto is gone). The gate fails until the regenerated output is committed, whether the drift sits in the working tree, the index, or both. `git status --short -- '*.pb.go' '*.pb.gw.go'` lists all three, its first column reporting the index and its second the working tree (extend the same way)."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -24,19 +24,28 @@ gates:
   # `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs alone never selects an
   # ecosystem under auto-targeting, so without that `globs` entry a change touching only `.proto`
   # files would never reach this gate outside `/toolchain:check go` or `check all`.
-  # The freshness `cmd` is deliberately three parts, because a bare `git diff --exit-code` misses two
-  # ways generated output can be stale. `git diff` with no commit argument compares the working tree
-  # to the *index*, so a regeneration the consumer already staged reports clean — hence `git diff
-  # HEAD`, which compares both the worktree and the index against the last commit. And `git diff`
-  # never reports untracked paths at all, so a *newly* generated `.pb.go` (the output of a brand-new
-  # `.proto`) would false-pass either form — `git ls-files --others --exclude-standard` is what
-  # catches that, honoring .gitignore so a repo that deliberately ignores generated output still
-  # passes. Neither check writes to the index: `git add --intent-to-add` would fold the untracked
-  # case into the diff, but it leaves index residue in the consumer's worktree, and a CI-parity gate
-  # stays read-only. On failure the gate reports its `remediation`, which names the listing command.
+  # Every part of the `cmd` closes one way stale generated code slips past a naive freshness check —
+  # a bare `buf generate && git diff --exit-code` false-passes all three:
+  #   1. Staged regeneration. `git diff` with no commit argument compares the working tree to the
+  #      *index*, so output the consumer already staged reports clean. `git diff HEAD` compares the
+  #      worktree AND the index against the last commit.
+  #   2. Newly generated output. `git diff` never reports untracked paths, so the `.pb.go` for a
+  #      brand-new `.proto` false-passes either diff form. `git ls-files --others --exclude-standard`
+  #      catches it, honoring .gitignore so a repo that deliberately ignores generated code passes.
+  #   3. Orphaned output. When a `.proto` is deleted or renamed, generation writes nothing over the
+  #      now-sourceless `.pb.go`, so both git checks pass a file that should no longer exist. The
+  #      `clean` field in buf.gen.yaml "defaults to false", and `--clean` deletes "the directories,
+  #      jar files, or zip files that the plugins will write to" before generating, so the orphan
+  #      surfaces as a deletion `git diff HEAD` reports. Passing the flag keeps the gate correct
+  #      regardless of the consumer's buf.gen.yaml. Refs:
+  #      https://buf.build/docs/reference/cli/buf/generate/ and
+  #      https://buf.build/docs/configuration/v2/buf-gen-yaml/
+  # The two git checks leave the index untouched — `git add --intent-to-add` would fold case 2 into
+  # the diff, but it leaves index residue in the consumer's worktree. Neither prints filenames on
+  # failure, so the `remediation` (which the gate reports on FAIL) names the listing command.
   - name: proto-gen-freshness
-    cmd: "buf generate && git diff HEAD --exit-code -- '*.pb.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go')\""
+    cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go')\""
     trigger-globs: ["*.proto", "buf.gen.yaml"]
     run-from: repo-root
-    remediation: "Run buf generate from the repo root and commit the regenerated *.pb.go files, including any newly generated ones — `git status --short -- '*.pb.go'` lists both the modified and the untracked outputs."
+    remediation: "Run buf generate --clean from the repo root, then commit every resulting change to *.pb.go — modified, newly generated, and deleted (a .pb.go whose .proto is gone). `git status --short -- '*.pb.go'` lists all three."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -1,6 +1,6 @@
 # Example .claude/ecosystems/go.yaml — a consuming repo's Go command surface.
 # Contract: docs/conventions/ecosystem-commands/README.md (schema: ecosystem.schema.json).
-globs: ["*.go", "go.mod", "go.sum"]
+globs: ["*.go", "go.mod", "go.sum", "*.proto", "buf.gen.yaml"]
 project-discovery: ["go.mod"]
 build-cmd: "go build ./..."
 test-cmd: "go test ./..."
@@ -13,4 +13,20 @@ gates:
     cmd: "go mod tidy -diff"
     trigger-globs: ["go.mod", "go.sum", "*.go"]
     remediation: "Run go mod tidy and commit the updated go.mod/go.sum. (go mod tidy -diff requires Go 1.23+; an older toolchain rejects the flag, so the gate reports skip rather than drift.)"
+  # Illustrative only — no bundled default or example repo currently needs this gate (see the
+  # ecosystem-commands CHANGELOG 1.2.0 entry and #1361's Trigger: "revisit when a consumer needs a
+  # repo-wide gate ... or when a bundled default wants one"). Shown here purely to document the
+  # `run-from: repo-root` shape (README.md "Gate execution scope"): this ecosystem declares
+  # `project-discovery: ["go.mod"]`, so without `run-from: repo-root` a repo-wide check like
+  # protobuf-generated-code freshness would run once per discovered go.mod root instead of once
+  # from $REPO_ROOT — redundant at best, failing in roots that lack a buf.gen.yaml at worst.
+  # `*.proto`/`buf.gen.yaml` are added to this file's own `globs` above (not just this gate's
+  # `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs alone never selects an
+  # ecosystem under auto-targeting, so without that `globs` entry a change touching only `.proto`
+  # files would never reach this gate outside `/toolchain:check go` or `check all`.
+  - name: proto-gen-freshness
+    cmd: "buf generate && git diff --exit-code -- '*.pb.go'"
+    trigger-globs: ["*.proto", "buf.gen.yaml"]
+    run-from: repo-root
+    remediation: "Run buf generate from the repo root and commit the regenerated *.pb.go files."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -20,14 +20,13 @@ gates:
   # `project-discovery: ["go.mod"]`, so without `run-from: repo-root` a repo-wide check like
   # protobuf-generated-code freshness would run once per discovered go.mod root instead of once
   # from $REPO_ROOT — redundant at best, failing in roots that lack a buf.gen.yaml at worst.
-  # Every input that can change what `buf generate` produces is added to this file's own `globs`
-  # above (not just this gate's `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs
-  # alone never selects an ecosystem under auto-targeting, so without a `globs` entry a change
-  # touching only that file would never reach this gate outside `/toolchain:check go` or
-  # `check all`. The rule is "every input that can change what generation produces", and the entries
-  # below are this example's application of it — buf's own configuration surface, which is what an
-  # example can know. Editing any one alone can strand or orphan generated output, so each needs its
-  # own `globs` entry:
+  # Every input that can change what `buf generate` produces gets an entry in this file's own
+  # `globs` above, not just this gate's `trigger-globs`, per the 1.1.1 reachability rule —
+  # trigger-globs alone never selects an ecosystem under auto-targeting, so without a `globs` entry
+  # a change touching only that file would never reach this gate outside `/toolchain:check go` or
+  # `check all`. The entries below are this example's application of that rule to buf's own
+  # configuration surface, which is what an example can know; editing any one alone can strand or
+  # orphan generated output:
   #   - `*.proto` — the sources themselves.
   #   - `buf.gen.yaml` — which plugins run and where they write.
   #   - `buf.yaml` (v1 also `buf.work.yaml`) — the workspace `modules`/`includes`/`excludes` that
@@ -40,9 +39,9 @@ gates:
   # A consuming repo must extend the list with its own generation inputs, which no example can
   # enumerate for it. The common case is a `local:` plugin built from sources in this repo — buf
   # documents `local` as a binary or command array, e.g. `local: ["go", "run", "./tools/pgen"]` —
-  # whose `*.go` sources change the generated output while matching none of the globs below. Add a
-  # pathspec for each such generator (`tools/pgen/**`), plus any template, options file, or
-  # environment input the repo's own plugins read.
+  # whose `*.go` sources change the generated output while matching none of the entries above. Add
+  # a glob for each such generator (`tools/pgen/**`), plus any template, options file, or other
+  # input the repo's own plugins read.
   # Ref: https://buf.build/docs/configuration/v2/buf-gen-yaml/. The gate's
   # `trigger-globs` below also lists the plugins' own generated-output patterns (`*.pb.go`,
   # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -40,51 +40,43 @@ gates:
   # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would
   # produce still fires this gate — unlike the buf inputs above, they need no separate `globs`
   # entry: both already end in `.go`, so the ecosystem's own `*.go` glob already selects them.
-  # Every part of the `cmd` closes one way stale generated code slips past a naive freshness check.
-  # Three are ways a bare `buf generate && git diff --exit-code` false-passes; the fourth is a gap
-  # `git diff HEAD` itself introduces, covered in the paragraph below the list:
-  #   1. Staged regeneration. `git diff` with no commit argument compares the working tree to the
-  #      *index*, so output the consumer already staged reports clean. `git diff HEAD` compares the
-  #      working tree to the last commit — it never inspects the index — so a regeneration that is
-  #      staged but not yet committed still differs from the stale commit and the gate fires.
-  #   2. Newly generated output. `git diff` never reports untracked paths, so a brand-new `.proto`'s
-  #      generated output false-passes every diff form. `git ls-files --others --exclude-standard`
-  #      catches it, honoring .gitignore so a repo that deliberately ignores generated code passes.
-  #   3. Orphaned output. When a `.proto` is deleted or renamed, generation writes nothing over the
-  #      now-sourceless output, so every git check passes a file that should no longer exist. The
-  #      `clean` field in buf.gen.yaml "defaults to false", and `--clean` deletes "the directories,
-  #      jar files, or zip files that the plugins will write to" before generating, so the orphan
-  #      surfaces as a deletion `git diff HEAD` reports. Passing the flag keeps the gate correct
-  #      regardless of the consumer's buf.gen.yaml. Refs:
-  #      https://buf.build/docs/reference/cli/buf/generate/ and
-  #      https://buf.build/docs/configuration/v2/buf-gen-yaml/
-  # Swapping bare `git diff` for `git diff HEAD` closes case 1 but opens a gap the bare form did not
-  # have: a hand-edit staged in the index, whose worktree copy `buf generate --clean` then overwrites
-  # with correct output. The worktree now matches HEAD, so `git diff HEAD --exit-code` exits 0 while
-  # the bad entry sits in the index, still committable — the very drift the gate exists to stop.
-  # `git diff --cached` compares the *index* to the last commit, so it sees the staged entry that
-  # `git diff HEAD` cannot. Neither form subsumes the other — `--cached` alone would miss drift that
-  # is only in the working tree — so the `cmd` chains both rather than substituting one for the other.
-  # `git diff <commit>` is documented as showing "the changes you have in your working tree relative
-  # to the named <commit>" and `git diff --cached` as "the changes you staged for the next commit
-  # relative to the named <commit>". Ref: https://git-scm.com/docs/git-diff
-  # Known property of any regenerate-and-diff gate, not a defect of this one: `buf generate --clean`
-  # deletes and rewrites the plugins' output directories before any check reads them, so a hand-edit
-  # to a generated file that was never staged or committed is destroyed by running the gate rather
-  # than reported by it. Only staged or committed drift survives to be caught — treat generated
-  # output as read-only rather than a place to hold in-progress edits.
-  # The pathspec after `--` must cover every plugin buf.gen.yaml configures, not just protoc-gen-go's
+  # One `git status --porcelain` with a pathspec is the whole freshness check: it reports modified,
+  # newly generated, and orphaned output in a single command, staged or not, and omits .gitignore'd
+  # paths so a repo that deliberately ignores generated code still passes. A naive
+  # `buf generate && git diff --exit-code` catches almost none of that — `git diff` with no commit
+  # argument compares the working tree to the *index*, so staged output reports clean, and no diff
+  # form reports untracked paths at all. The check runs on BOTH sides of generation, because the
+  # two positions answer different questions:
+  #   * Before (`-uno`, tracked paths only) — the guard. `--clean` deletes "the directories, jar
+  #     files, or zip files that the plugins will write to" before generating, so generation
+  #     overwrites any uncommitted edit to a tracked output. Refusing to generate over one keeps a
+  #     freshness check from destroying work, and closes a false pass no post-generation diff form
+  #     can reach: once regeneration has reverted a hand-edit the worktree matches HEAD, and
+  #     `git diff <commit>` shows "the changes you have in your working tree relative to the named
+  #     <commit>" — never the index — so a staged bad entry survives every post-generation diff and
+  #     stays committable. Ref: https://git-scm.com/docs/git-diff. `-uno` scopes the guard to
+  #     tracked paths: untracked output is regenerated identically, so letting `--clean` delete it
+  #     loses nothing, and the ordinary "edited a .proto, forgot to regenerate" flow starts from a
+  #     clean tracked tree, passes the guard, and fails at the post-generation check as it should.
+  #   * After (all paths) — the freshness assertion. Regeneration surfaces stale committed output
+  #     as a modification and a new `.proto`'s output as an untracked path. An output orphaned by a
+  #     deleted or renamed `.proto` has no source left to regenerate it, so it surfaces only as
+  #     `--clean`'s deletion — and the `clean` field in buf.gen.yaml "defaults to false", so the
+  #     flag keeps the gate correct regardless of the consumer's buf.gen.yaml. Refs:
+  #     https://buf.build/docs/reference/cli/buf/generate/ and
+  #     https://buf.build/docs/configuration/v2/buf-gen-yaml/
+  # The pathspec must cover every plugin buf.gen.yaml configures, not just protoc-gen-go's
   # `*.pb.go` — a repo that also runs grpc-gateway writes `*.pb.gw.go`, and every other configured
   # plugin writes its own extension again, so scoping to one plugin's output would leave --clean's
-  # deletion of the others undetected. This example covers `*.pb.go` and grpc-gateway's `*.pb.gw.go`;
-  # add one pathspec per additional plugin this repo's buf.gen.yaml configures.
-  # The three git checks leave the index untouched (`git diff --cached` reads the index, never writes
-  # it) — `git add --intent-to-add` would fold case 2 into the diff, but it leaves index residue in
-  # the consumer's worktree. None of the three prints filenames on failure, so the `remediation`
-  # (which the gate reports on FAIL) names the listing command.
+  # deletion of the others undetected. This example covers `*.pb.go` and grpc-gateway's
+  # `*.pb.gw.go`; add one pathspec per additional plugin this repo's buf.gen.yaml configures. A git
+  # pathspec is not shell globbing — `*` matches `/` — so these reach output at any nesting depth.
+  # Both checks read the index without writing it, and neither prints filenames, so the
+  # `remediation` (surfaced on FAIL per the check skill's gate "Outcome" rule) names the listing
+  # command and tells the two failure points apart.
   - name: proto-gen-freshness
-    cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' '*.pb.gw.go' && git diff --cached --exit-code -- '*.pb.go' '*.pb.gw.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go' '*.pb.gw.go')\""
+    cmd: "test -z \"$(git status --porcelain -uno -- '*.pb.go' '*.pb.gw.go')\" && buf generate --clean && test -z \"$(git status --porcelain -- '*.pb.go' '*.pb.gw.go')\""
     trigger-globs: ["*.proto", "buf.gen.yaml", "buf.yaml", "buf.work.yaml", "buf.lock", "*.pb.go", "*.pb.gw.go"]
     run-from: repo-root
-    remediation: "Run buf generate --clean from the repo root, then stage and commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins) — modified, newly generated, and deleted (an output whose .proto is gone). The gate fails until the regenerated output is committed, whether the drift sits in the working tree, the index, or both. `git status --short -- '*.pb.go' '*.pb.gw.go'` lists all three, its first column reporting the index and its second the working tree (extend the same way)."
+    remediation: "Two distinct failures. (1) Refused before generating: tracked generated output has uncommitted changes, and buf generate --clean would overwrite them — commit or discard them, then re-run. (2) Failed after generating: the committed output is stale — run buf generate --clean from the repo root and commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins), modified, newly generated, and deleted (an output whose .proto is gone). `git status --short -- '*.pb.go' '*.pb.gw.go'` lists what either case is reporting, its first column the index and its second the working tree (extend the same way)."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -53,6 +53,9 @@ gates:
   # `git diff --cached` compares the *index* to the last commit, so it sees the staged entry that
   # `git diff HEAD` cannot. Neither form subsumes the other — `--cached` alone would miss drift that
   # is only in the working tree — so the `cmd` chains both rather than substituting one for the other.
+  # `git diff <commit>` is documented as showing "the changes you have in your working tree relative
+  # to the named <commit>" and `git diff --cached` as "the changes you staged for the next commit
+  # relative to the named <commit>". Ref: https://git-scm.com/docs/git-diff
   # Known property of any regenerate-and-diff gate, not a defect of this one: `buf generate --clean`
   # deletes and rewrites the plugins' output directories before any check reads them, so a hand-edit
   # to a generated file that was never staged or committed is destroyed by running the gate rather

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -24,9 +24,19 @@ gates:
   # `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs alone never selects an
   # ecosystem under auto-targeting, so without that `globs` entry a change touching only `.proto`
   # files would never reach this gate outside `/toolchain:check go` or `check all`.
+  # The freshness `cmd` is deliberately three parts, because a bare `git diff --exit-code` misses two
+  # ways generated output can be stale. `git diff` with no commit argument compares the working tree
+  # to the *index*, so a regeneration the consumer already staged reports clean — hence `git diff
+  # HEAD`, which compares both the worktree and the index against the last commit. And `git diff`
+  # never reports untracked paths at all, so a *newly* generated `.pb.go` (the output of a brand-new
+  # `.proto`) would false-pass either form — `git ls-files --others --exclude-standard` is what
+  # catches that, honoring .gitignore so a repo that deliberately ignores generated output still
+  # passes. Neither check writes to the index: `git add --intent-to-add` would fold the untracked
+  # case into the diff, but it leaves index residue in the consumer's worktree, and a CI-parity gate
+  # stays read-only. On failure the gate reports its `remediation`, which names the listing command.
   - name: proto-gen-freshness
-    cmd: "buf generate && git diff --exit-code -- '*.pb.go'"
+    cmd: "buf generate && git diff HEAD --exit-code -- '*.pb.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go')\""
     trigger-globs: ["*.proto", "buf.gen.yaml"]
     run-from: repo-root
-    remediation: "Run buf generate from the repo root and commit the regenerated *.pb.go files."
+    remediation: "Run buf generate from the repo root and commit the regenerated *.pb.go files, including any newly generated ones — `git status --short -- '*.pb.go'` lists both the modified and the untracked outputs."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -24,18 +24,26 @@ gates:
   # above (not just this gate's `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs
   # alone never selects an ecosystem under auto-targeting, so without a `globs` entry a change
   # touching only that file would never reach this gate outside `/toolchain:check go` or
-  # `check all`. Apply that rule to buf's whole documented input surface, not a favourite subset —
-  # the sources plus every file that changes what generation sees or emits:
+  # `check all`. The rule is "every input that can change what generation produces", and the entries
+  # below are this example's application of it — buf's own configuration surface, which is what an
+  # example can know. Editing any one alone can strand or orphan generated output, so each needs its
+  # own `globs` entry:
   #   - `*.proto` — the sources themselves.
   #   - `buf.gen.yaml` — which plugins run and where they write.
   #   - `buf.yaml` (v1 also `buf.work.yaml`) — the workspace `modules`/`includes`/`excludes` that
   #     decide which Protobuf files generation discovers at all.
   #   - `buf.lock` — the resolved external-dependency pins; `buf dep update` can change imported
   #     descriptors and options with no local `.proto` edit at all.
-  # Editing any one of them alone can strand or orphan generated output, so each needs its own
-  # `globs` entry. Refs: https://buf.build/docs/configuration/v2/buf-yaml/,
+  # Refs: https://buf.build/docs/configuration/v2/buf-yaml/,
   # https://buf.build/docs/configuration/v1/buf-work-yaml/, and
-  # https://buf.build/docs/configuration/v2/buf-lock/. The gate's
+  # https://buf.build/docs/configuration/v2/buf-lock/.
+  # A consuming repo must extend the list with its own generation inputs, which no example can
+  # enumerate for it. The common case is a `local:` plugin built from sources in this repo — buf
+  # documents `local` as a binary or command array, e.g. `local: ["go", "run", "./tools/pgen"]` —
+  # whose `*.go` sources change the generated output while matching none of the globs below. Add a
+  # pathspec for each such generator (`tools/pgen/**`), plus any template, options file, or
+  # environment input the repo's own plugins read.
+  # Ref: https://buf.build/docs/configuration/v2/buf-gen-yaml/. The gate's
   # `trigger-globs` below also lists the plugins' own generated-output patterns (`*.pb.go`,
   # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would
   # produce still fires this gate — unlike the buf inputs above, they need no separate `globs`

--- a/docs/conventions/ecosystem-commands/examples/go.yaml
+++ b/docs/conventions/ecosystem-commands/examples/go.yaml
@@ -23,29 +23,38 @@ gates:
   # `*.proto`/`buf.gen.yaml` are added to this file's own `globs` above (not just this gate's
   # `trigger-globs`) per the 1.1.1 reachability rule — trigger-globs alone never selects an
   # ecosystem under auto-targeting, so without that `globs` entry a change touching only `.proto`
-  # files would never reach this gate outside `/toolchain:check go` or `check all`.
+  # files would never reach this gate outside `/toolchain:check go` or `check all`. The gate's
+  # `trigger-globs` below also lists the plugins' own generated-output patterns (`*.pb.go`,
+  # `*.pb.gw.go`), so a hand-edit that drifts a generated file from what `buf generate` would
+  # produce still fires this gate — unlike `*.proto`/`buf.gen.yaml`, they need no separate `globs`
+  # entry: both already end in `.go`, so the ecosystem's own `*.go` glob already selects them.
   # Every part of the `cmd` closes one way stale generated code slips past a naive freshness check —
   # a bare `buf generate && git diff --exit-code` false-passes all three:
   #   1. Staged regeneration. `git diff` with no commit argument compares the working tree to the
   #      *index*, so output the consumer already staged reports clean. `git diff HEAD` compares the
   #      worktree AND the index against the last commit.
-  #   2. Newly generated output. `git diff` never reports untracked paths, so the `.pb.go` for a
-  #      brand-new `.proto` false-passes either diff form. `git ls-files --others --exclude-standard`
+  #   2. Newly generated output. `git diff` never reports untracked paths, so a brand-new `.proto`'s
+  #      generated output false-passes either diff form. `git ls-files --others --exclude-standard`
   #      catches it, honoring .gitignore so a repo that deliberately ignores generated code passes.
   #   3. Orphaned output. When a `.proto` is deleted or renamed, generation writes nothing over the
-  #      now-sourceless `.pb.go`, so both git checks pass a file that should no longer exist. The
+  #      now-sourceless output, so both git checks pass a file that should no longer exist. The
   #      `clean` field in buf.gen.yaml "defaults to false", and `--clean` deletes "the directories,
   #      jar files, or zip files that the plugins will write to" before generating, so the orphan
   #      surfaces as a deletion `git diff HEAD` reports. Passing the flag keeps the gate correct
   #      regardless of the consumer's buf.gen.yaml. Refs:
   #      https://buf.build/docs/reference/cli/buf/generate/ and
   #      https://buf.build/docs/configuration/v2/buf-gen-yaml/
+  # The pathspec after `--` must cover every plugin buf.gen.yaml configures, not just protoc-gen-go's
+  # `*.pb.go` — a repo that also runs grpc-gateway writes `*.pb.gw.go`, and every other configured
+  # plugin writes its own extension again, so scoping to one plugin's output would leave --clean's
+  # deletion of the others undetected. This example covers `*.pb.go` and grpc-gateway's `*.pb.gw.go`;
+  # add one pathspec per additional plugin this repo's buf.gen.yaml configures.
   # The two git checks leave the index untouched — `git add --intent-to-add` would fold case 2 into
   # the diff, but it leaves index residue in the consumer's worktree. Neither prints filenames on
   # failure, so the `remediation` (which the gate reports on FAIL) names the listing command.
   - name: proto-gen-freshness
-    cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go')\""
-    trigger-globs: ["*.proto", "buf.gen.yaml"]
+    cmd: "buf generate --clean && git diff HEAD --exit-code -- '*.pb.go' '*.pb.gw.go' && test -z \"$(git ls-files --others --exclude-standard -- '*.pb.go' '*.pb.gw.go')\""
+    trigger-globs: ["*.proto", "buf.gen.yaml", "*.pb.go", "*.pb.gw.go"]
     run-from: repo-root
-    remediation: "Run buf generate --clean from the repo root, then commit every resulting change to *.pb.go — modified, newly generated, and deleted (a .pb.go whose .proto is gone). `git status --short -- '*.pb.go'` lists all three."
+    remediation: "Run buf generate --clean from the repo root, then commit every resulting change to every buf.gen.yaml-configured plugin's output (this example's *.pb.go and grpc-gateway's *.pb.gw.go — extend to match this repo's plugins) — modified, newly generated, and deleted (an output whose .proto is gone). `git status --short -- '*.pb.go' '*.pb.gw.go'` lists all three (extend the same way)."
 notes: "govulncheck is intentionally not a rung-4 default (per the epic brief's \"optional\" framing) — add it as a consumer-local gate via .claude/ecosystems/go.local.yaml if desired."

--- a/plugins/toolchain/.claude-plugin/plugin.json
+++ b/plugins/toolchain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "toolchain",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Repo-agnostic polyglot verification toolchain: build + test + lint for changed files across .NET, Python, TypeScript, Bash, PowerShell, Markdown, Go, YAML, and cross-cutting surfaces (`/toolchain:check`, `/toolchain:lint`), plus a re-runnable `/toolchain:setup` with check (report the configured ecosystems and their command surface) and apply (interview, infer, and write the tracked per-ecosystem command config those skills resolve first).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/toolchain/CHANGELOG.md
+++ b/plugins/toolchain/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `toolchain` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.1]
+
+### Changed
+
+- **`/toolchain:check` report-results template now illustrates the aggregated multi-root gate
+  failure format.** §3's `## Build Results` example previously showed only a single-invocation
+  `Gates:` line; §2's "Outcome" bullet already stated the aggregation rule in prose (one line per
+  gate name, `FAIL` if any invocation failed, each failing invocation's output shown below labeled
+  by its execution root) but had no worked anchor. Added a second illustrative block showing that
+  shape, with the `Gates:` paragraph now citing §2 "Outcome" by name. Docs-only, no runtime behavior
+  change. Follows the ecosystem-commands convention bump to 1.2.1, which adds the companion worked
+  `run-from: repo-root` example (`proto-gen-freshness` in `examples/go.yaml`). Closes #1462,
+  deferred from #1460's review (itself closing #1361).
+
 ## [0.11.0]
 
 ### Added

--- a/plugins/toolchain/skills/check/SKILL.md
+++ b/plugins/toolchain/skills/check/SKILL.md
@@ -154,6 +154,16 @@ Use `pass`, `FAIL`, `skip` (tool missing), `skip (opt-in unmet: ...)` (config co
 
 If any CI-parity gates fired, summarize each by name + outcome below the per-ecosystem block, with the remediation pointer on failure. A fired gate that failed flips Overall to `FAIL` and is counted in it — including when every ecosystem's build/test/lint cell passed (e.g. `Overall: FAIL (0 of 2 ecosystems failed, 1 gate failed)`). The Overall line names both counts whenever a gate fires, pass or fail — a fired-and-passed gate still reports its count (e.g. `Overall: PASS (2 of 2 ecosystems passed, 1 gate passed)`), so the report is unambiguous about whether a gate ran.
 
+A gate declared under a `project-discovery` ecosystem without `run-from: repo-root` runs once per discovered project root (§2 "Run"); per the aggregation rule (§2 "Outcome"), that still reports **one** `Gates:` line per gate name, with each failing root's output shown underneath, labeled by its execution root:
+
+```text
+Gates: go-mod-tidy-drift — FAIL (run go mod tidy and commit the updated go.mod/go.sum)
+  [services/auth] go: updates to go.sum needed, disabled by -mod=readonly
+  [services/billing] go.mod: missing go.sum entry for module golang.org/x/text v0.14.0
+```
+
+Only the roots that actually failed are listed — a root whose invocation passed contributes nothing below the line. A gate declaring `run-from: repo-root` never produces this per-root breakdown (it runs exactly once), so its `FAIL` line stands alone as in the first example above.
+
 ## For other skills referencing /toolchain:check
 
 When composing `/toolchain:check` from another skill (like `/verification:confirm` or `/toolchain:lint`):


### PR DESCRIPTION
Closes #1462
Closes #1516

## Summary

Two documentation-depth findings deferred from PR #1460's review (which added `gates[].run-from` to
the `ecosystem-commands` schema, closing #1361):

- **`examples/go.yaml` gains a worked `run-from: repo-root` example.** A clearly-commented
  `proto-gen-freshness` gate demonstrates the shape — no bundled default or example repo currently
  *needs* this gate for real (per the ecosystem-commands CHANGELOG 1.2.0 entry and #1361's own
  Trigger: "revisit when a consumer needs a repo-wide gate ... or when a bundled default wants
  one"), so it is documentation, not a functioning gate. Its `trigger-globs` (`*.proto`,
  `buf.gen.yaml`) are also added to the file's own `globs` — per the 1.1.1 reachability rule
  (`trigger-globs` alone never selects an ecosystem under auto-targeting; PR #1458), a worked
  example that omitted this would ship the exact footgun that PR ratified.
- **`toolchain:check`'s `SKILL.md` report-results template now illustrates the aggregated
  multi-root gate failure format.** §2's "Outcome" bullet already states the rule in prose (a gate
  that runs once per discovered project root reports **one** `Gates:` line per gate name, `FAIL` if
  any invocation failed, with each failing invocation's output shown below labeled by its execution
  root) but §3's worked example previously showed only a single-invocation gate line. Added a second
  illustrative block showing the per-root breakdown, with a citation back to §2 "Outcome".
- **The `proto-gen-freshness` gate's `cmd` no longer destroys uncommitted generated-file edits**
  (#1516). The original three-check post-hoc form (`buf generate --clean` then `git diff HEAD` +
  `git diff --cached` + `git ls-files --others`) reported PASS on an unstaged hand-edit to tracked
  generated output while `--clean` silently deleted the edit before any diff could observe it.
  Commit c9c1c8e5 replaced it with a two-check bracket: a pre-generation
  `git status --porcelain -uno` guard that refuses to generate over uncommitted tracked output (so
  nothing is destroyed, closing the staged half too), and a post-generation
  `git status --porcelain` assertion that reports modified/untracked/deleted output in one command.
  The comment block's prior claim that this was an unavoidable property of every regenerate-and-diff
  gate is corrected — it's a property of *post-hoc-only* inspection; a pre-generation guard escapes it.

**Deliberate deviation from the issue's suggested format:** #1462 sketched an inline label
(`FAIL [/services/auth]: ...`). This PR ships one aggregated `Gates:` line followed by indented,
root-labeled lines underneath instead — that matches the shipped prose ("show each failing
invocation's output **below the table** labeled by its execution root") where the inline form
doesn't.

Bumps the `ecosystem-commands` convention to 1.2.1 and the `toolchain` plugin to 0.11.1, with
matching `CHANGELOG.md` entries in both (docs-only; no schema shape or runtime behavior change).

## Test plan

- `check-jsonschema --schemafile ecosystem.schema.json` against every worked example
  (`docs/conventions/ecosystem-commands/examples/*.yaml`) and every bundled default
  (`plugins/toolchain/reference/ecosystems/*.yaml`) — all still validate, including the new
  `proto-gen-freshness` gate.
- `jq empty` on `plugins/toolchain/.claude-plugin/plugin.json` — valid.
- `npx markdownlint-cli2` on the three changed Markdown files — 0 issues.
- `skill-quality:check`'s `check-skill.sh` against the modified `toolchain:check` skill — PASS, 0
  errors (1 pre-existing warning unrelated to this change: no `Use when:` phrasing in the
  frontmatter description).
- Manual re-read of the new `proto-gen-freshness` example against the `run-from` schema
  description and the README's "Gate execution scope" section — the example's `globs` now include
  its own `trigger-globs` (`*.proto`, `buf.gen.yaml`), confirming the gate is actually reachable
  under auto-targeting rather than only via `/toolchain:check go`/`check all`.
- For #1516: executed the literal `cmd` string with a real shell against a real git repo with a
  stub `buf` on `PATH`. Old post-hoc-only form: clean-tree PASS, unstaged hand-edit PASS+DESTROYED.
  New bracketed form: clean-tree PASS(0), unstaged hand-edit refused(1)+SURVIVED, staged hand-edit
  refused(1)+SURVIVED, nested-directory generated file (`gen/nested/deep/bar.pb.go`) caught by the
  `-uno` pre-check (pathspec `*` matches `/`, confirming depth is not a shell-globbing limitation).

## Related

Refs #1460 — the PR whose review deferred both findings this PR resolves
Refs #1361 — the original `run-from` decision issue #1460 closed
Closes #1516 — the proto-gen-freshness destructive-gate follow-up, fixed by commit c9c1c8e5 already
on this branch (originally landed addressing a Codex review thread on this PR); re-verified
independently per the Test plan entry above.

*This was generated by AI during work-loop execution.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
