### PR TITLE
feat(claude-ops): gate telemetry-upsert bodies before the write, confirm after

### DIFF
--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -225,7 +225,9 @@ identified by a machine sentinel marker and **edited in place** every cycle — 
 `claude-ops`'s `telemetry-upsert.sh` is the interim home of this contract and a compatible reader
 (`morning-brief` reads the same surface); an installed plugin cannot invoke a sibling plugin's
 script, so each lane **inlines** the small `gh api` upsert and the coupling to `claude-ops` stays
-one-directional.
+one-directional. An inlined upsert carries none of the wrapper's body checks, so it is bound by the
+`@path`-as-body rule in [`claude-ops` lanes](../../../plugins/claude-ops/skills/lanes/SKILL.md),
+section "Never pass a body as an `@path` string".
 
 **Durable loop state.** Conversation context is lossy across compaction, so a lane persists its
 adaptive-cap streak counter, its rate-limit-warning latch, and its cycle count in a machine-readable

--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.21.6",
+  "version": "0.22.0",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort and a repo-pull + marketplace-refresh launch step), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.22.0]
+
+### Added
+
+- **`lanes`: `telemetry-upsert.sh` refuses a degraded telemetry body before it writes it, then
+  confirms what landed (#952).** The gate is pre-write: the caller's body is rejected with exit `3`,
+  having made no API call at all, if it begins with a literal `@` or falls under a 16-byte floor.
+  This guards the #943 defect class — a caller that composed an `@path` string as its body content,
+  meaning the file, posts the literal path text, and because the comment's timestamp still moves the
+  telemetry surface looks fresh while carrying no data, an observability fail-open no freshness check
+  can see. Catching it before the `POST`/`PATCH` means nothing degraded is ever published to a public
+  tracking issue, and there is no window in which a reader finds one. The wrapper's own plumbing
+  cannot commit the mistake (it reads the body into a shell variable before any `gh` call), so the
+  gate exists for the body TEXT a lane hands it. After the write the comment is re-read through a
+  separate `GET` and the same assertions re-run against what a reader will actually find, plus the
+  marker sentinel. That pass is scoped honestly: because the sent body was already cleared and the
+  `GET` targets the id just written, it sees only what happened to that comment afterwards — a
+  mangled store, a concurrent writer stripping the sentinel, a deletion — and a failure exits `6`
+  naming the comment's URL. It cannot detect that detection resolved the wrong comment, and editing
+  another user's comment is not its job either (that `PATCH` 403s and exits `5`). The create/update
+  response echo is deliberately not trusted in place of the re-read: it proves the request was
+  accepted, not what landed. An unreachable `GET` is retried once and then reports the cycle
+  UNCONFIRMED rather than known-bad — a check that could not run is not a check that disagreed —
+  and now carries `gh`'s own error text, because a `404` (the comment is gone) and a `403`/`429`
+  (secondary rate limit) call for opposite responses. There is no `--no-verify` opt-out; this script
+  is driven by lane prompts, so an escape hatch would be reachable by the same caller the gate
+  exists to catch.
+- **`lanes` doctrine: the `@path`-as-body anti-pattern is stated once, in the skill.** Telemetry and
+  comment bodies are passed as file contents or piped, never as an `@path` string interpolated into
+  a body value: `gh issue comment --body @path` and `gh api -f body=@path` send the literal text.
+  Reading from a file takes `gh issue comment --body-file`, or `gh api -F`/`--field key=@path` —
+  `gh api` has no `--body-file` flag at all. The rule covers the `gh api` upsert a lane inlines as
+  well as the wrapper, because an installed plugin cannot invoke a sibling plugin's script and an
+  inlined upsert carries none of the wrapper's body checks.
+
+### Changed
+
+- **`telemetry-upsert.sh` now rejects bodies it previously accepted (#952).** A body beginning with
+  a literal `@`, or shorter than 16 bytes, exits `3` instead of being posted. Both shapes are the
+  #943 fail-open rather than legitimate telemetry, so the rejection is the point — but a caller
+  passing either today changes from a silent success to a hard failure. No in-repo caller is
+  affected: nothing invokes the wrapper yet, by design (routing the operator loop-prompt through it
+  is #943, out-of-repo).
+
+### Fixed
+
+- **`telemetry-upsert.sh` no longer exits `1` after a successful upsert whose API response carried
+  no `html_url`.** The trailing `[[ -n "$html_url" ]] && printf …` was the script's last command, so
+  its false branch became the exit status.
+
 ## [0.21.6]
 
 ### Fixed

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -25,11 +25,13 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   another user's comment is not its job either (that `PATCH` 403s and exits `5`). The create/update
   response echo is deliberately not trusted in place of the re-read: it proves the request was
   accepted, not what landed. An unreachable `GET` is retried once and then reports the cycle
-  UNCONFIRMED rather than known-bad — a check that could not run is not a check that disagreed —
-  and now carries `gh`'s own error text, because a `404` (the comment is gone) and a `403`/`429`
-  (secondary rate limit) call for opposite responses. There is no `--no-verify` opt-out; this script
-  is driven by lane prompts, so an escape hatch would be reachable by the same caller the gate
-  exists to catch.
+  UNCONFIRMED rather than known-bad — a check that could not run is not a check that disagreed. It
+  carries `gh`'s own error text and branches its verdict on it: a `404` says the comment is GONE,
+  while anything else (a `403`/`429` secondary rate limit) keeps the "probably intact, unconfirmed"
+  reading. The retry is a network-blip guard only — it does not honor `Retry-After`, so a secondary
+  rate limit outlasts both attempts by design. There is no `--no-verify` opt-out; this script is
+  driven by lane prompts, so an escape hatch would be reachable by the same caller the gate exists
+  to catch.
 - **`lanes` doctrine: the `@path`-as-body anti-pattern is stated once, in the skill.** Telemetry and
   comment bodies are passed as file contents or piped, never as an `@path` string interpolated into
   a body value: `gh issue comment --body @path` and `gh api -f body=@path` send the literal text.
@@ -43,9 +45,10 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
 - **`telemetry-upsert.sh` now rejects bodies it previously accepted (#952).** A body beginning with
   a literal `@`, or shorter than 16 bytes, exits `3` instead of being posted. Both shapes are the
   #943 fail-open rather than legitimate telemetry, so the rejection is the point — but a caller
-  passing either today changes from a silent success to a hard failure. No in-repo caller is
-  affected: nothing invokes the wrapper yet, by design (routing the operator loop-prompt through it
-  is #943, out-of-repo).
+  passing either today changes from a silent success to a hard failure. The `@` rule is positional,
+  so a body whose FIRST line is a GitHub @mention is rejected too: lead with a telemetry key and put
+  mentions on a later line. No in-repo caller is affected: nothing invokes the wrapper yet, by
+  design (routing the operator loop-prompt through it is #943, out-of-repo).
 
 ### Fixed
 

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -26,12 +26,17 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   response echo is deliberately not trusted in place of the re-read: it proves the request was
   accepted, not what landed. An unreachable `GET` is retried once and then reports the cycle
   UNCONFIRMED rather than known-bad — a check that could not run is not a check that disagreed. It
-  carries `gh`'s own error text and branches its verdict on it: a `404` says the comment is GONE,
-  while anything else (a `403`/`429` secondary rate limit) keeps the "probably intact, unconfirmed"
-  reading. The retry is a network-blip guard only — it does not honor `Retry-After`, so a secondary
-  rate limit outlasts both attempts by design. There is no `--no-verify` opt-out; this script is
-  driven by lane prompts, so an escape hatch would be reachable by the same caller the gate exists
-  to catch.
+  carries `gh`'s own error text (bounded) and branches its verdict on it: a `404` says the comment
+  is NOT RETRIEVABLE — deleted, its issue deleted, or the token's read access lost — which rules out
+  the "probably intact" reading that anything else (a `403`/`429` secondary rate limit) keeps. The
+  retry is a network-blip guard only — it does not honor `Retry-After`, so a secondary rate limit
+  outlasts both attempts by design. Capturing that error text is a diagnostic and never the thing
+  that fails a good write: an unwritable `TMPDIR` degrades to no capture rather than turning exit
+  `0` into exit `6`. One limitation is stated rather than papered over — the read-back asserts
+  properties, not that the body changed, so a PATCH that silently no-ops still verifies and a stale
+  comment reads as a good cycle; freshness belongs to the reader (`morning-brief`), not here. There
+  is no `--no-verify` opt-out; this script is driven by lane prompts, so an escape hatch would be
+  reachable by the same caller the gate exists to catch.
 - **`lanes` doctrine: the `@path`-as-body anti-pattern is stated once, in the skill.** Telemetry and
   comment bodies are passed as file contents or piped, never as an `@path` string interpolated into
   a body value: `gh issue comment --body @path` and `gh api -f body=@path` send the literal text.

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -237,7 +237,9 @@ each — the summary below is a pointer, not a copy.
   `3` having called no API at all; after the write it re-reads the comment and
   exits `6` if what landed lost the sentinel or fails those same assertions — or
   if the read-back could not be performed at all, which reports the cycle
-  UNCONFIRMED rather than bad (#952).
+  UNCONFIRMED rather than bad (#952). The `@` rule is positional, so a body whose
+  FIRST line is a GitHub @mention is rejected too: lead with a telemetry key
+  (`lane:`) and put mentions on a later line.
 
 ### Never pass a body as an `@path` string
 

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -232,7 +232,30 @@ each — the summary below is a pointer, not a copy.
   piped from `machine-behavior.sh`); a real `--body-file PATH` must resolve under
   `--body-dir` (default `$CLAUDE_PLUGIN_DATA`), may not be a symlink, and is capped
   at 64 KiB — a prompt-driven script must not be coaxed into posting an arbitrary
-  file (a secret, a token store) as a public comment.
+  file (a secret, a token store) as a public comment. Before the write it rejects
+  a body that begins with a literal `@` or falls under a 16-byte floor, exiting
+  `3` having called no API at all; after the write it re-reads the comment and
+  exits `6` if what landed lost the sentinel or fails those same assertions — or
+  if the read-back could not be performed at all, which reports the cycle
+  UNCONFIRMED rather than bad (#952).
+
+### Never pass a body as an `@path` string
+
+**Applies to every telemetry or comment write a lane makes** — through
+`telemetry-upsert.sh` or through the `gh api` upsert a lane inlines, since an
+installed plugin cannot invoke a sibling plugin's script.
+
+Pass the body as file contents (`--body-file PATH`) or pipe it (`--body-file -`).
+**Never interpolate an `@path` string into a body value**: `gh issue comment --body
+@path` and `gh api -f body=@path` send the literal text `@path`. Reading from a file
+takes `gh issue comment --body-file`, or `gh api -F`/`--field key=@path` — per each
+command's own `--help` (gh 2.95.0); `gh api` has no `--body-file` flag at all.
+
+The failure is invisible from the outside (#943): the comment's timestamp still
+moves, so the telemetry surface looks **fresh** while carrying no data, and a
+freshness check passes over a blind lane. `telemetry-upsert.sh` refuses such a
+body before it writes anything; an inlined upsert has no such gate, so this rule
+is the only thing standing between it and a silent observability fail-open.
 
 ## Cross-references
 

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -235,11 +235,13 @@ each — the summary below is a pointer, not a copy.
   file (a secret, a token store) as a public comment. Before the write it rejects
   a body that begins with a literal `@` or falls under a 16-byte floor, exiting
   `3` having called no API at all; after the write it re-reads the comment and
-  exits `6` if what landed lost the sentinel or fails those same assertions — or
-  if the read-back could not be performed at all, which reports the cycle
-  UNCONFIRMED rather than bad (#952). The `@` rule is positional, so a body whose
-  FIRST line is a GitHub @mention is rejected too: lead with a telemetry key
-  (`lane:`) and put mentions on a later line.
+  exits `6` if what landed lost the sentinel or fails those same assertions. A
+  read-back that could not be performed also exits `6`, reporting the cycle
+  UNCONFIRMED — except a `404`, which reports the comment NOT RETRIEVABLE
+  (deleted, its issue deleted, or read access lost) and rules the UNCONFIRMED
+  reading out (#952). The `@` rule is positional, so a body whose FIRST line is a
+  GitHub @mention is rejected too: lead with a telemetry key (`lane:`) and put
+  mentions on a later line.
 
 ### Never pass a body as an `@path` string
 

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
@@ -97,7 +97,17 @@
 #   second failure is still fail-closed — the cycle is reported UNCONFIRMED
 #   rather than good — but its message says so, because a check that could not
 #   run is not a check that disagreed, and it branches on gh's own error: a 404
-#   means the comment is gone, not merely unread.
+#   means the comment is not retrievable, not merely unread.
+#
+#   KNOWN LIMITATION — this pass asserts PROPERTIES, not that the body changed.
+#   A PATCH that silently no-ops (storing the previous cycle's body) still
+#   verifies: the old body carries the sentinel, has no leading `@`, and clears
+#   the floor. So a STALE telemetry comment reads as a good cycle here. That is a
+#   freshness defect, a different class from the `@path` fail-open this guards,
+#   and it is deliberately not addressed by asserting round-trip equality —
+#   GitHub normalizes stored bodies, so an equality assert would fail real lane
+#   writes for cosmetic reasons. Freshness is the reader's job (`morning-brief`
+#   reads last-cycle age off this same comment), not this script's.
 #
 # Output (stdout): one action line, e.g.
 #   telemetry-upsert: updated comment 12345 (marker=lane:triage) on <owner/repo>#<issue>
@@ -426,26 +436,36 @@ unconfirmed="the body cleared the pre-write gate, so the comment is probably int
 # reading, while a 403/429 means it is almost certainly still there and simply
 # unread. The two call for opposite responses, so neither the raw message nor
 # the conclusion drawn from it can be one-size-fits-all.
-verify_err="$(mktemp)" || verify_fail "could not create a temp file to capture the read-back error" "$unconfirmed"
-trap 'rm -f "$verify_err"' EXIT
+# Capturing stderr is a DIAGNOSTIC, so it must never be the thing that fails an
+# otherwise good write: on a full or unwritable TMPDIR the capture is skipped and
+# the read-back proceeds blind rather than turning exit 0 into exit 6.
+verify_err="$(mktemp 2>/dev/null)" || verify_err=""
+[[ -n "$verify_err" ]] && trap 'rm -f "$verify_err"' EXIT INT TERM
 verify_body=""
 verify_read=0
 for verify_attempt in 1 2; do
-  if verify_body="$(gh api "repos/$REPO/issues/comments/$new_id" --jq '.body' 2>"$verify_err" | tr -d '\r')"; then
+  if verify_body="$(gh api "repos/$REPO/issues/comments/$new_id" --jq '.body' 2>"${verify_err:-/dev/null}" | tr -d '\r')"; then
     verify_read=1
     break
   fi
   ((verify_attempt == 1)) && sleep 2
 done
 if ((verify_read == 0)); then
-  verify_err_text="$(tr -d '\r' <"$verify_err" | tr '\n' ' ')"
+  verify_err_text=""
+  [[ -n "$verify_err" ]] && verify_err_text="$(tr -d '\r' <"$verify_err" | tr '\n' ' ')"
+  # Bounded: gh's stderr is remote-influenced text going into an operator-facing
+  # message, and an unbounded splice would let a long error bury the verdict.
+  verify_err_text="${verify_err_text:0:500}"
   case "$verify_err_text" in
   *"HTTP 404"*)
-    verify_verdict="comment $new_id is GONE — the write landed and the comment no longer exists (deleted, or the issue was); the next cycle will create a fresh one"
+    # 404 is also what GitHub returns when a token loses READ access, so this
+    # says "not retrievable", not "deleted" — the one thing it rules out is the
+    # default "probably intact" reading.
+    verify_verdict="comment $new_id is NOT RETRIEVABLE (404) — it was deleted, its issue was, or this token can no longer read it; do not read this as 'probably intact'"
     ;;
   *) verify_verdict="$unconfirmed" ;;
   esac
-  verify_fail "could not re-read comment $new_id after 2 attempts (gh api GET): $verify_err_text" "$verify_verdict"
+  verify_fail "could not re-read comment $new_id after 2 attempts (gh api GET): ${verify_err_text:-no error text captured}" "$verify_verdict"
 fi
 
 case "$verify_body" in

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
@@ -53,16 +53,63 @@
 #                    perform no write.
 #   --help
 #
+# PRE-WRITE BODY VALIDATION (#952, guarding the #943 fail-open) — the real gate:
+#   Before anything is sent, the caller's body is asserted to not begin with a
+#   literal `@` and to clear MIN_BODY_BYTES. A failure exits 3 having made zero
+#   API calls, so the degraded body never reaches the tracking issue — there is
+#   no public comment to retract and no window in which a reader sees it.
+#
+#   The `@` assertion is the specific defect this guards (see the lanes SKILL.md
+#   section "Never pass a body as an `@path` string" for the caller-facing rule):
+#   a body argument given an `@path` string posts the literal path text, and the
+#   comment's timestamp still moves — so the telemetry surface looks FRESH while
+#   carrying no data, an observability fail-open a timestamp check cannot see.
+#   The length floor catches the degenerate sibling: a sentinel-only comment
+#   from an empty body.
+#
+#   This script cannot commit the `@path` mistake through its own plumbing (it
+#   reads the body into a shell variable before any gh call, so `-f body=` never
+#   sees an `@path`). The gate is here for the body TEXT a caller hands it: a
+#   lane that composed `@/tmp/telemetry.txt` as its body content, meaning the
+#   file, arrives at this script as that literal string.
+#
+#   Validation is unconditional and has no opt-out flag: this script is driven by
+#   AI lane prompts, and a `--no-verify` escape hatch would be reachable by the
+#   same prompt-injected caller the check exists to catch.
+#
+# POST-WRITE READ-BACK (secondary confirmation, not the gate):
+#   After the create/update, the comment is re-read via a separate GET and the
+#   same assertions re-run against what a reader of the issue will actually find,
+#   plus the sentinel. A body that fails exits 6 with the comment id/url named.
+#
+#   Scope it honestly. The pre-write gate already proved the body we SENT is
+#   sound, and the GET targets the id we just wrote, so this pass sees only what
+#   happened to THAT comment after the write returned: a truncated or mangled
+#   store, a concurrent writer overwriting or stripping the sentinel, or the
+#   comment being deleted out from under us (404). It cannot tell that detection
+#   resolved the WRONG comment — we would have stamped our sentinel and body onto
+#   it, and reading that id back finds exactly what we expect. (Nor is it the
+#   guard for editing another user's comment: that PATCH 403s and exits 5.)
+#
+#   The GET is retried once: the write has already landed by then, so a transient
+#   read failure must not report a good cycle as a bad one. A second failure is
+#   still fail-closed — the cycle is reported UNCONFIRMED rather than good — but
+#   its message says so, because a check that could not run is not a check that
+#   disagreed.
+#
 # Output (stdout): one action line, e.g.
 #   telemetry-upsert: updated comment 12345 (marker=lane:triage) on <owner/repo>#<issue>
 #   <html_url>
 #
 # Exit codes:
-#   0  upserted (or, with --dry-run, resolved)
-#   3  invalid argument (bad issue/marker/repo, body-file outside the safe dir,
-#      or a body over the size cap)
+#   0  upserted and verified (or, with --dry-run, resolved)
+#   3  invalid argument (bad issue/marker/repo, body-file outside the safe dir),
+#      or a body that failed the pre-write gate (over the size cap, under the
+#      size floor, or starting with a literal `@`) — NOTHING was written
 #   4  prerequisite missing (gh or jq), or the repo / safe body dir unresolved
 #   5  a gh API call (list / create / update) failed
+#   6  the write went through but its read-back did not verify (or could not be
+#      performed) — the comment on the issue is NOT confirmed telemetry
 
 set -uo pipefail
 
@@ -78,6 +125,7 @@ for bin in gh jq; do
 done
 
 MAX_BODY_BYTES=65536 # 64 KiB — a telemetry body, not an essay
+MIN_BODY_BYTES=16    # sanity floor for the body — below this is not telemetry
 
 ISSUE=""
 MARKER=""
@@ -225,10 +273,25 @@ else
   body_text="$(cat "$BODY_FILE")"
 fi
 
-# Size guard (defense in depth), applied to file AND stdin bodies alike.
+# --- Pre-write body gate -----------------------------------------------------
+# All three checks run against the caller's body BEFORE any gh call, so a body
+# that fails costs zero API calls and never lands on the tracking issue. The
+# read-back below re-asserts the same properties on what came back; THIS is what
+# keeps a degraded body from being published in the first place. Applied to file
+# and stdin bodies alike.
 body_bytes="$(printf '%s' "$body_text" | wc -c | tr -d ' ')"
 if ((body_bytes > MAX_BODY_BYTES)); then
   err "body is ${body_bytes} bytes, over the ${MAX_BODY_BYTES}-byte cap — telemetry bodies are small"
+  exit 3
+fi
+if [[ "$body_text" == @* ]]; then
+  err "body starts with a literal '@' — a body argument was given an @path instead of the file's contents (use --body-file PATH, or pipe the body via --body-file -)"
+  err "nothing was written: fix the caller's body, do not re-run blind"
+  exit 3
+fi
+if ((body_bytes < MIN_BODY_BYTES)); then
+  err "body is ${body_bytes} bytes, under the ${MIN_BODY_BYTES}-byte floor — a comment that would look fresh but hold no telemetry"
+  err "nothing was written: fix the caller's body, do not re-run blind"
   exit 3
 fi
 
@@ -320,6 +383,79 @@ fi
 
 new_id="$(jq -r '.id // empty' <<<"$resp")"
 html_url="$(jq -r '.html_url // empty' <<<"$resp")"
+
+# --- Post-write read-back (secondary confirmation) ---------------------------
+# Re-READ the comment rather than trusting the create/update response echo: the
+# echo proves the request was accepted, a GET proves what a reader of the issue
+# will actually find. The body's CONTENT was already cleared by the pre-write
+# gate, so what remains for this pass to catch is what happened to the comment
+# AFTER the write returned — a mangled store, a concurrent overwrite, a deletion.
+# It cannot detect that detection resolved the wrong comment; see the header.
+#
+# $2 overrides the remediation line, because "the check disagreed" and "the check
+# could not run" call for opposite next steps.
+verify_fail() {
+  err "post-write read-back FAILED for $REPO#$ISSUE (marker=$MARKER): $1"
+  [[ -n "$html_url" ]] && err "the written comment is at $html_url"
+  err "${2:-telemetry for this cycle is NOT trustworthy — inspect the comment, do not re-run blind}"
+  exit 6
+}
+unconfirmed="the body cleared the pre-write gate, so the comment is probably intact — but this cycle is UNCONFIRMED, not proven good"
+
+# On the update path the id is already known — fall back to it rather than
+# calling a successful PATCH unverifiable over a missing field in its response.
+[[ -n "$new_id" ]] || new_id="${target_id:-}"
+[[ -n "$new_id" ]] || verify_fail "the ${action} response carried no comment id, so the write cannot be read back" "$unconfirmed"
+
+# Same rule the $REPO validation states above: nothing reaches a gh api URL path
+# unvalidated. A GitHub comment id is an integer from either source, so this can
+# only fire on a malformed response — but the rule does not carry an exception.
+[[ "$new_id" =~ ^[0-9]+$ ]] ||
+  verify_fail "the ${action} response carried a non-numeric comment id ('$new_id'), so the write cannot be read back" "$unconfirmed"
+
+# The write has already landed by this point, so a transient GET failure would
+# otherwise report a good cycle as a bad one. Retry once before concluding the
+# comment is unverifiable; a second failure is still fail-closed. gh's stderr is
+# kept rather than discarded: a 404 (the comment is gone — act now) and a 403/429
+# (secondary rate limit — it will pass next cycle) are the same exit status here
+# and call for opposite responses, so the operator needs the real message.
+verify_err="$(mktemp)" || verify_fail "could not create a temp file to capture the read-back error" "$unconfirmed"
+trap 'rm -f "$verify_err"' EXIT
+verify_body=""
+verify_read=0
+for verify_attempt in 1 2; do
+  if verify_body="$(gh api "repos/$REPO/issues/comments/$new_id" --jq '.body' 2>"$verify_err" | tr -d '\r')"; then
+    verify_read=1
+    break
+  fi
+  ((verify_attempt == 1)) && sleep 2
+done
+((verify_read)) ||
+  verify_fail "could not re-read comment $new_id after 2 attempts (gh api GET): $(tr -d '\r' <"$verify_err" | tr '\n' ' ')" "$unconfirmed"
+
+case "$verify_body" in
+*"$SENTINEL"*) : ;;
+*) verify_fail "comment $new_id does not carry the marker sentinel after the write" ;;
+esac
+
+# Everything below the sentinel is the caller's body — the sentinel is ours and
+# would otherwise mask a leading `@` in the part that carries the data.
+verify_rest="${verify_body#*"$SENTINEL"}"
+verify_rest="${verify_rest#$'\n'}"
+
+# The body that was sent cleared the same two assertions pre-write, so failing
+# them now means the stored comment diverged from it afterwards. Naming that
+# keeps an operator from hunting a caller-side `@path` bug the gate excluded.
+[[ "$verify_rest" == @* ]] &&
+  verify_fail "comment $new_id starts with a literal '@' below the sentinel, but the body sent did not — the stored comment diverged from what was written"
+
+verify_bytes="$(printf '%s' "$verify_rest" | wc -c | tr -d ' ')"
+((verify_bytes >= MIN_BODY_BYTES)) ||
+  verify_fail "comment $new_id carries ${verify_bytes} bytes below the sentinel, under the ${MIN_BODY_BYTES}-byte floor — a comment that looks fresh but holds no telemetry"
+
 printf 'telemetry-upsert: %sd comment %s (marker=%s) on %s#%s\n' \
-  "$action" "${new_id:-?}" "$MARKER" "$REPO" "$ISSUE"
+  "$action" "$new_id" "$MARKER" "$REPO" "$ISSUE"
 [[ -n "$html_url" ]] && printf '%s\n' "$html_url"
+# Explicit: without it a response carrying no html_url leaves the `[[ ]] &&`
+# above as the last command, and a verified upsert would exit 1.
+exit 0

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
@@ -440,7 +440,14 @@ unconfirmed="the body cleared the pre-write gate, so the comment is probably int
 # otherwise good write: on a full or unwritable TMPDIR the capture is skipped and
 # the read-back proceeds blind rather than turning exit 0 into exit 6.
 verify_err="$(mktemp 2>/dev/null)" || verify_err=""
-[[ -n "$verify_err" ]] && trap 'rm -f "$verify_err"' EXIT INT TERM
+# INT/TERM are trapped SEPARATELY and re-exit. A handler that only cleans up
+# does not terminate: bash runs it and RESUMES the interrupted command, so a
+# single `trap … EXIT INT TERM` would swallow an operator's Ctrl-C (or a
+# supervisor's SIGTERM) during the retry sleep and carry on to exit 0.
+if [[ -n "$verify_err" ]]; then
+  trap 'rm -f "$verify_err"' EXIT
+  trap 'rm -f "$verify_err"; exit 130' INT TERM
+fi
 verify_body=""
 verify_read=0
 for verify_attempt in 1 2; do

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.sh
@@ -91,11 +91,13 @@
 #   it, and reading that id back finds exactly what we expect. (Nor is it the
 #   guard for editing another user's comment: that PATCH 403s and exits 5.)
 #
-#   The GET is retried once: the write has already landed by then, so a transient
-#   read failure must not report a good cycle as a bad one. A second failure is
-#   still fail-closed — the cycle is reported UNCONFIRMED rather than good — but
-#   its message says so, because a check that could not run is not a check that
-#   disagreed.
+#   The GET is retried once: the write has already landed by then, so a momentary
+#   read failure must not report a good cycle as a bad one. That retry is a
+#   network-blip guard only — it does not wait out a secondary rate limit. A
+#   second failure is still fail-closed — the cycle is reported UNCONFIRMED
+#   rather than good — but its message says so, because a check that could not
+#   run is not a check that disagreed, and it branches on gh's own error: a 404
+#   means the comment is gone, not merely unread.
 #
 # Output (stdout): one action line, e.g.
 #   telemetry-upsert: updated comment 12345 (marker=lane:triage) on <owner/repo>#<issue>
@@ -413,12 +415,17 @@ unconfirmed="the body cleared the pre-write gate, so the comment is probably int
 [[ "$new_id" =~ ^[0-9]+$ ]] ||
   verify_fail "the ${action} response carried a non-numeric comment id ('$new_id'), so the write cannot be read back" "$unconfirmed"
 
-# The write has already landed by this point, so a transient GET failure would
+# The write has already landed by this point, so a momentary GET failure would
 # otherwise report a good cycle as a bad one. Retry once before concluding the
-# comment is unverifiable; a second failure is still fail-closed. gh's stderr is
-# kept rather than discarded: a 404 (the comment is gone — act now) and a 403/429
-# (secondary rate limit — it will pass next cycle) are the same exit status here
-# and call for opposite responses, so the operator needs the real message.
+# comment is unverifiable; a second failure is still fail-closed. The retry is a
+# network-blip guard ONLY — it does not honor Retry-After, so a secondary rate
+# limit (which outlasts it by far) reliably burns both attempts.
+#
+# gh's stderr is kept rather than discarded, and the verdict branches on it: a
+# 404 means the comment is GONE, which contradicts the default "probably intact"
+# reading, while a 403/429 means it is almost certainly still there and simply
+# unread. The two call for opposite responses, so neither the raw message nor
+# the conclusion drawn from it can be one-size-fits-all.
 verify_err="$(mktemp)" || verify_fail "could not create a temp file to capture the read-back error" "$unconfirmed"
 trap 'rm -f "$verify_err"' EXIT
 verify_body=""
@@ -430,8 +437,16 @@ for verify_attempt in 1 2; do
   fi
   ((verify_attempt == 1)) && sleep 2
 done
-((verify_read)) ||
-  verify_fail "could not re-read comment $new_id after 2 attempts (gh api GET): $(tr -d '\r' <"$verify_err" | tr '\n' ' ')" "$unconfirmed"
+if ((verify_read == 0)); then
+  verify_err_text="$(tr -d '\r' <"$verify_err" | tr '\n' ' ')"
+  case "$verify_err_text" in
+  *"HTTP 404"*)
+    verify_verdict="comment $new_id is GONE — the write landed and the comment no longer exists (deleted, or the issue was); the next cycle will create a fresh one"
+    ;;
+  *) verify_verdict="$unconfirmed" ;;
+  esac
+  verify_fail "could not re-read comment $new_id after 2 attempts (gh api GET): $verify_err_text" "$verify_verdict"
+fi
 
 case "$verify_body" in
 *"$SENTINEL"*) : ;;

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
@@ -12,6 +12,12 @@
 #   - --dry-run resolves the action but performs no write
 #   - `-` reads the body from stdin
 #   - missing jq BINARY (not just the in-script wrapper function) exits 4
+#   - pre-write body gate: an `@path` body (file AND stdin), an under-floor body,
+#     and an empty body each exit 3 having made NO API call
+#   - post-write read-back: a good body verifies; a body that came back `@`-led,
+#     sentinel-only, or without the sentinel exits 6; a failed GET is retried
+#     once then exits 6 reporting the cycle UNCONFIRMED; a response with no id
+#     exits 6; --dry-run reads nothing back
 #
 # PATH-stubs `gh`; the stub logs every mutating call and serves a fixture
 # comment list, so no network or real issue is touched.
@@ -43,15 +49,24 @@ mkdir -p "$STUB_BIN"
 LOG="$TMP/gh.log"
 
 # gh stub: serves `repo view`, `api user`, a paginated comment list from
-# $STUB_COMMENTS_FILE, and logs PATCH/POST mutations (echoing a synthetic
-# response so the script can extract .id / .html_url).
+# $STUB_COMMENTS_FILE, the post-write read-back GET of a single comment, and logs
+# PATCH/POST mutations (echoing a synthetic response so the script can extract
+# .id / .html_url).
+#
+# Read-back knobs (all default to a body that verifies):
+#   STUB_READBACK_BODY  exact body the read-back GET returns
+#   STUB_READBACK_FAIL  non-empty: the read-back GET exits non-zero
+#   STUB_NO_ID          non-empty: mutations answer with no `id` field
+#   STUB_NO_HTML_URL    non-empty: mutations answer with an `id` but no `html_url`
+#   STUB_BAD_ID         non-empty: mutations answer with a non-numeric traversal `id`
 cat >"$STUB_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 args=("$@")
-method=""; url=""; seen_api=0
+method=""; url=""; jq_query=""; seen_api=0
 for ((i = 0; i < ${#args[@]}; i++)); do
   case "${args[$i]}" in
     --method) method="${args[$((i + 1))]}" ;;
+    --jq) jq_query="${args[$((i + 1))]}" ;;
     api) seen_api=1 ;;
     repos/*|user) ((seen_api)) && [[ -z "$url" ]] && url="${args[$i]}" ;;
   esac
@@ -68,7 +83,13 @@ fi
 if [[ -n "$method" ]]; then
   # Mutation: log it, echo a synthetic response.
   printf 'CALL method=%s url=%s\n' "$method" "$url" >>"$STUB_LOG"
-  if [[ "$method" == "PATCH" ]]; then
+  if [[ -n "${STUB_NO_ID:-}" ]]; then
+    printf '{"html_url":"https://github.com/o/r/issues/1#c0"}\n'
+  elif [[ -n "${STUB_BAD_ID:-}" ]]; then
+    printf '{"id":"../../../org2/target/issues/comments/1","html_url":"https://github.com/o/r/issues/1#c0"}\n'
+  elif [[ -n "${STUB_NO_HTML_URL:-}" ]]; then
+    printf '{"id":999}\n'
+  elif [[ "$method" == "PATCH" ]]; then
     id="${url##*/}"
     printf '{"id":%s,"html_url":"https://github.com/o/r/issues/1#c%s"}\n' "$id" "$id"
   else
@@ -76,8 +97,28 @@ if [[ -n "$method" ]]; then
   fi
   exit 0
 fi
-# List comments (GET, --paginate): serve the fixture verbatim.
+# Read-back (GET one comment by id). Only `--jq .body` yields the raw body text
+# — real `gh` without it emits the whole comment JSON, so a regression that drops
+# the projection must not keep passing here.
+if [[ "$url" == */issues/comments/* ]]; then
+  printf 'CALL method=GET url=%s\n' "$url" >>"$STUB_LOG"
+  [[ -n "${STUB_READBACK_FAIL:-}" ]] && exit 1
+  if [[ "$jq_query" != ".body" ]]; then
+    printf '{"id":999,"body":"a JSON object, not the raw body"}\n'
+    exit 0
+  fi
+  if [[ -n "${STUB_READBACK_BODY+set}" ]]; then
+    printf '%s\n' "$STUB_READBACK_BODY"
+  else
+    printf '%s\nlane: triage\nlast-cycle: 2026-07-21T06:00:00Z\nflags: none\n' "${STUB_SENTINEL:-}"
+  fi
+  exit 0
+fi
+# List comments (GET, --paginate): serve the fixture verbatim. Logged like every
+# other call so a pre-write rejection can assert an EMPTY log — proving zero API
+# calls, not merely zero mutations.
 if [[ "$url" == */comments ]]; then
+  printf 'CALL method=GET url=%s\n' "$url" >>"$STUB_LOG"
   cat "${STUB_COMMENTS_FILE:-/dev/null}"
   exit 0
 fi
@@ -97,6 +138,7 @@ REPO="melodic-software/claude-code-plugins"
 run() { STUB_COMMENTS_FILE="$1" bash "$SCRIPT" --repo "$REPO" --issue 502 --marker "lane:triage" --body-file "$BODY" --body-dir "$SAFE_DIR" "${@:2}"; }
 
 SENT='<!-- claude-ops:lane-telemetry marker=lane:triage -->'
+export STUB_SENTINEL="$SENT"
 
 # ============================================================================
 # create — no matching comment
@@ -124,10 +166,15 @@ cat >"$TMP/has-sentinel.json" <<JSON
 JSON
 : >"$LOG"
 out="$(run "$TMP/has-sentinel.json" 2>&1)"
+rc=$?
 log="$(cat "$LOG")"
+assert_eq "update exits 0" 0 "$rc"
 assert_contains "update reports updated" "$out" "updated comment 222"
 assert_contains "update PATCHes the sentinel comment" "$log" "method=PATCH url=repos/$REPO/issues/comments/222"
 assert_not_contains "update does not POST a second comment" "$log" "method=POST"
+# The read-back must GET the comment that was actually written, not a fixed id:
+# reading back the wrong comment would verify somebody else's body as ours.
+assert_contains "update reads back the comment it PATCHed" "$log" "method=GET url=repos/$REPO/issues/comments/222"
 
 # ============================================================================
 # fallback — no sentinel, my comment carries the raw marker -> adopt (PATCH)
@@ -291,6 +338,9 @@ assert_contains "oversized body message" "$out" "over the"
 # ============================================================================
 # `-` reads body from stdin
 # ============================================================================
+# The body length is load-bearing: `lane: from-stdin` is exactly MIN_BODY_BYTES
+# once the trailing newline is stripped, so it doubles as the floor's inclusive
+# boundary. Shortening it turns this into a pre-write rejection.
 : >"$LOG"
 out="$(printf 'lane: from-stdin\n' | STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" --repo "$REPO" --issue 502 --marker "lane:triage" --body-file - 2>&1)"
 rc=$?
@@ -312,6 +362,144 @@ out="$(PATH="$STUB_BIN" "$BASH_BIN" "$SCRIPT" --repo "$REPO" --issue 502 --marke
 rc=$?
 assert_eq "missing jq binary exits 4" 4 "$rc"
 assert_contains "missing jq binary message" "$out" "jq not found"
+
+# ============================================================================
+# PRE-WRITE BODY GATE (#952) — the #943 fail-open is a comment whose timestamp
+# moves while its body carries no telemetry. The gate catches it BEFORE the
+# write, so nothing degraded is ever published: every case below must exit 3
+# having made no API call at all (an EMPTY stub log, not merely no mutation).
+# ============================================================================
+
+# The #943 defect itself: a caller composed `@path` as its body content, meaning
+# the file. Posting that verbatim is the fail-open — refuse before writing.
+ATPATH="$SAFE_DIR/atpath.txt"
+printf '@C:/Users/KYLESE~1/AppData/Local/Temp/telemetry_combined.txt\n' >"$ATPATH"
+: >"$LOG"
+out="$(STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" --repo "$REPO" --issue 502 \
+  --marker "lane:triage" --body-file "$ATPATH" --body-dir "$SAFE_DIR" 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "@path body rejected pre-write exit 3" 3 "$rc"
+assert_contains "@path rejection names the literal @" "$out" "starts with a literal '@'"
+assert_contains "@path rejection points at the fix" "$out" "use --body-file PATH"
+assert_contains "@path rejection says nothing was written" "$out" "nothing was written"
+assert_eq "@path body reaches no API call at all" "" "$log"
+
+# Same gate on the stdin path — a lane piping an interpolated `@path` string is
+# the realistic vector, since `-` is the recommended body input.
+: >"$LOG"
+out="$(printf '@/tmp/telemetry.txt\n' | STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" \
+  --repo "$REPO" --issue 502 --marker "lane:triage" --body-file - 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "@path stdin body rejected pre-write exit 3" 3 "$rc"
+assert_eq "@path stdin body reaches no API call at all" "" "$log"
+
+# Degenerate sibling: a body too short to be telemetry would leave a comment
+# that still looks fresh.
+TINY="$SAFE_DIR/tiny.txt"
+printf 'ok\n' >"$TINY"
+: >"$LOG"
+out="$(STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" --repo "$REPO" --issue 502 \
+  --marker "lane:triage" --body-file "$TINY" --body-dir "$SAFE_DIR" 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "under-floor body rejected pre-write exit 3" 3 "$rc"
+assert_contains "under-floor rejection names the floor" "$out" "under the 16-byte floor"
+assert_eq "under-floor body reaches no API call at all" "" "$log"
+
+# An empty body is the same rejection, not a special case.
+: >"$LOG"
+out="$(printf '' | STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" --repo "$REPO" \
+  --issue 502 --marker "lane:triage" --body-file - 2>&1)"
+rc=$?
+assert_eq "empty stdin body rejected pre-write exit 3" 3 "$rc"
+
+# ============================================================================
+# POST-WRITE READ-BACK (#952) — secondary confirmation. The body's content was
+# already cleared pre-write, so these cases stand in for damage between the
+# write and what a reader of the issue finds.
+# ============================================================================
+
+# A verified write re-reads the comment it just wrote (guard is not inert).
+: >"$LOG"
+out="$(run "$TMP/empty.json" 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "verified write exits 0" 0 "$rc"
+assert_contains "verified write re-reads the written comment" "$log" "method=GET url=repos/$REPO/issues/comments/999"
+
+# What landed starts with `@` although what was sent did not. The sentinel is
+# line one, so the check must look BELOW it.
+: >"$LOG"
+out="$(STUB_READBACK_BODY="$SENT"$'\n@C:/Users/KYLESE~1/AppData/Local/Temp/telemetry_combined.txt' \
+  run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "@path read-back body exits 6" 6 "$rc"
+assert_contains "@path read-back names the literal @" "$out" "starts with a literal '@'"
+assert_contains "@path read-back blames the store, not the caller's body" "$out" "the stored comment diverged from what was written"
+assert_contains "@path read-back names the comment url" "$out" "https://github.com/o/r/issues/1#c999"
+
+# Degenerate sibling: an empty body leaves a sentinel-only comment that still
+# looks fresh.
+out="$(STUB_READBACK_BODY="$SENT" run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "sentinel-only read-back body exits 6" 6 "$rc"
+assert_contains "sentinel-only failure names the floor" "$out" "under the 16-byte floor"
+
+# A body that lost the sentinel is not this marker's comment any more.
+out="$(STUB_READBACK_BODY="lane: triage, but no sentinel at all" run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "read-back without the sentinel exits 6" 6 "$rc"
+assert_contains "missing-sentinel message" "$out" "does not carry the marker sentinel"
+
+# Cannot verify == not verified: a failed read-back is never treated as success,
+# but it is retried first — the write already landed, so a transient read failure
+# must not report a good cycle as a bad one.
+: >"$LOG"
+out="$(STUB_READBACK_FAIL=1 run "$TMP/empty.json" 2>&1)"
+rc=$?
+gets="$(grep -c "url=repos/$REPO/issues/comments/" "$LOG")"
+assert_eq "failed read-back GET exits 6" 6 "$rc"
+assert_contains "failed read-back message" "$out" "could not re-read comment"
+assert_eq "failed read-back is retried once before failing" 2 "$gets"
+# A read-back that could not RUN is reported differently from one that disagreed:
+# the body already cleared the pre-write gate, so the comment is unconfirmed
+# rather than known-bad, and the operator is told so.
+assert_contains "unreachable read-back is reported as unconfirmed" "$out" "UNCONFIRMED"
+
+# Same rule when the write response carries no id to read back.
+out="$(STUB_NO_ID=1 run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "write response with no comment id exits 6" 6 "$rc"
+assert_contains "no-id message" "$out" "carried no comment id"
+
+# A non-numeric comment id never reaches a gh api URL path — the same rule the
+# --repo validation enforces, applied to the one other interpolated value. A
+# traversal id would otherwise redirect the read-back GET to another repo.
+: >"$LOG"
+out="$(STUB_BAD_ID=1 run "$TMP/empty.json" 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "non-numeric comment id exits 6" 6 "$rc"
+assert_contains "non-numeric id message" "$out" "non-numeric comment id"
+assert_not_contains "traversal id never reaches a read-back GET" "$log" "org2/target"
+
+# A response carrying an id but NO html_url still exits 0. The trailing
+# `[[ -n "$html_url" ]] && printf` used to be the script's last command, so its
+# false branch became the exit status and a verified upsert reported failure.
+out="$(STUB_NO_HTML_URL=1 run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "verified write with no html_url still exits 0" 0 "$rc"
+assert_contains "no-html_url write still reports the upsert" "$out" "created comment 999"
+
+# --dry-run writes nothing, so it reads nothing back.
+: >"$LOG"
+out="$(run "$TMP/has-sentinel.json" --dry-run 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "dry-run exits 0" 0 "$rc"
+assert_not_contains "dry-run performs no read-back" "$log" "url=repos/$REPO/issues/comments/"
 
 # ============================================================================
 echo

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
@@ -200,7 +200,7 @@ assert_contains "update PATCHes the sentinel comment" "$log" "method=PATCH url=r
 assert_not_contains "update does not POST a second comment" "$log" "method=POST"
 # The read-back must GET the comment that was actually written, not a fixed id:
 # reading back the wrong comment would verify somebody else's body as ours.
-assert_contains "update reads back the comment it PATCHed" "$log" "method=GET url=repos/$REPO/issues/comments/222"
+assert_contains "update reads back the comment it just wrote" "$log" "method=GET url=repos/$REPO/issues/comments/222"
 
 # ============================================================================
 # fallback — no sentinel, my comment carries the raw marker -> adopt (PATCH)
@@ -399,7 +399,7 @@ assert_contains "missing jq binary message" "$out" "jq not found"
 # The #943 defect itself: a caller composed `@path` as its body content, meaning
 # the file. Posting that verbatim is the fail-open — refuse before writing.
 ATPATH="$SAFE_DIR/atpath.txt"
-printf '@C:/Users/KYLESE~1/AppData/Local/Temp/telemetry_combined.txt\n' >"$ATPATH"
+printf '@/tmp/telemetry_combined.txt\n' >"$ATPATH"
 : >"$LOG"
 out="$(STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" --repo "$REPO" --issue 502 \
   --marker "lane:triage" --body-file "$ATPATH" --body-dir "$SAFE_DIR" 2>&1)"
@@ -458,7 +458,7 @@ assert_contains "verified write re-reads the written comment" "$log" "method=GET
 # What landed starts with `@` although what was sent did not. The sentinel is
 # line one, so the check must look BELOW it.
 : >"$LOG"
-out="$(STUB_READBACK_BODY="$SENT"$'\n@C:/Users/KYLESE~1/AppData/Local/Temp/telemetry_combined.txt' \
+out="$(STUB_READBACK_BODY="$SENT"$'\n@/tmp/telemetry_combined.txt' \
   run "$TMP/empty.json" 2>&1)"
 rc=$?
 assert_eq "@path read-back body exits 6" 6 "$rc"

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
@@ -124,10 +124,19 @@ if [[ "$url" == */issues/comments/* ]]; then
   # without the script's `tr -d '\r'` the `@`-prefix assertion below the sentinel
   # silently stops matching, and the guard would go inert against the real API
   # while a LF-only stub kept the suite green.
+  #
+  # Emitted in pure bash rather than `sed 's/$/\r/'`: `\r` in a sed REPLACEMENT is
+  # a GNU extension that BSD/macOS sed renders as a literal `r`, which would make
+  # this stub emit the wrong bytes on the one platform the repo's portability
+  # check does not cover (its token list scans patterns, not replacements).
+  emit_crlf() {
+    local line
+    while IFS= read -r line; do printf '%s\r\n' "$line"; done
+  }
   if [[ -n "${STUB_READBACK_BODY+set}" ]]; then
-    printf '%s\n' "$STUB_READBACK_BODY" | sed 's/$/\r/'
+    printf '%s\n' "$STUB_READBACK_BODY" | emit_crlf
   else
-    printf '%s\nlane: triage\nlast-cycle: 2026-07-21T06:00:00Z\nflags: none\n' "${STUB_SENTINEL:-}" | sed 's/$/\r/'
+    printf '%s\nlane: triage\nlast-cycle: 2026-07-21T06:00:00Z\nflags: none\n' "${STUB_SENTINEL:-}" | emit_crlf
   fi
   exit 0
 fi
@@ -493,8 +502,15 @@ out="$(STUB_READBACK_404=1 run "$TMP/empty.json" 2>&1)"
 rc=$?
 assert_eq "404 read-back exits 6" 6 "$rc"
 assert_contains "404 read-back surfaces gh's error text" "$out" "HTTP 404"
-assert_contains "404 read-back says the comment is gone" "$out" "is GONE"
-assert_not_contains "404 read-back does not claim the comment is intact" "$out" "probably intact"
+assert_contains "404 read-back says the comment is not retrievable" "$out" "NOT RETRIEVABLE"
+assert_not_contains "404 read-back does not assert the comment is intact" "$out" "so the comment is probably intact"
+
+# The stderr capture is a DIAGNOSTIC: an unwritable TMPDIR must not turn an
+# otherwise good write into a verification failure.
+out="$(TMPDIR="$TMP/nonexistent-dir" run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "unwritable TMPDIR does not fail a good write" 0 "$rc"
+assert_contains "unwritable TMPDIR still reports the upsert" "$out" "created comment 999"
 
 # Same rule when the write response carries no id to read back.
 out="$(STUB_NO_ID=1 run "$TMP/empty.json" 2>&1)"

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
@@ -54,9 +54,11 @@ LOG="$TMP/gh.log"
 # .id / .html_url).
 #
 # Read-back knobs (all default to a body that verifies):
-#   STUB_READBACK_BODY  exact body the read-back GET returns
-#   STUB_READBACK_FAIL  non-empty: the read-back GET exits non-zero
+#   STUB_READBACK_BODY  exact body the read-back GET returns (emitted CRLF)
+#   STUB_READBACK_FAIL  non-empty: the read-back GET fails with a 403 rate limit
+#   STUB_READBACK_404   non-empty: the read-back GET fails with a 404
 #   STUB_NO_ID          non-empty: mutations answer with no `id` field
+#   STUB_NO_ID_PATCH    non-empty: only PATCH answers with no `id` field
 #   STUB_NO_HTML_URL    non-empty: mutations answer with an `id` but no `html_url`
 #   STUB_BAD_ID         non-empty: mutations answer with a non-numeric traversal `id`
 cat >"$STUB_BIN/gh" <<'STUB'
@@ -85,6 +87,8 @@ if [[ -n "$method" ]]; then
   printf 'CALL method=%s url=%s\n' "$method" "$url" >>"$STUB_LOG"
   if [[ -n "${STUB_NO_ID:-}" ]]; then
     printf '{"html_url":"https://github.com/o/r/issues/1#c0"}\n'
+  elif [[ -n "${STUB_NO_ID_PATCH:-}" && "$method" == "PATCH" ]]; then
+    printf '{"html_url":"https://github.com/o/r/issues/1#c222"}\n'
   elif [[ -n "${STUB_BAD_ID:-}" ]]; then
     printf '{"id":"../../../org2/target/issues/comments/1","html_url":"https://github.com/o/r/issues/1#c0"}\n'
   elif [[ -n "${STUB_NO_HTML_URL:-}" ]]; then
@@ -102,15 +106,28 @@ fi
 # the projection must not keep passing here.
 if [[ "$url" == */issues/comments/* ]]; then
   printf 'CALL method=GET url=%s\n' "$url" >>"$STUB_LOG"
-  [[ -n "${STUB_READBACK_FAIL:-}" ]] && exit 1
+  # Failure knobs write to STDERR the way real gh does, so the script's capture
+  # of that text (and the 404-vs-rate-limit verdict it derives) is exercised.
+  if [[ -n "${STUB_READBACK_404:-}" ]]; then
+    printf 'gh: Not Found (HTTP 404)\n' >&2
+    exit 1
+  fi
+  if [[ -n "${STUB_READBACK_FAIL:-}" ]]; then
+    printf 'gh: You have exceeded a secondary rate limit (HTTP 403)\n' >&2
+    exit 1
+  fi
   if [[ "$jq_query" != ".body" ]]; then
     printf '{"id":999,"body":"a JSON object, not the raw body"}\n'
     exit 0
   fi
+  # GitHub stores comment bodies with CRLF line endings, so the stub emits them:
+  # without the script's `tr -d '\r'` the `@`-prefix assertion below the sentinel
+  # silently stops matching, and the guard would go inert against the real API
+  # while a LF-only stub kept the suite green.
   if [[ -n "${STUB_READBACK_BODY+set}" ]]; then
-    printf '%s\n' "$STUB_READBACK_BODY"
+    printf '%s\n' "$STUB_READBACK_BODY" | sed 's/$/\r/'
   else
-    printf '%s\nlane: triage\nlast-cycle: 2026-07-21T06:00:00Z\nflags: none\n' "${STUB_SENTINEL:-}"
+    printf '%s\nlane: triage\nlast-cycle: 2026-07-21T06:00:00Z\nflags: none\n' "${STUB_SENTINEL:-}" | sed 's/$/\r/'
   fi
   exit 0
 fi
@@ -467,6 +484,17 @@ assert_eq "failed read-back is retried once before failing" 2 "$gets"
 # the body already cleared the pre-write gate, so the comment is unconfirmed
 # rather than known-bad, and the operator is told so.
 assert_contains "unreachable read-back is reported as unconfirmed" "$out" "UNCONFIRMED"
+# gh's own error text must reach the operator — it is the only thing separating a
+# rate limit (the comment is there, just unread) from a 404 (it is gone).
+assert_contains "rate-limited read-back surfaces gh's error text" "$out" "secondary rate limit"
+
+# A 404 contradicts the default "probably intact" reading, so the verdict branches.
+out="$(STUB_READBACK_404=1 run "$TMP/empty.json" 2>&1)"
+rc=$?
+assert_eq "404 read-back exits 6" 6 "$rc"
+assert_contains "404 read-back surfaces gh's error text" "$out" "HTTP 404"
+assert_contains "404 read-back says the comment is gone" "$out" "is GONE"
+assert_not_contains "404 read-back does not claim the comment is intact" "$out" "probably intact"
 
 # Same rule when the write response carries no id to read back.
 out="$(STUB_NO_ID=1 run "$TMP/empty.json" 2>&1)"
@@ -484,6 +512,16 @@ log="$(cat "$LOG")"
 assert_eq "non-numeric comment id exits 6" 6 "$rc"
 assert_contains "non-numeric id message" "$out" "non-numeric comment id"
 assert_not_contains "traversal id never reaches a read-back GET" "$log" "org2/target"
+
+# A PATCH response with no `id` is still verifiable: the update path already
+# resolved the target id, so it falls back to that rather than declaring a
+# successful write unverifiable over a missing response field.
+: >"$LOG"
+out="$(STUB_NO_ID_PATCH=1 run "$TMP/has-sentinel.json" 2>&1)"
+rc=$?
+log="$(cat "$LOG")"
+assert_eq "PATCH response with no id still exits 0" 0 "$rc"
+assert_contains "id-less PATCH reads back the resolved target id" "$log" "method=GET url=repos/$REPO/issues/comments/222"
 
 # A response carrying an id but NO html_url still exits 0. The trailing
 # `[[ -n "$html_url" ]] && printf` used to be the script's last command, so its

--- a/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/telemetry-upsert.test.sh
@@ -505,6 +505,32 @@ assert_contains "404 read-back surfaces gh's error text" "$out" "HTTP 404"
 assert_contains "404 read-back says the comment is not retrievable" "$out" "NOT RETRIEVABLE"
 assert_not_contains "404 read-back does not assert the comment is intact" "$out" "so the comment is probably intact"
 
+# A signal during the read-back retry must TERMINATE, not be swallowed. A cleanup
+# trap that does not itself exit lets bash resume the interrupted command, so a
+# combined `trap … EXIT INT TERM` would absorb a supervisor's SIGTERM (or an
+# operator's Ctrl-C) and still report the cycle good. Driven through
+# STUB_READBACK_FAIL so the script is inside its `sleep 2` retry when it lands.
+# SIGTERM, not SIGINT: bash sets SIGINT to ignored in background children, so an
+# INT here would test the harness rather than the trap.
+# Timing is not guessed: the stub logs the read-back GET before failing it, so
+# waiting for that line puts the signal inside the retry sleep deterministically
+# — signalling on a fixed delay raced the trap's installation and reported the
+# un-trapped default (143) instead.
+SIGLOG="$TMP/sig.log"
+: >"$SIGLOG"
+STUB_LOG="$SIGLOG" STUB_READBACK_FAIL=1 STUB_COMMENTS_FILE="$TMP/empty.json" bash "$SCRIPT" \
+  --repo "$REPO" --issue 502 --marker "lane:triage" --body-file "$BODY" --body-dir "$SAFE_DIR" \
+  >/dev/null 2>&1 &
+sig_pid=$!
+for _ in $(seq 1 100); do
+  grep -q 'method=GET url=repos/.*/issues/comments/' "$SIGLOG" 2>/dev/null && break
+  sleep 0.1
+done
+kill -TERM "$sig_pid" 2>/dev/null
+wait "$sig_pid"
+rc=$?
+assert_eq "a signal during the retry terminates instead of resuming" 130 "$rc"
+
 # The stderr capture is a DIAGNOSTIC: an unwritable TMPDIR must not turn an
 # otherwise good write into a verification failure.
 out="$(TMPDIR="$TMP/nonexistent-dir" run "$TMP/empty.json" 2>&1)"


### PR DESCRIPTION
## Summary

`telemetry-upsert.sh` treated the create/update API response as proof the telemetry comment was
good. That echo proves the request was *accepted*, not what a reader of the issue will find — the
#943 observability fail-open.

This adds a **pre-write body gate** as the real guard, with the post-write read-back kept as
secondary confirmation.

**The gate is pre-write.** The caller's body is rejected with **exit 3, having made no API call at
all**, if it begins with a literal `@` or falls under a 16-byte floor. Both properties are already
known in-process before the `POST`/`PATCH`, so checking them there costs no network round trip and,
crucially, means a degraded body is **never published** to a public tracking issue — there is no
window in which a reader finds one, and nothing to retract.

**Why not rely on the read-back alone.** The wrapper reads the body into a shell variable before any
`gh` call, so `-f body=` never sees an `@path` — it was never susceptible to the wrapper-side bug.
The defect it must catch is the body *text* a lane hands it: a caller that composed
`@/tmp/telemetry.txt` as its body content, meaning the file. That string is in hand at parse time, so
a post-write check would publish the bad comment first and complain afterwards.

**The read-back is scoped honestly.** The `GET` targets the id just written, so it sees only what
happened to that comment *after* the write returned — a mangled store, a concurrent writer stripping
the sentinel, a deletion. It **cannot** detect that detection resolved the wrong comment (we would
have stamped our own sentinel and body onto it), and it is not the guard against editing another
user's comment (that `PATCH` 403s and exits 5). An unreachable `GET` is retried once, then reports
the cycle **UNCONFIRMED** rather than known-bad, carrying `gh`'s own stderr and branching on it: a
404 says the comment is gone; a 403/429 keeps the intact-but-unread reading.

## Acceptance criteria

| # | Criterion | How it is met |
|---|---|---|
| 1 | An `@path`-as-body write routed through the wrapper is caught at write time and fails loudly instead of silently degrading | Pre-write gate at `telemetry-upsert.sh` rejects it with exit 3 **before any `gh` call**. Tests assert an **empty stub log** — zero API calls, not merely zero mutations. Stronger than the issue asked for: nothing degraded is ever published. |
| 2 | The anti-pattern rule is stated once in the canonical lane doctrine location | `plugins/claude-ops/skills/lanes/SKILL.md`, section "Never pass a body as an `@path` string". `docs/conventions/loop-lane/README.md` **points at it** rather than restating it. The decision defaulted in the issue (`lanes/SKILL.md`, not `babysit-prs`) is honored. |
| 3 | Regression coverage, since a test harness exists | Suite grew to **84 cases**. Every gate is verified by killing a mutation of it, not by counting assertions. |

## Evidence

- `telemetry-upsert.test.sh`: **84 cases PASS**.
- `shellcheck -x` on both scripts: clean.
- `shfmt -d` (repo `.editorconfig`): clean.
- `markdownlint-cli2` on all three changed `.md`: 0 errors.
- `scripts/check-shell-portability.sh --paths` on both scripts: no unexcused GNU-only constructs.
- `scripts/check-changelog-parity.sh --check-bump origin/main`: pass.
- `gh` flag claims in SKILL.md/CHANGELOG verified against the installed **gh 2.95.0**, not from
  memory: `gh api` has no `--body-file`; `-f/--raw-field` sends a literal string (so `-f body=@path`
  posts the path text); `-F/--field` does `@path` file expansion; `gh issue comment` has
  `-b/--body` and `-F/--body-file`.

**Mutation testing** — every guard was proven non-inert by deleting it and observing the suite fail:

| Mutation | Result |
|---|---|
| Drop the pre-write `@` gate | KILLED (7 cases) |
| Drop the pre-write byte floor | KILLED (4 cases) |
| Drop the read-back's `--jq '.body'` projection | KILLED (12 cases) |
| Drop the trailing `exit 0` | KILLED |
| Hardcode the read-back id to `comments/999` | KILLED |
| Drop the `new_id` → `target_id` fallback | KILLED (2 cases) |
| Drop the read-back's `tr -d '\r'` | KILLED (3 cases) |
| Gut the stderr capture / 404 branch | KILLED (4 cases) |
| Drop the `new_id` numeric validation | KILLED (3 cases) |
| Drop the retry | KILLED |
| Combine the cleanup trap into `EXIT INT TERM` | KILLED |
| Drop safe-dir containment / size cap / `--repo` traversal validation | KILLED (pre-existing guards, confirmed unweakened) |

Two of these are worth calling out, because both are classes of **vacuous pass** that only a
mutation run surfaces:

- **CRLF.** GitHub stores comment bodies with CRLF. Without `tr -d '\r'` the text below the sentinel
  keeps a leading `\r`, the `@`-prefix assertion stops matching, and the read-back's headline check
  goes **silently inert against the real API** while an LF-only stub keeps the suite green. The stub
  now emits CRLF, so that strip is load-bearing. It emits it in pure bash, not `sed 's/$/\r/'` —
  `\r` in a sed *replacement* is a GNU extension that BSD/macOS sed renders as a literal `r`, and
  the repo's `check-shell-portability.sh` cannot see it (its token list covers patterns and `sed -i`
  forms, not replacement escapes). A macOS developer would have hit a failure indistinguishable from
  a real defect.
- **The trap.** A cleanup handler that does not itself exit makes bash run it and then *resume*, so
  a combined `trap … EXIT INT TERM` absorbed a SIGTERM during the retry sleep and let the script
  finish reporting a verdict. Split into `EXIT` plus an `INT TERM` handler that re-exits 130. The
  regression test waits for the stub's read-back log line before signalling rather than guessing a
  delay — a fixed delay raced the trap's own installation and observed the un-trapped default,
  which would have passed for the wrong reason.

## Review

Reviewed by **four** independent fresh-context reviewers. Every finding is addressed in this branch:
four over-claims in shipped text, five surviving mutations, a BSD-portability defect, and one
behavioral regression a review pass had itself introduced. Verification was by mutation rather than
by assertion count throughout.

## Breaking change

Bodies that previously upserted fine — under 16 bytes, or beginning with `@` — now hard-fail exit 3.
Both shapes are the #943 fail-open rather than legitimate telemetry, so the rejection is the point.
The `@` rule is **positional**, so a body whose first line is a GitHub @mention is rejected too: lead
with a telemetry key and put mentions on a later line (documented in SKILL.md and the CHANGELOG).
**No in-repo caller is affected** — nothing invokes the wrapper yet, by design; routing the operator
loop-prompt through it is tracked on #943, out-of-repo. Verified by repo-wide grep for
invocation-shaped references.

## Known limitations (stated, not papered over)

- The read-back asserts **properties**, not that the body changed, so a `PATCH` that silently
  no-ops still verifies — the previous cycle's body carries the sentinel and clears the floor, and a
  stale comment reads as a good cycle. That is a freshness defect, a different class from the
  `@path` fail-open this guards; asserting round-trip equality would fail real lane writes because
  GitHub normalizes stored bodies. Freshness belongs to the reader (`morning-brief`). Stated in the
  script header rather than left for a reader to discover.
- The read-back's retry is a network-blip guard and does not honor `Retry-After`, so a secondary
  rate limit outlasts both attempts and the cycle is reported UNCONFIRMED rather than good.

## Related

- Closes #952
- Part of #943 (telemetry `@path`-as-body observability fail-open). Full closure of #943 also
  requires the operator loop-prompt to route its telemetry writes through this wrapper, which is
  out-of-repo and stays tracked there.
- #502 — the per-lane telemetry surface this wrapper maintains.
- Supersedes the abandoned branch `guardrails/952-telemetry-upsert-readback` — a stale orphan at an
  earlier commit with no PR attached. Force-push is unavailable in this environment, so history here
  is additive and that branch is safe to prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
