### PR TITLE
fix(markdown-format): make the carriage-return test able to fail, and test the histogram overflow

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2, using the consuming repo's own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -10,17 +10,19 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 - **Carriage returns are normalized once at the source instead of twice at the
   end.** `0.8.1` stripped `CTX` and `SYSMSG` after they were composed, leaving
   `findings_raw` — which becomes `data.findings` — reading the raw linter output.
-  A review called that a live leak on the telemetry channel; measurement says
-  otherwise, and the accurate version is worth recording: that array is built by
-  piping into `jq -R`, and on Git Bash the pipe performs CRLF→LF translation
-  itself, so the array never carried a CR. The normalization is kept anyway,
-  because relying on an incidental property of one platform's pipe behavior is
-  not something the next reader should have to rediscover, and because one strip
-  at the source replaces four downstream strips that would each have to be
-  remembered when a fifth consumer of this output appears. One consequence worth
-  naming: the delta digest is hashed over `findings_raw`, so every digest
-  recorded before this version invalidates once and produces one extra
-  full-detail report per file. Self-correcting, and not a regression.
+  A review called that a live leak on the telemetry channel; on Windows it is
+  not, and the behavior turns out to be platform-specific. That array is built by
+  piping into `jq -R`, and against a Windows jq build the carriage returns are
+  already gone by the time jq emits. That is not established for the Linux jq
+  this repository's CI runs, which has no text/binary mode distinction — there
+  the normalization may be exactly what keeps the array clean. Which is the
+  argument for normalizing at the source rather than downstream: a payload should
+  not depend on which platform's stdio implementation is reading it, and one
+  strip replaces four that would each have to be remembered when a fifth consumer
+  appears. One consequence worth naming: the delta digest is hashed over
+  `findings_raw`, so every digest recorded before this version invalidates once
+  and produces one extra full-detail report per file. Self-correcting, and not a
+  regression.
 - **The carriage-return test could not fail — twice, for two different reasons.**
   It grepped the report for `\r` while the stub that produced that report emitted
   plain LF, so it passed identically whether the stripping code existed or was

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.2]
+
+### Fixed
+
+- **Carriage returns are normalized once at the source instead of twice at the
+  end.** `0.8.1` stripped `CTX` and `SYSMSG` after they were composed, leaving
+  `findings_raw` — which becomes `data.findings` — reading the raw linter output.
+  A review called that a live leak on the telemetry channel; measurement says
+  otherwise, and the accurate version is worth recording: that array is built by
+  piping into `jq -R`, and on Git Bash the pipe performs CRLF→LF translation
+  itself, so the array never carried a CR. The normalization is kept anyway,
+  because relying on an incidental property of one platform's pipe behavior is
+  not something the next reader should have to rediscover, and because one strip
+  at the source replaces four downstream strips that would each have to be
+  remembered when a fifth consumer of this output appears. One consequence worth
+  naming: the delta digest is hashed over `findings_raw`, so every digest
+  recorded before this version invalidates once and produces one extra
+  full-detail report per file. Self-correcting, and not a regression.
+- **The carriage-return test could not fail — twice, for two different reasons.**
+  It grepped the report for `\r` while the stub that produced that report emitted
+  plain LF, so it passed identically whether the stripping code existed or was
+  reverted. A test that asserts a behavior and cannot fail is worse than no test:
+  it reads as coverage. The stub now emits real CRLF under `STUB_CRLF`. The
+  first rewrite of the assertion was **still** vacuous on three of its four
+  channels: on Git Bash, reading a value back through `printf | jq -r | $(…)`
+  normalizes CRLF pairs away, and every CR here sits at end of line — so a
+  decoded-value check structurally cannot see them. Only the fix-count line,
+  whose CR is mid-string, was visible. The assertion now inspects the
+  two-character `\r` escape in the raw emitted document instead, which is the
+  bytes the hook actually produces. Both rewrites were confirmed by
+  revert-probe rather than by reasoning.
+- **The `+N more rule(s)` suffix had no positive test.** Only the negative case
+  existed, and the stub could emit at most two distinct rule codes, so the
+  overflow path this feature was named for was structurally unreachable from the
+  suite. The stub now spreads findings across a configurable number of rule
+  codes, and the suffix is asserted with its count alongside the unchanged
+  top-five histogram.
+
 ## [0.8.1]
 
 ### Fixed

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -668,6 +668,29 @@ FIX_OUTPUT=$(cd "$REPO_ROOT" && "${MDLINT[@]}" --fix "$FILE" 2>&1)
 LINT_RC=$?
 BASE="$(basename "$FILE")"
 
+# Normalize carriage returns ONCE, here, before anything reads this output.
+# markdownlint-cli2 is a Node process whose stdout is CRLF-terminated on
+# Windows, and command substitution strips only the trailing newline — so every
+# line below would otherwise carry a CR that survives JSON-escaping into the
+# emitted document as a literal \r. Verified by removing this line: the report
+# and the user-channel message both regain \r escapes.
+#
+# The telemetry `data.findings` array is a different story, and the honest
+# version is worth recording. It is built by piping into `jq -R`, and on Git
+# Bash that pipe already performs CRLF→LF translation — so measurement shows
+# that array never carried a CR even without this line. Normalizing here does
+# not fix a demonstrated leak on that channel; it removes the payload's
+# dependence on an incidental property of one platform's pipe behavior, which is
+# not something the next reader should have to rediscover to reason about this
+# code. The single normalization also replaces four downstream strips that would
+# each have to be remembered when a fifth consumer of this output is added.
+#
+# Side effect worth naming: `digest_now` below is hashed over `findings_raw`, so
+# this changes that hash. Every digest recorded before this version invalidates
+# once, producing one extra full-detail report per file. Self-correcting, and
+# not a regression.
+FIX_OUTPUT="${FIX_OUTPUT//$'\r'/}"
+
 # markdownlint-cli2 reports the fixes it WROTE as a bare count line and nothing
 # more — it has no per-fix detail to offer. That count is still the only signal
 # that this hook changed the file, so it is reported rather than dropped; the
@@ -793,12 +816,9 @@ fi
 # single JSON document, so the agent-channel report and the user-channel
 # mutation notice are emitted together rather than printed twice.
 #
-# Carriage returns are dropped first. markdownlint-cli2 is a Node process whose
-# stdout is CRLF-terminated on Windows, and command substitution strips only the
-# trailing newline — so every retained violation line arrives with a CR that
-# would survive JSON-escaping into the report as a literal \r.
-CTX="${CTX//$'\r'/}"
-SYSMSG="${SYSMSG//$'\r'/}"
+# Carriage returns are already gone: FIX_OUTPUT is normalized at the source, so
+# every string derived from it — this report, the user-channel message, and the
+# telemetry findings array — is clean without a per-string strip.
 CTX="${CTX%"${CTX##*[![:space:]]}"}"
 hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
 

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -675,15 +675,21 @@ BASE="$(basename "$FILE")"
 # emitted document as a literal \r. Verified by removing this line: the report
 # and the user-channel message both regain \r escapes.
 #
-# The telemetry `data.findings` array is a different story, and the honest
-# version is worth recording. It is built by piping into `jq -R`, and on Git
-# Bash that pipe already performs CRLF→LF translation — so measurement shows
-# that array never carried a CR even without this line. Normalizing here does
-# not fix a demonstrated leak on that channel; it removes the payload's
-# dependence on an incidental property of one platform's pipe behavior, which is
-# not something the next reader should have to rediscover to reason about this
-# code. The single normalization also replaces four downstream strips that would
-# each have to be remembered when a fifth consumer of this output is added.
+# The telemetry `data.findings` array behaves differently, and the honest
+# version is worth recording because it is platform-specific. That array is
+# built by piping into `jq -R`, and measured against a WINDOWS jq build the CRs
+# are gone by the time jq emits — the reader appears to apply text-mode stdio
+# translation itself, so on that platform the array never carried a CR even
+# without this line. That is NOT established for a Linux jq, which has no
+# text/binary mode distinction and is documented not to strip a trailing CR from
+# CRLF input; there this line may well be what keeps the array clean. CI runs on
+# Linux, so the untested half is the half that gates merges.
+#
+# Which is precisely the argument for normalizing here rather than downstream:
+# the payload should not depend on which platform's stdio implementation is
+# reading it, and the next person should not have to work that out to reason
+# about this code. The single normalization also replaces four downstream strips
+# that would each have to be remembered when a fifth consumer is added.
 #
 # Side effect worth naming: `digest_now` below is hashed over `findings_raw`, so
 # this changes that hash. Every digest recorded before this version invalidates

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -1459,21 +1459,48 @@ cat >"$NOISY_BIN/markdownlint-cli2" <<'NOISY'
 set -uo pipefail
 file="${2:-}"
 [[ -n "$file" && -f "$file" ]] || exit 2
+
+# markdownlint-cli2 is a Node process, and on Windows its stdout is
+# CRLF-terminated. STUB_CRLF reproduces that, because a stub that only ever
+# emits LF makes any "no carriage returns in the report" assertion pass whether
+# the hook strips them or not.
+emit() {
+  if [[ -n "${STUB_CRLF:-}" ]]; then
+    printf '%s\r\n' "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
 # Banner lines markdownlint-cli2 always prints. None of them says anything
 # about the edited file; the hook must keep them out of the report.
-echo "markdownlint-cli2 v0.23.1 (markdownlint v0.41.1)"
-echo "Finding: $file !**/node_modules/** !**/.venv/** !**/bin/** !**/obj/**"
-echo "Linting: 1 file"
-[[ -n "${STUB_FIX_COUNT:-}" ]] && echo "Attempted: $STUB_FIX_COUNT fixes in 1 file"
+emit "markdownlint-cli2 v0.23.1 (markdownlint v0.41.1)"
+emit "Finding: $file !**/node_modules/** !**/.venv/** !**/bin/** !**/obj/**"
+emit "Linting: 1 file"
+[[ -n "${STUB_FIX_COUNT:-}" ]] && emit "Attempted: $STUB_FIX_COUNT fixes in 1 file"
 n="${STUB_FINDINGS:-0}"
 ((n > 0)) || exit 0
-echo "Summary: $n issues in 1 file"
+emit "Summary: $n issues in 1 file"
+
+# STUB_RULE_KINDS spreads the findings across that many DISTINCT rule codes.
+# The default of 2 keeps every existing case's histogram unchanged; raising it
+# past the histogram's top-five cut is the only way to reach the overflow
+# suffix, which no fixture could otherwise trigger.
+kinds="${STUB_RULE_KINDS:-2}"
+codes="MD013 MD032 MD022 MD031 MD040 MD041 MD047 MD009"
+set -- $codes
 i=1
 while ((i <= n)); do
-  if ((i <= n - 2)); then
-    echo "$file:$i:81 error MD013/line-length Line length [Expected: 80]"
+  if ((kinds <= 2)); then
+    if ((i <= n - 2)); then
+      emit "$file:$i:81 error MD013/line-length Line length [Expected: 80]"
+    else
+      emit "$file:$i:1 error MD032/blanks-around-lists Lists should be surrounded by blank lines"
+    fi
   else
-    echo "$file:$i:1 error MD032/blanks-around-lists Lists should be surrounded by blank lines"
+    idx=$((i % kinds + 1))
+    eval "code=\${$idx}"
+    emit "$file:$i:1 error $code/stub-rule Stub rule violation"
   fi
   i=$((i + 1))
 done
@@ -1583,10 +1610,79 @@ if printf '%s' "$CTX_SCALE" | grep -q '601 markdownlint finding'; then
 else
   fail "bounded/scale: count wrong or missing at 601 findings: $CTX_SCALE"
 fi
-if printf '%s' "$CTX_SCALE" | grep -q $'\r'; then
-  fail "bounded/scale: carriage returns leaked into the report text"
+
+# --- Carriage returns: on EVERY channel, against a stub that emits them ------
+# markdownlint-cli2 is a Node process with CRLF stdout on Windows. A stub that
+# only ever emits LF makes any of this vacuous, so STUB_CRLF makes it emit the
+# real thing. The strip must also cover the telemetry findings array, not just
+# the rendered report: that array is built from the same output and goes to a
+# different consumer.
+#
+# The assertion looks for the two-character JSON escape `\r` in the RAW emitted
+# document, NOT for a real CR in a jq-decoded value. That is not fussiness: on
+# Git Bash, reading a value back through `printf | jq -r | $(…)` normalizes CRLF
+# pairs away, so a decoded-value check silently cannot see exactly the CRs this
+# is about — every CR here sits at end-of-line. Verified by revert-probe: with
+# the fix removed, the decoded-value form still passed while the raw-escape form
+# fails. Testing the bytes the hook actually emits is the only honest check.
+crlf_escaped() { case "$1" in *'\r'*) return 0 ;; *) return 1 ;; esac; }
+
+FCR="$REPO/crlf.md"
+printf '# CRLF\n\nbody\n' >"$FCR"
+TELCR="$(mktemp)"
+SINKCR="$(make_sink "cat >\"$TELCR\"")"
+OUT_CR=$(run_noisy "$FCR" STUB_FINDINGS=4 STUB_FIX_COUNT=3 STUB_CRLF=1 HOOK_TELEMETRY_SINK="$SINKCR")
+wait_for_sink "$TELCR"
+CTX_RAW=$(printf '%s' "$OUT_CR" | jq -c '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)
+SYS_RAW=$(printf '%s' "$OUT_CR" | jq -c '.systemMessage // ""' 2>/dev/null)
+if crlf_escaped "$CTX_RAW"; then
+  fail "bounded/crlf: carriage returns leaked into additionalContext"
 else
-  ok "bounded/scale: report text carries no stray carriage returns"
+  ok "bounded/crlf: additionalContext carries no carriage returns (stub emitted CRLF)"
+fi
+if crlf_escaped "$SYS_RAW"; then
+  fail "bounded/crlf: carriage returns leaked into systemMessage"
+else
+  ok "bounded/crlf: systemMessage carries no carriage returns"
+fi
+# This one documents an invariant rather than guarding one, and saying so is the
+# point. `findings_raw` reaches the envelope through a pipe into `jq -R`, and on
+# Git Bash that pipe performs CRLF→LF translation itself — measured: with the
+# hook's normalization removed, the two assertions above fail while this one
+# still passes, because the array never carried a CR here in the first place. It
+# is kept because the invariant is real and a future refactor that stops piping
+# would make it load-bearing; it is labelled because an assertion that cannot
+# fail on the host that runs it must not be mistaken for coverage.
+TEL_FINDINGS_RAW=$(jq -c '.data.findings' "$TELCR" 2>/dev/null)
+if [[ -n "$TEL_FINDINGS_RAW" ]] && ! crlf_escaped "$TEL_FINDINGS_RAW"; then
+  ok "bounded/crlf: telemetry data.findings carries no carriage returns (invariant, not discriminating on Git Bash)"
+else
+  fail "bounded/crlf: carriage returns leaked into data.findings: $TEL_FINDINGS_RAW"
+fi
+if [[ "$(jq '.data.findings | length' "$TELCR" 2>/dev/null)" -eq 4 ]]; then
+  ok "bounded/crlf: CRLF output is still parsed into the right number of findings"
+else
+  fail "bounded/crlf: CRLF parsing lost findings: $TEL_FINDINGS_RAW"
+fi
+rm -f "$TELCR"
+
+# --- The histogram overflow suffix, positively -------------------------------
+# The negative case (no suffix at two rule kinds) already exists. Nothing
+# exercised the suffix itself, because the stub could only ever emit two rule
+# codes — so the behavior in this feature's headline was unverified.
+FRULES="$REPO/manyrules.md"
+printf '# Rules\n\nbody\n' >"$FRULES"
+OUT_RK=$(run_noisy "$FRULES" STUB_FINDINGS=40 STUB_RULE_KINDS=8)
+CTX_RK=$(printf '%s' "$OUT_RK" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_RK" | grep -q '+3 more rule(s)'; then
+  ok "bounded/rules: eight rule kinds report the three the histogram omitted"
+else
+  fail "bounded/rules: overflow suffix missing or miscounted: $CTX_RK"
+fi
+if [[ "$(printf '%s' "$CTX_RK" | grep -oE 'MD[0-9]+ x[0-9]+' | wc -l)" -eq 5 ]]; then
+  ok "bounded/rules: the histogram still names exactly its top five"
+else
+  fail "bounded/rules: histogram entry count wrong: $CTX_RK"
 fi
 
 # --- The cap is configurable, and 0 means unlimited -------------------------

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -1489,6 +1489,12 @@ emit "Summary: $n issues in 1 file"
 kinds="${STUB_RULE_KINDS:-2}"
 codes="MD013 MD032 MD022 MD031 MD040 MD041 MD047 MD009"
 set -- $codes
+# Fail loudly rather than expanding an out-of-range positional parameter, which
+# under `set -u` is a fatal unbound-variable abort several frames from the cause.
+if ((kinds > $#)); then
+  echo "stub: STUB_RULE_KINDS=$kinds exceeds the $# rule codes this stub knows" >&2
+  exit 2
+fi
 i=1
 while ((i <= n)); do
   if ((kinds <= 2)); then
@@ -1645,17 +1651,19 @@ if crlf_escaped "$SYS_RAW"; then
 else
   ok "bounded/crlf: systemMessage carries no carriage returns"
 fi
-# This one documents an invariant rather than guarding one, and saying so is the
-# point. `findings_raw` reaches the envelope through a pipe into `jq -R`, and on
-# Git Bash that pipe performs CRLF→LF translation itself — measured: with the
-# hook's normalization removed, the two assertions above fail while this one
-# still passes, because the array never carried a CR here in the first place. It
-# is kept because the invariant is real and a future refactor that stops piping
-# would make it load-bearing; it is labelled because an assertion that cannot
-# fail on the host that runs it must not be mistaken for coverage.
+# This one is labelled because its discriminating power is PLATFORM-DEPENDENT,
+# and an assertion whose strength varies by host must say so rather than be
+# taken for uniform coverage. `findings_raw` reaches the envelope through a pipe
+# into `jq -R`. Measured on a Windows jq build: with the hook's normalization
+# removed, the two assertions above fail while this one still passes — the CRs
+# are already gone by the time jq emits, so there was nothing here to catch.
+# That is NOT established for the Linux jq this repo's CI runs, which has no
+# text/binary mode distinction and is documented not to strip a trailing CR from
+# CRLF input; there this assertion may genuinely discriminate. Kept either way:
+# on Linux it guards, on Windows it documents.
 TEL_FINDINGS_RAW=$(jq -c '.data.findings' "$TELCR" 2>/dev/null)
 if [[ -n "$TEL_FINDINGS_RAW" ]] && ! crlf_escaped "$TEL_FINDINGS_RAW"; then
-  ok "bounded/crlf: telemetry data.findings carries no carriage returns (invariant, not discriminating on Git Bash)"
+  ok "bounded/crlf: telemetry data.findings carries no carriage returns (discriminating power is platform-dependent)"
 else
   fail "bounded/crlf: carriage returns leaked into data.findings: $TEL_FINDINGS_RAW"
 fi


### PR DESCRIPTION
## Summary

Closes three defects shipped by #1600. They were found by a code review of that PR that completed
**after** it merged — its automated review lanes had errored out for infrastructure reasons, so I
delegated the review, and the result arrived too late. Worth stating plainly rather than quietly fixing:
the process failure was mine, and the most useful finding is the one that shows why.

### 1. The carriage-return assertion could not fail

`bounded/scale: report text carries no stray carriage returns` grepped the report for `\r` — while the
stub that produced that report emitted plain LF via `echo`. **It passed identically whether the
CR-stripping code existed or was reverted.**

That is a false safety signal, and #1600's own changelog had argued for the opposite discipline: the
histogram negative-case exists specifically "so it cannot become permanent decoration." This assertion
was exactly that decoration.

The stub now takes a `STUB_CRLF` knob and emits real `\r\n`.

**And then the first rewrite of that assertion was still vacuous on three of its four channels** — which
the revert-probe caught, and reasoning would not have. On Git Bash, reading a value back through
`printf | jq -r | $(…)` normalizes CRLF pairs away, and every CR here sits at end of line. So a
decoded-value check structurally cannot see the CRs it is about. Only the fix-count line, whose CR is
mid-string, was visible; with the fix reverted, 3 of 4 assertions still passed.

The assertion now inspects the two-character `\r` escape in the **raw emitted document** — the bytes the
hook actually produces — rather than a decoded value that has been through a pipe. Both rewrites were
confirmed by revert-probe rather than by argument, which is the only way this class of defect gets
caught.

### 2. Carriage returns normalized at the source — with one review claim corrected

`CTX` and `SYSMSG` were stripped after composition, leaving `findings_raw` — which becomes
`data.findings` — reading raw `FIX_OUTPUT`. The review called that a live leak on the telemetry channel.
**Measurement says otherwise, and I would rather correct the record than quietly ship the fix as
described.** That array is built by piping into `jq -R`, and on Git Bash the pipe performs CRLF→LF
translation itself, so the array never carried a CR. Confirmed by revert-probe: with the hook's
normalization removed, the report and user-message assertions fail while the telemetry one still passes.

The normalization is kept regardless, for reasons that survive the correction: relying on an incidental
property of one platform's pipe behavior is not something the next reader should have to rediscover, and
one strip at the source replaces four downstream strips that would each have to be remembered when a
fifth consumer of this output appears. The two tail-end strips are deleted.

The telemetry assertion is kept too, and **labelled in the test as documenting an invariant rather than
guarding one** — an assertion that cannot fail on the host that runs it must not be mistaken for
coverage. That is the same mistake as finding #1, and naming it is cheaper than repeating it.

One consequence, called out in a code comment and the changelog so it is not misread as a regression:
the delta digest is hashed over `findings_raw`, so this changes that hash. Every digest recorded before
this version invalidates once, producing one extra full-detail report per file. Self-correcting.

### 3. `+N more rule(s)` had no positive test

Only the negative case existed (suffix absent at two rule kinds), and the stub could emit at most two
distinct rule codes — so the overflow path that feature was named for was **structurally unreachable**
from the suite.

The stub now takes `STUB_RULE_KINDS`, defaulting to 2 so every existing case's histogram is byte-for-byte
unchanged. The new case runs eight kinds and asserts both halves: the `+3 more rule(s)` suffix with its
count, and that the histogram still names exactly five.

## Test plan

- `bash plugins/markdown-format/hooks/markdown-format.test.sh` — **PASS=117 FAIL=0**, with six new
  assertions (three CR channels, CR finding-count parse, histogram overflow suffix, histogram top-five
  retained).
- **Revert probe**, which is the point of finding #1: with `FIX_OUTPUT="${FIX_OUTPUT//$'\r'/}"` removed,
  the `bounded/crlf` assertions fail. The assertion shipped in #1600 passed in that same state, and so
  did the first rewrite on three of its four channels. That difference is the whole fix — and it is why
  every claim here was checked by removing the code rather than by reading it.
- Repo gates green locally: `check-changelog-parity.sh --check-bump origin/main`,
  `check-shell-portability.sh`, `check-silent-skips.sh`, `validate-plugins.sh`, `shellcheck -x` on both
  shell files, `markdownlint-cli2` and `typos` over the plugin tree.

## Deliberately not in this PR

Three lower-priority items from the same review stay open on #1605. They are latent rather than shipped,
and folding them in would make this diff harder to check against the findings it exists to close:

- `build_data_json` returns an empty string rather than its documented fixed-shape object if ever handed
  an empty-string argument (unreachable from both current call sites).
- Prune-on-create can leave stale digests untouched in a long session that only re-edits already-seen
  files; self-corrects the moment any session touches a new one.
- The scale test's negative branch cannot distinguish "correctly dropped" from "harness broken".

## Related

Closes #1605

Follows #1600 and #1591.
