### PR TITLE
chore(knowledge): apply the docpage-digest evidence-forced profile and pipeline amendments

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.15]
+
+### Changed
+
+- **`docpage-digest` now carries the evidence-forced rules the eleven-run digest campaign proved on
+  itself.** Every rule below was demonstrated as a defect by the pipeline's own runs, not proposed
+  abstractly, and each states its evidence inline so a later maintainer can see why it exists.
+- **Anthropic profile — absence and citation evidence.** An `api-only` basis now records the exact
+  command and its raw result count rather than a prose summary of what was checked; every non-zero
+  result names its match site(s), with a sampled hit set stating that scope at the row; and a cited
+  `file.md:NN` counts as disclosed only when a command recorded in that same row produces it.
+  Absence-establishing fetches must use the raw `.md` channel with `curl` and record the retrieved
+  length — a rendered fetch of a long page returns a silent prefix, and truncation can fabricate an
+  absence but never a presence.
+- **`SKILL.md` Phase 4 — verification-record discipline.** No tree moves until every dispatched arm
+  has reported; every correction round leaves a dated applied record whose "New findings" section is
+  a required input to the next round's brief; verdicts land in `verification/` or they did not
+  happen; a mechanical gate errors loudly on input it cannot parse and is fixed *before* it is made
+  required; commands are replayable in every pipeline artifact, not just digest rows; and the digest
+  set is reconciled against itself before Phase 5, since every other check is scoped within a row.
+
+Contested amendments the campaign also surfaced are deliberately **not** applied here — the tag
+vocabulary questions (metadata and consumer-surface classes, pointer/navigation claims, archive-page
+representation, the form `api-only` corroboration should take) have two defensible readings each and
+belong to the dispositions interview, alongside the already-escalated Decision-A ordering question.
+
 ## [0.10.14]
 
 ### Changed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -22,8 +22,10 @@ only after that version increases.
   has reported; every correction round leaves a dated applied record whose "New findings" section is
   a required input to the next round's brief; verdicts land in `verification/` or they did not
   happen; a mechanical gate errors loudly on input it cannot parse and is fixed *before* it is made
-  required; commands are replayable in every pipeline artifact, not just digest rows; and the digest
-  set is reconciled against itself before Phase 5, since every other check is scoped within a row.
+  required; commands are replayable in every pipeline artifact, not just digest rows, and each is
+  replayed where it is authored — the Phase 5 handoff included, which no Phase 4 pass can reach; and
+  the digest set is reconciled against itself before Phase 5, since every other check is scoped
+  within a row.
 
 Contested amendments the campaign also surfaced are deliberately **not** applied here — the tag
 vocabulary questions (metadata and consumer-surface classes, pointer/navigation claims, archive-page

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -173,8 +173,9 @@ apply to the digests; re-verify what changed.
 
 **No tree moves until every dispatched arm has reported.** Editing a slice mid-audit voids that
 audit: the verifier's findings stop describing bytes that exist. (A prior run edited three digests
-minutes after one arm reported while the other was still auditing; that verdict came back BLOCKED
-and its subject had to be reconstructed by diffing frozen pins.)
+minutes after one arm reported while the other was still auditing; that arm re-hashed its pinned
+files at the end of its audit, found three no longer matched, and returned BLOCKED — the slice had
+to be re-pinned and the arm re-run.)
 
 **Every correction round leaves an applied record, and the next round reads it.** The record is
 dated, lands beside the verdicts, and names what changed and why; any finding the round surfaced but
@@ -182,9 +183,11 @@ was not scoped to fix goes in its "New findings" section, which is a **required 
 round's brief**. Both halves bind — a faithfully written record nobody reads drops findings on the
 floor exactly as silently as no record at all. A verdict likewise lands in
 `<work-root>/verification/` or it did not happen: one written to a session scratchpad is unreachable
-by every later round. (One run's rounds 2-3 left no record and only a verifier's cross-check noticed;
-an 18-unit fan-out elsewhere edited seven units with no record, leaving them unattested; two verdicts
-in that same slice were written outside `verification/` and no later round could read them.)
+by every later round. (One slice's round-3 record was written faithfully, "New findings" section and
+all, and the next round never read it — three findings it named were still unfixed a round later, and
+only a verifier's cross-check noticed; an 18-unit fan-out in the same slice edited seven units with
+no record, leaving them unattested; two of its verdicts were written outside `verification/` and no
+later round could read them.)
 
 **A mechanical gate reports only what it parsed, and only the fields it checks.** Any script used as
 a verification gate errors loudly on input it cannot recognize, and a clean result is read as
@@ -192,15 +195,15 @@ covering just the rows and fields it actually exercised. **The ordering is not n
 that silently skips what it cannot parse is fixed *before* it is made a required artifact, or the
 mandate converts a visible gap into an invisible pass. (Both arms independently caught the campaign's
 quote checker printing "all checks clean" over a digest whose 14 claims it could not parse at all;
-the same checker's command replay read only the first number in each `→ N lines, M files` pair, so
-it reported clean on a class it was structurally blind to.)
+a separate command-replay gate read only the first number in each `→ N lines, M files` pair, so it
+reported clean on a class it was structurally blind to.)
 
 **Commands are replayable in every pipeline artifact, not just digest rows.** INDEX rows, applied
 records, verdicts, rulings and handoffs carry commands too, in the same command-plus-raw-count form,
-and the replay sweep covers them. (One slice yielded five record-level command defects in a single
-round: two greps quoted without a path operand, an unrunnable command invisible to the replay regex,
-and two records mis-stating their own pair counts — and one correction record propagated the wrong
-line number it had been written to fix.)
+and the replay sweep covers them. (One slice yielded five record-level command defects: two greps
+quoted without a path operand, an unrunnable command invisible to the replay regex, and two records
+mis-stating their own pair counts — and one correction record propagated the wrong line number it
+had been written to fix.)
 
 **Reconcile the digest set against itself before Phase 5.** Every other check is scoped within a row
 or between a row and `source.md`, so parallel digest agents can affirm, deny, and abstain on the same

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -186,8 +186,8 @@ floor exactly as silently as no record at all. A verdict likewise lands in
 by every later round. (One slice's round-3 record was written faithfully, "New findings" section and
 all, and the next round never read it — three findings it named were still unfixed a round later, and
 only a verifier's cross-check noticed; an 18-unit fan-out in the same slice edited seven units with
-no record, leaving them unattested; two of its verdicts were written outside `verification/` and no
-later round could read them.)
+no record, leaving them unattested; two of the slice's verdicts were written outside `verification/`
+and no later round could read them.)
 
 **A mechanical gate reports only what it parsed, and only the fields it checks.** Any script used as
 a verification gate errors loudly on input it cannot recognize, and a clean result is read as

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -171,6 +171,46 @@ Verdicts land in `<work-root>/verification/` and are **append-only historical re
 wrong verdict gets a dated corrections-applied file beside it, never a rewrite. Corrections
 apply to the digests; re-verify what changed.
 
+**No tree moves until every dispatched arm has reported.** Editing a slice mid-audit voids that
+audit: the verifier's findings stop describing bytes that exist. (A prior run edited three digests
+minutes after one arm reported while the other was still auditing; that verdict came back BLOCKED
+and its subject had to be reconstructed by diffing frozen pins.)
+
+**Every correction round leaves an applied record, and the next round reads it.** The record is
+dated, lands beside the verdicts, and names what changed and why; any finding the round surfaced but
+was not scoped to fix goes in its "New findings" section, which is a **required input to the next
+round's brief**. Both halves bind — a faithfully written record nobody reads drops findings on the
+floor exactly as silently as no record at all. A verdict likewise lands in
+`<work-root>/verification/` or it did not happen: one written to a session scratchpad is unreachable
+by every later round. (One run's rounds 2-3 left no record and only a verifier's cross-check noticed;
+an 18-unit fan-out elsewhere edited seven units with no record, leaving them unattested; two verdicts
+in that same slice were written outside `verification/` and no later round could read them.)
+
+**A mechanical gate reports only what it parsed, and only the fields it checks.** Any script used as
+a verification gate errors loudly on input it cannot recognize, and a clean result is read as
+covering just the rows and fields it actually exercised. **The ordering is not negotiable:** a gate
+that silently skips what it cannot parse is fixed *before* it is made a required artifact, or the
+mandate converts a visible gap into an invisible pass. (Both arms independently caught the campaign's
+quote checker printing "all checks clean" over a digest whose 14 claims it could not parse at all;
+the same checker's command replay read only the first number in each `→ N lines, M files` pair, so
+it reported clean on a class it was structurally blind to.)
+
+**Commands are replayable in every pipeline artifact, not just digest rows.** INDEX rows, applied
+records, verdicts, rulings and handoffs carry commands too, in the same command-plus-raw-count form,
+and the replay sweep covers them. (One slice yielded five record-level command defects in a single
+round: two greps quoted without a path operand, an unrunnable command invisible to the replay regex,
+and two records mis-stating their own pair counts — and one correction record propagated the wrong
+line number it had been written to fix.)
+
+**Reconcile the digest set against itself before Phase 5.** Every other check is scoped within a row
+or between a row and `source.md`, so parallel digest agents can affirm, deny, and abstain on the same
+external page and still earn PASS from both verifiers. Group the digests' claims by quoted text and
+by cited site: identical quotes carrying non-identical tags, and rows of the same assertion class
+resting on materially different absence bases, are defects to resolve or to disclose in the handoff.
+(Ten rows digesting one directive reached two different tags via at least three distinct absence
+bases; the tag split was the visible symptom, the bases diverged first. Both arms found splits of
+this shape by hand, and only by choosing to look.)
+
 **Degraded-verifier fallback (never silent):** when the cross-vendor verifier is unavailable
 (not installed, sandbox-broken, quota), substitute a second same-vendor verifier briefed as an
 adversarial refuter, and RECORD the degradation and its reason in the verdict file header. A

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -202,7 +202,7 @@ reported clean on a class it was structurally blind to.)
 records, verdicts, rulings and handoffs carry commands too, in the same command-plus-raw-count form,
 and the replay sweep covers them. (One slice yielded five record-level command defects: two greps
 quoted without a path operand, an unrunnable command invisible to the replay regex, and two records
-mis-stating their own pair counts — and one correction record propagated the wrong line number it
+misstating their own pair counts — and one correction record propagated the wrong line number it
 had been written to fix.)
 
 **Reconcile the digest set against itself before Phase 5.** Every other check is scoped within a row

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -200,10 +200,11 @@ reported clean on a class it was structurally blind to.)
 
 **Commands are replayable in every pipeline artifact, not just digest rows.** INDEX rows, applied
 records, verdicts, rulings and handoffs carry commands too, in the same command-plus-raw-count form,
-and the replay sweep covers them. (One slice yielded five record-level command defects: two greps
-quoted without a path operand, an unrunnable command invisible to the replay regex, and two records
-misstating their own pair counts — and one correction record propagated the wrong line number it
-had been written to fix.)
+and each is replayed where it is authored — no sweep reaches an artifact that did not yet exist
+when it ran, so the phase that writes one replays it before that phase ends. (One slice yielded
+five record-level command defects: two greps quoted without a path operand, an unrunnable command
+invisible to the replay regex, and two records misstating their own pair counts — and one
+correction record propagated the wrong line number it had been written to fix.)
 
 **Reconcile the digest set against itself before Phase 5.** Every other check is scoped within a row
 or between a row and `source.md`, so parallel digest agents can affirm, deny, and abstain on the same
@@ -223,10 +224,12 @@ verification record that hides its degraded provenance is worse than a missing o
 
 Author `<work-root>/interview-handoff.md`: a validation-answer-set-shaped artifact — one entry
 per open question or candidate artifact surfaced by the digests, each carrying the digest
-citation, the verifiers' verdict state, and a recommended disposition. Then hand off: run
-`/planning:interview` over it when that plugin is installed, otherwise present the artifact and
-stop. The pipeline ends at the handoff — deciding what to BUILD from a verified slice is the
-interview's job, and building it belongs to the consuming repo's planning/implementation flow.
+citation, the verifiers' verdict state, and a recommended disposition. **Replay the handoff's own
+commands before handing off** — every Phase 4 check precedes it, so this pass is the only one that
+can reach them. Then hand off: run `/planning:interview` over it when that plugin is installed,
+otherwise present the artifact and stop. The pipeline ends at the handoff — deciding what to BUILD
+from a verified slice is the interview's job, and building it belongs to the consuming repo's
+planning/implementation flow.
 
 Emit a continuation prompt (sibling convention) when the run pauses mid-pipeline: a short
 self-contained prompt naming the slug, the first unticked checklist phase, and the work root.

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -24,8 +24,8 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   fetch cannot fabricate a PRESENCE, only an ABSENCE. (Two runs asserted a false absence exactly
   this way. In the steering-thinking slice the orchestrator's *resolution* re-fetched the same page
   through the same channel and reproduced the blind spot instead of testing it —
-  `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line page whose fetch stopped around
-  row 49.)
+  `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line page whose rendered fetch surfaced
+  roughly the first fifth of its 316 table rows.)
 
 ## Claude-Code-applicability filter (with teeth)
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -17,6 +17,15 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
 - **PDFs (model/system cards):** download the original binary as `source.pdf` plus a text
   extraction as `source.txt`; both are originals, the extraction tooling is named in the
   checklist.
+- **Absence-establishing fetches must be complete.** Any fetch that will support a negative claim —
+  an `api-only` basis, a "no harness surface states this" finding — goes through the raw `.md`
+  channel with `curl` and records the retrieved length; a rendered `WebFetch` of a long page returns
+  a silent prefix with no truncation signal. The asymmetry is what makes this binding: a truncated
+  fetch cannot fabricate a PRESENCE, only an ABSENCE. (Two runs asserted a false absence exactly
+  this way. In the steering-thinking slice the orchestrator's *resolution* re-fetched the same page
+  through the same channel and reproduced the blind spot instead of testing it —
+  `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line page whose fetch stopped around
+  row 49.)
 
 ## Claude-Code-applicability filter (with teeth)
 
@@ -32,7 +41,20 @@ the tag asserts:
 - **`api-only` (a negative claim — "no harness surface exists"):** absence cannot be proven from
   one page. Record the basis (the harness doc section(s) checked, or `unverified-inference` when
   none was); a contested or load-bearing `api-only` tag escalates to the interview rather than
-  standing on an absence citation.
+  standing on an absence citation. **The basis records the exact command run and its raw result
+  count**, not a prose summary of what was checked — an attested zero is not a reproducible zero,
+  and a row that both performs an absence search and certifies its own result leaves a verifier
+  nothing to replay. (One run produced eight fabricated absence bases before this rule was imposed;
+  every one was caught against the corpus rather than by the producing agent — `llms.txt` asserted
+  absent while present in 174 files, `thumbs` while `data-usage.md:28` states it, `knowledge cutoff`
+  while `changelog.md:4820` states it.)
+- **Every non-zero result names its match site(s).** A recorded count plus a filename histogram is
+  still unfalsifiable: a reader who replays the command gets the same number and still cannot tell
+  whether anyone read the matching lines. A row whose hit set was **sampled** rather than read in
+  full states that scope at the row. (Adopted slice-wide as a ruling in the system-prompts run and
+  still the most-violated rule in that slice; the cost is documented, not hypothetical — an
+  undisclosed `settings.md:727` near-miss was exactly what the unread portion of a 199-line hit set
+  contained.)
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
   SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
   reserved for claims naming no API surface.
@@ -42,6 +64,16 @@ the tag asserts:
   uncertainty marker, never a substitute for the tag. (Both rulings from the sonnet-5 guide
   slice's cross-vendor verification, where citation-by-reference and marker-as-tag were the
   dominant correction class.)
+- **Row-local reachability — a cited site no recorded command produces has been asserted, not
+  disclosed.** A `file.md:NN` in a row's evidence counts as disclosed only when some command
+  recorded in that same row produces it; otherwise the row says so explicitly, and an explicit
+  read-not-grepped note is the sanctioned form. Two corollaries the evidence forces: a `| wc -l`
+  count produces no sites and cannot support a citation, and a site named from a sampled set records
+  the narrower command that reaches it. (Three independent auditors raised this class separately — a
+  corrector and both verification arms, each with its own instrument; arm A measured 57 citations
+  across ~35 rows in one slice produced by no command in their own rows. Every cited line was read
+  and found true, so the claims survived and the defect was the audit trail — which is precisely why
+  no verifier's spot-check substitutes for the rule.)
 - **Harness docs are their own live basis:** when the digested page is itself a live
   code.claude.com harness doc, intrinsic harness-guidance claims cite the canonical page URL +
   section as their row-local basis; the boundary rule still routes claims naming an API surface

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -24,8 +24,8 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   fetch cannot fabricate a PRESENCE, only an ABSENCE. (Two runs asserted a false absence exactly
   this way. In the steering-thinking slice the orchestrator's *resolution* re-fetched the same page
   through the same channel and reproduced the blind spot instead of testing it —
-  `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line page whose rendered fetch surfaced
-  roughly the first fifth of its 316 table rows.)
+  `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line, 316-row page whose rendered fetch
+  surfaced only roughly its first fifth.)
 
 ## Claude-Code-applicability filter (with teeth)
 

--- a/plugins/knowledge/skills/docpage-digest/templates/checklist.md
+++ b/plugins/knowledge/skills/docpage-digest/templates/checklist.md
@@ -26,8 +26,8 @@ collision check reads them to tell a resume from a slug collision.
 - [ ] Phase 3: Digest fan-out — one agent per digest unit → `digests/NN-slug.md` (fixed structure)
 - [ ] Phase 4: Dual verification — Verifier A (same-vendor) + Verifier B (cross-vendor) verdicts
       in `verification/` (append-only; degraded fallback recorded, never silent)
-- [ ] Phase 5: Interview handoff — `interview-handoff.md` authored; `/planning:interview` run or
-      artifact presented
+- [ ] Phase 5: Interview handoff — `interview-handoff.md` authored and its own commands replayed
+      (every Phase 4 check precedes it); `/planning:interview` run or artifact presented
 
 ## Skip criteria
 


### PR DESCRIPTION
Applies the evidence-forced profile and pipeline amendments the docpage-digest campaign produced, and nothing else. `knowledge` 0.10.14 -> 0.10.15.

## What this ships

Eleven normative rules across `SKILL.md` and `context/anthropic-docs-profile.md`, each mapping to a triage row marked `evidence-forced`:

- **PA-A** row-local reachability — a cited `file.md:NN` counts as disclosed only when a command recorded in that same row produces it, plus the `| wc -l` and sampled-set corollaries.
- **PA-B** a mechanical gate reports only what it parsed, and only the fields it checks; unrecognized input becomes a hard error *before* the gate is made required.
- **PA-C** every correction round leaves an applied record, and its "New findings" section is a required input to the next round's brief; a verdict lands in `verification/` or it did not happen.
- **PA-D** commands are replayable in every pipeline artifact, not just digest rows.
- **PA-E** reconcile the digest set against itself before Phase 5.
- **PA-G** every non-zero result names its match sites; a sampled hit set states that scope at the row.
- **PA-R** absence-establishing fetches use the raw `.md` channel via `curl` and record the retrieved length.
- Plus the frozen-tree rule (no tree moves until every dispatched arm has reported) and the `api-only` exact-command-and-raw-count basis. Both were forced by the record but had no triage row, because the triage never ingested the process-failure file; rows `PA-AL` and `PA-AM` were added to close that classification gap.

## Verification

Two independent verifier arms, one adversarial, audited whether any amendment here is really a judgment call. Both concluded no: every rule maps to an `evidence-forced` row, nothing from the judgment-amendments file is present, and the escalated Decision-A ordering amendment (PA-AI) is untouched.

Both arms then failed the branch on its *supporting evidence* — five parentheticals that misattributed an instrument, compressed defects spanning three jobs into "a single round", reported a written-but-unconsumed record as "left no record", blended a run-9 figure into a run-10 slice, and asserted a reconstruction the record does not describe. All five are corrected against primary sources and re-verified by two fresh arms.

Rules were proven untouched mechanically rather than by eye: stripping every balanced parenthetical span and normalizing whitespace yields byte-identical remainders against the pre-correction commit (15,210 and 5,838 chars).

No linked issue

## Related

- Follows the three merged doc-queue PRs #1872, #1873, #1874, which emptied the digest queue.
- Triage and judgment classification live in the campaign's memory tier under `.work/_harness-snapshots-2026-07-31/`, which is deliberately not committed.