### PR TITLE
fix(ci): shell-portability-lint's sort -V token misses operator-terminated forms

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1063,15 +1063,12 @@ fi
 rm -f "$f"
 
 # --- operator-terminated sed -Ei / --in-place forms are active in the
-# SHIPPED list too (#1545): both tokens use the control-operator/redirection/
-# subshell-close boundary, the same one `sort -V`/`grep -P`/`echo -e` now carry
-# after #1546 removed quotes and backticks from the short-option classes — a
-# quote after a short-option CLUSTER opens a word rather than ending it, so
-# `echo -e"mail"` passes the literal `-email` and the flag never activates.
-# `--sort=WORD` (#1530) is the one token that still includes quotes, because
-# there the quote follows the option's VALUE and is unambiguously closing.
-# Proven here against the real token list rather than only the isolated-token
-# mechanism above ------------------------------------------------------------
+# SHIPPED list too (#1545): both tokens end at a control operator, redirection
+# or subshell close, and -- like the `sort -V` / `grep -P` / `echo -e` classes
+# after #1546 -- not at a quote. Each token's own reason for excluding one is
+# recorded in shell-portability-tokens.txt; `--sort=WORD` (#1530) is the one
+# token that still admits a quote. Proven here against the real token list
+# rather than only the isolated-token mechanism above -----------------------
 f="$(tmpsh "$(printf '%s\n' \
   'x=$(sed -Ei)' \
   'sed -Ei|cat' \

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -335,6 +335,26 @@ else
 fi
 rm -f "$f"
 
+# --- an EMPTY quote pair is the one quoted form that must still match (#1546).
+# Quote removal deletes it, so the flag really is passed: on bash,
+# `printf '[%s]\n' -P'' pattern` prints `[-P]` then `[pattern]`, `grep -P'' '\d'`
+# matches a digit where a -P-less grep does not, and `echo -e'' 'a\tb'` emits a
+# real tab. Ignoring these was a false negative, not the accepted narrowing.
+f="$(tmpsh "$(printf '%s\n' \
+  "grep -P'' pattern" \
+  'sort -V"" file' \
+  "echo -e'' value" \
+  "grep -P''" \
+  'sort -V""')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "empty quote pairs should still be detected, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 5 ]]; then
+  ok "an empty quote pair after an option cluster is still detected"
+else
+  fail "expected all 5 empty-pair forms flagged, got: $out"
+fi
+rm -f "$f"
+
 # --- a process substitution attached to an option word is the same shape as an
 # attached quote, not a redirection (#1546): the shell concatenates `<(`/`>(`
 # into the current word, so bash runs `echo -e<(printf x)` as the single

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -335,6 +335,40 @@ else
 fi
 rm -f "$f"
 
+# --- a process substitution attached to an option word is the same shape as an
+# attached quote, not a redirection (#1546): the shell concatenates `<(`/`>(`
+# into the current word, so bash runs `echo -e<(printf x)` as the single
+# argument `-e/dev/fd/63` and prints it literally -- the flag never activates.
+f="$(tmpsh "$(printf '%s\n' \
+  'echo -e<(printf x)' \
+  'grep -P<(printf x) foo' \
+  'sort -V<(printf x)' \
+  'sort --sort=version<(printf x)' \
+  'grep -P>(cat) foo')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  ok "a process substitution attached to an option cluster is not flagged"
+else
+  fail "attached process substitutions must not be flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- ...but a bare `<`/`>` still opens a REDIRECTION, which does terminate the
+# word, so the operator-terminated detections #1537 added must all survive.
+f="$(tmpsh "$(printf '%s\n' \
+  'sort -V <file' \
+  'sort -V >out' \
+  'grep -P<file' \
+  'echo -e>out' \
+  'sort --sort=version<file')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "redirection-terminated GNU options should fail, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 5 ]]; then
+  ok "a redirection after an option cluster still terminates the word and is flagged"
+else
+  fail "expected all 5 redirection forms flagged, got: $out"
+fi
+rm -f "$f"
+
 # =============================================================================
 # sed -i without a backup-suffix argument
 # =============================================================================

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -140,7 +140,7 @@ done
 # grep -P / --perl-regexp
 # =============================================================================
 
-tok="$(one_token_list 'grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]]|$)')"
+tok="$(one_token_list 'grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>'"'"'"`]|$)')"
 
 f="$(tmpsh 'grep -P "\\d+" "$file"')"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -175,11 +175,30 @@ else
 fi
 rm -f "$f" "$tok"
 
+# --- operator-terminated forms: no trailing whitespace before a control
+# operator, redirection, subshell close or quote must still be detected
+# (#1537 — the boundary originally accepted only whitespace or end of line) -
+tok="$(one_token_list 'grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>'"'"'"`]|$)')"
+while IFS= read -r case; do
+  f="$(tmpsh "$case")"
+  if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+    fail "[$case] should fail, got success: $out"
+  else
+    ok "[$case] is detected"
+  fi
+  rm -f "$f"
+done <<'CASES'
+x=$(grep -P)
+grep -P|head -n1
+grep -P; echo done
+CASES
+rm -f "$tok"
+
 # =============================================================================
 # echo -e / sort -V
 # =============================================================================
 
-tok="$(one_token_list 'echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]]|$)')"
+tok="$(one_token_list 'echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>'"'"'"`]|$)')"
 
 f="$(tmpsh 'echo -e "line1\nline2"')"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -196,9 +215,25 @@ if scan_paths "$tok" "$f" >/dev/null 2>&1; then
 else
   ok "echo -ne (combined flags) is detected"
 fi
-rm -f "$f" "$tok"
+rm -f "$f"
 
-tok="$(one_token_list 'sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]]|$)')"
+# --- operator-terminated forms (#1537) --------------------------------------
+while IFS= read -r case; do
+  f="$(tmpsh "$case")"
+  if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+    fail "[$case] should fail, got success: $out"
+  else
+    ok "[$case] is detected"
+  fi
+  rm -f "$f"
+done <<'CASES'
+x=$(echo -e)
+echo -e|cat
+echo -e; echo done
+CASES
+rm -f "$tok"
+
+tok="$(one_token_list 'sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()<>'"'"'"`]|$)')"
 
 f="$(tmpsh 'sort -V "$file"')"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -215,7 +250,26 @@ if scan_paths "$tok" "$f" >/dev/null 2>&1; then
 else
   ok "sort -Vr (V not last in the cluster) is detected"
 fi
-rm -f "$f" "$tok"
+rm -f "$f"
+
+# --- operator-terminated forms: no trailing whitespace before a control
+# operator, redirection, subshell close or quote must still be detected
+# (#1537 — the boundary originally accepted only whitespace or end of line,
+# missing exactly these three forms cited in the issue) ---------------------
+while IFS= read -r case; do
+  f="$(tmpsh "$case")"
+  if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+    fail "[$case] should fail, got success: $out"
+  else
+    ok "[$case] is detected"
+  fi
+  rm -f "$f"
+done <<'CASES'
+x=$(sort -V)
+sort -V|head -n1
+sort -V; echo done
+CASES
+rm -f "$tok"
 
 # --- sort -V's long-form spellings: --version-sort and --sort=version ------
 tok="$(one_token_list '--version-sort')"
@@ -708,6 +762,26 @@ elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 5 ]] &&
   ok "the shipped list detects every sort long form and spares git tag --sort=<key>"
 else
   fail "expected hits on lines 1-5 only, got: $out"
+fi
+rm -f "$f"
+
+# --- operator-terminated short-flag forms are active in the SHIPPED list too
+# (#1537): sort -V, grep -P, echo -e each widened to the same boundary
+# `--sort=WORD` already used, proven here against the real token list rather
+# than only the isolated-token mechanism above ------------------------------
+f="$(tmpsh "$(printf '%s\n' \
+  'x=$(sort -V)' \
+  'sort -V|head -n1' \
+  'x=$(grep -P)' \
+  'grep -P|head -n1' \
+  'x=$(echo -e)' \
+  'echo -e|cat')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "operator-terminated sort -V/grep -P/echo -e should fail under the shipped list, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 6 ]]; then
+  ok "the shipped list detects every operator-terminated sort -V/grep -P/echo -e form"
+else
+  fail "expected all 6 operator-terminated forms flagged, got: $out"
 fi
 rm -f "$f"
 

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -403,6 +403,42 @@ else
 fi
 rm -f "$f"
 
+# --- a cluster letter AFTER a quoted pair is still part of the same word, so
+# letters and quoted chunks interleave rather than the letters having to come
+# first (#1546). Verified on bash: `grep -P"a"i '\d'` matches a digit where a
+# -P-less grep does not, `sort -V"r"f` reverse version-sorts, and
+# `echo -e"n"E 'a\tb'` consumes the whole word as the `-enE` option cluster
+# (nothing of it is printed).
+f="$(tmpsh "$(printf '%s\n' \
+  'grep -P"x"i pattern file' \
+  "grep -P'x'i pattern file" \
+  'sort -V"r"f file' \
+  "echo -e\"n\"E 'a\\tb'")")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "a cluster letter after a quoted pair should be flagged, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 4 ]]; then
+  ok "cluster letters and quoted chunks interleave in either order"
+else
+  fail "expected all 4 interleaved forms flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- ...and the option scan stops at a shell command separator (#1546), the
+# same rule the mktemp -p token carries: a physical line is not a command, so
+# with `|` and `;` in the boundary a LATER command's option-shaped argument
+# was being attributed to an earlier grep/sort.
+f="$(tmpsh "$(printf '%s\n' \
+  "grep foo /dev/null; printf '%s\\n' -P|cat" \
+  "sort /dev/null; printf '%s\\n' -V|cat" \
+  "grep foo /dev/null && printf '%s\\n' -P" \
+  "sort /dev/null && printf '%s\\n' --sort=version")")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  ok "a later command's -P/-V/--sort argument is not attributed to grep/sort"
+else
+  fail "the option scan must stop at a command separator, got: $out"
+fi
+rm -f "$f"
+
 # --- a process substitution attached to an option word is the same shape as an
 # attached quote, not a redirection (#1546): the shell concatenates `<(`/`>(`
 # into the current word, so bash runs `echo -e<(printf x)` as the single

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -318,20 +318,52 @@ fi
 rm -f "$f" "$tok"
 
 # --- an OPENING quote after a short-option cluster is not a word terminator
-# (#1546). The shell concatenates it into the same word, so the flag never
-# activates: bash prints `echo -e"mail"` as the literal `-email`, and
-# `echo -e"mail\tX"` as `-email\tX` with no escape interpretation. Flagging
-# these would be a false positive on portable code, so quotes and backticks are
-# excluded from the short-option boundary — unlike `--sort=WORD` above, where
-# the quote follows the option's VALUE and is unambiguously closing.
+# (#1546): the shell splices it into the same word. For `echo` that ends the
+# matter, because a non-cluster splice is simply printed -- bash prints
+# `echo -e"mail"` as the literal `-email` and `echo -e"mail\tX"` as
+# `-email\tX` with no escape interpretation. That is working portable code and
+# flagging it would be a false positive, so echo's continuation class is
+# limited to its own cluster letters (bash advertises `echo [-neE]`).
 f="$(tmpsh "$(printf '%s\n' \
   'echo -e"mail"' \
-  'grep -P"attern" file' \
-  'sort -V"ersion" file')")"
+  'echo -e"mail\tX"')")"
 if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
-  ok "an opening quote after a short-option cluster is not flagged (word continues, flag never set)"
+  ok "a non-cluster quoted splice after echo -e is not flagged (printed literally)"
 else
-  fail "opening-quote concatenations must not be flagged, got: $out"
+  fail "echo -e non-cluster splices must not be flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- ...but the splice DOES keep the flag live when the content is option
+# letters, so grep and sort must still be flagged there (#1546). Verified on
+# bash: `grep -P"i" '\d'` matches a digit where the same grep without -P does
+# not, `grep -Px '.*\d.*'` likewise, and `sort -V"r"` reverse version-sorts.
+f="$(tmpsh "$(printf '%s\n' \
+  'grep -P"x" file' \
+  "grep -P'x' file" \
+  'sort -V"r" file' \
+  "echo -e\"n\" 'a\\tb'")")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "letter splices keep the GNU flag live and should fail, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 4 ]]; then
+  ok "a quoted splice of option letters still reports the live GNU flag"
+else
+  fail "expected all 4 letter splices flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- a splice that is neither empty nor option letters is not a cluster at
+# all, and for grep/sort it is not working code either (`grep -P"attern"` and
+# `sort -V"ersion"` both abort with `unknown option`), so a variable or a
+# multi-word value stays unflagged rather than guessing at its expansion.
+f="$(tmpsh "$(printf '%s\n' \
+  'grep -P"$re" file' \
+  'sort -V"$v" file' \
+  'grep -P"x y" file')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  ok "a non-letter quoted splice is not treated as a cluster"
+else
+  fail "variable and multi-word splices must not be flagged, got: $out"
 fi
 rm -f "$f"
 
@@ -352,6 +384,22 @@ elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 5 ]]; then
   ok "an empty quote pair after an option cluster is still detected"
 else
   fail "expected all 5 empty-pair forms flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- REPEATED empty pairs are removed just the same, so the class is starred
+# rather than optional (#1546): `printf '[%s]\n' -P'''' pattern` prints `[-P]`
+# then `[pattern]`, exactly as the single-pair form does.
+f="$(tmpsh "$(printf '%s\n' \
+  "grep -P'''' pattern" \
+  'sort -V'"''"'"" file' \
+  "echo -e\"\"'' value")")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "repeated empty quote pairs should be detected, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 3 ]]; then
+  ok "repeated empty quote pairs are detected, not just a single pair"
+else
+  fail "expected all 3 repeated-pair forms flagged, got: $out"
 fi
 rm -f "$f"
 

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -452,6 +452,39 @@ else
 fi
 rm -f "$f"
 
+# --- ...but echo's cluster admits only its own letters, quoted or not (#1546).
+# `help echo` advertises `echo [-neE]`, so any other letter makes the word an
+# unrecognized option that bash prints literally rather than a longer cluster
+# -- verified: `echo -em "a\tb"`, `echo -me "a\tb"` and
+# `echo -e"n"mail "a\tb"` each emit the option word followed by the literal
+# `a\tb`. All three are working portable code. grep and sort need no such
+# narrowing: an unrecognized cluster aborts them, so there is nothing working
+# to break.
+f="$(tmpsh "$(printf '%s\n' \
+  "echo -e\"n\"mail 'a\\tb'" \
+  "echo -em 'a\\tb'" \
+  "echo -me 'a\\tb'")")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  ok "a non-[neE] letter in echo's cluster is printed literally and is not flagged"
+else
+  fail "echo clusters with a non-[neE] letter must not be flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- ...while every genuine [neE] cluster still is.
+f="$(tmpsh "$(printf '%s\n' \
+  "echo -ne 'a\\tb'" \
+  "echo -eE 'a\\tb'" \
+  "echo -e\"n\"E 'a\\tb'")")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "genuine [neE] clusters should still be flagged, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 3 ]]; then
+  ok "echo clusters built only from n/e/E are still flagged"
+else
+  fail "expected all 3 [neE] clusters flagged, got: $out"
+fi
+rm -f "$f"
+
 # --- ...and the option scan stops at a shell command separator (#1546), the
 # same rule the mktemp -p token carries: a physical line is not a command, so
 # with `|` and `;` in the boundary a LATER command's option-shaped argument

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -317,6 +317,24 @@ else
 fi
 rm -f "$f" "$tok"
 
+# --- an OPENING quote after a short-option cluster is not a word terminator
+# (#1546). The shell concatenates it into the same word, so the flag never
+# activates: bash prints `echo -e"mail"` as the literal `-email`, and
+# `echo -e"mail\tX"` as `-email\tX` with no escape interpretation. Flagging
+# these would be a false positive on portable code, so quotes and backticks are
+# excluded from the short-option boundary — unlike `--sort=WORD` above, where
+# the quote follows the option's VALUE and is unambiguously closing.
+f="$(tmpsh "$(printf '%s\n' \
+  'echo -e"mail"' \
+  'grep -P"attern" file' \
+  'sort -V"ersion" file')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  ok "an opening quote after a short-option cluster is not flagged (word continues, flag never set)"
+else
+  fail "opening-quote concatenations must not be flagged, got: $out"
+fi
+rm -f "$f"
+
 # =============================================================================
 # sed -i without a backup-suffix argument
 # =============================================================================

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -367,6 +367,35 @@ else
 fi
 rm -f "$f"
 
+# --- the segment scan stops at a command SEPARATOR, but a command
+# SUBSTITUTION in an earlier argument is not one: the outer command continues
+# past the closing paren, so excluding `(`/`)` from the gap hid a live GNU-only
+# option later on the same command (#1546).
+f="$(tmpsh "$(printf '%s\n' \
+  'grep -e "$(printf pattern)" -P file' \
+  'sort -k "$(printf 1)" -V file' \
+  'sort -k "$(printf 1)" --sort=version file')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "an option after a command substitution should fail, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 3 ]]; then
+  ok "the scan continues past a command substitution to a later GNU-only option"
+else
+  fail "expected all 3 post-substitution options flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- ...while a real separator still stops it, so the #1546 false positive
+# that motivated scoping the gap stays fixed.
+f="$(tmpsh "$(printf '%s\n' \
+  "grep foo /dev/null; printf '%s\\\\n' -P|cat" \
+  "sort /dev/null; printf '%s\\\\n' -V|cat")")"
+if scan_paths "$REAL_TOKENS" "$f" >/dev/null 2>&1; then
+  ok "a later command's option-shaped argument is still not attributed backwards"
+else
+  fail "the separator scoping must still hold: $(scan_paths "$REAL_TOKENS" "$f" 2>&1)"
+fi
+rm -f "$f"
+
 # --- an EMPTY quote pair is the one quoted form that must still match (#1546).
 # Quote removal deletes it, so the flag really is passed: on bash,
 # `printf '[%s]\n' -P'' pattern` prints `[-P]` then `[pattern]`, `grep -P'' '\d'`

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -66,12 +66,24 @@
 # without PCRE support. `P` may appear anywhere in a combined short-option
 # cluster (`-riP`, `-nP`), not only as the cluster's last letter. Boundary
 # after the cluster is every character that can actually END a shell word —
-# whitespace, a control operator, a redirection, a subshell close, a quote —
-# or end of line (the same class #1530 landed for `--sort=WORD` below), so an
-# operator-terminated form with no trailing whitespace (`x=$(grep -P ...)`,
-# `grep -P ...|head`, `grep -P ...; echo`) is still detected — a whitespace-
-# only boundary silently missed those (#1537).
-grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>'"`]|$)
+# whitespace, a control operator, a redirection, a subshell close — or end of
+# line, so an operator-terminated form with no trailing whitespace
+# (`x=$(grep -P ...)`, `grep -P ...|head`, `grep -P ...; echo`) is still
+# detected; a whitespace-only boundary silently missed those (#1537).
+#
+# Quotes and backticks are deliberately NOT in this class, unlike the
+# `--sort=WORD` boundary below (#1546). After a SHORT-OPTION CLUSTER a quote is
+# an OPENING delimiter, not a terminator: the shell concatenates it into the
+# same word, so `grep -P"x"` passes the single argument `-Px` and never enables
+# `-P` at all. Verified on bash: `echo -e"mail"` prints the literal `-email`,
+# and `echo -e"mail\tX"` prints `-email\tX` with no escape interpretation.
+# Flagging those is a false positive on portable code. Accepted narrowing: a
+# genuine GNU use terminated by a CLOSING quote (`alias g='grep -P'`) is no
+# longer matched — an ERE cannot tell an opening delimiter from a closing one,
+# and a gate that rejects correct code gets switched off, which costs more than
+# this residue. `--sort=WORD` keeps quotes because there the quote follows the
+# option's VALUE and is unambiguously closing.
+grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>]|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
@@ -82,7 +94,7 @@ grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>'"`]|$)
 # operator-terminated boundary as `grep -P` above (#1537): `x=$(echo -e ...)`,
 # `echo -e ...|cat`, `echo -e ...; echo` are detected, not only the
 # whitespace-terminated form.
-echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>'"`]|$)
+echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>]|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
@@ -108,7 +120,7 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>'"`]|$)
 # of false negative the `--sort=WORD` boundary above was built to avoid, now
 # widened to match it (#1537, found while auditing #1530's own new token for
 # the same defect).
-sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()<>'"`]|$)
+sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()<>]|$)
 --version-sort
 sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()<>'"`]|$)
 

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -91,7 +91,15 @@
 # passed. `[<>]([^(]|$)` therefore keeps the redirection boundary
 # (`grep -P ... <file`) while excluding the process-substitution one. Every
 # boundary below that admits `<`/`>` carries the same shape.
-grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
+#
+# An EMPTY quote pair is the one quoted form that must still match (#1546).
+# Quote removal deletes it outright, so `grep -P'' pattern` passes the argument
+# `-P` exactly — verified on bash: `printf '[%s]\n' -P'' pattern` prints `[-P]`
+# and `[pattern]`, `grep -P'' '\d'` matches a digit where a `-P`-less grep does
+# not, and `echo -e'' 'a\tb'` emits a real tab. A NONEMPTY pair still opens a
+# word and is still ignored, so `(''|"")?` sits before the boundary rather than
+# inside it: the empty pair is skipped, then a genuine terminator must follow.
+grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
@@ -102,7 +110,7 @@ grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
 # operator-terminated boundary as `grep -P` above (#1537): `x=$(echo -e ...)`,
 # `echo -e ...|cat`, `echo -e ...; echo` are detected, not only the
 # whitespace-terminated form.
-echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
+echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
@@ -128,7 +136,7 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
 # of false negative the `--sort=WORD` boundary above was built to avoid, now
 # widened to match it (#1537, found while auditing #1530's own new token for
 # the same defect).
-sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
+sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
 --version-sort
 sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
 

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -64,16 +64,25 @@
 
 # `grep -P` (PCRE mode) — absent in BSD grep, and in some GNU builds compiled
 # without PCRE support. `P` may appear anywhere in a combined short-option
-# cluster (`-riP`, `-nP`), not only as the cluster's last letter.
-grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]]|$)
+# cluster (`-riP`, `-nP`), not only as the cluster's last letter. Boundary
+# after the cluster is every character that can actually END a shell word —
+# whitespace, a control operator, a redirection, a subshell close, a quote —
+# or end of line (the same class #1530 landed for `--sort=WORD` below), so an
+# operator-terminated form with no trailing whitespace (`x=$(grep -P ...)`,
+# `grep -P ...|head`, `grep -P ...; echo`) is still detected — a whitespace-
+# only boundary silently missed those (#1537).
+grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>'"`]|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
 # builtin `echo` treats `-e` as a literal argument, not an escape-interpretation
 # flag. `printf '%b\n'` (or a literal `$'...'` ANSI-C string) is the portable
 # replacement. `e` may appear anywhere in echo's short-option cluster
-# (bash advertises `echo [-neE]`), not only as a standalone `-e`.
-echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]]|$)
+# (bash advertises `echo [-neE]`), not only as a standalone `-e`. Same
+# operator-terminated boundary as `grep -P` above (#1537): `x=$(echo -e ...)`,
+# `echo -e ...|cat`, `echo -e ...; echo` are detected, not only the
+# whitespace-terminated form.
+echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>'"`]|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
@@ -92,8 +101,14 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]]|$)
 # matched, while a longer word like `version:refname` still is not. WORD is a
 # MANDATORY argument, so GNU's getopt_long takes it attached after `=` or as
 # the next argv element, and the shell may hand it over quoted — every one of
-# those spellings is the same GNU-only operation.
-sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]]|$)
+# those spellings is the same GNU-only operation. The short-flag cluster
+# pattern below carries the identical operator-terminated boundary: it
+# originally accepted only trailing whitespace or end of line, missing
+# `x=$(sort -V)` / `sort -V|head -n1` / `sort -V; echo done` — the same class
+# of false negative the `--sort=WORD` boundary above was built to avoid, now
+# widened to match it (#1537, found while auditing #1530's own new token for
+# the same defect).
+sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()<>'"`]|$)
 --version-sort
 sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()<>'"`]|$)
 

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -83,7 +83,15 @@
 # and a gate that rejects correct code gets switched off, which costs more than
 # this residue. `--sort=WORD` keeps quotes because there the quote follows the
 # option's VALUE and is unambiguously closing.
-grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>]|$)
+#
+# `<` and `>` terminate a word only when they open a REDIRECTION. `<(` and `>(`
+# open a process substitution, which the shell concatenates into the current
+# word exactly as a quote does (#1546): bash expands `echo -e<(printf x)` to
+# the single argument `-e/dev/fd/63` and prints it literally, so `-e` is never
+# passed. `[<>]([^(]|$)` therefore keeps the redirection boundary
+# (`grep -P ... <file`) while excluding the process-substitution one. Every
+# boundary below that admits `<`/`>` carries the same shape.
+grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
@@ -94,7 +102,7 @@ grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*([[:space:]|&;()<>]|$)
 # operator-terminated boundary as `grep -P` above (#1537): `x=$(echo -e ...)`,
 # `echo -e ...|cat`, `echo -e ...; echo` are detected, not only the
 # whitespace-terminated form.
-echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>]|$)
+echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
@@ -120,9 +128,9 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*([[:space:]|&;()<>]|$)
 # of false negative the `--sort=WORD` boundary above was built to avoid, now
 # widened to match it (#1537, found while auditing #1530's own new token for
 # the same defect).
-sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()<>]|$)
+sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --version-sort
-sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()<>'"`]|$)
+sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
 
 # `sed -i` with no suffix argument attached — GNU treats the suffix as
 # optional; BSD sed requires one immediately after `-i`. This intentionally

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -92,14 +92,23 @@
 # (`grep -P ... <file`) while excluding the process-substitution one. Every
 # boundary below that admits `<`/`>` carries the same shape.
 #
-# An EMPTY quote pair is the one quoted form that must still match (#1546).
-# Quote removal deletes it outright, so `grep -P'' pattern` passes the argument
-# `-P` exactly — verified on bash: `printf '[%s]\n' -P'' pattern` prints `[-P]`
-# and `[pattern]`, `grep -P'' '\d'` matches a digit where a `-P`-less grep does
-# not, and `echo -e'' 'a\tb'` emits a real tab. A NONEMPTY pair still opens a
-# word and is still ignored, so `(''|"")?` sits before the boundary rather than
-# inside it: the empty pair is skipped, then a genuine terminator must follow.
-grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
+# What a quoted continuation does depends on what is INSIDE it, so the rule is
+# not "ignore every quote" (#1546). Quote removal splices the content straight
+# into the word, and for a flag that takes no argument the result is a longer
+# OPTION CLUSTER rather than a value:
+#   - an EMPTY pair, however many — spliced away entirely, so the bare flag is
+#     what runs: `printf '[%s]\n' -P'''' pattern` prints `[-P]` then `[pattern]`.
+#   - option LETTERS — a valid longer cluster with the GNU flag still set:
+#     `grep -P"x"` runs as `grep -Px`, and `grep -P"i" '\d'` matches a digit
+#     where the same grep without `-P` does not; `sort -V"r"` reverse
+#     version-sorts.
+#   - anything else — not a cluster at all, and not portable code either:
+#     `grep -P"attern"` and `sort -V"ersion"` both abort with `unknown option`,
+#     so there is no GNU-only behaviour to report and nothing working to break.
+# `(['"][A-Za-z]*['"])*` admits the first two and excludes the third, and being
+# starred it accepts repeated pairs. `echo` is the exception and narrows the
+# class to its own cluster letters — see its token below.
+grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*(['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
@@ -110,7 +119,12 @@ grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|
 # operator-terminated boundary as `grep -P` above (#1537): `x=$(echo -e ...)`,
 # `echo -e ...|cat`, `echo -e ...; echo` are detected, not only the
 # whitespace-terminated form.
-echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
+# echo is the exception to the quoted-continuation class above: bash advertises
+# `echo [-neE]`, so only those letters extend the cluster. `echo -e"n" 'a\tb'`
+# emits a real tab (`-en` is live), while `echo -e"mail"` is not a cluster at
+# all and — unlike grep and sort, which abort — echo just prints the literal
+# `-email`. That last form is working portable code and must stay unflagged.
+echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*(['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
@@ -136,7 +150,7 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
 # of false negative the `--sort=WORD` boundary above was built to avoid, now
 # widened to match it (#1537, found while auditing #1530's own new token for
 # the same defect).
-sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*(''|"")?([[:space:]|&;()]|[<>]([^(]|$)|$)
+sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*(['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --version-sort
 sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
 

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -105,10 +105,24 @@
 #   - anything else — not a cluster at all, and not portable code either:
 #     `grep -P"attern"` and `sort -V"ersion"` both abort with `unknown option`,
 #     so there is no GNU-only behaviour to report and nothing working to break.
-# `(['"][A-Za-z]*['"])*` admits the first two and excludes the third, and being
-# starred it accepts repeated pairs. `echo` is the exception and narrows the
-# class to its own cluster letters — see its token below.
-grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*(['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+# `(['"][A-Za-z]*['"])*` admits the first two, and being starred it accepts
+# repeated pairs. `echo` is the exception and narrows the class to its own
+# cluster letters — see its token below.
+#
+# Cluster letters and quoted chunks INTERLEAVE, so the continuation is one
+# alternation rather than a letter run followed by a quote run (#1546). Quote
+# removal produces a single word either way, and a plain letter after a pair
+# is as much part of the cluster as one before it: `grep -P"x"i` runs as
+# `grep -Pxi` (verified: it matches `\d` where the same grep without `-P` does
+# not), `sort -V"r"f` reverse version-sorts, and `echo -e"n"E` is consumed
+# whole as the `-enE` option cluster.
+#
+# The scan gap stops at a shell command separator, exactly as the `mktemp -p`
+# token below does (#1546): a physical line is not a command, so `[^\n]*` let
+# a LATER command's option-shaped word be attributed to this one — with `|`
+# and `;` now in the boundary, `grep foo /dev/null; printf '%s\n' -P|cat` was
+# reported even though the `-P` is printf's data.
+grep[^;&|()\n]*[[:space:]]-[A-Za-z]*P([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
@@ -124,7 +138,7 @@ grep[^\n]*[[:space:]]-[A-Za-z]*P[A-Za-z]*(['"][A-Za-z]*['"])*([[:space:]|&;()]|[
 # emits a real tab (`-en` is live), while `echo -e"mail"` is not a cluster at
 # all and — unlike grep and sort, which abort — echo just prints the literal
 # `-email`. That last form is working portable code and must stay unflagged.
-echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*(['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+echo[[:space:]]+-[a-zA-Z]*e([a-zA-Z]|['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),
@@ -150,9 +164,9 @@ echo[[:space:]]+-[a-zA-Z]*e[a-zA-Z]*(['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]
 # of false negative the `--sort=WORD` boundary above was built to avoid, now
 # widened to match it (#1537, found while auditing #1530's own new token for
 # the same defect).
-sort[^\n]*[[:space:]]-[A-Za-z]*V[A-Za-z]*(['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+sort[^;&|()\n]*[[:space:]]-[A-Za-z]*V([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --version-sort
-sort[^\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
+sort[^;&|()\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
 
 # `sed -i` with no suffix argument attached — GNU treats the suffix as
 # optional; BSD sed requires one immediately after `-i`. This intentionally

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -122,7 +122,7 @@
 # a LATER command's option-shaped word be attributed to this one — with `|`
 # and `;` now in the boundary, `grep foo /dev/null; printf '%s\n' -P|cat` was
 # reported even though the `-P` is printf's data.
-grep[^;&|()\n]*[[:space:]]-[A-Za-z]*P([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+grep[^;&|\n]*[[:space:]]-[A-Za-z]*P([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash
@@ -164,9 +164,9 @@ echo[[:space:]]+-[a-zA-Z]*e([a-zA-Z]|['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]
 # of false negative the `--sort=WORD` boundary above was built to avoid, now
 # widened to match it (#1537, found while auditing #1530's own new token for
 # the same defect).
-sort[^;&|()\n]*[[:space:]]-[A-Za-z]*V([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+sort[^;&|\n]*[[:space:]]-[A-Za-z]*V([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --version-sort
-sort[^;&|()\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
+sort[^;&|\n]*[[:space:]]--sort(=|[[:space:]]+)['"]?version([[:space:]|&;()'"`]|[<>]([^(]|$)|$)
 
 # `sed -i` with no suffix argument attached — GNU treats the suffix as
 # optional; BSD sed requires one immediately after `-i`. This intentionally

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -134,11 +134,15 @@ grep[^;&|\n]*[[:space:]]-[A-Za-z]*P([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()
 # `echo -e ...|cat`, `echo -e ...; echo` are detected, not only the
 # whitespace-terminated form.
 # echo is the exception to the quoted-continuation class above: bash advertises
-# `echo [-neE]`, so only those letters extend the cluster. `echo -e"n" 'a\tb'`
-# emits a real tab (`-en` is live), while `echo -e"mail"` is not a cluster at
-# all and — unlike grep and sort, which abort — echo just prints the literal
-# `-email`. That last form is working portable code and must stay unflagged.
-echo[[:space:]]+-[a-zA-Z]*e([a-zA-Z]|['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+# `echo [-neE]`, so only those letters extend the cluster — QUOTED OR NOT
+# (#1546). A letter outside that set makes the word an unrecognized option
+# rather than a longer cluster, and bash then just prints it: `echo -em`,
+# `echo -me` and `echo -e"n"mail` all emit the option word literally, so every
+# one of them is working portable code that must stay unflagged. `echo -e"n"`
+# and `echo -ne` do emit a real tab. Unlike grep and sort — which abort on an
+# unrecognized cluster, leaving nothing working to break — a too-liberal class
+# here rejects code that runs correctly on both dialects.
+echo[[:space:]]+-[neE]*e([neE]|['"][neE]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 
 # `sort -V` (natural/version sort) — a GNU coreutils extension; BSD sort has no
 # `-V`. `V` may appear anywhere in a combined short-option cluster (`-Vr`),


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

Closes #1537

## Summary

- #1530 (which added `--sort=WORD` for `sort -V`'s long form) fixed the whitespace-only-boundary
  false negative on its own new token, but deliberately left the pre-existing `sort -V` short-flag
  cluster token untouched — widening it changes the gate's firing envelope over the existing corpus,
  not just #1530's new token, so it was scoped out. #1537 asked for exactly that widening, plus the
  same treatment for the sibling `grep -P` / `echo -e` short-flag tokens, which share the identical
  defect: the boundary accepted only trailing whitespace or end of line, so a flag terminated by a
  shell control operator with no intervening whitespace evaded detection — `x=$(sort -V)`,
  `sort -V|head -n1`, `sort -V; echo done` (and the same shapes for `grep -P` / `echo -e`).
- Widens all three tokens to the operator-terminated boundary #1530 already established for
  `--sort=WORD`: `([[:space:]|&;()<>'"`+"`"+`]|$)` — every character that can actually end a shell
  word (whitespace, a control operator, a redirection, a subshell close, a quote), not only
  whitespace.
- **Verified before landing, per the issue's instruction.** Ran `check-shell-portability.sh --all`
  against the corpus before and after the token edit: the hit sets are byte-for-byte identical (68
  pre-existing findings — the regex-escape family `\b \< \> \s \S \w \W` plus one unrelated `sed -i`
  site — none of them `sort`/`grep`/`echo`), so the widened boundary surfaces no new corpus
  violations and needs no `portability-ok:` annotations.
- **Found the same defect in two more tokens while auditing the three named siblings — scoped out,
  not absorbed.** `sed -Ei` and `sed --in-place` (from #1513/#1534) carry the identical
  whitespace-or-end-of-line boundary and the identical false negative, verified empirically:
  `x=$(sed -Ei)`, `sed -Ei|cat`, `sed --in-place|cat`, `x=$(sed --in-place)` all pass the shipped
  list today. #1537 named only `sort -V` / `grep -P` / `echo -e`, so — following the same
  narrow-scope discipline #1530 itself modeled — filed as #1545 rather than expanding this PR's
  blast radius.

## Test plan

- [x] `bash scripts/check-shell-portability.test.sh` — 78/78 passing (12 new regression cases:
      3 operator-terminated forms each for `sort -V`, `grep -P`, `echo -e` at the isolated-token
      level, plus one shipped-list assertion proving all 6 forms are detected under the real
      `shell-portability-tokens.txt`, not just the isolated-token mechanism).
- [x] Verified the new tests are meaningful: stashed only `shell-portability-tokens.txt` (reverting
      to the old boundary) while keeping the widened test file — the shipped-list assertion fails
      as expected (`PASS=77 FAIL=1`); restored and confirmed 78/78 again. (The isolated-token tests
      hardcode the widened pattern directly via `one_token_list` and so are unaffected by the
      tokens-file revert — same shape as the existing `--sort=WORD` tests.)
- [x] `scripts/check-shell-portability.sh --all` — before/after hit sets identical (68 findings,
      unrelated to these tokens); see summary above.
- [x] `scripts/check-shell-portability.sh origin/main` run directly against this branch's own diff
      — clean (no unexcused GNU-only constructs in the 1 changed `.sh` file).
- [x] `shellcheck --rcfile=.shellcheckrc scripts/check-shell-portability.test.sh` — clean.
- [x] `typos --config _typos.toml` on both changed files — clean.

## Related

- #1530 (established the operator-terminated boundary shape this PR mirrors onto the sibling
  short-flag tokens)
- #1545 (follow-up: `sed -Ei` / `sed --in-place` carry the identical boundary defect, found while
  auditing this PR's three named siblings, explicitly scoped out)
- Follows #1491, #1511, #1513, #1519, #1534, #1538, #1543, #1544 on the same gate.
