### PR TITLE
chore(knowledge): retire thinking doc-queue entry after slice completion

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.10]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: thinking queue entry removed.** The extended-thinking
+  platform doc slice completed — raw-md fetch through interview handoff, dual verification (one
+  correction round of ten items, re-verified PASS by both verifiers, no degraded fallback) — so
+  its entry leaves the doc queue per the queue's remove-on-completion rule. The paired
+  thinking-steering-and-cost entry and the "Thinking" category heading remain: that page is a
+  separate concurrent run under the category's one-page-per-run contract, and its own queue PR
+  removes both.
+
 ## [0.10.9]
 
 ### Fixed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -81,7 +81,6 @@ their slices complete.
 
 Thinking (two overlapping docs — two runs, one page per run by contract):
 
-- <https://platform.claude.com/docs/en/build-with-claude/thinking>
 - <https://platform.claude.com/docs/en/build-with-claude/thinking-steering-and-cost>
 
 Deferred with trigger (not queued):


### PR DESCRIPTION
## Summary

The extended-thinking platform doc slice
(<https://platform.claude.com/docs/en/build-with-claude/thinking>) completed the full
docpage-digest pipeline, so its queue entry leaves the profile per the remove-on-completion rule.

Pipeline record: raw-md fetch (`.md` appended to the page URL; HTTP 200, no redirect) of a
917-line source, 13-unit digest fan-out, dual verification, one correction round of ten items
(C1–C10), re-verified PASS by both verifiers, no degraded fallback at any stage, and an interview
handoff carrying 2 cross-doc divergences, 9 candidate artifacts, 12 open questions, and all 41
digest open questions mapped (verified by a scripted 41/41 citation sweep).

Verification chain:

| Stage | Verifier | Verdict |
|---|---|---|
| Round 1 | A — same-vendor Claude, fresh context | PASS, 5 findings (all MINOR) |
| Round 1 | B — cross-vendor Codex CLI 0.146.0, gpt-5.6-sol, per the #1740 recipe | FAIL, 9 findings (5 MAJOR, 4 MINOR) |
| Re-verify | A | PASS — C1–C10 all RESOLVED, 1 MINOR residual |
| Re-verify | B | PASS — no findings |

The re-verify MINOR residual (user-specific routing-lane context in digest 06) was fixed by
applying the already-ratified generic-reframe treatment from finding B-5 to the sibling
occurrence; it is disclosed in the handoff's verification-state paragraph and recorded as a
round-1 addendum rather than silently absorbed.

## Profile change

A single deleted bullet. The paired `thinking-steering-and-cost` entry and the "Thinking"
category heading deliberately REMAIN — that page is a separate concurrent run under the
category's one-page-per-run contract, and its own queue PR removes both. Keeping this diff to one
line makes it disjoint from the sibling run's diff, so the two merge in either order.

Knowledge plugin 0.10.9 → 0.10.10 with a matching changelog entry.

## Merge sequencing (for the orchestrator)

The concurrent sibling run bumps from this same 0.10.9 baseline, so both PRs claim **0.10.10**
and will collide on `plugin.json` and `CHANGELOG.md`. Whichever merges second needs a rebase onto
0.10.11. The profile edits themselves do not conflict.

Note: the "two overlapping docs — two runs, one page per run by contract" parenthetical above the
queue bullets reads as transiently inaccurate between these two merges. That is the chosen
sequencing, not a defect for this PR to repair; the sibling PR retires the heading and its
parenthetical together.

## Cross-doc divergences surfaced (recorded for the interview, not acted on here)

- **Terminology drift.** `code.claude.com/docs/en/model-config` describes interactive sessions
  receiving "redacted thinking blocks by default", while this page's `display` field takes
  `"summarized"`/`"omitted"` and documents `redacted_thinking` as a *distinct* safety mechanism —
  and states that Fable 5 / Mythos 5 return regular `thinking` blocks, "not `redacted_thinking`".
  Either the harness doc uses "redacted" loosely for `display: "omitted"`, or one page is stale.
- **Harness-vs-API thinking-off exception gap.** The harness thinking-off exception list names
  only Fable 5, while the API rejects `disabled` at `xhigh`/`max` effort on "Claude Opus 5 and
  later models" with a per-request 400. Open whether the harness guards the combination or a user
  can hit repeated 400s from settings alone.

No linked issue

## Related

- #1816 — run 8 (models-explained blog), the preceding queue PR and the 0.10.9 baseline this
  bumps from
- #1740 — the elevated Codex Verifier B recipe used for cross-vendor verification
