### PR TITLE
fix(claude-memory): hoist audit pre-compute shell expansion into a bundled script

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.2]
+
+### Fixed
+
+- **The `audit` skill no longer fails to load when invoked from a worktree-isolated agent.** Two
+  `## Pre-computed context` lines resolved the memory dir inline — `d=$(… resolve-memory-dir.sh);
+  ls "$d"/*.md …` — and the harness composes that block into one shell invocation whose
+  worktree-isolation guard refuses any `$` expansion, so the whole skill was refused rather than
+  merely reporting `0`. Both lines now call a bundled `memory-dir-stats.sh` (`--md-count` /
+  `--memory-lines`) through the harness-substituted `${CLAUDE_PLUGIN_ROOT}`, leaving the pre-compute
+  command free of every expansion the guard rejects; the script still resolves the memory dir via
+  the single-source-of-truth `resolve-memory-dir.sh`, reports `0` on every failure path the old
+  fallback covered, and now also survives BSD `wc` padding. Refs #1687.
+
 ## [0.5.1]
 
 ### Fixed

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -12,8 +12,8 @@ metadata:
 
 ## Pre-computed context
 
-Memory files: !`d=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/resolve-memory-dir.sh" 2>/dev/null); ls "$d"/*.md 2>/dev/null | wc -l | tr -d '\r' || echo "0"`
-MEMORY.md lines: !`d=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/resolve-memory-dir.sh" 2>/dev/null); test -f "$d/MEMORY.md" && wc -l < "$d/MEMORY.md" | tr -d '\r' || echo "0"`
+Memory files: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --md-count 2>/dev/null || echo "0"`
+MEMORY.md lines: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --memory-lines 2>/dev/null || echo "0"`
 Rules files: !`find .claude/rules -name "*.md" 2>/dev/null | wc -l | tr -d '\r' || echo "0"`
 CLAUDE.md lines: !`test -f CLAUDE.md && wc -l < CLAUDE.md | tr -d '\r' || echo "0"`
 CLAUDE.local.md exists: !`test -f CLAUDE.local.md && echo "yes" || echo "no"`

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# memory-dir-stats.sh — single-integer auto-memory statistics for the audit skill's
+# `## Pre-computed context` block.
+#
+# Why this exists as a script rather than inline in SKILL.md: the harness composes
+# every `` !`command` `` line of a skill into one shell invocation, and the
+# worktree-isolation Bash guard refuses any command string carrying a shell
+# expansion — `$var`, `$(…)`, `${VAR:-default}`. The stats these lines report need
+# the resolved memory dir, so inline they read
+# `d=$(resolve-memory-dir.sh); ls "$d"/*.md | wc -l`, which the guard rejects and
+# the whole skill then fails to load from an isolated agent (#1687). Hoisting the
+# logic here leaves the pre-compute line free of every `$` except the plugin
+# variables the harness substitutes into literal paths before any shell sees them.
+#
+# The memory dir is resolved by the sibling resolve-memory-dir.sh — this plugin's
+# single source of truth for that resolution — never by re-deriving the slug here.
+#
+# OUTPUT CONTRACT (both stat modes): exactly one integer on stdout, always exit 0.
+# Every failure path — resolver failure, absent memory dir, absent MEMORY.md —
+# reports `0` rather than an error, because the caller is a pre-compute line whose
+# output is injected verbatim into the skill body. A non-zero exit is reserved for
+# a bad or missing mode argument, which prints usage to stderr and nothing to stdout.
+#
+# Usage:
+#   memory-dir-stats.sh --md-count      # count of *.md files in the memory dir
+#   memory-dir-stats.sh --memory-lines  # line count of MEMORY.md (0 when absent)
+#   memory-dir-stats.sh --help
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+memory-dir-stats.sh — emit one auto-memory statistic as a single integer.
+
+Usage: memory-dir-stats.sh (--md-count|--memory-lines|--help)
+
+  --md-count       print the number of *.md files in the current project's memory dir
+  --memory-lines   print the line count of that dir's MEMORY.md (0 when absent)
+  --help           this message
+
+Resolves the memory dir via the sibling resolve-memory-dir.sh. Both stat modes print
+exactly one integer and always exit 0; a bad or missing mode exits 2.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+mode="${1:-}"
+if [[ "$mode" != "--md-count" && "$mode" != "--memory-lines" ]]; then
+  usage >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# No repo guard here: the sibling resolver handles the non-repo case itself (outside a
+# git repo the cwd is the project key, per the memory doc).
+memory_dir=$(bash "$SCRIPT_DIR/resolve-memory-dir.sh" 2>/dev/null)
+
+# An empty resolution would make the glob below expand against the filesystem root.
+if [[ -z "$memory_dir" ]]; then
+  echo "0"
+  exit 0
+fi
+
+if [[ "$mode" == "--md-count" ]]; then
+  # nullglob (the idiom the sibling memory-index-refs-check.sh already uses) so an
+  # empty or absent dir yields an empty array rather than the literal pattern —
+  # and, unlike `ls | wc -l`, cannot fail the pipeline under `pipefail`.
+  shopt -s nullglob
+  files=("$memory_dir"/*.md)
+  shopt -u nullglob
+  printf '%s\n' "${#files[@]}"
+  exit 0
+fi
+
+index="$memory_dir/MEMORY.md"
+if [[ ! -f "$index" ]]; then
+  echo "0"
+  exit 0
+fi
+
+# `wc -l` (newline count) is kept deliberately — the semantics the audit checklist's
+# line budget has always been measured against. tr guards Git Bash CRLF; the
+# arithmetic expansion strips the leading padding BSD `wc` emits on macOS.
+lines=$(wc -l <"$index" | tr -d '\r')
+printf '%s\n' "$((lines))"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Regression tests for memory-dir-stats.sh (self-contained — ships with the plugin).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/memory-dir-stats.sh"
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+FAILED=0
+CASE_NUM=0
+
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  detail: %s\n' "$1" "$2" >&2
+}
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected: $2, actual: $3"; fi
+}
+assert_exit() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected exit $2, got $3"; fi
+}
+assert_contains() {
+  case "$2" in
+  *"$3"*) pass "$1" ;;
+  *) fail "$1" "expected to contain: $3" ;;
+  esac
+}
+
+# Fixture git repos must never inherit an outer hook chain's exported git env.
+make_repo() {
+  unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR
+  mkdir -p "$1"
+  (cd "$1" && git init -q && git config user.email "test@example.com" && git config user.name "test" && git commit -q --allow-empty -m init)
+}
+
+slug_of() {
+  local root
+  root=$(cd "$1" && (cygpath -w "$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" 2>/dev/null ||
+    git rev-parse --show-toplevel 2>/dev/null | tr -d '\r'))
+  printf '%s' "$root" | sed 's/[:\\/.]/-/g'
+}
+
+REPO="$TEST_TMPDIR/repo"
+make_repo "$REPO"
+SLUG=$(slug_of "$REPO")
+
+# mem_dir_for <home> — create + echo the memory dir the resolver will pick for that HOME.
+mem_dir_for() {
+  local dir="$1/.claude/projects/$SLUG/memory"
+  mkdir -p "$dir"
+  printf '%s' "$dir"
+}
+
+# CLAUDE_CONFIG_DIR is unset per-run: the resolver honors it over $HOME, so leaving an
+# ambient value in place would let the host machine's real config answer for the fixture.
+run() { (cd "$REPO" && env -u CLAUDE_CONFIG_DIR HOME="$1" bash "$SCRIPT" "$2"); }
+
+# --- Case 1: --help ---
+rc=0
+OUT=$(bash "$SCRIPT" --help) || rc=$?
+assert_exit "--help exits 0" 0 "$rc"
+assert_contains "--help prints usage" "$OUT" "Usage:"
+
+# --- Case 2: bad flag and missing mode -> usage on stderr, exit 2, empty stdout ---
+rc=0
+OUT=$(bash "$SCRIPT" --bogus 2>"$TEST_TMPDIR/err") || rc=$?
+assert_exit "bad flag exits 2" 2 "$rc"
+assert_eq "bad flag prints nothing on stdout" "" "$OUT"
+assert_contains "bad flag prints usage on stderr" "$(cat "$TEST_TMPDIR/err")" "Usage:"
+rc=0
+OUT=$(bash "$SCRIPT" 2>/dev/null) || rc=$?
+assert_exit "missing mode exits 2" 2 "$rc"
+assert_eq "missing mode prints nothing on stdout" "" "$OUT"
+
+# --- Case 3: --md-count with N md files (MEMORY.md included, as the old inline `ls *.md` counted it) ---
+H3="$TEST_TMPDIR/h3"
+M3=$(mem_dir_for "$H3")
+printf '# Index\n' >"$M3/MEMORY.md"
+printf 'a\n' >"$M3/a.md"
+printf 'b\n' >"$M3/b.md"
+printf 'not markdown\n' >"$M3/notes.txt"
+rc=0
+OUT=$(run "$H3" --md-count) || rc=$?
+assert_exit "--md-count exits 0" 0 "$rc"
+assert_eq "--md-count counts every *.md (MEMORY.md + 2 topics)" "3" "$OUT"
+
+# --- Case 4: --memory-lines with MEMORY.md present ---
+printf 'one\ntwo\nthree\n' >"$M3/MEMORY.md"
+rc=0
+OUT=$(run "$H3" --memory-lines) || rc=$?
+assert_exit "--memory-lines exits 0" 0 "$rc"
+assert_eq "--memory-lines counts MEMORY.md lines" "3" "$OUT"
+
+# --- Case 5: fresh project — no memory dir at all: both modes report 0, exit 0 ---
+H5="$TEST_TMPDIR/h5"
+mkdir -p "$H5"
+rc=0
+OUT=$(run "$H5" --md-count) || rc=$?
+assert_exit "absent memory dir --md-count exits 0" 0 "$rc"
+assert_eq "absent memory dir --md-count == 0" "0" "$OUT"
+rc=0
+OUT=$(run "$H5" --memory-lines) || rc=$?
+assert_exit "absent MEMORY.md exits 0" 0 "$rc"
+assert_eq "absent MEMORY.md --memory-lines == 0" "0" "$OUT"
+
+# --- Case 6: memory dir exists but is empty (no MEMORY.md) ---
+H6="$TEST_TMPDIR/h6"
+mem_dir_for "$H6" >/dev/null
+assert_eq "empty memory dir --md-count == 0" "0" "$(run "$H6" --md-count)"
+assert_eq "empty memory dir --memory-lines == 0" "0" "$(run "$H6" --memory-lines)"
+
+# --- Case 7: output contract — a single bare integer, nothing else, for every stat mode ---
+for m in --md-count --memory-lines; do
+  OUT=$(run "$H3" "$m")
+  if [[ "$OUT" =~ ^[0-9]+$ ]]; then
+    pass "$m emits exactly one bare integer"
+  else
+    fail "$m emits exactly one bare integer" "got: [$OUT]"
+  fi
+done
+
+if [[ "$FAILED" -eq 0 ]]; then
+  printf '\nAll %d checks passed.\n' "$CASE_NUM"
+  exit 0
+fi
+printf '\n%d/%d checks failed.\n' "$FAILED" "$CASE_NUM" >&2
+exit 1


### PR DESCRIPTION
## Summary

`claude-memory:audit`'s `## Pre-computed context` lines 15–16 each carried a
`d=$(bash … resolve-memory-dir.sh)` assignment plus command substitution. The harness composes a
skill's pre-compute block into one shell invocation, and the worktree-isolation Bash guard refuses
any genuine `$` expansion — so the whole block, and with it the skill, fails to load when `audit` is
invoked from a worktree-isolated agent. It did not degrade to the `0` fallback; it was refused
outright.

Both lines now call a new bundled `plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh`:

```text
Memory files: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --md-count 2>/dev/null || echo "0"`
MEMORY.md lines: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --memory-lines 2>/dev/null || echo "0"`
```

No `$` remains in either command string beyond `${CLAUDE_PLUGIN_ROOT}`, which the harness
substitutes into a literal path before any shell sees it. `$` inside the script file is
unrestricted.

The script resolves the memory dir by calling the sibling `resolve-memory-dir.sh` — this plugin's
single source of truth for that resolution — never by re-deriving the slug. Its output contract is
stated in the header and asserted in the tests: both stat modes print **exactly one integer and
always exit 0**, including on resolver failure, absent memory dir, and absent `MEMORY.md`; exit 2
(usage to stderr, empty stdout) is reserved for a bad or missing mode. That matters because the
injected stdout lands verbatim in the skill body, and a print-then-fail would append a second line
from the call site's `|| echo "0"`.

Only lines 15–16 changed. Lines 20–21 already use the recorded-PASS `bash "<literal path>" || echo`
form and are untouched; the line label text is byte-identical.

Fresh-docs check (repo CLAUDE.md fresh-docs mandate; both fetched this session):

- <https://code.claude.com/docs/en/skills> — "Inject dynamic context": "The `` !`<command>` `` syntax
  runs shell commands before the skill content is sent to Claude. The command output replaces the
  placeholder, so Claude receives actual data, not the command itself… Each `` !`<command>` ``
  executes immediately (before Claude sees anything)… This is preprocessing, not something Claude
  executes." The same page's frontmatter table documents `shell` as "Shell to use for
  `` !`command` `` and ` ```! ` blocks in this skill" (`bash` default) — this skill declares
  `shell: bash`. The page contains **no** mention of `CLAUDE_PLUGIN_ROOT`.
- <https://code.claude.com/docs/en/plugins-reference> — the path-substitution table gives
  `${CLAUDE_PLUGIN_ROOT}` = "Absolute path to the plugin's installation directory", and the
  component table's row "Skill and agent content | Anywhere the placeholder appears" is what makes
  the placeholder resolve inside a pre-compute line. That is the half the skills page does not
  cover, so it is cited separately rather than attributed to one page.

Version: `claude-memory` 0.5.1 → 0.5.2, with a matching `## [0.5.2]` `### Fixed` CHANGELOG entry.

## Test plan

Gates run from the worktree root, all passing:

| Gate | Result |
| --- | --- |
| `bash scripts/check-changelog-parity.sh --check-bump origin/main` | PASS |
| `bash scripts/check-changed-skills.sh origin/main` | PASS — 0 errors, 1 warning, pre-existing (no Gotchas surface); it also ran the new script test |
| `bash scripts/check-skill-portability.sh origin/main` | PASS — no unexcused coupling tokens in 2 skill files |
| `bash scripts/check-shell-portability.sh --paths …/memory-dir-stats.sh …/memory-dir-stats.test.sh` | PASS — no unexcused GNU-only constructs |
| `npx --yes markdownlint-cli2 "plugins/claude-memory/**/*.md"` | PASS — 0 errors, 14 files |
| `shellcheck --rcfile=.shellcheckrc` on both new scripts | clean |
| `shfmt -d` on both new scripts | clean |
| `bash plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh` | 19/19 checks pass |

`check-skill-portability.sh` invoked bare exits 2 with a usage message — it requires
`<base-ref> | --all | --paths FILE...`. It was re-run as `check-skill-portability.sh origin/main`,
which is byte-for-byte the form `.github/workflows/ci.yml:876` uses
(`scripts/check-skill-portability.sh "origin/$BASE_REF"`). Nothing was suppressed.

Behavioral equivalence, checked by hand in a fixture repo — the old inline commands and the new
script were each run and their stdout compared:

```text
--- WITH auto-memory (MEMORY.md 4 lines + a.md + b.md + c.txt) ---
OLD md-count : 3     NEW md-count : 3
OLD mem-lines: 4     NEW mem-lines: 4
--- WITHOUT auto-memory (fresh HOME) ---
OLD md-count : 0     NEW md-count : 0
OLD mem-lines: 0     NEW mem-lines: 0
```

Also sanity-run directly against two real repos on this machine that have no auto-memory written
(`0` / `0`, matching the old fallback). No repo on this machine currently has a real `MEMORY.md`, so
the non-zero path is exercised through fixture `HOME`s rather than by writing into
`~/.claude/projects/**`.

`memory-dir-stats.test.sh` follows the sibling `memory-index-refs-check.test.sh` harness pattern and
is fully offline. It covers: `--help`; a bad flag and a missing mode, each exit 2 with usage on
stderr and **empty stdout**; `--md-count` with N `.md` files plus a non-`.md` file that must not be
counted (`MEMORY.md` is counted, as the old `ls *.md` counted it); `--memory-lines` with `MEMORY.md`
present; both modes with no memory dir at all and with an empty memory dir; and a contract assertion
that each stat mode emits exactly one bare integer. `run()` unsets `CLAUDE_CONFIG_DIR` per case —
the resolver honors it over `$HOME`, so an ambient value would otherwise let the host's real config
answer for the fixture. `scripts/run-plugin-tests.sh` discovers tests with
`find plugins -type f -name '*.test.sh'`, so this file runs in CI without registration.

One incidental fidelity gain, flagged rather than claimed as a fixed bug: under `set -o pipefail`
the old `--md-count` form emitted **two** lines when the memory dir was absent (`wc -l` printed `0`,
then the failed pipeline tripped `|| echo "0"`), injecting `0\n0` into the skill body. Reproduced
here. Without `pipefail` it emitted one line, so whether this was ever user-visible depends on the
harness's shell options. The new always-exit-0 contract emits exactly one integer either way.

### Residual risk — what is NOT proven here

- The replacement form `bash "<literal path>" || echo` is a **recorded PASS class** in #1687's probe
  tables. The removed `d=$(…)` form is a **confirmed REFUSED class** — `claude-memory:audit` was the
  CONFIRMED Class 2 case in that investigation.
- CI never invokes a skill from an isolated agent, so nothing in this PR's gates proves the fix
  end-to-end.
- The plugin cache is version-keyed, so the edited skill cannot be invoked until this merges and
  plugins update. End-to-end proof is post-merge, per #1687's closure criterion: invoke the fixed
  skill from an `Agent` with `isolation: "worktree"`, with a negative control predicted to still
  refuse.
- **Adjacent surface deliberately left unfixed.** `skills/audit/context/audit.md:20` and
  `skills/audit/context/fix.md:88` still instruct the model to run
  `MEMORY_DIR=$(bash "${CLAUDE_PLUGIN_ROOT}/…/resolve-memory-dir.sh")` — the same `$(…)` shape the
  guard refuses, but as a normal Bash tool call the model makes mid-skill, not as a pre-compute
  line. This PR is scoped to the pre-compute block, so those are untouched and a worktree-isolated
  `audit` run would still be blocked at that step. Flagging it as a real gap in #1687's coverage
  rather than silently widening this PR.
- The `$((lines))` BSD-`wc`-padding strip is asserted by reasoning, not by an automated case — no
  Linux/Git Bash runner can produce BSD `wc` output. Noted by the CI review agent as well.
- This is one of five partial PRs on #1687. It deliberately carries no closing keyword so a partial
  merge cannot auto-close the tracker; the tracker closes only after all five merge and post-ship
  verification passes.

## Related

No linked issue

Refs #1687
Refs #1619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C
