### PR TITLE
fix(review): hoist fanout pre-compute diff probe into a bundled script

### DIFF
--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.4]
+
+### Fixed
+
+- `fanout`'s pre-computed committed-diff-size probe no longer fails to load the skill from a
+  worktree-isolated agent. The harness composes a skill's `## Pre-computed context` lines into one
+  shell invocation, and the worktree-isolation Bash guard refuses any genuine `$` expansion — the
+  line's `D="$(git ls-remote …)"` assignment and command substitution were therefore enough to make
+  the whole block, and with it the skill, refuse to load. The fallback chain moves verbatim into a
+  bundled `skills/fanout/scripts/diff-vs-base.sh` invoked through `${CLAUDE_PLUGIN_ROOT}`, which the
+  harness substitutes into a literal path before any shell sees it; `$` inside the script file is
+  unrestricted. Behavior is unchanged, including the `git fetch origin <default-branch>` side effect
+  and the distinction between an empty resolved range (prints nothing) and no resolvable base
+  (prints `unavailable`). The line's awk `$2` was probed and is not a trigger, so it stays. Covered
+  by `diff-vs-base.test.sh` across all four branches of the chain (#1687).
+
 ## [0.15.3]
 
 ### Fixed

--- a/plugins/review/skills/fanout/SKILL.md
+++ b/plugins/review/skills/fanout/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
 Working tree status: !`git status --porcelain 2>/dev/null | head -20 || echo "unavailable"`
 Open PRs (match headRefName to current branch above; baseRefName is the PR's real base): !`gh pr list --json number,title,headRefName,baseRefName --limit 10 2>/dev/null || echo "unknown"`
-Committed diff size vs default-base merge base (recompute against the PR's baseRefName when it differs): !`git diff --shortstat origin/HEAD...HEAD 2>/dev/null || { D="$(git ls-remote --symref --end-of-options origin HEAD 2>/dev/null | awk '/^ref:/{sub(/refs\/heads\//,"",$2); print $2; exit}')"; [ -n "$D" ] && git fetch origin "$D" 2>/dev/null && git diff --shortstat FETCH_HEAD...HEAD 2>/dev/null; } || git diff --shortstat origin/main...HEAD 2>/dev/null || echo "unavailable"`
+Committed diff size vs default-base merge base (recompute against the PR's baseRefName when it differs): !`bash "${CLAUDE_PLUGIN_ROOT}/skills/fanout/scripts/diff-vs-base.sh" 2>/dev/null || echo "unavailable"`
 Uncommitted diff size: !`git diff --shortstat HEAD 2>/dev/null || echo "unavailable"`
 
 ## Purpose

--- a/plugins/review/skills/fanout/scripts/diff-vs-base.sh
+++ b/plugins/review/skills/fanout/scripts/diff-vs-base.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Print `git diff --shortstat` for the committed range between the remote's default
+# branch and HEAD, walking a fallback chain until one range resolves.
+#
+# Why this is a script and not an inline pre-compute line: the fanout skill's
+# `## Pre-computed context` block composes its ` !`cmd` ` lines into one shell
+# invocation, and the worktree-isolation Bash guard refuses any genuine `$`
+# expansion — a `$local` assignment or `$(…)` substitution makes the whole block,
+# and therefore the skill, fail to load from an isolated agent (#1687). Plugin
+# variables are substituted by the harness into literal paths before a shell sees
+# them, so `bash "${CLAUDE_PLUGIN_ROOT}/…/diff-vs-base.sh"` is guard-safe while the
+# same logic inline is not. Inside this file `$` is free.
+#
+# Usage (from anywhere inside the target repository — the caller's cwd is the repo):
+#   bash "${CLAUDE_PLUGIN_ROOT}/skills/fanout/scripts/diff-vs-base.sh"
+#
+# Output: one `git diff --shortstat` line on stdout, or `unavailable` when no
+# candidate base resolves. A range that resolves but is empty prints NOTHING —
+# `git diff` exits 0 with no output when there is no difference, and the caller
+# must be able to tell "no committed changes" from "no base to compare against".
+#
+# Exit code is 0 on every path, including `unavailable`, so the call site's
+# `|| echo "unavailable"` fires only when this file is missing or unreadable.
+
+# `set -e` omitted deliberately: the fallback chain advances on non-zero exit from
+# each `git diff` attempt, and `set -e` would abort at the first one.
+set -uo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'EOF'
+diff-vs-base.sh — print `git diff --shortstat` for HEAD vs the remote's default branch.
+
+Usage:
+  diff-vs-base.sh [--help]
+
+Operates on the current repository (cwd) and walks a fallback chain of candidate
+base refs, so it may fetch the remote's default branch as a side effect.
+
+Prints the first `--shortstat` line that resolves; nothing when a range resolves
+but is empty; `unavailable` when none does. Always exits 0.
+EOF
+  exit 0
+fi
+
+git diff --shortstat origin/HEAD...HEAD 2>/dev/null && exit 0
+
+# The remote's own symbolic HEAD, for clones whose refs/remotes/origin/HEAD was
+# never set locally. The fetch is a pre-existing side effect of this probe: it is
+# what makes FETCH_HEAD point at the default branch.
+default_branch=$(git ls-remote --symref --end-of-options origin HEAD 2>/dev/null |
+  awk '/^ref:/{sub(/refs\/heads\//,"",$2); print $2; exit}')
+
+if [[ -n "$default_branch" ]] &&
+  git fetch origin "$default_branch" 2>/dev/null &&
+  git diff --shortstat FETCH_HEAD...HEAD 2>/dev/null; then
+  exit 0
+fi
+
+# portability-ok: last rung of a detection-first ladder — reached only after the
+# origin/HEAD range and the `git ls-remote --symref` resolution above have both
+# failed, which is the split-across-lines shape the branch-coupling gate exempts
+# per-site rather than by co-located evidence.
+git diff --shortstat origin/main...HEAD 2>/dev/null && exit 0
+
+echo "unavailable"

--- a/plugins/review/skills/fanout/scripts/diff-vs-base.test.sh
+++ b/plugins/review/skills/fanout/scripts/diff-vs-base.test.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Regression tests for diff-vs-base.sh (self-contained, offline — ships with the plugin).
+#
+# Every fixture is a local repo whose "remote" is a bare repo on disk, so no
+# network is touched. Branch names are explicit (never init.defaultBranch) and the
+# non-`main` fixtures make the assertions unambiguous about WHICH fallback ran.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/diff-vs-base.sh"
+
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+FAILED=0
+CASE_NUM=0
+
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  detail: %s\n' "$1" "$2" >&2
+}
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected: [$2], actual: [$3]"; fi
+}
+assert_exit() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected exit $2, got $3"; fi
+}
+assert_contains() {
+  case "$2" in
+  *"$3"*) pass "$1" ;;
+  *) fail "$1" "expected to contain: $3" ;;
+  esac
+}
+
+# Fixture repos must never inherit an outer hook chain's exported git env.
+git_env_reset() { unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR; }
+
+# make_fixture <name> <branch> — bare origin whose HEAD is <branch>, plus a clone-ish
+# work repo one commit ahead of the pushed tip. Echoes the work-repo path.
+make_fixture() {
+  local name="$1" branch="$2"
+  local bare="$TEST_TMPDIR/$name.git" work="$TEST_TMPDIR/$name"
+  git_env_reset
+  git init -q --bare "$bare"
+  git -C "$bare" symbolic-ref HEAD "refs/heads/$branch"
+  mkdir -p "$work"
+  git -C "$work" init -q
+  git -C "$work" config user.email "test@example.com"
+  git -C "$work" config user.name "test"
+  # Fixtures must not inherit a developer's global core.autocrlf: it makes git warn
+  # about LF->CRLF rewrites and would change the byte counts these cases assert on.
+  git -C "$work" config core.autocrlf false
+  git -C "$work" checkout -q -b "$branch"
+  printf 'base\n' >"$work/base.txt"
+  git -C "$work" add base.txt
+  git -C "$work" commit -q -m base
+  git -C "$work" remote add origin "$bare"
+  git -C "$work" push -q origin "$branch"
+  printf '%s\n' "$work"
+}
+
+add_commit_ahead() {
+  printf 'one\ntwo\nthree\n' >"$1/ahead.txt"
+  git -C "$1" add ahead.txt
+  git -C "$1" commit -q -m ahead
+}
+
+# Git >= 2.49 may create refs/remotes/origin/HEAD on fetch/push
+# (remote.<name>.followRemoteHEAD defaults to "create"), so the fallback fixtures
+# clear it explicitly rather than assuming it was never written.
+drop_origin_head() { git -C "$1" symbolic-ref -q -d refs/remotes/origin/HEAD >/dev/null 2>&1 || true; }
+
+run_in() { (cd "$1" && git_env_reset && bash "$SCRIPT"); }
+
+# --- Case 1: --help ---
+rc=0
+OUT=$(bash "$SCRIPT" --help) || rc=$?
+assert_exit "--help exits 0" 0 "$rc"
+assert_contains "--help prints usage" "$OUT" "Usage:"
+
+# --- Case 2: origin/HEAD resolves (first branch of the chain) ---
+W2=$(make_fixture case2 trunk)
+git -C "$W2" remote set-head origin -a >/dev/null 2>&1
+add_commit_ahead "$W2"
+rc=0
+OUT=$(run_in "$W2") || rc=$?
+assert_exit "origin/HEAD path exits 0" 0 "$rc"
+assert_contains "origin/HEAD path reports the changed file" "$OUT" "1 file changed"
+assert_contains "origin/HEAD path reports the insertions" "$OUT" "3 insertions"
+
+# --- Case 3: range resolves but is empty -> prints NOTHING, not "unavailable" ---
+W3=$(make_fixture case3 trunk)
+git -C "$W3" remote set-head origin -a >/dev/null 2>&1
+rc=0
+OUT=$(run_in "$W3") || rc=$?
+assert_exit "empty range exits 0" 0 "$rc"
+assert_eq "empty range prints nothing" "" "$OUT"
+
+# --- Case 4: no origin/HEAD -> ls-remote --symref resolves the default branch ---
+# The default branch is `trunk`, so `origin/main` cannot satisfy this case.
+W4=$(make_fixture case4 trunk)
+drop_origin_head "$W4"
+add_commit_ahead "$W4"
+rc=0
+OUT=$(run_in "$W4") || rc=$?
+assert_exit "ls-remote path exits 0" 0 "$rc"
+assert_contains "ls-remote path reports the changed file" "$OUT" "1 file changed"
+
+# --- Case 5: no origin/HEAD and an unreachable remote -> origin/main fallback ---
+W5=$(make_fixture case5 main)
+drop_origin_head "$W5"
+add_commit_ahead "$W5"
+git -C "$W5" remote set-url origin "$TEST_TMPDIR/no-such-remote.git"
+rc=0
+OUT=$(run_in "$W5") || rc=$?
+assert_exit "origin/main path exits 0" 0 "$rc"
+assert_contains "origin/main path reports the changed file" "$OUT" "1 file changed"
+
+# --- Case 6: nothing resolves -> "unavailable", still exit 0 ---
+W6="$TEST_TMPDIR/case6"
+git_env_reset
+mkdir -p "$W6"
+git -C "$W6" init -q
+git -C "$W6" config user.email "test@example.com"
+git -C "$W6" config user.name "test"
+git -C "$W6" config core.autocrlf false
+git -C "$W6" commit -q --allow-empty -m init
+rc=0
+OUT=$(run_in "$W6") || rc=$?
+assert_exit "no-base path exits 0" 0 "$rc"
+assert_eq "no-base path prints unavailable" "unavailable" "$OUT"
+
+if [[ "$FAILED" -eq 0 ]]; then
+  printf '\nAll %d checks passed.\n' "$CASE_NUM"
+  exit 0
+fi
+printf '\n%d/%d checks failed.\n' "$FAILED" "$CASE_NUM" >&2
+exit 1


### PR DESCRIPTION
No linked issue

## Summary

`review:fanout`'s `## Pre-computed context` line 18 carried a `D="$(git ls-remote --symref … )"`
assignment plus command substitution. The harness composes a skill's pre-compute block into one
shell invocation, and the worktree-isolation Bash guard refuses any genuine `$` expansion — so the
whole block, and with it the skill, fails to load when `fanout` is invoked from a worktree-isolated
agent.

The fallback chain moves verbatim into a new bundled `plugins/review/skills/fanout/scripts/diff-vs-base.sh`,
invoked as `bash "${CLAUDE_PLUGIN_ROOT}/skills/fanout/scripts/diff-vs-base.sh" 2>/dev/null || echo "unavailable"`.
`$` inside the script file is unrestricted.

Behavior is intentionally unchanged, including:

- the `git fetch origin <default-branch>` side effect (pre-existing; neither added nor removed);
- the four rungs in order — `origin/HEAD...HEAD`, then `FETCH_HEAD...HEAD` after the same
  `git ls-remote --symref` + awk resolution, then `origin/main...HEAD`, then `unavailable`;
- the distinction between a range that resolves but is empty (prints **nothing**, because
  `git diff --shortstat` exits 0 with no output) and no resolvable base (prints `unavailable`).
  The `||` chain advances on exit status, never on emptiness.

The script exits 0 on every path including `unavailable`, so the call site's `|| echo "unavailable"`
fires only if the file is missing or unreadable.

Only line 18 changed. Lines 15–17 and 19 are recorded PASS classes and are untouched. The line label
text is byte-identical.

Fresh-docs check (repo CLAUDE.md fresh-docs mandate; both fetched this session):

- <https://code.claude.com/docs/en/skills> — "The `` !`<command>` `` syntax runs shell commands
  before the skill content is sent to Claude. The command output replaces the placeholder, so Claude
  receives actual data, not the command itself." The page documents the injection mechanic but
  contains **no** mention of `CLAUDE_PLUGIN_ROOT`.
- <https://code.claude.com/docs/en/plugins-reference> — the path-substitution table gives
  `${CLAUDE_PLUGIN_ROOT}` = "Absolute path to the plugin's installation directory", and the
  component table's row "Skill and agent content | Anywhere the placeholder appears" is what makes
  the placeholder resolve inside a pre-compute line. That is the half the skills page does not
  cover, so it is cited separately rather than attributed to one page.

Version: `review` 0.15.3 → 0.15.4, with a matching `## [0.15.4]` `### Fixed` CHANGELOG entry.

## Test plan

Gates run from the worktree root, all passing:

| Gate | Result |
| --- | --- |
| `bash scripts/check-changelog-parity.sh --check-bump origin/main` | PASS |
| `bash scripts/check-changed-skills.sh origin/main` | PASS — 0 errors, 3 warnings, all pre-existing (no Gotchas surface, no `Use when:` phrasing, fix-pass-mode fresh-eyes hand-verify); it also ran the new script test |
| `bash scripts/check-skill-portability.sh origin/main` | PASS (see note below) |
| `bash scripts/check-shell-portability.sh --paths …/diff-vs-base.sh …/diff-vs-base.test.sh` | PASS |
| `npx --yes markdownlint-cli2 "plugins/review/**/*.md"` | PASS — 0 errors, 27 files |
| `shellcheck` on both new scripts | clean |
| `shfmt -d` on both new scripts | clean |
| `bash plugins/review/skills/fanout/scripts/diff-vs-base.test.sh` | 13/13 checks pass |

Portability-gate note, stated plainly rather than buried: `check-skill-portability.sh` first FAILED
on the new file's `origin/main` last-resort ref (the gate's branch-coupling class). It was resolved
two ways, neither of them a suppression: the `--help` text no longer restates the ladder (that copy
duplicated the file-header comment and was the second hit), and the remaining hit carries the gate's
own documented per-site `portability-ok:` escape with the reason recorded at the site. The gate's
header explicitly designates that escape for "a legitimately split-across-lines ladder", which is
exactly this shape — the resolution evidence is on the lines above, where the gate's same-line
detector cannot see it. No token list, baseline, or gate logic was edited.

Behavioral equivalence, checked by hand in the worktree: the old inline pipeline and the new script
were each run and their stdout diffed, byte-identical in both fixture states — with
`refs/remotes/origin/HEAD` present (rung 1) and with it deleted (rung 2). Both also matched on the
empty-range case before any commit existed, where both correctly printed nothing.

Because a live run in a normal clone only ever exercises rung 1, `diff-vs-base.test.sh` covers all
four offline with local bare-repo fixtures: rung 1 via `git remote set-head origin -a`; rung 2 with
`refs/remotes/origin/HEAD` deleted and a non-`main` default branch, so `origin/main` cannot satisfy
it; rung 3 with the remote URL pointed at a nonexistent path so `ls-remote` fails while
`origin/main` still resolves locally; rung 4 in a repo with no remote. Plus `--help`, and an
explicit assertion that the empty-range case prints the empty string rather than `unavailable`.
Fixtures pin `core.autocrlf false` and use explicit branch names, never `init.defaultBranch`.
`scripts/run-plugin-tests.sh` auto-discovers `plugins/**/*.test.sh`, so this runs in CI; it is fully
offline.

### Residual risk — what is NOT proven here

- The replacement form `bash "<literal path>" || echo` is a **recorded PASS class** in #1687's probe
  tables (`claude-config:audit-automation-gaps` ships the same shape and was observed loading under
  isolation with real script output, not its fallback). `$D=$(…)` forms are **confirmed REFUSED**.
  The awk `$2` on the old line was explicitly probed and **PASSES**, so it was never the trigger and
  was carried over unchanged.
- Those probes exercise the worktree-isolation Bash guard on standalone Bash calls. Pre-compute
  injection at skill-load time is a different execution path none of them can drive.
- CI never invokes a skill from an isolated agent, so nothing in this PR's gates proves the fix
  end-to-end.
- The plugin cache is version-keyed, so the edited skill cannot be invoked until this merges and
  plugins update. End-to-end proof is post-merge, per #1687's closure criterion: invoke the fixed
  skill from an `Agent` with `isolation: "worktree"`, with a negative control predicted to still
  refuse.
- This is one of five partial PRs on #1687. It deliberately carries no closing keyword so a partial
  merge cannot auto-close the tracker again; the tracker closes manually after all five merge and
  post-ship verification passes.

## Related

Refs #1687
Refs #1619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C
