### PR TITLE
docs(readme): complete the repo map with every tracked top-level directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 - `.claude-plugin/marketplace.json` — the marketplace catalog.
 - `plugins/` — one directory per plugin.
-- `lib/` — single source of truth for the shared shell helpers; the self-contained copies at
-  `plugins/*/hooks/` are synced from here by `scripts/sync-*.sh`, never edited directly.
+- `lib/` — single source of truth for the shared shell helpers; the self-contained copies vendored
+  under `plugins/`, into hook and skill-script directories alike, are synced from here by
+  `scripts/sync-*.sh` and CI rejects drift, so never edit a copy.
 - `scripts/` — repo-level CI checks, sync scripts, and catalog generators, with their tests
   alongside.
 - `prompts/` — launch-prompt templates meant to be filled in and pasted into a session; unlike

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 
 - `.claude-plugin/marketplace.json` — the marketplace catalog.
 - `plugins/` — one directory per plugin.
+- `lib/` — single source of truth for the shared shell helpers; the self-contained copies at
+  `plugins/*/hooks/` are synced from here by `scripts/sync-*.sh`, never edited directly.
+- `scripts/` — repo-level CI checks, sync scripts, and catalog generators, with their tests
+  alongside.
+- `prompts/` — launch-prompt templates meant to be filled in and pasted into a session; unlike
+  `lib/`, nothing copies them, and plugin skills cite them by path.
+- `.claude/` — this checkout's own Claude Code configuration (session and PR-linkage hooks, the
+  source-control convention). It governs work done here and ships to no one.
+- `.github/` — workflows plus the policy files they read (runner policy, security paths, recurring
+  schedule, PR template).
 - `docs/MIGRATION-PLAYBOOK.md` — design charter, extensibility model, the per-plugin migration
   gate, and the local development loop.
 - `docs/` — further design records and audits (CI runner routing, extensibility-contract smoke

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 - `plugins/` — one directory per plugin.
 - `lib/` — single source of truth for the shared shell helpers; the self-contained copies vendored
   under `plugins/`, into hook and skill-script directories alike, are synced from here by
-  `scripts/sync-*.sh` and CI rejects drift, so never edit a copy.
+  each helper's own `scripts/sync-<helper>.sh` and CI rejects drift, so never edit a copy.
 - `scripts/` — repo-level CI checks, sync scripts, and catalog generators, with their tests
   alongside.
 - `prompts/` — launch-prompt templates meant to be filled in and pasted into a session; unlike


### PR DESCRIPTION
## Summary

Supersedes #1847, which fixed the same defect but reproduced it: it added `lib/` and `scripts/`
while leaving `prompts/` — a directory its own test plan enumerated — off the map, so the "list the
tracked top-level directories" rationale still did not hold after the change. Widening the check
from that PR's six-directory count to `git ls-tree -d` turned up two more omissions, `.claude/` and
`.github/`.

This lists all five that were missing. The "What's here" map now names all eight tracked top-level
directories, which is a criterion a reviewer can re-run rather than eyeball.

The `lib/` line states the sync DIRECTION, which is the part that is actually easy to get wrong:
`lib/` is the single source of truth, and the copies vendored under `plugins/` exist only because
installed plugins are cache-isolated and must be self-contained. It deliberately does not say those
copies live at `plugins/*/hooks/` — that glob holds only for `lib/hook-utils.sh`, and #1847 was
flagged in review for exactly that overstatement. `lib/parse-concern-value.sh` is vendored into
three skill-script directories, so a reader who trusted the glob would take a copy found outside
`hooks/` for an unmanaged file.

The `prompts/` line states the opposite relationship on purpose, so a reader does not generalize
"shared dir at the root" into "synced": nothing copies those templates, and plugin skills cite them
by path.

Prose only; no code, config, or workflow changes.

## Test plan

- `npx markdownlint-cli2 README.md` — 0 errors.
- Completeness is checked, not asserted: `git ls-tree -d --name-only HEAD` yields `.claude`,
  `.claude-plugin`, `.github`, `docs`, `lib`, `plugins`, `prompts`, `scripts`; the directory names
  in the "What's here" section now yield the same eight.
- Every new entry verified against the tree rather than assumed:
  - `lib/` sync direction — each `scripts/sync-*.sh` read for its actual `src` and destinations:
    `sync-hook-utils.sh` globs `plugins/*/hooks/hook-utils.sh`; `sync-parse-concern-value.sh` lists
    three `plugins/*/skills/**` script paths; `sync-resolve-convention-pattern.sh` lists one
    guardrails hook. Hence the wording covers hook and skill-script directories alike. CI's
    `hook-utils-sync`, `parse-concern-value-sync`, and `resolve-convention-pattern-sync` jobs reject
    drifted copies.
  - `scripts/` — `check-*.sh`, `sync-*.sh`, and `generate-catalog.mjs` / `generate-cheatsheet.mjs`,
    each with a `*.test.sh` beside it.
  - `prompts/` — holds `prompts/loops/loop-lane-prompts.md`; no sync script or CI check references
    it, and `plugins/claude-ops/skills/lanes/context/restart-consumer.md:40` cites it by path.
  - `.claude/` — `settings.json` wiring `hooks/session-start.sh` and `hooks/pr-linkage-mcp-gate.sh`,
    plus `source-control.md`; not part of any published plugin.
  - `.github/` — `workflows/` plus `runner-policy.json`, `claude-security-paths`,
    `recurring-schedule.json`, and `pull_request_template.md`.
- Independently verified by a fresh-context reviewer with the rationale withheld. It recomputed both
  directory sets (match, 8/8) and caught the carried-forward `plugins/*/hooks/` overstatement, fixed
  in `d7e588ba`.

No linked issue

## Related

- #1847 — superseded by this PR; closed as incomplete by its own rationale. Its `lib/`
  sync-direction sentence is carried forward here, with the destination corrected.
