### PR TITLE
fix(disk-hygiene): destructive guard denies at exit 2 when its decision can't reach stdout

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.7]
+
+### Fixed
+
+- **A broken *stdout* turned the guard's deny into a fail-open, the seventh of the class #1449
+  closed and the one none of its in-process tests could see.** `_decide`'s decision `print` only
+  buffers, so a closed stdout pipe raises nowhere inside `main` — the failure surfaces at interpreter
+  shutdown, and CPython reports that by replacing the exit status with `120`. Measured on the merged
+  code: a `deny` decision with stdout wired to a pipe whose reader is closed exited `120`, which
+  PreToolUse treats as non-blocking, so the destructive command runs even though the guard decided to
+  deny it. The module tail now flushes stdout itself, catching an undeliverable decision while there
+  is still a decision to make — it denies at exit `2` with a diagnostic, because a decision the host
+  never received is not a decision — then flushes stderr best-effort and `os._exit`s the resolved
+  code, so a shutdown flush can no longer rewrite it. Reuses `_write_diagnostic`'s null-device
+  fallback, extracted as `_discard_stream`. Covered by a real-subprocess `GuardTests` case against a
+  genuinely closed stdout pipe (the in-process helpers never reach interpreter shutdown, so they
+  cannot reproduce it); 212 tests pass.
+
 ## [0.9.6]
 
 ### Fixed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -7,19 +7,32 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
 
 ### Fixed
 
-- **A broken *stdout* turned the guard's deny into a fail-open, the seventh of the class #1449
-  closed and the one none of its in-process tests could see.** `_decide`'s decision `print` only
-  buffers, so a closed stdout pipe raises nowhere inside `main` — the failure surfaces at interpreter
-  shutdown, and CPython reports that by replacing the exit status with `120`. Measured on the merged
-  code: a `deny` decision with stdout wired to a pipe whose reader is closed exited `120`, which
-  PreToolUse treats as non-blocking, so the destructive command runs even though the guard decided to
-  deny it. The module tail now flushes stdout itself, catching an undeliverable decision while there
-  is still a decision to make — it denies at exit `2` with a diagnostic, because a decision the host
-  never received is not a decision — then flushes stderr best-effort and `os._exit`s the resolved
-  code, so a shutdown flush can no longer rewrite it. Reuses `_write_diagnostic`'s null-device
-  fallback, extracted as `_discard_stream`. Covered by a real-subprocess `GuardTests` case against a
-  genuinely closed stdout pipe (the in-process helpers never reach interpreter shutdown, so they
-  cannot reproduce it); 212 tests pass.
+- **A broken *stdout* turned the guard's deny into a fail-open (#1524), the seventh of the class
+  #1449 closed and the one none of its in-process tests could see.** `_decide`'s decision `print`
+  only buffers, so a closed stdout pipe raises nowhere inside `main` — the failure surfaces at
+  interpreter shutdown, and CPython reports that by replacing the exit status with `120`. Measured on
+  the merged code: a `deny` decision with stdout wired to a pipe whose reader is closed exited `120`,
+  which PreToolUse treats as non-blocking, so the destructive command runs even though the guard
+  decided to deny it. The module tail now flushes stdout itself, catching an undeliverable decision
+  while there is still a decision to make — it denies at exit `2` with a diagnostic, because a
+  decision the host never received is not a decision — then flushes stderr best-effort and
+  `os._exit`s the resolved code, so a shutdown flush can no longer rewrite it. Reuses
+  `_write_diagnostic`'s null-device fallback, extracted as `_discard_stream`. Covered by a
+  real-subprocess `GuardTests` case against a genuinely closed stdout pipe (the in-process helpers
+  never reach interpreter shutdown, so they cannot reproduce it).
+
+  **Also closes #1526's independently-reported trigger (fd 2 closed outright, not merely broken) as a
+  structural side effect**, without touching `_discard_stream` itself. #1526 exists because
+  `_discard_stream`'s null-device repair can self-undo: when `os.open(os.devnull, ...)` happens to
+  return the very fd being repaired (POSIX allocates the lowest free descriptor, so a *closed* fd 2
+  is reused rather than a fresh one), `os.dup2` is a no-op and the following `close` re-closes it —
+  and the pre-#1524 tail (`raise SystemExit(main())`) then hits that closed fd during the
+  interpreter's own shutdown flush and gets rewritten to `120` the same way. Every exit path now ends
+  in `os._exit` instead, which never runs that shutdown flush, so nothing downstream depends on
+  `_discard_stream` having actually repaired the fd — the latent self-undo bug it describes is still
+  present in `_discard_stream`, but can no longer surface as a rewritten exit code. Covered by a
+  second real-subprocess case that closes fd 2 outright and forces the internal-error deny path;
+  213 tests pass.
 
 ## [0.9.6]
 

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -892,12 +892,26 @@ def _write_diagnostic(message: str) -> None:
     try:
         print(message, file=sys.stderr, flush=True)
     except BaseException:  # noqa: BLE001 -- deny must outrank the diagnostic; see docstring
-        with contextlib.suppress(BaseException):
-            null_fd = os.open(os.devnull, os.O_WRONLY)
-            try:
-                os.dup2(null_fd, sys.stderr.fileno())
-            finally:
-                os.close(null_fd)
+        _discard_stream(sys.stderr)
+
+
+def _discard_stream(stream: object) -> None:
+    """Point a broken stream's fd at the null device, best-effort.
+
+    A failed write can leave data buffered, and the interpreter's own shutdown
+    flush of that buffer then raises too — which CPython reports as exit 120,
+    another status PreToolUse treats as non-blocking. Redirecting the
+    underlying fd lets the shutdown flush succeed into nothing, so the exit
+    code stays the one this module chose. Best-effort throughout: ``fileno``
+    itself raises for a stream with no fd (a redirected in-process test
+    stream), and there is nowhere left to report a failure to report.
+    """
+    with contextlib.suppress(BaseException):
+        null_fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            os.dup2(null_fd, stream.fileno())
+        finally:
+            os.close(null_fd)
 
 
 def _watchdog_fire(deadline: float) -> None:
@@ -1038,6 +1052,14 @@ def main() -> int:
             f"destructive_guard: internal error, denying by default "
             f"({type(exc).__name__}: {exc})"
         )
+        # stdout gets the same treatment as a broken stderr, and for the same
+        # reason. A closed stdout pipe makes `_decide`'s decision `print` raise
+        # into this handler; the partially-written JSON stays buffered, the
+        # shutdown flush of it fails, and CPython replaces this deliberate `2`
+        # with `120` — non-blocking, destructive command runs. Nothing on
+        # stdout is wanted on the exit-2 path anyway, so discarding it costs
+        # nothing and keeps the deny.
+        _discard_stream(sys.stdout)
         return 2
     finally:
         # `watchdog` stays None if construction itself raised; cancelling an
@@ -1047,4 +1069,26 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    _exit_code = main()
+    try:
+        sys.stdout.flush()
+    except BaseException:
+        # A decision the host never received is not a decision. `_decide`'s
+        # `print` only buffers, so a closed stdout pipe surfaces here rather
+        # than at that call — outside `main`'s boundary, where an allow would
+        # otherwise sail out as exit 0 with nothing delivered.
+        _write_diagnostic(
+            "destructive_guard: the decision could not be written to stdout; "
+            "denying by default."
+        )
+        _discard_stream(sys.stdout)
+        _exit_code = 2
+    with contextlib.suppress(BaseException):
+        sys.stderr.flush()
+    # `os._exit`, not `SystemExit`: interpreter shutdown flushes the std
+    # streams again and CPython replaces the exit status with 120 when that
+    # flush fails — non-blocking under PreToolUse, so a deliberate `2` would
+    # let the destructive command run. Both streams are already flushed as far
+    # as they can be, so nothing deliverable is lost by exiting hard. Same
+    # reasoning as `_watchdog_fire`'s exit.
+    os._exit(_exit_code)  # noqa: SLF001 -- see comment above

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -1052,14 +1052,6 @@ def main() -> int:
             f"destructive_guard: internal error, denying by default "
             f"({type(exc).__name__}: {exc})"
         )
-        # stdout gets the same treatment as a broken stderr, and for the same
-        # reason. A closed stdout pipe makes `_decide`'s decision `print` raise
-        # into this handler; the partially-written JSON stays buffered, the
-        # shutdown flush of it fails, and CPython replaces this deliberate `2`
-        # with `120` — non-blocking, destructive command runs. Nothing on
-        # stdout is wanted on the exit-2 path anyway, so discarding it costs
-        # nothing and keeps the deny.
-        _discard_stream(sys.stdout)
         return 2
     finally:
         # `watchdog` stays None if construction itself raised; cancelling an

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -2882,7 +2882,7 @@ class GuardTests(unittest.TestCase):
     def test_engine_gate_catches_engine_after_wrapper_with_option_operands(self) -> None:
         """Wrapper option operands must not hide the bare engine name (P1 r9)."""
         result = self.run_guard_engine_gate(
-            f"env -i PATH=/usr/bin nice -n 10 hygiene.py apply --plan p --token t",
+            "env -i PATH=/usr/bin nice -n 10 hygiene.py apply --plan p --token t",
             "Bash",
             enabled=False,
         )
@@ -3951,6 +3951,47 @@ class GuardTests(unittest.TestCase):
         ):
             guard._watchdog_fire(1.0)
         fake_exit.assert_called_once_with(2)
+
+    def test_undeliverable_stdout_decision_denies_at_exit_2_in_a_real_process(
+        self,
+    ) -> None:
+        """A decision the host never received must deny, not exit 0 or 120.
+
+        The sibling cases above cover a broken *stderr*. Broken *stdout* is the
+        other half and cannot be observed in-process: `_decide`'s decision
+        `print` only buffers, so a closed stdout pipe raises nowhere inside
+        `main` — it surfaces at interpreter shutdown, which CPython reports by
+        replacing the exit status with 120. Non-blocking under the PreToolUse
+        contract, so the destructive command runs even though the guard had
+        decided to deny it. Only a real process with a real closed pipe shows
+        this; against the pre-fix module tail it exits 120.
+        """
+        env = dict(os.environ)
+        read_fd, write_fd = os.pipe()
+        os.close(read_fd)
+        try:
+            proc = subprocess.Popen(
+                [self.python_command(), str(SCRIPT_DIR / "destructive_guard.py")],
+                stdin=subprocess.PIPE,
+                stdout=write_fd,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+        finally:
+            os.close(write_fd)
+        with proc:
+            proc.stdin.write(
+                json.dumps(
+                    {"tool_name": "Bash", "tool_input": {"command": "rm -rf /tmp/x"}}
+                )
+            )
+            proc.stdin.close()
+            proc.wait(timeout=30)
+            stderr = proc.stderr.read()
+        self.assertEqual(2, proc.returncode)
+        self.assertNotEqual(120, proc.returncode)
+        self.assertIn("could not be written to stdout", stderr)
 
     def test_main_arms_watchdog_at_resolved_deadline_and_cancels_on_return(
         self,

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -3993,6 +3993,64 @@ class GuardTests(unittest.TestCase):
         self.assertNotEqual(120, proc.returncode)
         self.assertIn("could not be written to stdout", stderr)
 
+    def test_stderr_fd_closed_outright_still_denies_at_exit_2_in_a_real_process(
+        self,
+    ) -> None:
+        """#1526's literal trigger: fd 2 *closed*, not merely broken.
+
+        `_write_diagnostic`'s fallback (`_discard_stream`) opens the null
+        device and `dup2`s it onto the broken fd. When fd 2 is closed
+        outright rather than left open with a dead reader, `os.open` can
+        return fd 2 itself (POSIX allocates the lowest free descriptor),
+        making the `dup2` a no-op -- and the `finally: os.close(null_fd)`
+        that follows then re-closes fd 2, undoing the very repair it just
+        made. Against the pre-#1524 module tail (`raise SystemExit(main())`),
+        the interpreter's own shutdown flush then hits that closed fd and
+        CPython rewrites the exit status to 120: non-blocking under
+        PreToolUse, so the destructive command would run even though the
+        guard had decided to deny it (#1526, reproduced against merged
+        `efb6c271`).
+
+        This module's tail no longer depends on `_discard_stream` actually
+        repairing the fd for the exit code to survive: every path now ends in
+        `os._exit`, which skips the interpreter's normal shutdown flush --
+        the mechanism `120` comes from -- entirely. So the #1526 trigger is
+        closed as a structural side effect of the #1524 fix, not by touching
+        `_discard_stream` itself (which still has the self-undoing dup2/close
+        pattern described above; nothing downstream depends on it working).
+        """
+        env = dict(os.environ)
+        script = str(SCRIPT_DIR / "destructive_guard.py")
+        # Runs *inside* the subprocess: close fd 2 outright (not merely break
+        # its reader) before the guard module executes, then run it as
+        # `__main__` so the module tail under test actually runs.
+        child = "\n".join(
+            [
+                "import os, runpy, sys",
+                "os.close(2)",
+                f"sys.argv = [{script!r}]",
+                "runpy.run_path(sys.argv[0], run_name='__main__')",
+            ]
+        )
+        proc = subprocess.Popen(
+            [self.python_command(), "-c", child],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        # A JSON array, not an object: `payload.get(...)` raises
+        # `AttributeError`, which main()'s inner
+        # `except (KeyError, TypeError, ValueError, json.JSONDecodeError)`
+        # does not catch -- it reaches the outer `except BaseException`,
+        # which is the exit-2 diagnostic path `_write_diagnostic` (and so
+        # `_discard_stream`) sits on.
+        out, _err = proc.communicate(input=json.dumps([]), timeout=30)
+        self.assertEqual(2, proc.returncode)
+        self.assertNotEqual(120, proc.returncode)
+        self.assertEqual("", out)
+
     def test_main_arms_watchdog_at_resolved_deadline_and_cancels_on_return(
         self,
     ) -> None:


### PR DESCRIPTION
Closes #1524

## Summary

- **Fixes the seventh fail-open of the class #1449 closed, and the one none of its in-process tests
  could see (#1524).** `_decide`'s decision `print` only buffers, so a closed *stdout* pipe raises
  nowhere inside `main` — the failure surfaces at interpreter shutdown instead, and CPython reports a
  failed shutdown flush by replacing the process exit status with `120`. `120` is "any other exit
  code" under the [hooks reference](https://code.claude.com/docs/en/hooks) (fetched 2026-07-26):
  exit `1` is treated as non-blocking, and only exit `2` enforces a policy — so `120` is non-blocking
  too, and the destructive command ran even though the guard had decided to deny it. Measured on
  merged `efb6c271`: a `deny` decision with stdout wired to a pipe whose reader is closed exits `120`.
- **Fix, already implemented on the pushed branch this issue named** (`fix/1449-followup-stdout-failopen`,
  commits `2de5f36e`/`26c0b7f8`, rebased here onto current `main` as `58d88a16`/`ffa0606b`): the module
  tail now flushes stdout itself, catching an undeliverable decision while there is still a decision
  to make — it denies at exit `2` with a diagnostic, because a decision the host never received is not
  a decision — then flushes stderr best-effort and `os._exit`s the resolved code, so a subsequent
  interpreter shutdown flush can no longer rewrite it. Reuses `_write_diagnostic`'s null-device
  fallback, extracted as `_discard_stream`.
- **This PR adds one thing beyond what the issue's branch already had: proof that the fix also
  structurally closes #1526** (fd 2 closed outright, a distinct, not-yet-triaged report), plus a
  CHANGELOG note so #1526's triage doesn't have to re-derive it. #1526's trigger is that
  `_discard_stream`'s null-device repair can self-undo — when `os.open(os.devnull, ...)` happens to
  return the very fd being repaired (POSIX allocates the lowest free descriptor, so a fd that's
  *closed outright* gets reused rather than a fresh one), `os.dup2` is a no-op and the following
  `close` re-closes it, undoing the repair. Against the pre-#1524 tail
  (`raise SystemExit(main())`), the interpreter's shutdown flush then hits that closed fd and gets
  rewritten to `120` the same way #1524 does. Every exit path now ends in `os._exit` instead, which
  never runs that shutdown flush — so nothing downstream depends on `_discard_stream` having actually
  repaired the fd, and #1526's externally-visible symptom (exit `120`) can no longer surface, even
  though the self-undo bug it describes is still present in `_discard_stream` as dead-weight. **This
  PR does not fix that latent bug in `_discard_stream` itself** — #1526 is a separate, not-yet-triaged
  item and doing so here would be out of this fix's scope; verified with a new regression test instead
  of just asserted (see Test plan).
- `plugin.json` 0.9.6 → 0.9.7, `CHANGELOG.md` entry.

## Test plan

- [x] `python -m unittest test_hygiene` (`plugins/disk-hygiene/skills/clean/scripts/`) — 213 tests
  pass, 4 skipped (pre-existing, platform-gated). Includes:
  - `test_undeliverable_stdout_decision_denies_at_exit_2_in_a_real_process` (from the issue's
    branch) — real subprocess, stdout wired to a pipe whose reader is closed, deny decision:
    asserts exit `2`, not `120`, diagnostic present on stderr.
  - `test_stderr_fd_closed_outright_still_denies_at_exit_2_in_a_real_process` (new, this PR) —
    real subprocess, fd 2 closed outright (`os.close(2)`, the literal #1526 reproduction, not a
    broken-pipe stand-in) before the guard module runs, forced onto the internal-error deny path
    (a JSON array payload raises `AttributeError` where `main`'s inner `except` tuple doesn't catch
    it): asserts exit `2`, not `120`.
- [x] `ruff check plugins/disk-hygiene/skills/clean/scripts/` — clean.
- [x] `markdownlint-cli2 --config .markdownlint-cli2.jsonc plugins/disk-hygiene/CHANGELOG.md` — 0
  issues.
- [x] `bash scripts/check-changelog-parity.sh --check-bump origin/main` — pass.
- [x] `node scripts/validate-plugin-contracts.mjs` — pass (43 setup skills, 2105 plugin files).
- [x] `claude plugin validate plugins/disk-hygiene/` — pass.
- [x] `bash scripts/run-plugin-tests.sh` (full repo `*.test.sh` files) — run locally; time-boxed
  partway through (no failures) given this change's isolation to two Python files plus the
  repo-wide structural gates above already passing. CI runs the same script to completion as the
  authoritative full-repo gate.
- [x] Manually reproduced #1526's own exit-`120` trigger against pre-fix merged `main`
  (`efb6c271`) with an equivalent fd-2-closed-outright + forced-internal-error probe, to confirm the
  new regression test is a real discriminator and not a false negative.

## Related

Refs #1526 — independently-reported, not-yet-triaged, and **structurally closed by this PR** as
documented above and proven by the new regression test; its own literal defect
(`_discard_stream`'s self-undoing `dup2`/`close`) is still present in the code but is no longer
reachable in its consequence, since every exit path now bypasses the interpreter shutdown flush that
`120` comes from. Whoever triages #1526 next should be able to close it by reference to this PR
rather than re-implementing a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*This was generated by AI during work-loop execution.*
