### PR TITLE
chore(ci): bump the review reusables to pick up infra-failure classes

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@90f1c54935203fa31b5b3d1f41531228be2c2b7f # 90f1c54 2026-07-18
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@e2951077a7b43c09fc5a8dee4da52ba6f0fb39ed # e295107 2026-07-26 infra-failure class in the annotation + PR comment
     with:
       runner: ubuntu-24.04
       # Passing skip-actors replaces the reusable's default (dependabot[bot]),

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@99cb082ebb942b9da08e8345a851be5bf252ad79 # 99cb082 2026-07-21
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@e2951077a7b43c09fc5a8dee4da52ba6f0fb39ed # e295107 2026-07-26 infra-failure class in the annotation + PR comment
     with:
       runner: ubuntu-24.04
       skip-actors: "dependabot[bot],melodic-standards-sync[bot]"


### PR DESCRIPTION
## Summary

This repository is where both silent-review blackouts were measured, and it is the one repository still blind to them. It pinned the review reusable at `90f1c54` (2026-07-18) and the security-review reusable at `99cb082` (2026-07-21) — both predate the infra-failure classifier. When the review lane fails here it reports green and says nothing about why.

Bumps both to `ci-workflows@e295107`, which carries:

- **melodic-software/ci-workflows#248** — infra failures classify as `auth` | `rate-limit` | `overloaded` | `other`, emitted as a bare `class=<token>` term in the job's `::error` annotation and a `Failure class:` line in the marker-managed infra-status PR comment, with the numeric `api_error_status` alongside in the safe structured projection.
- **melodic-software/ci-workflows#249** — the substring allowlist mirrors the status mapping type-for-type, so a payload with no recoverable numeric status lands in the class the status would have chosen.

**Gate behavior is unchanged.** Passing the check on an infrastructure failure remains an explicit non-goal upstream; this bump adds diagnosis, not blocking. Nothing about which checks gate a merge here changes.

### Why it matters here specifically

The measured impact on this repo, from the investigation on ci-workflows#228:

- 2026-07-25T22:48:55Z → 2026-07-26T01:40:48Z, ~2h52m
- **158 of the 159** review runs launched in that window failed — a complete census, every run's step conclusions inspected — and every one reported job conclusion `success`
- **36 of the 38** PRs merged in that window merged with a silently failed review
- A second blackout was still live at the time of writing, with every run since 09:02Z failing

Throughout all of it, the only signal was a warning comment. There was no machine-readable cause, and no way to tell a revoked credential from a rate limit without guessing from `duration_ms`.

### Interface compatibility — checked, not assumed

- `claude-review.yml`: the `workflow_call` block is **byte-identical** across `90f1c54..e295107`.
- `claude-security-review.yml`: differs only in the prose of an input *default* — the security prompt now defers to zizmor's static lane for supply-chain, dangerous-trigger, excessive-permission, and template-injection findings, so this lane focuses on logic, architecture, data-flow, and trust-boundary reasoning.

No input or secret was added, removed, or renamed in either.

## Test plan

- Interface diff of both reusables' `workflow_call` blocks across the pin jump — verified above, no breaking change.
- Confirmed the target SHA exists and that both reusables at `e295107` contain the class emission (`gh api .../contents/...?ref=e295107`).
- Upstream verification at the source: 273 node tests and 23 shell cases passing on `ci-workflows@e295107`, with the classification branches and the no-leak canary mutation-verified.
- Already proven end-to-end in production: the lane infra-failed on ci-workflows#248's own run and emitted `class=rate-limit` with `"api_error_status":429`, on the exact `subtype: success` / `is_error: true` shape both blackouts produced.
- **This PR's own review runs are the live check.** If the lane is still rate-limited when CI runs, the infra-status comment on this PR should now name the class instead of leaving it unexplained — which is the whole point of the bump.

## Related

No linked issue.

Upstream work is melodic-software/ci-workflows#228, #237, #248, #249. The prior diagnosis in this repo, #1122, is closed; this is the consumer-side adoption of the fix that came out of it, not new work needing its own tracking item.
