### PR TITLE
fix(skill-quality): drop the duplicate version member from plugin.json

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.11.0",
   "version": "0.12.0",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-one deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema for validation. Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {


### PR DESCRIPTION
## Summary

`plugins/skill-quality/.claude-plugin/plugin.json` carried **two** `version` members on `main`:

```text
4:  "version": "0.11.0",
5:  "version": "0.12.0",
```

The advertised release was therefore parser-dependent — last-wins readers (`jq`, Python `json.load`) resolve `0.12.0`, first-wins readers retain `0.11.0`, and duplicate-rejecting consumers can reject the manifest outright. Any of those can misidentify or block a plugin update.

**Why `0.12.0` is correct.** `main` carried `0.11.0` before #1096, released in #1450, and this plugin's CHANGELOG has `## [0.12.0]` above main's `## [0.11.0]`. The `0.11.0` member is the stale one, and it is what this PR deletes.

**Scope.** One file, one deletion. Nothing else in the manifest and nothing else in the repo.

**How it happened.** Introduced while resolving a `main` merge in #1096. Both sides of that conflict carried `"version": "0.11.0"` — main had released 0.11.0 in #1450 and the branch also claimed 0.11.0 — so git treated the version line as **common context outside** the conflict region and placed only the differing `description` inside it. A scripted replacement of the conflict region then emitted a fresh `version` + `description` pair above the surviving common-context one.

## Test plan

A duplicate-key-aware parse is the only check that observes this, and it is clean after the change:

```console
$ python -c "... json.load(..., object_pairs_hook=<duplicate detector>) ..."
duplicate keys: NONE
version: 0.12.0
```

Also confirmed:

- `git diff --stat` is exactly `1 file changed, 1 deletion(-)`.
- The CHANGELOG's top section is still `## [0.12.0]`, so the manifest and the release notes agree.
- `changelog-parity-gate` and `plugin-gate` pass in CI on this branch.

Worth flagging for reviewers: `json.load`, `jq`, and JSON Schema validation all resolve duplicate keys last-wins, so every one of them reports `0.12.0` whether or not the duplicate is present. That is why this defect passed a fully green 27-context suite on #1096, and it is why the fix is verified with a duplicate-key hook rather than a plain parse.

## Related

- #1096 — the PR whose merge-conflict resolution introduced the duplicate member.
- #1450 — released skill-quality `0.11.0` on `main`, the collision that produced the conflict shape.
- #1498 — follow-up covering the gate gap: no CI check detects a duplicate key in a plugin manifest
  (verified: schema validation cannot express key uniqueness, and every consumer resolves last-wins).
- #1493 — follow-up narrowing what check 21 claims to parse.

Closes #1492
