### PR TITLE
chore: raise loop-lane merge rung to c3-autonomous

### DIFF
--- a/.claude/source-control.md
+++ b/.claude/source-control.md
@@ -25,7 +25,7 @@ worker
 
 ## babysit_loop_merge
 
-c2-mechanical
+c3-autonomous
 
 ## babysit_loop_grace_window_minutes
 


### PR DESCRIPTION
## Summary
Raises `babysit_loop_merge` from `c2-mechanical` to `c3-autonomous` in the team-tracked loop-lane config. Per the loop-lane convention, merge-rung raises are seam-only reviewed changes; merging this PR is the ratification. The C4-structural / C5-untrusted-provenance human-merge floor is unconditional and unaffected.

## Test plan
Config-only change. Verified `c3-autonomous` is a valid rung name per the plugin's config-resolution reference (`human-only` < `c2-mechanical` < `c3-autonomous` < `full-autonomy`) and that only the one value line changed.

## Related
Loop-lane convention: https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/loop-lane/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eb4vPNzgNh7Br4qoiN4Yj
