### PR TITLE
docs(knowledge): admit anthropic.com/engineering and add cross-slice synthesis artifact target

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.18]
+
+### Changed
+
+- **Anthropic profile — `anthropic.com/engineering` is now an in-scope property.** The profile
+  scoped this publisher to `platform.claude.com`, `code.claude.com`, and `claude.com/blog`, which
+  put Anthropic's own engineering posts outside the pipeline even though they are first-party and
+  are the stated best-practices channel for several topics the corpus already wants. Engineering
+  pages are in scope by default now, rather than admitted one at a time by exception — the same
+  coverage either way, with an honest boundary instead of a growing list of one-off exemptions.
+  Two standing costs come with it and are not yet written into any rule: the vendor-blog
+  attestation bullet below still names `claude.com/blog` literally and does not reach the new
+  property, and unlike the two docs properties, `anthropic.com/engineering` publishes no
+  machine-readable page index, so page selection and absence checks against it have no instrument.
+
 ## [0.10.17]
 
 ### Changed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -18,6 +18,14 @@ only after that version increases.
   attestation bullet below still names `claude.com/blog` literally and does not reach the new
   property, and unlike the two docs properties, `anthropic.com/engineering` publishes no
   machine-readable page index, so page selection and absence checks against it have no instrument.
+- **Anthropic profile — a fourth artifact target: cross-slice synthesis.** The taxonomy named three
+  targets, all of which describe a shape a cross-model synthesis artifact is not — it is not
+  per-model, not an audit rule row, and not graduation of one slice. Content deferred to such a pass
+  therefore had nowhere to route: the digest fan-out is barred from reaching across units by design,
+  and no later pipeline stage exists to pick it up. Four units in one slice deferred content into
+  that gap. The target is named without a host — which repository or seam it lands in is a separate
+  decision no run has taken — so the taxonomy stops silently converting cross-unit findings into
+  out-of-scope ones.
 
 ## [0.10.17]
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -166,5 +166,12 @@ Deferred with trigger (not queued):
 
 Interview-handoff dispositions for this publisher typically route to: per-model doctrine
 chapters (a playbooks-style model-adaptation seam), instruction-audit rule rows (a
-model-delta audit class), or corpus graduation (a knowledge-corpus repository). The handoff
-records the candidate target per finding; the interview decides.
+model-delta audit class), corpus graduation (a knowledge-corpus repository), or cross-slice
+synthesis (a cross-model artifact spanning units and slices the per-unit digest fan-out cannot
+reach — not per-model, not an audit rule row, not graduation of one slice; its host is
+undecided). The handoff records the candidate target per finding; the interview decides.
+
+The fourth target exists because content deferred *to* a synthesis pass had nowhere to land:
+the fan-out is barred from reaching across units by design, no later pipeline stage exists, and
+the first three targets each describe a shape it is not. A disposition with no target in this
+list is a corpus hole, not a scoping success.

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -1,10 +1,10 @@
 # Publisher profile — Anthropic docs
 
 Publisher-specific configuration for `/knowledge:docpage-digest` runs against Anthropic
-documentation properties (`platform.claude.com`, `code.claude.com`, `claude.com/blog`). The
-pipeline engine in `SKILL.md` stays generic; everything here is this publisher's own contract.
-A second publisher joins as a sibling profile file; engine extraction waits for the third
-(Rule of Three).
+documentation properties (`platform.claude.com`, `code.claude.com`, `claude.com/blog`,
+`anthropic.com/engineering`). The pipeline engine in `SKILL.md` stays generic; everything here
+is this publisher's own contract. A second publisher joins as a sibling profile file; engine
+extraction waits for the third (Rule of Three).
 
 ## Fetch channel
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -170,8 +170,3 @@ model-delta audit class), corpus graduation (a knowledge-corpus repository), or 
 synthesis (a cross-model artifact spanning units and slices the per-unit digest fan-out cannot
 reach — not per-model, not an audit rule row, not graduation of one slice; its host is
 undecided). The handoff records the candidate target per finding; the interview decides.
-
-The fourth target exists because content deferred *to* a synthesis pass had nowhere to land:
-the fan-out is barred from reaching across units by design, no later pipeline stage exists, and
-the first three targets each describe a shape it is not. A disposition with no target in this
-list is a corpus hole, not a scoping success.

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -2,7 +2,8 @@
 
 Publisher-specific configuration for `/knowledge:docpage-digest` runs against Anthropic
 documentation properties (`platform.claude.com`, `code.claude.com`, `claude.com/blog`,
-`anthropic.com/engineering`). The pipeline engine in `SKILL.md` stays generic; everything here
+`anthropic.com/engineering` — hosts match with or without a leading `www.`; live engineering
+links use `www.anthropic.com`). The pipeline engine in `SKILL.md` stays generic; everything here
 is this publisher's own contract. A second publisher joins as a sibling profile file; engine
 extraction waits for the third (Rule of Three).
 


### PR DESCRIPTION
## Summary

Implements two adopted doc-corpus campaign decisions in the docpage-digest publisher profile (`plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md`):

- **Property extension** (Sitting 2): admits `anthropic.com/engineering` as a fourth covered property in the profile's property list. The two standing costs are stated in the CHANGELOG rather than silently absorbed: the vendor-blog attestation bullet remains literally scoped to `claude.com/blog` (rescoping it is a separate judgment), and the new property contributes no machine-readable page index.
- **Fourth artifact target** (Sitting 6): adds cross-slice / cross-model synthesis as a fourth Artifact target — the prerequisite landing site for the commissioned cross-model synthesis pass (not per-model, not an audit rule row; host repository deliberately undecided).

Bumps knowledge plugin 0.10.17 → 0.10.18 with CHANGELOG entry. Independently verified against the adoption records with author rationale withheld: net branch diff = exactly the two adopted amendments, nothing more; merge-tree clean against current main.

No linked issue

## Related

- #1888 — prior profile change (property doctrine PA-M/PA-V), whose versioning convention this mirrors
- #1891 — adjacent campaign lane (playbooks rehost), disjoint files, merged while this branch was in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UarawwEnZQu7cB6i7WatJ
