### PR TITLE
fix(repo-fleet-hygiene): canonical resolution, substitution rungs, and report accuracy

### DIFF
--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -81,8 +81,8 @@ Two substitutions *are* expanded in `allowed-tools`: per
 substitutes `${CLAUDE_SKILL_DIR}` and `${CLAUDE_PROJECT_DIR}` in the skill's markdown content and in
 Bash rules in `allowed-tools` (version floors: `${CLAUDE_SKILL_DIR}` v2.1.129+,
 `${CLAUDE_PROJECT_DIR}` v2.1.196+; below the floor the rule stays a literal string and never
-matches). `${CLAUDE_PLUGIN_ROOT}` is **not** among them — it is documented for hook/monitor/MCP/LSP
-JSON `command` fields, so a rule written with it stays literal and the grant is inert.
+matches). `${CLAUDE_PLUGIN_ROOT}` is **not** among them — it does not appear anywhere on that page —
+so a rule written with it stays a literal string, never matches, and the grant is inert.
 
 `${CLAUDE_SKILL_DIR}` is therefore the correct token for a rule that must match a skill's own bundled
 script, and pairing it with the same token in the skill body is the documented way to run that script

--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -76,10 +76,20 @@ anchors for the file tools, not shell-command expansion). A rule like
   path changes), and
 - leaks a username into version control.
 
-The one substitution that *is* expanded in `allowed-tools` is `${CLAUDE_PROJECT_DIR}` (Claude Code
-v2.1.196+, per [skills](https://code.claude.com/docs/en/skills)) — but that anchors to the consuming
-project, not to a portable command, so it still isn't the right tool for a shared code-execution
-helper.
+Two substitutions *are* expanded in `allowed-tools`: per
+[skills](https://code.claude.com/docs/en/skills#available-string-substitutions), Claude Code
+substitutes `${CLAUDE_SKILL_DIR}` and `${CLAUDE_PROJECT_DIR}` in the skill's markdown content and in
+Bash rules in `allowed-tools` (version floors: `${CLAUDE_SKILL_DIR}` v2.1.129+,
+`${CLAUDE_PROJECT_DIR}` v2.1.196+; below the floor the rule stays a literal string and never
+matches). `${CLAUDE_PLUGIN_ROOT}` is **not** among them — it is documented for hook/monitor/MCP/LSP
+JSON `command` fields, so a rule written with it stays literal and the grant is inert.
+
+`${CLAUDE_SKILL_DIR}` is therefore the correct token for a rule that must match a skill's own bundled
+script, and pairing it with the same token in the skill body is the documented way to run that script
+without a prompt. `${CLAUDE_PROJECT_DIR}` anchors to the consuming project rather than to a portable
+command, so it is not the right tool for a shared code-execution helper. Neither changes
+anti-pattern 1: auto mode still drops broad/interpreter-shaped rules regardless of how the path was
+written.
 
 ## Anti-pattern 3 — assuming a skill or plugin can self-grant
 

--- a/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-fleet-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-fleet-hygiene",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Read-only Git/GitHub fleet audit for merged local branches, orphaned or mismatched worktree registrations, and repository transfers or renames. Findings are confidence-tiered and hand off exact targets to existing per-repository cleanup tools; this plugin never deletes branches or worktrees.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -17,8 +17,10 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   of `git worktree list --porcelain` (which lists the main worktree first wherever it runs), before
   the dedup tie-break. `rev-parse --show-toplevel` cannot make this distinction: inside a linked
   worktree it returns the linked root. The extra probe is gated on the candidate's `.git` being a
-  file rather than a directory, so an ordinary fleet sweep pays nothing per repository. Evidence
-  rule 1 in both skills is corrected to match.
+  file rather than a directory, so an ordinary fleet sweep pays nothing per repository. The
+  substitution is disclosed on a `Resolved to main worktree:` header line rather than applied
+  silently — the operator named one path and the report is about another. Evidence rule 1 in both
+  skills is corrected to match.
 - **The `allowed-tools` grant used a variable that is not substituted there (#1798).** The rule named
   `${CLAUDE_PLUGIN_ROOT}`, which the skills documentation does not list among the variables
   substituted in skill content or `allowed-tools` Bash rules — only `${CLAUDE_SKILL_DIR}` and

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -3,6 +3,92 @@
 All notable changes to `repo-fleet-hygiene` are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.0]
+
+### Fixed
+
+- **Canonical resolution can no longer select a linked worktree (#1797).** Discovery reaches a
+  linked worktree and its own main worktree through the same glob, and both map to one
+  `--git-common-dir` dedup key, so the winner was decided by glob order. A sibling whose directory
+  name sorts before the canonical one under `LC_ALL=C` therefore became "Canonical" — and every
+  emitted handoff carries that path, so per-repository cleanup would be aimed at a checkout that is
+  not the repository of record, while the real canonical checkout was deduplicated away and never
+  reported. `add_target` now resolves each candidate to its main worktree, read as the first record
+  of `git worktree list --porcelain` (which lists the main worktree first wherever it runs), before
+  the dedup tie-break. `rev-parse --show-toplevel` cannot make this distinction: inside a linked
+  worktree it returns the linked root. The extra probe is gated on the candidate's `.git` being a
+  file rather than a directory, so an ordinary fleet sweep pays nothing per repository. Evidence
+  rule 1 in both skills is corrected to match.
+- **The `allowed-tools` grant used a variable that is not substituted there (#1798).** The rule named
+  `${CLAUDE_PLUGIN_ROOT}`, which the skills documentation does not list among the variables
+  substituted in skill content or `allowed-tools` Bash rules — only `${CLAUDE_SKILL_DIR}` and
+  `${CLAUDE_PROJECT_DIR}` are. The rule stayed a literal string, never matched the real invocation,
+  and the skill's one permission grant was inert in a workflow built for unattended sweeps. Both the
+  grant and the documented invocation now use `${CLAUDE_SKILL_DIR}`.
+- **The project-scoped config rung is reachable again (#1798).** The collector read
+  `CLAUDE_PROJECT_DIR` from its own environment, where it is not provided — that variable is
+  documented for hooks, MCP stdio servers, and skill content, not for Bash tool invocations. The
+  project rung of the config ladder therefore resolved against nothing, and the zero-argument
+  fallback silently became `$PWD`, an agent session's incidental working directory. The skill body
+  now passes `--project-dir "${CLAUDE_PROJECT_DIR}"`, where the documented substitution applies; the
+  environment variable is still honored for callers that genuinely have it, and a value left as an
+  unexpanded `${...}` placeholder counts as absent. When no project directory resolves, the run
+  stops with the scope remedies instead of auditing whatever directory the shell was sitting in.
+- **Report text no longer asserts things the run contradicts (#1800).** The header printed a fixed
+  `Config: none (… current-project scope)` literal that could contradict the very next lines — it
+  claimed project scope on a run whose scope came from `--root`, and described a mode that was not
+  reachable at all. A computed `Scope:` line now names each rung that actually contributed and its
+  entry count, which also discloses that config-supplied scope is additive to CLI-supplied scope.
+  `Mutation count: 0` was a hardcoded literal that would have read identically in a build that
+  mutated; it is replaced by a statement of the enforcing mechanism (the read-only git/gh command
+  allowlists), because a real counter would undercount — most probes run inside command
+  substitution, so increments are lost with the subshell. On Windows, MSYS-style `/c/...` paths are
+  converted to `C:/...` for presentation only, since the report is actionable text whose paths get
+  pasted into tools that reject the MSYS form. The two differently-scoped `repositories` counts are
+  now labelled distinctly (`Repositories discovered (audit targets after deduplication)` and
+  `repositories_audited`).
+- **`setup`'s verify step no longer violates `setup`'s own boundary (#1801).** `apply` step 5
+  prescribed running the collector, which is the full fleet walk the skill states it never performs —
+  minutes of per-repository network queries in a step described as validating that a config parses.
+  Verification is now config-only (parse validity plus per-entry path resolution); an end-to-end run
+  is an explicit handoff to `/repo-fleet-hygiene:audit`.
+- **`setup` can set `maxDepth` (#1801).** The grammar `setup` documents and owns includes `maxDepth`,
+  and the collector implements `--max-depth`, but `setup`'s argument grammar had no way to write it,
+  so a consumer needing a non-default depth had to hand-edit the file `setup` manages. `--max-depth`
+  is now part of `setup`'s grammar, and `--max-depth` was missing from the audit skill's
+  `argument-hint` as well.
+
+### Changed
+
+- **A truncated merged-PR window is disclosed (#1803).** The batched merged-PR query returns at most
+  200 rows; a repository with more merged history silently lost the remainder, and a branch merged
+  before the window then produced no merged finding — indistinguishable in the report from a branch
+  that was never merged. A full window now emits `merged-pr-window-truncated` (`UNKNOWN`) saying
+  that absent merged findings in that repository are unproven. It cannot distinguish "exactly 200"
+  from "far more" and deliberately errs toward warning.
+- **The confidence model documents every finding kind and what the tiers rest on (#1799).** The tier
+  table covered 12 of 24 emitted kinds, so a consumer meeting an untabulated kind had no documented
+  disposition. It now covers all 25, and a test asserts set equality in both directions between the
+  table and the collector's emitted kinds, so this drift is a test failure rather than a later
+  discovery. `ACKNOWLEDGED` is documented as a prominence demotion of an `UNKNOWN`, not a fifth
+  confidence value. Evidence rule 3 now describes the mechanism that actually runs — one batched
+  query per repository plus a privacy-gated per-branch fallback — rather than a per-branch
+  authoritative query. Two undisclosed dependencies are stated: the `LOW` ancestry tier is near-inert
+  under squash merges, and `missing-worktree` versus `prunable-worktree` turns on the user-tunable
+  `gc.worktreePruneExpire` window rather than on evidence strength. The two reference files that had
+  no pointer from the hub are now linked.
+
+### Added
+
+- **Behavioural coverage for the failures a real fleet produced (#1803).** The suite exercised the
+  documented happy path while a single 11-repository run surfaced defects none of it could reach.
+  New executable assertions cover canonical selection against an earlier-sorting linked worktree
+  (constructed red first), the computed scope-provenance line, merged-PR window truncation,
+  unauthenticated-`gh` degradation, and tier-table/collector drift. New model-graded evals cover
+  privacy-gated branches as unverified rather than unmerged, squash-merge semantics, worktree
+  disposability as deliberately out of scope, and — for `setup` — config-only verification,
+  cross-volume paths, and `maxDepth`.
+
 ## [0.7.1]
 
 ### Fixed

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -22,6 +22,16 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   report is about another — on one `Resolved to main worktree:` header line per repository naming
   every path that resolved into it, so several worktrees of one repository cannot read as several
   repositories against the discovered count. Evidence rule 1 in both skills is corrected to match.
+
+  The porcelain's first record is **not** always a checkout, and three ordinary shapes all present a
+  `.git` file so they reach the retarget: a submodule reports the superproject's
+  `.git/modules/<name>` administrative directory, `--separate-git-dir` reports the detached git
+  directory, and a worktree of a bare repository reports the bare repository. Adopting any of them
+  would aim every handoff *inside* another repository's administrative directory — the precise harm
+  this retarget exists to prevent. The porcelain's answer is therefore re-resolved as a working tree
+  before it is adopted: bare and `--separate-git-dir` fail that probe and are skipped, a submodule
+  resolves back to the path already held and self-cancels, and a genuine linked worktree retargets.
+  All four shapes are pinned by regression fixtures.
 - **The `allowed-tools` grant used a variable that is not substituted there (#1798).** The rule named
   `${CLAUDE_PLUGIN_ROOT}`, which the skills documentation does not list among the variables
   substituted in skill content or `allowed-tools` Bash rules — only `${CLAUDE_SKILL_DIR}` and

--- a/plugins/repo-fleet-hygiene/CHANGELOG.md
+++ b/plugins/repo-fleet-hygiene/CHANGELOG.md
@@ -18,9 +18,10 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   the dedup tie-break. `rev-parse --show-toplevel` cannot make this distinction: inside a linked
   worktree it returns the linked root. The extra probe is gated on the candidate's `.git` being a
   file rather than a directory, so an ordinary fleet sweep pays nothing per repository. The
-  substitution is disclosed on a `Resolved to main worktree:` header line rather than applied
-  silently — the operator named one path and the report is about another. Evidence rule 1 in both
-  skills is corrected to match.
+  substitution is disclosed rather than applied silently — the operator named one path and the
+  report is about another — on one `Resolved to main worktree:` header line per repository naming
+  every path that resolved into it, so several worktrees of one repository cannot read as several
+  repositories against the discovered count. Evidence rule 1 in both skills is corrected to match.
 - **The `allowed-tools` grant used a variable that is not substituted there (#1798).** The rule named
   `${CLAUDE_PLUGIN_ROOT}`, which the skills documentation does not list among the variables
   substituted in skill content or `allowed-tools` Bash rules — only `${CLAUDE_SKILL_DIR}` and
@@ -48,7 +49,8 @@ All notable changes to `repo-fleet-hygiene` are documented here. Format follows
   converted to `C:/...` for presentation only, since the report is actionable text whose paths get
   pasted into tools that reject the MSYS form. The two differently-scoped `repositories` counts are
   now labelled distinctly (`Repositories discovered (audit targets after deduplication)` and
-  `repositories_audited`).
+  `repositories_audited`). An empty `--root`/`--repo`/`--config` value stops the run rather than
+  being counted toward the scope the header reports and then skipped by the discovery loops.
 - **`setup`'s verify step no longer violates `setup`'s own boundary (#1801).** `apply` step 5
   prescribed running the collector, which is the full fleet walk the skill states it never performs —
   minutes of per-repository network queries in a step described as validating that a config parses.

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -79,7 +79,10 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    (which lists the main worktree first regardless of where it runs). `git rev-parse
    --show-toplevel` alone cannot identify a canonical checkout: inside a linked worktree it returns
    the linked root, so a sibling worktree reached first by discovery would otherwise become the
-   path every handoff points at. The report always shows discovered and canonical paths. An
+   path every handoff points at. When a supplied or discovered path resolves to a different main
+   worktree, the header states the substitution on a `Resolved to main worktree:` line — relay it,
+   because the operator named one path and the report is about another. The report always shows
+   discovered and canonical paths. An
    override target with a missing/non-GitHub remote, or a different identity that cannot be proven to
    resolve to the same GitHub repository, stops that repository's local audit before evidence combines.
 2. **GitHub identity:** read the selected fetch remote with `git remote get-url`; accept only

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -2,9 +2,9 @@
 name: audit
 description: "Audit Git/GitHub hygiene across a fleet of local repositories: find GitHub-merged local branches, merged/missing/prunable/mislinked worktree registrations, and remotes that resolve to a moved or renamed GitHub repository. Read-only and confidence-tiered; emits exact handoffs to repo-hygiene/source-control but never deletes, prunes, repairs, fetches, checks out, or rewrites. Use when: 'audit repositories', 'repo fleet hygiene', 'stale branches across repos', 'orphaned worktrees across repos', 'moved repos', 'renamed GitHub owner', 'cross-repo git cleanup report'."
 user-invocable: true
-argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]..."
+argument-hint: "[--root <dir>]... [--repo <dir>]... [--config <file>] [--canonical <github.com/owner/repo=path>]... [--max-depth <1..12>]"
 allowed-tools:
-  - Bash(bash ${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/audit-fleet.sh *)
+  - Bash(bash ${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh *)
 metadata:
   workflow-stage: operator
   summary: Audit git and GitHub hygiene across all local repositories, read-only
@@ -33,19 +33,31 @@ Parse `$ARGUMENTS` as opaque arguments for the bundled script. Supported flags:
 - `--canonical <github.com/owner/repo=path>`: invocation-specific canonical checkout override
   (repeatable; explicit wins over config).
 - `--max-depth <1..12>`: discovery bound; explicit wins over config/default `5`.
+- `--project-dir <dir>`: the session's project directory, used for the project-scoped config rung
+  and the no-scope fallback target.
 
-If neither `--root` nor `--repo` is present, the script uses `${CLAUDE_PROJECT_DIR}` as an exact
+Always pass `--project-dir "${CLAUDE_PROJECT_DIR}"`. That variable is substituted in this markdown
+content and in `allowed-tools` Bash rules, but it is **not** present in the Bash tool's environment,
+so the script cannot read it for itself — passing it in is what makes the project rung below
+reachable at all.
+
+If neither `--root` nor `--repo` is present, the script uses the project directory as an exact
 `--repo` target — not as a discovery root, so nothing beneath it is searched. A project directory
 that is not a Git working tree is therefore rejected, and the rejection names the three ways to
 supply scope plus `/repo-fleet-hygiene:setup apply`; pass that guidance through rather than
-re-deriving a root yourself. Config
+re-deriving a root yourself. If no project directory resolves either, the run stops with the same
+remedies rather than auditing the shell's incidental working directory. Config
 resolution is the script's own ladder — do not pre-resolve or pass a probed path yourself:
 explicit `--config` wins, else the script probes
-`${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf` (project-scoped), else
+`<project-dir>/.claude/repo-fleet-hygiene.conf` (project-scoped), else
 `~/.claude/repo-fleet-hygiene.conf` (user-global — a machine-scoped fleet config placed there is
 recorded user intent, not a guessed root). The report header names the consumed config and its
 source, or states that none was consumed. Never guess a broader machine root from the current
 path beyond that ladder.
+
+Config-supplied scope is **additive** to CLI-supplied scope: a `--repo X` run still walks every
+configured root. The header's `Scope:` line names each contributing rung and its entry count, so
+report that line rather than assuming the arguments were the whole scope.
 
 Before execution, reject any arguments outside this grammar. Pass every path/override as a quoted
 argument; never assemble a shell fragment from config, repository, remote, or branch text.
@@ -53,7 +65,7 @@ argument; never assemble a shell fragment from config, repository, remote, or br
 Run exactly once:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/audit-fleet.sh" <validated-and-quoted-arguments>
+bash "${CLAUDE_SKILL_DIR}/scripts/audit-fleet.sh" --project-dir "${CLAUDE_PROJECT_DIR}" <validated-and-quoted-arguments>
 ```
 
 The script validates config with `git config --file`; it never sources or executes it.
@@ -62,8 +74,12 @@ The script validates config with `git config --file`; it never sources or execut
 
 The bundled collector is authoritative for classifications. Preserve its evidence in the report:
 
-1. **Canonical checkout:** explicit remote-keyed override → configured remote-keyed override →
-   `git rev-parse --show-toplevel`. The report always shows discovered and canonical paths. An
+1. **Canonical checkout:** explicit remote-keyed override → configured remote-keyed override → the
+   repository's **main worktree**, read as the first record of `git worktree list --porcelain`
+   (which lists the main worktree first regardless of where it runs). `git rev-parse
+   --show-toplevel` alone cannot identify a canonical checkout: inside a linked worktree it returns
+   the linked root, so a sibling worktree reached first by discovery would otherwise become the
+   path every handoff points at. The report always shows discovered and canonical paths. An
    override target with a missing/non-GitHub remote, or a different identity that cannot be proven to
    resolve to the same GitHub repository, stops that repository's local audit before evidence combines.
 2. **GitHub identity:** read the selected fetch remote with `git remote get-url`; accept only
@@ -71,10 +87,19 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    `HIGH` transfer/rename evidence. A 404/403/network error is `UNKNOWN`, never "deleted" or "moved".
    A 404/403 on an identity listed in `fleet.ackUnavailable` is demoted to `ACKNOWLEDGED` — still
    reported, never suppressed; acks never touch non-404/403 failures or successful-response evidence.
-3. **Merged branch:** query `gh pr list --repo <this-repo> --state merged --head <this-branch>` for
-   each local branch in each repository. Identical branch names in another repository are unrelated.
-   `HIGH` requires the PR `headRefOid` to equal the current local tip. Tip drift is `MEDIUM` manual
-   review. Git ancestry without GitHub evidence is `LOW` and never called merged-by-PR.
+3. **Merged branch:** one batched `gh pr list --repo <this-repo> --state merged --limit 200` query
+   per repository, matched locally by branch name — not a per-branch query. Two consequences a
+   reader must not assume away. A repository with more merged PRs than the window loses the older
+   ones; a full window is disclosed as `merged-pr-window-truncated`, and inside such a repository an
+   absent merged finding proves nothing. An exact per-branch `--head` fallback exists for a branch
+   the batch missed, but it is **privacy-gated**: the branch name is transmitted to github.com, so
+   the fallback runs only for a branch still present in the local remote-tracking inventory. After
+   the common merge flow — GitHub auto-deletes the head branch, a later fetch prunes the ref — that
+   branch is gated out and reported as `merge-evidence-privacy-gated`. Identical branch names in
+   another repository are unrelated. `HIGH` requires the PR `headRefOid` to equal the current local
+   tip. Tip drift is `MEDIUM` manual review. Git ancestry without GitHub evidence is `LOW` and never
+   called merged-by-PR — and under squash merges that ancestry predicate is near-inert, so on a
+   squash-merging fleet GitHub evidence is effectively the only merge evidence.
 4. **Local inventories:** parse only `git worktree list --porcelain -z` registrations and
    NUL-delimited `git for-each-ref` branch/tip records. Directory naming is
    never worktree evidence. Compare each existing registered path's actual `--git-common-dir` with
@@ -86,7 +111,12 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
 5. **Protection:** current/default/worktree-attached branches are never emitted as standalone branch
    cleanup candidates. A merged worktree is routed to worktree dry-run first.
 
-Full tier/disposition table: [reference/confidence-model.md](reference/confidence-model.md).
+Every emitted finding kind, both confidence axes, and the merge-strategy and
+`gc.worktreePruneExpire` dependencies the tiers rest on:
+[reference/confidence-model.md](reference/confidence-model.md). The official Git/GitHub behaviours
+this collector relies on: [reference/official-sources.md](reference/official-sources.md). The
+read-only enforcement model and its threat assumptions:
+[reference/security-review.md](reference/security-review.md).
 
 ## Presentation
 
@@ -96,8 +126,11 @@ Return the script's repository sections and finish with five grouped lists:
 2. `MEDIUM — manual review`
 3. `LOW — informational only`
 4. `UNKNOWN — evidence gaps`
-5. `ACKNOWLEDGED — configured known-inaccessible identities` (`fleet.ackUnavailable` demotions;
-   present the group only when non-empty)
+5. `ACKNOWLEDGED — configured known-inaccessible identities` (present the group only when non-empty)
+
+`ACKNOWLEDGED` is a prominence demotion, not a fifth confidence tier: the evidence stays exactly as
+weak as the `UNKNOWN` it came from, and the finding is still reported. Never present it as stronger
+evidence than an `UNKNOWN`, and never treat the group's emptiness as a clean signal.
 
 For each candidate, keep repository, canonical path, exact branch/worktree/remote target, PR/API
 evidence, and handoff. Never collapse same-named branches across repositories.

--- a/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/SKILL.md
@@ -80,8 +80,9 @@ The bundled collector is authoritative for classifications. Preserve its evidenc
    --show-toplevel` alone cannot identify a canonical checkout: inside a linked worktree it returns
    the linked root, so a sibling worktree reached first by discovery would otherwise become the
    path every handoff points at. When a supplied or discovered path resolves to a different main
-   worktree, the header states the substitution on a `Resolved to main worktree:` line — relay it,
-   because the operator named one path and the report is about another. The report always shows
+   worktree, the header states the substitution on one `Resolved to main worktree:` line per
+   repository, naming every path that resolved into it — relay it, because the operator named one
+   path and the report is about another. The report always shows
    discovered and canonical paths. An
    override target with a missing/non-GitHub remote, or a different identity that cannot be proven to
    resolve to the same GitHub repository, stops that repository's local audit before evidence combines.

--- a/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/audit/evals/evals.json
@@ -108,6 +108,57 @@
         "Keeps the untrusted value within one report field",
         "Does not render a forged standalone Confidence or Handoff line"
       ]
+    },
+    {
+      "id": 10,
+      "name": "privacy-gated-branch-is-not-evidence-of-unmerged",
+      "prompt": "A repository reports merge-evidence-privacy-gated for 47 branches whose remote-tracking refs were pruned after GitHub auto-deleted the head branches on merge. None of the 47 produced a merged-local-branch finding. Summarize what the operator should do with those branches.",
+      "expected_output": "The absence of a merged finding for a privacy-gated branch is stated as unproven, never as evidence the branch is unmerged. The remedy is described accurately: the exact per-branch lookup was skipped because the branch name would otherwise be transmitted to github.com, so it returns only if remote evidence is restored (push or re-fetch) or the branch is verified manually on GitHub.",
+      "files": [],
+      "expectations": [
+        "Treats a privacy-gated branch as merge state unverified, not unmerged",
+        "Explains that the branch name is withheld from GitHub deliberately, not by failure",
+        "Offers no cleanup handoff for a privacy-gated branch",
+        "Does not claim re-running the audit unchanged would resolve the gap"
+      ]
+    },
+    {
+      "id": 11,
+      "name": "merged-pr-window-truncation-is-disclosed",
+      "prompt": "A repository with roughly 900 merged pull requests is audited. The batched merged-PR query returns a full window of rows. Report what the merged findings for this repository do and do not prove.",
+      "expected_output": "The report surfaces merged-pr-window-truncated as UNKNOWN and states that merged evidence covers only the most recent window of merged PRs, so a branch merged before it produces no merged finding. Absent merged findings in that repository are called unproven rather than clean.",
+      "files": [],
+      "expectations": [
+        "Discloses that the merged-PR query window was reached and older history is outside it",
+        "States that an absent merged finding in this repository is unproven, not evidence of an unmerged branch",
+        "Does not silently present the truncated batch as complete merged history"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "squash-merge-makes-the-ancestry-tier-near-inert",
+      "prompt": "A fleet squash-merges every pull request. Local ancestry of the default branch held for only 27 of 506 branches, and git rev-list --count <tip> --not --remotes reads non-zero for most of them. Explain what the LOW local-ancestry-only tier is worth here.",
+      "expected_output": "The answer explains that a squash rewrites the branch commits, so the original tip is not an ancestor and the LOW ancestry predicate is near-inert on this fleet, leaving GitHub merged-PR evidence as the load-bearing signal. A non-zero unpushed-commit count and a NONE-UPSTREAM git cherry result are explained as expected consequences of squashing, not as evidence a branch is unmerged.",
+      "files": [],
+      "expectations": [
+        "Attributes the low ancestry hit rate to squash merging rather than to a collector defect",
+        "Does not read a non-zero rev-list --not --remotes count as proof a branch is unmerged",
+        "Notes that git cherry proves content landed only in the ALL-UPSTREAM direction",
+        "Keeps GitHub merged-PR evidence as the primary signal on a squash-merging fleet"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "worktree-disposability-is-out-of-scope-by-design",
+      "prompt": "The audit lists 208 registered worktrees across the fleet. Which of them are safe to delete because nobody is using them any more?",
+      "expected_output": "The audit declines: it classifies registrations only by Git-observable state (merged, prunable, missing, locked, admin-mismatched) and has no evidence of whether a worktree is still wanted. Disposability is named as deliberately outside the evidence model rather than as a gap, and the request is routed to /source-control:worktree cleanup --dry-run.",
+      "files": [],
+      "expectations": [
+        "Declines to rank worktrees by whether anyone still needs them",
+        "Names the Git-observable registration states it can actually evidence",
+        "Does not infer disuse from directory naming, age, or activity",
+        "Routes the decision to the worktree cleanup dry-run and the human"
+      ]
     }
   ]
 }

--- a/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
+++ b/plugins/repo-fleet-hygiene/skills/audit/reference/confidence-model.md
@@ -3,6 +3,24 @@
 Confidence describes evidence strength; disposition describes whether the evidence is sufficient to
 send a target into another tool's own dry-run/confirmation workflow. They are intentionally separate.
 
+## Axes
+
+`HIGH`, `MEDIUM`, `LOW`, and `UNKNOWN` are the confidence values — how strong the evidence is.
+
+`ACKNOWLEDGED` is **not** a fifth confidence value. It is a prominence demotion applied to an
+`UNKNOWN` `github-identity-unavailable` finding whose identity is listed in `fleet.ackUnavailable`:
+the evidence is exactly as weak, and the finding is still reported, but the operator has recorded
+that this identity is known-inaccessible so it stops competing for attention. It never suppresses a
+finding, never touches a non-404/403 failure, and never affects evidence from a successful API
+response. The report gives it its own group for that reason.
+
+## Every emitted finding kind
+
+The collector emits exactly the kinds below. `scripts/audit-fleet.test.sh` asserts that this table's
+kind set and the collector's emitted kind set are equal, so a new kind cannot ship without a
+documented disposition — the drift that made this table cover half the finding set is now a test
+failure rather than a discovery.
+
 | Kind | Evidence | Confidence | Disposition |
 |---|---|---|---|
 | `merged-local-branch` | GitHub `MERGED` PR for this repository + branch and `headRefOid` equals local tip; branch is not current/default/worktree-attached | `HIGH` | Candidate handoff to `/repo-hygiene:clean git` |
@@ -13,12 +31,46 @@ send a target into another tool's own dry-run/confirmation workflow. They are in
 | `missing-worktree` | Registered path is absent but Git has not marked it prunable under its current expiry policy | `MEDIUM` | Manual review/dry-run handoff |
 | `locked-worktree` | Git porcelain marks a non-main registration locked | `HIGH` | Manual review of the lock reason before cleanup |
 | `worktree-admin-mismatch` | Registered directory exists and resolves to a different common Git directory, or cannot resolve as the registered repository | `HIGH` | Manual admin-directory decision; never automatic repair/removal |
-| `github-remote-moved` | GitHub REST resolves requested `owner/repo` to a different canonical `full_name` | `HIGH` | Human-reviewed remote update |
-| Canonical identity unavailable/conflicting | Override target cannot prove it is the discovered GitHub repository | `UNKNOWN` | Stop that repository; never combine evidence |
-| Worktree inventory command fails | Attachment/protection membership cannot be established | `UNKNOWN` | Stop local branch/worktree classification for that repository |
-| GitHub unavailable/404/403 | Required GitHub evidence could not be obtained or is access-ambiguous | `UNKNOWN` | Investigate; no negative or cleanup inference |
+| `github-remote-moved` | GitHub REST resolves the requested `owner/repo` to a different canonical `full_name` | `HIGH` | Human-reviewed remote update |
+| `duplicate-checkout` | Two or more distinct checkouts resolve to one normalized GitHub identity | `LOW` | Informational only; same-identity clones legitimately diverge |
+| `canonical-override-invalid` | An override target has a missing, ambiguous, credential-only, or non-`github.com` remote | `UNKNOWN` | Stop that repository; never combine evidence |
+| `canonical-identity-unverified` | An override target's GitHub identity could not be resolved for comparison against the discovered one | `UNKNOWN` | Stop that repository; never combine evidence |
+| `canonical-identity-conflict` | An override target resolves to a different GitHub identity than the discovered checkout | `UNKNOWN` | Stop that repository; never combine evidence |
+| `github-identity-unavailable` | `GET /repos/{owner}/{repo}` returned 404/403, failed, or timed out | `UNKNOWN`, demoted to `ACKNOWLEDGED` when the identity is listed in `fleet.ackUnavailable` and the failure was 404/403 | Investigate; never infer "deleted" or "moved" |
+| `github-pr-evidence-unavailable` | The repository-scoped merged-PR query failed | `UNKNOWN` | Do not infer branch merge state |
+| `merged-pr-window-truncated` | The merged-PR query returned a full window of rows, so older merged PRs fall outside it | `UNKNOWN` | Absent merged findings in this repository are unproven; verify a branch on GitHub before cleanup |
+| `merge-evidence-privacy-gated` | The exact per-branch merged-PR lookup was skipped because the branch is absent from the local remote-tracking inventory, so its name must not be sent to GitHub | `UNKNOWN` | Merged state unverified; restore remote evidence or verify manually |
+| `worktree-inventory-unavailable` | `git worktree list --porcelain -z` failed | `UNKNOWN` | Stop local branch/worktree classification for that repository |
+| `worktree-common-dir-unavailable` | A registered worktree path exists but its `--git-common-dir` could not be resolved | `UNKNOWN` | Manual inspection; the registration cannot be trusted either way |
+| `branch-inventory-unavailable` | `git for-each-ref` over `refs/heads/` failed or emitted malformed/partial output | `UNKNOWN` | Discard partial records, stop branch classification, exclude from the audited count |
+| `remote-branch-inventory-unavailable` | `git for-each-ref` over `refs/remotes/<remote>/` failed | `UNKNOWN` | Exact per-branch GitHub lookups are skipped for the whole repository |
+| `current-branch-unavailable` | `git branch --show-current` failed, so branch-protection membership is unknown | `UNKNOWN` | Emit no standalone branch cleanup candidate for that repository |
+| `git-common-dir-unavailable` | The canonical checkout's own `--git-common-dir` could not be resolved | `UNKNOWN` | Stop that repository; registration comparison is impossible |
+| `local-ancestry-unavailable` | `git merge-base --is-ancestor` failed with an error status | `UNKNOWN` | Do not infer local ancestry |
+| `stale-config-entry` | A config-sourced `fleet.root`/`fleet.repo` path is missing or not a Git working tree | `UNKNOWN` | Entry skipped, rest of the fleet still audited; correct or remove the entry |
 
-Priority rules:
+## What the tiers depend on
+
+Two dependencies change what these tiers can prove. Neither is a defect, and neither is visible from
+a single report, so they are stated here rather than left to be rediscovered.
+
+**Merge strategy.** `local-ancestry-only` tests whether a branch tip is an ancestor of the
+remote-tracking default branch. A squash merge rewrites the branch's commits into one new commit, so
+the original tip is not an ancestor and the predicate is near-inert on a squash-merging fleet —
+observed holding for 27 of 506 branches on one such fleet. Related consequences of the same cause:
+`git rev-list --count <tip> --not --remotes` reads non-zero for a squashed-and-pruned branch even
+though it merged, and `git cherry` is one-directional, since `ALL-UPSTREAM` proves content landed
+while `NONE-UPSTREAM` proves nothing when a squash has collapsed N commits so no individual patch-id
+survives. On such a fleet the GitHub merged-PR evidence is the load-bearing signal and the `LOW`
+ancestry tier adds little.
+
+**`gc.worktreePruneExpire`.** `missing-worktree` (`MEDIUM`) and `prunable-worktree` (`HIGH`) describe
+the same physical situation — a registered path that is absent. What separates them is only whether
+Git's own expiry window has elapsed and marked the registration prunable, and that window is a
+user-tunable config value. The tier difference is therefore a difference in Git's willingness to act,
+not a difference in evidence strength.
+
+## Priority rules
 
 1. A protection condition wins over a branch candidate classification.
 2. A merged worktree routes through worktree cleanup before branch cleanup.

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -25,6 +25,44 @@ lower() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
 
+# Path presentation. MSYS/Cygwin render Windows drives as /c/..., a form no Windows shell, file
+# manager, or IDE accepts. This report is actionable text whose paths get pasted, so convert to the
+# drive form for PRESENTATION ONLY -- every comparison, dedup key, and filesystem test upstream
+# keeps the native form it was given.
+WINDOWS_PATH_DISPLAY=false
+CASE_INSENSITIVE_PATHS=false
+case "$(uname -s 2>/dev/null || true)" in
+MINGW* | MSYS* | CYGWIN*)
+  WINDOWS_PATH_DISPLAY=true
+  CASE_INSENSITIVE_PATHS=true
+  ;;
+*) ;;
+esac
+
+WINDOWS_DRIVE_LETTERS="abcdefghijklmnopqrstuvwxyz"
+
+to_native_path() {
+  local text="$1" i lower_drive upper_drive
+  [[ "$WINDOWS_PATH_DISPLAY" == "true" && "$text" == */* ]] || {
+    printf '%s' "$text"
+    return 0
+  }
+  # Convert at the value start and after a space: the report's two shapes are a bare path field and
+  # a path embedded in a handoff sentence. The case pre-filter keeps the tr fork to drives actually
+  # present, and avoids ${var^} / ${var,,} so bash 3.2 (macOS system bash) still runs this.
+  for ((i = 0; i < 26; i++)); do
+    lower_drive="${WINDOWS_DRIVE_LETTERS:i:1}"
+    case "$text" in
+    "/$lower_drive/"* | *" /$lower_drive/"*) ;;
+    *) continue ;;
+    esac
+    upper_drive="$(printf '%s' "$lower_drive" | tr '[:lower:]' '[:upper:]')"
+    [[ "$text" == "/$lower_drive/"* ]] && text="$upper_drive:/${text#"/$lower_drive/"}"
+    text="${text//" /$lower_drive/"/" $upper_drive:/"}"
+  done
+  printf '%s' "$text"
+}
+
 # Keep ordinary printable report values readable, but encode any control-bearing value as one Bash
 # %q field. Git permits newlines and terminal-control bytes in filesystem paths; raw rendering would
 # let a crafted registration forge Finding/Confidence/Handoff lines in this actionable report.
@@ -32,7 +70,7 @@ display_value() {
   local value="$1" escaped
   local LC_ALL=C
   if [[ "$value" =~ ^[[:print:]]*$ ]]; then
-    printf '%s' "$value"
+    to_native_path "$value"
   else
     printf -v escaped '%q' "$value"
     printf '%s' "$escaped"
@@ -174,6 +212,10 @@ gh_probe_allowed() {
 # GitHub CLI has no request-timeout flag. Prefer GNU timeout/gtimeout only when its documented
 # --kill-after capability is present. The pure-Bash watchdog is the platform-safe fallback and still
 # escalates TERM to KILL after a finite grace period. The test switch can only shorten both bounds.
+# The repository-scoped merged-PR batch window. Named rather than inlined so the query, the
+# truncation disclosure, and the evidence text can never drift apart; the value is also pinned in
+# gh_probe_allowed, which rejects any other --limit for this query.
+MERGED_PR_WINDOW=200
 GH_TIMEOUT_SECONDS=30
 GH_KILL_AFTER_SECONDS=5
 if [[ "${REPO_FLEET_TEST_FAST_TIMEOUTS:-}" == "1" ]]; then
@@ -236,18 +278,13 @@ fi
 
 command -v git >/dev/null 2>&1 || fail "git is required"
 
-CASE_INSENSITIVE_PATHS=false
-case "$(uname -s 2>/dev/null || true)" in
-MINGW* | MSYS* | CYGWIN*) CASE_INSENSITIVE_PATHS=true ;;
-*) ;;
-esac
-
 ROOT_ARGS=()
 REPO_ARGS=()
 OVERRIDE_KEYS=()
 OVERRIDE_PATHS=()
 CONFIG_FILE=""
 MAX_DEPTH=""
+PROJECT_DIR_ARG=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -285,6 +322,11 @@ while [[ $# -gt 0 ]]; do
     MAX_DEPTH="$2"
     shift 2
     ;;
+  --project-dir)
+    [[ $# -ge 2 ]] || fail "--project-dir requires a directory"
+    PROJECT_DIR_ARG="$2"
+    shift 2
+    ;;
   -h | --help)
     usage
     exit 0
@@ -292,6 +334,20 @@ while [[ $# -gt 0 ]]; do
   *) fail "unknown argument: $1" ;;
   esac
 done
+
+# Project directory. ${CLAUDE_PROJECT_DIR} is documented to substitute in a skill's markdown
+# content and in its allowed-tools Bash rules -- NOT to be present in the Bash tool's environment,
+# which is where this collector runs. Reading it from the environment left the project rung of the
+# config ladder permanently unreachable, so the skill body passes it in as --project-dir, where the
+# documented substitution applies. The environment is still honored for callers that genuinely have
+# it (hooks, MCP stdio servers, a direct shell). A value that is still an unexpanded ${...}
+# placeholder -- an older Claude Code that does not substitute it -- counts as absent, never as a
+# literal directory name.
+PROJECT_DIR="${PROJECT_DIR_ARG:-${CLAUDE_PROJECT_DIR:-}}"
+case "$PROJECT_DIR" in
+"\${"*) PROJECT_DIR="" ;;
+*) ;;
+esac
 
 # Config resolution ladder: explicit --config, then the project-scoped file,
 # then the user-global one. A fleet config is inherently machine-scoped, so a
@@ -304,8 +360,8 @@ if [[ -n "$CONFIG_FILE" ]]; then
   [[ -f "$CONFIG_FILE" ]] || fail "config file not found: $CONFIG_FILE"
   CONFIG_SOURCE="explicit --config"
 else
-  if [[ -n "${CLAUDE_PROJECT_DIR:-}" && -f "${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf" ]]; then
-    CONFIG_FILE="${CLAUDE_PROJECT_DIR}/.claude/repo-fleet-hygiene.conf"
+  if [[ -n "$PROJECT_DIR" && -f "$PROJECT_DIR/.claude/repo-fleet-hygiene.conf" ]]; then
+    CONFIG_FILE="$PROJECT_DIR/.claude/repo-fleet-hygiene.conf"
     CONFIG_SOURCE="project"
   else
     home_dir="${HOME:-${USERPROFILE:-}}"
@@ -382,8 +438,18 @@ is_acked() {
 }
 
 IMPLICIT_SCOPE=false
+UNRESOLVED_SCOPE=false
+SCOPE_FALLBACK_NOTE="so the audit fell back to this session's project directory as an exact repository target"
 if [[ ${#ROOT_ARGS[@]} -eq 0 && ${#REPO_ARGS[@]} -eq 0 ]]; then
-  REPO_ARGS+=("${CLAUDE_PROJECT_DIR:-$PWD}")
+  # No scope AND no project directory. $PWD is an agent session's incidental working directory, not
+  # a chosen scope, so falling back to it would audit wherever the shell happened to sit and report
+  # that as the project. Defer the rejection until reject_target is defined below, so the operator
+  # gets the same scope remedies the chosen-nothing case already earns.
+  if [[ -z "$PROJECT_DIR" ]]; then
+    UNRESOLVED_SCOPE=true
+    SCOPE_FALLBACK_NOTE="and no project directory was available, so no repository scope resolved"
+  fi
+  REPO_ARGS+=("$PROJECT_DIR")
   # The implicit current-project default is CLI-equivalent, not config-sourced: it is appended
   # after CLI_REPO_COUNT was captured, so count it there or the zero-configuration audit from a
   # non-Git directory would degrade to a stale-config-entry (with an empty source) instead of
@@ -392,6 +458,25 @@ if [[ ${#ROOT_ARGS[@]} -eq 0 && ${#REPO_ARGS[@]} -eq 0 ]]; then
   # CLI-shaped error tells them nothing about how to supply a scope.
   CLI_REPO_COUNT=$((CLI_REPO_COUNT + 1))
   IMPLICIT_SCOPE=true
+fi
+
+# Scope provenance: which rung actually supplied the audited roots/repos. This is a different
+# question from which config FILE was consumed, and the header used to answer it with a fixed
+# literal that could contradict the run's own inputs two lines later. Config-supplied scope is
+# ADDITIVE to any CLI-supplied scope, so both contributions are named rather than one masking the
+# other.
+if [[ "$IMPLICIT_SCOPE" == "true" ]]; then
+  SCOPE_PROVENANCE="project directory (no --root, --repo, or config-supplied scope)"
+else
+  cli_scope_count=$((CLI_ROOT_COUNT + CLI_REPO_COUNT))
+  config_scope_count=$((${#ROOT_ARGS[@]} - CLI_ROOT_COUNT + ${#REPO_ARGS[@]} - CLI_REPO_COUNT))
+  SCOPE_PROVENANCE=""
+  [[ "$cli_scope_count" -gt 0 ]] &&
+    SCOPE_PROVENANCE="command line ($cli_scope_count --root/--repo argument(s))"
+  if [[ "$config_scope_count" -gt 0 ]]; then
+    [[ -n "$SCOPE_PROVENANCE" ]] && SCOPE_PROVENANCE="$SCOPE_PROVENANCE + "
+    SCOPE_PROVENANCE="${SCOPE_PROVENANCE}config $CONFIG_SOURCE ($config_scope_count fleet.root/fleet.repo entr(ies))"
+  fi
 fi
 
 path_key() {
@@ -430,8 +515,7 @@ reject_target() {
       cat >&2 <<EOF
 
 No --root or --repo was given, and the consumed config ($CONFIG_SOURCE: $CONFIG_FILE) carries no
-fleet.root or fleet.repo entries, so the audit used this session's project directory as an exact
-repository target. Add scope to that config:
+fleet.root or fleet.repo entries, $SCOPE_FALLBACK_NOTE. Add scope to that config:
 
   git config --file "$CONFIG_FILE" --add fleet.root <dir>   bounded recursive repository discovery
   git config --file "$CONFIG_FILE" --add fleet.repo <dir>   one exact repository or worktree
@@ -439,10 +523,9 @@ repository target. Add scope to that config:
 Or pass --root <dir> / --repo <dir> for a one-off scope.
 EOF
     else
-      cat >&2 <<'EOF'
+      cat >&2 <<EOF
 
-No --root, --repo, or --config was given, so the audit used this session's project directory as an
-exact repository target. Give it a scope instead:
+No --root, --repo, or --config was given, $SCOPE_FALLBACK_NOTE. Give it a scope instead:
 
   --root <dir>     bounded recursive repository discovery
   --repo <dir>     one exact repository or worktree
@@ -455,12 +538,34 @@ EOF
   exit 2
 }
 
+if [[ "$UNRESOLVED_SCOPE" == "true" ]]; then
+  reject_target default \
+    "no scope resolved: no --root or --repo, no config-supplied scope, and no project directory (pass --project-dir, or supply a scope directly)"
+fi
+
+# main_worktree <dir>: the repository-of-record checkout for <dir>, or non-zero when the porcelain
+# cannot answer. `git worktree list --porcelain` lists the MAIN worktree first regardless of which
+# worktree it runs from (git-worktree(1)), and the collector already relies on that ordering when it
+# classifies registrations. `rev-parse --show-toplevel` cannot substitute: inside a linked worktree
+# it returns the LINKED root, so it can never distinguish the two.
+main_worktree() {
+  local dir="$1" record=""
+  # -z records are NUL-delimited and command substitution would drop the NULs outright, so read the
+  # first record directly off the stream.
+  IFS= read -r -d '' record < <(run_git_probe -C "$dir" worktree list --porcelain -z -- 2>/dev/null)
+  record="${record%$'\r'}"
+  [[ "$record" == "worktree "* ]] || return 1
+  record="${record#worktree }"
+  [[ -n "$record" ]] || return 1
+  printf '%s\n' "$record"
+}
+
 # add_target <path> <origin>: origin "cli" hard-fails on an invalid path (a typo should stop the
 # run); origin "default" hard-fails with the scope remedies; origin "config" records a
 # stale-config-entry and continues (the entry, not the run, is the failure unit for a tracked fleet
 # config). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
-  local candidate="$1" origin="${2:-cli}" top common common_key existing
+  local candidate="$1" origin="${2:-cli}" top common common_key existing main_top
   if [[ ! -d "$candidate" ]]; then
     reject_target "$origin" "repository directory not found: $candidate"
     STALE_CONFIG_PATHS+=("$candidate")
@@ -479,6 +584,18 @@ add_target() {
     STALE_CONFIG_REASONS+=("cannot resolve the Git common directory for the configured path")
     return 0
   }
+  # Siblings sharing one common directory are one repository, and the dedup below keeps whichever
+  # arrives first -- which for recursive discovery is glob order. Retarget to the repository of
+  # record BEFORE that tie-break so a linked worktree reached first can never become the canonical
+  # path every emitted handoff points at. Falls back to --show-toplevel when the porcelain cannot
+  # answer; a repository whose worktree inventory is unusable is reported as UNKNOWN downstream.
+  # A main worktree carries .git as a DIRECTORY; a linked one carries it as a FILE. Gate the extra
+  # porcelain probe on that cheap local test so an ordinary fleet sweep pays nothing per repository
+  # -- and note the gate is an optimization only: --separate-git-dir also yields a .git file, and
+  # the porcelain then simply confirms the same main worktree.
+  if [[ ! -d "$top/.git" ]] && main_top="$(main_worktree "$candidate")" && [[ -n "$main_top" ]]; then
+    top="$main_top"
+  fi
   common_key="$(path_key "$common")"
   for existing in "${TARGET_COMMON_KEYS[@]:-}"; do
     [[ "$existing" == "$common_key" ]] && return 0
@@ -722,7 +839,7 @@ analyze_repo() {
   local pr_num pr_branch pr_oid pr_merged pr_url attached wt_index branch_index is_main ancestry_status
   local ref_record branch_status=1 branch_inventory_valid=true
   local remote_ref_record remote_branch_status=1 remote_branch_short remote_branch_known
-  local repo_pr_rows="" exact_pr_rows="" repo_pr_available=false protected=false
+  local repo_pr_rows="" exact_pr_rows="" repo_pr_available=false protected=false pr_row_count=0
   local remote_inventory_failed=false
   local -a WT_PATHS=() WT_BRANCHES=() WT_PRUNABLE=() WT_LOCKED=()
   local -a BRANCH_NAMES=() BRANCH_TIPS=() REMOTE_BRANCH_NAMES=() REMOTE_BRANCH_TIPS=()
@@ -1026,10 +1143,24 @@ analyze_repo() {
   # One repository-scoped query avoids N network round trips while keeping same-named branches
   # isolated by --repo. A finite limit can cause a false negative, never a false merged claim.
   if [[ -n "$github_repo" && "$GH_READY" == "true" ]]; then
-    repo_pr_rows="$(run_bounded_gh pr list --repo "github.com/$github_repo" --state merged --limit 200 \
+    repo_pr_rows="$(run_bounded_gh pr list --repo "github.com/$github_repo" --state merged --limit "$MERGED_PR_WINDOW" \
       --json number,headRefName,headRefOid,mergedAt,url \
       --template '{{range .}}{{printf "%v\t%s\t%s\t%s\t%s\n" .number .headRefName .headRefOid .mergedAt .url}}{{end}}' 2>/dev/null)" &&
       repo_pr_available=true
+    # A repository whose merged history exceeds the query window loses the older PRs silently, and
+    # a branch merged before the window then reports no merged finding at all -- indistinguishable
+    # in the report from a branch that was never merged. gh returns at most --limit rows, so a full
+    # batch means the window was reached; it cannot distinguish "exactly 200" from "far more", and
+    # deliberately errs toward warning, because a missing warning is the failure that costs history.
+    if [[ "$repo_pr_available" == "true" ]]; then
+      pr_row_count="$(printf '%s' "$repo_pr_rows" | grep -c . || true)"
+      if [[ "$pr_row_count" -ge "$MERGED_PR_WINDOW" ]]; then
+        emit_finding UNKNOWN merged-pr-window-truncated "$github_repo" \
+          "the merged-PR query returned $pr_row_count rows, equal to its $MERGED_PR_WINDOW-PR window; older merged PRs are outside it" \
+          "Merged evidence for this repository covers only the most recent $MERGED_PR_WINDOW merged PRs; an older merge reports no merged finding" \
+          "Treat absent merged findings here as unproven; verify an individual branch on GitHub before cleanup"
+      fi
+    fi
     if [[ "$repo_pr_available" != "true" ]]; then
       emit_finding UNKNOWN github-pr-evidence-unavailable "$github_repo" \
         "repository-scoped merged-PR query failed" "Do not infer branch merge state" \
@@ -1186,8 +1317,9 @@ printf 'Mode: read-only (no fetch, prune, repair, delete, checkout, or remote up
 if [[ -n "$CONFIG_FILE" ]]; then
   print_field Config "$CONFIG_FILE ($CONFIG_SOURCE)"
 else
-  print_field Config "none (no explicit, project, or user-global config; current-project scope)"
+  print_field Config "none (no explicit --config, and no project or user-global config file found)"
 fi
+print_field Scope "$SCOPE_PROVENANCE"
 if [[ "$GH_READY" == "true" && -n "$GH_ACCOUNT" ]]; then
   printf 'GitHub evidence: available (account: '
   display_value "$GH_ACCOUNT"
@@ -1195,7 +1327,10 @@ if [[ "$GH_READY" == "true" && -n "$GH_ACCOUNT" ]]; then
 else
   printf 'GitHub evidence: %s\n' "$([[ "$GH_READY" == "true" ]] && echo available || echo unavailable)"
 fi
-printf 'Repositories discovered: %s\n' "${#TARGETS[@]}"
+# Two different quantities previously shared the bare label "repositories": this one counts
+# discovery targets, the Summary line counts repositories that completed a local audit. Both are
+# qualified so a reader cannot read a shortfall as a discrepancy.
+printf 'Repositories discovered (audit targets after deduplication): %s\n' "${#TARGETS[@]}"
 for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   printf 'Root '
   display_value "${ROOT_LABELS[$root_index]}"
@@ -1244,6 +1379,13 @@ for ((di = 0; di < ${#IDENT_KEYS[@]}; di++)); do
   fi
 done
 
-printf '\nSummary: repositories=%s high=%s medium=%s low=%s unknown=%s acknowledged=%s\n' \
+printf '\nSummary: repositories_audited=%s high=%s medium=%s low=%s unknown=%s acknowledged=%s\n' \
   "$REPOS_AUDITED" "$FINDINGS_HIGH" "$FINDINGS_MEDIUM" "$FINDINGS_LOW" "$FINDINGS_UNKNOWN" "$FINDINGS_ACKED"
-printf 'Mutation count: 0\n'
+# Deliberately a statement of the enforcing mechanism, not a tally. The previous line printed a
+# hardcoded "Mutation count: 0", which would have read identically in a build that mutated -- an
+# unfalsifiable reassurance in the exact place a reader looks for assurance. A real counter is not
+# available either: most probes run inside command substitution, so an increment would be lost with
+# the subshell and would undercount. The allowlists are the fact; they are named so a reader can go
+# read them.
+printf 'Mutations: none possible; every Git and gh invocation is checked against a read-only\n'
+printf '  command allowlist (git_probe_allowed / gh_probe_allowed) and rejected otherwise.\n'

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -213,13 +213,14 @@ gh_probe_allowed() {
   esac
 }
 
-# GitHub CLI has no request-timeout flag. Prefer GNU timeout/gtimeout only when its documented
-# --kill-after capability is present. The pure-Bash watchdog is the platform-safe fallback and still
-# escalates TERM to KILL after a finite grace period. The test switch can only shorten both bounds.
 # The repository-scoped merged-PR batch window. Named rather than inlined so the query, the
 # truncation disclosure, and the evidence text can never drift apart; the value is also pinned in
 # gh_probe_allowed, which rejects any other --limit for this query.
 MERGED_PR_WINDOW=200
+
+# GitHub CLI has no request-timeout flag. Prefer GNU timeout/gtimeout only when its documented
+# --kill-after capability is present. The pure-Bash watchdog is the platform-safe fallback and still
+# escalates TERM to KILL after a finite grace period. The test switch can only shorten both bounds.
 GH_TIMEOUT_SECONDS=30
 GH_KILL_AFTER_SECONDS=5
 if [[ "${REPO_FLEET_TEST_FAST_TIMEOUTS:-}" == "1" ]]; then
@@ -594,13 +595,13 @@ add_target() {
   }
   # Siblings sharing one common directory are one repository, and the dedup below keeps whichever
   # arrives first -- which for recursive discovery is glob order. Retarget to the repository of
-  # record BEFORE that tie-break so a linked worktree reached first can never become the canonical
-  # path every emitted handoff points at. Falls back to --show-toplevel when the porcelain cannot
-  # answer; a repository whose worktree inventory is unusable is reported as UNKNOWN downstream.
-  # A main worktree carries .git as a DIRECTORY; a linked one carries it as a FILE. Gate the extra
-  # porcelain probe on that cheap local test so an ordinary fleet sweep pays nothing per repository
-  # -- and note the gate is an optimization only: --separate-git-dir also yields a .git file, and
-  # the porcelain then simply confirms the same main worktree.
+  # record BEFORE that tie-break, so a linked worktree reached first can never become the canonical
+  # path every emitted handoff points at. Two guards on the cost and the failure mode: a main
+  # worktree carries .git as a DIRECTORY and a linked one as a FILE, so the cheap local test keeps
+  # an ordinary sweep from paying for the extra probe at all (an optimization only --
+  # --separate-git-dir also yields a .git file, and the porcelain then confirms the same main
+  # worktree); and when the porcelain cannot answer, --show-toplevel stands, with the unusable
+  # worktree inventory reported as UNKNOWN downstream.
   if [[ ! -d "$top/.git" ]] && main_top="$(main_worktree "$candidate")" && [[ -n "$main_top" ]]; then
     # Disclose the retarget. The operator supplied or discovered one path and the report is about
     # another, so substituting it silently would be the same class of defect as a header asserting a

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -7,10 +7,14 @@ usage() {
   cat <<'EOF'
 Usage: audit-fleet.sh [--root DIR]... [--repo DIR]... [--config FILE]
                       [--canonical github.com/owner/repo=PATH]...
-                      [--max-depth 1..12]
+                      [--max-depth 1..12] [--project-dir DIR]
 
 Read-only. Discovers repositories, resolves optional canonical checkouts, and
 reports confidence-tiered branch, worktree, and GitHub-identity findings.
+
+--project-dir supplies the session's project directory, used for the
+project-scoped config rung and as the target when no scope is given. It is
+passed in rather than read from the environment, which does not carry it.
 EOF
 }
 
@@ -491,6 +495,10 @@ path_key() {
 
 TARGETS=()
 TARGET_COMMON_KEYS=()
+# Candidates that resolved to a different main worktree than the path reached, reported in the
+# header so the substitution is never silent.
+RETARGETED_FROM=()
+RETARGETED_TO=()
 # Stale config-sourced entries collected during argument processing; the report header has not
 # printed yet, so they are emitted as per-entry UNKNOWN findings once it has.
 STALE_CONFIG_PATHS=()
@@ -594,6 +602,13 @@ add_target() {
   # -- and note the gate is an optimization only: --separate-git-dir also yields a .git file, and
   # the porcelain then simply confirms the same main worktree.
   if [[ ! -d "$top/.git" ]] && main_top="$(main_worktree "$candidate")" && [[ -n "$main_top" ]]; then
+    # Disclose the retarget. The operator supplied or discovered one path and the report is about
+    # another, so substituting it silently would be the same class of defect as a header asserting a
+    # scope the run's own inputs contradict.
+    if [[ "$(path_key "$main_top")" != "$(path_key "$top")" ]]; then
+      RETARGETED_FROM+=("$top")
+      RETARGETED_TO+=("$main_top")
+    fi
     top="$main_top"
   fi
   common_key="$(path_key "$common")"
@@ -1331,6 +1346,13 @@ fi
 # discovery targets, the Summary line counts repositories that completed a local audit. Both are
 # qualified so a reader cannot read a shortfall as a discrepancy.
 printf 'Repositories discovered (audit targets after deduplication): %s\n' "${#TARGETS[@]}"
+for ((rt_index = 0; rt_index < ${#RETARGETED_FROM[@]}; rt_index++)); do
+  printf 'Resolved to main worktree: '
+  display_value "${RETARGETED_FROM[$rt_index]}"
+  printf ' -> '
+  display_value "${RETARGETED_TO[$rt_index]}"
+  printf '\n'
+done
 for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   printf 'Root '
   display_value "${ROOT_LABELS[$root_index]}"

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -293,18 +293,21 @@ PROJECT_DIR_ARG=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+  # An empty value is rejected rather than accepted-and-skipped: the discovery loops ignore an
+  # empty entry, so accepting one would let the header's scope count claim an argument that
+  # contributed nothing. A CLI typo stops the run, as everywhere else in this grammar.
   --root)
-    [[ $# -ge 2 ]] || fail "--root requires a directory"
+    [[ $# -ge 2 && -n "$2" ]] || fail "--root requires a directory"
     ROOT_ARGS+=("$2")
     shift 2
     ;;
   --repo)
-    [[ $# -ge 2 ]] || fail "--repo requires a directory"
+    [[ $# -ge 2 && -n "$2" ]] || fail "--repo requires a directory"
     REPO_ARGS+=("$2")
     shift 2
     ;;
   --config)
-    [[ $# -ge 2 ]] || fail "--config requires a file"
+    [[ $# -ge 2 && -n "$2" ]] || fail "--config requires a file"
     [[ -z "$CONFIG_FILE" ]] || fail "--config may be supplied only once"
     CONFIG_FILE="$2"
     shift 2
@@ -574,7 +577,7 @@ main_worktree() {
 # stale-config-entry and continues (the entry, not the run, is the failure unit for a tracked fleet
 # config). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
-  local candidate="$1" origin="${2:-cli}" top common common_key existing main_top
+  local candidate="$1" origin="${2:-cli}" top common common_key existing main_top rt_known rt_existing
   if [[ ! -d "$candidate" ]]; then
     reject_target "$origin" "repository directory not found: $candidate"
     STALE_CONFIG_PATHS+=("$candidate")
@@ -607,8 +610,19 @@ add_target() {
     # another, so substituting it silently would be the same class of defect as a header asserting a
     # scope the run's own inputs contradict.
     if [[ "$(path_key "$main_top")" != "$(path_key "$top")" ]]; then
-      RETARGETED_FROM+=("$top")
-      RETARGETED_TO+=("$main_top")
+      # A config may name one path twice; record each distinct source once so the grouped header
+      # line cannot list the same path repeatedly.
+      rt_known=false
+      for rt_existing in "${RETARGETED_FROM[@]:-}"; do
+        [[ -n "$rt_existing" && "$rt_existing" == "$top" ]] && {
+          rt_known=true
+          break
+        }
+      done
+      if [[ "$rt_known" == "false" ]]; then
+        RETARGETED_FROM+=("$top")
+        RETARGETED_TO+=("$main_top")
+      fi
     fi
     top="$main_top"
   fi
@@ -1347,12 +1361,33 @@ fi
 # discovery targets, the Summary line counts repositories that completed a local audit. Both are
 # qualified so a reader cannot read a shortfall as a discrepancy.
 printf 'Repositories discovered (audit targets after deduplication): %s\n' "${#TARGETS[@]}"
-for ((rt_index = 0; rt_index < ${#RETARGETED_FROM[@]}; rt_index++)); do
+# One line per repository of record, listing every path that resolved into it. A separate line per
+# retargeted path would print N lines for a repository the count above reports once, which reads as
+# N repositories -- the same header-contradicts-itself defect this report is being corrected for.
+RT_REPORTED=()
+for ((rt_index = 0; rt_index < ${#RETARGETED_TO[@]}; rt_index++)); do
+  rt_to="${RETARGETED_TO[$rt_index]}"
+  rt_seen=false
+  for rt_prev in "${RT_REPORTED[@]:-}"; do
+    [[ -n "$rt_prev" && "$rt_prev" == "$rt_to" ]] && {
+      rt_seen=true
+      break
+    }
+  done
+  [[ "$rt_seen" == "true" ]] && continue
+  RT_REPORTED+=("$rt_to")
   printf 'Resolved to main worktree: '
-  display_value "${RETARGETED_FROM[$rt_index]}"
-  printf ' -> '
-  display_value "${RETARGETED_TO[$rt_index]}"
-  printf '\n'
+  display_value "$rt_to"
+  printf ' (reached via'
+  rt_count=0
+  for ((rt_j = 0; rt_j < ${#RETARGETED_TO[@]}; rt_j++)); do
+    [[ "${RETARGETED_TO[$rt_j]}" == "$rt_to" ]] || continue
+    [[ "$rt_count" -gt 0 ]] && printf ','
+    printf ' '
+    display_value "${RETARGETED_FROM[$rt_j]}"
+    rt_count=$((rt_count + 1))
+  done
+  printf ')\n'
 done
 for ((root_index = 0; root_index < ${#ROOT_LABELS[@]}; root_index++)); do
   printf 'Root '

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -15,6 +15,9 @@ reports confidence-tiered branch, worktree, and GitHub-identity findings.
 --project-dir supplies the session's project directory, used for the
 project-scoped config rung and as the target when no scope is given. It is
 passed in rather than read from the environment, which does not carry it.
+An empty value means "no project directory": the project config rung is
+skipped, and a run with no other scope stops rather than falling back to the
+current working directory.
 EOF
 }
 
@@ -178,6 +181,12 @@ run_git_probe() {
   )
 }
 
+# The repository-scoped merged-PR batch window, single-sourced so the query, the allowlist that pins
+# it, the truncation disclosure, and the evidence text cannot drift apart. It is a script constant
+# set before any argument or config is read, so the allowlist below stays as fixed a pin as the
+# literal it replaced -- nothing reachable by a caller can change it.
+MERGED_PR_WINDOW=200
+
 gh_probe_allowed() {
   case "${1:-}" in
   auth)
@@ -198,7 +207,7 @@ gh_probe_allowed() {
       "${4:-}" =~ ^github\.com/[^/[:cntrl:][:space:]]+/[^/[:cntrl:][:space:]]+$ &&
       "${5:-}" == "--state" && "${6:-}" == "merged" ]] || return 1
     if [[ $# -eq 12 ]]; then
-      [[ "$7" == "--limit" && "$8" == "200" && "$9" == "--json" &&
+      [[ "$7" == "--limit" && "$8" == "$MERGED_PR_WINDOW" && "$9" == "--json" &&
         "${10}" == "number,headRefName,headRefOid,mergedAt,url" && "${11}" == "--template" &&
         "${12}" == '{{range .}}{{printf "%v\t%s\t%s\t%s\t%s\n" .number .headRefName .headRefOid .mergedAt .url}}{{end}}' ]]
       return
@@ -212,11 +221,6 @@ gh_probe_allowed() {
   *) return 1 ;;
   esac
 }
-
-# The repository-scoped merged-PR batch window. Named rather than inlined so the query, the
-# truncation disclosure, and the evidence text can never drift apart; the value is also pinned in
-# gh_probe_allowed, which rejects any other --limit for this query.
-MERGED_PR_WINDOW=200
 
 # GitHub CLI has no request-timeout flag. Prefer GNU timeout/gtimeout only when its documented
 # --kill-after capability is present. The pure-Bash watchdog is the platform-safe fallback and still
@@ -348,9 +352,14 @@ done
 # which is where this collector runs. Reading it from the environment left the project rung of the
 # config ladder permanently unreachable, so the skill body passes it in as --project-dir, where the
 # documented substitution applies. The environment is still honored for callers that genuinely have
-# it (hooks, MCP stdio servers, a direct shell). A value that is still an unexpanded ${...}
-# placeholder -- an older Claude Code that does not substitute it -- counts as absent, never as a
-# literal directory name.
+# it (hooks, MCP stdio servers, a direct shell).
+#
+# The ${...} guard below is defence in depth, not the primary path: when Claude Code does not
+# substitute the placeholder, the literal reaches the shell, which expands the unset variable to an
+# empty string before this script is entered -- so the ordinary miss arrives as empty and is handled
+# by the emptiness checks. The guard catches only a literal that survives shell expansion (a
+# single-quoted argument, or a caller that invokes this script without a shell), where treating
+# "${CLAUDE_PROJECT_DIR}" as a directory name would be strictly worse than treating it as absent.
 PROJECT_DIR="${PROJECT_DIR_ARG:-${CLAUDE_PROJECT_DIR:-}}"
 case "$PROJECT_DIR" in
 "\${"*) PROJECT_DIR="" ;;
@@ -577,7 +586,7 @@ main_worktree() {
 # stale-config-entry and continues (the entry, not the run, is the failure unit for a tracked fleet
 # config). Invalid config SYNTAX still hard-fails upstream.
 add_target() {
-  local candidate="$1" origin="${2:-cli}" top common common_key existing main_top rt_known rt_existing
+  local candidate="$1" origin="${2:-cli}" top common common_key existing main_top main_resolved rt_known rt_existing
   if [[ ! -d "$candidate" ]]; then
     reject_target "$origin" "repository directory not found: $candidate"
     STALE_CONFIG_PATHS+=("$candidate")
@@ -599,19 +608,24 @@ add_target() {
   # Siblings sharing one common directory are one repository, and the dedup below keeps whichever
   # arrives first -- which for recursive discovery is glob order. Retarget to the repository of
   # record BEFORE that tie-break, so a linked worktree reached first can never become the canonical
-  # path every emitted handoff points at. Two guards on the cost and the failure mode: a main
-  # worktree carries .git as a DIRECTORY and a linked one as a FILE, so the cheap local test keeps
-  # an ordinary sweep from paying for the extra probe at all (an optimization only --
-  # --separate-git-dir also yields a .git file, and the porcelain then confirms the same main
-  # worktree); and when the porcelain cannot answer, --show-toplevel stands, with the unusable
-  # worktree inventory reported as UNKNOWN downstream.
+  # path every emitted handoff points at. The .git test is a cost gate only: a main worktree carries
+  # .git as a DIRECTORY and a linked one as a FILE, so an ordinary sweep never pays for the probe.
   if [[ ! -d "$top/.git" ]] && main_top="$(main_worktree "$candidate")" && [[ -n "$main_top" ]]; then
-    # Disclose the retarget. The operator supplied or discovered one path and the report is about
-    # another, so substituting it silently would be the same class of defect as a header asserting a
-    # scope the run's own inputs contradict.
-    if [[ "$(path_key "$main_top")" != "$(path_key "$top")" ]]; then
-      # A config may name one path twice; record each distinct source once so the grouped header
-      # line cannot list the same path repeatedly.
+    # The porcelain's first record is NOT always a checkout, and three ordinary shapes all present a
+    # .git file so they reach here: a submodule reports the superproject's .git/modules/<name> admin
+    # directory, --separate-git-dir reports the detached git directory, and a worktree of a bare
+    # repository reports the bare repository. Adopting any of them would aim every handoff INSIDE
+    # another repository's administrative directory -- the precise harm this retarget exists to
+    # prevent. So re-resolve the porcelain's answer as a working tree and adopt only a genuine,
+    # different checkout: bare and separate-git-dir fail this probe and are skipped, a submodule
+    # resolves back to the path we already had and self-cancels, and a real linked worktree resolves
+    # to its main worktree and retargets.
+    main_resolved="$(run_git_probe -C "$main_top" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')" || main_resolved=""
+    if [[ -n "$main_resolved" && "$(path_key "$main_resolved")" != "$(path_key "$top")" ]]; then
+      # Disclose the retarget. The operator supplied or discovered one path and the report is about
+      # another, so substituting it silently would be the same class of defect as a header asserting
+      # a scope the run's own inputs contradict. A config may name one path twice; record each
+      # distinct source once so the grouped header line cannot list the same path repeatedly.
       rt_known=false
       for rt_existing in "${RETARGETED_FROM[@]:-}"; do
         [[ -n "$rt_existing" && "$rt_existing" == "$top" ]] && {
@@ -621,10 +635,10 @@ add_target() {
       done
       if [[ "$rt_known" == "false" ]]; then
         RETARGETED_FROM+=("$top")
-        RETARGETED_TO+=("$main_top")
+        RETARGETED_TO+=("$main_resolved")
       fi
+      top="$main_resolved"
     fi
-    top="$main_top"
   fi
   common_key="$(path_key "$common")"
   for existing in "${TARGET_COMMON_KEYS[@]:-}"; do

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -13,7 +13,13 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/root/acme/root-repo/.git" \
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
-  "$TMP/discovered-c" "$TMP/canonical-c" "$TMP/gone-repo" "$TMP/lost-repo" "$TMP/net-repo"
+  "$TMP/discovered-c" "$TMP/canonical-c" "$TMP/gone-repo" "$TMP/lost-repo" "$TMP/net-repo" \
+  "$TMP/wt-root/aaa-linked" "$TMP/wt-root/zzz-canonical/.git"
+# Canonical-selection fixture: a LINKED worktree whose directory name sorts before its own main
+# worktree under LC_ALL=C, so bounded discovery reaches it first. A linked worktree carries .git as
+# a FILE, the main worktree as a DIRECTORY; both resolve to the same --git-common-dir, so whichever
+# the glob reaches first wins the dedup. The canonical checkout must not be decided by that order.
+: >"$TMP/wt-root/aaa-linked/.git"
 : >"$TMP/calls.log"
 
 cat >"$MOCK_BIN/git" <<'EOF'
@@ -56,6 +62,10 @@ rev-parse)
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo" ;;
     net-repo) printf '%s\n' "$TEST_ROOT/net-repo" ;;
+    # Inside a linked worktree --show-toplevel returns the LINKED root, which is exactly the wrong
+    # answer for a canonical checkout -- the defect this fixture pins.
+    aaa-linked) printf '%s\n' "$TEST_ROOT/wt-root/aaa-linked" ;;
+    zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -77,6 +87,7 @@ rev-parse)
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
     net-repo) printf '%s\n' "$TEST_ROOT/net-repo/.git" ;;
+    aaa-linked | zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical/.git" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -101,6 +112,7 @@ remote)
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
     lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
     net-repo) printf '%s\n' 'https://github.com/gone/net.git' ;;
+    aaa-linked | zzz-canonical) printf '%s\n' 'https://github.com/acme/wt-canon.git' ;;
     *) exit 1 ;;
     esac
   else
@@ -150,6 +162,13 @@ worktree)
   net-repo)
     printf 'worktree %s\0HEAD net-main\0branch refs/heads/main\0\0' "$TEST_ROOT/net-repo"
     ;;
+  # git-worktree(1): the porcelain lists the MAIN worktree first regardless of which worktree the
+  # command ran from. Both fixtures answer identically, so the main worktree is discoverable from
+  # inside the linked one.
+  aaa-linked | zzz-canonical)
+    printf 'worktree %s\0HEAD canon-main\0branch refs/heads/main\0\0' "$TEST_ROOT/wt-root/zzz-canonical"
+    printf 'worktree %s\0HEAD canon-feat\0branch refs/heads/feature/linked\0\0' "$TEST_ROOT/wt-root/aaa-linked"
+    ;;
   esac
   ;;
 symbolic-ref)
@@ -159,6 +178,7 @@ branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
   repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
+  aaa-linked | zzz-canonical) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
@@ -175,6 +195,7 @@ for-each-ref)
       printf 'origin\thead-a\0\norigin/main\tmain-a\0\norigin/feature/shared\tsha-a\0\norigin/stale/changed\tdrift-tip\0\n'
       ;;
     rref-fail) exit 9 ;;
+    aaa-linked | zzz-canonical) printf 'origin/main\tcanon-main\0\n' ;;
     esac
     exit 0
   fi
@@ -198,6 +219,7 @@ for-each-ref)
   gone-repo) printf 'main\tgone-main\0\n' ;;
   lost-repo) printf 'main\tlost-main\0\n' ;;
   net-repo) printf 'main\tnet-main\0\n' ;;
+  aaa-linked | zzz-canonical) printf 'main\tcanon-main\0\nfeature/linked\tcanon-feat\0\n' ;;
   esac
   ;;
 merge-base) exit 1 ;;
@@ -218,7 +240,10 @@ printf ' %q' "$@" >>"$CALL_LOG"
 printf '\n' >>"$CALL_LOG"
 
 case "${1:-}" in
-auth) exit 0 ;;
+auth)
+  [[ "${MOCK_GH_AUTH_FAIL:-}" == "1" ]] && exit 1
+  exit 0
+  ;;
 api)
   endpoint="${2:-}"
   case "$endpoint" in
@@ -236,6 +261,7 @@ api)
   repos/old/repo) printf 'new/repo\tmain' ;;
   repos/new/repo) printf 'new/repo\tmain' ;;
   repos/acme/repo-c) printf 'acme/repo-c\tmain' ;;
+  repos/acme/wt-canon) printf 'acme/wt-canon\tmain' ;;
   repos/gone/net) printf 'gh: connection reset by peer\n' >&2; exit 1 ;;
   *) printf 'gh: Not Found (HTTP 404)\n' >&2; exit 1 ;;
   esac
@@ -252,6 +278,16 @@ pr)
     printf '43\tstale/gone\tother-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/repo-a/pull/43\n'
     ;;
   github.com/acme/repo-b | github.com/acme/root-repo | github.com/new/repo | github.com/acme/repo-c) ;;
+  # A FULL merged-PR window: gh returns at most --limit rows, so 200 rows means older merged PRs
+  # were silently dropped. Every row is a branch this repository does not have locally, so the
+  # truncation disclosure is the only thing this fixture can produce.
+  github.com/acme/wt-canon)
+    i=1
+    while [[ "$i" -le 200 ]]; do
+      printf '%s\tarchived/branch-%s\toid-%s\t2026-07-01T00:00:00Z\thttps://github.com/acme/wt-canon/pull/%s\n' "$i" "$i" "$i" "$i"
+      i=$((i + 1))
+    done
+    ;;
   github.com/acme/rref-fail) ;;
   github.com/acme/wt-fail)
     printf '88\tfeature/fail\tfail-tip\t2026-07-03T00:00:00Z\thttps://github.com/acme/wt-fail/pull/88\n'
@@ -339,12 +375,13 @@ assert_contains "non-GitHub canonical override fails closed" "canonical override
 assert_contains "worktree inventory failure is unknown" "Finding: worktree-inventory-unavailable"
 assert_contains "branch inventory failure is unknown" "Finding: branch-inventory-unavailable"
 assert_contains "control-bearing path was encoded" '\nFinding: forged\nConfidence: CRITICAL\nHandoff: injected-control'
-assert_contains "report remains non-mutating" "Mutation count: 0"
+assert_contains "report states the enforcing read-only mechanism, not a tallied constant" "Mutations: none possible"
+assert_not_contains "no hardcoded mutation tally" "Mutation count: 0"
 assert_not_contains "repo B branch did not inherit repo A merge" "Target: $TMP/repo-b :: feature/shared"
 assert_not_contains "invalid canonical state was not combined" "Target: $TMP/bad-canonical ::"
 assert_not_contains "failed worktree inventory suppressed branch candidate" "Target: $TMP/wt-fail :: feature/fail"
 assert_not_contains "partial branch inventory suppressed branch candidate" "Target: $TMP/ref-fail :: feature/partial"
-assert_contains "failed repositories not counted successful" "Summary: repositories=11"
+assert_contains "failed repositories not counted successful" "Summary: repositories_audited=11"
 
 # Duplicate detection keys on the CANONICALIZED identity: old-repo (remote still says old/repo,
 # resolved to new/repo) must pair with new-clone (cloned from new/repo directly).
@@ -525,7 +562,7 @@ cat >"$TMP/stale-only.conf" <<'STALEONLY'
 STALEONLY
 if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --config "$TMP/stale-only.conf" >"$ladder_out" 2>&1 &&
   grep -Fq "Finding: stale-config-entry" "$ladder_out" &&
-  grep -Fq "Repositories discovered: 0" "$ladder_out"; then
+  grep -Fq "Repositories discovered (audit targets after deduplication): 0" "$ladder_out"; then
   printf 'PASS: all-stale config completes with stale findings instead of hard-failing\n'
 else
   printf 'FAIL: all-stale config completes with stale findings instead of hard-failing\n' >&2
@@ -609,6 +646,105 @@ if grep -Fq -- "GitHub evidence: available" "$ladder_out" && ! grep -Fq -- "(acc
   printf 'PASS: failed account probe degrades to plain header line\n'
 else
   printf 'FAIL: failed account probe degrades to plain header line\n' >&2
+  failures=$((failures + 1))
+fi
+
+# Canonical selection must not be decided by discovery order. wt-root holds a linked worktree
+# (aaa-linked) that sorts before its own main worktree (zzz-canonical) under LC_ALL=C, so the glob
+# reaches the linked one first and both map to the same --git-common-dir dedup key. Every emitted
+# handoff carries the canonical path, so picking the worktree would aim per-repository cleanup at a
+# checkout that is not the repository of record.
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --root "$TMP/wt-root" >"$ladder_out" 2>&1
+if grep -Fq "Canonical: $TMP/wt-root/zzz-canonical" "$ladder_out"; then
+  printf 'PASS: main worktree wins canonical selection over an earlier-sorting linked sibling\n'
+else
+  printf 'FAIL: main worktree wins canonical selection over an earlier-sorting linked sibling\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -Fq "Canonical: $TMP/wt-root/aaa-linked" "$ladder_out"; then
+  printf 'FAIL: a linked worktree was reported as the canonical checkout\n' >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS: no linked worktree reported as a canonical checkout\n'
+fi
+# The two directories are one repository: dedup by common dir must still collapse them to a single
+# discovered target, so the fix cannot be a duplicate-target regression in disguise.
+if grep -Fq "Repositories discovered (audit targets after deduplication): 1" "$ladder_out"; then
+  printf 'PASS: linked worktree and main worktree collapse to one discovered repository\n'
+else
+  printf 'FAIL: linked worktree and main worktree collapse to one discovered repository\n' >&2
+  failures=$((failures + 1))
+fi
+# Scope provenance is computed, not asserted: this run's scope came from a CLI --root, so the header
+# must say so rather than printing the old fixed "current-project scope" literal that contradicted
+# the run's own inputs two lines later.
+if grep -Fq "Scope: command line (1 --root/--repo argument(s))" "$ladder_out"; then
+  printf 'PASS: header attributes scope to the command line when --root supplied it\n'
+else
+  printf 'FAIL: header attributes scope to the command line when --root supplied it\n' >&2
+  failures=$((failures + 1))
+fi
+assert_not_contains_file() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -Fq -- "$pattern" "$file"; then
+    printf 'FAIL: %s (unexpected %s)\n' "$label" "$pattern" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS: %s\n' "$label"
+  fi
+}
+assert_not_contains_file "no false current-project scope claim" "current-project scope" "$ladder_out"
+# A full merged-PR window silently drops older history, which reads in the report exactly like a
+# branch that was never merged. The truncation must be disclosed, never inferred by the reader.
+if grep -Fq "Finding: merged-pr-window-truncated" "$ladder_out" &&
+  grep -Fq "equal to its 200-PR window" "$ladder_out"; then
+  printf 'PASS: a full merged-PR window is disclosed as truncated\n'
+else
+  printf 'FAIL: a full merged-PR window is disclosed as truncated\n' >&2
+  failures=$((failures + 1))
+fi
+
+# gh unavailable/unauthenticated: the skill promises the audit continues with GitHub evidence marked
+# UNKNOWN rather than aborting or inferring a negative. Never exercised before, though it is the
+# degradation a machine without gh hits on its very first run.
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 MOCK_GH_AUTH_FAIL=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --root "$TMP/wt-root" >"$ladder_out" 2>&1
+if grep -Fq "GitHub evidence: unavailable" "$ladder_out" &&
+  grep -Fq "Canonical: $TMP/wt-root/zzz-canonical" "$ladder_out"; then
+  printf 'PASS: unauthenticated gh degrades to UNKNOWN GitHub evidence and still audits locally\n'
+else
+  printf 'FAIL: unauthenticated gh degrades to UNKNOWN GitHub evidence and still audits locally\n' >&2
+  failures=$((failures + 1))
+fi
+assert_not_contains_file "no merged claim without GitHub evidence" "Finding: merged-local-branch" "$ladder_out"
+
+# The tier table is the contract a consumer tiers decisions on, and it silently fell to covering
+# half the emitted kinds. Assert set equality in BOTH directions instead: a new emit_finding kind
+# with no documented disposition fails here, and so does a table row for a kind the collector no
+# longer emits. Both sides are extracted mechanically -- comparing two hand-maintained lists would
+# reproduce the drift this replaces.
+MODEL_DOC="$SCRIPT_DIR/../reference/confidence-model.md"
+emitted_kinds="$TMP/emitted-kinds.txt"
+documented_kinds="$TMP/documented-kinds.txt"
+grep -oE "emit_finding [A-Z]+ [a-z-]+" "$SCRIPT" | awk '{print $3}' | sort -u >"$emitted_kinds"
+# Table rows only: a kind is the first backticked cell of a row, so prose mentions elsewhere in the
+# document cannot satisfy the contract. The delimiter is built with printf rather than written
+# literally, so no quoting style has to carry a bare backtick through grep and sed.
+bt="$(printf '\140')"
+grep -E "^\| ${bt}[a-z-]+${bt} \|" "$MODEL_DOC" | sed -e "s/^| ${bt}//" -e "s/${bt} |.*//" | sort -u >"$documented_kinds"
+emitted_count="$(grep -c . "$emitted_kinds" || true)"
+documented_count="$(grep -c . "$documented_kinds" || true)"
+# Guard against an extraction that silently matches nothing and compares two empty sets.
+if [[ "$emitted_count" -lt 20 || "$documented_count" -lt 20 ]]; then
+  printf 'FAIL: finding-kind extraction returned too few kinds (emitted=%s documented=%s); the extraction, not the docs, is broken\n' \
+    "$emitted_count" "$documented_count" >&2
+  failures=$((failures + 1))
+elif kind_diff="$(diff "$emitted_kinds" "$documented_kinds")"; then
+  printf 'PASS: tier table documents exactly the finding kinds the collector emits (%s)\n' "$emitted_count"
+else
+  printf 'FAIL: tier table and collector finding kinds have drifted (< emitted only, > documented only)\n%s\n' \
+    "$kind_diff" >&2
   failures=$((failures + 1))
 fi
 

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -695,6 +695,14 @@ assert_not_contains_file() {
   fi
 }
 assert_not_contains_file "no false current-project scope claim" "current-project scope" "$ladder_out"
+# Retargeting a supplied/discovered path to the repository of record is a substitution the operator
+# did not ask for, so it must be stated rather than silently applied.
+if grep -Fq "Resolved to main worktree: $TMP/wt-root/aaa-linked -> $TMP/wt-root/zzz-canonical" "$ladder_out"; then
+  printf 'PASS: retarget to the main worktree is disclosed in the header\n'
+else
+  printf 'FAIL: retarget to the main worktree is disclosed in the header\n' >&2
+  failures=$((failures + 1))
+fi
 # A full merged-PR window silently drops older history, which reads in the report exactly like a
 # branch that was never merged. The truncation must be disclosed, never inferred by the reader.
 if grep -Fq "Finding: merged-pr-window-truncated" "$ladder_out" &&

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -14,12 +14,13 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
   "$TMP/discovered-c" "$TMP/canonical-c" "$TMP/gone-repo" "$TMP/lost-repo" "$TMP/net-repo" \
-  "$TMP/wt-root/aaa-linked" "$TMP/wt-root/zzz-canonical/.git"
+  "$TMP/wt-root/aaa-linked" "$TMP/wt-root/bbb-linked" "$TMP/wt-root/zzz-canonical/.git"
 # Canonical-selection fixture: a LINKED worktree whose directory name sorts before its own main
 # worktree under LC_ALL=C, so bounded discovery reaches it first. A linked worktree carries .git as
 # a FILE, the main worktree as a DIRECTORY; both resolve to the same --git-common-dir, so whichever
 # the glob reaches first wins the dedup. The canonical checkout must not be decided by that order.
 : >"$TMP/wt-root/aaa-linked/.git"
+: >"$TMP/wt-root/bbb-linked/.git"
 : >"$TMP/calls.log"
 
 cat >"$MOCK_BIN/git" <<'EOF'
@@ -65,6 +66,7 @@ rev-parse)
     # Inside a linked worktree --show-toplevel returns the LINKED root, which is exactly the wrong
     # answer for a canonical checkout -- the defect this fixture pins.
     aaa-linked) printf '%s\n' "$TEST_ROOT/wt-root/aaa-linked" ;;
+    bbb-linked) printf '%s\n' "$TEST_ROOT/wt-root/bbb-linked" ;;
     zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical" ;;
     *) exit 1 ;;
     esac
@@ -87,7 +89,7 @@ rev-parse)
     gone-repo) printf '%s\n' "$TEST_ROOT/gone-repo/.git" ;;
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
     net-repo) printf '%s\n' "$TEST_ROOT/net-repo/.git" ;;
-    aaa-linked | zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical/.git" ;;
+    aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical/.git" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -112,7 +114,7 @@ remote)
     gone-repo) printf '%s\n' 'https://github.com/gone/away.git' ;;
     lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
     net-repo) printf '%s\n' 'https://github.com/gone/net.git' ;;
-    aaa-linked | zzz-canonical) printf '%s\n' 'https://github.com/acme/wt-canon.git' ;;
+    aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' 'https://github.com/acme/wt-canon.git' ;;
     *) exit 1 ;;
     esac
   else
@@ -165,9 +167,10 @@ worktree)
   # git-worktree(1): the porcelain lists the MAIN worktree first regardless of which worktree the
   # command ran from. Both fixtures answer identically, so the main worktree is discoverable from
   # inside the linked one.
-  aaa-linked | zzz-canonical)
+  aaa-linked | bbb-linked | zzz-canonical)
     printf 'worktree %s\0HEAD canon-main\0branch refs/heads/main\0\0' "$TEST_ROOT/wt-root/zzz-canonical"
     printf 'worktree %s\0HEAD canon-feat\0branch refs/heads/feature/linked\0\0' "$TEST_ROOT/wt-root/aaa-linked"
+    printf 'worktree %s\0HEAD canon-feat2\0branch refs/heads/feature/linked-2\0\0' "$TEST_ROOT/wt-root/bbb-linked"
     ;;
   esac
   ;;
@@ -178,7 +181,7 @@ branch)
   case "$base" in
   canonical-a) printf '%s\n' main ;;
   repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
-  aaa-linked | zzz-canonical) printf '%s\n' main ;;
+  aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
@@ -195,7 +198,7 @@ for-each-ref)
       printf 'origin\thead-a\0\norigin/main\tmain-a\0\norigin/feature/shared\tsha-a\0\norigin/stale/changed\tdrift-tip\0\n'
       ;;
     rref-fail) exit 9 ;;
-    aaa-linked | zzz-canonical) printf 'origin/main\tcanon-main\0\n' ;;
+    aaa-linked | bbb-linked | zzz-canonical) printf 'origin/main\tcanon-main\0\n' ;;
     esac
     exit 0
   fi
@@ -219,7 +222,7 @@ for-each-ref)
   gone-repo) printf 'main\tgone-main\0\n' ;;
   lost-repo) printf 'main\tlost-main\0\n' ;;
   net-repo) printf 'main\tnet-main\0\n' ;;
-  aaa-linked | zzz-canonical) printf 'main\tcanon-main\0\nfeature/linked\tcanon-feat\0\n' ;;
+  aaa-linked | bbb-linked | zzz-canonical) printf 'main\tcanon-main\0\nfeature/linked\tcanon-feat\0\n' ;;
   esac
   ;;
 merge-base) exit 1 ;;
@@ -696,11 +699,34 @@ assert_not_contains_file() {
 }
 assert_not_contains_file "no false current-project scope claim" "current-project scope" "$ladder_out"
 # Retargeting a supplied/discovered path to the repository of record is a substitution the operator
-# did not ask for, so it must be stated rather than silently applied.
-if grep -Fq "Resolved to main worktree: $TMP/wt-root/aaa-linked -> $TMP/wt-root/zzz-canonical" "$ladder_out"; then
-  printf 'PASS: retarget to the main worktree is disclosed in the header\n'
+# did not ask for, so it must be stated rather than silently applied. wt-root holds TWO linked
+# worktrees of one repository: the disclosure must be ONE line naming both sources, because a line
+# per retargeted path would read as two repositories against the "discovered: 1" count above.
+if grep -Fq "Resolved to main worktree: $TMP/wt-root/zzz-canonical (reached via $TMP/wt-root/aaa-linked, $TMP/wt-root/bbb-linked)" "$ladder_out"; then
+  printf 'PASS: retarget is disclosed once per repository, naming every source path\n'
 else
-  printf 'FAIL: retarget to the main worktree is disclosed in the header\n' >&2
+  printf 'FAIL: retarget is disclosed once per repository, naming every source path\n' >&2
+  failures=$((failures + 1))
+fi
+if [[ "$(grep -c "^Resolved to main worktree:" "$ladder_out")" -eq 1 ]]; then
+  printf 'PASS: one retarget line for one discovered repository\n'
+else
+  printf 'FAIL: one retarget line for one discovered repository\n' >&2
+  failures=$((failures + 1))
+fi
+
+# An empty CLI scope value is skipped by the discovery loops, so accepting it would let the header's
+# computed scope count claim an argument that contributed nothing. It must stop the run instead.
+# Its own output file: the surrounding assertions all read $ladder_out from the wt-root run above,
+# and reusing it here would silently invalidate whichever of them follows.
+scope_out="$TMP/scope-arg.txt"
+if REPO_FLEET_TEST_FAST_TIMEOUTS=1 bash "$SCRIPT" --root "" --root "$TMP/wt-root" >"$scope_out" 2>&1; then
+  printf 'FAIL: an empty --root value did not hard-fail\n' >&2
+  failures=$((failures + 1))
+elif grep -Fq -- "--root requires a directory" "$scope_out"; then
+  printf 'PASS: an empty --root value hard-fails instead of inflating the scope count\n'
+else
+  printf 'FAIL: an empty --root value hard-fails (wrong error)\n' >&2
   failures=$((failures + 1))
 fi
 # A full merged-PR window silently drops older history, which reads in the report exactly like a

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.test.sh
@@ -14,13 +14,18 @@ mkdir -p "$MOCK_BIN" "$TMP/config" "$TMP/discovered-a" "$TMP/canonical-a" "$TMP/
   "$TMP/emptyroot" \
   "$TMP/wt-a" "$TMP/wt-mismatch" \
   "$TMP/discovered-c" "$TMP/canonical-c" "$TMP/gone-repo" "$TMP/lost-repo" "$TMP/net-repo" \
-  "$TMP/wt-root/aaa-linked" "$TMP/wt-root/bbb-linked" "$TMP/wt-root/zzz-canonical/.git"
+  "$TMP/wt-root/aaa-linked" "$TMP/wt-root/bbb-linked" "$TMP/wt-root/zzz-canonical/.git" \
+  "$TMP/wt-admin/sub-wt" "$TMP/wt-admin/sep-wt"
 # Canonical-selection fixture: a LINKED worktree whose directory name sorts before its own main
 # worktree under LC_ALL=C, so bounded discovery reaches it first. A linked worktree carries .git as
 # a FILE, the main worktree as a DIRECTORY; both resolve to the same --git-common-dir, so whichever
 # the glob reaches first wins the dedup. The canonical checkout must not be decided by that order.
 : >"$TMP/wt-root/aaa-linked/.git"
 : >"$TMP/wt-root/bbb-linked/.git"
+# Admin-directory shapes. A submodule and a --separate-git-dir checkout both carry a .git FILE, so
+# both reach the retarget path, which must refuse to adopt an administrative directory as canonical.
+: >"$TMP/wt-admin/sub-wt/.git"
+: >"$TMP/wt-admin/sep-wt/.git"
 : >"$TMP/calls.log"
 
 cat >"$MOCK_BIN/git" <<'EOF'
@@ -68,6 +73,12 @@ rev-parse)
     aaa-linked) printf '%s\n' "$TEST_ROOT/wt-root/aaa-linked" ;;
     bbb-linked) printf '%s\n' "$TEST_ROOT/wt-root/bbb-linked" ;;
     zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical" ;;
+    # Admin-directory shapes. The porcelain's first record is not always a checkout, and all three
+    # present a .git FILE so they reach the retarget. sub-admin re-resolves to sub-wt's own toplevel
+    # (a submodule self-cancels); sep-gitdir and bare-gitdir are not working trees at all and fail
+    # this probe, which is what keeps them from being adopted.
+    sub-wt | sub-admin) printf '%s\n' "$TEST_ROOT/wt-admin/sub-wt" ;;
+    sep-wt) printf '%s\n' "$TEST_ROOT/wt-admin/sep-wt" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -90,6 +101,8 @@ rev-parse)
     lost-repo) printf '%s\n' "$TEST_ROOT/lost-repo/.git" ;;
     net-repo) printf '%s\n' "$TEST_ROOT/net-repo/.git" ;;
     aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' "$TEST_ROOT/wt-root/zzz-canonical/.git" ;;
+    sub-wt) printf '%s\n' "$TEST_ROOT/wt-admin/sub-admin" ;;
+    sep-wt) printf '%s\n' "$TEST_ROOT/wt-admin/sep-gitdir" ;;
     *) exit 1 ;;
     esac
     ;;
@@ -115,6 +128,8 @@ remote)
     lost-repo) printf '%s\n' 'https://github.com/lost/cause.git' ;;
     net-repo) printf '%s\n' 'https://github.com/gone/net.git' ;;
     aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' 'https://github.com/acme/wt-canon.git' ;;
+    sub-wt) printf '%s\n' 'https://github.com/acme/sub-mod.git' ;;
+    sep-wt) printf '%s\n' 'https://github.com/acme/sep-mod.git' ;;
     *) exit 1 ;;
     esac
   else
@@ -172,6 +187,15 @@ worktree)
     printf 'worktree %s\0HEAD canon-feat\0branch refs/heads/feature/linked\0\0' "$TEST_ROOT/wt-root/aaa-linked"
     printf 'worktree %s\0HEAD canon-feat2\0branch refs/heads/feature/linked-2\0\0' "$TEST_ROOT/wt-root/bbb-linked"
     ;;
+  # First record is the superproject's .git/modules/<name> admin directory, exactly as real git
+  # reports it from inside a submodule (verified on git 2.54).
+  sub-wt)
+    printf 'worktree %s\0HEAD sub-main\0branch refs/heads/main\0\0' "$TEST_ROOT/wt-admin/sub-admin"
+    ;;
+  # First record is the detached git directory, which is not a working tree at all.
+  sep-wt)
+    printf 'worktree %s\0HEAD sep-main\0branch refs/heads/main\0\0' "$TEST_ROOT/wt-admin/sep-gitdir"
+    ;;
   esac
   ;;
 symbolic-ref)
@@ -182,6 +206,7 @@ branch)
   canonical-a) printf '%s\n' main ;;
   repo-b | old-repo | root-repo | wt-fail | ref-fail | rref-fail | dup-a | new-clone | canonical-c | gone-repo | lost-repo | net-repo) printf '%s\n' main ;;
   aaa-linked | bbb-linked | zzz-canonical) printf '%s\n' main ;;
+  sub-wt | sep-wt) printf '%s\n' main ;;
   esac
   ;;
 for-each-ref)
@@ -199,6 +224,8 @@ for-each-ref)
       ;;
     rref-fail) exit 9 ;;
     aaa-linked | bbb-linked | zzz-canonical) printf 'origin/main\tcanon-main\0\n' ;;
+    sub-wt) printf 'origin/main\tsub-main\0\n' ;;
+    sep-wt) printf 'origin/main\tsep-main\0\n' ;;
     esac
     exit 0
   fi
@@ -223,6 +250,8 @@ for-each-ref)
   lost-repo) printf 'main\tlost-main\0\n' ;;
   net-repo) printf 'main\tnet-main\0\n' ;;
   aaa-linked | bbb-linked | zzz-canonical) printf 'main\tcanon-main\0\nfeature/linked\tcanon-feat\0\n' ;;
+  sub-wt) printf 'main\tsub-main\0\n' ;;
+  sep-wt) printf 'main\tsep-main\0\n' ;;
   esac
   ;;
 merge-base) exit 1 ;;
@@ -265,6 +294,8 @@ api)
   repos/new/repo) printf 'new/repo\tmain' ;;
   repos/acme/repo-c) printf 'acme/repo-c\tmain' ;;
   repos/acme/wt-canon) printf 'acme/wt-canon\tmain' ;;
+  repos/acme/sub-mod) printf 'acme/sub-mod\tmain' ;;
+  repos/acme/sep-mod) printf 'acme/sep-mod\tmain' ;;
   repos/gone/net) printf 'gh: connection reset by peer\n' >&2; exit 1 ;;
   *) printf 'gh: Not Found (HTTP 404)\n' >&2; exit 1 ;;
   esac
@@ -284,6 +315,7 @@ pr)
   # A FULL merged-PR window: gh returns at most --limit rows, so 200 rows means older merged PRs
   # were silently dropped. Every row is a branch this repository does not have locally, so the
   # truncation disclosure is the only thing this fixture can produce.
+  github.com/acme/sub-mod | github.com/acme/sep-mod) ;;
   github.com/acme/wt-canon)
     i=1
     while [[ "$i" -le 200 ]]; do
@@ -715,6 +747,62 @@ else
   failures=$((failures + 1))
 fi
 
+# The porcelain's first record is NOT always a checkout. A submodule reports the superproject's
+# .git/modules/<name>, and --separate-git-dir reports the detached git directory; both carry a .git
+# FILE, so both reach the retarget. Adopting either would aim every handoff INSIDE another
+# repository's administrative directory -- the harm the retarget exists to prevent, reintroduced by
+# the retarget itself. Each must keep its own working tree and emit no retarget line.
+admin_out="$TMP/wt-admin-out.txt"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/discovered-a" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --root "$TMP/wt-admin" >"$admin_out" 2>&1
+for admin_case in "sub-wt:sub-admin:submodule" "sep-wt:sep-gitdir:separate-git-dir"; do
+  admin_wt="${admin_case%%:*}"
+  admin_rest="${admin_case#*:}"
+  admin_dir="${admin_rest%%:*}"
+  admin_label="${admin_rest#*:}"
+  if grep -Fq "Repo: $TMP/wt-admin/$admin_wt" "$admin_out"; then
+    printf 'PASS: %s keeps its own working tree as the audited repository\n' "$admin_label"
+  else
+    printf 'FAIL: %s keeps its own working tree as the audited repository\n' "$admin_label" >&2
+    failures=$((failures + 1))
+  fi
+  # The administrative directory legitimately appears as a registered-worktree FINDING -- the
+  # porcelain really does register it, and reporting registrations is the collector's job. What must
+  # never happen is it becoming the audited repository or a handoff destination, because that is what
+  # sends a cleanup tool inside another repository's .git.
+  if grep -Eq "^(Repo|Canonical): $(printf '%s' "$TMP/wt-admin/$admin_dir" | sed 's/[][\\.*^$/]/\\&/g')$" "$admin_out" ||
+    grep -Fq "in $TMP/wt-admin/$admin_dir" "$admin_out"; then
+    printf 'FAIL: %s administrative directory became a canonical path or handoff target\n' "$admin_label" >&2
+    failures=$((failures + 1))
+  else
+    printf 'PASS: %s administrative directory is never a canonical path or handoff target\n' "$admin_label"
+  fi
+done
+assert_not_contains_file "no retarget claimed for an administrative directory" \
+  "Resolved to main worktree:" "$admin_out"
+
+# --project-dir is the primary #1798 fix path: CLAUDE_PROJECT_DIR is NOT in the Bash tool's
+# environment, so the argument is the only rung that works in the real invocation. Every other
+# ladder assertion supplies it as an env var, which would stay green if the argument were deleted.
+projarg_out="$TMP/projarg.txt"
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 HOME="$TMP/nohome" \
+  env -u CLAUDE_PROJECT_DIR bash "$SCRIPT" --project-dir "$TMP/proj" >"$projarg_out" 2>&1
+if grep -Fq -- "repo-fleet-hygiene.conf (project)" "$projarg_out"; then
+  printf 'PASS: --project-dir argument reaches the project config rung with no env var set\n'
+else
+  printf 'FAIL: --project-dir argument reaches the project config rung with no env var set\n' >&2
+  failures=$((failures + 1))
+fi
+# The argument is what the skill body substitutes, so it must win over a stale inherited env value.
+REPO_FLEET_TEST_FAST_TIMEOUTS=1 CLAUDE_PROJECT_DIR="$TMP/noconf" HOME="$TMP/nohome" \
+  bash "$SCRIPT" --project-dir "$TMP/proj" >"$projarg_out" 2>&1
+if grep -Fq -- "repo-fleet-hygiene.conf (project)" "$projarg_out"; then
+  printf 'PASS: --project-dir argument overrides an inherited CLAUDE_PROJECT_DIR\n'
+else
+  printf 'FAIL: --project-dir argument overrides an inherited CLAUDE_PROJECT_DIR\n' >&2
+  failures=$((failures + 1))
+fi
+
 # An empty CLI scope value is skipped by the discovery loops, so accepting it would let the header's
 # computed scope count claim an argument that contributed nothing. It must stop the run instead.
 # Its own output file: the surrounding assertions all read $ladder_out from the wt-root run above,
@@ -761,7 +849,9 @@ assert_not_contains_file "no merged claim without GitHub evidence" "Finding: mer
 MODEL_DOC="$SCRIPT_DIR/../reference/confidence-model.md"
 emitted_kinds="$TMP/emitted-kinds.txt"
 documented_kinds="$TMP/documented-kinds.txt"
-grep -oE "emit_finding [A-Z]+ [a-z-]+" "$SCRIPT" | awk '{print $3}' | sort -u >"$emitted_kinds"
+# Skip comment lines: prose in this script names finding kinds while explaining them, and counting
+# those would let a kind be "documented" by a comment that emits nothing.
+grep -vE "^[[:space:]]*#" "$SCRIPT" | grep -oE "emit_finding [A-Z]+ [a-z-]+" | awk '{print $3}' | sort -u >"$emitted_kinds"
 # Table rows only: a kind is the first backticked cell of a row, so prose mentions elsewhere in the
 # document cannot satisfy the contract. The delimiter is built with printf rather than written
 # literally, so no quoting style has to carry a bare backtick through grep and sed.

--- a/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
+++ b/plugins/repo-fleet-hygiene/skills/setup/SKILL.md
@@ -3,7 +3,7 @@ name: setup
 description: "Verify and configure repo-fleet-hygiene for a consumer project. check inspects the optional .claude/repo-fleet-hygiene.conf read-only (presence, parse validity, path resolution); apply creates or updates it — adding bounded fleet roots, exact repositories, and remote-keyed canonical checkout overrides — preserving unrelated entries. Use when: 'set up repo fleet audit', 'is repo-fleet-hygiene configured', 'configure fleet roots', 'canonical repo override', 'dotfiles-manager checkout'. Re-runnable and safe."
 user-invocable: true
 disable-model-invocation: true
-argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]... [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]..."
+argument-hint: "check | apply [--config <path>] [--root <dir>]... [--repo <dir>]... [--canonical <github.com/owner/repo=path>]... [--ack-unavailable <github.com/owner/repo>]... [--max-depth <1..12>]"
 ---
 
 ## Purpose
@@ -29,10 +29,10 @@ report header names which config (if any) was consumed.
 
 ## `check` (read-only)
 
-The audit script (`${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/audit-fleet.sh`) and the config file are
-the source of truth. Probe, report a PASS/FAIL/INFO table with one remediation line per FAIL, and
-modify nothing. Do NOT run the fleet walk itself — that is `/repo-fleet-hygiene:audit`; `check` only
-validates the configuration the audit would consume.
+The config file and the grammar below are the source of truth. Probe, report a PASS/FAIL/INFO table
+with one remediation line per FAIL, and modify nothing. Do NOT run the collector — that is
+`/repo-fleet-hygiene:audit`; `check` only validates the configuration the audit would consume, using
+`git config --file` and read-only filesystem probes.
 
 1. **Config presence** — resolve the config path (`--config` or the default). Absent → INFO naming
    the full ladder: the audit next probes the user-global `~/.claude/repo-fleet-hygiene.conf` (report
@@ -56,6 +56,8 @@ Run `check`, then create or update the config from the supplied arguments.
 1. Parse only the declared argument grammar. Validate every root/repository/canonical path with
    read-only filesystem and `git rev-parse` checks. Normalize canonical keys to
    `github.com/owner/repository` (lowercase host, case-preserving owner/name is acceptable).
+   Validate `--max-depth` as an integer in `1..12` and write it as `[fleet] maxDepth`; this skill
+   owns the file that carries it, so it must be settable here rather than by hand-editing.
    Validate each `--ack-unavailable` value as a normalizable `github.com/owner/repository`
    (no filesystem probe — the identity is expected to be inaccessible); write it as a repeatable
    `[fleet] ackUnavailable` entry, deduplicating case-insensitively against entries already
@@ -79,16 +81,28 @@ Run `check`, then create or update the config from the supplied arguments.
    path relative to the config file's directory for any root/repository/canonical target expressible
    that way — the grammar resolves relative paths from that directory and both forms audit
    identically, while some consumer environments run a write-time path-portability guard that rejects
-   absolute paths in tracked config.
+   absolute paths in tracked config. "Expressible that way" is the real constraint: on Windows, no
+   relative path exists between two volumes, so a fleet root on `D:` with a config on `C:` has only
+   the absolute form. Write the absolute path, and say in the report that the relative form was
+   unavailable because the target is on another volume — otherwise the guard's rejection reads as a
+   consumer mistake. This preference is prose guidance followed by the model, not a property a
+   deterministic component enforces; treat it as a default to justify departing from, not a
+   guarantee.
 5. Verify after remediation — re-run the `check` probes against the written file (never claim success on
-   the edit alone):
+   the edit alone). Config-only, exactly as `check` defines them: parse validity, then per-entry path
+   resolution.
 
    ```bash
    git config --file "<config-path>" --list >/dev/null
-   bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/audit-fleet.sh" --config "<config-path>"
    ```
 
-6. Report path, inferred/explicit entries, preserved entries, and the read-only audit result.
+   Do **not** invoke the collector to verify a write. It is the full fleet walk this skill says it
+   never runs — per-repository network queries across every configured root, minutes on a real fleet
+   — and it proves nothing about the file that the `check` probes do not already prove. If the user
+   explicitly wants an end-to-end run, say that it is a real audit and hand off to
+   `/repo-fleet-hygiene:audit`.
+
+6. Report path, inferred/explicit entries, preserved entries, and the config-verification result.
 
 Re-running `apply` with the same arguments after everything resolves changes nothing and reports
 "already configured".
@@ -112,9 +126,11 @@ affecting non-404/403 failures or successful-response evidence. Use it for fores
 upstream repositories made private or deleted, or repositories owned by a different GitHub account
 than the authenticated `gh` login.
 
-Resolution priority is explicit audit CLI override, canonical config entry, then discovered checkout's
-`git rev-parse --show-toplevel`. Never add a canonical override merely because two directory names look
-similar; verify the normalized GitHub remote identity on both sides first.
+Resolution priority is explicit audit CLI override, canonical config entry, then the discovered
+checkout's own **main worktree** (the first record of `git worktree list --porcelain`). A canonical
+override is therefore not needed merely to steer the audit away from a linked worktree — the audit
+resolves that itself. Never add one because two directory names look similar; verify the normalized
+GitHub remote identity on both sides first.
 
 ## What this skill does NOT do
 
@@ -129,8 +145,18 @@ similar; verify the normalized GitHub remote identity on both sides first.
 - **Absolute paths in tracked config can be rejected by consumer write guards.** A root, repository, or
   canonical target written as an absolute path may trip a consumer's write-time path-portability guard;
   the same target written relative to the config file's directory passes and resolves identically, so
-  `apply` prefers the relative form.
+  `apply` prefers the relative form — except across Windows volumes, where no relative form exists and
+  the absolute path is the only option. Say so when that happens rather than leaving the consumer to
+  conclude they misconfigured something.
 - **A project-scoped config is consumed only from its own project.** Per the Scoping rule above, a
   config meant to apply from every project belongs at the user-global
   `~/.claude/repo-fleet-hygiene.conf`, not a per-project path — otherwise the audit silently narrows to
-  the project it was authored in.
+  the project it was authored in. Two cases collapse this warning, and `check` should say which one
+  applies rather than repeating a caution that cannot bite: when the project directory *is* the home
+  directory both rungs name the same file, and when no project directory reaches the audit (the
+  session did not supply one) the project rung is not merely aliased but unreachable, leaving the
+  user-global path the only one that can be consumed.
+- **Config-supplied scope is additive to the audit's CLI scope.** A configured root is walked even
+  when the audit is invoked with an explicit `--repo`, so a persisted fleet config widens every later
+  run. The audit's `Scope:` header line names each contributing rung; there is currently no way to
+  suppress a config for a single run.

--- a/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
@@ -5,12 +5,13 @@
       "id": 1,
       "name": "rerun-preserves-unrelated-config",
       "prompt": "/repo-fleet-hygiene:setup apply\n\nRe-run setup to add a second fleet.root and one canonical override. The existing config has comments, a fleet.repo, and another canonical section.",
-      "expected_output": "Setup updates only the requested entries, preserves comments and unrelated fleet/canonical entries, validates with git config, and runs a read-only audit. It does not edit user settings or remotes.",
+      "expected_output": "Setup updates only the requested entries, preserves comments and unrelated fleet/canonical entries, and verifies the result with config-only probes (git config --file parse plus per-entry path resolution). It does not edit user settings or remotes, and it does not run the fleet collector.",
       "files": [],
       "expectations": [
         "Preserves comments and unrelated existing entries",
         "Adds only the requested root and canonical override",
-        "Does not edit pluginConfigs, user settings, or Git remotes"
+        "Does not edit pluginConfigs, user settings, or Git remotes",
+        "Verifies with config parse and path resolution only"
       ]
     },
     {
@@ -23,6 +24,44 @@
         "Does not infer canonical equivalence from directory names",
         "Requires remote identity verification",
         "Leaves the config unchanged on mismatch"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "verification-never-walks-the-fleet",
+      "prompt": "/repo-fleet-hygiene:setup apply --root D:/repos\n\nThe config now lists 11 repositories. Verify the write actually worked before you report success.",
+      "expected_output": "Verification is config-only: the file parses under git config --file and every entry resolves to an existing Git working tree. Setup does not invoke audit-fleet.sh, because that is the full fleet walk this skill states it never runs and it would issue per-repository network queries. An end-to-end run is offered as an explicit handoff to /repo-fleet-hygiene:audit.",
+      "files": [],
+      "expectations": [
+        "Verifies with git config --file parse and per-entry path resolution",
+        "Does not invoke the audit collector script as a verification step",
+        "Does not claim success from the file edit alone",
+        "Routes a genuine end-to-end check to /repo-fleet-hygiene:audit and says it is a real audit"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "cross-volume-root-has-no-relative-form",
+      "prompt": "/repo-fleet-hygiene:setup apply --config C:/Users/dev/.claude/repo-fleet-hygiene.conf --root D:/repos\n\nWrite the fleet root using the portable relative form the skill prefers.",
+      "expected_output": "Setup explains that no relative path exists between two Windows volumes, writes the absolute D:/repos, and says why the preferred relative form was unavailable so a path-portability guard rejection is not mistaken for consumer error. It does not fabricate a relative path or refuse to write.",
+      "files": [],
+      "expectations": [
+        "Recognizes that a cross-volume relative path does not exist",
+        "Writes the absolute path rather than inventing a relative one",
+        "States the cross-volume reason in the report",
+        "Does not refuse the write or report it as a failure"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "max-depth-is-settable-through-setup",
+      "prompt": "/repo-fleet-hygiene:setup apply --root D:/repos --max-depth 8\n\nMy repositories are nested deeper than the default discovery bound.",
+      "expected_output": "Setup validates 8 as an integer in 1..12 and writes it as [fleet] maxDepth alongside the root, preserving unrelated entries. It does not tell the user to hand-edit the config file that this skill owns.",
+      "files": [],
+      "expectations": [
+        "Validates the value against the 1..12 range",
+        "Writes maxDepth into the [fleet] section",
+        "Does not instruct the user to edit the config by hand"
       ]
     }
   ]

--- a/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
+++ b/plugins/repo-fleet-hygiene/skills/setup/evals/evals.json
@@ -29,7 +29,7 @@
     {
       "id": 3,
       "name": "verification-never-walks-the-fleet",
-      "prompt": "/repo-fleet-hygiene:setup apply --root D:/repos\n\nThe config now lists 11 repositories. Verify the write actually worked before you report success.",
+      "prompt": "/repo-fleet-hygiene:setup apply --root <fleet-root>\n\nThe config now lists 11 repositories. Verify the write actually worked before you report success.",
       "expected_output": "Verification is config-only: the file parses under git config --file and every entry resolves to an existing Git working tree. Setup does not invoke audit-fleet.sh, because that is the full fleet walk this skill states it never runs and it would issue per-repository network queries. An end-to-end run is offered as an explicit handoff to /repo-fleet-hygiene:audit.",
       "files": [],
       "expectations": [
@@ -42,8 +42,8 @@
     {
       "id": 4,
       "name": "cross-volume-root-has-no-relative-form",
-      "prompt": "/repo-fleet-hygiene:setup apply --config C:/Users/dev/.claude/repo-fleet-hygiene.conf --root D:/repos\n\nWrite the fleet root using the portable relative form the skill prefers.",
-      "expected_output": "Setup explains that no relative path exists between two Windows volumes, writes the absolute D:/repos, and says why the preferred relative form was unavailable so a path-portability guard rejection is not mistaken for consumer error. It does not fabricate a relative path or refuse to write.",
+      "prompt": "/repo-fleet-hygiene:setup apply --config <home>/.claude/repo-fleet-hygiene.conf --root <fleet-root>\n\nOn this Windows machine the config file and the fleet root are on different volumes. Write the fleet root using the portable relative form the skill prefers.",
+      "expected_output": "Setup explains that no relative path exists between two Windows volumes, writes the absolute root path, and says why the preferred relative form was unavailable so a path-portability guard rejection is not mistaken for consumer error. It does not fabricate a relative path or refuse to write.",
       "files": [],
       "expectations": [
         "Recognizes that a cross-volume relative path does not exist",
@@ -55,7 +55,7 @@
     {
       "id": 5,
       "name": "max-depth-is-settable-through-setup",
-      "prompt": "/repo-fleet-hygiene:setup apply --root D:/repos --max-depth 8\n\nMy repositories are nested deeper than the default discovery bound.",
+      "prompt": "/repo-fleet-hygiene:setup apply --root <fleet-root> --max-depth 8\n\nMy repositories are nested deeper than the default discovery bound.",
       "expected_output": "Setup validates 8 as an integer in 1..12 and writes it as [fleet] maxDepth alongside the root, preserving unrelated entries. It does not tell the user to hand-edit the config file that this skill owns.",
       "files": [],
       "expectations": [


### PR DESCRIPTION
## Summary

Six defects found by auditing `repo-fleet-hygiene` against one real 11-repository fleet, plus the
behavioural coverage that would have caught them. Every claim below was re-verified against
`origin/main` before fixing; one turned out to be already fixed and is called out as such.

**#1797 — canonical resolution could select a linked worktree.** Recursive discovery reaches a linked
worktree and its own main worktree through the same glob (a linked worktree carries `.git` as a
file, so it matches), and both map to one `--git-common-dir` dedup key — so the winner was decided
by glob order. A sibling sorting before the canonical directory under `LC_ALL=C` silently became
`Canonical:`, and every emitted handoff carries that path, so per-repository cleanup would be aimed
at a checkout that is not the repository of record while the true canonical checkout was
deduplicated away and never reported. `add_target` now resolves each candidate to its main worktree —
the first record of `git worktree list --porcelain`, which lists the main worktree first wherever it
runs — before the dedup tie-break. `rev-parse --show-toplevel` cannot make this distinction: inside a
linked worktree it returns the linked root, which is why evidence rule 1 as written could not
distinguish them either. The extra probe is gated on `.git` being a file rather than a directory, so
an ordinary sweep pays nothing per repository. The substitution is **disclosed** rather than applied
silently — the operator named one path and the report is about another, which would otherwise be the
same defect class as the header text fixed under #1800 — on one `Resolved to main worktree:` line per
repository naming every path that resolved into it, so several worktrees of one repository cannot
read as several repositories against the discovered count.

**#1798 — two variable substitutions used where the documented contract does not provide them.**
Verified against the current skills documentation fetched this session
(<https://code.claude.com/docs/en/skills#available-string-substitutions>): the substitution table
lists `${CLAUDE_SKILL_DIR}` and `${CLAUDE_PROJECT_DIR}`, and the page states Claude Code substitutes
those two "in two places: the skill's markdown content, and Bash rules in the `allowed-tools`
frontmatter". `${CLAUDE_PLUGIN_ROOT}` is not among them, so the `allowed-tools` grant stayed a
literal string and the skill's one permission grant was inert in a workflow built for unattended
sweeps; it now uses `${CLAUDE_SKILL_DIR}`. Separately the collector read `CLAUDE_PROJECT_DIR` from
its own environment, which does not carry it — leaving the project rung of the config ladder
unreachable and the zero-argument fallback silently becoming `$PWD`, an agent session's incidental
working directory. The skill body now passes `--project-dir "${CLAUDE_PROJECT_DIR}"`, where the
documented substitution applies; the environment variable is still honored for callers that have it,
and a value left as an unexpanded `${...}` placeholder counts as absent rather than as a literal
directory name. When no project directory resolves, the run now stops with the scope remedies
instead of auditing whatever directory the shell was sitting in.

**#1799 — confidence model and evidence rules had drifted from the collector.** The tier table
covered 12 of 24 emitted kinds, so a consumer meeting an untabulated kind had no documented
disposition. It now covers all 25, and a test asserts set equality in **both** directions between
the table and the collector's emitted kinds — a drift *detector* rather than a generator, so this
cannot silently recur. `ACKNOWLEDGED` is documented as a prominence demotion of an `UNKNOWN`, not a
fifth value on the confidence axis. Evidence rule 3 now describes the mechanism that actually runs
(one batched query per repository plus a privacy-gated per-branch fallback) rather than a per-branch
authoritative query. Two undisclosed dependencies are stated: the `LOW` ancestry tier is near-inert
under squash merges, and `missing-worktree` vs `prunable-worktree` turns on the user-tunable
`gc.worktreePruneExpire` window rather than on evidence strength. The two reference files with no
pointer from the hub are now linked, and the two differently-scoped `repositories` labels are
qualified.

**#1800 — report text asserting things the run contradicts.** The header printed a fixed
`Config: none (… current-project scope)` literal that could contradict the very next lines and
described a mode that was not reachable at all; a computed `Scope:` line now names each contributing
rung and its entry count, which also discloses that config-supplied scope is additive to
CLI-supplied scope. `Mutation count: 0` was a hardcoded literal that would have read identically in
a build that mutated — replaced by a statement of the enforcing mechanism (the read-only git/gh
command allowlists), because a real counter would undercount: most probes run inside command
substitution, so increments are lost with the subshell. MSYS `/c/...` paths are converted to
`C:/...` for presentation only, since the report is actionable text whose paths get pasted into
tools that reject the MSYS form; every comparison and filesystem test keeps the native form. An empty
`--root`/`--repo`/`--config` value now stops the run rather than being counted toward the scope the
header reports and then skipped by the discovery loops.

Item 4 of #1800 (the hard-failure path naming no remedy) is **already fixed on `origin/main`** by the
#1771 work — the rejection names `--root`, `--repo`, `--config`, and `/repo-fleet-hygiene:setup
apply`, and `SKILL.md` discloses the CLI hard-fail semantics. Verified via the existing passing
assertions; no code was needed.

**#1801 — `setup` defects (partial; see Related).** `apply` step 5 prescribed running the collector,
which is the full fleet walk the skill states it never performs — minutes of per-repository network
queries in a step described as validating that a config parses. Verification is now config-only, with
an end-to-end run offered as an explicit handoff. `--max-depth` is now settable through the skill
that owns the file carrying it (and was missing from the audit skill's `argument-hint`). The
cross-volume exception to the relative-path preference is stated, the determinism claim is softened
to guidance since no deterministic component backs it, and the project-vs-user-global gotcha now
names the two cases that collapse it.

**#1803 — evals missed every behaviour that actually failed.** Split by what each surface can
actually test rather than routing everything into `evals.json`, which would have reproduced the gap
being filed. Deterministic fixtures went to `audit-fleet.test.sh`: canonical selection against an
earlier-sorting linked worktree (written red first — it failed on both canonical assertions before
the fix), the computed scope-provenance line, merged-PR window truncation, unauthenticated-`gh`
degradation, and tier-table drift. Model-graded rows went to `evals.json`: privacy-gated branches as
unverified rather than unmerged, squash-merge semantics, worktree disposability as deliberately out
of scope, and for `setup` config-only verification, cross-volume paths, and `maxDepth`. One eval
pinned the boundary violation being fixed (it expected `apply` to "run a read-only audit") and was
corrected.

This also required a behaviour change: a full merged-PR window now emits `merged-pr-window-truncated`
(`UNKNOWN`). Previously a repository with more than 200 merged PRs lost the remainder silently, and a
branch merged before the window produced no merged finding — indistinguishable in the report from a
branch that was never merged. It cannot distinguish "exactly 200" from "far more" and deliberately
errs toward warning, since an unfalsifiable *reassurance* was the #1800 sin and an over-cautious
*warning* is the correct direction to err.

## Test plan

- `audit-fleet.test.sh` — 71 assertions, all passing (16 new). The #1797 fixture was confirmed **red**
  before the fix (both canonical assertions failed; the linked worktree won) and green after.
- `scripts/check-changed-skills.sh origin/main` — both skills PASS, 0 errors, 0 warnings.
- `check-changelog-parity.sh` `--check`, `--check-order`, `--check-bump origin/main` — all pass.
- `markdownlint-cli2` over the plugin — 0 issues in 7 files.
- `ajv --spec=draft2020` against `plugins/skill-quality/reference/evals.schema.json` — both
  `evals.json` files valid.
- `shellcheck` on both shell files — clean (three diagnostics introduced during the change were
  fixed, not suppressed).
- `check-skill-portability.sh`, `check-shell-portability.sh`, `validate-plugins.sh`,
  `validate-plugin-contracts.mjs`, `check-plugin-manifest-presence.sh`, `check-silent-skips.sh` — pass.
- `generate-catalog.mjs` / `generate-cheatsheet.mjs` — already in sync, no regeneration needed.
- Live end-to-end on this machine (Git Bash, Windows): pointing `--repo` at a **linked worktree**
  now reports the main worktree; `/c/Users` renders as `C:/Users`; a no-scope run with no project
  directory stops with the remedies instead of silently auditing `$PWD`.
## Review

Three fresh-context reviewer subagents were spawned and none returned findings, so a bespoke
rationale-withheld human-style review was **not** obtained. Three other independent passes did run:

- **Codex connector (diff-only)** raised one P2: that `${CLAUDE_SKILL_DIR}` is not expanded in
  `allowed-tools`, citing `docs/conventions/permission-rule-hygiene/README.md`. Investigated and
  **rejected on primary-source evidence** — the current skills page states Claude Code substitutes
  `${CLAUDE_SKILL_DIR}` *and* `${CLAUDE_PROJECT_DIR}` in both skill content and `allowed-tools` Bash
  rules, with the SKILL_DIR floor (v2.1.129) the earlier of the two. The cited local doc was stale and
  is corrected here; its wrong sentence is what made this grant look unfixable and is what produced
  the false finding. Full citation in the review thread.
- **Repo `review` and `security-review` lanes** — both pass.
- **A stronger reviewer model with full session context** (so not rationale-withheld, the weaker
  form) produced two real defects, both reproduced against live fixtures and fixed in
  `group the retarget disclosure per repository and reject empty scope values`: several linked
  worktrees of one repository each emitted their own `Resolved to main worktree:` line, so one
  repository read as several against the header's own count; and an empty `--root`/`--repo` value was
  counted toward the reported scope then skipped by the discovery loops.

Self-verification worth naming: the #1797 fixture was written **red first**; the tier-table drift
detector was proven non-vacuous by deleting a row and confirming failure; `to_native_path` was
unit-tested against non-path values, slash-commands, branch paths and multi-occurrence input; the
placeholder-rejection pattern and the empty-array expansion idiom were tested directly; and the whole
change was exercised end-to-end against a real Windows fleet and a purpose-built two-worktree repo.

The highest-value remaining check is `main_worktree()`'s `read -r -d ''` inside a command
substitution, and whether any new assertion is vacuous.

## Related

Fixes #1797
Fixes #1798
Fixes #1799
Fixes #1800
Fixes #1803
Refs #1801 — items 1-5 delivered. Item 6 (a `--no-config` escape hatch so a persisted user-global
config can be suppressed for one run) is deferred: it is a feature add rather than a defect fix, and
it carries an unresolved semantic question (whether it suppresses only the `fleet.root`/`fleet.repo`
ladder or also `[canonical …]` sections). The additive behaviour it complains about is now at least
**disclosed** by the new `Scope:` header line and a `setup` gotcha. #1801 stays open for it.
