### PR TITLE
chore(knowledge): retire sonnet-5 guide doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.4]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: sonnet-5 prompting-guide queue entry removed.** The
+  prompting-claude-sonnet-5 slice completed — raw-md fetch through interview handoff, dual
+  verification with corrections applied and cross-vendor re-verified — so its entry leaves the
+  doc queue per the queue's remove-on-completion rule. It was the last remaining per-model
+  guide, so the emptied category heading goes with it.
+- **`docpage-digest` Anthropic profile: applicability-filter clarifications from that slice's
+  verification.** Evidence is row-local ("same basis as claim N" never satisfies the contract),
+  and `unverified-inference` is an additional uncertainty marker, never a substitute for the
+  `cc-applicable`/`api-only`/`mixed` tag itself.
+
 ## [0.10.3]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -26,8 +26,8 @@ the tag asserts:
 
 - **`cc-applicable` / `mixed` (positive claims):** verified against live code.claude.com docs at
   tag time — cite the URL consulted in the digest row. A positive tag assigned by inference,
-  without a live-doc check, is recorded as `unverified-inference` and becomes an interview
-  question, never a silent fact. (This rule exists because inference has already produced a
+  without a live-doc check, is additionally recorded as `unverified-inference` and becomes an
+  interview question, never a silent fact. (This rule exists because inference has already produced a
   wrong tag once — the failure mode is real.)
 - **`api-only` (a negative claim — "no harness surface exists"):** absence cannot be proven from
   one page. Record the basis (the harness doc section(s) checked, or `unverified-inference` when
@@ -36,6 +36,12 @@ the tag asserts:
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
   SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
   reserved for claims naming no API surface.
+- **Row-local, tag always present:** the evidence (a positive tag's live-doc URL, an `api-only`
+  basis) appears in the claim's own row — "same basis as claim N" does not satisfy the contract —
+  and every claim carries exactly one vocabulary tag: `unverified-inference` is an additional
+  uncertainty marker, never a substitute for the tag. (Both rulings from the sonnet-5 guide
+  slice's cross-vendor verification, where citation-by-reference and marker-as-tag were the
+  dominant correction class.)
 
 ## Digest-agent model matching
 
@@ -55,10 +61,6 @@ Every model-pinned spawn brief uses the conditional framing contract from `SKILL
 
 Pending Anthropic docs for this pipeline. Verify each URL live at fetch time; remove entries as
 their slices complete.
-
-Per-model guides:
-
-- <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5>
 
 Guardrail guides:
 


### PR DESCRIPTION
## Summary

- Removes the prompting-claude-sonnet-5 entry from the `docpage-digest` Anthropic profile's doc queue — its slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule. It was the last remaining per-model guide, so the emptied category heading goes with it.
- Channel: raw-md (`.md` appended to the page URL; HTTP 200, 15,864 bytes — channel re-verified for this page, no degradation); provenance recorded in the slice checklist.
- Slice verification: Verifier A (same-vendor, fresh context) CORRECTION-NEEDED (3+5); Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED (21+1). Three correction rounds (round 3 orchestrator-approved per the >2-round rule; digest corrections applied by subject-model-pinned agents), re-verified each round; final state REVERIFY3: PASS from both verifiers. Records under `.work/platform-claude-com-docs-en-bui-1b530928/verification/`.
- Profile applicability-filter clarifications codified from that verification's binding rulings: evidence is row-local ("same basis as claim N" never satisfies the contract), and `unverified-inference` is an additional uncertainty marker, never a substitute for the `cc-applicable`/`api-only`/`mixed` tag; the sibling positive-claims bullet now says "additionally recorded" to close the substitute-tag misreading at its origin.
- Knowledge plugin `0.10.3` → `0.10.4` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on changed markdown: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning, SKILL.md length)
- `check-changelog-parity.sh --check-bump origin/main`: PASS
- Independent fresh-context reviewer on the diff: APPROVE (traced the changelog claims to the slice checklist and verification records; its one non-blocking wording observation was applied before commit)
- Base freshness: fetched origin/main immediately before commit; zero commits behind

No linked issue — this PR closes no GitHub issue; the doc queue is tracked in the profile file itself.

## Related

- #1756 (previous doc-queue completion in this series — context-engineering blog slice)
- #1740 (Verifier B elevated recipe used for cross-vendor verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

