### PR TITLE
fix(ci): re-narrow the security lane's skip-actor exception to two actors

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -2,9 +2,11 @@ name: claude-security-review
 
 # Dedicated LLM security-review pass via the ci-workflows reusable workflow — the
 # security sibling of claude-review.yml, ADR 0002's default-on advisory posture.
-# The caller owns the triggers, the GITHUB_TOKEN grant, and the `paths-file`
-# input pointing at `.github/claude-security-paths`, the repo-owned list of this
-# repo's security-sensitive surfaces (workflows, scripts, hooks, shell, and
+# The caller owns the triggers, the GITHUB_TOKEN grant, the narrowed
+# `skip-actors` list (see the comment beside it — ADR 0002's 2026-07-31
+# addendum), and the `paths-file` input pointing at
+# `.github/claude-security-paths`, the repo-owned list of this repo's
+# security-sensitive surfaces (workflows, scripts, hooks, shell, and
 # permission/settings config) that the reusable reads from the PR's BASE branch.
 # There is deliberately NO workflow-level path filter: a path miss would leave
 # the required execution check Pending and wedge prose PRs, so the reusable
@@ -35,6 +37,19 @@ jobs:
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths
+      # DELIBERATE DIVERGENCE from the reusable's inherited default — do not
+      # delete this line at a re-pin, and do not "simplify" it away. The
+      # upstream default is
+      # `dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]`;
+      # inheriting it lets `claude[bot]` and `melodic-ai[bot]` satisfy this
+      # repo's REQUIRED `security-review / security-review` check with no
+      # review run, on security-sensitive paths, with no compensating control
+      # (the two actors listed below each have one — see ADR 0002's
+      # 2026-07-31 addendum). A stale explicit list fails closed; a stale
+      # inherited default fails open. runner-policy rejects inputs outside the
+      # reviewed contract but cannot require one, so dropping this line
+      # re-widens the exception silently and CI stays green.
+      skip-actors: "dependabot[bot],melodic-standards-sync[bot]"
     # One named secret (least privilege), never `secrets: inherit`.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -113,6 +113,78 @@ mitigation is that workflow-file diffs are themselves security-review surface an
 file is human-reviewed. This is the consensus-accepted bound of Actions-based required checks,
 not a defect introduced here.
 
+## Addendum (2026-07-31): skip-actor exception re-deliberated — widening rejected
+
+The step-3 revisit trigger fired, through a channel it did not name. The v0.9.1 lane re-pin
+deleted both callers' explicit `skip-actors` lists so each inherited the reusable workflow's
+default — `dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]` — silently
+widening the exception above from two actors to four (#1767).
+
+**Ruling: the widening is REJECTED for the security lane.** The caller
+(`.github/workflows/claude-security-review.yml`) restores an explicit
+`skip-actors: "dependabot[bot],melodic-standards-sync[bot]"`, re-narrowing the exception to
+exactly the two actors the step-3 addendum ratified. The general lane (`claude-review.yml`)
+**keeps inheriting** the default: it is advisory with no required check, so its skip list is
+runner-minute economy, not evidence.
+
+Rationale:
+
+1. **Each ratified actor carries a compensating control; the two new ones carry none.**
+   Dependabot pin bumps are forced through the reviewed runner-policy contract and standards-sync
+   PRs materialize byte-exact upstream-reviewed content (step-3 addendum above). `claude[bot]` and
+   `melodic-ai[bot]` have no analogue — and the general review lane skips them too, so an
+   AI-app-pushed commit would satisfy the required security check with zero review of any kind.
+   AI-authored change is precisely the provenance class this lane exists to cover (NIST SP
+   800-218A's same-bar principle, already this ADR's attribution basis).
+2. **Latency is not absence.** No workflow here lets either app push today — no `@claude`
+   dispatcher exists in this repo — so the channel is dormant. Adding one is a routine, plausible
+   change that would silently activate a review bypass. Fail-closed bias: the exception must not
+   pre-authorize it.
+3. **Staleness asymmetry decides inheritance-vs-explicit for an evidence gate.** A stale explicit
+   list fails **closed** (an actor gets a review it may not have needed — a visible cost); a stale
+   inherited default fails **open** (an actor this repo never deliberated skips review silently —
+   exactly what the re-pin did). The fleet's inheritance-over-explicit-list decision stands for
+   defaults that are cost/config; an evidence-gate exception is the deliberate-divergence case the
+   caller seam exists for, and the runner-policy `allowedInputs` contract makes that divergence a
+   reviewed, standards-visible act.
+
+Rejected alternatives:
+
+- **Accept and document the widened exception** — converts a cost optimization into an
+  unreviewed-provenance bypass of a required check, contradicting the step-3 addendum's own
+  bounded-scope clause with no compensating control.
+- **Narrow the reusable workflow's default upstream (ci-workflows)** — not chosen as *this repo's*
+  fix: that default serves every consumer and its self-trigger/cost rationale is legitimate for
+  advisory lanes. Whether ci-workflows should split the security reusable's default from the
+  review one is ci-workflows' own deliberation; recorded there as a follow-up, not a blocker here.
+- **Do nothing, relying on human merge review of AI-provenance PRs** — process convention, not a
+  technical control. The required check exists to be evidence.
+
+Cross-vendor advisory (Codex, gpt-5.6-sol) concurred with the explicit narrow list. Strongest
+counterargument recorded: if the apps later gain push capability, the narrow list risks
+self-triggering recursion, extra spend, and "independent" review by substantially the same AI
+system. Accepted — those are visible availability and cost failures, while the inherited default's
+failure mode is a silent security bypass, the worse direction.
+
+Composition with the github-iac work: #248 (merged) app-pins all four required contexts to the
+GitHub Actions app, narrowing *who may report* a check — orthogonal and complementary to this
+ruling, which narrows *when the check may be satisfied without a review run*. #228 remains open
+for the live forgery test; this addendum deliberately does **not** touch the "creatable only by
+the App that runs the pass, so a branch cannot forge it" sentence in the step-3 enforcement
+addendum — that sentence stays #228's to update from the tested result.
+
+Sequencing (fail-closed, deliberate): `policy.json` is a managed materialization of the standards
+`runner-policy` component, and the contract for `claude-security-review.yml@c136b27` admitted only
+`runner` and `paths-file`, so restoring the input is an input-surface change that lands upstream
+first — standards contract PR → standards-to-here sync PR → this caller and addendum. This repo's
+`runner-policy` check stays red until the sync merges.
+
+**Residual gap (open, not fixed here):** the runner-policy validator rejects *unexpected* inputs
+but cannot *require* one, so a future re-pin that again drops the caller's `skip-actors` passes CI
+and silently re-widens the exception. The guard until standards grows a `requiredInputs`-style
+contract field is the rewritten revisit trigger below plus the caller-side comment beside the
+input.
+
 ## Revisit triggers
 
 - The security lane's findings prove precise over a sustained window → open the promotion
@@ -120,9 +192,16 @@ not a defect introduced here.
 - The general lane's advisory threads measurably gate merges again (#618's class) → tune
   scope before considering demotion.
 - ci-workflows ships a release changing either reusable workflow's contract → re-pin the
-  callers through the ordinary Dependabot/SHA-bump path.
+  callers through the ordinary Dependabot/SHA-bump path. Not a rubber stamp for the security
+  caller: a re-pin is one of the two channels that widens the skip-actor exception (below).
 - A merge queue is enabled on the base → the security workflow must add the `merge_group`
   trigger, or its required check is never reported for queued PRs (a required check that never
   runs blocks the merge).
-- An actor is added to the caller's `skip-actors` list → the step-3 skip-actor exception
-  widens; re-deliberate before landing, and record the rationale beside the addendum above.
+- The security caller's effective `skip-actors` set gains an actor, through **either** channel →
+  the skip-actor exception widens; re-deliberate before landing and record the rationale beside
+  the addenda above. Channel A: the caller's explicit list is edited. Channel B (the one that
+  actually fired, #1767): the caller's explicit list is deleted or the reusable workflow's pin
+  moves, so the *inherited default* supplies the set — CI stays green either way, because
+  runner-policy rejects unexpected inputs but cannot require one. Reviewing a re-pin of
+  `.github/workflows/claude-security-review.yml` therefore means diffing the new pin's
+  `skip-actors` default against the caller's explicit list, not just the SHA.

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -137,8 +137,10 @@ Rationale:
    AI-authored change is precisely the provenance class this lane exists to cover (NIST SP
    800-218A's same-bar principle, already this ADR's attribution basis).
 2. **Latency is not absence.** No workflow here lets either app push today — no `@claude`
-   dispatcher exists in this repo — so the channel is dormant. Adding one is a routine, plausible
-   change that would silently activate a review bypass. Fail-closed bias: the exception must not
+   dispatcher exists in this repo — so the channel is dormant. It is not speculative, though:
+   an org-wide `@claude` mention-responder lane is already proposed
+   ([ci-workflows#255](https://github.com/melodic-software/ci-workflows/issues/255)), and adopting
+   it would silently activate a review bypass. Fail-closed bias: the exception must not
    pre-authorize it.
 3. **Staleness asymmetry decides inheritance-vs-explicit for an evidence gate.** A stale explicit
    list fails **closed** (an actor gets a review it may not have needed — a visible cost); a stale
@@ -156,7 +158,9 @@ Rejected alternatives:
 - **Narrow the reusable workflow's default upstream (ci-workflows)** — not chosen as *this repo's*
   fix: that default serves every consumer and its self-trigger/cost rationale is legitimate for
   advisory lanes. Whether ci-workflows should split the security reusable's default from the
-  review one is ci-workflows' own deliberation; recorded there as a follow-up, not a blocker here.
+  review one is ci-workflows' own deliberation, filed there as
+  [ci-workflows#330](https://github.com/melodic-software/ci-workflows/issues/330) — a follow-up,
+  not a blocker here.
 - **Do nothing, relying on human merge review of AI-provenance PRs** — process convention, not a
   technical control. The required check exists to be evidence.
 
@@ -181,9 +185,10 @@ first — standards contract PR → standards-to-here sync PR → this caller an
 
 **Residual gap (open, not fixed here):** the runner-policy validator rejects *unexpected* inputs
 but cannot *require* one, so a future re-pin that again drops the caller's `skip-actors` passes CI
-and silently re-widens the exception. The guard until standards grows a `requiredInputs`-style
-contract field is the rewritten revisit trigger below plus the caller-side comment beside the
-input.
+and silently re-widens the exception. Closing it needs a `requiredInputs`-style contract field
+upstream, filed as
+[standards#308](https://github.com/melodic-software/standards/issues/308); until that lands the
+guard is the rewritten revisit trigger below plus the caller-side comment beside the input.
 
 ## Revisit triggers
 

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -137,11 +137,14 @@ Rationale:
    AI-authored change is precisely the provenance class this lane exists to cover (NIST SP
    800-218A's same-bar principle, already this ADR's attribution basis).
 2. **Latency is not absence.** No workflow here lets either app push today — no `@claude`
-   dispatcher exists in this repo — so the channel is dormant. It is not speculative, though:
-   an org-wide `@claude` mention-responder lane is already proposed
-   ([ci-workflows#255](https://github.com/melodic-software/ci-workflows/issues/255)), and adopting
-   it would silently activate a review bypass. Fail-closed bias: the exception must not
-   pre-authorize it.
+   dispatcher exists in this repo — so the channel is dormant. The path to it is charted, not
+   speculative: an org-wide `@claude` mention-responder lane is proposed as
+   [ci-workflows#255](https://github.com/melodic-software/ci-workflows/issues/255). Its V1 is
+   deliberately read-only (no Edit/Write, no push), so adopting V1 would *not* open the channel;
+   its V2 — tag-mode fix-and-push, behind that issue's own approval gate — would, and in tag mode
+   the action pushes to the PR's own branch. So the activating change is a gated future step
+   rather than an imminent one, which is exactly when a fail-closed exception is cheap to set:
+   the bypass must not already be pre-authorized when that gate is considered on its own merits.
 3. **Staleness asymmetry decides inheritance-vs-explicit for an evidence gate.** A stale explicit
    list fails **closed** (an actor gets a review it may not have needed — a visible cost); a stale
    inherited default fails **open** (an actor this repo never deliberated skips review silently —

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -173,12 +173,16 @@ self-triggering recursion, extra spend, and "independent" review by substantiall
 system. Accepted — those are visible availability and cost failures, while the inherited default's
 failure mode is a silent security bypass, the worse direction.
 
-Composition with the github-iac work: #248 (merged) app-pins all four required contexts to the
-GitHub Actions app, narrowing *who may report* a check — orthogonal and complementary to this
-ruling, which narrows *when the check may be satisfied without a review run*. #228 remains open
-for the live forgery test; this addendum deliberately does **not** touch the "creatable only by
-the App that runs the pass, so a branch cannot forge it" sentence in the step-3 enforcement
-addendum — that sentence stays #228's to update from the tested result.
+Composition with the github-iac work (repository-qualified — a bare `#N` here would resolve to this
+repository): [github-iac#248](https://github.com/melodic-software/github-iac/pull/248) (merged
+2026-07-30) app-pins all four required contexts — `pr-title / pr-title`,
+`do-not-merge / do-not-merge`, `ci-status`, and `security-review / security-review` — to the GitHub
+Actions app (`integration_id` 15368), narrowing *who may report* a check. That is orthogonal and
+complementary to this ruling, which narrows *when the check may be satisfied without a review run*.
+[github-iac#228](https://github.com/melodic-software/github-iac/issues/228) remains open for the
+live forgery test; this addendum deliberately does **not** touch the "creatable only by the App
+that runs the pass, so a branch cannot forge it" sentence in the step-3 enforcement addendum — that
+sentence stays github-iac#228's to update from the tested result.
 
 Sequencing (fail-closed, deliberate): `policy.json` is a managed materialization of the standards
 `runner-policy` component, and the contract for `claude-security-review.yml@c136b27` admitted only

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -173,8 +173,8 @@ self-triggering recursion, extra spend, and "independent" review by substantiall
 system. Accepted — those are visible availability and cost failures, while the inherited default's
 failure mode is a silent security bypass, the worse direction.
 
-Composition with the github-iac work (repository-qualified — a bare `#N` here would resolve to this
-repository): [github-iac#248](https://github.com/melodic-software/github-iac/pull/248) (merged
+Composition with the github-iac work:
+[github-iac#248](https://github.com/melodic-software/github-iac/pull/248) (merged
 2026-07-30) app-pins all four required contexts — `pr-title / pr-title`,
 `do-not-merge / do-not-merge`, `ci-status`, and `security-review / security-review` — to the GitHub
 Actions app (`integration_id` 15368), narrowing *who may report* a check. That is orthogonal and


### PR DESCRIPTION
## Summary

Implements the delegated-authority decision recorded on #1767: the skip-actor widening
introduced by the v0.9.1 lane re-pin is **REJECTED** for the security lane.

- `.github/workflows/claude-security-review.yml` restores an explicit
  `skip-actors: "dependabot[bot],melodic-standards-sync[bot]"`, re-narrowing the exception to
  exactly the two actors ADR 0002's step-3 addendum ratified. Inheriting the reusable workflow's
  default (`dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]`) let
  `claude[bot]` and `melodic-ai[bot]` satisfy the **required** `security-review / security-review`
  check with no review run, on security-sensitive paths, with no compensating control — and the
  general review lane skips them too, so an AI-app-pushed commit would get zero review of any kind.
- `.github/workflows/claude-review.yml` is deliberately **untouched** — advisory with no required
  check, so its skip list is runner-minute economy, not evidence. It keeps inheriting.
- ADR 0002 gains a `2026-07-31` addendum with the ruling, the three rationale strands
  (compensating controls, latency-is-not-absence, staleness asymmetry), the three rejected
  alternatives, the cross-vendor advisory and its accepted counterargument, the composition with
  github-iac #248/#228, and the sequencing.
- The ADR's final revisit trigger is **rewritten** to cover both widening channels: a caller-list
  edit (Channel A) *and* inherited-default drift at a re-pin (Channel B — the one that actually
  fired here and which the old trigger did not name). The re-pin trigger above it now cross-links.

The restored value is byte-identical to the list this caller carried before the re-pin deleted it
(`9ed2956a`, #1766) — verified against that commit's diff, which dropped the same line from both
callers.

### ⚠️ The `runner-policy` check is EXPECTED RED on this PR — do not "fix" it by dropping the input

`policy.json` is a **managed** materialization of the standards `runner-policy` component, and the
contract for `claude-security-review.yml@c136b27` currently admits only `runner` and `paths-file`.
Restoring `skip-actors` is an input-surface change that must land upstream first. This is
intentional fail-closed ordering, not a defect:

1. **melodic-software/standards#307** — adds `skip-actors` to that contract entry's `allowedInputs`
   (open, this is the blocker). It restores parity: the previous approved SHA's contract
   (`66073e58`) already admitted the input; the `c136b27` entry dropped it.
2. standards → here sync PR materializes the new `policy.json`.
3. This PR goes green.

Verified locally: with the local `policy.json` temporarily patched to the post-sync shape, the
validator reports `Runner policy passed.`; reverted before commit, so this PR touches no managed
file.

The reason a green-check reflex is dangerous here is the residual gap the ADR records: runner-policy
rejects *unexpected* inputs but cannot *require* one, so deleting the `skip-actors` line turns the
check green **and** silently re-widens a required-check bypass. The caller carries an inline comment
saying exactly that, and the gap is filed upstream as melodic-software/standards#308.

## Test plan

- `actionlint .github/workflows/claude-security-review.yml` — clean.
- `zizmor .github/workflows/claude-security-review.yml` — "No findings to report."
- `markdownlint-cli2` on the ADR — 0 issues.
- `node .github/standards/runner-policy/runner-policy.mjs` — fails with exactly one finding,
  `runner-target-contract: the reusable workflow call has inputs absent from its reviewed contract:
  skip-actors`, and nothing else; passes cleanly (`Runner policy passed.`) once the contract entry
  is patched to the post-sync shape (simulated locally, then reverted).
- Input verified against the reusable at the pinned SHA
  (`ci-workflows@c136b27f404dd32ce3873f39a6f3443891d1c16e`): `skip-actors` is a declared
  `workflow_call` input whose default is the four-actor list, and it gates the `security-review`
  **job**, not the workflow — so the check stays name-stable and a skipped actor still reports a
  passing context. No wedge risk for the two retained actors.
- Provenance claim verified: `git grep` over `.github/workflows/` on `main` finds no `issue_comment`
  trigger and no `@claude` dispatcher, so neither app can push in this repo today. The change is
  therefore dormant-by-construction on merge. The activating step is charted but gated:
  melodic-software/ci-workflows#255's V1 is read-only (no Edit/Write, no push) and would not open
  the channel; only its V2 (tag-mode fix-and-push, behind that issue's own approval gate) would.
  Landing now keeps that gate from silently carrying a security-review-bypass decision it was never
  scoped to make.
- Every other check on this PR is green, including `security-review / security-review` itself.

## Related

- Fixes #1767
- Blocked by melodic-software/standards#307 (contract `allowedInputs`), then its sync PR
- Composes with melodic-software/github-iac#248 (merged; app-pins the required contexts) and
  melodic-software/github-iac#228 (open; live forgery test — this PR deliberately does not touch
  ADR 0002's "cannot forge it" sentence, which stays #228's to update)
- Follow-ups filed rather than implemented here, each cited from the ADR so it cannot drop silently:
  - melodic-software/ci-workflows#330 — narrow the security reusable's own `skip-actors` default,
    so the next adopter does not inherit the widened exception
  - melodic-software/standards#308 — a `requiredInputs`-style contract field, closing the residual
    gap where deleting a caller's input passes green (also records the parked
    `claude-security-review-caller` component's matching hazard when it unparks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVoZoMYXqf8ZVbQYixPVPW
