### PR TITLE
chore(knowledge): retire models-explained blog doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.9]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: models-explained blog queue entry removed.** The
+  claude-models-explained blog slice completed — rendered-channel fetch (raw-md confirmed
+  absent, matching the profile's blog-post channel note) with firecrawl extraction, through
+  interview handoff, dual verification (two correction rounds, re-verified REVERIFY2: PASS by
+  both verifiers, no degraded fallback) — so its entry leaves the doc queue per the queue's
+  remove-on-completion rule, taking its inlined seven-item pairing cross-link contract with it
+  (the contract was executed by the slice; its results live in the slice's handoff).
+- **`docpage-digest` Anthropic profile: vendor-blog attestation rule.** Blog-only assertions
+  (behavioral, performance, figure/percentage, comparative, positioning — an illustrative, not
+  exhaustive, list) carry an assertion-specific `vendor-claimed (blog, <fetch date> fetch)`
+  marker beside their vocabulary tag — never satisfied by related-property citations, never
+  co-occurring with a same-assertion live-doc citation, never deferred to the interview. Closes
+  the rule gap the context-engineering blog slice's handoff flagged (its OQ-3), with the shape
+  enforced end-to-end by both verifiers on this slice.
+
 ## [0.10.8]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -48,6 +48,17 @@ the tag asserts:
   to `mixed`, and third-party APIs (e.g. the GitHub API) count as API surfaces — no vendor
   exemption. (From the best-practices slice: the third-party-API ruling is its cross-vendor
   finding; the own-basis rule was applied there and ratified by both re-verifications.)
+- **Vendor-blog attestation:** a `claude.com/blog` page is marketing-adjacent vendor voice, not
+  reference documentation. Any assertion of fact that exists ONLY in the blog (no harness or
+  platform doc states the same assertion) — behavioral, performance, figure/percentage,
+  comparative, frequency, methodological/definitional, positioning, or any other class; the
+  list is illustrative, not exhaustive — additionally carries
+  `vendor-claimed (blog, <fetch date> fetch)` beside its vocabulary tag — assertion-specific
+  (related-property citations never exempt it), never co-occurring with a live-doc citation for
+  the same assertion, and never deferred to the interview. The marker is an attestation note
+  that composes with the tag and, where applicability itself is inferred, with
+  `unverified-inference`. (Shape recommended by the context-engineering blog slice's handoff,
+  exercised end-to-end and enforced by both verifiers on the models-explained slice.)
 
 ## Digest-agent model matching
 
@@ -86,24 +97,6 @@ Supplementary references:
 
 Blog posts:
 
-- <https://claude.com/blog/claude-models-explained-choosing-the-best-model-for-your-use-case>
-  — pairs with the completed choosing-a-model doc digest (routing vet executed 2026-07-29,
-  melodic-software/claude-code-plugins#1697). Cross-link contract for this run (portable copy
-  of that slice's pairing package; the fuller original also lives in the slice's interview
-  handoff, work-root slug `platform-claude-com-docs-en-abo-38ebff0f`, where that machine-local
-  memory-tier slice still exists): compare the blog against the choosing-a-model doc on
-  (a) the capabilities/speed/cost triad framing, also cross-linking the other model-choice
-  blog ("Choosing a Claude model and effort level in Claude Code") that
-  code.claude.com/docs/en/model-config.md links for harness model-fit guidance;
-  (b) whether Effort is a third consideration or a fourth factor (the considerations-count
-  split); (c) the selection-factors frame, the effort-vs-model-switch lever, and any
-  per-model effort recommendations; (d) the two-approach framing, Opus 5 / Fable 5 /
-  Mythos 5 positioning language, and pricing figures; (e) per-model fit sections vs the
-  doc's matrix rows (source lines 71–74); (f) the upgrade/switch decision's eval-first
-  four steps; (g) overlap with the models-overview cards, including Sonnet 5's "The best
-  combination of speed and intelligence" tagline. Divergences between the channels escalate
-  as the blog slice's own open questions; agreements are recorded once, pointer each way,
-  never restated in both.
 - <https://claude.com/blog/building-verification-loops-in-claude-code-with-skills>
   — pairs with any verification-loop or loop-engineering work the consuming setup already tracks
 


### PR DESCRIPTION
## Summary

The claude-models-explained blog slice completed the full docpage-digest pipeline: rendered-channel fetch (raw-md confirmed absent per the profile's blog-post channel note) with firecrawl extraction, 7-unit digest fan-out executing the run-7 pairing cross-link contract (a)–(g), dual verification (Verifier A fable-5 + cross-vendor Codex per the #1740 recipe, two correction rounds, final REVERIFY2: PASS from both, no degraded fallback), and interview handoff (pairing results + 8 CAs + 8 OQs, all 32 digest questions mapped).

Profile changes:

- Models-explained blog queue entry removed per the remove-on-completion rule, taking its inlined seven-item pairing contract with it (executed; results recorded in the slice's handoff).
- Vendor-blog attestation rule codified: assertion-specific `vendor-claimed (blog, <fetch date> fetch)` markers, illustrative assertion-class list — the rule the context-engineering slice's handoff recommended (its OQ-3), enforced end-to-end by both verifiers on this slice.

Knowledge plugin 0.10.8 → 0.10.9 with changelog.

No linked issue

## Related

- #1788 — run 7 (choosing-a-model digest), whose OQ-10 pairing contract this slice executed
- #1775 / #1779 — the guardrail-lane queue PRs preceding this run
- #1740 — the elevated Codex Verifier B recipe used for cross-vendor verification