### PR TITLE
chore(knowledge): retire increase-consistency doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.7]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: increase-consistency queue entry removed.** The
+  increase-consistency guardrail slice completed — raw-md fetch through interview handoff,
+  dual verification (one correction round, re-verified REVERIFY: PASS by both verifiers, no
+  degraded fallback) — so its entry leaves the doc queue per the queue's remove-on-completion
+  rule. It was the last remaining guardrail guide, so the emptied category heading goes with it.
+
 ## [0.10.6]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -68,10 +68,6 @@ Every model-pinned spawn brief uses the conditional framing contract from `SKILL
 Pending Anthropic docs for this pipeline. Verify each URL live at fetch time; remove entries as
 their slices complete.
 
-Guardrail guides:
-
-- <https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/increase-consistency>
-
 Model selection (special handling — vet/validate/correct the consuming setup's existing
 model-routing configuration against the doc, rather than only digesting):
 


### PR DESCRIPTION
## Summary

- Removes the increase-consistency guardrail entry from the `docpage-digest` Anthropic profile's doc queue — its slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule. It was the last remaining guardrail guide, so the emptied category heading goes with it.
- Channel: raw-md (`.md` appended to the page URL; HTTP 200, 93 lines / 29,682 bytes — channel re-verified for this page, no degradation); provenance recorded in the slice checklist.
- Slice verification: Verifier A (same-vendor, fresh context) CORRECTION-NEEDED (1+3); Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED (4+2; B-4 shared A-1's root — the digest set had omitted the `claude -p --json-schema` CLI structured-output surface, since corrected against live headless/cli-reference checks). One correction round (session-default agents — guardrail guide, no model pin per the profile's model-matching table); re-verified REVERIFY: PASS by both verifiers, 10/10 findings resolved, zero new findings, both re-verifiers independently re-fetched the cited live docs. Records under `.work/platform-claude-com-docs-en-tes-44ba86b3/verification/`.
- No profile-learning bullet this run: the generalizable-ruling candidates (api-only absence-basis standard, "system prompt" boundary ruling, unverified-inference dispositions) were all escalated to the interview by the verifiers rather than settled — codifying now would front-run those open questions (same precedent as #1775).
- Knowledge plugin `0.10.6` → `0.10.7` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on changed markdown: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning, SKILL.md length)
- `check-changelog-parity.sh --check-bump origin/main`: PASS (0.10.7 ordering conforms to the changelog-order gate)
- Independent fresh-context reviewer on the diff: APPROVE, no blocking findings (traced every changelog claim to the slice checklist and verification records; confirmed the profile-learning omission matches the escalated-to-interview precedent)
- Base freshness: fetched origin/main immediately before commit; zero commits behind

No linked issue — this PR closes no GitHub issue; the doc queue is tracked in the profile file itself.

## Related

- #1775 (previous doc-queue completion in this series — reduce-hallucinations slice)
- #1740 (Verifier B elevated recipe used for cross-vendor verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
