### PR TITLE
fix(repo-fleet-hygiene): name the remedy when a no-scope audit finds no Git tree

### DIFF
--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,12 +1,22 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["git", "github", "repository", "fleet", "hygiene", "worktree", "audit", "maintenance", "skill"]
+  "keywords": [
+    "git",
+    "github",
+    "repository",
+    "fleet",
+    "hygiene",
+    "worktree",
+    "audit",
+    "maintenance",
+    "skill"
+  ]
 }

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.1]
+
+### Fixed
+
+- **A no-scope audit from a non-Git project directory now names the remedy (#1771).** With no
+  `--root`, `--repo`, or `--config` and no config on the ladder, the audit uses the session's
+  project directory as an exact repository target. When that directory is not a Git working tree —
+  the shape of the very first invocation on a machine whose fleet lives elsewhere — the run stopped
+  at `Error: not a Git working tree: <path>` and said nothing else, so recovering meant reading the
+  collector source to learn that the implicit default was a `--repo` rather than a discovery root.
+  The implicit target now carries its own rejection origin: it still fails closed, and the failure
+  now lists `--root`, `--repo`, and `--config` with a pointer to `/repo-fleet-hygiene:setup apply`.
+  An explicitly supplied bad path stays terse — the operator just passed a scope, so repeating how
+  to pass one is noise. The skill body described the same default in discovery-root terms and now
+  states that it is an exact target.
+
 ## [0.7.0]
 
 ### Changed

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -16,8 +16,10 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   The implicit target now carries its own rejection origin: it still fails closed, and the failure
   now lists `--root`, `--repo`, and `--config` with a pointer to `/repo-fleet-hygiene:setup apply`.
   An explicitly supplied bad path stays terse — the operator just passed a scope, so repeating how
-  to pass one is noise. The skill body described the same default in discovery-root terms and now
-  states that it is an exact target.
+  to pass one is noise. When a config WAS consumed but carries no `fleet.root`/`fleet.repo` entries
+  (only `maxDepth`, acknowledgments, or overrides), the rejection no longer claims `--config` was
+  omitted: it names the consumed config and directs scope into it. The skill body described the
+  same default in discovery-root terms and now states that it is an exact target.
 
 ## [0.7.0]
 

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -34,7 +34,11 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
   (repeatable; explicit wins over config).
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
 
-If neither `--root` nor `--repo` is present, the script uses `${CLAUDE_PROJECT_DIR}`. Config
+If neither `--root` nor `--repo` is present, the script uses `${CLAUDE_PROJECT_DIR}` as an exact
+`--repo` target — not as a discovery root, so nothing beneath it is searched. A project directory
+that is not a Git working tree is therefore rejected, and the rejection names the three ways to
+supply scope plus `/repo-fleet-hygiene:setup apply`; pass that guidance through rather than
+re-deriving a root yourself. Config
 resolution is the script's own ladder — do not pre-resolve or pass a probed path yourself:
 explicit `--config` wins, else the script probes
 `${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf` (project-scoped), else
@@ -106,6 +110,9 @@ do not turn "no verified finding" into "fleet is clean".
 - Git missing or too old: stop before scanning and give the prerequisite error.
 - Invalid config SYNTAX, invalid override, or an invalid CLI-supplied `--repo`/`--root` path: report
   the exact invalid input and stop; never silently fall back.
+- No scope given and the project directory is not a Git working tree: stop, and relay the script's
+  remedy block verbatim — the operator did not choose that path, so the rejection alone is not
+  actionable.
 - A config-sourced `fleet.repo`/`fleet.root` path that is missing or not a Git working tree degrades
   per-entry, not per-run: the entry becomes an `UNKNOWN` `stale-config-entry` finding and the rest of
   the fleet is still audited (deleting repositories right after an audit must not abort every

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -422,7 +422,24 @@ reject_target() {
   display_value "$message" >&2
   printf '\n' >&2
   if [[ "$origin" == "default" ]]; then
-    cat >&2 <<'EOF'
+    # A config can be consumed yet carry no scope: valid entries like maxDepth or
+    # acknowledgments without any fleet.root/fleet.repo. Claiming --config was
+    # omitted would send the operator to create a file that already exists, so
+    # the remedy names the consumed config and directs scope INTO it.
+    if [[ -n "$CONFIG_FILE" ]]; then
+      cat >&2 <<EOF
+
+No --root or --repo was given, and the consumed config ($CONFIG_SOURCE: $CONFIG_FILE) carries no
+fleet.root or fleet.repo entries, so the audit used this session's project directory as an exact
+repository target. Add scope to that config:
+
+  git config --file "$CONFIG_FILE" --add fleet.root <dir>   bounded recursive repository discovery
+  git config --file "$CONFIG_FILE" --add fleet.repo <dir>   one exact repository or worktree
+
+Or pass --root <dir> / --repo <dir> for a one-off scope.
+EOF
+    else
+      cat >&2 <<'EOF'
 
 No --root, --repo, or --config was given, so the audit used this session's project directory as an
 exact repository target. Give it a scope instead:
@@ -433,6 +450,7 @@ exact repository target. Give it a scope instead:
 
 Or run /repo-fleet-hygiene:setup apply to write a config the audit picks up on its own.
 EOF
+    fi
   fi
   exit 2
 }

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -381,13 +381,17 @@ is_acked() {
   return 1
 }
 
+IMPLICIT_SCOPE=false
 if [[ ${#ROOT_ARGS[@]} -eq 0 && ${#REPO_ARGS[@]} -eq 0 ]]; then
   REPO_ARGS+=("${CLAUDE_PROJECT_DIR:-$PWD}")
   # The implicit current-project default is CLI-equivalent, not config-sourced: it is appended
   # after CLI_REPO_COUNT was captured, so count it there or the zero-configuration audit from a
   # non-Git directory would degrade to a stale-config-entry (with an empty source) instead of
-  # hard-failing like the explicit-path case it stands in for.
+  # hard-failing like the explicit-path case it stands in for. It carries its own origin so a
+  # rejection can name the remedies: the operator never chose this path, so the bare path in a
+  # CLI-shaped error tells them nothing about how to supply a scope.
   CLI_REPO_COUNT=$((CLI_REPO_COUNT + 1))
+  IMPLICIT_SCOPE=true
 fi
 
 path_key() {
@@ -406,25 +410,53 @@ TARGET_COMMON_KEYS=()
 # printed yet, so they are emitted as per-entry UNKNOWN findings once it has.
 STALE_CONFIG_PATHS=()
 STALE_CONFIG_REASONS=()
+# reject_target <origin> <message>: apply the rejection policy for a target that failed a
+# prerequisite. "config" returns 1 so the caller records a stale-config entry and continues; every
+# other origin stops the run. "default" is the implicit no-argument target — the same hard failure,
+# plus the scope remedies, because the operator did not choose this path and the bare rejection
+# gives them nothing to act on.
+reject_target() {
+  local origin="$1" message="$2"
+  [[ "$origin" == "config" ]] && return 1
+  printf 'Error: ' >&2
+  display_value "$message" >&2
+  printf '\n' >&2
+  if [[ "$origin" == "default" ]]; then
+    cat >&2 <<'EOF'
+
+No --root, --repo, or --config was given, so the audit used this session's project directory as an
+exact repository target. Give it a scope instead:
+
+  --root <dir>     bounded recursive repository discovery
+  --repo <dir>     one exact repository or worktree
+  --config <file>  a Git-format fleet config listing fleet.root / fleet.repo entries
+
+Or run /repo-fleet-hygiene:setup apply to write a config the audit picks up on its own.
+EOF
+  fi
+  exit 2
+}
+
 # add_target <path> <origin>: origin "cli" hard-fails on an invalid path (a typo should stop the
-# run); origin "config" records a stale-config-entry and continues (the entry, not the run, is
-# the failure unit for a tracked fleet config). Invalid config SYNTAX still hard-fails upstream.
+# run); origin "default" hard-fails with the scope remedies; origin "config" records a
+# stale-config-entry and continues (the entry, not the run, is the failure unit for a tracked fleet
+# config). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
   local candidate="$1" origin="${2:-cli}" top common common_key existing
   if [[ ! -d "$candidate" ]]; then
-    [[ "$origin" == "config" ]] || fail "repository directory not found: $candidate"
+    reject_target "$origin" "repository directory not found: $candidate"
     STALE_CONFIG_PATHS+=("$candidate")
     STALE_CONFIG_REASONS+=("configured fleet.repo path is not a directory")
     return 0
   fi
   top="$(run_git_probe -C "$candidate" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" || {
-    [[ "$origin" == "config" ]] || fail "not a Git working tree: $candidate"
+    reject_target "$origin" "not a Git working tree: $candidate"
     STALE_CONFIG_PATHS+=("$candidate")
     STALE_CONFIG_REASONS+=("configured fleet.repo path is not a Git working tree")
     return 0
   }
   common="$(run_git_probe -C "$candidate" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')" || {
-    [[ "$origin" == "config" ]] || fail "cannot resolve Git common directory: $candidate"
+    reject_target "$origin" "cannot resolve Git common directory: $candidate"
     STALE_CONFIG_PATHS+=("$candidate")
     STALE_CONFIG_REASONS+=("cannot resolve the Git common directory for the configured path")
     return 0
@@ -441,7 +473,13 @@ repo_index=0
 for repo in "${REPO_ARGS[@]:-}"; do
   if [[ -n "$repo" ]]; then
     if [[ "$repo_index" -lt "$CLI_REPO_COUNT" ]]; then
-      add_target "$repo" cli
+      # IMPLICIT_SCOPE is set only when no --root and no --repo were given, so the sole CLI-counted
+      # entry in that case is the implicit default and no explicit target can be mislabelled.
+      if [[ "$IMPLICIT_SCOPE" == "true" ]]; then
+        add_target "$repo" default
+      else
+        add_target "$repo" cli
+      fi
     else
       add_target "$repo" config
     fi

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -556,6 +556,29 @@ else
   failures=$((failures + 1))
 fi
 
+# A consumed config without any fleet.root/fleet.repo (e.g. only maxDepth) still falls back to the
+# implicit project-dir target, but the rejection must not claim --config was omitted -- the remedy
+# is adding scope to the config that was already consumed.
+cat >"$TMP/scopeless.conf" <<'SCOPELESS'
+[fleet]
+    maxDepth = 5
+SCOPELESS
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/noconf" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --config "$TMP/scopeless.conf" >"$ladder_out" 2>&1; then
+  printf 'FAIL: scope-less config with non-Git project dir did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "scopeless.conf" "$ladder_out" && grep -Fq -- "--add fleet.root" "$ladder_out"; then
+  if grep -Fq "No --root, --repo, or --config was given" "$ladder_out"; then
+    printf 'FAIL: scope-less config rejection claims --config was omitted\n' >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS: scope-less config rejection names the consumed config and directs scope into it\n'
+  fi
+else
+  printf 'FAIL: scope-less config rejection does not direct scope into the consumed config\n' >&2
+  failures=$((failures + 1))
+fi
+
 # The guidance belongs to the IMPLICIT default only: an explicitly supplied bad path is a typo, and
 # the operator already knows how to pass a scope -- they just did.
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/noconf" >"$ladder_out" 2>&1; then

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -546,6 +546,28 @@ else
   failures=$((failures + 1))
 fi
 
+# ...and it must name the remedy. The operator never chose the implicit path, so a bare rejection
+# leaves the very first invocation on a machine whose fleet lives elsewhere with no way forward.
+if grep -Fq -- "--root <dir>" "$ladder_out" && grep -Fq -- "--repo <dir>" "$ladder_out" &&
+  grep -Fq -- "--config <file>" "$ladder_out" && grep -Fq "repo-fleet-hygiene:setup apply" "$ladder_out"; then
+  printf 'PASS: zero-config rejection names --root, --repo, --config, and the setup skill\n'
+else
+  printf 'FAIL: zero-config rejection does not name the scope remedies\n' >&2
+  failures=$((failures + 1))
+fi
+
+# The guidance belongs to the IMPLICIT default only: an explicitly supplied bad path is a typo, and
+# the operator already knows how to pass a scope -- they just did.
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/noconf" >"$ladder_out" 2>&1; then
+  printf 'FAIL: explicit --repo on a non-Git dir did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq "not a Git working tree" "$ladder_out" && ! grep -Fq -- "--config <file>" "$ladder_out"; then
+  printf 'PASS: explicit --repo rejection stays terse (no scope guidance)\n'
+else
+  printf 'FAIL: explicit --repo rejection leaked the implicit-default scope guidance\n' >&2
+  failures=$((failures + 1))
+fi
+
 # A CLI-supplied bad path is a typo, not config drift: the run must still hard-fail.
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --repo "$TMP/never-existed" >"$ladder_out" 2>&1; then
   printf 'FAIL: CLI-supplied missing repo did not hard-fail\n' >&2


### PR DESCRIPTION
## Summary

- **Root cause, confirmed as reported.** `audit-fleet.sh` applies the no-argument fallback as an
  exact `--repo` target (`REPO_ARGS+=("${CLAUDE_PROJECT_DIR:-$PWD}")`, counted into
  `CLI_REPO_COUNT`), so `add_target` takes the `cli` branch and hard-fails on a project directory
  that is not a Git working tree. Correct as a fail-closed decision, useless as an operator
  experience: the message named the rejected path and nothing else, so the first invocation on a
  machine whose fleet lives elsewhere had no way forward.
- **Fix — the second option the issue offers: keep the exact target, degrade with guidance.** The
  implicit target now carries its own rejection origin (`default`), and a new `reject_target`
  centralizes the policy the three prerequisite checks in `add_target` already shared. `config`
  still degrades per-entry to a `stale-config-entry`; `cli` still fails terse; `default` fails with
  the same error plus the three ways to supply scope (`--root`, `--repo`, `--config`) and a pointer
  to `/repo-fleet-hygiene:setup apply`.
- **Why not option 1 (treat the default as a discovery root).** A bare invocation from a home
  directory would then recursively scan the whole home tree by default — slow, surprising, and it
  would surface every repository on the machine when the operator asked for nothing. Fail-closed
  with a named remedy keeps the audit's "never guess a broader machine root" rule intact, which the
  skill body states in its own Input-resolution section.
- **Documentation aligned to the behavior.** The skill body said "the script uses
  `${CLAUDE_PROJECT_DIR}`" next to a `--root` flag documented as "bounded recursive repository
  discovery", which reasonably reads as a discovery root. It now says the default is an exact
  `--repo` target and that nothing beneath it is searched, and the graceful-degradation list carries
  the no-scope case with an instruction to relay the remedy block verbatim.

## Test plan

Repro-first: the new guidance assertion fails against the unmodified collector and passes after.

- **Reproduction** (config ladder neutralized with an isolated `HOME` and a non-Git
  `CLAUDE_PROJECT_DIR`, because a `repo-fleet-hygiene.conf` has since appeared on the reporting
  machine's project rung):
  - before: `Error: not a Git working tree: /tmp/.../proj`, exit 2, nothing else
  - after: same error and exit 2, followed by the `--root` / `--repo` / `--config` block and the
    `/repo-fleet-hygiene:setup apply` pointer
- **Behavior preserved.** An explicit `--repo <non-git-dir>` still fails with the bare one-line
  error; a no-scope run from a directory that *is* a Git working tree still audits normally
  (`Repositories discovered: 1`, `Config: none (... current-project scope)`).
- **Collector suite** — `plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh`: all
  tests pass, including two new cases —
  - `zero-config rejection names --root, --repo, --config, and the setup skill` (against the
    pristine collector: `FAIL: zero-config rejection does not name the scope remedies`)
  - `explicit --repo rejection stays terse (no scope guidance)` — a non-regression guard keeping the
    two failure shapes distinct
- **Gates** — `scripts/check-changelog-parity.sh --check-bump origin/main`,
  `scripts/check-shell-portability.sh --paths`, `scripts/check-skill-portability.sh --paths`,
  `shellcheck --rcfile .shellcheckrc -x`, `shfmt -d`, `markdownlint-cli2` — all clean.

## Related

- N/A

Fixes #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C>
