### PR TITLE
chore(knowledge): land the near-miss disclosure rule and the blog-channel extraction artifacts

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -8,9 +8,9 @@ only after that version increases.
 
 ### Changed
 
-- **`docpage-digest` — the second and final batch of the campaign's evidence-forced amendments.**
-  Same standard as 0.10.15: every rule below was demonstrated as a defect by the pipeline's own
-  runs, and each states its evidence inline.
+- **`docpage-digest` — a second batch of the campaign's evidence-forced amendments.** Same standard
+  as 0.10.15: each rule below was forced by a defect the pipeline's own runs produced, and each
+  states its evidence inline. Not the last batch — the two classes held below say why.
 - **Anthropic profile — what falsifies `api-only`, written down once.** Only the corpus documenting
   the claim's *own specific assertion* falsifies the tag; topical overlap never does. Below that
   line sits the **near-miss** — a harness page covering the row's subject without stating its

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.16]
+
+### Changed
+
+- **`docpage-digest` — the second and final batch of the campaign's evidence-forced amendments.**
+  Same standard as 0.10.15: every rule below was demonstrated as a defect by the pipeline's own
+  runs, and each states its evidence inline.
+- **Anthropic profile — what falsifies `api-only`, stated once as a graded rule.** Only the corpus
+  documenting the claim's *own specific assertion* falsifies the tag. A harness page covering the
+  row's subject without stating its rule is a **near-miss**: the tag survives and the row must name
+  it by page and line. Weaker still and not even a near-miss: a counterpart artifact on the other
+  property, and a workload named only as an example beside a guide that teaches it. Undisclosed
+  near-misses were the largest MINOR class in the slice that measured them — one unit disclosed 24
+  on its own — and the rule had been re-derived per unit rather than written down.
+- **Anthropic profile — a positive tag's row answers two questions as two bullets.** *Is the
+  assertion documented?* and *does the harness have the surface the guidance operates on?* are
+  separate questions; merging them is what leaves a positive tag unauditable.
+- **Anthropic profile — vendor-voice attestation follows the voice, not the page.** A blog passage
+  embedded in a non-blog page (a system prompt quoting an announcement) carries the marker on the
+  same terms.
+- **Anthropic profile — absence checks select their pages from the publisher's own `llms.txt`
+  index, never a guessed slug**, and any non-zero hit is READ at its match site rather than
+  counted: a corpus-snapshot page can be rendered HTML, in which case its hits are markup and the
+  count is noise.
+- **Anthropic profile — the two reproducible `claude.com/blog` extraction artifacts are recorded**
+  (H1 word-spacing collapse; reading-time value and unit split across lines) with reconstruction
+  from the canonical URL slug. Both reproduced exactly across two blog runs, which is what the
+  earlier deferral was waiting for.
+- **`SKILL.md` Phase 2 — site-injected matter is flagged, not stripped.** Page chrome that reached
+  `source.md` stays there (Phase 1 snapshots the original unaltered) and INDEX.md flags it as
+  non-prose with its source lines, so the Phase 3 agent does not digest it as doc content.
+
+Three further evidence-forced items are deliberately **not** applied here, for one shared reason:
+they change instruments that live in the campaign's untracked work root, not in the shipped plugin
+— making the quote checker a required artifact (whose own precondition, unrecognized-row detection
+erroring loudly, cannot be demonstrated as shipped), the command-replay gate reading only the first
+number of a `→ N lines, M files` pair, and the absence-measurement script skipping positive rows.
+Whether any of those graduates into the skill is a scope decision, not a forced one. The contested
+tag-vocabulary questions remain where 0.10.15 left them: with the dispositions interview.
+
 ## [0.10.15]
 
 ### Changed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -11,38 +11,38 @@ only after that version increases.
 - **`docpage-digest` — the second and final batch of the campaign's evidence-forced amendments.**
   Same standard as 0.10.15: every rule below was demonstrated as a defect by the pipeline's own
   runs, and each states its evidence inline.
-- **Anthropic profile — what falsifies `api-only`, stated once as a graded rule.** Only the corpus
-  documenting the claim's *own specific assertion* falsifies the tag. A harness page covering the
-  row's subject without stating its rule is a **near-miss**: the tag survives and the row must name
-  it by page and line. Weaker still and not even a near-miss: a counterpart artifact on the other
-  property, and a workload named only as an example beside a guide that teaches it. Undisclosed
+- **Anthropic profile — what falsifies `api-only`, written down once.** Only the corpus documenting
+  the claim's *own specific assertion* falsifies the tag; topical overlap never does. Below that
+  line sits the **near-miss** — a harness page covering the row's subject without stating its
+  specific rule: the tag survives, and the row must name the near-miss by page and line, so an
+  affirmative "no surface" or "undisclosed" phrasing in such a row is simply false. Undisclosed
   near-misses were the largest MINOR class in the slice that measured them — one unit disclosed 24
   on its own — and the rule had been re-derived per unit rather than written down.
-- **Anthropic profile — a positive tag's row answers two questions as two bullets.** *Is the
-  assertion documented?* and *does the harness have the surface the guidance operates on?* are
-  separate questions; merging them is what leaves a positive tag unauditable.
-- **Anthropic profile — vendor-voice attestation follows the voice, not the page.** A blog passage
-  embedded in a non-blog page (a system prompt quoting an announcement) carries the marker on the
-  same terms.
-- **Anthropic profile — absence checks select their pages from the publisher's own `llms.txt`
-  index, never a guessed slug**, and any non-zero hit is READ at its match site rather than
-  counted: a corpus-snapshot page can be rendered HTML, in which case its hits are markup and the
-  count is noise.
 - **Anthropic profile — the two reproducible `claude.com/blog` extraction artifacts are recorded**
   (H1 word-spacing collapse; reading-time value and unit split across lines) with reconstruction
-  from the canonical URL slug. Both reproduced exactly across two blog runs, which is what the
-  earlier deferral was waiting for.
-- **`SKILL.md` Phase 2 — site-injected matter is flagged, not stripped.** Page chrome that reached
-  `source.md` stays there (Phase 1 snapshots the original unaltered) and INDEX.md flags it as
-  non-prose with its source lines, so the Phase 3 agent does not digest it as doc content.
+  from the canonical URL slug, labelled reconstructed because a slug recovers word boundaries only.
+  Both reproduced exactly across two blog runs, which is what the earlier deferral was waiting for.
 
-Three further evidence-forced items are deliberately **not** applied here, for one shared reason:
-they change instruments that live in the campaign's untracked work root, not in the shipped plugin
+Two classes of item are deliberately **not** applied here, for two different reasons.
+
+Three change instruments that live in the campaign's untracked work root, not in the shipped plugin
 — making the quote checker a required artifact (whose own precondition, unrecognized-row detection
 erroring loudly, cannot be demonstrated as shipped), the command-replay gate reading only the first
 number of a `→ N lines, M files` pair, and the absence-measurement script skipping positive rows.
-Whether any of those graduates into the skill is a scope decision, not a forced one. The contested
-tag-vocabulary questions remain where 0.10.15 left them: with the dispositions interview.
+Whether any of those graduates into the skill is a scope decision, not a forced one.
+
+Five more are held for the dispositions interview, having been reclassified out of this batch. The
+campaign's triage marks each `evidence-forced`, but the judgment-amendments file writes all five up
+as judgment calls with two named readings apiece — vendor-voice attestation for blog material
+embedded in a non-blog page (J-6), splitting the two questions a positive tag's row collapses (J-7),
+naming the publisher's `llms.txt` index as the page-selection instrument (J-8), the scope of
+"harness surface" for counterpart artifacts and same-workload mentions (J-12), and the standing
+convention for site-injected matter in a snapshot (J-14). That file's own reasoning governs: J-14
+says outright it is held "only because no defect was demonstrated, so the bar for the applied subset
+is not met", and J-7 says it should be decided *after* the Decision-A ordering question already
+escalated to the maintainer. All five now carry recommendations in the interview's decision block.
+The contested tag-vocabulary questions therefore remain where 0.10.15 left them, and these five join
+them: with the dispositions interview.
 
 ## [0.10.15]
 

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -135,15 +135,6 @@ pre-H2 introduction plus each H2 section is one unit; sub-bullets stay as sub-di
 their unit's file. INDEX.md is the representation layer every later phase (and the interview)
 walks — keep its rows in parity with the digest files.
 
-**Site-injected matter is flagged here, not stripped at fetch.** Text the site wraps around the
-doc's own prose — a "Documentation Index" pointer blockquote, a beta or cookie banner — is in
-`source.md` because Phase 1 snapshots the original unaltered, and it stays there. INDEX.md flags it
-as non-prose in the unit that contains it, naming its source lines, so the Phase 3 agent for that
-unit treats it as page chrome rather than doc content. (One run met such a blockquote, declared it
-in INDEX.md and digested its unit correctly — and then asked for a standing convention, because
-without one the treatment is decided per run. The alternative, stripping at fetch, would edit an
-immutable artifact.)
-
 ## Phase 3 — Digest fan-out
 
 One subagent per digest unit, each writing `<work-root>/digests/NN-slug.md` with this fixed

--- a/plugins/knowledge/skills/docpage-digest/SKILL.md
+++ b/plugins/knowledge/skills/docpage-digest/SKILL.md
@@ -135,6 +135,15 @@ pre-H2 introduction plus each H2 section is one unit; sub-bullets stay as sub-di
 their unit's file. INDEX.md is the representation layer every later phase (and the interview)
 walks — keep its rows in parity with the digest files.
 
+**Site-injected matter is flagged here, not stripped at fetch.** Text the site wraps around the
+doc's own prose — a "Documentation Index" pointer blockquote, a beta or cookie banner — is in
+`source.md` because Phase 1 snapshots the original unaltered, and it stays there. INDEX.md flags it
+as non-prose in the unit that contains it, naming its source lines, so the Phase 3 agent for that
+unit treats it as page chrome rather than doc content. (One run met such a blockquote, declared it
+in INDEX.md and digested its unit correctly — and then asked for a standing convention, because
+without one the treatment is decided per run. The alternative, stripping at fetch, would edit an
+immutable artifact.)
+
 ## Phase 3 — Digest fan-out
 
 One subagent per digest unit, each writing `<work-root>/digests/NN-slug.md` with this fixed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -13,7 +13,16 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   (2026-07); **re-verify per doc** — precedent, not a guarantee. Fallback: fetch the rendered
   page and record the degradation.
 - **Blog posts (`claude.com/blog/...`):** no raw-markdown channel known; fetch rendered and
-  extract. Record the channel used.
+  extract. Record the channel used. **Two extraction artifacts reproduce on this channel; record
+  them, never repair them** — `source.*` is immutable, so the fix belongs in whatever reads the
+  snapshot, not in the snapshot. (a) The animated hero heading collapses every space in the H1.
+  Reconstruct the title from the canonical URL slug; when the run also retained the rendered HTML,
+  that file's `<title>`/`<h1>` carries the spaced form, but nothing in the pipeline contracts such
+  a file — the slug is the reconstruction that is always available. (b) The reading-time widget
+  splits its value and its unit onto separate physical lines, so neither line reads as a duration
+  on its own. (Both observed identically in two runs, at each slice's `source.md:7`:
+  `# Claudemodelsexplained:choosingthebestmodelforyourusecase` with the reading time at lines
+  83/87, and `# BuildingverificationloopsinClaudeCodewithskills` with it at lines 45/49.)
 - **PDFs (model/system cards):** download the original binary as `source.pdf` plus a text
   extraction as `source.txt`; both are originals, the extraction tooling is named in the
   checklist.
@@ -26,6 +35,19 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   through the same channel and reproduced the blind spot instead of testing it —
   `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line, 316-row page whose rendered fetch
   surfaced only roughly its first fifth.)
+- **The publisher's own index picks which pages such a check reads — never a guessed slug.**
+  <https://platform.claude.com/llms.txt> enumerates the platform property's pages and
+  <https://code.claude.com/docs/llms.txt> the harness property's; fetch the index raw with `curl`,
+  record the retrieved length as for any other absence-establishing fetch, and let it select the
+  pages. **A non-zero hit — in the index or in any corpus snapshot — is READ at its match site,
+  never counted.** A snapshot page can be rendered HTML rather than doc prose, in which case its
+  hits are page chrome and the count is noise no reader of the number can detect. (Both indexes
+  verified live 2026-08-02: 616 lines / 56,941 bytes and 180 lines / 38,847 bytes. The
+  page-chrome counter-fact is measured, not hypothetical — one campaign snapshot of nine platform
+  pages held two that begin `<!DOCTYPE html>`, and two of the three terms a slice probed that
+  directory with matched in those two files and nowhere else. Narrow guessed slugs, the practice
+  this index replaces, are what produced absence bases that never reached the page stating the
+  claim.)
 
 ## Claude-Code-applicability filter (with teeth)
 
@@ -55,6 +77,25 @@ the tag asserts:
   still the most-violated rule in that slice; the cost is documented, not hypothetical — an
   undisclosed `settings.md:727` near-miss was exactly what the unread portion of a 199-line hit set
   contained.)
+- **What falsifies `api-only`, and what only comes close — one graded rule, because the whole class
+  of defects here is the boundary being re-derived per row.** `api-only` asserts no harness surface
+  for **the claim's own specific assertion**, so only the corpus documenting *that assertion*
+  falsifies it; topical overlap never does. Two grades sit below the falsifying line, and the tag
+  survives both:
+  - **Near-miss — a harness page covers the row's subject without stating the row's specific
+    rule.** The row MUST name it by page and line (the term this profile already uses of
+    `settings.md:727` above), and an affirmative "no surface" or "undisclosed" phrasing in such a
+    row is simply false and goes. Silence here was the largest MINOR class in the slice that
+    measured it: one release-notes unit disclosed 24 near-miss rows on its own, and two sibling
+    units in that slice raised the same boundary independently, one of them asking outright for a
+    standing notation so a reader can tell "no surface at all" from "adjacent surface exists".
+  - **Weaker than a near-miss, and often mistaken for one.** A counterpart artifact on the *other*
+    property (a harness `llms.txt` beside a claim about the platform's own `llms.txt`) and a
+    workload named only as an example beside a guide that teaches it (an SDK hosting page naming
+    "a customer support agent") do not cover the row's subject at all. Neither falsifies
+    `api-only`: the tag scopes to the specific artifact or surface the row names. (Both were
+    contested escalations on the resources-hub slice, and both verification arms adjudicated them
+    the same way.)
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
   SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
   reserved for claims naming no API surface.
@@ -64,6 +105,18 @@ the tag asserts:
   uncertainty marker, never a substitute for the tag. (Both rulings from the sonnet-5 guide
   slice's cross-vendor verification, where citation-by-reference and marker-as-tag were the
   dominant correction class.)
+- **A positive tag's row answers two questions as two bullets, never as one merged sentence.** They
+  are separate questions with separate answers, and merging them is what leaves a tag unauditable:
+  - *Is the assertion itself documented?* — the live-doc citation for the assertion, or the
+    attestation marker saying no doc states it.
+  - *Does the harness have the surface the guidance operates on?* — the live-doc citation the
+    positive tag itself rests on.
+  A row that answers only the first reads as "nothing to cite" and silently drops the second. The
+  collapse is most tempting where the assertion is blog-only and the surface is well documented,
+  but the requirement is on **every** positive-tag row. (Both verification arms independently filed
+  the same finding against one unit — 12 positive-tag rows with no row-local live URL, 6 with no
+  applicability evidence at all — and the corrector who repaired those rows diagnosed this collapse
+  as their cause and asked for it to be carried into the profile.)
 - **Row-local reachability — a cited site no recorded command produces has been asserted, not
   disclosed.** A `file.md:NN` in a row's evidence counts as disclosed only when some command
   recorded in that same row produces it; otherwise the row says so explicitly, and an explicit
@@ -91,6 +144,14 @@ the tag asserts:
   that composes with the tag and, where applicability itself is inferred, with
   `unverified-inference`. (Shape recommended by the context-engineering blog slice's handoff,
   exercised end-to-end and enforced by both verifiers on the models-explained slice.)
+- **The attestation follows the vendor voice, not the containing page.** Vendor-voice material
+  EMBEDDED in a non-blog page — a blog passage a system prompt quotes, an announcement excerpt
+  inside a release note — carries the same marker on the same terms, sourced to the embedded
+  material rather than to the host page. The marker exists to stop an unverifiable vendor
+  assertion being read as documented fact, and that risk does not change with the type of page the
+  assertion happens to sit inside. (A release-notes system prompt embedded a blog passage whose
+  "less than 5% of sessions" trigger-rate figure no harness doc restates; the digest disclosed the
+  gap in prose but the row carried no marker, because the rule was scoped to blog *sources*.)
 
 ## Digest-agent model matching
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -23,7 +23,8 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   way is labelled reconstructed. When the run also retained the rendered HTML, that file's
   `<title>`/`<h1>` carries the exact form — but nothing in the pipeline contracts such a file, so
   it is a bonus, not the method. (b) The reading-time widget splits its value and its unit onto
-  separate physical lines, so neither line reads as a duration on its own. (Both observed identically in two runs, at each slice's `source.md:7`:
+  separate physical lines, so neither line reads as a duration on its own. (Both observed
+  identically in two runs, at each slice's `source.md:7`:
   `# Claudemodelsexplained:choosingthebestmodelforyourusecase` with the reading time at lines
   83/87, and `# BuildingverificationloopsinClaudeCodewithskills` with it at lines 45/49.)
 - **PDFs (model/system cards):** download the original binary as `source.pdf` plus a text
@@ -38,21 +39,6 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   through the same channel and reproduced the blind spot instead of testing it —
   `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line, 316-row page whose rendered fetch
   surfaced only roughly its first fifth.)
-- **The publisher's own index picks which pages such a check reads — never a guessed slug.**
-  <https://platform.claude.com/llms.txt> enumerates the platform property's pages and
-  <https://code.claude.com/docs/llms.txt> the harness property's; fetch the index raw with `curl`,
-  record the retrieved length as for any other absence-establishing fetch, and let it select the
-  pages. **A non-zero hit in the index, or in a snapshot page that turns out to be rendered HTML
-  rather than doc prose, is READ at its match site and never treated as a count** — such a page's
-  hits are its markup, and no reader of the number can detect that. The sampled-scope disclosure in
-  the applicability filter's non-zero-result rule below stays the one sanctioned way to fall short
-  of reading a hit set in full. (Both indexes
-  verified live 2026-08-02: 616 lines / 56,941 bytes and 180 lines / 38,847 bytes. The
-  page-chrome counter-fact is measured, not hypothetical — one campaign snapshot of nine platform
-  pages held two that begin `<!DOCTYPE html>`, and two of the three terms a slice probed that
-  directory with matched in those two files and nowhere else. Narrow guessed slugs, the practice
-  this index replaces, are what produced absence bases that never reached the page stating the
-  claim.)
 
 ## Claude-Code-applicability filter (with teeth)
 
@@ -66,7 +52,8 @@ the tag asserts:
   interview question, never a silent fact. (This rule exists because inference has already produced a
   wrong tag once — the failure mode is real.)
 - **`api-only` (a negative claim — "no harness surface exists" for the claim's own specific
-  assertion; see the graded rule below):** absence cannot be proven from one page. Record the basis (the harness doc section(s) checked, or `unverified-inference` when
+  assertion; see the near-miss rule below):** absence cannot be proven from one page. Record the
+  basis (the harness doc section(s) checked, or `unverified-inference` when
   none was); a contested or load-bearing `api-only` tag escalates to the interview rather than
   standing on an absence citation. **The basis records the exact command run and its raw result
   count**, not a prose summary of what was checked — an attested zero is not a reproducible zero,
@@ -82,25 +69,17 @@ the tag asserts:
   still the most-violated rule in that slice; the cost is documented, not hypothetical — an
   undisclosed `settings.md:727` near-miss was exactly what the unread portion of a 199-line hit set
   contained.)
-- **What falsifies `api-only`, and what only comes close — one graded rule, because the whole class
-  of defects here is the boundary being re-derived per row.** `api-only` asserts no harness surface
-  for **the claim's own specific assertion**, so only the corpus documenting *that assertion*
-  falsifies it; topical overlap never does. Two grades sit below the falsifying line, and the tag
-  survives both:
-  - **Near-miss — a harness page covers the row's subject without stating the row's specific
-    rule.** The row MUST name it by page and line (the term this profile already uses of
-    `settings.md:727` above), and an affirmative "no surface" or "undisclosed" phrasing in such a
-    row is simply false and goes. Silence here was the largest MINOR class in the slice that
-    measured it: one release-notes unit disclosed 24 near-miss rows on its own, and two sibling
-    units in that slice raised the same boundary independently, one of them asking outright for a
-    standing notation so a reader can tell "no surface at all" from "adjacent surface exists".
-  - **Weaker than a near-miss, and often mistaken for one.** A counterpart artifact on the *other*
-    property (a harness `llms.txt` beside a claim about the platform's own `llms.txt`) and a
-    workload named only as an example beside a guide that teaches it (an SDK hosting page naming
-    "a customer support agent") do not cover the row's subject at all. Neither falsifies
-    `api-only`: the tag scopes to the specific artifact or surface the row names. (Both were
-    contested escalations on the resources-hub slice, and both verification arms adjudicated them
-    the same way.)
+- **What falsifies `api-only`, and what only comes close — written down once, because the whole
+  class of defects here is the boundary being re-derived per row.** `api-only` asserts no harness
+  surface for **the claim's own specific assertion**, so only the corpus documenting *that
+  assertion* falsifies it; topical overlap never does. Below that falsifying line sits the
+  **near-miss** — a harness page covers the row's subject without stating the row's specific rule.
+  The tag survives, the row MUST name the near-miss by page and line (the term this profile already
+  uses of `settings.md:727` above), and an affirmative "no surface" or "undisclosed" phrasing in
+  such a row is simply false and goes. Silence here was the largest MINOR class in the slice that
+  measured it: one release-notes unit disclosed 24 near-miss rows on its own, and two sibling units
+  in that slice raised the same boundary independently, one of them asking outright for a standing
+  notation so a reader can tell "no surface at all" from "adjacent surface exists".
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
   SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
   reserved for claims naming no API surface.
@@ -110,18 +89,6 @@ the tag asserts:
   uncertainty marker, never a substitute for the tag. (Both rulings from the sonnet-5 guide
   slice's cross-vendor verification, where citation-by-reference and marker-as-tag were the
   dominant correction class.)
-- **A positive tag's row answers two questions as two bullets, never as one merged sentence.** They
-  are separate questions with separate answers, and merging them is what leaves a tag unauditable:
-  - *Is the assertion itself documented?* — the live-doc citation for the assertion, or the
-    attestation marker saying no doc states it.
-  - *Does the harness have the surface the guidance operates on?* — the live-doc citation the
-    positive tag itself rests on.
-  A row that answers only the first reads as "nothing to cite" and silently drops the second. The
-  collapse is most tempting where the assertion is blog-only and the surface is well documented,
-  but the requirement is on **every** positive-tag row. (Both verification arms independently filed
-  the same finding against one unit — 12 positive-tag rows with no row-local live URL, 6 with no
-  applicability evidence at all — and the corrector who repaired those rows diagnosed this collapse
-  as their cause and asked for it to be carried into the profile.)
 - **Row-local reachability — a cited site no recorded command produces has been asserted, not
   disclosed.** A `file.md:NN` in a row's evidence counts as disclosed only when some command
   recorded in that same row produces it; otherwise the row says so explicitly, and an explicit
@@ -149,14 +116,6 @@ the tag asserts:
   that composes with the tag and, where applicability itself is inferred, with
   `unverified-inference`. (Shape recommended by the context-engineering blog slice's handoff,
   exercised end-to-end and enforced by both verifiers on the models-explained slice.)
-- **The attestation follows the vendor voice, not the containing page.** Vendor-voice material
-  EMBEDDED in a non-blog page — a blog passage a system prompt quotes, an announcement excerpt
-  inside a release note — carries the same marker on the same terms, sourced to the embedded
-  material rather than to the host page. The marker exists to stop an unverifiable vendor
-  assertion being read as documented fact, and that risk does not change with the type of page the
-  assertion happens to sit inside. (A release-notes system prompt embedded a blog passage whose
-  "less than 5% of sessions" trigger-rate figure no harness doc restates; the digest disclosed the
-  gap in prose but the row carried no marker, because the rule was scoped to blog *sources*.)
 
 ## Digest-agent model matching
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -16,11 +16,14 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   extract. Record the channel used. **Two extraction artifacts reproduce on this channel; record
   them, never repair them** — `source.*` is immutable, so the fix belongs in whatever reads the
   snapshot, not in the snapshot. (a) The animated hero heading collapses every space in the H1.
-  Reconstruct the title from the canonical URL slug; when the run also retained the rendered HTML,
-  that file's `<title>`/`<h1>` carries the spaced form, but nothing in the pipeline contracts such
-  a file — the slug is the reconstruction that is always available. (b) The reading-time widget
-  splits its value and its unit onto separate physical lines, so neither line reads as a duration
-  on its own. (Both observed identically in two runs, at each slice's `source.md:7`:
+  Reconstruct the title from the canonical URL slug, which the checklist already records — but the
+  slug recovers word boundaries only, never punctuation or casing
+  (`claude-models-explained-choosing-the-best-model-for-your-use-case` cannot yield the colon in
+  "Claude models explained: choosing the best model for your use case"), so a title recovered that
+  way is labelled reconstructed. When the run also retained the rendered HTML, that file's
+  `<title>`/`<h1>` carries the exact form — but nothing in the pipeline contracts such a file, so
+  it is a bonus, not the method. (b) The reading-time widget splits its value and its unit onto
+  separate physical lines, so neither line reads as a duration on its own. (Both observed identically in two runs, at each slice's `source.md:7`:
   `# Claudemodelsexplained:choosingthebestmodelforyourusecase` with the reading time at lines
   83/87, and `# BuildingverificationloopsinClaudeCodewithskills` with it at lines 45/49.)
 - **PDFs (model/system cards):** download the original binary as `source.pdf` plus a text
@@ -39,9 +42,11 @@ A second publisher joins as a sibling profile file; engine extraction waits for 
   <https://platform.claude.com/llms.txt> enumerates the platform property's pages and
   <https://code.claude.com/docs/llms.txt> the harness property's; fetch the index raw with `curl`,
   record the retrieved length as for any other absence-establishing fetch, and let it select the
-  pages. **A non-zero hit — in the index or in any corpus snapshot — is READ at its match site,
-  never counted.** A snapshot page can be rendered HTML rather than doc prose, in which case its
-  hits are page chrome and the count is noise no reader of the number can detect. (Both indexes
+  pages. **A non-zero hit in the index, or in a snapshot page that turns out to be rendered HTML
+  rather than doc prose, is READ at its match site and never treated as a count** — such a page's
+  hits are its markup, and no reader of the number can detect that. The sampled-scope disclosure in
+  the applicability filter's non-zero-result rule below stays the one sanctioned way to fall short
+  of reading a hit set in full. (Both indexes
   verified live 2026-08-02: 616 lines / 56,941 bytes and 180 lines / 38,847 bytes. The
   page-chrome counter-fact is measured, not hypothetical — one campaign snapshot of nine platform
   pages held two that begin `<!DOCTYPE html>`, and two of the three terms a slice probed that
@@ -60,8 +65,8 @@ the tag asserts:
   without a live-doc check, is additionally recorded as `unverified-inference` and becomes an
   interview question, never a silent fact. (This rule exists because inference has already produced a
   wrong tag once — the failure mode is real.)
-- **`api-only` (a negative claim — "no harness surface exists"):** absence cannot be proven from
-  one page. Record the basis (the harness doc section(s) checked, or `unverified-inference` when
+- **`api-only` (a negative claim — "no harness surface exists" for the claim's own specific
+  assertion; see the graded rule below):** absence cannot be proven from one page. Record the basis (the harness doc section(s) checked, or `unverified-inference` when
   none was); a contested or load-bearing `api-only` tag escalates to the interview rather than
   standing on an absence citation. **The basis records the exact command run and its raw result
   count**, not a prose summary of what was checked — an attested zero is not a reproducible zero,


### PR DESCRIPTION
Second batch of evidence-forced docpage-digest amendments. `knowledge` 0.10.15 -> 0.10.16. Two rules ship; six items are deliberately held, each with its reason stated.

## What ships

- **PA-Y — the near-miss disclosure rule, written into the profile.** It previously lived only inside Ruling 1 Decision A and was re-derived per unit, which is why undisclosed near-misses are the largest MINOR class in the slice that measured it. A harness page covering the same subject without stating the claim's specific rule is a near-miss: the tag survives, and the row must disclose it by name and line.
- **PA-Z — blog-channel extraction artifacts** (collapsed H1, split reading-time) with reconstruction guidance. Its deferral condition was met: a second `claude.com/blog` run reproduced both exactly, re-verified byte-exact in both slices. The guidance leads with the canonical URL slug and states what a slug **loses** — word boundaries recover, punctuation and casing do not — so a slug-recovered title is labelled reconstructed.
- **PA-AG — verified and closed, no edit.** The `cc-applicable`/`mixed` boundary rule already in the profile matches what its source asked for.

## What is held, and why — two different reasons

**Five held because the campaign's judgment file holds them.** PA-I (J-6), PA-Q (J-7), PA-N (J-8), PA-M (J-12) and PA-AD (J-14) were shipped in the first draft of this branch and then withdrawn. The triage marks them `evidence-forced`; `PHASE2-JUDGMENT-AMENDMENTS` writes them up as judgment calls under a header stating "None applied." Two records disagreed, and the judgment file governs on its own reasoning:

- J-14 says outright it is "held here only because no defect was demonstrated, so the bar for the applied subset is not met."
- J-7 says it "should be decided **after** Decision-A ordering" — an escalated, owner-reserved question. Shipping it would have pre-empted a decision the owner kept for himself.

They are now full rows in the owner-decision artifact, each restating the triage-vs-judgment conflict rather than resolving it silently. Between the two readings they would otherwise have landed in neither place.

**Three held because they change untracked instruments.** PA-B's second half, PA-P and PA-AK all modify scripts under the memory-tier `.work/` root, which is never committed and is not part of the shipped plugin.

## Verification

Independently verified twice. The first round FAILED on the five judgment-held rules. The second confirmed the split is clean: `SKILL.md` is byte-identical to its 0.10.15 state, grep finds no residue of the withdrawn rules, and PA-Y reads as a whole rule rather than half of the graded pair it was originally merged into.

The implementer also ran a second pass over the whole *file* rather than the diff, and caught three defects in its own first commit — including a new rule that contradicted one shipped in #1875, which is exactly the two-rules-for-one-boundary drift this pipeline exists to prevent.

No linked issue

## Related

- Follows #1875 (`knowledge` 0.10.15), which shipped the first evidence-forced batch.
- Phase 3a self-alignment merged in #1876, #1877, #1878; this repo conforms before any of it ships outward.