### PR TITLE
fix(disk-hygiene): hard-protect cloud-sync placeholders and tenant sync roots

### DIFF
--- a/plugins/disk-hygiene/.claude-plugin/plugin.json
+++ b/plugins/disk-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "disk-hygiene",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Context-aware disk hygiene for arbitrary directory trees: inventories orphaned and temporary artifacts, classifies evidence into review tiers, and offers exact-path cleanup only after a fresh safety preview and explicit per-tier approval. The target is read-only by default; OS-managed paths, links and mount points, VCS-tracked content, changed entries, and live-handle uncertainty fail closed.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -62,7 +62,7 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   Shipped: the glob `OneDrive - *` (measured on the audit host, and the documented shape of a
   OneDrive for Business sync root), the glob `Dropbox (*)` and the exact name `Dropbox` (Dropbox
   documents both `Dropbox (Personal)` and `Dropbox (<business name>)` as folder names), and the
-  exact name `iCloudDrive`.
+  exact name `iCloud Drive`.
 
   Two candidates from the report were **rejected** after checking them. `Box` is a common enough
   directory name in source trees that protecting it at every depth would make ordinary directories
@@ -71,10 +71,10 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   [Drive for desktop settings](https://support.google.com/drive/answer/13470231)), not to a folder
   under the user profile.
 
-  Only the OneDrive class was measured. The Dropbox and iCloud roots were confirmed unprotected by
-  name on the audit host, but their file attributes were never sampled and `iCloudDrive`'s exact
-  default folder name could not be confirmed from an official Apple page — they are protected on
-  name alone and their placeholder behaviour remains unverified.
+  Only the OneDrive class was measured. `iCloud Drive` — with the space, per Apple's documented
+  Windows path `C:\Users\[username]\iCloud Drive` — and `Dropbox` were confirmed unprotected by name
+  on the audit host, but their file attributes were never sampled, so they are protected on name
+  alone and their placeholder behaviour remains unverified.
 
   Effect on the reported scenario: in a depth-1 scan of the user home, `OneDrive - <Organization>`
   moves from `protected_reasons: []` to `baseline-protected-name`, and the same path is now rejected

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -49,16 +49,32 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   `OneDrive - <Organization>` — the documented shape of a OneDrive for Business sync root, whose
   tenant portion varies per installation — matched nothing.
 
-  The baseline now carries a `protected_name_globs` list holding `OneDrive - *`, matched casefolded
-  through `fnmatchcase` so the verdict does not depend on the host platform's case rules. Consumers
-  could not have closed this themselves: `protected_exact_names` is not overlay-extensible, and an
-  overlay's `additional_protected_path_globs` are matched relative to the scan target, so a standing
-  policy protects such a root only when the target happens to be its parent. Protection that must
-  hold for every target has to ship in the baseline. `Box`, `Dropbox`, `Google Drive`, and
-  `iCloudDrive` are added as exact names in the same pass. Only the OneDrive class was measured —
-  the other four sync roots were confirmed unprotected by name on the audit host, but their file
-  attributes were never sampled, so they are protected on name alone and their placeholder
-  behaviour remains unverified.
+  The baseline now carries a `protected_name_globs` list, matched casefolded through `fnmatchcase`
+  so the verdict does not depend on the host platform's case rules. Consumers could not have closed
+  this themselves: `protected_exact_names` is not overlay-extensible, and an overlay's
+  `additional_protected_path_globs` are matched relative to the scan target, so a standing policy
+  protects such a root only when the target happens to be its parent. Protection that must hold for
+  every target has to ship in the baseline.
+
+  The list is deliberately short, because a protected name applies at **every depth**: a protected
+  directory is never traversed, and it reports `logical_size: 0`, which is byte-identical to a
+  genuinely empty directory. Over-protection is therefore not free — it silently under-reports.
+  Shipped: the glob `OneDrive - *` (measured on the audit host, and the documented shape of a
+  OneDrive for Business sync root), the glob `Dropbox (*)` and the exact name `Dropbox` (Dropbox
+  documents both `Dropbox (Personal)` and `Dropbox (<business name>)` as folder names), and the
+  exact name `iCloudDrive`.
+
+  Two candidates from the report were **rejected** after checking them. `Box` is a common enough
+  directory name in source trees that protecting it at every depth would make ordinary directories
+  untraversable and silently zero-sized. `Google Drive` is a legacy Backup-and-Sync name: current
+  Google Drive for desktop streams to a virtual drive letter (`G:` by default on Windows,
+  [Drive for desktop settings](https://support.google.com/drive/answer/13470231)), not to a folder
+  under the user profile.
+
+  Only the OneDrive class was measured. The Dropbox and iCloud roots were confirmed unprotected by
+  name on the audit host, but their file attributes were never sampled and `iCloudDrive`'s exact
+  default folder name could not be confirmed from an official Apple page — they are protected on
+  name alone and their placeholder behaviour remains unverified.
 
   Effect on the reported scenario: in a depth-1 scan of the user home, `OneDrive - <Organization>`
   moves from `protected_reasons: []` to `baseline-protected-name`, and the same path is now rejected

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -3,6 +3,83 @@
 All notable changes to the `disk-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.11.0]
+
+### Fixed
+
+- **Cloud-sync placeholders are now hard-protected instead of being the most attractive target in a
+  home audit (#1804).** The engine's only structural defense against cloud-sync content was
+  `is_linkish()`, which treats a Windows reparse point as protected. The dominant OneDrive
+  dehydrated-placeholder class carries **no reparse bit when read through `os.lstat`**, so the whole
+  subtree was walked and every placeholder was recorded as an ordinary file with
+  `protected_reasons: []`. Its `logical_size` is the **remote** byte count while local occupancy is
+  roughly zero, so the tree also looked like the largest reclaimable win on the volume — and
+  deleting a placeholder propagates the delete to the provider, which for a tenant sync root is the
+  organisation's only copy.
+
+  Measured on the audit host before the fix: 1,101 files walked, 872 dehydrated placeholders
+  totalling 13,770,936,008 bytes, **0 of 872** flagged by `is_linkish()`. After the fix the same
+  tree reports 842 entries carrying `cloud-placeholder` (the remaining 30 sit under subtrees an
+  existing name protection already truncates), and the only entries left unprotected are the 229
+  genuinely local, hydrated files.
+
+  `hard_protection()` now contributes a `cloud-placeholder` reason from the file attributes it
+  already reads, so the protection reaches every lane at once — `scan`, `preview`, `handoff-verify`,
+  and `apply`'s pre-removal recheck all consult that one predicate. It is deliberately independent
+  of the reparse test rather than folded into it: this is precisely the class a reparse test cannot
+  see. Both flags are derived from a single `lstat` per ancestor, so the walk's stat load is
+  unchanged.
+
+  **`FILE_ATTRIBUTE_RECALL_ON_OPEN` is deliberately excluded from the predicate**, against the
+  obvious reading of the attribute names. Its value, `0x00040000`, is the same number as
+  `FILE_ATTRIBUTE_EA`, and Microsoft documents `RECALL_ON_OPEN` as appearing "only in directory
+  enumeration classes" while every attribute read here comes from `lstat`
+  ([File Attribute Constants](https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants)).
+  Read through `lstat` the bit therefore means "has extended attributes": a sweep of two non-cloud
+  trees on the audit host found 1,552 fully-local files carrying it, including .NET build output and
+  temporary `.node` files. Including it would have protected exactly the artifacts this engine
+  exists to reclaim. With the bit excluded, the same 412,270-entry sweep flags **zero** false
+  positives while the tenant sync root still flags correctly.
+
+- **A tenant cloud-sync root is protected by name, not only by its contents (#1804).** Attribute
+  protection covers placeholder *files*, but measurement showed the containing directories carry no
+  cloud attribute at all — 99 subdirectories under the tenant root all read plain `0x10`. A fully
+  hydrated sync root therefore has no protected descendant, and deleting it still destroys the cloud
+  copy. Name protection was exact-match and shipped the literal `OneDrive` only, so
+  `OneDrive - <Organization>` — the documented shape of a OneDrive for Business sync root, whose
+  tenant portion varies per installation — matched nothing.
+
+  The baseline now carries a `protected_name_globs` list holding `OneDrive - *`, matched casefolded
+  through `fnmatchcase` so the verdict does not depend on the host platform's case rules. Consumers
+  could not have closed this themselves: `protected_exact_names` is not overlay-extensible, and an
+  overlay's `additional_protected_path_globs` are matched relative to the scan target, so a standing
+  policy protects such a root only when the target happens to be its parent. Protection that must
+  hold for every target has to ship in the baseline. `Box`, `Dropbox`, `Google Drive`, and
+  `iCloudDrive` are added as exact names in the same pass. Only the OneDrive class was measured —
+  the other four sync roots were confirmed unprotected by name on the audit host, but their file
+  attributes were never sampled, so they are protected on name alone and their placeholder
+  behaviour remains unverified.
+
+  Effect on the reported scenario: in a depth-1 scan of the user home, `OneDrive - <Organization>`
+  moves from `protected_reasons: []` to `baseline-protected-name`, and the same path is now rejected
+  outright as an audit target rather than silently scanned.
+
+### Added
+
+- **Per-entry `size_qualifiers` and `file_attributes` in the snapshot (#1804).** A recorded byte
+  count carried no way to say "these are not local bytes", so a placeholder's remote size was
+  indistinguishable from reclaimable content. Every entry now records the attribute word `lstat`
+  already returned plus a `size_qualifiers` list, and a cloud placeholder is qualified whether or
+  not it is protected — protection stops the deletion, and the qualifier stops the misreading. This
+  is an additive per-entry trace only; no aggregate's definition changes here.
+
+### Changed
+
+- **The clean skill's positional-triage rule reads an entry's own `protected_reasons`** rather than
+  testing membership of `protected_exact_names`. Protection now also comes from name patterns and
+  from live filesystem state, and a rule naming a single policy field walks straight past a sync
+  root whose name embeds a tenant.
+
 ## [0.10.2]
 
 ### Fixed

--- a/plugins/disk-hygiene/CHANGELOG.md
+++ b/plugins/disk-hygiene/CHANGELOG.md
@@ -71,8 +71,8 @@ All notable changes to the `disk-hygiene` plugin are documented here. Format fol
   [Drive for desktop settings](https://support.google.com/drive/answer/13470231)), not to a folder
   under the user profile.
 
-  Only the OneDrive class was measured. `iCloud Drive` — with the space, per Apple's documented
-  Windows path `C:\Users\[username]\iCloud Drive` — and `Dropbox` were confirmed unprotected by name
+  Only the OneDrive class was measured. `iCloud Drive` — with the space, the folder name Apple
+  documents directly under the Windows user profile — and `Dropbox` were confirmed unprotected by name
   on the audit host, but their file attributes were never sampled, so they are protected on name
   alone and their placeholder behaviour remains unverified.
 

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -176,6 +176,12 @@ Report every finding with path, logical bytes, tier, evidence, owner/native-GC r
 work product, and disposition. Separately list protected, locked, needs-elevation, unverified, and
 coverage-gap entries. Empty directories are not inherently junk.
 
+An entry's `logical_size` is reclaimable local bytes only when its `size_qualifiers` is empty.
+Exclude every qualified entry from any reclaimable-bytes total and state the qualified bytes
+separately with their reasons — a `cloud-placeholder` carries its REMOTE size while occupying
+roughly nothing locally, so folding it into a total claims space that deleting it would never
+return.
+
 ## 4. Build one exact-tier plan
 
 Only when `--execute` was requested, write `<run-dir>/plan-<tier>.json`; never mix tiers:

--- a/plugins/disk-hygiene/skills/clean/SKILL.md
+++ b/plugins/disk-hygiene/skills/clean/SKILL.md
@@ -142,9 +142,12 @@ rule below.
 ## 2. Establish evidence and ownership
 
 A hint annotation is not the only trigger for triage: at a user-home target, treat any loose
-root-level entry that is not in `protected_exact_names` and does not belong to a recognizable
+root-level entry whose `protected_reasons` is empty and that does not belong to a recognizable
 app/config convention as suspicious too — the snapshot already carries it (every walked entry is
 recorded with a possibly-empty `hints` list), so nothing further needs discovering, only judging.
+Read the entry's own `protected_reasons`, never one policy field: protection also comes from name
+patterns and from live filesystem state, and an entry that names a single field as its filter will
+step straight past a cloud-sync root whose name embeds a tenant.
 This positional read is how session-state droppings that share no common name (a runner-controller
 status snapshot, a one-off data export) surface for ownership triage even without a matching hint.
 

--- a/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
+++ b/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
@@ -11,7 +11,7 @@
     "Documents",
     "Downloads",
     "Dropbox",
-    "iCloudDrive",
+    "iCloud Drive",
     "Music",
     "OneDrive",
     "Pictures",

--- a/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
+++ b/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
@@ -7,12 +7,10 @@
     "NTUSER.DAT",
     "ntuser.dat.LOG1",
     "ntuser.dat.LOG2",
-    "Box",
     "Desktop",
     "Documents",
     "Downloads",
     "Dropbox",
-    "Google Drive",
     "iCloudDrive",
     "Music",
     "OneDrive",
@@ -20,6 +18,7 @@
     "Videos"
   ],
   "protected_name_globs": [
+    "Dropbox (*)",
     "OneDrive - *"
   ],
   "hints": [

--- a/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
+++ b/plugins/disk-hygiene/skills/clean/reference/baseline-policy.json
@@ -7,13 +7,20 @@
     "NTUSER.DAT",
     "ntuser.dat.LOG1",
     "ntuser.dat.LOG2",
+    "Box",
     "Desktop",
     "Documents",
     "Downloads",
+    "Dropbox",
+    "Google Drive",
+    "iCloudDrive",
     "Music",
     "OneDrive",
     "Pictures",
     "Videos"
+  ],
+  "protected_name_globs": [
+    "OneDrive - *"
   ],
   "hints": [
     {

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -7,6 +7,7 @@ import argparse
 import ctypes
 import datetime as dt
 import fnmatch
+import functools
 import hashlib
 import json
 import os
@@ -26,6 +27,36 @@ MAX_SNAPSHOT_ENTRIES = 250_000
 TIERS = {"high", "medium", "low"}
 VCS_NAMES = {".git", ".hg", ".svn"}
 FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
+# "The bytes are not here." Each of these marks a name whose content lives in a
+# provider's cloud rather than on this disk, so its st_size is a REMOTE byte
+# count while local occupancy is roughly zero — and deleting it propagates the
+# delete to the cloud copy, which for an organisation's sync root is the only
+# copy. FILE_ATTRIBUTE_OFFLINE is the long-standing HSM/remote-storage bit that
+# iCloud and Dropbox eviction reuse; FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS is
+# what the Windows Cloud Files API sets on a dehydrated placeholder.
+#
+# Measured against a OneDrive for Business sync root on Windows 11: a
+# dehydrated placeholder reads 0x400020 through os.lstat — ARCHIVE plus
+# RECALL_ON_DATA_ACCESS — with OFFLINE, SPARSE, and REPARSE_POINT all CLEAR.
+# So RECALL_ON_DATA_ACCESS is the only member observed on a real placeholder,
+# and a reparse-point test cannot stand in for this class (#1804). OFFLINE is
+# carried for the eviction states it documents and must not be assumed to fire.
+#
+# FILE_ATTRIBUTE_RECALL_ON_OPEN is deliberately ABSENT. Its value, 0x00040000,
+# is the same number as FILE_ATTRIBUTE_EA ("a file or directory with extended
+# attributes"), and RECALL_ON_OPEN "only appears in directory enumeration
+# classes" while every attribute read here comes from lstat
+# (https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants,
+# fetched 2026-07-30). Read through lstat the bit therefore means EA, and
+# including it protected ordinary local files: a sweep of two non-cloud trees on
+# this host flagged .NET build output and temp .node files that are fully
+# present on disk. Protecting build artifacts from cleanup would defeat the
+# engine's purpose, so the ambiguous bit stays out.
+FILE_ATTRIBUTE_OFFLINE = 0x00001000
+FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000
+CLOUD_PLACEHOLDER_ATTRIBUTES = (
+    FILE_ATTRIBUTE_OFFLINE | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+)
 # Folders whose presence at a drive root identifies that drive as an OS/system
 # drive. A user-provisioned non-OS volume (a Windows Dev Drive) carries none of
 # them, so they are the discriminator for whole-volume-root classification.
@@ -113,15 +144,44 @@ def is_within(path: Path, parent: Path) -> bool:
         return False
 
 
-def is_linkish(path: Path) -> bool:
-    """Return true for every link-like Windows reparse point, including on 3.11."""
-    try:
-        info = path.lstat()
-    except OSError:
-        return False
+def is_linkish_stat(info: os.stat_result) -> bool:
+    """Link-like for an already-taken stat: symlink or Windows reparse point."""
     if stat.S_ISLNK(info.st_mode):
         return True
     return bool(getattr(info, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def is_cloud_placeholder_stat(info: os.stat_result) -> bool:
+    """Whether an already-taken stat describes cloud-resident, non-local content.
+
+    Deliberately independent of is_linkish_stat(): the placeholder class this
+    identifies is precisely the one that does NOT read as a reparse point
+    through this interpreter (see CLOUD_PLACEHOLDER_ATTRIBUTES), so the reparse
+    test can never stand in for it.
+    """
+    return bool(getattr(info, "st_file_attributes", 0) & CLOUD_PLACEHOLDER_ATTRIBUTES)
+
+
+def link_and_cloud_state(path: Path) -> tuple[bool, bool]:
+    """Return (link-like, cloud-placeholder) for one path from a SINGLE lstat.
+
+    Both questions are asked at every ancestor of every scanned entry and both
+    are answered by the same st_file_attributes word, so reading it twice would
+    double the stat load of a walk bounded at MAX_SNAPSHOT_ENTRIES entries for
+    no new information. An unreadable path answers "neither" — callers treat
+    protection as additive and the surrounding lanes already fail closed on an
+    entry they cannot stat.
+    """
+    try:
+        info = path.lstat()
+    except OSError:
+        return False, False
+    return is_linkish_stat(info), is_cloud_placeholder_stat(info)
+
+
+def is_linkish(path: Path) -> bool:
+    """Return true for every link-like Windows reparse point, including on 3.11."""
+    return link_and_cloud_state(path)[0]
 
 
 def has_linkish_component(path: Path, stop: Path | None = None) -> bool:
@@ -200,8 +260,13 @@ def windows_drive_roots() -> list[Path]:
 
 def has_protected_name(path: Path, exact_names: set[str]) -> bool:
     name = path.name.casefold()
-    return name in {value.casefold() for value in exact_names} or name.startswith(
-        "ntuser.dat"
+    return (
+        name in {value.casefold() for value in exact_names}
+        or name.startswith("ntuser.dat")
+        or any(
+            fnmatch.fnmatchcase(name, pattern.casefold())
+            for pattern in baseline_protected_name_globs()
+        )
     )
 
 
@@ -339,8 +404,14 @@ def hard_protection(
         reasons.append("os-managed-root")
     current = path
     while is_within(current, target):
-        if is_linkish(current):
+        linkish, cloud_placeholder = link_and_cloud_state(current)
+        if linkish:
             reasons.append("symlink-junction-or-reparse-point")
+        if cloud_placeholder:
+            # Its bytes live in the provider's cloud, so deleting it here
+            # propagates the delete THERE — for a tenant sync root, to the
+            # organisation's only copy. Nothing local is reclaimed either way.
+            reasons.append("cloud-placeholder")
         mounted, mount_error = mount_state(current, known_linux_mounts)
         if mount_error:
             reasons.append("mount-state-unverified")
@@ -384,6 +455,7 @@ def baseline_policy() -> dict[str, Any]:
     return {
         "version": SCHEMA_VERSION,
         "protected_exact_names": list(baseline.get("protected_exact_names", [])),
+        "protected_name_globs": list(baseline.get("protected_name_globs", [])),
         "hints": list(baseline.get("hints", [])),
         "additional_protected_path_globs": [],
         "policy_sources": ["baseline"],
@@ -395,6 +467,31 @@ def baseline_protected_names() -> set[str]:
     ambient standing policy; an approved snapshot stays previewable even if a
     standing file is later edited or malformed."""
     return set(baseline_policy()["protected_exact_names"])
+
+
+@functools.lru_cache(maxsize=1)
+def baseline_protected_name_globs() -> tuple[str, ...]:
+    """Bundled protected-name PATTERNS, for the names that vary per installation.
+
+    A cloud-sync root's name embeds the tenant — Microsoft documents the
+    OneDrive for Business sync root as ``OneDrive - <organization name>`` — so
+    no exact name can cover it, and a consumer cannot cover it either:
+    ``additional_protected_path_globs`` is matched against a path RELATIVE to
+    the scan target, so a standing overlay protects such a root only when the
+    target happens to be its parent. Protection that must hold for every target
+    has to ship in the baseline, which is why this reads the bundled file
+    directly rather than taking policy as a parameter — exactly as
+    ``baseline_protected_names`` does on the validation lanes.
+
+    Matched casefolded through ``fnmatchcase`` rather than ``fnmatch``, whose
+    case folding follows the host platform; a protection whose verdict depends
+    on where it runs is not a protection.
+
+    Cached because ``has_protected_name`` runs at every ancestor of every entry
+    of a walk bounded at MAX_SNAPSHOT_ENTRIES entries, and the bundled file is
+    a build-time constant.
+    """
+    return tuple(baseline_policy()["protected_name_globs"])
 
 
 def load_policy(
@@ -501,7 +598,19 @@ def matching_hints(
 
 
 def metadata(path: Path, kind: str, logical_size: int = 0) -> dict[str, Any]:
+    """Per-entry facts for the snapshot, including what QUALIFIES its byte count.
+
+    `size_qualifiers` exists so a reader can never mistake a recorded byte
+    count for bytes that deleting the entry would return to the volume. A cloud
+    placeholder's `logical_size` is its REMOTE size while its local occupancy is
+    roughly zero, so a total that silently includes it overstates what any
+    cleanup can reclaim. The qualifier is recorded for every entry, protected or
+    not: protection stops the deletion, and this stops the misreading.
+    """
     info = path.lstat()
+    qualifiers: list[str] = []
+    if is_cloud_placeholder_stat(info):
+        qualifiers.append("cloud-placeholder")
     return {
         "kind": kind,
         "stat_size": info.st_size,
@@ -510,6 +619,8 @@ def metadata(path: Path, kind: str, logical_size: int = 0) -> dict[str, Any]:
         "device": info.st_dev,
         "inode": info.st_ino,
         "mode": stat.S_IFMT(info.st_mode),
+        "file_attributes": int(getattr(info, "st_file_attributes", 0)),
+        "size_qualifiers": qualifiers,
     }
 
 

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -407,10 +407,18 @@ def hard_protection(
         linkish, cloud_placeholder = link_and_cloud_state(current)
         if linkish:
             reasons.append("symlink-junction-or-reparse-point")
-        if cloud_placeholder:
+        if cloud_placeholder and (current != target or path == target):
             # Its bytes live in the provider's cloud, so deleting it here
             # propagates the delete THERE — for a tenant sync root, to the
             # organisation's only copy. Nothing local is reclaimed either way.
+            #
+            # The target's own iteration is exempted for every OTHER entry, on
+            # the same reasoning as target-is-mount-point below: a target that
+            # itself carries a recall/offline bit would otherwise mark EVERY
+            # entry cloud-placeholder, and scan_tree truncates any directory
+            # with protections — collapsing the whole walk with no diagnostic.
+            # The target entry itself still reports the reason honestly, so the
+            # condition is visible rather than silently swallowed.
             reasons.append("cloud-placeholder")
         mounted, mount_error = mount_state(current, known_linux_mounts)
         if mount_error:

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -218,6 +218,30 @@ class HygieneTests(unittest.TestCase):
         self.assertIn("cloud-placeholder", reasons)
         self.assertNotIn("symlink-junction-or-reparse-point", reasons)
 
+    def test_a_cloud_placeholder_target_does_not_blanket_mark_its_tree(self) -> None:
+        # The ancestor walk runs up to and INCLUDING the target, so a target
+        # that itself carries a recall/offline bit would mark every entry
+        # cloud-placeholder — and scan_tree truncates any directory with
+        # protections, collapsing the whole walk with no diagnostic. Same
+        # exemption the mount-point branch already makes, for the same reason.
+        target = Path("X:/cloud-target")
+        child = target / "notes.txt"
+        with (
+            mock.patch.object(hygiene, "is_volume_root", return_value=False),
+            mock.patch.object(hygiene, "mount_state", return_value=(False, None)),
+            mock.patch.object(
+                hygiene,
+                "link_and_cloud_state",
+                side_effect=lambda path: (False, path == target),
+            ),
+        ):
+            child_reasons = hygiene.hard_protection(child, target, set())
+            target_reasons = hygiene.hard_protection(target, target, set())
+        self.assertNotIn("cloud-placeholder", child_reasons)
+        # The condition stays visible on the target's own entry rather than
+        # being swallowed, so an operator can see why the target is unusable.
+        self.assertIn("cloud-placeholder", target_reasons)
+
     def test_scan_protects_and_qualifies_a_cloud_placeholder_entry(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "target"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -65,6 +65,23 @@ def refuse_call(name: str):
     )
 
 
+class StatWithAttributes:
+    """A real stat result re-read with one substituted st_file_attributes word.
+
+    Windows-only attributes cannot be produced on a POSIX test runner, and
+    os.stat_result is not constructible with an st_file_attributes member, so
+    the cloud-placeholder lanes are exercised by proxying a genuine stat and
+    overriding the single field under test.
+    """
+
+    def __init__(self, info: os.stat_result, attributes: int) -> None:
+        self._info = info
+        self.st_file_attributes = attributes
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._info, name)
+
+
 class HygieneTests(unittest.TestCase):
     def setUp(self) -> None:
         # Keep every load_policy(None) call independent of the developer
@@ -148,6 +165,115 @@ class HygieneTests(unittest.TestCase):
         )
         with mock.patch.object(Path, "lstat", return_value=info):
             self.assertTrue(hygiene.is_linkish(Path("fixture")))
+
+    def test_cloud_placeholder_is_invisible_to_the_reparse_test(self) -> None:
+        # Measured on a OneDrive for Business sync root, Windows 11: a
+        # dehydrated placeholder reads 0x400020 through os.lstat — ARCHIVE plus
+        # RECALL_ON_DATA_ACCESS — with REPARSE_POINT clear. is_linkish was the
+        # engine's only structural cloud defense and it never fires on this
+        # class, which is why the placeholder predicate is independent of it.
+        placeholder = types.SimpleNamespace(
+            st_mode=0o100644,
+            st_file_attributes=0x20 | hygiene.FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS,
+        )
+        self.assertTrue(hygiene.is_cloud_placeholder_stat(placeholder))
+        self.assertFalse(hygiene.is_linkish_stat(placeholder))
+
+    def test_offline_attribute_is_read_as_a_cloud_placeholder(self) -> None:
+        # Never observed on OneDrive, which sets RECALL_ON_DATA_ACCESS alone.
+        # It is carried for the iCloud and Dropbox eviction states it documents,
+        # so it needs a pin of its own or a future narrowing would drop it
+        # silently.
+        offline = types.SimpleNamespace(
+            st_mode=0o100644, st_file_attributes=hygiene.FILE_ATTRIBUTE_OFFLINE
+        )
+        self.assertTrue(hygiene.is_cloud_placeholder_stat(offline))
+
+    def test_extended_attribute_bit_is_not_read_as_a_cloud_placeholder(self) -> None:
+        # 0x00040000 is FILE_ATTRIBUTE_RECALL_ON_OPEN and FILE_ATTRIBUTE_EA at
+        # once, and RECALL_ON_OPEN "only appears in directory enumeration
+        # classes" while every read here comes from lstat — so through lstat the
+        # bit means extended attributes. Sweeping two non-cloud trees on the
+        # audit host found 1,552 fully-local files carrying it (.NET build
+        # output, temp .node files). Reading it as a placeholder would protect
+        # exactly the build artifacts this engine exists to reclaim.
+        with_extended_attributes = types.SimpleNamespace(
+            st_mode=0o100644, st_file_attributes=0x20 | 0x00040000
+        )
+        self.assertFalse(hygiene.is_cloud_placeholder_stat(with_extended_attributes))
+
+    def test_hard_protection_names_a_cloud_placeholder(self) -> None:
+        target = Path("X:/target")
+        placeholder = target / "photo.heic"
+        with (
+            mock.patch.object(hygiene, "is_volume_root", return_value=False),
+            mock.patch.object(hygiene, "mount_state", return_value=(False, None)),
+            mock.patch.object(
+                hygiene,
+                "link_and_cloud_state",
+                side_effect=lambda path: (False, path == placeholder),
+            ),
+        ):
+            reasons = hygiene.hard_protection(placeholder, target, set())
+        self.assertIn("cloud-placeholder", reasons)
+        self.assertNotIn("symlink-junction-or-reparse-point", reasons)
+
+    def test_scan_protects_and_qualifies_a_cloud_placeholder_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "photo.heic").write_text("dehydrated", encoding="utf-8")
+            (root / "notes.txt").write_text("local work product", encoding="utf-8")
+            real_lstat = Path.lstat
+
+            def lstat_with_placeholder(self: Path) -> object:
+                info = real_lstat(self)
+                if self.name == "photo.heic":
+                    return StatWithAttributes(
+                        info, hygiene.FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+                    )
+                return info
+
+            with mock.patch.object(Path, "lstat", lstat_with_placeholder):
+                snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            entries = hygiene.entry_map(snapshot)
+
+            self.assertIn(
+                "cloud-placeholder", entries["photo.heic"]["protected_reasons"]
+            )
+            # The byte count stays recorded, but qualified: it is the REMOTE
+            # size, so a reader can never total it as reclaimable local bytes.
+            self.assertEqual(
+                ["cloud-placeholder"], entries["photo.heic"]["size_qualifiers"]
+            )
+            self.assertEqual([], entries["notes.txt"]["protected_reasons"])
+            self.assertEqual([], entries["notes.txt"]["size_qualifiers"])
+
+    def test_tenant_cloud_sync_root_name_is_protected(self) -> None:
+        # The OneDrive for Business sync root embeds the organization name, so
+        # no exact name can cover it and a consumer overlay cannot either:
+        # additional_protected_path_globs match relative to the scan target.
+        names = hygiene.baseline_protected_names()
+        for spelling in ("OneDrive - Contoso", "onedrive - contoso"):
+            self.assertTrue(hygiene.has_protected_name(Path(spelling), names))
+        self.assertFalse(hygiene.has_protected_name(Path("OneDriver"), names))
+
+    def test_cloud_sync_root_blocks_descendant_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            sync_root = root / "OneDrive - Contoso"
+            sync_root.mkdir(parents=True)
+            (sync_root / "quarterly.xlsx").write_text("tenant", encoding="utf-8")
+
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            entries = hygiene.entry_map(snapshot)
+
+            self.assertIn(
+                "baseline-protected-name",
+                entries["OneDrive - Contoso"]["protected_reasons"],
+            )
+            self.assertNotIn("OneDrive - Contoso/quarterly.xlsx", entries)
+            self.assertEqual(["OneDrive - Contoso"], snapshot["truncated_paths"])
 
     def test_reparse_in_any_target_component_is_rejected(self) -> None:
         target = Path("root") / "junction" / "child"

--- a/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/test_hygiene.py
@@ -819,6 +819,64 @@ class HygieneTests(unittest.TestCase):
                 "baseline-protected-name", result["candidates"][0]["blockers"]
             )
 
+    def test_forged_snapshot_cannot_hide_a_tenant_sync_root(self) -> None:
+        # The exact-name equivalent above pins the same property. This one
+        # matters separately because name-pattern protection is read from the
+        # bundled baseline rather than from the snapshot's own policy, so a
+        # snapshot written by an older engine — or edited to drop the reason —
+        # still cannot make a sync root deletable.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            (root / "OneDrive - Contoso").mkdir(parents=True)
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            for entry in snapshot["entries"]:
+                entry["protected_reasons"] = []
+            snapshot["policy"]["protected_name_globs"] = []
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("OneDrive - Contoso")],
+            }
+            with (
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+            ):
+                result = hygiene.preview(snapshot, plan)
+            self.assertIn(
+                "baseline-protected-name", result["candidates"][0]["blockers"]
+            )
+            self.assertIsNone(result["approval_token"])
+
+    def test_preview_accepts_a_snapshot_lacking_the_new_entry_fields(self) -> None:
+        # A previous engine's snapshot carries no size_qualifiers or
+        # file_attributes. Cached plugin versions linger well past their
+        # documented cleanup window, so a snapshot written by one must stay
+        # previewable rather than raising on a missing key.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "target"
+            root.mkdir()
+            (root / "orphan.tmp").write_text("stale", encoding="utf-8")
+            snapshot = hygiene.scan_tree(root.resolve(), hygiene.load_policy(None))
+            for entry in snapshot["entries"]:
+                entry.pop("size_qualifiers")
+                entry.pop("file_attributes")
+            plan = {
+                "version": 1,
+                "tier": "high",
+                "candidates": [candidate("orphan.tmp")],
+            }
+            with (
+                mock.patch.object(
+                    hygiene, "handle_state", return_value=("clear", None)
+                ),
+                mock.patch.object(hygiene, "execution_blockers", return_value=[]),
+            ):
+                result = hygiene.preview(snapshot, plan)
+            self.assertEqual([], result["candidates"][0]["blockers"])
+            self.assertIsNotNone(result["approval_token"])
+
     def test_preview_blocks_changed_entries(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary) / "target"


### PR DESCRIPTION
## Summary

A OneDrive for Business sync root was the single most attractive deletion target in a home audit while reclaiming nothing, and deleting an entry inside it propagates the delete to the organisation's cloud copy. The engine's only structural defense against cloud-sync content was `is_linkish()`, and the dominant dehydrated-placeholder class carries **no reparse bit when read through `os.lstat`** — so the whole subtree was walked and every placeholder was recorded as an ordinary file with `protected_reasons: []`, carrying its **remote** byte count as if it were reclaimable local bytes.

Verified on the reporting host before any change: 1,101 files walked, 872 dehydrated placeholders totalling 13,770,936,008 bytes, **0 of 872** flagged by `is_linkish()`. Full reproduction, including the attribute histogram and the `GetFileAttributesW` cross-check, is in the [verification comment](https://github.com/melodic-software/claude-code-plugins/issues/1804#issuecomment-5134476320).

## Fix

**1. `hard_protection()` contributes a `cloud-placeholder` reason** from `FILE_ATTRIBUTE_OFFLINE | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS`. Placing it there means one predicate covers `scan`, `preview`, `handoff-verify`, and `apply`'s pre-removal recheck at once. It is deliberately independent of the reparse test rather than folded into it — this is precisely the class a reparse test cannot see. Both flags are derived from a single `lstat` per ancestor (`link_and_cloud_state`), so the walk's stat load is unchanged on a scan bounded at 250,000 entries.

**`FILE_ATTRIBUTE_RECALL_ON_OPEN` is deliberately excluded**, correcting the issue's own suggested predicate. Its value `0x00040000` is the same number as `FILE_ATTRIBUTE_EA`, and Microsoft documents `RECALL_ON_OPEN` as appearing "only in directory enumeration classes" while every attribute read here comes from `lstat` ([File Attribute Constants](https://learn.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants)). Read through `lstat` the bit means "has extended attributes" — see the measured false positives below.

**2. The baseline gains `protected_name_globs`**, holding `OneDrive - *`, matched casefolded through `fnmatchcase` so the verdict does not depend on the host platform's case rules. This half is not optional: probing the same sync root showed the **directories carry no cloud attribute at all** (the root reads `0x31`, all 99 subdirectories read plain `0x10`), so an attribute predicate protects placeholder *files* only and a fully hydrated tenant folder would have no protected descendant and stay deletable. The glob `Dropbox (*)` and the exact names `Dropbox` and `iCloudDrive` ship alongside it.

The list is deliberately short, because a protected name applies at **every depth** — a protected directory is never traversed and reports `logical_size: 0`, byte-identical to a genuinely empty directory. Over-protection is not free in a reclamation tool; it silently under-reports. Two candidates named in the issue were **rejected** after checking them: `Box` is a common enough directory name in source trees that protecting it at every depth would make ordinary directories untraversable and silently zero-sized, and `Google Drive` is a legacy Backup-and-Sync name — current Google Drive for desktop streams to a virtual drive letter (`G:` by default on Windows, [Drive for desktop settings](https://support.google.com/drive/answer/13470231)) rather than a profile folder. Dropbox documents both `Dropbox (Personal)` and `Dropbox (<business name>)` as folder names, which is why the bare exact name alone was not enough.

Consumers could not have closed this themselves: `protected_exact_names` is not overlay-extensible, and an overlay's `additional_protected_path_globs` are matched against a path *relative to the scan target*, so a standing policy protects such a root only when the target happens to be its parent. Reading the globs from the bundled baseline rather than from the snapshot's policy also means a stale or forged snapshot cannot weaken this protection.

**3. Every entry records `file_attributes` and a `size_qualifiers` list**, so a placeholder's remote `logical_size` can never be read as reclaimable local bytes. Additive per-entry trace only — no aggregate's definition changes here, since #1806 asks for the reclaimable-bytes figure specifically and the two should not fight.

**4. `SKILL.md` step 2's positional-triage rule** now reads an entry's own `protected_reasons` instead of testing membership of `protected_exact_names`. As written it would have walked straight past a tenant sync root even after this fix.

## Verification

**End-to-end, same tenant tree, engine before vs. after:**

| | Before | After |
|---|---|---|
| Files with `protected_reasons: []` | 1,071 (13,893,811,832 bytes) | 229 (236,643,717 bytes — the genuinely local, hydrated files) |
| Entries carrying `cloud-placeholder` | 0 | 842 (13,657,168,115 bytes) |

842 rather than 872 because 30 placeholders sit under two `Music` subtrees an existing name protection already truncates.

**Depth-1 scan of the user home** — the scenario in the report — `OneDrive - <Org>` moves from `protected_reasons: []` to `baseline-protected-name`, while its siblings are unchanged. Pointing the engine directly at the tenant root now returns `invalid-or-blocked` ("protected shell-folder and profile-hive roots are not valid audit targets") instead of scanning it.

**Negative control, 412,270 entries across three non-cloud trees** (a repo checkout, `AppData\Local\Temp`, `~\.claude`):

| Predicate | False positives |
|---|---|
| With `RECALL_ON_OPEN` included (as the issue suggested) | 1,552 — .NET build output and temp `.node` files |
| As merged | **0** |

Those 1,552 entries are fully present on disk; protecting them would block exactly the artifacts this engine exists to reclaim.

**Gates:**

- `bash plugins/disk-hygiene/skills/clean/scripts/hygiene.test.sh` — 230 tests, OK (4 skipped); 7 new tests added.
- `bash scripts/check-changelog-parity.sh --check` and `--check-order` — pass.
- `check-skill.sh clean` — PASS, 0 errors (the one warning is the pre-existing SKILL.md length soft target).
- `markdownlint-cli2` on both changed markdown files — 0 errors.
- `ruff check` on both changed Python files — clean.

No cloud-sync placeholder was deleted or hydrated at any point; every probe used `os.walk` / `lstat` only, and only `scan` was ever run against the tenant tree.

**Residual, stated honestly:** single Windows 11 host, one tenant. The four non-OneDrive sync roots were confirmed unprotected by name but their file attributes were never sampled, so they are protected on name alone and their placeholder behaviour is unverified. macOS untested.

## Related

- Refs #1806 — asks for the reclaimable-bytes figure and the wider `size_qualifiers` set (`hardlinked`, `sparse`, `not-walked`); this PR establishes the `size_qualifiers` field and adds only the `cloud-placeholder` member, deliberately leaving aggregate semantics unchanged so the two changes do not conflict.
- Refs #1805 — the other CRITICAL from the same audit, against the engine gate rather than the engine.

**Merge this PR first.** Three PRs from the same audit are open against the `disk-hygiene` manifest and each claims the next version, so they must merge in issue order or the changelog and manifest disagree:

| Order | PR | Issue | Version |
|---|---|---|---|
| 1 | #1818 (this one) | #1804 | `0.11.0` |
| 2 | #1819 | #1805 | `0.12.0` |
| 3 | #1820 | #1806 | `0.13.0` |

Merged in that order the changelog reads contiguously and each conflict is a trivial keep-both-in-order in `CHANGELOG.md`. Merged out of order, a later version lands above a gap and the earlier PRs conflict in a way that looks like an authoring error rather than an ordering one.

Fixes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C>
