### PR TITLE
feat(knowledge): land the harness-surface definition and bare-name boundary in the docs profile

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.16",
+  "version": "0.10.17",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -21,6 +21,15 @@ only after that version increases.
   Without the definition, an `api-only` tag turned on whether the reader read "harness surface" as
   user-reachable selection or as any harness mention at all — and the two readings disagree on real
   rows.
+- **Anthropic profile — bare names are not API surfaces.** The `cc-applicable`/`mixed` boundary now
+  says what an API surface is not: a product name, display name, or docs-path slug never by itself
+  triggers `mixed`, and the enumeration gains the fourth surface it had been missing (model ID)
+  alongside parameter, endpoint, and SDK call. This ratifies a standard 15+ rows in the
+  models-explained slice already stood on and a cross-vendor retag already applied in-slice — it is
+  written down, not invented. It also gives the tier-name line `changelog.md:961` a destination: the
+  harness-surface definition above excludes it from sub-shape (3), and this rule is what it routes
+  to instead — a bare-name near-miss, disclosed under 0.10.16's rule, neither an API surface nor a
+  harness surface.
 
 ## [0.10.16]
 

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.17]
+
+### Changed
+
+- **Anthropic profile — "harness surface" now has a written definition, and three shapes that come
+  close without falsifying `api-only`.** J-12 was one of the five items 0.10.16 deliberately held
+  for the dispositions interview; it is answered here. A harness surface is a surface a user can
+  reach. Two of the three non-falsifying shapes — a **counterpart artifact** and a
+  **same-workload mention** — carry an identical adjudication from two independent verification
+  arms. The third, **harness-internal recognition or support** (a harness doc naming the subject in
+  describing the harness's own behavior toward it, with no user-reachable path), is new: it rests on
+  one attested instance, and the amendment is labelled as the campaign's own choice rather than an
+  inherited adjudication, because nothing in the corpus ever defined the term. Every such hit is
+  still disclosed as a near-miss under 0.10.16's rule, which this appends to rather than replaces.
+  Without the definition, an `api-only` tag turned on whether the reader read "harness surface" as
+  user-reachable selection or as any harness mention at all — and the two readings disagree on real
+  rows.
+
 ## [0.10.16]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -96,8 +96,13 @@ the tag asserts:
   doc line describing some *other* model's tier is not harness-internal behavior toward the subject,
   fails (3)'s own test, and is disclosed as a near-miss without entering this list.
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
-  SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
-  reserved for claims naming no API surface.
+  SDK call, model ID) tags `mixed` even when its guidance transfers to the harness;
+  `cc-applicable` is reserved for claims naming no API surface. **Bare names are not API
+  surfaces:** a product name, display name, or docs-path slug never by itself triggers `mixed` —
+  only the four surfaces above do. (Ratified from the de facto standard 15+ rows already stood
+  on, applied in-slice by a cross-vendor retag; a tier-name line such as `changelog.md:961` is
+  therefore a bare-name near-miss — disclosed per the near-miss rule — not an API surface and
+  not a harness surface.)
 - **Row-local, tag always present:** the evidence (a positive tag's live-doc URL, an `api-only`
   basis) appears in the claim's own row — "same basis as claim N" does not satisfy the contract —
   and every claim carries exactly one vocabulary tag: `unverified-inference` is an additional

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -80,6 +80,21 @@ the tag asserts:
   measured it: one release-notes unit disclosed 24 near-miss rows on its own, and two sibling units
   in that slice raised the same boundary independently, one of them asking outright for a standing
   notation so a reader can tell "no surface at all" from "adjacent surface exists".
+- **What a harness surface *is*, and three shapes that come close without falsifying it.**
+  **[campaign-owned amendment]** A harness surface is a surface a user can reach. The following do
+  **not** falsify `api-only`: (1) a **counterpart artifact** — the harness has a thing playing the
+  same role, without referencing the claimed artifact; (2) a **same-workload mention** — a doc names
+  a workload another guide teaches, with no shared guidance or cross-reference;
+  (3) **[campaign-owned amendment] harness-internal recognition or support** — a harness doc names
+  the subject in describing the harness's own internal behavior toward it, without exposing a
+  user-reachable path to it (sole attested instance: retry/fallback, `env-vars.md:394`). Each such
+  hit is disclosed as a near-miss per the rule above. Both labels are load-bearing, not decoration:
+  shapes (1) and (2) carry an identical adjudication from two independent verification arms, but
+  nothing in the corpus ever *defined* "harness surface", so an unlabelled definition would read as
+  inherited when it is this choice — selection over support — being made. Sub-shape (3) stands on
+  **one** attested instance against that two-instance base, and is enumerated no wider than that: a
+  doc line describing some *other* model's tier is not harness-internal behavior toward the subject,
+  fails (3)'s own test, and is disclosed as a near-miss without entering this list.
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
   SDK call) tags `mixed` even when its guidance transfers to the harness; `cc-applicable` is
   reserved for claims naming no API surface.


### PR DESCRIPTION
Lands two adopted Sitting-2 decisions in the anthropic-docs publisher profile — the campaign's consumer-facing tag-selection doctrine. `knowledge` 0.10.16 -> 0.10.17.

## PA-M — the harness-surface definition

New bullet appended to the near-miss rule: **a harness surface is a surface a user can reach**, with three non-falsifying sub-shapes that harness-doc text can take without establishing one. Both the definition sentence and sub-shape (3) carry explicit `[campaign-owned amendment]` labels — the record shows the campaign making the selection-over-support choice, not inheriting an adjudication. Sub-shape (3) rests on its single attested instance (`env-vars.md:394`, a retry/fallback row) and carries its own over-broadening boundary: a doc line describing some *other* model's tier fails the sub-shape's own test.

The landing site was derived three independent ways: the profile already uses "harness surface" as its negative-claim term (`:34`, `:54`); the adopted row's own text says "write into the profile"; and the 0.10.16 CHANGELOG deliberately held this exact question (J-12) for the dispositions interview this answers.

## PA-V — the bare-name boundary

The `cc-applicable`/`mixed` boundary bullet now carries the fourth API surface (**model ID**) and the negative half the profile never stated: **bare names are not API surfaces** — a product name, display name, or docs-path slug never by itself triggers `mixed`. Ratified from the de facto standard 15+ rows already stood on (cross-vendor retag applied in-slice). Deliberately excluded: a `[campaign-owned amendment]` label (this ratifies an evidence-carried standard, not a campaign-invented definition) and "feature names" (present only in one slice's wording, not the adopted row — widening the enumeration would exceed the adopted authority).

## Verification

Both commits independently verified by a second model with the implementer's rationale withheld: the PA-M landing audited across landing-site derivation, amendment fidelity (verbatim vs the adopted blockquote), self-fire (no profile or checklist conflict; no live campaign artifact violates the definition), and mechanics; the PA-V text was *authored* by that verifier from the adopted row and applied verbatim, with the producer re-confirming the authority citations at the bytes before editing. The one enumeration of the API-surface list repo-wide is this bullet — no drift introduced. markdownlint 0 errors; CHANGELOG newest-first, both entries folded into the unreleased 0.10.17.

Downstream, already discharged against these rules: the four slice-local `api-only` ratifications (memory-tier) now cite the landed definition and route their three disclosed near-miss hits per these bullets.

No linked issue

## Related

- Sitting 2 of the doc-corpus decision block, ADOPTED 2026-08-03 after adversarial validation (21/21 CONFIRMED); PA-M ordered first carrying its amendment flags, exactly as the adoption block specifies.
- Siblings this session: #1881, #1882, #1884, #1885, #1887 (open); standards#311 + ADR-0002; dotfiles#394, #399 (open).
- The J-12 hold this closes: `knowledge` 0.10.16's CHANGELOG (PR #1879).
