### PR TITLE
chore(knowledge): retire reduce-hallucinations doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.6]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: reduce-hallucinations queue entry removed.** The
+  reduce-hallucinations guardrail slice completed — raw-md fetch through interview handoff,
+  dual verification (two correction rounds, re-verified REVERIFY2: PASS by both verifiers, no
+  degraded fallback) — so its entry leaves the doc queue per the queue's remove-on-completion
+  rule. The increase-consistency guardrail entry remains queued.
+
 ## [0.10.5]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -70,7 +70,6 @@ their slices complete.
 
 Guardrail guides:
 
-- <https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations>
 - <https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/increase-consistency>
 
 Model selection (special handling — vet/validate/correct the consuming setup's existing


### PR DESCRIPTION
## Summary

- Removes the reduce-hallucinations guardrail entry from the `docpage-digest` Anthropic profile's doc queue — its slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule. The increase-consistency guardrail entry remains queued, so the "Guardrail guides" heading stays.
- Channel: raw-md (`.md` appended to the page URL; HTTP 200, 49 lines / 6,309 bytes — channel re-verified for this page, no degradation); provenance recorded in the slice checklist.
- Slice verification: Verifier A (same-vendor, fresh context) PASS with 2 advisories; Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED (5+3, two findings against INDEX.md). Two correction rounds (session-default agents — guardrail guide, no model pin per the profile's model-matching table; round 2 fixed one pre-existing finding the round-1 re-verify newly detected plus a Verifier A advisory); final state REVERIFY2: PASS from both verifiers, zero new correction-needed findings (one non-blocking pre-existing narrowing note recorded in reverify2-a). Records under `.work/platform-claude-com-docs-en-tes-2baa7563/verification/`.
- No profile-learning bullet this run: the one generalizable-ruling candidate (the unverified-inference marker threshold for adjacent/mechanism-level harness support) was deliberately escalated to the interview by both verifiers rather than settled — codifying it now would front-run that open question.
- Knowledge plugin `0.10.5` → `0.10.6` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on changed markdown: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning, SKILL.md length)
- `check-changelog-parity.sh --check-bump origin/main`: PASS (re-run after rebasing onto the new changelog-order gate commit; 0.10.6 ordering conforms)
- Independent fresh-context reviewer on the diff: APPROVE (traced the changelog claims to the slice checklist and verification records; applied its rebase-before-PR recommendation)
- Base freshness: rebased onto origin/main immediately before commit; zero commits behind

No linked issue — this PR closes no GitHub issue; the doc queue is tracked in the profile file itself.

## Related

- #1765 (previous doc-queue completion in this series — best-practices slice)
- #1740 (Verifier B elevated recipe used for cross-vendor verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

