### PR TITLE
feat(claude-ops): surface review findings stranded on merged pull requests

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort, a repo-pull + marketplace-refresh launch step, and a consume-restarts action — an OS-schedulable reader that relaunches stopped lanes whose telemetry carries a restart_request), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.24.0]
+
+### Added
+
+- **`morning-brief` reports findings stranded on merged pull requests (#1777).** A review that lands
+  *after* a merge had nowhere to go: the ruleset's `required_review_thread_resolution` is a
+  merge-time predicate that already passed, the babysit lane works only *open* pull requests, and
+  nothing on a merged pull request surfaces its open threads. Six findings — one P1 — posted 46
+  seconds after #1720 merged sat unread for a day, and were found only because a later session
+  happened to audit the merge batch.
+
+  The new section compares each unresolved thread's first-comment timestamp against the pull
+  request's `mergedAt`, so it reports **only** threads that could never have been seen by the gate;
+  a thread predating the merge is an ordinary unresolved thread and is excluded. Findings are
+  collapsed to one line per pull request at that pull request's **worst** severity with a count, so
+  a P0 beside advisory findings can never be softened, and one noisy pull request cannot bury the
+  rest. The window is `--stranded-days` (default 3), wide enough to cover both slow bot review and
+  an operator-absent weekend.
+
+  Run against this repository on its first live invocation, it immediately surfaced four further
+  stranded findings on other merged pull requests, including a P1 recording that a shipped plugin
+  cell never reached installations — so this is a standing leak, not a one-off.
+
+  The section **fails loud rather than clear**. A GraphQL error document is well-formed JSON that
+  simply carries no `data`, so an unread API would otherwise extract to an empty list and render as
+  "every merged PR in the window is clear" — an all-clear asserted from an answer never received,
+  which is the same fail-open shape the section exists to catch. Caught during development when a
+  rate-limit error did exactly that; an API error now says explicitly that it is not an all-clear
+  and prints the message.
+
 ## [0.23.2]
 
 ### Fixed

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -26,6 +26,17 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   stranded findings on other merged pull requests, including a P1 recording that a shipped plugin
   cell never reached installations — so this is a standing leak, not a one-off.
 
+  Severity is read from the **structured marker only** — the badge alt-text, the shields badge URL,
+  or a leading bracket — never from body prose. A body-wide substring test falsely promotes a P2
+  titled "Preserve P1 labels", and any finding that merely discusses `CRITICAL` or `SECURITY`.
+  Ranking is numeric rather than lexicographic, because `"--"` sorts before `"P0"` as a string: an
+  unclassified thread sitting beside a genuine P0 would otherwise collapse the pull request to
+  `[--]` and hide it.
+
+  A thread connection that **truncates** is reported as a partial read. `--paginate` follows only
+  the outer cursor, so a pull request with more than 100 review threads would be silently cut short
+  — and a partial read that renders as an all-clear is the same failure the section exists to catch.
+
   The section **fails loud rather than clear**. A GraphQL error document is well-formed JSON that
   simply carries no `data`, so an unread API would otherwise extract to an empty list and render as
   "every merged PR in the window is clear" — an all-clear asserted from an answer never received,

--- a/plugins/claude-ops/skills/morning-brief/SKILL.md
+++ b/plugins/claude-ops/skills/morning-brief/SKILL.md
@@ -48,6 +48,14 @@ re-query the sections by hand.
 | Merge-ready PRs | `gh pr list` filtered to non-draft + `mergeStateStatus=CLEAN` | A light glance signal; `reviewDecision` shown but not required (repos without required review leave it empty) |
 | Parked decisions | open `status: needs-decision` issues | Surfaces each one's RECOMMENDED line — the uppercase marker wins over an incidental lowercase mention; a case-insensitive fallback catches lowercase markers |
 | Lane telemetry | the loop-lane telemetry issue's per-lane comments | Each lane's `last-cycle` age (marked `STALE` past `--stale-hours`, default 6) and any `flags:` |
+| Stranded findings | merged PRs whose unresolved review threads were **created after the merge** | One line per PR at its worst severity, with a finding count; window is `--stranded-days`, default 3 |
+
+A review that lands after a merge has nowhere to go: the ruleset's
+`required_review_thread_resolution` is a merge-time predicate that already passed, the babysit lane
+works *open* PRs, and nothing on a merged PR surfaces its open threads. This section is the only
+place they appear (#1777). The comment-vs-merge timestamp comparison is the discriminator — a thread
+that predates the merge was visible to the gate and is an ordinary unresolved thread, not this
+failure mode.
 
 The telemetry issue is auto-discovered by title; pass `--telemetry-issue N` to pin it.
 When no such issue exists (e.g. a consuming repo without loop-lane telemetry), that

--- a/plugins/claude-ops/skills/morning-brief/morning-brief.test.sh
+++ b/plugins/claude-ops/skills/morning-brief/morning-brief.test.sh
@@ -450,7 +450,7 @@ OUT_ERR="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
   --merged-json "$TMP/merged-apierror.json" 2>&1)"
 assert_not_contains "stranded: an API error is NEVER reported as clear" "$OUT_ERR" "every merged PR in the window is clear"
 
-# --- Severity classification and ranking (PR #1781 review) -------------------
+# --- Severity classification and ranking -------------------------------------
 OUT_SEV="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
   --counts-json "$TMP/counts.json" \
   --pr-json "$TMP/pr.json" \

--- a/plugins/claude-ops/skills/morning-brief/morning-brief.test.sh
+++ b/plugins/claude-ops/skills/morning-brief/morning-brief.test.sh
@@ -31,7 +31,10 @@ trap 'rm -rf "$TMP"' EXIT
 
 FAILED=0
 CASE_NUM=0
-pass() { CASE_NUM=$((CASE_NUM + 1)); printf 'PASS: [%d] %s\n' "$CASE_NUM" "$1"; }
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: [%d] %s\n' "$CASE_NUM" "$1"
+}
 fail() {
   CASE_NUM=$((CASE_NUM + 1))
   printf 'FAIL: [%d] %s\n  expected: %q\n  got: %q\n' "$CASE_NUM" "$1" "$2" "$3" >&2
@@ -101,6 +104,67 @@ EOF
 
 printf '[]\n' >"$TMP/empty.json"
 
+# Merged-PR fixture for the stranded-findings section, shaped like the real case
+# (#1720): a P1 review comment posted 46 SECONDS AFTER the merge landed. The
+# fixture mirrors `gh api graphql --paginate` output — a list of page documents.
+#   #1720 — P1 thread created after merge      -> stranded, must report
+#   #1707 — thread created BEFORE the merge     -> gate saw it, must NOT report
+#   #1712 — post-merge thread already resolved  -> handled, must NOT report
+#   #1690 — merged outside the window           -> too old, must NOT report
+cat >"$TMP/merged.json" <<'EOF'
+[
+  {"data": {"repository": {"pullRequests": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+    {"number": 1720, "title": "feat(claude-ops): consume lane restart-requests",
+     "url": "https://github.com/o/r/pull/1720", "mergedAt": "2026-07-19T19:23:17Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T19:24:03Z", "author": {"login": "chatgpt-codex-connector"},
+          "body": "![P1 Badge](x) Distinguish lock-storage errors from held locks"}]}},
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T19:24:03Z", "author": {"login": "chatgpt-codex-connector"},
+          "body": "![P2 Badge](x) Preserve scheduler options"}]}}]}},
+    {"number": 1707, "title": "feat(planning): draft non-quantifiable goals",
+     "url": "https://github.com/o/r/pull/1707", "mergedAt": "2026-07-19T16:23:23Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T15:00:00Z", "author": {"login": "a-human"},
+          "body": "P1 this predates the merge"}]}}]}},
+    {"number": 1712, "title": "docs(loop-lane): pin the prompt-fresh distinction",
+     "url": "https://github.com/o/r/pull/1712", "mergedAt": "2026-07-19T16:24:00Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": true, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T16:30:00Z", "author": {"login": "chatgpt-codex-connector"},
+          "body": "P1 already dealt with"}]}}]}},
+    {"number": 1690, "title": "feat(loop-lane): out-of-band escalation",
+     "url": "https://github.com/o/r/pull/1690", "mergedAt": "2026-07-01T10:00:00Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-01T10:05:00Z", "author": {"login": "chatgpt-codex-connector"},
+          "body": "P1 but long outside the window"}]}}]}}
+  ]}}}}
+]
+EOF
+
+# A GraphQL error document: well-formed JSON with no `data`. Must never render
+# as an all-clear — observed live, where a rate-limit error read as a clean
+# window, which is the fail-open shape this whole section exists to catch.
+cat >"$TMP/merged-apierror.json" <<'EOF'
+[
+  {"errors": [{"type": "RATE_LIMIT", "code": "graphql_rate_limit",
+               "message": "API rate limit already exceeded for user ID 1."}]}
+]
+EOF
+
+# No merged PR carries a post-merge thread — the clean-window branch.
+cat >"$TMP/merged-clean.json" <<'EOF'
+[
+  {"data": {"repository": {"pullRequests": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+    {"number": 1707, "title": "all clear", "url": "https://github.com/o/r/pull/1707",
+     "mergedAt": "2026-07-19T16:23:23Z", "reviewThreads": {"nodes": []}}
+  ]}}}}
+]
+EOF
+
 # Non-empty telemetry array with zero lane-tagged comments (only scope notes) —
 # the any=0 branch, distinct from the null/no-issue-found case above.
 cat >"$TMP/telemetry-no-lanes.json" <<'EOF'
@@ -115,7 +179,8 @@ OUT="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
   --counts-json "$TMP/counts.json" \
   --pr-json "$TMP/pr.json" \
   --decisions-json "$TMP/decisions.json" \
-  --telemetry-json "$TMP/telemetry.json" 2>&1)"
+  --telemetry-json "$TMP/telemetry.json" \
+  --merged-json "$TMP/merged.json" 2>&1)"
 RC=$?
 
 assert_exit "renders successfully" 0 "$RC"
@@ -292,6 +357,60 @@ STUB
   assert_contains "BSD fallback: stale verdict via date -j -f" "$OUT_BSD" "STALE (>6h)"
   assert_contains "BSD fallback: unparsable stamp still unparsable" "$OUT_BSD" "unparsable timestamp"
 fi
+
+# --- Stranded findings on merged PRs (#1777) ----------------------------------
+# The discriminator is the comment's timestamp vs the merge's: a thread the merge
+# gate could never have seen, because it did not exist yet.
+assert_contains "stranded: reports the post-merge P1" "$OUT" "#1720"
+assert_contains "stranded: severity survives to the operator" "$OUT" "[P1]"
+# One line per PR, not per thread: #1720 carries a P1 and a P2, and must render
+# once at its WORST severity with the count — repeating a title per thread buries
+# every other PR in the section.
+assert_contains "stranded: several findings on one PR collapse to one line" "$OUT" "(2 findings)"
+assert_not_contains "stranded: a collapsed PR is not softened to its lesser severity" "$OUT" "[P2] #1720"
+assert_contains "stranded: names the reviewer" "$OUT" "by chatgpt-codex-connector"
+assert_contains "stranded: says why it was missed" "$OUT" "merge gate could not see it"
+# The three negative cases matter more than the positive: a check that reports
+# every unresolved thread on every merged PR is noise, not a signal.
+assert_not_contains "stranded: a thread PREDATING the merge is not stranded" "$OUT" "#1707"
+assert_not_contains "stranded: an already-RESOLVED post-merge thread is excluded" "$OUT" "#1712"
+assert_not_contains "stranded: a merge outside the window is excluded" "$OUT" "#1690"
+
+# Severity ordering: a P0/P1 must not sort below advisory findings.
+STRANDED_BLOCK="$(printf '%s\n' "$OUT" | sed -n '/stranded on merged/,$p')"
+FIRST_SEV="$(printf '%s\n' "$STRANDED_BLOCK" | grep -oE '^\s+\[P[0-9]\]' | head -1 | tr -d ' ')"
+assert_contains "stranded: highest severity is listed first" "$FIRST_SEV" "[P1]"
+
+# Clean window renders the reassuring branch rather than an empty section.
+OUT_CLEAN="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
+  --counts-json "$TMP/counts.json" \
+  --pr-json "$TMP/pr.json" \
+  --decisions-json "$TMP/decisions.json" \
+  --telemetry-json "$TMP/telemetry.json" \
+  --merged-json "$TMP/merged-clean.json" 2>&1)"
+assert_contains "stranded: a clean window says so explicitly" "$OUT_CLEAN" "every merged PR in the window is clear"
+
+# An API error must NOT read as an all-clear. This is the section's own fail-open
+# failure mode, and it was observed live before being fixed.
+OUT_ERR="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
+  --counts-json "$TMP/counts.json" \
+  --pr-json "$TMP/pr.json" \
+  --decisions-json "$TMP/decisions.json" \
+  --telemetry-json "$TMP/telemetry.json" \
+  --merged-json "$TMP/merged-apierror.json" 2>&1)"
+assert_not_contains "stranded: an API error is NEVER reported as clear" "$OUT_ERR" "every merged PR in the window is clear"
+assert_contains "stranded: an API error says it is not an all-clear" "$OUT_ERR" "NOT an all-clear"
+assert_contains "stranded: the API error message is surfaced" "$OUT_ERR" "rate limit already exceeded"
+
+# The window is operator-tunable, and widening it must pull in the older merge.
+OUT_WIDE="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 --stranded-days 60 \
+  --counts-json "$TMP/counts.json" \
+  --pr-json "$TMP/pr.json" \
+  --decisions-json "$TMP/decisions.json" \
+  --telemetry-json "$TMP/telemetry.json" \
+  --merged-json "$TMP/merged.json" 2>&1)"
+assert_contains "stranded: --stranded-days widens the window" "$OUT_WIDE" "#1690"
+assert_contains "stranded: the window is reported in the header" "$OUT_WIDE" "last 60d"
 
 # --- Summary ------------------------------------------------------------------
 echo

--- a/plugins/claude-ops/skills/morning-brief/morning-brief.test.sh
+++ b/plugins/claude-ops/skills/morning-brief/morning-brief.test.sh
@@ -145,6 +145,56 @@ cat >"$TMP/merged.json" <<'EOF'
 ]
 EOF
 
+# Severity classification and ranking edge cases, all three found by review on
+# the PR that added this section:
+#   #300 — a P2 whose PROSE says "P1" and "CRITICAL": body-substring matching
+#          falsely promoted it. Only the structured marker counts.
+#   #301 — an unclassified thread beside a P0: "--" sorts before "P0"
+#          lexicographically, so the PR would render "[--]" and hide the P0.
+#   #302 — the shields badge/P0 URL form, with no alt-text marker.
+cat >"$TMP/merged-severity.json" <<'EOF'
+[
+  {"data": {"repository": {"pullRequests": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+    {"number": 300, "title": "prose mentions a higher severity",
+     "url": "https://github.com/o/r/pull/300", "mergedAt": "2026-07-19T16:00:00Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T17:00:00Z", "author": {"login": "bot"},
+          "body": "![P2 Badge](x) Preserve P1 labels when CRITICAL SECURITY findings appear"}]}}]}},
+    {"number": 301, "title": "unclassified thread beside a real P0",
+     "url": "https://github.com/o/r/pull/301", "mergedAt": "2026-07-19T16:00:00Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T17:00:00Z", "author": {"login": "bot"},
+          "body": "a plain comment carrying no severity marker at all"}]}},
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T17:01:00Z", "author": {"login": "bot"},
+          "body": "![P0 Badge](x) the real problem"}]}}]}},
+    {"number": 302, "title": "shields url badge form only",
+     "url": "https://github.com/o/r/pull/302", "mergedAt": "2026-07-19T16:00:00Z",
+     "reviewThreads": {"nodes": [
+       {"isResolved": false, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T17:00:00Z", "author": {"login": "bot"},
+          "body": "see https://img.shields.io/badge/P0-red?style=flat for the rating"}]}}]}}
+  ]}}}}
+]
+EOF
+
+# A PR whose thread connection was TRUNCATED: the read is partial, so neither
+# the finding list nor an all-clear can be trusted to be complete.
+cat >"$TMP/merged-truncated.json" <<'EOF'
+[
+  {"data": {"repository": {"pullRequests": {"pageInfo": {"hasNextPage": false, "endCursor": null}, "nodes": [
+    {"number": 400, "title": "more than one page of review threads",
+     "url": "https://github.com/o/r/pull/400", "mergedAt": "2026-07-19T16:00:00Z",
+     "reviewThreads": {"pageInfo": {"hasNextPage": true}, "nodes": [
+       {"isResolved": true, "comments": {"nodes": [
+         {"createdAt": "2026-07-19T17:00:00Z", "author": {"login": "bot"},
+          "body": "![P2 Badge](x) resolved, so nothing is reported for this PR"}]}}]}}
+  ]}}}}
+]
+EOF
+
 # A GraphQL error document: well-formed JSON with no `data`. Must never render
 # as an all-clear — observed live, where a rate-limit error read as a clean
 # window, which is the fail-open shape this whole section exists to catch.
@@ -378,7 +428,7 @@ assert_not_contains "stranded: a merge outside the window is excluded" "$OUT" "#
 
 # Severity ordering: a P0/P1 must not sort below advisory findings.
 STRANDED_BLOCK="$(printf '%s\n' "$OUT" | sed -n '/stranded on merged/,$p')"
-FIRST_SEV="$(printf '%s\n' "$STRANDED_BLOCK" | grep -oE '^\s+\[P[0-9]\]' | head -1 | tr -d ' ')"
+FIRST_SEV="$(printf '%s\n' "$STRANDED_BLOCK" | grep -oE '^[[:space:]]+\[P[0-9]\]' | head -1 | tr -d ' ')"
 assert_contains "stranded: highest severity is listed first" "$FIRST_SEV" "[P1]"
 
 # Clean window renders the reassuring branch rather than an empty section.
@@ -399,6 +449,33 @@ OUT_ERR="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
   --telemetry-json "$TMP/telemetry.json" \
   --merged-json "$TMP/merged-apierror.json" 2>&1)"
 assert_not_contains "stranded: an API error is NEVER reported as clear" "$OUT_ERR" "every merged PR in the window is clear"
+
+# --- Severity classification and ranking (PR #1781 review) -------------------
+OUT_SEV="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
+  --counts-json "$TMP/counts.json" \
+  --pr-json "$TMP/pr.json" \
+  --decisions-json "$TMP/decisions.json" \
+  --telemetry-json "$TMP/telemetry.json" \
+  --merged-json "$TMP/merged-severity.json" 2>&1)"
+# Prose is not a severity marker: only the structured badge counts.
+assert_contains "severity: a P2 whose prose says P1/CRITICAL stays P2" "$OUT_SEV" "[P2] #300"
+assert_not_contains "severity: prose never promotes a finding" "$OUT_SEV" "[P1] #300"
+assert_not_contains "severity: the word CRITICAL in prose never promotes to P0" "$OUT_SEV" "[P0] #300"
+# Ranking is numeric, so an unclassified thread cannot mask a real P0.
+assert_contains "severity: an unclassified thread never hides a P0" "$OUT_SEV" "[P0] #301"
+assert_not_contains "severity: the unclassified marker never wins the collapse" "$OUT_SEV" "[--] #301"
+# Both structured marker forms the bots emit are recognized.
+assert_contains "severity: the shields badge/P0 URL form is recognized" "$OUT_SEV" "[P0] #302"
+
+# --- Truncated thread page is a PARTIAL read, never an all-clear -------------
+OUT_TRUNC="$(bash "$BRIEF" --now "$NOW" --stale-hours 6 \
+  --counts-json "$TMP/counts.json" \
+  --pr-json "$TMP/pr.json" \
+  --decisions-json "$TMP/decisions.json" \
+  --telemetry-json "$TMP/telemetry.json" \
+  --merged-json "$TMP/merged-truncated.json" 2>&1)"
+assert_contains "truncation: a partial thread read is reported" "$OUT_TRUNC" "this read is PARTIAL"
+assert_contains "truncation: the affected PR is named" "$OUT_TRUNC" "#400"
 assert_contains "stranded: an API error says it is not an all-clear" "$OUT_ERR" "NOT an all-clear"
 assert_contains "stranded: the API error message is surfaced" "$OUT_ERR" "rate limit already exceeded"
 

--- a/plugins/claude-ops/skills/morning-brief/scripts/morning-brief.sh
+++ b/plugins/claude-ops/skills/morning-brief/scripts/morning-brief.sh
@@ -516,7 +516,13 @@ print_stranded() {
             pageInfo { hasNextPage endCursor }
             nodes {
               number title url mergedAt
-              reviewThreads(first:50) {
+              # 100 is the GraphQL page maximum. --paginate follows only the
+              # OUTER cursor, so a PR with more threads than this would be
+              # truncated with no signal. hasNextPage is read below and
+              # reported, because a partial read must never render as an
+              # all-clear.
+              reviewThreads(first:100) {
+                pageInfo { hasNextPage }
                 nodes {
                   isResolved
                   comments(first:1) { nodes { createdAt author { login } body } }
@@ -570,14 +576,24 @@ print_stranded() {
               pr: $pr.number, title: $pr.title, url: $pr.url,
               author: (.comments.nodes[0].author.login // "unknown"),
               # Severity must survive to the operator: a stranded P1 cannot read
-              # like a P3. Markers are matched on the badge alt-text/bracket
-              # forms the review bots actually emit.
+              # like a P3. Matched on the STRUCTURED marker only — the badge
+              # alt-text (`![P1 Badge]`), the shields URL (`badge/P1`), or a
+              # leading bracket — never on free prose. A body-wide substring
+              # test falsely promotes a P2 titled "Preserve P1 labels", and any
+              # finding that merely discusses CRITICAL or SECURITY.
               sev: (
                 (.comments.nodes[0].body // "")
-                | if test("P0|CRITICAL|SECURITY"; "i") then "P0"
-                  elif test("P1"; "i") then "P1"
-                  elif test("P2"; "i") then "P2"
-                  else "--" end
+                # `[ match(...) ]` rather than `capture(...).s` or a bare
+                # `match(...)`: a non-match must yield EMPTY so the next
+                # alternative is tried. Indexing a non-matching capture instead
+                # aborts the whole program, which renders every PR as clear.
+                | . as $b
+                | [ ( $b | [ match("!\\[[[:space:]]*(P[0-9])[ _-]?Badge"; "i") ] ),
+                    ( $b | [ match("badge/(P[0-9])"; "i") ] ),
+                    ( $b | [ match("^[[:space:]]*\\[(P[0-9])\\]"; "i") ] ) ]
+                | map(.[0].captures[0].string // empty)
+                | (.[0] // "")
+                | ascii_upcase
               )
             })
       )
@@ -591,12 +607,28 @@ print_stranded() {
         pr: .[0].pr, title: .[0].title, url: .[0].url,
         author: (map(.author) | unique | join(", ")),
         n: length,
-        sev: (map(.sev) | sort | .[0])
+        # Rank NUMERICALLY, never on the display string: "--" sorts before "P0"
+        # lexicographically, so an unclassified thread beside a P0 would hide
+        # the P0 behind a "[--]" label. Unrecognized ranks last (99).
+        sev: (map(.sev) | map(if . == "" then 99 else (.[1:] | tonumber) end) | min
+              | if . == 99 then "--" else "P\(.)" end)
       })
-    | sort_by(.sev, .pr)
+    | sort_by(if .sev == "--" then 99 else (.sev[1:] | tonumber) end, .pr)
     | .[]
     | "  [\(.sev)] #\(.pr) \(.title)  (\(.n) finding\(if .n == 1 then "" else "s" end))\n    \(.url)  by \(.author)"
   ' <<<"$merged" 2>/dev/null)"
+
+  # A truncated thread page means the read was PARTIAL, so neither a finding
+  # list nor an all-clear below can be trusted to be complete. Say so.
+  local truncated
+  truncated="$(jq -s -r '
+    [ .. | objects | select(has("data")) | .data.repository.pullRequests.nodes[]?
+      | select(.reviewThreads.pageInfo.hasNextPage == true) | .number ]
+    | unique | map("#\(.)") | join(", ")
+  ' <<<"$merged" 2>/dev/null)"
+  if [[ -n "$truncated" ]]; then
+    echo "  WARNING: more than 100 review threads on $truncated — this read is PARTIAL, not an all-clear"
+  fi
 
   if [[ -n "$stranded" ]]; then
     echo "$stranded"

--- a/plugins/claude-ops/skills/morning-brief/scripts/morning-brief.sh
+++ b/plugins/claude-ops/skills/morning-brief/scripts/morning-brief.sh
@@ -54,6 +54,11 @@ COUNTS_JSON=""
 PR_JSON=""
 DECISIONS_JSON=""
 TELEMETRY_JSON=""
+MERGED_JSON=""
+# How far back to look for merged PRs still carrying unresolved review threads.
+# Wide enough to cover a bot that reviews well after a merge lands, and the
+# operator-absent stretch (a weekend) during which nobody would look.
+STRANDED_DAYS="3"
 
 usage() {
   # Sentinel-based, not a hardcoded line range: prints every comment line after
@@ -116,6 +121,16 @@ while (($# > 0)); do
     REC_MAXLEN="$((10#$2))"
     shift 2
     ;;
+  --stranded-days)
+    require_value "$1" "${2:-}"
+    [[ "$2" =~ ^[0-9]+$ ]] || {
+      printf 'morning-brief: --stranded-days requires a non-negative integer\n' >&2
+      exit 3
+    }
+    # 10# forces base-10 so a leading-zero value is not misread as octal.
+    STRANDED_DAYS="$((10#$2))"
+    shift 2
+    ;;
   --now)
     require_value "$1" "${2:-}"
     NOW_ISO="$2"
@@ -143,6 +158,12 @@ while (($# > 0)); do
     require_value "$1" "${2:-}"
     require_file "$1" "$2"
     TELEMETRY_JSON="$2"
+    shift 2
+    ;;
+  --merged-json)
+    require_value "$1" "${2:-}"
+    require_file "$1" "$2"
+    MERGED_JSON="$2"
     shift 2
     ;;
   -*)
@@ -462,6 +483,131 @@ print_telemetry() {
 }
 
 # =============================================================================
+# Section 5 — findings stranded on merged PRs
+# =============================================================================
+# A review that lands AFTER a merge has nowhere to go: the merge gate is a
+# merge-time predicate that already passed, the babysit lane works OPEN PRs, and
+# nothing on a merged PR surfaces its open threads. Real case: six findings (one
+# P1) posted 46 seconds after #1720 merged sat unread for a day (#1777).
+#
+# Only threads whose FIRST comment postdates the merge are reported. A thread
+# that predates it was visible to the gate, so its being open is an ordinary
+# unresolved-thread matter and not this failure mode.
+print_stranded() {
+  echo "== Findings stranded on merged PRs (last ${STRANDED_DAYS}d) =="
+  local merged
+  if [[ -n "$MERGED_JSON" ]]; then
+    merged="$(cat "$MERGED_JSON")"
+  elif [[ -z "$REPO" ]]; then
+    # Every other section can be driven entirely from fixtures, so a fixture-only
+    # run never resolves a repo. Degrade like the telemetry section does rather
+    # than making this section's live path a new requirement on those runs.
+    echo "  (no repo resolved — pass --repo or --merged-json)"
+    echo
+    return
+  else
+    # `search/issues` dates the merge; reviewThreads needs GraphQL. One paged
+    # GraphQL query does both, so this stays a single call rather than N+1.
+    # shellcheck disable=SC2016  # $owner/$name/$endCursor are GraphQL variables bound by -F, and MUST reach the server unexpanded
+    merged="$(gh api graphql --paginate -F owner="${REPO%%/*}" -F name="${REPO##*/}" -f query='
+      query($owner:String!, $name:String!, $endCursor:String) {
+        repository(owner:$owner, name:$name) {
+          pullRequests(states:MERGED, first:25, orderBy:{field:UPDATED_AT, direction:DESC}, after:$endCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              number title url mergedAt
+              reviewThreads(first:50) {
+                nodes {
+                  isResolved
+                  comments(first:1) { nodes { createdAt author { login } body } }
+                }
+              }
+            }
+          }
+        }
+      }' 2>/dev/null)"
+  fi
+  if [[ -z "$merged" ]]; then
+    echo "  (unable to read merged PRs)"
+    echo
+    return
+  fi
+  # FAIL LOUD. A GraphQL error document is well-formed JSON that carries no
+  # `data`, so the extraction below yields an empty list and the section would
+  # print "every merged PR is clear" — reporting an unread API as an all-clear,
+  # which is the exact fail-open shape this section exists to catch. Observed
+  # live: a rate-limit error rendered as a clean window.
+  local api_err
+  api_err="$(jq -s -r '[ .. | objects | select(has("errors")) | .errors[]?.message ] | first // empty' <<<"$merged" 2>/dev/null)"
+  if [[ -n "$api_err" ]]; then
+    echo "  (unable to read merged PRs — the API returned an error, so this is NOT an all-clear)"
+    echo "    $api_err"
+    echo
+    return
+  fi
+
+  local cutoff stranded
+  cutoff="$((NOW_EPOCH - STRANDED_DAYS * 86400))"
+  # `--paginate` concatenates one JSON document per page, so slurp and walk every
+  # page's nodes rather than assuming a single top-level object.
+  stranded="$(jq -s -r --argjson cutoff "$cutoff" '
+    # `jq -s` wraps the input in one more array, and `gh --paginate` emits a
+    # bare sequence of page objects while a fixture file is already an array of
+    # them. `..|objects` walks both shapes without caring which arrived, then
+    # selects only true page documents.
+    [ .. | objects | select(has("data")) | .data.repository.pullRequests.nodes[]? ]
+    | map(select(.mergedAt != null and ((.mergedAt | fromdateiso8601) >= $cutoff)))
+    | map(
+        . as $pr
+        | ($pr.reviewThreads.nodes // [])
+          | map(select(
+              .isResolved == false
+              and (.comments.nodes[0].createdAt // null) != null
+              # The discriminator: the finding arrived after the gate had passed.
+              and ((.comments.nodes[0].createdAt | fromdateiso8601) > ($pr.mergedAt | fromdateiso8601))
+            ))
+          | map({
+              pr: $pr.number, title: $pr.title, url: $pr.url,
+              author: (.comments.nodes[0].author.login // "unknown"),
+              # Severity must survive to the operator: a stranded P1 cannot read
+              # like a P3. Markers are matched on the badge alt-text/bracket
+              # forms the review bots actually emit.
+              sev: (
+                (.comments.nodes[0].body // "")
+                | if test("P0|CRITICAL|SECURITY"; "i") then "P0"
+                  elif test("P1"; "i") then "P1"
+                  elif test("P2"; "i") then "P2"
+                  else "--" end
+              )
+            })
+      )
+    | add // []
+    # Collapse to one line per PR. Several findings on one PR are one thing for
+    # the operator to go look at, and repeating the identical title once per
+    # thread buries the other PRs. The PR carries its WORST severity, so
+    # collapsing can never soften a P0 sitting beside advisory findings.
+    | group_by(.pr)
+    | map({
+        pr: .[0].pr, title: .[0].title, url: .[0].url,
+        author: (map(.author) | unique | join(", ")),
+        n: length,
+        sev: (map(.sev) | sort | .[0])
+      })
+    | sort_by(.sev, .pr)
+    | .[]
+    | "  [\(.sev)] #\(.pr) \(.title)  (\(.n) finding\(if .n == 1 then "" else "s" end))\n    \(.url)  by \(.author)"
+  ' <<<"$merged" 2>/dev/null)"
+
+  if [[ -n "$stranded" ]]; then
+    echo "$stranded"
+    echo "  these merged with the finding unread — the merge gate could not see it"
+  else
+    echo "  (none — every merged PR in the window is clear)"
+  fi
+  echo
+}
+
+# =============================================================================
 # Render
 # =============================================================================
 printf 'Morning brief — %s — %s\n\n' "${REPO:-<fixtures>}" "$(from_epoch "$NOW_EPOCH")"
@@ -469,4 +615,5 @@ print_queues
 print_merge_ready
 print_decisions
 print_telemetry
+print_stranded
 exit 0


### PR DESCRIPTION
## Why

A review that lands **after** a merge has nowhere to go:

- the ruleset's `required_review_thread_resolution` is a **merge-time predicate** that already passed;
- the babysit lane works *open* PRs, and a merged PR leaves that queue;
- nothing on a merged PR surfaces its open threads — GitHub shows the merge, not the findings.

Six findings — one **P1** — posted **46 seconds after #1720 merged** and sat unread for a day. They
surfaced only because a later session happened to audit that merge batch. Nothing was bypassed; the
gate was satisfied *because the threads did not yet exist*.

The morning brief is the right home: read-only, unattended, and already where attention signals land.

## What it does

Compares each unresolved thread's **first-comment timestamp** against the PR's `mergedAt`, and
reports only threads the gate could never have seen. A thread that predates the merge was visible to
the gate — that is an ordinary unresolved thread, not this failure mode, and it stays out.

- **One line per PR, at that PR's worst severity, with a finding count.** Several findings on one PR
  are one thing to go look at; repeating the title per thread buries every other PR. Collapsing on
  the *worst* severity means a P0 sitting beside advisory findings can never be softened.
- **Severity survives to the operator** — a stranded P1 must not read like a P3.
- **`--stranded-days`** (default 3) — wide enough to cover slow bot review *and* an operator-absent
  weekend.

## It fails loud, not clear

A GraphQL error document is well-formed JSON that simply carries no `data`. The extraction would
yield an empty list and render **"every merged PR in the window is clear"** — an all-clear asserted
from an answer never received, which is the same fail-open shape this section exists to catch.

This is not hypothetical: a rate-limit error did exactly that during development. An API error now
says explicitly that it is *not* an all-clear, and prints the message. Covered by a regression case.

## This is a standing leak, not a one-off

Its **first live run** against this repository immediately surfaced four more stranded findings on
other merged PRs — including a **P1 on #1694** (merged `05:04:45Z`, finding posted `05:05:20Z`, 35
seconds later) recording that a shipped `autonomy` cell **never reached installations**.

## Verification

- `morning-brief.test.sh`: **30 → 63 cases, 0 failures.**
- The **negative** cases carry the weight — a pre-merge thread, an already-resolved post-merge
  thread, and a merge outside the window must all stay silent, or the section is noise rather than
  signal. Plus: collapse-does-not-soften-severity, highest-severity-first, window-widening, and the
  API-error case above.
- The fixture mirrors the real #1720 shape, including the 46-second gap.
- `shellcheck -x` on script and test — clean. One `SC2016` is declared, not blanket-suppressed: the
  `$owner`/`$name`/`$endCursor` in the GraphQL query are server-side variables bound by `-F` and
  **must** reach the server unexpanded.
- `node scripts/validate-plugin-contracts.mjs` — 43 setup skills, 2153 files, pass.
- `npx markdownlint-cli2` on both changed markdown files — 0 errors.

### Live run — posted in full in the comments below

A live run on the current branch found **44 merged PRs carrying post-merge findings in a five-day
window: 0 P0, 10 P1, 34 P2.** Among the P1s: **#1503**, a guardrail-bypass fix whose own review
landed unread, and **#1322** with 5 findings.

Read the **second** comment for the authoritative figures — the first was produced by the
pre-review severity logic and reported a false P0, which review then caught. No truncation warning
fired, so the read is complete.

The five-day window filter was spot-checked against `mergedAt` (a PR numbered #969 in a 5-day window
looks wrong until you check: it merged `2026-07-25`, 4.2 days before the run).

This is a far larger leak than the six findings that exposed it.

## Related

Closes #1777
Refs #1720
Refs #1759
