### PR TITLE
chore(knowledge): retire fable-5 guide doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.2]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: fable-5 prompting-guide queue entry removed.** The
+  prompting-claude-fable-5 slice completed — fetch through interview handoff, dual verification
+  (same-vendor PASS; cross-vendor corrections applied and re-verified PASS) — so its entry
+  leaves the doc queue per the queue's remove-on-completion rule. The two thinking docs the
+  effort-slice disposition enqueued were already queued in 0.10.1; verified still live at their
+  queued URLs.
+
 ## [0.10.1]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -58,7 +58,6 @@ their slices complete.
 
 Per-model guides:
 
-- <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5>
 - <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5>
 
 Guardrail guides:


### PR DESCRIPTION
## Summary

- Removes the `prompting-claude-fable-5` entry from the `docpage-digest` Anthropic profile's doc queue — its slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule.
- Slice verification: Verifier A (same-vendor, fresh context) PASS with 3 advisories; Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED with 8+1 findings — all corrections applied and re-verified PASS with no new findings. Records live under the untracked slice at `.work/platform-claude-com-docs-en-bui-ad459d21/verification/`.
- The two thinking docs decided by the effort-slice Q10 disposition were already enqueued as two runs in 0.10.1 and remain queued; both URLs verified live (HTTP 200, no redirect) at edit time, so this PR adds no queue entries.
- Knowledge plugin `0.10.1` → `0.10.2` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on both changed markdown files: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning: SKILL.md 223 lines vs soft target 200)
- `check-changelog-parity.sh --check-bump origin/main`: PASS
- Independent fresh-context reviewer on the diff: APPROVE, no findings (traced the changelog's claims to the slice's checklist and verification records, and re-checked both queued thinking URLs live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
