### PR TITLE
fix(markdown-format): bound lint emission and disclose applied fixes

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",
@@ -21,6 +21,13 @@
       "title": "markdown-format hook",
       "description": "Auto-format and lint Markdown on Write/Edit of .md/.mdc files",
       "default": true
+    },
+    "markdown_format_max_findings": {
+      "type": "number",
+      "title": "Max findings reported per run",
+      "description": "How many individual markdownlint violations are listed per run. The total count and the leading rule codes are always reported regardless. 0 = unlimited.",
+      "default": 20,
+      "min": 0
     }
   }
 }

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.0]
+
+### Fixed
+
+- **Lint reporting is bounded instead of unbounded.** The hook appended every
+  line of markdownlint's whole-file output to `additionalContext` on every
+  touch — no cap, no baseline, no dedup — so a file edited repeatedly produced
+  a full re-dump each time. Measured in one consuming session: 21 dumps,
+  ~378 KB (~95K tokens), one file dumped eight times with byte-identical
+  content, and 97% of one real file's 324 findings from a single rule that
+  repository intentionally violates. Now every run reports the finding count
+  and a rule histogram (which rules dominate, highest first), lists at most 20
+  individual violations, and reports the omitted remainder as a count.
+  markdownlint's own banner lines (its version, the resolved `Finding:` glob
+  list, `Linting:`, `Summary:`) no longer enter the report at all — they say
+  nothing about the edited file and cost context on every edit.
+- **An unchanged finding set no longer repeats its detail.** The finding set is
+  content-hashed per file per session under `CLAUDE_PLUGIN_DATA`; a repeat with
+  the same set reports its summary and omits the per-finding lines. The
+  **summary always goes out** — suppressing the message entirely would
+  reproduce, on this plugin, exactly the invisible-hook defect the disclosure
+  below fixes.
+- **A run that rewrote the file is no longer silent about it.** On the
+  clean-after-fix path the hook emitted nothing at all, so `--fix` rewriting the
+  user's file was indistinguishable from the hook not running. The count
+  markdownlint-cli2 reports (`Attempted: N fixes in 1 file`) is now surfaced on
+  both channels. It is only a count: `markdownlint-cli2` offers no per-fix
+  detail, so neither can this hook.
+
+### Added
+
+- **`markdown_format_max_findings` userConfig (default `20`, `0` = unlimited).**
+  Bounds the per-run violation listing only; the count and rule histogram are
+  always reported. Read from the
+  `CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_MAX_FINDINGS` environment mirror, because
+  shell-form hook commands reject `${user_config.*}` substitution outright. A
+  value that is not a non-negative integer falls back to the default and is
+  never interpolated anywhere.
+- Contract tests for the cap, the configurable cap (including a garbage value),
+  the rule histogram, banner exclusion, the delta gate in both directions,
+  uncapped telemetry, and the applied-fix disclosure.
+
+### Changed
+
+- The telemetry payload is deliberately **not** capped — a sink is a machine,
+  and the cap exists to protect the model's context, not a log file.
+  `data.findings` keeps its shape and its full contents.
+
 ## [0.7.1]
 
 ### Changed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -12,10 +12,19 @@ imposes no rules of its own.
 ## Behavior
 
 - **Auto-fix on edit.** Fixable violations (final newline, list-marker style,
-  trailing spaces, …) are corrected in place.
+  trailing spaces, …) are corrected in place, and the count of fixes written is
+  reported to Claude and to you — a run that changed your file never passes
+  unannounced. `markdownlint-cli2` reports no per-fix detail, so neither can
+  this hook; the count is what there is.
 - **Advisory, never blocking.** The hook always exits `0`. Unfixable findings are
   reported via `additionalContext`; they never reject the edit. Make a commit
   hook or CI your hard gate.
+- **Bounded reporting.** Every run reports the total finding count and the rules
+  that dominate it. Individual violation lines are capped (20 by default,
+  `markdown_format_max_findings`), and an unchanged finding set on a re-edited
+  file reports its summary without repeating the detail. The linter's own banner
+  lines never enter the report. A rule firing in bulk is a signal to configure
+  that rule once in your markdownlint config, not to re-read it on every edit.
 - **Config from the consumer.** `markdownlint-cli2` discovers config
   (`.markdownlint-cli2.jsonc`, `.markdownlint.json`, …) per edited file, from
   the file's directory up through its parents — so a nested config governs its
@@ -90,13 +99,14 @@ The rules themselves are never configured here — the plugin's only rule source
 the markdownlint config already in your repository, which it reads automatically.
 To change the rules, edit your repo's markdownlint config.
 
-One `userConfig` option tunes the hook itself:
+Two `userConfig` options tune the hook itself:
 
 | Option | Type | Default | Effect |
 |--------|------|---------|--------|
 | `markdown_format_enabled` | boolean | `true` | Toggle the markdown-format hook; set `false` for a clean no-op. |
+| `markdown_format_max_findings` | number | `20` | How many individual violations are listed per run. The total count and the leading rule codes are always reported regardless. `0` = unlimited. |
 
-Set it interactively with `/plugin configure markdown-format`, or headless on
+Set them interactively with `/plugin configure markdown-format`, or headless on
 the install command:
 
 ```shell

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -635,31 +635,149 @@ if ((${#RISK_CONFIGS[@]} > 0)); then
   fi
 fi
 
-if FIX_OUTPUT=$(cd "$REPO_ROOT" && "${MDLINT[@]}" --fix "$FILE" 2>&1); then
-  # Clean after fix — emit ok with empty findings.
-  hook::ctx_flush PostToolUse
-  emit_tel "ok" '[]'
-  exit 0
-fi
+# Per-run cap on how many individual violation lines reach the context. The
+# whole finding set is ALWAYS summarized — count plus the leading rule codes —
+# so raising or lowering this never hides the fact that findings exist; it only
+# bounds the detail. 0 means unlimited.
+#
+# Read from the CLAUDE_PLUGIN_OPTION_<KEY> environment mirror, not a
+# `${user_config.*}` placeholder: shell-form hook commands reject
+# `${user_config.*}` substitution outright — "substituting a configured value
+# into a shell command would let the shell run whatever that value contains, so
+# the component fails" — while every option is exported to hook processes as
+# CLAUDE_PLUGIN_OPTION_<KEY> anyway (Plugins reference, "User configuration",
+# https://code.claude.com/docs/en/plugins-reference, fetched 2026-07-26). A
+# value that is not a non-negative integer falls back to the default rather
+# than being interpolated anywhere.
+MAX_FINDINGS=20
+case "${CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_MAX_FINDINGS:-}" in
+"") ;;
+*[!0-9]*) ;;
+*) MAX_FINDINGS="${CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_MAX_FINDINGS}" ;;
+esac
 
-# Residual findings — surface one JSON object via additionalContext, then
-# emit ok with findings.
-# ctx_append receives all output lines (human-readable context for Claude Code).
-# FINDINGS_JSON is filtered to violation lines only — schema requires
-# "Unfixable markdownlint violations remaining after --fix, one per line";
-# banner/diagnostic lines (version, Finding:, Linting:, Summary:) are excluded.
-# Violation lines are identified by the " MD<digits>/" rule-code pattern.
-hook::ctx_append "markdown-format: $(basename "$FILE") has markdownlint findings:"
-findings_raw=""
+FIX_OUTPUT=$(cd "$REPO_ROOT" && "${MDLINT[@]}" --fix "$FILE" 2>&1)
+LINT_RC=$?
+BASE="$(basename "$FILE")"
+
+# markdownlint-cli2 reports the fixes it WROTE as a bare count line and nothing
+# more — it has no per-fix detail to offer. That count is still the only signal
+# that this hook changed the file, so it is reported rather than dropped; the
+# clean-after-fix path used to emit nothing at all, which made a rewrite of the
+# user's file indistinguishable from the hook not running.
+FIXES_LINE=""
 while IFS= read -r line; do
-  hook::ctx_append "  $line"
-  if [[ "$line" =~ [[:space:]]MD[0-9]+/ ]]; then
+  case "$line" in
+  "Attempted: 0 fixes"*) ;;
+  "Attempted:"*) FIXES_LINE="$line" ;;
+  *) ;;
+  esac
+done <<<"$FIX_OUTPUT"
+
+# Split the output into violation lines and everything else. The banner lines
+# markdownlint-cli2 always prints (its version, the resolved `Finding:` glob
+# list, `Linting: N files`, `Summary: N issues`) carry no information about the
+# file being edited and cost context on every single edit, so they do not enter
+# the report — the counts below are derived here instead. Violation lines are
+# identified by the " MD<digits>/" rule-code pattern, matching what the
+# telemetry schema calls a finding.
+findings_raw=""
+FINDING_COUNT=0
+RULE_TALLY=""
+while IFS= read -r line; do
+  if [[ "$line" =~ [[:space:]](MD[0-9]+)/ ]]; then
     findings_raw+="$line"$'\n'
+    FINDING_COUNT=$((FINDING_COUNT + 1))
+    RULE_TALLY+="${BASH_REMATCH[1]}"$'\n'
   fi
 done <<<"$FIX_OUTPUT"
-hook::ctx_flush PostToolUse
+
+hook::ctx_reset
+CTX=""
+SYSMSG=""
+
+if [[ -n "$FIXES_LINE" ]]; then
+  CTX+="markdown-format rewrote $BASE after your edit — markdownlint-cli2 reports \"$FIXES_LINE\" (structural fixes only; it reports no per-fix detail)."$'\n'
+  SYSMSG="markdown-format rewrote $BASE: $FIXES_LINE."
+fi
+
+if ((FINDING_COUNT > 0)); then
+  # Rule histogram, highest count first, so a report truncated to N lines still
+  # says WHICH rules dominate — the single most useful thing about a 300-finding
+  # set, and the thing a raw first-N truncation destroys.
+  RULE_SUMMARY=$(printf '%s' "$RULE_TALLY" | sort | uniq -c | sort -rn |
+    awk 'NR<=5 {printf "%s%s x%s", (NR>1 ? ", " : ""), $2, $1} END {print ""}' 2>/dev/null) || RULE_SUMMARY=""
+
+  # Delta gate. A file edited eight times in a session produced eight
+  # byte-identical whole-file dumps; re-sending an unchanged finding set is pure
+  # cost. The SUMMARY still goes out every time — suppressing the message
+  # entirely would recreate, on this plugin, exactly the invisible-hook problem
+  # the disclosure above exists to fix.
+  SAME_AS_LAST=0
+  DIGEST_FILE=""
+  if [[ -n "${CLAUDE_PLUGIN_DATA:-}" ]] && command -v git >/dev/null 2>&1; then
+    session_key=$(printf '%s' "$INPUT" | jq -r '.session_id // "no-session"' 2>/dev/null) || session_key="no-session"
+    session_key="${session_key//[^A-Za-z0-9_-]/-}"
+    file_key=$(printf '%s' "$FILE" | git hash-object --stdin 2>/dev/null) || file_key=""
+    # The cap is part of the digest input: the truncation hint tells the user to
+    # raise markdown_format_max_findings to see the rest, and a digest over the
+    # finding set alone would then answer that with "unchanged, detail omitted"
+    # — making the advice this hook gives impossible to act on.
+    digest_now=$(printf '%s\n%s' "$MAX_FINDINGS" "$findings_raw" | git hash-object --stdin 2>/dev/null) || digest_now=""
+    if [[ -n "$file_key" && -n "$digest_now" ]]; then
+      digest_dir="${CLAUDE_PLUGIN_DATA%/}/finding-digests"
+      if mkdir -p "$digest_dir" 2>/dev/null; then
+        find "$digest_dir" -type f -mtime +7 -delete 2>/dev/null
+        DIGEST_FILE="$digest_dir/${session_key}.${file_key}"
+        if [[ -f "$DIGEST_FILE" ]] && [[ "$(cat "$DIGEST_FILE" 2>/dev/null)" == "$digest_now" ]]; then
+          SAME_AS_LAST=1
+        fi
+        printf '%s' "$digest_now" >"$DIGEST_FILE" 2>/dev/null || DIGEST_FILE=""
+      fi
+    fi
+  fi
+
+  CTX+="markdown-format: $BASE has $FINDING_COUNT markdownlint finding(s)${RULE_SUMMARY:+ — $RULE_SUMMARY}."$'\n'
+  if ((SAME_AS_LAST == 1)); then
+    CTX+="  Unchanged from the previous run on this file; per-finding detail omitted. A rule firing in bulk here (a house style markdownlint does not know about) is configured away once in this repository's markdownlint config, not re-read every edit."$'\n'
+  else
+    shown=0
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      if ((MAX_FINDINGS > 0 && shown >= MAX_FINDINGS)); then break; fi
+      CTX+="  $line"$'\n'
+      shown=$((shown + 1))
+    done <<<"$findings_raw"
+    if ((FINDING_COUNT > shown)); then
+      CTX+="  ... and $((FINDING_COUNT - shown)) more finding(s), omitted to bound context. Raise markdown_format_max_findings to see them, or configure the dominant rule in this repository's markdownlint config."$'\n'
+    fi
+  fi
+elif ((LINT_RC != 0)) && [[ -n "$FIX_OUTPUT" ]]; then
+  # Non-zero exit with no parseable violation line: markdownlint itself broke
+  # (bad config, unreadable file). That diagnostic must never be swallowed by
+  # the banner filter above, so the raw output goes through, still bounded.
+  CTX+="markdown-format: markdownlint-cli2 failed for $BASE (tool break, not a finding):"$'\n'
+  shown=0
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    if ((MAX_FINDINGS > 0 && shown >= MAX_FINDINGS)); then
+      CTX+="  ... output truncated."$'\n'
+      break
+    fi
+    CTX+="  $line"$'\n'
+    shown=$((shown + 1))
+  done <<<"$FIX_OUTPUT"
+fi
+
+# Compose ONE stdout document: Claude Code parses a hook's entire stdout as a
+# single JSON document, so the agent-channel report and the user-channel
+# mutation notice are emitted together rather than printed twice.
+CTX="${CTX%"${CTX##*[![:space:]]}"}"
+hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
 
 # Build the findings array in one jq pass (one JSON string per matched line).
+# The telemetry payload is NOT capped — a sink is a machine, and the cap exists
+# to protect the model's context, not a log file.
 FINDINGS_JSON='[]'
 if [[ -n "$findings_raw" ]]; then
   FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -1442,6 +1442,186 @@ else
 fi
 rm -f "$TEL_GATE"
 
+# ============================================================================
+# Bounded emission — cap, rule histogram, delta gate, mutation disclosure
+# ============================================================================
+# The defect: the hook appended EVERY line of markdownlint's whole-file output
+# to additionalContext on every touch, with no cap, no baseline and no dedup.
+# One measured session burned roughly 95K tokens across 21 byte-identical
+# whole-file dumps, 97% of them one rule the repository intentionally violates.
+#
+# A second stub is used rather than the fixture stub above: these cases need a
+# controllable finding COUNT and the "Attempted: N fixes" line markdownlint-cli2
+# prints when it rewrites a file, neither of which the fixture stub produces.
+NOISY_BIN="$(mktemp -d "$WORK/noisybin.XXXXXX")"
+cat >"$NOISY_BIN/markdownlint-cli2" <<'NOISY'
+#!/usr/bin/env bash
+set -uo pipefail
+file="${2:-}"
+[[ -n "$file" && -f "$file" ]] || exit 2
+# Banner lines markdownlint-cli2 always prints. None of them says anything
+# about the edited file; the hook must keep them out of the report.
+echo "markdownlint-cli2 v0.23.1 (markdownlint v0.41.1)"
+echo "Finding: $file !**/node_modules/** !**/.venv/** !**/bin/** !**/obj/**"
+echo "Linting: 1 file"
+[[ -n "${STUB_FIX_COUNT:-}" ]] && echo "Attempted: $STUB_FIX_COUNT fixes in 1 file"
+n="${STUB_FINDINGS:-0}"
+((n > 0)) || exit 0
+echo "Summary: $n issues in 1 file"
+i=1
+while ((i <= n)); do
+  if ((i <= n - 2)); then
+    echo "$file:$i:81 error MD013/line-length Line length [Expected: 80]"
+  else
+    echo "$file:$i:1 error MD032/blanks-around-lists Lists should be surrounded by blank lines"
+  fi
+  i=$((i + 1))
+done
+exit 1
+NOISY
+chmod +x "$NOISY_BIN/markdownlint-cli2"
+
+NOISY_DATA="$(mktemp -d "$WORK/noisydata.XXXXXX")"
+run_noisy() {
+  local file_path="$1"
+  shift
+  (cd "$UNRELATED" && printf '{"session_id":"noisy-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+    env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true \
+      CLAUDE_PLUGIN_DATA="$NOISY_DATA" PATH="$NOISY_BIN:$PATH" "$@" bash "$HOOK")
+}
+
+FN="$REPO/noisy.md"
+printf '# Noisy\n\nbody\n' >"$FN"
+
+# --- 50 findings: capped detail, but the count and the rules always survive ---
+OUT_N=$(run_noisy "$FN" STUB_FINDINGS=50)
+CTX_N=$(printf '%s' "$OUT_N" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+DETAIL_N=$(printf '%s' "$CTX_N" | grep -c 'error MD')
+if [[ "$DETAIL_N" -eq 20 ]]; then
+  ok "bounded/cap: per-finding detail capped at the 20-line default (got $DETAIL_N)"
+else
+  fail "bounded/cap: expected 20 detail lines, got $DETAIL_N"
+fi
+if printf '%s' "$CTX_N" | grep -q '50 markdownlint finding'; then
+  ok "bounded/cap: the full finding count is still reported"
+else
+  fail "bounded/cap: total count missing: $CTX_N"
+fi
+if printf '%s' "$CTX_N" | grep -q 'MD013 x48' && printf '%s' "$CTX_N" | grep -q 'MD032 x2'; then
+  ok "bounded/cap: rule histogram names which rules dominate the truncated set"
+else
+  fail "bounded/cap: rule histogram missing or wrong: $CTX_N"
+fi
+if printf '%s' "$CTX_N" | grep -q 'and 30 more finding'; then
+  ok "bounded/cap: the omitted remainder is reported as a count"
+else
+  fail "bounded/cap: remainder not reported: $CTX_N"
+fi
+if printf '%s' "$CTX_N" | grep -q 'markdownlint-cli2 v0.23.1' ||
+  printf '%s' "$CTX_N" | grep -q 'Finding:' ||
+  printf '%s' "$CTX_N" | grep -q 'Linting: 1 file'; then
+  fail "bounded/cap: banner noise leaked into the report: $CTX_N"
+else
+  ok "bounded/cap: markdownlint banner lines kept out of the report"
+fi
+
+# --- Telemetry is NOT capped: a sink is a machine, the cap protects context ---
+TELN="$(mktemp)"
+SINKN="$(make_sink "cat >\"$TELN\"")"
+run_noisy "$FN" STUB_FINDINGS=50 HOOK_TELEMETRY_SINK="$SINKN" >/dev/null
+wait_for_sink "$TELN"
+if [[ "$(jq '.data.findings | length' "$TELN" 2>/dev/null)" -eq 50 ]]; then
+  ok "bounded/telemetry: all 50 findings still reach the sink uncapped"
+else
+  fail "bounded/telemetry: expected 50, got $(jq '.data.findings | length' "$TELN" 2>/dev/null)"
+fi
+rm -f "$TELN"
+
+# --- The cap is configurable, and 0 means unlimited -------------------------
+# Raising the cap must bring the detail back on an OTHERWISE UNCHANGED finding
+# set: the truncation hint tells the user to raise it, so a delta gate keyed on
+# the finding set alone would make that advice impossible to act on. Run against
+# the same file and the same 50 findings the capped run above already digested.
+OUT_C=$(run_noisy "$FN" STUB_FINDINGS=50 CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_MAX_FINDINGS=3)
+CTX_C=$(printf '%s' "$OUT_C" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ "$(printf '%s' "$CTX_C" | grep -c 'error MD')" -eq 3 ]]; then
+  ok "bounded/config: markdown_format_max_findings lowers the cap, and a cap change defeats the delta gate"
+else
+  fail "bounded/config: cap not honored: $CTX_C"
+fi
+OUT_U=$(run_noisy "$FN" STUB_FINDINGS=50 CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_MAX_FINDINGS=0)
+CTX_U=$(printf '%s' "$OUT_U" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ "$(printf '%s' "$CTX_U" | grep -c 'error MD')" -eq 50 ]]; then
+  ok "bounded/config: 0 means unlimited"
+else
+  fail "bounded/config: 0 did not disable the cap: $(printf '%s' "$CTX_U" | grep -c 'error MD')"
+fi
+FG="$REPO/garbage.md"
+printf '# Garbage\n\nbody\n' >"$FG"
+OUT_G=$(run_noisy "$FG" STUB_FINDINGS=5 CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_MAX_FINDINGS="not-a-number; rm -rf /")
+CTX_G=$(printf '%s' "$OUT_G" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ "$(printf '%s' "$CTX_G" | grep -c 'error MD')" -eq 5 ]]; then
+  ok "bounded/config: a non-integer value falls back to the default, never interpolated"
+else
+  fail "bounded/config: garbage value not rejected: $CTX_G"
+fi
+
+# --- Delta gate: repeats drop the detail, never the message -----------------
+# Suppressing the whole message on a repeat would recreate the invisible-hook
+# defect on this plugin, so the summary must survive every run.
+FD="$REPO/delta.md"
+printf '# Delta\n\nbody\n' >"$FD"
+OUT_D1=$(run_noisy "$FD" STUB_FINDINGS=30)
+CTX_D1=$(printf '%s' "$OUT_D1" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+OUT_D2=$(run_noisy "$FD" STUB_FINDINGS=30)
+CTX_D2=$(printf '%s' "$OUT_D2" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ "$(printf '%s' "$CTX_D1" | grep -c 'error MD')" -eq 20 ]]; then
+  ok "bounded/delta: first run carries the (capped) detail"
+else
+  fail "bounded/delta: first run detail missing: $CTX_D1"
+fi
+if [[ "$(printf '%s' "$CTX_D2" | grep -c 'error MD')" -eq 0 ]]; then
+  ok "bounded/delta: unchanged repeat drops the per-finding detail"
+else
+  fail "bounded/delta: repeat still dumped detail: $CTX_D2"
+fi
+if printf '%s' "$CTX_D2" | grep -q '30 markdownlint finding' &&
+  printf '%s' "$CTX_D2" | grep -q 'Unchanged from the previous run'; then
+  ok "bounded/delta: the repeat still reports the count and says why it is short"
+else
+  fail "bounded/delta: repeat went silent — that is the defect, not the fix: $CTX_D2"
+fi
+OUT_D3=$(run_noisy "$FD" STUB_FINDINGS=31)
+CTX_D3=$(printf '%s' "$OUT_D3" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if [[ "$(printf '%s' "$CTX_D3" | grep -c 'error MD')" -eq 20 ]]; then
+  ok "bounded/delta: a changed finding set brings the detail back"
+else
+  fail "bounded/delta: changed set stayed suppressed: $CTX_D3"
+fi
+
+# --- Applied fixes are disclosed on both channels ---------------------------
+FF="$REPO/fixed.md"
+printf '# Fixed\n\nbody\n' >"$FF"
+OUT_F=$(run_noisy "$FF" STUB_FIX_COUNT=7)
+CTX_F=$(printf '%s' "$OUT_F" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+SYS_F=$(printf '%s' "$OUT_F" | jq -r '.systemMessage // empty' 2>/dev/null)
+if printf '%s' "$CTX_F" | grep -q 'Attempted: 7 fixes'; then
+  ok "bounded/fixes: a clean-after-fix run no longer stays silent about the rewrite"
+else
+  fail "bounded/fixes: no agent-channel disclosure of the rewrite: $CTX_F"
+fi
+if printf '%s' "$SYS_F" | grep -q 'Attempted: 7 fixes'; then
+  ok "bounded/fixes: the rewrite is disclosed on the user channel too"
+else
+  fail "bounded/fixes: no user-channel disclosure: $SYS_F"
+fi
+OUT_F0=$(run_noisy "$FF" STUB_FIX_COUNT=0)
+if [[ -z "$OUT_F0" ]]; then
+  ok "bounded/fixes: a run that changed nothing stays silent"
+else
+  fail "bounded/fixes: no-op run emitted output: $OUT_F0"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

`markdown-format` appended **every line** of markdownlint's whole-file output to `additionalContext`
on every `Write`/`Edit` — no cap, no baseline, no dedup — so a repeatedly-edited file produced a full
re-dump each time. Measured in one consuming session: **21 dumps, ~378 KB (~95K tokens)**, one file
dumped eight times with byte-identical content, and 97% of one real file's 324 findings from a single
rule that repository intentionally violates as house style.

What changed:

- **Every run reports the count and a rule histogram.** `noisy.md has 50 markdownlint finding(s) —
  MD013 x48, MD032 x2.` A truncated first-N list destroys exactly the information that makes a bulk
  report actionable — *which* rule is firing — so the histogram is computed before truncation.
- **Individual violation lines are capped** at 20 by default, with the omitted remainder reported as a
  count and a pointer at the one action that actually fixes a dominant rule: configure it once in the
  repository's markdownlint config.
- **An unchanged finding set drops its detail, never its message.** The set is content-hashed per
  file per session under `CLAUDE_PLUGIN_DATA`; a repeat reports its summary and omits the per-finding
  lines. The summary **always** goes out — a delta gate that went fully silent would recreate, on this
  plugin, exactly the invisible-hook defect #1578 is about. There is a test asserting the repeat is
  not silent, phrased as such.
- **Banner lines are excluded.** markdownlint-cli2's version line, the resolved
  `Finding: <path> !**/node_modules/** …` glob list, `Linting:`, `Summary:` — none says anything about
  the edited file, and all of them were paid for on every edit.
- **A run that rewrote the file says so.** The clean-after-fix path previously emitted nothing at all,
  making `--fix` rewriting the user's file indistinguishable from the hook not running. The
  `Attempted: N fixes in 1 file` count now goes to both channels, per the content-mutation clause
  added to `docs/conventions/hook-observability/README.md` in #1580. It is only a count —
  markdownlint-cli2 offers no per-fix detail, so neither can this hook, and the report says so rather
  than implying more.
- **`markdown_format_max_findings` userConfig** (default `20`, `0` = unlimited), read from the
  `CLAUDE_PLUGIN_OPTION_` environment mirror because shell-form hook commands reject
  `${user_config.*}` substitution outright (Plugins reference, "User configuration",
  <https://code.claude.com/docs/en/plugins-reference>, fetched this session). A value that is not a
  non-negative integer falls back to the default and is never interpolated anywhere; there is a test
  that feeds it `not-a-number; rm -rf /`.

### Two design points worth a reviewer's attention

1. **The cap is part of the delta digest.** The truncation hint tells the user to raise
   `markdown_format_max_findings` to see the rest. A digest over the finding set alone would answer
   that with "unchanged, detail omitted" — making the hook's own advice impossible to act on. The
   digest covers `MAX_FINDINGS` + the finding set, so raising the cap brings the detail back on an
   otherwise unchanged file. There is a test for it.
2. **Telemetry is deliberately not capped.** A sink is a machine; the cap exists to protect the
   model's context, not a log file. `data.findings` keeps its shape and its full contents, so the
   schema is unchanged.

## Test plan

- `bash plugins/markdown-format/hooks/markdown-format.test.sh` — full suite green, including 17 new
  assertions: the default cap, the configurable cap, `0` = unlimited, a garbage cap value falling back
  safely, the rule histogram surviving truncation, banner exclusion, the delta gate suppressing detail,
  the delta gate **not** going silent, a changed set restoring detail, a cap change defeating the delta
  gate, uncapped telemetry (50 findings still reach the sink), and applied-fix disclosure on both
  channels plus silence when nothing was fixed.
- The new cases run against a second stub binary (the existing fixture stub produces neither a
  controllable finding count nor the `Attempted:` line), so they execute on the CI runner, which has no
  real `markdownlint-cli2`.
- Repo gates run locally, all green: `check-changelog-parity.sh --check-bump origin/main`,
  `check-hook-userconfig-argv.sh`, `check-silent-skips.sh`, `check-shell-portability.sh`,
  `validate-plugins.sh`, `shellcheck -x` on both shell files, `markdownlint-cli2` on the changed
  Markdown, and `typos` over the plugin tree.
- The output shape the new parser depends on was reproduced directly against markdownlint-cli2 v0.23.1
  (banner lines, `Attempted: N fixes in 1 file`, `Summary: N issues`, then violation lines carrying
  ` MD<digits>/`).

### Not addressed here

- The **cross-hook write race** (`typos-format`, `markdown-format`, and `eol-normalizer` all match
  `Write|Edit`, run in parallel with no documented ordering and no locking). No hook-level locking
  primitive exists in Claude Code today; it stays documented as a known limitation.
- The **stdin-buffer timeout no-op** (`INPUT=$(hook::buffer_stdin) || exit 0` discards the helper's
  BLOCKED diagnostic). That idiom lives in the shared `lib/hook-utils.sh` and is fleet-wide across
  ~15 plugins, so fixing it here would either fork the shared library or force a version bump wave
  across every carrying plugin. Deferred deliberately, not overlooked.

## Related

Closes #1589
