### PR TITLE
fix(review): call /code-review a bundled skill, not a built-in

### DIFF
--- a/docs/conventions/loop-lane/CHANGELOG.md
+++ b/docs/conventions/loop-lane/CHANGELOG.md
@@ -5,6 +5,20 @@ topology, the escalation contract, the capability-tier vocabulary, or any loop-l
 major bump, and additive guidance is a minor bump. A new model release re-audits the capability-tier
 table (§3); drift found by that audit is recorded here.
 
+## 7.0.1 — 2026-08-02
+
+Corrective, no topology, escalation, tier, or invariant change — §"Launch surfaces" describes the
+same launch surface with the label the official docs use for it.
+
+- **`/loop` was called "built-in"; it is a bundled skill.** The official commands reference states
+  "Most are built-in commands whose behavior is coded into the CLI" and marks `/loop` **[Skill]**,
+  "a bundled skill"; the skills page adds that bundled skills are "prompt-based … Most built-in
+  commands instead execute fixed logic directly", and that `/doctor` was "a built-in command rather
+  than a bundled skill" before v2.1.205 — the two labels name different things. The sentence now
+  reads "a [bundled skill](https://code.claude.com/docs/en/skills#bundled-skills) needing no
+  install", preserving the point the old wording was making: `/loop` needs no plugin, so it is the
+  dependency-free launch surface against which the `claude-ops` `lanes` launcher is optional.
+
 ## 7.0.0 — 2026-07-30
 
 Repartitions §4's telemetry binding from the lane **type** to the lane **instance**, resolving

--- a/docs/conventions/loop-lane/CHANGELOG.md
+++ b/docs/conventions/loop-lane/CHANGELOG.md
@@ -15,9 +15,10 @@ same launch surface with the label the official docs use for it.
   "a bundled skill"; the skills page adds that bundled skills are "prompt-based … Most built-in
   commands instead execute fixed logic directly", and that `/doctor` was "a built-in command rather
   than a bundled skill" before v2.1.205 — the two labels name different things. The sentence now
-  reads "a [bundled skill](https://code.claude.com/docs/en/skills#bundled-skills) needing no
-  install", preserving the point the old wording was making: `/loop` needs no plugin, so it is the
-  dependency-free launch surface against which the `claude-ops` `lanes` launcher is optional.
+  reads "a bundled skill needing no install", carrying the four-part record §Versioning's second
+  recheck trigger obliges — basis, as-of date, and this file's existing `(<url>, verified <date>)`
+  shape — and preserving the point the old wording was making: `/loop` needs no plugin, so it is
+  the dependency-free launch surface against which the `claude-ops` `lanes` launcher is optional.
 
 ## 7.0.0 — 2026-07-30
 

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -606,9 +606,10 @@ conventions). The reference is presence-gated with this inline fallback per the
 All three adopters have shipped. This owner doc landed ahead of them, per the convention-registry
 rule; the table above is a live consumer list, not a forward reference.
 
-**Launch surfaces.** A lane launches interactively via `/loop` — the primary surface, built-in and
-dependency-free — or headless via the `claude-ops` `lanes` launcher, which stores the one-line lane
-prompt through its `prompt_dir` seam (#480). `lanes` is a **supporting, strictly one-directional**
+**Launch surfaces.** A lane launches interactively via `/loop` — the primary surface, a
+[bundled skill](https://code.claude.com/docs/en/skills#bundled-skills) needing no install — or
+headless via the `claude-ops` `lanes` launcher, which stores the one-line lane prompt through its
+`prompt_dir` seam (#480). `lanes` is a **supporting, strictly one-directional**
 launcher: it launches the lane; no lane body ever requires, imports, or degrades without
 `claude-ops`. Every mention of `lanes` in a lane body is presence-gated with the `/loop` fallback
 documented at the site, per the [seam-phrasing convention](../seam-phrasing/README.md).

--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -606,10 +606,10 @@ conventions). The reference is presence-gated with this inline fallback per the
 All three adopters have shipped. This owner doc landed ahead of them, per the convention-registry
 rule; the table above is a live consumer list, not a forward reference.
 
-**Launch surfaces.** A lane launches interactively via `/loop` — the primary surface, a
-[bundled skill](https://code.claude.com/docs/en/skills#bundled-skills) needing no install — or
-headless via the `claude-ops` `lanes` launcher, which stores the one-line lane prompt through its
-`prompt_dir` seam (#480). `lanes` is a **supporting, strictly one-directional**
+**Launch surfaces.** A lane launches interactively via `/loop` — the primary surface, a bundled
+skill needing no install (<https://code.claude.com/docs/en/skills#bundled-skills>, verified
+2026-08-02) — or headless via the `claude-ops` `lanes` launcher, which stores the one-line lane
+prompt through its `prompt_dir` seam (#480). `lanes` is a **supporting, strictly one-directional**
 launcher: it launches the lane; no lane body ever requires, imports, or degrades without
 `claude-ops`. Every mention of `lanes` in a lane body is presence-gated with the `/loop` fallback
 documented at the site, per the [seam-phrasing convention](../seam-phrasing/README.md).

--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Documentation-hygiene toolkit of six skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — docs-hygiene plugin
 
+## [0.9.4]
+
+### Fixed
+
+- **`compress`'s scope-boundary list no longer calls `/code-review` and `/simplify`
+  "built-in".** The "Not a `/code-review` / `/simplify` shadow" bullet read "The built-in
+  `/code-review` and `/simplify` review code changes", mixing two categories the official
+  docs keep apart: the commands reference states "Most are built-in commands whose behavior
+  is coded into the CLI" and marks both `/code-review` and `/simplify` **[Skill]**, "a
+  bundled skill", while the skills page adds that bundled skills are "prompt-based" and
+  that `/doctor` was "a built-in command rather than a bundled skill" before v2.1.205 — the
+  labels are mutually exclusive. Both surfaces are bundled skills; the bullet now says so
+  (<https://code.claude.com/docs/en/skills#bundled-skills>). Scope is unchanged — the bullet
+  still excludes code review from `/compress`'s markdown-prose remit.
+
 ## [0.9.3]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/compress/SKILL.md
+++ b/plugins/docs-hygiene/skills/compress/SKILL.md
@@ -114,7 +114,7 @@ Observed failure points — each traces to a real incident; grown iteratively.
 - **Not an orchestrator surface.** `/compress` prints a human-readable summary; no structured/`--json` output
 - **Not a lint front-end.** `markdownlint-cli2` is the post-edit verifier, not the primary purpose
 - **Not a code-comment compressor.** Out of scope
-- **Not a `/code-review` / `/simplify` shadow.** The built-in `/code-review` and `/simplify` review code changes; `/compress` rewrites markdown prose. Different concerns
+- **Not a `/code-review` / `/simplify` shadow.** The bundled `/code-review` and `/simplify` skills review code changes; `/compress` rewrites markdown prose. Different concerns
 - **Not `/audit-noise`.** `/compress` owns FLAVOR (filler, hedging, articles, redundant restatement). `/audit-noise` owns NOISE classification (historical citations, ghost refs, "Why this file exists" preambles, hard-coupled enumerated consumer lists) per its own taxonomy. Different concerns; both may apply to the same target iteratively
 - **Not a content-relocation / cite-don't-recap tool.** When an inline passage recaps detail that already lives in a cited single source of truth (another doc or rule), condensing it is content RELOCATION, not flavor removal — the mandatory semantic-diff net sees the words gone from THIS file and reverts them as SEMANTIC LOSS, blind to the SSOT. Apply "reference, don't duplicate" as a MANUAL editorial pass (verify the cited SSOT actually holds the detail first — an unread pointer is an unverified claim); use `/extract-ssot` when the duplicated cluster spans 3+ files
 

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.5]
+
+### Fixed
+
+- **`quality-gate`'s code-mode boundary no longer calls `/code-review` "built-in"**
+  (doc-accuracy fix). `context/code.md` headed its boundary "the built-in `/code-review`
+  skill" and opened "Claude Code ships a built-in `/code-review` bundled skill" — a
+  compound of two categories the official docs keep apart. The commands reference
+  states "Most are built-in commands whose behavior is coded into the CLI" and marks
+  `/code-review` **[Skill]**, "a bundled skill"; the skills page lists `/code-review`
+  among the bundled skills and says bundled skills are "prompt-based … Most built-in
+  commands instead execute fixed logic directly", with `/doctor` cited as having been
+  "a built-in command rather than a bundled skill" before v2.1.205 — the two labels are
+  mutually exclusive. `/code-review` **is** a bundled skill; only the "built-in"
+  modifier was wrong, so the fix drops it rather than re-labelling the surface. The
+  heading and opening sentence now read "bundled skill" and link
+  <https://code.claude.com/docs/en/skills#bundled-skills>. The plugin's other
+  `/code-review` references (`README.md`, `fanout/SKILL.md`,
+  `fanout/context/findings-normalization.md`, `quality-gate/context/pr.md`) already
+  carry the correct "bundled" modifier and are untouched. Behavior is unchanged — the
+  boundary's routing advice, the report-only contract, and the `--fix` / `--comment`
+  opt-in gate all stand.
+
+  Three released entries below carry the same smear — `0.15.1` ("a bundled built-in
+  command"), `0.14.7` (the entry that added this boundary section: "always-available
+  built-in `/code-review`"), and `0.14.2` ("`/simplify` is an external/built-in
+  skill"). They are left as written: a released entry records what that version
+  shipped, and this file's own `0.15.3` entry sets the precedent of correcting a past
+  rationale in a new entry rather than editing the old one.
+
 ## [0.15.4]
 
 ### Fixed

--- a/plugins/review/skills/quality-gate/context/code.md
+++ b/plugins/review/skills/quality-gate/context/code.md
@@ -2,9 +2,9 @@
 
 Specialized multi-aspect code feedback during development, before the formal PR gate.
 
-## Boundary — the built-in `/code-review` skill
+## Boundary — the bundled `/code-review` skill
 
-Claude Code ships a built-in `/code-review` bundled skill that reviews the same target this mode does — the branch's commits ahead of upstream plus uncommitted working-tree changes — for correctness bugs and reuse, simplification, and efficiency cleanups. It is always available (no plugin install), honors effort levels, and its `ultra` mode runs a deeper cloud review. Because it overlaps this mode on the "code review" trigger and the current diff, choose deliberately:
+Claude Code ships `/code-review` as a [bundled skill](https://code.claude.com/docs/en/skills#bundled-skills) that reviews the same target this mode does — the branch's commits ahead of upstream plus uncommitted working-tree changes — for correctness bugs and reuse, simplification, and efficiency cleanups. It is always available (no plugin install), honors effort levels, and its `ultra` mode runs a deeper cloud review. Because it overlaps this mode on the "code review" trigger and the current diff, choose deliberately:
 
 - **This mode** when the review must ground in the project's own standards and severity vocabulary (resolved through the standards index), stay report-only, and land in the gate's unified findings report. It dispatches convention-aware reviewers — the paths below. (This is one lens per invocation; for a breadth fan-out across many review surfaces, reach for this plugin's `fanout` skill.)
 - **`/code-review`** for a fast zero-dependency pass, or its `ultra` cloud deep-dive, when project-standards grounding is not the point. It does not read `REVIEW.md`, and its `--fix` / `--comment` flags mutate the working tree or PR — outside this mode's report-only contract, so reach for those only on explicit user opt-in (the sibling `pr` mode gates the same side effect).


### PR DESCRIPTION
Repo-alignment finding RA-5 from the doc-corpus campaign's Phase 3a. The harness documentation keeps "built-in command" and "bundled skill" as distinct categories; `plugins/review/skills/quality-gate/context/code.md` called `/code-review` a "built-in ... bundled skill", smearing both.

## What the docs actually say

Established from the raw upstream markdown before writing the correction, not from recall:

- `commands.md:35` — "Most are built-in commands whose behavior is coded into the CLI"
- `commands.md:37` — "**[Skill](/docs/en/skills#bundled-skills)**: a bundled skill"
- `skills.md:23` — "Bundled skills are prompt-based... Most built-in commands instead execute fixed logic directly"

`/code-review`, `/simplify` and `/loop` all carry the `[Skill]` marker. So the correct category is bundled skill, and the corrected text links the live `#bundled-skills` anchor.

## The CHANGELOG question, decided explicitly

`plugins/review/CHANGELOG.md:272` carries the same smear. It is **left as written**. Released changelog entries are history, and this repo already set that precedent in its own 0.15.3 entry: "Those entries are left as written — history is corrected forward, not rewritten." The forward correction is this entry.

## A method note worth carrying

The verifier re-grounded against raw markdown via `curl` rather than a summarizing fetch — and that mattered. WebFetch's summarizer twice reported that `/simplify` does not appear in the commands reference, which would have produced a wrong FAIL. The raw file carries it at line 130.

That is the same failure mode the knowledge plugin's new absence-fetch rule exists to prevent: a truncating or summarizing channel cannot manufacture a presence, only a false absence.

## Verification

Independently verified with the implementer's rationale withheld. Every quoted upstream string checked verbatim against the live pages; every quoted historical changelog string checked against the repo's own history. Three surveyed-and-excluded sites are recorded in the review so a later round does not re-litigate them: the vendored Boris copy (three sites, one a literal quotation whose correction would falsify the quote) and `plugins/debugging/CHANGELOG.md:32`, both covered by the same never-rewrite-history policy.

No linked issue

## Related

- Phase 3a of the doc-corpus application campaign; this repo conforms before any check ships to consumers.
- Siblings: #1875 (knowledge, pipeline amendments), #1876 (playbooks, effort/benchmark/thinking alignment).