### PR TITLE
fix(discovery,docs): close eight stranded review findings from #1322 and #1425

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -8,3 +8,11 @@
 .work/*/RESEARCH.md
 .work/*/RESEARCH-*.md
 .work/*/*-checklist.md
+# Sub-slices (<memory_dir>/<slug>/<sub-slug>/) — a parallel fan-out assigns one
+# per topic. Globs do not descend, so without these a worktree carries the
+# top-level index and silently drops every nested index, sidecar, and ledger.
+.work/*/*/EXPLORE.md
+.work/*/*/EXPLORE-*.md
+.work/*/*/RESEARCH.md
+.work/*/*/RESEARCH-*.md
+.work/*/*/*-checklist.md

--- a/docs/topics/context-engineering-claude-5/PLAN.md
+++ b/docs/topics/context-engineering-claude-5/PLAN.md
@@ -140,9 +140,15 @@ source with explicit staleness triggers — not restated across the skills that 
 - Every source section maps to either a check that runs, an incumbent that already covers it, or an
   explicit recorded exclusion — traceable back to
   [design/article-sections.md](design/article-sections.md).
-- A rerun over an unchanged tree produces the same **derived-tier** result, never a different one. A
-  rerun after accepted fixes produces a strictly smaller one. Absent a change to the tree, it grows
-  again only on a **detection-version** bump — the catalog version, the host plugin's semver, and a
+- A rerun over a **comparable** pair produces the same **derived-tier** result, never a different
+  one. Comparability is the design's own list and is cited rather than restated here, because it has
+  already grown twice; an unchanged tree is only its first and weakest input. A rerun after accepted
+  fixes drops every accepted finding **from whichever tier reported it** — not
+  necessarily a smaller derived set, because fixing a judged-only finding such as D1 legitimately
+  leaves the inventory, the exclusion set, shadowed definitions, and the raw candidate rows
+  identical, so a strict-shrink gate would fail the ordinary success case. The derived set grows
+  again only when a comparability input moved — a **detection-version** bump among them, which is
+  the catalog version, the host plugin's semver, and a
   digest over the prompt text and scripts that actually decide detection, because the catalog version
   alone does not cover `SKILL.md`'s Phase B and Phase C prompts. A skill authored between runs
   legitimately grows it, and the tree is moving under a parallel session. That is the acceptance test
@@ -502,9 +508,11 @@ definition before any detector is designed against it.
   a rate limit, or a crash. Findings persist incrementally as collected, and an interrupted run
   resumes from the last completed lane rather than restarting.
 
-Then the properties themselves: unchanged tree yields an identical finding set; accepted fixes yield a
-strictly smaller one; judged-tier findings carry the delete-and-watch follow-through where their host check defines one, or the check's own stated loop where it does not (D1); the set grows
-again only on a detection-version bump or a change to the tree.
+Then the properties themselves: a comparable pair yields an identical finding set; accepted fixes
+remove each accepted finding from the tier that reported it, which leaves the derived set unchanged
+when the fix landed a judged-only finding; judged-tier findings carry the delete-and-watch
+follow-through where their host check defines one, or the check's own stated loop where it does not
+(D1); the set grows again only when a comparability input moved.
 
 - **Sanity Check:** `design/rerun-contract.md` states the identity tuple, the report location rule, the
   state key, the concurrency posture, the per-class suppression surface, the checkpoint property, and
@@ -952,8 +960,18 @@ surface is the same defect this deliverable exists to detect.
 input.** #1318's P1 was conditioned on tree and live surface set alone, so a harness or
 detection-version change — which legitimately moves the derived tier, since it reads a versioned
 registry of harness behavior — read as a determinism failure. Closed by giving the shipped contract
-the same single **comparability** precondition the design carries: tree, live surface set, detection
-version, and harness version, defined once and cited by every property.
+a single **comparability** precondition, defined once and cited by every property, matching the
+design's at the time: tree, live surface set, detection version, and harness version.
+
+**That parity has since lapsed in both directions, and reconciling it is Phase 8 work rather than a
+design edit.** The design doc has since widened its first input to a **scan-baseline state digest**
+(the shipped contract's own term, adopted from it) and added a **sweep version** the shipped
+contract has no concept of; the shipped contract carries **behavior-affecting arguments** and an
+**observable detection version** — a form it adopted after finding the design's catalog-version-plus-
+prompt-digest triple unestablishable from outside a delegate plugin — that the design still lacks.
+Neither list is wrong; they are two documents that moved at different times. The reconciliation is
+recorded here rather than performed in passing, because changing either predicate changes what the
+shipped pass reports.
 
 None of these is a gate criterion; each would have made the shipped contract fail its own idempotence
 claim, which is why they are recorded with the gate rather than after it.

--- a/docs/topics/context-engineering-claude-5/PLAN.md
+++ b/docs/topics/context-engineering-claude-5/PLAN.md
@@ -976,13 +976,14 @@ Neither list is wrong; they are two documents that moved at different times. The
 recorded here rather than performed in passing, because changing either predicate changes what the
 shipped pass reports.
 
-**Widening the cross-run input left the within-run one behind, and that asymmetry is owed the same
-pass.** The design's Assertion 3.4 still records a *working-tree* content digest, scoped to the
-repository, while comparability now spans every inventoried scope. So an edit to `~/.claude/CLAUDE.md`
-**between** runs correctly renders the pair non-comparable, and the same edit **during** a run is
-invisible to the mid-run integrity check. The shipped contract unified the two deliberately — its
-assertion 6.1b yields `indeterminate` for exactly that mid-run case — so this is a gap on the design
-side only, and closing it is part of the same Phase 8 reconciliation rather than a separate question.
+**Widening the cross-run input briefly left the within-run one behind, and that asymmetry is now
+closed.** Assertion 3.4 recorded a *working-tree* content digest scoped to the repository while
+comparability spanned every inventoried scope, so an edit to `~/.claude/CLAUDE.md` **between** runs
+correctly rendered the pair non-comparable while the same edit **during** a run stayed invisible to
+the mid-run integrity check. 3.4's endpoint capture is now the same all-scope state digest, matching
+the shipped contract's assertion 6.1b. Within-run and cross-run integrity have to read the same
+surfaces or neither is worth asserting — a rule worth carrying forward the next time either side
+widens.
 
 None of these is a gate criterion; each would have made the shipped contract fail its own idempotence
 claim, which is why they are recorded with the gate rather than after it.

--- a/docs/topics/context-engineering-claude-5/PLAN.md
+++ b/docs/topics/context-engineering-claude-5/PLAN.md
@@ -169,9 +169,12 @@ source with explicit staleness triggers — not restated across the skills that 
   judgement, so two runs over an identical tree may legitimately differ; a finding-identity function
   normalizes how a finding is *reported* and cannot make the *detection* deterministic. Judged
   findings are reported separately, excluded from the diff-clean gate, and held instead to: none
-  contradicts an accepted suppression, and the set does not grow on an unchanged tree beyond a stated
-  tolerance — **whose violation fails the run's self-check** rather than being absorbed by
-  recalibrating the tolerance.
+  contradicts an accepted suppression, and the **symmetric difference** between the two judged sets
+  stays within a stated tolerance over a comparable pair **whose judging configuration is also
+  equal** — **whose violation fails the run's self-check** rather than being absorbed by
+  recalibrating the tolerance. The metric counts removals as well as additions, because a check that
+  silently stops firing is the more damaging direction; and the judging configuration is a
+  precondition rather than an obligation, since a model swap moves the judged set legitimately.
 - **A surface that silently leaves the inventory fails the gate.** The inventory and exclusion set are
   *in* the derived tier, not scaffolding beneath it, so a scope regression is caught. This is the
   property the original two-tier split could not express, and it matters more than a changed finding:
@@ -972,6 +975,14 @@ prompt-digest triple unestablishable from outside a delegate plugin — that the
 Neither list is wrong; they are two documents that moved at different times. The reconciliation is
 recorded here rather than performed in passing, because changing either predicate changes what the
 shipped pass reports.
+
+**Widening the cross-run input left the within-run one behind, and that asymmetry is owed the same
+pass.** The design's Assertion 3.4 still records a *working-tree* content digest, scoped to the
+repository, while comparability now spans every inventoried scope. So an edit to `~/.claude/CLAUDE.md`
+**between** runs correctly renders the pair non-comparable, and the same edit **during** a run is
+invisible to the mid-run integrity check. The shipped contract unified the two deliberately — its
+assertion 6.1b yields `indeterminate` for exactly that mid-run case — so this is a gap on the design
+side only, and closing it is part of the same Phase 8 reconciliation rather than a separate question.
 
 None of these is a gate criterion; each would have made the shipped contract fail its own idempotence
 claim, which is why they are recorded with the gate rather than after it.

--- a/docs/topics/context-engineering-claude-5/design/rerun-contract.md
+++ b/docs/topics/context-engineering-claude-5/design/rerun-contract.md
@@ -393,7 +393,7 @@ repository the operator owns, committed to it.
 **The tree can move under a run, and the self-check must be able to say so.** Found by running the
 pass (Phase 10): the target's `HEAD` and branch both moved mid-measurement, with a plugin rename
 landing in between. The state key is computed once at the start and nothing re-validates it, so
-*"any inequality over an unchanged tree is a defect"* is **unfalsifiable on a shared checkout** — an
+*"any inequality over a comparable pair is a defect"* is **unfalsifiable on a shared checkout** — an
 inequality could mean a defect or could mean the tree moved, and the run cannot tell which.
 
 - **Assertion 3.4** — a run records the target's revision **at start and at end**. When they differ,
@@ -510,10 +510,11 @@ Restarting from zero wastes the whole run and, worse, tempts an operator to narr
 - Findings persist **incrementally, per lane**, as each lane completes — not buffered to the end.
 - A run manifest records, per lane: the lane id, its **input digest**, and its completion state.
 - **Input digest** = `sha256` over the lane's ordered file list paired with each file's content hash,
-  **and over the run basis** — the state-digest entries **for that lane's own surfaces**, the
-  liveness basis (launch directory, effective merged `claudeMdExcludes`, external-import approval
-  state, setting sources), the harness version, the sweep version, the lane's detection version
-  triple, and, for a judged lane, the judging configuration.
+  **and over the run basis** — the state-digest entries **for the surfaces in that lane's scan set**
+  (which for a cross-class lane is its whole comparison set, per §1), the liveness basis (launch
+  directory, the additional-directory set, effective merged `claudeMdExcludes`, external-import
+  approval state, setting sources), the harness version, the sweep version, the lane's detection
+  version triple, and, for a judged lane, the judging configuration.
 - **Every content-bearing term is scoped to the lane, and taking a whole-run digest here would
   falsify Assertion 5.2.** §6 compares whole runs, so it takes the state digest entire and the
   detection triple of *every* check consulted. A lane digest cannot: fold the whole-run state digest
@@ -802,15 +803,23 @@ claim is not a weaker claim, it is not a claim.
   > differences **attributable to the edits accepted in `R1`** — no more.
 
   **Attribution is what makes this a constraint rather than a hole, and it is why the exemption is
-  not scoped to the state digest alone.** Exempting only the digest would re-break P2 on the
-  remediation these checks most often recommend: moving always-loaded material into a skill changes
-  what loads at startup, so the accepted fix moves the **liveness basis** as a consequence and P2
-  would abstain on exactly the fix it is meant to verify. A surface entering or leaving because an
-  accepted edit created, deleted, or moved it is attributable; one that moved because the launch
-  directory, `claudeMdExcludes`, the harness version, or a catalog bump changed is not, and P2
-  abstains exactly as P1 would. `audit-pass`'s shipped run contract already carries this relation
-  under this name; adopting it rather than minting a second, narrower one is what keeps the two from
-  disagreeing.
+  not scoped to the state digest alone.** A surface entering or leaving because an accepted edit
+  created, deleted, or moved it is attributable; one that moved because the launch directory,
+  `claudeMdExcludes`, the harness version, or a catalog bump changed is not, and P2 abstains exactly
+  as P1 would. `audit-pass`'s shipped run contract already carries this relation under this name;
+  adopting it rather than minting a second, narrower one is what keeps the two from disagreeing.
+
+  **Under this document's *current* input list an accepted edit can only move the state digest, and
+  the relation is still stated over every input.** The liveness basis is defined above as inputs
+  *outside* the tree, and an accepted fix is a tree edit, so no fix moves it — the wider form buys
+  nothing today. It is stated wide anyway for two reasons. The list has already grown twice, and a
+  relation scoped to whichever inputs a fix happens to move today is a restatement that goes stale
+  the next time one is added — the exact drift this section was rewritten to stop. And the shipped
+  contract's second input is the **live surface set**, an *output* that a tree edit genuinely does
+  move: moving always-loaded material into a skill changes what loads at startup, so there the
+  exemption has to reach past the digest or P2 abstains on the remediation these checks most often
+  recommend. This document owes that input (recorded in `PLAN.md` as Phase 8 reconciliation work),
+  and the relation is written so that adopting it is not also a re-derivation of P2.
 
   **The sweep version is never attributable, even when an accepted edit is what moved it.** Phase 10
   runs this pass against this repository, so a finding whose fix edits `audit-pass`'s own anchor
@@ -829,8 +838,11 @@ claim is not a weaker claim, it is not a claim.
   Phase 6 owes one** — until it exists, `fix-comparable` is a definition without a decision
   procedure. The gap bites hardest where the pass never performs the edit itself: a user-scope
   finding is routed as a recommendation and applied by the operator outside the repository, so
-  nothing the run captures establishes that the applied edit matches what was recommended. Until the
-  capture covers that case, P2 abstains on routed findings rather than claiming them.
+  nothing the run captures establishes that the applied edit matches what was recommended. That
+  difference is therefore **not attributable**, which makes the pair not fix-comparable at all —
+  abstention is over the *pair*, as every relation here is, never over a finding within an otherwise
+  admitted pair. A round mixing routed and applied fixes consequently yields no P2 verdict rather
+  than a partial one, and closing that is the capture's job, not a per-finding exception.
 
   **The tier clause replaces a strict subset over `D`, and the strict subset was wrong.** Raised by
   the cross-vendor review. D1 — the deliverable's only new check — is a judged finding and
@@ -838,8 +850,9 @@ claim is not a weaker claim, it is not a claim.
   shadowed definitions, and the raw script candidate rows all legitimately identical. `D(R2) ⊊ D(R1)`
   then *fails* the successful remediation of the primary detector, making the headline convergence
   gate unsatisfiable for the normal case. Strictness belongs in "every accepted finding is gone",
-  which is the claim convergence is actually making; the containment half over `D` is P3's job and
-  P3 already states it.
+  which is the claim convergence is actually making. Containment over `D` splits by relation: for a
+  **comparable** pair it is P3's job and P3 states it, and for a **fix-comparable** pair — where P3's
+  antecedent does not hold — it is the attributable-addition clause above.
 - **P3 — no spontaneous growth.** `R1` and `R2` **comparable** ⇒ `D(R2) ⊆ D(R1)`. The set may grow
   only when a comparability input moved — and a skill authored between runs is a change to the tree.
   **The licensing condition is the negation of comparability, and P3 no longer restates it.** P3
@@ -946,10 +959,13 @@ claim is not a weaker claim, it is not a claim.
   lanes, since a lane completed under one judge has stale findings under another.
 - **P4a — a violation has a consequence, or the property is decoration.** Exceeding the tolerance
   **fails the run's self-check and is reported as an instability finding against the sweep itself**,
-  naming the checks whose output moved. A pair failing P4's precondition — non-comparable, or run
-  under a different judging configuration — is **not** an exceedance: it is reported as
-  non-comparable naming the input that moved, exactly as P1 does, and never routed here. It is not
-  silently absorbed by recalibrating the constant.
+  naming the checks whose output moved. A pair failing P4's precondition is **not** an exceedance and
+  is never routed here: it is reported as **outside the tolerance's scope, naming the input that
+  moved**, on the same posture P1 takes toward a non-comparable pair. The two halves of that
+  precondition are named separately in the report, because only one of them is comparability — a pair
+  that is comparable but ran under a different judging configuration is reported as such, not
+  relabelled non-comparable, since comparability deliberately excludes the judging configuration. It
+  is not silently absorbed by recalibrating the constant.
   The tolerance may be revised only by an explicit, recorded decision citing the observed
   distribution — never as an implicit response to a failure. Without that clause the metric absorbs
   its own counterevidence, which is what a placeholder does.

--- a/docs/topics/context-engineering-claude-5/design/rerun-contract.md
+++ b/docs/topics/context-engineering-claude-5/design/rerun-contract.md
@@ -409,6 +409,18 @@ inequality could mean a defect or could mean the tree moved, and the run cannot 
   So the run records a **working-tree content digest** beside each revision, over the same
   enumeration the scan set uses, and `indeterminate` follows when *either* pair differs. The revision
   is what makes a mismatch legible to an operator; the digest is what makes it detectable at all.
+
+  **The endpoint capture is the full scan-baseline state digest, not the working tree alone.**
+  Raised by review after §6 widened comparability's first input past the repository. A
+  repository-scoped endpoint check leaves the mid-run door open in exactly the place the cross-run
+  door was just closed: a user-scope or managed-policy surface edited after the baseline is frozen
+  but before its lane reads it produces a report mixing two external states, while both recorded
+  revisions and both working-tree digests match. The manifest then describes the baseline rather than
+  what the lanes audited, and a later run compared against that manifest reports a P1 or P4 defect
+  that never happened. So the endpoint capture is the same **all-scope** digest as the baseline —
+  every inventoried scope plus the dirty set — and `indeterminate` follows when it moved, on the same
+  posture the revision pair already takes. Within-run and cross-run integrity read the same surfaces
+  or neither is worth asserting; `audit-pass`'s shipped contract unified them for this reason.
 - **Assertion 3.5** — a read-only run overlapping an applying run against one target never reports a
   finding set mixing pre-apply and post-apply content. Test: an apply that rewrites a fixture surface
   while a reader is mid-run; the reader's report matches exactly one of the two tree states.

--- a/docs/topics/context-engineering-claude-5/design/rerun-contract.md
+++ b/docs/topics/context-engineering-claude-5/design/rerun-contract.md
@@ -510,9 +510,20 @@ Restarting from zero wastes the whole run and, worse, tempts an operator to narr
 - Findings persist **incrementally, per lane**, as each lane completes — not buffered to the end.
 - A run manifest records, per lane: the lane id, its **input digest**, and its completion state.
 - **Input digest** = `sha256` over the lane's ordered file list paired with each file's content hash,
-  **and over the run basis** — the liveness basis (launch directory, effective merged
-  `claudeMdExcludes`, external-import approval state, setting sources), the harness version, and the
-  lane's detection version triple.
+  **and over the run basis** — the state-digest entries **for that lane's own surfaces**, the
+  liveness basis (launch directory, effective merged `claudeMdExcludes`, external-import approval
+  state, setting sources), the harness version, the sweep version, the lane's detection version
+  triple, and, for a judged lane, the judging configuration.
+- **Every content-bearing term is scoped to the lane, and taking a whole-run digest here would
+  falsify Assertion 5.2.** §6 compares whole runs, so it takes the state digest entire and the
+  detection triple of *every* check consulted. A lane digest cannot: fold the whole-run state digest
+  into it and editing any file anywhere moves every lane's digest, so every completed lane re-runs
+  and 5.2's "that lane re-runs and no other completed lane does" is false by construction. What the
+  two lists share is the criterion, not the values — a lane resumed across a moved input is the same
+  defect as a pair compared across one, so an input recognized by §6 is owed to §5 **narrowed to
+  what that lane actually read**. The run-wide terms that remain (harness version, sweep version,
+  liveness basis) are run-wide because no lane-local narrowing of them exists; a change to one
+  legitimately invalidates every lane.
 - **The non-file half is not optional, and the digest was file-only until the cross-vendor review.**
   §6 establishes every one of those values as an input the derived tier depends on. A file-only
   digest is unmoved when any of them changes, so a resume skips the completed lanes and assembles
@@ -574,12 +585,19 @@ things", which is the question an operator actually asks first — and it is whe
 regression would show up. A surface that vanished from the inventory between runs is a defect the
 old two-tier split could not have caught, because the inventory was never a reported artifact.
 
-### Two inputs to the derived tier that are not the tree
+### Inputs to the derived tier that are not the tree
 
-Both surfaced 2026-07-24. They are separate problems with fixes an order of magnitude apart, and
-both arise the same way: a **dead-surface finding** — "this instruction file is reachable from no
-loaded entry point" — is derived-tier by construction (filesystem enumeration plus graph
+The two below surfaced 2026-07-24. They are separate problems with fixes an order of magnitude
+apart, and both arise the same way: a **dead-surface finding** — "this instruction file is reachable
+from no loaded entry point" — is derived-tier by construction (filesystem enumeration plus graph
 reachability, no model in the path), so it inherits every promise P1 makes.
+
+The cross-vendor review later added two more, both stated with the properties rather than here
+because neither is specific to dead-surface findings: the **sweep version**, since `audit-pass`'s own
+anchor normalization and `finding_id` construction decide derived *identities* without belonging to
+any check; and the content of scan surfaces outside the repository, which is why the first
+comparability input is a **scan-baseline state digest** spanning every inventoried scope rather than
+a target tree. The heading no longer carries a count, because it had already gone stale once.
 
 #### The harness version is an undeclared input
 
@@ -693,12 +711,14 @@ Stated as assertions over two runs, `R1` then `R2`. `D(R)` is the derived-tier i
 is the judged-tier set.
 
 **Every property below is conditioned on one shared precondition, stated here once rather than
-per-property.** The cross-vendor review found P1 and P4a missing a clause P3 already carried, and
-stating it three times is what allowed two of the three to drift — so the **comparable-runs**
-precondition is defined in one place and the properties cite it:
+per-property** — with one named exemption, P2's, argued at P2 itself. The cross-vendor review found
+P1 and P4a missing a clause P3 already carried, and stating it three times is what allowed two of
+the three to drift — so the **comparable-runs** precondition is defined in one place and the
+properties cite it:
 
-> `R1` and `R2` are **comparable** when their **target tree**, **liveness basis**, **detection
-> version triple** of every check consulted, and **harness version** are all equal.
+> `R1` and `R2` are **comparable** when their **scan-baseline state digest**, **liveness basis**,
+> **detection version triple** of every check consulted, **harness version**, and **sweep version**
+> are all equal.
 
 The **liveness basis** is every input outside the tree that changes which surfaces the harness loads:
 the launch directory, the **additional-directory set** (`--add-dir` and the
@@ -714,14 +734,40 @@ Like the `prompt_digest`, this list is governed by its criterion rather than its
 input outside the tree that changes what the harness loads belongs to the liveness basis, and one
 found missing is a defect in the list.
 
+**The first input is the scan-baseline state digest, not the target tree, and that widening is the
+whole point.** The first input read "target tree" until the cross-vendor review, and a target tree
+covers only the repository: §1 places user-scope (`user:.claude/CLAUDE.md`) and managed-policy
+(`managed:CLAUDE.md`) surfaces outside it by construction, giving them a scope prefix precisely
+because they are not repo-relative. So adding, removing, or editing `~/.claude/CLAUDE.md` moves the
+three-scope inventory, the raw candidates, and the judged conflicts while the tree and every
+liveness selector stay equal — the pair reads as comparable and P1 or P4 accuses a correct run of a
+determinism defect, which is the accusation-instead-of-abstention direction this whole section
+exists to avoid. The digest spans **every inventoried scope** plus the target's dirty set and is
+taken with the inventory frozen, so comparing baselines compares exactly what the lanes were about
+to read. Liveness answers *which* surfaces load; the state digest answers *what is in them*, and
+neither substitutes for the other. `audit-pass`'s shipped run contract already made this widening
+and names it the same way; this document had not caught up.
+
+The **sweep version** is a digest over `audit-pass`'s own machinery: anchor normalization,
+`finding_id` construction, the inventory and exclusion logic, and the report schema. The detection
+version triple is *per check* and its `host_plugin_version` is the **check's** host plugin, so a
+change to the sweep's shared identity machinery moves derived identities without moving the triple
+of any check consulted — and for a check hosted outside `claude-config` the triple cannot move at
+all. Per-lane resume is the worse half of that failure: it carries forward records built by the
+superseded identity function and presents them beside new ones as a single run. Same fail-closed
+direction as the `prompt_digest` — machinery not covered is a defect in the digest, and adding
+coverage is a version event on first observation.
+
 A property asserts nothing about a non-comparable pair. This is not a weakening — it is what makes
 the assertions falsifiable at all. Each of those inputs changes what a correct run finds: a harness
 update legitimately moves the versioned registry of harness behavior that dead-surface
 classification and raw script candidates are read against, and a catalog or prompt change
 legitimately moves what the judged tier reports. Comparing across them makes correct behavior
 indistinguishable from a defect, in the direction that raises a false alarm — the failure mode this
-whole contract exists to avoid. The run already records all four, because all four affect detection;
-the only thing that was missing was applying them uniformly. A non-comparable pair is **reported as
+whole contract exists to avoid. The liveness, detection, and harness inputs the run already records
+were only ever missing uniform application; the widened state digest and the sweep version have to
+be captured before they can be compared, and a run that cannot record one of them is a run that
+cannot assert these properties. A non-comparable pair is **reported as
 non-comparable, naming which input moved**, never as a pass and never as a failure: an unfalsifiable
 claim is not a weaker claim, it is not a claim.
 
@@ -734,10 +780,57 @@ claim is not a weaker claim, it is not a claim.
   of the harness version, so the paragraph above this one already conceded that a harness update
   breaks the unqualified form. P1 carried the liveness half and not the version half until the
   cross-vendor review found the asymmetry.
-- **P2 — convergence, measured in the tier the fix acted on.** Accepted fixes applied between `R1`
-  and `R2` ⇒ every accepted finding is absent from `R2`, in whichever tier it was reported, and every
-  member of `D(R1) \ D(R2)` corresponds to a fix that was actually applied. A finding that vanishes
-  without a fix is a defect in the check, not a success.
+- **P2 — convergence, measured in the tier the fix acted on.** `R1` and `R2` **fix-comparable** ⇒
+  every accepted finding is absent from `R2`, in whichever tier it was reported; every
+  member of `D(R1) \ D(R2)` corresponds to a fix that was actually applied; **and every derived
+  addition in `D(R2) \ D(R1)` is likewise attributable to an accepted edit.** A finding that vanishes
+  without a fix is a defect in the check, not a success — and an addition that no fix accounts for is
+  the same defect in the other direction. The addition half is not redundant with P3: P3 is gated on
+  **comparable**, a fix pair is only **fix-comparable**, so without this clause nothing at all would
+  govern derived growth during exactly the round where edits are landing. Renaming a definition is
+  the ordinary case that needs it — the old identity leaves `D` and the renamed one enters, and only
+  attribution distinguishes that from spontaneous growth.
+
+  **P2 takes the one exemption to the shared precondition, because comparability contradicts P2's
+  own antecedent.** Raised by the cross-vendor review. P2 is the one property whose whole subject is
+  a *changed* tree: an accepted fix edits the tree, so "comparable *and* fixes were applied" is a
+  condition almost no real pair meets, leaving P2 asserting nothing about precisely the pairs it
+  exists to judge. It therefore takes the comparability relation **modulo the accepted mutation
+  set**:
+
+  > `R1` and `R2` are **fix-comparable** when every comparability input is equal *except* for the
+  > differences **attributable to the edits accepted in `R1`** — no more.
+
+  **Attribution is what makes this a constraint rather than a hole, and it is why the exemption is
+  not scoped to the state digest alone.** Exempting only the digest would re-break P2 on the
+  remediation these checks most often recommend: moving always-loaded material into a skill changes
+  what loads at startup, so the accepted fix moves the **liveness basis** as a consequence and P2
+  would abstain on exactly the fix it is meant to verify. A surface entering or leaving because an
+  accepted edit created, deleted, or moved it is attributable; one that moved because the launch
+  directory, `claudeMdExcludes`, the harness version, or a catalog bump changed is not, and P2
+  abstains exactly as P1 would. `audit-pass`'s shipped run contract already carries this relation
+  under this name; adopting it rather than minting a second, narrower one is what keeps the two from
+  disagreeing.
+
+  **The sweep version is never attributable, even when an accepted edit is what moved it.** Phase 10
+  runs this pass against this repository, so a finding whose fix edits `audit-pass`'s own anchor
+  normalization or `finding_id` construction is a planned case rather than a hypothetical. That edit
+  moves the sweep version — which is a digest over the identity function itself — so every
+  `finding_id` in `R2` is computed differently and cross-run matching is destroyed wholesale: P2's
+  absence half would pass vacuously because no `R1` identity can appear in `R2` at all, and its
+  attribution halves would fire against every finding that never moved. §1 versions the anchor
+  (`anchor/v1`) for this same reason. A pair straddling an identity-machinery change is therefore
+  **not fix-comparable** and P2 abstains, naming the sweep version as the input that moved.
+
+  **What attribution requires, and what this document still owes.** A difference is attributable only
+  against a recorded applied-set — the run has to know which edits it accepted and what each one
+  touched, and compare that against the observed delta. The shipped contract grounds this in the
+  mutation-integrity capture it already performs; **this document names no equivalent mechanism, and
+  Phase 6 owes one** — until it exists, `fix-comparable` is a definition without a decision
+  procedure. The gap bites hardest where the pass never performs the edit itself: a user-scope
+  finding is routed as a recommendation and applied by the operator outside the repository, so
+  nothing the run captures establishes that the applied edit matches what was recommended. Until the
+  capture covers that case, P2 abstains on routed findings rather than claiming them.
 
   **The tier clause replaces a strict subset over `D`, and the strict subset was wrong.** Raised by
   the cross-vendor review. D1 — the deliverable's only new check — is a judged finding and
@@ -748,11 +841,12 @@ claim is not a weaker claim, it is not a claim.
   which is the claim convergence is actually making; the containment half over `D` is P3's job and
   P3 already states it.
 - **P3 — no spontaneous growth.** `R1` and `R2` **comparable** ⇒ `D(R2) ⊆ D(R1)`. The set may grow
-  only on a detection-version bump, a harness-version bump, a change to the liveness basis, or a
-  change to the tree — and a skill authored between runs is a change to the tree. That enumeration is
-  exactly the negation of comparability, which is why the precondition is shared rather than restated
-  here: P3 spelled all four out inline, P1 and P4a spelled out fewer, and the divergence was the
-  defect.
+  only when a comparability input moved — and a skill authored between runs is a change to the tree.
+  **The licensing condition is the negation of comparability, and P3 no longer restates it.** P3
+  originally spelled its four inline while P1 and P4a spelled out fewer, and that divergence was the
+  original defect; an inline copy would have to be re-edited every time the basis gains an input,
+  which is the same drift by a slower route. Citing the shared precondition is what keeps the two
+  from parting again.
 
   **The liveness clause was added to P1 and left out here, which made P3 read correct behavior as a
   defect.** Raised by the cross-vendor review. A changed launch directory, a changed effective
@@ -822,10 +916,11 @@ claim is not a weaker claim, it is not a claim.
   made deterministic; an identity function normalizes how a finding is *reported* and cannot make the
   *detection* reproducible. So judged findings are reported in a separate section, excluded from
   P1–P3, and held instead to:
-  - `|J(R1) △ J(R2)| ≤ max(2, ceil(0.10 × |J(R1)|))` over a **comparable** pair — **the stated
-    tolerance**, measured across three consecutive runs, with the worst pair taken. The tolerance
+  - `|J(R1) △ J(R2)| ≤ max(2, ceil(0.10 × |J(R1)|))` over a **comparable** pair **whose judging
+    configuration is also equal** — **the stated tolerance**, measured across three consecutive
+    runs, with the worst pair taken. The tolerance
     read "over an unchanged tree" until the cross-vendor review, and an unchanged tree is the weakest
-    of the four comparability inputs: a changed catalog or prompt is precisely a change to what the
+    of the comparability inputs: a changed catalog or prompt is precisely a change to what the
     judged tier is asked to find, so the judged set can move far past 10% while every run is correct,
     and P4a would then fail the sweep for model instability that is not instability at all. This is
     the same drift as P1's, in the tier where it is most likely, since a catalog revision is the
@@ -836,9 +931,25 @@ claim is not a weaker claim, it is not a claim.
     is the more damaging of the two directions. The constant is unchanged and is still the
     calibration Phase 10 tests;
   - no member of `J(R2)` contradicts an accepted suppression.
+
+  **The judging configuration is a precondition on the tolerance, not an obligation on the run.**
+  Raised by the cross-vendor review. It is the selected model together with its effort and sampling
+  settings, and an operator who changes either between runs moves `J` legitimately and arbitrarily
+  far past the tolerance while state digest, liveness basis, detection triples, harness version, and
+  sweep version all hold equal. Stated as an obligation it would be self-defeating — the model swap
+  would *violate* P4 and route into P4a as instability, which is the very false alarm being closed;
+  stated as a precondition, the pair is simply not one the tolerance speaks about. **The condition
+  is P4's and P4a's alone and is deliberately absent from the shared precondition**, because `D`
+  contains no model judgement — P1 is assertable exactly *because* nothing in the derived tier
+  passes through one — so conditioning P1, P3, and P3a on it would make them unfalsifiable across a
+  model swap while asserting nothing extra. It is recorded in the **resume digest** for judged
+  lanes, since a lane completed under one judge has stale findings under another.
 - **P4a — a violation has a consequence, or the property is decoration.** Exceeding the tolerance
   **fails the run's self-check and is reported as an instability finding against the sweep itself**,
-  naming the checks whose output moved. It is not silently absorbed by recalibrating the constant.
+  naming the checks whose output moved. A pair failing P4's precondition — non-comparable, or run
+  under a different judging configuration — is **not** an exceedance: it is reported as
+  non-comparable naming the input that moved, exactly as P1 does, and never routed here. It is not
+  silently absorbed by recalibrating the constant.
   The tolerance may be revised only by an explicit, recorded decision citing the observed
   distribution — never as an implicit response to a failure. Without that clause the metric absorbs
   its own counterevidence, which is what a placeholder does.
@@ -864,9 +975,10 @@ P5. Counted by grep over the assertion labels, not transcribed; the previous fig
 Assertions 1.5 and 3.4 and was already stale before this round added 2.3 and 3.5.
 
 **Two properties are now explicitly scoped rather than universal**, and the scoping is the honest
-form: Assertion 1.1 holds for excerpt-granularity findings, and P1's exact equality holds for a
-fixed tree *and* a fixed liveness basis. Both were falsifiable as originally written — not by a
-defect in the sweep, but by correct behavior on a second machine.
+form: Assertion 1.1 holds for excerpt-granularity findings, and P1's exact equality holds over a
+**comparable** pair — cited, never re-enumerated here, since the list has grown twice and a
+restatement is exactly how P1, P3, and P4a drifted apart in the first place. Both were falsifiable as
+originally written — not by a defect in the sweep, but by correct behavior on a second machine.
 
 **What this document deliberately does not decide.** The report's concrete schema, the suppression
 file's path and format, and the lane decomposition are Phase 6 design, because they depend on the

--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog — discovery plugin
 
+## [0.9.2]
+
+### Fixed
+
+- **`/research-deep`'s single-topic tiers returned an artifact nobody had graded.** The
+  post-dispatch verification boundary — dispatch the sibling verifier, apply project fit, write both
+  back into the index — was stated only inside the `N >= 2` multi-topic branch. Tier 2 returned the
+  worker's summary and artifact path directly and Tier 1 said to surface the engine's return, yet no
+  producing context can complete the `/research` outcome gate's verifier-owned rows (independent
+  corroboration, HIGH confidence) or its parent-owned row (project fit): the first two belong to a
+  fresh context by design, the third needs the consuming project's conventions, and nested `Agent`
+  availability is not something a producer can be relied on to have. The main session could
+  therefore present claims as gate-passed that were never graded.
+
+  The boundary is now **one section that every dispatching tier cites** rather than prose inside the
+  multi-topic branch, so Tier 1, Tier 2, and each topic worker are covered by construction and the
+  multi-topic paragraph points at it instead of restating it. Tier 2's dispatch envelope asks the
+  worker to leave those rows `pending`.
+
+- **The evals encoded the retired artifact layout and rewarded the defect above.** `evals/evals.json`
+  required each topic worker to write a sibling `research-<topic>.md` at the slice root — the
+  collision-prone contract replaced by per-topic sub-slices (`<memory_dir>/<slug>/<topic-slug>/`)
+  each holding a normal `RESEARCH.md` — so running it penalized the compliant layout and could not
+  protect the fix from regression. Eval 1 now requires per-topic sub-slices, session-assigned paths,
+  and the per-topic verification boundary. Evals 2 and 3 gain that boundary for Tier 1 and Tier 2;
+  eval 2 previously expected the engine's summary and artifact path to be surfaced directly, which
+  is exactly the behavior the fix removes.
+
 ## [0.9.1]
 
 ### Fixed

--- a/plugins/discovery/skills/research-deep/SKILL.md
+++ b/plugins/discovery/skills/research-deep/SKILL.md
@@ -91,11 +91,12 @@ This variant tracks `/research`'s conventions — same discipline file, same art
   angles; given N separable topics, every broad agent researches all N shallowly — N× the cost for
   worse depth. Run the multi-topic check FIRST, before any tier selection.
 - **Dispatching this skill itself.** It must run in main context: `Workflow` is unavailable in every
-  non-fork subagent, and the multi-topic path needs the `Agent` tool, whose availability inside a
-  subagent depends on a nesting default that has moved three times — and which, inside a fork,
-  cannot spawn a further fork at all. A dispatched `/research-deep` risks silently losing Tier 1 and
-  the N-topic fan-out — the two things
-  it exists for. The sibling `/research` is the one that dispatches.
+  non-fork subagent, and **every** tier needs the `Agent` tool — the N-topic fan-out to spawn topic
+  workers, and all four paths to close the post-dispatch boundary — whose availability inside a
+  subagent depends on a nesting default that has moved three times, and which, inside a fork, cannot
+  spawn a further fork at all. A dispatched `/research-deep` therefore risks silently losing Tier 1,
+  the N-topic fan-out, and the verification boundary that makes any tier's artifact trustworthy. The
+  sibling `/research` is the one that dispatches.
 - **Accepting a subagent return without cited primaries.** That is ungrounded synthesis, Tier 3 by
   the discipline's own rule. Instruct every topic agent to cite primary source URLs, and treat a
   return without them as unfinished rather than as evidence.

--- a/plugins/discovery/skills/research-deep/SKILL.md
+++ b/plugins/discovery/skills/research-deep/SKILL.md
@@ -28,7 +28,7 @@ If no topic was provided, infer it from the current conversation — identify th
 
 ## Dispatch decision (multi-topic check, then three tiers)
 
-**Multi-topic check — run FIRST, before any tier.** Count the independent sub-topics in the ask (numbered list, enumerated questions, separable subjects that share no claims). **N ≥ 2 separable topics → do NOT dispatch an engine on the combined blob.** An engine decomposes ONE question into generic research *angles*; fed a multi-topic blob, every broad agent researches all N topics shallowly — N× the wall-clock and tokens for worse depth. Instead: spawn **N parallel topic agents** (Agent tool, `general-purpose`, one per topic, each running the full `/research` discipline; instruct each to cite primary sources by URL — a subagent return without citations is ungrounded synthesis). **Give each agent its own sub-slice** — `<memory_dir>/<slug>/<topic-slug>/`, assigned by this session in the dispatch envelope, never chosen by the worker (two workers choosing independently can choose the same one). Each writes the normal `RESEARCH.md` index, its sidecars, and its own `research-checklist.md` inside that sub-slice; those filenames are fixed, so N agents pointed at one slice root would overwrite one another's index and ledger rather than producing separable artifacts. **This session owns each topic's post-dispatch boundary — synthesis is the last step, not the only one.** The `/research` gate assigns its independent-corroboration and HIGH-confidence rows to a fresh verifier precisely because a producing context may not grade its own choices, and a topic worker cannot be relied on to dispatch that verifier: whether a non-fork subagent holds `Agent` depends on the harness's current nesting depth allowance (`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`), a default that has moved three times and is not worth designing against. So for **each** topic, this session dispatches the sibling verifier, applies project fit, and writes both results back into that topic's index — before synthesizing. Skipping it produces the worst available artifact: a root `RESEARCH.md` presenting claims as gate-passed when the rows that matter were never graded by anyone. Then synthesize the slice-root `RESEARCH.md` from the per-topic indexes. An engine is for a SINGLE contested or deep question that needs falsification rounds and adversarial claim-checking.
+**Multi-topic check — run FIRST, before any tier.** Count the independent sub-topics in the ask (numbered list, enumerated questions, separable subjects that share no claims). **N ≥ 2 separable topics → do NOT dispatch an engine on the combined blob.** An engine decomposes ONE question into generic research *angles*; fed a multi-topic blob, every broad agent researches all N topics shallowly — N× the wall-clock and tokens for worse depth. Instead: spawn **N parallel topic agents** (Agent tool, `general-purpose`, one per topic, each running the full `/research` discipline; instruct each to cite primary sources by URL — a subagent return without citations is ungrounded synthesis). **Give each agent its own sub-slice** — `<memory_dir>/<slug>/<topic-slug>/`, assigned by this session in the dispatch envelope, never chosen by the worker (two workers choosing independently can choose the same one). Each writes the normal `RESEARCH.md` index, its sidecars, and its own `research-checklist.md` inside that sub-slice; those filenames are fixed, so N agents pointed at one slice root would overwrite one another's index and ledger rather than producing separable artifacts. **This session owns each topic's post-dispatch boundary — synthesis is the last step, not the only one.** Close "The post-dispatch boundary" below for **each** topic, then synthesize the slice-root `RESEARCH.md` from the per-topic indexes. Skipping it produces the worst available artifact: a root `RESEARCH.md` presenting claims as gate-passed when the rows that matter were never graded by anyone. An engine is for a SINGLE contested or deep question that needs falsification rounds and adversarial claim-checking.
 
 For a single-topic ask, detection is **engine-biased**: prefer the heaviest available tier UNLESS the task is clearly small/targeted. Unknown scope or any doubt → heavier tier.
 
@@ -44,7 +44,7 @@ For a single-topic ask, detection is **engine-biased**: prefer the heaviest avai
 
 ### Tier 1 — workflow engine (preferred)
 
-If your tool list includes the Workflow tool and a deep-research workflow is available (check the consuming project's workflow registry first — a project-provided engine may superset the built-in one), dispatch it with the topic and, if it accepts one, the artifact destination — `<memory_dir>/<slug>/RESEARCH.md`, resolved per the plugin's topic-docs binding ([`${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`](${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md)). The engine runs in the background; its completion notification carries the summary + artifact path. Surface those to the user. Do **NOT** re-run the research inline.
+If your tool list includes the Workflow tool and a deep-research workflow is available (check the consuming project's workflow registry first — a project-provided engine may superset the built-in one), dispatch it with the topic and, if it accepts one, the artifact destination — `<memory_dir>/<slug>/RESEARCH.md`, resolved per the plugin's topic-docs binding ([`${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md`](${CLAUDE_PLUGIN_ROOT}/reference/topic-docs.md)). The engine runs in the background; its completion notification carries the summary + artifact path. Do **NOT** re-run the research inline, and do **not** surface the return as-is — an engine is a producing context like any other, so close the post-dispatch boundary below first.
 
 If no workflow engine resolves, fall through to Tier 2.
 
@@ -64,7 +64,8 @@ Agent({
            assume a fixed set. Every accepted claim needs a primary source cited by URL
            captured this run; uncited claims are ungrounded synthesis. RUN THE OUTCOME GATE
            before returning. Write the RESEARCH.md artifact per the skill's Final step.
-           Return ONLY a one-paragraph summary + the artifact path + any unresolved questions."
+           Return ONLY a one-paragraph summary + the artifact path + any unresolved questions +
+           the gate result, leaving the verifier-owned and parent-owned rows `pending`."
 })
 ```
 
@@ -72,7 +73,13 @@ Agent({
 
 ### Tier 3 — inline (clearly small task)
 
-Run `/research` inline in this session. No subagent, no workflow. The full `/research` discipline still applies.
+Run `/research` inline in this session — no dispatched *research* tier, no workflow. The full `/research` discipline still applies, including its own rule that an inline run hands the verifier-owned rows to a fresh context rather than self-grading them. That fresh context is a subagent; what Tier 3 declines to dispatch is the research, not the verification, and the boundary below arrives here through the parent skill rather than being restated.
+
+### The post-dispatch boundary — every dispatching tier owns it
+
+**A dispatched run is not finished when it returns.** No producing context — engine, forked subagent, or topic worker — can complete the `/research` outcome gate's verifier-owned rows (independent corroboration, HIGH confidence) or its parent-owned row (project fit). The first two are assigned to a fresh context precisely because a producer may not grade its own choices; the third needs the consuming project's conventions, which only this session holds. Nor can the producer be relied on to dispatch that verifier itself — whether a non-fork subagent holds `Agent` depends on the harness's current nesting allowance (`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`), a default that has moved three times and is not worth designing against.
+
+So for **every** dispatched run — one per topic on the N-topic path, once on Tier 1 and Tier 2 — this session dispatches the sibling verifier against the artifact on disk, applies project fit, and writes both results back into that artifact's index **before** surfacing anything. Surfacing a producer's summary and artifact path directly presents claims as gate-passed when the rows that matter were never graded by anyone. A single-topic ask earns no weaker boundary than a multi-topic one, and an engine earns no weaker boundary than a subagent.
 
 ## Relationship to `/research` (parent skill)
 

--- a/plugins/discovery/skills/research-deep/evals/evals.json
+++ b/plugins/discovery/skills/research-deep/evals/evals.json
@@ -26,7 +26,7 @@
         "Output treats this single broad comparison as one heavy topic (not split into parallel agents)",
         "Output dispatches the heaviest available tier (a deep-research workflow engine when available)",
         "Output does NOT re-run the deep research inline in the main session after dispatching",
-        "Output does NOT surface the engine's summary and artifact path directly — it dispatches the sibling verifier and applies project fit, writing both back into the index first"
+        "Output does NOT treat dispatch as the end of its work — it states that the engine's return will go through the post-dispatch boundary (sibling verifier, project fit, write-back) before being surfaced, rather than promising to surface the summary and artifact path directly"
       ]
     },
     {

--- a/plugins/discovery/skills/research-deep/evals/evals.json
+++ b/plugins/discovery/skills/research-deep/evals/evals.json
@@ -5,59 +5,66 @@
       "id": 1,
       "name": "multi-topic-parallel-agents",
       "prompt": "Research three separate things for me: (1) best practices for EF Core compiled queries, (2) whether we should adopt OpenTelemetry metrics, and (3) the current state of .NET native AOT for ASP.NET APIs.",
-      "expected_output": "Runs the multi-topic check first, recognizes three separable topics, and dispatches N parallel topic agents (one per topic, each running the full /research discipline) rather than feeding the combined blob to a single engine. Each agent writes its own sibling research-<topic>.md and the main session synthesizes RESEARCH.md.",
+      "expected_output": "Runs the multi-topic check first, recognizes three separable topics, and dispatches N parallel topic agents (one per topic, each running the full /research discipline) rather than feeding the combined blob to a single engine. Each agent is assigned its own sub-slice (<memory_dir>/<slug>/<topic-slug>/) by the dispatching session and writes the normal RESEARCH.md, sidecars, and research-checklist.md inside it. The main session then dispatches the sibling verifier per topic, applies project fit, writes both back into each topic index, and only then synthesizes the slice-root RESEARCH.md.",
       "files": [],
       "expectations": [
         "Output identifies that the ask contains multiple separable topics",
         "Output dispatches one research agent per topic in parallel rather than running one engine over the combined blob",
-        "Each topic agent runs the full research discipline and writes its own sibling research-<topic>.md artifact",
-        "The main session synthesizes a combined RESEARCH.md from the per-topic artifacts"
+        "Each topic agent runs the full research discipline and writes a normal RESEARCH.md plus its sidecars and checklist inside its OWN sub-slice directory, not a sibling research-<topic>.md at the slice root",
+        "The sub-slice path for each topic is assigned by the dispatching session rather than chosen by the worker",
+        "The main session dispatches the sibling verifier and applies project fit per topic, writing both results back into that topic's index before synthesizing",
+        "The main session synthesizes a combined slice-root RESEARCH.md from the per-topic indexes"
       ]
     },
     {
       "id": 2,
       "name": "single-heavy-topic-dispatches-engine",
       "prompt": "Do a deep, thorough research pass comparing Dapper vs EF Core vs raw ADO.NET for our data-access layer, covering performance, maintainability, and migration cost.",
-      "expected_output": "For a single heavy/broad topic, prefers the heaviest available execution tier: dispatches a deep-research workflow engine when one is available, surfaces the returned summary and artifact path, and does NOT re-run the research inline in the main session.",
+      "expected_output": "For a single heavy/broad topic, prefers the heaviest available execution tier: dispatches a deep-research workflow engine when one is available and does NOT re-run the research inline in the main session. The engine's return is not surfaced as-is — the main session closes the post-dispatch boundary first (sibling verifier against the artifact, project fit, both written back into the index), because an engine is a producing context like any other.",
       "files": [],
       "expectations": [
         "Output treats this single broad comparison as one heavy topic (not split into parallel agents)",
         "Output dispatches the heaviest available tier (a deep-research workflow engine when available)",
-        "Output does NOT re-run the deep research inline in the main session after dispatching"
+        "Output does NOT re-run the deep research inline in the main session after dispatching",
+        "Output does NOT surface the engine's summary and artifact path directly — it dispatches the sibling verifier and applies project fit, writing both back into the index first"
       ]
     },
     {
       "id": 3,
       "name": "forked-agent-fallback-no-engine",
       "prompt": "Deep-research the tradeoffs between gRPC and REST for our internal service-to-service calls. Note: no Workflow tool / deep-research workflow is available this session.",
-      "expected_output": "With no workflow-engine path and a heavy task, falls back to spawning an isolated general-purpose subagent that runs the full /research discipline (not a read-only Explore agent, since Phase 3 needs tool access and the artifact must be written).",
+      "expected_output": "With no workflow-engine path and a heavy task, falls back to spawning an isolated general-purpose subagent that runs the full /research discipline (not a read-only Explore agent, since Phase 3 needs tool access and the artifact must be written). The main session then dispatches the sibling verifier against the written artifact and applies project fit, writing both back into the index before surfacing the result — the same post-dispatch boundary the multi-topic path owns.",
       "files": [],
       "expectations": [
         "Output falls back to a forked/isolated subagent when no workflow engine is available",
         "The subagent is a general-purpose agent (able to use tools and write the artifact), not a read-only Explore agent",
-        "The subagent is instructed to run the full /research discipline"
+        "The subagent is instructed to run the full /research discipline",
+        "The main session dispatches the sibling verifier against the returned artifact and applies project fit rather than presenting the worker's summary and artifact path directly",
+        "The verifier and project-fit results are written back into the artifact index before the result is surfaced"
       ]
     },
     {
       "id": 4,
       "name": "small-task-still-full-discipline",
       "prompt": "Deep-research just one small thing: the current stable version number of Node.js LTS.",
-      "expected_output": "Recognizes a clearly-small single-fact task and runs inline (Tier 3) rather than dispatching an engine, but still applies the full /research discipline — task size never reduces depth.",
+      "expected_output": "Recognizes a clearly-small single-fact task and runs the research inline (Tier 3) rather than dispatching an engine, but still applies the full /research discipline — task size never reduces depth. Running inline does not make the run its own grader: the verifier-owned rows still go to a fresh context, per the parent skill's own rule.",
       "files": [],
       "expectations": [
         "Output routes a clearly-small single-fact task to inline execution rather than an engine or parallel agents",
-        "Output still applies the full /research discipline (phases, source tiers) despite the small task size"
+        "Output still applies the full /research discipline (phases, source tiers) despite the small task size",
+        "Output does NOT self-grade the verifier-owned outcome-gate rows — they go to a fresh context even though the research itself ran inline"
       ]
     },
     {
       "id": 5,
       "name": "dispatcher-not-inline-deep-pass",
       "prompt": "Deep-research the security implications of enabling CORS wildcard origins across our API gateway — this is a big one.",
-      "expected_output": "Acts as a dispatcher: selects an execution tier that provides context isolation (engine or forked subagent) and does NOT run the heavy deep pass itself in the main context. The main session stays clean; the isolation comes from the chosen tier.",
+      "expected_output": "Acts as a dispatcher: selects an execution tier that provides context isolation (engine or forked subagent) and does NOT run the heavy deep pass itself in the main context. The main session stays clean of the research transcript — but it still owns the post-dispatch boundary (sibling verifier, project fit, write-back), which is orchestration rather than research and does not belong to the isolated tier.",
       "files": [],
       "expectations": [
         "Output dispatches the heavy pass to an isolated tier rather than running it in the main context",
-        "The main-session output stays a dispatch/summary, not a full inline deep-research transcript"
+        "The main-session output stays a dispatch/summary, not a full inline deep-research transcript",
+        "The main session still closes the post-dispatch boundary itself rather than treating dispatch as the end of its work"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Eight review threads were posted on #1322 and #1425 **after** those PRs merged, so the merge gate
never saw them and they stranded unresolved. All eight were verified against `origin/main` and all
eight were still real — none had been fixed by a later PR.

Two of them, though, were not design gaps. They were the design doc
(`docs/topics/context-engineering-claude-5/design/rerun-contract.md`) having gone **stale against a
shipped contract that already solved them** —
`plugins/claude-config/skills/audit-pass/reference/run-contract.md` already carries both
`fix-comparable` and the widened `scan-baseline state digest`. Those two adopt the shipped
vocabulary and semantics rather than minting a parallel set beside it.

## Findings and disposition

| # | Finding | Verdict | Fix |
|---|---|---|---|
| 1 | P2 vacuous under the shared unchanged-tree precondition | Real; solved upstream | Adopt shipped `fix-comparable` (attribution-based) |
| 2 | External instruction surfaces missing from the run basis | Real; solved upstream | Adopt shipped `scan-baseline state digest` |
| 3 | Judging model config missing from the run basis | Real; uncovered in both | Precondition on P4/P4a only, not the shared list |
| 4 | Sweep machinery version missing from the run basis | Real; uncovered in both | Added to comparability and the resume digest |
| 5 | `PLAN.md` acceptance gate demands a strictly smaller derived set | Real | Disappearance in the tier that reported it |
| 6 | `/research-deep` single-topic Tier 2 returns an ungraded artifact | Real | One boundary section every dispatching tier cites |
| 7 | Root `.worktreeinclude` missing nested sub-slice patterns | Real | Materialized; verified empirically |
| 8 | Multi-topic eval encodes the retired artifact layout | Real | All six evals realigned |

## Notable design decisions

- **F3 is deliberately narrower than the finding asked.** The finding said "record the judging model
  configuration in comparability and lane digests". Putting it in the *shared* precondition would
  make P1/P3/P3a unfalsifiable across a model swap while asserting nothing extra, since `D` contains
  no model judgement — P1 is assertable precisely *because* nothing in the derived tier passes
  through a model. It conditions P4's tolerance and P4a only, plus the resume digest for judged lanes.
- **F1's fix carries two bounds the finding did not name**, both surfaced by review: an
  identity-machinery change is never attributable (it recomputes every `finding_id`, so the pair is
  not fix-comparable at all), and attribution requires a recorded applied-set the design doc does not
  yet name. Phase 6 owes that capture; until it exists P2 abstains on operator-applied routed
  findings rather than claiming them.

## Verification

- Two independent fresh-context audit rounds with rationale withheld. Round 1 found the shipped
  contract I had missed and the parallel-vocabulary problem; round 2 found nine defects in the
  revision, of which the ones this diff caused are fixed here (lane-digest scope falsifying Assertion
  5.2, the judging-configuration clause sitting in P4's consequent, the sweep-version attribution
  hole, the orphaned containment half, an over-reaching user-scope claim, and PLAN.md collateral).
- `.worktreeinclude` verified empirically, not by reading: `git ls-files -o -i --exclude-from`
  intersected with `git check-ignore` in a throwaway repo. Before: nested sub-slice files silently
  dropped. After: carried, with baselines and raw scratch still excluded. The tracked file now
  matches the documented block in `docs/conventions/topic-docs/README.md` byte for byte.
- Gates: `check-changed-skills.sh origin/main` PASS (0 errors, 0 warnings — a pre-existing warning
  cleared as a side effect), `check-changelog-parity.sh` `--check` / `--check-order` /
  `--check-bump` all clean, markdownlint clean, `evals.json` valid.

## Known gaps, recorded not fixed

- The design doc and the shipped contract now diverge in **both** directions: the design has
  `sweep version`, the shipped has `behavior-affecting arguments` and an `observable detection
  version` (a form it adopted after finding the design's triple unestablishable from outside a
  delegate plugin). Recorded in `PLAN.md` as Phase 8 reconciliation work, because changing either
  predicate changes what the shipped pass reports.
- The design doc's new basis inputs land as prose without named assertions. So do the four incumbent
  inputs — this is a pre-existing structural gap, not one this diff introduces.
- `PLAN.md` marks Phases 6, 8 and 9 TODO while `audit-pass` ships a more advanced run contract.
  Implementation ran ahead of the plan; flagged, not reconciled here.

No linked issue

## Related

- Refs #1322 — five stranded threads (findings 1-5)
- Refs #1425 — three stranded threads (findings 6-8)
- Adopts vocabulary from `plugins/claude-config/skills/audit-pass/reference/run-contract.md`
