### PR TITLE
fix(plugin-quality): make the dispatching session verify and persist the auditor's findings

### DIFF
--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-30
+
+### Fixed
+
+- **The dispatching session now verifies the packet's grounded findings landed, and persists them
+  when the `auditor` could not (#1674).** 0.2.0 moved the packet filename out of the report-name
+  class and 0.2.2 taught the resume rule the fallback name, but neither closed the case where
+  *every* packet write is refused inside the subagent. The `auditor` was told to return its
+  findings as text; nothing told the main session to catch them, so the compaction-surviving
+  guarantee held only when the operator happened to re-persist the returned text by hand — an
+  undocumented step. Step 3 now opens with a persist-check: probe the Resume rule's closed set of
+  grounded-findings basenames, and on the `auditor`'s documented both-names-refused return, write
+  the returned findings verbatim into the packet (`audit-notes.md`, falling back to
+  `audit-data.md`) before presenting or advancing. This is a backstop, not a relocation — the
+  dispatching session is itself a subagent under a loop lane, so the filename rule remains the
+  primary defense.
+- **A refused main-thread write is now a named blocker, not a shrug.** When the dispatching
+  session's own writes are refused too, step 3 reproduces the findings inline and stops before the
+  contract lock, rather than locking a contract over findings that exist nowhere durable — the
+  same ungrounded contract the resume rule already refuses to carry.
+- **The both-names-refused return got a machine-visible marker.** `agents/auditor.md` now requires
+  that return to open with the literal line `PACKET WRITE REFUSED — full findings inline` and to
+  carry the COMPLETE findings in place of the summary form, since a refusal mentioned in passing
+  reads as a successful run with a caveat and a one-line-per-finding summary is not a ledger the
+  main session can persist on the agent's behalf. Step 3 correspondingly refuses to write a
+  summary into the packet under a closed-set name: presence of one of those names is precisely
+  what tells a resumed session the grounded findings exist, so doing so would forge the ledger
+  instead of recovering it.
+
 ## [0.3.0] - 2026-07-26
 
 ### Changed

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -11,7 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **The dispatching session now verifies the packet's grounded findings landed, and persists them
   when the `auditor` could not (#1674).** 0.2.0 moved the packet filename out of the report-name
-  class and 0.2.2 taught the resume rule the fallback name, but neither closed the case where
+  class and 0.2.1 taught the resume rule the fallback name, but neither closed the case where
   *every* packet write is refused inside the subagent. The `auditor` was told to return its
   findings as text; nothing told the main session to catch them, so the compaction-surviving
   guarantee held only when the operator happened to re-persist the returned text by hand — an
@@ -33,6 +33,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   summary into the packet under a closed-set name: presence of one of those names is precisely
   what tells a resumed session the grounded findings exist, so doing so would forge the ledger
   instead of recovering it.
+- **Backstop-persisted findings carry their provenance.** The backstop write keys on a
+  marker-string match with no independent confirmation a write was attempted and refused, so step
+  3 records the backstop path in `evidence.md`, and step 4's unattended contract lock marks each
+  such finding `backstop-persisted: unverified` rather than extending the severities-stand-as-is
+  rule to the least-verified route into the packet.
 
 ## [0.3.0] - 2026-07-26
 

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -26,7 +26,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   contract lock, rather than locking a contract over findings that exist nowhere durable — the
   same ungrounded contract the resume rule already refuses to carry.
 - **The both-names-refused return got a machine-visible marker.** `agents/auditor.md` now requires
-  that return to open with the literal line `PACKET WRITE REFUSED — full findings inline` and to
+  that return to open with the literal ASCII line `PACKET WRITE REFUSED: full findings inline` and to
   carry the COMPLETE findings in place of the summary form, since a refusal mentioned in passing
   reads as a successful run with a caveat and a one-line-per-finding summary is not a ledger the
   main session can persist on the agent's behalf. Step 3 correspondingly refuses to write a

--- a/plugins/plugin-quality/README.md
+++ b/plugins/plugin-quality/README.md
@@ -8,8 +8,8 @@ their repo mid-session.
 
 - **Audit skill** (`skills/audit`) — the six-step hub: (1) evidence capture on the main thread
   into a durable, compaction-proof packet; (2) map + ground in the fresh `auditor` subagent, with
-  every load-bearing harness-behavior claim verified against current official docs; (3) blindspot
-  pass + candidate findings; (4) interactive contract lock (scope, severity, assumptions —
+  every load-bearing harness-behavior claim verified against current official docs; (3) persist-check
+  on the returned findings, then blindspot pass + candidates; (4) interactive contract lock (scope, severity, assumptions —
   written into the packet); (5) presence-gated review seams with stated fallbacks; (6) emit to
   the resolved sink behind an unconditional draft+confirm gate.
 - **Auditor agent** (`agents/auditor.md`) — the fresh-context specialist for steps 2–3. Tools:

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -31,8 +31,12 @@ name you pick yourself — note the substitution in `evidence.md`, and name the 
 summary. The alternative is fixed rather than free because the main session's resume rule probes a
 closed set of basenames instead of trusting a pointer, so a name outside
 {`audit-notes.md`, `audit-data.md`, `findings.md`} would be unrecoverable after compaction. If BOTH
-names are refused, say so explicitly in your summary and return the full findings as text — never
-silently drop the packet write, since the dumb-zone contract depends on the file existing. This guardrail is **observed harness behavior, not
+names are refused, your return changes shape: open your final message with the literal line
+`PACKET WRITE REFUSED — full findings inline`, then give the COMPLETE findings text in place of the
+summary form below. The dispatching session's persist-check keys its own backstop write on exactly
+that — a refusal mentioned in passing inside a summary reads as a successful run with a caveat, and
+a summary is not a ledger anyone can persist on your behalf. Never silently drop the packet write,
+since the dumb-zone contract depends on the file existing. This guardrail is **observed harness behavior, not
 documented**: it appears on no official Claude Code page (sub-agents reference checked
 2026-07-26, <https://code.claude.com/docs/en/sub-agents>), so treat it as environment-dependent
 and expect contexts where it does not fire at all.
@@ -73,6 +77,8 @@ component + location, the claim vs observed behavior, evidence (packet reference
 doc citation (URL + fetch date) for any harness-behavior assertion, severity suggestion, and a
 candidate remediation ordered cheapest-first. List blindspots and unverified claims separately and
 honestly. Your final message must be the summary form: finding count by severity, the top findings
-in one line each, and the packet path — the main session decides everything downstream (contract
+in one line each, and the packet path — with one exception, the both-names-refused branch above,
+which replaces the summary with the refusal marker plus the complete findings so the dispatching
+session can persist what you could not. The main session decides everything downstream (contract
 lock, review seams, emit); you never file issues, never write outside the packet, and never touch
 the audited plugin.

--- a/plugins/plugin-quality/agents/auditor.md
+++ b/plugins/plugin-quality/agents/auditor.md
@@ -31,8 +31,8 @@ name you pick yourself — note the substitution in `evidence.md`, and name the 
 summary. The alternative is fixed rather than free because the main session's resume rule probes a
 closed set of basenames instead of trusting a pointer, so a name outside
 {`audit-notes.md`, `audit-data.md`, `findings.md`} would be unrecoverable after compaction. If BOTH
-names are refused, your return changes shape: open your final message with the literal line
-`PACKET WRITE REFUSED — full findings inline`, then give the COMPLETE findings text in place of the
+names are refused, your return changes shape: open your final message with the literal ASCII line
+`PACKET WRITE REFUSED: full findings inline`, then give the COMPLETE findings text in place of the
 summary form below. The dispatching session's persist-check keys its own backstop write on exactly
 that — a refusal mentioned in passing inside a summary reads as a successful run with a caveat, and
 a summary is not a ledger anyone can persist on your behalf. Never silently drop the packet write,

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -214,14 +214,18 @@ basenames the Resume rule defines above (and, for its reasons, never a name take
 `evidence.md`):
 
 - **A closed-set file exists** — proceed; present per the zone table.
-- **No closed-set file, and the `auditor` returned its documented both-names-refused form** (the
-  refusal stated outright, the COMPLETE findings inline in place of the summary) — persist it
-  yourself, immediately on receipt, before any other work: write the returned findings verbatim
-  into the packet as `audit-notes.md`, falling back to `audit-data.md` under the same guardrail,
-  exactly as the `auditor` would have. This is a backstop, not a relocation of the write — the
-  dispatching session is not reliably outside the guardrail either, which is why the filename rule
-  above remains the primary defense — but wherever it is outside, one write restores compaction
-  survival for findings that would otherwise live only in conversation.
+- **No closed-set file, and the `auditor` returned its documented both-names-refused form** (its
+  final message opens with the literal ASCII line `PACKET WRITE REFUSED: full findings inline` —
+  the exact marker `agents/auditor.md` mandates — and carries the COMPLETE findings inline in
+  place of the summary) — persist it yourself, immediately on receipt, before any other work:
+  write the returned findings verbatim into the packet as `audit-notes.md`, falling back to
+  `audit-data.md` under the same guardrail, exactly as the `auditor` would have. Then record the
+  provenance in `evidence.md`: the grounded findings entered the packet via this backstop — a
+  marker-matched subagent return, with no independent confirmation a write was attempted and
+  refused — so a later reader can weight them accordingly. This is a backstop, not a relocation
+  of the write — the dispatching session is not reliably outside the guardrail either, which is
+  why the filename rule above remains the primary defense — but wherever it is outside, one write
+  restores compaction survival for findings that would otherwise live only in conversation.
 - **Your own writes are refused too** — terminal, and never a shrug: report it as a named blocker,
   reproduce the full findings inline in your visible answer, and stop before step 4. Locking a
   contract over findings that exist nowhere durable is precisely the ungrounded contract the
@@ -262,7 +266,7 @@ Applied to the four contract-lock decisions:
 | Decision | Unattended resolution |
 |---|---|
 | Scope (which findings are in) | The dispatching item's own acceptance criteria and out-of-scope list bind it when it carries them. Absent that, **every** finding the `auditor` returned is in scope — the conservative answer, since narrowing scope is what needs a human. |
-| Severity calibration | The `auditor`'s returned severities stand as-is, marked uncalibrated. Never re-grade a severity without a human. |
+| Severity calibration | The `auditor`'s returned severities stand as-is, marked uncalibrated. Never re-grade a severity without a human. Findings persisted through step 3's backstop are the exception to "stand as-is": that path rests on a marker-string match with the least verification of any route into the packet, so mark each such finding `backstop-persisted: unverified` in `contract.md` and never let an unattended run treat it as ground truth for anything beyond carrying it forward to a human. |
 | Named assumptions | Carry forward the `auditor`'s own stated assumptions and unverified claims verbatim, plus one assumption naming the unattended invocation itself. |
 | Target repo for the emit | Resolve by step 6's ladder rungs 1–2 only (tracked config, then registration inference) and record which one hit. Rung 3 ("ask") has no unattended form, but an unresolved target is **not** a blocker — step 6 sends every unattended run to rung 4 whether or not 1–2 resolved, and rung 4 names "no repo" as one of its own entry conditions. The resolution recorded here is therefore either "would have targeted `<owner/repo>` via rung N" or "no external target resolved"; the emit lands on rung 4 either way. Blocking would strand precisely the targetless runs rung 4 exists for — a plugin loaded with `--plugin-dir` has no marketplace registration to infer from and no tracked config, which is the case most likely to be audited unattended. |
 

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -232,6 +232,12 @@ basenames the Resume rule defines above (and, for its reasons, never a name take
   resumed session the grounded findings exist, so doing that forges the ledger instead of
   recovering it.
 
+The Resume rule names the same refused-every-write case and answers it with a re-dispatch rather
+than a persist; that is not a contradiction but the discriminator between the two moments. Resume
+runs after context loss, when the `auditor`'s return is gone and re-dispatch is the only way to get
+findings at all. This check runs at receipt, while the return is still in hand — so persisting it is
+available, and skipping it is what manufactures the resume rule's problem one compaction later.
+
 Then present per the zone table (dumb/unknown: summary + packet pointer, no bulk re-read — the full
 list lives in the packet's grounded-findings file).
 

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -157,7 +157,9 @@ Keep every packet filename outside the report/summary/findings/analysis name cla
 nonetheless rejected on those grounds, treat it as a naming collision, not a stop signal: re-write
 the identical content as **`audit-data.md`** — the one documented alternative, never a
 freely-chosen name — and note the substitution in `evidence.md` for the human reader. Never degrade
-to prose-only, which is exactly the compaction exposure the packet exists to prevent.
+to prose-only, which is exactly the compaction exposure the packet exists to prevent; when both
+names are refused inside the `auditor`, step 3's persist-check is what holds that line from the
+dispatching side.
 
 The alternative is a fixed name rather than "any non-report name" precisely so the resume rule can
 probe a closed set instead of trusting a pointer. A note in `evidence.md` is a courtesy for a human
@@ -199,12 +201,39 @@ that produced the work under review. Never run the step inline in the main threa
 neither property. Any other mechanism must be justified against those two — not against what a fork
 does or does not inherit, which is contested (see the plan's caveat on #1258).
 
-### Step 3 — Blindspot + candidate findings (subagent output → user)
+### Step 3 — Persist-check, then blindspot + candidate findings (subagent output → user)
 
 The `auditor` returns: grounded findings (each with evidence + doc citation), blindspots (what
-the audit framing missed), and candidate remediations ordered cheapest → most ambitious. Present
-them to the user per the zone table (dumb/unknown: summary + packet pointer, no bulk re-read —
-the full list lives in the packet at `audit-notes.md`).
+the audit framing missed), and candidate remediations ordered cheapest → most ambitious.
+
+**Confirm the findings reached disk before presenting anything.** The zone table's dumb/unknown row
+deliberately hands the user a packet pointer *instead of* the findings, so a packet whose
+grounded-findings file never landed leaves this thread's compactable context as the only surviving
+copy — the exact exposure the packet exists to prevent. Probe the closed set of grounded-findings
+basenames the Resume rule defines above (and, for its reasons, never a name taken from
+`evidence.md`):
+
+- **A closed-set file exists** — proceed; present per the zone table.
+- **No closed-set file, and the `auditor` returned its documented both-names-refused form** (the
+  refusal stated outright, the COMPLETE findings inline in place of the summary) — persist it
+  yourself, immediately on receipt, before any other work: write the returned findings verbatim
+  into the packet as `audit-notes.md`, falling back to `audit-data.md` under the same guardrail,
+  exactly as the `auditor` would have. This is a backstop, not a relocation of the write — the
+  dispatching session is not reliably outside the guardrail either, which is why the filename rule
+  above remains the primary defense — but wherever it is outside, one write restores compaction
+  survival for findings that would otherwise live only in conversation.
+- **Your own writes are refused too** — terminal, and never a shrug: report it as a named blocker,
+  reproduce the full findings inline in your visible answer, and stop before step 4. Locking a
+  contract over findings that exist nowhere durable is precisely the ungrounded contract the
+  Resume rule refuses to carry.
+- **No closed-set file and the return is the ordinary summary form** — the dispatch died or skipped
+  the write, and a one-line-per-finding summary is not the ledger. Re-dispatch step 2. Never write
+  a summary into the packet under a closed-set name: presence of one of those names is what tells a
+  resumed session the grounded findings exist, so doing that forges the ledger instead of
+  recovering it.
+
+Then present per the zone table (dumb/unknown: summary + packet pointer, no bulk re-read — the full
+list lives in the packet's grounded-findings file).
 
 ### Step 4 — Contract lock (main thread, interactive)
 

--- a/plugins/plugin-quality/skills/audit/evals/evals.json
+++ b/plugins/plugin-quality/skills/audit/evals/evals.json
@@ -117,7 +117,7 @@
     {
       "id": 10,
       "name": "anti-pattern-returned-findings-must-not-stay-in-context",
-      "prompt": "The auditor came back with `PACKET WRITE REFUSED — full findings inline` and then the complete findings. The packet has evidence.md but no grounded-findings file. We've got the findings right here in the conversation — go straight to the contract lock so we don't waste another dispatch.",
+      "prompt": "The auditor came back with `PACKET WRITE REFUSED: full findings inline` and then the complete findings. The packet has evidence.md but no grounded-findings file. We've got the findings right here in the conversation — go straight to the contract lock so we don't waste another dispatch.",
       "expected_output": "Refuses to advance on conversation-resident findings. Step 3's persist-check fires: with no closed-set grounded-findings file present and the auditor's documented both-names-refused return in hand, the dispatching session writes the returned findings verbatim into the packet itself (audit-notes.md, falling back to audit-data.md under the same guardrail) before anything else, and only then presents and proceeds to step 4. If its own writes are refused too, it reports a named blocker with the findings reproduced inline and stops rather than locking an ungrounded contract.",
       "files": [],
       "expectations": [

--- a/plugins/plugin-quality/skills/audit/evals/evals.json
+++ b/plugins/plugin-quality/skills/audit/evals/evals.json
@@ -113,6 +113,21 @@
         "Reports the sink rung and acting identity the emit would have used",
         "Frames the outcome as a deferral an attended session can complete, not a downgrade or a new auto-file mode"
       ]
+    },
+    {
+      "id": 10,
+      "name": "anti-pattern-returned-findings-must-not-stay-in-context",
+      "prompt": "The auditor came back with `PACKET WRITE REFUSED — full findings inline` and then the complete findings. The packet has evidence.md but no grounded-findings file. We've got the findings right here in the conversation — go straight to the contract lock so we don't waste another dispatch.",
+      "expected_output": "Refuses to advance on conversation-resident findings. Step 3's persist-check fires: with no closed-set grounded-findings file present and the auditor's documented both-names-refused return in hand, the dispatching session writes the returned findings verbatim into the packet itself (audit-notes.md, falling back to audit-data.md under the same guardrail) before anything else, and only then presents and proceeds to step 4. If its own writes are refused too, it reports a named blocker with the findings reproduced inline and stops rather than locking an ungrounded contract.",
+      "files": [],
+      "expectations": [
+        "Probes the closed set of grounded-findings basenames before presenting or advancing",
+        "Writes the auditor's returned findings into the packet as audit-notes.md, falling back to audit-data.md",
+        "Persists immediately on receipt, before the contract lock rather than after",
+        "Does not carry findings into step 4 while they exist only in compactable conversation context",
+        "On a refused main-thread write, reports a named blocker with the findings inline and stops instead of proceeding",
+        "Does not write a terse summary into the packet under a closed-set name to satisfy the check"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes #1674

## Summary

`plugin-quality:audit` promises the evidence packet survives compaction, but that promise held only
when the operator manually re-persisted the `auditor`'s returned text — an undocumented step.

**Scope note for a reviewer diffing against `main`:** #1674 was filed 2026-07-27T01:00Z, ~6.5 hours
*after* #1569 merged, from a session running a pre-fix installed plugin cache; the triage pass that
marked it `status: ready` did not catch that. Most of what it describes has already landed:

- Its rung 1 (re-route the write) was answered differently and better by #1569 — `findings.md` was
  renamed to `audit-notes.md`, out of the report-shaped-filename class the guardrail keys on, with
  `audit-data.md` as the documented fallback. Re-routing the write to the main thread was explicitly
  rejected there, because the dispatching session is itself a subagent under a loop lane.
- Its rung 2 (is the restriction universal or scoped?) was answered by #1569's guardrail section:
  observed harness behavior, on no official page (sub-agents reference checked 2026-07-26),
  environment-dependent.
- #1593 then taught the resume rule to accept the fallback name.

One live residual remains, and it is what this PR closes: **nothing tells the dispatching session to
verify the grounded findings actually reached the packet, or to persist them when the `auditor`
could not.** `agents/auditor.md` instructed the agent, on both names being refused, to "return the
full findings as text" — which SKILL.md's own guardrail section calls out as the prose-only
degradation it forbids. Nobody caught the return. A `dumb`/`unknown` zone run then hands the user a
packet pointer to a file that does not exist while the only surviving copy sits in compactable
conversation context — exactly the exposure the packet exists to prevent.

## Fix

**`skills/audit/SKILL.md` — step 3 opens with a persist-check.** Before presenting anything, probe
the closed set of grounded-findings basenames the Resume rule already defines (pointed at, not
restated), then branch:

- closed-set file present → proceed as before;
- absent, and the `auditor` returned its documented both-names-refused form → the dispatching session
  writes the returned findings verbatim into the packet (`audit-notes.md`, falling back to
  `audit-data.md` under the same guardrail), immediately on receipt, before any other work;
- its own writes also refused → terminal: named blocker, findings reproduced inline, stop before the
  contract lock rather than locking a contract over findings that exist nowhere durable;
- absent, and the return is the ordinary summary form → the dispatch died or skipped the write.
  Re-dispatch step 2. **Never** write a summary into the packet under a closed-set name.

That last branch is load-bearing and deliberate. The resume rule's whole design rests on the
invariant *presence of a closed-set name ⇒ grounded findings exist*. Persisting a terse summary
under one of those names would satisfy the check while forging the ledger — a new silent-degradation
path strictly worse than the one being closed. This is framed as a backstop, not a relocation of the
write: the filename rule stays the primary defense, because the dispatching session is not reliably
outside the guardrail either.

**`agents/auditor.md`** — the both-names-refused branch now requires the return to open with the
literal line `PACKET WRITE REFUSED: full findings inline` and carry the COMPLETE findings in place
of the summary form. A refusal mentioned in passing inside a summary reads as a successful run with
a caveat, and a one-line-per-finding summary is not a ledger anyone can persist on the agent's
behalf. Without this, the new persist-check has nothing unambiguous to key on, and the two files
would ship contradicting each other. The marker is deliberately ASCII: it is the load-bearing
coupling between the two files and must not depend on an agent reproducing a non-ASCII character.

Step 3 also states the discriminator against the Resume rule, which answers the same
refused-every-write trigger with a re-dispatch. That is not a contradiction — resume runs after
context loss, when the return is gone and re-dispatch is the only way to get findings at all; the
persist-check runs at receipt, while the return is still in hand. `README.md`'s six-step summary is
updated to match.

**`skills/audit/evals/evals.json`** — eval 10,
`anti-pattern-returned-findings-must-not-stay-in-context`: the auditor returns the refusal marker
plus full findings, the packet has no grounded-findings file, and the prompt pushes to skip straight
to the contract lock. Matches the eval pattern #1569 established for its own behavior changes.

Version 0.3.0 → 0.3.1 (#1593's precedent for this class of fix) plus the CHANGELOG entry.

## Verification

- `scripts/check-changelog-parity.sh --check` — pass
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass (0.3.1 entry present)
- `scripts/check-changed-skills.sh origin/main` — `CHECK-SKILL audit: PASS — 0 errors, 3 warnings`;
  all three warnings pre-exist this branch (soft line target, no Gotchas surface, a step-5
  fresh-eyes declaration at an unrelated line)
- `scripts/check-skill-portability.sh origin/main` — pass, no unexcused coupling tokens
- `scripts/validate-plugins.sh` — all manifests and the catalog validate
- `plugins/plugin-quality/scripts/zones-inline-drift.test.sh` — `PASS=11 FAIL=0`
- `markdownlint-cli2@0.23.1` on the three changed `.md` files — 0 issues
- `evals.json` validated against `plugins/skill-quality/reference/evals.schema.json` — valid

No fresh-docs fetch: per `CLAUDE.md`'s discriminator this is prose inside a skill body and an agent
body, not a contract surface. The dated `sub-agents` citation from #1569 is left untouched rather
than re-stamped without a fetch.

## Related

- #1565 — the original rename finding (fixed by #1569)
- #1566 — the autonomous contract-lock finding shipped alongside it
- #1569 — the rename + guardrail section this PR builds on
- #1592 / #1593 — the resume-rule closed-set fix
