### PR TITLE
fix(claude-ops): correct six restart-consumer defects found after #1720 merged

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort, a repo-pull + marketplace-refresh launch step, and a consume-restarts action — an OS-schedulable reader that relaunches stopped lanes whose telemetry carries a restart_request), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,41 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.23.2]
+
+### Fixed
+
+Six review findings raised on #1720 forty-six seconds *after* it merged, so they were never triaged
+(#1759). All are in `lanes/scripts/restart-consumer.sh`.
+
+- **A broken lock store reported as a held lock.** An ignored `mkdir` failure fell through to the
+  contention branch: the absent stamp read as zero and the run reported `lock-held` with exit 0. An
+  unattended consumer with a mistyped path, a permissions problem, or an unavailable volume would
+  **never process a lane while Task Scheduler recorded successful ticks**. `acquire_lock` now
+  separates "the store is unusable" (exit 4, loud) from "another run holds it" (exit 0, routine).
+- **A lock reclaimed on age alone.** A legitimate run outliving the one-hour bound had its live lock
+  removed, letting a second run enter the relaunch span concurrently — reachable because
+  `lane-launcher.sh` performs an unbounded `git pull --ff-only` and marketplace update before launch.
+  The holder now records an owner PID, and age only gates *when to ask*; liveness decides.
+- **Offline telemetry parse failures swallowed.** An unconditional `return 0` after the fixture-read
+  `jq` turned a missing, unreadable, or malformed `--telemetry-json` into a successful empty read,
+  reported as `no-state` — indistinguishable from "the lane did not ask". The offline branch now
+  carries the same contract the network read already had.
+- **An unwritable ledger reduced to a warning.** The breaker counts attempts by querying the ledger,
+  so an attempt that could not be recorded was invisible to `--max-restarts`: a launcher that kept
+  failing was retried on every polling tick forever. Writability is now proved *before* the relaunch,
+  and a failed append fails the lane instead of warning past it.
+- **Liveness read from a stale snapshot before mutating.** The session list is loaded once per run,
+  so a lane started since — by a concurrent operator invocation — still read as stopped, and
+  `lane-launcher.sh restart` *stops* a running lane before relaunching. A healthy session could be
+  interrupted despite the documented "not currently running" predicate. The predicate is now
+  rechecked against a fresh list immediately before the mutation.
+- **`print-schedule` dropped behavior-affecting options.** A non-default `--config` or
+  `--target-repo` was absent from the emitted schtasks, logon, cron, and offline forms, so the
+  scheduled invocation silently fell back to `<repo>/.work/lanes.json` and the checkout's own
+  repository — a different lane configuration and a different telemetry repository than the command
+  that generated it. All four forms now carry them; a defaulted option is still omitted.
+
 ## [0.23.1]
 
 ### Changed

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -32,6 +32,19 @@ Six review findings raised on #1720 forty-six seconds *after* it merged, so they
   `lane-launcher.sh restart` *stops* a running lane before relaunching. A healthy session could be
   interrupted despite the documented "not currently running" predicate. The predicate is now
   rechecked against a fresh list immediately before the mutation.
+- **A reused PID could masquerade as the lock owner.** `kill -0` proves only that *some* process
+  holds that number — and after the reboot this reclaim path exists to handle, the number is very
+  likely reused, which would wedge every later tick exactly as before. The lock now records a boot
+  identity beside the PID: a lock from a previous boot is reclaimed regardless of who holds its PID
+  now, and where no boot identity is available a live PID may only *defer* the reclaim, never defer
+  it past a hard 24-hour ceiling.
+- **The fresh liveness re-check failed open.** A transient `claude agents --json` failure made the
+  `&&` condition false and fell through to the launcher on the stale snapshot — reintroducing the
+  race the re-check exists to prevent. A failed re-read is now an error that skips the mutation.
+- **A post-launch ledger failure was still invisible.** The pre-flight probe cannot cover storage
+  that disappears *during* the launcher's unbounded work, so a relaunch could succeed while its
+  breaker row silently failed to persist and later ticks restarted the lane again. The outcome
+  append now fails the lane even when the restart itself worked.
 - **`print-schedule` dropped behavior-affecting options.** A non-default `--config` or
   `--target-repo` was absent from the emitted schtasks, logon, cron, and offline forms, so the
   scheduled invocation silently fell back to `<repo>/.work/lanes.json` and the checkout's own

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lanes
 description: "Start, restart, stop, and check loop lanes as named background Claude Code sessions seeded from canonical prompt files — the scripted replacement for the manual morning refresh (cancel loop, clear, re-paste the canonical prompt) across N lanes on a machine. `start`/`restart` first pull the repo and refresh the plugin marketplace, then launch each configured lane with its per-lane model/effort. `consume-restarts` reads each configured lane's telemetry `restart_request` and relaunches the stopped lanes that asked — the scheduled headless reader (#1653). Use when: 'launch my lanes', 'restart the loop lanes', 'start the work lanes', 'morning lane refresh', 'stop a lane', 'which lanes are running', 'lane status', 'consume restart requests', 'lane restart consumer', 'relaunch the lanes that asked'. Mutating and operator-initiated; never touches a session whose name is not a configured lane."
-argument-hint: "[start|restart|status|stop|consume-restarts] [lane...] — start (default); restart/stop accept lane names; consume-restarts takes [check|run|print-schedule]; --config, --repo, --dry-run, --no-pull, --no-update"
+argument-hint: "[start|restart|status|stop|consume-restarts] [lane...] — start (default); restart/stop accept lane names; consume-restarts takes [check|run|print-schedule]; --config, --repo, --target-repo, --dry-run, --no-pull, --no-update"
 user-invocable: true
 disable-model-invocation: true
 shell: bash

--- a/plugins/claude-ops/skills/lanes/context/restart-consumer.md
+++ b/plugins/claude-ops/skills/lanes/context/restart-consumer.md
@@ -197,8 +197,13 @@ parity claim.
   lock skips cleanly: exit 0, a `lock-held` flag, nothing launched and nothing
   written. A lock left by a hard-killed run (no EXIT trap) is reclaimed so an
   unattended schedule cannot wedge permanently — but **age alone never
-  reclaims**: the holder records its PID, the one-hour bound only decides when to
-  ask, and a lock whose owner is still alive stays held however old it is. That
+  reclaims**: the holder records its PID *and a boot identity*, the one-hour
+  bound only decides when to ask, and a lock whose owner is still alive stays
+  held however old it is. The boot identity matters because `kill -0` proves
+  only that some process holds that number, and after a reboot it is very likely
+  reused; a lock from a previous boot is reclaimed whoever holds its PID now,
+  and where no boot identity is available a live PID only defers the reclaim to
+  a hard 24-hour ceiling. That
   matters because a legitimate run can outlive any bound — `lane-launcher.sh`
   does an unbounded `git pull --ff-only` and marketplace update before launch.
   Failing to create the lock is separated from losing the race: an unusable lock

--- a/plugins/claude-ops/skills/lanes/context/restart-consumer.md
+++ b/plugins/claude-ops/skills/lanes/context/restart-consumer.md
@@ -195,8 +195,16 @@ parity claim.
   both relaunch, and one lane name ends up with two `claude --bg` sessions and
   two `restarted` rows for one effective restart. A run that cannot take the
   lock skips cleanly: exit 0, a `lock-held` flag, nothing launched and nothing
-  written. A lock left by a hard-killed run (no EXIT trap) ages out after an
-  hour so an unattended schedule cannot wedge permanently. `check` and
+  written. A lock left by a hard-killed run (no EXIT trap) is reclaimed so an
+  unattended schedule cannot wedge permanently — but **age alone never
+  reclaims**: the holder records its PID, the one-hour bound only decides when to
+  ask, and a lock whose owner is still alive stays held however old it is. That
+  matters because a legitimate run can outlive any bound — `lane-launcher.sh`
+  does an unbounded `git pull --ff-only` and marketplace update before launch.
+  Failing to create the lock is separated from losing the race: an unusable lock
+  **store** (mistyped path, permissions, unavailable volume) exits 4 loudly
+  rather than reporting `lock-held` and exiting 0, which would let an unattended
+  consumer log healthy ticks forever while processing nothing. `check` and
   `--dry-run` mutate nothing and never contend.
 - **Exit codes are honest.** A relaunch that fails, never comes up, trips the
   breaker, or a lane whose telemetry could not be READ (`api-error` — never

--- a/plugins/claude-ops/skills/lanes/scripts/restart-consumer.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/restart-consumer.sh
@@ -453,17 +453,20 @@ ledger_relpath() { printf '%s/restart-consumer.jsonl' "$(repo_marker_key)"; }
 LOCK_DIR=""
 OWN_LOCK=0
 # A run hard-killed mid-flight (reboot, Task Scheduler kill) never reaches its
-# EXIT trap, so a lock older than this is treated as abandoned and reclaimed.
-# Without that, a 15-minute unattended schedule wedges silently forever — the
-# exact failure mode this consumer exists not to become. The bound is far longer
-# than a real run, which is bounded by the per-lane confirmation retries.
+# EXIT trap, so an abandoned lock must eventually be reclaimed — without that, a
+# 15-minute unattended schedule wedges silently forever, the exact failure mode
+# this consumer exists not to become. Age alone is the WRONG discriminator: a
+# legitimate run can outlive any bound, because `lane-launcher.sh` performs an
+# unbounded `git pull --ff-only` and `claude plugin marketplace update` before
+# launch. So age is necessary but not sufficient — the holder's liveness decides,
+# and the age bound only gates when we bother to ask.
 LOCK_STALE_SECONDS=3600
 
 # shellcheck disable=SC2329  # invoked indirectly: acquire_lock installs it as the EXIT trap
 release_lock() {
   ((OWN_LOCK)) || return 0
   OWN_LOCK=0
-  rm -f "$LOCK_DIR/acquired-at" 2>/dev/null || true
+  rm -f "$LOCK_DIR/acquired-at" "$LOCK_DIR/owner-pid" 2>/dev/null || true
   rmdir "$LOCK_DIR" 2>/dev/null || true
 }
 
@@ -474,6 +477,25 @@ lock_stamp() {
   printf '%s' "$stamp"
 }
 
+lock_owner_pid() {
+  local pid=""
+  pid="$(tr -d '\r\n' <"$LOCK_DIR/owner-pid" 2>/dev/null)" || pid=""
+  [[ "$pid" =~ ^[0-9]+$ ]] || pid=0
+  printf '%s' "$pid"
+}
+
+# Is the recorded lock owner still running? Overridable so the tests can drive
+# both branches without spawning real processes.
+lock_owner_alive() {
+  local pid="$1"
+  ((pid > 0)) || return 1
+  if [[ -n "${RESTART_CONSUMER_FAKE_ALIVE_PIDS-}" ]]; then
+    [[ " $RESTART_CONSUMER_FAKE_ALIVE_PIDS " == *" $pid "* ]]
+    return
+  fi
+  kill -0 "$pid" 2>/dev/null
+}
+
 # `mkdir` is the atomic arbiter: exactly one process can create the directory, so
 # a loser never mutates. The stamp file dates the lock for the abandonment check.
 # A loser that finds NO stamp adopts one at `now` rather than reclaiming: the
@@ -481,28 +503,63 @@ lock_stamp() {
 # and stealing that lock is the very duplication this guards. Stamping instead
 # ages the lock out on a later tick, so a hard-killed run bounds the wedge at
 # LOCK_STALE_SECONDS after it is first observed instead of wedging forever.
+# Returns 0 = acquired, 1 = another run holds it, 2 = the lock STORE is unusable.
+# Distinguishing 2 from 1 matters more than it looks: an unattended consumer whose
+# data dir is mistyped, unwritable, or on an unavailable volume would otherwise
+# report `lock-held` and exit 0 forever, so Task Scheduler records healthy ticks
+# while no lane is ever processed.
 acquire_lock() {
-  local now="$1" stamp
+  local now="$1" stamp pid parent
   LOCK_DIR="$(dirname "$(ledger_path)")/.restart-consumer-lock"
-  # The data dir does not exist until the first ledger write, and an ENOENT
-  # mkdir is indistinguishable from a held lock — so materialize the parent.
-  mkdir -p "$(dirname "$LOCK_DIR")" 2>/dev/null || true
+  parent="$(dirname "$LOCK_DIR")"
+  # The data dir does not exist until the first ledger write, so materialize the
+  # parent — but a failure here is a storage fault, never contention.
+  if ! mkdir -p "$parent" 2>/dev/null && [[ ! -d "$parent" ]]; then
+    err "cannot create the lock directory's parent: $parent"
+    return 2
+  fi
   if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    # mkdir failed. Contention writes a stamp we can read; a storage fault does
+    # not even leave a directory behind.
+    if [[ ! -d "$LOCK_DIR" ]]; then
+      err "cannot create the lock directory: $LOCK_DIR"
+      return 2
+    fi
     stamp="$(lock_stamp)"
+    pid="$(lock_owner_pid)"
+    # A loser that finds NO stamp adopts one at `now` rather than reclaiming: the
+    # holder may have won the mkdir microseconds ago and not written its stamp
+    # yet, and stealing that lock is the very duplication this guards.
     if ((stamp == 0)); then
-      printf '%s\n' "$now" >"$LOCK_DIR/acquired-at" 2>/dev/null || true
+      write_lock_file "$LOCK_DIR/acquired-at" "$now" || return 2
       return 1
     fi
     ((now - stamp < LOCK_STALE_SECONDS)) && return 1
+    # Aged out — but age alone never reclaims. A recorded owner that is still
+    # running means a legitimately long run, not an abandoned lock.
+    if lock_owner_alive "$pid"; then
+      warn "lock held since epoch $stamp is past the stale bound but its owner (pid $pid) is alive; leaving it held: $LOCK_DIR"
+      return 1
+    fi
     warn "reclaiming a lock held since epoch $stamp with no live run to release it: $LOCK_DIR"
-    rm -f "$LOCK_DIR/acquired-at" 2>/dev/null || true
+    rm -f "$LOCK_DIR/acquired-at" "$LOCK_DIR/owner-pid" 2>/dev/null || true
     rmdir "$LOCK_DIR" 2>/dev/null || true
     mkdir "$LOCK_DIR" 2>/dev/null || return 1
   fi
   OWN_LOCK=1
   trap release_lock EXIT
-  printf '%s\n' "$now" >"$LOCK_DIR/acquired-at" 2>/dev/null || true
+  write_lock_file "$LOCK_DIR/acquired-at" "$now" || return 2
+  write_lock_file "$LOCK_DIR/owner-pid" "$$" || return 2
   return 0
+}
+
+# A lock whose stamp cannot be persisted is not a lock — silently continuing
+# would let the next tick reclaim it as unstamped while this run is live.
+write_lock_file() {
+  local path="$1" value="$2"
+  printf '%s\n' "$value" >"$path" 2>/dev/null && return 0
+  err "cannot write the lock file: $path"
+  return 1
 }
 
 resolve_launcher() {
@@ -620,7 +677,11 @@ resolve_issue_by_title() {
 lane_comment_bodies() {
   local lane="$1" repo="$2" issue="$3" raw
   if [[ -n "$TELEMETRY_JSON_FILE" ]]; then
-    jq -c --arg l "$lane" '[ (.[$l] // [])[] | .body // "" ]' "$TELEMETRY_JSON_FILE"
+    # The fixture read gets the same contract as the network read: a missing,
+    # unreadable, malformed, or wrongly-shaped file is a FAILURE, not an empty
+    # comment list. An unconditional `return 0` here would report `no-state` —
+    # indistinguishable from "the lane did not ask".
+    jq -c --arg l "$lane" '[ (.[$l] // [])[] | .body // "" ]' "$TELEMETRY_JSON_FILE" 2>/dev/null || return 1
     return 0
   fi
   raw="$(gh api --paginate "repos/$repo/issues/$issue/comments" -q '.[] | {body}' 2>/dev/null)" || return 1
@@ -702,6 +763,29 @@ ledger_decision() {
   esac
 }
 
+# Can the ledger take an append right now? Probed before a relaunch so a lane
+# whose attempt could not be counted is never launched. `check` and dry runs
+# never append, so nothing is claimed about them.
+ledger_writable() {
+  local ledger dir
+  ((DRY_RUN)) && return 0
+  [[ "$ACTION" == "run" ]] || return 0
+  ledger="$(ledger_path)"
+  dir="$(dirname "$ledger")"
+  mkdir -p "$dir" 2>/dev/null || [[ -d "$dir" ]] || return 1
+  # O_APPEND of nothing: creates the file when absent, proves writability when
+  # present, and adds no row either way. The redirection runs in a subshell so
+  # that bash's OWN failure message — which `2>/dev/null` on the command cannot
+  # suppress, because the shell emits it before the command runs — stays out of
+  # the operator's report.
+  (: >>"$ledger") 2>/dev/null || return 1
+}
+
+# Returns non-zero when the row could not be persisted. The breaker
+# (`--max-restarts`) is computed by querying this ledger, so an attempt that
+# never lands is an attempt the breaker cannot count: a launcher that keeps
+# failing would be retried on every polling tick, forever, without reaching the
+# cap. Persistence failure is therefore a run failure, not a warning.
 append_ledger() {
   local row="$1" ledger dir
   ((DRY_RUN)) && return 0
@@ -712,8 +796,12 @@ append_ledger() {
   [[ "$ACTION" == "run" ]] || return 0
   ledger="$(ledger_path)"
   dir="$(dirname "$ledger")"
-  if ! mkdir -p "$dir" 2>/dev/null || ! printf '%s\n' "$row" >>"$ledger" 2>/dev/null; then
-    warn "run ledger write failed: $ledger"
+  # Subshell for the same reason as ledger_writable: bash reports a failed
+  # redirection itself, before the command runs, so `2>/dev/null` on printf
+  # alone would still leak the message into the report.
+  if ! mkdir -p "$dir" 2>/dev/null || ! (printf '%s\n' "$row" >>"$ledger") 2>/dev/null; then
+    err "run ledger write failed: $ledger"
+    return 1
   fi
 }
 
@@ -722,6 +810,8 @@ declare -a REPORT_ROWS=()
 declare -a FLAGS=()
 EXIT_STATUS=0
 
+# Propagates append_ledger's status so a caller that is about to mutate (relaunch)
+# can refuse when its attempt could not be recorded.
 record() {
   local lane="$1" decision="$2" detail="$3" request="$4" now="$5"
   REPORT_ROWS+=("| $lane | $decision | $detail |")
@@ -729,7 +819,7 @@ record() {
   append_ledger "$(jq -c -n \
     --arg ts "$(iso_utc "$now")" --argjson epoch "$now" --arg lane "$lane" \
     --arg decision "$decision" --arg detail "$detail" --argjson request "$request" \
-    '{ts:$ts,epoch:$epoch,lane:$lane,decision:$decision,detail:$detail,request:$request}')"
+    '{ts:$ts,epoch:$epoch,lane:$lane,decision:$decision,detail:$detail,request:$request}')" || return 1
 }
 
 fail_lane() {
@@ -830,6 +920,28 @@ process_lane() {
     return 0
   fi
 
+  # Recheck liveness against a FRESH list immediately before mutating. The
+  # snapshot above is loaded once per run, so a lane started since — by a
+  # concurrent operator invocation — still reads as stopped. `lane-launcher.sh
+  # restart` deliberately STOPS a running lane before relaunching it, so acting
+  # on the stale snapshot would interrupt a healthy session, which the documented
+  # "not currently running" predicate promises never to do.
+  if read_sessions && lane_is_running "$lane"; then
+    record "$lane" "skipped-running" "lane started after the run's snapshot; not restarting ($reason)" "$request" "$now"
+    return 0
+  fi
+
+  # Prove the outcome row can land BEFORE mutating. The breaker counts attempts
+  # by querying the ledger, so a relaunch whose `restarted`/`failed` row cannot
+  # be written is invisible to `--max-restarts` — a launcher that keeps failing
+  # would be retried on every polling tick forever. Probing first keeps the
+  # breaker's memory intact without adding a second row per attempt.
+  if ! ledger_writable; then
+    record "$lane" "error" "run ledger is not writable; refusing to relaunch a lane whose attempt cannot be counted" "$request" "$now" || true
+    fail_lane "ledger-unwritable($lane)" 5
+    return 0
+  fi
+
   info "restarting lane '$lane' ($reason)"
   local -a launch=(restart "$lane" --config "$CONFIG" --repo "$REPO")
   [[ -n "$DATA_DIR_OVERRIDE" ]] && launch+=(--data-dir "$DATA_DIR_OVERRIDE")
@@ -914,8 +1026,22 @@ Run ledger: \`<data-dir>/$(ledger_relpath)\` on the machine running this consume
 
 # --- print-schedule -----------------------------------------------------------
 action_print_schedule() {
-  local self claude_bin run_cmd win_repo win_claude data_dir
+  local self claude_bin run_cmd win_repo win_claude data_dir opts opts_sq
   self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+  # Behavior-affecting options must survive into every emitted command. This
+  # action runs BEFORE resolve_config/resolve_target_repo, so these hold exactly
+  # what the operator passed — empty means "defaulted", and a defaulted option is
+  # the one case it is safe to omit. Dropping a passed one would silently
+  # schedule a run against `<repo>/.work/lanes.json` and the checkout's own
+  # repository: a different lane configuration and a different telemetry
+  # repository than the command that generated it.
+  opts=""
+  [[ -n "$CONFIG" ]] && opts+=" --config $CONFIG"
+  [[ -n "$TARGET_REPO" ]] && opts+=" --target-repo $TARGET_REPO"
+  # Single-quoted variant for the cron and offline forms, which quote their args.
+  opts_sq=""
+  [[ -n "$CONFIG" ]] && opts_sq+=" --config '$CONFIG'"
+  [[ -n "$TARGET_REPO" ]] && opts_sq+=" --target-repo '$TARGET_REPO'"
   # The offline form's --data-dir must be COPY-PASTEABLE, because the warning
   # under it is that a second data dir splits the breaker ledger. When the caller
   # passed one, echo it back; otherwise keep the placeholder that says what to
@@ -930,7 +1056,7 @@ action_print_schedule() {
   # `run` is load-bearing: the script's default action is the read-only
   # `check`, so a schedule registered without `run` would report forever and
   # never relaunch anything.
-  run_cmd='claude -p "/claude-ops:lanes consume-restarts run" --output-format text'
+  run_cmd="claude -p \"/claude-ops:lanes consume-restarts run${opts}\" --output-format text"
 
   cat <<EOF
 Registering the schedule is an OPERATOR action — this script never performs it.
@@ -951,7 +1077,7 @@ Reader: $run_cmd
   cmd.exe syntax). NOT from Git Bash: MSYS path conversion rewrites /-style
   options — 'schtasks /Query' becomes an invalid 'C:/Program Files/Git/Query'.
 
-schtasks /Create /TN "$TASK_NAME" /SC MINUTE /MO ${INTERVAL_MINUTES} /F /RU "%USERNAME%" /IT /RL LIMITED /TR "cmd /c cd /d \"$win_repo\" && \"$win_claude\" -p \"/claude-ops:lanes consume-restarts run\" --output-format text"
+schtasks /Create /TN "$TASK_NAME" /SC MINUTE /MO ${INTERVAL_MINUTES} /F /RU "%USERNAME%" /IT /RL LIMITED /TR "cmd /c cd /d \"$win_repo\" && \"$win_claude\" -p \"/claude-ops:lanes consume-restarts run${opts}\" --output-format text"
 
   /IT runs the task only while that user is logged on, so the CLI reads the
   credentials already in the user profile: no stored password, no elevation.
@@ -959,7 +1085,7 @@ schtasks /Create /TN "$TASK_NAME" /SC MINUTE /MO ${INTERVAL_MINUTES} /F /RU "%US
 
   Cold start after a reboot — add a logon trigger alongside the poll:
 
-schtasks /Create /TN "$TASK_NAME (logon)" /SC ONLOGON /F /RU "%USERNAME%" /IT /RL LIMITED /TR "cmd /c cd /d \"$win_repo\" && \"$win_claude\" -p \"/claude-ops:lanes consume-restarts run\" --output-format text"
+schtasks /Create /TN "$TASK_NAME (logon)" /SC ONLOGON /F /RU "%USERNAME%" /IT /RL LIMITED /TR "cmd /c cd /d \"$win_repo\" && \"$win_claude\" -p \"/claude-ops:lanes consume-restarts run${opts}\" --output-format text"
 
   Remove both (also from cmd.exe):
 
@@ -970,14 +1096,14 @@ schtasks /Delete /TN "$TASK_NAME (logon)" /F
 
   Same command on the same interval. cron form:
 
-*/${INTERVAL_MINUTES} * * * * cd '$REPO' && '$claude_bin' -p '/claude-ops:lanes consume-restarts run' --output-format text
+*/${INTERVAL_MINUTES} * * * * cd '$REPO' && '$claude_bin' -p '/claude-ops:lanes consume-restarts run${opts}' --output-format text
 
 == Offline variant (no model turn) ==
 
   The reader is a deterministic script; the headless 'claude -p' wrapper only
   routes through the skill. Schedule this where a model turn is unwanted:
 
-bash '$self' run --repo '$REPO' --data-dir '$data_dir'
+bash '$self' run --repo '$REPO' --data-dir '$data_dir'${opts_sq}
 
   --data-dir matters here: skill-invoked runs pass the resolved
   CLAUDE_PLUGIN_DATA directory explicitly, and this form's env-var fallback
@@ -1004,19 +1130,28 @@ main() {
   require_claude
   load_sessions
 
-  local now n i
+  local now n i lock_rc=0
   now="$(now_epoch)"
 
   # Held across the whole read -> decide -> relaunch -> append span, and across
   # the telemetry upsert, so a losing tick writes nothing at all. Only a real
   # `run` mutates, so only a real `run` contends.
-  if [[ "$ACTION" == "run" ]] && ((!DRY_RUN)) && ! acquire_lock "$now"; then
-    warn "another restart-consumer run holds the lock ($LOCK_DIR) — skipping this tick"
-    info "restart-consumer: $ACTION on ${TARGET_REPO:-<fixtures>} at $(iso_utc "$now")"
-    info "| lane | decision | detail |"
-    info "|---|---|---|"
-    info "| (none) | lock-held | another run holds $LOCK_DIR; skipped |"
-    exit 0
+  if [[ "$ACTION" == "run" ]] && ((!DRY_RUN)); then
+    acquire_lock "$now" || lock_rc=$?
+    # 2 = the lock store itself is unusable. Exiting 0 here would let an
+    # unattended schedule log healthy ticks forever while processing nothing.
+    if ((${lock_rc:-0} == 2)); then
+      err "restart-consumer: the lock store is unusable — not a held lock; failing rather than reporting a skipped tick"
+      exit 4
+    fi
+    if ((${lock_rc:-0} != 0)); then
+      warn "another restart-consumer run holds the lock ($LOCK_DIR) — skipping this tick"
+      info "restart-consumer: $ACTION on ${TARGET_REPO:-<fixtures>} at $(iso_utc "$now")"
+      info "| lane | decision | detail |"
+      info "|---|---|---|"
+      info "| (none) | lock-held | another run holds $LOCK_DIR; skipped |"
+      exit 0
+    fi
   fi
 
   n="$(jq -r '(.lanes // []) | length' "$CONFIG")"

--- a/plugins/claude-ops/skills/lanes/scripts/restart-consumer.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/restart-consumer.sh
@@ -466,7 +466,7 @@ LOCK_STALE_SECONDS=3600
 release_lock() {
   ((OWN_LOCK)) || return 0
   OWN_LOCK=0
-  rm -f "$LOCK_DIR/acquired-at" "$LOCK_DIR/owner-pid" 2>/dev/null || true
+  rm -f "$LOCK_DIR/acquired-at" "$LOCK_DIR/owner-pid" "$LOCK_DIR/boot-id" 2>/dev/null || true
   rmdir "$LOCK_DIR" 2>/dev/null || true
 }
 
@@ -484,11 +484,47 @@ lock_owner_pid() {
   printf '%s' "$pid"
 }
 
-# Is the recorded lock owner still running? Overridable so the tests can drive
-# both branches without spawning real processes.
+# An identity for THIS boot of the machine, recorded beside the owner PID.
+# `kill -0` proves only that SOME process currently holds that number: after the
+# reboot this reclaim path exists to handle, the PID is very likely reused by an
+# unrelated long-lived process, and trusting it would wedge every later tick
+# exactly as before. A boot identity settles the reboot case outright.
+boot_identity() {
+  [[ -n "${RESTART_CONSUMER_FAKE_BOOT_ID-}" ]] && {
+    printf '%s' "$RESTART_CONSUMER_FAKE_BOOT_ID"
+    return 0
+  }
+  [[ -r /proc/sys/kernel/random/boot_id ]] && {
+    tr -d '\r\n' </proc/sys/kernel/random/boot_id
+    return 0
+  }
+  return 1
+}
+
+lock_boot_id() { tr -d '\r\n' <"$LOCK_DIR/boot-id" 2>/dev/null || printf ''; }
+
+# The absolute ceiling. Reached only when boot identity is unavailable on this
+# platform, where a live PID cannot be distinguished from a reused one — so the
+# wedge is bounded rather than trusted away. Far beyond any real run.
+LOCK_HARD_STALE_SECONDS=86400
+
+# Is the recorded lock owner still the process that took the lock? Overridable
+# so the tests can drive every branch without spawning real processes.
 lock_owner_alive() {
-  local pid="$1"
+  local pid="$1" age="$2" recorded_boot current_boot
   ((pid > 0)) || return 1
+
+  recorded_boot="$(lock_boot_id)"
+  if current_boot="$(boot_identity)" && [[ -n "$recorded_boot" ]]; then
+    # Booted since the lock was taken: the owner cannot have survived, whatever
+    # process wears its PID now.
+    [[ "$recorded_boot" == "$current_boot" ]] || return 1
+  else
+    # No boot identity to compare. A live PID is suggestive, not proof, so it
+    # only defers the reclaim — it can never defer it forever.
+    ((age >= LOCK_HARD_STALE_SECONDS)) && return 1
+  fi
+
   if [[ -n "${RESTART_CONSUMER_FAKE_ALIVE_PIDS-}" ]]; then
     [[ " $RESTART_CONSUMER_FAKE_ALIVE_PIDS " == *" $pid "* ]]
     return
@@ -509,7 +545,7 @@ lock_owner_alive() {
 # report `lock-held` and exit 0 forever, so Task Scheduler records healthy ticks
 # while no lane is ever processed.
 acquire_lock() {
-  local now="$1" stamp pid parent
+  local now="$1" stamp pid parent boot_now
   LOCK_DIR="$(dirname "$(ledger_path)")/.restart-consumer-lock"
   parent="$(dirname "$LOCK_DIR")"
   # The data dir does not exist until the first ledger write, so materialize the
@@ -537,12 +573,12 @@ acquire_lock() {
     ((now - stamp < LOCK_STALE_SECONDS)) && return 1
     # Aged out — but age alone never reclaims. A recorded owner that is still
     # running means a legitimately long run, not an abandoned lock.
-    if lock_owner_alive "$pid"; then
-      warn "lock held since epoch $stamp is past the stale bound but its owner (pid $pid) is alive; leaving it held: $LOCK_DIR"
+    if lock_owner_alive "$pid" "$((now - stamp))"; then
+      warn "lock held since epoch $stamp is past the stale bound but its owner (pid $pid) is alive on the same boot; leaving it held: $LOCK_DIR"
       return 1
     fi
     warn "reclaiming a lock held since epoch $stamp with no live run to release it: $LOCK_DIR"
-    rm -f "$LOCK_DIR/acquired-at" "$LOCK_DIR/owner-pid" 2>/dev/null || true
+    rm -f "$LOCK_DIR/acquired-at" "$LOCK_DIR/owner-pid" "$LOCK_DIR/boot-id" 2>/dev/null || true
     rmdir "$LOCK_DIR" 2>/dev/null || true
     mkdir "$LOCK_DIR" 2>/dev/null || return 1
   fi
@@ -550,6 +586,11 @@ acquire_lock() {
   trap release_lock EXIT
   write_lock_file "$LOCK_DIR/acquired-at" "$now" || return 2
   write_lock_file "$LOCK_DIR/owner-pid" "$$" || return 2
+  # Best-effort: absent on platforms without a boot identity, which the
+  # liveness check handles by bounding the wedge instead of trusting the PID.
+  if boot_now="$(boot_identity)"; then
+    write_lock_file "$LOCK_DIR/boot-id" "$boot_now" || return 2
+  fi
   return 0
 }
 
@@ -926,8 +967,16 @@ process_lane() {
   # restart` deliberately STOPS a running lane before relaunching it, so acting
   # on the stale snapshot would interrupt a healthy session, which the documented
   # "not currently running" predicate promises never to do.
-  if read_sessions && lane_is_running "$lane"; then
-    record "$lane" "skipped-running" "lane started after the run's snapshot; not restarting ($reason)" "$request" "$now"
+  # Fail CLOSED on a failed re-read. `read_sessions && lane_is_running` would
+  # fall through to the launcher on a transient read failure, still holding the
+  # stale snapshot — which is precisely the race this recheck exists to prevent.
+  if ! read_sessions; then
+    record "$lane" "error" "could not re-read the session list immediately before relaunching; not restarting on a stale snapshot" "$request" "$now" || true
+    fail_lane "session-recheck-failed($lane)" 5
+    return 0
+  fi
+  if lane_is_running "$lane"; then
+    record "$lane" "skipped-running" "lane started after the run's snapshot; not restarting ($reason)" "$request" "$now" || true
     return 0
   fi
 
@@ -946,7 +995,8 @@ process_lane() {
   local -a launch=(restart "$lane" --config "$CONFIG" --repo "$REPO")
   [[ -n "$DATA_DIR_OVERRIDE" ]] && launch+=(--data-dir "$DATA_DIR_OVERRIDE")
   if ! bash "$LAUNCHER" "${launch[@]}"; then
-    record "$lane" "failed" "lane-launcher.sh restart exited non-zero" "$request" "$now"
+    record "$lane" "failed" "lane-launcher.sh restart exited non-zero" "$request" "$now" ||
+      fail_lane "ledger-unwritable($lane)" 5
     fail_lane "restart-failed($lane)" 5
     return 0
   fi
@@ -954,10 +1004,18 @@ process_lane() {
   # Confirm rather than trust: whether a `claude --bg` session launched from a
   # scheduler-spawned parent survives that parent is unverified on Windows, so a
   # relaunch that does not come up must be loud here, not silent.
+  # The preflight probe cannot cover this: storage can go away DURING the
+  # launcher's unbounded work. A relaunch that happened but left no breaker row
+  # would let later ticks restart the lane again without spending budget, so a
+  # post-mutation append failure fails the lane even though the restart worked.
   if confirm_running "$lane"; then
-    record "$lane" "restarted" "$reason" "$request" "$now"
+    if ! record "$lane" "restarted" "$reason" "$request" "$now"; then
+      err "lane '$lane' WAS relaunched but its breaker row could not be written; later ticks cannot count this attempt"
+      fail_lane "ledger-unwritable($lane)" 5
+    fi
   else
-    record "$lane" "failed" "relaunched but the lane never appeared in the session list" "$request" "$now"
+    record "$lane" "failed" "relaunched but the lane never appeared in the session list" "$request" "$now" ||
+      fail_lane "ledger-unwritable($lane)" 5
     fail_lane "restart-unconfirmed($lane)" 5
   fi
 }

--- a/plugins/claude-ops/skills/lanes/scripts/restart-consumer.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/restart-consumer.test.sh
@@ -519,18 +519,21 @@ assert_not_contains "an unusable store is never reported as contention" "$OUT" "
 # launch, so a legitimate run can outlive any age bound. Liveness decides.
 KEY="$(printf '%s' "$(git -C "$REPO" rev-parse --show-toplevel)" | git hash-object --stdin)"
 LOCKDIR="$DATA/lanes/$KEY/.restart-consumer-lock"
-seed_lock() { # $1 stamp, $2 owner pid
+seed_lock() { # $1 stamp, $2 owner pid, $3 optional recorded boot id
   mkdir -p "$LOCKDIR"
   printf '%s\n' "$1" >"$LOCKDIR/acquired-at"
   printf '%s\n' "$2" >"$LOCKDIR/owner-pid"
+  rm -f "$LOCKDIR/boot-id"
+  [[ -n "${3:-}" ]] && printf '%s\n' "$3" >"$LOCKDIR/boot-id"
 }
 release_seeded_lock() { rm -rf "$LOCKDIR"; }
 
 TEL="$TMP/tel-23.json"
 write_telemetry "$TEL" 'true' 'null'
-# Stamp is two hours old — well past LOCK_STALE_SECONDS=3600 — but pid 4242 is alive.
-seed_lock 1799992800 4242
-OUT="$(RESTART_CONSUMER_FAKE_ALIVE_PIDS='4242' run_consumer run \
+# Stamp is two hours old — well past LOCK_STALE_SECONDS=3600 — but pid 4242 is
+# alive and the recorded boot identity still matches, so the owner is genuine.
+seed_lock 1799992800 4242 boot-A
+OUT="$(RESTART_CONSUMER_FAKE_BOOT_ID='boot-A' RESTART_CONSUMER_FAKE_ALIVE_PIDS='4242' run_consumer run \
   --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
 assert_contains "an aged lock whose owner is ALIVE stays held" "$OUT" "| (none) | lock-held |"
 assert_contains "and says why it declined to reclaim" "$OUT" "owner (pid 4242) is alive"
@@ -541,11 +544,115 @@ assert_not_contains "a live owner's lock is never reclaimed" "$OUT" "reclaiming 
 # already spent against lane `work` in the shared data dir — this case is about
 # the reclaim, not the budget.
 : >"$LAUNCH_LOG"
-OUT="$(RESTART_CONSUMER_FAKE_ALIVE_PIDS='' run_consumer run --max-restarts 0 \
+OUT="$(RESTART_CONSUMER_FAKE_BOOT_ID='boot-A' RESTART_CONSUMER_FAKE_ALIVE_PIDS='' run_consumer run --max-restarts 0 \
   --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
 assert_contains "an aged lock whose owner is GONE is still reclaimed" "$OUT" "reclaiming a lock"
 assert_contains "and the reclaiming run goes on to do its work" "$(cat "$LAUNCH_LOG")" "restart work"
 release_seeded_lock
+
+# A REUSED pid must not masquerade as the owner. The machine has rebooted since
+# the lock was taken (boot id differs), so whatever holds pid 4242 now is an
+# unrelated process — trusting `kill -0` alone would wedge every later tick.
+seed_lock 1799992800 4242 boot-OLD
+: >"$LAUNCH_LOG"
+OUT="$(RESTART_CONSUMER_FAKE_BOOT_ID='boot-NEW' RESTART_CONSUMER_FAKE_ALIVE_PIDS='4242' run_consumer run --max-restarts 0 \
+  --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
+assert_contains "a live pid from a PREVIOUS boot is a reused pid, not the owner" "$OUT" "reclaiming a lock"
+assert_contains "and the reclaiming run proceeds" "$(cat "$LAUNCH_LOG")" "restart work"
+release_seeded_lock
+
+# With no boot identity recorded at all, a live pid may only DEFER the reclaim —
+# past the hard ceiling the wedge is broken regardless.
+seed_lock 1799992800 4242 # no boot id
+OUT="$(RESTART_CONSUMER_FAKE_ALIVE_PIDS='4242' run_consumer run \
+  --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
+assert_contains "without a boot identity a live pid still defers the reclaim" "$OUT" "| (none) | lock-held |"
+release_seeded_lock
+
+# Same, but the lock is older than LOCK_HARD_STALE_SECONDS=86400 (two days).
+seed_lock 1799827200 4242
+: >"$LAUNCH_LOG"
+OUT="$(RESTART_CONSUMER_FAKE_ALIVE_PIDS='4242' run_consumer run --max-restarts 0 \
+  --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
+assert_contains "past the hard ceiling an unverifiable pid never wedges forever" "$OUT" "reclaiming a lock"
+release_seeded_lock
+
+# --- 28. A failed session re-read fails CLOSED (#1760 review) -----------------
+# `read_sessions && lane_is_running` would fall through to the launcher on a
+# transient read failure, still holding the stale snapshot — the exact race the
+# recheck exists to prevent.
+FAIL_STUB="$TMP/stubs-failread"
+mkdir -p "$FAIL_STUB"
+FAIL_COUNT="$TMP/failread-count"
+: >"$FAIL_COUNT"
+cat >"$FAIL_STUB/claude" <<'SH'
+#!/usr/bin/env bash
+# The run's own snapshot succeeds; the pre-mutation re-read fails.
+n="$(wc -l <"$FAIL_COUNT" | tr -d ' ')"
+echo x >>"$FAIL_COUNT"
+if [[ "$n" -eq 0 ]]; then echo '[]'; else exit 1; fi
+SH
+chmod +x "$FAIL_STUB/claude"
+cp "$STUBS/gh" "$FAIL_STUB/gh"
+chmod +x "$FAIL_STUB/gh"
+TEL="$TMP/tel-28.json"
+write_telemetry "$TEL" 'true' 'null'
+: >"$LAUNCH_LOG"
+OUT="$(FAIL_COUNT="$FAIL_COUNT" PATH="$FAIL_STUB:$PATH" bash "$SCRIPT" run \
+  --config "$CONFIG" --repo "$REPO" --data-dir "$DATA" --target-repo "owner/name" \
+  --launcher "$LAUNCHER" --no-telemetry --now 1800000000 --max-restarts 0 --telemetry-json "$TEL" 2>&1)"
+RC=$?
+assert_not_contains "a failed re-read NEVER relaunches on the stale snapshot" "$(cat "$LAUNCH_LOG")" "restart work"
+assert_contains "a failed re-read is an error decision" "$OUT" "| work | error |"
+assert_contains "and says it refused to act on a stale snapshot" "$OUT" "stale snapshot"
+assert_eq "a failed re-read exits non-zero" "5" "$RC"
+
+# --- 29. A POST-launch ledger failure fails the lane (#1760 review) -----------
+# The preflight probe cannot cover storage that disappears DURING the launcher's
+# unbounded work: a relaunch that leaves no breaker row would be repeatable.
+LEDGER_DIR_PATH="$DATA/lanes/$KEY"
+POST_LAUNCHER="$TMP/launcher-eats-ledger.sh"
+cat >"$POST_LAUNCHER" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"\$LAUNCH_LOG"
+# Storage goes away mid-launch, after ledger_writable already succeeded.
+rm -f '$LEDGER_DIR_PATH/restart-consumer.jsonl'
+mkdir -p '$LEDGER_DIR_PATH/restart-consumer.jsonl'
+exit 0
+SH
+chmod +x "$POST_LAUNCHER"
+TEL="$TMP/tel-29.json"
+write_telemetry "$TEL" 'true' 'null'
+: >"$LAUNCH_LOG"
+# The lane must read STOPPED for the run's snapshot and for the pre-mutation
+# recheck, then RUNNING once confirm_running looks — otherwise the relaunch
+# never happens and there is no post-launch append to fail.
+POST_STUB="$TMP/stubs-postledger"
+mkdir -p "$POST_STUB"
+POST_COUNT="$TMP/post-count"
+: >"$POST_COUNT"
+cat >"$POST_STUB/claude" <<'SH'
+#!/usr/bin/env bash
+n="$(wc -l <"$POST_COUNT" | tr -d ' ')"
+echo x >>"$POST_COUNT"
+if [[ "$n" -lt 2 ]]; then
+  echo '[]'
+else
+  echo '[{"name":"work","kind":"background","startedAt":1,"sessionId":"post"}]'
+fi
+SH
+chmod +x "$POST_STUB/claude"
+cp "$STUBS/gh" "$POST_STUB/gh"
+chmod +x "$POST_STUB/gh"
+OUT="$(POST_COUNT="$POST_COUNT" PATH="$POST_STUB:$PATH" bash "$SCRIPT" run \
+  --config "$CONFIG" --repo "$REPO" --data-dir "$DATA" \
+  --target-repo "owner/name" --launcher "$POST_LAUNCHER" --no-telemetry --now 1800000000 \
+  --max-restarts 0 --telemetry-json "$TEL" 2>&1)"
+RC=$?
+assert_contains "the launcher DID run, so the relaunch really happened" "$(cat "$LAUNCH_LOG")" "restart work"
+assert_contains "a post-launch ledger failure is reported, not swallowed" "$OUT" "breaker row could not be written"
+assert_eq "a post-launch ledger failure exits non-zero" "5" "$RC"
+rm -rf "$LEDGER_DIR_PATH/restart-consumer.jsonl"
 
 # --- 24. Offline telemetry parse failures propagate (#1759 P2) ----------------
 # An unconditional `return 0` turned a jq failure into a successful empty read,

--- a/plugins/claude-ops/skills/lanes/scripts/restart-consumer.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/restart-consumer.test.sh
@@ -498,6 +498,136 @@ assert_contains "a passed --data-dir is substituted into the offline form" "$OUT
 OUT="$(bash "$SCRIPT" print-schedule --repo "$REPO" 2>&1)"
 assert_contains "without one, the placeholder still says what to substitute" "$OUT" "<the CLAUDE_PLUGIN_DATA dir skill runs use>"
 
+# --- 22. A broken lock STORE is not reported as a held lock (#1759 P1) --------
+# An ignored `mkdir` failure used to fall through to the contention branch, so an
+# unattended consumer with a mistyped path or an unavailable volume reported
+# `lock-held` and exited 0 forever while Task Scheduler logged healthy ticks.
+NOTADIR="$TMP/notadir"
+: >"$NOTADIR" # a FILE where a directory must be: mkdir -p can never succeed
+TEL="$TMP/tel-22.json"
+write_telemetry "$TEL" 'true' 'null'
+OUT="$(bash "$SCRIPT" run --config "$CONFIG" --repo "$REPO" --data-dir "$NOTADIR/sub" \
+  --target-repo "owner/name" --launcher "$LAUNCHER" --no-telemetry --now 1800000000 \
+  --telemetry-json "$TEL" --agents-json "$AGENTS_NONE" 2>&1)"
+RC=$?
+assert_eq "an unusable lock store exits non-zero instead of 0" "4" "$RC"
+assert_contains "and says the store is unusable, not that a lock is held" "$OUT" "lock store is unusable"
+assert_not_contains "an unusable store is never reported as contention" "$OUT" "| (none) | lock-held |"
+
+# --- 23. A lock is never reclaimed on age alone (#1759 P2) --------------------
+# `lane-launcher.sh` does an unbounded `git pull` + marketplace update before
+# launch, so a legitimate run can outlive any age bound. Liveness decides.
+KEY="$(printf '%s' "$(git -C "$REPO" rev-parse --show-toplevel)" | git hash-object --stdin)"
+LOCKDIR="$DATA/lanes/$KEY/.restart-consumer-lock"
+seed_lock() { # $1 stamp, $2 owner pid
+  mkdir -p "$LOCKDIR"
+  printf '%s\n' "$1" >"$LOCKDIR/acquired-at"
+  printf '%s\n' "$2" >"$LOCKDIR/owner-pid"
+}
+release_seeded_lock() { rm -rf "$LOCKDIR"; }
+
+TEL="$TMP/tel-23.json"
+write_telemetry "$TEL" 'true' 'null'
+# Stamp is two hours old — well past LOCK_STALE_SECONDS=3600 — but pid 4242 is alive.
+seed_lock 1799992800 4242
+OUT="$(RESTART_CONSUMER_FAKE_ALIVE_PIDS='4242' run_consumer run \
+  --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
+assert_contains "an aged lock whose owner is ALIVE stays held" "$OUT" "| (none) | lock-held |"
+assert_contains "and says why it declined to reclaim" "$OUT" "owner (pid 4242) is alive"
+assert_not_contains "a live owner's lock is never reclaimed" "$OUT" "reclaiming a lock"
+
+# Same aged stamp, but the owner is gone: reclaiming is correct here.
+# --max-restarts 0 disables the breaker, which earlier cases in this file have
+# already spent against lane `work` in the shared data dir — this case is about
+# the reclaim, not the budget.
+: >"$LAUNCH_LOG"
+OUT="$(RESTART_CONSUMER_FAKE_ALIVE_PIDS='' run_consumer run --max-restarts 0 \
+  --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
+assert_contains "an aged lock whose owner is GONE is still reclaimed" "$OUT" "reclaiming a lock"
+assert_contains "and the reclaiming run goes on to do its work" "$(cat "$LAUNCH_LOG")" "restart work"
+release_seeded_lock
+
+# --- 24. Offline telemetry parse failures propagate (#1759 P2) ----------------
+# An unconditional `return 0` turned a jq failure into a successful empty read,
+# so unreadable telemetry was indistinguishable from "the lane did not ask".
+BADTEL="$TMP/tel-24-malformed.json"
+printf '{"work": [ THIS IS NOT JSON\n' >"$BADTEL"
+OUT="$(run_consumer run --telemetry-json "$BADTEL" --agents-json "$AGENTS_NONE")"
+assert_not_contains "malformed offline telemetry is NOT reported as no-state" "$OUT" "| work | no-state |"
+assert_contains "malformed offline telemetry surfaces as an error decision" "$OUT" "api-error"
+
+MISSINGTEL="$TMP/tel-24-absent.json" # deliberately never created
+OUT="$(run_consumer run --telemetry-json "$MISSINGTEL" --agents-json "$AGENTS_NONE")"
+assert_not_contains "an absent telemetry fixture is NOT reported as no-state" "$OUT" "| work | no-state |"
+assert_contains "an absent telemetry fixture surfaces as an error decision" "$OUT" "api-error"
+
+# --- 25. An unwritable ledger fails closed before relaunching (#1759 P2) ------
+# The breaker counts attempts by querying the ledger, so an attempt that cannot
+# be recorded is invisible to --max-restarts and would be retried every tick.
+LEDGER_AS_DIR="$DATA/lanes/$KEY/restart-consumer.jsonl"
+rm -rf "$LEDGER_AS_DIR"
+mkdir -p "$LEDGER_AS_DIR" # a DIRECTORY where the ledger file must be: append always fails
+TEL="$TMP/tel-25.json"
+write_telemetry "$TEL" 'true' 'null'
+: >"$LAUNCH_LOG"
+OUT="$(run_consumer run --telemetry-json "$TEL" --agents-json "$AGENTS_NONE")"
+RC=$?
+assert_contains "an unwritable ledger is an error decision, not a warning" "$OUT" "| work | error |"
+assert_contains "and the row says why the relaunch was refused" "$OUT" "refusing to relaunch a lane whose attempt cannot be counted"
+assert_not_contains "the lane is NOT launched when its attempt cannot be counted" "$(cat "$LAUNCH_LOG")" "restart work"
+assert_eq "an unwritable ledger exits non-zero" "5" "$RC"
+assert_not_contains "bash's own redirection error never leaks into the report" "$OUT" "Is a directory"
+rm -rf "$LEDGER_AS_DIR"
+
+# --- 26. Liveness is rechecked against a FRESH list before mutating (#1759 P2)-
+# The session snapshot is loaded once per run, so a lane started since — by a
+# concurrent operator invocation — still reads as stopped. `lane-launcher.sh
+# restart` STOPS a running lane before relaunching, so acting on the stale
+# snapshot would interrupt a healthy session.
+RACE_STUB="$TMP/stubs-race"
+mkdir -p "$RACE_STUB"
+RACE_COUNT="$TMP/race-count"
+: >"$RACE_COUNT"
+cat >"$RACE_STUB/claude" <<'SH'
+#!/usr/bin/env bash
+# First call (the run's snapshot) sees nothing running; every later call — the
+# pre-mutation recheck — sees the lane that started in between.
+n="$(wc -l <"$RACE_COUNT" | tr -d ' ')"
+echo x >>"$RACE_COUNT"
+if [[ "$n" -eq 0 ]]; then
+  echo '[]'
+else
+  echo '[{"name":"work","kind":"background","startedAt":1,"sessionId":"race"}]'
+fi
+SH
+chmod +x "$RACE_STUB/claude"
+cp "$STUBS/gh" "$RACE_STUB/gh"
+chmod +x "$RACE_STUB/gh"
+TEL="$TMP/tel-26.json"
+write_telemetry "$TEL" 'true' 'null'
+: >"$LAUNCH_LOG"
+OUT="$(RACE_COUNT="$RACE_COUNT" PATH="$RACE_STUB:$PATH" bash "$SCRIPT" run \
+  --config "$CONFIG" --repo "$REPO" --data-dir "$DATA" --target-repo "owner/name" \
+  --launcher "$LAUNCHER" --no-telemetry --now 1800000000 --telemetry-json "$TEL" 2>&1)"
+assert_contains "a lane that started after the snapshot is skipped, not restarted" "$OUT" "| work | skipped-running |"
+assert_contains "and the report says the snapshot was stale" "$OUT" "started after the run's snapshot"
+assert_not_contains "a lane alive at mutation time is never stopped-and-relaunched" "$(cat "$LAUNCH_LOG")" "restart work"
+
+# --- 27. print-schedule preserves behavior-affecting options (#1759 P2) -------
+# Dropping a passed --config/--target-repo silently schedules a run against
+# <repo>/.work/lanes.json and the checkout's own repository instead.
+OUT="$(bash "$SCRIPT" print-schedule --repo "$REPO" --config "$CONFIG" --target-repo "owner/name" 2>&1)"
+for form in 'schtasks /Create /TN' 'ONLOGON' '* * * * cd' "bash '"; do
+  line="$(printf '%s\n' "$OUT" | grep -F -- "$form" | head -1)"
+  assert_contains "the emitted form [$form] keeps --config" "$line" "--config"
+  assert_contains "the emitted form [$form] keeps --target-repo" "$line" "--target-repo"
+done
+assert_contains "the offline form quotes the passed --config" "$OUT" "--config '$CONFIG'"
+# A defaulted option is the one case it is safe to omit.
+OUT="$(bash "$SCRIPT" print-schedule --repo "$REPO" 2>&1)"
+assert_not_contains "a defaulted --config is not emitted as noise" "$OUT" "--config"
+assert_not_contains "a defaulted --target-repo is not emitted as noise" "$OUT" "--target-repo"
+
 # --- Summary -----------------------------------------------------------------
 printf '\n%d case(s), %d failure(s)\n' "$CASE_NUM" "$FAILED"
 ((FAILED == 0)) || exit 1


### PR DESCRIPTION
## Why

`chatgpt-codex-connector` posted six findings on #1720 at `19:24:03Z` — **46 seconds after it
merged** at `19:23:17Z`. No ruleset gate could hold them (the threads did not exist at merge time),
and nothing surfaces open threads on a merged PR, so they were never triaged. All six are real, all
are in `lanes/scripts/restart-consumer.sh`, and none was addressed on `main`.

## What changed

**Two that could silently disable an unattended consumer**

- **A broken lock store read as a held lock.** An ignored `mkdir` failure fell through to the
  contention branch: the absent stamp read as zero and the run reported `lock-held` with exit 0. A
  mistyped data dir, a permissions problem, or an unavailable volume meant **Task Scheduler recorded
  healthy ticks forever while no lane was ever processed**. `acquire_lock` now returns a third state
  — store unusable (exit 4, loud) vs. race lost (exit 0, routine).
- **An unwritable ledger was a warning.** The breaker counts attempts by querying that ledger, so an
  unrecordable attempt was invisible to `--max-restarts` and a failing launcher was retried on every
  tick forever. Writability is proved *before* the relaunch, and a failed append fails the lane.

**Two concurrency races**

- **A lock reclaimed on age alone.** A legitimate run outliving the one-hour bound had its live lock
  removed, letting a second run enter the relaunch span — reachable because `lane-launcher.sh` does
  an unbounded `git pull --ff-only` and marketplace update before launch. The holder now records a
  PID; age only decides *when to ask*, liveness decides the outcome.
- **The relaunch predicate read a stale snapshot.** The session list loads once per run, so a lane
  started since by a concurrent operator invocation still read as stopped — and `lane-launcher.sh
  restart` **stops** a running lane before relaunching. A healthy session could be interrupted
  despite the documented "not currently running" predicate. Now rechecked against a fresh list
  immediately before mutating.

**Two correctness gaps**

- **Offline telemetry parse failures were swallowed** by an unconditional `return 0`, so an
  unreadable or malformed `--telemetry-json` reported `no-state` — indistinguishable from "the lane
  did not ask". The offline branch now carries the contract the network read already had.
- **`print-schedule` dropped behavior-affecting options.** A non-default `--config`/`--target-repo`
  was missing from all four emitted forms (schtasks, logon, cron, offline), so the registered task
  would silently drive a different lane configuration and a different telemetry repository than the
  command that generated it.

## Also fixed while here

Bash reports a failed redirection *itself*, before the command runs, so `2>/dev/null` on `printf`
never suppressed it — `Is a directory` was leaking into the operator's report. The redirections now
run in a subshell.

## Verification

- `restart-consumer.test.sh`: **95 → 126 cases, 0 failures.** Every finding gets a regression case,
  each paired with a negative case so the fix cannot over-correct — a *dead* owner's lock is still
  reclaimed, a *defaulted* option is still omitted, and the report must not contain the leaked
  redirection error.
- `shellcheck -x` on both scripts — clean.
- `node scripts/validate-plugin-contracts.mjs` — 43 setup skills, 2150 files, pass.
- `npx markdownlint-cli2` on all three changed markdown files — 0 errors.

## Docs

`context/restart-consumer.md` claimed a lock "ages out after an hour", which is no longer the whole
rule — updated to state that age never reclaims on its own. `SKILL.md`'s `argument-hint` gained
`--target-repo`, which `print-schedule` now emits and the hint omitted.

## Related

Closes #1759
Refs #1720
Refs #1653
