### PR TITLE
fix(rate-limit-guard): scope the tee's account forward-pass claim to what the writer does

### DIFF
--- a/plugins/rate-limit-guard/.claude-plugin/plugin.json
+++ b/plugins/rate-limit-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "rate-limit-guard",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Shared rate-limit guard for loop lanes: a statusline wrapper tees the subscription rate-limit windows to a fixed machine-scope file, a StopFailure hook records rate-limit stops reactively, and a reader contract fixes how consuming sessions pause and resume.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `rate-limit-guard` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.3.5]
+
+### Fixed
+
+- **Reader contract: the tee's `account` forward-pass no longer promises a no-change upgrade path it
+  cannot deliver (#1685).** Two bullets — the tee-shape field list and the single-account gap
+  invariant — described the writer's filter accurately and then drew a conclusion broader than the
+  filter supports: that the release adding an account identifier "upgrades this file without a plugin
+  change" and "costs no plugin change". The filter is `to_entries` over the **root object only**, with
+  `test("account"; "i")` matching a **substring** of the key, and it has **no else branch**. So the
+  promise holds only for a field that is both top-level and `account`-named; a field nested inside an
+  object (`user.account_uuid`) or named `user`, `identity`, `org`, or `seat` is dropped, and dropped
+  silently — in a contract that fail-closes on every other unresolvable input. Both bullets now state
+  the filter's actual reach (top-level, substring, case-insensitive), name the silent drop, and scope
+  the no-change claim to that one shape; every other shape is called out as needing a writer change.
+  The tee-shape bullet owns the statement and the invariant bullet points at it. `statusline-tee.sh`
+  is unchanged — widening the filter is a design question owned by `TODO(#1218)`, not this
+  correction.
+
 ## [0.3.4]
 
 ### Fixed

--- a/plugins/rate-limit-guard/CHANGELOG.md
+++ b/plugins/rate-limit-guard/CHANGELOG.md
@@ -7,20 +7,24 @@ All notable changes to the `rate-limit-guard` plugin are documented here. Format
 
 ### Fixed
 
-- **Reader contract: the tee's `account` forward-pass no longer promises a no-change upgrade path it
-  cannot deliver (#1685).** Two bullets — the tee-shape field list and the single-account gap
-  invariant — described the writer's filter accurately and then drew a conclusion broader than the
-  filter supports: that the release adding an account identifier "upgrades this file without a plugin
-  change" and "costs no plugin change". The filter is `to_entries` over the **root object only**, with
-  `test("account"; "i")` matching a **substring** of the key, and it has **no else branch**. So the
-  promise holds only for a field that is both top-level and `account`-named; a field nested inside an
-  object (`user.account_uuid`) or named `user`, `identity`, `org`, or `seat` is dropped, and dropped
-  silently — in a contract that fail-closes on every other unresolvable input. Both bullets now state
-  the filter's actual reach (top-level, substring, case-insensitive), name the silent drop, and scope
-  the no-change claim to that one shape; every other shape is called out as needing a writer change.
-  The tee-shape bullet owns the statement and the invariant bullet points at it. `statusline-tee.sh`
-  is unchanged — widening the filter is a design question owned by `TODO(#1218)`, not this
-  correction.
+- **The tee's `account` forward-pass no longer promises a no-change upgrade path it cannot deliver
+  (#1685).** Four surfaces claimed that the release adding an account identifier upgrades the tee
+  file for free — the reader contract's tee-shape bullet and single-account gap invariant, the
+  README's known-gap bullet ("the wrapper automatically adopts any future account-identifying field
+  the schema grows"), and the tee script's own header comment. Each described the writer accurately
+  and then drew a conclusion broader than it supports. The writer selects on the **top-level key
+  name only** (`to_entries` over the root object), matching `account` as a **case-insensitive
+  substring**; an unmatched key is dropped with no diagnostic, in a contract that fail-closes on
+  every other unresolvable input. The promise therefore holds only when the new field's own
+  top-level key name contains `account`: `user`, `identity`, `org`, `seat`, and an `account_uuid`
+  buried inside a non-matching object all vanish silently. All four surfaces now scope the claim to
+  that shape and say every other shape needs a writer change.
+- **The reader contract now states that a forward-passed key carries its whole value.** A selected
+  top-level key crosses complete, nested objects included (`account_info: {uuid, display_name}`), so
+  the untrusted-value discipline is restated to cover an **object of arbitrary strings** rather than
+  only a scalar — the parse-with-a-JSON-parser, never-interpolate rule applies to the whole subtree.
+- `statusline-tee.sh`'s **behavior is unchanged**; only its header comment was corrected. Widening
+  the filter is a design question owned by `TODO(#1218)`, not this correction.
 
 ## [0.3.4]
 

--- a/plugins/rate-limit-guard/README.md
+++ b/plugins/rate-limit-guard/README.md
@@ -35,8 +35,9 @@ resume on their own after the reset. Four parts:
 - **Multi-account operation is a known gap, not a supported mode.** The snapshot carries no account
   identifier (none exists in the statusline schema today), so a machine switching accounts mid-drain
   feeds wrong windows to running lanes and the guard cannot detect it. The loop-lane convention §6
-  owns that framing; the reader contract cites it. The wrapper automatically adopts any future
-  account-identifying field the schema grows.
+  owns that framing; the reader contract cites it. The wrapper adopts a future account-identifying
+  field automatically only when its own top-level key name contains `account`; every other shape
+  needs a writer change (`reference/reader-contract.md`, "Tee file shape").
 
 ## Install
 

--- a/plugins/rate-limit-guard/reference/reader-contract.md
+++ b/plugins/rate-limit-guard/reference/reader-contract.md
@@ -47,15 +47,18 @@ never sees torn JSON; the file is **last-writer-wins** across all sessions on th
   (<https://code.claude.com/docs/en/statusline>, verified 2026-07-23): `used_percentage` is 0–100,
   `resets_at` is Unix epoch seconds. The key is present **only** when the session observes
   subscription windows; each window may be independently absent.
-- Session-distinguishing fields — `session_id`, `session_name`, and any **top-level** field whose key
-  **contains** `account`, case-insensitively, are copied through automatically. That is the whole of
-  the writer's filter, and it has no else branch: a field nested inside an object
-  (`user.account_uuid`), or named anything else (`user`, `identity`, `org`, `seat`), is dropped
-  silently. A future account identifier therefore reaches this file unchanged only if it arrives
-  top-level and `account`-named; any other shape needs a writer change. Treat these values as
-  **untrusted**: `session_name` (and potentially a future account field) is user/AI-influenced, so
-  consumers parse them only with a JSON parser and never string-interpolate them into a shell
-  command, another interpreter, or a prompt.
+- Session-distinguishing fields — `session_id`, `session_name`, and any **top-level** key whose name
+  **contains** `account` (case-insensitive) are copied through automatically. The writer selects on
+  the **top-level key name only**, and a selected key carries its **whole value** across, nested
+  objects included: `account_info: {uuid, display_name}` arrives complete. A key that does not match
+  is dropped with no diagnostic — `user`, `identity`, `org`, and `seat` all vanish silently, and so
+  does an `account_uuid` buried inside a non-matching object such as `user`, because nothing at the
+  top level matched. A future account identifier therefore arrives without a writer change only when
+  its own top-level key name contains `account`; every other shape needs one. Treat these values as
+  **untrusted**: `session_name`, and any future account field — which may be an **object of
+  arbitrary strings**, not just a scalar — are user/AI-influenced, so consumers parse them only with
+  a JSON parser and never string-interpolate them into a shell command, another interpreter, or a
+  prompt.
 
 ## Capability detection (fail-open)
 
@@ -107,10 +110,9 @@ is part of the seam only in the sense that tooling sweeping the directory should
   on the first, and the guard cannot detect it. The loop-lane convention §6 owns the framing and
   records it as a gap rather than as a safe assumption; the account-identity design that resolves
   it — writer-side field, reader-side invalidation of latched state, lane-floor re-audit — is
-  `TODO(#1218)`. Locally relevant today, and only this far: the writer already forward-passes a
-  top-level key containing `account` (see "Tee file shape"), so an identity field of exactly that
-  shape costs no writer change the release one appears. Any other shape — nested, or named anything
-  else — is dropped silently and needs a filter change.
+  `TODO(#1218)`. Locally relevant today, and only this far: the writer already forward-passes an
+  account-matching key under the exact rule "Tee file shape" states, so an identity field of that
+  shape costs no writer change the release one appears — and every other shape costs one.
 - **No shipped Monitor config.** Consumers arm their own session Monitor on the tee file (the
   staleness rule makes this mandatory while paused). The plugin ships no `experimental.monitors`
   entry — Monitors is an experimental Claude Code component, and this plugin takes no dependency on

--- a/plugins/rate-limit-guard/reference/reader-contract.md
+++ b/plugins/rate-limit-guard/reference/reader-contract.md
@@ -47,9 +47,12 @@ never sees torn JSON; the file is **last-writer-wins** across all sessions on th
   (<https://code.claude.com/docs/en/statusline>, verified 2026-07-23): `used_percentage` is 0–100,
   `resets_at` is Unix epoch seconds. The key is present **only** when the session observes
   subscription windows; each window may be independently absent.
-- Session-distinguishing fields — `session_id`, `session_name`, and any future top-level field whose
-  key matches `account` (case-insensitive) are copied through automatically, so the release that
-  adds an account identifier upgrades this file without a plugin change. Treat these values as
+- Session-distinguishing fields — `session_id`, `session_name`, and any **top-level** field whose key
+  **contains** `account`, case-insensitively, are copied through automatically. That is the whole of
+  the writer's filter, and it has no else branch: a field nested inside an object
+  (`user.account_uuid`), or named anything else (`user`, `identity`, `org`, `seat`), is dropped
+  silently. A future account identifier therefore reaches this file unchanged only if it arrives
+  top-level and `account`-named; any other shape needs a writer change. Treat these values as
   **untrusted**: `session_name` (and potentially a future account field) is user/AI-influenced, so
   consumers parse them only with a JSON parser and never string-interpolate them into a shell
   command, another interpreter, or a prompt.
@@ -104,8 +107,10 @@ is part of the seam only in the sense that tooling sweeping the directory should
   on the first, and the guard cannot detect it. The loop-lane convention §6 owns the framing and
   records it as a gap rather than as a safe assumption; the account-identity design that resolves
   it — writer-side field, reader-side invalidation of latched state, lane-floor re-audit — is
-  `TODO(#1218)`. Locally relevant today: the writer already forward-passes any top-level key
-  matching `account`, so an identity field costs no plugin change the release one appears.
+  `TODO(#1218)`. Locally relevant today, and only this far: the writer already forward-passes a
+  top-level key containing `account` (see "Tee file shape"), so an identity field of exactly that
+  shape costs no writer change the release one appears. Any other shape — nested, or named anything
+  else — is dropped silently and needs a filter change.
 - **No shipped Monitor config.** Consumers arm their own session Monitor on the tee file (the
   staleness rule makes this mandatory while paused). The plugin ships no `experimental.monitors`
   entry — Monitors is an experimental Claude Code component, and this plugin takes no dependency on

--- a/plugins/rate-limit-guard/scripts/statusline-tee.sh
+++ b/plugins/rate-limit-guard/scripts/statusline-tee.sh
@@ -22,8 +22,10 @@
 # side): every refresh writes ~/.claude/rate-limit-guard/rate-limits.json —
 # one JSON object with captured_at (ISO-8601 UTC) plus, when present on
 # stdin, rate_limits and every session-distinguishing top-level field
-# (session_id, session_name, and any key matching "account", so a future
-# account-identifier field is adopted automatically the release it appears).
+# (session_id, session_name, and any key whose name contains "account", so a
+# future account-identifier field is adopted automatically only when it
+# arrives under a top-level key of that shape; every other shape needs a
+# writer change).
 # The path is deliberately HOME-anchored and outside ${CLAUDE_PLUGIN_DATA}:
 # it is a documented cross-plugin artifact seam that sibling-plugin lane
 # sessions read, machine-scope by design (the file is last-writer-wins and


### PR DESCRIPTION
🤖 Agent-authored (autonomous worker lane).

Closes #1685.

## Summary

The plugin told readers that the release adding an account identifier upgrades the tee file for free. The writer cannot guarantee that.

`scripts/statusline-tee.sh` selects on the **top-level key name only** — `to_entries` over the root object — matching `account` as a **case-insensitive substring**, and an unmatched key is dropped **with no diagnostic**. So the promise holds only when the new field's own top-level key name contains `account`. A field called `user`, `identity`, `org`, or `seat`, or an `account_uuid` buried inside a non-matching object, vanishes silently — in a contract that fail-closes on every other unresolvable input.

The doc now follows the code. `statusline-tee.sh`'s **behavior is unchanged**: the jq filter is byte-identical to `main` and only its header comment moved. Widening the filter is a design question owned by `TODO(#1218)`, which the issue and triage both scoped out of this correction.

## What changed

**Four surfaces carried the same overstatement, not the one the issue quotes.** The issue quotes only the reader contract's Invariants bullet; fixing that alone would have shipped a document contradicting its own Tee-file-shape section, and would have left the claim standing on the plugin's front door.

| Surface | Was | Now |
| --- | --- | --- |
| `reference/reader-contract.md` "Tee file shape" | "...so the release that adds an account identifier upgrades this file without a plugin change" | States the writer's actual reach; owns the rule |
| `reference/reader-contract.md` "Invariants" (the quoted one) | "...so an identity field costs no plugin change the release one appears" | Scoped to that shape; **points at** the rule rather than restating it |
| `README.md` known-gap bullet | "The wrapper automatically adopts any future account-identifying field the schema grows" — fully unqualified, and broader than the sentence the issue quotes | Scoped, with a pointer to the contract |
| `scripts/statusline-tee.sh` header comment | qualifiers sat in the parenthetical; the `so ...` inference did not carry them forward | Inference now carries the qualifiers |

**One correction the issue did not anticipate.** An earlier draft of this PR implied that *nesting* defeats the forward-pass. It does not: a selected top-level key crosses with its **whole value**, nested objects included (`account_info: {uuid, display_name}` arrives complete). The drop is caused by no top-level key matching, not by depth. Because a passed key may therefore carry an **object of arbitrary user/AI-influenced strings**, the untrusted-value discipline is restated to cover the subtree rather than a scalar — the parse-with-a-JSON-parser, never-interpolate rule applies to all of it.

**Terminology unified** on "writer change"; the contract had split between "writer change" and "filter change" for the same fact.

**Two phrasings from the issue body were rejected as not surviving contact with the code:** the filter also selects `rate_limits`, so it is not "the whole of" the forward-pass; and `map(select(...))` has no branch to lack an else — the accurate statement is that unmatched keys are dropped with no diagnostic.

## Verification

**This is a doc-only prose correction with no executable surface. No test can reach the claim, and I did not invent coverage for it.** Verification is the read of the filter against the new prose, plus the gates below. The one executable file touched changed only a comment; `git diff origin/main -- scripts/statusline-tee.sh` shows two comment hunks and nothing else.

| Gate | Result |
| --- | --- |
| `check-changelog-parity.sh --check` | pass |
| `check-changelog-parity.sh --check-bump origin/main` | pass |
| `generate-catalog.mjs --check` | catalog in sync |
| `validate-plugins.sh` | all manifests + catalog validated |
| `validate-plugin-contracts.mjs` | 43 setup skills, 2123 plugin files |
| `check-cross-plugin-source-drift.sh --check` | no drift |
| `check-changed-skills.sh origin/main` | no changed skills (correctly a no-op) |
| `check-shell-portability.sh origin/main` | no unexcused GNU-only constructs, 1 file |
| `shellcheck` + `bash -n` on `statusline-tee.sh` | clean |
| `markdownlint-cli2` on all 3 changed `.md` | 0 errors |

The **operable floor** (the block the three lane skills inline byte-identically per loop-lane convention §6) is untouched, so no lane-skill fan-out is needed and §6 needs nothing.

**`CHANGELOG.md:146` deliberately still carries the old wording.** It is a historical `[0.2.0]` release note, not a live surface — changelog entries are immutable history. Not a missed site.

## Reviewer note — version collision with #1692

This PR takes `rate-limit-guard` **0.3.4 → 0.3.5**. **PR #1692 also claims 0.3.5** for this plugin. Whichever merges second must rebase and re-bump, and `check-changelog-parity.sh --check-bump` will fail for the loser until it does. Not pre-emptively jumping to 0.3.6, since that guesses at merge order and would leave a version gap.

The bump is warranted by `docs/MIGRATION-PLAYBOOK.md:373-375` — a `version` bump is the only delivery vehicle, so an unbumped plugin never delivers a corrected reference to consumers. Note `--check-bump` only fires *when* a version changes; it does not itself compel one.

## Related

- Closes #1685
- `TODO(#1218)` — widening the filter is that issue's call, explicitly not this one's. #1218 specifies **no field name**, so this PR makes no claim about whether its eventual field will satisfy the existing filter.
- Reader contract: `plugins/rate-limit-guard/reference/reader-contract.md`
- Loop-lane convention §6 (inline-floor rule): `docs/conventions/loop-lane/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
