### PR TITLE
fix(markdown-format): stop the telemetry payload lying when it exceeds argv

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.1]
+
+### Fixed
+
+- **The telemetry payload could be falsified rather than merely lost.**
+  `build_data_json` handed the findings array to `jq -n` as an `--argjson`
+  value. Windows caps a process command line at 32767 characters, and
+  `data.findings` is deliberately uncapped, so the array blew past that
+  somewhere between 300 and 600 entries (reproduced with the hooks' own jq:
+  300 pass, 600 fail with `rc=126`, "argument list too long"). `jq` never ran
+  and the fallback emitted an envelope claiming **zero** findings, with `tool`
+  and `file` blanked — for the noisiest files in the repository, which are the
+  ones a sink is most likely wired for. Telemetry is documented best-effort and
+  lossy, so a *dropped* envelope is inside contract; one that *arrives*
+  reporting a 600-finding file as clean is not. The array now reaches `jq` on
+  stdin; `tool` and `file` stay as arguments, both bounded by a path length.
+  The shared `hook::emit_telemetry` hands the finished payload over the same
+  way (#1595), so an oversized envelope is currently dropped rather than
+  delivered — the correct failure direction, and the one this change
+  establishes. The 600-finding case asserts the invariant that holds either way
+  and keeps holding once #1595 lands: lost, never falsified.
+- **Carriage returns leaked into the report.** `markdownlint-cli2` is a Node
+  process whose stdout is CRLF-terminated on Windows, and command substitution
+  strips only the trailing newline — so every retained violation line carried a
+  CR that survived JSON-escaping into `additionalContext` as a literal `\r`.
+- **The digest-store prune ran on every Markdown edit and was unbounded in
+  depth.** It now runs only when a *new* digest file is created — the steady
+  state for a repeatedly-edited file already has one, so the common path no
+  longer walks the directory at all — and carries `-maxdepth 1`.
+  `CLAUDE_PLUGIN_DATA` is shared with the `trust-approvals` tree and with
+  whatever a future version of this plugin puts there; a recursive age-based
+  `-delete` has no business reaching into a sibling's state.
+- **The rule histogram truncated silently.** It named the top five rules and
+  stopped, so `MD013 x48` read as the whole story on a file where twelve more
+  rules were firing. It now carries `+N more rule(s)`, the same way the finding
+  list already reported its own remainder. A test asserts the suffix is absent
+  when every rule fits, so it cannot become permanent decoration.
+
 ## [0.8.0]
 
 ### Fixed

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -145,12 +145,20 @@ fi
 # unreachable in practice (it fires only if `jq -n` fails, and when jq is absent
 # hook::emit_telemetry drops the envelope anyway), so losing the values here is
 # harmless and strictly safer than emitting malformed JSON.
+#
+# The findings array arrives on STDIN, never as an --argjson value. Windows caps
+# a process command line at 32767 characters, and this array is deliberately
+# uncapped — a real file with a few hundred findings serializes past that,
+# `jq -n` then fails with "argument list too long" (reproduced: 300 findings
+# pass, 600 fail), and the fallback below would emit an envelope claiming ZERO
+# findings for the noisiest files in the repository. A payload that lies is
+# worse than no payload. TOOL and FILE_REL stay as arguments: both are bounded
+# by a path length.
 build_data_json() {
-  jq -n \
+  printf '%s' "$1" | jq -c \
     --arg tool "$TOOL" \
     --arg file "$FILE_REL" \
-    --argjson findings "$1" \
-    '{tool:$tool,file:$file,findings:$findings}' 2>/dev/null ||
+    '{tool:$tool,file:$file,findings:.}' 2>/dev/null ||
     printf '{"tool":"","file":"","findings":[]}'
 }
 
@@ -705,8 +713,11 @@ if ((FINDING_COUNT > 0)); then
   # Rule histogram, highest count first, so a report truncated to N lines still
   # says WHICH rules dominate — the single most useful thing about a 300-finding
   # set, and the thing a raw first-N truncation destroys.
+  # Only the top five rules are named, but the count of the rest rides along:
+  # a bare truncation would leave "MD013 x48" reading as the whole story on a
+  # file that also has twelve other rules firing.
   RULE_SUMMARY=$(printf '%s' "$RULE_TALLY" | sort | uniq -c | sort -rn |
-    awk 'NR<=5 {printf "%s%s x%s", (NR>1 ? ", " : ""), $2, $1} END {print ""}' 2>/dev/null) || RULE_SUMMARY=""
+    awk 'NR<=5 {printf "%s%s x%s", (NR>1 ? ", " : ""), $2, $1} NR>5 {extra++} END {if (extra) printf ", +%s more rule(s)", extra; print ""}' 2>/dev/null) || RULE_SUMMARY=""
 
   # Delta gate. A file edited eight times in a session produced eight
   # byte-identical whole-file dumps; re-sending an unchanged finding set is pure
@@ -727,10 +738,19 @@ if ((FINDING_COUNT > 0)); then
     if [[ -n "$file_key" && -n "$digest_now" ]]; then
       digest_dir="${CLAUDE_PLUGIN_DATA%/}/finding-digests"
       if mkdir -p "$digest_dir" 2>/dev/null; then
-        find "$digest_dir" -type f -mtime +7 -delete 2>/dev/null
         DIGEST_FILE="$digest_dir/${session_key}.${file_key}"
-        if [[ -f "$DIGEST_FILE" ]] && [[ "$(cat "$DIGEST_FILE" 2>/dev/null)" == "$digest_now" ]]; then
-          SAME_AS_LAST=1
+        if [[ -f "$DIGEST_FILE" ]]; then
+          [[ "$(cat "$DIGEST_FILE" 2>/dev/null)" == "$digest_now" ]] && SAME_AS_LAST=1
+        else
+          # Prune only when a new digest is created — the steady state for a
+          # file edited repeatedly in one session is a digest that already
+          # exists, and sweeping the whole directory on every Markdown edit
+          # would cost a directory walk for nothing. -maxdepth 1 keeps the
+          # sweep to this hook's own flat store: CLAUDE_PLUGIN_DATA is shared
+          # with the trust-approvals tree and anything a future version of this
+          # plugin puts there, and a recursive age-based delete has no business
+          # reaching into a sibling's state.
+          find "$digest_dir" -maxdepth 1 -type f -mtime +7 -delete 2>/dev/null
         fi
         printf '%s' "$digest_now" >"$DIGEST_FILE" 2>/dev/null || DIGEST_FILE=""
       fi
@@ -772,6 +792,13 @@ fi
 # Compose ONE stdout document: Claude Code parses a hook's entire stdout as a
 # single JSON document, so the agent-channel report and the user-channel
 # mutation notice are emitted together rather than printed twice.
+#
+# Carriage returns are dropped first. markdownlint-cli2 is a Node process whose
+# stdout is CRLF-terminated on Windows, and command substitution strips only the
+# trailing newline — so every retained violation line arrives with a CR that
+# would survive JSON-escaping into the report as a literal \r.
+CTX="${CTX//$'\r'/}"
+SYSMSG="${SYSMSG//$'\r'/}"
 CTX="${CTX%"${CTX##*[![:space:]]}"}"
 hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
 

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -1512,6 +1512,11 @@ if printf '%s' "$CTX_N" | grep -q 'MD013 x48' && printf '%s' "$CTX_N" | grep -q 
 else
   fail "bounded/cap: rule histogram missing or wrong: $CTX_N"
 fi
+if printf '%s' "$CTX_N" | grep -q 'more rule(s)'; then
+  fail "bounded/cap: claimed omitted rules when only two rules fired: $CTX_N"
+else
+  ok "bounded/cap: no omitted-rule suffix when every rule fits in the histogram"
+fi
 if printf '%s' "$CTX_N" | grep -q 'and 30 more finding'; then
   ok "bounded/cap: the omitted remainder is reported as a count"
 else
@@ -1536,6 +1541,53 @@ else
   fail "bounded/telemetry: expected 50, got $(jq '.data.findings | length' "$TELN" 2>/dev/null)"
 fi
 rm -f "$TELN"
+
+# --- Scale: a large payload may be LOST, but must never be FALSIFIED ---------
+# The 50-finding case above cannot see this. Windows caps a process command line
+# at 32767 characters; a findings array handed to jq as an --argjson value blows
+# that somewhere past ~300 entries (reproduced with the hooks' own jq: 300 pass,
+# 600 fail, rc=126 "argument list too long").
+#
+# There are two such call sites, and only one is this plugin's to fix.
+# build_data_json is local and now feeds jq on stdin. hook::emit_telemetry then
+# passes the FINISHED payload the same way from the shared lib/hook-utils.sh,
+# which is byte-synced into every carrying plugin — fixing it there is a
+# fleet-wide wave, tracked as #1595.
+#
+# So the assertion is the invariant that holds either way, and keeps holding
+# after #1595 lands: telemetry is documented best-effort and lossy, so a dropped
+# envelope is inside contract. An envelope that ARRIVES claiming zero findings
+# for a 600-finding file is not — that is the local fallback firing, and it
+# reports the noisiest files in the repository as clean.
+FS="$REPO/scale.md"
+printf '# Scale\n\nbody\n' >"$FS"
+TELS="$(mktemp)"
+SINKS="$(make_sink "cat >\"$TELS\"")"
+run_noisy "$FS" STUB_FINDINGS=600 HOOK_TELEMETRY_SINK="$SINKS" >/dev/null
+wait_for_sink "$TELS" 50
+if [[ -s "$TELS" ]]; then
+  SCALE_LEN=$(jq '.data.findings | length' "$TELS" 2>/dev/null)
+  if [[ "$SCALE_LEN" == "600" ]]; then
+    ok "bounded/scale: the envelope arrived carrying all 600 findings"
+  else
+    fail "bounded/scale: an envelope arrived claiming ${SCALE_LEN:-?} findings for a 600-finding file — a payload that lies is worse than none"
+  fi
+else
+  ok "bounded/scale: oversized payload was dropped, not falsified (envelope loss is in contract; see #1595)"
+fi
+rm -f "$TELS"
+OUT_SCALE=$(run_noisy "$FS" STUB_FINDINGS=601)
+CTX_SCALE=$(printf '%s' "$OUT_SCALE" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_SCALE" | grep -q '601 markdownlint finding'; then
+  ok "bounded/scale: the report still states the true count at 601 findings"
+else
+  fail "bounded/scale: count wrong or missing at 601 findings: $CTX_SCALE"
+fi
+if printf '%s' "$CTX_SCALE" | grep -q $'\r'; then
+  fail "bounded/scale: carriage returns leaked into the report text"
+else
+  ok "bounded/scale: report text carries no stray carriage returns"
+fi
 
 # --- The cap is configurable, and 0 means unlimited -------------------------
 # Raising the cap must bring the detail back on an OTHERWISE UNCHANGED finding


### PR DESCRIPTION
## Summary

Follow-ups to #1591, which merged before these landed. One is a real defect that #1591's own claim
about telemetry made visible; the rest are that PR's non-blocking review findings.

**The telemetry payload could be falsified, not merely lost.** `build_data_json` handed the findings
array to `jq -n` as an `--argjson` value. Windows caps a process command line at 32767 characters, and
`data.findings` is deliberately uncapped — so the array blew past it between 300 and 600 entries.
Reproduced with the same jq the hooks use:

```text
n=100   serialized 6401 B    rc=0    findings preserved
n=300   serialized 19201 B   rc=0    findings preserved
n=600   serialized 38401 B   rc=126  <- argument list too long
n=1200  serialized 76801 B   rc=126
```

`jq` never ran, and the `|| printf '{"tool":"","file":"","findings":[]}'` fallback emitted an envelope
claiming **zero** findings with `tool` and `file` blanked — for the noisiest files in the repository,
which are exactly the ones a sink is most likely wired for. A real 324-finding file is past the limit,
so this was not a corner case; #1591's body and CHANGELOG both affirmatively claimed the payload keeps
its full contents.

The array now reaches `jq` on stdin. `tool` and `file` stay as arguments — both bounded by a path
length.

**There are two such call sites and only one is this plugin's.** `hook::emit_telemetry` hands the
*finished* payload over the same way from the byte-synced `lib/hook-utils.sh`; fixing it there is a
sync-and-bump wave across every carrying plugin, filed as #1595. So the honest end-to-end behaviour
today is that an oversized envelope is **dropped**, not delivered — and that is the point. Telemetry is
documented best-effort and lossy, so a dropped envelope is inside contract; one that arrives reporting
a 600-finding file as clean is not. **This PR moves the failure from a lie to a loss**, and the new
case asserts that invariant rather than a count, so it keeps passing unchanged once #1595 lands.

The existing 50-finding telemetry assertion could not have caught this — 50 findings is about 6 KB,
comfortably under the limit. Two runs that each passed for a different reason.

Also in this PR, the three non-blocking findings from #1591's review:

- **Prune frequency.** The digest sweep ran on every Markdown edit. It now runs only when a *new*
  digest file is created — the steady state for a repeatedly-edited file already has one, so the common
  path no longer walks the directory at all. That needs no session sentinel and no extra state.
- **`-maxdepth 1`.** Added, and for a stronger reason than a hypothetical subdirectory:
  `CLAUDE_PLUGIN_DATA` is shared with the `trust-approvals` tree and with whatever a future version of
  this plugin puts there. A recursive age-based `-delete` has no business reaching into a sibling's
  state, so the bound is stated as a boundary rather than a micro-optimization.
- **Silent histogram truncation.** The histogram now carries `+N more rule(s)` when more than five
  rules fire, so `MD013 x48` cannot read as the whole story on a file where twelve others are firing.

And one more found while verifying the above: **carriage returns leaked into the report**.
`markdownlint-cli2` is a Node process whose stdout is CRLF-terminated on Windows, and command
substitution strips only the trailing newline — so every retained violation line carried a CR that
survived JSON-escaping into `additionalContext` as a literal `\r`. Pre-existing, but it lands in the
report format #1591 restructured.

Findings 4 and 5 of that review were self-resolved as non-issues; I agree with both readings and made
no change.

## Test plan

- `bash plugins/markdown-format/hooks/markdown-format.test.sh` — **PASS=112 FAIL=0**, including six new
  or changed assertions: the oversized payload is dropped rather than falsified, the report still states
  the true count at 601 findings, no carriage returns in the report text, the histogram's omitted-rule
  suffix appears when it should, and does **not** appear when every rule fits.
- The argv ceiling itself was reproduced directly against the hooks' own jq at 100 / 300 / 600 / 1200
  findings (table above) before and after the change.
- Repo gates run locally, all green: `check-changelog-parity.sh --check-bump origin/main`,
  `check-shell-portability.sh`, `validate-plugins.sh`, `shellcheck -x` on both shell files, and
  `markdownlint-cli2` on the changed Markdown.

## Related

Closes #1597

Follows #1591. The shared-library half is #1595.
