### PR TITLE
docs: migrate remaining docs.claude.com URLs to code.claude.com

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.5]
+
+### Fixed
+
+- **`known-issues` contact links now point at the migrated documentation domain.** Anthropic moved
+  the Claude Code docs from `docs.claude.com/en/docs/claude-code/<slug>` to
+  `code.claude.com/docs/en/<slug>`; the three links in
+  `skills/known-issues/context/issue-templates.md` still used the old host and survived only on a
+  301. Each replacement was verified by fetching the old URL, observing the redirect, and
+  confirming the target page's topic. The bare docs root does not redirect like the others (302 to
+  `platform.claude.com`, then 307 to `code.claude.com/docs`), so it now points at the Overview
+  page, which matches this repo's dominant `/docs/en/<slug>` convention.
+
 ## [0.21.4]
 
 ### Changed

--- a/plugins/claude-ops/skills/known-issues/context/issue-templates.md
+++ b/plugins/claude-ops/skills/known-issues/context/issue-templates.md
@@ -195,6 +195,6 @@ These fields can be pre-filled automatically:
 ## Contact links (non-issue options)
 
 - Discord: https://anthropic.com/discord
-- Docs: https://docs.claude.com/en/docs/claude-code
-- Getting Started: https://docs.claude.com/en/docs/claude-code/quickstart
-- Troubleshooting: https://docs.claude.com/en/docs/claude-code/troubleshooting
+- Docs: https://code.claude.com/docs/en/overview
+- Getting Started: https://code.claude.com/docs/en/quickstart
+- Troubleshooting: https://code.claude.com/docs/en/troubleshooting

--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.5.2]
+
+### Fixed
+
+- **`boris` settings reference now points at the migrated documentation domain.** Anthropic moved
+  the Claude Code docs from `docs.claude.com/en/docs/claude-code/<slug>` to
+  `code.claude.com/docs/en/<slug>`; the settings link in `skills/boris/reference/autonomy.md`
+  still used the old host and survived only on a 301. Verified by fetching the old URL, observing
+  the 301, and confirming the target is the "Claude Code settings" page.
+  `skills/boris/vendor/SKILL.md` carries the same stale URL and is deliberately **not** changed —
+  it is the verbatim upstream baseline used for drift detection, so editing it would manufacture
+  false drift.
+
 ## [0.5.1]
 
 Runs the context-engineering rightsizing effort's criteria catalog

--- a/plugins/playbooks/skills/boris/reference/autonomy.md
+++ b/plugins/playbooks/skills/boris/reference/autonomy.md
@@ -75,7 +75,7 @@ Why this works: stays below the rot zone while still getting most of the 1M bene
 
 Pair with proactive `/compact <hint>` when you feel bad-compact risk.
 
-Docs: [Claude Code settings](https://docs.claude.com/en/docs/claude-code/settings)
+Docs: [Claude Code settings](https://code.claude.com/docs/en/settings)
 Source: [@trq212 status 2044548257058328723](https://x.com/trq212/status/2044548257058328723)
 
 ## 65. Delegation over Guidance (Opus 4.7)


### PR DESCRIPTION
Closes #1564

## Summary

Anthropic moved the Claude Code documentation from `docs.claude.com/en/docs/claude-code/<slug>` to
`code.claude.com/docs/en/<slug>`. The old URLs still **301-redirect**, so this migrates the repo
while the redirect works rather than after it is retired.

A repo-wide sweep (every file type, not just markdown) found **369** `code.claude.com` references
against **5** stale `docs.claude.com` ones — the bulk migration was already done. Four are
rewritten here; the fifth is deliberately left alone.

`docs/OFFICIAL-DOCS.md`, this repo's canonical index of official pages, was checked and is
**already fully migrated** (51 `code.claude.com` hits, zero stale).

## What changed

| file | old | new |
| --- | --- | --- |
| `plugins/claude-ops/skills/known-issues/context/issue-templates.md` | `docs.claude.com/en/docs/claude-code` | `code.claude.com/docs/en/overview` |
| ″ | `…/claude-code/quickstart` | `code.claude.com/docs/en/quickstart` |
| ″ | `…/claude-code/troubleshooting` | `code.claude.com/docs/en/troubleshooting` |
| `plugins/playbooks/skills/boris/reference/autonomy.md` | `…/claude-code/settings` | `code.claude.com/docs/en/settings` |

Version bumps + changelog entries: `claude-ops` 0.21.4 → 0.21.5, `playbooks` 0.5.1 → 0.5.2.

## Verification

The path shape changes (`/en/docs/claude-code/X` → `/docs/en/X`), so a mechanical string swap is
not safe. Every rewritten URL was verified by fetching the old URL, observing where it landed, then
fetching the proposed target and confirming its topic:

- `/settings` — old 301s to `code.claude.com/docs/en/settings`; target is "Claude Code settings".
- `/quickstart` — old 301s to `code.claude.com/docs/en/quickstart`; target is "Quickstart".
- `/troubleshooting` — old 301s to `code.claude.com/docs/en/troubleshooting`; target is
  "Troubleshooting".
- The **bare docs root** does not behave like the others: `docs.claude.com/en/docs/claude-code`
  302s to `platform.claude.com/docs/en/claude-code`, then 307s to `code.claude.com/docs` — a
  different host from the other three. `code.claude.com/docs/en/overview` is therefore an
  **inferred** target, fetched and confirmed independently to be the real Overview page, chosen
  because it matches this repo's dominant `/docs/en/<slug>` convention rather than the bare root.

## Deliberately not changed

`plugins/playbooks/skills/boris/vendor/SKILL.md:1129` carries the same stale URL. Its sibling
`skills/boris/SKILL.md` declares it the "verbatim upstream baseline… for drift detection only", so
it is byte-compared against upstream and any edit here would manufacture false drift.

## Deferred (not in this PR)

`lychee.toml` link-checks every markdown file including that vendored baseline, and its `exclude`
list has no claude.com entry. When Anthropic retires the 301, the weekly advisory link-check lane
will start filing a tracking issue for a URL that cannot be fixed by editing the file. The remedy
is a `lychee.toml` `exclude` entry (or an `exclude_path` for the boris `vendor/` directory) — but
`lychee.toml` is a tool config materialized from `melodic-software/standards`, so per `AGENTS.md`
that fix belongs upstream rather than as a local patch. Recorded on #1564.

## Related

- Refs #1563 — the other half of the same handoff item (guardrails stdin-read fail-closed block on
  large writes). Independent change, separate PR.
