### PR TITLE
chore(knowledge): retire choosing-a-model doc-queue entry after digest-half completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.8]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: choosing-a-model queue entry removed.** The
+  choosing-a-model digest slice completed — raw-md fetch through interview handoff, dual
+  verification (two correction rounds, re-verified REVERIFY2: PASS by both verifiers, no
+  degraded fallback) — closing the entry's second half; its routing-vet half was already
+  executed 2026-07-29 (#1697). The emptied "Model selection" special-handling category goes
+  with it. The paired models-explained blog entry now points at the completed slice's handoff
+  for its pairing observations.
+
 ## [0.10.7]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -68,13 +68,6 @@ Every model-pinned spawn brief uses the conditional framing contract from `SKILL
 Pending Anthropic docs for this pipeline. Verify each URL live at fetch time; remove entries as
 their slices complete.
 
-Model selection (special handling — vet/validate/correct the consuming setup's existing
-model-routing configuration against the doc, rather than only digesting):
-
-- <https://platform.claude.com/docs/en/about-claude/models/choosing-a-model>
-  — routing vet executed 2026-07-29 (melodic-software/claude-code-plugins#1697); digest slice
-  still pending
-
 Thinking (two overlapping docs — two runs, one page per run by contract):
 
 - <https://platform.claude.com/docs/en/build-with-claude/thinking>
@@ -94,7 +87,10 @@ Supplementary references:
 Blog posts:
 
 - <https://claude.com/blog/claude-models-explained-choosing-the-best-model-for-your-use-case>
-  — pair with the choosing-a-model slice for the routing vet
+  — pair with the completed choosing-a-model slice (work-root slug
+  `platform-claude-com-docs-en-abo-38ebff0f` on the machine that ran it), whose interview
+  handoff records the pairing-relevant observations; the routing vet was executed 2026-07-29
+  (melodic-software/claude-code-plugins#1697)
 - <https://claude.com/blog/building-verification-loops-in-claude-code-with-skills>
   — pairs with any verification-loop or loop-engineering work the consuming setup already tracks
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -87,10 +87,23 @@ Supplementary references:
 Blog posts:
 
 - <https://claude.com/blog/claude-models-explained-choosing-the-best-model-for-your-use-case>
-  — pair with the completed choosing-a-model slice (work-root slug
-  `platform-claude-com-docs-en-abo-38ebff0f` on the machine that ran it), whose interview
-  handoff records the pairing-relevant observations; the routing vet was executed 2026-07-29
-  (melodic-software/claude-code-plugins#1697)
+  — pairs with the completed choosing-a-model doc digest (routing vet executed 2026-07-29,
+  melodic-software/claude-code-plugins#1697). Cross-link contract for this run (portable copy
+  of that slice's pairing package; the fuller original also lives in the slice's interview
+  handoff, work-root slug `platform-claude-com-docs-en-abo-38ebff0f`, where that machine-local
+  memory-tier slice still exists): compare the blog against the choosing-a-model doc on
+  (a) the capabilities/speed/cost triad framing, also cross-linking the other model-choice
+  blog ("Choosing a Claude model and effort level in Claude Code") that
+  code.claude.com/docs/en/model-config.md links for harness model-fit guidance;
+  (b) whether Effort is a third consideration or a fourth factor (the considerations-count
+  split); (c) the selection-factors frame, the effort-vs-model-switch lever, and any
+  per-model effort recommendations; (d) the two-approach framing, Opus 5 / Fable 5 /
+  Mythos 5 positioning language, and pricing figures; (e) per-model fit sections vs the
+  doc's matrix rows (source lines 71–74); (f) the upgrade/switch decision's eval-first
+  four steps; (g) overlap with the models-overview cards, including Sonnet 5's "The best
+  combination of speed and intelligence" tagline. Divergences between the channels escalate
+  as the blog slice's own open questions; agreements are recorded once, pointer each way,
+  never restated in both.
 - <https://claude.com/blog/building-verification-loops-in-claude-code-with-skills>
   — pairs with any verification-loop or loop-engineering work the consuming setup already tracks
 


### PR DESCRIPTION
## Summary

- Removes the choosing-a-model entry from the `docpage-digest` Anthropic profile's doc queue — its digest slice completed end-to-end (fetch through interview handoff) per the queue's remove-on-completion rule, closing the entry's second half. The routing-vet half was already executed 2026-07-29 (#1697, PR #1725) and was NOT redone; the slice checklist records that scope explicitly. The emptied "Model selection" special-handling category goes with the entry.
- The paired models-explained blog entry's annotation now points at the completed slice's interview handoff (its OQ-10 is a clearly-marked pairing package for that run) and carries the fully-qualified vet reference.
- Channel: raw-md (`.md` appended; HTTP 200, 112 lines / 7,568 bytes — channel re-verified for this page, no degradation).
- Slice verification: Verifier A (same-vendor, fresh context) CORRECTION-NEEDED (1+1); Verifier B (cross-vendor Codex CLI 0.146.0 via the issue #1740 elevated recipe, no degraded fallback) CORRECTION-NEEDED (3+2; B-1 shared A-1's root — a dropped launch-page cross-link sentence). Two correction rounds (session-default agents — cross-model doc, no model pin); round 2 resolved a shorthand residual plus two round-1-reverify findings, one a genuine verifier split (external-doc price-shorthand relay) resolved by applying the stricter cross-vendor ruling in-slice and escalating the standard to the interview. Final: REVERIFY2: PASS from both verifiers, zero new findings. Records under `.work/platform-claude-com-docs-en-abo-38ebff0f/verification/`.
- No profile-learning bullet this run: the ruling candidates (product/feature-name tag boundary, Mythos api-only basis, the price-shorthand standard) are all escalated for interview ratification in the handoff's OQ-2 — codifying now would front-run them (#1775/#1779 precedent).
- Knowledge plugin `0.10.7` → `0.10.8` with matching CHANGELOG entry.

## Verification

- `markdownlint-cli2` on changed markdown: 0 errors
- `check-skill.sh docpage-digest` (`CHECK_SKILL_SKILLS_ROOT=plugins/knowledge/skills`, base `origin/main`): PASS (1 pre-existing soft warning, SKILL.md length)
- `check-changelog-parity.sh --check-bump origin/main`: PASS
- Independent fresh-context reviewer on the diff: APPROVE (traced every changelog claim to the slice records; its three advisories — a machine-local path ghost-ref in the blog annotation, a de-qualified issue reference, and a missing ratification home for the verifier-split ruling — were all applied before commit)
- Base freshness: fetched origin/main immediately before commit; zero commits behind

No linked issue — this PR closes no GitHub issue; the doc queue is tracked in the profile file itself.

## Related

- #1779 (previous doc-queue completion in this series — increase-consistency slice)
- #1697 (the routing-vet half of this queue entry, executed 2026-07-29; PR #1725)
- #1740 (Verifier B elevated recipe used for cross-vendor verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
