### PR TITLE
fix(ci): correct sed -Ei/--in-place boundary comment and extend shipped-list coverage

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -400,9 +400,11 @@ fi
 rm -f "$f"
 
 # --- operator-terminated forms: no trailing whitespace before a control
-# operator, redirection, subshell close or quote must still be detected
-# (#1545 — the boundary originally accepted only whitespace or end of line,
-# the same class of false negative #1537 fixed for sort -V/grep -P/echo -e) -
+# operator, redirection, or subshell close must still be detected (#1545 —
+# the boundary originally accepted only whitespace or end of line, the same
+# class of false negative #1537 fixed for sort -V/grep -P/echo -e). Quotes
+# are NOT in this token's boundary (unlike the sibling tokens above) — see
+# the "sed -Ei'' must not be flagged" test above for why. --------------------
 while IFS= read -r case; do
   f="$(tmpsh "$case")"
   if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -747,21 +749,24 @@ fi
 rm -f "$f"
 
 # --- operator-terminated sed -Ei / --in-place forms are active in the
-# SHIPPED list too (#1545): both tokens widened to the same boundary
-# `--sort=WORD` (#1530) and `sort -V`/`grep -P`/`echo -e` (#1537) already use,
-# proven here against the real token list rather than only the isolated-token
-# mechanism above -------------------------------------------------------------
+# SHIPPED list too (#1545): both tokens widened to the control-operator/
+# redirection/subshell-close boundary (deliberately narrower than
+# `--sort=WORD` (#1530) and `sort -V`/`grep -P`/`echo -e` (#1537), which also
+# include quotes — see the token-file comment), proven here against the real
+# token list rather than only the isolated-token mechanism above -----------
 f="$(tmpsh "$(printf '%s\n' \
   'x=$(sed -Ei)' \
   'sed -Ei|cat' \
+  'sed -Ei; echo done' \
   'x=$(sed --in-place)' \
-  'sed --in-place|cat')")"
+  'sed --in-place|cat' \
+  'sed --in-place; echo done')")"
 if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
   fail "operator-terminated sed -Ei/--in-place should fail under the shipped list, got success: $out"
-elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 4 ]]; then
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 6 ]]; then
   ok "the shipped list detects every operator-terminated sed -Ei/--in-place form"
 else
-  fail "expected all 4 operator-terminated forms flagged, got: $out"
+  fail "expected all 6 operator-terminated forms flagged, got: $out"
 fi
 rm -f "$f"
 


### PR DESCRIPTION
*This was generated by AI during work-loop execution.*

No linked issue

## Summary

- #1548 (`sed -Ei` / `--in-place` operator-terminated boundary fix, closing #1545) picked up two
  non-blocking findings from its automated post-green review before it was merged out from under
  this follow-up by a concurrent auto-merge (worker-tier `babysit-prs`, gate-proven `c2-mechanical`)
  — the fix commit landed but a second, already-written commit addressing the review findings
  never made it in. This PR carries that second commit forward against current `main`.
- **Comment accuracy.** The operator-terminated regression-case comment said "...or quote must
  still be detected", which is backwards for this specific token pair: quotes are deliberately
  *excluded* from the `sed -Ei`/`--in-place` boundary (unlike the sibling `sort -V`/`grep -P`/
  `echo -e` tokens) — that exclusion is the entire point of #1548's narrower boundary, preserving
  the `sed -Ei''` attached-empty-suffix deferral from #1513/#1534. Reworded and pointed at the
  `"sed -Ei'' must not be flagged"` test that explains why. Also corrected a stale claim in the
  shipped-list assertion's own comment, which likewise implied these two tokens share the sibling
  tokens' (quote-inclusive) boundary.
- **Shipped-list test completeness.** The shipped-list assertion proved 4 of the 6
  operator-terminated forms the isolated-token loops cover (missing the `;`-terminated pair for
  both tokens). Not a correctness gap — the isolated-token path already exercises `;` — but the
  shipped-list check is meant to be the exhaustive real-token-file proof, so added the two missing
  cases.

## Test plan

- [x] `bash scripts/check-shell-portability.test.sh` — 75/75 passing (unchanged pass count; this
      PR only edits comments and extends one assertion's input set from 4 to 6 lines).
- [x] `scripts/check-shell-portability.sh origin/main` run directly against this branch's own
      diff — clean (no unexcused GNU-only constructs in the 1 changed file).
- [x] `shellcheck --rcfile=.shellcheckrc scripts/check-shell-portability.test.sh` — clean.
- [x] `typos --config _typos.toml scripts/check-shell-portability.test.sh` — clean.

## Related

- #1548 (the PR these findings were raised against, and whose second commit this one carries
  forward) — review comment:
  https://github.com/melodic-software/claude-code-plugins/pull/1548#issuecomment-5083530464
- #1545 (the issue #1548 closed)
