### PR TITLE
fix(guardrails): hoist the Shared defang out of the per-candidate loop

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.5]
+
+### Fixed
+
+- **Shared-heavy content could push hardcoded-path-check past its hook timeout, and a guard killed at
+  its timeout fails open.** The macOS block defanged `Shared` tokens inside a per-candidate `while
+  read` loop, spawning a `sed` and a `grep` for every candidate line. The loop's only escape was the
+  trailing `head -3`, which fires when candidates *survive* the defang — so on a block where every
+  candidate is a legitimate `Users/Shared` reference, nothing was ever written, the short-circuit
+  never closed the pipe, and the loop ran to completion. The guard was slowest on precisely the
+  innocent content the exclusion exists to serve, and fastest on violations.
+
+  The defang now runs once over the whole candidate block. `sed` is line-oriented in this pipeline —
+  no `N`/`H` multiline commands, and `$` anchors per line in both shapes — so hoisting cannot change
+  any individual line's result. A `grep -nE` over the defanged block yields the block-relative
+  indices of the survivors, and `awk` selects those lines from the **original** block by `NR`, so the
+  reported entry still carries the original line number and original un-defanged text. `grep -E`
+  remains the sole matcher; `awk` does no regex work, so no second regex dialect enters and the
+  shared `HPP_*` bodies stay the single source of truth.
+
+  A block containing no `Shared` token at all skips the pipeline entirely via a bash-builtin
+  substring test — the defang is a provable no-op there, so the common case costs nothing.
+
+  The subprocess count is now constant instead of proportional to the candidate count. Measured
+  through the hook over the same corpora on one machine, swapping only this library: the
+  per-candidate loop spawned 210 `grep`/`sed` processes at 100 Shared-only lines (100 `sed` + 110
+  `grep`) and its wall clock grew 13x for a 4x input increase — 22s at 100 lines to 288s at 400. The
+  hoisted form spawns 12 at either size and holds flat at ~10s. The regression case pins that count
+  rather than a wall-clock ratio: elapsed time here is dominated by process-spawn latency, and
+  repeats of the identical 400-line corpus measured 5.0s and 15.2s — a spread wider than the signal
+  a timing ratio would have to resolve.
+
+- **The survivor re-test now strips `grep -n`'s line-number prefix before matching.** The hoisted
+  form re-tests the defanged candidates, and those lines still carried the `<n>:` prefix the first
+  `grep -n` added — so a violation at **column 0** reached the re-test as `<n>:/Users/…` and could no
+  longer satisfy the left boundary's `^` alternative. It matched only because the boundary class also
+  accepts `:`, which is there for yaml/docker value position and carries no obligation to this
+  pipeline: narrowing that class for its own stated purpose would have silently dropped a violation
+  the first pass had already flagged. The strip is one more expression on the `sed` the defang
+  already runs, so it costs no extra process, and it keeps both passes matching identical bytes
+  rather than coupling the second to an unrelated member of the class. Pinned by a column-0 case.
+
+- **The macOS candidate pipeline could abort a scan under `set -e`.** The candidate block now ends in
+  an explicit `|| true`: its trailing `grep -v` exits non-zero whenever nothing survives the Windows
+  exclusion — the common clean case — and this library is sourced by commit-time hooks whose shell
+  options it does not control. Aborting there would fail open, the same failure mode the hoisting
+  addresses.
+
 ## [0.18.4]
 
 ### Fixed

--- a/plugins/guardrails/hooks/hardcoded-path-check.test.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.test.sh
@@ -241,6 +241,117 @@ OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE"
 RC=$?
 assert_exit "single-quoted Shared → exit 0" 0 "$RC"
 
+# Every macOS-body candidate is a Windows path, so the candidate block is empty
+# once the Windows exclusion has run. Under `pipefail` that stage reports
+# failure, and a scan that aborts there would fail OPEN rather than pass clean.
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$PS1_FIXTURE" "copy ${WIN_HOME}${BS}a.txt ${WIN_HOME}${BS}b.txt")" 2>&1)
+RC=$?
+assert_exit "macOS candidates all excluded as Windows → exit 0" 0 "$RC"
+assert_silent "all-Windows candidates → no stderr" "$OUT"
+
+# The defang is evaluated over the whole candidate block, so the survivor's
+# reported entry must still carry its ORIGINAL line number and ORIGINAL
+# un-defanged text. Padding with Shared-only lines puts the real violation
+# beyond the first three candidates, which is exactly where a block-relative
+# index would be reported in place of the file-relative one.
+MIXED="ls ${SL}Users${SL}Shared${SL}a
+ls ${SL}Users${SL}Shared${SL}b
+ls ${SL}Users${SL}Shared${SL}c
+ls ${SL}Users${SL}Shared${SL}d
+cd ${MAC_HOME}"
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "$MIXED")" 2>&1)
+RC=$?
+assert_exit "Shared-padded block, violation at line 5 → exit 2" 2 "$RC"
+assert_contains "padded block → original file line number" "$OUT" "5:cd ${MAC_HOME}"
+assert_absent "padded block → never reports the defanged copy" "$OUT" "${SL}Users-Shared"
+
+# Survivor at COLUMN 0 of its line, inside a block that also carries a Shared
+# token so the defang branch runs. The candidate reaches the re-test carrying
+# `grep -n`'s line-number prefix, so the boundary's `^` alternative no longer
+# sits at the start of the string — the lib strips that prefix to keep both
+# passes' conditions identical. Without the strip this case is matched only by
+# the boundary class also happening to accept ":", and a violation flagged on
+# the first pass would be silently dropped on the second.
+COL0="ls ${SL}Users${SL}Shared${SL}a
+${MAC_HOME} is the checkout"
+OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "$COL0")" 2>&1)
+RC=$?
+assert_exit "Shared block, violation at column 0 → exit 2" 2 "$RC"
+assert_contains "column-0 violation → original file line number" "$OUT" "2:${MAC_HOME}"
+
+# Shared-heavy content must cost a BOUNDED number of subprocesses, not one per
+# candidate. All-Shared is the pathological shape: no candidate survives the
+# defang, so the reporting short-circuit never fires and a per-candidate loop
+# runs to completion, spawning a sed and a grep on every line. A guard killed
+# at its hook timeout fails OPEN, so this is a correctness property.
+#
+# The pin COUNTS SPAWNS instead of timing the run. Elapsed time here is
+# dominated by process-spawn latency: repeats of the identical 400-line corpus
+# measured 5.0s and 15.2s on one machine, a spread wider than the 4x signal a
+# wall-clock ratio exists to detect, so any such ratio is either flaky or too
+# loose to discriminate. A count is exact and load-invariant. `grep`/`sed`
+# shims on PATH tally every spawn the hook makes; the hoisted form issues one
+# fixed pipeline, so quadrupling the input must not add a single process.
+# Measured on Git Bash: 12 spawns at both sizes hoisted, against 210 at 100
+# lines for the per-candidate loop (100 `sed` + 110 `grep`) — and that shape's
+# wall clock grew 13x for 4x the input (22s to 288s), fork pressure compounding
+# into exactly the timeout death this case exists to prevent.
+SPAWN_SHIM="$TEST_TMPDIR/spawn-shim"
+SPAWN_LOG="$TEST_TMPDIR/spawn-log"
+mkdir -p "$SPAWN_SHIM"
+for _bin in grep sed; do
+  _real="$(command -v "$_bin")"
+  # Unquoted delimiter so the real binary path is baked in; every other
+  # expansion is escaped and resolves when the shim RUNS.
+  cat >"$SPAWN_SHIM/$_bin" <<SHIM
+#!/usr/bin/env bash
+printf 'x\n' >>"\${HPP_SPAWN_LOG:-/dev/null}"
+exec '$_real' "\$@"
+SHIM
+  chmod +x "$SPAWN_SHIM/$_bin"
+done
+
+shared_block() {
+  local n="$1" i out=""
+  for ((i = 1; i <= n; i++)); do out="${out}cp ${SL}Users${SL}Shared${SL}lib${i}${SL}a.txt out${i}"$'\n'; done
+  printf '%s' "$out"
+}
+SHARED_100=$(write_json "$FIXTURE" "$(shared_block 100)")
+SHARED_400=$(write_json "$FIXTURE" "$(shared_block 400)")
+
+# Sets SPAWN_RC and SPAWN_COUNT. Not a command substitution — that would run
+# the body in a subshell and strand both.
+run_shimmed() {
+  : >"$SPAWN_LOG"
+  CLAUDE_PROJECT_DIR="$TEST_TMPDIR" HPP_SPAWN_LOG="$SPAWN_LOG" PATH="$SPAWN_SHIM:$PATH" \
+    bash "$HOOK" <<<"$1" >/dev/null 2>&1
+  SPAWN_RC=$?
+  SPAWN_COUNT=$(wc -l <"$SPAWN_LOG")
+  SPAWN_COUNT=${SPAWN_COUNT//[[:space:]]/}
+}
+
+run_shimmed "$SHARED_100"
+assert_exit "100 Shared-only lines → exit 0" 0 "$SPAWN_RC"
+SPAWNS_SMALL=$SPAWN_COUNT
+
+run_shimmed "$SHARED_400"
+assert_exit "400 Shared-only lines → exit 0" 0 "$SPAWN_RC"
+SPAWNS_LARGE=$SPAWN_COUNT
+
+# A zero tally means the shims never ran, which would make the equality below
+# pass vacuously — the silent-skip shape this suite otherwise guards against.
+if ((SPAWNS_SMALL > 0)); then
+  ok "spawn shims active (${SPAWNS_SMALL} grep/sed spawns at 100 lines)"
+else
+  bad "spawn shims never fired — the bounded-cost pin cannot discriminate"
+fi
+
+if ((SPAWNS_LARGE == SPAWNS_SMALL)); then
+  ok "Shared defang is bounded, not per-candidate (${SPAWNS_SMALL} spawns at 100 lines, ${SPAWNS_LARGE} at 400)"
+else
+  bad "Shared defang scales with candidate count: ${SPAWNS_SMALL} spawns at 100 lines, ${SPAWNS_LARGE} at 400"
+fi
+
 # Left boundary: a URL whose path merely CONTAINS a home-root suffix is not a
 # filesystem root — must stay clean (macOS and Linux shapes).
 OUT=$(CLAUDE_PROJECT_DIR="$TEST_TMPDIR" bash "$HOOK" <<<"$(write_json "$FIXTURE" "see https://example.test${SL}home${SL}alice for docs")" 2>&1)

--- a/plugins/guardrails/lib/path-detection/hardcoded-path-patterns.sh
+++ b/plugins/guardrails/lib/path-detection/hardcoded-path-patterns.sh
@@ -146,17 +146,65 @@ hpp::scan_text() {
   #     The Shared literal is assembled from pieces so this driver's own source
   #     never carries a contiguous Users-root token for the write-scan hook
   #     that consumes these bodies to flag.
+  #
+  # The defang runs ONCE over the whole candidate block, not once per candidate
+  # line, so the subprocess count is constant rather than proportional to the
+  # candidate count. `sed` is line-oriented in this pipeline — no `N`/`H`
+  # multiline commands, and `$` is a per-line anchor in both shapes — so
+  # hoisting cannot change any individual line's result. A per-line loop is
+  # pathologically slow on exactly the innocent input this exclusion exists to
+  # serve: the loop's only escape is the trailing `head -3`, which fires when
+  # candidates SURVIVE, so an all-Shared block never short-circuits and pays a
+  # `sed` plus a `grep` on every line. Measured through the hook on Git Bash
+  # over the same corpora, swapping only this library: the per-line shape
+  # spawned 210 `grep`/`sed` processes at 100 Shared-only lines and its wall
+  # clock grew 13x for 4x the input (22s to 288s), against 12 spawns at either
+  # size and a flat ~10s hoisted.
+  # A guard killed at its hook timeout fails OPEN, so the bound is a correctness
+  # property, not merely a speed one. `grep -E` stays the sole matcher — `awk`
+  # only selects lines by index and does no regex work, so no second regex
+  # dialect enters the pipeline and the shared HPP_* bodies stay the SSOT.
   if [[ -z "$macos_context" ]]; then
-    local _shared _shared_defused
+    local _shared _shared_defused _cands _keep
     _shared='/Use''rs/Shared'
     _shared_defused='/Use''rs-Shared'
-    match=$(printf '%s' "$content" | grep -nE "${_posix_boundary}${HPP_MACOS_USER_BODY}" 2>/dev/null | grep -vE '[A-Za-z]:[/\\]' |
-      while IFS= read -r _line; do
-        _defanged=$(printf '%s' "$_line" | sed -e "s|${_shared}\([^A-Za-z0-9._-]\)|${_shared_defused}\1|g" \
-          -e "s|${_shared}\$|${_shared_defused}|")
-        printf '%s' "$_defanged" | grep -qE "${_posix_boundary}${HPP_MACOS_USER_BODY}" && printf '%s\n' "$_line"
-      done | head -3)
-    [[ -n "$match" ]] && violations="${violations}macOS user path detected:${nl}${match}${nl}${nl}"
+    # `|| true`: the trailing `grep -v` exits 1 when nothing survives (the
+    # common clean case). This lib is sourced by commit-time hooks whose shell
+    # options it does not control, and aborting the scan under `set -e` would
+    # fail OPEN — the very failure mode this block is shaped to avoid.
+    _cands=$(printf '%s' "$content" | grep -nE "${_posix_boundary}${HPP_MACOS_USER_BODY}" 2>/dev/null |
+      grep -vE '[A-Za-z]:[/\\]') || true
+    if [[ -n "$_cands" ]]; then
+      if [[ "$_cands" != *"$_shared"* ]]; then
+        # No Shared token anywhere in the block, so the defang is a provable
+        # no-op and every candidate survives it. This bash-builtin substring
+        # test keeps the common case free; the branch below costs four more
+        # processes, and on Git Bash spawn cost — not matching — dominates.
+        match=$(printf '%s\n' "$_cands" | head -3)
+      else
+        # Block-relative indices of the candidates that still match once
+        # defanged, then select those lines from the ORIGINAL block so the
+        # reported line is never the defanged copy.
+        #
+        # The leading `s/^[0-9]*://` drops the line-number prefix the first
+        # `grep -n` added, so this re-test sees the same bytes the first pass
+        # matched. Without it a violation at COLUMN 0 reaches the re-test as
+        # `<n>:/Users/…` and can no longer satisfy the boundary's `^`
+        # alternative — it survives today only because the class happens to
+        # also accept ":", which is there for yaml/docker value position and
+        # carries no obligation to this pipeline. Stripping keeps the two
+        # passes' conditions identical instead of coupling the second to an
+        # unrelated member of the class. It costs no extra process: the strip
+        # is another expression on the `sed` the defang already runs.
+        _keep=$(printf '%s\n' "$_cands" |
+          sed -e 's|^[0-9]*:||' -e "s|${_shared}\([^A-Za-z0-9._-]\)|${_shared_defused}\1|g" -e "s|${_shared}\$|${_shared_defused}|" |
+          grep -nE "${_posix_boundary}${HPP_MACOS_USER_BODY}" 2>/dev/null | cut -d: -f1)
+        match=$(printf '%s\n' "$_cands" | awk -v keep="$_keep" '
+          BEGIN { n = split(keep, a, "\n"); for (i = 1; i <= n; i++) k[a[i]] = 1 }
+          k[NR]' | head -3)
+      fi
+      [[ -n "$match" ]] && violations="${violations}macOS user path detected:${nl}${match}${nl}${nl}"
+    fi
   fi
 
   # Linux user home paths (same driver-owned left boundary).


### PR DESCRIPTION
## Summary

`hpp::scan_text`'s macOS block defanged `Shared` tokens inside a per-candidate `while read` loop,
spawning a `sed` and a `grep` for every candidate line. The loop's only escape was the trailing
`head -3`, and that short-circuit fires when candidates **survive** the defang. On a block where
every candidate is a legitimate `Users/Shared` reference, none survives, nothing is ever written,
`head -3` never closes the pipe, and the loop runs to completion.

So the guard was slowest on precisely the innocent content the exclusion exists to serve, and
fastest on violations — the wrong way round for something with a hook timeout. A `PreToolUse` guard
killed at its timeout **fails open**, which makes this a correctness bug, not a speed one. This
plugin has been bitten by that before (#1345).

The defang now runs **once over the whole candidate block**:

- One `sed` over the candidate block. `sed` is line-oriented in this pipeline — no `N`/`H` multiline
  commands, and `$` anchors per line in both shapes — so hoisting cannot change any individual
  line's result.
- One `grep -nE` over the defanged block yields the block-relative indices of the survivors; `awk`
  then selects those lines from the **original** block by `NR`. The reported entry therefore still
  carries its original line number and original un-defanged text, never the defanged copy.
- A block containing no `Shared` token at all skips the pipeline entirely via a bash-builtin
  substring test. The defang is a provable no-op there, so the common case costs nothing.

`grep -E` remains the sole matcher and `awk` does no regex work, so no second regex dialect enters
and the shared `HPP_*` bodies stay the single source of truth.

The survivor re-test also strips `grep -n`'s `<n>:` line-number prefix before matching. Hoisting
made that necessary and it is easy to miss: the re-test runs over the **numbered** candidate lines,
so a violation at **column 0** arrives as `<n>:/Users/…` and can no longer satisfy the left
boundary's `^` alternative. It matched anyway only because that class also accepts `:` — a member
added for yaml/docker value position, which owes this pipeline nothing. Narrowing the class for its
own stated purpose would therefore have silently dropped a violation the first pass had already
flagged. Verified by rerunning the pipeline with `:` removed from the class: the column-0 survivor
set goes from `[2]` to `[]` unstripped, and stays `[2]` stripped. The strip is one more expression on
the `sed` the defang already runs, so it adds no process, and a column-0 case now pins it.

Detection semantics are otherwise unchanged. Only the hoisting was ported — this repo's
`_posix_boundary` and its `[^A-Za-z0-9._-]` defang boundary class are untouched.

One adjacent fail-open fix: the candidate assignment gains an explicit `|| true`. Its trailing
`grep -v` exits non-zero whenever nothing survives the Windows exclusion (the common clean case),
and this library is sourced by commit-time hooks whose shell options it does not control — aborting
there under `set -e` would fail open in the same way.

## Measured

A matched pair: one machine, one harness, the same two corpora driven **through the hook**, with
only `lib/path-detection/hardcoded-path-patterns.sh` swapped between the sides. Spawn counts come
from `grep`/`sed` shims on `PATH`; wall clock is `EPOCHREALTIME` around the hook invocation with the
payload precomputed outside the timed region.

| Corpus — 100 vs 400 Shared-only lines | Per-candidate loop | Hoisted |
| --- | --- | --- |
| `grep`/`sed` spawns at 100 | 210 (100 `sed` + 110 `grep`) | 12 |
| `grep`/`sed` spawns at 400 | proportional | 12 |
| Wall clock at 100 | 22s (median of 3: 21.2 / 22.0 / 23.5) | 11s (median of 5, range 9.5–13.9) |
| Wall clock at 400 | 288s | 10s (median of 5, range 5.0–15.2) |

Spawn count is the exact figure; wall clock is its consequence. The per-candidate shape grew **13x
for a 4x input increase** — super-linear, because fork pressure compounds — while the hoisted shape
is flat and its spread is machine noise. A control corpus of the same size carrying no `Shared`
token cost 1.9–4.0s on **both** sides, which places the delta in the defang rather than in payload
size.

The figures in the issue (108s per-line against 0.92s hoisted) are #1792's own measurement on a
different machine, not this pair.

## Test plan

Regression cases in `hardcoded-path-check.test.sh`, plus the existing suite:

- **Bounded, not per-candidate** — the headline pin. It counts **subprocesses**, not seconds.
  `grep`/`sed` shims on `PATH` tally every spawn the hook makes, and the tally must not move when
  the input quadruples. A companion assertion fails if the shims never fire, so the equality cannot
  pass vacuously.

  This replaces a wall-clock ratio assertion, and the reason is the most reviewer-relevant fact in
  the PR: **the timing assertion failed on unchanged code.** Repeats of the identical 400-line
  corpus measured 5.0s and 15.2s, so the noise floor was wider than the 4x signal the ratio existed
  to detect, and the gate reported `FAIL: Shared defang scales with candidate count: 4s at 100
  lines, 18s at 400` on a green branch. Widening the tolerance would have left a gate that cannot
  discriminate the bug it guards. A count is exact, load-invariant, and pins the property the fix
  actually establishes — a constant subprocess count.
- **Shared-padded block** — four Shared-only lines then a real user path at line 5, so the violation
  sits beyond the first three candidates. Asserts the reported entry carries the **original file
  line number** (`5:cd …`) and that the defanged spelling never appears in output. This is exactly
  where a block-relative index would leak through in place of the file-relative one.
- **Violation at column 0 inside a Shared block** — pins the prefix strip described above. It passes
  both with and without the strip *today*, which is the point: it guards the coupling rather than a
  live defect, and it fails the moment `:` leaves the boundary class if the strip is ever reverted.
- **All candidates excluded as Windows paths** — the candidate block is empty after the `-v` stage,
  which under `pipefail` reports failure. Asserts exit 0 and silence, distinguishing a clean pass
  from a silent abort.
- Existing Shared cases (bare `Shared` at EOL, `Shared` + user path on one line, `SharedStuff`,
  trailing punctuation, quoted forms) all still pass, pinning that the exclusion stays match-level.

Results on this branch:

```
ok: spawn shims active (12 grep/sed spawns at 100 lines)
ok: Shared defang is bounded, not per-candidate (12 spawns at 100 lines, 12 at 400)
PASS=81 FAIL=0
```

Version bumped 0.18.4 → 0.18.5 with a matching `## [0.18.5]` CHANGELOG entry. (The branch
originally claimed 0.18.4; #1821 released that version on `main` while this was open, so it was
renumbered when this branch rebased rather than co-owning a released version.)

Gates, all run from the worktree root after the rebase:

| Gate | Result |
| --- | --- |
| `bash plugins/guardrails/hooks/hardcoded-path-check.test.sh` | PASS=81 FAIL=0 |
| `shellcheck` (lib + test) | clean |
| `shfmt -d` (lib + test) | clean |
| `scripts/check-shell-portability.sh origin/main` | PASS — 2 files, no unexcused GNU-only constructs |
| `scripts/check-changed-skills.sh origin/main` | PASS — no changed skills to gate |
| `scripts/check-changelog-parity.sh --check` | PASS |
| `scripts/check-changelog-parity.sh --check-bump origin/main` | PASS |
| `scripts/check-changelog-parity.sh --check-order` | PASS — 71 changelogs, newest-first, no duplicates |
| `scripts/check-cross-plugin-source-drift.sh --check` | PASS — no unregistered or drifted clusters |
| `scripts/check-silent-skips.sh` | PASS |
| `scripts/validate-plugins.sh` | PASS — manifests + catalog |
| `markdownlint-cli2 "plugins/guardrails/**/*.md"` | PASS — 0 issues, 3 files |

## Related

- Fixes #1792
- Refs #1095 — the match-level Shared carve-out this reports on
- Refs #1345 — prior incident: guards killed at their timeout
- Refs melodic-software/medley#1685 — the same block-hoisted shape over the same
  `machine-path-patterns.sh` bodies. Porting it here reconverges the two drivers rather than leaving
  them forked. That PR also carries a derived `_seg_end` and a `:-` boundary addition which are
  **not** included here — those are separate semantic changes belonging to their own issues.

### Overlap with concurrent guardrails work

Sibling lanes are working #1814/#1811/#1810 (git wrapper argv parsing) on other branches. Different
code path — those touch the commit-guard argv helpers, this touches the path-detection driver — so
no functional overlap is expected. Both land in the same plugin, so `CHANGELOG.md` and
`plugin.json`'s version are the likely textual conflict points; whichever merges second rebases the
version bump. Rebased onto current `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVoZoMYXqf8ZVbQYixPVPW
