### PR TITLE
feat: enforce the pr-issue-linkage PR-body contract at authoring time

### DIFF
--- a/.claude/hooks/pr-linkage-mcp-gate.sh
+++ b/.claude/hooks/pr-linkage-mcp-gate.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# PreToolUse gate: block an MCP-created PR whose BODY would fail this
+# repository's required `pr-issue-linkage` CI check.
+#
+# WHY IT EXISTS — cloud/remote sessions have no `gh` CLI and create PRs through
+# the GitHub MCP server (`mcp__github__create_pull_request` /
+# `mcp__github__update_pull_request`), a surface the source-control plugin's
+# `pr-body-linkage-gate.sh` Bash hook never sees. Because this hook and the
+# settings entry that wires it are checked into the repository, it loads in any
+# session that opens this repo — cloud containers included — with no plugin
+# install step. It is the MCP-surface sibling of the plugin hook and mirrors
+# the same validator semantics.
+#
+# WHAT IT ENFORCES — the two halves the
+# melodic-software/ci-workflows pr-issue-linkage validator requires: after
+# stripping HTML comments (terminated spans, then an unterminated `<!--`
+# swallowing the rest), the body must carry
+#   (a) a native closing keyword (`Closes/Fixes/Resolves #N`, including
+#       `owner/repo#N`) OR the literal `No linked issue` / `No related issue:`;
+#   (b) a `## Related` section that is present AND non-empty, where a DEEPER
+#       heading (`### ...`) is that section's content, not its terminator.
+#
+# SCOPE GUARDS —
+#   - enforcement is keyed to the repository's OWN policy: the gate runs only
+#     when the project root carries `.github/workflows/pr-issue-linkage.yml`
+#     (or `.yaml`), so a copy of this hook in a repo without the check never
+#     blocks anything;
+#   - a call targeting a DIFFERENT repository (tool_input owner/repo not
+#     matching the project's origin remote) is out of scope and allowed —
+#     this repo's policy is not another repo's;
+#   - `update_pull_request` with no `body` field changes nothing the CI gate
+#     re-validates, and is allowed.
+#
+# FAIL-OPEN ON EXTRACTION, FAIL-CLOSED ON A DETERMINABLE BAD BODY — unreadable
+# stdin, missing jq, or an undeterminable target repo allow (policy gate, not a
+# security guard). A present-but-failing body blocks. A `create_pull_request`
+# with NO body field is a determinable bad body (GitHub opens the PR with an
+# empty body, which the CI gate rejects) and blocks.
+#
+# LOCALE — matching runs under LC_ALL=C and the JavaScript-`\s`-only Unicode
+# whitespace characters are normalized to plain spaces first, so the verdict
+# does not depend on the ambient locale. Mirrors the plugin hook's LOCALE note.
+#
+# BLOCKING: exits 2 naming the missing half(s) plus the line to add.
+
+set -uo pipefail
+export LC_ALL=C
+
+INPUT=$(cat) || exit 0
+[[ -n "$INPUT" ]] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+case "$TOOL" in
+mcp__github__create_pull_request | mcp__github__update_pull_request) ;;
+*) exit 0 ;;
+esac
+
+ROOT="${CLAUDE_PROJECT_DIR:-.}"
+
+# The consuming repo's own gate definition is the authority; no gate, no
+# enforcement.
+GATE_FILE=""
+for candidate in "$ROOT/.github/workflows/pr-issue-linkage.yml" \
+  "$ROOT/.github/workflows/pr-issue-linkage.yaml"; do
+  [[ -f "$candidate" ]] && {
+    GATE_FILE="$candidate"
+    break
+  }
+done
+[[ -n "$GATE_FILE" ]] || exit 0
+
+# Out-of-scope guard: only judge PRs aimed at THIS repository. The origin URL's
+# separators are normalized so https, ssh (`git@host:owner/repo`), and proxied
+# forms all end in `/owner/repo`; comparison is case-insensitive because GitHub
+# routing is.
+T_OWNER=$(printf '%s' "$INPUT" | jq -r '.tool_input.owner // empty' 2>/dev/null)
+T_REPO=$(printf '%s' "$INPUT" | jq -r '.tool_input.repo // empty' 2>/dev/null)
+ORIGIN=$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)
+if [[ -n "$ORIGIN" && -n "$T_OWNER" && -n "$T_REPO" ]]; then
+  norm="${ORIGIN%/}"
+  norm="${norm%.git}"
+  norm="${norm//:/\/}"
+  [[ "${norm,,}" == *"/${T_OWNER,,}/${T_REPO,,}" ]] || exit 0
+fi
+
+# An update that carries no body leaves the body CI already validated
+# untouched.
+if [[ "$TOOL" == "mcp__github__update_pull_request" ]]; then
+  printf '%s' "$INPUT" | jq -e '.tool_input | has("body")' >/dev/null 2>&1 || exit 0
+fi
+
+BODY=$(printf '%s' "$INPUT" | jq -r '.tool_input.body // ""' 2>/dev/null)
+
+# --- Body validation (mirrors the ci-workflows validator; see the plugin
+# hook plugins/source-control/hooks/pr-body-linkage-gate.sh for the fully
+# annotated original of each function) ---------------------------------------
+
+UNICODE_SPACES=(
+  $'\xc2\xa0' $'\xe1\x9a\x80'
+  $'\xe2\x80\x80' $'\xe2\x80\x81' $'\xe2\x80\x82' $'\xe2\x80\x83'
+  $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' $'\xe2\x80\x87'
+  $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a'
+  $'\xe2\x80\xa8' $'\xe2\x80\xa9' $'\xe2\x80\xaf'
+  $'\xe2\x81\x9f' $'\xe3\x80\x80' $'\xef\xbb\xbf'
+)
+
+strip_html_comments() {
+  local body="$1" line rest kept out="" in_comment=0 sp
+  for sp in "${UNICODE_SPACES[@]}"; do body="${body//"$sp"/ }"; done
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    rest="${line%$'\r'}"
+    kept=""
+    while [[ -n "$rest" ]]; do
+      if ((in_comment)); then
+        if [[ "$rest" == *"-->"* ]]; then
+          rest="${rest#*-->}"
+          in_comment=0
+        else
+          rest=""
+        fi
+      else
+        if [[ "$rest" == *"<!--"* ]]; then
+          kept+="${rest%%<!--*}"
+          rest="${rest#*<!--}"
+          in_comment=1
+        else
+          kept+="$rest"
+          rest=""
+        fi
+      fi
+    done
+    out+="$kept"$'\n'
+  done <<<"$body"
+  printf '%s' "$out"
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+KEYWORD_ERE='[^a-z0-9_](close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*([a-z0-9_.-]+/[a-z0-9_.-]+)?#[0-9]+[^a-z0-9_]'
+NO_ISSUE_ERE='[^a-z0-9_]no (linked|related) issue[^a-z0-9_]'
+
+has_linkage() {
+  local probe
+  probe=$'\n'"${1,,}"$'\n'
+  [[ "$probe" =~ $KEYWORD_ERE || "$probe" =~ $NO_ISSUE_ERE ]]
+}
+
+related_section() {
+  local body="$1" line t start=0 lvl i=0 out=""
+  local -a lines=()
+  while IFS= read -r line || [[ -n "$line" ]]; do lines+=("$line"); done <<<"$body"
+  for ((i = 0; i < ${#lines[@]}; i++)); do
+    t="${lines[i]}"
+    t="${t#"${t%%[![:space:]]*}"}"
+    t="${t%"${t##*[![:space:]]}"}"
+    [[ "${t,,}" =~ ^##[[:space:]]+related$ ]] && {
+      start=$((i + 1))
+      break
+    }
+  done
+  ((start)) || return 1
+  for ((i = start; i < ${#lines[@]}; i++)); do
+    t="${lines[i]}"
+    t="${t#"${t%%[![:space:]]*}"}"
+    t="${t%"${t##*[![:space:]]}"}"
+    if [[ "$t" =~ ^#+[[:space:]]+[^[:space:]] ]]; then
+      lvl=0
+      while [[ "${t:lvl:1}" == "#" ]]; do ((lvl++)); done
+      ((lvl <= 2)) && break
+    fi
+    out+="${lines[i]}"$'\n'
+  done
+  trim "$out"
+}
+
+problems=()
+stripped=$(strip_html_comments "$BODY")
+# shellcheck disable=SC2310  # the two exits ARE the verdict: absent vs present
+if related=$(related_section "$stripped"); then
+  [[ -n "$related" ]] || problems+=('The "## Related" section is empty.')
+else
+  problems+=('Missing a "## Related" section.')
+fi
+has_linkage "$stripped" ||
+  problems+=('Missing a native closing keyword (Closes/Fixes/Resolves #N) and no "No linked issue" marker.')
+
+((${#problems[@]})) || exit 0
+
+echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
+for p in "${problems[@]}"; do echo "  - $p" >&2; done
+echo "Gate: ${GATE_FILE#"$ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
+echo "Add to the body:" >&2
+echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2
+echo "  ## Related" >&2
+echo "  - <related PR / ADR / decision this PR does not close, or N/A>" >&2
+exit 2

--- a/.claude/hooks/pr-linkage-mcp-gate.sh
+++ b/.claude/hooks/pr-linkage-mcp-gate.sh
@@ -41,6 +41,11 @@
 # whitespace characters are normalized to plain spaces first, so the verdict
 # does not depend on the ambient locale. Mirrors the plugin hook's LOCALE note.
 #
+# NO KILL SWITCH, by design — this hook IS this repository's tracked policy,
+# so "disable it" is an edit to .claude/settings.json that goes through a PR,
+# exactly like changing the CI gate itself. The plugin sibling carries the
+# per-user userConfig switch; a repo-level policy file deliberately does not.
+#
 # BLOCKING: exits 2 naming the missing half(s) plus the line to add.
 
 set -uo pipefail
@@ -56,6 +61,9 @@ mcp__github__create_pull_request | mcp__github__update_pull_request) ;;
 *) exit 0 ;;
 esac
 
+# `.` is a last-resort fallback for running outside a Claude session (tests
+# set CLAUDE_PROJECT_DIR); if it points somewhere without the gate workflow,
+# the gate-file check below simply fails to find it and the hook allows.
 ROOT="${CLAUDE_PROJECT_DIR:-.}"
 
 # The consuming repo's own gate definition is the authority; no gate, no
@@ -77,12 +85,14 @@ done
 T_OWNER=$(printf '%s' "$INPUT" | jq -r '.tool_input.owner // empty' 2>/dev/null)
 T_REPO=$(printf '%s' "$INPUT" | jq -r '.tool_input.repo // empty' 2>/dev/null)
 ORIGIN=$(git -C "$ROOT" remote get-url origin 2>/dev/null || true)
-if [[ -n "$ORIGIN" && -n "$T_OWNER" && -n "$T_REPO" ]]; then
-  norm="${ORIGIN%/}"
-  norm="${norm%.git}"
-  norm="${norm//:/\/}"
-  [[ "${norm,,}" == *"/${T_OWNER,,}/${T_REPO,,}" ]] || exit 0
-fi
+# Undeterminable target (no origin remote, or payload missing owner/repo):
+# allow — imposing this checkout's policy on a repository it was never proven
+# to be is the worse failure (see FAIL-OPEN above).
+[[ -n "$ORIGIN" && -n "$T_OWNER" && -n "$T_REPO" ]] || exit 0
+norm="${ORIGIN%/}"
+norm="${norm%.git}"
+norm="${norm//:/\/}"
+[[ "${norm,,}" == *"/${T_OWNER,,}/${T_REPO,,}" ]] || exit 0
 
 # An update that carries no body leaves the body CI already validated
 # untouched.

--- a/.claude/hooks/pr-linkage-mcp-gate.sh
+++ b/.claude/hooks/pr-linkage-mcp-gate.sh
@@ -92,108 +92,27 @@ fi
 
 BODY=$(printf '%s' "$INPUT" | jq -r '.tool_input.body // ""' 2>/dev/null)
 
-# --- Body validation (mirrors the ci-workflows validator; see the plugin
-# hook plugins/source-control/hooks/pr-body-linkage-gate.sh for the fully
-# annotated original of each function) ---------------------------------------
-
-UNICODE_SPACES=(
-  $'\xc2\xa0' $'\xe1\x9a\x80'
-  $'\xe2\x80\x80' $'\xe2\x80\x81' $'\xe2\x80\x82' $'\xe2\x80\x83'
-  $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' $'\xe2\x80\x87'
-  $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a'
-  $'\xe2\x80\xa8' $'\xe2\x80\xa9' $'\xe2\x80\xaf'
-  $'\xe2\x81\x9f' $'\xe3\x80\x80' $'\xef\xbb\xbf'
-)
-
-strip_html_comments() {
-  local body="$1" line rest kept out="" in_comment=0 sp
-  for sp in "${UNICODE_SPACES[@]}"; do body="${body//"$sp"/ }"; done
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    rest="${line%$'\r'}"
-    kept=""
-    while [[ -n "$rest" ]]; do
-      if ((in_comment)); then
-        if [[ "$rest" == *"-->"* ]]; then
-          rest="${rest#*-->}"
-          in_comment=0
-        else
-          rest=""
-        fi
-      else
-        if [[ "$rest" == *"<!--"* ]]; then
-          kept+="${rest%%<!--*}"
-          rest="${rest#*<!--}"
-          in_comment=1
-        else
-          kept+="$rest"
-          rest=""
-        fi
-      fi
-    done
-    out+="$kept"$'\n'
-  done <<<"$body"
-  printf '%s' "$out"
-}
-
-trim() {
-  local s="$1"
-  s="${s#"${s%%[![:space:]]*}"}"
-  s="${s%"${s##*[![:space:]]}"}"
-  printf '%s' "$s"
-}
-
-KEYWORD_ERE='[^a-z0-9_](close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*([a-z0-9_.-]+/[a-z0-9_.-]+)?#[0-9]+[^a-z0-9_]'
-NO_ISSUE_ERE='[^a-z0-9_]no (linked|related) issue[^a-z0-9_]'
-
-has_linkage() {
-  local probe
-  probe=$'\n'"${1,,}"$'\n'
-  [[ "$probe" =~ $KEYWORD_ERE || "$probe" =~ $NO_ISSUE_ERE ]]
-}
-
-related_section() {
-  local body="$1" line t start=0 lvl i=0 out=""
-  local -a lines=()
-  while IFS= read -r line || [[ -n "$line" ]]; do lines+=("$line"); done <<<"$body"
-  for ((i = 0; i < ${#lines[@]}; i++)); do
-    t="${lines[i]}"
-    t="${t#"${t%%[![:space:]]*}"}"
-    t="${t%"${t##*[![:space:]]}"}"
-    [[ "${t,,}" =~ ^##[[:space:]]+related$ ]] && {
-      start=$((i + 1))
-      break
-    }
-  done
-  ((start)) || return 1
-  for ((i = start; i < ${#lines[@]}; i++)); do
-    t="${lines[i]}"
-    t="${t#"${t%%[![:space:]]*}"}"
-    t="${t%"${t##*[![:space:]]}"}"
-    if [[ "$t" =~ ^#+[[:space:]]+[^[:space:]] ]]; then
-      lvl=0
-      while [[ "${t:lvl:1}" == "#" ]]; do ((lvl++)); done
-      ((lvl <= 2)) && break
-    fi
-    out+="${lines[i]}"$'\n'
-  done
-  trim "$out"
-}
-
-problems=()
-stripped=$(strip_html_comments "$BODY")
-# shellcheck disable=SC2310  # the two exits ARE the verdict: absent vs present
-if related=$(related_section "$stripped"); then
-  [[ -n "$related" ]] || problems+=('The "## Related" section is empty.')
-else
-  problems+=('Missing a "## Related" section.')
+# --- Body validation ----------------------------------------------------------
+# The validator core is the source-control plugin's pr-linkage-validator.sh,
+# resolved relative to THIS FILE — the hook is checked into the marketplace
+# repo whose checkout always carries the plugin source, so no plugin install
+# is needed and a drift fix lands on every surface at once. Resolution is
+# deliberately not via CLAUDE_PROJECT_DIR: the hook judges payloads against
+# whatever repo it ships in, wherever that checkout lives. If the lib moves,
+# fail OPEN with a loud note (policy gate, not a security guard) — CI still
+# holds the contract, and the test suite fails on the silent-skip.
+VALIDATOR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../plugins/source-control/hooks/pr-linkage-validator.sh"
+# shellcheck source=../../plugins/source-control/hooks/pr-linkage-validator.sh
+if ! source "$VALIDATOR" 2>/dev/null; then
+  echo "pr-linkage-mcp-gate: shared validator not found at $VALIDATOR — gate skipped." >&2
+  exit 0
 fi
-has_linkage "$stripped" ||
-  problems+=('Missing a native closing keyword (Closes/Fixes/Resolves #N) and no "No linked issue" marker.')
 
-((${#problems[@]})) || exit 0
+# shellcheck disable=SC2310  # the return status IS the verdict
+linkage::problems "$BODY" && exit 0
 
 echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
-for p in "${problems[@]}"; do echo "  - $p" >&2; done
+for p in "${LINKAGE_PROBLEMS[@]}"; do echo "  - $p" >&2; done
 echo "Gate: ${GATE_FILE#"$ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
 echo "Add to the body:" >&2
 echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2

--- a/.claude/hooks/pr-linkage-mcp-gate.test.sh
+++ b/.claude/hooks/pr-linkage-mcp-gate.test.sh
@@ -18,8 +18,14 @@ git -C "$FIXTURE" remote add origin https://github.com/melodic-software/claude-c
 
 # Second fixture WITHOUT the gate file, for the no-policy case.
 NOGATE=$(mktemp -d)
-trap 'rm -rf "$FIXTURE" "$NOGATE"' EXIT
+# Third fixture WITH the gate file but NO origin remote: the target repo is
+# undeterminable, so even a bad body must allow.
+NOORIGIN=$(mktemp -d)
+trap 'rm -rf "$FIXTURE" "$NOGATE" "$NOORIGIN"' EXIT
 git -C "$NOGATE" init -q
+mkdir -p "$NOORIGIN/.github/workflows"
+: >"$NOORIGIN/.github/workflows/pr-issue-linkage.yml"
+git -C "$NOORIGIN" init -q
 
 PASS=0
 FAIL=0
@@ -77,6 +83,7 @@ run 0 "update with no body field passes" "$FIXTURE" "$(payload $UPDATE $OWNER $R
 run 2 "update with bad body blocks" "$FIXTURE" "$(payload $UPDATE $OWNER $REPO "$NO_RELATED")"
 run 0 "different target repo is out of scope" "$FIXTURE" "$(payload $CREATE other-org other-repo "$NO_RELATED")"
 run 0 "repo without the gate file never blocks" "$NOGATE" "$(payload $CREATE $OWNER $REPO "$NO_RELATED")"
+run 0 "gated repo with no origin remote allows (undeterminable target)" "$NOORIGIN" "$(payload $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "unrelated tool passes" "$FIXTURE" "$(payload mcp__github__get_me $OWNER $REPO "$NO_RELATED")"
 run 0 "empty stdin allows" "$FIXTURE" ""
 

--- a/.claude/hooks/pr-linkage-mcp-gate.test.sh
+++ b/.claude/hooks/pr-linkage-mcp-gate.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tests for pr-linkage-mcp-gate.sh. Builds a throwaway fixture repo carrying
+# the pr-issue-linkage gate file and an origin remote, then drives the hook
+# with synthetic PreToolUse payloads and asserts on exit codes.
+#
+# Run: bash .claude/hooks/pr-linkage-mcp-gate.test.sh
+
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pr-linkage-mcp-gate.sh"
+FIXTURE=$(mktemp -d)
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/.github/workflows"
+: >"$FIXTURE/.github/workflows/pr-issue-linkage.yml"
+git -C "$FIXTURE" init -q
+git -C "$FIXTURE" remote add origin https://github.com/melodic-software/claude-code-plugins.git
+
+# Second fixture WITHOUT the gate file, for the no-policy case.
+NOGATE=$(mktemp -d)
+trap 'rm -rf "$FIXTURE" "$NOGATE"' EXIT
+git -C "$NOGATE" init -q
+
+PASS=0
+FAIL=0
+
+# run <expected-exit> <name> <project-dir> <payload-json>
+run() {
+  local expected="$1" name="$2" dir="$3" payload="$4" rc=0
+  CLAUDE_PROJECT_DIR="$dir" bash "$HOOK" <<<"$payload" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" == "$expected" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $name (expected exit $expected, got $rc)" >&2
+  fi
+}
+
+# payload <tool> <owner> <repo> [body-json-string-or-omitted]
+payload() {
+  local tool="$1" owner="$2" repo="$3"
+  if (($# >= 4)); then
+    jq -cn --arg t "$tool" --arg o "$owner" --arg r "$repo" --arg b "$4" \
+      '{tool_name:$t, tool_input:{owner:$o, repo:$r, title:"t", body:$b}}'
+  else
+    jq -cn --arg t "$tool" --arg o "$owner" --arg r "$repo" \
+      '{tool_name:$t, tool_input:{owner:$o, repo:$r, title:"t"}}'
+  fi
+}
+
+CREATE=mcp__github__create_pull_request
+UPDATE=mcp__github__update_pull_request
+OWNER=melodic-software
+REPO=claude-code-plugins
+
+GOOD=$'Closes #12\n\n## Summary\n\nx\n\n## Related\n\n- N/A'
+NO_RELATED=$'Closes #12\n\n## Summary\n\nx'
+EMPTY_RELATED=$'Closes #12\n\n## Related\n'
+NO_KEYWORD=$'## Summary\n\nx\n\n## Related\n\n- N/A'
+OPTOUT=$'No linked issue\n\n## Related\n\n- N/A'
+COMMENTED=$'<!-- Closes #12 -->\n\n## Summary\n\nx\n\n<!-- ## Related\n- N/A -->'
+BARE_HASH=$'Closes #\n\n## Related\n\n- N/A'
+DEEP_HEADING=$'Fixes #7\n\n## Related\n\n### sub\n\ncontent'
+CROSS_REPO=$'Resolves other/repo#9\n\n## Related\n\n- N/A'
+
+run 0 "valid body passes" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$GOOD")"
+run 2 "missing Related blocks" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$NO_RELATED")"
+run 2 "empty Related blocks" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$EMPTY_RELATED")"
+run 2 "missing keyword blocks" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$NO_KEYWORD")"
+run 0 "No linked issue opt-out passes" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$OPTOUT")"
+run 2 "markers only inside HTML comments block" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$COMMENTED")"
+run 2 "bare 'Closes #' with no number blocks" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$BARE_HASH")"
+run 0 "deeper heading is Related content" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$DEEP_HEADING")"
+run 0 "owner/repo#N keyword form passes" "$FIXTURE" "$(payload $CREATE $OWNER $REPO "$CROSS_REPO")"
+run 2 "create with no body field blocks (empty body)" "$FIXTURE" "$(payload $CREATE $OWNER $REPO)"
+run 0 "update with no body field passes" "$FIXTURE" "$(payload $UPDATE $OWNER $REPO)"
+run 2 "update with bad body blocks" "$FIXTURE" "$(payload $UPDATE $OWNER $REPO "$NO_RELATED")"
+run 0 "different target repo is out of scope" "$FIXTURE" "$(payload $CREATE other-org other-repo "$NO_RELATED")"
+run 0 "repo without the gate file never blocks" "$NOGATE" "$(payload $CREATE $OWNER $REPO "$NO_RELATED")"
+run 0 "unrelated tool passes" "$FIXTURE" "$(payload mcp__github__get_me $OWNER $REPO "$NO_RELATED")"
+run 0 "empty stdin allows" "$FIXTURE" ""
+
+echo "pass=$PASS fail=$FAIL"
+((FAIL == 0))

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "mcp__github__create_pull_request|mcp__github__update_pull_request",
+        "matcher": "^mcp__github__(create|update)_pull_request$",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,31 @@
 {
   "worktree": {
     "baseRef": "head"
+  },
+  "extraKnownMarketplaces": {
+    "melodic-software": {
+      "source": {
+        "source": "github",
+        "repo": "melodic-software/claude-code-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "source-control@melodic-software": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__create_pull_request|mcp__github__update_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pr-linkage-mcp-gate.sh",
+            "timeout": 15,
+            "statusMessage": "Checking PR body against the repo's pr-issue-linkage gate..."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/"
-    }
-  }
-}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_MCP_PAT}"
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_MCP_PAT}"
-      }
+      "url": "https://api.githubcopilot.com/mcp/"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,8 @@ costs a full CI round trip to discover. After stripping HTML comments, the body 
 
 Fill in `.github/pull_request_template.md`; an unedited template fails, because its guidance lives
 inside the HTML comments the check strips. A bare `Closes #` with no number also fails.
+
+Enforcement at authoring time: a checked-in PreToolUse gate
+(`.claude/hooks/pr-linkage-mcp-gate.sh`, wired in `.claude/settings.json`) blocks an MCP-created PR
+body that would fail the check; the source-control plugin's `pr-body-linkage-gate` hook covers
+`gh pr create`/`edit` the same way.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,5 +67,6 @@ inside the HTML comments the check strips. A bare `Closes #` with no number also
 
 Enforcement at authoring time: a checked-in PreToolUse gate
 (`.claude/hooks/pr-linkage-mcp-gate.sh`, wired in `.claude/settings.json`) blocks an MCP-created PR
-body that would fail the check; the source-control plugin's `pr-body-linkage-gate` hook covers
-`gh pr create`/`edit` the same way.
+body that would fail the check even in a session with no plugins; the source-control plugin
+enforces the same contract on both surfaces (`pr-body-linkage-gate` for `gh pr create`/`edit`,
+`pr-linkage-mcp-gate` for the MCP tools) wherever it is installed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,14 @@ migration.
 PRs required; squash merge; branch `<type>/<description>`. `.github/workflows/pr-title.yml` enforces
 the PR-title convention (squash merge sets the commit subject to the PR title). Org convention home:
 `melodic-software/standards` `conventions/`.
+
+`.github/workflows/pr-issue-linkage.yml` is a required check on the PR **body** — write the body to
+this contract when opening the PR (through any surface: `gh`, API, or MCP tools), or the failure
+costs a full CI round trip to discover. After stripping HTML comments, the body must carry BOTH:
+
+1. a native closing keyword — `Closes`/`Fixes`/`Resolves #N` (or `owner/repo#N`) — or the literal
+   line `No linked issue` when the PR closes nothing; and
+2. a non-empty `## Related` section (`N/A` when nothing applies).
+
+Fill in `.github/pull_request_template.md`; an unedited template fails, because its guidance lives
+inside the HTML comments the check strips. A bare `Closes #` with no number also fails.

--- a/plugins/source-control/.claude-plugin/plugin.json
+++ b/plugins/source-control/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "source-control",
-  "version": "0.40.2",
+  "version": "0.41.0",
   "description": "Git and GitHub delivery workflow: /commit (Conventional Commits + Co-Authored-By trailer via safe heredoc mechanics), /pull-request (prep, create, CI monitoring, review-comment triage, merge, CI-log fetch), /babysit-prs (self-pacing fleet loop — safe by default; opt-in worker/autopilot tiers add gate-checked merge and thread resolution behind a deterministic Python engine), /babysit-loop (the loop-lane merge lane: a standing or drain loop that invokes babysit-prs per cycle, configured through repo-scoped babysit_loop_* keys on the layered source-control.md seam, with merge authority human-only until the target repo's tracked config adopts the lane, a gate-proven C2-mechanical baseline once adopted, and standing merge-rung raises binding from the team-tracked layer only — with one named exception, where an invocation line explicitly typing both the autopilot tier keyword and the dedicated raise argument --merge c3-this-run widens that single invocation's merge authority up to C3 behind a fresh independent frontier-tier resolver, while C4-structural and C5-untrusted-provenance stay unconditionally human-merge), /worktree (create, status, cleanup, audit for parallel-session isolation), /setup (check the effective commit-subject / PR-title convention merged across its config layers and the babysit-prs config, or apply — interview the repo and write the convention config to a chosen layer), and /resolve-conflicts (intent-first merge/rebase conflict resolution with a semantic-conflict sweep — never --abort). The commit-subject / PR-title convention is configurable via a source-control.md config written by a re-runnable setup skill, layered across a ~/.claude user-global file, the tracked team file, and a gitignored .claude/source-control.local.md personal overlay merged per key; Conventional Commits is the default when no convention is declared.",
   "author": {
     "name": "Melodic Software",
@@ -27,6 +27,12 @@
       "type": "boolean",
       "title": "pr-body-linkage-gate hook",
       "description": "Block a `gh pr create`/`gh pr edit` whose statically-readable PR body would fail the repository's required pr-issue-linkage check (missing a closing keyword, or a missing/empty `## Related` section). Enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml; a body the hook cannot read statically always passes.",
+      "default": true
+    },
+    "pr_linkage_mcp_gate_enabled": {
+      "type": "boolean",
+      "title": "pr-linkage-mcp-gate hook",
+      "description": "Block a GitHub MCP create_pull_request/update_pull_request whose PR body would fail the repository's required pr-issue-linkage check — the MCP-surface sibling of pr-body-linkage-gate, covering cloud/remote sessions that open PRs without the gh CLI. Same policy scope: enforced only in a repository that carries .github/workflows/pr-issue-linkage.yml, and only for the repository the origin remote names.",
       "default": true
     },
     "babysit_watched_owners": {

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to the `source-control` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.41.0]
+
+### Added
+
+- **`pr-linkage-mcp-gate` hook — the MCP-surface sibling of `pr-body-linkage-gate`.** Cloud/remote
+  sessions have no `gh` CLI and open PRs through the GitHub MCP server
+  (`mcp__github__create_pull_request` / `mcp__github__update_pull_request`), a surface the Bash
+  hook never sees — so a body failing the consuming repo's required `pr-issue-linkage` check was
+  only discovered a full CI round trip after the PR was open. The new PreToolUse hook mirrors the
+  same validator semantics on the MCP payload (comment stripping, closing keyword or
+  `No linked issue`, present-and-non-empty `## Related` with deeper headings as content) and the
+  same scope guards (enforced only in a repo carrying
+  `.github/workflows/pr-issue-linkage.yml`/`.yaml`; a call targeting a different repo than origin
+  is out of scope; an `update` with no `body` field allows). The MCP surface hands the hook the
+  body as a plain JSON field, so the Bash sibling's extraction caveats don't apply; the one
+  fail-closed addition is a `create` with no `body` field at all, which GitHub would open with an
+  empty body the CI gate rejects. Kill switch: `pr_linkage_mcp_gate_enabled` (default true).
+
 ## [0.40.2]
 
 ### Fixed

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to the `source-control` plugin are documented here. Format f
   body as a plain JSON field, so the Bash sibling's extraction caveats don't apply; the one
   fail-closed addition is a `create` with no `body` field at all, which GitHub would open with an
   empty body the CI gate rejects. Kill switch: `pr_linkage_mcp_gate_enabled` (default true).
+- **`pr-linkage-validator.sh` — the validator core extracted to one sourced lib.** The comment
+  stripping, keyword/`## Related` judging, and the verdict wording now exist once, sourced by both
+  hooks (and by the marketplace repo's checked-in MCP gate), so a drift fix against the upstream
+  ci-workflows validator lands on every surface atomically instead of being hand-mirrored across
+  copies. Behavior unchanged; each surface keeps its own extraction, scope guards, and block
+  message.
 
 ## [0.40.2]
 

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -16,7 +16,9 @@ All notable changes to the `source-control` plugin are documented here. Format f
   `No linked issue`, present-and-non-empty `## Related` with deeper headings as content) and the
   same scope guards (enforced only in a repo carrying
   `.github/workflows/pr-issue-linkage.yml`/`.yaml`; a call targeting a different repo than origin
-  is out of scope; an `update` with no `body` field allows). The MCP surface hands the hook the
+  is out of scope, and a target that cannot be established — no origin remote, or a payload
+  missing owner/repo — allows rather than imposing this checkout's policy on an unproven
+  repository; an `update` with no `body` field allows). The MCP surface hands the hook the
   body as a plain JSON field, so the Bash sibling's extraction caveats don't apply; the one
   fail-closed addition is a `create` with no `body` field at all, which GitHub would open with an
   empty body the CI gate rejects. Kill switch: `pr_linkage_mcp_gate_enabled` (default true).

--- a/plugins/source-control/README.md
+++ b/plugins/source-control/README.md
@@ -146,6 +146,26 @@ outcome and which body form was read (`body-literal`, `body-file`,
 `stdin-heredoc`, `body-substitution`). Never the PR body, the command, or a
 path. Unset `HOOK_TELEMETRY_SINK` → no-op.
 
+### `pr-linkage-mcp-gate`
+
+The MCP-surface sibling of `pr-body-linkage-gate`: a `PreToolUse` hook on the
+GitHub MCP server's `create_pull_request` / `update_pull_request` tools, which
+is how cloud/remote sessions — where the `gh` CLI doesn't exist — open PRs.
+Same contract, same authority (the consuming repository's own
+`.github/workflows/pr-issue-linkage.yml`), same block-with-the-fix-named
+behavior. The MCP payload hands over the body as a plain JSON field, so the
+Bash sibling's static-readability caveats don't apply here; the scope guards
+that remain are the gate-file check, an origin-remote match on the call's
+`owner`/`repo` (another repository's PR is not this repo's policy), and an
+`update_pull_request` that carries no `body` field, which changes nothing CI
+already validated and passes. A `create_pull_request` with no `body` at all
+blocks — GitHub would open the PR with an empty body, which the CI check
+rejects. Set `pr_linkage_mcp_gate_enabled` to `false` to turn it off.
+
+Telemetry matches the sibling's: one envelope per run (`ok`/`blocked`,
+`duration_ms`, and the tool name as its only data label), only when
+`HOOK_TELEMETRY_SINK` is set.
+
 ## Works in any repo
 
 - **Self-contained.** Everything runs on `git`, `gh` (authenticated), `jq`,
@@ -188,6 +208,7 @@ repo's owner.
 | Key | Type | Default / absent behavior |
 |---|---|---|
 | `pr_body_linkage_gate_enabled` | boolean | `true` (the PR-body hook above; inert in a repo with no `pr-issue-linkage` workflow) |
+| `pr_linkage_mcp_gate_enabled` | boolean | `true` (the MCP-surface sibling; inert in a repo with no `pr-issue-linkage` workflow) |
 | `babysit_watched_owners` | string (multiple) | infer the current repo's owner |
 | `babysit_self_logins` | string (multiple) | your `gh api user` login (extras add to it) |
 | `babysit_default_tier` | string | `safe` (explicit invocations only) |

--- a/plugins/source-control/hooks/hooks.json
+++ b/plugins/source-control/hooks/hooks.json
@@ -11,6 +11,17 @@
             "statusMessage": "Checking PR body against the repo's pr-issue-linkage gate..."
           }
         ]
+      },
+      {
+        "matcher": "^mcp__github__(create|update)_pull_request$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/pr-linkage-mcp-gate.sh",
+            "timeout": 15,
+            "statusMessage": "Checking PR body against the repo's pr-issue-linkage gate..."
+          }
+        ]
       }
     ]
   }

--- a/plugins/source-control/hooks/pr-body-linkage-gate.sh
+++ b/plugins/source-control/hooks/pr-body-linkage-gate.sh
@@ -147,122 +147,13 @@ emit_tel() {
   hook::emit_telemetry "pr-body-linkage-gate" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 
-# --- Body validation (mirrors the ci-workflows validator) --------------------
-
-# Every character JavaScript's `\s` matches beyond the six ASCII ones, as its
-# literal UTF-8 bytes. Spelled as bytes rather than `\uXXXX` because bash
-# renders `\u` through the ambient charmap, which is the very dependency the
-# LOCALE note removes. NBSP in particular arrives routinely in text pasted from
-# an issue title.
-UNICODE_SPACES=(
-  $'\xc2\xa0' $'\xe1\x9a\x80'
-  $'\xe2\x80\x80' $'\xe2\x80\x81' $'\xe2\x80\x82' $'\xe2\x80\x83'
-  $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' $'\xe2\x80\x87'
-  $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a'
-  $'\xe2\x80\xa8' $'\xe2\x80\xa9' $'\xe2\x80\xaf'
-  $'\xe2\x81\x9f' $'\xe3\x80\x80' $'\xef\xbb\xbf'
-)
-
-# Remove HTML comments the way the validator does — every terminated `<!-- … -->`
-# span, then an unterminated `<!--` taking everything after it. Both strips are
-# one left-to-right pass with a carried in-comment state, which produces exactly
-# that result: once a `<!--` has no `-->`, the state never clears again.
-# GitHub's own closing-keyword parser and its Markdown renderer both ignore
-# commented-out text, so an unedited PR template — whose instructional prose
-# names the very markers this gate looks for — must not pass vacuously.
-# Unicode-space normalization rides along on the same pass; the delimiters are
-# ASCII, so neither step can disturb the other.
-# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
-strip_html_comments() {
-  local body="$1" line rest kept out="" in_comment=0 sp
-  for sp in "${UNICODE_SPACES[@]}"; do body="${body//"$sp"/ }"; done
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    rest="${line%$'\r'}"
-    kept=""
-    while [[ -n "$rest" ]]; do
-      if ((in_comment)); then
-        if [[ "$rest" == *"-->"* ]]; then
-          rest="${rest#*-->}"
-          in_comment=0
-        else
-          rest=""
-        fi
-      else
-        if [[ "$rest" == *"<!--"* ]]; then
-          kept+="${rest%%<!--*}"
-          rest="${rest#*<!--}"
-          in_comment=1
-        else
-          kept+="$rest"
-          rest=""
-        fi
-      fi
-    done
-    out+="$kept"$'\n'
-  done <<<"$body"
-  printf '%s' "$out"
-}
-
-# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
-trim() {
-  local s="$1"
-  s="${s#"${s%%[![:space:]]*}"}"
-  s="${s%"${s##*[![:space:]]}"}"
-  printf '%s' "$s"
-}
-
-# The validator's regexes, transcribed to POSIX ERE. JavaScript's `\b` has no
-# ERE equivalent, so the probe is wrapped in newlines and the boundary is spelled
-# as an explicit non-word character on each side — `#12abc` and `unclosed #5`
-# stay non-matches, exactly as `\b` makes them. Matched against a lower-cased
-# probe in place of the `i` flag.
-KEYWORD_ERE='[^a-z0-9_](close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*([a-z0-9_.-]+/[a-z0-9_.-]+)?#[0-9]+[^a-z0-9_]'
-NO_ISSUE_ERE='[^a-z0-9_]no (linked|related) issue[^a-z0-9_]'
-
-# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
-has_linkage() {
-  local probe
-  probe=$'\n'"${1,,}"$'\n'
-  [[ "$probe" =~ $KEYWORD_ERE || "$probe" =~ $NO_ISSUE_ERE ]]
-}
-
-# Content of the first `## Related` section on stdout; returns 1 when there is
-# no such heading, which is a different verdict from an empty one. Only a
-# heading at the SAME level or higher (fewer or equal `#`) closes the section,
-# so a nested `### …` subsection is content — a naive "next line starting with
-# #" reading would call such a section empty.
-#
-# Trimming is spelled inline at both per-line sites rather than through `trim`:
-# a command substitution forks, and one fork per body line put a 1000-line body
-# past this hook's own declared timeout.
-# shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
-related_section() {
-  local body="$1" line t start=0 lvl i=0 out=""
-  local -a lines=()
-  while IFS= read -r line || [[ -n "$line" ]]; do lines+=("$line"); done <<<"$body"
-  for ((i = 0; i < ${#lines[@]}; i++)); do
-    t="${lines[i]}"
-    t="${t#"${t%%[![:space:]]*}"}"
-    t="${t%"${t##*[![:space:]]}"}"
-    [[ "${t,,}" =~ ^##[[:space:]]+related$ ]] && {
-      start=$((i + 1))
-      break
-    }
-  done
-  ((start)) || return 1
-  for ((i = start; i < ${#lines[@]}; i++)); do
-    t="${lines[i]}"
-    t="${t#"${t%%[![:space:]]*}"}"
-    t="${t%"${t##*[![:space:]]}"}"
-    if [[ "$t" =~ ^#+[[:space:]]+[^[:space:]] ]]; then
-      lvl=0
-      while [[ "${t:lvl:1}" == "#" ]]; do ((lvl++)); done
-      ((lvl <= 2)) && break
-    fi
-    out+="${lines[i]}"$'\n'
-  done
-  trim "$out"
-}
+# --- Body validation ----------------------------------------------------------
+# The validator core (comment stripping, keyword/Related judging) is shared
+# with the MCP-surface sibling pr-linkage-mcp-gate.sh; the annotated functions
+# live in pr-linkage-validator.sh, sourced so a drift fix against the upstream
+# ci-workflows validator lands on every surface at once.
+# shellcheck source=pr-linkage-validator.sh
+source "$(dirname "${BASH_SOURCE[0]}")/pr-linkage-validator.sh"
 
 # --- Command extraction ------------------------------------------------------
 
@@ -330,19 +221,9 @@ block() {
 
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 validate_body() {
-  local body="$1" related
-  local -a problems=()
-  body=$(strip_html_comments "$body")
-  # shellcheck disable=SC2310  # the two exits ARE the verdict: absent vs present
-  if related=$(related_section "$body"); then
-    [[ -n "$related" ]] || problems+=('The "## Related" section is empty.')
-  else
-    problems+=('Missing a "## Related" section.')
-  fi
-  has_linkage "$body" ||
-    problems+=('Missing a native closing keyword (Closes/Fixes/Resolves #N) and no "No linked issue" marker.')
-  ((${#problems[@]})) || return 0
-  block "${problems[@]}"
+  # shellcheck disable=SC2310  # the return status IS the verdict
+  linkage::problems "$1" && return 0
+  block "${LINKAGE_PROBLEMS[@]}"
 }
 
 # gh long flags that consume the following argv word. Enumerated so a

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -88,16 +88,18 @@ done
 # Out-of-scope guard: only judge PRs aimed at THIS repository. The origin URL's
 # separators are normalized so https, ssh (`git@host:owner/repo`), and proxied
 # forms all end in `/owner/repo`; comparison is case-insensitive because GitHub
-# routing is.
+# routing is. When the match cannot be ESTABLISHED — no origin remote, or a
+# payload missing owner/repo — the target is undeterminable and the call is
+# allowed: imposing this checkout's policy on a repository it was never proven
+# to be is the worse failure (see FAIL-OPEN above).
 T_OWNER=$(printf '%s' "$INPUT" | jq -r '.tool_input.owner // empty' 2>/dev/null)
 T_REPO=$(printf '%s' "$INPUT" | jq -r '.tool_input.repo // empty' 2>/dev/null)
 ORIGIN=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
-if [[ -n "$ORIGIN" && -n "$T_OWNER" && -n "$T_REPO" ]]; then
-  norm="${ORIGIN%/}"
-  norm="${norm%.git}"
-  norm="${norm//:/\/}"
-  [[ "${norm,,}" == *"/${T_OWNER,,}/${T_REPO,,}" ]] || exit 0
-fi
+[[ -n "$ORIGIN" && -n "$T_OWNER" && -n "$T_REPO" ]] || exit 0
+norm="${ORIGIN%/}"
+norm="${norm%.git}"
+norm="${norm//:/\/}"
+[[ "${norm,,}" == *"/${T_OWNER,,}/${T_REPO,,}" ]] || exit 0
 
 # An update that carries no body leaves the body CI already validated
 # untouched.
@@ -130,7 +132,6 @@ if linkage::problems "$BODY"; then
   exit 0
 fi
 
-emit_tel "blocked"
 echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
 for p in "${LINKAGE_PROBLEMS[@]}"; do echo "  - $p" >&2; done
 echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
@@ -138,4 +139,5 @@ echo "Add to the body:" >&2
 echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2
 echo "  ## Related" >&2
 echo "  - <links, or N/A>" >&2
+emit_tel "blocked"
 exit 2

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -117,111 +117,23 @@ emit_tel() {
   hook::emit_telemetry "pr-linkage-mcp-gate" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 
-# --- Body validation (mirrors the ci-workflows validator; see the sibling
-# pr-body-linkage-gate.sh for the fully annotated original of each function) --
+# --- Body validation ----------------------------------------------------------
+# The validator core is shared with the Bash-surface sibling
+# pr-body-linkage-gate.sh; the annotated functions live in
+# pr-linkage-validator.sh, sourced so a drift fix against the upstream
+# ci-workflows validator lands on every surface at once.
+# shellcheck source=pr-linkage-validator.sh
+source "$(dirname "${BASH_SOURCE[0]}")/pr-linkage-validator.sh"
 
-UNICODE_SPACES=(
-  $'\xc2\xa0' $'\xe1\x9a\x80'
-  $'\xe2\x80\x80' $'\xe2\x80\x81' $'\xe2\x80\x82' $'\xe2\x80\x83'
-  $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' $'\xe2\x80\x87'
-  $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a'
-  $'\xe2\x80\xa8' $'\xe2\x80\xa9' $'\xe2\x80\xaf'
-  $'\xe2\x81\x9f' $'\xe3\x80\x80' $'\xef\xbb\xbf'
-)
-
-strip_html_comments() {
-  local body="$1" line rest kept out="" in_comment=0 sp
-  for sp in "${UNICODE_SPACES[@]}"; do body="${body//"$sp"/ }"; done
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    rest="${line%$'\r'}"
-    kept=""
-    while [[ -n "$rest" ]]; do
-      if ((in_comment)); then
-        if [[ "$rest" == *"-->"* ]]; then
-          rest="${rest#*-->}"
-          in_comment=0
-        else
-          rest=""
-        fi
-      else
-        if [[ "$rest" == *"<!--"* ]]; then
-          kept+="${rest%%<!--*}"
-          rest="${rest#*<!--}"
-          in_comment=1
-        else
-          kept+="$rest"
-          rest=""
-        fi
-      fi
-    done
-    out+="$kept"$'\n'
-  done <<<"$body"
-  printf '%s' "$out"
-}
-
-trim() {
-  local s="$1"
-  s="${s#"${s%%[![:space:]]*}"}"
-  s="${s%"${s##*[![:space:]]}"}"
-  printf '%s' "$s"
-}
-
-KEYWORD_ERE='[^a-z0-9_](close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*([a-z0-9_.-]+/[a-z0-9_.-]+)?#[0-9]+[^a-z0-9_]'
-NO_ISSUE_ERE='[^a-z0-9_]no (linked|related) issue[^a-z0-9_]'
-
-has_linkage() {
-  local probe
-  probe=$'\n'"${1,,}"$'\n'
-  [[ "$probe" =~ $KEYWORD_ERE || "$probe" =~ $NO_ISSUE_ERE ]]
-}
-
-related_section() {
-  local body="$1" line t start=0 lvl i=0 out=""
-  local -a lines=()
-  while IFS= read -r line || [[ -n "$line" ]]; do lines+=("$line"); done <<<"$body"
-  for ((i = 0; i < ${#lines[@]}; i++)); do
-    t="${lines[i]}"
-    t="${t#"${t%%[![:space:]]*}"}"
-    t="${t%"${t##*[![:space:]]}"}"
-    [[ "${t,,}" =~ ^##[[:space:]]+related$ ]] && {
-      start=$((i + 1))
-      break
-    }
-  done
-  ((start)) || return 1
-  for ((i = start; i < ${#lines[@]}; i++)); do
-    t="${lines[i]}"
-    t="${t#"${t%%[![:space:]]*}"}"
-    t="${t%"${t##*[![:space:]]}"}"
-    if [[ "$t" =~ ^#+[[:space:]]+[^[:space:]] ]]; then
-      lvl=0
-      while [[ "${t:lvl:1}" == "#" ]]; do ((lvl++)); done
-      ((lvl <= 2)) && break
-    fi
-    out+="${lines[i]}"$'\n'
-  done
-  trim "$out"
-}
-
-problems=()
-stripped=$(strip_html_comments "$BODY")
-# shellcheck disable=SC2310  # the two exits ARE the verdict: absent vs present
-if related=$(related_section "$stripped"); then
-  [[ -n "$related" ]] || problems+=('The "## Related" section is empty.')
-else
-  problems+=('Missing a "## Related" section.')
-fi
-has_linkage "$stripped" ||
-  problems+=('Missing a native closing keyword (Closes/Fixes/Resolves #N) and no "No linked issue" marker.')
-
-if ((${#problems[@]} == 0)); then
+# shellcheck disable=SC2310  # the return status IS the verdict
+if linkage::problems "$BODY"; then
   emit_tel "ok"
   exit 0
 fi
 
 emit_tel "blocked"
 echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
-for p in "${problems[@]}"; do echo "  - $p" >&2; done
+for p in "${LINKAGE_PROBLEMS[@]}"; do echo "  - $p" >&2; done
 echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
 echo "Add to the body:" >&2
 echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block an MCP-created PR whose BODY would fail the consuming
+# repository's own `pr-issue-linkage` CI gate.
+#
+# WHY IT EXISTS — cloud/remote sessions have no `gh` CLI and create PRs through
+# the GitHub MCP server (`mcp__github__create_pull_request` /
+# `mcp__github__update_pull_request`), a surface the sibling
+# pr-body-linkage-gate.sh Bash hook never sees. This hook is that sibling's
+# MCP-surface counterpart: same validator semantics, same scope guards, on the
+# payload shape the MCP tools deliver. Where the Bash sibling must tokenize a
+# command line to even find the body, here the body arrives as a plain JSON
+# field — so the extraction caveats (heredocs, dynamic values, directory
+# changes) don't exist on this surface, and the fail-open set is much smaller.
+#
+# WHAT IT ENFORCES — the two halves the reusable
+# melodic-software/ci-workflows pr-issue-linkage validator requires: after
+# stripping HTML comments (terminated spans, then an unterminated `<!--`
+# swallowing the rest), the body must carry
+#   (a) a native closing keyword (`Closes/Fixes/Resolves #N`, including
+#       `owner/repo#N`) OR the literal `No linked issue` / `No related issue:`;
+#   (b) a `## Related` section that is present AND non-empty, where a DEEPER
+#       heading (`### ...`) is that section's content, not its terminator.
+#
+# SCOPE GUARDS —
+#   - enforcement is keyed to the repository's OWN policy: the gate runs only
+#     when the repo root carries `.github/workflows/pr-issue-linkage.yml`
+#     (or `.yaml`), so a consumer without the check is never gated;
+#   - a call targeting a DIFFERENT repository (tool_input owner/repo not
+#     matching the repo's origin remote) is out of scope and allowed —
+#     this repo's policy is not another repo's;
+#   - `update_pull_request` with no `body` field changes nothing the CI gate
+#     re-validates, and is allowed.
+#
+# FAIL-OPEN ON EXTRACTION, FAIL-CLOSED ON A DETERMINABLE BAD BODY — unreadable
+# stdin, missing jq, or an undeterminable target repo allow (policy gate, not a
+# security guard). A present-but-failing body blocks. A `create_pull_request`
+# with NO body field is a determinable bad body (GitHub opens the PR with an
+# empty body, which the CI gate rejects) and blocks.
+#
+# LOCALE — matching runs under LC_ALL=C and the JavaScript-`\s`-only Unicode
+# whitespace characters are normalized to plain spaces first, so the verdict
+# does not depend on the ambient locale. See the sibling's LOCALE note for the
+# full rationale.
+#
+# Kill switch: pr_linkage_mcp_gate_enabled userConfig option.
+#
+# BLOCKING: exits 2 naming the missing half(s) plus the line to add.
+
+set -uo pipefail
+
+# Pinned for the whole process: see LOCALE above. Set before anything reads a
+# character class, including the shared lib.
+export LC_ALL=C
+
+# shellcheck source=hook-utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/hook-utils.sh"
+
+hook::check_enabled "PR_LINKAGE_MCP_GATE"
+
+start=${EPOCHREALTIME:-}
+
+INPUT=$(hook::buffer_stdin) || exit 0
+[[ -n "$INPUT" ]] || exit 0
+
+hook::require_jq "PreToolUse" "source-control-pr-linkage-mcp-gate" "$INPUT"
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+case "$TOOL" in
+mcp__github__create_pull_request | mcp__github__update_pull_request) ;;
+*) exit 0 ;;
+esac
+
+HOOK_CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null | tr -d '\r')
+REPO_ROOT=$(hook::repo_root "${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}")
+
+# The consuming repo's own gate definition is the authority; no gate, no
+# enforcement.
+GATE_FILE=""
+for candidate in "$REPO_ROOT/.github/workflows/pr-issue-linkage.yml" \
+  "$REPO_ROOT/.github/workflows/pr-issue-linkage.yaml"; do
+  [[ -f "$candidate" ]] && {
+    GATE_FILE="$candidate"
+    break
+  }
+done
+[[ -n "$GATE_FILE" ]] || exit 0
+
+# Out-of-scope guard: only judge PRs aimed at THIS repository. The origin URL's
+# separators are normalized so https, ssh (`git@host:owner/repo`), and proxied
+# forms all end in `/owner/repo`; comparison is case-insensitive because GitHub
+# routing is.
+T_OWNER=$(printf '%s' "$INPUT" | jq -r '.tool_input.owner // empty' 2>/dev/null)
+T_REPO=$(printf '%s' "$INPUT" | jq -r '.tool_input.repo // empty' 2>/dev/null)
+ORIGIN=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+if [[ -n "$ORIGIN" && -n "$T_OWNER" && -n "$T_REPO" ]]; then
+  norm="${ORIGIN%/}"
+  norm="${norm%.git}"
+  norm="${norm//:/\/}"
+  [[ "${norm,,}" == *"/${T_OWNER,,}/${T_REPO,,}" ]] || exit 0
+fi
+
+# An update that carries no body leaves the body CI already validated
+# untouched.
+if [[ "$TOOL" == "mcp__github__update_pull_request" ]]; then
+  printf '%s' "$INPUT" | jq -e '.tool_input | has("body")' >/dev/null 2>&1 || exit 0
+fi
+
+BODY=$(printf '%s' "$INPUT" | jq -r '.tool_input.body // ""' 2>/dev/null)
+
+emit_tel() {
+  [[ -n "$start" ]] || return 0
+  hook::telemetry_enabled || return 0
+  local data
+  data=$(jq -n --arg outcome "$1" --arg tool "$TOOL" \
+    '{outcome:$outcome,tool:$tool}' 2>/dev/null) || data='{"outcome":"","tool":""}'
+  hook::emit_telemetry "pr-linkage-mcp-gate" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
+}
+
+# --- Body validation (mirrors the ci-workflows validator; see the sibling
+# pr-body-linkage-gate.sh for the fully annotated original of each function) --
+
+UNICODE_SPACES=(
+  $'\xc2\xa0' $'\xe1\x9a\x80'
+  $'\xe2\x80\x80' $'\xe2\x80\x81' $'\xe2\x80\x82' $'\xe2\x80\x83'
+  $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' $'\xe2\x80\x87'
+  $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a'
+  $'\xe2\x80\xa8' $'\xe2\x80\xa9' $'\xe2\x80\xaf'
+  $'\xe2\x81\x9f' $'\xe3\x80\x80' $'\xef\xbb\xbf'
+)
+
+strip_html_comments() {
+  local body="$1" line rest kept out="" in_comment=0 sp
+  for sp in "${UNICODE_SPACES[@]}"; do body="${body//"$sp"/ }"; done
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    rest="${line%$'\r'}"
+    kept=""
+    while [[ -n "$rest" ]]; do
+      if ((in_comment)); then
+        if [[ "$rest" == *"-->"* ]]; then
+          rest="${rest#*-->}"
+          in_comment=0
+        else
+          rest=""
+        fi
+      else
+        if [[ "$rest" == *"<!--"* ]]; then
+          kept+="${rest%%<!--*}"
+          rest="${rest#*<!--}"
+          in_comment=1
+        else
+          kept+="$rest"
+          rest=""
+        fi
+      fi
+    done
+    out+="$kept"$'\n'
+  done <<<"$body"
+  printf '%s' "$out"
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+KEYWORD_ERE='[^a-z0-9_](close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*([a-z0-9_.-]+/[a-z0-9_.-]+)?#[0-9]+[^a-z0-9_]'
+NO_ISSUE_ERE='[^a-z0-9_]no (linked|related) issue[^a-z0-9_]'
+
+has_linkage() {
+  local probe
+  probe=$'\n'"${1,,}"$'\n'
+  [[ "$probe" =~ $KEYWORD_ERE || "$probe" =~ $NO_ISSUE_ERE ]]
+}
+
+related_section() {
+  local body="$1" line t start=0 lvl i=0 out=""
+  local -a lines=()
+  while IFS= read -r line || [[ -n "$line" ]]; do lines+=("$line"); done <<<"$body"
+  for ((i = 0; i < ${#lines[@]}; i++)); do
+    t="${lines[i]}"
+    t="${t#"${t%%[![:space:]]*}"}"
+    t="${t%"${t##*[![:space:]]}"}"
+    [[ "${t,,}" =~ ^##[[:space:]]+related$ ]] && {
+      start=$((i + 1))
+      break
+    }
+  done
+  ((start)) || return 1
+  for ((i = start; i < ${#lines[@]}; i++)); do
+    t="${lines[i]}"
+    t="${t#"${t%%[![:space:]]*}"}"
+    t="${t%"${t##*[![:space:]]}"}"
+    if [[ "$t" =~ ^#+[[:space:]]+[^[:space:]] ]]; then
+      lvl=0
+      while [[ "${t:lvl:1}" == "#" ]]; do ((lvl++)); done
+      ((lvl <= 2)) && break
+    fi
+    out+="${lines[i]}"$'\n'
+  done
+  trim "$out"
+}
+
+problems=()
+stripped=$(strip_html_comments "$BODY")
+# shellcheck disable=SC2310  # the two exits ARE the verdict: absent vs present
+if related=$(related_section "$stripped"); then
+  [[ -n "$related" ]] || problems+=('The "## Related" section is empty.')
+else
+  problems+=('Missing a "## Related" section.')
+fi
+has_linkage "$stripped" ||
+  problems+=('Missing a native closing keyword (Closes/Fixes/Resolves #N) and no "No linked issue" marker.')
+
+if ((${#problems[@]} == 0)); then
+  emit_tel "ok"
+  exit 0
+fi
+
+emit_tel "blocked"
+echo "BLOCKED: PR body fails this repo's required pr-issue-linkage check." >&2
+for p in "${problems[@]}"; do echo "  - $p" >&2; done
+echo "Gate: ${GATE_FILE#"$REPO_ROOT/"} (required check 'pr-issue-linkage / pr-issue-linkage')." >&2
+echo "Add to the body:" >&2
+echo "  Closes #<issue>      (or the literal line: No linked issue)" >&2
+echo "  ## Related" >&2
+echo "  - <links, or N/A>" >&2
+exit 2

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.sh
@@ -63,7 +63,6 @@ INPUT=$(hook::buffer_stdin) || exit 0
 [[ -n "$INPUT" ]] || exit 0
 
 hook::require_jq "PreToolUse" "source-control-pr-linkage-mcp-gate" "$INPUT"
-command -v jq >/dev/null 2>&1 || exit 0
 
 TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 case "$TOOL" in

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Black-box contract test for pr-linkage-mcp-gate.sh — the MCP-surface sibling
+# of pr-body-linkage-gate.test.sh. Same caveat as that file: expectations are
+# transcribed by hand from a reading of the ci-workflows pr-issue-linkage
+# validator, not proven against it. What these cases cover is the payload
+# handling unique to the MCP surface (create-without-body blocks,
+# update-without-body allows, owner/repo scope guard, kill switch) plus the
+# validator shapes a hand port gets wrong (comment stripping, deeper headings
+# as Related content, bare `Closes #`).
+#
+# Self-contained: builds throwaway git repos with runtime-generated fixtures
+# and invokes the hook as a subprocess.
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HOOK_DIR/pr-linkage-mcp-gate.sh"
+
+PASS=0
+FAIL=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not on PATH -- pr-linkage-mcp-gate tests skipped"
+  exit 0
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+GATED="$WORK/gated"
+NOGATE="$WORK/nogate"
+mkdir -p "$GATED/.github/workflows" "$NOGATE"
+: >"$GATED/.github/workflows/pr-issue-linkage.yml"
+git -C "$GATED" init -q
+git -C "$GATED" remote add origin https://github.com/acme-corp/widgets.git
+git -C "$NOGATE" init -q
+
+# run <expected-exit> <name> <cwd> <payload-json>
+run() {
+  local expected="$1" name="$2" dir="$3" payload="$4" rc=0
+  bash "$HOOK" <<<"$payload" >/dev/null 2>&1 || rc=$?
+  if [[ "$rc" == "$expected" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $name (expected exit $expected, got $rc)" >&2
+  fi
+}
+
+# payload <cwd> <tool> <owner> <repo> [body] — body omitted = no body field.
+payload() {
+  local dir="$1" tool="$2" owner="$3" repo="$4"
+  if (($# >= 5)); then
+    jq -cn --arg d "$dir" --arg t "$tool" --arg o "$owner" --arg r "$repo" --arg b "$5" \
+      '{session_id:"test", cwd:$d, tool_name:$t, tool_input:{owner:$o, repo:$r, title:"t", body:$b}}'
+  else
+    jq -cn --arg d "$dir" --arg t "$tool" --arg o "$owner" --arg r "$repo" \
+      '{session_id:"test", cwd:$d, tool_name:$t, tool_input:{owner:$o, repo:$r, title:"t"}}'
+  fi
+}
+
+CREATE=mcp__github__create_pull_request
+UPDATE=mcp__github__update_pull_request
+OWNER=acme-corp
+REPO=widgets
+
+GOOD=$'Closes #12\n\n## Summary\n\nx\n\n## Related\n\n- N/A'
+NO_RELATED=$'Closes #12\n\n## Summary\n\nx'
+EMPTY_RELATED=$'Closes #12\n\n## Related\n'
+NO_KEYWORD=$'## Summary\n\nx\n\n## Related\n\n- N/A'
+OPTOUT=$'No linked issue\n\n## Related\n\n- N/A'
+COMMENTED=$'<!-- Closes #12 -->\n\n## Summary\n\nx\n\n<!-- ## Related\n- N/A -->'
+BARE_HASH=$'Closes #\n\n## Related\n\n- N/A'
+DEEP_HEADING=$'Fixes #7\n\n## Related\n\n### sub\n\ncontent'
+CROSS_REPO=$'Resolves other/repo#9\n\n## Related\n\n- N/A'
+
+run 0 "valid body passes" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$GOOD")"
+run 2 "missing Related blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$NO_RELATED")"
+run 2 "empty Related blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$EMPTY_RELATED")"
+run 2 "missing keyword blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$NO_KEYWORD")"
+run 0 "No linked issue opt-out passes" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$OPTOUT")"
+run 2 "markers only inside HTML comments block" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$COMMENTED")"
+run 2 "bare 'Closes #' with no number blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$BARE_HASH")"
+run 0 "deeper heading is Related content" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$DEEP_HEADING")"
+run 0 "owner/repo#N keyword form passes" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$CROSS_REPO")"
+run 2 "create with no body field blocks (empty body)" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO)"
+run 0 "update with no body field passes" "$GATED" "$(payload "$GATED" $UPDATE $OWNER $REPO)"
+run 2 "update with bad body blocks" "$GATED" "$(payload "$GATED" $UPDATE $OWNER $REPO "$NO_RELATED")"
+run 0 "different target repo is out of scope" "$GATED" "$(payload "$GATED" $CREATE other-org other-repo "$NO_RELATED")"
+run 0 "repo without the gate file never blocks" "$NOGATE" "$(payload "$NOGATE" $CREATE $OWNER $REPO "$NO_RELATED")"
+run 0 "unrelated tool passes" "$GATED" "$(payload "$GATED" mcp__github__get_me $OWNER $REPO "$NO_RELATED")"
+run 0 "empty stdin allows" "$GATED" ""
+
+# Kill switch: disabled via the userConfig mirror allows a bad body through.
+rc=0
+CLAUDE_PLUGIN_OPTION_PR_LINKAGE_MCP_GATE_ENABLED=false \
+  bash "$HOOK" <<<"$(payload "$GATED" $CREATE $OWNER $REPO "$NO_RELATED")" >/dev/null 2>&1 || rc=$?
+if [[ "$rc" == "0" ]]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  echo "FAIL: kill switch disables the gate (expected exit 0, got $rc)" >&2
+fi
+
+echo "pass=$PASS fail=$FAIL"
+((FAIL == 0))

--- a/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
+++ b/plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh
@@ -29,11 +29,14 @@ trap 'rm -rf "$WORK"' EXIT
 
 GATED="$WORK/gated"
 NOGATE="$WORK/nogate"
-mkdir -p "$GATED/.github/workflows" "$NOGATE"
+NOORIGIN="$WORK/noorigin"
+mkdir -p "$GATED/.github/workflows" "$NOGATE" "$NOORIGIN/.github/workflows"
 : >"$GATED/.github/workflows/pr-issue-linkage.yml"
+: >"$NOORIGIN/.github/workflows/pr-issue-linkage.yml"
 git -C "$GATED" init -q
 git -C "$GATED" remote add origin https://github.com/acme-corp/widgets.git
 git -C "$NOGATE" init -q
+git -C "$NOORIGIN" init -q
 
 # run <expected-exit> <name> <cwd> <payload-json>
 run() {
@@ -69,6 +72,8 @@ NO_RELATED=$'Closes #12\n\n## Summary\n\nx'
 EMPTY_RELATED=$'Closes #12\n\n## Related\n'
 NO_KEYWORD=$'## Summary\n\nx\n\n## Related\n\n- N/A'
 OPTOUT=$'No linked issue\n\n## Related\n\n- N/A'
+OPTOUT_ALIAS=$'No related issue: tracked in the profile file itself.\n\n## Related\n\n- N/A'
+PAST_TENSE=$'Fixed #31\n\n## Related\n\n- N/A'
 COMMENTED=$'<!-- Closes #12 -->\n\n## Summary\n\nx\n\n<!-- ## Related\n- N/A -->'
 BARE_HASH=$'Closes #\n\n## Related\n\n- N/A'
 DEEP_HEADING=$'Fixes #7\n\n## Related\n\n### sub\n\ncontent'
@@ -79,6 +84,8 @@ run 2 "missing Related blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO
 run 2 "empty Related blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$EMPTY_RELATED")"
 run 2 "missing keyword blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$NO_KEYWORD")"
 run 0 "No linked issue opt-out passes" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$OPTOUT")"
+run 0 "No related issue alias passes" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$OPTOUT_ALIAS")"
+run 0 "past-tense keyword (Fixed #N) passes" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$PAST_TENSE")"
 run 2 "markers only inside HTML comments block" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$COMMENTED")"
 run 2 "bare 'Closes #' with no number blocks" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$BARE_HASH")"
 run 0 "deeper heading is Related content" "$GATED" "$(payload "$GATED" $CREATE $OWNER $REPO "$DEEP_HEADING")"
@@ -87,6 +94,7 @@ run 2 "create with no body field blocks (empty body)" "$GATED" "$(payload "$GATE
 run 0 "update with no body field passes" "$GATED" "$(payload "$GATED" $UPDATE $OWNER $REPO)"
 run 2 "update with bad body blocks" "$GATED" "$(payload "$GATED" $UPDATE $OWNER $REPO "$NO_RELATED")"
 run 0 "different target repo is out of scope" "$GATED" "$(payload "$GATED" $CREATE other-org other-repo "$NO_RELATED")"
+run 0 "gated repo with no origin remote allows (undeterminable target)" "$NOORIGIN" "$(payload "$NOORIGIN" $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "repo without the gate file never blocks" "$NOGATE" "$(payload "$NOGATE" $CREATE $OWNER $REPO "$NO_RELATED")"
 run 0 "unrelated tool passes" "$GATED" "$(payload "$GATED" mcp__github__get_me $OWNER $REPO "$NO_RELATED")"
 run 0 "empty stdin allows" "$GATED" ""

--- a/plugins/source-control/hooks/pr-linkage-validator.sh
+++ b/plugins/source-control/hooks/pr-linkage-validator.sh
@@ -1,0 +1,156 @@
+# shellcheck shell=bash
+# Shared pr-issue-linkage BODY VALIDATOR. Sourced (not executed) — the single
+# in-repo transcription of the melodic-software/ci-workflows pr-issue-linkage
+# validator's semantics, consumed by every hook that judges a PR body against
+# that check:
+#   - pr-body-linkage-gate.sh   (Bash surface: `gh pr create` / `gh pr edit`)
+#   - pr-linkage-mcp-gate.sh    (MCP surface: GitHub MCP create/update PR)
+#   - the marketplace repo's checked-in .claude/hooks/pr-linkage-mcp-gate.sh,
+#     which sources this file from its own checkout
+# A drift fix against the upstream validator lands here once and reaches every
+# surface atomically; per-surface extraction, scope guards, and block messages
+# stay in the consuming hooks.
+#
+# CONTRACT — callers pin `export LC_ALL=C` BEFORE sourcing: the character
+# classes below are locale-dependent and the whole point of the
+# UNICODE_SPACES normalization is a locale-independent verdict. See the LOCALE
+# note in either consuming hook.
+#
+# Function names are kept exactly as they were when these lived inline in
+# pr-body-linkage-gate.sh (unprefixed), so its annotated history still reads;
+# only the aggregate verdict added with the extraction is namespaced.
+
+# Guard against double-sourcing.
+[[ -n "${_PR_LINKAGE_VALIDATOR_LOADED:-}" ]] && return 0
+readonly _PR_LINKAGE_VALIDATOR_LOADED=1
+
+# Every character JavaScript's `\s` matches beyond the six ASCII ones, as its
+# literal UTF-8 bytes. Spelled as bytes rather than `\uXXXX` because bash
+# renders `\u` through the ambient charmap, which is the very dependency the
+# LOCALE note removes. NBSP in particular arrives routinely in text pasted from
+# an issue title.
+UNICODE_SPACES=(
+  $'\xc2\xa0' $'\xe1\x9a\x80'
+  $'\xe2\x80\x80' $'\xe2\x80\x81' $'\xe2\x80\x82' $'\xe2\x80\x83'
+  $'\xe2\x80\x84' $'\xe2\x80\x85' $'\xe2\x80\x86' $'\xe2\x80\x87'
+  $'\xe2\x80\x88' $'\xe2\x80\x89' $'\xe2\x80\x8a'
+  $'\xe2\x80\xa8' $'\xe2\x80\xa9' $'\xe2\x80\xaf'
+  $'\xe2\x81\x9f' $'\xe3\x80\x80' $'\xef\xbb\xbf'
+)
+
+# Remove HTML comments the way the validator does — every terminated `<!-- … -->`
+# span, then an unterminated `<!--` taking everything after it. Both strips are
+# one left-to-right pass with a carried in-comment state, which produces exactly
+# that result: once a `<!--` has no `-->`, the state never clears again.
+# GitHub's own closing-keyword parser and its Markdown renderer both ignore
+# commented-out text, so an unedited PR template — whose instructional prose
+# names the very markers this gate looks for — must not pass vacuously.
+# Unicode-space normalization rides along on the same pass; the delimiters are
+# ASCII, so neither step can disturb the other.
+strip_html_comments() {
+  local body="$1" line rest kept out="" in_comment=0 sp
+  for sp in "${UNICODE_SPACES[@]}"; do body="${body//"$sp"/ }"; done
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    rest="${line%$'\r'}"
+    kept=""
+    while [[ -n "$rest" ]]; do
+      if ((in_comment)); then
+        if [[ "$rest" == *"-->"* ]]; then
+          rest="${rest#*-->}"
+          in_comment=0
+        else
+          rest=""
+        fi
+      else
+        if [[ "$rest" == *"<!--"* ]]; then
+          kept+="${rest%%<!--*}"
+          rest="${rest#*<!--}"
+          in_comment=1
+        else
+          kept+="$rest"
+          rest=""
+        fi
+      fi
+    done
+    out+="$kept"$'\n'
+  done <<<"$body"
+  printf '%s' "$out"
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# The validator's regexes, transcribed to POSIX ERE. JavaScript's `\b` has no
+# ERE equivalent, so the probe is wrapped in newlines and the boundary is spelled
+# as an explicit non-word character on each side — `#12abc` and `unclosed #5`
+# stay non-matches, exactly as `\b` makes them. Matched against a lower-cased
+# probe in place of the `i` flag.
+KEYWORD_ERE='[^a-z0-9_](close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*([a-z0-9_.-]+/[a-z0-9_.-]+)?#[0-9]+[^a-z0-9_]'
+NO_ISSUE_ERE='[^a-z0-9_]no (linked|related) issue[^a-z0-9_]'
+
+has_linkage() {
+  local probe
+  probe=$'\n'"${1,,}"$'\n'
+  [[ "$probe" =~ $KEYWORD_ERE || "$probe" =~ $NO_ISSUE_ERE ]]
+}
+
+# Content of the first `## Related` section on stdout; returns 1 when there is
+# no such heading, which is a different verdict from an empty one. Only a
+# heading at the SAME level or higher (fewer or equal `#`) closes the section,
+# so a nested `### …` subsection is content — a naive "next line starting with
+# #" reading would call such a section empty.
+#
+# Trimming is spelled inline at both per-line sites rather than through `trim`:
+# a command substitution forks, and one fork per body line put a 1000-line body
+# past this hook's own declared timeout.
+related_section() {
+  local body="$1" line t start=0 lvl i=0 out=""
+  local -a lines=()
+  while IFS= read -r line || [[ -n "$line" ]]; do lines+=("$line"); done <<<"$body"
+  for ((i = 0; i < ${#lines[@]}; i++)); do
+    t="${lines[i]}"
+    t="${t#"${t%%[![:space:]]*}"}"
+    t="${t%"${t##*[![:space:]]}"}"
+    [[ "${t,,}" =~ ^##[[:space:]]+related$ ]] && {
+      start=$((i + 1))
+      break
+    }
+  done
+  ((start)) || return 1
+  for ((i = start; i < ${#lines[@]}; i++)); do
+    t="${lines[i]}"
+    t="${t#"${t%%[![:space:]]*}"}"
+    t="${t%"${t##*[![:space:]]}"}"
+    if [[ "$t" =~ ^#+[[:space:]]+[^[:space:]] ]]; then
+      lvl=0
+      while [[ "${t:lvl:1}" == "#" ]]; do ((lvl++)); done
+      ((lvl <= 2)) && break
+    fi
+    out+="${lines[i]}"$'\n'
+  done
+  trim "$out"
+}
+
+# Aggregate verdict: strip comments, judge both halves. Fills the global
+# LINKAGE_PROBLEMS array with one line per missing half; returns 0 when the
+# body passes (array empty), 1 otherwise. The consuming hook owns what a
+# failure DOES — block message, telemetry, exit code.
+LINKAGE_PROBLEMS=()
+linkage::problems() {
+  local body related
+  body=$(strip_html_comments "$1")
+  LINKAGE_PROBLEMS=()
+  # shellcheck disable=SC2310  # the two exits ARE the verdict: absent vs present
+  if related=$(related_section "$body"); then
+    [[ -n "$related" ]] || LINKAGE_PROBLEMS+=('The "## Related" section is empty.')
+  else
+    LINKAGE_PROBLEMS+=('Missing a "## Related" section.')
+  fi
+  has_linkage "$body" ||
+    LINKAGE_PROBLEMS+=('Missing a native closing keyword (Closes/Fixes/Resolves #N) and no "No linked issue" marker.')
+  ((${#LINKAGE_PROBLEMS[@]} == 0))
+}


### PR DESCRIPTION
No linked issue

## Summary

Every first-attempt `pr-issue-linkage` CI failure in this repo is an authoring-time knowledge gap: the agent writing the PR body has no way to know the contract until CI rejects it one full round trip later (#1766 showed the pattern today — red at creation, green after a body edit). This PR makes the contract known and enforced at authoring time, on every surface a PR body can be written through, without weakening the required check itself.

## Fix

Three layers, repo-level and plugin-level:

- **CLAUDE.md** documents the body contract (closing keyword or literal `No linked issue`, plus a non-empty `## Related` section, validated after HTML-comment stripping) so agents write a passing body on the first try.
- **Checked-in MCP gate** (`.claude/hooks/pr-linkage-mcp-gate.sh`, wired in `.claude/settings.json`): a PreToolUse hook that blocks a GitHub-MCP `create_pull_request`/`update_pull_request` whose body would fail the check — the surface cloud sessions use — with the exact missing lines named in the block message. Loads in any session that opens this repo, no plugin required.
- **source-control plugin 0.41.0**: the same gate ships as `pr-linkage-mcp-gate` for every marketplace consumer, sibling to the existing `pr-body-linkage-gate` (`gh` surface); kill switch `pr_linkage_mcp_gate_enabled` (default true). The validator core (comment stripping, keyword/`## Related` judging, verdict wording) is extracted to one sourced lib, `pr-linkage-validator.sh`, consumed by both plugin hooks and the checked-in repo hook, so a drift fix against the upstream ci-workflows validator lands on every surface atomically.

The merge with `main` also hand-reconciles `.claude/settings.json` where git's textual merge of this branch and #1763 produced duplicate `hooks`/`extraKnownMarketplaces`/`enabledPlugins` keys (JSON last-wins would have silently dropped the SessionStart hook and the 9-plugin roster): the file now carries both hooks and #1763's marketplace source and plugin set.

## Verification

- `plugins/source-control/hooks/pr-linkage-mcp-gate.test.sh`: 17/17 (validator shapes, create-without-body blocks, update-without-body allows, owner/repo scope guard, kill switch).
- `plugins/source-control/hooks/pr-body-linkage-gate.test.sh`: 135/135 — sibling regression across the shared-lib extraction.
- `.claude/hooks/pr-linkage-mcp-gate.test.sh`: 16/16 against the checked-in hook sourcing the lib.
- `shellcheck` (repo rcfile semantics) and `shfmt` clean on all four shell files; `check-changelog-parity.sh --check-bump origin/main`, `sync-hook-utils.sh --check`, and `check-manifest-duplicate-keys.py` all pass.
- Hook contracts (PreToolUse MCP matchers, plugin `hooks/hooks.json`, `userConfig` → `CLAUDE_PLUGIN_OPTION_*` mapping) verified against the current hooks and plugins-reference docs fetched this session, per the fresh-docs mandate.

## Related

- Refs #1763 — the cloud-session provisioning PR whose `.claude/settings.json` this branch merges with and reconciles.
- Refs #1766 — today's observed instance of the first-attempt `pr-issue-linkage` failure this PR prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJdyaSTPhgkjYwJnVnhdV4)_