### PR TITLE
ci: honor -- end-of-options in shell-portability-lint via a word layer

### DIFF
--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -778,8 +778,11 @@ scan_file() {
     # (the bare regex-escape classes, a literal `--perl-regexp`) never demote:
     # their match ends in the same word it starts in, or in a word that does
     # not unquote to an option, and `--` does not un-GNU a regex operand.
-    function dashdash_demoted(view, m, at, matchend,   ce, pe, os, oe) {
-      pe = matchend
+    # On demotion DD_OS holds the start offset of the demoted word so the
+    # caller can discard the tail alone — the greedy gap can carry one match
+    # THROUGH the marker, and an option before it is still real.
+    function dashdash_demoted(view, m, at, mend,   ce, pe, os, oe) {
+      pe = mend
       while (pe > at && is_wordbreak(substr(m, pe, 1))) pe--
       ce = word_end(m, at)
       if (pe <= ce) return 0
@@ -787,6 +790,7 @@ scan_file() {
       if (os <= ce + 1) return 0
       oe = word_end(m, pe)
       if (unquote_word(substr(view, os, oe - os + 1)) !~ /^-/) return 0
+      DD_OS = os
       return dashdash_between(view, m, ce + 1, os - 1)
     }
     # fallback_proven — is the BSD-side `-f` of the ladder PROVEN to be an
@@ -817,8 +821,9 @@ scan_file() {
     # Every rejection here is an over-flag with the one-line
     # `portability-ok:` escape; accepting any of them ships a GNU-only call
     # whose "fallback" cannot run.
-    function fallback_proven(q, m, opos, os, oe,   i, c, w, uw, phase, j) {
+    function fallback_proven(q, m, opos, os, oe,   i, c, w, uw, phase, j, wantarg) {
       phase = 0
+      wantarg = 0
       w = ""
       i = opos + 2
       while (i < os) {
@@ -833,13 +838,20 @@ scan_file() {
         if (is_wordbreak(c)) {
           if (w != "") {
             uw = unquote_word(w)
-            if (uw == "--") return 0
-            if (phase == 0) {
+            if (wantarg) {
+              # The previous word was a cluster whose detached `-t`/`-f`
+              # takes an argument: THIS word is that argument, not an
+              # operand and not an end-of-options marker, so
+              # `|| stat -t "%Y" -f "%z"` stays a real ladder.
+              wantarg = 0
+            } else if (uw == "--") return 0
+            else if (phase == 0) {
               # Before the command word only the shapes CMDPOS admitted can
               # appear — assignments, wrappers, group openers — so nothing
               # here is an operand of the stat call yet.
               if (uw ~ /(^|\/)stat$/) phase = 1
             } else if (uw !~ /^-/) return 0
+            else if (uw ~ /^-[FHhLlnqrsx]*[ft]$/) wantarg = 1
           }
           w = ""
           i++
@@ -848,6 +860,10 @@ scan_file() {
         w = w substr(q, i, 1)
         i++
       }
+      # A pending detached argument swallows the final word itself:
+      # `|| stat -t -f "%z"` hands `-f` to `-t` as its timefmt, so the
+      # ladder ends in an argument, not an option BSD getopt parses.
+      if (wantarg) return 0
       uw = unquote_word(substr(q, os, oe - os + 1))
       if (uw !~ /^-[FHhLlnqrsx]*f/) return 0
       if (substr(uw, index(uw, "f") + 1) != "") return 1
@@ -1088,8 +1104,15 @@ scan_file() {
         # A `--` word inside this invocation demotes the matched option to an
         # operand (dashdash_demoted); a demoted occurrence is discarded and
         # matching RESUMES, exactly as it does past a guarded one, so a later
-        # real invocation on the same record is still evaluated.
-        if (!dashdash_demoted(view, m, at, st + len - 1) && !is_guarded(q, p, at, m)) return at
+        # real invocation on the same record is still evaluated. Only the
+        # demoted word onward is discarded: the greedy gap can extend one
+        # match through the marker (`grep -P pattern -- -P`), and the real
+        # option before the marker must stay visible to the next match.
+        if (dashdash_demoted(view, m, at, st + len - 1)) {
+          scan = substr(scan, 1, DD_OS - 1) blanks(st + len - DD_OS) substr(scan, st + len)
+          continue
+        }
+        if (!is_guarded(q, p, at, m)) return at
         scan = substr(scan, 1, st - 1) blanks(len) substr(scan, st + len)
       }
       return 0

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -65,11 +65,13 @@
 # a string literal is the whole mechanism behind the regex-escape classes,
 # where `grep -E "\bword"` lives inside quotes and MUST still be caught.
 # Requiring command position for the option-based classes alone would need a
-# per-class axis in the token data plus word-level tokenization (#1562), and
-# every partial answer to it trades this false positive for a fail-OPEN — the
-# same trade already made and withdrawn for `--` (recorded above
-# collapse_subs()), which is the direction this gate is explicitly tuned
-# against. `portability-ok: <reason>` is the one-line escape for a diagnostic
+# per-class axis in the token data on top of the word layer (#1551), and every
+# partial answer to it trades this false positive for a fail-OPEN — the
+# direction this gate is explicitly tuned against. The word layer's first
+# consumer, `--` end-of-options (#1562, recorded above dashdash_between()),
+# shows the cost of doing it right: suppression fires on nothing weaker than a
+# statically unambiguous marker word inside the matched extent.
+# `portability-ok: <reason>` is the one-line escape for a diagnostic
 # or example that names one of these utilities.
 # Guard markers are seeded for the one class that needs one today
 # (readlink -f, requiring an actual `||` fallback relationship with a
@@ -617,21 +619,248 @@ scan_file() {
       }
       return r
     }
-    # `--` (end-of-options) is deliberately NOT honored — `stat -- -c` and
-    # `date -- -d` are reported even though the flag-shaped word after the
-    # marker is an operand. This is the documented over-flag direction, and
-    # `portability-ok: <reason>` is the one-line escape.
+    # ---- Word layer (#1551 stage 1) ----
+    # The mask decides which CHARACTER is quoted; these functions decide which
+    # run of characters is one shell WORD and what that word becomes after
+    # quote removal (2.6.7). They are the first slice of the word-aware layer
+    # #1551 records: word delimitation reads the MASK (a quoted space never
+    # splits a word, a masked separator never splits a command), and quote
+    # removal runs on the word text alone, which starts in the unquoted state
+    # by construction — its left boundary is structural.
     #
-    # It was implemented and withdrawn. Honoring it correctly needs the marker
-    # scoped to the invocation that owns it, resumed matching after a discarded
-    # occurrence, and recognition of a quoted `"--"` word — and each partial
-    # answer traded the false positive for a fail-OPEN, which is the worse
-    # direction this gate is explicitly tuned against:
+    # First consumer: `--` (end-of-options). `stat -- -c` passes `-c` as a
+    # FILE OPERAND, so reporting it was a false positive; the same marker on
+    # a fallback the guard trusts (`|| stat -- -f`) means the ladder has NO
+    # real BSD call, so trusting it failed OPEN. The feature was implemented
+    # three times inside #1544 and withdrawn whole (caecb44) because each
+    # partial answer traded the false positive for a fail-open:
     #   stat -- -c; stat -c "%s" "$f"      later real call went unreported
     #   printf -- "%s" "$(stat -c ...)"    outer marker hid the nested call
     #   stat -c "%s" "$f" || stat "--" -f  guard trusted an -f that names a file
-    # Tracked in #1562 rather than carried here half-built; that issue holds
-    # the reproductions and what a correct implementation needs.
+    # What was missing each time is exactly the word layer: per-invocation
+    # scope (the marker word must sit between the command word of THIS hit
+    # and its matched option, never reach a nested frame), resumed matching
+    # (already provided by has_unguarded blanking), and quoted-word
+    # recognition (the double-quoted, single-quoted, backslash and ANSI-C
+    # spellings of the marker all unquote to it).
+    #
+    # Both directions read a TRUSTED input, so both err toward over-flag:
+    #   - the REPORTING side suppresses a hit only on a word that STATICALLY
+    #     unquotes to exactly `--`. A word carrying an expansion (`$marker`),
+    #     a substitution frame, or undecoded escape content is never a marker
+    #     here — variable indirection sits outside the scope of this gate
+    #     throughout (#1513), and the residue direction is a reportable false
+    #     positive with the one-line `portability-ok:` escape, never a
+    #     fail-open;
+    #   - the GUARD side rejects a fallback whenever such a word precedes the
+    #     BSD option, and scans FLAT — a `--` inside a `|| y=$(stat -- -f)`
+    #     frame belongs to the command of the fallback itself and still
+    #     rejects. A wrongly rejected guard is an over-flag with the same
+    #     escape.
+    function is_wordbreak(mc) { return index(" \t;&|()<>" NL BT, mc) > 0 }
+    function word_start(m, pos,   i) {
+      for (i = pos; i > 1; i--)
+        if (is_wordbreak(substr(m, i - 1, 1))) return i
+      return 1
+    }
+    function word_end(m, pos,   i, len) {
+      len = length(m)
+      for (i = pos; i < len; i++)
+        if (is_wordbreak(substr(m, i + 1, 1))) return i
+      return len
+    }
+    # POSIX quote removal (2.6.7) over ONE word: quote characters go, content
+    # stays. A `$` directly before a quote (the ANSI-C and locale quoting
+    # forms) is removed with it, so those forms are quote OPENERS here; their
+    # content is NOT decoded (an octal `\055\055` spelling stays escaped), so
+    # an escape-spelled marker fails the `--` comparison on both sides — no
+    # suppression (safe) and no guard rejection (accepted residue, same
+    # indirection class as a marker held in a variable).
+    function unquote_word(w,   i, c, n, st, r, len) {
+      r = ""
+      st = "U"
+      len = length(w)
+      for (i = 1; i <= len; i++) {
+        c = substr(w, i, 1)
+        if (st == "S") {
+          if (c == SQ) st = "U"
+          else r = r c
+          continue
+        }
+        if (st == "D") {
+          if (c == DQ) { st = "U"; continue }
+          if (c == BS) {
+            n = substr(w, i + 1, 1)
+            # 2.2.3: in double quotes a backslash is removed only before the
+            # characters it can there escape; before anything else it stays.
+            if (n == DQ || n == "$" || n == BT || n == BS) { r = r n; i++ }
+            else r = r c
+            continue
+          }
+          r = r c
+          continue
+        }
+        if (c == "$" && (substr(w, i + 1, 1) == SQ || substr(w, i + 1, 1) == DQ)) continue
+        if (c == SQ) { st = "S"; continue }
+        if (c == DQ) { st = "D"; continue }
+        if (c == BS) { i++; if (i <= len) r = r substr(w, i, 1); continue }
+        r = r c
+      }
+      return r
+    }
+    # dashdash_between — does a whole ARGV word inside [from, to] statically
+    # unquote to `--`? Reporting-side trust rules:
+    #   - a structural separator ABORTS: the extent spans more than one
+    #     command (the gap of the sed token can cross `;`), so marker
+    #     ownership is undecidable and the hit stays reported;
+    #   - a nested `$(…)`/`(…)`/backquote frame is skipped whole and TAINTS
+    #     its word — a marker inside it belongs to the nested command
+    #     (`grep "$(printf -- x)" -P` keeps its hit), and a word gluing a
+    #     frame could expand to anything, so it never suppresses;
+    #   - a REDIRECTION target is not an argv word: in `stat > -- -c "%s"`
+    #     the `--` names the file stdout goes to and `-c` stays a real
+    #     option, so the operator (fd digits included) and its target word
+    #     are dropped, never compared. A bash `&>` reaches here through the
+    #     `&`-then-`>` peek; a plain control `&` still aborts above it.
+    function dashdash_between(view, m, from, to,   i, c, w, tainted, depth) {
+      w = ""
+      tainted = 0
+      for (i = from; i <= to; i++) {
+        c = substr(m, i, 1)
+        if (c == "<" || c == ">" || (c == "&" && substr(m, i + 1, 1) == ">")) {
+          w = ""
+          tainted = 0
+          while (i <= to && substr(m, i, 1) ~ /[<>&]/) i++
+          while (i <= to && substr(m, i, 1) ~ /[ \t]/) i++
+          while (i <= to && !is_wordbreak(substr(m, i, 1))) i++
+          i--
+          continue
+        }
+        if (c == ";" || c == "&" || c == "|" || c == NL) return 0
+        if (c == "(") {
+          depth = 1
+          while (i < to && depth > 0) {
+            i++
+            c = substr(m, i, 1)
+            if (c == "(") depth++
+            else if (c == ")") depth--
+          }
+          if (depth > 0) return 0
+          tainted = 1
+          continue
+        }
+        if (c == BT) {
+          i++
+          while (i <= to && substr(m, i, 1) != BT) i++
+          if (i > to) return 0
+          tainted = 1
+          continue
+        }
+        if (c == ")") return 0
+        if (is_wordbreak(c)) {
+          if (w != "" && !tainted && unquote_word(w) == "--") return 1
+          w = ""
+          tainted = 0
+          continue
+        }
+        w = w substr(view, i, 1)
+      }
+      if (w != "" && !tainted && unquote_word(w) == "--") return 1
+      return 0
+    }
+    # dashdash_demoted — is the OPTION this match ends in demoted to an
+    # operand by a `--` word earlier in its own invocation? Anchored entirely
+    # inside the matched extent: the extent starts at the command word and
+    # cannot cross the separators its token gap excludes, which is what scopes
+    # the marker to the invocation that owns it — a `--` belonging to an
+    # outer command sits BEFORE `at` and is never examined, and a hit inside
+    # a nested frame walks only that frame. Tokens whose match is not command-then-option
+    # (the bare regex-escape classes, a literal `--perl-regexp`) never demote:
+    # their match ends in the same word it starts in, or in a word that does
+    # not unquote to an option, and `--` does not un-GNU a regex operand.
+    function dashdash_demoted(view, m, at, matchend,   ce, pe, os, oe) {
+      pe = matchend
+      while (pe > at && is_wordbreak(substr(m, pe, 1))) pe--
+      ce = word_end(m, at)
+      if (pe <= ce) return 0
+      os = word_start(m, pe)
+      if (os <= ce + 1) return 0
+      oe = word_end(m, pe)
+      if (unquote_word(substr(view, os, oe - os + 1)) !~ /^-/) return 0
+      return dashdash_between(view, m, ce + 1, os - 1)
+    }
+    # fallback_proven — is the BSD-side `-f` of the ladder PROVEN to be an
+    # option the fallback stat call actually parses? Anything the guard reads
+    # in order to SUPPRESS a report is a trusted input, so this side must be
+    # at least as strict as the reporting side (#1562). The regex established
+    # the shape of the ladder; this walk, over [the `||` at opos, the option
+    # word at os..oe], rejects what BSD getopt would never parse as `-f`
+    # (FreeBSD/macOS stat(1): `stat [-FHhLnq] [-f format | -l | -r | -s |
+    # -x] [-t timefmt] [file ...]` — option parsing stops at the first
+    # operand, `--` ends it explicitly, `-f`/`-t` take an argument):
+    #   - a word unquoting to `--` before the option: `|| stat -- -f` names
+    #     a FILE `-f`, not an option — the shape that failed OPEN while `--`
+    #     was not honored. Scanned FLAT, frames included: in
+    #     `|| y=$(stat -- -f)` the marker belongs to the command of the
+    #     fallback itself and still rejects;
+    #   - an OPERAND word between the command name and the option:
+    #     `|| stat "$f" -f "%z"` — BSD getopt stops at `"$f"`, so `-f` is
+    #     never parsed (unlike GNU, which permutes). Redirections are not
+    #     operands and are skipped whole, fd digits and target included,
+    #     which is what keeps `|| stat 2>/dev/null -f "%z"` a real ladder;
+    #   - an ARGUMENT-TAKING letter before `f` in its own cluster:
+    #     `|| stat -tf "%z"` hands `f` to `-t` as its timefmt value;
+    #   - a missing FORMAT argument: `-f` requires one, so a ladder ending
+    #     at a bare `|| stat -f` runs no BSD call at all. Attached content
+    #     (`-f%z`) satisfies it; otherwise a following word must exist
+    #     before the command ends.
+    # Every rejection here is an over-flag with the one-line
+    # `portability-ok:` escape; accepting any of them ships a GNU-only call
+    # whose "fallback" cannot run.
+    function fallback_proven(q, m, opos, os, oe,   i, c, w, uw, phase, j) {
+      phase = 0
+      w = ""
+      i = opos + 2
+      while (i < os) {
+        c = substr(m, i, 1)
+        if (c == "<" || c == ">" || (c == "&" && substr(m, i + 1, 1) == ">")) {
+          w = ""
+          while (i < os && substr(m, i, 1) ~ /[<>&]/) i++
+          while (i < os && substr(m, i, 1) ~ /[ \t]/) i++
+          while (i < os && !is_wordbreak(substr(m, i, 1))) i++
+          continue
+        }
+        if (is_wordbreak(c)) {
+          if (w != "") {
+            uw = unquote_word(w)
+            if (uw == "--") return 0
+            if (phase == 0) {
+              # Before the command word only the shapes CMDPOS admitted can
+              # appear — assignments, wrappers, group openers — so nothing
+              # here is an operand of the stat call yet.
+              if (uw ~ /(^|\/)stat$/) phase = 1
+            } else if (uw !~ /^-/) return 0
+          }
+          w = ""
+          i++
+          continue
+        }
+        w = w substr(q, i, 1)
+        i++
+      }
+      uw = unquote_word(substr(q, os, oe - os + 1))
+      if (uw !~ /^-[FHhLlnqrsx]*f/) return 0
+      if (substr(uw, index(uw, "f") + 1) != "") return 1
+      j = oe + 1
+      while (substr(m, j, 1) ~ /[ \t]/) j++
+      c = substr(m, j, 1)
+      # The comment test reads the TEXT, not the mask: an inline comment is
+      # masked to the same filler a quoted argument is, but only a comment
+      # can put an unquoted `#` at a word start — that is why the mask
+      # blanked it. A quoted argument starts at its quote character.
+      if (c == "" || substr(q, j, 1) == "#" || index(";&|)" NL BT, c) > 0) return 0
+      return 1
+    }
     # SEG is the run between the GNU call and the `||`, and stops at a command
     # separator. Without it the two calls need not be in the same command at
     # all: `stat -c %s "$f"; true || stat -f %z "$f"` runs the GNU-only call
@@ -654,10 +883,11 @@ scan_file() {
     # that may swallow a `;` lets the guard be satisfied by a ladder belonging
     # to a later command.
     #
-    # Known gap, same one the `--` withdrawal above describes, on the TRUSTED
-    # side: a `stat "--" -f` counterpart is accepted as a fallback although the
-    # `-f` names a file there. That direction fails OPEN, which is the argument
-    # for honoring `--` properly rather than partially.
+    # The TRUSTED side of that regex is re-checked by fallback_proven() after
+    # it matches: a `stat -- -f` / `stat "--" -f` counterpart, an operand
+    # before the `-f`, an argument-taking cluster letter ahead of it, or a
+    # missing format argument each mean the "fallback" runs no BSD stat at
+    # all, and each previously failed OPEN.
     # A `!` in front of the GNU call inverts its status, so the `||` fires when
     # the call SUCCEEDS and is skipped when it fails — the fallback never runs
     # on the dialect that needs it. A negated probe therefore has no guard at
@@ -769,7 +999,7 @@ scan_file() {
       }
       return 0
     }
-    function is_guarded(q, p, at, m,   CMDPOS, SEG, PRE, NAME, QP, QL) {
+    function is_guarded(q, p, at, m,   CMDPOS, SEG, PRE, NAME, QP, QL, lend, opos, os, i) {
       if (is_negated(q, at)) return 0
       # An opener after the `||` may be any spelling that makes the command
       # which follows it what the `||` actually runs: either substitution
@@ -815,7 +1045,18 @@ scan_file() {
       # its own status propagates to is not what that guard asks about.
       if (index(p, STATNAME) || index(p, "stat")) {
         if (status_swallowed(q, at, m)) return 0
-        return substr(q, at) ~ ("^" STATNAME PRE QP "(-" QL "c|--format|--printf)" SEG CMDPOS NAME STATNAME PRE QP "-" QL "f")
+        if (!match(substr(q, at), "^" STATNAME PRE QP "(-" QL "c|--format|--printf)" SEG CMDPOS NAME STATNAME PRE QP "-" QL "f")) return 0
+        # match() so the EXTENT of the ladder is known: fallback_proven()
+        # walks from its `||` to its final `-f` word. SEG admits no `|`, so
+        # the first `||` inside the extent is the operator of the ladder
+        # itself.
+        lend = at + RLENGTH - 1
+        opos = 0
+        for (i = at; i < lend; i++)
+          if (substr(m, i, 1) == "|" && substr(m, i + 1, 1) == "|") { opos = i; break }
+        if (opos == 0) return 0
+        os = word_start(m, lend)
+        return fallback_proven(q, m, opos, os, word_end(m, lend))
       }
       return 0
     }
@@ -844,7 +1085,11 @@ scan_file() {
         # Step over the leading word-boundary character the token consumed, so
         # the guard can anchor on the command name itself.
         if (substr(scan, at, 1) !~ /[A-Za-z]/) at++
-        if (!is_guarded(q, p, at, m)) return at
+        # A `--` word inside this invocation demotes the matched option to an
+        # operand (dashdash_demoted); a demoted occurrence is discarded and
+        # matching RESUMES, exactly as it does past a guarded one, so a later
+        # real invocation on the same record is still evaluated.
+        if (!dashdash_demoted(view, m, at, st + len - 1) && !is_guarded(q, p, at, m)) return at
         scan = substr(scan, 1, st - 1) blanks(len) substr(scan, st + len)
       }
       return 0

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1602,6 +1602,25 @@ else
 fi
 rm -f "$f"
 
+# --- ...even when a flag-shaped OPERAND after the marker pulls the greedy
+# match through it: the demotion discards the demoted word alone, and the
+# real option before the marker is still evaluated by the resumed match.
+# Blanking the whole extent silenced it -- the lint passed a live GNU-only
+# option because a same-named operand followed the `--`.
+for line in \
+  'grep -P pattern -- -P' \
+  'sort -V -- -V' \
+  'stat -c "%s" -- -c' \
+  'mktemp -p /tmp -- -p'; do
+  f="$(tmpsh "$line")"
+  if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+    fail "a real option before -- must fail despite a demoted twin after it: $line"
+  else
+    ok "a real option before -- is reported past its demoted twin: $line"
+  fi
+  rm -f "$f"
+done
+
 # --- an invocation wrapper still reaches the real BSD utility, so a ladder
 # through one is a genuine fallback. `command` is POSIX-specified; `env` and a
 # leading backslash reach the same utility.
@@ -1800,7 +1819,9 @@ done
 # the documented BSD invocation.
 for line in \
   'stat -c "%s" "$g" || stat -Lf "%z" "$g"' \
-  'stat -c "%s" "$g" || stat -f%z "$g"'; do
+  'stat -c "%s" "$g" || stat -f%z "$g"' \
+  'stat -c "%s" "$g" || stat -t "%Y" -f "%z" "$g"' \
+  'stat -c "%s" "$g" || stat -Ht "%Y" -f "%z" "$g"'; do
   f="$(tmpsh "$line")"
   if scan_paths "$REAL_TOKENS" "$f" >/dev/null 2>&1; then
     ok "provable fallback still guarded: $line"
@@ -1809,6 +1830,18 @@ for line in \
   fi
   rm -f "$f"
 done
+
+# --- a detached `-t`/`-f` consumes the NEXT word as its argument, in both
+# directions: its argument is not an operand that ends option parsing
+# (above), and a `-f` sitting in the argument slot is timefmt content, not
+# the option the ladder needs.
+f="$(tmpsh 'stat -c "%s" "$g" || stat -t -f "%z" "$g"')"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "a -f consumed by a detached -t must be rejected, got success: $out"
+else
+  ok "a -f in a detached -t's argument slot is not a parsed option"
+fi
+rm -f "$f"
 
 # =============================================================================
 # Word structure the physical line hides -- #1544

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1506,26 +1506,81 @@ rm -f "$f"
 # `;` between commands stop being the same character to it.
 # =============================================================================
 
-# --- `--` (end-of-options) is deliberately NOT honored: a flag-shaped word
-# after the marker is an operand, but reporting it is the documented over-flag
-# direction and `portability-ok:` is the escape. Pinned as a test so the
-# withdrawal is a stated behaviour rather than an absence -- honoring it needs
-# per-invocation scoping, resumed matching after a discarded occurrence, and
-# quoted-`"--"` recognition, and every partial answer traded this false
-# positive for a fail-OPEN (see the #1544 review rounds).
+# --- `--` (end-of-options) IS honored (#1562, via the #1551 word layer): a
+# flag-shaped word after the marker is an operand, so it no longer reports.
+# The three capabilities whose absence got the feature withdrawn in #1544 are
+# what the word layer supplies: per-invocation scoping (the marker must sit
+# inside the matched extent, between the command word and its option),
+# resumed matching after a discarded occurrence, and quoted-word recognition
+# (quote removal hands the utility the same `--` in every spelling).
 f="$(tmpsh "$(printf '%s\n' \
   'stat -- -c' \
-  'date -- -d')")"
+  'date -- -d' \
+  'stat "--" -c' \
+  "stat '--' -c" \
+  'stat \-\- -c' \
+  "stat \$'--' -c" \
+  'date -u -- -d tomorrow' \
+  'mktemp -- -p /tmp')")"
 if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
-  fail "the over-flag on -- operands is the documented behaviour, got success: $out"
+  ok "a flag-shaped operand after -- (any quote spelling) is not reported"
 else
-  ok "a flag-shaped operand after -- is still reported (documented over-flag)"
+  fail "an operand demoted by -- must not be reported, got: $out"
 fi
 rm -f "$f"
 
-# --- and a later real invocation on the same line is never lost behind one.
-# This is the direction that actually matters, and the one a partial `--`
-# implementation broke: the marker suppressed the whole line.
+# --- the marker is recognized inside the invocation that owns it, wherever
+# that invocation lives: a nested call whose own `--` precedes the flag-shaped
+# word is clean even inside a double-quoted substitution -- the shape a
+# partial implementation reported because the marker was invisible there.
+f="$(tmpsh 'printf "%s\n" "$(stat -- -c)"')"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  ok "a -- inside a quoted substitution demotes the nested option"
+else
+  fail "the nested marker must reach the nested invocation, got: $out"
+fi
+rm -f "$f"
+
+# --- suppression is TRUSTED-input territory, so only a word that statically
+# unquotes to exactly `--` demotes. Everything ambiguous keeps reporting (the
+# over-flag direction): a quoted string that merely CONTAINS the marker is one
+# word; a variable could expand to anything; ANSI-C escape content is not
+# decoded; a redirection target is not an argv word; a marker inside a nested
+# frame belongs to the nested command, on both views.
+for line in \
+  'stat "a -- b" -c %s' \
+  'stat "-- x" -c %s' \
+  'stat $marker -c %s' \
+  "stat \$'\\055\\055' -c %s" \
+  'stat > -- -c "%s" "$f"' \
+  'date 3>-- -d tomorrow' \
+  'date --utc -d @0' \
+  'stat "$(printf "%s" x --)" -c "%s" "$f"' \
+  'grep "$(printf -- x)" -P file'; do
+  f="$(tmpsh "$line")"
+  if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+    fail "an ambiguous marker shape must keep reporting: $line"
+  else
+    ok "no suppression from an ambiguous marker shape: $line"
+  fi
+  rm -f "$f"
+done
+
+# --- `--` demotes OPTIONS, not operands that were never options: the bare
+# regex-escape classes match pattern text, and a pattern operand after `--` is
+# still handed to grep as the same GNU-only regex.
+f="$(tmpsh "grep -- '\\bfoo' file")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "a \\b pattern after -- should still fail, got success: $out"
+else
+  ok "a regex-escape operand is not demoted by --"
+fi
+rm -f "$f"
+
+# --- and a later real invocation on the same line is never lost behind one:
+# a demoted occurrence is discarded and matching RESUMES, so the marker
+# suppresses its own invocation only. A partial implementation without resume
+# suppressed the whole line -- the fail-open that got the feature withdrawn.
 f="$(tmpsh "$(printf '%s\n' \
   'stat -- -c; stat -c "%s" "$g"' \
   'date -- -d; date -d tomorrow')")"
@@ -1707,11 +1762,7 @@ else
 fi
 rm -f "$f"
 
-# --- the guard reads a real -f as a real fallback. A `stat -- -f` counterpart
-# is NOT recognized as a non-fallback today, because `--` is not honored at all
-# -- the same known gap, on the trusted side. Pinned here so its direction is
-# explicit: this one fails OPEN, which is why honoring `--` is worth doing
-# properly rather than partially.
+# --- the guard reads a real -f as a real fallback...
 f="$(tmpsh 'stat -c "%s" "$g" || stat -f "%z" "$g"')"
 if scan_paths "$REAL_TOKENS" "$f" >/dev/null 2>&1; then
   ok "a real BSD -f counterpart is recognized as the fallback"
@@ -1719,6 +1770,45 @@ else
   fail "the plain stat -f ladder must not be flagged"
 fi
 rm -f "$f"
+
+# --- ...and everything the guard reads in order to SUPPRESS a report is a
+# trusted input (#1562), so a fallback whose `-f` BSD getopt would never parse
+# as an option is rejected. FreeBSD/macOS stat(1): option parsing stops at the
+# first operand, `--` ends it explicitly, and `-f`/`-t` take an argument.
+# Every shape below previously read as a guarded ladder and failed OPEN -- the
+# GNU-only call shipped with a "fallback" that runs no BSD stat at all.
+for line in \
+  'stat -c "%s" "$g" || stat -- -f' \
+  'stat -c "%s" "$g" || stat "--" -f' \
+  'stat -c "%s" "$g" || y=$(stat -- -f)' \
+  'stat -c "%s" "$g" || stat "$g" -f "%z"' \
+  'stat -c "%s" "$g" || stat -tf "%z" "$g"' \
+  'stat -c "%s" "$g" || stat -f' \
+  'stat -c "%s" "$g" || stat -f # comment, not a format'; do
+  f="$(tmpsh "$line")"
+  if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+    fail "a fallback whose -f is not a parsed option must be rejected: $line"
+  else
+    ok "unprovable fallback rejected (trusted side): $line"
+  fi
+  rm -f "$f"
+done
+
+# --- while every fallback spelling BSD getopt genuinely parses stays a real
+# ladder: a no-argument cluster letter before `f`, an attached format
+# argument, and a redirection between the command name and its option are all
+# the documented BSD invocation.
+for line in \
+  'stat -c "%s" "$g" || stat -Lf "%z" "$g"' \
+  'stat -c "%s" "$g" || stat -f%z "$g"'; do
+  f="$(tmpsh "$line")"
+  if scan_paths "$REAL_TOKENS" "$f" >/dev/null 2>&1; then
+    ok "provable fallback still guarded: $line"
+  else
+    fail "a genuine BSD fallback spelling must stay guarded: $line"
+  fi
+  rm -f "$f"
+done
 
 # =============================================================================
 # Word structure the physical line hides -- #1544


### PR DESCRIPTION
Fixes #1562. Refs #1551 (stage 1 of the decision recorded at
https://github.com/melodic-software/claude-code-plugins/issues/1551#issuecomment-5135995574 —
made under owner-delegated session authority; #1551 stays open for stages 2–4).

## Summary

First slice of the #1551 word layer, built additively on the #1544 character mask, consumed by
`--` (end-of-options) handling in both trust directions:

- **Word primitives** inside the scanner's awk pass: word delimitation read from the quote mask
  (a quoted space never splits a word, a masked separator never splits a command) and per-word
  POSIX quote removal (2.6.7; ANSI-C/locale `$`-quote forms recognized as openers, content not
  decoded). No re-lexing — tokens still match exactly as before.
- **Reporting side (`dashdash_demoted`)**: a matched option is discarded when a word that
  *statically unquotes to exactly `--`* sits as a whole argv word between the hit's command word
  and its matched option, inside the matched extent. Matching resumes past a discarded
  occurrence, so a later real invocation on the same record is still evaluated. Everything
  ambiguous keeps reporting: expansions (`$marker`), nested frames on either view
  (`stat "$(printf '%s' x --)" -c`), redirection targets (`stat > -- -c`), undecoded ANSI-C
  escapes, and any extent that crosses a command separator.
- **Guard side (`fallback_proven`)**: the stat fallback ladder is now rejected unless its `-f`
  is proven to be an option BSD getopt actually parses (verified against FreeBSD/macOS stat(1)):
  no `--` word before it — closing the fail-open that was live on `main`
  (`stat -c '%s' "$f" || stat -- -f` read as guarded) — no operand word between the fallback's
  `stat` and its option (BSD getopt stops at the first operand), no argument-taking cluster
  letter ahead of `f` (`-tf` hands `f` to `-t` as its timefmt value), and a format argument
  present (attached or following). Every rejection is an over-flag with the one-line
  `portability-ok:` escape; every acceptance of those shapes was a fail-open.

Both directions read a trusted input, so both are built to err toward over-flag — the posture
the token list documents.

## Why now, and why this shape

#1562's five recorded failure shapes (from the three withdrawn `--` attempts in #1544) all trace
to three missing capabilities: per-invocation scoping, resumed matching, quoted-word
recognition. Resumed matching already landed in #1544; the other two are exactly the word layer.
The decision comment on #1551 records the full rationale, the staged plan (command-position axis
and the reporting-side short-option table deferred with triggers), and the rejected alternatives
(big-bang re-lexing rewrite; narrow guard patch; won't-fix).

An independent different-vendor review (Codex CLI, advisory) of the design contributed the
redirection-target, wrong-frame-marker, and `-tf`/operand/missing-argument adversarial shapes;
all are pinned as tests.

## Tests

- The suite test that pinned the withdrawal as stated behaviour now pins the honored behaviour;
  the resume and option-before-marker pins are unchanged and still pass.
- New: 8 marker spellings demote (incl. quoted/backslash/ANSI-C and inside a quoted
  substitution); 9 ambiguous shapes never suppress; regex-escape operands are never demoted;
  7 unprovable fallbacks rejected on the trusted side; provable spellings (`-Lf`, attached
  `-f%z`) plus every pre-existing genuine-ladder pin stay guarded.
- Full suite green; `shellcheck` clean on the scanner.
- Corpus: `--all` over the tracked tree produces an identical hit set under the `origin/main`
  scanner and this branch's scanner (same tree, both scanners).

## Related

- #1551 — the word-layer decision this PR implements stage 1 of (stages 2-4 remain open there;
  decision recorded at
  https://github.com/melodic-software/claude-code-plugins/issues/1551#issuecomment-5135995574)
- #1544 — the character mask this layer builds on, and where the feature was previously withdrawn

## Residuals (recorded in scanner comments)

A marker held in a variable (suppression side) and an ANSI-C escape-spelled marker (both sides)
are not recognized — variable indirection is out of the gate's scope throughout (#1513); both
residuals err toward over-flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhS3T7ShwJgKTrvk2Mvd3C

