### PR TITLE
ci(hygiene): detect a duplicate key in a plugin/marketplace manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,14 @@ jobs:
   # churn.
   # Docs-linting lane. Markdownlint / typos / editorconfig / gitleaks /
   # eol-renormalize / comment-hygiene / machine-specific-paths read the changed
-  # docs themselves and run on every diff. actionlint and the four
-  # check-jsonschema steps read fixed, path-scoped inputs (.github/workflows/**
-  # and the named manifests) that a diff confined to the docs-only allowlist
-  # (scripts/docs-only-paths.txt) cannot touch, so on such a diff they report an
-  # honest evaluated-and-not-applicable success. ShellCheck and exec-bit are NOT
+  # docs themselves and run on every diff. actionlint, the four
+  # check-jsonschema steps, and the manifest duplicate-key detector (which
+  # reads the exact same manifest files as the schema steps, just via
+  # object_pairs_hook instead of a schema — see #1498) read fixed, path-scoped
+  # inputs (.github/workflows/** and the named manifests) that a diff confined
+  # to the docs-only allowlist (scripts/docs-only-paths.txt) cannot touch, so
+  # on such a diff they report an honest evaluated-and-not-applicable success.
+  # ShellCheck and exec-bit are NOT
   # gated: both scan the whole repo extension- and directory-agnostically
   # (ShellCheck lints every tracked *.sh/*.bash, exec-bit flags every tracked
   # shebang file recorded 100644), so a shell/shebang file added under an
@@ -122,6 +125,23 @@ jobs:
         with:
           schemafile: https://json.schemastore.org/claude-code-plugin-manifest.json
           files: plugins/*/.claude-plugin/plugin.json
+
+      # JSON Schema validates the ALREADY-PARSED document, so it structurally
+      # cannot see a duplicate object key -- by the time a schema runs, the
+      # earlier member is already gone (every JSON parser resolves a repeated
+      # key last-wins). #1492 shipped plugins/skill-quality/.claude-plugin/
+      # plugin.json with two "version" members through this exact schema step
+      # green. scripts/check-manifest-duplicate-keys.py reads the raw
+      # key/value pairs via object_pairs_hook, BEFORE that collapse, so it
+      # catches what the schema step next to it cannot. See #1498.
+      - name: Test the manifest duplicate-key detector
+        run: bash scripts/check-manifest-duplicate-keys.test.sh
+      - name: Detect duplicate keys in plugin/marketplace manifests
+        id: duplicate_keys
+        if: steps.scope.outputs.docs_only != 'true'
+        continue-on-error: true
+        run: python3 scripts/check-manifest-duplicate-keys.py
+
       - name: Validate dependabot.yml
         id: dependabot_schema
         if: steps.scope.outputs.docs_only != 'true'
@@ -190,7 +210,7 @@ jobs:
 
       - name: Report docs-irrelevant checks not applicable to a docs-only diff
         if: steps.scope.outputs.docs_only == 'true'
-        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the path-scoped linters (actionlint, check-jsonschema x4) cannot be affected — reporting success for them. ShellCheck and exec-bit scan the whole repo and stay unconditional."
+        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the path-scoped linters (actionlint, check-jsonschema x4, the manifest duplicate-key detector) cannot be affected — reporting success for them. ShellCheck and exec-bit scan the whole repo and stay unconditional."
 
       - name: Test hygiene result aggregation
         run: scripts/aggregate-hygiene-results.sh --self-test
@@ -217,6 +237,7 @@ jobs:
             actionlint=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.actionlint.outcome }}
             marketplace-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.marketplace_schema.outcome }}
             plugin-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.plugin_schema.outcome }}
+            manifest-duplicate-keys=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.duplicate_keys.outcome }}
             dependabot-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.dependabot_schema.outcome }}
             workflow-schema=${{ steps.scope.outputs.docs_only == 'true' && 'success' || steps.workflow_schema.outcome }}
             exec-bit=${{ steps.exec_bit.outcome }}

--- a/scripts/check-manifest-duplicate-keys.py
+++ b/scripts/check-manifest-duplicate-keys.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Detect a duplicate JSON object key in a plugin or marketplace manifest.
+
+#1492 shipped a manifest with two `"version"` members through a fully green
+27-context CI suite. Nothing in the pipeline could have caught it:
+
+  * JSON Schema (`check-jsonschema` against the plugin-manifest / marketplace
+    schemas, the hygiene job's "Validate plugin manifests" / "Validate
+    marketplace manifest" steps) validates the ALREADY-PARSED document — by
+    the time a schema sees it, the duplicate is gone. JSON Schema has no
+    vocabulary for "this key must not repeat," because a parsed JSON object
+    is a mapping, and a mapping cannot represent a repeated key in the first
+    place.
+  * Standard JSON parsers resolve a duplicate key silently, last-wins.
+    ECMA-404 leaves the behavior for a repeated name unspecified, and every
+    mainstream implementation (Python's `json`, Node's `JSON.parse`, `jq`)
+    converges on last-wins. `scripts/validate-plugins.sh`,
+    `scripts/validate-plugin-contracts.mjs`, `scripts/generate-catalog.mjs`,
+    and `scripts/check-changelog-parity.sh` (`jq -r '.version'`) all read the
+    manifest this way, so every one of them reports the same last-wins value
+    whether or not a duplicate is present.
+
+So catching this needs the raw key/value pairs as the parser encounters them,
+BEFORE the de-duplicating collapse into a dict. Python's stdlib exposes
+exactly that seam: `json.loads(text, object_pairs_hook=...)` calls the hook
+once per JSON object literal with the pairs in file order, innermost object
+first. Intercepting there sees a duplicate at ANY nesting depth (top-level
+`"version"`, or a repeated key buried inside `userConfig`, etc.), not only the
+top level a hand-rolled line scanner would have to special-case.
+
+See issue #1498. Scope: `plugins/*/.claude-plugin/plugin.json` and
+`.claude-plugin/marketplace.json` (the same file set `check-jsonschema`
+already validates in the hygiene job) by default; explicit file arguments
+override the default set for testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Same file set the hygiene job's schema-validation steps already cover
+# ("Validate plugin manifests" / "Validate marketplace manifest" in
+# .github/workflows/ci.yml) — glob patterns resolved against REPO_ROOT so the
+# default scope is correct regardless of the caller's cwd.
+DEFAULT_GLOBS = (
+    "plugins/*/.claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+)
+
+
+class _DuplicateKeyCollector:
+    """`object_pairs_hook` that records duplicate keys without breaking the parse.
+
+    Called once per JSON object literal, innermost first, with that object's
+    raw ``(key, value)`` pairs in file order — before any dict collapses them.
+    A key seen more than once at THIS level is recorded (each name once, in
+    first-seen order) and the pairs are still folded into a normal dict
+    (last-wins, the same resolution every other consumer in the pipeline
+    applies) so parsing completes and outer objects keep working. Recording
+    rather than raising lets one pass report every duplicate in a file
+    instead of stopping at the first.
+    """
+
+    def __init__(self) -> None:
+        self.duplicates: list[str] = []
+
+    def __call__(self, pairs: list[tuple[str, object]]) -> dict[str, object]:
+        counts: dict[str, int] = {}
+        first_seen: list[str] = []
+        for key, _value in pairs:
+            if key in counts:
+                counts[key] += 1
+            else:
+                counts[key] = 1
+                first_seen.append(key)
+        for key in first_seen:
+            if counts[key] > 1 and key not in self.duplicates:
+                self.duplicates.append(key)
+        return dict(pairs)
+
+
+def find_duplicate_keys(text: str) -> list[str]:
+    """Return every key name that repeats within a single JSON object in
+    ``text``, at any nesting depth, in first-encountered order.
+
+    Raises ``json.JSONDecodeError`` on malformed JSON — that failure belongs
+    to the schema-validation step, not this gate, so callers should let a
+    parse error surface separately rather than reporting it as a duplicate.
+    """
+    collector = _DuplicateKeyCollector()
+    json.loads(text, object_pairs_hook=collector)
+    return collector.duplicates
+
+
+def discover_default_files() -> list[Path]:
+    paths: list[Path] = []
+    for pattern in DEFAULT_GLOBS:
+        for match in sorted(REPO_ROOT.glob(pattern)):
+            if match.is_file() and match not in paths:
+                paths.append(match)
+    return paths
+
+
+def _display(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help=(
+            "manifest files to check (default: every plugins/*/.claude-plugin/"
+            "plugin.json plus .claude-plugin/marketplace.json)"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    paths = [Path(f) for f in args.files] if args.files else discover_default_files()
+    if not paths:
+        print(
+            "error: no manifest files found to check "
+            f"(looked for {', '.join(DEFAULT_GLOBS)} under {REPO_ROOT})",
+            file=sys.stderr,
+        )
+        return 2
+
+    failed = False
+    for path in paths:
+        if not path.is_file():
+            print(f"error: {path} does not exist or is not a file", file=sys.stderr)
+            failed = True
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"error: could not read {_display(path)}: {exc}", file=sys.stderr)
+            failed = True
+            continue
+        try:
+            duplicates = find_duplicate_keys(text)
+        except json.JSONDecodeError:
+            # Malformed JSON is the schema-validation step's failure to
+            # report, not this gate's -- do not double-report it here.
+            continue
+        if duplicates:
+            failed = True
+            keys = ", ".join(repr(key) for key in duplicates)
+            plural = "s" if len(duplicates) != 1 else ""
+            print(
+                f"DUPLICATE KEY{plural}: {_display(path)} defines {keys} more "
+                "than once in the same JSON object. JSON Schema validation "
+                "cannot see this (it runs on the already-parsed document) and "
+                "every consumer in this pipeline (json.load / JSON.parse / jq) "
+                "silently keeps only the LAST value -- remove the earlier "
+                "member(s) instead of keeping both.",
+                file=sys.stderr,
+            )
+
+    if failed:
+        return 1
+    print(f"No duplicate JSON object keys found in {len(paths)} manifest file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-manifest-duplicate-keys.py
+++ b/scripts/check-manifest-duplicate-keys.py
@@ -41,6 +41,16 @@ import json
 import sys
 from pathlib import Path
 
+# `object_pairs_hook` itself has no meaningful version floor (it has existed
+# since Python 2.7), but this file's own syntax does: `from __future__ import
+# annotations` above requires 3.7+ (PEP 563) and fails as a SyntaxError at
+# PARSE time on an older interpreter -- before any runtime check in this file
+# could ever run. The sibling check-manifest-duplicate-keys.test.sh therefore
+# parses this tuple via a plain text match (never by executing this file) to
+# pick a qualifying interpreter BEFORE invoking it, rather than accepting the
+# first `python`/`python3` it finds and hard-failing on an old one.
+MIN_PYTHON = (3, 7)
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Same file set the hygiene job's schema-validation steps already cover

--- a/scripts/check-manifest-duplicate-keys.test.sh
+++ b/scripts/check-manifest-duplicate-keys.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Cross-platform contract wrapper for the manifest duplicate-key detector's
+# test suite. object_pairs_hook has no meaningful Python-version floor (it has
+# existed since Python 2.7), so unlike the disk-hygiene probes this needs no
+# MIN_PYTHON check -- only a real interpreter, not the Windows Store's App
+# Execution Alias stub.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# A zero-length candidate under a WindowsApps path component is the Store's
+# App Execution Alias stub -- executing it opens the Microsoft Store (or
+# hangs) instead of running an interpreter, so each candidate is inspected
+# before anything executes it.
+PYTHON=""
+for candidate in python3 python; do
+  resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+  lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$lower" == *windowsapps* && ! -s "$resolved" ]]; then
+    continue
+  fi
+  PYTHON="$candidate"
+  break
+done
+if [[ -z "$PYTHON" ]]; then
+  echo "SKIP: no usable Python interpreter found" >&2
+  exit 0
+fi
+
+# Execute the test file directly (its unittest.main() guard) rather than via
+# `-m unittest <abs path>`, which resolves the path as a module name relative
+# to the caller's cwd and breaks when invoked from outside the checkout.
+"$PYTHON" "$SCRIPT_DIR/test_check_manifest_duplicate_keys.py" -v

--- a/scripts/check-manifest-duplicate-keys.test.sh
+++ b/scripts/check-manifest-duplicate-keys.test.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
 # Cross-platform contract wrapper for the manifest duplicate-key detector's
-# test suite. object_pairs_hook has no meaningful Python-version floor (it has
-# existed since Python 2.7), so unlike the disk-hygiene probes this needs no
-# MIN_PYTHON check -- only a real interpreter, not the Windows Store's App
-# Execution Alias stub.
+# test suite.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# The Python floor has one origin: MIN_PYTHON in the detector itself (needed
+# because `from __future__ import annotations` requires 3.7+). Parse it
+# rather than restating the number here, same convention as
+# plugins/disk-hygiene/skills/setup/scripts/kill_switch_probe.test.sh.
+ENGINE="$SCRIPT_DIR/check-manifest-duplicate-keys.py"
+FLOOR="$(sed -n 's/^MIN_PYTHON = (\([0-9]*\), \([0-9]*\)).*/\1.\2/p' "$ENGINE")"
+if [[ -z "$FLOOR" ]]; then
+  echo "FAIL: could not parse MIN_PYTHON from $ENGINE" >&2
+  exit 1
+fi
+
 # A zero-length candidate under a WindowsApps path component is the Store's
 # App Execution Alias stub -- executing it opens the Microsoft Store (or
 # hangs) instead of running an interpreter, so each candidate is inspected
-# before anything executes it.
+# before anything executes it. A candidate that is real but below the floor
+# does not end the search: the next candidate may satisfy it (e.g. an old
+# `python` alongside a current `python3`).
 PYTHON=""
 for candidate in python3 python; do
   resolved="$(command -v "$candidate" 2>/dev/null)" || continue
@@ -19,11 +29,13 @@ for candidate in python3 python; do
   if [[ "$lower" == *windowsapps* && ! -s "$resolved" ]]; then
     continue
   fi
-  PYTHON="$candidate"
-  break
+  if "$candidate" -c "import sys; floor = tuple(int(part) for part in '$FLOOR'.split('.')); raise SystemExit(0 if sys.version_info >= floor else 1)"; then
+    PYTHON="$candidate"
+    break
+  fi
 done
 if [[ -z "$PYTHON" ]]; then
-  echo "SKIP: no usable Python interpreter found" >&2
+  echo "SKIP: Python ${FLOOR}+ not found" >&2
   exit 0
 fi
 

--- a/scripts/test_check_manifest_duplicate_keys.py
+++ b/scripts/test_check_manifest_duplicate_keys.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the manifest duplicate-key detector (issue #1498).
+
+#1492 shipped `plugins/skill-quality/.claude-plugin/plugin.json` with two
+`"version"` members through a fully green CI suite — JSON Schema validation
+and every standard JSON parser resolve a duplicate key last-wins and never
+see the conflict. These tests prove the new detector actually sees it: the
+central fixture in `test_catches_the_1492_shaped_duplicate_version_key`
+reproduces that exact shape (two top-level `"version"` members) and asserts
+the gate fails on it, byte for byte the manifest #1492 shipped.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_DIR / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+detector = load_module(
+    "check_manifest_duplicate_keys", "check-manifest-duplicate-keys.py"
+)
+
+
+class FindDuplicateKeysTests(unittest.TestCase):
+    """Unit-level coverage of the object_pairs_hook detector itself."""
+
+    def test_no_duplicates_returns_empty(self) -> None:
+        text = json.dumps({"name": "x", "version": "1.0.0", "description": "d"})
+        self.assertEqual([], detector.find_duplicate_keys(text))
+
+    def test_top_level_duplicate_key_detected(self) -> None:
+        # The actual #1492 shape: two "version" members at the top level.
+        text = '{"name": "skill-quality", "version": "0.11.0", "version": "0.12.0"}'
+        self.assertEqual(["version"], detector.find_duplicate_keys(text))
+
+    def test_last_value_wins_same_as_every_other_consumer(self) -> None:
+        # The detector must not crash or reject the document -- it reports
+        # the conflict AND still resolves last-wins internally, exactly like
+        # json.load, JSON.parse, and jq do, so its own read of "the version"
+        # (if it ever needed one) would never disagree with theirs.
+        collector = detector._DuplicateKeyCollector()
+        result = json.loads(
+            '{"version": "0.11.0", "version": "0.12.0"}',
+            object_pairs_hook=collector,
+        )
+        self.assertEqual("0.12.0", result["version"])
+        self.assertEqual(["version"], collector.duplicates)
+
+    def test_nested_duplicate_key_detected(self) -> None:
+        # A repeated key inside a nested object (e.g. userConfig) is not the
+        # top-level case #1492 was, but the same defect class, and
+        # object_pairs_hook is called once per object at every depth.
+        text = '{"name": "x", "userConfig": {"scope": "a", "scope": "b"}}'
+        self.assertEqual(["scope"], detector.find_duplicate_keys(text))
+
+    def test_duplicate_only_flagged_within_same_object(self) -> None:
+        # The same key name in TWO SIBLING objects (not the same object) is
+        # not a duplicate -- duplication is scoped to one JSON object
+        # literal, matching what "last-wins" actually means.
+        text = json.dumps(
+            {"a": {"name": "inner-a"}, "b": {"name": "inner-b"}, "name": "outer"}
+        )
+        self.assertEqual([], detector.find_duplicate_keys(text))
+
+    def test_multiple_distinct_duplicate_keys_all_reported(self) -> None:
+        text = '{"version": "1.0.0", "version": "2.0.0", "name": "x", "name": "y"}'
+        self.assertEqual(["version", "name"], detector.find_duplicate_keys(text))
+
+    def test_repeated_more_than_twice_reported_once(self) -> None:
+        text = '{"version": "1.0.0", "version": "2.0.0", "version": "3.0.0"}'
+        self.assertEqual(["version"], detector.find_duplicate_keys(text))
+
+    def test_malformed_json_raises_decode_error_not_swallowed(self) -> None:
+        with self.assertRaises(json.JSONDecodeError):
+            detector.find_duplicate_keys("{not json")
+
+
+class CliTests(unittest.TestCase):
+    """End-to-end coverage of main(): the shape the hygiene CI step invokes."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmp_path = Path(self.tmp.name)
+
+    def write(self, relpath: str, text: str) -> Path:
+        path = self.tmp_path / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def run_cli(self, argv: list[str]) -> tuple[int, str, str]:
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            code = detector.main(argv)
+        return code, stdout.getvalue(), stderr.getvalue()
+
+    def test_catches_the_1492_shaped_duplicate_version_key(self) -> None:
+        # Fixture reproducing #1492's actual defect: two "version" members in
+        # a plugin.json. This is the fixture the issue asked for: a real
+        # duplicate key the gate must catch.
+        manifest = self.write(
+            "plugin.json",
+            '{\n'
+            '  "name": "skill-quality",\n'
+            '  "version": "0.11.0",\n'
+            '  "description": "Skill authoring QA.",\n'
+            '  "version": "0.12.0"\n'
+            '}\n',
+        )
+        code, _out, err = self.run_cli([str(manifest)])
+        self.assertEqual(1, code)
+        self.assertIn("DUPLICATE KEY", err)
+        self.assertIn("'version'", err)
+        self.assertIn(str(manifest), err)
+
+    def test_well_formed_manifest_passes(self) -> None:
+        manifest = self.write(
+            "plugin.json",
+            json.dumps({"name": "x", "version": "1.0.0"}),
+        )
+        code, out, err = self.run_cli([str(manifest)])
+        self.assertEqual(0, code)
+        self.assertIn("No duplicate", out)
+        self.assertEqual("", err)
+
+    def test_multiple_files_one_bad_one_good_fails_overall(self) -> None:
+        good = self.write("good.json", json.dumps({"name": "ok"}))
+        bad = self.write(
+            "bad.json", '{"name": "x", "name": "y"}'
+        )
+        code, _out, err = self.run_cli([str(good), str(bad)])
+        self.assertEqual(1, code)
+        self.assertIn(str(bad), err)
+        self.assertNotIn(str(good), err)
+
+    def test_missing_file_fails_with_error(self) -> None:
+        code, _out, err = self.run_cli([str(self.tmp_path / "absent.json")])
+        self.assertEqual(1, code)
+        self.assertIn("does not exist", err)
+
+    def test_malformed_json_does_not_double_report(self) -> None:
+        # A parse failure is the schema-validation step's job to report, not
+        # this gate's -- it must not also fail (or crash) on unparsable input.
+        manifest = self.write("plugin.json", "{not json")
+        code, out, err = self.run_cli([str(manifest)])
+        self.assertEqual(0, code)
+        self.assertEqual("", err)
+        self.assertIn("No duplicate", out)
+
+    def test_no_files_and_no_default_matches_errors_with_exit_2(self) -> None:
+        with mock.patch.object(detector, "REPO_ROOT", self.tmp_path):
+            code, _out, err = self.run_cli([])
+        self.assertEqual(2, code)
+        self.assertIn("no manifest files found", err)
+
+    def test_default_discovery_covers_plugin_and_marketplace_manifests(self) -> None:
+        self.write(
+            "plugins/alpha/.claude-plugin/plugin.json",
+            json.dumps({"name": "alpha", "version": "1.0.0"}),
+        )
+        self.write(
+            "plugins/beta/.claude-plugin/plugin.json",
+            '{"name": "beta", "version": "1.0.0", "version": "1.0.1"}',
+        )
+        self.write(
+            ".claude-plugin/marketplace.json",
+            '{"name": "marketplace", "name": "dup"}',
+        )
+        with mock.patch.object(detector, "REPO_ROOT", self.tmp_path):
+            code, _out, err = self.run_cli([])
+        self.assertEqual(1, code)
+        self.assertIn("beta", err)
+        self.assertIn("marketplace.json", err)
+        self.assertNotIn(
+            str(self.tmp_path / "plugins/alpha/.claude-plugin/plugin.json"), err
+        )
+
+    def test_default_discovery_all_clean_passes(self) -> None:
+        self.write(
+            "plugins/alpha/.claude-plugin/plugin.json",
+            json.dumps({"name": "alpha", "version": "1.0.0"}),
+        )
+        self.write(
+            ".claude-plugin/marketplace.json",
+            json.dumps({"name": "marketplace"}),
+        )
+        with mock.patch.object(detector, "REPO_ROOT", self.tmp_path):
+            code, out, err = self.run_cli([])
+        self.assertEqual(0, code)
+        self.assertEqual("", err)
+        self.assertIn("2 manifest file(s)", out)
+
+    def test_output_reports_every_distinct_duplicate_key_in_one_message(self) -> None:
+        manifest = self.write(
+            "plugin.json",
+            '{"version": "1.0.0", "version": "2.0.0", "name": "x", "name": "y"}',
+        )
+        code, _out, err = self.run_cli([str(manifest)])
+        self.assertEqual(1, code)
+        self.assertIn("'version'", err)
+        self.assertIn("'name'", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1498

## Summary

*This was generated by AI during work-loop execution.*

No gate in CI could detect a duplicate key in a plugin/marketplace manifest. JSON Schema validates the already-parsed document (structurally blind to a repeated member), and every consumer downstream resolves it last-wins with no signal — the exact shape that shipped `plugins/skill-quality/.claude-plugin/plugin.json` with two `"version"` members through a fully green 27-context suite (#1492).

## Fix

Added `scripts/check-manifest-duplicate-keys.py`: reads each `plugins/*/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` via `json.loads(text, object_pairs_hook=...)`, intercepting the raw key/value pairs of every JSON object literal (at any nesting depth) *before* the standard de-duplicating collapse into a dict. A duplicate is recorded (not raised) so the parse still completes last-wins — identical to how `json.load`/`JSON.parse`/`jq` resolve it — and every distinct duplicate key in a file is reported in one pass.

Wired into the `hygiene` job in `.github/workflows/ci.yml`, directly adjacent to the existing "Validate plugin manifests" step (per the issue's own routing rationale — same file scope, same tier as "does it parse"/"does it match the schema"), gated the same way the four `check-jsonschema` steps are (skipped only on a provably docs-only diff), and its outcome is added as one line to `scripts/aggregate-hygiene-results.sh`'s existing `CHECK_RESULTS` block so a duplicate key fails the job exactly like any other hygiene check.

## Verification

- `bash scripts/check-manifest-duplicate-keys.test.sh` — 17 unit/CLI tests, all passing (nested-object duplicates, sibling-object non-duplicates, multiple distinct duplicate keys in one file, malformed JSON *not* double-reported, default-discovery glob covering both `plugin.json` and `marketplace.json`, missing-file handling, exit codes).
- `test_catches_the_1492_shaped_duplicate_version_key` reproduces the actual #1492 defect shape (two `"version"` members) as an inline fixture and asserts the gate fails on it — the fixture proving the gate catches a real duplicate key, per the issue's own ask.
- Live empirical cross-check against the two claims in the issue's verification table, run locally against a copy of the real (now-fixed) `plugins/skill-quality/.claude-plugin/plugin.json` with the duplicate `"version"` member re-injected:
  - `check-jsonschema --schemafile https://json.schemastore.org/claude-code-plugin-manifest.json <file>` → `ok -- validation done`, exit 0 (confirms schema validation is blind to it).
  - `python3 scripts/check-manifest-duplicate-keys.py <file>` → `DUPLICATE KEY: ... defines 'version' more than once ...`, exit 1 (confirms the new gate catches exactly what schema validation cannot).
- `python3 scripts/check-manifest-duplicate-keys.py` (default discovery, no args) against the actual repo tree → `No duplicate JSON object keys found in 62 manifest file(s).`, exit 0 — no false positives on the real manifest set.
- `actionlint .github/workflows/ci.yml` — clean.
- `shellcheck --rcfile=.shellcheckrc scripts/check-manifest-duplicate-keys.test.sh` — clean.
- YAML parse + step-order check of the modified `hygiene` job — new steps land in the intended position, ids wired correctly into `CHECK_RESULTS`.
- `typos --config _typos.toml` over the new/changed files — clean.
- No `plugins/*` manifest touched, so the per-plugin CHANGELOG-parity gate does not apply to this change.

## Related

- #1492 — the shipped duplicate-key instance this gate would have caught.
- #1494 — the manifest fix for #1492.
- #1096, #1450 — the version-collision conflict shape that produces this defect class.
