### PR TITLE
fix(ci): correct two shell-portability-lint false results

### DIFF
--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -46,10 +46,14 @@
 # contiguous block directly above a hit) — comment-skip is for CONSTRUCT
 # matching only, never for annotation detection.
 #
-# This is a grep-level tripwire, not a semantic proof. Guard markers are
-# seeded for the two classes that need one today (readlink -f, sed -i's
-# empty-suffix idiom); a further class enables its own guard here, proven
-# against an `--all` audit first — see the token file's STAGED section.
+# This is a grep-level tripwire, not a semantic proof: it matches per
+# PHYSICAL line, so a command split across a backslash line-continuation, or
+# assembled into a variable before use, evades detection (tracked in #1513).
+# Guard markers are seeded for the one class that needs one today
+# (readlink -f, requiring an actual `||` fallback relationship with a
+# co-located realpath attempt — not mere co-location); a further class
+# enables its own guard here, proven against an `--all` audit first — see the
+# token file's STAGED section.
 #
 # Exit 0 = clean (or nothing in scope); 1 = one or more violations; 2 = usage /
 # environment error (fail closed — never a silent skip).
@@ -142,28 +146,35 @@ scan_file() {
     function is_annotated(l) { return l ~ /portability-ok:/ }
     function is_comment(l) { return l ~ /^[[:space:]]*#/ }
     # Same-line auto-guard: a portable BSD-side attempt already co-located on
-    # the hit line. Scoped to the two active shapes that need one today:
-    #   - readlink -f, guarded by a co-located realpath attempt — the shape
-    #     lib/hook-utils.sh already uses: `realpath ... || readlink -f ...`;
-    #   - sed -i, guarded by an explicit empty-suffix argument (a quoted empty
-    #     string immediately following -i) — the portable BSD-safe idiom this
-    #     class exists to encourage; without this guard the gate would flag
-    #     the CORRECT form.
-    # Takes the matched pattern text too, so the realpath guard applies only
+    # the hit line, ACTUALLY WIRED as the fallback (a `||` between the two
+    # calls) — not merely mentioned somewhere on the line. Scoped to the one
+    # active shape that needs one today: readlink -f, guarded by a co-located
+    # `realpath ... || readlink -f ...` fallback ladder (the shape
+    # lib/hook-utils.sh already uses). Requiring the literal `||` between the
+    # two (not just both substrings present) matters: `realpath "$1";
+    # readlink -f "$1"` runs the GNU-only call unconditionally right after a
+    # realpath attempt with no fallback relationship at all, and must still
+    # flag. Takes the matched pattern text too, so the guard applies only
     # when the readlink pattern itself matched — a line that merely mentions
     # "realpath" elsewhere must not blanket-excuse an unrelated hit on the
     # same line. A further class enables its own marker here when it is
     # activated (see the token file STAGED section) — this is deliberately
     # not a generic heuristic, the same posture check-skill-portability.sh
     # takes.
-    function is_guarded(l, p,    q1, q2, empty_suffix) {
-      if (p ~ /readlink/ && l ~ /realpath/) return 1
-      if (p ~ /sed\[/) {
-        q1 = sprintf("%c", 39) # single quote, kept out of the literal source
-        q2 = sprintf("%c", 34) # double quote, kept out of the literal source
-        empty_suffix = "-i[[:space:]]+(" q1 q1 "|" q2 q2 ")([[:space:]]|$)"
-        if (l ~ empty_suffix) return 1
-      }
+    #
+    # sed -i has NO guard. An earlier revision auto-guarded the space-
+    # separated empty-suffix idiom ("-i" followed by an empty quoted string
+    # as a SEPARATE argument), believing it to be the portable BSD-safe form
+    # — that was wrong, verified against a real GNU sed 4.9: that exact
+    # invocation exits 2, because GNU consumes the space-separated empty
+    # string as the sed SCRIPT argument, leaving the real script and the
+    # target file to be opened as filenames. It is BSD-only, not portable, so it
+    # correctly stays flagged. The actually dual-compatible spelling is an
+    # ATTACHED nonempty suffix (sed -i.bak ... && rm -f the backup after),
+    # which this token never matches (attached, no separating whitespace)
+    # and so is correctly never flagged.
+    function is_guarded(l, p) {
+      if (p ~ /readlink/ && l ~ /realpath[^|]*\|\|[^|]*readlink/) return 1
       return 0
     }
     # Pass 1: collect active ERE patterns from the token list.

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -59,6 +59,15 @@ tmpsh() {
   printf '%s' "$f"
 }
 
+# escape_token <esc> — builds the shipped grep/sed-context-required ERE for
+# one regex-escape class, matching scripts/shell-portability-tokens.txt's
+# active pattern shape exactly (kept here rather than sourced, so a fixture
+# is not coupled to the shipping list's other active classes).
+escape_token() {
+  local esc="$1"
+  printf '(grep|sed)[^\\n]*%s|%s[^\\n]*(grep|sed)' "$esc" "$esc"
+}
+
 # =============================================================================
 # Regex-escape classes (\b \< \> \s \S \w \W) — the exact near-miss family.
 # =============================================================================
@@ -68,7 +77,7 @@ tmpsh() {
 # backspace BYTE, not a boundary, when used as a boundary anchor — verify the
 # LITERAL-TWO-CHARACTER-SEQUENCE form this gate uses is not silently inert
 # under whichever awk resolves on the runner) -------------------------------
-tok="$(one_token_list '\\b')"
+tok="$(one_token_list "$(escape_token '\\b')")"
 f="$(tmpsh "grep -Eq '\\brequire\\b' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
   fail "literal \\\\b in a grep pattern should fail, got success: $out"
@@ -77,21 +86,32 @@ elif echo "$out" | grep -q "PORTABILITY: ${f}:1:"; then
 else
   fail "expected PORTABILITY with file:line, got: $out"
 fi
-rm -f "$f" "$tok"
+rm -f "$f"
 
 # --- the POSIX-portable bracket-expression replacement does NOT fire -------
-tok="$(one_token_list '\\b')"
 f="$(tmpsh 'grep -Eq "(^|[^A-Za-z0-9_\$])require($|[^A-Za-z0-9_\$])" "$file"')"
 if scan_paths "$tok" "$f" >/dev/null 2>&1; then
   ok "the bracket-expression word-boundary replacement does not fire"
 else
   fail "the POSIX-portable replacement must not be flagged"
 fi
+rm -f "$f"
+
+# --- a co-located printf/$'...' use of the SAME two characters is NOT
+# regex-pattern syntax and must not fire, even though it is not inside a
+# grep/sed invocation on this line (confirmed against a real shell: printf
+# '\b' emits an actual backspace byte, on GNU and BSD alike) ----------------
+f="$(tmpsh "printf '\\bspinner-frame\\n'")"
+if scan_paths "$tok" "$f" >/dev/null 2>&1; then
+  ok "printf '\\b' (no grep/sed on the line) is not flagged"
+else
+  fail "printf '\\b' must not be flagged -- it is portable escape-sequence syntax, not a regex pattern"
+fi
 rm -f "$f" "$tok"
 
-# --- \s \w \S \W \< \> each fire individually -------------------------------
+# --- \s \w \S \W \< \> each fire individually, only with grep/sed context --
 for esc in '\\s' '\\S' '\\w' '\\W' '\\<' '\\>'; do
-  tok="$(one_token_list "$esc")"
+  tok="$(one_token_list "$(escape_token "$esc")")"
   f="$(tmpsh "sed -E 's/${esc}foo${esc}/bar/' \"\$file\"")"
   if out="$(scan_paths "$tok" "$f" 2>&1)"; then
     fail "literal $esc should fail, got success: $out"
@@ -184,6 +204,16 @@ else
 fi
 rm -f "$f" "$tok"
 
+# --- the --version-sort long form is a separate literal token -------------
+tok="$(one_token_list '--version-sort')"
+f="$(tmpsh 'sort --version-sort "$file"')"
+if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+  fail "sort --version-sort should fail, got success: $out"
+else
+  ok "sort --version-sort (long form) is detected"
+fi
+rm -f "$f" "$tok"
+
 # =============================================================================
 # sed -i without a backup-suffix argument
 # =============================================================================
@@ -206,20 +236,23 @@ else
 fi
 rm -f "$f"
 
-# --- the portable BSD-safe -i '' / -i "" idiom is auto-guarded, not flagged
+# --- the space-separated empty-suffix idiom (-i '' / -i "") is NOT the
+# portable form it looks like -- verified against a real GNU sed 4.9, that
+# exact invocation exits 2 (the empty string is consumed as sed's SCRIPT
+# argument, not as -i's suffix), so it must stay flagged, not be excused.
 f="$(tmpsh "sed -i '' 's/foo/bar/' \"\$file\"")"
-if scan_paths "$tok" "$f" >/dev/null 2>&1; then
-  ok "sed -i '' (explicit empty-suffix, single-quoted) is not flagged"
+if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+  fail "sed -i '' should fail -- it is GNU-incompatible despite looking BSD-safe, got success: $out"
 else
-  fail "sed -i '' must not be flagged -- it is the portable BSD-safe idiom"
+  ok "sed -i '' (space-separated empty-suffix, single-quoted) is detected, not excused"
 fi
 rm -f "$f"
 
 f="$(tmpsh 'sed -i "" -E "s/foo/bar/" "$file"')"
-if scan_paths "$tok" "$f" >/dev/null 2>&1; then
-  ok "sed -i \"\" (explicit empty-suffix, double-quoted) is not flagged"
+if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+  fail "sed -i \"\" should fail -- it is GNU-incompatible despite looking BSD-safe, got success: $out"
 else
-  fail 'sed -i "" must not be flagged -- it is the portable BSD-safe idiom'
+  ok "sed -i \"\" (space-separated empty-suffix, double-quoted) is detected, not excused"
 fi
 rm -f "$f" "$tok"
 
@@ -242,6 +275,19 @@ if scan_paths "$tok" "$f" >/dev/null 2>&1; then
   ok "readlink -f co-located with a realpath attempt is auto-guarded"
 else
   fail "the realpath-first fallback ladder must not be flagged"
+fi
+rm -f "$f"
+
+# --- mere co-location is not enough -- the guard requires an actual `||`
+# fallback relationship. Two unconditional statements (semicolon-separated,
+# no ||) both mentioning realpath/readlink on one line must still flag: the
+# GNU-only readlink -f call runs unconditionally regardless of what realpath
+# did, so there is no real fallback protecting it.
+f="$(tmpsh 'realpath -- "$1" >/dev/null; readlink -f -- "$1"')"
+if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+  fail "realpath;readlink with no || fallback relationship should fail, got success: $out"
+else
+  ok "realpath and readlink with no actual || fallback relationship is still flagged"
 fi
 rm -f "$f" "$tok"
 

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -59,15 +59,6 @@ tmpsh() {
   printf '%s' "$f"
 }
 
-# escape_token <esc> — builds the shipped grep/sed-context-required ERE for
-# one regex-escape class, matching scripts/shell-portability-tokens.txt's
-# active pattern shape exactly (kept here rather than sourced, so a fixture
-# is not coupled to the shipping list's other active classes).
-escape_token() {
-  local esc="$1"
-  printf '(grep|sed)[^\\n]*%s|%s[^\\n]*(grep|sed)' "$esc" "$esc"
-}
-
 # =============================================================================
 # Regex-escape classes (\b \< \> \s \S \w \W) — the exact near-miss family.
 # =============================================================================
@@ -77,7 +68,7 @@ escape_token() {
 # backspace BYTE, not a boundary, when used as a boundary anchor — verify the
 # LITERAL-TWO-CHARACTER-SEQUENCE form this gate uses is not silently inert
 # under whichever awk resolves on the runner) -------------------------------
-tok="$(one_token_list "$(escape_token '\\b')")"
+tok="$(one_token_list '\\b')"
 f="$(tmpsh "grep -Eq '\\brequire\\b' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
   fail "literal \\\\b in a grep pattern should fail, got success: $out"
@@ -97,21 +88,43 @@ else
 fi
 rm -f "$f"
 
-# --- a co-located printf/$'...' use of the SAME two characters is NOT
-# regex-pattern syntax and must not fire, even though it is not inside a
-# grep/sed invocation on this line (confirmed against a real shell: printf
-# '\b' emits an actual backspace byte, on GNU and BSD alike) ----------------
+# --- a pattern BUILT on one line and CONSUMED on another still fires. This
+# is the shape a grep/sed-same-line context requirement silently un-catches,
+# and it is live in this repo (instruction-scan.sh's I6_ERE/RATIONALE_ERE),
+# so the class deliberately stays bare — see the token file's note. ---------
+f="$(tmpsh "PAT=\"\\brequire\\b\"
+grep -Eq \"\$PAT\" \"\$file\"")"
+if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+  fail "a \\\\b pattern assigned to a variable should fail, got success: $out"
+elif echo "$out" | grep -q "PORTABILITY: ${f}:1:"; then
+  ok "a \\\\b pattern built in a variable and used later is detected"
+else
+  fail "expected PORTABILITY on the assignment line, got: $out"
+fi
+rm -f "$f"
+
+# --- the mirror-image cost of staying bare: portable printf escape syntax
+# carrying the same two characters DOES fire (over-flag, the documented
+# direction), and `portability-ok:` is the recorded one-line escape for it --
 f="$(tmpsh "printf '\\bspinner-frame\\n'")"
 if scan_paths "$tok" "$f" >/dev/null 2>&1; then
-  ok "printf '\\b' (no grep/sed on the line) is not flagged"
+  fail "printf '\\b' must still fire -- the class is bare by design"
 else
-  fail "printf '\\b' must not be flagged -- it is portable escape-sequence syntax, not a regex pattern"
+  ok "printf '\\b' fires (accepted over-flag, excusable per site)"
+fi
+rm -f "$f"
+
+f="$(tmpsh "printf '\\bspinner-frame\\n'  # portability-ok: printf escape, not a regex")"
+if scan_paths "$tok" "$f" >/dev/null 2>&1; then
+  ok "printf '\\b' with a portability-ok: annotation is excused"
+else
+  fail "an annotated printf '\\b' must be excused"
 fi
 rm -f "$f" "$tok"
 
-# --- \s \w \S \W \< \> each fire individually, only with grep/sed context --
+# --- \s \w \S \W \< \> each fire individually -------------------------------
 for esc in '\\s' '\\S' '\\w' '\\W' '\\<' '\\>'; do
-  tok="$(one_token_list "$(escape_token "$esc")")"
+  tok="$(one_token_list "$esc")"
   f="$(tmpsh "sed -E 's/${esc}foo${esc}/bar/' \"\$file\"")"
   if out="$(scan_paths "$tok" "$f" 2>&1)"; then
     fail "literal $esc should fail, got success: $out"

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -38,19 +38,29 @@
 # ERE/BRE define no `\b`/`\<`/`\>`/`\s`/`\S`/`\w`/`\W`; BSD grep/sed either
 # rejects them or (worse) reads `\b` as a literal `b`, silently turning
 # `\brequire\b` into `brequireb` — matches nothing, exactly the near-miss above.
-# Each token requires a co-located `grep` or `sed` invocation on the same
-# line (either order) — these escapes are meaningful ONLY as regex-pattern
-# syntax; the bare two-character sequence is also legitimate, portable
-# `printf`/`$'...'` escape-sequence syntax (`printf '\b'` — a real backspace
-# byte, identical on GNU and BSD) that must not be flagged just for
-# containing the same two characters.
-(grep|sed)[^\n]*\\b|\\b[^\n]*(grep|sed)
-(grep|sed)[^\n]*\\<|\\<[^\n]*(grep|sed)
-(grep|sed)[^\n]*\\>|\\>[^\n]*(grep|sed)
-(grep|sed)[^\n]*\\s|\\s[^\n]*(grep|sed)
-(grep|sed)[^\n]*\\S|\\S[^\n]*(grep|sed)
-(grep|sed)[^\n]*\\w|\\w[^\n]*(grep|sed)
-(grep|sed)[^\n]*\\W|\\W[^\n]*(grep|sed)
+# Each token matches the literal two-character escape sequence, with NO
+# required co-located `grep`/`sed` on the line. Requiring one was tried and
+# reverted: a pattern is very often built on its own line and consumed
+# several lines later, so the requirement silently un-catches exactly the
+# near-miss shape above. The live proof is in this repo —
+# plugins/claude-config/skills/audit-instructions/scripts/instruction-scan.sh
+# assigns `\b`-bearing EREs to I6_ERE/RATIONALE_ERE and only later passes
+# them to `grep -niE`; a grep/sed-context requirement reports that file
+# clean. The cost of staying bare is the mirror-image false positive: the
+# same two characters are also legitimate, portable `printf`/`$'...'`
+# escape-sequence syntax (`printf '\b'` — a real backspace byte, identical
+# on GNU and BSD), which this list DOES flag. That is the documented
+# over-flag direction, and `portability-ok: <reason>` is the one-line escape
+# for it. Narrowing the class precisely — knowing which operand of which
+# command is a regex — needs real shell parsing, not a token edit; tracked
+# in #1517.
+\\b
+\\<
+\\>
+\\s
+\\S
+\\w
+\\W
 
 # `grep -P` (PCRE mode) — absent in BSD grep, and in some GNU builds compiled
 # without PCRE support. `P` may appear anywhere in a combined short-option

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -26,7 +26,7 @@
 #
 # Escaping a legitimate hit (see the script header for detection detail):
 #   - an auto-recognized same-line BSD-counterpart guard (readlink -f tried
-#     only after a co-located realpath attempt already failed);
+#     only as the `||` fallback after a co-located realpath attempt);
 #   - a per-site recorded exemption: `portability-ok: <reason>`.
 # Direction is deliberately over-flag, not under-flag (see the linked issue's
 # "Two design notes"): a justified false positive costs a reviewer one line: a
@@ -38,14 +38,19 @@
 # ERE/BRE define no `\b`/`\<`/`\>`/`\s`/`\S`/`\w`/`\W`; BSD grep/sed either
 # rejects them or (worse) reads `\b` as a literal `b`, silently turning
 # `\brequire\b` into `brequireb` — matches nothing, exactly the near-miss above.
-# Each token below matches the literal two-character escape sequence.
-\\b
-\\<
-\\>
-\\s
-\\S
-\\w
-\\W
+# Each token requires a co-located `grep` or `sed` invocation on the same
+# line (either order) — these escapes are meaningful ONLY as regex-pattern
+# syntax; the bare two-character sequence is also legitimate, portable
+# `printf`/`$'...'` escape-sequence syntax (`printf '\b'` — a real backspace
+# byte, identical on GNU and BSD) that must not be flagged just for
+# containing the same two characters.
+(grep|sed)[^\n]*\\b|\\b[^\n]*(grep|sed)
+(grep|sed)[^\n]*\\<|\\<[^\n]*(grep|sed)
+(grep|sed)[^\n]*\\>|\\>[^\n]*(grep|sed)
+(grep|sed)[^\n]*\\s|\\s[^\n]*(grep|sed)
+(grep|sed)[^\n]*\\S|\\S[^\n]*(grep|sed)
+(grep|sed)[^\n]*\\w|\\w[^\n]*(grep|sed)
+(grep|sed)[^\n]*\\W|\\W[^\n]*(grep|sed)
 
 # `grep -P` (PCRE mode) — absent in BSD grep, and in some GNU builds compiled
 # without PCRE support. `P` may appear anywhere in a combined short-option
@@ -62,21 +67,30 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]]|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
-# not only as the cluster's last letter.
+# not only as the cluster's last letter. `--version-sort` is the long-form
+# alias GNU documents for the same flag.
 sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]]|$)
+--version-sort
 
 # `sed -i` with no suffix argument attached — GNU treats the suffix as
-# optional; BSD sed requires one immediately after `-i` (even an explicit
-# empty string, `-i ''` / `-i ""`, auto-guarded by is_guarded() so the
-# portable BSD-safe idiom is not itself flagged). Does not yet cover every
-# GNU spelling (`-Ei`, `--in-place`, an attached-not-space-separated empty
-# suffix) — see #1513.
+# optional; BSD sed requires one immediately after `-i`. This intentionally
+# ALSO flags the space-separated empty-suffix idiom (`-i ''` / `-i ""`): it
+# looks BSD-safe but is not actually portable — verified against a real GNU
+# sed 4.9, that exact invocation exits 2, because GNU consumes the
+# space-separated empty string as sed's SCRIPT argument, silently shifting
+# the real script and target file to be opened as filenames. The one
+# genuinely dual-compatible spelling is an ATTACHED nonempty suffix
+# (`sed -i.bak '...' file && rm -f file.bak`), which this token does not
+# match (no separating whitespace) — correctly never flagged. Does not yet
+# cover every remaining GNU spelling (`-Ei`, `--in-place`) — see #1513.
 sed[^\n]*-i[[:space:]]+[^[:space:]]
 
 # `readlink -f` (canonicalize) — a GNU coreutils extension; BSD/macOS readlink
-# has no `-f`/`--canonicalize`. Auto-guarded when a `realpath` attempt sits on
-# the same line (the portable-first pattern this repo's own lib/hook-utils.sh
-# already uses: `realpath ... || readlink -f ...`).
+# has no `-f`/`--canonicalize`. Auto-guarded when a `realpath` attempt is
+# ACTUALLY WIRED as its fallback via `||` on the same line (the pattern this
+# repo's own lib/hook-utils.sh already uses: `realpath ... || readlink -f
+# ...`) — a realpath call merely mentioned nearby with no `||` relationship
+# (e.g. two unconditional statements in sequence) still flags.
 readlink[[:space:]]+(-[A-Za-z]*f|--canonicalize)
 
 # --- STAGED (commented until enabled — see #1510 for the enable trigger) ---


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

## Summary

- #1511 (`ci: add shell-portability-lint gate for GNU-only constructs`, refs #1491) merged
  (`8949b577`) before a second round of automated Codex review on that branch's later pushes could
  land two confirmed correctness fixes — the review comments landed on the PR only ~1 minute before
  an independent merge-lane session merged it as gate-proven-green, so this follow-up carries the
  fixes forward. Both were verified empirically against real tools before landing here, not assumed.
- **The `sed -i ''` / `sed -i ""` auto-guard was wrong and is removed.** It was added believing a
  space-separated empty-suffix argument was "the portable BSD-safe idiom" for `sed -i`. Verified
  against a real GNU sed 4.9: `sed -i '' 's/foo/bar/' file` exits 2, because GNU consumes the
  space-separated empty string as sed's *SCRIPT* argument (not `-i`'s suffix), shifting the real
  script and target file to be read as filenames. That idiom is BSD-only — it breaks on this repo's
  own GNU/Linux CI — so it correctly stays flagged now. The genuinely dual-compatible spelling (an
  ATTACHED nonempty suffix, `sed -i.bak '...' file && rm -f file.bak`) was already, correctly, never
  matched by the token (no separating whitespace).
- **The regex-escape family (`\b \< \> \s \S \w \W`) stays BARE — a co-located-`grep`/`sed`
  requirement was tried here and reverted in review.** The motivation was real (the bare token flags
  portable, non-regex uses like `printf '\b'`, a genuine backspace byte on GNU and BSD alike), but
  the requirement bought a worse defect than it removed: a pattern is very often assigned on one line
  and consumed several lines later, so requiring the command on the escape's own line silently
  un-catches exactly the near-miss shape the class exists for. Verified against this repo's corpus,
  not assumed — `plugins/claude-config/.../audit-instructions/scripts/instruction-scan.sh` assigns
  `\b`-bearing EREs to `I6_ERE`/`RATIONALE_ERE` (lines 66, 68) and passes them to `grep -niE` (lines
  83-85); with the requirement the gate reports that file clean, bare it flags both assignment lines.
  The `printf '\b'` false positive is the mirror-image cost of the token file's documented over-flag
  direction, and the per-site `portability-ok: <reason>` annotation is the one-line escape already
  shipped for it. Narrowing the class precisely needs real shell parsing, not a token edit — tracked
  in #1517.
- Also lands two precision fixes from the same review round that were correct and already tested,
  but likewise never made it into the merge:
  - The `readlink -f` / `realpath` guard now requires an actual `||` fallback relationship, not mere
    line co-location (`realpath "$1"; readlink -f "$1"` — semicolon-separated, no real fallback —
    still flags).
  - `sort --version-sort` (GNU's documented long-form alias for `-V`) is now a separate literal
    token alongside the existing short-flag pattern.

## Test plan

- [x] `bash scripts/check-shell-portability.test.sh` — 40/40 passing (6 new regression tests: a
      `\b` pattern built in a variable and consumed later still fires, `printf '\b'` fires and is
      excused by a `portability-ok:` annotation, the `sed -i ''`/`-i ""` now-correctly-flagged cases,
      the `||`-required readlink guard, `sort --version-sort`), run against the current `main`
      baseline (this branch was cut fresh from `main` after #1511 merged, not carried over from the
      closed PR's stale branch).
- [x] The reviewer's own counter-example run directly:
      `scripts/check-shell-portability.sh --paths .../instruction-scan.sh` exits 1 (flags lines 66
      and 68) — the false negative the reverted requirement introduced is gone.
- [x] `scripts/check-shell-portability.sh origin/main` run directly against this branch's own diff —
      clean.
- [x] `shellcheck --rcfile=.shellcheckrc` on both changed scripts — clean.
- [x] `typos --config _typos.toml` — clean.
- [x] `actionlint .github/workflows/ci.yml` — clean (workflow itself untouched by this PR).
- [x] `bash scripts/check-skill-portability.test.sh` (sibling gate) — still passing, no cross-gate
      regression.
- [x] Empirically verified both defects against real tools before fixing (not assumed): `sed -i ''`
      exit code on GNU sed 4.9, and `printf '\b'` byte output via `xxd`.

## Related

No related issue: #1491 (the original item) and #1511 (the PR this fixes) are both already closed —
there is no open issue for this PR to close. Refs #1491 and #1511 for context only. This corrects a
defect in #1511 found by automated review after that PR had already merged.

#1517 tracks the same review round and stays OPEN: this PR lands its items 3 (`readlink`/`realpath`
`||` fallback), 4 (`sed -i ''` scope) and 5 (`sort --version-sort`), while item 1 (escape-class
scoping) is re-confirmed here as needing real shell parsing rather than a token edit, and item 2
(backslash line-continuation normalization) is untouched.

