### PR TITLE
feat(claude-config): corroborate I10 and concretize its remediation surfaces

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Five audit skills for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), and audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.18.0]
+
+### Added
+
+- **`audit-instructions`: I10 gains a second corroborating source and a concretized remediation**
+  (criteria 1.4.0 → 1.5.0). The Thinking page states the same `reasoning_extraction` refusal I10
+  already cited from the Fable 5 guide, from a second, independent page — a feature page rather than
+  a model guide. The row records why that citation does **not** move the promotion gate: the page's
+  own section names both Claude Fable 5 and Claude Mythos 5 for the adjacent raw-chain-of-thought
+  property, then names Fable 5 alone for the refusal, so the narrower scope is deliberate rather
+  than an omission. **`Model scope: fable-5` is unchanged, and `mythos-5` is deliberately not
+  added** — no source states the refusal for Mythos 5, and inheriting it from a claim about a
+  different property is exactly the near-miss scope inheritance the catalog's model-scoping block
+  forbids.
+
+  **The Remediate line now names the surfaces instead of gesturing at them.** It said "read
+  structured `thinking` blocks or use a send-to-user tool"; the sanctioned reading surfaces are
+  `Ctrl+O` verbose mode and the `showThinkingSummaries: true` setting in Claude Code, and
+  `display: "summarized"` on the API. The two Claude Code surfaces are stated on the model
+  configuration page, **not** on the Thinking page, so both pages join the catalog's `## Sources`
+  list — the Recheck-triggers block makes the trigger set the source set, and a cited page nothing
+  watches would leave the row depending on an unwatched source.
+
 ## [0.17.0]
 
 ### Fixed

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -1,6 +1,6 @@
 ---
-version: 1.4.0
-last-updated: 2026-07-30
+version: 1.5.0
+last-updated: 2026-08-02
 ---
 
 # Instruction-Audit Criteria
@@ -83,6 +83,10 @@ I15–I16 apply to all surfaces; I13 and I14 name narrower surface sets in their
   <https://code.claude.com/docs/en/hooks>
 - Refusals and fallback (`reasoning_extraction`) —
   <https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback>
+- Thinking (the sanctioned reasoning-visibility path, and the `display` field) —
+  <https://platform.claude.com/docs/en/build-with-claude/thinking>
+- Model configuration (the harness-side thinking-display surfaces) —
+  <https://code.claude.com/docs/en/model-config>
 - CLI reference (`claude doctor` and the other terminal forms) —
   <https://code.claude.com/docs/en/cli-reference>
 - Subagents (what loads into a subagent at startup) — <https://code.claude.com/docs/en/sub-agents>
@@ -299,10 +303,19 @@ Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces:
 
 - **Detect:** instructions telling the model to show, echo, transcribe, or explain its internal
   reasoning as response text. The deterministic pre-scan marks show-your-thinking phrasing.
-- **Remediate:** remove them; read structured `thinking` blocks or use a send-to-user tool if
-  reasoning visibility is needed.
+- **Remediate:** remove them; where reasoning visibility is genuinely needed, read structured
+  `thinking` blocks through the surface that already exposes them — in Claude Code, `Ctrl+O` verbose
+  mode and the `showThinkingSummaries: true` setting (model configuration); on the API,
+  `display: "summarized"` (Thinking). A send-to-user tool remains the path when the reasoning has to
+  reach the user as ordinary response text.
 - **Source:** Fable 5 guide — such instructions "can trigger the `reasoning_extraction` refusal
-  category on Claude Fable 5, causing elevated fallbacks."
+  category on Claude Fable 5, causing elevated fallbacks." Corroborated by the Thinking page, which
+  states the same refusal for the same model: "On Claude Fable 5, a request that attempts to elicit
+  the model's internal reasoning as part of the response text can be refused with
+  `stop_details.category: "reasoning_extraction"`." That second citation does **not** move the
+  promotion gate: its own section names both Claude Fable 5 and Claude Mythos 5 for the adjacent
+  raw-chain-of-thought property, then names Fable 5 alone for the refusal — a sentence-adjacent
+  chance to widen, declined, so the narrower scope is deliberate.
 
 ### I11: CLI over MCP where equivalent
 


### PR DESCRIPTION
Applies the evidence-forced half of the RA-9 extend-or-cite pass to instruction-audit catalog row **I10** (reasoning-echo). `claude-config` 0.17.0 -> 0.18.0; `criteria.md` 1.4.0 -> 1.5.0.

## What this does NOT do, and why that is the point

**I10 keeps `Model scope: fable-5`. It is not promoted, and `mythos-5` is not added.**

The campaign triage ranked this promotion its **#1 item**, on the theory that the extended-thinking platform page is a second, model-independent source that would satisfy I10's promotion gate. It is not, and the page's own structure is what settles it:

- `:874` — the H2 reads "Thinking output on Claude Fable 5 **and Claude Mythos 5**"
- `:876` — names **both** models for the adjacent raw-chain-of-thought property
- `:887` — names **only** Claude Fable 5 for `stop_details.category: "reasoning_extraction"`

Eleven lines apart, in one section. The page had a sentence-adjacent opportunity to widen the refusal and declined it. That is deliberate scoping, not loose phrasing. Adding `mythos-5` would fabricate scope from a claim about a different property — exactly what the catalog's own model-scoping block warns against.

That reasoning is now recorded **in the row itself**, so it is not re-litigated a fourth time.

## What it does

- **A corroborating second Source** — the extended-thinking page, independent of the Fable 5 model guide already cited.
- **A concretized Remediate line.** It previously said, abstractly, to read structured `thinking` blocks or use a send-to-user tool. It now names the actual surfaces: `Ctrl+O` verbose mode and `showThinkingSummaries: true`, and `display: "summarized"`.

**Each surface is attributed to the page that actually states it.** The pass this work came from asserted all three were on the thinking page; two of them are not — `Ctrl+O` and `showThinkingSummaries` are stated at `model-config:532`, and only `display: "summarized"` is on the thinking page. Both pages are therefore added to `## Sources`, because `criteria.md` carries its own invariant that "the trigger set is the source set — naming a subset would leave the harness-behavior rows depending on pages nothing watches."

## Verification

Independently verified by a second model, with the implementer's rationale withheld. Both pages re-fetched raw (`model-config.md` 83,644 bytes; `thinking.md` 52,769 bytes, byte-identical to the frozen snapshot), all three surface names confirmed verbatim, and the promotion-gate facts re-confirmed at both snapshot and live bytes.

**Self-fire check.** Because a catalog row that fires on this repo would break the campaign's own rule against shipping a consumer check we fail: the scanner was run against both trees. I10 candidates in `criteria.md` go 2 -> 4, and all four are inert — `criteria.md` is a skill reference file, outside the audited population (`CLAUDE.md` / `rules/` / `skills/` / `agents/` / `output-styles/` under the user and project roots). No new class of self-hit is introduced.

Detection is untouched: `instruction-scan.test.sh` reports 46/46, and this edit changes Source and Remediate only.

## Held back deliberately

The **I8-b promotion**, whose gate genuinely IS met by verbatim two-guide convergence, is not here. Promoting it makes the row fire on this repo's own `plugins/review/context/severity.md` — the same work as triage row RA-2, an open owner decision. Shipping the promotion first would make the next audit run flag this repository.

No linked issue

## Related

- Phase 3b of the doc-corpus campaign; Phase 3a self-alignment merged in #1875, #1876, #1877, #1878, #1879.
- Source pass: `RA9-EXTEND-OR-CITE-PASS-2026-08-02.md` (23 rows adjudicated; the triage had checked 6).