### PR TITLE
fix(ci): shell-portability-lint's sed -Ei / --in-place tokens miss operator-terminated forms

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -310,7 +310,7 @@ rm -f "$f" "$tok"
 # cluster), and --in-place (GNU long form) — #1513
 # =============================================================================
 
-tok="$(one_token_list '(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]-[A-Za-z]*E[A-Za-z]*i([[:space:]]|$)')"
+tok="$(one_token_list '(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]-[A-Za-z]*E[A-Za-z]*i([[:space:]|&;()<>]|$)')"
 
 f="$(tmpsh "sed -Ei 's/foo/bar/' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -397,9 +397,28 @@ if scan_paths "$tok" "$f" >/dev/null 2>&1; then
 else
   fail "used=\"\$(grep -Ei ...)\" must not fire -- 'sed' inside an identifier is not a sed command"
 fi
-rm -f "$f" "$tok"
+rm -f "$f"
 
-tok="$(one_token_list '(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]--in-place([[:space:]]|=|$)')"
+# --- operator-terminated forms: no trailing whitespace before a control
+# operator, redirection, subshell close or quote must still be detected
+# (#1545 — the boundary originally accepted only whitespace or end of line,
+# the same class of false negative #1537 fixed for sort -V/grep -P/echo -e) -
+while IFS= read -r case; do
+  f="$(tmpsh "$case")"
+  if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+    fail "[$case] should fail, got success: $out"
+  else
+    ok "[$case] is detected"
+  fi
+  rm -f "$f"
+done <<'CASES'
+x=$(sed -Ei)
+sed -Ei|cat
+sed -Ei; echo done
+CASES
+rm -f "$tok"
+
+tok="$(one_token_list '(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]--in-place([[:space:]|&;()<>]|=|$)')"
 
 f="$(tmpsh "sed --in-place 's/foo/bar/' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -425,7 +444,23 @@ if scan_paths "$tok" "$f" >/dev/null 2>&1; then
 else
   fail "--in-place must be scoped to a sed invocation -- an unrelated option arm must not fire"
 fi
-rm -f "$f" "$tok"
+rm -f "$f"
+
+# --- operator-terminated forms (#1545) --------------------------------------
+while IFS= read -r case; do
+  f="$(tmpsh "$case")"
+  if out="$(scan_paths "$tok" "$f" 2>&1)"; then
+    fail "[$case] should fail, got success: $out"
+  else
+    ok "[$case] is detected"
+  fi
+  rm -f "$f"
+done <<'CASES'
+x=$(sed --in-place)
+sed --in-place|cat
+sed --in-place; echo done
+CASES
+rm -f "$tok"
 
 # =============================================================================
 # readlink -f / --canonicalize, auto-guarded by a co-located realpath attempt
@@ -708,6 +743,25 @@ elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 5 ]] &&
   ok "the shipped list detects every sort long form and spares git tag --sort=<key>"
 else
   fail "expected hits on lines 1-5 only, got: $out"
+fi
+rm -f "$f"
+
+# --- operator-terminated sed -Ei / --in-place forms are active in the
+# SHIPPED list too (#1545): both tokens widened to the same boundary
+# `--sort=WORD` (#1530) and `sort -V`/`grep -P`/`echo -e` (#1537) already use,
+# proven here against the real token list rather than only the isolated-token
+# mechanism above -------------------------------------------------------------
+f="$(tmpsh "$(printf '%s\n' \
+  'x=$(sed -Ei)' \
+  'sed -Ei|cat' \
+  'x=$(sed --in-place)' \
+  'sed --in-place|cat')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "operator-terminated sed -Ei/--in-place should fail under the shipped list, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 4 ]]; then
+  ok "the shipped list detects every operator-terminated sed -Ei/--in-place form"
+else
+  fail "expected all 4 operator-terminated forms flagged, got: $out"
 fi
 rm -f "$f"
 

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -128,8 +128,17 @@ sed[^\n]*-i[[:space:]]+[^[:space:]]
 # a `sed` COMMAND token (start of line or a non-identifier character before
 # it, whitespace after) — `-i` alone is common across tools (`grep -i`,
 # `sort -i`...), and a bare `sed` substring match would fire on identifiers
-# that merely contain those three letters (`used="$(grep -Ei ...)"`).
-(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]-[A-Za-z]*E[A-Za-z]*i([[:space:]]|$)
+# that merely contain those three letters (`used="$(grep -Ei ...)"`). Boundary
+# after the cluster widens to a control operator, a redirection, or a
+# subshell close — NOT a quote or backtick, unlike the sibling `sort -V` /
+# `grep -P` / `echo -e` tokens (#1537/#1546): a quote immediately following
+# `i` with no separating whitespace is exactly the attached-EMPTY-suffix
+# shape (`-Ei''`) deferred two paragraphs up, so including quotes in the
+# boundary would silently un-defer it by making `-Ei''` match at the `i`+`'`
+# junction. An operator-terminated form with no trailing whitespace
+# (`x=$(sed -Ei)`, `sed -Ei|cat`, `sed -Ei; echo done`) is still detected —
+# a whitespace-only boundary silently missed those (#1545).
+(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]-[A-Za-z]*E[A-Za-z]*i([[:space:]|&;()<>]|$)
 
 # `sed --in-place[=SUFFIX]` (GNU long-form spelling of `-i`) — BSD sed has no
 # long options at all, so this flags suffixed or not (unlike short `-i`, where
@@ -139,8 +148,13 @@ sed[^\n]*-i[[:space:]]+[^[:space:]]
 # `--perl-regexp` / `--version-sort`, the option name `--in-place` is not
 # unique to one tool (several formatters spell their own in-place flag that
 # way), so a bare token would flag a script that merely defines or forwards an
-# unrelated `--in-place` option of its own.
-(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]--in-place([[:space:]]|=|$)
+# unrelated `--in-place` option of its own. Same operator-terminated boundary
+# as the cluster token above (#1545) — no quote/backtick in the boundary
+# either, kept alongside the pre-existing `=` alternative for the
+# `--in-place=SUFFIX` attached-value form: `x=$(sed --in-place)`,
+# `sed --in-place|cat`, `sed --in-place; echo done` are now detected, not
+# only the whitespace- or `=`-terminated forms.
+(^|[^[:alnum:]_])sed([[:space:]][^\n]*)?[[:space:]]--in-place([[:space:]|&;()<>]|=|$)
 
 # `readlink -f` (canonicalize) — a GNU coreutils extension; BSD/macOS readlink
 # has no `-f`/`--canonicalize`. Auto-guarded when a `realpath` attempt is


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

Closes #1545

## Summary

- #1513/#1534 added GNU-only `sed -Ei` (combined extended-regex + in-place short-flag cluster) and
  `sed --in-place` (long-form) tokens to `scripts/shell-portability-tokens.txt`, but both only
  accepted a trailing whitespace-or-end-of-line boundary — the same shape #1530's original
  `sort -V` short-flag token had, and the same false negative #1537/#1546 fixed for `sort -V` /
  `grep -P` / `echo -e`: an operator-terminated form with no separating whitespace
  (`x=$(sed -Ei)`, `sed -Ei|cat`, `sed --in-place|cat`, `x=$(sed --in-place)`) evaded detection
  entirely. **Verified via repro** before any fix: all four forms passed the gate clean on `main`.
- Widens both tokens' trailing boundary to a control operator, redirection, or subshell close —
  `([[:space:]|&;()<>]|$)` (plus the pre-existing `=` alternative for `--in-place=SUFFIX`).
- **Deliberately narrower than the sibling `sort -V`/`grep -P`/`echo -e` boundary** (which also
  includes quote/backtick chars): a quote immediately following `-Ei` with no separating
  whitespace is exactly the attached-EMPTY-suffix shape (`sed -Ei''`) #1513/#1534 explicitly
  deferred as ambiguous sed-dialect territory (same as the `-i''` case). Confirmed empirically —
  copying the sibling tokens' full quote-inclusive boundary verbatim broke the existing
  `"sed -Ei'' must not be flagged"` regression test, since a bare quote character then satisfied
  the widened boundary at the `i`+`'` junction. Excluding quotes/backtick from this pair's
  boundary keeps that deferred case correctly unflagged while still catching every
  operator-terminated form the issue named (none of which need a quote as the terminator).
- **Verified before landing, per the issue's instruction.** Ran `check-shell-portability.sh --all`
  against the corpus before and after the token edit: the hit sets are byte-for-byte identical
  (75 pre-existing findings, none `sed`-related), so the widened boundary surfaces no new corpus
  violations and needs no `portability-ok:` annotations.

## Test plan

- [x] `bash scripts/check-shell-portability.test.sh` — 75/75 passing (6 new regression cases: 3
      operator-terminated forms each for `sed -Ei` and `sed --in-place` at the isolated-token
      level, plus one shipped-list assertion proving all 4 forms are detected under the real
      `shell-portability-tokens.txt`).
- [x] Verified the new tests are meaningful: reproduced the bug first (`bash
      scripts/check-shell-portability.sh --paths t.sh` against a file containing the four
      operator-terminated forms passed clean on `main`'s shipped list); after the fix, all four
      are flagged.
- [x] Verified the boundary is not over-widened: the full sibling (quote-inclusive) boundary was
      tried first and demonstrably broke the pre-existing `sed -Ei''` deferred-ambiguous-suffix
      test (`PASS=74 FAIL=1`); narrowed to exclude quotes/backtick, re-ran — `PASS=75 FAIL=0`.
- [x] `scripts/check-shell-portability.sh --all` — before/after hit sets identical (75 findings,
      unrelated to these tokens); see summary above.
- [x] `scripts/check-shell-portability.sh origin/main` run directly against this branch's own
      diff — clean (no unexcused GNU-only constructs in the 2 changed files).
- [x] `shellcheck --rcfile=.shellcheckrc scripts/check-shell-portability.test.sh` — clean.
- [x] `typos --config _typos.toml` on both changed files — clean.

## Related

- #1537 / #1546 (established the operator-terminated boundary shape this PR mirrors, and named
  `sed -Ei` / `sed --in-place` as the deferred-out sibling defect this PR fixes)
- #1513 / #1534 (introduced the two tokens this PR widens, and the attached-empty-suffix
  deferral this PR's narrower boundary deliberately preserves)
