### PR TITLE
fix(playbooks): resolve the max-effort contradiction, stamp benchmark figures, join the thinking-off rule

### DIFF
--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.6.2]
+
+### Fixed
+
+- **`boris` no longer contradicts this repo on `max` effort durability.**
+  `skills/boris/SKILL.md`'s Quick Reference row read "max is session-only" flat, and
+  `skills/boris/reference/autonomy.md` §72 read "Max applies only to current session. All other
+  effort levels (including xhigh) are sticky" — while `docs/PLUGIN-PHILOSOPHY.md` carried the
+  exception. Two statements of one actionable fact, disagreeing. `PLUGIN-PHILOSOPHY.md` is right,
+  verified 2026-08-02 against
+  [model config — adjust effort level](https://code.claude.com/docs/en/model-config#adjust-effort-level):
+  "`max` provides the deepest reasoning and applies to the current session only, except when set
+  through the `CLAUDE_CODE_EFFORT_LEVEL` environment variable", and for the persisted `effortLevel`
+  setting, `max` and `ultracode` "are not accepted here". Both files now carry the exception. §72
+  additionally records the two further limits on "sticky" that the same page states — a level set
+  with `/effort` in non-interactive `-p` mode is session-only, and first-running Fable 5, Opus 4.8,
+  or Opus 4.7 holds that model's default across sessions until an explicit choice (Opus 5 has no
+  such hold) — as a conforming `docs/conventions/upstream-drift` record: claim, cited page, as-of
+  date, and a divergence-at-fetch recheck trigger. `skills/boris/vendor/SKILL.md` carries the same
+  claim at 3 lines and is deliberately **not** changed — it is the verbatim upstream baseline used
+  for drift detection, so editing it would manufacture false drift.
+
+- **`boris` benchmark figures now declare themselves launch-day snapshots and carry a recheck
+  trigger.** `skills/boris/reference/orchestration.md` restated volatile scores — SWE-Bench Pro,
+  Terminal-Bench 2.1, GDPval-AA, FrontierCode/Diamond, OSWorld-Verified — at §78 and §94 with no
+  as-of date and no stated re-derivation event, so nothing told a reader they had aged past the
+  releases they announced. Benchmark names, suite versions, and scores churn independently of the
+  models they rank. A file-level four-part record now classifies the figures as historical and
+  fires on a decision that would turn on any of them, a new frontier-model release, or a suite
+  version bump; both carrier lines are prefixed "Launch-day benchmarks". The figures themselves are
+  unchanged — they are accurate for their releases, and refreshing them here would restate a fresh
+  snapshot the record exists to avoid. `skills/boris/vendor/SKILL.md` carries the same figures at
+  14 lines and is deliberately not changed, for the drift-detection reason above.
+
+### Changed
+
+- **`fable-5` states the thinking-off × effort hazard as one checkable rule instead of two loose
+  halves.** `context/model-adaptation/opus-5.md`'s thinking-controls section documented the
+  effort-conditional 400 in one bullet and the harness thinking-disable surfaces — including the
+  `MAX_THINKING_TOKENS=0` Fable 5 exception — in another, and never joined them. A third bullet now
+  states the rule they imply: a configuration pairing a thinking-disable surface with `xhigh` or
+  `max` effort on Opus 5 and later is a per-request 400 assembled from configuration alone, with
+  both operands literals in settings files, so it is findable by reading them. Stated at the
+  strength the evidence supports — it records the *config-time* question as untested rather than
+  claiming Claude Code guards the combination (the section's existing probe covers only an
+  already-sent request), keeps upstream's own unexpanded "and later models" scope, and repeats that
+  `MAX_THINKING_TOKENS=0` is not a universal kill switch.
+
 ## [0.6.1]
 
 ### Fixed

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -56,8 +56,8 @@ only after that version increases.
   both operands literals in settings files, so it is findable by reading them. Stated at the
   strength the evidence supports — it records the *config-time* question as untested rather than
   claiming Claude Code guards the combination (the section's existing probe covers only an
-  already-sent request), keeps upstream's own unexpanded "and later models" scope, and repeats that
-  `MAX_THINKING_TOKENS=0` is not a universal kill switch.
+  already-sent request), leaves upstream's "Claude Opus 5 onward" scope unexpanded, and repeats
+  that `MAX_THINKING_TOKENS=0` is not a universal kill switch.
 
 ## [0.6.1]
 

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -33,7 +33,14 @@ only after that version increases.
   releases they announced. Benchmark names, suite versions, and scores churn independently of the
   models they rank. A file-level four-part record now classifies the figures as historical and
   fires on a decision that would turn on any of them, a new frontier-model release, or a suite
-  version bump; both carrier lines are prefixed "Launch-day benchmarks". The figures themselves are
+  version bump. Both carrier lines are prefixed "Launch-day benchmarks" and now cite the basis the
+  record claims for them — the vendor's own launch announcement, [Opus 4.8, May 28
+  2026](https://www.anthropic.com/news/claude-opus-4-8#opus-48s-capabilities) and [Fable 5 /
+  Mythos 5, Jun 9
+  2026](https://www.anthropic.com/news/claude-fable-5-mythos-5#evaluating-claude-fable-5-and-claude-mythos-5).
+  Both pages publish their figures in a capabilities-table **image**, never in page text, so the
+  record says so: a re-checker who greps the fetched HTML finds nothing and would read a correct
+  citation as broken. The figures themselves are
   unchanged — they are accurate for their releases, and refreshing them here would restate a fresh
   snapshot the record exists to avoid. `skills/boris/vendor/SKILL.md` carries the same figures at
   14 lines and is deliberately not changed, for the drift-detection reason above.

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -23,8 +23,8 @@ only after that version increases.
   or Opus 4.7 holds that model's default across sessions until an explicit choice (Opus 5 has no
   such hold) — as a conforming `docs/conventions/upstream-drift` record: claim, cited page, as-of
   date, and a divergence-at-fetch recheck trigger. `skills/boris/vendor/SKILL.md` carries the same
-  claim at 3 lines and is deliberately **not** changed — it is the verbatim upstream baseline used
-  for drift detection, so editing it would manufacture false drift.
+  claim and is deliberately **not** changed — it is the verbatim upstream baseline used for drift
+  detection, so editing it would manufacture false drift.
 
 - **`boris` benchmark figures now declare themselves launch-day snapshots and carry a recheck
   trigger.** `skills/boris/reference/orchestration.md` restated volatile scores — SWE-Bench Pro,
@@ -42,8 +42,8 @@ only after that version increases.
   record says so: a re-checker who greps the fetched HTML finds nothing and would read a correct
   citation as broken. The figures themselves are
   unchanged — they are accurate for their releases, and refreshing them here would restate a fresh
-  snapshot the record exists to avoid. `skills/boris/vendor/SKILL.md` carries the same figures at
-  14 lines and is deliberately not changed, for the drift-detection reason above.
+  snapshot the record exists to avoid. `skills/boris/vendor/SKILL.md` carries the same figures and
+  is deliberately not changed, for the drift-detection reason above.
 
 ### Changed
 

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -53,11 +53,19 @@ only after that version increases.
   `MAX_THINKING_TOKENS=0` Fable 5 exception — in another, and never joined them. A third bullet now
   states the rule they imply: a configuration pairing a thinking-disable surface with `xhigh` or
   `max` effort on Opus 5 and later is a per-request 400 assembled from configuration alone, with
-  both operands literals in settings files, so it is findable by reading them. Stated at the
+  both operands configuration literals, so it is findable by reading them. Stated at the
   strength the evidence supports — it records the *config-time* question as untested rather than
   claiming Claude Code guards the combination (the section's existing probe covers only an
   already-sent request), leaves upstream's "Claude Opus 5 onward" scope unexpanded, and repeats
-  that `MAX_THINKING_TOKENS=0` is not a universal kill switch.
+  that `MAX_THINKING_TOKENS=0` is not a universal kill switch. Each enumerated surface is stated
+  at the value it can actually carry — the persisted `effortLevel` setting takes `xhigh` but not
+  `max` ([model config — set the effort level](https://code.claude.com/docs/en/model-config#set-the-effort-level):
+  `max` and `ultracode` "are not accepted here"), matching what §72 of `boris` records above — and
+  the API disable literal is written the way upstream writes it, `thinking: {"type": "disabled"}`
+  ([what's new in Opus 5 — disabling thinking requires effort `high` or
+  below](https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5#disabling-thinking-requires-effort-high-or-below)),
+  since a rule whose whole claim is that the hazard is readable off configuration literals cannot
+  ship an invalid one as its example. Both re-verified 2026-08-02.
 
 ## [0.6.1]
 

--- a/plugins/playbooks/skills/boris/SKILL.md
+++ b/plugins/playbooks/skills/boris/SKILL.md
@@ -116,7 +116,7 @@ Read the reference file matching the user's question. Multi-topic question = rea
 | /fewer-permission-prompts | Scan history, tune your permission allowlist |
 | Recaps | Short summary of what happened and what's next |
 | Focus Mode | `/focus` — hide intermediate work, show only final result |
-| Effort Mastery | xhigh for most, max for hardest (max is session-only) |
+| Effort Mastery | xhigh for most, max for hardest — `max` is session-only except through `CLAUDE_CODE_EFFORT_LEVEL`, its one durable route; the persisted `effortLevel` setting does not accept it (Section 72) |
 | /go | Verify end-to-end + /simplify + put up a PR |
 | 4.6→4.7 Shifts | Calibrated length, less auto-tool-use, judicious subagents |
 | Task Notifications | Hooks and alerts for autonomous runs |

--- a/plugins/playbooks/skills/boris/reference/autonomy.md
+++ b/plugins/playbooks/skills/boris/reference/autonomy.md
@@ -202,6 +202,23 @@ The effort scale: low → medium → high → xhigh → max (Speed ← → Intel
 
 **Key detail:** Max applies only to current session. All other effort levels (including xhigh) are sticky and persist for next session too.
 
+> **Amended (verified 2026-08-02 against
+> [model config — adjust effort level](https://code.claude.com/docs/en/model-config#adjust-effort-level)):**
+> the session-only claim holds for the interactive surfaces Boris is describing, but it is not
+> exhaustive — there is one durable route to `max`. Upstream, verbatim: "`low`, `medium`, `high`,
+> and `xhigh` persist across sessions when you set them in an interactive session. `max` provides
+> the deepest reasoning and applies to the current session only, except when set through the
+> `CLAUDE_CODE_EFFORT_LEVEL` environment variable." The persisted `effortLevel` setting takes
+> `low`, `medium`, `high`, or `xhigh` — `max` and `ultracode` "are not accepted here" — and the
+> environment variable "takes precedence over all other methods". Two further limits on "sticky":
+> stickiness comes from setting the level *interactively* (a level set with `/effort` in
+> non-interactive `-p` mode "applies to the current session only and isn't saved as your
+> default"), and first-running Fable 5, Opus 4.8, or Opus 4.7 applies that model's default effort
+> and "holds it across sessions until you make an explicit effort choice" — Opus 5 has no such
+> hold. That page owns the current level names, persistence rules, and per-model availability;
+> read it rather than trusting this snapshot. **Recheck trigger:** a read-time re-fetch of that
+> page finds it no longer matching this record.
+
 To steer thinking without changing effort level:
 
 - Harder problems: "Think carefully and step-by-step before responding; this problem is harder than it looks."

--- a/plugins/playbooks/skills/boris/reference/orchestration.md
+++ b/plugins/playbooks/skills/boris/reference/orchestration.md
@@ -3,8 +3,10 @@
 Tips from Boris Cherny's Parts 13–15 threads + the Thariq/Sid workflows deep-dive + the Boris/Cat interview (May 28 – Jun 10, 2026): Opus 4.8 launch, dynamic workflows, auto-mode-retired-plan-mode, context minimalism, nested subagents, `fork: true`, Fable 5.
 
 > **Benchmark figures in this file are launch-day snapshots, not current standings** (Sections 78
-> and 94). Each figure's basis is the launch announcement cited in its own section, and it holds
-> only for the release that announcement made: benchmark names, suite versions, and scores churn —
+> and 94). Each figure's basis is the launch announcement cited in its own section — on both pages
+> the figures live in the capabilities-table **image**, not the page text, so grepping the fetched
+> HTML finds nothing and the table image itself has to be opened. A figure holds only for the
+> release its announcement made: benchmark names, suite versions, and scores churn —
 > a suite revises, a vendor reports against a different harness, a later model reorders the table.
 > Classified as historical 2026-08-02 and deliberately not refreshed here. **Recheck trigger:** a
 > decision that would turn on any figure below, a new frontier-model release, or a suite version
@@ -15,7 +17,7 @@ Tips from Boris Cherny's Parts 13–15 threads + the Thariq/Sid workflows deep-d
 
 ## 78. Opus 4.8 — Strongest Coding Model Yet
 
-Shipped May 28, 2026. Launch-day benchmarks: SWE-Bench Pro 64.3 → 69.2; Terminal-Bench 2.1 66.1 → 74.6. Same price as 4.7. The bigger shift is honesty: it tells you when it's unsure and catches its own bugs instead of declaring victory early — a model that overclaims at step 4 wastes the next 40 steps, so honesty is what makes async work (`/goal`, workflows) actually finish. Also shipped: Fast mode for Opus 4.8 (research preview, ~2.5× speed, toggle `/fast`) and effort control on claude.ai.
+Shipped May 28, 2026. Launch-day benchmarks, from the [launch announcement](https://www.anthropic.com/news/claude-opus-4-8#opus-48s-capabilities): SWE-Bench Pro 64.3 → 69.2; Terminal-Bench 2.1 66.1 → 74.6. Same price as 4.7. The bigger shift is honesty: it tells you when it's unsure and catches its own bugs instead of declaring victory early — a model that overclaims at step 4 wastes the next 40 steps, so honesty is what makes async work (`/goal`, workflows) actually finish. Also shipped: Fast mode for Opus 4.8 (research preview, ~2.5× speed, toggle `/fast`) and effort control on claude.ai.
 
 > **Superseded (Jun 9, 2026):** Fable 5 is now the strongest coding model (Section 94). Opus 4.8 details remain accurate for that release.
 
@@ -85,7 +87,7 @@ Correction to Section 80's launch guidance: say **"use a workflow"**, not the ba
 
 Launched Jun 9, 2026 — a "Mythos-class" model made safe for general use, in Claude Code and Cowork. Boris: "the best model I have used for coding, by a wide margin… less prompts and steers, more efficient token use, better code quality, better tool use, more intelligent self-verification, longer running sessions, and higher trust & autonomy." A day later: "Fable has judgement, taste, and dimensionality… the first model I've used that was so methodical and precise [debugging] — taking measurements and adding logs then verifying that it truly fixed the issue before declaring victory… It really has this 'big model smell.'"
 
-Launch-day benchmarks (Fable 5 → Opus 4.8): SWE-Bench Pro **80.3%** → 69.2%; FrontierCode/Diamond (xhigh) **29.3%** → 13.4%; GDPval-AA **1932** → 1890; OSWorld-Verified **85.0%** → 83.4%. On starred benchmarks (cybersecurity, biology, Terminal-Bench, HLE, HealthBench) Fable performs closer to Opus 4.8 due to safety fallbacks — those higher figures are Mythos 5. Boris confirms the safety classifiers are currently "trigger-happy" (flagging ordinary debugging as cyber/bio) and being improved.
+Launch-day benchmarks (Fable 5 → Opus 4.8), from the [launch announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5#evaluating-claude-fable-5-and-claude-mythos-5): SWE-Bench Pro **80.3%** → 69.2%; FrontierCode/Diamond (xhigh) **29.3%** → 13.4%; GDPval-AA **1932** → 1890; OSWorld-Verified **85.0%** → 83.4%. On starred benchmarks (cybersecurity, biology, Terminal-Bench, HLE, HealthBench) Fable performs closer to Opus 4.8 due to safety fallbacks — those higher figures are Mythos 5. Boris confirms the safety classifiers are currently "trigger-happy" (flagging ordinary debugging as cyber/bio) and being improved.
 
 Specs: model id `claude-fable-5`; 1M context; 128K max output; adaptive thinking; knowledge cutoff Jan 2026; no fast mode yet. **Pricing: $10/M input · $50/M output — exactly 2× Opus 4.8**; cache write $12.50, cache read $1; full 1M context at standard rate. Karpathy: "SOTA on everything by a margin… a major-version-bump-deserving step change… You can give it a lot more ambitious tasks — the model 'gets it' and it will just go."
 

--- a/plugins/playbooks/skills/boris/reference/orchestration.md
+++ b/plugins/playbooks/skills/boris/reference/orchestration.md
@@ -2,9 +2,20 @@
 
 Tips from Boris Cherny's Parts 13–15 threads + the Thariq/Sid workflows deep-dive + the Boris/Cat interview (May 28 – Jun 10, 2026): Opus 4.8 launch, dynamic workflows, auto-mode-retired-plan-mode, context minimalism, nested subagents, `fork: true`, Fable 5.
 
+> **Benchmark figures in this file are launch-day snapshots, not current standings** (Sections 78
+> and 94). Each figure's basis is the launch announcement cited in its own section, and it holds
+> only for the release that announcement made: benchmark names, suite versions, and scores churn —
+> a suite revises, a vendor reports against a different harness, a later model reorders the table.
+> Classified as historical 2026-08-02 and deliberately not refreshed here. **Recheck trigger:** a
+> decision that would turn on any figure below, a new frontier-model release, or a suite version
+> bump (e.g. Terminal-Bench 2.1 → 2.2). On a firing, resolve current figures from the vendor's own
+> announcement for that release plus
+> [models overview](https://platform.claude.com/docs/en/about-claude/models/overview), and leave
+> these lines as history rather than restating a fresh snapshot here.
+
 ## 78. Opus 4.8 — Strongest Coding Model Yet
 
-Shipped May 28, 2026. SWE-Bench Pro 64.3 → 69.2; Terminal-Bench 2.1 66.1 → 74.6. Same price as 4.7. The bigger shift is honesty: it tells you when it's unsure and catches its own bugs instead of declaring victory early — a model that overclaims at step 4 wastes the next 40 steps, so honesty is what makes async work (`/goal`, workflows) actually finish. Also shipped: Fast mode for Opus 4.8 (research preview, ~2.5× speed, toggle `/fast`) and effort control on claude.ai.
+Shipped May 28, 2026. Launch-day benchmarks: SWE-Bench Pro 64.3 → 69.2; Terminal-Bench 2.1 66.1 → 74.6. Same price as 4.7. The bigger shift is honesty: it tells you when it's unsure and catches its own bugs instead of declaring victory early — a model that overclaims at step 4 wastes the next 40 steps, so honesty is what makes async work (`/goal`, workflows) actually finish. Also shipped: Fast mode for Opus 4.8 (research preview, ~2.5× speed, toggle `/fast`) and effort control on claude.ai.
 
 > **Superseded (Jun 9, 2026):** Fable 5 is now the strongest coding model (Section 94). Opus 4.8 details remain accurate for that release.
 
@@ -74,7 +85,7 @@ Correction to Section 80's launch guidance: say **"use a workflow"**, not the ba
 
 Launched Jun 9, 2026 — a "Mythos-class" model made safe for general use, in Claude Code and Cowork. Boris: "the best model I have used for coding, by a wide margin… less prompts and steers, more efficient token use, better code quality, better tool use, more intelligent self-verification, longer running sessions, and higher trust & autonomy." A day later: "Fable has judgement, taste, and dimensionality… the first model I've used that was so methodical and precise [debugging] — taking measurements and adding logs then verifying that it truly fixed the issue before declaring victory… It really has this 'big model smell.'"
 
-Benchmarks (Fable 5 → Opus 4.8): SWE-Bench Pro **80.3%** → 69.2%; FrontierCode/Diamond (xhigh) **29.3%** → 13.4%; GDPval-AA **1932** → 1890; OSWorld-Verified **85.0%** → 83.4%. On starred benchmarks (cybersecurity, biology, Terminal-Bench, HLE, HealthBench) Fable performs closer to Opus 4.8 due to safety fallbacks — those higher figures are Mythos 5. Boris confirms the safety classifiers are currently "trigger-happy" (flagging ordinary debugging as cyber/bio) and being improved.
+Launch-day benchmarks (Fable 5 → Opus 4.8): SWE-Bench Pro **80.3%** → 69.2%; FrontierCode/Diamond (xhigh) **29.3%** → 13.4%; GDPval-AA **1932** → 1890; OSWorld-Verified **85.0%** → 83.4%. On starred benchmarks (cybersecurity, biology, Terminal-Bench, HLE, HealthBench) Fable performs closer to Opus 4.8 due to safety fallbacks — those higher figures are Mythos 5. Boris confirms the safety classifiers are currently "trigger-happy" (flagging ordinary debugging as cyber/bio) and being improved.
 
 Specs: model id `claude-fable-5`; 1M context; 128K max output; adaptive thinking; knowledge cutoff Jan 2026; no fast mode yet. **Pricing: $10/M input · $50/M output — exactly 2× Opus 4.8**; cache write $12.50, cache read $1; full 1M context at standard rate. Karpathy: "SOTA on everything by a margin… a major-version-bump-deserving step change… You can give it a lot more ambitious tasks — the model 'gets it' and it will just go."
 

--- a/plugins/playbooks/skills/fable-5/context/model-adaptation/opus-5.md
+++ b/plugins/playbooks/skills/fable-5/context/model-adaptation/opus-5.md
@@ -122,16 +122,17 @@ enumeration); any effort claim beyond the three above defers to the verified eff
 - **The two bullets above compose into one statically checkable config rule** — neither states it
   alone, so state it here. A configuration pairing a thinking-disable surface
   (`MAX_THINKING_TOKENS=0`, the `/config` thinking toggle, `alwaysThinkingEnabled: false`, or API
-  `thinking: {type: "disabled"}`) with `xhigh` or `max` effort (`effortLevel`,
-  `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, or skill/subagent `effort` frontmatter) is, on Opus 5
-  and later, a per-request 400 assembled from configuration alone: both operands are literals in
-  settings files, so the defect is findable by reading them, with nothing run. Two limits on the
-  rule — it bites only where the disable surface actually takes effect (per the bullet above,
-  `MAX_THINKING_TOKENS=0` is no universal kill switch and does nothing on Fable 5), and upstream
-  scopes this "Claude Opus 5 onward", left unexpanded here because which models that names today
-  is unresolved. Whether Claude Code refuses the pairing at *config* time is untested: the
-  first bullet's probe covers only what a request that was already sent does. So treat the pairing
-  as an authoring defect to fix wherever a settings file is audited, never as a guarded case.
+  `thinking: {"type": "disabled"}`) with `xhigh` or `max` effort (`effortLevel`, which takes
+  `xhigh` but not `max`; `CLAUDE_CODE_EFFORT_LEVEL`; `--effort`; or skill/subagent `effort`
+  frontmatter) is, on Opus 5 and later, a per-request 400 assembled from configuration alone: both
+  operands are configuration literals, so the defect is findable by reading them, with nothing run.
+  Two limits on the rule — it bites only where the disable surface actually takes effect (per the
+  bullet above, `MAX_THINKING_TOKENS=0` is no universal kill switch and does nothing on Fable 5),
+  and upstream scopes this "Claude Opus 5 onward", left unexpanded here because which models that
+  names today is unresolved. Whether Claude Code refuses the pairing at *config* time is untested:
+  the first bullet's probe covers only what a request that was already sent does. So treat the
+  pairing as an authoring defect to fix wherever such configuration is audited, never as a guarded
+  case.
   `[CC: direct]`
 - With thinking disabled you can leak tool calls as plain text (never executed, and the leaked
   text persists in agentic history) and internal XML tags into visible output. Primary mitigation

--- a/plugins/playbooks/skills/fable-5/context/model-adaptation/opus-5.md
+++ b/plugins/playbooks/skills/fable-5/context/model-adaptation/opus-5.md
@@ -119,6 +119,20 @@ enumeration); any effort claim beyond the three above defers to the verified eff
   `alwaysThinkingEnabled`, and `MAX_THINKING_TOKENS=0` all have no effect there). Third-party
   providers omit the `thinking` parameter instead, and adaptive-reasoning models may still think.
   `[CC: direct]`
+- **The two bullets above compose into one statically checkable config rule** — neither states it
+  alone, so state it here. A configuration pairing a thinking-disable surface
+  (`MAX_THINKING_TOKENS=0`, the `/config` thinking toggle, `alwaysThinkingEnabled: false`, or API
+  `thinking: {type: "disabled"}`) with `xhigh` or `max` effort (`effortLevel`,
+  `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, or skill/subagent `effort` frontmatter) is, on Opus 5
+  and later, a per-request 400 assembled from configuration alone: both operands are literals in
+  settings files, so the defect is findable by reading them, with nothing run. Two limits on the
+  rule — it bites only where the disable surface actually takes effect (per the bullet above,
+  `MAX_THINKING_TOKENS=0` is no universal kill switch and does nothing on Fable 5), and "and later
+  models" is upstream's own scope wording, left unexpanded here because which models it names
+  today is unresolved. Whether Claude Code refuses the pairing at *config* time is untested: the
+  first bullet's probe covers only what a request that was already sent does. So treat the pairing
+  as an authoring defect to fix wherever a settings file is audited, never as a guarded case.
+  `[CC: direct]`
 - With thinking disabled you can leak tool calls as plain text (never executed, and the leaked
   text persists in agentic history) and internal XML tags into visible output. Primary mitigation
   is avoidance: keep thinking ON and lower effort instead — "for most tasks, thinking enabled at

--- a/plugins/playbooks/skills/fable-5/context/model-adaptation/opus-5.md
+++ b/plugins/playbooks/skills/fable-5/context/model-adaptation/opus-5.md
@@ -127,9 +127,9 @@ enumeration); any effort claim beyond the three above defers to the verified eff
   and later, a per-request 400 assembled from configuration alone: both operands are literals in
   settings files, so the defect is findable by reading them, with nothing run. Two limits on the
   rule — it bites only where the disable surface actually takes effect (per the bullet above,
-  `MAX_THINKING_TOKENS=0` is no universal kill switch and does nothing on Fable 5), and "and later
-  models" is upstream's own scope wording, left unexpanded here because which models it names
-  today is unresolved. Whether Claude Code refuses the pairing at *config* time is untested: the
+  `MAX_THINKING_TOKENS=0` is no universal kill switch and does nothing on Fable 5), and upstream
+  scopes this "Claude Opus 5 onward", left unexpanded here because which models that names today
+  is unresolved. Whether Claude Code refuses the pairing at *config* time is untested: the
   first bullet's probe covers only what a request that was already sent does. So treat the pairing
   as an authoring defect to fix wherever a settings file is audited, never as a guarded case.
   `[CC: direct]`


### PR DESCRIPTION
Three repo-alignment findings from the doc-corpus campaign's Phase 3a — making this repo conform to the digested Anthropic documentation before any of it ships outward. `playbooks` 0.6.1 -> 0.6.2.

## RA-1 — the repo contradicted itself on `max` effort durability

`boris/SKILL.md` stated flatly that `max` effort is session-only; `docs/PLUGIN-PHILOSOPHY.md` carried the `CLAUDE_CODE_EFFORT_LEVEL` exception. Both describe a fact a user could act on.

Resolved against the live page, fetched this session rather than recalled — model-config states verbatim that `max` "applies to the current session only, **except when set through the `CLAUDE_CODE_EFFORT_LEVEL` environment variable**", and that `max` is "not accepted" in the persisted `effortLevel` setting.

**Population was enumerated, not taken from the finding.** The finding named one site; the sweep found a second undocumented one at `boris/reference/autonomy.md:203` ("Max applies only to current session"), which is also fixed.

## RA-4 — volatile benchmark figures carried no re-check trigger

`boris/reference/orchestration.md` cites GDPval-AA, Terminal-Bench 2.1 and SWE-Bench Pro figures with nothing recording when they were last true. Both carriers now sit under a four-part upstream-drift record (claim, cited page, as-of date, recheck trigger) per this repo's own `docs/conventions/upstream-drift/README.md`. Figures are unchanged — they are true of the releases they announced, and the convention's prefer-the-pointer rule argues against restating a fresh snapshot.

## RA-8 — two halves of one checkable rule, never joined

`fable-5/context/model-adaptation/opus-5.md` documented the effort-conditional thinking-off 400 and the `MAX_THINKING_TOKENS=0` exception as separate bullets. They are now stated as the single statically-checkable rule: a config pairing a thinking-disable surface with `xhigh`/`max` effort on Opus 5+ produces a per-request 400.

Deliberately stated at evidence strength: it does **not** claim the harness guards the combination. Whether it does is an unrun empirical check, and the section records the config-time question as untested.

## Verification

Independently verified with the implementer's rationale withheld. The hard block held — zero vendored files in the diff, though `boris/vendor/SKILL.md` carries the same strings at three sites and is hand-copy-prohibited. Every load-bearing quoted string re-fetched from the live upstream pages by the verifier.

The RA-1 check instrument was validated against four trees including two that must fail; the first-pass version would have false-passed by largely measuring its own fix.

No linked issue

## Related

- Phase 3a of the doc-corpus application campaign; gates the outward-facing Phase 3b work per the campaign's north star (this repo conforms first).
- Sibling: #1875 (knowledge plugin, evidence-forced pipeline amendments).