### PR TITLE
chore(knowledge): remove the verification-loops blog entry from the docpage-digest queue

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.13]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: verification-loops blog entry removed, and the "Blog posts"
+  heading with it.** The `claude.com/blog/building-verification-loops-in-claude-code-with-skills`
+  slice completed — raw-md fetch through interview handoff, with dual verification reached on
+  identical SHA-256-pinned bytes (both arms PASS, no MAJOR findings) — so its entry leaves the doc
+  queue per the queue's remove-on-completion rule, and the heading is removed because it emptied.
+  The slice exercised the vendor-blog attestation rule (profile 0.10.9) at scale: all 44
+  `vendor-claimed` rows carry a targeted row-local `platform.claude.com` check, because the rule's
+  predicate — "no harness **or platform** doc states the same assertion" — names both properties and
+  a harness-only search never establishes it.
+
 ## [0.10.12]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -89,11 +89,6 @@ Supplementary references:
 
 - <https://platform.claude.com/docs/en/release-notes/system-prompts>
 
-Blog posts:
-
-- <https://claude.com/blog/building-verification-loops-in-claude-code-with-skills>
-  — pairs with any verification-loop or loop-engineering work the consuming setup already tracks
-
 ## Artifact targets
 
 Interview-handoff dispositions for this publisher typically route to: per-model doctrine


### PR DESCRIPTION
The `claude.com/blog/building-verification-loops-in-claude-code-with-skills` slice ran end to end and reached dual verification, so its entry leaves the `docpage-digest` Anthropic doc queue under the queue's remove-on-completion rule. It was the last entry under **"Blog posts"**, so that heading is removed too.

## What ran

- Raw-md fetch, per-unit digests (6 digests, 78 claim rows, **0 `api-only`** — every row is positive-tagged), correction rounds, and Phase 5 interview handoff.
- **Dual verification on identical SHA-256-pinned bytes**: arm A and cross-vendor arm B both returned `VERDICT: PASS` with **no MAJOR findings**.
- Arm B's coverage: 78/78 rows examined including all 44 `vendor-claimed` rows; 7/7 pin hashes matched; 50 commands replayed with every count agreeing; 78/78 source quotes exact including ellipsis placement; a structural platform-scope sweep over 68 candidate paragraphs found no unscoped absence claim remaining.

## Why this slice took extra rounds

It exercised the **vendor-blog attestation rule** (profile 0.10.9) at scale. The rule's predicate names two properties — an assertion exists only in the blog when *"no harness **or platform** doc states the same assertion"* — so a `code.claude.com`-only search never establishes it. All 44 `vendor-claimed` rows now carry a **targeted row-local `platform.claude.com` check**, using `curl -sSL` for pages outside the snapshot subset per DIGEST-BRIEF §5. Exhaustiveness language stays scoped to `code.claude.com`; the platform half is stated as the check performed, never as corpus-wide platform absence.

Residual MINOR findings are disclosed in the slice's `interview-handoff.md` as Open questions for the batched dispositions interview.

## What this PR changes

- Removes the blog entry and the now-empty "Blog posts" heading from the profile's Doc queue.
- Bumps the `knowledge` plugin `0.10.12` → `0.10.13`.
- Adds the matching CHANGELOG entry.

No linked issue

## Related

- Second of three serialized run-11 queue PRs; follows #1872 (resources overview). All three touch the same profile file, so they merge one at a time.
- Same queue-drain pattern as #1868, #1842, #1816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
