### PR TITLE
docs(event-storming): clear the Design-Level y-overlap and collapse the duplicate scheme

### DIFF
--- a/plugins/event-storming/skills/simulation/reference/miro-integration.md
+++ b/plugins/event-storming/skills/simulation/reference/miro-integration.md
@@ -182,8 +182,9 @@ Persona 1 sits at the `y=0` timeline baseline.
 | Business Rules | 300 | Gray — invariants (stack at y=300, 550, 800) |
 | Domain Events | 1100 | Orange — outcomes |
 | Alternative outcomes | 1400 | Rejection/failure events |
-| What-if challenges | 1700 | Red hot spots |
-| BC Contracts (outbound) | 2000 | Published events |
+| Policies | 1650 | Violet — reactive `Whenever X, do Y` |
+| What-if challenges | 1950 | Red hot spots |
+| BC Contracts (outbound) | 2250 | Published events |
 
 **Reading the layout:** every row's y comes from that phase's Y-Coordinate Table
 above — negative is up, positive is down, and the bolded row is the baseline. The
@@ -194,11 +195,12 @@ item, independent of phase. A command and the actor that issues it share one x a
 differ only by row, so a single flow segment is a column per step:
 
 ```
+Read Model       x=0       row: Read Models
 Actor            x=0       row: Actors
 Command          x=0       row: Commands
 Domain Event     x=400     row: Domain Events        (happy path)
 Event (alt)      x=400     row: Alternative outcomes (rejection/failure)
-Policy           x=800     row: Domain Events        (reactive — "whenever")
+Policy           x=800     row: Policies             (reactive — "whenever")
 Next Command     x=1200    row: Commands             (triggered by policy)
 Next Event       x=1600    row: Domain Events
 ```

--- a/plugins/event-storming/skills/simulation/reference/miro-integration.md
+++ b/plugins/event-storming/skills/simulation/reference/miro-integration.md
@@ -174,10 +174,10 @@ Persona 1 sits at the `y=0` timeline baseline.
 
 | Row | y | Purpose |
 |-----|---|---------|
-| BC Contracts (inbound) | -600 | Consumed events from other BCs |
-| Read Models | -400 | Information panels |
-| Actors | -200 | Who issues commands |
-| Commands | -100 | Blue imperative actions |
+| BC Contracts (inbound) | -1000 | Consumed events from other BCs |
+| Read Models | -750 | Information panels |
+| Actors | -500 | Who issues commands |
+| Commands | -250 | Blue imperative actions |
 | **Aggregates** | **0** | Light yellow — blank first, named last |
 | Business Rules | 300 | Gray — invariants (stack at y=300, 550, 800) |
 | Domain Events | 1100 | Orange — outcomes |
@@ -185,33 +185,22 @@ Persona 1 sits at the `y=0` timeline baseline.
 | What-if challenges | 1700 | Red hot spots |
 | BC Contracts (outbound) | 2000 | Published events |
 
-**Main flow (y=0 baseline):**
+**Reading the layout:** every row's y comes from that phase's Y-Coordinate Table
+above — negative is up, positive is down, and the bolded row is the baseline. The
+tables are the only place y values are written down; nothing below restates them.
 
-- Commands, Events, Policies all sit on y=0
-- Flow reads left-to-right, incrementing x by 400 per item
-
-**Above the flow (negative y = up):**
-
-- Actors: y=-250 (directly above their command)
-- Read Models: y=-450 (above the actor)
-- Hot Spots: y=-250 (above the related event)
-
-**Below the flow (positive y = down):**
-
-- Alternative outcomes: y=+250 (below the happy path event)
-
-**Example: one complete flow segment**
+**Horizontal placement:** the flow reads left to right, incrementing x by 400 per
+item, independent of phase. A command and the actor that issues it share one x and
+differ only by row, so a single flow segment is a column per step:
 
 ```
-Read Model:       x=0,    y=-450
-Actor:            x=0,    y=-250
-Command:          x=0,    y=0
-Domain Event:     x=400,  y=0       (happy path)
-Event (alt):      x=400,  y=250     (rejection/failure)
-Hot Spot:         x=400,  y=-250    (above the event)
-Policy:           x=800,  y=0       (reactive — "whenever")
-Next Command:     x=1200, y=0       (triggered by policy)
-Next Event:       x=1600, y=0
+Actor            x=0       row: Actors
+Command          x=0       row: Commands
+Domain Event     x=400     row: Domain Events        (happy path)
+Event (alt)      x=400     row: Alternative outcomes (rejection/failure)
+Policy           x=800     row: Domain Events        (reactive — "whenever")
+Next Command     x=1200    row: Commands             (triggered by policy)
+Next Event       x=1600    row: Domain Events
 ```
 
 **Legend frame positioning and sizing:**


### PR DESCRIPTION
## Summary

Implements the owner-approved decision on melodic-software/medley#1555: widen Design-Level row spacing past the overlap threshold, keeping the single-flow model, then collapse the orphaned duplicate scheme into a reference to the corrected table. Both findings live in one file, `plugins/event-storming/skills/simulation/reference/miro-integration.md`.

**Finding 1 — the Design-Level table overlapped itself.** Actors (`-200`), Commands (`-100`) and Aggregates (`0`) sat in 100px gaps, under the ~199px threshold these layouts use.

Rows above the Aggregates baseline now sit **250px** apart. The decision permits any gap ≥200px; I used 250 for two reasons rather than taking the minimum. This file's own Spacing summary already states `Vertical (rows) | 250px`, so 250 makes the table agree with the guidance printed below it. And the threshold is written as *"~199px"* — a 200px gap clears an approximate bound by one pixel, which is not margin. Aggregates stays the `y=0` baseline. Rows below it were untouched as first pushed; review has since added a `Policies` row, which shifts the two bottom rows down by 250px — see *Finding 3*.

**Finding 2 — the orphaned block was a third scheme, not a stale copy of either table.** It restated Actors `-250`, Read Models `-450`, Hot Spots `-250`, alternatives `+250`, matching neither canonical table, and it opened with *"Main flow (y=0 baseline): Commands, Events, Policies all sit on y=0"* — true of the single-flow model it was written for, but not of Design-Level, where **Aggregates** holds `y=0`. So it was not merely duplicated, it was actively wrong for the phase it sat under.

Its y literals are gone. What it uniquely carried is kept: the flow reads left to right at 400px per item, and one flow step is a column sharing an x. The worked example now names table rows instead of restating their values, so the tables stay the only place y is written down — the same treatment #1473 / #219 gave the drifting literals.

**Finding 3 — the Design-Level table had no `Policies` row (found in review).** Raised as a
P2 by `chatgpt-codex-connector` against the worked example. `agentic-simulation.md` puts
policies on this board twice — `:875` carries them over from Process Modeling, and `:881`
adds more in Step 3 — but the Design-Level table never gave them a row, so the example
borrowed `Domain Events`, whose Purpose column reads *"Orange — outcomes"* while a policy is
violet. Finding 2's new wording is what makes the omission load-bearing rather than
cosmetic: once the text says the tables are the only place y is written down, an element with
no row leaves an agent nothing correct to pick.

Pre-existing state was wrong differently — on `main` the example read `Policy: x=800, y=0`,
and `y=0` in this phase is the **Aggregates** baseline. So the gap predates this PR, but it
lands on lines this PR rewrote under a rule this PR tightened, which makes it a fix rather
than a deferral.

`Policies` now sits at **1650**, directly below the two event rows — a policy reacts to an
event, and the Process Modeling table already groups the two on its `Event-Command-Policy`
spine. That keeps `Domain Events` and `Alternative outcomes` adjacent and keeps internal
reactive logic above the `BC Contracts (outbound)` boundary row. It shifts `What-if
challenges` 1700 → **1950** and `BC Contracts (outbound)` 2000 → **2250**. Nothing
downstream restates these values — `simulation-evaluation.md`, `iteration-workflow.md` and
`SKILL.md` all reference phase rows by *name*, never by coordinate — so the shift is
contained to this one table.

Review also noted the worked example had dropped the Read Model that used to head its `x=0`
column. Restored, so the example again walks every row it touches.

## Test plan

The issue asks for an x-aware geometric overlap check (two elements overlap only when their x-ranges intersect **and** `|Δy| < ~199px`). Every row in one phase's table shares the same x band — a flow step is a column — so x always intersects and the test reduces to adjacent `|Δy|` across the sorted rows.

Run against `origin/main` and against this branch:

**Before — reproduces exactly the two overlaps the issue reported:**

```text
  ok:      Read Models <-> Actors |dy|=200px
  OVERLAP: Actors <-> Commands |dy|=100px
  OVERLAP: Commands <-> Aggregates |dy|=100px
  ok:      Aggregates <-> Business Rules |dy|=300px
RESULT: 2 overlap(s)          exit=1
```

**After:**

```text
  ok:      BC Contracts (inbound) <-> Read Models |dy|=250px
  ok:      Read Models <-> Actors |dy|=250px
  ok:      Actors <-> Commands |dy|=250px
  ok:      Commands <-> Aggregates |dy|=250px
  ok:      Aggregates <-> Business Rules |dy|=300px
RESULT: no overlaps           exit=0
```

That the *before* run independently reproduces the issue's reported figures is what makes the *after* run meaningful — the check is measuring the right thing, not passing vacuously.

The other two phase tables were run through the same check to confirm this change did not disturb them: **Big Picture** — no overlaps; **Process Modeling** — no overlaps.

**After Finding 3's row insert**, the same adjacent-`|dy|` walk was re-run over the widened
Design-Level table, since the shift has to keep clearing the minimum. This run also flags
gaps that clear the ~199px overlap bound but fall under the file's own stated 250px minimum,
which the earlier pass did not distinguish:

```text
=== Design-Level Y-Coordinate Table (11 rows) ===
  ok             BC Contracts (inbound) <-> Read Models |dy|=250px
  ok             Read Models <-> Actors |dy|=250px
  ok             Actors <-> Commands |dy|=250px
  ok             Commands <-> Aggregates |dy|=250px
  ok             Aggregates <-> Business Rules |dy|=300px
  ok             Business Rules <-> Domain Events |dy|=800px
  ok             Domain Events <-> Alternative outcomes |dy|=300px
  ok             Alternative outcomes <-> Policies |dy|=250px
  ok             Policies <-> What-if challenges |dy|=300px
  ok             What-if challenges <-> BC Contracts (outbound) |dy|=300px
```

The walk reads each row's declared y, so the Business Rules row shows an 800px delta to
Domain Events; that row stacks at 300/550/800, so the real clearance from the bottom of the
stack is 300px. Every other pair is its literal gap.

Big Picture stays clean on that stricter check. **Process Modeling does not** — its three
rows above the baseline are 200px apart, clear of the ~199px overlap bound but 50px short of
the stated minimum. That is pre-existing, reproduces on `main`, and is out of scope here;
filed as melodic-software/medley#1689 with the mechanical output.

`markdownlint-cli2` on the edited file: 0 errors.

## Not covered

No Miro render was performed — the verification is geometric, as the issue specifies. A to-scale visual confirmation is still worth doing by whoever next opens one of these boards, since only a render exercises sticky dimensions rather than centre coordinates.

## Related

Refs melodic-software/medley#1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C>

Fixes melodic-software/medley#1555

