### PR TITLE
chore(knowledge): remove the system-prompts entry and empty the docpage-digest queue

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.14]
+
+### Changed
+
+- **`docpage-digest` Anthropic profile: system-prompts release-notes entry removed, and the doc
+  queue is now empty.** The `platform.claude.com/docs/en/release-notes/system-prompts` slice
+  completed — 18 digests over a 2,548-line source, 659 claim rows, 561 `api-only`. It is the
+  largest slice the pipeline has run and the last entry in the queue; only the deferred
+  task-budgets trigger entry remains, which was never queued.
+- **The "Supplementary references" heading is removed with it**, since the entry was the last one
+  under it.
+
+Verification reached `VERDICT: PASS` on both arms across the run's rounds, on SHA-256-pinned bytes,
+with a final confirming round after the last corrections. Residual MINOR findings are disclosed in
+the slice's `interview-handoff.md` as Open questions for the batched dispositions interview, per the
+run's stopping rule; one contested tag-ordering question is escalated there as a candidate profile
+amendment rather than decided in-run.
+
 ## [0.10.13]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -85,10 +85,6 @@ Deferred with trigger (not queued):
   states task budgets are not supported on Claude Code or Cowork; verified 2026-07-27); enqueue
   when harness support lands
 
-Supplementary references:
-
-- <https://platform.claude.com/docs/en/release-notes/system-prompts>
-
 ## Artifact targets
 
 Interview-handoff dispositions for this publisher typically route to: per-model doctrine


### PR DESCRIPTION
The `platform.claude.com/docs/en/release-notes/system-prompts` slice completed. It is the **last entry in the doc queue** — after this merges, the queue section holds only the deferred task-budgets trigger entry, which was never queued.

## What ran

The largest slice this pipeline has processed: **18 digests over a 2,548-line source, 659 claim rows, 561 `api-only`.**

- Seven correction rounds and five dual-verification rounds, each on SHA-256-pinned bytes with the frozen-tree rule enforced — both arms re-hash before *and* after auditing, and no correction runs while a verifier holds the tree.
- Final state: both arms `VERDICT: PASS`, with a confirming round after the last corrections.
- Final gates: **1,895 recorded command/count pairs replay with 0 mismatches**, 0 `<corpus>` placeholders, 659/659 rows parse with `N. Quote (line` count equal to `- Tag:` count in all 18 digests, every stated tally equal to its anchored `grep -c`, `check-quotes.py` clean.

## What the run found worth carrying forward

- **Narrow-slug false absences** remained the dominant defect — a basis testing one literal while the corpus documents the same concept in other words. Rows now disclose near-misses by name and line, each produced by a command recorded in that row.
- **Prose is unparsed by every gate.** Summary paragraphs, Implications bullets and Open questions carried stale counts and false statements across several rounds; two sweeps (one whitespace-normalized with an offset map back to physical lines) closed the class.
- **A contested tag-ordering question is escalated, not decided** — whether selecting a positive tag requires first establishing harness applicability. It is written up as a candidate profile amendment with both readings, the evidence, and a recommendation, for the dispositions interview.

Residual MINOR findings are disclosed in the slice's `interview-handoff.md` as Open questions, per the run's stopping rule.

## What this PR changes

- Removes the system-prompts entry and the now-empty "Supplementary references" heading from the profile's Doc queue.
- Bumps the `knowledge` plugin `0.10.13` → `0.10.14`.
- Adds the matching CHANGELOG entry.

No linked issue

## Related

- Third and final of the serialized run-11 queue PRs, after #1872 (resources overview) and #1873 (verification-loops blog). All three touch the same profile file, so they merged one at a time.
- Completes the queue drain begun in #1752 and continued through #1756, #1761, #1765, #1775, #1779, #1788, #1816, #1842 and #1868.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
