### PR TITLE
docs(readme): list lib/ and scripts/ in the repo map

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 - `.claude-plugin/marketplace.json` — the marketplace catalog.
 - `plugins/` — one directory per plugin.
+- `lib/` — single source of truth for the shared shell helpers; the self-contained copies at
+  `plugins/*/hooks/` are synced from here, never edited directly.
+- `scripts/` — repo-level CI checks and generators, with their tests alongside.
 - `docs/MIGRATION-PLAYBOOK.md` — design charter, extensibility model, the per-plugin migration
   gate, and the local development loop.
 - `docs/` — further design records and audits (CI runner routing, extensibility-contract smoke


### PR DESCRIPTION
## Summary

README's "What's here" map listed two of the six tracked top-level directories, so a contributor
met `lib/` and `scripts/` for the first time in a diff rather than in the map.

The `lib/` line states the sync DIRECTION, which is the part that is actually easy to get wrong:
`lib/hook-utils.sh` is the single source of truth, and the copies at `plugins/*/hooks/hook-utils.sh`
exist only because installed plugins are cache-isolated and must be self-contained. Editing a copy
is reverted by `scripts/sync-hook-utils.sh` and rejected by CI's drift check — the file's own header
says so, but only once you are already in it.

Prose only; no code, config, or workflow changes.

## Test plan

- `npx markdownlint-cli2 README.md` — 0 errors.
- Both claims verified against the tree rather than assumed:
  - `git ls-tree --name-only HEAD` lists exactly `docs`, `lib`, `plugins`, `prompts`, `scripts` as
    tracked top-level directories; `lib/` and `scripts/` were the ones the map omitted.
  - The sync direction is `lib/hook-utils.sh`'s own header plus `scripts/sync-hook-utils.sh`
    (`src="lib/hook-utils.sh"`, copied to `plugins/*/hooks/hook-utils.sh`, with `--check` failing
    on drift).
  - Both directories carry their tests beside the sources (`*.test.sh` alongside each script).

## Related

No linked issue. Noticed while reading the repo map to locate the shared hook library.
