### PR TITLE
docs(knowledge): repopulate the doc queue with the adopted enqueue roster

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -42,8 +42,8 @@ only after that version increases.
 - **Retention and ZDR are queued as one slice, and the slice remains owner-vetoable.** A corpus that
   will be pointed at repositories we do not control is precisely the one that should not be silent
   on retention: it is the one queued topic carrying compliance weight, and both properties are
-  already in scope, so the slice costs a single fetch — the API lane is the only page not already
-  held. The org-policy posture is the argument for it rather than against, but the posture is real
+  already in scope. The slice drains as three page runs per the engine's one-page-per-run rule;
+  the API lane is the only page not already held in the harness snapshot. The org-policy posture is the argument for it rather than against, but the posture is real
   and cuts against the standing self-alignment-before-packaging ordering, so the enqueue is recorded
   as still open to an owner veto. A queue entry is trivially reversible if that veto fires.
 - **The engineering-post entry's contingency is discharged.** Its enqueue was sequenced behind the

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -10,8 +10,8 @@ only after that version increases.
 
 - **Anthropic profile — the doc queue is repopulated from the Sitting-5 doc-queue dispositions.**
   The queue had been emptied as its slices completed, so twelve adopted rows had nowhere to land and
-  the pipeline had no stated next page. Counted at the bytes, one bullet per page: **11 pages
-  queued** across six groups, and **5 pages deferred with triggers** — the deferred section now
+  the pipeline had no stated next page. Counted at the bytes, one bullet per page: **14 pages
+  queued** across seven groups, and **5 pages deferred with triggers** — the deferred section now
   holds six bullets, the sixth being `task-budgets`, which predates this batch. Each entry carries
   the reason it is where it is rather than a bare URL.
 - **`thinking-troubleshooting` is queued first, on a corrected rationale.** DQ-2's original ground —
@@ -39,9 +39,13 @@ only after that version increases.
   The source's premise that best-practices was "already in the profile doc queue" is false at the
   bytes — it never has been — but the disposition is unaffected, because folding resolves to no
   standalone entry either way.
-- **The retention/ZDR slice is deliberately not queued here.** It is an org-policy posture with
-  enterprise-facing weight that cuts against the standing self-alignment-before-packaging ordering,
-  and no owner decision has closed that question. Recorded rather than dropped.
+- **Retention and ZDR are queued as one slice, and the slice remains owner-vetoable.** A corpus that
+  will be pointed at repositories we do not control is precisely the one that should not be silent
+  on retention: it is the one queued topic carrying compliance weight, and both properties are
+  already in scope, so the slice costs a single fetch — the API lane is the only page not already
+  held. The org-policy posture is the argument for it rather than against, but the posture is real
+  and cuts against the standing self-alignment-before-packaging ordering, so the enqueue is recorded
+  as still open to an owner veto. A queue entry is trivially reversible if that veto fires.
 
 ## [0.10.18]
 

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -43,7 +43,8 @@ only after that version increases.
   will be pointed at repositories we do not control is precisely the one that should not be silent
   on retention: it is the one queued topic carrying compliance weight, and both properties are
   already in scope. The slice drains as three page runs per the engine's one-page-per-run rule;
-  the API lane is the only page not already held in the harness snapshot. The org-policy posture is the argument for it rather than against, but the posture is real
+  the API lane is the only page not already held in the harness snapshot. The org-policy posture
+  is the argument for it rather than against, but the posture is real
   and cuts against the standing self-alignment-before-packaging ordering, so the enqueue is recorded
   as still open to an owner veto. A queue entry is trivially reversible if that veto fires.
 - **The engineering-post entry's contingency is discharged.** Its enqueue was sequenced behind the

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -10,8 +10,10 @@ only after that version increases.
 
 - **Anthropic profile — the doc queue is repopulated from the Sitting-5 doc-queue dispositions.**
   The queue had been emptied as its slices completed, so twelve adopted rows had nowhere to land and
-  the pipeline had no stated next page. Ten pages are queued and five deferred-with-trigger records
-  added, each carrying the reason it is where it is rather than a bare URL.
+  the pipeline had no stated next page. Counted at the bytes, one bullet per page: **11 pages
+  queued** across six groups, and **5 pages deferred with triggers** — the deferred section now
+  holds six bullets, the sixth being `task-budgets`, which predates this batch. Each entry carries
+  the reason it is where it is rather than a bare URL.
 - **`thinking-troubleshooting` is queued first, on a corrected rationale.** DQ-2's original ground —
   that the page backs the thinking doc set's *weakest* absence check — is not what the corpus says.
   The check is **falsified, not weak**: the harness carries a parallel troubleshooting surface

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -46,6 +46,10 @@ only after that version increases.
   held. The org-policy posture is the argument for it rather than against, but the posture is real
   and cuts against the standing self-alignment-before-packaging ordering, so the enqueue is recorded
   as still open to an owner veto. A queue entry is trivially reversible if that veto fires.
+- **The engineering-post entry's contingency is discharged.** Its enqueue was sequenced behind the
+  engineering-property profile edit, which landed in 0.10.18 — the same merge that closed that
+  property decision's veto window — so the entry ships unconditionally; the deferred-with-trigger
+  fallback written for a fired veto never engaged.
 
 ## [0.10.18]
 

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.19]
+
+### Changed
+
+- **Anthropic profile — the doc queue is repopulated from the Sitting-5 doc-queue dispositions.**
+  The queue had been emptied as its slices completed, so twelve adopted rows had nowhere to land and
+  the pipeline had no stated next page. Ten pages are queued and five deferred-with-trigger records
+  added, each carrying the reason it is where it is rather than a bare URL.
+- **`thinking-troubleshooting` is queued first, on a corrected rationale.** DQ-2's original ground —
+  that the page backs the thinking doc set's *weakest* absence check — is not what the corpus says.
+  The check is **falsified, not weak**: the harness carries a parallel troubleshooting surface
+  (`errors.md`, `prompt-caching.md`), which is why the page's transfer is demonstrated rather than
+  conjectured and why digesting it lets the corpus state the mapping instead of guessing at it.
+  Carrying the old wording forward would have re-inherited a premise the evidence disproves. Rider
+  R1 — the `api-only` → `mixed` retag the falsification compels on the affected claim — was
+  discharged separately on 2026-08-03 and does not close silently with this enqueue.
+- **Companion-doc order amended: `memory` moves to second.** DQ-9's source ranked
+  `how-claude-code-works` ahead of it and held `memory` entirely. Two things have moved since:
+  `memory.md` carries four to five times the corpus citation load of either page ranked ahead of it
+  (47 line-anchored citations across 22 distinct sites in 18 files, against 11/6/9 and 9/5/6), and
+  `claude-memory:audit` became a live adopted routing destination for memory-layer findings.
+  `features-overview` keeps first place on its own reasoning; `common-workflows` stays held as
+  recipe-level content whose citations are concentrated rather than distributed.
+- **The Agent SDK entry queues one page, not the SDK doc set.** All thirty snapshotted `agent-sdk_*`
+  pages sit inside the harness boundary, so a loosely phrased entry would take a scope decision
+  nobody has made. The heading states the boundary instead of leaving it to inference.
+- **Two pages fold into existing entries rather than gaining their own (DQ-15).**
+  `whats-new-sonnet-5` is already a subject of the models deferral with a trigger, and a second
+  differently-triggered standalone entry is how one page acquires two custody records that drift
+  apart; `prompting-best-practices` is API-side content this corpus points at rather than digests.
+  The source's premise that best-practices was "already in the profile doc queue" is false at the
+  bytes — it never has been — but the disposition is unaffected, because folding resolves to no
+  standalone entry either way.
+- **The retention/ZDR slice is deliberately not queued here.** It is an org-policy posture with
+  enterprise-facing weight that cuts against the standing self-alignment-before-packaging ordering,
+  and no owner decision has closed that question. Recorded rather than dropped.
+
 ## [0.10.18]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -167,6 +167,18 @@ Thinking (completes the set's custody map — troubleshooting first):
   — the last uncovered page of the thinking doc set; two already-digested slices defer to it by
   anchor, so the marginal cost of the last page is the lowest it will ever be
 
+Retention and ZDR (one slice, two lanes — retention is org-level policy and the one topic queued
+here carrying compliance weight; both properties are already in scope, so the slice costs one
+fetch):
+
+- <https://platform.claude.com/docs/en/manage-claude/api-and-data-retention>
+  — the API lane
+- <https://code.claude.com/docs/en/data-usage>
+  — the harness lane
+- <https://code.claude.com/docs/en/zero-data-retention>
+  — the harness lane's enterprise posture: ZDR is scoped to qualified accounts on Claude for
+  Enterprise, which is the commitment a consuming setup needs stated rather than inferred
+
 Agent SDK (one page — SDK docs are canonically harness docs, but queueing the rest of that doc set
 is a separate scope decision nobody has taken):
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -199,10 +199,12 @@ Deferred with trigger (not queued):
 - <https://platform.claude.com/docs/en/build-with-claude/fallback-credit> — the two API-side claims
   it would settle carry a weak, openly disclosed absence basis that nothing is built on; enqueue
   when an artifact actually depends on fallback-credit behavior
-- <https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5> and
-  <https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5> — release notes for
-  models the models `overview` page already covers canonically; enqueue either when its model
-  enters or materially changes a fleet lane
+- <https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5> — release notes for a
+  model the models `overview` page already covers canonically; enqueue when Opus 5 enters or
+  materially changes a fleet lane
+- <https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5> — release notes for a
+  model the models `overview` page already covers canonically; enqueue when Sonnet 5 enters or
+  materially changes a fleet lane
 - <https://claude.com/blog/complete-guide-to-building-skills-for-claude> — a vendor-voice
   restatement of a schema whose first-party canons are already reachable, so digesting it adds
   attestation cost and no authority; enqueue for the first artifact that needs schema detail no

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -157,11 +157,73 @@ Every model-pinned spawn brief uses the conditional framing contract from `SKILL
 Pending Anthropic docs for this pipeline. Verify each URL live at fetch time; remove entries as
 their slices complete.
 
+Thinking (completes the set's custody map — troubleshooting first):
+
+- <https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting>
+  — the harness carries a parallel troubleshooting surface (`errors.md`, `prompt-caching.md`), so
+  this page's transfer to the harness is demonstrated rather than conjectured; digesting it is what
+  lets the corpus state the mapping instead of guessing at it
+- <https://platform.claude.com/docs/en/build-with-claude/thinking-tool-workflows>
+  — the last uncovered page of the thinking doc set; two already-digested slices defer to it by
+  anchor, so the marginal cost of the last page is the lowest it will ever be
+
+Agent SDK (one page — SDK docs are canonically harness docs, but queueing the rest of that doc set
+is a separate scope decision nobody has taken):
+
+- <https://code.claude.com/docs/en/agent-sdk/agent-loop>
+
+Models:
+
+- <https://platform.claude.com/docs/en/about-claude/models/overview>
+  — the canonical model-fact freshness source; re-fetching this one page *is* the freshness check,
+  where a release-notes corpus would grow monotonically and age entry by entry
+- <https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5>
+  — the launch source the corpus's own Fable 5 / Mythos 5 positioning claims rest on, and linked
+  from the harness model-config doc's "Work with Fable 5"
+
+Claude Code companion docs (digest in this order):
+
+- <https://code.claude.com/docs/en/features-overview>
+- <https://code.claude.com/docs/en/memory>
+- <https://code.claude.com/docs/en/how-claude-code-works>
+
 Deferred with trigger (not queued):
 
 - <https://platform.claude.com/docs/en/build-with-claude/task-budgets> — api-only (the page
   states task budgets are not supported on Claude Code or Cowork; verified 2026-07-27); enqueue
   when harness support lands
+- <https://code.claude.com/docs/en/context-window> — read against the 2026-07-31 harness snapshot
+  rather than left untested: it documents behavior as the limit approaches (Claude Code compacts
+  automatically) but never the `model_context_window_exceeded` stop reason, so it does not move the
+  claim it was checked for; enqueue if the page starts documenting that stop reason's handling
+- <https://platform.claude.com/docs/en/build-with-claude/fallback-credit> — the two API-side claims
+  it would settle carry a weak, openly disclosed absence basis that nothing is built on; enqueue
+  when an artifact actually depends on fallback-credit behavior
+- <https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5> and
+  <https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5> — release notes for
+  models the models `overview` page already covers canonically; enqueue either when its model
+  enters or materially changes a fleet lane
+- <https://claude.com/blog/complete-guide-to-building-skills-for-claude> — a vendor-voice
+  restatement of a schema whose first-party canons are already reachable, so digesting it adds
+  attestation cost and no authority; enqueue for the first artifact that needs schema detail no
+  first-party canon states
+
+Blog posts:
+
+- <https://claude.com/blog/the-advisor-strategy>
+  — the harness advisor doc cites this post as its own "why"; digest it alongside
+  <https://code.claude.com/docs/en/advisor> and
+  <https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool> so one slice covers
+  the concept's three surfaces
+- <https://claude.com/blog/a-field-guide-to-claude-fable-finding-your-unknowns>
+  — the designated deep-dive for prompting the Claude 5 generation, already being read by local
+  work without a custody record, applicability tags, or an attestation pass
+
+Engineering posts:
+
+- <https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents>
+  — the cited best-practices source for custom agent evaluations, and methodology input to the
+  deferred re-pin checklist and the eval-set gap
 
 ## Artifact targets
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -199,6 +199,23 @@ Claude Code companion docs (digest in this order):
 - <https://code.claude.com/docs/en/memory>
 - <https://code.claude.com/docs/en/how-claude-code-works>
 
+Blog posts:
+
+- <https://claude.com/blog/the-advisor-strategy>
+  — the harness advisor doc cites this post as its own "why"; digest it alongside
+  <https://code.claude.com/docs/en/advisor> and
+  <https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool> so one slice covers
+  the concept's three surfaces
+- <https://claude.com/blog/a-field-guide-to-claude-fable-finding-your-unknowns>
+  — the designated deep-dive for prompting the Claude 5 generation, already being read by local
+  work without a custody record, applicability tags, or an attestation pass
+
+Engineering posts:
+
+- <https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents>
+  — the cited best-practices source for custom agent evaluations, and methodology input to the
+  deferred re-pin checklist and the eval-set gap
+
 Deferred with trigger (not queued):
 
 - <https://platform.claude.com/docs/en/build-with-claude/task-budgets> — api-only (the page
@@ -221,23 +238,6 @@ Deferred with trigger (not queued):
   restatement of a schema whose first-party canons are already reachable, so digesting it adds
   attestation cost and no authority; enqueue for the first artifact that needs schema detail no
   first-party canon states
-
-Blog posts:
-
-- <https://claude.com/blog/the-advisor-strategy>
-  — the harness advisor doc cites this post as its own "why"; digest it alongside
-  <https://code.claude.com/docs/en/advisor> and
-  <https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool> so one slice covers
-  the concept's three surfaces
-- <https://claude.com/blog/a-field-guide-to-claude-fable-finding-your-unknowns>
-  — the designated deep-dive for prompting the Claude 5 generation, already being read by local
-  work without a custody record, applicability tags, or an attestation pass
-
-Engineering posts:
-
-- <https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents>
-  — the cited best-practices source for custom agent evaluations, and methodology input to the
-  deferred re-pin checklist and the eval-set gap
 
 ## Artifact targets
 

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -160,16 +160,17 @@ their slices complete.
 Thinking (completes the set's custody map — troubleshooting first):
 
 - <https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting>
-  — the harness carries a parallel troubleshooting surface (`errors.md`, `prompt-caching.md`), so
-  this page's transfer to the harness is demonstrated rather than conjectured; digesting it is what
-  lets the corpus state the mapping instead of guessing at it
+  — the harness documents this page's specific assertions on its own pages (`errors.md` documents
+  thinking-configuration 400s; `prompt-caching.md` documents cache-miss causes), which is
+  claim-level transfer under the falsifying rule above, not topical overlap; the digest still tags
+  each claim against those pages individually — this entry pre-classifies none of them
 - <https://platform.claude.com/docs/en/build-with-claude/thinking-tool-workflows>
   — the last uncovered page of the thinking doc set; two already-digested slices defer to it by
   anchor, so the marginal cost of the last page is the lowest it will ever be
 
-Retention and ZDR (one slice, two lanes — retention is org-level policy and the one topic queued
-here carrying compliance weight; both properties are already in scope, so the slice costs one
-fetch):
+Retention and ZDR (one topic slice, two lanes, drained as three page runs — one page per run, per
+the engine; retention is org-level policy and the one topic queued here carrying compliance
+weight, and both properties are already in scope):
 
 - <https://platform.claude.com/docs/en/manage-claude/api-and-data-retention>
   — the API lane


### PR DESCRIPTION
## Summary

Repopulates the docpage-digest Anthropic profile's doc queue with the doc-corpus campaign's adopted enqueue roster (knowledge 0.10.18 → 0.10.19):

- **14 pages queued across seven groups** — thinking troubleshooting first (on the corrected rationale: the harness carries a parallel troubleshooting surface, so the page's transfer is demonstrated, not conjectured), then the last thinking page, the retention/ZDR slice (one slice, two lanes, three pages — org-level policy, the one queued topic with compliance weight), one Agent SDK page with the wider-scope boundary stated in the group heading, the models freshness pair, three Claude Code companion docs in digestion order, two blog posts, and one engineering post (the property admitted in 0.10.18).
- **5 pages deferred with triggers** — each carrying its named re-arm condition, including a context-window deferral that states its discharged check's result rather than leaving the trigger dormant.
- The retention/ZDR enqueue is recorded as still open to an owner veto; the engineering entry's contingency is disclosed as discharged (its prerequisite property edit was the 0.10.18 merge).

Independently verified (fresh-context, rationale withheld): SHIP, with the two findings (deferred-block position; contingency disclosure) applied in `6395841eb3` and confirmed CLOSED. All 14 queued URLs return HTTP 200 live; queue counts recounted at the bytes by producer and verifier independently.

No linked issue

## Related

- #1892 — the property admission and artifact-target amendment this queue builds on (0.10.18)
- #1887 — DOC bundle 2, where the queue's prior entries were retired on slice completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UarawwEnZQu7cB6i7WatJ
