### PR TITLE
feat(claude-config,review): promote I8-b to unscoped and give severity.md enumerable tier criteria

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Five audit skills for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), and audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   follows literally" is now "which **current models** follow literally" — the demonstrative
   referred to the row's scoped model, and an unscoped row has none.
 
+  **The Recheck-triggers block no longer enumerates the model-specific pages.** It read
+  "Model-specific pages (the Fable 5 and Opus 5 guides) are superseded on each model generation" —
+  a closed list the Sonnet 5 addition immediately falsified. It now reads "the per-model prompting
+  guides under Sources", which stays true as guides join. The enumeration also contradicted its own
+  paragraph three lines above, which argues that "naming a subset would leave the harness-behavior
+  rows depending on pages nothing watches."
+
 - **I8-b's Source line now cites the phrase it could not.** The row's Detect names three trigger
   phrases; **"don't nitpick" appears nowhere in the Opus 5 guide**, which states only the other
   two. The Sonnet 5 guide names all three verbatim, so it is that phrase's only cited home, and the

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -15,7 +15,9 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   thoroughly and then withholds findings below the stated bar. Two first-party model guides of the
   same class converging is the promotion gate's **second arm**, so the row is now annotated the way
   I7 is and fires for every target model. The Sonnet 5 guide joins `## Sources`, as the
-  Recheck-triggers block requires of every cited page.
+  Recheck-triggers block requires of every cited page. The Detect line's "which **this** model
+  follows literally" is now "which **current models** follow literally" — the demonstrative
+  referred to the row's scoped model, and an unscoped row has none.
 
 - **I8-b's Source line now cites the phrase it could not.** The row's Detect names three trigger
   phrases; **"don't nitpick" appears nowhere in the Opus 5 guide**, which states only the other

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.0]
+
+### Changed
+
+- **`audit-instructions`: I8-b (conservative-reporting detection) is promoted to unscoped**
+  (criteria 1.5.0 → 1.6.0). The row carried `Model scope: opus-5` and fired only when the resolved
+  target model was Opus 5. The **Sonnet 5** prompting guide, "Code review harnesses", states the
+  same claim about the same behavior — a review prompt saying "only report high-severity issues",
+  "be conservative", or "don't nitpick" is followed literally, so the model investigates just as
+  thoroughly and then withholds findings below the stated bar. Two first-party model guides of the
+  same class converging is the promotion gate's **second arm**, so the row is now annotated the way
+  I7 is and fires for every target model. The Sonnet 5 guide joins `## Sources`, as the
+  Recheck-triggers block requires of every cited page.
+
+- **I8-b's Source line now cites the phrase it could not.** The row's Detect names three trigger
+  phrases; **"don't nitpick" appears nowhere in the Opus 5 guide**, which states only the other
+  two. The Sonnet 5 guide names all three verbatim, so it is that phrase's only cited home, and the
+  Source line says so rather than leaving a trigger phrase attributed to a page that does not
+  contain it.
+
+- **I8-b's Remediate line gains the constructive half.** It said only "rephrase to
+  report-everything + a separate filter/rank pass", which does not answer the case where a
+  single-pass self-filter is genuinely wanted. The Sonnet 5 guide covers that case — "be concrete
+  about where the bar is rather than using qualitative terms like `important`" — so the line now
+  keeps the filter and asks for an enumerable test in place of a qualitative label.
+
+  **Promoting this row flags nothing new in this repository.** The scanner's I8-b population here
+  is 23 candidate rows across 6 files, every one of them already fenced by the row's own two
+  fences — the restraint-clause shape (`code-tidying`'s tidyings catalog) and the quoted/meta
+  surface (this criteria file, the scanner and its tests, two model-adaptation delta chapters).
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -248,7 +248,7 @@ on its second arm: a second model guide, the Sonnet 5 one, states the same claim
 three trigger phrases (see Source), so this fires for every target model.
 
 - **Detect:** review/report instructions that gate severity at the FINDING stage — "be
-  conservative," "only report high-severity issues," "don't nitpick" — which this model follows
+  conservative," "only report high-severity issues," "don't nitpick" — which current models follow
   literally, withholding real findings. The gate is about WITHHOLDING findings from the audit or
   report output: severity-based routing where everything is still reported somewhere ("only page
   on-call for high-severity; log the rest") and non-reporting uses of "conservative"

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -1,5 +1,5 @@
 ---
-version: 1.5.0
+version: 1.6.0
 last-updated: 2026-08-02
 ---
 
@@ -72,6 +72,8 @@ I15–I16 apply to all surfaces; I13 and I14 name narrower surface sets in their
   <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5>
 - Prompting Claude Opus 5 —
   <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5>
+- Prompting Claude Sonnet 5 —
+  <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5>
 - Memory (CLAUDE.md, rules, auto memory) — <https://code.claude.com/docs/en/memory>
 - The `.claude` directory — <https://code.claude.com/docs/en/claude-directory>
 - Skills (what loads when, how supporting files are referenced, the listing budget,
@@ -211,8 +213,8 @@ so this fires for every target model.
 
 Tier `behavioral` · Authority `ANTHROPIC-DOCS` · Severity `warning` · Surfaces: all.
 
-The base row and each model row carry their own `Model scope` (single-model guide sources;
-promotion gate unmet for all of them).
+The base row and rows I8-a and I8-c carry their own `Model scope` (single-model guide sources;
+promotion gate unmet). Row I8-b is unscoped — two model guides converge on it (see the row).
 
 **Base row** · Model scope: `fable-5`.
 
@@ -241,7 +243,9 @@ promotion gate unmet for all of them).
   tokens with no loss in quality"; "Self-correction" — avoid instructing re-checks it already
   performs.
 
-**Row I8-b: conservative-reporting detection** · Tier `behavioral` · Model scope: `opus-5`.
+**Row I8-b: conservative-reporting detection** · Tier `behavioral`. Unscoped — promotion gate MET
+on its second arm: a second model guide, the Sonnet 5 one, states the same claim about the same
+three trigger phrases (see Source), so this fires for every target model.
 
 - **Detect:** review/report instructions that gate severity at the FINDING stage — "be
   conservative," "only report high-severity issues," "don't nitpick" — which this model follows
@@ -261,11 +265,20 @@ promotion gate unmet for all of them).
      an operative directive ("follow the maxim: 'only report high-severity issues'") is still
      operative and IS a finding; the exemption is for documents about the pattern, never for
      quotation as packaging.
-- **Remediate:** rephrase to report-everything + a separate filter/rank pass.
+- **Remediate:** rephrase to report-everything + a separate filter/rank pass. Where a single-pass
+  self-filter is genuinely wanted, keep it but **state the bar concretely** — an enumerable test the
+  reader can decide a novel finding against — rather than a qualitative term.
 - **Bounded by:** the **Stopping condition** below, which is enabled by default.
-- **Source:** Opus 5 guide, "Code review and bug-finding" — the model "may follow that
-  instruction literally and report less; ask it to report everything and filter in a separate
-  pass instead."
+- **Source:** Opus 5 guide, "Code review and bug-finding" — if the prompt says "only report
+  high-severity issues" or "be conservative," the model "may follow that instruction literally and
+  report less; ask it to report everything and filter in a separate pass instead." Convergent
+  second model guide (the gate-meeting one): Sonnet 5 guide, "Code review harnesses" — on the same
+  three phrases, "Claude Sonnet 5 may follow that instruction more faithfully than earlier models
+  did: it may investigate the code just as thoroughly, identify the bugs, and then not report
+  findings it judges to be below your stated bar." That guide is also the only cited home of the
+  third trigger phrase — **"don't nitpick" appears nowhere in the Opus 5 guide** — and it states
+  the Remediate line's concrete-bar half: "be concrete about where the bar is rather than using
+  qualitative terms like `important`."
 
 **Row I8-c: don't-think / don't-reason directive** · Tier `behavioral` · Model scope: `opus-5`.
 

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -14,8 +14,8 @@ cited URL, not restated here).
 docs when any fires: a new frontier model release; **a change to any page listed under Sources
 below**. Every check cites one of those pages, so the trigger set is the source set — naming a
 subset would leave the harness-behavior rows depending on pages nothing watches. One staleness event
-fires the whole catalog, not the check that noticed it. Model-specific pages (the Fable 5 and
-Opus 5 guides) are superseded on each model generation.
+fires the whole catalog, not the check that noticed it. Model-specific pages — the per-model
+prompting guides under Sources — are superseded on each model generation.
 
 **Axes.** Three orthogonal axes, never conflated:
 

--- a/plugins/review/.claude-plugin/plugin.json
+++ b/plugins/review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "review",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "description": "Code-review toolkit: six read-only reviewer agents (code, security, architecture, doc drift, build/test/lint, CI-log audit) plus two orchestration skills — a single-lens quality gate and a multi-surface review fan-out with severity-ranked, deduplicated findings.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the `review` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.16.0]
+
+### Changed
+
+- **`context/severity.md`: each severity tier is now stated as a decidable test, not a qualitative
+  label.** The tiers read "Must fix" / "Should fix" / "Consider" plus a list of examples, which lets
+  a reviewer place a finding that resembles a listed example but leaves a novel finding undecidable.
+  The Sonnet 5 prompting guide, "Code review harnesses", names this shape directly — "be concrete
+  about where the bar is rather than using qualitative terms like `important`", the qualitative term
+  being one of this file's own tier names. Each tier now carries a test the reviewer can argue a
+  finding against: CRITICAL, whether you can name a concrete input, caller, or subsequent change the
+  defect makes produce a wrong, unsafe, or absent result; IMPORTANT, whether the finding names a
+  stated rule violated, behavior added that no test covers, or a degradation or maintenance cost
+  with a named trigger; SUGGESTION, neither, so a preference among alternatives that all work. The
+  example lists are retained as illustrations of the tests.
+
+  **No finding changes tier.** The tests were written to restate the existing bars, and the example
+  lists are unchanged — this states the criterion, it does not re-tier.
+
+- **The P1–P5 security fold now states its precedence over the tier tests.** `security-reviewer`
+  emits CVSS-anchored P-levels folded as P1/P2 → CRITICAL, P3 → IMPORTANT, P4/P5 → SUGGESTION.
+  CRITICAL's new test names an unsafe result, which a P3 finding also satisfies read literally, so
+  the fold is now marked as deciding the tier for a P-scored finding. Without that precedence the
+  criterion-stating change would have silently promoted every P3 to CRITICAL.
+
 ## [0.15.5]
 
 ### Fixed

--- a/plugins/review/CHANGELOG.md
+++ b/plugins/review/CHANGELOG.md
@@ -13,14 +13,25 @@ All notable changes to the `review` plugin are documented here. Format follows
   The Sonnet 5 prompting guide, "Code review harnesses", names this shape directly — "be concrete
   about where the bar is rather than using qualitative terms like `important`", the qualitative term
   being one of this file's own tier names. Each tier now carries a test the reviewer can argue a
-  finding against: CRITICAL, whether you can name a concrete input, caller, or subsequent change the
-  defect makes produce a wrong, unsafe, or absent result; IMPORTANT, whether the finding names a
+  finding against: CRITICAL, whether you can name a concrete input, caller, or subsequent
+  otherwise-correct change the defect makes produce a wrong, unsafe, or absent result; IMPORTANT,
+  whether the finding names a
   stated rule violated, behavior added that no test covers, or a degradation or maintenance cost
   with a named trigger; SUGGESTION, neither, so a preference among alternatives that all work. The
   example lists are retained as illustrations of the tests.
 
   **No finding changes tier.** The tests were written to restate the existing bars, and the example
   lists are unchanged — this states the criterion, it does not re-tier.
+
+  **CRITICAL's subsequent-change limb is qualified `otherwise-correct`, which is what holds that
+  guarantee.** Unqualified, "a subsequent change that the defect makes produce a wrong result" is
+  satisfied by **code duplication** read literally — the subsequent change is an edit to one copy,
+  after which the copies diverge. Because the tests are applied in order and resemblance to a listed
+  example is explicitly not a rebuttal, that CRITICAL match would win and silently promote
+  duplication out of IMPORTANT, where the previous text pinned it. The qualifier draws the line the
+  example lists already assumed: a **cascading architecture violation** breaks a future change whose
+  author did everything right, so it stays CRITICAL, while **duplication** bites only through a
+  future edit that is itself incomplete, so it stays IMPORTANT.
 
 - **The P1–P5 security fold now states its precedence over the tier tests.** `security-reviewer`
   emits CVSS-anchored P-levels folded as P1/P2 → CRITICAL, P3 → IMPORTANT, P4/P5 → SUGGESTION.

--- a/plugins/review/context/severity.md
+++ b/plugins/review/context/severity.md
@@ -4,11 +4,15 @@ Shared vocabulary for every finding this plugin's agents and skills emit. **Cons
 
 ## Severity tiers
 
-| Tier | Definition | Action |
-|---|---|---|
-| **CRITICAL** | Must fix before merge: correctness bugs, security vulnerabilities, broken contracts, architecture violations that will cascade | Block until fixed |
-| **IMPORTANT** | Should fix: convention drift, missing tests for new behavior, code duplication, error-handling gaps that degrade but do not break | Fix before or shortly after merge |
-| **SUGGESTION** | Consider: naming improvements, minor refactoring opportunities, hardening with no current exploitability | Optional; author's judgment |
+Apply the tests in order; the first tier whose test the finding satisfies is its tier. **The test decides the tier — the examples illustrate the test rather than enumerating the tier.** Argue a finding's tier from its test; resemblance to a listed example is not that argument.
+
+| Tier | Test | Illustrative findings | Action |
+|---|---|---|---|
+| **CRITICAL** | You can name a concrete input, caller, or subsequent change that the defect makes produce a wrong result, an unsafe one, or none at all | correctness bugs, security vulnerabilities, broken contracts, architecture violations that will cascade | Block until fixed |
+| **IMPORTANT** | Nothing produces a wrong result today, but the finding names a stated rule the change violates, behavior it adds that no test covers, or a degradation or maintenance cost with a named trigger | convention drift, missing tests for new behavior, code duplication, error-handling gaps that degrade but do not break | Fix before or shortly after merge |
+| **SUGGESTION** | Neither test holds — the finding is a preference among alternatives that all work, or hardening with no path reachable today | naming improvements, minor refactoring opportunities, hardening with no current exploitability | Optional; author's judgment |
+
+Stating the bar as a decidable test rather than a qualitative label follows the Sonnet 5 prompting guide, "Code review harnesses" — "be concrete about where the bar is rather than using qualitative terms like `important`" (<https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5>). The tests restate the existing bars rather than moving any finding between tiers.
 
 ## Confidence axis
 
@@ -24,3 +28,5 @@ Independent of severity — how sure the reviewer is that the finding is real:
 ## Security severity mapping
 
 The `security-reviewer` agent emits P1–P5 (CVSS-anchored). Fold into tiers as: P1/P2 → CRITICAL, P3 → IMPORTANT, P4/P5 → SUGGESTION.
+
+**This fold decides the tier for a P-scored finding and takes precedence over the tier tests above.** The P-level already encodes exploitability and impact, so a P3 folds to IMPORTANT rather than being re-tested against CRITICAL's "unsafe result" clause and promoted.

--- a/plugins/review/context/severity.md
+++ b/plugins/review/context/severity.md
@@ -8,7 +8,7 @@ Apply the tests in order; the first tier whose test the finding satisfies is its
 
 | Tier | Test | Illustrative findings | Action |
 |---|---|---|---|
-| **CRITICAL** | You can name a concrete input, caller, or subsequent change that the defect makes produce a wrong result, an unsafe one, or none at all | correctness bugs, security vulnerabilities, broken contracts, architecture violations that will cascade | Block until fixed |
+| **CRITICAL** | You can name a concrete input, caller, or subsequent **otherwise-correct** change that the defect makes produce a wrong result, an unsafe one, or none at all | correctness bugs, security vulnerabilities, broken contracts, architecture violations that will cascade | Block until fixed |
 | **IMPORTANT** | Nothing produces a wrong result today, but the finding names a stated rule the change violates, behavior it adds that no test covers, or a degradation or maintenance cost with a named trigger | convention drift, missing tests for new behavior, code duplication, error-handling gaps that degrade but do not break | Fix before or shortly after merge |
 | **SUGGESTION** | Neither test holds — the finding is a preference among alternatives that all work, or hardening with no path reachable today | naming improvements, minor refactoring opportunities, hardening with no current exploitability | Optional; author's judgment |
 


### PR DESCRIPTION
Promotes instruction-audit catalog row **I8-b** (conservative-reporting detection) to unscoped and gives `plugins/review/context/severity.md` enumerable tier criteria. `claude-config` 0.18.0 -> 0.19.0; `review` 0.15.5 -> 0.16.0; `criteria.md` 1.5.0 -> 1.6.0.

## The promotion

I8-b's gate is MET on its second arm (multiple model guides converge): the Sonnet 5 prompting guide states all three trigger phrases verbatim in one sentence (`source.md:140`, "Code review harnesses"), converging with the Opus 5 guide. Annotated in row I7's met-gate precedent form; the Sonnet 5 guide URL added to `## Sources` per the trigger-set-is-the-source-set invariant.

**Source attribution corrected while citing:** "don't nitpick" appears nowhere in the Opus 5 guide (`grep -cin nitpick` -> 0); that guide states only the other two phrases (its line 20). The Sonnet 5 guide is the phrase's only cited home. This strengthens the convergence gate — three phrases now each attributed to a page that actually contains them.

## #1880's "Held back deliberately" premise was wrong

That PR deferred this promotion because unscoping I8-b would allegedly make it fire on `severity.md`. It does not, on three independently verified grounds:

1. **Zero scanner candidates** — the real scanner over `severity.md` emits one I6 row and no I8-b; the I8-b ERE greps 0 on both trees.
2. **I8-b's own carve-out** (`criteria.md:252-255`) excludes "severity-based routing where everything is still reported somewhere" — severity.md classifies findings and withholds none.
3. **Outside the audited population** — SKILL.md Phase A inventories CLAUDE.md / rules/ / skills/ / agents/ / output-styles/ under user and project roots plus hook text; `plugins/review/context/` is none of those (same result #1880 recorded for `criteria.md` itself).

The promotion could have shipped alone. The severity.md work ships here anyway, **re-founded on its own source**: nine lines below the three-phrase line, the same Sonnet 5 guide says to "be concrete about where the bar is rather than using qualitative terms like `important`" (`source.md:150`) — and `important` is one of severity.md's own tier names. That is triage row RA-2, a distinct claim from the one I8-b cites.

## The severity rewrite

Each tier now carries a decidable test instead of a qualitative label; no finding changes tier. Guards added where the criterion-stating change could have silently re-tiered:

- The P1-P5 fold explicitly takes precedence for P-scored findings (otherwise every P3 security finding would have read into the new CRITICAL test).
- CRITICAL's subsequent-change limb reads "otherwise-correct change", so cascade architecture violations (break a *correct* future change) stay CRITICAL while code duplication (bites only through an *incomplete* future edit) stays IMPORTANT. All eleven tier examples adjudicated against the new tests — twice, independently.

## Verification

Independently verified by a second model with the implementer's rationale withheld, across two rounds. Scanner counts replayed from git refs both rounds: origin/main 23 rows / 6 files, all fenced; working tree 28 / 7, every addition this branch's own quoting. Planted-positive check: a constructed three-phrase file emitted I8-b on all three lines in the same invocation where severity.md emitted zero. Scanner-vs-git-grep equivalence proven on identical row sets. `instruction-scan.test.sh` 46/46; markdownlint 0 errors.

**Known citation defect in an immutable commit message:** `3603c8a9b8` says "eight lines later (`source.md:149`)". Both figures are wrong — the correct citation is `source.md:150`, ten lines after the three-phrase line at `source.md:140`. No tracked file carries the wrong number; recorded here rather than rewriting pushed history.

No linked issue

## Related

- Phase 3b of the doc-corpus campaign; Phase 3a merged in #1875, #1876, #1877, #1878, #1879, #1880.
- Reverses #1880's "Held back deliberately" reasoning with evidence (above).
- Triage rows: RA-2 (severity criteria), RA-9/Q6 (I8-b promotion), owner decision Q9 (bundling).
