### PR TITLE
fix(ci): check-skill-portability.sh's awk operand shares the identifier=value edge case (#1513)

### DIFF
--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -152,6 +152,18 @@ scan_file() {
   if grep -qE '^[[:space:]]*(#|<!--)[[:space:]]*portability-scope:' -- "$file"; then
     return 0
   fi
+  # awk operand disambiguation: a bare relative operand shaped like
+  # identifier=value (e.g. a top-level file literally named FOO=bar.md) is
+  # parsed by awk as a command-line variable assignment, not opened as a
+  # file — silently dropping it from the scan. Prefixing an unrooted operand
+  # with `./` breaks the identifier=value shape (`./` is never a valid awk
+  # identifier lead character) so it is unambiguously a filename. Shared fix
+  # with check-shell-portability.sh's identical mechanism — see #1513, #1531.
+  local awk_file="$file"
+  case "$awk_file" in
+  ./* | /*) ;;
+  *) awk_file="./$awk_file" ;;
+  esac
   awk '
     function is_annotated(l) { return l ~ /portability-ok:/ }
     # Block-level only: a content line that merely happens to carry an inline
@@ -202,7 +214,7 @@ scan_file() {
         }
       }
     }
-  ' "$TOKENS" "$file"
+  ' "$TOKENS" "$awk_file"
 }
 
 violations=0

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -196,6 +196,25 @@ else
 fi
 rm -f "$f"
 
+# =============================================================================
+# awk operand disambiguation: a scanned file whose name is shaped like an
+# identifier=value assignment must not be silently dropped from the scan
+# (#1513, shared fix with check-shell-portability.sh's identical mechanism —
+# see #1531)
+# =============================================================================
+fx="$(mktemp -d)"
+mkdir -p "$fx/scripts"
+cp "$SCRIPT" "$fx/scripts/"
+printf 'diff against origin/main\n' >"$fx/FOO=bar.md"
+out="$(cd "$fx" && SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash scripts/check-skill-portability.sh --paths "FOO=bar.md" 2>&1)"
+rc=$?
+if [[ "$rc" -ne 0 ]] && echo "$out" | grep -q 'COUPLING: FOO=bar\.md:1:'; then
+  ok "a filename shaped like identifier=value is scanned, not silently dropped by awk"
+else
+  fail "an identifier=value-shaped filename must be scanned, not dropped (rc=$rc): $out"
+fi
+rm -rf "$fx"
+
 # --- staged (commented) tokens stay inactive under the REAL token list -----
 f="$(mktemp --suffix=.md)"
 printf '%s\n' 'This agnostic skill mentions dotnet and raw.githubusercontent.com.' >"$f"


### PR DESCRIPTION
Closes #1531

## Summary

`check-skill-portability.sh`'s `scan_file()` passed `"$TOKENS" "$file"` positionally to `awk`. A
scanned file whose relative path is shaped like an `identifier=value` assignment (e.g. a top-level
file literally named `FOO=bar.md`) is silently consumed by `awk` as a command-line variable
assignment instead of opened as a file, dropping it from the scan with no error.

`#1513` fixed the textually identical pattern in the sibling `check-shell-portability.sh` (landed
in `#1534`) by prefixing an unrooted file operand with `./` before it reaches `awk`, but that PR's
scope was limited to `check-shell-portability.sh` — `#1531` tracks applying the same fix here.
This PR:

- Applies the identical `./`-prefix disambiguation to `check-skill-portability.sh`'s `scan_file()`.
- Adds a mirrored regression test (`check-skill-portability.test.sh`) proving an
  `identifier=value`-shaped filename (`FOO=bar.md`) is scanned and its violation reported, not
  silently dropped.

## Test plan

- [x] `bash scripts/check-skill-portability.test.sh` — 20/20 passing (1 new: the
      identifier=value-shaped-filename regression case).
- [x] `bash scripts/check-shell-portability.test.sh` — 56/56 passing (sibling suite, unaffected —
      regression sanity check).
- [x] Verified the new test is meaningful: stashed the `check-skill-portability.sh` fix while
      keeping the new test and confirmed it fails (`PASS=19 FAIL=1`) without the fix, then restored
      the fix and confirmed it passes.
- [x] `shellcheck` on both modified files — clean, no findings.

## Related

- #1513 (identified the identical pattern in `check-shell-portability.sh`)
- #1534 (fixed #1513 in `check-shell-portability.sh`; explicitly scoped this awk-operand item out
  of `check-skill-portability.sh`)
- #1532 (duplicate of #1531, closed against it)

---

*This was generated by AI during work-loop execution.*
