### PR TITLE
docs: record hash-bump procedure and registry-integrity rationale in session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -39,9 +39,13 @@ export PATH="$bin_dir:$PATH"
 # The proxy blocks the GitHub API and /releases/latest redirects; only direct
 # /releases/download/ asset URLs resolve, hence hard pins. Each pinned asset
 # also carries a SHA-256 recorded from a verified download of that exact
-# version; a mismatch refuses the install. Bump pin and hash together: on a
-# bump, download the new asset, confirm the binary reports the pinned version,
-# then record `sha256sum <downloaded-asset>` here.
+# version; a mismatch refuses the install. Bump pin and hash together — and
+# authenticate before executing: on a bump, download the new asset, check it
+# against the checksums file / signature / attestation the project publishes
+# for that release BEFORE running the binary (a compromised artifact can lie
+# about its version, and hashing it here would only legitimize it), then
+# confirm the binary reports the pinned version and record
+# `sha256sum <downloaded-asset>` here.
 shellcheck_pin="v0.11.0" # .shellcheckrc targets 0.11.0+
 shellcheck_sha="8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
 actionlint_pin="1.7.12" # matches the pin documented in .github/actionlint.yaml

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -39,7 +39,9 @@ export PATH="$bin_dir:$PATH"
 # The proxy blocks the GitHub API and /releases/latest redirects; only direct
 # /releases/download/ asset URLs resolve, hence hard pins. Each pinned asset
 # also carries a SHA-256 recorded from a verified download of that exact
-# version; a mismatch refuses the install. Bump pin and hash together.
+# version; a mismatch refuses the install. Bump pin and hash together: on a
+# bump, download the new asset, confirm the binary reports the pinned version,
+# then record `sha256sum <downloaded-asset>` here.
 shellcheck_pin="v0.11.0" # .shellcheckrc targets 0.11.0+
 shellcheck_sha="8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198"
 actionlint_pin="1.7.12" # matches the pin documented in .github/actionlint.yaml
@@ -164,6 +166,10 @@ fetch_release_tool shfmt \
   "https://github.com/mvdan/sh/releases/download/${shfmt_pin}/shfmt_${shfmt_pin}_linux_amd64" \
   "$shfmt_sha" "-"
 
+# The npm and pip/uv installs below carry no committed hash: both registries
+# verify package integrity against registry metadata (npm `_integrity`
+# sha512, PyPI digests), a weaker trust anchor than the committed SHA-256s
+# above but an accepted one — npm -g has no --require-hashes equivalent.
 if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
   npm install -g --no-audit --no-fund "markdownlint-cli2@${markdownlint_pin}" ||
     echo "session-start: warning: markdownlint-cli2 install failed" >&2


### PR DESCRIPTION
No linked issue

## Summary

Comment-only follow-up closing out the two informational notes the automated reviews left on #1763 after its blocking findings were fixed, so they're recorded in the code instead of a merged PR thread.

## Fix

- Document the hash-bump procedure alongside the `VERSION PINS` block in `.claude/hooks/session-start.sh`: download the new asset, confirm the binary reports the pinned version, record `sha256sum <downloaded-asset>`.
- State explicitly that the npm and pip/uv installs (markdownlint-cli2, check-jsonschema) rely on registry-level integrity metadata — an accepted, weaker trust anchor than the committed SHA-256s, since `npm install -g` has no `--require-hashes` equivalent.
- The third low-severity review note (NVM_DIR path validation) is deliberately declined, with the reasoning in the commit message: forcing `/opt/nvm` risks breaking session start if the cloud image legitimately relocates nvm, against a threat that already requires environment control.

## Verification

Comment-only diff (7 insertions, 1 deletion, one file). shfmt, shellcheck (repo rcfile), typos, and editorconfig-checker all pass on the changed file; hook behavior unchanged.

## Related

Refs #1763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxpZePLupZiV8E5bwFbmBS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxpZePLupZiV8E5bwFbmBS)_