### PR TITLE
ci: wire ai-briefing url-policy tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,6 +645,55 @@ jobs:
         if: steps.scope.outputs.docs_only == 'true'
         run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the youtube extraction suite cannot be affected — reporting success."
 
+  # ai-briefing's build/render pipeline is a Node package (native `node --test`
+  # suite) no other lane installs or runs — including test/url-policy.test.js,
+  # which asserts the SSRF gate (lib/url-policy.js) that decides which URLs the
+  # briefing validator is allowed to dereference: loopback/private/link-local/
+  # CGN/benchmarking/documentation/multicast rejection, DNS-gate-time A/AAAA
+  # resolution, and the IPv6 2000::/3 allowlist inversion. Without this lane
+  # that suite runs locally only, so a future refactor could silently break the
+  # predicate with nothing red in CI (#1488). Same never-skip, self-test-first,
+  # fail-closed docs-only gate as plugin-gate, miro-plugin and
+  # youtube-extraction. (Scoping this lane to its own paths — skipping it on
+  # unrelated diffs — is the same separately-tracked optimization noted on
+  # miro-plugin.)
+  ai-briefing-build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the PR base ref resolves for the docs-only diff.
+          fetch-depth: 0
+      - name: Test the docs-only detector
+        run: bash scripts/check-docs-only.test.sh
+      - name: Detect a docs-only diff
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-docs-only.sh "origin/$BASE_REF"
+      - name: Set up Node
+        if: steps.scope.outputs.docs_only != 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+          cache-dependency-path: plugins/ai-briefing/skills/generate/output/build/package-lock.json
+      - name: Install dependencies
+        if: steps.scope.outputs.docs_only != 'true'
+        run: npm ci
+        working-directory: plugins/ai-briefing/skills/generate/output/build
+      - name: Test
+        if: steps.scope.outputs.docs_only != 'true'
+        run: npm test
+        working-directory: plugins/ai-briefing/skills/generate/output/build
+      - name: Report not applicable to a docs-only diff
+        if: steps.scope.outputs.docs_only == 'true'
+        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the ai-briefing build suite cannot be affected — reporting success."
+
   # Skill-regression net: the only lane that invokes the skill-quality checker.
   # On a PR it runs the static contract gate (trigger-keyword preservation vs
   # the base ref, frontmatter, line caps, broken refs, evals presence) over each
@@ -757,6 +806,7 @@ jobs:
       - plugin-gate
       - miro-plugin
       - youtube-extraction
+      - ai-briefing-build
       - runner-policy
       - skill-quality-gate
       - portability-lint

--- a/scripts/docs-only-paths.txt
+++ b/scripts/docs-only-paths.txt
@@ -18,6 +18,8 @@
 #      - miro-plugin: reads only plugins/miro/**;
 #      - youtube-extraction: reads only plugins/knowledge/skills/youtube-digest/**
 #        and plugins/knowledge/vendor/**;
+#      - ai-briefing-build: reads only
+#        plugins/ai-briefing/skills/generate/output/build/**;
 #      - hygiene's path-scoped subset — actionlint + the workflow
 #        check-jsonschema (read .github/workflows/**), and the marketplace /
 #        plugin / dependabot check-jsonschema steps (read


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

Closes #1488

## Summary

- `plugins/ai-briefing/skills/generate/output/build/test/url-policy.test.js` — the test suite for the
  SSRF gate `lib/url-policy.js` (loopback/private/link-local/CGN/benchmarking/documentation/multicast
  rejection, DNS-gate-time A/AAAA resolution, and the IPv6 `2000::/3` allowlist inversion) — appeared
  nowhere in `.github/workflows/ci.yml` and had only ever run locally.
- Adds a new `ai-briefing-build` job mirroring the existing `miro-plugin` / `youtube-extraction` Node
  lanes exactly: checkout, docs-only self-test + scope detection, `actions/setup-node` pinned to
  `.node-version` with `cache-dependency-path` on the build directory's `package-lock.json`, `npm ci`,
  `npm test` (native `node --test`, which runs the whole `test/` directory — `url-policy.test.js` plus
  the sibling `brand-overlay` / `build-sinks` / `parse-briefing` / `paths` / `provider-logos` /
  `schema` suites), all gated behind the existing docs-only scope guard.
- Wires the new job into `ci-status`'s `needs` list so it becomes a required check, and adds its
  read-scope bullet to `scripts/docs-only-paths.txt`'s inertness-proof comment (matching the entries
  already there for `plugin-gate` / `miro-plugin` / `youtube-extraction`).
- Note on the issue's "wiring assertion": #1488 mentions a strict-boolean/both-directions assertion on
  `shouldSkipLinkCheck` that guards against an always-skip regression. That assertion currently lives
  only on the unmerged branch `fix/trust-gate-residual-bypasses`, not on `main` — this PR wires the
  suite that exists on `main` today into CI; the always-skip guard starts being enforced in CI once
  that branch lands separately.

## Test plan

- [x] `npm ci && npm test` run locally from `plugins/ai-briefing/skills/generate/output/build`
      (matching exactly what the new CI steps run): 33 pass, 1 skipped (a Windows-only symlink case —
      `file symlinks require Windows Developer Mode or elevation` — that runs unskipped on the
      `ubuntu-24.04` CI runner), 0 fail.
- [x] Fails-closed check: temporarily patched `shouldSkipLinkCheck` in `lib/url-policy.js` to
      unconditionally `return false`, re-ran `npm test` — exit code 1, multiple `url-policy.test.js`
      assertions failed (`AssertionError [ERR_ASSERTION] ... false !== true`). Confirms the lane
      actually fails on a broken predicate rather than passing vacuously. Reverted before committing
      (`git diff` on `lib/url-policy.js` is empty).
- [x] `actionlint .github/workflows/ci.yml` — no findings.
- [x] `zizmor .github/workflows/ci.yml` — "No findings to report."
- [x] `bash scripts/check-docs-only.test.sh` — 19/19 pass (the new lane's docs-only gating doesn't
      break the self-test).
- [x] `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` — both pass; no
      plugin version changed, so no CHANGELOG bump is owed for this repo-level CI-only change.
- [x] Confirmed no postinstall/install script on the `playwright` dependency
      (`node_modules/playwright/package.json` has no `scripts` key, and `package-lock.json` sets no
      `hasInstallScript` flag on it), so `npm ci` does not trigger a browser download in CI — no
      `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` env needed.

## Related

- #1507 — filed while auditing for this issue's own suggested follow-up ("consider whether any other
  plugin ships a test suite CI never invokes"): `plugins/knowledge/skills/course-digest/extraction`
  has a real `vitest` suite with no CI lane either. Intentionally out of scope for this PR — separate
  plugin, separate lane, needs its own triage pass.
