### PR TITLE
fix(playwright): document video-start --size and correct the frame-size guidance

### DIFF
--- a/plugins/playwright/.claude-plugin/plugin.json
+++ b/plugins/playwright/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playwright",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Live E2E browser automation via Microsoft's @playwright/cli — named sessions, accessibility-ref snapshots, click/fill by ref, screenshots, console and network capture, mocking, tracing, video, and auth state, with artifacts written to disk so only paths enter context, plus a vendored upstream baseline and maintainer drift-check update flow.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `playwright` plugin are documented here. Format follo
 
 ### Added
 
-- `reference/tracing-and-video.md` gains a **Frame size — two levers, not one**
+- `reference/tracing-and-video.md` gains a **Frame size (two levers, not one)**
   section documenting `playwright-cli video-start --size "<W>x<H>"`, which the
   skill had never mentioned. Video frame size is derived from the viewport at
   browser-context creation and fitted into an 800×800 box, so the previously

--- a/plugins/playwright/CHANGELOG.md
+++ b/plugins/playwright/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to the `playwright` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.0]
+
+### Added
+
+- `reference/tracing-and-video.md` gains a **Frame size — two levers, not one**
+  section documenting `playwright-cli video-start --size "<W>x<H>"`, which the
+  skill had never mentioned. Video frame size is derived from the viewport at
+  browser-context creation and fitted into an 800×800 box, so the previously
+  canonical bare `video-start demo.webm` recorded at 800×450 regardless of
+  viewport intent, and `resize` afterwards did not change it. A correct
+  recording needs two matched levers — `PLAYWRIGHT_MCP_VIEWPORT_SIZE` prefixed
+  on `open` for what the page renders at, and `--size` for the output frame —
+  and the section tabulates the measured outcome of each partial combination.
+  Also notes that the config file's `saveVideo` block is whole-session
+  auto-save, a different mechanism from on-demand `video-start`.
+
+### Changed
+
+- The canonical video example now carries both size levers, with a neutral
+  illustrative resolution, and the capture checklist points at the new section.
+- `SKILL.md`'s "Defaults (accept, don't override)" section gains an explicit
+  video-recording exception. The `1280×720` viewport row stays — it is the
+  correct CLI default — and so does the "don't put `PLAYWRIGHT_MCP_*` in
+  project settings" posture; what was missing was the documented carve-out that
+  video needs a per-command viewport prefix on `open`. Skill frontmatter is
+  untouched.
+
+### Fixed
+
+- "Known costs" no longer claims "1280×720 WebM is ~5 MB/minute". The CLI never
+  emits 1280×720 by default, and the figure was unsourced — it appears in no
+  upstream or official Playwright documentation. Replaced with a qualitative
+  statement that size scales with frame area and on-screen motion, rather than
+  re-anchoring an invented number to a different resolution.
+
 ## [0.4.0]
 
 ### Added

--- a/plugins/playwright/skills/playwright/SKILL.md
+++ b/plugins/playwright/skills/playwright/SKILL.md
@@ -75,6 +75,8 @@ Microsoft's defaults are right for autonomous E2E work. Don't add `PLAYWRIGHT_MC
 | Console level | `info` | Actionable errors/warnings without debug noise |
 | Viewport | 1280×720 | Standard laptop — matches most users' view |
 
+**One exception — video recording.** The video frame size is derived from the viewport at browser-context creation, then fitted into an 800×800 box, so a bare `video-start` records at 800×450 no matter what you do afterwards; `resize` does not change it. Recording at any other size takes two matched levers — `PLAYWRIGHT_MCP_VIEWPORT_SIZE=<W>x<H>` prefixed on the `open` command *plus* `video-start --size "<W>x<H>"`. That is a per-command prefix, not a project-settings entry, so it does not contradict the guidance above. Details and measured outcomes: [reference/tracing-and-video.md](reference/tracing-and-video.md).
+
 The full env var / config file schema lives in Microsoft's upstream README at `$(npm root -g)/@playwright/cli/README.md` — not duplicated here.
 
 ## Actions

--- a/plugins/playwright/skills/playwright/reference/tracing-and-video.md
+++ b/plugins/playwright/skills/playwright/reference/tracing-and-video.md
@@ -38,12 +38,15 @@ find .playwright-cli/traces -mtime +7 -delete
 ## Video — basic
 
 ```bash
-playwright-cli open
-playwright-cli video-start demo.webm
-playwright-cli goto https://example.com
-playwright-cli click e1
-playwright-cli video-stop
+PLAYWRIGHT_MCP_VIEWPORT_SIZE=1440x900 playwright-cli -s=demo open
+playwright-cli -s=demo video-start demo.webm --size "1440x900"
+playwright-cli -s=demo goto https://example.com
+playwright-cli -s=demo click e1
+playwright-cli -s=demo video-stop
 ```
+
+Both size arguments are deliberate — see [Frame size](#frame-size-two-levers-not-one) below. Pick
+whatever resolution your evidence needs; `1440x900` here is only an illustration.
 
 Add chapter markers for section transitions:
 
@@ -62,6 +65,44 @@ playwright-cli video-hide-actions
 
 `--position` accepts `top-left|top|top-right|bottom-left|bottom|bottom-right` (default `top-right`); `--cursor=pointer` (default) animates a mouse pointer between action points, `--cursor=none` disables it.
 
+## Frame size — two levers, not one
+
+**A bare `video-start <name>.webm` does not record at your viewport size.** Upstream's default is
+"the size of the recorded video will fit 800x800" (`playwright-cli video-start --help`), so the CLI's
+default 1280×720 viewport records as **800×450**. Playwright's own docs say the same thing and give
+the same fallback number ([recordVideo.size](https://playwright.dev/docs/api/class-browser#browser-new-context),
+[Videos](https://playwright.dev/docs/videos): *"You may need to set the viewport size to match your
+desired video size."*).
+
+Two independent levers control the result. A full-resolution recording needs **both**, matched:
+
+| Lever | Where it goes | What it governs |
+|---|---|---|
+| Context viewport | `PLAYWRIGHT_MCP_VIEWPORT_SIZE=<W>x<H>` prefixed on the `open` command | What the page actually renders at |
+| Video frame | `video-start <name>.webm --size "<W>x<H>"` | The output file's pixel dimensions |
+
+The viewport must be set on `open`, because that is the command that creates the browser context the
+recorder derives its geometry from.
+
+Measured outcomes (ffprobe on the resulting `.webm`, `@playwright/cli` 0.1.14):
+
+| What you do | What you get |
+|---|---|
+| `open`, then bare `video-start` | 800×450 — the default viewport fitted into an 800 box |
+| `open`, `resize <w> <h>`, then bare `video-start` | still 800×450 — **`resize` does not change the video frame size** |
+| `PLAYWRIGHT_MCP_VIEWPORT_SIZE=1920x1200 open`, bare `video-start` | 800×500 — a bigger viewport is still fitted into 800 |
+| `open`, `video-start --size "1920x1200"` | a 1920×1200 file, but the 1280×720 render sits in the top-left corner and the rest is padded grey |
+| both levers, matched | the size you asked for |
+
+`resize` is for exercising responsive layout; it is not a video lever. If a recording came back
+smaller than expected, the fix is at `open` time, not after it.
+
+**Not the same thing as `saveVideo`.** The config file (`.playwright/cli.config.json`) has a
+top-level `saveVideo: { width, height }` that auto-saves a video of the *whole session* to the output
+directory, and a `browser.contextOptions` block that accepts a `viewport` — per the `@playwright/cli`
+README schema. That is a different mechanism from on-demand `video-start`/`video-stop`; treat the
+config route as unverified until you have measured it yourself.
+
 ## Video — hero scripts (via `run-code`)
 
 For polished recordings (demos, PR evidence), build a single `run-code` script with typing delays, overlays, and chapter cards. See [running-code.md](running-code.md) for execution mechanism. Upstream ships a detailed pattern at `../vendor/references/video-recording.md` covering:
@@ -79,7 +120,8 @@ When capturing for a PR or bug report:
 
 1. **Plan the flow first** — know exactly which commands and element refs you'll hit
 2. **Open browser, take initial snapshot** to get refs
-3. **Start capture** (`tracing-start` or `video-start <name>.webm`)
+3. **Start capture** — `tracing-start`, or `video-start <name>.webm --size "<W>x<H>"` with the
+   viewport already set on `open` (see [Frame size](#frame-size-two-levers-not-one))
 4. **Perform the flow** using refs from snapshot
 5. **Stop capture** (`tracing-stop` or `video-stop`)
 6. **Move output to a meaningful location** — don't leave artifacts named `page-<timestamp>.png` in `.playwright-cli/`; use `--filename=` or `mv` to something like `<artifact-dir>/<descriptive-name>.webm`
@@ -87,5 +129,7 @@ When capturing for a PR or bug report:
 ## Known costs
 
 - Tracing adds ~50-150ms/action overhead
-- Video adds real-time encoding overhead; 1280×720 WebM is ~5 MB/minute
+- Video adds real-time encoding overhead. WebM file size scales with frame area and with how much of
+  the screen moves, so raising `--size` raises cost roughly in proportion — measure your own flow
+  rather than budgeting from a rule of thumb
 - Both grow `.playwright-cli/` unboundedly — clean up old runs

--- a/plugins/playwright/skills/playwright/reference/tracing-and-video.md
+++ b/plugins/playwright/skills/playwright/reference/tracing-and-video.md
@@ -51,16 +51,16 @@ whatever resolution your evidence needs; `1440x900` here is only an illustration
 Add chapter markers for section transitions:
 
 ```bash
-playwright-cli video-chapter "Login" --description="Entering credentials" --duration=2000
+playwright-cli -s=demo video-chapter "Login" --description="Entering credentials" --duration=2000
 ```
 
 Auto-annotate subsequent actions (click, type, ...) with a callout naming the action and highlighting the target — cheaper than hand-building overlays via `run-code` for simple demos:
 
 ```bash
-playwright-cli video-show-actions --duration=600 --position=top-right --cursor=pointer
-playwright-cli click e1
-playwright-cli fill e2 "test"
-playwright-cli video-hide-actions
+playwright-cli -s=demo video-show-actions --duration=600 --position=top-right --cursor=pointer
+playwright-cli -s=demo click e1
+playwright-cli -s=demo fill e2 "test"
+playwright-cli -s=demo video-hide-actions
 ```
 
 `--position` accepts `top-left|top|top-right|bottom-left|bottom|bottom-right` (default `top-right`); `--cursor=pointer` (default) animates a mouse pointer between action points, `--cursor=none` disables it.

--- a/plugins/playwright/skills/playwright/reference/tracing-and-video.md
+++ b/plugins/playwright/skills/playwright/reference/tracing-and-video.md
@@ -65,7 +65,7 @@ playwright-cli video-hide-actions
 
 `--position` accepts `top-left|top|top-right|bottom-left|bottom|bottom-right` (default `top-right`); `--cursor=pointer` (default) animates a mouse pointer between action points, `--cursor=none` disables it.
 
-## Frame size — two levers, not one
+## Frame size (two levers, not one)
 
 **A bare `video-start <name>.webm` does not record at your viewport size.** Upstream's default is
 "the size of the recorded video will fit 800x800" (`playwright-cli video-start --help`), so the CLI's
@@ -83,6 +83,10 @@ Two independent levers control the result. A full-resolution recording needs **b
 
 The viewport must be set on `open`, because that is the command that creates the browser context the
 recorder derives its geometry from.
+
+The `VAR=value <command>` prefix shown here is POSIX shell syntax (Git Bash, WSL, macOS, Linux).
+PowerShell has no inline env prefix — set `$env:PLAYWRIGHT_MCP_VIEWPORT_SIZE = '<W>x<H>'` on its own
+line before the `open`, then clear it afterwards if later sessions should use the default.
 
 Measured outcomes (ffprobe on the resulting `.webm`, `@playwright/cli` 0.1.14):
 


### PR DESCRIPTION
Closes #1575
Closes #1576
Closes #1577

## The problem

The `playwright` skill's canonical video example is a bare
`playwright-cli video-start demo.webm`. That deterministically produces an **800x450** file. An
operator following the skill verbatim — including setting a large viewport with `resize` — gets
800x450 recordings every time, and nothing in the skill explains why or how to change it. The
downstream report was nine E2E screen recordings, all 800x450, after a 1920x1200 `resize`.

## Which fix is correct, and why (stated explicitly)

The task framing offers two valid resolutions: make the guarantee true, or stop claiming it.

**`--size` does exist upstream** — verified in `help.json` extracted from `@playwright/cli@0.1.17`,
the exact version this skill's frontmatter pins:

```text
Options:
  --size    video frame size, e.g. "800x600". if not specified, the size of the recorded video will fit 800x800.
```

So the guarantee is deliverable, and this PR makes it true rather than retracting it. Worth being
explicit about what "behavior" means for a skill: **this skill's behavior *is* the commands it
instructs an agent to run.** Changing the canonical example to pass `--size` is therefore the
behavior fix, not a prose paper-over of a broken one. There is no separate code path left unfixed.

The one place I *did* choose retraction over repair is the cost figure — see defect 3.

## Verdicts on the three reported defects

### 1. `--size` undocumented — REAL (#1575)

Confirmed three ways: the installed CLI's `--help`, `help.json` from the pinned 0.1.17, and an
ffprobe-measured repro. The string `--size` appeared nowhere in the skill.

### 2. "Defaults (accept, don't override)" steers wrong — REAL, but NARROWER than reported

The report framed this as the section contradicting the fix. On inspection it is more precisely an
*omission*, and two sub-claims do not survive:

- The `| Viewport | 1280x720 |` row is **factually correct** — that is the CLI's default viewport, per
  the `@playwright/cli@0.1.17` README (`PLAYWRIGHT_MCP_VIEWPORT_SIZE` — "specify browser viewport size
  in pixels, for example \"1280x720\""). It is not a defect and it stays.
- The section says "don't add `PLAYWRIGHT_MCP_*` env vars **to project settings**". The video fix is a
  per-command env prefix on `open`, which that sentence does not forbid. Not a contradiction.

What was genuinely missing is a documented exception: an agent reading "accept, don't override" next
to a 1280x720 row reasonably concludes the viewport is not a knob to touch. So the fix here is one
added carve-out paragraph with a cross-link — not the section rework the report suggested. Demolishing
the section would be overreach the evidence does not support.

### 3. "1280x720 WebM is ~5 MB/minute" — REAL

Two errors in one line. The CLI never emits 1280x720 by default, *and* the `~5 MB/minute` figure is
unsourced — it appears in no upstream skill, no `@playwright/cli` README, and no official Playwright
doc. **Deliberately removed rather than re-anchored to 800x450**: correcting only the resolution
would relocate the fabrication instead of fixing it, and short clips of a static page cannot ground a
replacement number. Replaced with a qualitative statement (size scales with frame area and on-screen
motion).

## Evidence

Empirical repro, ffprobe on the resulting `.webm`, `@playwright/cli` 0.1.14 on Windows:

| Scenario | Measured |
|---|---|
| `open`, bare `video-start` | `vp8, 800, 450` |
| `open`, `resize 1920 1200`, bare `video-start` | `vp8, 800, 450` — `resize` does not move it |
| `PLAYWRIGHT_MCP_VIEWPORT_SIZE=1920x1200 open`, bare `video-start` | `vp8, 800, 500` |
| `open`, `video-start --size "1920x1200"` | `vp8, 1920, 1200` — but a frame extracted at n=20 shows the 1280x720 render in the **top-left corner**, rest padded grey |
| both levers, matched | `vp8, 1920, 1200`, correct |

That last row refines the original report, which described it as an "upscaled 1280-wide render". It is
not upscaled — it is letterboxed top-left, exactly as
<https://playwright.dev/docs/videos> describes: *"The video of the viewport is placed in the top-left
corner of the output video, scaled down to fit if necessary."*

Sources, all fetched or executed this session:

- `help.json` from `@playwright/cli@0.1.17` (npm tarball, the pinned version) — `--size` present,
  identical text to 0.1.14; `flags: { size: "string" }`
- `@playwright/cli@0.1.17` README — `PLAYWRIGHT_MCP_VIEWPORT_SIZE` env var and format; the
  `.playwright/cli.config.json` schema showing `browser.contextOptions` and a top-level
  `saveVideo: { width, height }`
- <https://playwright.dev/docs/api/class-browser#browser-new-context> — `recordVideo.size`: "If not
  specified the size will be equal to `viewport` scaled down to fit into 800x800. If `viewport` is not
  configured explicitly the video size defaults to 800x450."
- <https://playwright.dev/docs/videos> — "You may need to set the viewport size to match your desired
  video size."

## Repo-convention compliance

- **Version**: `0.4.0` → `0.5.0`. Precedent in this plugin's own CHANGELOG: 0.3.1/0.3.2 were pure doc
  corrections → patch; 0.4.0 folded in newly-surfaced upstream commands and flags → minor. Surfacing
  `--size` matches the 0.4.0 pattern.
- **Frontmatter untouched.** No listing description or trigger-keyword change was needed, so none was
  made. `check-skill.sh` confirms *"all 10 base-ref trigger phrase(s) preserved"*.
- **`vendor/` untouched.** It is a verbatim upstream baseline for drift detection; editing it would
  make the next `update --check` report false drift. Upstream's own shipped skill omits `--size` too —
  that is an upstream gap, noted as reportable, not patched here.
- **Repo-agnostic.** The reported fix used `1920x1200`, the reporting operator's personal preference.
  Not baked in — the docs use a neutral illustrative `1440x900` and teach the *pattern* (set viewport
  at `open` AND pass `--size`, matched), since the number is the consumer's call.
- **Fresh-docs mandate.** Scope is contract surfaces; this change is confined to skill prose bodies
  with frontmatter untouched, so it falls outside that scope. The load-bearing claims are grounded in
  the pinned package's own `help.json` and README plus playwright.dev, all obtained this session and
  cited above. No stale `docs.claude.com` URLs exist under `plugins/playwright`.

## Checks run locally

- `check-skill.sh playwright` — **PASS**, 0 errors (1 pre-existing advisory warning: no Gotchas surface)
- `validate-plugins.sh` — all manifests + catalog pass
- `check-changelog-parity.sh --check` and `--check-bump origin/main` — pass
- `check-skill-portability.sh origin/main`, `check-contract-slice-prune.sh --check-diff origin/main`,
  `check-shell-portability.sh origin/main`, `generate-catalog.mjs --check` — pass

## Deliberately deferred

- **A dedicated `## Gotchas` section.** The report suggested one for "resize does not affect video
  frame size". That fact now lives in two places a reader actually hits — the SKILL.md Defaults
  exception (the exact spot that previously steered wrong) and the measured-outcomes table. A separate
  section would duplicate it to silence an advisory warning that predates this PR.
- **The `.playwright/cli.config.json` route.** The README schema shows `browser.contextOptions`
  (accepts `viewport`) and a top-level `saveVideo: { width, height }`, and confirms `saveVideo` governs
  whole-session auto-save — a different mechanism from on-demand `video-start`. Documented as such and
  explicitly flagged unverified, since I did not measure it.
- **Reporting the `--size` omission upstream** to `microsoft/playwright-cli`.

## Not verified

Official Playwright docs do **not** anywhere state that video frame size is fixed at context creation
and immune to a later resize. I searched `docs/src/videos.md` and the `Page.setViewportSize` section of
`docs/src/api/class-page.md` in full. The claim is therefore attributed to measurement in this repo's
wording ("`resize` does not change the video frame size" — what ffprobe showed), never asserted as
documented upstream behavior.

## Related

- #1567 — migrated remaining `docs.claude.com` URLs to `code.claude.com` repo-wide. Merged before
  this branch was cut, so there was no collision. Verified independently that no stale
  `docs.claude.com` URL remains under `plugins/playwright`; this PR adds none.
- Upstream `microsoft/playwright-cli` — its own shipped skill
  (`vendor/references/video-recording.md`) omits `--size` too. Not closed by this PR and not patched
  here, since `vendor/` is a verbatim drift-detection baseline; reportable upstream as follow-up.
- No ADR or decision-log entry applies — this is a documentation-correctness fix inside one plugin,
  with no architecture or contract-surface decision attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
