### PR TITLE
fix(event-storming): widen Design-Level row spacing and collapse the orphaned coordinate scheme

### DIFF
--- a/plugins/event-storming/skills/simulation/reference/miro-integration.md
+++ b/plugins/event-storming/skills/simulation/reference/miro-integration.md
@@ -174,10 +174,10 @@ Persona 1 sits at the `y=0` timeline baseline.
 
 | Row | y | Purpose |
 |-----|---|---------|
-| BC Contracts (inbound) | -600 | Consumed events from other BCs |
-| Read Models | -400 | Information panels |
-| Actors | -200 | Who issues commands |
-| Commands | -100 | Blue imperative actions |
+| BC Contracts (inbound) | -800 | Consumed events from other BCs |
+| Read Models | -600 | Information panels |
+| Actors | -400 | Who issues commands |
+| Commands | -200 | Blue imperative actions |
 | **Aggregates** | **0** | Light yellow — blank first, named last |
 | Business Rules | 300 | Gray — invariants (stack at y=300, 550, 800) |
 | Domain Events | 1100 | Orange — outcomes |
@@ -185,34 +185,34 @@ Persona 1 sits at the `y=0` timeline baseline.
 | What-if challenges | 1700 | Red hot spots |
 | BC Contracts (outbound) | 2000 | Published events |
 
-**Main flow (y=0 baseline):**
+Every Design-Level y comes from the table above — it is the only place those
+values live. Rows are spaced ≥200px apart so no two bands overlap.
 
-- Commands, Events, Policies all sit on y=0
-- Flow reads left-to-right, incrementing x by 400 per item
+**X-axis placement (the table fixes y; this fixes x):**
 
-**Above the flow (negative y = up):**
+- The flow reads left-to-right, incrementing x by 400 per item along the spine.
+- An actor and the read model feeding it share the x of the command they issue.
+- A what-if challenge and an alternative outcome share the x of the event they
+  hang off.
 
-- Actors: y=-250 (directly above their command)
-- Read Models: y=-450 (above the actor)
-- Hot Spots: y=-250 (above the related event)
-
-**Below the flow (positive y = down):**
-
-- Alternative outcomes: y=+250 (below the happy path event)
-
-**Example: one complete flow segment**
+**Example: one complete flow segment** — x is literal, y is the element's row in
+the table above:
 
 ```
-Read Model:       x=0,    y=-450
-Actor:            x=0,    y=-250
-Command:          x=0,    y=0
-Domain Event:     x=400,  y=0       (happy path)
-Event (alt):      x=400,  y=250     (rejection/failure)
-Hot Spot:         x=400,  y=-250    (above the event)
-Policy:           x=800,  y=0       (reactive — "whenever")
-Next Command:     x=1200, y=0       (triggered by policy)
-Next Event:       x=1600, y=0
+Read Model:     x=0      (Read Models row)
+Actor:          x=0      (Actors row)
+Command:        x=0      (Commands row)
+Aggregate:      x=0      (Aggregates row — the spine)
+Domain Event:   x=400    (Domain Events row, happy path)
+Event (alt):    x=400    (Alternative outcomes row)
+What-if:        x=400    (What-if challenges row)
+Next Command:   x=800    (Commands row)
+Next Event:     x=1200   (Domain Events row)
 ```
+
+The table has no Policy row, so Design-Level policy placement is undefined here
+— unlike Process Modeling, whose spine row carries Event-Command-Policy
+together. Place policies by judgment until a row is agreed.
 
 **Legend frame positioning and sizing:**
 


### PR DESCRIPTION
## Summary

Implements the owner-approved decision on melodic-software/medley#1555: widen Design-Level row spacing to >=200px gaps, keep the single-flow model, no per-persona scheme import. Both findings live in one file, `plugins/event-storming/skills/simulation/reference/miro-integration.md`, and the spacing fix lands first because the collapse depends on the corrected table.

## Finding 1 — the Design-Level table overlapped itself

Actors (-200), Commands (-100), and Aggregates (0) sat in 100px gaps, under the ~199px threshold these layouts use. Widened the negative rows so every adjacent pair clears 200px, keeping Aggregates on the `y=0` spine:

| Row | before | after |
|---|---|---|
| BC Contracts (inbound) | -600 | **-800** |
| Read Models | -400 | **-600** |
| Actors | -200 | **-400** |
| Commands | -100 | **-200** |
| **Aggregates** | **0** | **0** (unchanged — the spine) |

Positive rows already cleared the threshold and are untouched, as are the Big Picture and Process Modeling tables.

## Finding 2 — the orphaned duplicate scheme

The four blocks below the table (`Main flow (y=0 baseline)` / `Above the flow` / `Below the flow` / `Example: one complete flow segment`) restated y values — Actors -250, Read Models -450, alternative outcomes +250 — matching **neither** canonical table, and described a flat single-row flow rather than the table's bands. Confirmed self-contained: those literals appear nowhere else under `plugins/event-storming/`, so nothing else depended on them.

Collapsed per the treatment #1473 / #219 gave the drifting literals — reference the canonical row, do not restate values. The block did own content the table has no room for, and that is preserved rather than deleted: the x-axis rules (left-to-right, +400 per item) and which elements share an x (an actor and its read model share their command's x; a what-if and an alternative outcome share their event's x). The worked example now gives literal x and names each element's **row** for y.

## One residual, surfaced rather than papered over

The removed block was the only statement of where a **Policy** goes at Design-Level, and the Design-Level table has no Policy row — unlike Process Modeling, whose spine row is explicitly "Event-Command-Policy". Inventing a y for it would be exactly the fabricated-value problem this issue exists to fix, so the doc now says the placement is undefined at the point a reader would look for it. Worth its own decision; deliberately not taken here.

## Verification (no Miro required)

Geometric x-aware overlap check per the issue's documented method — two elements overlap only when their x-ranges intersect AND `|dy| < ~199px`. Table rows are full-width bands, so their x-ranges always intersect and the check reduces to adjacent-row `|dy|`. Run by **parsing the tables straight out of the file** on both sides, so the check cannot drift from a hand-copied list:

**Before (`origin/main`)** — Design-Level: 2 overlaps

```text
OVERLAP Actors <-> Commands |dy|=100px
OVERLAP Commands <-> Aggregates |dy|=100px
-> 2 overlap(s)
```

Exactly the two pairs the issue names.

**After (this branch)** — Design-Level: 0 overlaps

```text
ok      BC Contracts (inbound) <-> Read Models |dy|=200px
ok      Read Models <-> Actors |dy|=200px
ok      Actors <-> Commands |dy|=200px
ok      Commands <-> Aggregates |dy|=200px
ok      Aggregates <-> Business Rules |dy|=300px
ok      Business Rules <-> Domain Events |dy|=800px
ok      Domain Events <-> Alternative outcomes |dy|=300px
ok      Alternative outcomes <-> What-if challenges |dy|=300px
ok      What-if challenges <-> BC Contracts (outbound) |dy|=300px
-> 0 overlap(s)
```

**No collateral damage:** the Big Picture (22 rows) and Process Modeling (10 rows) tables report 0 overlaps both before and after — the same run covers all three tables, so a regression in either would have shown up.

**Lint:** markdownlint-cli2 0 errors, `typos` clean, editorconfig-checker clean on the changed file.

## Note on the closing keyword

No linked issue — read as the gate's "this PR closes nothing" literal, not as a claim that nothing is referenced. The tracker issue is melodic-software/medley#1555, in a different repository and referenced non-closing under `## Related`: that issue's own worker protocol states "PR refs non-closing", and a cross-repo closing keyword is not what it asks for.

## Related

- Refs melodic-software/medley#1555 — the tracker issue and its owner-approved decision
- Refs melodic-software/claude-code-plugins#219 — the verification sweep that surfaced both Design-Level findings
- Refs melodic-software/claude-code-plugins#1473 — the reference-the-canonical-row treatment reused here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C>
