### PR TITLE
ci: commit security-review path scope to .github/claude-security-paths

### DIFF
--- a/.github/claude-security-paths
+++ b/.github/claude-security-paths
@@ -1,0 +1,31 @@
+# Repo-owned security-review scope: this repo's security-sensitive surfaces,
+# read by the ci-workflows claude-security-review reusable workflow via its
+# `paths-file` input from the PR's BASE branch. An absent file FAILS OPEN
+# (every PR reviewed). Format: GitHub Actions `paths:` patterns, one per line;
+# `#` comments and blank lines are ignored.
+.github/**
+.claude/**
+scripts/**
+plugins/*/hooks/**
+plugins/*/bin/**
+plugins/*/tools/**
+plugins/*/skills/**
+plugins/*/agents/**
+plugins/*/commands/**
+.claude-plugin/**
+REVIEW.md
+CLAUDE.md
+AGENTS.md
+plugins/*/src/**
+plugins/*/dist/**
+**/*.sh
+**/*.ps1
+**/*.mjs
+**/*.ts
+**/*.js
+**/*.cjs
+**/.mcp.json
+**/mcp.json
+**/package.json
+**/package-lock.json
+plugins/*/.claude-plugin/plugin.json


### PR DESCRIPTION
No linked issue

## Summary

Commits the repo's security-review path scope as `.github/claude-security-paths` — the caller's 26-entry inline `paths` list from `.github/workflows/claude-security-review.yml`, migrated verbatim (same patterns, same order) with a header comment stating the file's contract.

Sequencing safety, per the ci-workflows reusable's input descriptions (`melodic-software/ci-workflows` `.github/workflows/claude-security-review.yml@main`):

- **Inert now.** The live caller passes the list inline via `paths`, and a non-empty `paths` input wins over `paths-file`, so this file has no effect until the caller changes.
- **Load-bearing later.** The upcoming fleet-synced caller replaces the hand-written workflow with a component that passes only `paths-file: .github/claude-security-paths`, read from the PR's BASE branch. An absent file FAILS OPEN — every PR reviewed — so this file must land before that sync to keep the tuned scope.

The caller workflow itself is deliberately untouched; the sync replaces it.

## Test plan

- [x] Scripted verbatim proof: parsed the caller's `paths` input with PyYAML, normalized both lists (comments/blanks stripped), compared — 26 inline entries vs 26 file entries, byte-identical, same order
- [x] File hygiene per `.editorconfig`/`.gitattributes`: LF only, single final newline, no trailing whitespace, UTF-8 without BOM
- [x] No workflow or other file changed (single-file diff)

## Related

- `melodic-software/ci-workflows` reusable `claude-security-review.yml` — owns the `paths` / `paths-file` precedence contract and names `.github/claude-security-paths` as the conventional location
- Upcoming standards fleet sync that replaces this repo's hand-written security caller with the `paths-file` component

🤖 Generated with [Claude Code](https://claude.com/claude-code)
