### PR TITLE
chore(source-control): give babysit-loop headroom under the skill line cap

### DIFF
--- a/plugins/source-control/skills/babysit-loop/SKILL.md
+++ b/plugins/source-control/skills/babysit-loop/SKILL.md
@@ -128,12 +128,10 @@ raise → the unconditional C4/C5 ceiling (config-resolution reference, "The exc
 raise restriction only").
 
 The deterministic gate is not weakened: checks, thread resolution, and mergeability still all have
-to pass. What changes: an otherwise-eligible (C1-C3) PR blocked on a **machine-escalated**
-`needs-human` item, an open non-human finding, or a contradictory/unresolved **bot** thread draws
-one fresh frontier-tier resolution dispatch before falling through — the full dispatch contract,
-its lease and independence requirements, and the four blocker classes it never touches are owned by
-Escalation below. An unresolved or uncertain blocker, or a C4/C5 PR, still escalates exactly as it
-would without the exception — this widens *who tries first*, never what the gate requires.
+to pass. What changes is only *who tries first* on a blocked but otherwise-eligible PR — one fresh
+frontier-tier resolution dispatch before it falls through, scoped by Escalation below and owned in
+full by [reference/pre-escalation-dispatch.md](reference/pre-escalation-dispatch.md). A C4/C5 PR,
+and any blocker left unresolved or uncertain, escalates exactly as it would without the exception.
 
 **Always-on safety knobs** — never configurable off, whatever the tier or rung: the activity grace
 window (width configurable, existence not), babysit-prs's head-move yield and expected-head
@@ -290,61 +288,23 @@ writer (the same one-directional pattern as the `claude-ops:lane-telemetry` sent
 babysit escalations surface in the same attention view as worker escalations. Telemetry is the
 report surface, never the escalation channel.
 
-**Pre-escalation resolution attempt, explicit-`autopilot` only.** Before a merge-eligible (C1-C3)
-PR is escalated for a **machine-escalated** `needs-human` item, an open machine-authored finding, or
-a contradictory/unresolved **bot** review thread, and only when this invocation's own argument line
-typed both the literal `autopilot` tier argument and `--merge c3-this-run` (the widening pair
-above): dispatch a fresh subagent at the **frontier tier** — §3's top tier row, requested by tier
-and resolved to a live-updating model alias through that section's "Runtime resolution is by model
-alias only", never a dated model ID and never a family name written into this lane as the tier's
-*definition* (tiers are ordered by capability; a family mapping rots). A run that cannot establish
-which alias currently satisfies `frontier` **escalates rather than dispatching** — inheriting the
-session's model, or a lower review-work model, forfeits the capability this dispatch stands on. The
-subagent shares no context with whatever produced the PR or previously replied on the blocking
-thread, and **runs under the PR's worker lease**: acquire and heartbeat before it starts, release
-after, exactly as `babysit-prs` requires before any per-PR fix or worker assignment
-(`babysit-prs/reference/safety.md` and `babysit-prs/reference/orchestration.md`); the guarded wrappers pin comment
-state, not concurrency ownership, and a lease another worker already holds means no dispatch at
-all. Brief it with the blocker, the PR, and the convention's independence and frontier-tier
-requirements; it replies and resolves threads through babysit-prs's guarded-mutation path, never a
-raw mutation.
-**A blocker needing a code change runs the full per-PR worker lifecycle** — isolated PR worktree,
-HEAD asserted at the live PR head, commit and refspec push (`babysit-prs/reference/safety.md`) — not
-the wrappers alone, which implement merge and thread resolution and create no worktree; a lane
-launched from a neutral directory has no usable tree without it.
-
-**Four blocker classes this dispatch never touches**, each because the invoked mechanic's own
-contract already owns them and this exception does not amend those contracts:
-
-- **Operator-parked items.** The `needs-human` role label marks machine-*escalated* and
-  operator-*parked* items alike; only the machine escalation marker distinguishes them (loop-lane
-  convention, "Escalation contract"). An item wearing the label without that marker belongs to the
-  attended queue, not this lane: no dispatch, and step 3 withholds the PR from the merge-capable
-  set — dispatching on the label alone would answer an operator-owned question with an agent.
-- **Human blocking feedback.** A human `CHANGES_REQUESTED` review, explicit human blocking
-  language, or an unresolved inline human thread stays a stop-and-ask condition until GitHub state
-  resolves it — escalate, never fix or resolve past it (`babysit-prs/reference/feedback.md`,
-  "Human Feedback"). No dispatch is made, and step 3 withholds the PR from the merge-capable
-  set. The one exception `babysit-prs` gained in this change is
-  scoped to security/P1 escalation and to that dispatch path alone (`babysit-prs/reference/safety.md`,
-  "Security/P1 escalation"); it does not widen to human blocks.
-- **Merge conflicts.** These route to the dedicated fresh conflict-resolution worker
-  (`babysit-prs/reference/orchestration.md`, Merge Conflict Resolution), which integrates
-  **merge-only and never rebases** — rebasing a PR branch needs the force-push babysit-prs forbids
-  cross-tier. This dispatch never resolves a conflict itself and never rebases.
-- **C4/C5 PRs.** Already excluded at the rung partition (Cycle shape, step 3) — including the
-  provenance-derived C5 override and the diff-derived C4 veto — and they escalate normally.
-
-If the dispatch resolves the blocker, **re-snapshot the PR and rerun step 3's provenance, C4-diff and
-rung partition before** its normal `autopilot`-tier invocation and gate — the first partition read
-the cycle-start diff, and a resolution that pushed code can have turned a C2/C3 change into a
-refactor, migration, or contract change that the downstream merge gate does not class-check. A PR
-that leaves the eligible set on that second partition escalates instead of merging. The normal
-worker's own final push obeys the same head-pinning rule (Cycle shape, step 3, "The verdict
-authorizes a head SHA, not the PR"). If the dispatch cannot resolve the blocker — including any
-case where the subagent itself is uncertain the resolution is correct — the PR escalates exactly
-as it would without this exception; this dispatch adds one resolution attempt, it never removes
-the escalation path or lowers the gate's bar.
+**Pre-escalation resolution attempt, explicit-`autopilot` only.** When — and only when — this
+invocation's own argument line typed both the literal `autopilot` tier argument and
+`--merge c3-this-run` (the widening pair above), a merge-eligible (C1-C3) PR blocked on a
+**machine-escalated** `needs-human` item, an open machine-authored finding, or a
+contradictory/unresolved **bot** review thread draws one fresh **frontier-tier** subagent dispatch —
+context-independent, and run under the PR's worker lease — before it escalates. **Four blocker
+classes it never touches**, each owned by a contract this exception does not amend:
+operator-*parked* items (the role label without the machine escalation marker — the attended queue's,
+and step 3 withholds the PR), human blocking feedback (stop-and-ask until GitHub state resolves it,
+also withheld at step 3), merge conflicts (the dedicated merge-only conflict worker), and C4/C5 PRs
+(already excluded at the rung partition). A resolution that lands re-runs step 3's provenance,
+C4-diff and rung partition before any merge-capable invocation; an unresolved *or uncertain* blocker
+escalates exactly as it would without the exception. This widens *who tries first*, never what the
+gate requires. The full contract — frontier-tier resolution and its escalate-rather-than-dispatch
+rule, the lease and independence requirements, each blocker class's rationale, the code-change
+worker lifecycle, and the re-partition rule — is owned by
+[reference/pre-escalation-dispatch.md](reference/pre-escalation-dispatch.md).
 
 ## Telemetry and durable loop state
 

--- a/plugins/source-control/skills/babysit-loop/reference/pre-escalation-dispatch.md
+++ b/plugins/source-control/skills/babysit-loop/reference/pre-escalation-dispatch.md
@@ -1,0 +1,69 @@
+# Pre-escalation resolution dispatch (explicit-`autopilot` only)
+
+The full contract for the one resolution attempt the explicit-`autopilot` widening adds ahead of an
+escalation. This path is reachable **only** when an invocation's own argument line typed both the
+literal `autopilot` tier argument and `--merge c3-this-run`; every other invocation escalates
+directly and never reads this file. `SKILL.md`'s "Escalation" section owns when the dispatch fires
+and the bounds it cannot cross; this file owns how it runs.
+
+## The dispatch
+
+Before a merge-eligible (C1-C3) PR is escalated for a **machine-escalated** `needs-human` item, an
+open machine-authored finding, or a contradictory/unresolved **bot** review thread, and only when
+this invocation's own argument line typed both the literal `autopilot` tier argument and
+`--merge c3-this-run` (the widening pair): dispatch a fresh subagent at the **frontier tier** — §3's
+top tier row, requested by tier and resolved to a live-updating model alias through that section's
+"Runtime resolution is by model alias only", never a dated model ID and never a family name written
+into this lane as the tier's *definition* (tiers are ordered by capability; a family mapping rots).
+A run that cannot establish which alias currently satisfies `frontier` **escalates rather than
+dispatching** — inheriting the session's model, or a lower review-work model, forfeits the
+capability this dispatch stands on. The subagent shares no context with whatever produced the PR or
+previously replied on the blocking thread, and **runs under the PR's worker lease**: acquire and
+heartbeat before it starts, release after, exactly as `babysit-prs` requires before any per-PR fix
+or worker assignment (`babysit-prs/reference/safety.md` and
+`babysit-prs/reference/orchestration.md`); the guarded wrappers pin comment state, not concurrency
+ownership, and a lease another worker already holds means no dispatch at all. Brief it with the
+blocker, the PR, and the convention's independence and frontier-tier requirements; it replies and
+resolves threads through babysit-prs's guarded-mutation path, never a raw mutation.
+
+**A blocker needing a code change runs the full per-PR worker lifecycle** — isolated PR worktree,
+HEAD asserted at the live PR head, commit and refspec push (`babysit-prs/reference/safety.md`) — not
+the wrappers alone, which implement merge and thread resolution and create no worktree; a lane
+launched from a neutral directory has no usable tree without it.
+
+## Four blocker classes this dispatch never touches
+
+Each because the invoked mechanic's own contract already owns them and this exception does not amend
+those contracts:
+
+- **Operator-parked items.** The `needs-human` role label marks machine-*escalated* and
+  operator-*parked* items alike; only the machine escalation marker distinguishes them (loop-lane
+  convention, "Escalation contract"). An item wearing the label without that marker belongs to the
+  attended queue, not this lane: no dispatch, and step 3 withholds the PR from the merge-capable
+  set — dispatching on the label alone would answer an operator-owned question with an agent.
+- **Human blocking feedback.** A human `CHANGES_REQUESTED` review, explicit human blocking
+  language, or an unresolved inline human thread stays a stop-and-ask condition until GitHub state
+  resolves it — escalate, never fix or resolve past it (`babysit-prs/reference/feedback.md`,
+  "Human Feedback"). No dispatch is made, and step 3 withholds the PR from the merge-capable
+  set. The one exception `babysit-prs` gained in this change is
+  scoped to security/P1 escalation and to that dispatch path alone (`babysit-prs/reference/safety.md`,
+  "Security/P1 escalation"); it does not widen to human blocks.
+- **Merge conflicts.** These route to the dedicated fresh conflict-resolution worker
+  (`babysit-prs/reference/orchestration.md`, Merge Conflict Resolution), which integrates
+  **merge-only and never rebases** — rebasing a PR branch needs the force-push babysit-prs forbids
+  cross-tier. This dispatch never resolves a conflict itself and never rebases.
+- **C4/C5 PRs.** Already excluded at the rung partition (`SKILL.md` Cycle shape, step 3) — including
+  the provenance-derived C5 override and the diff-derived C4 veto — and they escalate normally.
+
+## After the dispatch
+
+If the dispatch resolves the blocker, **re-snapshot the PR and rerun step 3's provenance, C4-diff and
+rung partition before** its normal `autopilot`-tier invocation and gate — the first partition read
+the cycle-start diff, and a resolution that pushed code can have turned a C2/C3 change into a
+refactor, migration, or contract change that the downstream merge gate does not class-check. A PR
+that leaves the eligible set on that second partition escalates instead of merging. The normal
+worker's own final push obeys the same head-pinning rule (`SKILL.md` Cycle shape, step 3, "The
+verdict authorizes a head SHA, not the PR"). If the dispatch cannot resolve the blocker — including
+any case where the subagent itself is uncertain the resolution is correct — the PR escalates exactly
+as it would without this exception; this dispatch adds one resolution attempt, it never removes
+the escalation path or lowers the gate's bar.

--- a/prompts/loops/loop-lane-prompts.md
+++ b/prompts/loops/loop-lane-prompts.md
@@ -558,7 +558,7 @@ wakeup ceiling for days rather than finishing.
 > for CI fixes, review-comment work, and any judgment call; `haiku` only for
 > mechanical log pulls. Never leave it to inherit. One explicit exception to
 > the review-work binding: the explicit-`autopilot` pre-escalation resolver
-> (babysit-loop, Escalation) always dispatches at the frontier tier's current
+> (babysit-loop, `reference/pre-escalation-dispatch.md`) always dispatches at the frontier tier's current
 > alias — blocker resolution under that path never runs at the review-work
 > model, and a run that cannot resolve the frontier alias escalates instead.
 >
@@ -1389,7 +1389,7 @@ exists — not before.
 > for CI fixes, review-comment work, and any judgment call; `haiku` only for
 > mechanical log pulls. Never leave it to inherit. One explicit exception to
 > the review-work binding: the explicit-`autopilot` pre-escalation resolver
-> (babysit-loop, Escalation) always dispatches at the frontier tier's current
+> (babysit-loop, `reference/pre-escalation-dispatch.md`) always dispatches at the frontier tier's current
 > alias — blocker resolution under that path never runs at the review-work
 > model, and a run that cannot resolve the frontier alias escalates instead.
 >


### PR DESCRIPTION
Closes #1620. `babysit-loop/SKILL.md` goes from **499/500 to 459/500** — 41 lines of headroom, up from one. Nothing is deleted; one section is relocated to a skill-local spoke.

## The survey the triage deferred

The triage explicitly did not survey `babysit-loop`'s sections and asked whoever took it to confirm against the current file. Section sizes on `main`:

| Section | Lines | Verdict |
|---|---|---|
| Cycle shape | 111 | **No** — the skill's core algorithm and its safety-critical rung partition; extracting guts the body |
| Escalation | 69 | **Yes** — 55 of those are the pre-escalation dispatch, detail for one narrow gated path |
| Telemetry and durable loop state | 54 | **No** — convention §4 requires each lane to inline the `gh api` upsert |
| Autonomy dimensions, tiers, knobs | 51 | **No** — the merge-authority answer; readers need it inline |
| Required argument and config resolution | 48 | **No** — invocation basics, and it already defers to `reference/config-resolution.md` |
| Rate-limit guard floor | 36 | **No** — convention §6, byte-identical across lanes |
| Gotchas | 32 | **No** — short, scannable, high-value where it is |

The extracted section wins on three counts. It is reachable **only** when an invocation types both `autopilot` and `--merge c3-this-run`, so most readers never need it. It was already written as a pointer target ("the full dispatch contract … are owned by Escalation below"), so it was progressive-disclosure shaped before it was a spoke. And it is babysit-loop's *own* named exception, carrying no cross-lane symmetry constraint — which is exactly what disqualified the two obvious candidates.

## On §6 and §4 — why the floor did not move

The triage floated the rate-limit floor as a candidate and flagged the §6 problem. Confirmed, and it rules the floor out for a single-lane change: §6 requires each lane body to inline the operable floor and exists "so the values stay byte-identical across lanes; fleet audits check conformance per consumer". Moving it for one lane breaks that symmetry, and moving it for all three plus rewording §6 is the triage's option 1 — a much larger change that should be its own decision.

The same reasoning independently rules out Telemetry, which the triage did not flag: §4 requires each lane to inline the `gh api` upsert, for the same runtime-reach reason.

## What stayed in the body

Deliberately, every safety-relevant constraint is still named where a reader meets it:

- the four blocker classes the dispatch never touches (operator-parked items, human blocking feedback, merge conflicts, C4/C5), each named inline;
- that a landed resolution re-runs step 3's provenance, C4-diff and rung partition before any merge-capable invocation;
- that an unresolved **or uncertain** blocker escalates exactly as it would without the exception;
- that the deterministic gate is not weakened.

The spoke owns mechanics only: frontier-alias resolution and its escalate-rather-than-dispatch rule, the lease and independence requirements, each blocker class's rationale, and the code-change worker lifecycle. **No safety floor moved out of the body.**

## Two smaller changes that follow from the move

The Autonomy section's second widening paragraph restated the dispatch description the new pointer now carries. Rather than leave a third copy to drift, it is reduced to the part only it says — the deterministic gate is not weakened.

`prompts/loops/loop-lane-prompts.md` cited `(babysit-loop, Escalation)` for the frontier-alias rule this change moves. Both renders now cite the spoke that owns it. (That file carries the 3b block twice; block-body edits must land in both.)

## The honest residual

**This does not fix the underlying problem, and I want to be clear about that rather than imply otherwise.**

At 459 the file still sits well above the 200-line soft target, so `check-skill.sh` still warns. Closing that gap means either repeated extractions — each trading body cohesion for headroom, with diminishing candidates that are not convention-constrained or safety-critical — or accepting that a lane skill is legitimately a large document and the soft target is wrong for this class. That is a judgment call, it applies to more than this file, and it should be made once rather than re-litigated per PR. I did not force it here because forcing it is exactly what the issue warned against.

I also did **not** take option 3 (raise the cap). The cap did real work here: it surfaced a section that genuinely belonged in a spoke. Raising it would have deferred the same wall with nothing learned.

## Related

Not closed by this PR:

- #1626 — **`babysit-prs/SKILL.md` is also at exactly 499/500**, found while verifying this change. Same wall, same failure mode, separate survey needed. Two files independently landing on 499 is the signal: that is not where a document naturally ends, it is where authors stop when the gate is a wall. The soft-target judgment call above is filed there too, since it spans both.
- #1594, #1613 — earlier work on the 3b block in `loop-lane-prompts.md`, the file this PR touches for the citation fix.

## Verification

Run locally, not assumed:

- `scripts/check-changed-skills.sh origin/main` → `CHECK-SKILL babysit-loop: PASS — 0 errors, 1 warning(s)`, `SKILL.md 459/500 lines`.
- All four lane skills pass `check-skill.sh`: babysit-loop 459, babysit-prs 499, work-loop 330, attend-queue 192.
- No orphan-spoke warning — check 15 requires `SKILL.md` to reference `reference/`, and it does.
- `markdownlint-cli2` clean on all three touched files.
- Content preservation checked by word-stream diff of the extracted region against the spoke: the only differences are the heading restructure and two `SKILL.md` qualifiers added to cross-references that now point back at the hub.

🤖 Agent-authored (autonomous babysit lane). Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016E9qM8CanWf8KkFGcmg4jo
