### PR TITLE
docs: repoint three dead links reported by the link checker

### DIFF
--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -86,7 +86,7 @@ and wedges prose PRs (community discussion 72708); the gate must live inside the
 workflow. Caller-first against the old pin was also rejected: it would run a full security pass
 on every prose PR in the interim. The load-bearing constraint is unchanged — the ruleset flip
 stays LAST, after this caller restructure is verified
-([troubleshooting-required-status-checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)).
+([troubleshooting-required-status-checks](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks)).
 
 ## Addendum (2026-07-21): step 3 applied — required check live; skip-actor exception
 

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -86,7 +86,7 @@ and wedges prose PRs (community discussion 72708); the gate must live inside the
 workflow. Caller-first against the old pin was also rejected: it would run a full security pass
 on every prose PR in the interim. The load-bearing constraint is unchanged — the ruleset flip
 stays LAST, after this caller restructure is verified
-([troubleshooting-required-status-checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks)).
+([troubleshooting-required-status-checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)).
 
 ## Addendum (2026-07-21): step 3 applied — required check live; skip-actor exception
 

--- a/plugins/dometrain/README.md
+++ b/plugins/dometrain/README.md
@@ -7,7 +7,7 @@ the user's courses teach it.
 
 This is the marketplace's first plugin to ship a **remote** (not bundled/local) MCP server: the
 server is Dometrain-hosted (`https://mcp.dometrain.com/mcp`), closed-source, and requires an
-active [Dometrain Pro](https://dometrain.com/pro/) subscription — there is nothing to bundle,
+active [Dometrain Pro](https://dometrain.com/dometrain-pro/) subscription — there is nothing to bundle,
 unlike `miro`'s locally-run, self-contained Node server.
 
 ## Enabling and configuration

--- a/plugins/source-control/skills/babysit-prs/reference/freshness.md
+++ b/plugins/source-control/skills/babysit-prs/reference/freshness.md
@@ -15,7 +15,7 @@ data directory.
 
 GitHub's `mergeStateStatus` is a single-valued field (GraphQL `MergeStateStatus` enum: `BEHIND` =
 "The head ref is out of date."; `BLOCKED` = "The merge is blocked." —
-https://docs.github.com/en/graphql/reference/enums#mergestatestatus). When a PR is simultaneously
+https://docs.github.com/en/graphql/reference/pulls#enum-mergestatestatus). When a PR is simultaneously
 behind its base AND blocked by another gate (a failing required check, a missing review, ...),
 GitHub reports `BLOCKED` and the `BEHIND` signal is lost. This precedence is not documented by
 GitHub anywhere this skill's authors could find — it was observed live: a PR sat eleven commits


### PR DESCRIPTION
The rolling link-check report listed **8 errors**. Only **3 were dead links** — the other 5 are live
URLs the checker cannot reach, and their fix lands upstream (see below). Every replacement here was
verified against the live target, not inferred from the URL shape.

## The three dead links

**`docs/adr/0002-…md`** — GitHub retired the `repositories/configuring-branches-and-merges…/managing-protected-branches/`
path for the required-status-checks troubleshooting page. It now lives under
`pull-requests/how-tos/merge-and-close-pull-requests/`. Verified 200 with **no redirect**, H1 reads
"Troubleshooting required status checks", and it still covers the check-never-reports case the ADR
cites it for ("Associated checks stay in a 'Pending' state and block merging").

An independent fresh-context lookup caught that my first replacement here was itself a 301 — the
`collaborating-with-pull-requests/…` path redirects to the `how-tos/` one. Both resolve today, but a
redirect is a second thing that can be retired, and lychee already hints to prefer resolved URLs, so
the second commit swaps in the canonical target. Verified both directions: the old path returns 301
with that Location, the new one returns 200 with none.

**`plugins/dometrain/README.md`** — Dometrain moved its plans page from `/pro/` to `/dometrain-pro/`.
Verified 200, `<title>Dometrain Plans - Dometrain</title>`. The link text stays "Dometrain Pro"
because the slug and the product name both still are.

**`plugins/source-control/skills/babysit-prs/reference/freshness.md`** — the most interesting of the
three. `graphql/reference/enums` did not 404; it became a **navigation index** and no longer carries
any enum definitions at all, which is why the failure was `Cannot find fragment` rather than a dead
page. GitHub split the GraphQL reference by domain, so `MergeStateStatus` now lives on the `pulls`
page. The replacement was verified structurally, not just by status code: `id="enum-mergestatestatus"`
is present in the **served HTML** (so lychee's fragment check resolves it, rather than the anchor
being JS-injected), and the page carries both descriptions this doc quotes verbatim — "The head ref
is out of date" and "The merge is blocked".

## The other five are not content defects, and are fixed upstream

`lychee.toml` is a **`managed` component** for this repo per `standards/distribution/sync-manifest.yml`,
so editing it here would be silently overwritten by the next sync. The config half of this report is
therefore **melodic-software/standards#303**:

- **`www.gnu.org/software/coreutils/…` (429)** — verified 200. A 429 is the server rate-limiting the
  checker and lands on whichever host the shared runner IP is throttled against that run, so the fix
  is `accept`-ing 429 rather than excluding a healthy host that would just be replaced by a
  different one next run.
- **`dl.acm.org` and `queue.acm.org` (403)** — 403 even with a full browser User-Agent; no header
  tuning reaches them.
- **`docs.genius.com` (403)** — 200 with a browser User-Agent; the documented bot-block case.
- **`www.ntia.gov` (SSL not trusted)** — the chain verifies locally (`openssl s_client` →
  `Verify return code: 0 (ok)`, curl 200 under strict verification). A trust store failing an ECC
  chain, not an untrustworthy host.

This PR merging alone will not clear the report; #303 has to land and sync. Flagging that plainly
rather than letting a half-clear look like a regression.

## Verification

Run with the real `lychee.toml` plus the proposed upstream config, over all seven files the report
named:

```text
🔍 118 Total  🔗 116 Unique  ✅ 114 OK  🚫 0 Errors  👻 4 Excluded
```

All 8 reported errors resolved. Also run against this repo's gates:

- `scripts/check-changed-skills.sh origin/main` — 1 skill checked, 0 failed
- `scripts/check-contract-slice-prune.sh --check-diff origin/main` — pass (no `docs/topics/` path is
  touched; that file's two ACM URLs are handled by exclusion, not by editing it)
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass. **No plugin version bump**: a
  corrected external URL in a reference doc changes no behavior contract, no gate requires one, and
  bumping `source-control` would collide with the in-flight bump on #1782 — the collision class
  tracked as #1746.
- `markdownlint-cli2`, `typos` — clean

## Related

- Fixes #640
- melodic-software/standards#303 — the upstream half; owns `lychee.toml` for this repo
- #1746 — the concurrent version-bump collision class, the reason this change deliberately bumps
  nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C>
