### PR TITLE
chore: effort judgment recalibration (choosing-a-model routing vet)

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -516,8 +516,8 @@ A dispatch prompt at any rung:
 ### Named-agent bar
 
 A named agent is earned, not default: **the same worker with the same instructions dispatches from
-multiple sites (or repeats via description-triggered direct invocation) AND a model pin or an
-enforced tool restriction is load-bearing.** Otherwise the generic subagent with inline instructions
+multiple sites (or repeats via description-triggered direct invocation) AND a model pin, an effort
+pin, or an enforced tool restriction is load-bearing.** Otherwise the generic subagent with inline instructions
 is the simpler, equally independent form. On tool cages: an allowlist that includes Bash bars
 Edit/Write and recursive spawning but is **not read-only** — Bash can write; state what the cage
 actually enforces, never "read-only" ([plugin agents support `tools` frontmatter](https://code.claude.com/docs/en/plugins-reference),
@@ -565,14 +565,21 @@ model-config effort table changes — the effort scale is calibrated per model, 
 name is not the same underlying value across models):
 
 - **Consequential-output lanes with a frontmatter surface pin `high`** — verdicts, and research
-  that feeds decisions, wherever the lane is a named agent or a skill. The pin exists so the lane
-  does not silently degrade inside a session tuned down for cost. The pin is not relative: on a
-  model whose own default sits above `high`, it caps the lane below that model's default — the
-  recheck trigger above exists exactly for this. The reach is the mechanism's, not the rule's:
-  a generic Agent-tool dispatch carries no effort control (the tool accepts a `model` parameter,
-  no `effort`), so it structurally inherits the session level and its floor is the session
-  baseline; promoting such a lane to a named agent is how it gains the pin — an effort pin being
-  load-bearing counts toward the named-agent bar the same way a model pin does.
+  that feeds decisions, wherever the lane is a named agent or a skill doing that work in its own
+  context. The pin exists so the lane does not silently degrade inside a session tuned down for
+  cost (the environment variable still wins, per above). The pin is not relative: on a model
+  whose own default sits above `high`, it caps the lane below that model's default — the recheck
+  trigger above exists exactly for this. The reach is the mechanism's, not the rule's: a generic
+  Agent-tool dispatch carries no effort control — the tool takes a per-invocation `model`
+  parameter with no effort counterpart
+  ([sub-agents](https://code.claude.com/docs/en/sub-agents), doc-silence corroborated by the live
+  tool schema, 2026-07-29) — so it structurally inherits the session level and its floor is the
+  session baseline; promoting such a lane to a named agent is how it gains the pin (a
+  load-bearing effort pin satisfies the named-agent bar's pin clause). An orchestrator skill
+  whose consequential work executes in generic dispatches is likewise out of reach: a skill-level
+  pin governs the orchestrating conversation, and whether it propagates to subagents spawned
+  while the skill is active is undocumented — treat propagation as unknown alongside the cache
+  caveat below.
 - **Bulk mechanical sweeps may pin `low`** — upstream pitches `low` for simpler tasks needing the
   best speed and lowest cost, "such as subagents", and lower effort spends fewer tool calls
   ([effort](https://platform.claude.com/docs/en/build-with-claude/effort)).

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -554,7 +554,7 @@ the session default model changes):
 Effort routes per lane the way model does. Skill and subagent frontmatter `effort` overrides the
 session level while that lane is active — but never the `CLAUDE_CODE_EFFORT_LEVEL` environment
 variable — and accepts all five level names including `max`; a level the active model does not
-support falls back silently to the highest supported level at or below it
+support falls back to the highest supported level at or below it
 ([skills: frontmatter reference](https://code.claude.com/docs/en/skills#frontmatter-reference),
 [model config: adjust effort level](https://code.claude.com/docs/en/model-config#adjust-effort-level),
 verified 2026-07-29). The ladder itself — level names, per-model availability, per-model defaults —
@@ -565,21 +565,26 @@ model-config effort table changes — the effort scale is calibrated per model, 
 name is not the same underlying value across models):
 
 - **Consequential-output lanes pin `high`** — verdicts, and research that feeds decisions. The
-  pin mirrors the model-tier rule: a consequential output never runs below the cross-model default
-  level, and the pin exists so it does not silently degrade inside a session tuned down for cost.
-- **Bulk mechanical sweeps may pin `low`** — upstream reserves `low` for short, scoped tasks that
-  are not intelligence-sensitive, and lower effort spends fewer tool calls
+  pin exists so the lane does not silently degrade inside a session tuned down for cost. The pin
+  is not relative: on a model whose own default sits above `high`, it caps the lane below that
+  model's default — the recheck trigger above exists exactly for this.
+- **Bulk mechanical sweeps may pin `low`** — upstream pitches `low` for simpler tasks needing the
+  best speed and lowest cost, "such as subagents", and lower effort spends fewer tool calls
   ([effort](https://platform.claude.com/docs/en/build-with-claude/effort)).
 - **Every other lane omits the pin** and inherits the session level: effort is a general
   preference, not a task-by-task decision
   ([choosing a model and effort level](https://claude.com/blog/claude-model-and-effort-level-in-claude-code)).
-- **No lane pins above `high` without eval evidence** — upstream warns the top level shows
-  diminishing returns and is prone to overthinking; test before adopting broadly.
-- **Shallow output from a pinned-`low` lane raises the lane's effort — never prompt around it.**
-- **Cache caveat**: changing effort mid-conversation invalidates cached prompt prefixes; whether a
-  frontmatter override firing mid-session also invalidates the main conversation's cache is
-  undocumented — treat pinned lanes as cache-risk-unknown in cost-sensitive loops, and recheck
-  when upstream documents it.
+- **No lane pins `max` without eval evidence** — upstream warns it adds significant cost for
+  relatively small quality gains and can lead to overthinking. A pin above `high` (e.g. `xhigh`)
+  is a deliberate per-lane choice grounded in the target model's own recommended-levels guidance,
+  never a reflex.
+- **Shallow output from a pinned-`low` lane raises the lane's effort** rather than prompting
+  around it; only a lane that must stay `low` for latency gets upstream's targeted steering
+  guidance instead.
+- **Cache caveat**: changing effort between requests invalidates cached prompt prefixes, so a
+  skill pin firing mid-session is expected to cost the main conversation's cache (harness-side
+  request assembly unconfirmed), while a subagent pin is scoped to the subagent's own requests —
+  treat skill-lane pins as cache-costly in cost-sensitive loops.
 
 Session-level effort is the consumer's own knob, out of plugin scope: `low` through `xhigh`
 persist via the `effortLevel` setting, while `max` and `ultracode` are session-only — `max` is

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -549,6 +549,43 @@ the session default model changes):
 | Mechanical prep, one tier down | Sonnet 5 |
 | Bulk mechanical sweeps | Haiku 4.5 |
 
+### Effort tiers
+
+Effort routes per lane the way model does. Skill and subagent frontmatter `effort` overrides the
+session level while that lane is active — but never the `CLAUDE_CODE_EFFORT_LEVEL` environment
+variable — and accepts all five level names including `max`; a level the active model does not
+support falls back silently to the highest supported level at or below it
+([skills: frontmatter reference](https://code.claude.com/docs/en/skills#frontmatter-reference),
+[model config: adjust effort level](https://code.claude.com/docs/en/model-config#adjust-effort-level),
+verified 2026-07-29). The ladder itself — level names, per-model availability, per-model defaults —
+is upstream-owned: resolve it from the model-config page at decision time, never from this document.
+
+Lane rules, dated 2026-07-29 (recheck trigger: a model change on any pinned lane, or the
+model-config effort table changes — the effort scale is calibrated per model, so the same level
+name is not the same underlying value across models):
+
+- **Consequential-output lanes pin `high`** — verdicts, and research that feeds decisions. The
+  pin mirrors the model-tier rule: a consequential output never runs below the cross-model default
+  level, and the pin exists so it does not silently degrade inside a session tuned down for cost.
+- **Bulk mechanical sweeps may pin `low`** — upstream reserves `low` for short, scoped tasks that
+  are not intelligence-sensitive, and lower effort spends fewer tool calls
+  ([effort](https://platform.claude.com/docs/en/build-with-claude/effort)).
+- **Every other lane omits the pin** and inherits the session level: effort is a general
+  preference, not a task-by-task decision
+  ([choosing a model and effort level](https://claude.com/blog/claude-model-and-effort-level-in-claude-code)).
+- **No lane pins above `high` without eval evidence** — upstream warns the top level shows
+  diminishing returns and is prone to overthinking; test before adopting broadly.
+- **Shallow output from a pinned-`low` lane raises the lane's effort — never prompt around it.**
+- **Cache caveat**: changing effort mid-conversation invalidates cached prompt prefixes; whether a
+  frontmatter override firing mid-session also invalidates the main conversation's cache is
+  undocumented — treat pinned lanes as cache-risk-unknown in cost-sensitive loops, and recheck
+  when upstream documents it.
+
+Session-level effort is the consumer's own knob, out of plugin scope: `low` through `xhigh`
+persist via the `effortLevel` setting, while `max` and `ultracode` are session-only — `max` is
+durable only through the `CLAUDE_CODE_EFFORT_LEVEL` environment variable. Plugins never set
+session effort.
+
 ### Declared patterns
 
 Conformance is declared in the skill text itself, in one of two greppable forms: **delegation

--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -564,10 +564,15 @@ Lane rules, dated 2026-07-29 (recheck trigger: a model change on any pinned lane
 model-config effort table changes — the effort scale is calibrated per model, so the same level
 name is not the same underlying value across models):
 
-- **Consequential-output lanes pin `high`** — verdicts, and research that feeds decisions. The
-  pin exists so the lane does not silently degrade inside a session tuned down for cost. The pin
-  is not relative: on a model whose own default sits above `high`, it caps the lane below that
-  model's default — the recheck trigger above exists exactly for this.
+- **Consequential-output lanes with a frontmatter surface pin `high`** — verdicts, and research
+  that feeds decisions, wherever the lane is a named agent or a skill. The pin exists so the lane
+  does not silently degrade inside a session tuned down for cost. The pin is not relative: on a
+  model whose own default sits above `high`, it caps the lane below that model's default — the
+  recheck trigger above exists exactly for this. The reach is the mechanism's, not the rule's:
+  a generic Agent-tool dispatch carries no effort control (the tool accepts a `model` parameter,
+  no `effort`), so it structurally inherits the session level and its floor is the session
+  baseline; promoting such a lane to a named agent is how it gains the pin — an effort pin being
+  load-bearing counts toward the named-agent bar the same way a model pin does.
 - **Bulk mechanical sweeps may pin `low`** — upstream pitches `low` for simpler tasks needing the
   best speed and lowest cost, "such as subagents", and lower effort spends fewer tool calls
   ([effort](https://platform.claude.com/docs/en/build-with-claude/effort)).

--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.1]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: applicability-tag boundary + doc-queue dispositions.**
+  The Claude-Code-applicability filter gains the `cc-applicable`/`mixed` boundary rule (a claim
+  naming an API surface tags `mixed` even when its guidance transfers; `cc-applicable` is
+  reserved for claims naming no API surface). Doc queue: the choosing-a-model entry records its
+  routing vet as executed (melodic-software/claude-code-plugins#1697, digest slice still
+  pending); the two thinking docs are queued as two runs; the task-budgets doc is recorded as
+  deferred-with-trigger (api-only until harness support lands).
+
 ## [0.10.0]
 
 ### Added

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -33,6 +33,9 @@ the tag asserts:
   one page. Record the basis (the harness doc section(s) checked, or `unverified-inference` when
   none was); a contested or load-bearing `api-only` tag escalates to the interview rather than
   standing on an absence citation.
+- **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
+  SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
+  reserved for claims naming no API surface.
 
 ## Digest-agent model matching
 
@@ -67,6 +70,19 @@ Model selection (special handling — vet/validate/correct the consuming setup's
 model-routing configuration against the doc, rather than only digesting):
 
 - <https://platform.claude.com/docs/en/about-claude/models/choosing-a-model>
+  — routing vet executed 2026-07-29 (melodic-software/claude-code-plugins#1697); digest slice
+  still pending
+
+Thinking (two overlapping docs — two runs, one page per run by contract):
+
+- <https://platform.claude.com/docs/en/build-with-claude/thinking>
+- <https://platform.claude.com/docs/en/build-with-claude/thinking-steering-and-cost>
+
+Deferred with trigger (not queued):
+
+- <https://platform.claude.com/docs/en/build-with-claude/task-budgets> — api-only (the page
+  states task budgets are not supported on Claude Code or Cowork; verified 2026-07-27); enqueue
+  when harness support lands
 
 Supplementary references:
 

--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-07-29
+
+### Changed
+
+- **`auditor` agent pins `effort: high`.** The auditor is a consequential-verdict lane; the pin
+  keeps its audits from silently degrading when the dispatching session runs at a lowered effort
+  level, per the marketplace effort-tier rules (PLUGIN-PHILOSOPHY.md, "Effort tiers").
+
 ## [0.2.1] - 2026-07-26
 
 ### Fixed

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -2,6 +2,7 @@
 name: auditor
 description: "Fresh-context deep-audit specialist for the plugin-quality audit workflow (steps 2–3): maps what an installed Claude Code plugin component actually does versus what it claims, verifies every load-bearing harness-behavior claim against current official docs, and returns grounded findings, blindspots, and candidate remediations. Dispatched by /plugin-quality:audit with an evidence-packet path; not intended for direct ad-hoc use."
 tools: "Read, Grep, Glob, WebFetch, Bash, Write"
+effort: high
 ---
 You are the plugin-quality auditor: a fresh-context specialist that a main audit session
 dispatches for the map+ground and findings phases of a plugin-component audit. You start with no


### PR DESCRIPTION
## Summary

Executes issue #1697: the effort judgment recalibration, run as the choosing-a-model routing vet, using the dual-verified effort-doc slice as the evidence base and grounded exclusively in docs fetched live 2026-07-29 (model-config, skills + sub-agents frontmatter references, choosing-a-model, effort, task-budgets, and the model+effort blog post). The live effort doc is byte-identical (MD5 `9bc6261fd851cfcd0c2122cc7719219a`) to the slice's verified snapshot, so the evidence base is current.

**What changed:**

- **`docs/PLUGIN-PHILOSOPHY.md` — new "Effort tiers" subsection** under Delegation mechanics, sibling to "Model tiers". This is the recalibration's durable output: per-lane effort rules (consequential-output lanes pin `high`; bulk mechanical sweeps may pin `low`; every other lane inherits the session level; no `max` pin without eval evidence and no above-`high` pin as a reflex; raise a pinned-`low` lane's effort rather than prompting around shallow output, with upstream's must-stay-low steering carve-out; cache caveat for mid-session frontmatter overrides), a dated recheck trigger (model change on a pinned lane, or the effort table changes — the effort scale is calibrated per model), and the lane distinction the issue requires in every recalibration output: **pinnable** (`low`–`xhigh` via the `effortLevel` setting) vs **session-only** (`max` and `ultracode`; `max` durable only through `CLAUDE_CODE_EFFORT_LEVEL`).
- **`knowledge` plugin 0.10.0 → 0.10.1** (`docpage-digest` Anthropic profile): the `cc-applicable`/`mixed` tag-boundary rule (handoff Q8); doc queue updated per handoff Q10 — choosing-a-model entry annotated with this vet (digest slice still pending), the two thinking docs queued as two runs, task-budgets recorded deferred-with-trigger (page states it is unsupported on Claude Code/Cowork). CHANGELOG entry included.

**Vet verdicts producing no diff:**

- All eight existing agent effort pins (review ×6, discovery ×2 — every one `effort: high` on a consequential-output lane) conform to the new lane rules and stay unchanged. No repo lane currently qualifies for a `low` pin.
- The consuming setup's model-routing lanes (haiku mechanical fan-out / sonnet wide reads / fable long autonomous runs; "raise effort before reaching for a larger model"; wrong-despite-context = model, wrong-by-skipping = effort) all conform to the choosing-a-model matrix and the model+effort blog — no correction needed.
- The fleet pin (`effortLevel: high`, read read-only from the dotfiles seam) matches upstream default-first guidance on the pinned model. **No fleet pin change is proposed.**

**USER-RESERVED, left untouched:** the dotfiles `.chezmoidata/claude.json` fleet-pin seam; the user CLAUDE.md "Model routing" amendment for the `max`/`CLAUDE_CODE_EFFORT_LEVEL` durability exception (handoff Q3) is routed separately through the dotfiles flow and is not part of this PR.

**Independent verification:** a fresh-context verifier subagent (reasoning withheld) audited the diff against issue #1697 and the live docs: **PASS-with-findings** — 2 IMPORTANT (the above-`high` rule over-claimed upstream support that covers only `max`; the pin-`high` rationale stated an invariant the mechanism doesn't guarantee on above-`high`-default models) and 4 suggestions (unverified "silently", cache-caveat framing, dropped steering carve-out, over-generalized model-scoped `low` guidance). All six reconciled in the second commit.

## Test plan

- `npx markdownlint-cli2` clean on all touched markdown.
- `bash scripts/check-changelog-parity.sh --check` and `--check-bump origin/main` pass (0.10.1 entry present).
- `CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills ./plugins/skill-quality/scripts/check-skill.sh docpage-digest` → PASS (0 errors; 1 pre-existing line-count warning on the untouched SKILL.md).
- Every factual claim in the added prose verified against a doc fetched this session; the fresh-context verifier independently re-fetched and confirmed (findings reconciled as above).

## Related

Closes #1697. Evidence base: the `.work/effort/` slice (local, untracked) produced by the opus-5-prompting workstream (PR #1699); interview-handoff dispositions Q2, Q6, Q8, Q9, Q10 and candidates A2, A3, A4, A6 are adopted here — A1 (per-model rows) stays pointer-only per pointer-not-copy, A5 and A7 stay deferred per the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JifsqDc7vY8NfwBB1fi8sE
