### PR TITLE
fix(claude-ops): hoist lanes/observability pre-compute shell expansion into bundled scripts

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort, a repo-pull + marketplace-refresh launch step, and a consume-restarts action — an OS-schedulable reader that relaunches stopped lanes whose telemetry carries a restart_request), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.24.4]
+
+### Fixed
+
+- **`lanes` and `observability` load again when invoked from a worktree-isolated agent (#1687).**
+  Four `## Pre-computed context` lines carried genuine shell expansion — `lanes` line 16's
+  `$(claude --version)` and line 19's `$c` / `${CLAUDE_OPS_LANES_CONFIG:-…}` / `$(git rev-parse …)`,
+  `observability` line 19's `$f` / `$(…)` and line 21's `$d` / `${CC_OTEL_STORE:-…}`. The harness
+  composes that whole block into one shell invocation, and the worktree-isolation Bash guard refuses
+  any `$`-expansion, so the block failed and the skill never loaded. `lanes` line 16 is now the
+  `$`-free `claude --version 2>/dev/null || echo "MISSING (required)"`; the other three hoist their
+  logic into two bundled scripts — `skills/lanes/scripts/probe-lane-config.sh` and
+  `skills/observability/scripts/probe-observability-state.sh` (`--hook-events` / `--otel-store`) —
+  invoked through `${CLAUDE_PLUGIN_ROOT}`, which the harness substitutes into a literal path before
+  any shell sees it, so the replacement lines carry no `$` at all. Path resolution, env overrides
+  (`CLAUDE_OPS_LANES_CONFIG`, `CC_OTEL_STORE`), and every output string are unchanged and covered by
+  equivalence tests that diff each script against the line it replaced. **One output shape did
+  change:** the `claude CLI:` line now reads `2.1.220 (Claude Code)` rather than
+  `present (2.1.220 (Claude Code))` — same information, no `present (…)` wrapper. `observability`
+  line 20 (`OTEL collector :4318`) was already plugin-variable-only and is untouched.
+
 ## [0.24.3]
 
 ### Fixed

--- a/plugins/claude-ops/skills/lanes/SKILL.md
+++ b/plugins/claude-ops/skills/lanes/SKILL.md
@@ -13,10 +13,10 @@ metadata:
 
 ## Pre-computed context
 
-claude CLI: !`command -v claude >/dev/null 2>&1 && echo "present ($(claude --version 2>/dev/null))" || echo "MISSING (required)"`
+claude CLI: !`claude --version 2>/dev/null || echo "MISSING (required)"`
 jq: !`command -v jq >/dev/null 2>&1 && echo "present" || echo "MISSING (required)"`
 Repo root: !`git rev-parse --show-toplevel 2>/dev/null || echo "unknown (pass --repo)"`
-Lane config: !`c="${CLAUDE_OPS_LANES_CONFIG:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.work/lanes.json}"; [[ -f "$c" ]] && echo "$c ($(jq -r '(.lanes//[])|length' "$c" 2>/dev/null) lanes)" || echo "absent ($c) — author one (see context/config.md)"`
+Lane config: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/lanes/scripts/probe-lane-config.sh" 2>/dev/null || echo "unknown"`
 
 ## Variables
 

--- a/plugins/claude-ops/skills/lanes/scripts/probe-lane-config.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/probe-lane-config.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# probe-lane-config.sh — report where the lane config resolves to and whether it exists.
+#
+# One line of the lanes skill's `## Pre-computed context` block. Resolving it is
+# real shell work — an env override, a repo-root-or-working-directory default, a
+# jq count — and a pre-compute line carrying genuine shell expansion (`$c`,
+# `${VAR:-default}`, `$(…)`) is refused by the worktree-isolation guard, so the
+# whole skill fails to load when invoked from an isolated agent (#1687). The
+# logic therefore lives here and the skill invokes the script through
+# `${CLAUDE_PLUGIN_ROOT}`, which the harness substitutes into a literal path
+# before any shell sees it.
+#
+# Usage:
+#   probe-lane-config.sh
+#
+# Output (stdout, exactly one line):
+#   <path> (<N> lanes)  config present; N is `(.lanes//[])|length` over it
+#   <path> ( lanes)     config present but the count is unavailable — jq missing,
+#                       or the file is not readable as JSON. The count degrades to
+#                       empty rather than erroring, which is what the pre-compute
+#                       line this replaced produced from its `2>/dev/null` inside
+#                       the count substitution.
+#   absent (<path>) — author one (see context/config.md)
+#
+# Path resolution, unchanged from the line this replaced:
+#   CLAUDE_OPS_LANES_CONFIG when set and non-empty — used verbatim, no suffix
+#   appended; otherwise <git toplevel, or the working directory when not inside a
+#   repo>/.work/lanes.json.
+#
+# The jq count is CR-stripped per this directory's standing convention (see
+# machine-behavior.sh): some native-Windows jq builds CRLF-terminate their output
+# and `$(…)` strips only the trailing LF, leaving a stray CR inside the reported
+# count. The git toplevel is CR-stripped through an empty-means-fall-back test
+# rather than a `|| pwd` continuation, because piping through `tr` would make the
+# pipeline always succeed and swallow the not-in-a-repo fallback.
+#
+# Exit codes:
+#   0  a line was emitted (either state)
+#   3  invalid argument
+
+set -uo pipefail
+
+err() { printf 'ERROR: %s\n' "$*" >&2; }
+
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "${BASH_SOURCE[0]}"; }
+
+while (($#)); do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    err "unknown argument: $1"
+    exit 3
+    ;;
+  esac
+done
+
+repo_root() {
+  local root
+  root="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
+  if [[ -n "$root" ]]; then
+    printf '%s\n' "$root"
+  else
+    printf '%s\n' "$PWD"
+  fi
+}
+
+CONFIG="${CLAUDE_OPS_LANES_CONFIG:-$(repo_root)/.work/lanes.json}"
+
+if [[ -f "$CONFIG" ]]; then
+  printf '%s (%s lanes)\n' "$CONFIG" "$(jq -r '(.lanes//[])|length' "$CONFIG" 2>/dev/null | tr -d '\r')"
+else
+  printf 'absent (%s) — author one (see context/config.md)\n' "$CONFIG"
+fi

--- a/plugins/claude-ops/skills/lanes/scripts/probe-lane-config.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/probe-lane-config.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Regression tests for probe-lane-config.sh.
+#
+# The script exists only to reproduce, from a bundled file, what a pre-compute
+# line used to compute inline (#1687). So every case asserts TWO things: the
+# script's output against the expected literal, and the script's output against
+# the ORIGINAL inline one-liner run in the same environment. The second assertion
+# is the one that matters — it is the byte-for-byte equivalence claim, checked
+# rather than reasoned about, and it stays honest whatever jq the host ships.
+#
+# Coverage:
+#   - CLAUDE_OPS_LANES_CONFIG override: used verbatim, no `.work/lanes.json`
+#     suffix appended; an EMPTY value falls through to the default
+#   - default path from the git toplevel, and from the working directory when
+#     not inside a repo
+#   - a CRLF-terminated git toplevel does not leak a stray CR into the path
+#   - present config → `<path> (<N> lanes)`; `.lanes` absent → `0 lanes`
+#   - unavailable count (jq missing / malformed JSON) degrades to `( lanes)`
+#     rather than erroring
+#   - absent config → the `absent (<path>) — author one …` line, em dash intact
+#   - argument validation exit code
+#
+# PATH-stubs `git` so no real repository state is touched, and stubs a
+# not-found `jq` for the degradation case (empty stdout + nonzero status is
+# exactly what an absent binary produces once stderr is suppressed).
+#
+# Every case runs in THIS shell, never a `( … )` subshell: an assertion inside a
+# subshell increments a copy of the failure counter and the run would report
+# green with a failing case in it. Environment scoping is therefore explicit
+# set/unset around each case rather than subshell containment.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/probe-lane-config.sh"
+START_DIR="$PWD"
+TMP="$(mktemp -d)"
+trap 'cd "$START_DIR" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+FAILED=0
+CASE_NUM=0
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: [%d] %s\n' "$CASE_NUM" "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'FAIL: [%d] %s\n      expected: %q\n      got:      %q\n' "$CASE_NUM" "$1" "$2" "$3" >&2
+  FAILED=$((FAILED + 1))
+}
+assert_eq() { if [[ "$3" == "$2" ]]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+
+# --- The pre-compute line this script replaced, verbatim ---------------------
+ORIGINAL="$TMP/original.sh"
+cat >"$ORIGINAL" <<'ORIG'
+c="${CLAUDE_OPS_LANES_CONFIG:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.work/lanes.json}"; [[ -f "$c" ]] && echo "$c ($(jq -r '(.lanes//[])|length' "$c" 2>/dev/null) lanes)" || echo "absent ($c) — author one (see context/config.md)"
+ORIG
+
+# --- Stubs -------------------------------------------------------------------
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+cat >"$STUB/git" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--show-toplevel" ]]; then
+  if [[ -n "${STUB_GIT_TOPLEVEL:-}" ]]; then
+    if [[ -n "${STUB_GIT_CRLF:-}" ]]; then
+      printf '%s\r\n' "$STUB_GIT_TOPLEVEL"
+    else
+      printf '%s\n' "$STUB_GIT_TOPLEVEL"
+    fi
+    exit 0
+  fi
+  printf 'fatal: not a git repository\n' >&2
+  exit 128
+fi
+exit 0
+SH
+chmod +x "$STUB/git"
+
+NOJQ="$TMP/nojq"
+mkdir -p "$NOJQ"
+cat >"$NOJQ/jq" <<'SH'
+#!/usr/bin/env bash
+printf 'bash: jq: command not found\n' >&2
+exit 127
+SH
+chmod +x "$NOJQ/jq"
+
+BASE_PATH="$STUB:$PATH"
+export PATH="$BASE_PATH"
+
+# --- Fixtures ----------------------------------------------------------------
+ROOT="$TMP/repo"
+mkdir -p "$ROOT/.work"
+cat >"$ROOT/.work/lanes.json" <<'JSON'
+{ "lanes": [ { "name": "a" }, { "name": "b" }, { "name": "c" } ] }
+JSON
+
+NO_LANES_KEY="$TMP/no-lanes-key.json"
+cat >"$NO_LANES_KEY" <<'JSON'
+{ "other": true }
+JSON
+
+MALFORMED="$TMP/malformed.json"
+cat >"$MALFORMED" <<'JSON'
+{ "lanes": [ this is not json
+JSON
+
+ELSEWHERE="$TMP/elsewhere"
+mkdir -p "$ELSEWHERE/.work"
+
+HAVE_JQ=0
+command -v jq >/dev/null 2>&1 && HAVE_JQ=1
+
+# run_both <label> <expected-literal|SKIP> — runs the script and the original
+# one-liner in the CURRENT environment and asserts both.
+#
+# The original's output is CR-stripped before comparison, and that is the ONE
+# deliberate divergence between the two: some native-Windows jq builds
+# CRLF-terminate their output, `$(…)` strips only the trailing LF, and the
+# original line therefore embedded a stray CR mid-string on those hosts. The
+# script routes the count through `tr -d '\r'` per this directory's standing
+# convention (machine-behavior.sh). Comparing raw would make this suite fail on
+# exactly the hosts the CR-strip exists to fix, so the normalization is applied
+# to the original rather than the divergence being hidden.
+run_both() {
+  local label="$1" expected="$2" got orig
+  got="$(bash "$SCRIPT" 2>/dev/null)"
+  orig="$(bash "$ORIGINAL" 2>/dev/null | tr -d '\r')"
+  [[ "$expected" == "SKIP" ]] || assert_eq "$label" "$expected" "$got"
+  assert_eq "$label (matches the original inline line, modulo the CR-strip)" "$orig" "$got"
+}
+
+# --- 1. Env override, present config -----------------------------------------
+export STUB_GIT_TOPLEVEL="$ROOT"
+export CLAUDE_OPS_LANES_CONFIG="$ROOT/.work/lanes.json"
+if ((HAVE_JQ)); then
+  run_both "override → present config with a lane count" "$ROOT/.work/lanes.json (3 lanes)"
+else
+  run_both "override → present config (jq absent; equivalence only)" "SKIP"
+fi
+
+# --- 2. Env override used verbatim (no .work/lanes.json suffix appended) ------
+export CLAUDE_OPS_LANES_CONFIG="$TMP/nowhere.json"
+run_both "override is used verbatim when the file is absent" \
+  "absent ($TMP/nowhere.json) — author one (see context/config.md)"
+
+# --- 3. Empty override falls through to the default --------------------------
+export CLAUDE_OPS_LANES_CONFIG=""
+if ((HAVE_JQ)); then
+  run_both "empty override falls through to <toplevel>/.work/lanes.json" \
+    "$ROOT/.work/lanes.json (3 lanes)"
+else
+  run_both "empty override falls through (jq absent; equivalence only)" "SKIP"
+fi
+unset CLAUDE_OPS_LANES_CONFIG
+
+# --- 4. Default path from the git toplevel -----------------------------------
+export STUB_GIT_TOPLEVEL="$ELSEWHERE"
+run_both "default resolves under the git toplevel" \
+  "absent ($ELSEWHERE/.work/lanes.json) — author one (see context/config.md)"
+
+# --- 5. A CRLF-terminated toplevel leaves no stray CR in the path ------------
+export STUB_GIT_CRLF=1
+assert_eq "CRLF toplevel is stripped" \
+  "absent ($ELSEWHERE/.work/lanes.json) — author one (see context/config.md)" \
+  "$(bash "$SCRIPT" 2>/dev/null)"
+unset STUB_GIT_CRLF
+
+# --- 6. Not inside a repo → the working directory ----------------------------
+unset STUB_GIT_TOPLEVEL
+cd "$ELSEWHERE" || exit 1
+run_both "not in a repo → default resolves under the working directory" \
+  "absent ($ELSEWHERE/.work/lanes.json) — author one (see context/config.md)"
+cd "$START_DIR" || exit 1
+
+# --- 7. `.lanes` absent from the config, and malformed JSON ------------------
+export STUB_GIT_TOPLEVEL="$ROOT"
+if ((HAVE_JQ)); then
+  export CLAUDE_OPS_LANES_CONFIG="$NO_LANES_KEY"
+  run_both "config without a .lanes key counts 0" "$NO_LANES_KEY (0 lanes)"
+  export CLAUDE_OPS_LANES_CONFIG="$MALFORMED"
+  run_both "malformed config degrades the count to empty" "$MALFORMED ( lanes)"
+  unset CLAUDE_OPS_LANES_CONFIG
+else
+  printf 'SKIP: jq absent — real-count cases not exercised\n'
+fi
+
+# --- 8. jq missing → the count degrades to empty, not an error ---------------
+export PATH="$NOJQ:$BASE_PATH"
+export CLAUDE_OPS_LANES_CONFIG="$ROOT/.work/lanes.json"
+run_both "jq missing degrades the count to empty" "$ROOT/.work/lanes.json ( lanes)"
+unset CLAUDE_OPS_LANES_CONFIG
+export PATH="$BASE_PATH"
+
+# --- 9. Argument validation ---------------------------------------------------
+out="$(bash "$SCRIPT" --bogus 2>&1)"
+rc=$?
+assert_eq "unknown argument exits 3" "3" "$rc"
+case "$out" in
+*"unknown argument: --bogus"*) pass "unknown argument is named on stderr" ;;
+*) fail "unknown argument is named on stderr" "unknown argument: --bogus" "$out" ;;
+esac
+
+bash "$SCRIPT" --help >/dev/null 2>&1
+assert_eq "--help exits 0" "0" "$?"
+
+if [[ $FAILED -eq 0 ]]; then
+  printf '\nAll %d cases passed.\n' "$CASE_NUM"
+  exit 0
+fi
+printf '\n%d of %d cases FAILED.\n' "$FAILED" "$CASE_NUM" >&2
+exit 1

--- a/plugins/claude-ops/skills/observability/SKILL.md
+++ b/plugins/claude-ops/skills/observability/SKILL.md
@@ -16,9 +16,9 @@ metadata:
 Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
 Repo slug: !`git rev-parse --show-toplevel 2>/dev/null | sed 's|.*/||' || echo "unknown"`
 ccusage availability: !`command -v npx >/dev/null 2>&1 && echo "npx present" || echo "npx MISSING"`
-Hook event log: !`f="$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.claude/observability/hook-events.jsonl"; if [[ -f "$f" ]]; then echo "$(wc -l < "$f") events"; else echo "EMPTY (no hook-event emitter wired, or no hooks fired yet)"; fi`
+Hook event log: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/observability/scripts/probe-observability-state.sh" --hook-events 2>/dev/null || echo "unknown"`
 OTEL collector :4318: !`bash -c 'source "${CLAUDE_PLUGIN_ROOT}/skills/observability/otel/net-probe.sh" && port_status 4318' 2>/dev/null || echo unknown`
-OTEL store: !`d="${CC_OTEL_STORE:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.claude/observability/otel}"; for f in cc-logs.json cc-metrics.json cc-traces.json; do if [[ -f "$d/$f" ]]; then echo "$f:$(wc -c < "$d/$f" 2>/dev/null || echo 0)B"; else echo "$f:absent"; fi; done 2>/dev/null || echo "unknown"`
+OTEL store: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/observability/scripts/probe-observability-state.sh" --otel-store 2>/dev/null || echo "unknown"`
 
 ## Purpose
 

--- a/plugins/claude-ops/skills/observability/scripts/probe-observability-state.sh
+++ b/plugins/claude-ops/skills/observability/scripts/probe-observability-state.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# probe-observability-state.sh — report local telemetry-store state for the
+# observability skill's `## Pre-computed context` block.
+#
+# Two of that block's lines are real shell work — a repo-root-or-working-directory
+# default, an env override, a per-file size loop — and a pre-compute line carrying
+# genuine shell expansion (`$f`, `$d`, `${VAR:-default}`, `$(…)`) is refused by the
+# worktree-isolation guard, so the whole skill fails to load when invoked from an
+# isolated agent (#1687). Both lines therefore call this script through
+# `${CLAUDE_PLUGIN_ROOT}`, which the harness substitutes into a literal path before
+# any shell sees it.
+#
+# One script, two modes rather than two scripts: both lines read the same local
+# observability tree, so they are two facets of one probe surface, and a caller
+# picking a mode is the only difference between them.
+#
+# Usage:
+#   probe-observability-state.sh --hook-events
+#   probe-observability-state.sh --otel-store
+#
+# --hook-events output (stdout, exactly one line) over
+# <store root>/.claude/observability/hook-events.jsonl:
+#   <N> events
+#   EMPTY (no hook-event emitter wired, or no hooks fired yet)
+#
+# --otel-store output (stdout, three lines — one per store file, in order
+# cc-logs.json, cc-metrics.json, cc-traces.json):
+#   <name>:<bytes>B
+#   <name>:absent
+#
+# Store resolution, unchanged from the lines this replaced:
+#   --hook-events  <git toplevel, or the working directory when not inside a
+#                  repo>/.claude/observability/hook-events.jsonl — no env override,
+#                  matching the line it replaces.
+#   --otel-store   CC_OTEL_STORE when set and non-empty, used verbatim; otherwise
+#                  <git toplevel, or the working directory>/.claude/observability/otel.
+#
+# The git toplevel is CR-stripped through an empty-means-fall-back test rather than
+# a `|| pwd` continuation, because piping through `tr` would make the pipeline
+# always succeed and swallow the not-in-a-repo fallback. `wc` output is emitted
+# as captured, exactly as the pre-compute lines did.
+#
+# Exit codes:
+#   0  the requested mode's lines were emitted
+#   3  invalid, missing, or conflicting argument
+
+set -uo pipefail
+
+err() { printf 'ERROR: %s\n' "$*" >&2; }
+
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "${BASH_SOURCE[0]}"; }
+
+MODE=""
+while (($#)); do
+  case "$1" in
+  --hook-events | --otel-store)
+    if [[ -n "$MODE" ]]; then
+      err "modes are mutually exclusive: $MODE and $1"
+      exit 3
+    fi
+    MODE="$1"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    err "unknown argument: $1"
+    exit 3
+    ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  err "a mode is required: --hook-events or --otel-store"
+  exit 3
+fi
+
+repo_root() {
+  local root
+  root="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
+  if [[ -n "$root" ]]; then
+    printf '%s\n' "$root"
+  else
+    printf '%s\n' "$PWD"
+  fi
+}
+
+case "$MODE" in
+--hook-events)
+  HOOK_LOG="$(repo_root)/.claude/observability/hook-events.jsonl"
+  if [[ -f "$HOOK_LOG" ]]; then
+    printf '%s events\n' "$(wc -l <"$HOOK_LOG")"
+  else
+    printf 'EMPTY (no hook-event emitter wired, or no hooks fired yet)\n'
+  fi
+  ;;
+--otel-store)
+  STORE="${CC_OTEL_STORE:-$(repo_root)/.claude/observability/otel}"
+  for name in cc-logs.json cc-metrics.json cc-traces.json; do
+    if [[ -f "$STORE/$name" ]]; then
+      printf '%s:%sB\n' "$name" "$(wc -c <"$STORE/$name" 2>/dev/null || echo 0)"
+    else
+      printf '%s:absent\n' "$name"
+    fi
+  done
+  ;;
+*)
+  err "unhandled mode: $MODE"
+  exit 3
+  ;;
+esac

--- a/plugins/claude-ops/skills/observability/scripts/probe-observability-state.test.sh
+++ b/plugins/claude-ops/skills/observability/scripts/probe-observability-state.test.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Regression tests for probe-observability-state.sh.
+#
+# The script exists only to reproduce, from a bundled file, what two pre-compute
+# lines used to compute inline (#1687). So every case asserts TWO things: the
+# script's output against the expected literal, and the script's output against
+# the ORIGINAL inline one-liner run in the same environment. The second assertion
+# is the byte-for-byte equivalence claim, checked rather than reasoned about.
+#
+# Coverage:
+#   --hook-events
+#     - present log → `<N> events`; absent log → the EMPTY sentence verbatim
+#     - path resolves under the git toplevel, and under the working directory
+#       when not inside a repo
+#     - no env override (the line it replaces had none), so CC_OTEL_STORE must
+#       not steer it
+#   --otel-store
+#     - CC_OTEL_STORE used verbatim when set; an EMPTY value falls through
+#     - one line per store file, in fixed order, `<name>:<bytes>B` / `<name>:absent`
+#     - mixed present/absent across the three files
+#   - a CRLF-terminated git toplevel does not leak a stray CR into the path
+#   - mode validation: missing, unknown, and conflicting arguments all exit 3
+#
+# PATH-stubs `git` so no real repository state is touched.
+#
+# Every case runs in THIS shell, never a `( … )` subshell: an assertion inside a
+# subshell increments a copy of the failure counter and the run would report
+# green with a failing case in it. Environment scoping is therefore explicit
+# set/unset around each case rather than subshell containment.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/probe-observability-state.sh"
+START_DIR="$PWD"
+TMP="$(mktemp -d)"
+trap 'cd "$START_DIR" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+FAILED=0
+CASE_NUM=0
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: [%d] %s\n' "$CASE_NUM" "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'FAIL: [%d] %s\n      expected: %q\n      got:      %q\n' "$CASE_NUM" "$1" "$2" "$3" >&2
+  FAILED=$((FAILED + 1))
+}
+assert_eq() { if [[ "$3" == "$2" ]]; then pass "$1"; else fail "$1" "$2" "$3"; fi; }
+
+# --- The pre-compute lines this script replaced, verbatim --------------------
+ORIG_HOOK="$TMP/original-hook-events.sh"
+cat >"$ORIG_HOOK" <<'ORIG'
+f="$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.claude/observability/hook-events.jsonl"; if [[ -f "$f" ]]; then echo "$(wc -l < "$f") events"; else echo "EMPTY (no hook-event emitter wired, or no hooks fired yet)"; fi
+ORIG
+
+ORIG_OTEL="$TMP/original-otel-store.sh"
+cat >"$ORIG_OTEL" <<'ORIG'
+d="${CC_OTEL_STORE:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.claude/observability/otel}"; for f in cc-logs.json cc-metrics.json cc-traces.json; do if [[ -f "$d/$f" ]]; then echo "$f:$(wc -c < "$d/$f" 2>/dev/null || echo 0)B"; else echo "$f:absent"; fi; done 2>/dev/null || echo "unknown"
+ORIG
+
+# --- Stubs -------------------------------------------------------------------
+STUB="$TMP/stub"
+mkdir -p "$STUB"
+cat >"$STUB/git" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--show-toplevel" ]]; then
+  if [[ -n "${STUB_GIT_TOPLEVEL:-}" ]]; then
+    if [[ -n "${STUB_GIT_CRLF:-}" ]]; then
+      printf '%s\r\n' "$STUB_GIT_TOPLEVEL"
+    else
+      printf '%s\n' "$STUB_GIT_TOPLEVEL"
+    fi
+    exit 0
+  fi
+  printf 'fatal: not a git repository\n' >&2
+  exit 128
+fi
+exit 0
+SH
+chmod +x "$STUB/git"
+export PATH="$STUB:$PATH"
+
+# --- Fixtures ----------------------------------------------------------------
+# WIRED: a repo whose hook log has 4 lines and whose store holds two of three files.
+WIRED="$TMP/wired"
+mkdir -p "$WIRED/.claude/observability/otel"
+printf '{"a":1}\n{"a":2}\n{"a":3}\n{"a":4}\n' >"$WIRED/.claude/observability/hook-events.jsonl"
+printf '0123456789' >"$WIRED/.claude/observability/otel/cc-logs.json"
+printf '01234' >"$WIRED/.claude/observability/otel/cc-traces.json"
+
+# BARE: a repo with no observability tree at all.
+BARE="$TMP/bare"
+mkdir -p "$BARE"
+
+# ALTSTORE: a store outside any repo, for the CC_OTEL_STORE override.
+ALTSTORE="$TMP/altstore"
+mkdir -p "$ALTSTORE"
+printf 'xy' >"$ALTSTORE/cc-metrics.json"
+
+# Expected byte/line counts come from `wc` itself, not from GNU-shaped literals.
+# BSD `wc` left-pads its output (`       10`) where GNU does not, and the script
+# must keep emitting whatever the host's `wc` produces — that padding is part of
+# the output shape the replaced pre-compute line had. Hardcoding `10B` would make
+# these cases fail on macOS for a difference the script is required to preserve.
+wc_c() { wc -c <"$1"; }
+wc_l() { wc -l <"$1"; }
+
+WIRED_EVENTS="$(wc_l "$WIRED/.claude/observability/hook-events.jsonl") events"
+WIRED_STORE_LINES="$(printf 'cc-logs.json:%sB\ncc-metrics.json:absent\ncc-traces.json:%sB' \
+  "$(wc_c "$WIRED/.claude/observability/otel/cc-logs.json")" \
+  "$(wc_c "$WIRED/.claude/observability/otel/cc-traces.json")")"
+EMPTY_STORE_LINES="$(printf 'cc-logs.json:absent\ncc-metrics.json:absent\ncc-traces.json:absent')"
+ALT_STORE_LINES="$(printf 'cc-logs.json:absent\ncc-metrics.json:%sB\ncc-traces.json:absent' \
+  "$(wc_c "$ALTSTORE/cc-metrics.json")")"
+
+# run_both <label> <mode> <original-script> <expected-literal>
+run_both() {
+  local label="$1" mode="$2" original="$3" expected="$4" got orig
+  got="$(bash "$SCRIPT" "$mode" 2>/dev/null)"
+  orig="$(bash "$original" 2>/dev/null)"
+  assert_eq "$label" "$expected" "$got"
+  assert_eq "$label (matches the original inline line byte-for-byte)" "$orig" "$got"
+}
+
+# --- --hook-events ------------------------------------------------------------
+export STUB_GIT_TOPLEVEL="$WIRED"
+run_both "hook log present → line count" --hook-events "$ORIG_HOOK" "$WIRED_EVENTS"
+
+export STUB_GIT_TOPLEVEL="$BARE"
+run_both "hook log absent → EMPTY sentence" --hook-events "$ORIG_HOOK" \
+  "EMPTY (no hook-event emitter wired, or no hooks fired yet)"
+
+unset STUB_GIT_TOPLEVEL
+cd "$WIRED" || exit 1
+run_both "not in a repo → hook log resolves under the working directory" \
+  --hook-events "$ORIG_HOOK" "$WIRED_EVENTS"
+cd "$START_DIR" || exit 1
+
+export STUB_GIT_TOPLEVEL="$WIRED" STUB_GIT_CRLF=1
+assert_eq "CRLF toplevel is stripped (--hook-events)" "$WIRED_EVENTS" \
+  "$(bash "$SCRIPT" --hook-events 2>/dev/null)"
+unset STUB_GIT_CRLF
+
+# The replaced line had no env override; CC_OTEL_STORE must not steer this mode.
+export CC_OTEL_STORE="$ALTSTORE"
+run_both "CC_OTEL_STORE does not steer --hook-events" --hook-events "$ORIG_HOOK" "$WIRED_EVENTS"
+unset CC_OTEL_STORE
+
+# --- --otel-store -------------------------------------------------------------
+run_both "store under the git toplevel: mixed present/absent, fixed order" \
+  --otel-store "$ORIG_OTEL" "$WIRED_STORE_LINES"
+
+export STUB_GIT_TOPLEVEL="$BARE"
+run_both "store absent → every file reported absent" \
+  --otel-store "$ORIG_OTEL" "$EMPTY_STORE_LINES"
+
+export STUB_GIT_TOPLEVEL="$WIRED" CC_OTEL_STORE="$ALTSTORE"
+run_both "CC_OTEL_STORE is used verbatim" --otel-store "$ORIG_OTEL" "$ALT_STORE_LINES"
+
+export CC_OTEL_STORE=""
+run_both "empty CC_OTEL_STORE falls through to the repo default" \
+  --otel-store "$ORIG_OTEL" "$WIRED_STORE_LINES"
+unset CC_OTEL_STORE
+
+unset STUB_GIT_TOPLEVEL
+cd "$WIRED" || exit 1
+run_both "not in a repo → store resolves under the working directory" \
+  --otel-store "$ORIG_OTEL" "$WIRED_STORE_LINES"
+cd "$START_DIR" || exit 1
+
+export STUB_GIT_TOPLEVEL="$WIRED" STUB_GIT_CRLF=1
+assert_eq "CRLF toplevel is stripped (--otel-store)" "$WIRED_STORE_LINES" \
+  "$(bash "$SCRIPT" --otel-store 2>/dev/null)"
+unset STUB_GIT_CRLF
+
+# --- Mode validation ----------------------------------------------------------
+out="$(bash "$SCRIPT" 2>&1)"
+rc=$?
+assert_eq "no mode exits 3" "3" "$rc"
+case "$out" in
+*"a mode is required"*) pass "no mode names the requirement on stderr" ;;
+*) fail "no mode names the requirement on stderr" "a mode is required" "$out" ;;
+esac
+
+bash "$SCRIPT" --bogus >/dev/null 2>&1
+assert_eq "unknown argument exits 3" "3" "$?"
+
+out="$(bash "$SCRIPT" --hook-events --otel-store 2>&1)"
+rc=$?
+assert_eq "conflicting modes exit 3" "3" "$rc"
+case "$out" in
+*"mutually exclusive"*) pass "conflicting modes are named on stderr" ;;
+*) fail "conflicting modes are named on stderr" "mutually exclusive" "$out" ;;
+esac
+
+bash "$SCRIPT" --help >/dev/null 2>&1
+assert_eq "--help exits 0" "0" "$?"
+
+if [[ $FAILED -eq 0 ]]; then
+  printf '\nAll %d cases passed.\n' "$CASE_NUM"
+  exit 0
+fi
+printf '\n%d of %d cases FAILED.\n' "$FAILED" "$CASE_NUM" >&2
+exit 1


### PR DESCRIPTION
## Summary

`claude-ops`'s `lanes` and `observability` skills each carried `## Pre-computed context` lines with
genuine shell expansion. The harness composes a skill's whole pre-compute block into one shell
invocation, and the worktree-isolation Bash guard refuses any genuine `$` expansion — so the block,
and with it the skill, fails to load when invoked from a worktree-isolated agent. It did not degrade
to a fallback string; it was refused outright.

Four lines carried expansion, and all four are fixed:

| Skill | Line | Before | After |
| --- | --- | --- | --- |
| `lanes` | 16 `claude CLI:` | `command -v claude … && echo "present ($(claude --version))" \|\| …` | `claude --version 2>/dev/null \|\| echo "MISSING (required)"` |
| `lanes` | 19 `Lane config:` | `c="${CLAUDE_OPS_LANES_CONFIG:-$(git rev-parse …)/…}"; …` | `bash "${CLAUDE_PLUGIN_ROOT}/skills/lanes/scripts/probe-lane-config.sh"` |
| `observability` | 19 `Hook event log:` | `f="$(git rev-parse …)/…"; if [[ -f "$f" ]]; …` | `bash "${CLAUDE_PLUGIN_ROOT}/skills/observability/scripts/probe-observability-state.sh" --hook-events` |
| `observability` | 21 `OTEL store:` | `d="${CC_OTEL_STORE:-$(git rev-parse …)/…}"; for f in …` | `…/probe-observability-state.sh" --otel-store` |

`lanes` line 16 had a trivial `$`-free form available and takes it rather than growing a script.
The other three hoist into two bundled scripts invoked through `${CLAUDE_PLUGIN_ROOT}`, which the
harness substitutes into a literal path before any shell sees it — so no `$` remains in any of the
four command strings. `$` inside the script files is unrestricted.

Both `observability` lines share one script because both read the same local observability tree and
a mode flag (`--hook-events` / `--otel-store`) is their only difference. Path resolution, the
`CLAUDE_OPS_LANES_CONFIG` and `CC_OTEL_STORE` overrides, and every output string are unchanged.

**One output shape did change**, deliberately: the `claude CLI:` line now reads
`2.1.220 (Claude Code)` rather than `present (2.1.220 (Claude Code))` — same information, no
`present (…)` wrapper. Recorded in the CHANGELOG.

**Equivalence testing.** Each script ships a test that runs the ORIGINAL inline one-liner alongside
the script in the same environment and diffs the two outputs, so the behavior-preservation claim is
checked rather than reasoned about. 20 cases for `probe-lane-config.sh`, 26 for
`probe-observability-state.sh`, covering env-override precedence, repo/non-repo resolution, absent
and malformed config, missing `jq`, CRLF toplevel strip, and the usage/exit-code contract.

**Full-plugin sweep.** All seven `claude-ops` skills were swept for pre-compute expansion, not just
the two edited. `changelog`, `plugins`, and `setup` have no `## Pre-computed context` block at all;
`known-issues` and `morning-brief` have blocks whose every line is already `$`-free. Only `lanes`
and `observability` carried expansion, and this PR fixes every line that did — `claude-ops` is
complete for #1687's pre-compute scope once this merges. `observability` line 20
(`OTEL collector :4318`) was already plugin-variable-only and is untouched.

Version: `claude-ops` 0.24.3 → 0.24.4, with a matching `## [0.24.4]` `### Fixed` CHANGELOG entry.
The branch was rebased onto `main` after #1815 shipped 0.24.3 for this plugin, so the bump was
re-derived rather than carried.

## Test plan

Gates run from the worktree root after the rebase, all passing:

| Gate | Result |
| --- | --- |
| `bash scripts/check-changelog-parity.sh --check-bump origin/main` | PASS |
| `bash scripts/check-changelog-parity.sh --check` | PASS |
| `bash scripts/check-changelog-parity.sh --check-order` | PASS — 71 changelogs newest-first, no duplicate versions |
| `bash scripts/check-changed-skills.sh origin/main` | PASS — 2 skills, 0 errors, 1 warning (pre-existing: `lanes` SKILL.md 306 lines vs the 200 soft target); it also executed both new script tests |
| `bash scripts/check-skill-portability.sh origin/main` | PASS — no unexcused coupling tokens in 10 skill files |
| `bash scripts/check-shell-portability.sh --paths` (both scripts + both test files) | PASS — no unexcused GNU-only constructs in 4 shell files |
| `bash scripts/check-silent-skips.sh` | PASS |
| `bash scripts/check-skill-leaf-names.sh --check` | PASS |
| `bash scripts/check-orphaned-fixtures.sh --check` | PASS |
| `bash scripts/check-plugin-manifest-presence.sh` | PASS |
| `bash scripts/check-cross-plugin-source-drift.sh --check` | PASS |
| `shellcheck --rcfile=.shellcheckrc` on both scripts + both test files | clean, exit 0 |
| `shfmt -d` on both scripts + both test files | no diff |
| `npx --yes markdownlint-cli2 "plugins/claude-ops/**/*.md"` | PASS — 0 issues, 39 files |
| `bash plugins/claude-ops/skills/lanes/scripts/probe-lane-config.test.sh` | PASS — all 20 cases |
| `bash plugins/claude-ops/skills/observability/scripts/probe-observability-state.test.sh` | PASS — all 26 cases |

Limits of this evidence:

- CI never invokes a skill from an isolated agent, so nothing in this PR's gates proves the fix
  end-to-end.
- The plugin cache is version-keyed, so the edited skills cannot be invoked until this merges and
  plugins update. End-to-end proof is post-merge, per #1687's closure criterion: invoke `lanes` and
  `observability` from an `Agent` with `isolation: "worktree"`, with a negative control predicted to
  still refuse.
- **Adjacent surface deliberately left unfixed.** `skills/lanes/context/refresh.md` (lines 49, 58,
  63) and `skills/observability/context/data-sources.md` (lines 9, 15–17, 40, 204) still instruct
  the model to run `$(…)` command substitution — the same shape the guard refuses, but as a normal
  Bash tool call the model makes mid-skill, not as a pre-compute line. This PR is scoped to the
  pre-compute block, so those are untouched and a worktree-isolated run of either skill would still
  be blocked at those steps. Flagging it as a real gap in #1687's coverage rather than silently
  widening this PR — the same gap #1831 flagged for `claude-memory`.
- This is one of five partial PRs on #1687. It deliberately carries **no closing keyword** so a
  partial merge cannot auto-close the tracker; the tracker closes only after all five merge and
  post-ship verification passes.

## Related

No linked issue

Refs #1687
Refs #1619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVoZoMYXqf8ZVbQYixPVPW
