### PR TITLE
chore(knowledge): retire best-practices doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.5]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: best-practices queue entry removed.** The
+  code.claude.com best-practices slice completed — raw-md fetch through interview handoff,
+  dual verification (one correction round, re-verified REVERIFY: PASS by both verifiers, no
+  degraded fallback) — so its entry leaves the doc queue per the queue's remove-on-completion
+  rule. It was the sole "Applies across all of the above" entry, so the emptied category
+  heading goes with it.
+- **`docpage-digest` Anthropic profile: applicability-filter clarification from that slice's
+  verification.** A digested page that is itself a live code.claude.com harness doc serves as
+  its own row-local basis for intrinsic harness-guidance claims; the boundary rule still routes
+  API-surface-naming claims to `mixed`, with third-party APIs counting as API surfaces.
+
 ## [0.10.4]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -42,6 +42,12 @@ the tag asserts:
   uncertainty marker, never a substitute for the tag. (Both rulings from the sonnet-5 guide
   slice's cross-vendor verification, where citation-by-reference and marker-as-tag were the
   dominant correction class.)
+- **Harness docs are their own live basis:** when the digested page is itself a live
+  code.claude.com harness doc, intrinsic harness-guidance claims cite the canonical page URL +
+  section as their row-local basis; the boundary rule still routes claims naming an API surface
+  to `mixed`, and third-party APIs (e.g. the GitHub API) count as API surfaces — no vendor
+  exemption. (From the best-practices slice: the third-party-API ruling is its cross-vendor
+  finding; the own-basis rule was applied there and ratified by both re-verifications.)
 
 ## Digest-agent model matching
 
@@ -89,10 +95,6 @@ Supplementary references:
 
 - <https://platform.claude.com/docs/en/resources/overview>
 - <https://platform.claude.com/docs/en/release-notes/system-prompts>
-
-Applies across all of the above:
-
-- <https://code.claude.com/docs/en/best-practices>
 
 Blog posts:
 


### PR DESCRIPTION
## Summary

- Removes the code.claude.com best-practices entry from the `docpage-digest` Anthropic profile's doc queue — its slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule. It was the sole "Applies across all of the above" entry, so the emptied category heading goes with it.
- Channel: raw-md (`.md` appended to the page URL; HTTP 200, 610 lines / 39,668 bytes — channel re-verified for this page, no degradation); provenance recorded in the slice checklist.
- Slice verification: Verifier A (same-vendor, fresh context) CORRECTION-NEEDED (1+3); Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED (8+1). One correction round (session-default agents — cross-model harness doc, no model pin per the profile's model-matching table); re-verified REVERIFY: PASS by both verifiers, 12/12 findings resolved, zero new findings. Records under `.work/code-claude-com-docs-en-best-pr-9686dc16/verification/`.
- Profile applicability-filter clarification codified from that verification: a digested page that is itself a live code.claude.com harness doc serves as its own row-local basis for intrinsic harness-guidance claims; the boundary rule still routes API-surface-naming claims to `mixed`, with third-party APIs (e.g. the GitHub API) counting as API surfaces.
- Knowledge plugin `0.10.4` → `0.10.5` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on changed markdown: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning, SKILL.md length)
- `check-changelog-parity.sh --check-bump origin/main`: PASS
- Independent fresh-context reviewer on the diff: APPROVE (traced the changelog claims to the slice checklist and verification records; its one info-level attribution observation was applied before commit)
- Base freshness: fetched origin/main immediately before commit; zero commits behind

No linked issue — this PR closes no GitHub issue; the doc queue is tracked in the profile file itself.

## Related

- #1761 (previous doc-queue completion in this series — sonnet-5 prompting-guide slice)
- #1740 (Verifier B elevated recipe used for cross-vendor verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
