### PR TITLE
chore(knowledge): retire context-engineering blog doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.3]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: context-engineering blog queue entry removed.** The
+  new-rules-of-context-engineering blog slice completed — rendered-channel fetch (raw-md
+  confirmed absent for this page, matching the profile's blog-post channel note) through
+  interview handoff, dual verification (both verifiers returned corrections; all applied and
+  cross-vendor re-verified) — so its entry leaves the doc queue per the queue's
+  remove-on-completion rule.
+
 ## [0.10.2]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -94,8 +94,6 @@ Applies across all of the above:
 
 Blog posts:
 
-- <https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models>
-  — likely cross-cuts every slice
 - <https://claude.com/blog/claude-models-explained-choosing-the-best-model-for-your-use-case>
   — pair with the choosing-a-model slice for the routing vet
 - <https://claude.com/blog/building-verification-loops-in-claude-code-with-skills>


### PR DESCRIPTION
## Summary

- Removes the new-rules-of-context-engineering blog entry from the `docpage-digest` Anthropic profile's doc queue — its slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule.
- Channel: rendered (raw-md confirmed absent for this page — `.md` probe 404, `Accept: text/markdown` ignored — matching the profile's blog-post channel note); `source.html` unaltered original + firecrawl 1.19.27 markdown extraction, artifacts recorded in the slice checklist.
- Slice verification: Verifier A (same-vendor, fresh context) CORRECTION-NEEDED (1+3); Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED (10+1). All findings applied; cross-vendor re-verify round 1 resolved all 15 and surfaced 2 correction-introduced issues; round 2 REVERIFY2: PASS. Records under `.work/claude-com-blog-the-new-rules-o-8e418fc0/verification/`.
- Knowledge plugin `0.10.2` → `0.10.3` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on changed markdown: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning, SKILL.md length)
- `check-changelog-parity.sh --check-bump origin/main`: PASS
- Independent fresh-context reviewer on the diff: APPROVE (traced the changelog claims to the slice checklist and verification records; its one non-blocking wording observation was applied before commit)
- Base freshness: fetched origin/main immediately before commit; zero commits behind

## Related

- #1752 (previous doc-queue completion in this series — fable-5 guide slice)
- #1740 (Verifier B elevated recipe used for cross-vendor verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
