### PR TITLE
chore(knowledge): remove the resources-overview entry from the docpage-digest queue

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.12]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: resources-overview queue entry removed.** The
+  `platform.claude.com/docs/en/resources/overview` slice completed — raw-md fetch through interview
+  handoff, with dual verification reached on identical SHA-256-pinned bytes (both arms PASS, no
+  MAJOR findings) — so its entry leaves the doc queue per the queue's remove-on-completion rule. The
+  "Supplementary references" heading remains: the system-prompts release-notes page is a separate
+  concurrent run under the same heading, and its own queue PR removes the heading when it empties.
+
 ## [0.10.11]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -87,7 +87,6 @@ Deferred with trigger (not queued):
 
 Supplementary references:
 
-- <https://platform.claude.com/docs/en/resources/overview>
 - <https://platform.claude.com/docs/en/release-notes/system-prompts>
 
 Blog posts:


### PR DESCRIPTION
The `platform.claude.com/docs/en/resources/overview` slice ran end to end and reached dual verification, so its entry leaves the `docpage-digest` Anthropic doc queue under the queue's remove-on-completion rule.

## What ran

- Raw-md fetch, per-unit digests (4 digests, 57 claim rows, 13 `api-only`), correction rounds, and Phase 5 interview handoff.
- **Dual verification on identical SHA-256-pinned bytes**: verifier arm A and cross-vendor arm B both returned `VERDICT: PASS` with **no MAJOR findings**.
- Arm B's coverage: all 57 claim rows and all 117 source lines examined; 31 distinct commands replayed with every count agreeing; all 174 `llms.txt` hits mechanically verified; 57/57 quote anchors, row/tag parity, stated tallies and placeholder scans all clean.

Residual MINOR findings are disclosed in the slice's `interview-handoff.md` as Open questions for the batched dispositions interview, per the campaign's stopping rule.

## What this PR changes

- Removes the resources-overview entry from the profile's Doc queue section. The **"Supplementary references" heading remains** — the system-prompts release-notes page sits under it as a separate concurrent run, and its own queue PR removes the heading once it empties.
- Bumps the `knowledge` plugin `0.10.11` → `0.10.12`.
- Adds the matching CHANGELOG entry, mirroring the 0.10.8–0.10.11 exemplars.

No linked issue

## Related

- Follows the same queue-drain pattern as #1868 (thinking-steering-and-cost), #1842, and #1816.
- Two sibling run-11 slices (system-prompts release notes, verification-loops blog) follow in serialized PRs, since all three touch the same profile file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
