### PR TITLE
ci: wire course-digest extraction tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,59 @@ jobs:
         if: steps.scope.outputs.docs_only == 'true'
         run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the ai-briefing build suite cannot be affected — reporting success."
 
+  # The knowledge plugin's course-digest extraction pipeline is a Node package
+  # (typecheck + vitest suite) no other lane installs or runs — same shape as
+  # youtube-extraction, including the shared vendor/ packages pulled in as
+  # file: dependencies via the package's .npmrc install-links=true. Without
+  # this lane the suite (utils, the adapter contract, the dometrain/teachable
+  # adapters, clerk/teachable-sso auth, config, and the hotmart/mux players)
+  # runs locally only, so a future refactor could silently break it with
+  # nothing red in CI (#1507). Same never-skip, self-test-first, fail-closed
+  # docs-only gate as plugin-gate, miro-plugin, youtube-extraction and
+  # ai-briefing-build. (Scoping this lane to its own paths — skipping it on
+  # unrelated diffs — is the same separately-tracked optimization noted on
+  # miro-plugin.)
+  course-digest-extraction:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the PR base ref resolves for the docs-only diff.
+          fetch-depth: 0
+      - name: Test the docs-only detector
+        run: bash scripts/check-docs-only.test.sh
+      - name: Detect a docs-only diff
+        id: scope
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-docs-only.sh "origin/$BASE_REF"
+      - name: Set up Node
+        if: steps.scope.outputs.docs_only != 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+          cache-dependency-path: plugins/knowledge/skills/course-digest/extraction/package-lock.json
+      - name: Install dependencies
+        if: steps.scope.outputs.docs_only != 'true'
+        run: npm ci
+        working-directory: plugins/knowledge/skills/course-digest/extraction
+      - name: Typecheck
+        if: steps.scope.outputs.docs_only != 'true'
+        run: npm run build
+        working-directory: plugins/knowledge/skills/course-digest/extraction
+      - name: Test
+        if: steps.scope.outputs.docs_only != 'true'
+        run: npm test
+        working-directory: plugins/knowledge/skills/course-digest/extraction
+      - name: Report not applicable to a docs-only diff
+        if: steps.scope.outputs.docs_only == 'true'
+        run: echo "Diff is within the docs-only allowlist (scripts/docs-only-paths.txt); the course-digest extraction suite cannot be affected — reporting success."
+
   # Skill-regression net: the only lane that invokes the skill-quality checker.
   # On a PR it runs the static contract gate (trigger-keyword preservation vs
   # the base ref, frontmatter, line caps, broken refs, evals presence) over each
@@ -854,6 +907,7 @@ jobs:
       - miro-plugin
       - youtube-extraction
       - ai-briefing-build
+      - course-digest-extraction
       - runner-policy
       - skill-quality-gate
       - portability-lint

--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), and a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.9.6]
+
+### Fixed
+
+- **course-digest extraction: `npm ci` failed on a clean install (#1507).** The
+  `skills/course-digest/extraction` package pulls in the shared `@melodic/repo-analysis` and
+  `@melodic/video-digestion` vendor packages as `file:` dependencies, same as the sibling
+  `youtube-digest/extraction` package — but unlike that sibling, it shipped no `.npmrc` setting
+  `install-links=true`. Without it, `npm ci` failed with `EUSAGE` (`Missing:
+  @melodic/repo-analysis@0.1.0 from lock file`, `Missing: @melodic/video-digestion@0.1.0 from lock
+  file`) on a fresh install, even though the committed `package-lock.json` was otherwise in sync.
+  Added the missing `.npmrc`, matching `youtube-digest/extraction`'s. Discovered while wiring the
+  package's test suite into CI, which never ran `npm ci` from a clean state before.
+
+### Added
+
+- **course-digest extraction test suite now runs in CI (#1507).** The `vitest` suite under
+  `skills/course-digest/extraction` (`utils`, the adapter contract, the Dometrain/Teachable
+  adapters, Clerk/Teachable-SSO auth, config, and the Hotmart/Mux players — 91 tests across 10
+  files) had never been wired into `.github/workflows/ci.yml`; it only ever ran locally. Added a
+  `course-digest-extraction` CI job mirroring the existing `youtube-extraction` lane (typecheck +
+  `npm test`), gated behind the same docs-only scope guard as the repo's other Node lanes.
+
 ## [0.9.5]
 
 ### Fixed

--- a/plugins/knowledge/skills/course-digest/extraction/.npmrc
+++ b/plugins/knowledge/skills/course-digest/extraction/.npmrc
@@ -1,0 +1,1 @@
+install-links=true

--- a/scripts/docs-only-paths.txt
+++ b/scripts/docs-only-paths.txt
@@ -20,6 +20,9 @@
 #        and plugins/knowledge/vendor/**;
 #      - ai-briefing-build: reads only
 #        plugins/ai-briefing/skills/generate/output/build/**;
+#      - course-digest-extraction: reads only
+#        plugins/knowledge/skills/course-digest/** and
+#        plugins/knowledge/vendor/**;
 #      - hygiene's path-scoped subset — actionlint + the workflow
 #        check-jsonschema (read .github/workflows/**), and the marketplace /
 #        plugin / dependabot check-jsonschema steps (read


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

Closes #1507

## Summary

- `plugins/knowledge/skills/course-digest/extraction`'s `vitest` suite (`utils.test.js`, the
  adapter contract, the Dometrain/Teachable adapters, Clerk/Teachable-SSO auth, config, and the
  Hotmart/Mux players — 91 tests across 10 files) appeared nowhere in
  `.github/workflows/ci.yml` and had only ever run locally.
- Adds a new `course-digest-extraction` job mirroring the existing `youtube-extraction` lane
  exactly: checkout, docs-only self-test + scope detection, `actions/setup-node` pinned to
  `.node-version` with `cache-dependency-path` on the extraction directory's
  `package-lock.json`, `npm ci`, a typecheck step (`npm run build` → `tsc --noEmit`, same as
  `youtube-extraction`), then `npm test` (`vitest run`) — all gated behind the existing
  docs-only scope guard.
- Wires the new job into `ci-status`'s `needs` list so it becomes a required check, and adds its
  read-scope bullet to `scripts/docs-only-paths.txt`'s inertness-proof comment (matching the
  entries already there for `youtube-extraction` / `ai-briefing-build`).
- **Also fixes a broken clean install found while verifying the suite installs cleanly** (the
  same check the ai-briefing precedent, #1488/#1508, called out): the extraction package pulls
  in the shared `@melodic/repo-analysis` and `@melodic/video-digestion` vendor packages as
  `file:` dependencies — same as the sibling `youtube-digest/extraction` package — but unlike
  that sibling it shipped no `.npmrc` setting `install-links=true`. Without it, `npm ci` failed
  with `EUSAGE` (`Missing: @melodic/repo-analysis@0.1.0 from lock file`, `Missing:
  @melodic/video-digestion@0.1.0 from lock file`) on a fresh install, even though the committed
  `package-lock.json` was otherwise in sync. Added the missing `.npmrc`, matching
  `youtube-digest/extraction`'s.
- Bumps the `knowledge` plugin to `0.9.6` with a matching `CHANGELOG.md` entry, since the
  `.npmrc` fix is a real behavioral change a consumer of the plugin receives (not a CI-only
  file) — the new CI lane itself doesn't warrant a bump on its own (repo-level `.github/`/`scripts/`
  files), but the `.npmrc` fix lives inside the plugin directory.

## Test plan

- [x] `npm ci` from `plugins/knowledge/skills/course-digest/extraction` (matching exactly what
      the new CI step runs): **failed** before the `.npmrc` fix with `EUSAGE` /
      "Missing: @melodic/repo-analysis@0.1.0 from lock file"; **passes cleanly** after adding
      `.npmrc` (`install-links=true`) — 75 packages added, 0 vulnerabilities.
- [x] `npm run build` (typecheck, `tsc --noEmit`): passes with no output.
- [x] `npm test` (`vitest run`): **10 files passed (10), 91 tests passed (91)**, 0 fail.
- [x] `actionlint .github/workflows/ci.yml` — no findings.
- [x] `zizmor .github/workflows/ci.yml` — "No findings to report."
- [x] `bash scripts/check-docs-only.test.sh` — 19/19 pass (the new lane's docs-only gating
      doesn't break the self-test).
- [x] `scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` — both pass
      with the `knowledge` plugin's `0.9.5` → `0.9.6` bump and matching `## [0.9.6]` entry.
- [x] `jq empty plugins/knowledge/.claude-plugin/plugin.json` — valid JSON after the version
      bump.

## Related

- #1488 / #1508 — the sibling fix this item was filed while auditing for; same pattern
  (wiring an existing, previously CI-invisible test suite into `ci.yml`), and the same
  "confirm the suite installs cleanly before wiring it in" step that turned up an analogous
  missing-dependency gap there (`zod`) and here (`.npmrc`).
