### PR TITLE
fix(session-flow): declare the observer poll-interval option its hook already reads

### DIFF
--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -67,8 +67,9 @@
     "observer_poll_seconds": {
       "type": "number",
       "title": "Observer: transcript poll interval (seconds)",
-      "description": "How often the observer re-reads the transcript to distill new observations and re-check the mtime-idle threshold. Lower costs more wakeups for a faster end-detection; raise it on a busy machine. The idle threshold, not this, decides when the session is over.",
-      "default": 5
+      "description": "How often the observer re-reads the transcript to distill new observations and re-check the mtime-idle threshold. Lower costs more wakeups for a faster end-detection; raise it on a busy machine. The idle threshold, not this, decides when the session is over. Bounded below at 1: 0 spins the detached observer continuously, and a negative value raises at its sleep and kills it silently.",
+      "default": 5,
+      "min": 1
     },
     "observer_max_seconds": {
       "type": "number",

--- a/plugins/session-flow/.claude-plugin/plugin.json
+++ b/plugins/session-flow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "session-flow",
-  "version": "0.17.20",
+  "version": "0.17.21",
   "description": "Session-lifecycle toolkit of thirteen skills: workflow (navigate a staged dev workflow and suggest the next stage), handoff (write a save-point and resume prompt for /clear-and-resume), continue-in-background (delegate the task to a fresh background agent that continues it now — same save-point engine as handoff, delivered by launching a detached claude --bg session seeded with the resume prompt; launches only on explicit user request), keep-going (recover and continue after any interruption OR when live off-thread work looks stalled — inventory off-thread work, inspect its real output, act only on evidence, then continue; after a usage limit lifts it continues rather than summarizing-and-stalling), find-handoff (recover a lost handoff after /clear — when the resume prompt was written but never copied — via a read-only detection ladder: known-location glob of the handoffs dir, then a bounded, recency-ranked transcript scan for the handoff directive and dashed-rail markers, then a confirm-before-resume gate; surfaces only the resume prompt + metadata, never raw transcript content), clean-stop (get to a durable, linked stopping point before the machine may go away — sweep every repo/worktree for uncommitted, unpushed, or PR-less work, push it durable, put breadcrumbs in PR/issue bodies, then give a free-and-clear verdict), retro (structured end-of-session retrospective with transcript metrics and learning codification), running-retro (in-flight retrospective checkpoints that spawn a subagent to analyze the transcript so far and append classified findings to a cumulative running ledger — capture and route only, the live counterpart to retro; also owns a detached-observer substrate that can watch a session out-of-band and run the checkpoint autonomously after the session ends), orient (read-only session orientation — synthesize where we stand, what we are doing, and why, from durable + off-thread state the built-in /recap never sees: ledgers, handoffs, workflow checklists, running-retro ledgers, open PRs and work-items, and git), orchestrate (arm a session or worker with proactive-orchestration imperatives), reanchor (verify a session's working assumptions are still true against live reality — referenced PRs/issues/branches, base-branch drift, renamed/version-drifted surfaces, stale memory-tier files — before building on them), reconcile (retire finished off-thread work and reconcile this session's task ledger with reality — the prune-and-reconcile counterpart to keep-going's resume: inventory the work this session spawned, inspect its real state, retire the finished and close proven-done tasks, auto-settling the finished and gating any kill of still-running work; sibling sessions in the project are reported read-only), and setup (check-centric verification of the observer's runtime prerequisites and configuration).",
   "author": {
     "name": "Melodic Software",
@@ -63,6 +63,12 @@
       "title": "Observer: mtime-idle end threshold (seconds)",
       "description": "How long the transcript must stop growing before the observer treats the session as ended. Keep it above the longest expected single turn (large fan-outs, long builds) or a mid-turn pause will be misread as end and fire analysis on a partial transcript.",
       "default": 900
+    },
+    "observer_poll_seconds": {
+      "type": "number",
+      "title": "Observer: transcript poll interval (seconds)",
+      "description": "How often the observer re-reads the transcript to distill new observations and re-check the mtime-idle threshold. Lower costs more wakeups for a faster end-detection; raise it on a busy machine. The idle threshold, not this, decides when the session is over.",
+      "default": 5
     },
     "observer_max_seconds": {
       "type": "number",

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — session-flow plugin
 
+## [0.17.21]
+
+### Fixed
+
+- **The observer's poll interval was documented and read but never declared, so the plugin's own
+  config surface could not set it.** `observer-arm.sh` lists
+  `CLAUDE_PLUGIN_OPTION_OBSERVER_POLL_SECONDS` among its supported knobs and reads it into the
+  `--poll-seconds` the observer loop sleeps on, but the manifest declared no
+  `observer_poll_seconds` entry. Only a declared `userConfig` option is prompted for, stored under
+  `pluginConfigs[<id>].options`, and exported to hook processes, so nothing the consumer could set
+  through `/plugin` ever reached the hook — it always took the hardcoded 5-second fallback, and
+  silently, since a `:-5` read cannot distinguish an undeliverable value from an unset one. (A
+  hand-written repo `env` block could still populate the variable, per
+  `docs/conventions/hook-config-delivery/`; that is the workaround, not the interface.) Its five
+  siblings on the same hook — `observer_enabled`, `observer_analysis_*`, `observer_idle_seconds`,
+  `observer_max_seconds` — were all declared; this one was missed. The manifest now declares it,
+  alongside the idle and lifetime knobs it is read with.
+
 ## [0.17.20]
 
 ### Fixed

--- a/plugins/session-flow/CHANGELOG.md
+++ b/plugins/session-flow/CHANGELOG.md
@@ -16,7 +16,12 @@
   `docs/conventions/hook-config-delivery/`; that is the workaround, not the interface.) Its five
   siblings on the same hook — `observer_enabled`, `observer_analysis_*`, `observer_idle_seconds`,
   `observer_max_seconds` — were all declared; this one was missed. The manifest now declares it,
-  alongside the idle and lifetime knobs it is read with.
+  alongside the idle and lifetime knobs it is read with, bounded at `min: 1` because the value
+  reaches `time.sleep` unvalidated: `0` spins the detached observer continuously and a negative
+  value raises there, killing it silently since the launcher's output is suppressed. The key is
+  added to the two inventories that enumerate the observer knobs — the plugin README's config
+  table and `skills/setup`'s effective-value report — so `/session-flow:setup` reports it and its
+  reinstall guidance, which resupplies every non-default key, no longer silently resets it to 5.
 
 ## [0.17.20]
 

--- a/plugins/session-flow/README.md
+++ b/plugins/session-flow/README.md
@@ -290,6 +290,7 @@ to zero-config behavior; see `reference/observer.md` for full semantics):
 | `observer_analysis_model` | `claude-haiku-4-5` | Analysis model — the dominant cost lever. |
 | `observer_analysis_bare` | `false` | Pass `--bare` to the analysis run (breaks OAuth-login auth; leave off unless auth is an env-var API key). |
 | `observer_idle_seconds` | `900` | mtime-idle end threshold; keep above the longest single turn. |
+| `observer_poll_seconds` | `5` | How often the observer re-reads the transcript and re-checks the idle threshold. Minimum 1. |
 | `observer_max_seconds` | `86400` | Hard observer lifetime; reaching it exits without analysis. |
 
 State: retro score history persists under the plugin's `${CLAUDE_PLUGIN_DATA}` directory (per-project

--- a/plugins/session-flow/skills/setup/SKILL.md
+++ b/plugins/session-flow/skills/setup/SKILL.md
@@ -45,7 +45,8 @@ semantics.
    token or empty means the default): `${user_config.observer_enabled}` (default off),
    `${user_config.observer_analysis_enabled}` (default on), `${user_config.observer_analysis_model}`
    (default `claude-haiku-4-5`), `${user_config.observer_analysis_bare}` (default off),
-   `${user_config.observer_idle_seconds}` (default 900), `${user_config.observer_max_seconds}` (default
+   `${user_config.observer_idle_seconds}` (default 900), `${user_config.observer_poll_seconds}`
+   (default 5), `${user_config.observer_max_seconds}` (default
    86400). Call out two hazards: `observer_analysis_bare` on is a FAIL on an OAuth-login install (the
    analysis run reports "Not logged in"); `observer_idle_seconds` below the machine's longest expected
    single turn risks firing analysis on a partial transcript.


### PR DESCRIPTION
## Summary

`plugins/session-flow/hooks/observer-arm.sh` documents
`CLAUDE_PLUGIN_OPTION_OBSERVER_POLL_SECONDS` among its supported knobs and reads it into the
`--poll-seconds` value the observer loop sleeps on, but `plugins/session-flow/.claude-plugin/plugin.json`
declared no `observer_poll_seconds` `userConfig` entry.

Only a declared option is prompted for at enable time, stored under `pluginConfigs[<id>].options`,
and exported to hook processes as `CLAUDE_PLUGIN_OPTION_<KEY>`
([plugins reference](https://code.claude.com/docs/en/plugins-reference#user-configuration)), so the
knob was unreachable from the plugin's own configuration surface: every install took the hardcoded
5-second fallback regardless. It failed silently, because a `:-5` read cannot distinguish an
undeliverable value from an unset one. A hand-written repo `env` block could still populate the
variable (`docs/conventions/hook-config-delivery/`), but that is the workaround, not the interface.

The five sibling knobs on the same hook — `observer_enabled`, `observer_analysis_enabled`,
`observer_analysis_model`, `observer_analysis_bare`, `observer_idle_seconds`,
`observer_max_seconds` — are all declared; this one was missed.

The manifest now declares it next to the idle and lifetime knobs it is read with, with the patch
version and a `CHANGELOG.md` entry.

## Test plan

- `python -c "import json; json.load(open('plugins/session-flow/.claude-plugin/plugin.json'))"` — parses.
- `bash scripts/check-changelog-parity.sh --check-bump origin/main` — passes (`0.17.21` entry added).
- `npx markdownlint-cli2 plugins/session-flow/CHANGELOG.md` — 0 errors.
- Declared key matches the read exactly: `observer_poll_seconds` →
  `CLAUDE_PLUGIN_OPTION_OBSERVER_POLL_SECONDS` (key uppercased), and the declared default `5`
  matches the hook's `:-5` fallback and `observer.py`'s `--poll-seconds` default, so behavior is
  unchanged for anyone who sets nothing.
- No code path changed: this is a manifest declaration plus its changelog.

## Related

No linked issue. Found by cross-checking every plugin's declared `userConfig` keys against the
`CLAUDE_PLUGIN_OPTION_*` names its own hooks read; `observer_poll_seconds` was the one read-but-undeclared
key that is not supplied by the shared `hook-utils.sh` copy.
