### PR TITLE
feat(claude-config): ship the IA consumer rule cluster — I17, I18, I19, I20

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Five audit skills for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), and audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -11,48 +11,68 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   1.6.0). All four carry knowledge outward rather than inward: they detect defects in repos this
   fleet does not control, and each is agnostic to user, machine, company and repo.
 
-  - **I17 — thinking disabled at an effort level that forbids it.** Pairing a thinking-disable
-    surface with `xhigh` or `max` effort returns a per-request 400 on Opus 5, and the pairing is
-    assemblable from configuration literals alone. **No harness documentation describes a
-    pre-request guard**, and model configuration's `MAX_THINKING_TOKENS=0` row is headed "Disable
-    regardless of effort" — so a surface repeating that heading unqualified inherits a claim the
-    effort page contradicts. The row states the hazard as real and unguarded, and deliberately does
-    **not** claim the harness prevents it. Two mechanical details keep an auditor honest: the row
-    tells them **not** to hunt `effortLevel: max`, because the settings schema stops at `"xhigh"`
-    and that literal is unreachable there, and it names the surfaces `max` does reach
-    (`CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, skill and subagent `effort` frontmatter). The
-    settings-file scan is explicitly **not** taken: it belongs to `claude-config:audit`, and an
+  - **I17 — thinking disabled at an effort level that forbids it**, as a base row plus **I17-a**
+    and **I17-b**, on I8's pattern: three shapes with three different decisive sources are three
+    rows, not one row with three citations, and splitting them lets each carry its own severity.
+    Base row (`error`): pairing a thinking-disable surface with `xhigh` or `max` effort returns a
+    per-request 400, and the pairing is assemblable from configuration literals alone. **No harness
+    documentation describes a pre-request guard**, so the row states the hazard as real and
+    unguarded and deliberately does **not** claim the harness prevents it. It also catches
+    `ultracode`, which matches neither literal but "sends `xhigh` to the model" and so produces the
+    identical rejection — match the effort that reaches the request, not the spelling. And it tells
+    an auditor **not** to hunt `effortLevel: max`: the settings schema stops at `"xhigh"`, so that
+    literal is unreachable there. I17-a (`warning`) is `MAX_THINKING_TOKENS=0` sold as a universal
+    off switch, which it is not — no effect on Fable 5, parameter merely omitted on third-party
+    providers. I17-b (`info`) is a mid-session effort change prescribed without its cache cost, and
+    it explicitly does **not** fire on Claude Code surfaces, where the harness already asks for
+    confirmation; it is for surfaces instructing an API or Agent SDK caller, where no dialog exists.
+
+    **The model range is carried as a Detect condition, not a `Model scope` annotation** — the
+    catalog's annotation is for rows sourced from a single model's *guide*, matches by exact string
+    equality, and has no range form, so annotating `opus-5` would make the row inert on the next
+    generation while the restriction ("Claude Opus 5 and later models") still holds. The source is
+    a model-agnostic feature page, so the promotion gate is met and the row is unscoped. I20 handles
+    its own model range the same way.
+
+    The settings-file scan is explicitly **not** taken: it belongs to `claude-config:audit`, and an
     instruction-content catalog that also scanned settings files would claim authority a sibling
-    already holds.
+    already holds. The discriminator is whether the content instructs, not which file holds it, so
+    a prompt-type hook's injected text stays in scope even though it lives in a settings file.
   - **I18 — thinking blocks altered on the way back to the model.** Signature preservation, the
-    `block.type == "thinking"` type-filter smell, and within-turn echo integrity. Its reach is
-    wider than API and Agent SDK client code: signature-bearing `thinking` blocks are the normal
-    on-disk shape of a local transcript, so transcript parsing, excerpting and upload or share
-    paths are in scope, and the row treats the signature as sensitive in the share case. The row
+    `block.type == "thinking"` type-filter smell, and within-turn echo integrity. Reach is wider
+    than Messages API client code — Agent SDK callers, harness integrations, and tooling that
+    rewrites a stored transcript later replayed or resumed — but the criterion is **a path back to
+    the model**, not the file format read, so read-only transcript analysis stays out. The row
     ships **no `redacted_thinking` handling clause premised on those blocks being present in local
     transcripts** — that premise is unevidenced. The term survives only inside the upstream
     sentence that is the type filter's entire stated failure mode, which is where the harm lives.
-    The row records that this repository has zero instances of any of the three shapes, so it ships
-    unexercised by its own repo rather than passing a check it never ran.
+    Zero instances of all three shapes here, recorded as a dated measurement with its own trigger
+    rather than left to read as a clean audit.
   - **I19 — restated external benchmark figure with no recheck trigger.** `OPINION`-tier and off by
     default, because no official page states that a restated benchmark figure needs a
     re-derivation event; the four-part shape it asks for is this monorepo's upstream-drift
     convention, and in a standalone install the four parts rather than the path are the
     requirement. Carries one fence the fleet needed: **a verbatim upstream baseline held for drift
     detection is never flagged**, since stamping it would corrupt the byte comparison it exists to
-    serve — a third case alongside the standing plugin-cache and managed-materialization
-    exclusions.
-  - **I20 — prefilled assistant response.** A standing model-delta row with an expected hit rate
-    near zero, confirmed at zero here. Cheap to carry, and it fires in consumer repos that still
-    prefill.
+    serve. That is a genuine suppression, which is what separates it from plugin-cache content and
+    managed materializations — those are still flagged, and the finding becomes a routing
+    recommendation to the owning repository.
+  - **I20 — prefilled assistant response**, at `error`: following the instruction produces a
+    rejected request, the same consequence class as I17 and I18. Severity tracks consequence, not
+    expected frequency — this is a standing model-delta row whose hit rate here is zero, and it
+    fires in consumer repos that still prefill.
 
 - **`audit-instructions`: per-row verification stamps** (criteria 1.5.0 → 1.6.0). A row restating a
   volatile upstream *literal* now carries the four-part record — claim, basis, as-of date, and a
-  recheck trigger naming an observable event. The catalog block states explicitly that these
-  **narrow** the catalog-wide Recheck-triggers block rather than replacing it; without that
-  sentence the catalog would carry two authorities over one behavior, which is precisely the
-  cross-surface conflict I15 exists to find. Shipping a check that silently encodes a snapshot as
-  permanent truth would reproduce, in consumers' repos, the drift this catalog exists to detect.
+  recheck trigger naming an observable event. A row that only points at its page carries none,
+  because a pointer cannot go stale. The block resolves its own relationship to the catalog-wide
+  Recheck-triggers rule rather than leaving two authorities over one behavior, which is precisely
+  the conflict I15 exists to find: a per-row stamp **supplements** the catalog trigger and never
+  narrows it, a row's own trigger names only what the Sources set would miss, and **the catalog
+  trigger wins** where they disagree. The requirement **binds on touch**, per the upstream-drift
+  convention, so rows predating it are not retroactively non-compliant. Shipping a check that
+  silently encoded a snapshot as permanent truth would reproduce, in consumers' repos, the drift
+  this catalog exists to detect.
 
 - **`audit-instructions`: five pages join `## Sources`** — effort, thinking troubleshooting,
   settings, environment variables, and prompt caching. As at 0.18.0 this is a second-order change,

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -17,9 +17,11 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
     Base row (`error`): pairing a thinking-disable surface with `xhigh` or `max` effort returns a
     per-request 400, and the pairing is assemblable from configuration literals alone. **No harness
     documentation describes a pre-request guard**, so the row states the hazard as real and
-    unguarded and deliberately does **not** claim the harness prevents it. It also catches
-    `ultracode`, which matches neither literal but "sends `xhigh` to the model" and so produces the
-    identical rejection — match the effort that reaches the request, not the spelling. And it tells
+    unguarded and deliberately does **not** claim the harness prevents it. It also catches the
+    `ultracode` **setting**, which matches neither literal but "sends `xhigh` to the model" and so
+    produces the identical rejection — match the effort that reaches the request, not the spelling.
+    The same spelling as a **prompt keyword** is fenced out: it runs one task as a workflow
+    "without changing the session's effort level", so no effort reaches the request. And it tells
     an auditor **not** to hunt `effortLevel: max`: the settings schema stops at `"xhigh"`, so that
     literal is unreachable there. I17-a (`warning`) is `MAX_THINKING_TOKENS=0` sold as a universal
     off switch, which it is not — no effect on Fable 5, parameter merely omitted on third-party

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,63 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.0]
+
+### Added
+
+- **`audit-instructions`: four consumer-facing rows — I17, I18, I19, I20** (criteria 1.5.0 →
+  1.6.0). All four carry knowledge outward rather than inward: they detect defects in repos this
+  fleet does not control, and each is agnostic to user, machine, company and repo.
+
+  - **I17 — thinking disabled at an effort level that forbids it.** Pairing a thinking-disable
+    surface with `xhigh` or `max` effort returns a per-request 400 on Opus 5, and the pairing is
+    assemblable from configuration literals alone. **No harness documentation describes a
+    pre-request guard**, and model configuration's `MAX_THINKING_TOKENS=0` row is headed "Disable
+    regardless of effort" — so a surface repeating that heading unqualified inherits a claim the
+    effort page contradicts. The row states the hazard as real and unguarded, and deliberately does
+    **not** claim the harness prevents it. Two mechanical details keep an auditor honest: the row
+    tells them **not** to hunt `effortLevel: max`, because the settings schema stops at `"xhigh"`
+    and that literal is unreachable there, and it names the surfaces `max` does reach
+    (`CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, skill and subagent `effort` frontmatter). The
+    settings-file scan is explicitly **not** taken: it belongs to `claude-config:audit`, and an
+    instruction-content catalog that also scanned settings files would claim authority a sibling
+    already holds.
+  - **I18 — thinking blocks altered on the way back to the model.** Signature preservation, the
+    `block.type == "thinking"` type-filter smell, and within-turn echo integrity. Its reach is
+    wider than API and Agent SDK client code: signature-bearing `thinking` blocks are the normal
+    on-disk shape of a local transcript, so transcript parsing, excerpting and upload or share
+    paths are in scope, and the row treats the signature as sensitive in the share case. The row
+    ships **no `redacted_thinking` handling clause premised on those blocks being present in local
+    transcripts** — that premise is unevidenced. The term survives only inside the upstream
+    sentence that is the type filter's entire stated failure mode, which is where the harm lives.
+    The row records that this repository has zero instances of any of the three shapes, so it ships
+    unexercised by its own repo rather than passing a check it never ran.
+  - **I19 — restated external benchmark figure with no recheck trigger.** `OPINION`-tier and off by
+    default, because no official page states that a restated benchmark figure needs a
+    re-derivation event; the four-part shape it asks for is this monorepo's upstream-drift
+    convention, and in a standalone install the four parts rather than the path are the
+    requirement. Carries one fence the fleet needed: **a verbatim upstream baseline held for drift
+    detection is never flagged**, since stamping it would corrupt the byte comparison it exists to
+    serve — a third case alongside the standing plugin-cache and managed-materialization
+    exclusions.
+  - **I20 — prefilled assistant response.** A standing model-delta row with an expected hit rate
+    near zero, confirmed at zero here. Cheap to carry, and it fires in consumer repos that still
+    prefill.
+
+- **`audit-instructions`: per-row verification stamps** (criteria 1.5.0 → 1.6.0). A row restating a
+  volatile upstream *literal* now carries the four-part record — claim, basis, as-of date, and a
+  recheck trigger naming an observable event. The catalog block states explicitly that these
+  **narrow** the catalog-wide Recheck-triggers block rather than replacing it; without that
+  sentence the catalog would carry two authorities over one behavior, which is precisely the
+  cross-surface conflict I15 exists to find. Shipping a check that silently encodes a snapshot as
+  permanent truth would reproduce, in consumers' repos, the drift this catalog exists to detect.
+
+- **`audit-instructions`: five pages join `## Sources`** — effort, thinking troubleshooting,
+  settings, environment variables, and prompt caching. As at 0.18.0 this is a second-order change,
+  and it is intended: the Recheck-triggers block makes the trigger set the source set, so adding a
+  page widens the staleness trigger for the **entire** catalog, not only for the rows that cite it.
+  A cited page nothing watches would leave those rows depending on an unwatched source.
+
 ## [0.18.0]
 
 ### Added

--- a/plugins/claude-config/skills/audit-instructions/SKILL.md
+++ b/plugins/claude-config/skills/audit-instructions/SKILL.md
@@ -19,7 +19,7 @@ locally-owned instruction surfaces, cites each finding to current official promp
 it by how confident the evidence can be, and packages proposed removals or rewrites as a human-gated
 diff — so instruction surfaces shrink as models get better instead of only ever growing.
 
-The check catalog — the checks I1–I16, their evidence tier, authority tag, severity, per-surface
+The check catalog — the checks I1–I20, their evidence tier, authority tag, severity, per-surface
 applicability, and the `OPINION`-tier enablement policy — lives in
 [reference/criteria.md](reference/criteria.md); the deterministic pre-scan is
 `${CLAUDE_PLUGIN_ROOT}/skills/audit-instructions/scripts/instruction-scan.sh`.
@@ -43,7 +43,7 @@ concerns its siblings already cover — route rather than re-answer:
   portability is `claude-config:audit-permission-grants`.
 
 On **memory-layer surfaces** (CLAUDE.md, CLAUDE.local.md, `.claude/rules/`, `~/.claude/rules/`),
-this skill runs only the model-era checks I6–I16. It never runs or reports the hygiene checks
+this skill runs only the model-era checks I6–I20. It never runs or reports the hygiene checks
 I1–I5 (line-necessity, length, placement, inferable content, rule-to-hook) on these surfaces —
 that instruction-memory hygiene layer belongs to the `claude-memory` plugin. When that plugin is
 installed, route memory-layer hygiene to its `audit` skill; when it is not installed, emit a single
@@ -105,8 +105,8 @@ scope; non-matching ones are inert and the report lists them as `skipped-for-tar
 
 Two flags govern the `OPINION` tier, whose enablement policy the catalog defines:
 
-- `--opinion` — also run the `OPINION`-tier checks that emit findings (I16 today). Off by default;
-  their findings are capped at `info` and are never applied.
+- `--opinion` — also run the `OPINION`-tier checks that emit findings (I16 and I19 today). Off by
+  default; their findings are capped at `info` and are never applied.
 - `--no-stopping-condition` — disable the `OPINION`-tier stopping condition that bounds I6 and I8.
   It is on by default because it withholds findings rather than emitting them, so turning it off
   makes both trimming checks more aggressive, not the audit more conservative.

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -1,5 +1,5 @@
 ---
-version: 1.5.0
+version: 1.6.0
 last-updated: 2026-08-02
 ---
 
@@ -16,6 +16,15 @@ below**. Every check cites one of those pages, so the trigger set is the source 
 subset would leave the harness-behavior rows depending on pages nothing watches. One staleness event
 fires the whole catalog, not the check that noticed it. Model-specific pages (the Fable 5 and
 Opus 5 guides) are superseded on each model generation.
+
+**Per-row verification stamps.** A row that restates a volatile upstream *literal* — a level name, a
+model range, a type predicate — additionally carries the four-part record that claim needs: the
+claim, its basis, an as-of date, and a recheck trigger naming an observable event (the shape is
+`docs/conventions/upstream-drift/README.md` in this monorepo; in a standalone install the four parts,
+not the path, are the requirement). Per-row stamps **narrow** the catalog-wide trigger above rather
+than replacing it — the catalog trigger still fires every row on any Sources change, and a row's own
+trigger adds the events that move only that row's literal. A row that restates nothing and only
+points at its page carries no stamp, because a pointer cannot go stale.
 
 **Axes.** Three orthogonal axes, never conflated:
 
@@ -61,7 +70,7 @@ non-memory surfaces (skill bodies, agent definitions, hook instruction text, out
 memory-layer surfaces (CLAUDE.md, CLAUDE.local.md, `.claude/rules/`, `~/.claude/rules/`) their
 findings route to the `claude-memory` plugin's `audit` skill when it is installed, and fall back
 to the official include/exclude guidance (I1–I5 source below) when it is not. Checks I6–I12 and
-I15–I16 apply to all surfaces; I13 and I14 name narrower surface sets in their own rows.
+I15–I20 apply to all surfaces; I13 and I14 name narrower surface sets in their own rows.
 
 ## Sources
 
@@ -83,10 +92,18 @@ I15–I16 apply to all surfaces; I13 and I14 name narrower surface sets in their
   <https://code.claude.com/docs/en/hooks>
 - Refusals and fallback (`reasoning_extraction`) —
   <https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback>
-- Thinking (the sanctioned reasoning-visibility path, and the `display` field) —
-  <https://platform.claude.com/docs/en/build-with-claude/thinking>
-- Model configuration (the harness-side thinking-display surfaces) —
-  <https://code.claude.com/docs/en/model-config>
+- Thinking (the sanctioned reasoning-visibility path, the `display` field, and the thinking-block
+  round-trip protocol) — <https://platform.claude.com/docs/en/build-with-claude/thinking>
+- Troubleshooting thinking (the per-request 400s, and the models the effort restriction covers) —
+  <https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting>
+- Effort (the levels, and where thinking may not be disabled) —
+  <https://platform.claude.com/docs/en/build-with-claude/effort>
+- Model configuration (the harness-side thinking-display and thinking-disable surfaces, and which
+  effort levels each surface accepts) — <https://code.claude.com/docs/en/model-config>
+- Settings (the `effortLevel` value set) — <https://code.claude.com/docs/en/settings>
+- Environment variables (`CLAUDE_CODE_EFFORT_LEVEL`, `MAX_THINKING_TOKENS`) —
+  <https://code.claude.com/docs/en/env-vars>
+- Prompt caching (what belongs to the cache key) — <https://code.claude.com/docs/en/prompt-caching>
 - CLI reference (`claude doctor` and the other terminal forms) —
   <https://code.claude.com/docs/en/cli-reference>
 - Subagents (what loads into a subagent at startup) — <https://code.claude.com/docs/en/sub-agents>
@@ -488,6 +505,163 @@ by `--opinion`.
 - **Source:** none. No official page states definition-site locality, which is why this check is
   `OPINION`-tier. The *routing* half — which surface a class of content belongs in — is documented
   at features-overview, "Compare similar features", and is I3's concern, not this check's.
+
+### I17: Thinking disabled at an effort level that forbids it
+
+Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces: all · Model scope:
+`opus-5`.
+
+- **Detect:** three shapes, each in instruction text this skill's surfaces carry.
+  1. **The rejected pairing.** A surface that recommends, documents, or sets a **thinking-disable
+     surface** — `MAX_THINKING_TOKENS=0`, `alwaysThinkingEnabled: false`, the `/config` thinking
+     toggle and its `Alt+T` / `Option+T` session form, or API `thinking: {"type": "disabled"}` —
+     together with `xhigh` or `max` effort. Both operands are configuration literals, so a surface
+     prescribing both publishes a per-request 400 that nothing recovers. **Effort literals do not
+     all reach every surface**: `max` arrives only through `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`,
+     or skill / subagent `effort` frontmatter, and the frontmatter case is a surface this skill
+     already inventories.
+  2. **`MAX_THINKING_TOKENS=0` presented as a universal off switch.** It is not one. On Fable 5 it
+     has no effect at all, and on third-party providers it omits the `thinking` parameter instead,
+     so an adaptive-reasoning model may still think. The adjacent `CLAUDE_CODE_DISABLE_THINKING`
+     omits the parameter on every provider and therefore disables nothing by itself — a surface
+     that treats the two as interchangeable states a behavior neither has.
+  3. **A mid-session effort change prescribed without its cost.** Effort is part of the cache key,
+     so changing it re-reads the whole conversation uncached.
+- **Remediate:** for (1) lower the effort to `high` or below, or leave thinking on — and state
+  which, since the pairing has no third resolution. For (2) carry the exceptions with the claim.
+  For (3) name the re-read cost, and prefer choosing effort at session start.
+- **Scope, and where the config check lives:** this row audits **instruction text**. The same
+  pairing sitting in a settings file is a config-mechanics finding and belongs to
+  `claude-config:audit`, per this skill's own routing — an instruction-content catalog that also
+  scanned settings files would claim authority a sibling already holds.
+- **Adjacent axis:** shape (2) is also a harness-capability claim, so **I12 can fire on the same
+  line**. I12 asks whether the claim matches its page; this row asks whether following the
+  instruction produces a rejected request. Report both when both hold.
+- **Must NOT flag:** `effortLevel: max` as a literal to hunt — the settings schema accepts
+  `"low"`, `"medium"`, `"high"`, `"xhigh"` only, so that string is unreachable there and an auditor
+  sent after it finds nothing and learns nothing. Text that states the pairing **in order to warn
+  against it**, which is this row's own remediation. A thinking-disable surface named with no
+  effort level in reach of it.
+- **Source:** effort — "On Claude Opus 5, thinking cannot be disabled at `xhigh` or `max` effort:
+  requests that set `thinking: {"type": "disabled"}` at those levels return a 400 error."
+  Corroborated at thinking-troubleshooting, which adds that the restriction "is enforced on each
+  request". Model configuration heads its `MAX_THINKING_TOKENS=0` row "Disable regardless of
+  effort" and names Fable 5 as the sole exception, so a surface repeating that heading unqualified
+  inherits a claim the effort page contradicts. Prompt caching — "each effort level has its own
+  cache for the same model. Changing it mid-session recomputes the entire request." The per-surface
+  value sets shape (1)'s reach and are read from the surfaces' own pages: settings, for
+  `effortLevel` accepting `"low"`, `"medium"`, `"high"`, `"xhigh"` and no `max`; environment
+  variables, for `CLAUDE_CODE_EFFORT_LEVEL` accepting `max`, for `MAX_THINKING_TOKENS=0` being
+  ineffective on Fable 5 and omitting the parameter on third-party providers, and for
+  `CLAUDE_CODE_DISABLE_THINKING` omitting the parameter rather than disabling; skills and subagents,
+  for `effort` frontmatter accepting `max`.
+- **Verified 2026-08-02** against the four pages above, fetched as raw markdown. **Recheck
+  trigger:** any change to those pages (the catalog trigger already covers this), a new model
+  generation, or the effort level set gaining or losing a name.
+
+### I18: Thinking blocks altered on the way back to the model
+
+Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces: all. Unscoped —
+promotion gate MET: the round-trip protocol is stated on a model-agnostic feature page, not in a
+model guide.
+
+- **Detect:** instruction text directing an agent, a script, or a reader to handle assistant content
+  blocks in a way that breaks the round-trip protocol. Three shapes:
+  1. **Dropping the `signature`.** An instruction to reconstruct, summarize, re-serialize, or
+     hand-assemble an assistant turn before sending it back, where the reconstruction does not
+     carry each `thinking` block's `signature` through unchanged. The server decrypts that field to
+     rebuild the reasoning; a block without it is not the block the model produced.
+  2. **The type-filter smell.** An instruction to select content blocks by testing
+     `block.type == "thinking"` when round-tripping tool-use responses. The predicate silently
+     omits `redacted_thinking` blocks, which the protocol requires back unchanged.
+  3. **Within-turn echo integrity.** An instruction to reorder, edit, truncate, or partially drop
+     the consecutive `thinking` blocks of the latest assistant message — including "keep only the
+     last one" and "strip thinking before resending" advice. Modified blocks are rejected with a
+     400.
+- **Reach — this is wider than API client code.** Signature-bearing `thinking` blocks are the
+  normal on-disk shape of a local transcript, so instructions governing **transcript parsing,
+  excerpting, transformation, and any upload or share path** are in scope alongside instructions
+  governing Messages API and Agent SDK clients. Treat the signature as sensitive material in the
+  share case: it is an encrypted copy of the full reasoning, and it sits unencrypted at rest.
+- **Remediate:** echo the assistant `content` array back unchanged rather than rebuilding it; where
+  blocks must be selected, select by what is being *excluded* rather than by an equality test on one
+  type name; where a transcript is being read for analysis only, say so, since a read that never
+  re-sends is outside the protocol entirely.
+- **Must NOT flag:** an instruction to read or analyze a transcript with no path back to the model —
+  metrics extraction, retrospectives, search. **A `redacted_thinking` clause premised on those blocks
+  being present in local transcripts**, which is a separate and unevidenced claim; this row's
+  concern is only that a type filter would drop them if the API returned them. Pruning of *prior*
+  turns' thinking, which the API does for you and which the page explicitly allows outside tool use.
+  **A document that names the type-filter predicate in order to describe the smell** — this row,
+  a model-adaptation delta chapter, a verification record quoting it — on the same audience test
+  I8-b applies: the predicate quoted inside an operative directive is still operative and is a
+  finding; a document *about* the pattern is not.
+- **Source:** Thinking, "Preserving thinking blocks" — "Pass every `thinking` block back to the API
+  complete and unmodified, alongside the `tool_use` block it accompanied", and "Within the latest
+  assistant message, the sequence of consecutive `thinking` blocks must match what the model
+  generated in the original request: you can't rearrange, edit, or partially drop them." Same page,
+  "Thinking encryption" — "Filtering on `block.type == "thinking"` alone silently drops
+  `redacted_thinking` blocks and breaks the multi-turn protocol", and "Full thinking content is
+  encrypted and returned in the `signature` field on each thinking block."
+- **No local instance exists to validate against.** This repository carries zero occurrences of the
+  type-filter predicate and no transcript round-trip path, so the row ships consumer-facing and
+  unexercised by its own repo — a fact stated here rather than mistaken for a clean audit.
+- **Verified 2026-08-02** against the Thinking page, fetched as raw markdown. **Recheck trigger:**
+  any change to that page, or a content-block type joining the set the protocol requires echoed.
+
+### I19: Restated external benchmark figure with no recheck trigger
+
+Tier `mechanical` · Authority `OPINION` · Severity `info` · Surfaces: all · Default **off**, enabled
+by `--opinion`.
+
+- **Detect:** a surface restating a named benchmark's score, ranking, or suite version — a model
+  comparison table, a launch-figure list, a "state of the art on X" claim — carrying no recheck
+  trigger. Benchmark figures are attested by an announcement at a moment: suites revise, vendors
+  report against a different harness, and a later release reorders the table, so a figure with no
+  stated re-derivation event silently becomes a claim about the past told in the present tense.
+- **Remediate:** either point at the vendor's announcement and restate nothing, or keep the figure
+  and attach the four-part record — the claim, the announcement it came from, the as-of date, and a
+  trigger naming an observable event (a new frontier-model release, a suite version bump, a decision
+  that would turn on the figure). Label the figures as launch-day snapshots where that is what they
+  are; leaving them as history is a valid outcome and usually the right one.
+- **Must NOT flag: a verbatim upstream baseline held for drift detection.** A vendored copy exists
+  to be compared byte-for-byte against its source, so stamping it would corrupt the comparison it
+  exists to serve. This sits alongside the skill's standing exclusion of plugin-cache content and
+  managed materializations: all three are surfaces whose content is not the consuming repo's to
+  edit. Flag the locally-owned surface that *restates* the figure, never the baseline it was
+  restated from.
+- **Must NOT flag:** a benchmark named as a pointer with no figure attached. A figure already
+  carrying a trigger, whatever heading that trigger sits under.
+- **Source:** none. No official page states that a restated benchmark figure needs a re-derivation
+  event, which is why this check is `OPINION`-tier and off by default. The four-part shape it asks
+  for is this monorepo's `docs/conventions/upstream-drift/README.md`; in a standalone install the
+  four parts, not the path, are the requirement.
+
+### I20: Prefilled assistant response
+
+Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `warning` · Surfaces: all.
+
+- **Detect:** instruction text that tells a caller to prefill Claude's response — to supply a
+  partial assistant message on the last turn so the model continues from it. The classic uses are
+  the tells: forcing a JSON or YAML shape, opening with `Here is the requested summary:` to skip
+  preamble, steering around a refusal, resuming an interrupted generation, and re-injecting context
+  as a pseudo-assistant reminder.
+- **Remediate:** the technique is not deprecated advice but a rejected request — on current models a
+  prefilled last assistant turn returns a 400. Replace it per use: state the output contract in the
+  `user` turn or a structured-output facility for format control, ask directly for no preamble,
+  prompt clearly rather than prefill past a refusal, and move context reinjection into the user turn
+  or a tool.
+- **Must NOT flag:** an assistant message anywhere other than the last turn, which is unaffected.
+  Text describing prefill as retired, which is this row's own remediation. Instructions targeting an
+  explicitly pinned earlier model, which still supports it.
+- **Source:** prompting best practices, "Migrating away from prefilled responses" — "Starting with
+  Claude 4.6 models and Claude Mythos Preview, prefilled responses (providing a partial assistant
+  message for Claude to continue from) on the last assistant turn are no longer supported. Requests
+  with prefilled assistant messages to these models return a 400 error… Earlier models continue to
+  support prefills, and adding assistant messages elsewhere in the conversation is not affected."
+- **Verified 2026-08-02** against that page, fetched as raw markdown; the standalone prefill
+  technique page now redirects to the prompt-engineering overview. **Recheck trigger:** any change to
+  that page, or the unsupported-model range moving.
 
 ---
 

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -649,10 +649,10 @@ model guide.
   on each thinking block" — and "Redacted thinking blocks" — "Filtering on
   `block.type == "thinking"` alone silently drops `redacted_thinking` blocks and breaks the
   multi-turn protocol".
-- **Verified 2026-08-02: zero instances of any of the three shapes in this repository**, so the row
-  ships consumer-facing and unexercised by the repo that wrote it — recorded as an as-of measurement
-  rather than left to read as a clean audit. **Recheck trigger:** a round-trip or transcript-replay
-  path landing here.
+- **Local coverage, measured 2026-08-02: zero instances of all three shapes in the repository that
+  authored this row**, which ships it consumer-facing and unexercised by its own corpus. Stated so
+  the absence reads as an as-of measurement rather than as a passed check. **Re-measure when** a
+  round-trip or transcript-replay path lands here.
 - **Verified 2026-08-02** against the Thinking page, fetched as raw markdown. **Recheck trigger:** a
   content-block type joining or leaving the set the protocol requires echoed back.
 

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -661,7 +661,7 @@ model guide.
   "Thinking encryption" — "Full thinking content is encrypted and returned in the `signature` field
   on each thinking block" — and "Redacted thinking blocks" — "Filtering on
   `block.type == "thinking"` alone silently drops `redacted_thinking` blocks and breaks the
-  multi-turn protocol".
+  multi-turn protocol…".
 - **Local coverage, measured 2026-08-02: zero instances of all three shapes in the repository that
   authored this row**, which ships it consumer-facing and unexercised by its own corpus. Stated so
   the absence reads as an as-of measurement rather than as a passed check. **Re-measure when** a

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -20,11 +20,19 @@ Opus 5 guides) are superseded on each model generation.
 **Per-row verification stamps.** A row that restates a volatile upstream *literal* — a level name, a
 model range, a type predicate — additionally carries the four-part record that claim needs: the
 claim, its basis, an as-of date, and a recheck trigger naming an observable event (the shape is
-`docs/conventions/upstream-drift/README.md` in this monorepo; in a standalone install the four parts,
-not the path, are the requirement). Per-row stamps **narrow** the catalog-wide trigger above rather
-than replacing it — the catalog trigger still fires every row on any Sources change, and a row's own
-trigger adds the events that move only that row's literal. A row that restates nothing and only
-points at its page carries no stamp, because a pointer cannot go stale.
+`docs/conventions/upstream-drift/README.md` in this monorepo; in a standalone install the four
+parts, not the path, are the requirement). A row that restates nothing and only points at its page
+carries no stamp, because a pointer cannot go stale.
+
+A per-row stamp **supplements** the catalog-wide trigger above; it never replaces or narrows it.
+The catalog trigger still fires every row on any Sources change — that is why a row's own trigger
+names only the events the Sources set would *miss*, such as a value set changing while its page
+keeps the same URL. **Where the two disagree, the catalog trigger wins**, because it is the wider
+one and a staleness signal is not something to resolve by picking the narrower authority.
+
+The requirement **binds on touch**, per the convention above: rows predating this rule keep their
+citations as they are and adopt the four parts the next time they change. A missing stamp on an
+older row is therefore not itself a defect in this catalog.
 
 **Axes.** Three orthogonal axes, never conflated:
 
@@ -508,56 +516,94 @@ by `--opinion`.
 
 ### I17: Thinking disabled at an effort level that forbids it
 
-Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces: all · Model scope:
-`opus-5`.
+Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces: all. Unscoped —
+promotion gate MET: the claim is stated on a model-agnostic feature page, not in a model guide.
+**The model range is a Detect condition, not a `Model scope` annotation.** The source says the
+restriction "applies to Claude Opus 5 and later models", and the annotation's exact-string matching
+has no range form — annotating `opus-5` would make the row inert on the next generation while the
+restriction still holds. I20 handles a model range the same way.
 
-- **Detect:** three shapes, each in instruction text this skill's surfaces carry.
-  1. **The rejected pairing.** A surface that recommends, documents, or sets a **thinking-disable
-     surface** — `MAX_THINKING_TOKENS=0`, `alwaysThinkingEnabled: false`, the `/config` thinking
-     toggle and its `Alt+T` / `Option+T` session form, or API `thinking: {"type": "disabled"}` —
-     together with `xhigh` or `max` effort. Both operands are configuration literals, so a surface
-     prescribing both publishes a per-request 400 that nothing recovers. **Effort literals do not
-     all reach every surface**: `max` arrives only through `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`,
-     or skill / subagent `effort` frontmatter, and the frontmatter case is a surface this skill
-     already inventories.
-  2. **`MAX_THINKING_TOKENS=0` presented as a universal off switch.** It is not one. On Fable 5 it
-     has no effect at all, and on third-party providers it omits the `thinking` parameter instead,
-     so an adaptive-reasoning model may still think. The adjacent `CLAUDE_CODE_DISABLE_THINKING`
-     omits the parameter on every provider and therefore disables nothing by itself — a surface
-     that treats the two as interchangeable states a behavior neither has.
-  3. **A mid-session effort change prescribed without its cost.** Effort is part of the cache key,
-     so changing it re-reads the whole conversation uncached.
-- **Remediate:** for (1) lower the effort to `high` or below, or leave thinking on — and state
-  which, since the pairing has no third resolution. For (2) carry the exceptions with the claim.
-  For (3) name the re-read cost, and prefer choosing effort at session start.
+Each row below carries its own decisive source; they share a subject, not a citation.
+
+**Base row: the rejected pairing.**
+
+- **Detect:** a surface that recommends, documents, or sets a **thinking-disable surface** —
+  `MAX_THINKING_TOKENS=0`, `alwaysThinkingEnabled: false`, the `/config` global toggle, the
+  `Alt+T` / `Option+T` session toggle, or API `thinking: {"type": "disabled"}` — together with
+  `xhigh` or `max` effort, on Claude Opus 5 or a later model. Both operands are configuration
+  literals, so a surface prescribing both publishes a per-request 400 that nothing recovers.
+- **Effort literals do not all reach every surface, and the literal set is not the whole set.**
+  `max` reaches a session through `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, `/effort`, or skill and
+  subagent `effort` frontmatter — the frontmatter case being a surface this skill already
+  inventories. **`ultracode` also trips this** without matching either literal: it is a Claude Code
+  setting rather than an effort level and "sends `xhigh` to the model", so a surface pairing it with
+  a thinking-disable surface produces the identical rejection. Match on the effort that reaches the
+  request, not on the spelling.
+- **Remediate:** lower the effort to `high` or below, or leave thinking on — and state which, since
+  the pairing has no third resolution.
 - **Scope, and where the config check lives:** this row audits **instruction text**. The same
-  pairing sitting in a settings file is a config-mechanics finding and belongs to
+  pairing expressed as *settings keys* is a config-mechanics finding and belongs to
   `claude-config:audit`, per this skill's own routing — an instruction-content catalog that also
-  scanned settings files would claim authority a sibling already holds.
-- **Adjacent axis:** shape (2) is also a harness-capability claim, so **I12 can fire on the same
-  line**. I12 asks whether the claim matches its page; this row asks whether following the
-  instruction produces a rejected request. Report both when both hold.
-- **Must NOT flag:** `effortLevel: max` as a literal to hunt — the settings schema accepts
-  `"low"`, `"medium"`, `"high"`, `"xhigh"` only, so that string is unreachable there and an auditor
-  sent after it finds nothing and learns nothing. Text that states the pairing **in order to warn
-  against it**, which is this row's own remediation. A thinking-disable surface named with no
-  effort level in reach of it.
+  scanned settings files would claim authority a sibling already holds. Instruction text that
+  happens to *live* in a settings file, such as a prompt-type hook's injected text, stays here: the
+  discriminator is whether the content instructs, not which file holds it.
+- **Must NOT flag:** `effortLevel: max` as a literal to hunt — the settings schema accepts `"low"`,
+  `"medium"`, `"high"`, `"xhigh"` only, so that string is unreachable there and an auditor sent
+  after it finds nothing and learns nothing. **A document that states the pairing in order to
+  describe or forbid it** — this row, a model-adaptation delta chapter, a verification record
+  quoting it — on the same audience test I8-b applies: the pairing prescribed inside an operative
+  directive is a finding; a document *about* the pairing is not. A thinking-disable surface named
+  with no effort level in reach of it.
 - **Source:** effort — "On Claude Opus 5, thinking cannot be disabled at `xhigh` or `max` effort:
   requests that set `thinking: {"type": "disabled"}` at those levels return a 400 error."
-  Corroborated at thinking-troubleshooting, which adds that the restriction "is enforced on each
-  request". Model configuration heads its `MAX_THINKING_TOKENS=0` row "Disable regardless of
-  effort" and names Fable 5 as the sole exception, so a surface repeating that heading unqualified
-  inherits a claim the effort page contradicts. Prompt caching — "each effort level has its own
-  cache for the same model. Changing it mid-session recomputes the entire request." The per-surface
-  value sets shape (1)'s reach and are read from the surfaces' own pages: settings, for
-  `effortLevel` accepting `"low"`, `"medium"`, `"high"`, `"xhigh"` and no `max`; environment
-  variables, for `CLAUDE_CODE_EFFORT_LEVEL` accepting `max`, for `MAX_THINKING_TOKENS=0` being
-  ineffective on Fable 5 and omitting the parameter on third-party providers, and for
-  `CLAUDE_CODE_DISABLE_THINKING` omitting the parameter rather than disabling; skills and subagents,
-  for `effort` frontmatter accepting `max`.
-- **Verified 2026-08-02** against the four pages above, fetched as raw markdown. **Recheck
-  trigger:** any change to those pages (the catalog trigger already covers this), a new model
-  generation, or the effort level set gaining or losing a name.
+  Corroborated at thinking-troubleshooting, which supplies the model range and adds that the
+  restriction "is enforced on each request". The per-surface value sets are read from the surfaces'
+  own pages: settings for `effortLevel`, environment variables for `CLAUDE_CODE_EFFORT_LEVEL`,
+  skills and subagents for `effort` frontmatter, and model configuration for `/effort`, the session
+  and global thinking toggles, and ultracode.
+- **Verified 2026-08-02** against those pages, fetched as raw markdown. **Recheck trigger:** the
+  effort level set gaining or losing a name, or the restriction's model range moving.
+
+**Row I17-a: `MAX_THINKING_TOKENS=0` presented as a universal off switch** · Tier `mechanical` ·
+Severity `warning`.
+
+- **Detect:** text stating or implying that `MAX_THINKING_TOKENS=0` turns thinking off generally.
+  It does not. On Fable 5 it has no effect at all — nor do the session toggle or
+  `alwaysThinkingEnabled` — and on third-party providers it omits the `thinking` parameter instead,
+  so an adaptive-reasoning model may still think. Also flag text treating
+  `CLAUDE_CODE_DISABLE_THINKING` as equivalent: that variable omits the parameter on every
+  provider, which on a model that thinks by default leaves it still thinking.
+- **Remediate:** carry the exceptions with the claim, or point at the page instead of restating it.
+- **Adjacent axis:** this is also a harness-capability claim, so **I12 can fire on the same line**.
+  I12 asks whether the claim matches its page; this row asks whether a reader following it gets the
+  behavior they were promised. Report both when both hold.
+- **Must NOT flag:** a mention that already carries the Fable 5 or third-party exception. A bare
+  reference to the variable making no claim about its reach.
+- **Source:** environment variables — `MAX_THINKING_TOKENS` "Set to `0` to disable thinking on the
+  Anthropic API, except on Fable 5, which cannot have thinking turned off; on third-party providers,
+  `0` omits the `thinking` parameter instead". Model configuration heads the same control "Disable
+  regardless of effort", so a surface repeating that heading unqualified inherits a claim the
+  variable's own page contradicts.
+- **Verified 2026-08-02** against those two pages, fetched as raw markdown. **Recheck trigger:** the
+  set of models that cannot disable thinking changing.
+
+**Row I17-b: mid-session effort change prescribed without its cost** · Tier `mechanical` ·
+Severity `info`.
+
+- **Detect:** an instruction directing a reader to change effort part-way through a session without
+  naming what it costs. Effort is part of the cache key, so the next request re-reads the whole
+  conversation uncached.
+- **Must NOT flag: a Claude Code surface**, where the harness already surfaces the cost — it "asks
+  you to confirm before applying the change", and a change resolving to the level already in effect
+  skips the dialog and keeps the cache. This row is for surfaces instructing an API or Agent SDK
+  caller, where no dialog exists. Nor flag a change prescribed *with* its cost stated, which is the
+  remediation.
+- **Remediate:** name the re-read cost, and prefer choosing effort at session start.
+- **Source:** prompt caching — "**Effort level**: each effort level has its own cache for the same
+  model. Changing it mid-session recomputes the entire request, and Claude Code asks you to confirm
+  before applying the change."
+- **Verified 2026-08-02** against that page, fetched as raw markdown. **Recheck trigger:** effort
+  leaving the cache key, or the confirmation behavior changing.
 
 ### I18: Thinking blocks altered on the way back to the model
 
@@ -578,11 +624,10 @@ model guide.
      the consecutive `thinking` blocks of the latest assistant message — including "keep only the
      last one" and "strip thinking before resending" advice. Modified blocks are rejected with a
      400.
-- **Reach — this is wider than API client code.** Signature-bearing `thinking` blocks are the
-  normal on-disk shape of a local transcript, so instructions governing **transcript parsing,
-  excerpting, transformation, and any upload or share path** are in scope alongside instructions
-  governing Messages API and Agent SDK clients. Treat the signature as sensitive material in the
-  share case: it is an encrypted copy of the full reasoning, and it sits unencrypted at rest.
+- **Reach — this is wider than Messages API client code.** Any instruction whose output eventually
+  becomes a request body is in scope: Agent SDK callers, harness integrations, and **tooling that
+  parses, excerpts or rewrites a stored transcript that will later be replayed or resumed**. What
+  puts a surface in scope is a path back to the model, not the file format it reads.
 - **Remediate:** echo the assistant `content` array back unchanged rather than rebuilding it; where
   blocks must be selected, select by what is being *excluded* rather than by an equality test on one
   type name; where a transcript is being read for analysis only, say so, since a read that never
@@ -600,14 +645,16 @@ model guide.
   complete and unmodified, alongside the `tool_use` block it accompanied", and "Within the latest
   assistant message, the sequence of consecutive `thinking` blocks must match what the model
   generated in the original request: you can't rearrange, edit, or partially drop them." Same page,
-  "Thinking encryption" — "Filtering on `block.type == "thinking"` alone silently drops
-  `redacted_thinking` blocks and breaks the multi-turn protocol", and "Full thinking content is
-  encrypted and returned in the `signature` field on each thinking block."
-- **No local instance exists to validate against.** This repository carries zero occurrences of the
-  type-filter predicate and no transcript round-trip path, so the row ships consumer-facing and
-  unexercised by its own repo — a fact stated here rather than mistaken for a clean audit.
-- **Verified 2026-08-02** against the Thinking page, fetched as raw markdown. **Recheck trigger:**
-  any change to that page, or a content-block type joining the set the protocol requires echoed.
+  "Thinking encryption" — "Full thinking content is encrypted and returned in the `signature` field
+  on each thinking block" — and "Redacted thinking blocks" — "Filtering on
+  `block.type == "thinking"` alone silently drops `redacted_thinking` blocks and breaks the
+  multi-turn protocol".
+- **Verified 2026-08-02: zero instances of any of the three shapes in this repository**, so the row
+  ships consumer-facing and unexercised by the repo that wrote it — recorded as an as-of measurement
+  rather than left to read as a clean audit. **Recheck trigger:** a round-trip or transcript-replay
+  path landing here.
+- **Verified 2026-08-02** against the Thinking page, fetched as raw markdown. **Recheck trigger:** a
+  content-block type joining or leaving the set the protocol requires echoed back.
 
 ### I19: Restated external benchmark figure with no recheck trigger
 
@@ -626,10 +673,10 @@ by `--opinion`.
   are; leaving them as history is a valid outcome and usually the right one.
 - **Must NOT flag: a verbatim upstream baseline held for drift detection.** A vendored copy exists
   to be compared byte-for-byte against its source, so stamping it would corrupt the comparison it
-  exists to serve. This sits alongside the skill's standing exclusion of plugin-cache content and
-  managed materializations: all three are surfaces whose content is not the consuming repo's to
-  edit. Flag the locally-owned surface that *restates* the figure, never the baseline it was
-  restated from.
+  exists to serve — this is a genuine suppression, not a routing case, which is what distinguishes
+  it from plugin-cache content and managed materializations: those are still flagged, and the
+  finding becomes a routing recommendation to the owning repository. Flag the locally-owned surface
+  that *restates* the figure, never the baseline it was restated from.
 - **Must NOT flag:** a benchmark named as a pointer with no figure attached. A figure already
   carrying a trigger, whatever heading that trigger sits under.
 - **Source:** none. No official page states that a restated benchmark figure needs a re-derivation
@@ -639,7 +686,9 @@ by `--opinion`.
 
 ### I20: Prefilled assistant response
 
-Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `warning` · Surfaces: all.
+Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces: all — `error` because
+following the instruction produces a rejected request, the same consequence class as I17 and I18,
+not because instances are expected to be common.
 
 - **Detect:** instruction text that tells a caller to prefill Claude's response — to supply a
   partial assistant message on the last turn so the model continues from it. The classic uses are
@@ -652,8 +701,10 @@ Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `warning` · Surface
   prompt clearly rather than prefill past a refusal, and move context reinjection into the user turn
   or a tool.
 - **Must NOT flag:** an assistant message anywhere other than the last turn, which is unaffected.
-  Text describing prefill as retired, which is this row's own remediation. Instructions targeting an
-  explicitly pinned earlier model, which still supports it.
+  **A document that names the technique or its tells in order to describe it as retired** — this
+  row, a migration guide, a model-delta chapter — on the same audience test I8-b applies: a prefill
+  prescribed inside an operative directive is a finding; a document *about* prefill is not.
+  Instructions targeting an explicitly pinned earlier model, which still supports it.
 - **Source:** prompting best practices, "Migrating away from prefilled responses" — "Starting with
   Claude 4.6 models and Claude Mythos Preview, prefilled responses (providing a partial assistant
   message for Claude to continue from) on the last assistant turn are no longer supported. Requests

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -548,10 +548,12 @@ Each row below carries its own decisive source; they share a subject, not a cita
 - **Effort literals do not all reach every surface, and the literal set is not the whole set.**
   `max` reaches a session through `CLAUDE_CODE_EFFORT_LEVEL`, `--effort`, `/effort`, or skill and
   subagent `effort` frontmatter — the frontmatter case being a surface this skill already
-  inventories. **`ultracode` also trips this** without matching either literal: it is a Claude Code
-  setting rather than an effort level and "sends `xhigh` to the model", so a surface pairing it with
-  a thinking-disable surface produces the identical rejection. Match on the effort that reaches the
-  request, not on the spelling.
+  inventories. **The `ultracode` *setting* also trips this** without matching either literal: it is
+  a Claude Code setting rather than an effort level and "sends `xhigh` to the model", so a surface
+  pairing it with a thinking-disable surface produces the identical rejection. Only the
+  effort-setting forms count — instruction text prescribing `/effort ultracode`, `--effort
+  ultracode`, or `--settings` / Agent SDK `"ultracode": true` or `effortLevel: "ultracode"`. Match
+  on the effort that reaches the request, not on the spelling.
 - **Remediate:** lower the effort to `high` or below, or leave thinking on — and state which, since
   the pairing has no third resolution.
 - **Scope, and where the config check lives:** this row audits **instruction text**. The same
@@ -565,17 +567,24 @@ Each row below carries its own decisive source; they share a subject, not a cita
   after it finds nothing and learns nothing. **A document that states the pairing in order to
   describe or forbid it** — this row, a model-adaptation delta chapter, a verification record
   quoting it — on the same audience test I8-b applies: the pairing prescribed inside an operative
-  directive is a finding; a document *about* the pairing is not. A thinking-disable surface named
-  with no effort level in reach of it.
+  directive is a finding; a document *about* the pairing is not. **The bare `ultracode` prompt
+  keyword** — instruction text telling a reader to include it in a typed prompt runs one task as a
+  workflow "without changing the session's effort level", so no effort reaches the request and the
+  rejected pairing never assembles. A thinking-disable surface named with no effort level in reach
+  of it.
 - **Source:** effort — "On Claude Opus 5, thinking cannot be disabled at `xhigh` or `max` effort:
   requests that set `thinking: {"type": "disabled"}` at those levels return a 400 error."
   Corroborated at thinking-troubleshooting, which supplies the model range and adds that the
   restriction "is enforced on each request". The per-surface value sets are read from the surfaces'
   own pages: settings for `effortLevel`, environment variables for `CLAUDE_CODE_EFFORT_LEVEL`,
   skills and subagents for `effort` frontmatter, and model configuration for `/effort`, the session
-  and global thinking toggles, and ultracode.
-- **Verified 2026-08-02** against those pages, fetched as raw markdown. **Recheck trigger:** the
-  effort level set gaining or losing a name, or the restriction's model range moving.
+  and global thinking toggles, and ultracode — the last enumerating the three routes that turn the
+  *setting* on (`/effort`, `--effort`, `--settings` / Agent SDK). The keyword's separation from the
+  setting is read from workflows, "Ask for a workflow in your prompt": including `ultracode` in a
+  prompt runs "a single task as a workflow without changing the session's effort level".
+- **Verified 2026-08-03** against those pages, fetched as raw markdown. **Recheck trigger:** the
+  effort level set gaining or losing a name, the set of `ultracode` forms that reach `xhigh`
+  changing, or the restriction's model range moving.
 
 **Row I17-a: `MAX_THINKING_TOKENS=0` presented as a universal off switch** · Tier `mechanical` ·
 Severity `warning`.
@@ -701,11 +710,13 @@ by `--opinion`.
 
 Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces: all — `error` because
 following the instruction produces a rejected request, the same consequence class as I17 and I18,
-not because instances are expected to be common.
+not because instances are expected to be common. **The unsupported model range is a Detect
+condition, not a `Model scope` annotation**, for the reason I17 states.
 
 - **Detect:** instruction text that tells a caller to prefill Claude's response — to supply a
-  partial assistant message on the last turn so the model continues from it. The classic uses are
-  the tells: forcing a JSON or YAML shape, opening with `Here is the requested summary:` to skip
+  partial assistant message on the last turn so the model continues from it — where the run's
+  resolved target model is a Claude 4.6 or later model, or Claude Mythos Preview. The classic uses
+  are the tells: forcing a JSON or YAML shape, opening with `Here is the requested summary:` to skip
   preamble, steering around a refusal, resuming an interrupted generation, and re-injecting context
   as a pseudo-assistant reminder.
 - **Remediate:** the technique is not deprecated advice but a rejected request — on current models a


### PR DESCRIPTION
Ships the consumer-facing payload of the doc-corpus campaign: four new rows in the `claude-config:audit-instructions` catalog. `claude-config` 0.19.0 -> 0.20.0; `criteria.md` 1.6.0 -> 1.7.0.

## The rows

- **I17** (base + I17-a + I17-b) — the thinking-disable x `xhigh`/`max` effort hazard. Stated at full strength: a per-request 400, real and **unguarded** (EC-9 replayed live 400s in the local OTEL store at `cc-logs.json:65283/:65291`, `model=claude-opus-5`; no documented pre-request guard). Statically checkable against settings files. Fences: `effortLevel` accepts `xhigh` but not `max` (auditors are not sent hunting a literal that cannot exist); `ultracode` covered explicitly ("sends `xhigh` to the model" — matches neither literal yet triggers the hazard).
- **I18** — thinking blocks altered on the way back to the model: signature preservation, the `block.type == "thinking"` type-filter smell, within-turn echo integrity. Scope extends through the Agent SDK (owner decision Q3) and — per EC-2's structural corpus test (every thinking block in 3.6 GB carries `signature`, zero without) — local transcript handling and transcript-parsing tooling.
- **I19** — restated external benchmark figure with no recheck trigger. Ships at **OPINION tier, off by default**: no official page states the requirement, and claiming ANTHROPIC-DOCS with `Source: none` would break the catalog's own authority invariant. The worked example is this repo's own RA-4 fix (PR #1876) and `docs/conventions/upstream-drift/README.md`.
- **I20** — prefilled assistant response (model-delta standing row; RA-6 replayed `prefill` at 0 on this repo, expected hit rate near zero, cheap to carry).

## Disputes carried, resolved with evidence

- **`redacted_thinking`:** the brief forbade any clause; literal obedience was impossible — the type-filter rule's decisive upstream sentence (`thinking.md:867`) states its failure mode *as* silently dropping `redacted_thinking` blocks. Shipped: the upstream sentence verbatim, plus a Must-NOT-flag fencing out any clause premised on those blocks being present locally (EC-2 found zero structural instances in 3.6 GB).
- **IA-4's thinking-churn half dropped:** `prompt-caching.md` contains zero occurrences of "thinking" (replayed live twice) — a thinking-toggle cache-invalidation claim would have been a fabricated citation. I17-b covers effort churn only, quoting the page verbatim including the harness's own confirm-before-applying surface.
- **Brief/source count discrepancy, recorded:** the brief cites 136,295 thinking blocks; EC-2's own record says 136,176. No shipped row depends on either (a local count is not a consumer fact).

## Verification

Independently verified by a second model with the implementer's rationale withheld — two independent full passes (the first died with the session; the second re-derived everything from bytes and live raw fetches: 52,769 B `thinking.md`, 29,777 B `prompt-caching.md`).

- **Standing gate (never ship a check this repo fails):** zero adjudicated findings across all four rows on the merged tree, twice replayed. Every candidate adjudicated by name: `opus-5.md:125` (model-adaptation delta, fenced), `orchestration.md` x3 (carry the RA-4 four-part drift record), `action-quality.md:9` (pointer, no figure). The vendor fence is load-bearing: unfenced, I19 fires 15 times, 11 inside `boris/vendor/` — the verbatim upstream baseline kept for byte-drift detection.
- **Planted positives:** 7/8 greppable shapes fire on a constructed file; I18 shape 1 (signature dropped on reconstruction) has no greppable literal and is validated by reasoned read — recorded as a residual regression gap, not rounded up.
- Post-review corrections shipped as follow-up commits (append-only): two quote defects found by review (a silently converted comma, a wrong section attribution), one truncation-marker fix (`c375d90739`), and the merge-reconciliation with #1881 (versions renumbered; `plugin.json`/frontmatter auto-merged "clean and wrong" on identical strings and were corrected by hand).
- **Known inaccuracy in an immutable commit message:** `c375d90739`'s body claims the unmarked truncation "is the misquote-without-ellipsis defect the criteria file itself flags elsewhere" — `criteria.md` carries no quote-fidelity criterion; the classification came from the independent verifier, not the file. Recorded here rather than rewriting pushed history (same handling as #1881's citation defect).
- `instruction-scan.test.sh` 46/46; markdownlint 0 errors; changelog parity/bump/order pass; `check-skill.sh` PASS.

No linked issue

## Related

- Phase 3b consumer payload of the doc-corpus campaign; sibling merges #1875-#1881.
- Owner decisions Q3 (Agent SDK scope), Q4/IA-12 (agnosticism routing test), Q5.
- EC-2 and EC-9 empirical records: `.work/_harness-snapshots-2026-07-31/EMPIRICAL-CHECKS-RESULTS-2026-08-02.md` (memory tier).
- Follow-ups filed from this lane: mechanized pre-scan for I17-I20 (gate sweep is currently a scratchpad script), post-merge version-literal assertion for the silent auto-merge trap.
