### PR TITLE
ci: re-pin claude lane callers to v0.9.1, adopt paths-file, serialize the review lane

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,16 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
+    # Repo-wide review queue: serializes reviews so parallel PRs queue for the
+    # shared Claude seat instead of contending for it. Job-scoped and repo-wide
+    # by design, and deliberately distinct from the reusable's own inner group
+    # (keyed per PR and head SHA) — a caller group sharing that name would
+    # deadlock the call against itself. `queue: max` admits no
+    # `cancel-in-progress`, which the two cannot be combined with anyway
+    # (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idconcurrency).
+    concurrency:
+      group: claude-review-${{ github.repository }}
+      queue: max
     uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
     with:
       runner: ubuntu-24.04

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,12 +22,9 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post review + track_progress tracking comment
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@e2951077a7b43c09fc5a8dee4da52ba6f0fb39ed # e295107 2026-07-26 infra-failure class in the annotation + PR comment
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
     with:
       runner: ubuntu-24.04
-      # Passing skip-actors replaces the reusable's default (dependabot[bot]),
-      # so the default member is restated alongside the sync bot.
-      skip-actors: "dependabot[bot],melodic-standards-sync[bot]"
     # Pass only the one named secret (least privilege) rather than `secrets:
     # inherit`, which would forward every parent secret to the called workflow.
     secrets:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -2,16 +2,18 @@ name: claude-security-review
 
 # Dedicated LLM security-review pass via the ci-workflows reusable workflow — the
 # security sibling of claude-review.yml, ADR 0002's default-on advisory posture.
-# The caller owns the triggers, the GITHUB_TOKEN grant, and the `paths` input
-# listing this repo's security-sensitive surfaces (workflows, scripts, hooks,
-# shell, and permission/settings config). There is deliberately NO workflow-level
-# path filter: a path miss would leave the required execution check Pending and
-# wedge prose PRs, so the reusable workflow evaluates `paths` in a job-level gate
-# and a not-applicable PR yields a name-stable skipped check the required-check
-# ruleset reads as success. The verdict stays advisory per ADR 0002. Fork PRs
-# receive no secrets and a read-only token, so they are simply not reviewed by
-# design. Requires `claude-code-plugins` in the CLAUDE_CODE_OAUTH_TOKEN org
-# secret's selected-repositories scope. Public repo: hosted default runner.
+# The caller owns the triggers, the GITHUB_TOKEN grant, and the `paths-file`
+# input pointing at `.github/claude-security-paths`, the repo-owned list of this
+# repo's security-sensitive surfaces (workflows, scripts, hooks, shell, and
+# permission/settings config) that the reusable reads from the PR's BASE branch.
+# There is deliberately NO workflow-level path filter: a path miss would leave
+# the required execution check Pending and wedge prose PRs, so the reusable
+# workflow evaluates those patterns in a job-level gate and a not-applicable PR
+# yields a name-stable skipped check the required-check ruleset reads as
+# success. The verdict stays advisory per ADR 0002. Fork PRs receive no secrets
+# and a read-only token, so they are simply not reviewed by design. Requires
+# `claude-code-plugins` in the CLAUDE_CODE_OAUTH_TOKEN org secret's
+# selected-repositories scope. Public repo: hosted default runner.
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
@@ -32,33 +34,7 @@ jobs:
     uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
     with:
       runner: ubuntu-24.04
-      paths: |
-        .github/**
-        .claude/**
-        scripts/**
-        plugins/*/hooks/**
-        plugins/*/bin/**
-        plugins/*/tools/**
-        plugins/*/skills/**
-        plugins/*/agents/**
-        plugins/*/commands/**
-        .claude-plugin/**
-        REVIEW.md
-        CLAUDE.md
-        AGENTS.md
-        plugins/*/src/**
-        plugins/*/dist/**
-        **/*.sh
-        **/*.ps1
-        **/*.mjs
-        **/*.ts
-        **/*.js
-        **/*.cjs
-        **/.mcp.json
-        **/mcp.json
-        **/package.json
-        **/package-lock.json
-        plugins/*/.claude-plugin/plugin.json
+      paths-file: .github/claude-security-paths
     # One named secret (least privilege), never `secrets: inherit`.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -29,10 +29,9 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@66073e58e730f8bcd1d6533e26ac9411a637fe83 # 66073e5 2026-07-26 fail the required check when an in-scope review could not run
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
     with:
       runner: ubuntu-24.04
-      skip-actors: "dependabot[bot],melodic-standards-sync[bot]"
       paths: |
         .github/**
         .claude/**


### PR DESCRIPTION
## Summary

Re-pins both locally-owned Claude lane callers from two divergent stale pins (review `e295107`, security `66073e5`) to ci-workflows v0.9.1 (`c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1`), which makes both lanes reachable by the org kill-switch variables (`CLAUDE_LANES_DISABLED` etc.) for the first time. Three commits:

- Re-pin both callers; delete the explicit `skip-actors` lists so the reusable's upstream-reviewed 4-actor default applies (widens the skip set by `claude[bot]` + `melodic-ai[bot]` — ADR 0002 re-deliberation filed as a follow-up issue).
- Migrate the security caller's inline `paths` to `paths-file: .github/claude-security-paths` — required by the managed runner-policy contract at v0.9.1 (`allowedInputs: ["runner","paths-file"]`); the file pre-existed on main (#1701) and is order- and set-identical (26 patterns), so review scope is unchanged.
- Add the managed component's job-level serializer to the review caller (`group: claude-review-${{ github.repository }}`, `queue: max`) — this repo generates 52% of fleet lane volume and was the only consumer without it. Security caller concurrency untouched (per-PR group, correct for a required check).

Known: the `security-review / security-review` required check reports green on THIS PR without running a review (workflow-touching PRs cannot be reviewed by their own new caller; the action exits 0 on refusal). The diff was independently verified instead — fresh-context verifier, 9/9 criteria PASS, including control tests proving the runner-policy checker reads both files, byte-identical pin lines, and a no-deadlock analysis of the concurrency groups.

## Test plan

- Runner-policy checker: exit 0 on the branch (base also 0; interim `paths`-passing state correctly failed it — the contract works).
- actionlint clean under the repo's managed suppression (which is load-bearing for `queue: max` — rhysd/actionlint#654).
- paths-file equivalence: 26/26 patterns, order-identical, set-identical vs the removed inline list.
- Post-merge: next code-touching PR should produce an actual security run at the new pin — tracked as Phase 3 closure evidence in ci-workflows PLAN.md.

## Related

No linked issue: this PR closes no GitHub issue. Related: #1767 (ADR 0002 re-deliberation follow-up, opened by this change), #1701 (committed the paths file this PR activates), ci-workflows `docs/topics/claude-review-lanes/PLAN.md` Phase 3 (kill-switch reachability + closure evidence).