### PR TITLE
fix(typos-format): disclose every applied correction on both channels

### DIFF
--- a/docs/conventions/hook-observability/README.md
+++ b/docs/conventions/hook-observability/README.md
@@ -57,6 +57,20 @@ definition. (The `dim-N` numbers are an informal fleet-conformance shorthand —
 uniform setup-skill wave, dim-11 = seam phrasing — with no central registry defining the numbering;
 giving the whole scheme a documented home is a separate follow-up, tracked outside this doc.)
 
+**Also required — a hook that CHANGED the user's file content without being asked.** An autofix hook
+edits a file the user is working in, on the strength of an unrelated tool call, with no prompt and no
+diff. The harness's own signal for it is a generic "PostToolUse hook modified `<file>` after your
+edit (likely a formatter)" line that names no hook and shows no change — verified against
+<https://code.claude.com/docs/en/hooks> (fetched 2026-07-26): the three documented output channels
+carry no file-change or diff surface, so a benign reflow and a wrong dictionary rewrite arrive
+identically. The person whose file was changed is the only one who can judge whether the change was
+correct, so **the hook must name what it changed on the user channel**, not only the agent one: what
+was rewritten, to what, where, and how to prevent it. This is a *narrow* addition to the scope above,
+and its boundary is content the user did not request — a hook that only *reports* (a lint finding, a
+suggested fix, a diagnostic) still belongs on `additionalContext` alone. The same cap discipline as
+the repeat-notice rule applies: a per-item list must be bounded, with the remainder summarized as a
+count, or the disclosure becomes the noise problem it was meant to prevent.
+
 **Not required** for two situations that are already visible or already correctly agent-scoped:
 
 - **Exit-2 blocking paths.** A `PreToolUse` hook that blocks a tool call via exit code 2 is
@@ -64,7 +78,8 @@ giving the whole scheme a documented home is a separate follow-up, tracked outsi
   `systemMessage` on top of a block would be redundant, not more observable.
 - **Legitimate advisory findings.** A hook that surfaces a finding to Claude for it to act on
   (e.g. a lint result, a suggested fix) belongs on `additionalContext` only — that is the correct
-  channel for agent-actionable content, not a gap.
+  channel for agent-actionable content, not a gap. This is the case the content-mutation clause
+  above is deliberately distinguished from: reporting is agent-scoped, rewriting is not.
 
 **Repeat-notice discipline.** A missing-prerequisite notice behind a broad matcher (every
 `Write|Edit`, every `Bash` call) must not repeat on every invocation. Use `hook::require_jq`
@@ -112,9 +127,9 @@ melodic-software/claude-code-plugins#930.
 - **Not a new telemetry schema.** The envelope shape is `hook-telemetry`'s concern; this doc only
   states the adoption requirement.
 - **Not a blanket "add systemMessage everywhere" rule.** Scoped narrowly to the
-  missing-prerequisite-skip case; over-applying it to blocking paths or advisory findings is
-  itself a conformance defect (redundant user noise, or misrouting agent-actionable content to
-  the user channel).
+  missing-prerequisite-skip case and the unrequested-content-mutation case; over-applying it to
+  blocking paths or advisory findings is itself a conformance defect (redundant user noise, or
+  misrouting agent-actionable content to the user channel).
 - **Not a UI feature.** No native "verbose hooks" toggle exists in Claude Code as of 2026-07-22
   (confirmed against the same fresh fetch this doc cites) — `statusMessage` and `systemMessage`
   are the sanctioned surfaces available today. An upstream feature request for a native
@@ -128,6 +143,9 @@ Fleet audits check, per wired producer hook:
 - Every missing-prerequisite skip path emits a `systemMessage` (via `hook::require_jq` or
   `hook::notice_once` + `hook::emit_skip_notice`), gated so it fires once per session on a broad
   matcher.
+- Every path on which the hook rewrote file content names what it changed on the user channel,
+  bounded by a per-run cap with the remainder reported as a count. Not mechanically gated —
+  reviewed per hook. The adopting reference is `plugins/typos-format/hooks/typos-format.sh`.
 - The hook emits the telemetry envelope for every **meaningful outcome** — a check that ran and
   produced a result (ok / blocked / skipped-for-cause). A pure inapplicability short-circuit
   (wrong tool type, excluded path, empty content, outside the project) that fires before any

--- a/docs/conventions/hook-telemetry/data/typos-format.schema.json
+++ b/docs/conventions/hook-telemetry/data/typos-format.schema.json
@@ -15,9 +15,32 @@
       "type": "string",
       "description": "Path of the checked file, relative to the consuming repo root."
     },
+    "applied": {
+      "type": "array",
+      "description": "Corrections this run wrote into the file. Empty array = nothing was modified (clean, or the hook is in report-only mode).",
+      "items": {
+        "type": "object",
+        "required": ["typo", "correction", "line"],
+        "additionalProperties": false,
+        "properties": {
+          "typo": {
+            "type": "string",
+            "description": "The token as it appeared before the rewrite."
+          },
+          "correction": {
+            "type": "string",
+            "description": "The token it was rewritten to."
+          },
+          "line": {
+            "type": "integer",
+            "description": "1-based line number of the rewritten token, as reported before the write."
+          }
+        }
+      }
+    },
     "findings": {
       "type": "array",
-      "description": "Residual (unfixable) typos findings remaining after --write-changes. Empty array = clean or fully fixed.",
+      "description": "typos findings the run did NOT apply — no known correction, more than one candidate correction, or report-only mode. Empty array = clean or fully fixed.",
       "items": {
         "type": "object",
         "required": ["typo", "corrections"],

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Auto-fix spelling typos on edit via typos-cli, unconditionally — honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",
@@ -20,6 +20,12 @@
       "type": "boolean",
       "title": "typos-format hook",
       "description": "Run typos --write-changes on edit of any file, unconditionally",
+      "default": true
+    },
+    "typos_format_write_changes": {
+      "type": "boolean",
+      "title": "Apply corrections",
+      "description": "Rewrite the file in place. Turn off for a report-only hook that reports findings without ever modifying a file.",
       "default": true
     }
   }

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -100,6 +100,14 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   as an argument (#1595), so an oversized envelope is currently dropped rather
   than delivered — the correct failure direction, and what the scale assertion
   pins.
+- **The disclosure is bounded by characters, not only by entry count.** Capping
+  the list at ten entries does not cap the message: a token or a correction is
+  arbitrary text from the file, so ten long ones overrun the 10,000-character
+  `systemMessage` cap and the channel truncates or rejects the disclosure —
+  after the file has already been rewritten, which is the one outcome this path
+  exists to prevent. Rendered tokens are elided at 60 characters and each
+  channel carries a hard ceiling, with the truncation stated in the message.
+  The telemetry arrays keep the untruncated values.
 - Carriage returns no longer leak into the emitted report. `jq` writes stdout in
   text mode on Windows, so a multi-line value returns CRLF-terminated and
   command substitution strips only the last one, leaving a literal `\r` before

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -55,6 +55,13 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   that actually have findings — measured at roughly 80 ms on a 68 KB file,
   against the handler's 15-second timeout. The read-only pass runs first, so a
   run killed at the timeout between the two passes has modified nothing.
+  Both passes are guarded identically: an exit 2 with no output is a typos break,
+  not an empty residual set, so a write that broke mid-run is reported as a tool
+  break instead of being read as "every finding was applied".
+- Telemetry arrays are folded once at the end rather than re-serialized per
+  finding, so a file with many findings costs a linear number of subprocesses
+  rather than a quadratic one. The disclosure is capped; the telemetry arrays
+  are not, so that cost is paid over the whole finding set.
 
 ## [0.3.4]
 

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -36,6 +36,13 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
 - **`data.applied` on the telemetry envelope** — the corrections this run wrote,
   as `{typo, correction, line}`. Additive; `data.findings` keeps its existing
   residual-only meaning and shape.
+- **`/typos-format:setup check` reports the effective write mode.** The setup
+  skill described a single tunable and probed only `typos_format_enabled`, so
+  with `typos_format_write_changes=false` it could report the hook fully
+  operational to a user who invoked it precisely because spell-fixing was not
+  happening. Write mode is now a reported INFO row with its own remediation —
+  including the alternative that usually fits better, allow-listing the specific
+  words rather than turning every correction off.
 - **Stub-driven contract tests for the disclosure surface.** The suite
   previously skipped in full when no `typos` binary was installed, which is the
   CI runner's state — so nothing about this hook was gated there. The
@@ -75,6 +82,24 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   500 inside the budget; it runs in about 3 seconds against the real binary. The
   residual key is built and compared as a JSON string inside `jq`, so a token
   carrying a shell or glob metacharacter is data throughout.
+- **Residual membership is a hash lookup, not a linear scan.** Classifying with
+  `index` over an array is quadratic exactly when the residual set is large — a
+  minified or generated file where most findings are ambiguous. Measured: 10,000
+  all-residual findings took about 15.7 s inside `jq` alone, past the handler's
+  15-second timeout, and the file is rewritten *before* classification runs, so
+  that timeout lands after the mutation and before any disclosure. The same set
+  takes about 0.6 s keyed by object. The scale cases now cover an all-applied
+  AND an all-residual set: the applied path alone never touches that branch.
+- **The telemetry payload reaches `jq` on stdin too.** `data.findings` and the
+  new `data.applied` are uncapped, so roughly a thousand ordinary corrections
+  (about 45 KB of JSON) exceeded the same command-line ceiling and the fallback
+  would have emitted an envelope reporting `applied: []` for a file this hook
+  had just rewritten. A dropped envelope is inside the best-effort telemetry
+  contract; one that arrives claiming a heavily-rewritten file was untouched is
+  not. The shared `hook::emit_telemetry` still hands the finished payload over
+  as an argument (#1595), so an oversized envelope is currently dropped rather
+  than delivered — the correct failure direction, and what the scale assertion
+  pins.
 - Carriage returns no longer leak into the emitted report. `jq` writes stdout in
   text mode on Windows, so a multi-line value returns CRLF-terminated and
   command substitution strips only the last one, leaving a literal `\r` before

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -58,10 +58,16 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   Both passes are guarded identically: an exit 2 with no output is a typos break,
   not an empty residual set, so a write that broke mid-run is reported as a tool
   break instead of being read as "every finding was applied".
-- Telemetry arrays are folded once at the end rather than re-serialized per
-  finding, so a file with many findings costs a linear number of subprocesses
-  rather than a quadratic one. The disclosure is capped; the telemetry arrays
-  are not, so that cost is paid over the whole finding set.
+- **Classification is one `jq` pass, not a shell loop.** Process-spawn cost, not
+  typos, dominates this hook, and a per-finding loop turns a heavily-corrected
+  file into the very defect being fixed: the file is rewritten, the handler's
+  15-second timeout fires, and stdout is empty — silent mutation again, on
+  exactly the files where the disclosure matters most. The scan set, the
+  residual set, the split between them, and the capped display text are all
+  produced by a single invocation, so the subprocess count is constant in the
+  number of findings. A 120-correction file is asserted to disclose inside the
+  budget. The residual key is built and compared as a JSON string inside `jq`,
+  so a token carrying a shell or glob metacharacter is data throughout.
 
 ## [0.3.4]
 

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -65,9 +65,20 @@ All notable changes to the `typos-format` plugin are documented here. Format fol
   exactly the files where the disclosure matters most. The scan set, the
   residual set, the split between them, and the capped display text are all
   produced by a single invocation, so the subprocess count is constant in the
-  number of findings. A 120-correction file is asserted to disclose inside the
-  budget. The residual key is built and compared as a JSON string inside `jq`,
-  so a token carrying a shell or glob metacharacter is data throughout.
+  number of findings. Both finding sets reach `jq` on **stdin**, never as
+  `--arg` values: Windows caps a process command line at 32767 characters and
+  typos' jsonlines run about 110 bytes per finding, so an argument-passed set
+  broke silently somewhere past ~300 corrections — jq never ran and the hook
+  degraded to "could not be summarized" on precisely the typo-heavy files the
+  disclosure matters most for. A 500-correction file (past that limit, and the
+  scale at which the old per-finding loop timed out) is asserted to disclose all
+  500 inside the budget; it runs in about 3 seconds against the real binary. The
+  residual key is built and compared as a JSON string inside `jq`, so a token
+  carrying a shell or glob metacharacter is data throughout.
+- Carriage returns no longer leak into the emitted report. `jq` writes stdout in
+  text mode on Windows, so a multi-line value returns CRLF-terminated and
+  command substitution strips only the last one, leaving a literal `\r` before
+  every remaining newline in the escaped context.
 
 ## [0.3.4]
 

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.4.0]
+
+### Fixed
+
+- **Every correction the hook applies is now disclosed on both channels.** On the
+  all-fixed path the hook emitted nothing at all — no `additionalContext`, no
+  `systemMessage`, telemetry only — so a rewrite drawn from typos' built-in
+  dictionary reached the file with the only trace being the harness's generic
+  "a PostToolUse hook modified this file" notice: no hook name, no word, no
+  diff. An acronym or identifier the dictionary maps to an unrelated English
+  word was therefore corrupted invisibly, indistinguishably from a benign
+  reformat. The hook now reports each applied rewrite — token, replacement, and
+  line — to Claude via `additionalContext` and to the user via `systemMessage`,
+  capped at ten per run with a count of the remainder so the disclosure cannot
+  itself become a context flood.
+- **The allow-list remediation moved onto the applied-correction path.** The
+  "if intentional, add it to `extend-words` / `extend-identifiers`" guidance sat
+  only on the residual branch, so it never fired for the corrections that
+  actually change file content — the one case where it is load-bearing. A
+  dictionary autocorrect has no memory: a word repaired by hand is rewritten
+  again on the next edit until the repo allow-lists it, and until now nothing
+  said so.
+
+### Added
+
+- **`typos_format_write_changes` userConfig (default `true`).** Set it to
+  `false` for a report-only hook: findings are reported and no file is
+  modified. Read from the `CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES`
+  environment mirror, because shell-form hook commands reject
+  `${user_config.*}` substitution outright.
+- **`data.applied` on the telemetry envelope** — the corrections this run wrote,
+  as `{typo, correction, line}`. Additive; `data.findings` keeps its existing
+  residual-only meaning and shape.
+- **Stub-driven contract tests for the disclosure surface.** The suite
+  previously skipped in full when no `typos` binary was installed, which is the
+  CI runner's state — so nothing about this hook was gated there. The
+  disclosure, report-only, cap, and telemetry cases now run against a stub
+  binary and execute everywhere; the config-discovery and exclusion cases still
+  require a real `typos`.
+
+### Changed
+
+- **The hook now scans read-only before it writes.** `typos --write-changes`
+  emits nothing for a correction it applies (verified against typos-cli 1.44.0:
+  a fully-fixable file exits 0 with empty stdout after rewriting), so a
+  write-only run has no information about what it changed. A read-only pass
+  captures the pre-write finding set; the applied set is derived as scan minus
+  what survived the write, rather than by guessing which findings typos
+  considers safe to auto-fix. Cost is one extra typos invocation only on files
+  that actually have findings — measured at roughly 80 ms on a 68 KB file,
+  against the handler's 15-second timeout. The read-only pass runs first, so a
+  run killed at the timeout between the two passes has modified nothing.
+
 ## [0.3.4]
 
 ### Changed

--- a/plugins/typos-format/README.md
+++ b/plugins/typos-format/README.md
@@ -2,9 +2,9 @@
 
 A Claude Code plugin that fixes spelling typos the moment you edit any file.
 On every `Write` or `Edit` it runs [typos](https://github.com/crate-ci/typos)'s
-`--write-changes`, then surfaces any residual (unfixable) findings back to
-Claude as advisory context — including remediation guidance for allowlisting
-a false positive.
+`--write-changes`, reports every correction it applied, and surfaces any
+residual (unfixable) findings back to Claude as advisory context — including
+remediation guidance for allowlisting a false positive.
 
 It ships no rules of its own and runs unconditionally, using typos' built-in
 spelling dictionary. If your repository has its own typos configuration
@@ -24,11 +24,21 @@ opt-in required.
   typos is language-agnostic — it runs on any edited file.
 - **Fix in place.** `typos --write-changes` applies every correction it has
   confidence in. Residual findings — an entry with no known correction (e.g.
-  a blank-correction `extend-words` entry marking a term "disallowed") —
-  surface as advisory context, never auto-applied.
-- **Remediation guidance included.** Every residual finding's advisory text
-  points at the fix: add the term to `extend-words` / `extend-identifiers`
+  a blank-correction `extend-words` entry marking a term "disallowed"), or one
+  with more than one candidate correction — surface as advisory context, never
+  auto-applied.
+- **Every applied rewrite is disclosed.** A correction changes the content of
+  your file, so the hook reports each one it applied — the word, its
+  replacement, and the line — to Claude *and* to you, capped at ten per run
+  with a count of the remainder. Nothing this hook writes is silent.
+- **Remediation guidance included.** Both an applied rewrite and a residual
+  finding carry the fix: add the term to `extend-words` / `extend-identifiers`
   (or an `extend-ignore-re` pattern) in your typos config if it's intentional.
+  This matters most on the *applied* path — the dictionary has no memory of
+  your repair, so a word you correct by hand is rewritten again on the next
+  edit until the allowlist entry exists.
+- **Report-only mode available.** Set `typos_format_write_changes` to `false`
+  and the hook reports what typos found without ever modifying a file.
 - **Respects your excludes.** The hook passes `--force-exclude`, so a path
   your config's `[files] exclude`/`extend-exclude` excludes (generated or
   vendored code, intentional-misspelling fixtures) is left untouched even
@@ -82,13 +92,14 @@ config already in your repository, which the plugin reads automatically. To
 change the rules (allowlist a false positive, ignore a pattern), edit that
 file.
 
-One `userConfig` option tunes the hook itself:
+Two `userConfig` options tune the hook itself:
 
 | Option | Default | Effect |
 |--------|---------|--------|
 | `typos_format_enabled` | `true` | Kill switch — set `false` for a clean no-op. |
+| `typos_format_write_changes` | `true` | Set `false` for report-only: findings are reported, no file is modified. |
 
-Set it interactively with `/plugin configure typos-format`, or headless on the
+Set them interactively with `/plugin configure typos-format`, or headless on the
 install command:
 
 ```shell

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -280,15 +280,24 @@ fi
 #
 # The display lines are rendered here too, capped, so the shell never has to
 # walk the finding set at all.
-CLASSIFIED=$(jq -c -n \
-  --arg scan "$SCAN_OUTPUT" \
-  --arg residual "$RESIDUAL_OUTPUT" \
-  --argjson max "$MAX_REPORT" '
-    def parse($s): [$s | split("\n")[] | select(length > 0) | (fromjson? // empty) | select(.type == "typo")];
+#
+# Both streams arrive on STDIN, separated by a marker line, rather than as --arg
+# values. Windows caps a process command line at 32767 characters, and typos'
+# jsonlines run about 110 bytes per finding — so passing them as arguments
+# silently broke somewhere past ~300 corrections: jq never ran, and the run
+# degraded to "could not be summarized" on exactly the typo-heavy files the
+# disclosure matters most for. Reproduced at 500 corrections before the change,
+# clean after. The marker is not valid JSON, so it can never collide with a
+# finding line.
+CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL_OUTPUT" |
+  jq -R -s -c --argjson max "$MAX_REPORT" '
+    def parse($lines): [$lines[] | select(length > 0) | (fromjson? // empty) | select(.type == "typo")];
     def keyof: "\(.line_num // 0)\t\(.typo // "")";
     def corr1: (.corrections[0] // "");
-    (parse($residual) | map(keyof)) as $res
-    | parse($scan) as $all
+    (split("\n")) as $lines
+    | (($lines | index("@@typos-format-split@@")) // ($lines | length)) as $sep
+    | (parse($lines[($sep + 1):]) | map(keyof)) as $res
+    | parse($lines[0:$sep]) as $all
     | ($all | map(select((keyof) as $key | ($res | index($key)) != null))) as $r
     | ($all | map(select((keyof) as $key | ($res | index($key)) == null))) as $a
     | {
@@ -329,6 +338,14 @@ APPLIED_JSON=$(printf '%s' "$CLASSIFIED" | jq -c '.applied' 2>/dev/null) || APPL
 FINDINGS_JSON=$(printf '%s' "$CLASSIFIED" | jq -c '.findings' 2>/dev/null) || FINDINGS_JSON='[]'
 [[ "$APPLIED_COUNT" =~ ^[0-9]+$ ]] || APPLIED_COUNT=0
 [[ "$RESIDUAL_COUNT" =~ ^[0-9]+$ ]] || RESIDUAL_COUNT=0
+# jq writes stdout in text mode on Windows, so a multi-line value comes back
+# with CRLF line endings; command substitution strips only the trailing one and
+# leaves a CR embedded before every remaining newline, which then survives
+# JSON-escaping into the emitted context as a literal \r. These strings are
+# display text with no meaningful carriage returns of their own.
+APPLIED_LINES="${APPLIED_LINES//$'\r'/}"
+APPLIED_INLINE="${APPLIED_INLINE//$'\r'/}"
+RESIDUAL_LINES="${RESIDUAL_LINES//$'\r'/}"
 [[ -n "$APPLIED_LINES" ]] && APPLIED_LINES="$APPLIED_LINES"$'\n'
 [[ -n "$RESIDUAL_LINES" ]] && RESIDUAL_LINES="$RESIDUAL_LINES"$'\n'
 

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -248,7 +248,13 @@ RESIDUAL_OUTPUT="$SCAN_OUTPUT"
 if [[ "$WRITE_CHANGES" != "false" ]]; then
   WRITE_OUTPUT=$(cd "$RUN_DIR" && "$TYPOS_BIN" --write-changes --force-exclude --format json "$TYPOS_ARG" 2>&1)
   WRITE_RC=$?
-  if [[ $WRITE_RC -ne 0 && $WRITE_RC -ne 2 ]]; then
+  # The write pass is guarded exactly as the scan pass is, and for a sharper
+  # reason: an exit 2 with no output is a typos break mid-write, and reading it
+  # as "no residual findings" would classify EVERY scanned finding as applied —
+  # reporting rewrites that never happened, on the very channel this hook exists
+  # to make trustworthy. Any code other than 0-with-no-findings or
+  # 2-with-findings is a tool break, not a judgment.
+  if [[ $WRITE_RC -ne 0 ]] && [[ $WRITE_RC -ne 2 || -z "$WRITE_OUTPUT" ]]; then
     emit_tool_break "$WRITE_OUTPUT"
   fi
   RESIDUAL_OUTPUT="$WRITE_OUTPUT"
@@ -270,21 +276,34 @@ done <<<"$RESIDUAL_OUTPUT"
 APPLIED_LINES=""
 APPLIED_INLINE=""
 APPLIED_COUNT=0
-APPLIED_JSON="[]"
+APPLIED_OBJS=""
 RESIDUAL_LINES=""
 RESIDUAL_COUNT=0
-FINDINGS_JSON="[]"
+FINDING_OBJS=""
 
+# One jq per scanned finding extracts every field at once, and each classified
+# object is APPENDED to a newline-delimited buffer that a single `jq -s` folds
+# into an array at the end. Re-reading and rewriting an accumulating array once
+# per finding would be quadratic in a hook that fires on every edit; the
+# telemetry arrays are uncapped, so that cost is paid on the whole finding set,
+# not on the ten lines the report shows.
 while IFS= read -r line; do
   [[ -n "$line" ]] || continue
-  obj=$(printf '%s' "$line" | jq -c 'select(.type == "typo")' 2>/dev/null) || continue
-  [[ -n "$obj" ]] || continue
-  typo=$(printf '%s' "$obj" | jq -r '.typo // empty' 2>/dev/null)
+  fields=$(printf '%s' "$line" |
+    jq -r 'select(.type == "typo") | [(.line_num // 0), (.typo // ""), (.corrections[0] // ""), (.corrections | tojson)] | @tsv' 2>/dev/null) || continue
+  [[ -n "$fields" ]] || continue
+  IFS=$'\t' read -r line_num typo first_correction corrections <<<"$fields"
   [[ -n "$typo" ]] || continue
-  line_num=$(printf '%s' "$obj" | jq -r '.line_num // 0' 2>/dev/null)
-  corrections=$(printf '%s' "$obj" | jq -c '.corrections // null' 2>/dev/null)
-  first_correction=$(printf '%s' "$obj" | jq -r '.corrections[0] // empty' 2>/dev/null)
+  [[ -n "$corrections" ]] || corrections="null"
 
+  # A quoted expansion inside a `case` pattern is matched LITERALLY — POSIX
+  # requires quoted pattern characters not to act as pattern specials, and this
+  # was verified here against bash 5.3 for `*`, `?` and `[…]` in both
+  # directions. So a token carrying a glob metacharacter cannot widen this
+  # match, and no separate escaping pass is needed. Do not "fix" this into an
+  # unquoted expansion or a `grep -F` pipeline: `grep -F` splits a pattern on
+  # newlines, and this key is newline-delimited on both sides, which would
+  # match an empty pattern against everything.
   case "$RESIDUAL_KEYS" in
   *$'\n'"$line_num"$'\t'"$typo"$'\n'*)
     # Survived the write (or nothing was written) — advisory only.
@@ -296,8 +315,9 @@ while IFS= read -r line; do
         RESIDUAL_LINES+="  \"$typo\" (line $line_num) should be \"$first_correction\" — if intentional, add it to extend-words / extend-identifiers in your typos config."$'\n'
       fi
     fi
-    parsed=$(printf '%s' "$obj" | jq -c --arg typo "$typo" --argjson corrections "$corrections" '{typo:$typo,corrections:$corrections}' 2>/dev/null) || continue
-    FINDINGS_JSON=$(printf '%s' "$FINDINGS_JSON" | jq -c --argjson f "$parsed" '. + [$f]' 2>/dev/null) || true
+    parsed=$(jq -c -n --arg typo "$typo" --argjson corrections "$corrections" \
+      '{typo:$typo,corrections:$corrections}' 2>/dev/null) || continue
+    FINDING_OBJS+="$parsed"$'\n'
     ;;
   *)
     # Present before the write, gone after it: this hook rewrote it.
@@ -306,12 +326,21 @@ while IFS= read -r line; do
       APPLIED_LINES+="  \"$typo\" -> \"$first_correction\" (line $line_num)"$'\n'
       APPLIED_INLINE+="${APPLIED_INLINE:+; }\"$typo\" -> \"$first_correction\" (line $line_num)"
     fi
-    parsed=$(jq -n --arg typo "$typo" --arg correction "$first_correction" --argjson line "${line_num:-0}" \
+    parsed=$(jq -c -n --arg typo "$typo" --arg correction "$first_correction" --argjson line "${line_num:-0}" \
       '{typo:$typo,correction:$correction,line:$line}' 2>/dev/null) || continue
-    APPLIED_JSON=$(printf '%s' "$APPLIED_JSON" | jq -c --argjson a "$parsed" '. + [$a]' 2>/dev/null) || true
+    APPLIED_OBJS+="$parsed"$'\n'
     ;;
   esac
 done <<<"$SCAN_OUTPUT"
+
+FINDINGS_JSON="[]"
+if [[ -n "$FINDING_OBJS" ]]; then
+  FINDINGS_JSON=$(printf '%s' "$FINDING_OBJS" | jq -c -s . 2>/dev/null) || FINDINGS_JSON="[]"
+fi
+APPLIED_JSON="[]"
+if [[ -n "$APPLIED_OBJS" ]]; then
+  APPLIED_JSON=$(printf '%s' "$APPLIED_OBJS" | jq -c -s . 2>/dev/null) || APPLIED_JSON="[]"
+fi
 
 # Compose ONE stdout document. Claude Code parses a hook's entire stdout as a
 # single JSON document, so the agent-channel context and the user-channel

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -119,13 +119,21 @@ fi
 # fallback is a fixed empty-shape object — NOT an interpolation of
 # TOOL/FILE_REL, which could inject quotes or backslashes from a path and
 # corrupt the envelope.
+#
+# Both arrays arrive on STDIN, never as --argjson values. They are uncapped by
+# design, and Windows caps a process command line at 32767 characters — about
+# 1,000 ordinary corrections is 45 KB of JSON, at which point `jq` cannot start
+# and the fallback below would emit an envelope reporting `applied: []` for a
+# file this hook had just rewritten. Telemetry is documented best-effort and
+# lossy, so a dropped envelope is inside contract; one that arrives claiming a
+# heavily-rewritten file was untouched is not. TOOL and FILE_REL stay as
+# arguments: both are bounded by a path length.
 build_data_json() {
-  jq -n \
-    --arg tool "$TOOL" \
-    --arg file "$FILE_REL" \
-    --argjson findings "$1" \
-    --argjson applied "${2:-[]}" \
-    '{tool:$tool,file:$file,findings:$findings,applied:$applied}' 2>/dev/null ||
+  printf '{"findings":%s,"applied":%s}' "$1" "${2:-[]}" |
+    jq -c \
+      --arg tool "$TOOL" \
+      --arg file "$FILE_REL" \
+      '{tool:$tool,file:$file,findings:.findings,applied:.applied}' 2>/dev/null ||
     printf '{"tool":"","file":"","findings":[],"applied":[]}'
 }
 
@@ -278,6 +286,16 @@ fi
 # The key is built and compared inside jq as a JSON string, so a token carrying
 # a shell or glob metacharacter is data throughout and can never widen a match.
 #
+# Membership is an OBJECT lookup, not `index` over an array. `index` is a linear
+# scan, so classification went quadratic exactly when the residual set is large
+# — a minified or generated file where most findings survive the write.
+# Measured: 10,000 all-residual findings took ~15.7s with `index`, past the
+# handler's 15-second timeout, and the file is rewritten BEFORE classification
+# runs, so the timeout lands after the mutation and before any disclosure. Hash
+# lookup does the same 10,000 in ~0.6s. The scale case below therefore covers
+# both an all-applied and an all-residual set: the applied path alone never
+# touches the slow branch.
+#
 # The display lines are rendered here too, capped, so the shell never has to
 # walk the finding set at all.
 #
@@ -296,10 +314,10 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
     def corr1: (.corrections[0] // "");
     (split("\n")) as $lines
     | (($lines | index("@@typos-format-split@@")) // ($lines | length)) as $sep
-    | (parse($lines[($sep + 1):]) | map(keyof)) as $res
+    | ((parse($lines[($sep + 1):]) | map({(keyof): true}) | add) // {}) as $res
     | parse($lines[0:$sep]) as $all
-    | ($all | map(select((keyof) as $key | ($res | index($key)) != null))) as $r
-    | ($all | map(select((keyof) as $key | ($res | index($key)) == null))) as $a
+    | ($all | map(select($res[keyof] != null))) as $r
+    | ($all | map(select($res[keyof] == null))) as $a
     | {
         appliedCount: ($a | length),
         residualCount: ($r | length),

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -8,6 +8,16 @@
 # entry) findings surface via additionalContext but never block the edit. A
 # commit hook or CI is the hard gate.
 #
+# DISCLOSURE: every correction this hook APPLIES is reported on both channels —
+# additionalContext for the agent, systemMessage for the person whose file was
+# rewritten. A dictionary autocorrect is a content mutation the user never asked
+# for (a domain acronym rewritten into an unrelated English word is the failure
+# mode this exists to make visible), and it has no memory: repairing a word by
+# hand gets it re-corrected on the next save unless the repo allow-lists it. The
+# disclosure therefore carries the allow-list remediation with it. Set the
+# `typos_format_write_changes` userConfig to false for a report-only hook that
+# never modifies a file.
+#
 # Unconditional: typos ships a built-in spelling dictionary and runs with zero
 # configuration, so this hook runs on every edit regardless of whether the
 # repo has adopted a typos config — matching the sibling markdown-format
@@ -104,16 +114,19 @@ else
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
-# findings JSON array. jq is authoritative. The fallback is a fixed empty-shape
-# object — NOT an interpolation of TOOL/FILE_REL, which could inject quotes or
-# backslashes from a path and corrupt the envelope.
+# residual-findings JSON array; optional $2 is the applied-corrections JSON
+# array (additive schema property, defaults to empty). jq is authoritative. The
+# fallback is a fixed empty-shape object — NOT an interpolation of
+# TOOL/FILE_REL, which could inject quotes or backslashes from a path and
+# corrupt the envelope.
 build_data_json() {
   jq -n \
     --arg tool "$TOOL" \
     --arg file "$FILE_REL" \
     --argjson findings "$1" \
-    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null ||
-    printf '{"tool":"","file":"","findings":[]}'
+    --argjson applied "${2:-[]}" \
+    '{tool:$tool,file:$file,findings:$findings,applied:$applied}' 2>/dev/null ||
+    printf '{"tool":"","file":"","findings":[],"applied":[]}'
 }
 
 emit_skipped() {
@@ -154,67 +167,199 @@ if [[ -n "$root" && -n "$FILE_REL" && "$FILE_REL" != "$FILE" ]]; then
   TYPOS_ARG="$FILE_REL"
 fi
 
-# Apply every correction typos has confidence in, in place. --force-exclude
-# honors the config's own exclude/extend-exclude even for this explicitly-passed
-# path, so a file the repo excludes (generated or vendored code, intentional-
-# misspelling fixtures) is left untouched with no advisory noise — same
-# rationale as ruff-format.sh's identical flag. jsonlines output captured for
-# the residual-findings pass below. Verified against typos-cli 1.44.0: exit 0 =
-# clean or fully fixed; exit 2 = residual (unfixable, e.g. a blank-correction
-# "disallowed" entry) findings remain even after write; any other code = typos
-# itself failed (bad config, internal error) — not a judgment, no findings.
-OUTPUT=$(cd "$RUN_DIR" && "$TYPOS_BIN" --write-changes --force-exclude --format json "$TYPOS_ARG" 2>&1)
-RC=$?
+# Report-only switch. Writing is the default; a consumer that wants the findings
+# without the rewrites sets the `typos_format_write_changes` userConfig to
+# false. Read from the CLAUDE_PLUGIN_OPTION_<KEY> environment mirror rather than
+# a `${user_config.*}` placeholder: shell-form hook commands REJECT
+# `${user_config.*}` substitution outright — "substituting a configured value
+# into a shell command would let the shell run whatever that value contains, so
+# the component fails" — and every option is exported to hook processes as
+# CLAUDE_PLUGIN_OPTION_<KEY> anyway (Plugins reference, "User configuration",
+# https://code.claude.com/docs/en/plugins-reference, fetched 2026-07-26). Same
+# idiom as hook::check_enabled's kill switch. Any value other than the literal
+# "false" means write.
+WRITE_CHANGES="${CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES:-true}"
 
-if [[ $RC -eq 0 ]]; then
+# Disclosure cap. A file with hundreds of corrections must not turn this hook's
+# own report into the context flood it exists to prevent, so each list is capped
+# and the remainder is summarized as a count.
+MAX_REPORT=10
+
+# --- Pass 1: read-only scan ---------------------------------------------------
+# --write-changes emits NOTHING for a correction it applies: verified against
+# typos-cli 1.44.0, a file whose every finding is auto-fixable exits 0 with
+# empty stdout after rewriting the file. A write-only run therefore cannot tell
+# anyone what it changed — which is exactly how this hook came to rewrite file
+# content invisibly. The read-only pass below is the only place the pre-write
+# finding set exists; it never touches the file, so a run killed by the
+# handler's `timeout` between the two passes has mutated nothing.
+#
+# --force-exclude honors the config's own exclude/extend-exclude even for this
+# explicitly-passed path, so a file the repo excludes (generated or vendored
+# code, intentional-misspelling fixtures) is left untouched with no advisory
+# noise — same rationale as ruff-format.sh's identical flag. Verified against
+# typos-cli 1.44.0: exit 0 = clean (or excluded); exit 2 = findings; any other
+# code = typos itself failed (bad config, internal error) — not a judgment.
+SCAN_OUTPUT=$(cd "$RUN_DIR" && "$TYPOS_BIN" --force-exclude --format json "$TYPOS_ARG" 2>&1)
+SCAN_RC=$?
+
+# Emit the tool-break diagnostic for $1 and exit. typos broke for non-lint
+# reasons (config parse error, internal error) — no judgment was made. Surfaced
+# via additionalContext (NOT stderr — an advisory hook's exit-0 stderr can trip
+# a false "Hook Error" label). Recorded as "skipped" (typos never ran to
+# judgment), the same status as the no-binary path.
+emit_tool_break() {
+  hook::ctx_reset
+  hook::ctx_append "typos-format: typos failed for $(basename "$FILE") (no diagnostics; tool break, not a finding):"
+  local line
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    hook::ctx_append "  $line"
+  done <<<"$1"
+  hook::ctx_flush PostToolUse
+  local data_json
+  data_json=$(build_data_json '[]')
+  emit_tel "typos-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
+}
+
+if [[ $SCAN_RC -eq 0 ]]; then
+  # Clean, or excluded by the repo's own typos config. Nothing was changed and
+  # there is nothing to disclose.
   data_json=$(build_data_json '[]')
   emit_tel "typos-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
   exit 0
 fi
 
-if [[ $RC -eq 2 && -n "$OUTPUT" ]]; then
-  hook::ctx_reset
-  hook::ctx_append "typos-format: $(basename "$FILE") has residual typos findings (advisory):"
-  findings_raw="[]"
-  parsed=""
-  while IFS= read -r line; do
-    [[ -n "$line" ]] || continue
-    obj=$(printf '%s' "$line" | jq -c 'select(.type == "typo")' 2>/dev/null) || continue
-    [[ -n "$obj" ]] || continue
-    typo=$(printf '%s' "$obj" | jq -r '.typo // empty' 2>/dev/null)
-    [[ -n "$typo" ]] || continue
-    corrections=$(printf '%s' "$obj" | jq -c '.corrections // null' 2>/dev/null)
-    if [[ "$corrections" == "null" ]]; then
-      hook::ctx_append "  \"$typo\" is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."
-    else
-      first_correction=$(printf '%s' "$obj" | jq -r '.corrections[0] // empty' 2>/dev/null)
-      hook::ctx_append "  \"$typo\" should be \"$first_correction\" — if intentional, add it to extend-words / extend-identifiers in your typos config."
-    fi
-    parsed=$(printf '%s' "$obj" | jq -c --arg typo "$typo" --argjson corrections "$corrections" '{typo:$typo,corrections:$corrections}' 2>/dev/null) || continue
-    findings_raw=$(printf '%s' "$findings_raw" | jq -c --argjson f "$parsed" '. + [$f]' 2>/dev/null) || true
-  done <<<"$OUTPUT"
-  hook::ctx_flush PostToolUse
-
-  data_json=$(build_data_json "$findings_raw")
-  # Status "ok" — typos RAN and produced a judgment (findings live in
-  # data.findings), mirroring the sibling formatter plugins where status
-  # reflects whether the tool ran, not whether it was clean.
-  emit_tel "typos-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
-  exit 0
+if [[ $SCAN_RC -ne 2 || -z "$SCAN_OUTPUT" ]]; then
+  emit_tool_break "$SCAN_OUTPUT"
 fi
 
-# typos broke for non-lint reasons (config parse error, internal error) — no
-# judgment was made. Surface the diagnostic via additionalContext (NOT stderr —
-# an advisory hook's exit-0 stderr can trip a false "Hook Error" label). Record
-# as "skipped" (typos never ran to judgment), the same status as the
-# no-binary path.
-hook::ctx_reset
-hook::ctx_append "typos-format: typos failed for $(basename "$FILE") (no diagnostics; tool break, not a finding):"
+# --- Pass 2: apply ------------------------------------------------------------
+# In report-only mode no write happens at all, so every scanned finding stays in
+# the file and the residual set IS the scan set. Otherwise the write pass runs
+# and its own output is authoritative for what SURVIVED the write: exit 0 = all
+# fixed, nothing residual; exit 2 = the listed findings remain. Deriving the
+# applied set as scan-minus-residual keeps this correct without guessing which
+# findings typos considers safe to auto-fix (it declines ambiguous ones — a
+# finding with more than one candidate correction stays put), and stays correct
+# if that judgment changes in a future typos release.
+RESIDUAL_OUTPUT="$SCAN_OUTPUT"
+if [[ "$WRITE_CHANGES" != "false" ]]; then
+  WRITE_OUTPUT=$(cd "$RUN_DIR" && "$TYPOS_BIN" --write-changes --force-exclude --format json "$TYPOS_ARG" 2>&1)
+  WRITE_RC=$?
+  if [[ $WRITE_RC -ne 0 && $WRITE_RC -ne 2 ]]; then
+    emit_tool_break "$WRITE_OUTPUT"
+  fi
+  RESIDUAL_OUTPUT="$WRITE_OUTPUT"
+  [[ $WRITE_RC -eq 0 ]] && RESIDUAL_OUTPUT=""
+fi
+
+# Residual identity key: line number + the flagged token. Byte offsets shift as
+# earlier corrections on the same line change its length, so an offset-keyed
+# comparison would classify wrongly; a line/token pair is stable across the write
+# because a repeated token on one line always shares one fix decision.
+RESIDUAL_KEYS=$'\n'
 while IFS= read -r line; do
   [[ -n "$line" ]] || continue
-  hook::ctx_append "  $line"
-done <<<"$OUTPUT"
-hook::ctx_flush PostToolUse
-data_json=$(build_data_json '[]')
-emit_tel "typos-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  key=$(printf '%s' "$line" | jq -r 'select(.type == "typo") | "\(.line_num // 0)\t\(.typo // "")"' 2>/dev/null) || continue
+  [[ -n "$key" ]] || continue
+  RESIDUAL_KEYS+="$key"$'\n'
+done <<<"$RESIDUAL_OUTPUT"
+
+APPLIED_LINES=""
+APPLIED_INLINE=""
+APPLIED_COUNT=0
+APPLIED_JSON="[]"
+RESIDUAL_LINES=""
+RESIDUAL_COUNT=0
+FINDINGS_JSON="[]"
+
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  obj=$(printf '%s' "$line" | jq -c 'select(.type == "typo")' 2>/dev/null) || continue
+  [[ -n "$obj" ]] || continue
+  typo=$(printf '%s' "$obj" | jq -r '.typo // empty' 2>/dev/null)
+  [[ -n "$typo" ]] || continue
+  line_num=$(printf '%s' "$obj" | jq -r '.line_num // 0' 2>/dev/null)
+  corrections=$(printf '%s' "$obj" | jq -c '.corrections // null' 2>/dev/null)
+  first_correction=$(printf '%s' "$obj" | jq -r '.corrections[0] // empty' 2>/dev/null)
+
+  case "$RESIDUAL_KEYS" in
+  *$'\n'"$line_num"$'\t'"$typo"$'\n'*)
+    # Survived the write (or nothing was written) — advisory only.
+    RESIDUAL_COUNT=$((RESIDUAL_COUNT + 1))
+    if ((RESIDUAL_COUNT <= MAX_REPORT)); then
+      if [[ "$corrections" == "null" ]]; then
+        RESIDUAL_LINES+="  \"$typo\" (line $line_num) is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."$'\n'
+      else
+        RESIDUAL_LINES+="  \"$typo\" (line $line_num) should be \"$first_correction\" — if intentional, add it to extend-words / extend-identifiers in your typos config."$'\n'
+      fi
+    fi
+    parsed=$(printf '%s' "$obj" | jq -c --arg typo "$typo" --argjson corrections "$corrections" '{typo:$typo,corrections:$corrections}' 2>/dev/null) || continue
+    FINDINGS_JSON=$(printf '%s' "$FINDINGS_JSON" | jq -c --argjson f "$parsed" '. + [$f]' 2>/dev/null) || true
+    ;;
+  *)
+    # Present before the write, gone after it: this hook rewrote it.
+    APPLIED_COUNT=$((APPLIED_COUNT + 1))
+    if ((APPLIED_COUNT <= MAX_REPORT)); then
+      APPLIED_LINES+="  \"$typo\" -> \"$first_correction\" (line $line_num)"$'\n'
+      APPLIED_INLINE+="${APPLIED_INLINE:+; }\"$typo\" -> \"$first_correction\" (line $line_num)"
+    fi
+    parsed=$(jq -n --arg typo "$typo" --arg correction "$first_correction" --argjson line "${line_num:-0}" \
+      '{typo:$typo,correction:$correction,line:$line}' 2>/dev/null) || continue
+    APPLIED_JSON=$(printf '%s' "$APPLIED_JSON" | jq -c --argjson a "$parsed" '. + [$a]' 2>/dev/null) || true
+    ;;
+  esac
+done <<<"$SCAN_OUTPUT"
+
+# Compose ONE stdout document. Claude Code parses a hook's entire stdout as a
+# single JSON document, so the agent-channel context and the user-channel
+# message are built here and emitted together — printing twice would make the
+# second document unreadable and silently drop half the disclosure.
+CTX=""
+SYSMSG=""
+BASE="$(basename "$FILE")"
+
+if ((APPLIED_COUNT > 0)); then
+  CTX+="typos-format REWROTE $APPLIED_COUNT word(s) in $BASE after your edit:"$'\n'
+  CTX+="$APPLIED_LINES"
+  if ((APPLIED_COUNT > MAX_REPORT)); then
+    CTX+="  ... and $((APPLIED_COUNT - MAX_REPORT)) more."$'\n'
+  fi
+  CTX+="  These come from typos' built-in dictionary, not from this repository. If any is wrong here (an acronym, an identifier, a proper noun), add it to extend-words / extend-identifiers in your typos config — the autocorrect has no memory, so repairing the word by hand alone gets it rewritten again on the next edit."$'\n'
+  # The person whose file was just changed is the one who has to judge whether
+  # the change was correct, and they never asked for it. This is a content
+  # mutation, not a lint finding, so it goes to the user channel too.
+  SYSMSG="typos-format rewrote $APPLIED_COUNT word(s) in $BASE: $APPLIED_INLINE"
+  if ((APPLIED_COUNT > MAX_REPORT)); then
+    SYSMSG+="; ... and $((APPLIED_COUNT - MAX_REPORT)) more"
+  fi
+  SYSMSG+=". Add any wrong rewrite to extend-words / extend-identifiers in your typos config, or set the typos_format_write_changes option to false for report-only mode."
+elif [[ "$WRITE_CHANGES" == "false" ]]; then
+  CTX+="typos-format is in report-only mode (typos_format_write_changes = false) — $BASE was NOT modified. Findings:"$'\n'
+fi
+
+if ((RESIDUAL_COUNT > 0)); then
+  if ((APPLIED_COUNT > 0)); then
+    CTX+="typos-format: $BASE also has $RESIDUAL_COUNT finding(s) it did not rewrite (advisory):"$'\n'
+  elif [[ "$WRITE_CHANGES" != "false" ]]; then
+    CTX+="typos-format: $BASE has residual typos findings (advisory):"$'\n'
+  fi
+  CTX+="$RESIDUAL_LINES"
+  if ((RESIDUAL_COUNT > MAX_REPORT)); then
+    CTX+="  ... and $((RESIDUAL_COUNT - MAX_REPORT)) more."$'\n'
+  fi
+fi
+
+# Trim the trailing newline the same way hook::ctx_flush does.
+CTX="${CTX%"${CTX##*[![:space:]]}"}"
+hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
+
+data_json=$(build_data_json "$FINDINGS_JSON" "$APPLIED_JSON")
+# Status "ok" — typos RAN and produced a judgment (findings live in
+# data.findings, applied rewrites in data.applied), mirroring the sibling
+# formatter plugins where status reflects whether the tool ran, not whether it
+# was clean.
+emit_tel "typos-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
 exit 0

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -421,8 +421,17 @@ CTX="${CTX%"${CTX##*[![:space:]]}"}"
 # a disclosure that overruns it can be truncated or rejected by the channel
 # AFTER the file has already been rewritten — the one outcome this whole path
 # exists to prevent. The budget leaves headroom for JSON escaping, which can
-# expand a string well past its character count, and the trailing note names
-# the channel that still has the full list.
+# expand a string well past its character count.
+#
+# DEFENCE IN DEPTH, not the working bound: at MAX_REPORT=10 entries × 60-char
+# elided tokens the message tops out near 1,100 characters, so this ceiling does
+# not fire today and its branch is exercised only if one of those numbers moves.
+# It is kept because both of them are tunable and the documented channel cap is
+# not — raise MAX_REPORT or the elision width far enough and this is the only
+# thing standing between a rewrite and a rejected disclosure. Cutting on bytes
+# rather than characters is deliberate: it can split a multi-byte sequence, and
+# a mangled tail character is a strictly better failure than an over-long
+# message the channel drops whole.
 truncate_to() {
   local s="$1" n="$2"
   if ((${#s} > n)); then

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -261,86 +261,76 @@ if [[ "$WRITE_CHANGES" != "false" ]]; then
   [[ $WRITE_RC -eq 0 ]] && RESIDUAL_OUTPUT=""
 fi
 
+# Classify both finding sets in ONE jq invocation.
+#
+# The per-finding shell loop this replaces spawned jq several times per finding,
+# which is the difference between a hook that discloses and a hook that does
+# not: a 120-correction file rewrote the file and then hit the handler's
+# 15-second timeout with empty stdout — recreating, at scale, exactly the silent
+# mutation this change exists to end. Process-spawn cost dominates everything
+# else here (typos itself runs in ~80 ms on a 68 KB file), so the loop is gone
+# and the total spawn count is constant in the number of findings.
+#
 # Residual identity key: line number + the flagged token. Byte offsets shift as
 # earlier corrections on the same line change its length, so an offset-keyed
-# comparison would classify wrongly; a line/token pair is stable across the write
-# because a repeated token on one line always shares one fix decision.
-RESIDUAL_KEYS=$'\n'
-while IFS= read -r line; do
-  [[ -n "$line" ]] || continue
-  key=$(printf '%s' "$line" | jq -r 'select(.type == "typo") | "\(.line_num // 0)\t\(.typo // "")"' 2>/dev/null) || continue
-  [[ -n "$key" ]] || continue
-  RESIDUAL_KEYS+="$key"$'\n'
-done <<<"$RESIDUAL_OUTPUT"
+# comparison would classify wrongly; a line/token pair is stable across the
+# write because a repeated token on one line always shares one fix decision.
+# The key is built and compared inside jq as a JSON string, so a token carrying
+# a shell or glob metacharacter is data throughout and can never widen a match.
+#
+# The display lines are rendered here too, capped, so the shell never has to
+# walk the finding set at all.
+CLASSIFIED=$(jq -c -n \
+  --arg scan "$SCAN_OUTPUT" \
+  --arg residual "$RESIDUAL_OUTPUT" \
+  --argjson max "$MAX_REPORT" '
+    def parse($s): [$s | split("\n")[] | select(length > 0) | (fromjson? // empty) | select(.type == "typo")];
+    def keyof: "\(.line_num // 0)\t\(.typo // "")";
+    def corr1: (.corrections[0] // "");
+    (parse($residual) | map(keyof)) as $res
+    | parse($scan) as $all
+    | ($all | map(select((keyof) as $key | ($res | index($key)) != null))) as $r
+    | ($all | map(select((keyof) as $key | ($res | index($key)) == null))) as $a
+    | {
+        appliedCount: ($a | length),
+        residualCount: ($r | length),
+        applied: ($a | map({typo: (.typo // ""), correction: corr1, line: (.line_num // 0)})),
+        findings: ($r | map({typo: (.typo // ""), corrections: .corrections})),
+        appliedText: ([limit($max; $a[])] | map("  \"\(.typo)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("\n")),
+        appliedInline: ([limit($max; $a[])] | map("\"\(.typo)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("; ")),
+        residualText: ([limit($max; $r[])] | map(
+            if .corrections == null then
+              "  \"\(.typo)\" (line \(.line_num // 0)) is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."
+            else
+              "  \"\(.typo)\" (line \(.line_num // 0)) should be \"\(corr1)\" — if intentional, add it to extend-words / extend-identifiers in your typos config."
+            end) | join("\n"))
+      }' 2>/dev/null) || CLASSIFIED=""
 
-APPLIED_LINES=""
-APPLIED_INLINE=""
-APPLIED_COUNT=0
-APPLIED_OBJS=""
-RESIDUAL_LINES=""
-RESIDUAL_COUNT=0
-FINDING_OBJS=""
-
-# One jq per scanned finding extracts every field at once, and each classified
-# object is APPENDED to a newline-delimited buffer that a single `jq -s` folds
-# into an array at the end. Re-reading and rewriting an accumulating array once
-# per finding would be quadratic in a hook that fires on every edit; the
-# telemetry arrays are uncapped, so that cost is paid on the whole finding set,
-# not on the ten lines the report shows.
-while IFS= read -r line; do
-  [[ -n "$line" ]] || continue
-  fields=$(printf '%s' "$line" |
-    jq -r 'select(.type == "typo") | [(.line_num // 0), (.typo // ""), (.corrections[0] // ""), (.corrections | tojson)] | @tsv' 2>/dev/null) || continue
-  [[ -n "$fields" ]] || continue
-  IFS=$'\t' read -r line_num typo first_correction corrections <<<"$fields"
-  [[ -n "$typo" ]] || continue
-  [[ -n "$corrections" ]] || corrections="null"
-
-  # A quoted expansion inside a `case` pattern is matched LITERALLY — POSIX
-  # requires quoted pattern characters not to act as pattern specials, and this
-  # was verified here against bash 5.3 for `*`, `?` and `[…]` in both
-  # directions. So a token carrying a glob metacharacter cannot widen this
-  # match, and no separate escaping pass is needed. Do not "fix" this into an
-  # unquoted expansion or a `grep -F` pipeline: `grep -F` splits a pattern on
-  # newlines, and this key is newline-delimited on both sides, which would
-  # match an empty pattern against everything.
-  case "$RESIDUAL_KEYS" in
-  *$'\n'"$line_num"$'\t'"$typo"$'\n'*)
-    # Survived the write (or nothing was written) — advisory only.
-    RESIDUAL_COUNT=$((RESIDUAL_COUNT + 1))
-    if ((RESIDUAL_COUNT <= MAX_REPORT)); then
-      if [[ "$corrections" == "null" ]]; then
-        RESIDUAL_LINES+="  \"$typo\" (line $line_num) is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."$'\n'
-      else
-        RESIDUAL_LINES+="  \"$typo\" (line $line_num) should be \"$first_correction\" — if intentional, add it to extend-words / extend-identifiers in your typos config."$'\n'
-      fi
-    fi
-    parsed=$(jq -c -n --arg typo "$typo" --argjson corrections "$corrections" \
-      '{typo:$typo,corrections:$corrections}' 2>/dev/null) || continue
-    FINDING_OBJS+="$parsed"$'\n'
-    ;;
-  *)
-    # Present before the write, gone after it: this hook rewrote it.
-    APPLIED_COUNT=$((APPLIED_COUNT + 1))
-    if ((APPLIED_COUNT <= MAX_REPORT)); then
-      APPLIED_LINES+="  \"$typo\" -> \"$first_correction\" (line $line_num)"$'\n'
-      APPLIED_INLINE+="${APPLIED_INLINE:+; }\"$typo\" -> \"$first_correction\" (line $line_num)"
-    fi
-    parsed=$(jq -c -n --arg typo "$typo" --arg correction "$first_correction" --argjson line "${line_num:-0}" \
-      '{typo:$typo,correction:$correction,line:$line}' 2>/dev/null) || continue
-    APPLIED_OBJS+="$parsed"$'\n'
-    ;;
-  esac
-done <<<"$SCAN_OUTPUT"
-
-FINDINGS_JSON="[]"
-if [[ -n "$FINDING_OBJS" ]]; then
-  FINDINGS_JSON=$(printf '%s' "$FINDING_OBJS" | jq -c -s . 2>/dev/null) || FINDINGS_JSON="[]"
+if [[ -z "$CLASSIFIED" ]]; then
+  # jq is already a hard prerequisite (hook::require_jq above), so this is
+  # near-unreachable. It still must not degrade into silence: the file may
+  # already have been rewritten, and "changed, details unavailable" is a far
+  # better answer than nothing.
+  hook::ctx_reset
+  hook::ctx_append "typos-format ran on $(basename "$FILE") and its findings could not be summarized (internal parse failure). If the file was rewritten, review it — this run cannot say what changed."
+  hook::ctx_flush PostToolUse
+  data_json=$(build_data_json '[]')
+  emit_tel "typos-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  exit 0
 fi
-APPLIED_JSON="[]"
-if [[ -n "$APPLIED_OBJS" ]]; then
-  APPLIED_JSON=$(printf '%s' "$APPLIED_OBJS" | jq -c -s . 2>/dev/null) || APPLIED_JSON="[]"
-fi
+
+read_field() { printf '%s' "$CLASSIFIED" | jq -r "$1" 2>/dev/null; }
+APPLIED_COUNT=$(read_field '.appliedCount')
+RESIDUAL_COUNT=$(read_field '.residualCount')
+APPLIED_LINES=$(read_field '.appliedText')
+APPLIED_INLINE=$(read_field '.appliedInline')
+RESIDUAL_LINES=$(read_field '.residualText')
+APPLIED_JSON=$(printf '%s' "$CLASSIFIED" | jq -c '.applied' 2>/dev/null) || APPLIED_JSON='[]'
+FINDINGS_JSON=$(printf '%s' "$CLASSIFIED" | jq -c '.findings' 2>/dev/null) || FINDINGS_JSON='[]'
+[[ "$APPLIED_COUNT" =~ ^[0-9]+$ ]] || APPLIED_COUNT=0
+[[ "$RESIDUAL_COUNT" =~ ^[0-9]+$ ]] || RESIDUAL_COUNT=0
+[[ -n "$APPLIED_LINES" ]] && APPLIED_LINES="$APPLIED_LINES"$'\n'
+[[ -n "$RESIDUAL_LINES" ]] && RESIDUAL_LINES="$RESIDUAL_LINES"$'\n'
 
 # Compose ONE stdout document. Claude Code parses a hook's entire stdout as a
 # single JSON document, so the agent-channel context and the user-channel

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -311,7 +311,13 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
   jq -R -s -c --argjson max "$MAX_REPORT" '
     def parse($lines): [$lines[] | select(length > 0) | (fromjson? // empty) | select(.type == "typo")];
     def keyof: "\(.line_num // 0)\t\(.typo // "")";
-    def corr1: (.corrections[0] // "");
+    # Entry count is capped, but a single entry is not bounded by that: a token
+    # or correction is arbitrary text from the file, so ten of them can still
+    # blow the systemMessage character cap. Rendered tokens are elided; the
+    # telemetry arrays below keep the untruncated values.
+    def elide: if (length > 60) then (.[0:60] + "…") else . end;
+    def tok: ((.typo // "") | elide);
+    def corr1: ((.corrections[0] // "") | elide);
     (split("\n")) as $lines
     | (($lines | index("@@typos-format-split@@")) // ($lines | length)) as $sep
     | ((parse($lines[($sep + 1):]) | map({(keyof): true}) | add) // {}) as $res
@@ -323,13 +329,13 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
         residualCount: ($r | length),
         applied: ($a | map({typo: (.typo // ""), correction: corr1, line: (.line_num // 0)})),
         findings: ($r | map({typo: (.typo // ""), corrections: .corrections})),
-        appliedText: ([limit($max; $a[])] | map("  \"\(.typo)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("\n")),
-        appliedInline: ([limit($max; $a[])] | map("\"\(.typo)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("; ")),
+        appliedText: ([limit($max; $a[])] | map("  \"\(tok)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("\n")),
+        appliedInline: ([limit($max; $a[])] | map("\"\(tok)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("; ")),
         residualText: ([limit($max; $r[])] | map(
             if .corrections == null then
-              "  \"\(.typo)\" (line \(.line_num // 0)) is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."
+              "  \"\(tok)\" (line \(.line_num // 0)) is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."
             else
-              "  \"\(.typo)\" (line \(.line_num // 0)) should be \"\(corr1)\" — if intentional, add it to extend-words / extend-identifiers in your typos config."
+              "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corr1)\" — if intentional, add it to extend-words / extend-identifiers in your typos config."
             end) | join("\n"))
       }' 2>/dev/null) || CLASSIFIED=""
 
@@ -408,6 +414,26 @@ fi
 
 # Trim the trailing newline the same way hook::ctx_flush does.
 CTX="${CTX%"${CTX##*[![:space:]]}"}"
+
+# Hard character ceiling, belt to the per-entry elision's braces. systemMessage
+# is documented at a 10,000-character cap
+# (docs/conventions/hook-observability/README.md, from the hooks reference), and
+# a disclosure that overruns it can be truncated or rejected by the channel
+# AFTER the file has already been rewritten — the one outcome this whole path
+# exists to prevent. The budget leaves headroom for JSON escaping, which can
+# expand a string well past its character count, and the trailing note names
+# the channel that still has the full list.
+truncate_to() {
+  local s="$1" n="$2"
+  if ((${#s} > n)); then
+    printf '%s… (message truncated at %s characters; the run'"'"'s full finding set is in its telemetry payload, which is never capped)' "${s:0:n}" "$n"
+  else
+    printf '%s' "$s"
+  fi
+}
+SYSMSG=$(truncate_to "$SYSMSG" 4000)
+CTX=$(truncate_to "$CTX" 12000)
+
 hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
 
 data_json=$(build_data_json "$FINDINGS_JSON" "$APPLIED_JSON")

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -311,23 +311,42 @@ else
 fi
 
 # --- Scale: disclosure must still arrive on a heavily-corrected file ---------
-# The hook's handler declares a 15-second timeout. An implementation that spawns
-# a subprocess per finding rewrites the file and then times out with empty
-# stdout — reproducing the silent mutation at scale, on exactly the files where
-# the disclosure matters most. Classification is therefore one jq pass, and this
-# case pins that: 120 corrections in one file, well inside the budget.
+# Two distinct failures live here, both ending in the same place — the file is
+# rewritten and stdout is empty, which is the silent mutation this whole change
+# exists to end, hitting hardest on exactly the files that need it most:
+#
+#   1. A subprocess per finding. The handler declares a 15-second timeout; a
+#      per-finding loop blew it at ~100 corrections.
+#   2. Passing the finding sets to jq as --arg values. Windows caps a process
+#      command line at 32767 characters and typos' jsonlines run ~110 bytes per
+#      finding, so this broke silently somewhere past ~300 corrections — jq
+#      never ran and the hook degraded to "could not be summarized".
+#
+# 500 is therefore the floor for this case, not 100: it has to exceed the argv
+# limit, which a smaller count does not. Both streams go to jq on stdin now.
+SCALE_N=500
 : >"$STUB_REPO/scale.txt"
-for _i in $(seq 1 120); do
+for _i in $(seq 1 "$SCALE_N"); do
   printf 'line %s has teh typo\n' "$_i" >>"$STUB_REPO/scale.txt" # spellchecker:disable-line
 done
 SCALE_START=$(date +%s)
 OUT_SC=$(run_stub "$STUB_REPO/scale.txt")
 SCALE_ELAPSED=$(($(date +%s) - SCALE_START))
 CTX_SC=$(printf '%s' "$OUT_SC" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
-if printf '%s' "$CTX_SC" | grep -q 'REWROTE 120 word'; then
-  ok "stub/scale: 120 corrections are disclosed, not dropped"
+if printf '%s' "$CTX_SC" | grep -q "REWROTE $SCALE_N word"; then
+  ok "stub/scale: $SCALE_N corrections are disclosed, not dropped"
 else
-  fail "stub/scale: disclosure missing on a 120-correction file: $CTX_SC"
+  fail "stub/scale: disclosure missing on a $SCALE_N-correction file: $CTX_SC"
+fi
+if printf '%s' "$CTX_SC" | grep -q 'could not be summarized'; then
+  fail "stub/scale: classification failed at $SCALE_N findings (argv limit?): $CTX_SC"
+else
+  ok "stub/scale: classification survives a finding set larger than a Windows command line"
+fi
+if printf '%s' "$CTX_SC" | grep -q $'\r'; then
+  fail "stub/scale: carriage returns leaked into the report text"
+else
+  ok "stub/scale: report text carries no stray carriage returns"
 fi
 if [[ "$SCALE_ELAPSED" -lt 10 ]]; then
   ok "stub/scale: completed in ${SCALE_ELAPSED}s, inside the handler's 15s timeout"

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -34,16 +34,6 @@ ok() {
   PASS=$((PASS + 1))
 }
 
-# Resolve a real typos binary. Skip the suite when none is available.
-if [[ -n "${TYPOS_TEST_BIN:-}" && -x "${TYPOS_TEST_BIN}" ]]; then
-  REAL_TYPOS="${TYPOS_TEST_BIN}"
-elif command -v typos >/dev/null 2>&1; then
-  REAL_TYPOS="$(command -v typos)"
-else
-  echo "SKIP: no typos binary (set TYPOS_TEST_BIN or put typos on PATH) -- typos-format hook tests skipped"
-  exit 0
-fi
-
 WORK="$(mktemp -d)"
 UNRELATED="$(mktemp -d)"
 cleanup() { rm -rf "$WORK" "$UNRELATED"; }
@@ -112,6 +102,243 @@ run_hook_env() {
       env -u CLAUDE_PROJECT_DIR "$@" bash "$HOOK"
   )
 }
+
+# ============================================================================
+# Disclosure contract — driven by a STUB typos, so it runs everywhere
+# ============================================================================
+# The cases below assert the contract that matters most about this hook: it
+# changes the content of the user's files, and every change it makes must be
+# reported on both channels. A real typos binary is not installed on the CI
+# runner, so the real-binary suite further down SKIPs there — asserting this
+# contract only against a real binary would leave it ungated in exactly the
+# place a regression would land unnoticed. The stub implements the slice of
+# typos' documented contract this hook depends on and nothing more:
+#
+# spellchecker:off
+#   token       corrections            --write-changes behavior
+#   ----------- ---------------------- ---------------------------------------
+#   teh         ["the"]                applied
+#   wnat        ["want","what"]        NOT applied (ambiguous), stays residual
+#   disallowme  null                   NOT applied (no correction), residual
+#
+# Exit codes mirror typos-cli 1.44.0 as verified against the real binary:
+# 0 = nothing left to report, 2 = findings remain. jsonlines on stdout.
+STUB_BIN="$(mktemp -d "$WORK/stubbin.XXXXXX")"
+cat >"$STUB_BIN/typos" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+write=0
+target=""
+for arg in "$@"; do
+  case "$arg" in
+  --write-changes) write=1 ;;
+  --force-exclude | --format | json) ;;
+  *) target="$arg" ;;
+  esac
+done
+[[ -n "$target" && -f "$target" ]] || exit 0
+
+residual=0
+out=""
+lineno=0
+tmp="$target.stubtmp"
+: >"$tmp"
+while IFS= read -r line || [[ -n "$line" ]]; do
+  lineno=$((lineno + 1))
+  for tok in teh wnat disallowme; do
+    case " $line " in
+    *" $tok "*) ;;
+    *) continue ;;
+    esac
+    case "$tok" in
+    teh)
+      out+='{"type":"typo","path":"'"$target"'","line_num":'"$lineno"',"byte_offset":0,"typo":"teh","corrections":["the"]}'$'\n'
+      if ((write == 1)); then line="${line//" teh "/" the "}"; else residual=1; fi
+      ;;
+    wnat)
+      out+='{"type":"typo","path":"'"$target"'","line_num":'"$lineno"',"byte_offset":0,"typo":"wnat","corrections":["want","what"]}'$'\n'
+      residual=1
+      ;;
+    disallowme)
+      out+='{"type":"typo","path":"'"$target"'","line_num":'"$lineno"',"byte_offset":0,"typo":"disallowme","corrections":null}'$'\n'
+      residual=1
+      ;;
+    esac
+  done
+  printf '%s\n' "$line" >>"$tmp"
+done <"$target"
+
+if ((write == 1)); then
+  mv -f "$tmp" "$target"
+  # Re-emit only what survived the write.
+  printf '%s' "$out" | grep -v '"typo":"teh"'
+  ((residual == 1)) && exit 2
+  exit 0
+fi
+rm -f "$tmp"
+printf '%s' "$out"
+[[ -n "$out" ]] && exit 2
+exit 0
+STUB
+# spellchecker:on
+chmod +x "$STUB_BIN/typos"
+
+# Invoke the hook with the stub on PATH.
+run_stub() {
+  local file_path="$1"
+  shift
+  (
+    cd "$UNRELATED" || return 1
+    printf '{"session_id":"stub-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+      env -u CLAUDE_PROJECT_DIR PATH="$STUB_BIN:$PATH" \
+        CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_ENABLED=true "$@" bash "$HOOK"
+  )
+}
+
+STUB_REPO="$WORK/stub-repo"
+new_typos_repo "$STUB_REPO" NO_CONFIG
+
+# --- Applied correction is disclosed on BOTH channels ------------------------
+# The defect this closes: on the all-fixed path the hook emitted no stdout at
+# all, so a dictionary rewrite of a domain term reached the file with the only
+# trace being the harness's generic "a hook modified this file" line — no hook
+# name, no word, no diff.
+printf 'this has teh typo\n' >"$STUB_REPO/applied.txt" # spellchecker:disable-line
+OUT_AP=$(run_stub "$STUB_REPO/applied.txt")
+RC_AP=$?
+if [[ $RC_AP -eq 0 ]]; then ok "stub/applied: exit 0 (advisory)"; else fail "stub/applied: exit $RC_AP"; fi
+if grep -q ' the ' "$STUB_REPO/applied.txt"; then
+  ok "stub/applied: correction written to the file"
+else
+  fail "stub/applied: file not rewritten: $(cat "$STUB_REPO/applied.txt")"
+fi
+if printf '%s' "$OUT_AP" | jq -e . >/dev/null 2>&1; then
+  ok "stub/applied: stdout is one parseable JSON document"
+else
+  fail "stub/applied: stdout is not a single JSON document: $OUT_AP"
+fi
+CTX_AP=$(printf '%s' "$OUT_AP" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+SYS_AP=$(printf '%s' "$OUT_AP" | jq -r '.systemMessage // empty' 2>/dev/null)
+if printf '%s' "$CTX_AP" | grep -qF '"teh" -> "the"'; then # spellchecker:disable-line
+  ok "stub/applied: rewrite disclosed on the agent channel"
+else
+  fail "stub/applied: no agent-channel disclosure: $CTX_AP"
+fi
+if printf '%s' "$SYS_AP" | grep -qF '"teh" -> "the"'; then # spellchecker:disable-line
+  ok "stub/applied: rewrite disclosed on the user channel"
+else
+  fail "stub/applied: no user-channel disclosure: $SYS_AP"
+fi
+if printf '%s' "$CTX_AP" | grep -qi 'extend-words'; then
+  ok "stub/applied: allow-list remediation rides on the APPLIED path (not just the residual one)"
+else
+  fail "stub/applied: no extend-words guidance on the applied path: $CTX_AP"
+fi
+
+# --- Report-only mode never touches the file ---------------------------------
+printf 'this has teh typo\n' >"$STUB_REPO/readonly.txt" # spellchecker:disable-line
+BEFORE_RO="$(cat "$STUB_REPO/readonly.txt")"
+OUT_RO=$(run_stub "$STUB_REPO/readonly.txt" CLAUDE_PLUGIN_OPTION_TYPOS_FORMAT_WRITE_CHANGES=false)
+RC_RO=$?
+if [[ $RC_RO -eq 0 ]]; then ok "stub/report-only: exit 0"; else fail "stub/report-only: exit $RC_RO"; fi
+if [[ "$(cat "$STUB_REPO/readonly.txt")" == "$BEFORE_RO" ]]; then
+  ok "stub/report-only: file left byte-identical"
+else
+  fail "stub/report-only: file was modified: $(cat "$STUB_REPO/readonly.txt")"
+fi
+CTX_RO=$(printf '%s' "$OUT_RO" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_RO" | grep -q 'report-only' && printf '%s' "$CTX_RO" | grep -q 'NOT modified'; then
+  ok "stub/report-only: mode is stated in the report"
+else
+  fail "stub/report-only: mode not stated: $CTX_RO"
+fi
+if [[ -z "$(printf '%s' "$OUT_RO" | jq -r '.systemMessage // empty' 2>/dev/null)" ]]; then
+  ok "stub/report-only: no user-channel message (nothing was mutated)"
+else
+  fail "stub/report-only: emitted a systemMessage without mutating anything"
+fi
+
+# --- Applied + residual in one run: both sections, one document --------------
+printf 'this has teh typo and wnat and a disallowme term\n' >"$STUB_REPO/both.txt" # spellchecker:disable-line
+OUT_BOTH=$(run_stub "$STUB_REPO/both.txt")
+CTX_BOTH=$(printf '%s' "$OUT_BOTH" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_BOTH" | grep -qF '"teh" -> "the"' && # spellchecker:disable-line
+  printf '%s' "$CTX_BOTH" | grep -q 'disallowme' &&
+  printf '%s' "$CTX_BOTH" | grep -q 'wnat'; then # spellchecker:disable-line
+  ok "stub/both: applied rewrite and both residual findings reported together"
+else
+  fail "stub/both: sections missing: $CTX_BOTH"
+fi
+if printf '%s' "$OUT_BOTH" | jq -e '.systemMessage and .hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  ok "stub/both: both channels composed into ONE stdout document"
+else
+  fail "stub/both: channels not composed: $OUT_BOTH"
+fi
+
+# --- Disclosure is capped ----------------------------------------------------
+# A file with hundreds of corrections must not turn the disclosure into the
+# unbounded context flood it exists to prevent.
+: >"$STUB_REPO/many.txt"
+for _i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  printf 'line with teh typo\n' >>"$STUB_REPO/many.txt" # spellchecker:disable-line
+done
+OUT_MANY=$(run_stub "$STUB_REPO/many.txt")
+CTX_MANY=$(printf '%s' "$OUT_MANY" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+DETAIL_LINES=$(printf '%s' "$CTX_MANY" | grep -cF '(line ')
+if [[ "$DETAIL_LINES" -eq 10 ]]; then
+  ok "stub/cap: per-word detail capped at 10 lines (got $DETAIL_LINES)"
+else
+  fail "stub/cap: expected 10 detail lines, got $DETAIL_LINES: $CTX_MANY"
+fi
+if printf '%s' "$CTX_MANY" | grep -q 'REWROTE 15 word' && printf '%s' "$CTX_MANY" | grep -q 'and 5 more'; then
+  ok "stub/cap: full count and remainder still reported"
+else
+  fail "stub/cap: count/remainder missing: $CTX_MANY"
+fi
+
+# --- Telemetry carries the applied rewrites ----------------------------------
+printf 'this has teh typo and a disallowme term\n' >"$STUB_REPO/tel-applied.txt" # spellchecker:disable-line
+TELA="$(mktemp)"
+SINKA="$(make_sink "cat >\"$TELA\"")"
+run_stub "$STUB_REPO/tel-applied.txt" HOOK_TELEMETRY_SINK="$SINKA" >/dev/null
+wait_for_sink "$TELA"
+if [[ -s "$TELA" ]]; then
+  if [[ "$(jq -r '.data.applied[0].typo' "$TELA")" == "teh" ]]; then # spellchecker:disable-line
+    ok "stub/telemetry: data.applied records the rewritten token"
+  else
+    fail "stub/telemetry: data.applied wrong: $(jq -c '.data.applied' "$TELA")"
+  fi
+  if [[ "$(jq -r '.data.applied[0].correction' "$TELA")" == "the" ]]; then
+    ok "stub/telemetry: data.applied records the replacement"
+  else
+    fail "stub/telemetry: data.applied.correction wrong: $(jq -c '.data.applied' "$TELA")"
+  fi
+  if [[ "$(jq -r '.data.findings[0].typo' "$TELA")" == "disallowme" ]]; then
+    ok "stub/telemetry: data.findings still carries residual findings only"
+  else
+    fail "stub/telemetry: data.findings wrong: $(jq -c '.data.findings' "$TELA")"
+  fi
+else
+  fail "stub/telemetry: no envelope written"
+fi
+rm -f "$TELA"
+
+# ============================================================================
+# Real-binary suite — wiring, config discovery, exclusion, kill switch
+# ============================================================================
+# Resolve a real typos binary. Skip the REST of the suite when none is
+# available; the stub-driven contract cases above have already run.
+if [[ -n "${TYPOS_TEST_BIN:-}" && -x "${TYPOS_TEST_BIN}" ]]; then
+  REAL_TYPOS="${TYPOS_TEST_BIN}"
+elif command -v typos >/dev/null 2>&1; then
+  REAL_TYPOS="$(command -v typos)"
+else
+  echo "SKIP: no typos binary (set TYPOS_TEST_BIN or put typos on PATH) -- real-binary typos-format cases skipped"
+  echo
+  echo "PASS=$PASS FAIL=$FAIL"
+  [[ $FAIL -eq 0 ]]
+  exit
+fi
 
 # --- Case 1: no typos config anywhere -> hook still fixes unconditionally ---
 # typos ships a built-in spelling dictionary and runs with zero configuration.
@@ -215,10 +442,20 @@ else
 fi
 CTX_MIXED=$(printf '%s' "$OUT" | jq -r '.hookSpecificOutput.additionalContext' 2>/dev/null)
 FIXED_TYPO='teh' # spellchecker:disable-line
-if printf '%s' "$CTX_MIXED" | grep -q 'disallowme' && ! printf '%s' "$CTX_MIXED" | grep -qF "\"$FIXED_TYPO\""; then
-  ok "mixed fixable+unfixable -> only unfixable reported (fixed typo absent)"
+# BOTH halves are reported now: the residual finding as advisory, and the
+# correction the hook APPLIED as a disclosed content mutation. A rewrite the
+# user never asked for and never saw is the defect this reporting exists to
+# close, so the applied word must appear, not be filtered out.
+if printf '%s' "$CTX_MIXED" | grep -q 'disallowme' && printf '%s' "$CTX_MIXED" | grep -qF "\"$FIXED_TYPO\" -> \"the\""; then
+  ok "mixed fixable+unfixable -> applied rewrite disclosed AND residual reported"
 else
   fail "mixed case: reporting wrong: $CTX_MIXED"
+fi
+SYS_MIXED=$(printf '%s' "$OUT" | jq -r '.systemMessage // empty' 2>/dev/null)
+if printf '%s' "$SYS_MIXED" | grep -qF "\"$FIXED_TYPO\" -> \"the\""; then
+  ok "mixed fixable+unfixable -> applied rewrite also disclosed on the user channel"
+else
+  fail "mixed case: no user-channel disclosure of the rewrite: $SYS_MIXED"
 fi
 
 # --- Case 7: config excludes the edited file -> untouched, no nag ------------

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -310,6 +310,31 @@ else
   fail "stub/cap: count/remainder missing: $CTX_MANY"
 fi
 
+# --- Scale: disclosure must still arrive on a heavily-corrected file ---------
+# The hook's handler declares a 15-second timeout. An implementation that spawns
+# a subprocess per finding rewrites the file and then times out with empty
+# stdout — reproducing the silent mutation at scale, on exactly the files where
+# the disclosure matters most. Classification is therefore one jq pass, and this
+# case pins that: 120 corrections in one file, well inside the budget.
+: >"$STUB_REPO/scale.txt"
+for _i in $(seq 1 120); do
+  printf 'line %s has teh typo\n' "$_i" >>"$STUB_REPO/scale.txt" # spellchecker:disable-line
+done
+SCALE_START=$(date +%s)
+OUT_SC=$(run_stub "$STUB_REPO/scale.txt")
+SCALE_ELAPSED=$(($(date +%s) - SCALE_START))
+CTX_SC=$(printf '%s' "$OUT_SC" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_SC" | grep -q 'REWROTE 120 word'; then
+  ok "stub/scale: 120 corrections are disclosed, not dropped"
+else
+  fail "stub/scale: disclosure missing on a 120-correction file: $CTX_SC"
+fi
+if [[ "$SCALE_ELAPSED" -lt 10 ]]; then
+  ok "stub/scale: completed in ${SCALE_ELAPSED}s, inside the handler's 15s timeout"
+else
+  fail "stub/scale: took ${SCALE_ELAPSED}s — at or over the handler's 15s timeout budget"
+fi
+
 # --- A broken write pass must not be read as "everything was applied" --------
 printf 'this has teh typo and wnat too\n' >"$STUB_REPO/break.txt" # spellchecker:disable-line
 OUT_BR=$(run_stub "$STUB_REPO/break.txt" STUB_BREAK=1)

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -129,14 +129,28 @@ cat >"$STUB_BIN/typos" <<'STUB'
 set -uo pipefail
 write=0
 target=""
+skip_next=0
 for arg in "$@"; do
+  if ((skip_next == 1)); then
+    skip_next=0
+    continue
+  fi
   case "$arg" in
   --write-changes) write=1 ;;
-  --force-exclude | --format | json) ;;
+  --format) skip_next=1 ;;
+  --format=*) ;;
+  -*) ;;
   *) target="$arg" ;;
   esac
 done
 [[ -n "$target" && -f "$target" ]] || exit 0
+
+# STUB_BREAK: exit 2 with EMPTY output on the write pass — a typos break
+# mid-write. Read as "nothing residual" it would classify every scanned finding
+# as applied, disclosing rewrites that never happened.
+if ((write == 1)) && [[ -n "${STUB_BREAK:-}" ]]; then
+  exit 2
+fi
 
 residual=0
 out=""
@@ -296,6 +310,27 @@ else
   fail "stub/cap: count/remainder missing: $CTX_MANY"
 fi
 
+# --- A broken write pass must not be read as "everything was applied" --------
+printf 'this has teh typo and wnat too\n' >"$STUB_REPO/break.txt" # spellchecker:disable-line
+OUT_BR=$(run_stub "$STUB_REPO/break.txt" STUB_BREAK=1)
+RC_BR=$?
+CTX_BR=$(printf '%s' "$OUT_BR" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ $RC_BR -eq 0 ]] && printf '%s' "$CTX_BR" | grep -q 'tool break'; then
+  ok "stub/write-break: exit 2 with empty output is reported as a tool break"
+else
+  fail "stub/write-break: not reported as a tool break (rc=$RC_BR): $CTX_BR"
+fi
+if printf '%s' "$CTX_BR" | grep -q 'REWROTE'; then
+  fail "stub/write-break: claimed rewrites after a broken write: $CTX_BR"
+else
+  ok "stub/write-break: no rewrite is claimed when the write never completed"
+fi
+if [[ -z "$(printf '%s' "$OUT_BR" | jq -r '.systemMessage // empty' 2>/dev/null)" ]]; then
+  ok "stub/write-break: no user-channel mutation notice for a write that broke"
+else
+  fail "stub/write-break: emitted a mutation notice for a broken write"
+fi
+
 # --- Telemetry carries the applied rewrites ----------------------------------
 printf 'this has teh typo and a disallowme term\n' >"$STUB_REPO/tel-applied.txt" # spellchecker:disable-line
 TELA="$(mktemp)"
@@ -312,6 +347,14 @@ if [[ -s "$TELA" ]]; then
     ok "stub/telemetry: data.applied records the replacement"
   else
     fail "stub/telemetry: data.applied.correction wrong: $(jq -c '.data.applied' "$TELA")"
+  fi
+  # `line` is required by the data schema and is the only field that must be a
+  # JSON number rather than a string — a quoted line number would validate as
+  # neither the schema's integer nor anything a sink can sort on.
+  if jq -e '.data.applied[0].line | type == "number" and . >= 1' "$TELA" >/dev/null 2>&1; then
+    ok "stub/telemetry: data.applied.line is a positive number, as the schema requires"
+  else
+    fail "stub/telemetry: data.applied.line wrong: $(jq -c '.data.applied' "$TELA")"
   fi
   if [[ "$(jq -r '.data.findings[0].typo' "$TELA")" == "disallowme" ]]; then
     ok "stub/telemetry: data.findings still carries residual findings only"

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -152,6 +152,18 @@ if ((write == 1)) && [[ -n "${STUB_BREAK:-}" ]]; then
   exit 2
 fi
 
+# STUB_LONG: report an absurdly long correction for every fixable finding. The
+# entry COUNT is capped, but a single entry is arbitrary text from the file, so
+# ten of them can still overrun the systemMessage character cap.
+long=""
+if [[ -n "${STUB_LONG:-}" ]]; then
+  i=0
+  while ((i < 40)); do
+    long="${long}veryverylongcorrectiontoken"
+    i=$((i + 1))
+  done
+fi
+
 residual=0
 out=""
 lineno=0
@@ -166,7 +178,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     esac
     case "$tok" in
     teh)
-      out+='{"type":"typo","path":"'"$target"'","line_num":'"$lineno"',"byte_offset":0,"typo":"teh","corrections":["the"]}'$'\n'
+      out+='{"type":"typo","path":"'"$target"'","line_num":'"$lineno"',"byte_offset":0,"typo":"teh","corrections":["'"${long:-the}"'"]}'$'\n'
       if ((write == 1)); then line="${line//" teh "/" the "}"; else residual=1; fi
       ;;
     wnat)
@@ -418,6 +430,35 @@ if [[ "$RES_ELAPSED" -lt 10 ]]; then
   ok "stub/scale-residual: completed in ${RES_ELAPSED}s, inside the handler's 15s timeout"
 else
   fail "stub/scale-residual: took ${RES_ELAPSED}s — quadratic membership regression?"
+fi
+
+# --- The disclosure must respect the channel's character cap -----------------
+# Capping the number of entries does not cap the message: a token or correction
+# is arbitrary text from the file, so ten long ones can still overrun the
+# 10,000-character systemMessage cap and get the disclosure truncated or
+# rejected by the channel — after the file has already been rewritten. Ten
+# corrections of ~1,080 characters each is ~10,800 before any prose.
+: >"$STUB_REPO/longtok.txt"
+for _i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  printf 'line %s has teh typo\n' "$_i" >>"$STUB_REPO/longtok.txt" # spellchecker:disable-line
+done
+OUT_LT=$(run_stub "$STUB_REPO/longtok.txt" STUB_LONG=1)
+SYS_LT=$(printf '%s' "$OUT_LT" | jq -r '.systemMessage // empty' 2>/dev/null)
+CTX_LT=$(printf '%s' "$OUT_LT" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ -n "$SYS_LT" && "${#SYS_LT}" -lt 10000 ]]; then
+  ok "stub/long: systemMessage stays under the 10,000-character channel cap (${#SYS_LT})"
+else
+  fail "stub/long: systemMessage is ${#SYS_LT} characters — at or over the channel cap"
+fi
+if printf '%s' "$SYS_LT" | grep -q 'rewrote 12 word'; then
+  ok "stub/long: the true rewrite count survives the character bound"
+else
+  fail "stub/long: count lost under truncation: $SYS_LT"
+fi
+if printf '%s' "$CTX_LT" | grep -q 'veryverylongcorrectiontokenveryverylongcorrectiontokenveryverylongcorrectiontoken'; then
+  fail "stub/long: an unelided long token reached the report"
+else
+  ok "stub/long: long tokens are elided in the rendered report"
 fi
 
 # --- A broken write pass must not be read as "everything was applied" --------

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -354,6 +354,72 @@ else
   fail "stub/scale: took ${SCALE_ELAPSED}s — at or over the handler's 15s timeout budget"
 fi
 
+# The telemetry arrays are uncapped, so they hit the same argv ceiling as the
+# finding sets. build_data_json feeds jq on stdin for that reason. The shared
+# hook::emit_telemetry then hands the FINISHED payload over as an --argjson
+# value, which is a fleet-wide fix tracked separately (#1595) — so an oversized
+# envelope is currently dropped rather than delivered. Assert the invariant that
+# holds either way and keeps holding once #1595 lands: telemetry is documented
+# best-effort and lossy, so losing an envelope is inside contract. An envelope
+# that ARRIVES reporting `applied: []` for a file this hook just rewrote 500
+# words in is not — that is the local fallback firing.
+TELSC="$(mktemp)"
+SINKSC="$(make_sink "cat >\"$TELSC\"")"
+run_stub "$STUB_REPO/scale.txt" HOOK_TELEMETRY_SINK="$SINKSC" >/dev/null
+wait_for_sink "$TELSC" 50
+if [[ -s "$TELSC" ]]; then
+  SC_APPLIED=$(jq '.data.applied | length' "$TELSC" 2>/dev/null)
+  SC_FINDINGS=$(jq '.data.findings | length' "$TELSC" 2>/dev/null)
+  # The second run finds nothing left to fix (the first already rewrote the
+  # file), so an accurate envelope here is empty on both arrays — the point is
+  # that it is accurate, not that it is populated.
+  if [[ "$SC_APPLIED" =~ ^[0-9]+$ && "$SC_FINDINGS" =~ ^[0-9]+$ ]]; then
+    ok "stub/scale: the envelope that arrived carries well-formed arrays, not the blank fallback"
+  else
+    fail "stub/scale: envelope malformed at scale: $(cat "$TELSC")"
+  fi
+  if [[ "$(jq -r '.data.file' "$TELSC" 2>/dev/null)" == "" ]]; then
+    fail "stub/scale: envelope arrived with data.file blanked — that is the build_data_json fallback"
+  else
+    ok "stub/scale: envelope names the file (build_data_json did not fall back)"
+  fi
+else
+  ok "stub/scale: oversized envelope was dropped, not falsified (loss is in contract; see #1595)"
+fi
+rm -f "$TELSC"
+
+# --- Scale, residual side: the membership test must not be a linear scan -----
+# The case above is entirely APPLIED corrections, so it never exercises the
+# residual-membership branch. Classifying residuals with a linear `index` over
+# an array is quadratic: 10,000 all-residual findings measured ~15.7s in the jq
+# invocation alone, past the handler's 15-second timeout — and the file is
+# rewritten BEFORE classification, so that timeout lands after the mutation and
+# before any disclosure. A minified or generated file where most findings are
+# ambiguous is exactly that shape. Hash lookup does the same set in ~0.6s.
+: >"$STUB_REPO/scale-residual.txt"
+for _i in $(seq 1 "$SCALE_N"); do
+  printf 'line %s has wnat and disallowme\n' "$_i" >>"$STUB_REPO/scale-residual.txt" # spellchecker:disable-line
+done
+RES_START=$(date +%s)
+OUT_SR=$(run_stub "$STUB_REPO/scale-residual.txt")
+RES_ELAPSED=$(($(date +%s) - RES_START))
+CTX_SR=$(printf '%s' "$OUT_SR" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_SR" | grep -q "$((SCALE_N * 2)) finding(s)\|residual typos findings"; then
+  ok "stub/scale-residual: an all-residual set of $((SCALE_N * 2)) findings is still reported"
+else
+  fail "stub/scale-residual: residual report missing: $CTX_SR"
+fi
+if printf '%s' "$CTX_SR" | grep -q 'REWROTE'; then
+  fail "stub/scale-residual: claimed rewrites for a set where nothing was applied: $CTX_SR"
+else
+  ok "stub/scale-residual: nothing is claimed as rewritten when nothing was applied"
+fi
+if [[ "$RES_ELAPSED" -lt 10 ]]; then
+  ok "stub/scale-residual: completed in ${RES_ELAPSED}s, inside the handler's 15s timeout"
+else
+  fail "stub/scale-residual: took ${RES_ELAPSED}s — quadratic membership regression?"
+fi
+
 # --- A broken write pass must not be read as "everything was applied" --------
 printf 'this has teh typo and wnat too\n' >"$STUB_REPO/break.txt" # spellchecker:disable-line
 OUT_BR=$(run_stub "$STUB_REPO/break.txt" STUB_BREAK=1)

--- a/plugins/typos-format/skills/setup/SKILL.md
+++ b/plugins/typos-format/skills/setup/SKILL.md
@@ -10,7 +10,8 @@ disable-model-invocation: true
 
 Thin check-centric setup per the uniform contract: `check` inspects and reports, `apply`
 resolves. This plugin owns no consumer-project configuration — rules come from the
-repository's own typos config, and the only tunable is the native `userConfig` toggle. Unlike
+repository's own typos config, and the only tunables are the native `userConfig` options
+(the on/off toggle and the write-mode switch). Unlike
 sibling formatter plugins (Ruff, markdownlint-cli2), typos has no per-repo dependency-manager
 install path — it is a standalone Rust binary installed at the machine level (cargo, Homebrew,
 Conda, pacman, or a pre-built binary), never as a project dependency. `apply` is therefore
@@ -49,7 +50,14 @@ restores the FAIL semantics.
    absence never changes whether the hook runs.
 5. **Hook toggle** — report the effective `typos_format_enabled` value:
    `${user_config.typos_format_enabled}` (unexpanded or empty means default `true`).
-6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+6. **Write mode** — report the effective `typos_format_write_changes` value:
+   `${user_config.typos_format_write_changes}` (unexpanded or empty means default `true`).
+   When it is `false` the hook is in report-only mode: it still runs, still reports findings,
+   and never modifies a file. Report that as **INFO, not PASS** — every prerequisite can pass
+   while the one behavior the consumer came here for is deliberately off, and the commonest
+   reason to invoke this skill is that spell-fixing is not happening. Name the remediation in
+   the same line rather than leaving the reader to infer it.
+7. **Hook registration** — INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)
@@ -75,6 +83,12 @@ never claim resolved without re-verifying. For everything else `apply` only poin
   directory for a `project`/`local` scope. Defaulting instead uninstalls a separate user-scope
   record while the effective install stays in place, so the reinstall lands at a scope that
   does not load.
+- report-only mode on (`typos_format_write_changes=false`): the hook is working as configured,
+  so this is a configuration answer, not a repair. Say so, then offer the same
+  `/plugin configure typos-format` route (or the scope-preserving uninstall/reinstall
+  `--config typos_format_write_changes=true` recipe above) — and note the alternative that
+  usually fits better: keeping writes on and allow-listing the specific words in the
+  repository's typos config, since report-only turns off every correction to suppress a few.
 - no typos config: offer to create a minimal `_typos.toml` in the repository root only when
   explicitly asked — the plugin imposes no rules of its own.
 


### PR DESCRIPTION
## Summary

`typos-format` rewrote the content of the user's files on every `Write`/`Edit` of every file type
and, on the path where it succeeded, emitted nothing at all — no `additionalContext`, no
`systemMessage`, telemetry only. A correction drawn from typos-cli's built-in dictionary that is
wrong for the repository (an acronym, an identifier, a proper noun mapped to an unrelated English
word) therefore reached the file invisibly, indistinguishable from a benign reformat.

**The RC-0 branch had nothing to report even in principle.** Verified this session against typos-cli
1.44.0: `--write-changes` emits *nothing* for a correction it applies — a fully-fixable file exits `0`
with empty stdout after rewriting itself. A write-only run cannot know what it changed.

So the hook now **scans read-only first**, then writes, and derives the applied set as *scan minus what
survived the write*. That derivation is exact rather than heuristic: typos declines to auto-fix a
finding with more than one candidate correction (verified — `wnat → ["want","what"]` stays in the file
and is re-reported by the write pass), and a set difference stays correct if that judgment changes in a
future typos release. Cost is one extra invocation only on files that actually have findings —
measured at ~80 ms on a 68 KB file against the handler's 15-second timeout. The read-only pass runs
first on purpose: a run killed at the timeout between passes has modified nothing.

What changed, concretely:

- **Applied corrections are disclosed on both channels.** Token, replacement, and line — to Claude via
  `additionalContext` and to the user via `systemMessage`, composed into one stdout document. Capped at
  ten per run, with the remainder reported as a count, so the fix cannot become the noise problem.
- **The `extend-words` remediation moved onto the applied path.** It sat only on the residual branch,
  which by construction fires for findings that were *not* applied — so it never fired for the
  rewrites that change file content. That is where it is load-bearing: the autocorrect has no memory,
  so a word repaired by hand is rewritten again on the next edit until the repo allow-lists it.
- **`typos_format_write_changes` userConfig (default `true`)** for report-only mode.
- **`data.applied` on the telemetry envelope** (`{typo, correction, line}`), additive;
  `data.findings` keeps its residual-only meaning and its exact shape.
- **Stub-driven contract tests.** The suite skipped in full without a `typos` binary — the CI runner's
  state — so nothing about this hook was gated there. Seventeen assertions now run everywhere.

### Deliberate calls a reviewer will want to challenge

1. **`write_changes` stays default-`true`.** Disclosure plus a one-step allow-list path is the smaller
   change and preserves the plugin's purpose; report-only is opt-in. It does *not* give the autocorrect
   memory — a repaired word is still re-corrected until the allow-list entry exists. That is now stated
   in the disclosure text rather than left for the user to discover.
2. **`systemMessage` on a non-prerequisite path.** `docs/conventions/hook-observability/README.md`
   previously scoped `systemMessage` to missing-prerequisite skips only and called over-application a
   conformance defect. Its "not required" list covers *reporting* (lint findings, suggested fixes) —
   not *rewriting*. This PR adds that third situation to the convention explicitly, with its boundary
   stated: content the user did not request goes to the user channel; anything the hook merely reports
   stays agent-scoped. The convention change is in the diff, not implied.
3. **No `hook-telemetry/CHANGELOG.md` entry.** That file is scoped to the *envelope* contract; per-hook
   `data` schemas "churn independently under the additive / ignore-unknown rules" and are explicitly
   "not separately version-stamped" (`docs/conventions/hook-telemetry/README.md` §Versioning). Adding
   a top-level `data` key is exactly the sanctioned additive case, so the record lives in the plugin's
   own changelog and the schema file's descriptions.
4. **`lib/hook-utils.sh` untouched.** The fix is plugin-local by choice — a shared helper would force a
   version bump across ~15 vendored copies for a two-plugin problem.

## Test plan

- `bash plugins/typos-format/hooks/typos-format.test.sh` — **PASS=59 FAIL=0** with a real typos-cli
  1.44.0 on PATH.
- Same suite with the real binary hidden from `PATH` (the CI runner's state) — **PASS=17 FAIL=0**, the
  stub-driven contract cases: applied-rewrite disclosure on both channels, single-JSON-document
  composition, allow-list guidance on the applied path, report-only leaving the file byte-identical and
  emitting no `systemMessage`, applied+residual reported together, the ten-line cap with an
  "and 5 more" remainder on a 15-correction file, and `data.applied` / `data.findings` separation in
  telemetry.
- Repo gates run locally, all green: `check-silent-skips.sh`, `check-changelog-parity.sh --check` and
  `--check-bump origin/main`, `check-hook-userconfig-argv.sh`, `check-shell-portability.sh`,
  `validate-plugins.sh`, `validate-plugin-contracts.mjs`, `shellcheck -x` on both shell files,
  `markdownlint-cli2` on the changed Markdown, and `typos` over the changed trees.
- Empirical reproduction backing every behavioral claim above was run against typos-cli 1.44.0 on
  Windows / Git Bash; the read-only-vs-write output asymmetry and the ambiguous-correction
  non-application are both reproduced in the issue.

### Not verified

- The **`if` per-handler path filter** on `hooks.json` is *not* added here. The hooks reference
  documents `if` with permission-rule syntax (`"Edit(*.md)"`), but not whether a single `if` under a
  `"Write|Edit"` matcher admits both tools — and getting that wrong disables the hook for `Write`
  *silently*. Deferred pending verified multi-tool `if` semantics rather than shipped on an inference.
- The **cross-hook write race** (typos-format / markdown-format / eol-normalizer all matching
  `Write|Edit` with no ordering guarantee and no locking) is unchanged. No hook-level locking primitive
  exists in Claude Code today; it stays documented as a known limitation.

## Related

Closes #1578
