### PR TITLE
fix(ci): don't credit -e/-f's argument as grep's -P flag

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1040,6 +1040,41 @@ else
 fi
 rm -f "$f"
 
+# --- a P credited to -e/-f's OWN ARGUMENT is not a live -P flag (#1546):
+# `-e`/`-f` take a mandatory value attached directly after the letter, so a
+# `P` right after either is that option's PATTERN/FILE, not a fresh flag.
+# Verified on bash: `grep -eP probe.txt` matches the literal pattern "P" (no
+# PCRE activation), and `grep -fP probe.txt` fails trying to open a pattern
+# file named "P" -- neither run enables -P. A bare `grep -P` with no
+# preceding argument-taking letter must still be flagged (no regression) ----
+f="$(tmpsh "$(printf '%s\n' \
+  'grep -eP|cat' \
+  'grep -fP|cat' \
+  'grep -P|cat')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "grep -P|cat (line 3, no preceding argument-taking letter) should still fail, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 1 ]] &&
+  echo "$out" | grep -q "PORTABILITY: ${f}:3:"; then
+  ok "grep -eP/-fP are not flagged (P is the option's argument); bare grep -P still is"
+else
+  fail "expected only line 3 (bare grep -P) flagged, got: $out"
+fi
+rm -f "$f"
+
+# --- a P BEFORE -e/-f in the cluster is unaffected -- it is a live flag, and
+# -e/-f still take their own argument from whatever follows (#1546) ---------
+f="$(tmpsh "$(printf '%s\n' \
+  'grep -Pe pattern file|cat' \
+  'grep -EP pattern file|cat')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "grep -Pe / -EP (P precedes or is unaffected by e/E) should fail, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 2 ]]; then
+  ok "grep -Pe and -EP (P not consumed as an argument) are still detected"
+else
+  fail "expected both lines flagged, got: $out"
+fi
+rm -f "$f"
+
 # --- mktemp -p is now ACTIVE (#1527) ----------------------------------------
 f="$(tmpsh 't=$(mktemp -p "$d")')"
 if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -122,7 +122,28 @@
 # a LATER command's option-shaped word be attributed to this one — with `|`
 # and `;` now in the boundary, `grep foo /dev/null; printf '%s\n' -P|cat` was
 # reported even though the `-P` is printf's data.
-grep[^;&|\n]*[[:space:]]-[A-Za-z]*P([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
+#
+# A `P` credited to an ARGUMENT-TAKING option earlier in the same cluster is
+# not a flag at all — it is that option's value (#1546). GNU grep --help
+# documents `-e, --regexp=PATTERNS` and `-f, --file=FILE` as taking a
+# mandatory value attached directly after the letter, and GNU getopt's
+# short-cluster rule stops scanning for further flags there: `grep -eP|cat`
+# passes the single argument "P" as `-e`'s PATTERN, and `grep -fP|cat` reads
+# "P" as `-f`'s FILE — neither enables `-P`. Verified on bash: `grep -eP
+# probe.txt` matches the literal pattern "P" (no PCRE), and `grep -fP
+# probe.txt` fails with "P: No such file or directory" (tried to open a
+# pattern file named "P"), while `grep -P '\d' <<<a1b` genuinely activates
+# PCRE mode. Every other grep short option that takes a value (`-m`, `-d`,
+# `-D`, `-A`, `-B`, `-C`) requires a numeric or enumerated argument, so a bare
+# `P` right after one is not a valid value either way and is not working code
+# to protect (same "nothing working to break" reasoning as the quoted-splice
+# paragraph above) — only `e` and `f` take an arbitrary string, so only they
+# are excluded from the letters PRECEDING `P`. A `P` that appears BEFORE `e`
+# or `f` in the cluster is unaffected and still a live flag (`grep -Pe
+# pattern` sets `-P` first, then `-e` takes its own argument next). Uppercase
+# `E`/`F` (`--extended-regexp`/`--fixed-strings`) take no argument and still
+# count as ordinary flags ahead of `P`.
+grep[^;&|\n]*[[:space:]]-[A-Za-dg-z]*P([A-Za-z]|['"][A-Za-z]*['"])*([[:space:]|&;()]|[<>]([^(]|$)|$)
 --perl-regexp
 
 # `echo -e` — POSIX leaves echo's flag handling unspecified; BSD/macOS sh/bash


### PR DESCRIPTION
## Summary

- Follow-up to #1546, which merged (98507bfd) before this fix could land on
  that branch — a live P2 review thread from chatgpt-codex-connector went
  unaddressed as a result: https://github.com/melodic-software/claude-code-plugins/pull/1546#discussion_r3652868174
- `grep -eP|cat` and `grep -fP|cat` were reported as GNU-only `-P` (PCRE
  mode) use, but `-e`/`--regexp` and `-f`/`--file` take a mandatory value
  attached directly after the letter, so that `P` is the PATTERN/FILE
  argument, not a live flag. Verified on bash: `grep -eP` matches the
  literal pattern "P" (no PCRE), and `grep -fP` fails trying to open a
  pattern file named "P" — neither enables `-P`.
- Excludes lowercase `e`/`f` from the letters preceding `P` in the cluster
  match. A `P` before `e`/`f`, or after uppercase `E`/`F` (no-argument
  flags), is unaffected and still detected — proven by new test cases for
  `grep -Pe` and `grep -EP`.
- Deliberately out of scope: `sort -V` has the same latent shape (`sort -tV`
  reads `V` as `-t`'s separator argument, not `-V`), tracked for a future
  pass rather than widened here.

## Test plan

- [x] `scripts/check-shell-portability.test.sh`: PASS=109 FAIL=0 (added 2
      new cases: `-eP`/`-fP` not flagged while bare `-P` still is; `-Pe`/
      `-EP` still flagged)
- [x] `scripts/check-shell-portability.sh --all` repo-wide sweep: 63 hits,
      unchanged from before the fix (the false-positive shape does not
      occur in the tracked corpus today)
- [x] Diff against `origin/main` is exactly this fix (token-line change +
      two test blocks), confirmed clean cherry-pick with no other drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)