### PR TITLE
feat(ci): stage forge/branch/remote portability tokens with class-scoped guards

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -163,6 +163,22 @@ inherent scope at the coupling site — the same declared-narrower-boundary allo
 cross-platform contract makes for OS platform — rather than shipping the assumption bare under a
 neutral name.
 
+Two reviewer-visible comment tokens carry that declaration, and they differ in REACH rather than in
+strength. `portability-ok: <reason>` records one site: the coupling on that line (or the line below
+a comment block carrying it) is excused and nothing else in the file is. `portability-scope:
+<reason>` declares the whole file inherently locked — the case a forge-locked capability under a
+forge-neutral name actually needs. Reach is the entire distinction, so the choice is a claim about
+what is true: a per-site annotation on a file that is genuinely scope-locked buries the boundary,
+and a whole-file declaration used to silence one awkward line exempts every future coupling added to
+that file, including ones nobody reviewed. Neither is a frontmatter field; both are ordinary
+comments a reviewer reads in the diff. `scripts/check-skill-portability.sh` enforces this, with the
+coupling tokens it matches held as data in `scripts/skill-portability-tokens.txt`.
+
+Detection evidence is scoped to the coupling class that authored it. A command proving which
+*branch* was resolved says nothing about which *remote* holds it, so it cannot excuse a hardcoded
+remote name that happens to share the line — a guard that generalizes across classes turns one
+legitimate resolution into a blanket exemption for couplings it never examined.
+
 ## Configuration ownership and scope
 
 Choose one authoritative owner for each value:

--- a/scripts/check-skill-portability.sh
+++ b/scripts/check-skill-portability.sh
@@ -49,8 +49,10 @@
 #      declared narrower boundary).
 #
 # This is a grep-level tripwire, not a semantic proof. Guard markers are seeded
-# for the one active class (branch/default-branch); enabling a further class
-# revisits them here, proven against an `--all` audit first.
+# for the one active class (branch/default-branch) and SCOPED to it: is_guarded()
+# reads the matched pattern as well as the line, so branch-resolution evidence
+# never excuses a different class's coupling on the same line. Enabling a further
+# class adds its own markers here, proven against an `--all` audit first.
 #
 # Files scanned within a changed skill: *.md and *.sh, excluding *.test.sh (test
 # fixtures), vendor/ (upstream-synced copies with their own drift gate), and
@@ -184,9 +186,23 @@ scan_file() {
     # either; a legitimately split-across-lines ladder uses the per-site
     # portability-ok escape. A future class needing other markers adds them
     # here when it is enabled.
-    function is_guarded(l) {
-      return l ~ /origin\/HEAD/ || l ~ /symbolic-ref/ || l ~ /merge-base/ ||
-        l ~ /baseRefName/ || l ~ /-> *origin\//
+    #
+    # Takes the matched PATTERN too, so a marker guards only the class that
+    # authored it — the same is_guarded(l, p) shape check-shell-portability.sh
+    # already uses. Without that scoping every marker is global, and the first
+    # additional class to go active inherits branch-detection evidence as a
+    # blanket excuse: `git ls-remote --symref origin HEAD` resolving the
+    # default branch would also excuse a bare `git push origin` on the same
+    # line, which is a different coupling with different resolution evidence
+    # (branch.<name>.remote / @{upstream}). That is the false green the token
+    # file staged-class preamble forbids, so the scoping lands with the class
+    # set that made it reachable rather than with the class that trips over it.
+    function is_guarded(l, p) {
+      if (p ~ /origin\/\(main\|master\)/) {
+        return l ~ /origin\/HEAD/ || l ~ /symbolic-ref/ || l ~ /merge-base/ ||
+          l ~ /baseRefName/ || l ~ /-> *origin\//
+      }
+      return 0
     }
     # Pass 1: collect active ERE patterns from the token list.
     FNR == NR {
@@ -209,7 +225,7 @@ scan_file() {
       for (i = 1; i <= np; i++) {
         if (line ~ patterns[i]) {
           if (is_annotated(line) || annotated_above) continue
-          if (is_guarded(line)) continue
+          if (is_guarded(line, patterns[i])) continue
           printf "%d: %s -> %s\n", FNR, patterns[i], line
         }
       }

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -39,11 +39,53 @@ scan_paths() {
   SKILL_PORTABILITY_TOKENS="$TEST_TOKENS" bash "$SCRIPT" --paths "$@"
 }
 
+# scan_with <token-file> <file>... — run the gate over explicit paths with a
+# caller-supplied token list, for the staged Stage-2 classes whose patterns are
+# not in the default single-pattern list above.
+scan_with() {
+  local tokens="$1"
+  shift
+  SKILL_PORTABILITY_TOKENS="$tokens" bash "$SCRIPT" --paths "$@"
+}
+
 tmpfile() {
   local f
   f="$(mktemp --suffix=.md)"
   printf '%s\n' "$1" >"$f"
   printf '%s' "$f"
+}
+
+# tokenfile <pattern> — a one-pattern token list, the caller's to remove.
+tokenfile() {
+  local f
+  f="$(mktemp)"
+  printf '%s\n' "$1" >"$f"
+  printf '%s' "$f"
+}
+
+# assert_staged <label> <pattern> — assert <pattern> is present VERBATIM as a
+# commented line in the shipping token list's STAGED section.
+#
+# The fixtures below carry each staged pattern as a literal and assert it still
+# matches what ships, rather than parsing it back out of the token file:
+# a staged class is documented in prose that necessarily quotes its own pattern
+# fragments, so no "which commented line is the data" rule separates pattern
+# from commentary without marking up the shipped file with test scaffolding.
+#
+# Deliberately an assertion in the PARENT shell, never a value-returning
+# helper. A `fail` inside a `$(...)` substitution increments a subshell's copy
+# of the counter and is lost, and the empty result then makes every
+# `if [[ -n "$TOKEN" ]]` fixture below skip in silence — a green suite whose
+# Stage 2 coverage has quietly stopped running. That is the silent-skip this
+# repo's gates exist to forbid, so the pattern is always non-empty and a drifted
+# token file fails loudly here instead.
+assert_staged() {
+  local label="$1" pattern="$2"
+  if grep -qxF -- "# $pattern" "$REAL_TOKENS"; then
+    ok "staged $label pattern is present verbatim in the shipped token list"
+  else
+    fail "staged $label pattern not found verbatim in $REAL_TOKENS: $pattern"
+  fi
 }
 
 # --- bare origin/main fails with file:line ---------------------------------
@@ -224,6 +266,253 @@ else
   fail "shipped list should only enforce the active branch class"
 fi
 rm -f "$f"
+
+# =============================================================================
+# Stage 2 (#713) — forge / branch / remote grammar classes.
+#
+# Every class below is STAGED in the shipping token list, so each fixture first
+# asserts its pattern still matches what ships (assert_staged), then activates
+# that pattern in an isolated one-pattern list. Editing a staged class into a
+# shape that no longer catches its own defect therefore fails here rather than
+# leaving these tests passing against a stale retyped copy.
+#
+# Each case pairs the coupling that must FAIL with the compliant or declared
+# shape that must PASS — a token that only ever fires is indistinguishable from
+# one that fires on everything.
+# =============================================================================
+
+# --- remote-name class: bare `origin` as a git remote ARGUMENT (#442) -------
+REMOTE_TOKEN='git (push|fetch|pull|clone|ls-remote|remote (prune|show|add|rename|get-url|set-url))([[:space:]]+-[^[:space:]]+)*[[:space:]]+origin([^a-zA-Z0-9_/.-]|$)'
+assert_staged 'remote-name' "$REMOTE_TOKEN"
+rt="$(tokenfile "$REMOTE_TOKEN")"
+
+f="$(tmpfile 'Publish the branch with `git push origin HEAD` when the work is ready.')"
+if out="$(scan_with "$rt" "$f" 2>&1)"; then
+  fail "a bare 'git push origin' should fail, got success: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "remote class: a bare origin remote argument fails with file:line"
+else
+  fail "expected line 1 flagged for a bare origin remote argument, got: $out"
+fi
+rm -f "$f"
+
+f="$(tmpfile 'Fetch the base with `git fetch origin "$DEFAULT_BRANCH"` before merging.')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  fail "a bare origin remote argument must flag even when the BRANCH is resolved"
+else
+  ok "remote class: resolving the branch does not excuse a hardcoded remote name"
+fi
+rm -f "$f"
+
+# The compliant shape: the remote is resolved into a variable first, so no
+# literal `origin` sits in the remote-argument position at all.
+f="$(tmpfile 'REMOTE="$(bash scripts/resolve-remote.sh --push)"; git push "$REMOTE" HEAD')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  ok "remote class: a resolved remote variable is not flagged"
+else
+  fail "a resolved remote variable must pass — it is the pattern this class asks for"
+fi
+rm -f "$f"
+
+# The word `origin` appears in ordinary English and in unrelated compounds
+# without asserting a remote NAME; the class is anchored to the
+# remote-argument position precisely so none of these fire.
+f="$(tmpfile 'The lane requires cross-origin reads to succeed.
+Each finding records its origin, and the origin of a default is what this gate tests.')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  ok "remote class: prose uses of the word origin are not flagged"
+else
+  fail "the word origin in prose must not flag — only the remote-argument position"
+fi
+rm -f "$f"
+
+# A branch-DETECTION ladder still names the remote it queries, so it is a
+# true positive for this class even though it is exemplary for the branch
+# class. The two couplings are independent: resolving which branch is the
+# default says nothing about which remote holds it, and a `git clone -o
+# vendor` consumer breaks on the remote name regardless. Recorded as an
+# expectation because it is the shape most likely to be mistaken for a
+# false positive when this class is activated.
+f="$(tmpfile 'Resolve the default via `git ls-remote --symref origin HEAD`.')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  fail "a branch-detection ladder still hardcodes its remote name and must flag"
+else
+  ok "remote class: a branch-detection ladder still flags on its hardcoded remote"
+fi
+rm -f "$f"
+
+# A per-site escape works on this class exactly as on the active one.
+f="$(tmpfile 'Run `git fetch origin` here. <!-- portability-ok: this lane documents a single-remote reset -->')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  ok "remote class: a per-site portability-ok escape is honored"
+else
+  fail "the remote class must honor a per-site portability-ok escape"
+fi
+rm -f "$f"
+
+rm -f "$rt"
+
+# --- branch-grammar class: shipped Conventional-Commits types (#415) --------
+GRAMMAR_TOKEN='`(feat|fix|refactor|chore|docs|test|build|perf|style)/`[^`]*`(feat|fix|refactor|chore|docs|test|build|perf|style)/`'
+assert_staged 'branch-grammar' "$GRAMMAR_TOKEN"
+gt="$(tokenfile "$GRAMMAR_TOKEN")"
+
+f="$(tmpfile 'Derive the type from the change: `feat/`, `fix/`, `refactor/`, `chore/`.')"
+if out="$(scan_with "$gt" "$f" 2>&1)"; then
+  fail "a shipped Conventional-Commits type list should fail, got success: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "branch-grammar class: a shipped type enumeration fails with file:line"
+else
+  fail "expected line 1 flagged for a shipped type enumeration, got: $out"
+fi
+rm -f "$f"
+
+# The compliant shape: the grammar is READ from the consuming repo rather
+# than shipped, so no enumeration appears at all.
+f="$(tmpfile "Read the branch convention from the project's CLAUDE.md or rules index; do not assume one.")"
+if scan_with "$gt" "$f" >/dev/null 2>&1; then
+  ok "branch-grammar class: deferring to the consumer's convention is not flagged"
+else
+  fail "reading the consumer's convention must pass — it is this class's fix direction"
+fi
+rm -f "$f"
+
+# Ordinary prose paths share the type words and must not fire — the reason
+# this class ships as the narrow enumeration shape, not a bare alternation.
+f="$(tmpfile 'Screenshots land under `build/shots/` and the contract under `docs/conventions/`.')"
+if scan_with "$gt" "$f" >/dev/null 2>&1; then
+  ok "branch-grammar class: ordinary prose paths are not false-positives"
+else
+  fail "a prose path like build/shots must not be read as a branch-type grammar"
+fi
+rm -f "$f"
+
+rm -f "$gt"
+
+# --- branch-shape class: a shipped `<type>/<...>` placeholder (#415) --------
+SHAPE_TOKEN='<type>/<'
+assert_staged 'branch-shape' "$SHAPE_TOKEN"
+st="$(tokenfile "$SHAPE_TOKEN")"
+
+f="$(tmpfile 'Suggest `git checkout -b <type>/<topic-slug>` derived from the plan.')"
+if out="$(scan_with "$st" "$f" 2>&1)"; then
+  fail "a shipped <type>/<slug> branch shape should fail, got success: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "branch-shape class: a shipped <type>/<slug> placeholder fails with file:line"
+else
+  fail "expected line 1 flagged for a shipped branch shape, got: $out"
+fi
+rm -f "$f"
+
+f="$(tmpfile "Propose a name following the project's own branch-naming convention.")"
+if scan_with "$st" "$f" >/dev/null 2>&1; then
+  ok "branch-shape class: a convention-deferring suggestion is not flagged"
+else
+  fail "a convention-deferring suggestion must pass"
+fi
+rm -f "$f"
+
+rm -f "$st"
+
+# --- forge class: a hardcoded raw.githubusercontent URL (#432) --------------
+FORGE_TOKEN='raw\.githubusercontent\.com'
+assert_staged 'forge-URL' "$FORGE_TOKEN"
+ft="$(tokenfile "$FORGE_TOKEN")"
+
+f="$(tmpfile 'Apply the contract at <https://raw.githubusercontent.com/acme/plugins/main/docs/README.md> as written.')"
+if out="$(scan_with "$ft" "$f" 2>&1)"; then
+  fail "a runtime raw.githubusercontent fetch should fail, got success: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "forge class: a hardcoded raw content URL fails with file:line"
+else
+  fail "expected line 1 flagged for a hardcoded raw content URL, got: $out"
+fi
+rm -f "$f"
+
+# The compliant shape: the contract is bundled with the plugin, so resolution
+# needs no network and no publisher repo name.
+f="$(tmpfile 'Read the bundled contract at `${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`.')"
+if scan_with "$ft" "$f" >/dev/null 2>&1; then
+  ok "forge class: a bundled CLAUDE_PLUGIN_ROOT reference is not flagged"
+else
+  fail "a bundled reference must pass — it is this class's fix direction"
+fi
+rm -f "$f"
+
+rm -f "$ft"
+
+# =============================================================================
+# Declared-narrower-scope honor (#441): the acceptance pair proving a
+# scope-declared file is exempt while an otherwise identical undeclared one is
+# flagged, and that the two escapes do NOT have the same reach — a per-site
+# portability-ok covers its site only and must never silence the rest of the
+# file the way a whole-file portability-scope does.
+# =============================================================================
+rt="$(tokenfile "$REMOTE_TOKEN")"
+
+declared="$(tmpfile '<!-- portability-scope: forge=github — this skill wraps gh and is inherently GitHub-locked -->
+Fetch with `git fetch origin` and publish with `git push origin HEAD`.')"
+undeclared="$(tmpfile 'Fetch with `git fetch origin` and publish with `git push origin HEAD`.')"
+
+if scan_with "$rt" "$declared" >/dev/null 2>&1; then
+  ok "declared-scope: a portability-scope file is exempt from a Stage 2 class"
+else
+  fail "a portability-scope declaration must exempt the whole file for every active class"
+fi
+
+if out="$(scan_with "$rt" "$undeclared" 2>&1)"; then
+  fail "the undeclared twin of a scope-declared file must still flag, got success: $out"
+elif echo "$out" | grep -q "COUPLING: ${undeclared}:1:"; then
+  ok "declared-scope: the otherwise identical undeclared file is still flagged"
+else
+  fail "expected the undeclared twin flagged on line 1, got: $out"
+fi
+rm -f "$declared" "$undeclared"
+
+# Reach asymmetry: a per-site annotation is NOT a whole-file declaration.
+# Line 1 is excused by its own annotation; line 3's identical coupling is a
+# separate site and must still fail. Conflating the two would turn every
+# single-site exemption into a silent file-wide opt-out.
+f="$(tmpfile 'Run `git fetch origin` here. <!-- portability-ok: single-remote reset lane -->
+Then review the result.
+Finally run `git push origin HEAD` with no annotation at all.')"
+if out="$(scan_with "$rt" "$f" 2>&1)"; then
+  fail "a per-site portability-ok must not exempt the whole file, got success: $out"
+elif echo "$out" | grep -q ":3:" && ! echo "$out" | grep -q ":1:"; then
+  ok "declared-scope: a per-site portability-ok covers its site only, not the file"
+else
+  fail "expected line 3 flagged and line 1 excused, got: $out"
+fi
+rm -f "$f"
+
+rm -f "$rt"
+
+# =============================================================================
+# Guard markers are CLASS-SCOPED (#713): is_guarded() receives the matched
+# pattern, so the branch class's branch-detection evidence excuses only the
+# branch class. Without the scoping, one line carrying both a symbolic-ref
+# resolution and a hardcoded remote name would go green on BOTH — the false
+# exemption the token file's staged-class preamble forbids.
+# =============================================================================
+BOTH_TOKENS="$(mktemp)"
+printf '%s\n%s\n' 'origin/(main|master)' "$REMOTE_TOKEN" >"$BOTH_TOKENS"
+
+# One line, both couplings. `merge-base` is a branch-class guard marker, so
+# the co-located `origin/main` is legitimately excused as a detection-ladder
+# fallback. The `git fetch origin` on the same line is a DIFFERENT coupling
+# with no guard of its own and must still be reported. Before the guard was
+# class-scoped, the branch marker excused the whole line and this hit
+# vanished — a real remote hardcode reported clean.
+f="$(tmpfile 'Use `git merge-base origin/main HEAD` for the base, then `git fetch origin` to refresh.')"
+out="$(scan_with "$BOTH_TOKENS" "$f" 2>&1)"
+if echo "$out" | grep -q 'origin/(main|master)'; then
+  fail "branch-detection evidence must still guard the BRANCH class on its own line: $out"
+elif echo "$out" | grep -q 'ls-remote'; then
+  ok "class-scoped guards: branch evidence guards the branch class but not the remote class"
+else
+  fail "expected the remote class flagged while the branch class stayed guarded, got: $out"
+fi
+rm -f "$f" "$BOTH_TOKENS"
 
 # --- missing token list fails closed (exit 2) ------------------------------
 f="$(tmpfile 'origin/main')"

--- a/scripts/check-skill-portability.test.sh
+++ b/scripts/check-skill-portability.test.sh
@@ -282,7 +282,7 @@ rm -f "$f"
 # =============================================================================
 
 # --- remote-name class: bare `origin` as a git remote ARGUMENT (#442) -------
-REMOTE_TOKEN='git (push|fetch|pull|clone|ls-remote|remote (prune|show|add|rename|get-url|set-url))([[:space:]]+-[^[:space:]]+)*[[:space:]]+origin([^a-zA-Z0-9_/.-]|$)'
+REMOTE_TOKEN='git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+(push|fetch|pull|clone|ls-remote|remote (prune|show|add|rename|get-url|set-url))([[:space:]]+-[^[:space:]]+)*[[:space:]]+origin([^a-zA-Z0-9_/.-]|$)'
 assert_staged 'remote-name' "$REMOTE_TOKEN"
 rt="$(tokenfile "$REMOTE_TOKEN")"
 
@@ -304,9 +304,49 @@ else
 fi
 rm -f "$f"
 
+# Git's syntax is `git [<global-options>] <command> [<args>]`, so a global
+# option sits between `git` and the subcommand. A subcommand-adjacent anchor
+# reports this shape clean, which both understates the residue and lets the
+# same coupling through the future gate — the live corpus carries exactly this
+# form in plugins/source-control/skills/babysit-prs/reference/orchestration.md.
+f="$(tmpfile 'Re-fetch the base ref (`git -C <worktree> fetch origin <base>`) before merging.')"
+if out="$(scan_with "$rt" "$f" 2>&1)"; then
+  fail "a global option before the subcommand must not hide the hardcoded remote: $out"
+elif echo "$out" | grep -q "COUPLING: ${f}:1:"; then
+  ok "remote class: a global option before the subcommand still flags the remote"
+else
+  fail "expected line 1 flagged for 'git -C <path> fetch origin', got: $out"
+fi
+rm -f "$f"
+
+# Separate-value (`-c <k>=<v>`) and attached-value (`--git-dir=<path>`) global
+# options are both spanned, and several may precede the subcommand.
+f="$(tmpfile 'Run `git -c core.hooksPath=/dev/null --git-dir=/w/.git push origin HEAD` in the sandbox.')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  fail "a run of global options must not hide the hardcoded remote"
+else
+  ok "remote class: a run of value-taking global options still flags the remote"
+fi
+rm -f "$f"
+
+# The option run is not a blanket matcher: it may only span options between
+# `git` and a remote-taking subcommand. A different subcommand whose line
+# merely mentions the word origin later must stay clean, or widening the anchor
+# would have traded a false negative for a false-positive class.
+f="$(tmpfile 'Run `git -C "$WT" status`, then push to the origin remote you resolved.')"
+if scan_with "$rt" "$f" >/dev/null 2>&1; then
+  ok "remote class: global options on a non-remote subcommand are not false-positives"
+else
+  fail "a global option on an unrelated subcommand must not flag on nearby prose"
+fi
+rm -f "$f"
+
 # The compliant shape: the remote is resolved into a variable first, so no
 # literal `origin` sits in the remote-argument position at all.
-f="$(tmpfile 'REMOTE="$(bash scripts/resolve-remote.sh --push)"; git push "$REMOTE" HEAD')"
+# Paired with the global-option cases above: widening the anchor must leave the
+# fix direction passing under a global option too, not only under bare `git`.
+f="$(tmpfile 'REMOTE="$(bash scripts/resolve-remote.sh --push)"; git push "$REMOTE" HEAD
+Re-fetch with `git -C "$WT" fetch "$REMOTE" "$BASE"` before merging.')"
 if scan_with "$rt" "$f" >/dev/null 2>&1; then
   ok "remote class: a resolved remote variable is not flagged"
 else

--- a/scripts/skill-portability-tokens.txt
+++ b/scripts/skill-portability-tokens.txt
@@ -110,7 +110,15 @@ origin/(main|master)
 # origin"), inside `origin/HEAD` (the branch class's own detection ladder), and
 # in unrelated compounds like "cross-origin".
 #
-# Residue at bb0efe61: 19 hits / 14 files. #442 — the issue that named this
+# Git's documented syntax is `git [<global-options>] <command> [<args>]`, so the
+# pattern spans an optional global-option run between `git` and the subcommand —
+# `git -C <worktree> fetch origin` is as much a hardcoded remote as the bare
+# form, and a subcommand-adjacent anchor would report it clean and understate
+# the residue. Options that take a separate value (`-C <path>`, `-c <k>=<v>`,
+# `--git-dir <path>`) are spanned by allowing each option one following
+# non-option word; an attached `--git-dir=<path>` is one word already.
+#
+# Residue at bb0efe61: 20 hits / 14 files. #442 — the issue that named this
 # class — is CLOSED: source-control resolves the remote properly today via
 # skills/pull-request/scripts/resolve-remote.sh, and its remaining hits are
 # prose ABOUT that resolver. What keeps the class staged is that the fix did
@@ -126,7 +134,7 @@ origin/(main|master)
 # pattern is a resolved remote variable or a co-located `branch.<name>.remote` /
 # `@{upstream}` / resolve-remote.sh call. The branch class's markers must not be
 # reused — they prove which BRANCH was resolved, never which REMOTE.
-# git (push|fetch|pull|clone|ls-remote|remote (prune|show|add|rename|get-url|set-url))([[:space:]]+-[^[:space:]]+)*[[:space:]]+origin([^a-zA-Z0-9_/.-]|$)
+# git([[:space:]]+-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?)*[[:space:]]+(push|fetch|pull|clone|ls-remote|remote (prune|show|add|rename|get-url|set-url))([[:space:]]+-[^[:space:]]+)*[[:space:]]+origin([^a-zA-Z0-9_/.-]|$)
 
 # Branch-grammar hardcode: Conventional-Commits branch types shipped as the
 # grammar rather than read from the consuming repo (#415). This is a lane-1

--- a/scripts/skill-portability-tokens.txt
+++ b/scripts/skill-portability-tokens.txt
@@ -38,14 +38,23 @@ origin/(main|master)
 
 # --- STAGED (commented until the class is proven clean against the corpus) ---
 #
+# Every staged entry carries a MEASURED residue (`--all` hit and file counts at
+# the recorded commit, scored through the gate itself so guards, per-site
+# annotations, and whole-file scope declarations are already applied) plus the
+# named blocker that has to clear. A count is a measurement with a shelf life,
+# not a promise: re-run `--all` before acting on one.
+#
 # Before enabling ANY staged class below, beyond the corpus audit:
 #   - Audit and EXTEND `is_guarded()` in check-skill-portability.sh with the
-#     markers the new class legitimately needs. Its markers are scoped to the
-#     active branch/default-branch class — branch-detection evidence only. A
-#     class that genuinely needs optional-dependency presence signals (e.g.
-#     "useful if using .NET — requires dotnet CLI") must add its own
-#     class-scoped markers; a generic `if using` / `when present` must never
-#     guard a bare hardcode, or the gate goes green on a real coupling.
+#     markers the new class legitimately needs. Markers are CLASS-SCOPED — the
+#     function receives the matched pattern, so the branch class's
+#     symbolic-ref / merge-base / origin/HEAD evidence never excuses a
+#     different class's coupling that happens to share a line. Add markers
+#     under the new class's own pattern test, never by widening the branch
+#     class's. A class that genuinely needs optional-dependency presence
+#     signals (e.g. "useful if using .NET — requires dotnet CLI") must add its
+#     own class-scoped markers; a generic `if using` / `when present` must
+#     never guard a bare hardcode, or the gate goes green on a real coupling.
 #   - If the pattern uses `\b` as a word boundary, it is NOT reliable: POSIX ERE
 #     defines no word-boundary escape, and on common awks (gawk AND mawk/nawk)
 #     `\b` matches a literal backspace byte, not a boundary — verified: gawk uses
@@ -63,12 +72,78 @@ origin/(main|master)
 # \bClean Arch(itecture)?\b
 
 # Forge/marketplace-internal hardcode: a hardcoded raw GitHub content URL where a
-# portable fetch or a declared scope belongs. Enable when #405 and the forge-lock
-# members (e.g. #441 declares source-control's inherent GitHub scope) land.
+# portable fetch or a declared scope belongs (#432). Enable when the forge-lock
+# members land (e.g. #441 declares source-control's inherent GitHub scope).
+# Residue at bb0efe61: 27 hits / 22 files. Two shapes share the token and want
+# opposite dispositions, which is what keeps it staged: a RUNTIME fetch of the
+# publisher's own repo at a moving `main` (#432's defect — the plugin cannot
+# reach a doc it does not bundle, so behavior depends on repo name, branch, and
+# network) versus a PROVENANCE citation of a third-party upstream in a
+# sync/drift script that is inherently locked to that upstream (context7 →
+# upstash/context7, dometrain → Dometrain/mcp), which is a `portability-scope`
+# declaration, not a fix. Splitting those needs #432's bundle-vs-pin ruling
+# first; activating before it would push a `portability-scope` declaration onto
+# files whose correct disposition is still open.
 # raw\.githubusercontent\.com
 
 # Tracker hardcode: bare `gh` tracker calls in a tracker-agnostic skill that
-# should route the work-item seam (#416). Enable once the seam-routing members
-# land; `gh` is legitimate in forge-scope-declared skills, so this class needs
-# the declared-scope escape hatch exercised first.
+# should route the work-item seam (#416). Residue at bb0efe61: 358 hits across
+# 78 files — by far the largest class here, and #416 (wayfind re-implements
+# GitHub-direct instead of routing the seam) is still OPEN, so the corpus has no
+# clean landing yet. Enable once the seam-routing members land; `gh` is
+# legitimate in forge-scope-declared skills, so this class needs the
+# declared-scope escape hatch exercised on those plugins first.
+#
+# The `\b` spelling below is inert, per the POSIX note above — it must be
+# rewritten to a POSIX-safe boundary before activation, not merely uncommented.
+# A verified replacement shape, measured against this corpus:
+#   (^|[^a-zA-Z0-9_.-])gh (issue|pr|api|repo|run|label|release|search|workflow)([^a-zA-Z0-9_-]|$)
+# The leading class excludes `.` and `-` so a filename or hyphenated identifier
+# ending in "gh" is not read as the command.
 # \bgh (issue|api|pr|label)
+
+# Remote-name hardcode: a bare `origin` as the REMOTE ARGUMENT of a git command
+# (#442's class) asserts the consumer's remote name instead of resolving it —
+# `git clone -o vendor` and triangular fork flows (fetch `upstream`, push
+# `fork`) both break. Anchored to the remote-argument position rather than the
+# bare word: `origin` also appears legitimately as English prose ("the lane's
+# origin"), inside `origin/HEAD` (the branch class's own detection ladder), and
+# in unrelated compounds like "cross-origin".
+#
+# Residue at bb0efe61: 19 hits / 14 files. #442 — the issue that named this
+# class — is CLOSED: source-control resolves the remote properly today via
+# skills/pull-request/scripts/resolve-remote.sh, and its remaining hits are
+# prose ABOUT that resolver. What keeps the class staged is that the fix did
+# not generalize: real bare uses remain in repo-hygiene, work-items,
+# claude-ops, and education, none of which can reach a plugin-local resolver
+# in another plugin, and no open member issue owns them. Enable when a
+# resolve-remote-shaped seam those plugins can call actually exists — until
+# then the only way to green is a `portability-scope` declaration on files
+# whose forge-locking is not inherent at all, which is exactly the false
+# exemption the whole-file token exists to prevent.
+#
+# is_guarded() needs a CLASS-SCOPED marker before this activates: the correct
+# pattern is a resolved remote variable or a co-located `branch.<name>.remote` /
+# `@{upstream}` / resolve-remote.sh call. The branch class's markers must not be
+# reused — they prove which BRANCH was resolved, never which REMOTE.
+# git (push|fetch|pull|clone|ls-remote|remote (prune|show|add|rename|get-url|set-url))([[:space:]]+-[^[:space:]]+)*[[:space:]]+origin([^a-zA-Z0-9_/.-]|$)
+
+# Branch-grammar hardcode: Conventional-Commits branch types shipped as the
+# grammar rather than read from the consuming repo (#415). This is a lane-1
+# violation under PLUGIN-PHILOSOPHY's Two-lane convention posture — a repo on
+# Jira-key branches (`SW2-12345-desc`) gets wrong suggestions — and the same
+# plugin already defers commit policy correctly, so the inconsistency is
+# internal, not inherent.
+#
+# Residue at bb0efe61: 4 hits / 2 files for the type-enumeration shape,
+# 19 hits / 11 files for the `<type>/<` placeholder shape. Enable when #415's
+# consumer seam lands. The placeholder token is deliberately the narrower of
+# the two candidates: a bare `(feat|fix|chore)/` alternation also matches
+# ordinary prose paths (`build/shots/`, `docs/conventions/`), which is a
+# false-positive class no annotation should have to absorb.
+#
+# Both spellings are recorded because they catch different defects — the
+# enumeration catches a shipped type LIST, the placeholder catches a shipped
+# branch SHAPE — and #415 may resolve one without the other.
+# `(feat|fix|refactor|chore|docs|test|build|perf|style)/`[^`]*`(feat|fix|refactor|chore|docs|test|build|perf|style)/`
+# <type>/<


### PR DESCRIPTION
Closes #713

Stage 2 of the portability-lint program (#531): extends the engine to the forge/branch/remote coupling class and hardens the declared-narrower-scope honor.

## Ratified conventions

`portability-scope: <reason>` (whole-file) and `portability-ok: <reason>` (per-site) are the agnosticism-scope conventions, per the operator ratification on #713 (2026-07-22). **The `plugin.json` `keywords` alternative was rejected by that ruling and is not implemented here** — #713's body still labels it RECOMMENDED, which is stale text the ratification overrides. Discovery keywords are contaminated for lock-duty (source-control's plain `"github"` keyword would false-auto-exempt it from every forge check).

## Tokens covered

All five tokens the Stage 2 plan enumerates are now recorded in `scripts/skill-portability-tokens.txt`, each with a residue measured **through the gate itself** (guards, annotations, and scope declarations already applied) at base `bb0efe61`:

| Class | Pattern shape | Residue | Blocker |
|---|---|---|---|
| `origin/main` | already ACTIVE from Stage 1 | 1 hit | — |
| remote name `origin` | anchored to the remote-argument position, spanning git global options | 20 hits / 14 files | no seam those plugins can reach |
| Conventional-Commits grammar | type enumeration | 4 hits / 2 files | #415 |
| Conventional-Commits grammar | `<type>/<` branch shape | 19 hits / 11 files | #415 |
| `raw.githubusercontent` | literal | 27 hits / 22 files | #432 |
| `gh` / `gh api` | POSIX-safe replacement spelling recorded | 358 hits / 78 files | #416 |

### Why staged rather than active

The token file's ratified rollout rule (#531 Option A) is one class at a time, each proven green against the real corpus first. None of these can reach zero residue today by *fixing* the coupling — the only path to green would be declaring `portability-scope` on files that are **not** inherently forge-locked, which is precisely the false whole-file exemption that token exists to prevent. Each entry therefore carries its measured residue and a named enable trigger.

Worth flagging for the reviewer: **#442, the issue that named the remote class, is already CLOSED.** source-control resolves its remote correctly via `resolve-remote.sh`. That fix did not generalize, and the remaining bare uses in repo-hygiene, work-items, claude-ops and education cannot reach another plugin's local resolver — so the class is staged on the absence of a shared seam, not on an open ticket. If the maintainer prefers, activating it is defensible on changed-file scoping alone (it would gate only newly-touched files, never red-lining main); that is a judgment call left open rather than taken here.

The staged `gh` spelling on main (`\bgh (issue|api|pr|label)`) is **inert** — POSIX ERE defines no `\b`, and awk reads it as a literal backspace, so it would never have matched. A verified POSIX-safe replacement is recorded alongside it.

### Remote-name token spans git global options

Caught in review: git's documented syntax is `git [<global-options>] <command> [<args>]`, but the remote-name pattern originally required the subcommand immediately after `git`, so a legal `git -C <worktree> fetch origin` scanned clean. That is the same hardcoded remote the class exists to catch, and the corpus carries the form in `plugins/source-control/skills/babysit-prs/reference/orchestration.md:645`. The pattern now spans an optional global-option run, allowing each option one following non-option word so separate-value forms (`-C <path>`, `-c <k>=<v>`, `--git-dir <path>`) are covered; an attached `--git-dir=<path>` is already one word. Re-measured at the same corpus state, residue moves from 19 to 20 hits with no previously flagged site lost, so the widening is strictly additive.

## Correctness change

`is_guarded()` now takes the matched pattern, making guard markers class-scoped — the same shape `check-shell-portability.sh` already uses. Previously every marker was global, so the first additional class to activate would inherit branch-detection evidence as a blanket excuse: a `git merge-base origin/main HEAD` on a line would also have excused a hardcoded `git fetch origin` beside it. That is a real coupling reported clean.

## Verification

- Suite: **PASS=44 FAIL=0**; `shellcheck --rcfile .shellcheckrc` and `shfmt -d` clean; markdownlint clean.
- **Mutation-verified**, not merely green: reverting the guard scoping fails the new test, the pre-review remote-name pattern misses the global-option fixture, and drifting a staged pattern out of sync with its fixture also fails loudly.
- Every residue count above was re-measured through the gate rather than estimated by grep.
- Full `--all` audit at HEAD reports exactly one hit — a pre-existing `origin/main` in `plugins/playbooks/skills/boris/reference/foundations.md:15` that is present on main, untouched by this PR, and outside changed-file scope.
- Fixtures cover each token class plus both escapes, including the acceptance pair (a scope-declared file exempt, its otherwise identical undeclared twin still flagged) and the reach asymmetry: a per-site `portability-ok` covers its site only and does **not** silence the rest of the file.

One test-scaffolding defect found and fixed during self-review: the staged-pattern helper originally called `fail` inside a `$(...)` substitution, so on a missed pattern the counter increment was lost in the subshell and every guarded block skipped in silence behind a green suite — the exact silent-skip this repo's gates forbid. It is now a parent-shell assertion with no conditional guards.

## Files

- `scripts/skill-portability-tokens.txt` — Stage 2 classes staged with measured residue and enable triggers
- `scripts/check-skill-portability.sh` — class-scoped guard markers
- `scripts/check-skill-portability.test.sh` — Stage 2 fixtures, declared-scope acceptance pair, guard-scoping regression
- `docs/PLUGIN-PHILOSOPHY.md` — the two tokens' reach distinction and the class-scoping rule

CI wiring (`portability-lint` in `ci-status.needs`, self-test-first, never-skips, fail-closed) is unchanged from Stage 1 and already satisfies that acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related

- Refs #531 — parent portability-lint program; this PR is Stage 2 only.
- Refs #415, #416, #432 — blockers recorded per token class in the staging table above.

