### PR TITLE
docs(adr): repair ADR 0002's skip-actor exception record and mechanism

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,6 +35,14 @@ jobs:
     uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
     with:
       runner: ubuntu-24.04
+      # Stated explicitly rather than inherited — #1766 dropped this line from
+      # BOTH lane callers while re-pinning, silently adopting whatever the
+      # reusable's default happened to be. Value matches the v0.9.1 default, so
+      # this restores the declaration without changing who is skipped. This lane
+      # is advisory (no required check), so the list is not ADR 0002's ratified
+      # exception; it is kept identical to the security caller's so the two
+      # lanes cannot drift apart unnoticed.
+      skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
     # Pass only the one named secret (least privilege) rather than `secrets:
     # inherit`, which would forward every parent secret to the called workflow.
     secrets:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,14 +35,6 @@ jobs:
     uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
     with:
       runner: ubuntu-24.04
-      # Stated explicitly rather than inherited — #1766 dropped this line from
-      # BOTH lane callers while re-pinning, silently adopting whatever the
-      # reusable's default happened to be. Value matches the v0.9.1 default, so
-      # this restores the declaration without changing who is skipped. This lane
-      # is advisory (no required check), so the list is not ADR 0002's ratified
-      # exception; it is kept identical to the security caller's so the two
-      # lanes cannot drift apart unnoticed.
-      skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
     # Pass only the one named secret (least privilege) rather than `secrets:
     # inherit`, which would forward every parent secret to the called workflow.
     secrets:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -35,6 +35,13 @@ jobs:
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths
+      # Stated explicitly, never left to the reusable's default: this list IS
+      # ADR 0002's skip-actor exception, and the exception must be readable and
+      # reviewable in the repo it applies to. An inherited default silently
+      # rewrites the exception whenever ci-workflows changes it — which is how
+      # `claude[bot]` and `melodic-ai[bot]` entered it (#1766 dropped this line
+      # while re-pinning to a version whose default had widened).
+      skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
     # One named secret (least privilege), never `secrets: inherit`.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -219,6 +219,11 @@ This amendment deliberately does NOT decide the actor set. **If the amendment la
 explicit pick, Branch A is what merges** — silence ratifies four. Stating that so it is a
 choice, not a default reached by inattention.
 
+> **Superseded 2026-08-04:** the operator made an explicit pick, so the silence default was
+> never exercised and "this amendment deliberately does NOT decide the actor set" no longer
+> describes the record. The two branches below stand as what was weighed; the decision is in
+> the 2026-08-04 addendum.
+
 - **Branch A — ratify the widened exception (keep four).** The affirmative case: both added
   actors are dormant, so the exception costs nothing observable today; and the lane's value on
   agent-authored chore PRs (dependency re-pins, sync materializations, doc-queue churn) is low
@@ -250,6 +255,36 @@ the no-edit branch and Branch A would carry the one-line change and the ADR touc
 `allowed_bots` dependency is NOT an artifact — it is a real cost that attaches to Branch B
 whichever way this was drafted, and it is the row that makes Branch B a cross-repo change rather
 than a one-line edit. Weigh Branch B on its affirmative case against that cost.
+
+## Addendum (2026-08-04): operator decision — Branch A ratified, four actors
+
+Supersedes the 2026-08-03 amendment's OPERATOR DECISION POINT insofar as it left the actor set
+open and named silence as the ratifying default. The operator made an explicit pick on
+2026-08-04: **Branch A — the widened four-actor exception is ratified.** The silence default was
+not exercised.
+
+The ratified set, as `.github/workflows/claude-security-review.yml` now states explicitly:
+
+```yaml
+skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
+```
+
+`claude[bot]` and `melodic-ai[bot]` are thereby covered by the step-3 skip-actor exception through
+the deliberation the revisit trigger demands, rather than through the silent inheritance that put
+them there. No workflow edit accompanies the decision — the 2026-08-03 amendment already restored
+those four to stay behavior-preserving, so the effective skip set is unchanged on both lanes.
+
+What the ratification rests on, stated so a later reader can test it rather than take it: the two
+added actors are dormant, and the lane's value on agent-authored chore PRs is low relative to its
+spend. Branch B's affirmative case is not refuted — it is outweighed while those premises hold,
+and its `allowed_bots` cross-repo dependency is the cost that decided the margin. The trigger
+below for agent actors beginning to author substantive changes under security-sensitive paths is
+the condition that reopens this.
+
+Four is now the ratified baseline the `skip-actors` trigger measures additions against: a fifth
+actor widens a deliberated exception and warrants the same deliberation. Unchanged by this
+decision — the review lane's inherited default stays deferred with its own trigger, and the
+caller-tamper gap recorded above stays open pending ci-workflows#345.
 
 ## Revisit triggers
 

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -112,7 +112,9 @@ branch's caller file, a PR can alter its own `paths` input or `skip-actors` on i
 mitigation is that workflow-file diffs are themselves security-review surface and the caller
 file is human-reviewed. This is the consensus-accepted bound of Actions-based required checks,
 not a defect introduced here.
-<!-- Both halves of that mitigation are falsified; see the 2026-08-03 addendum. -->
+
+> **Superseded 2026-08-03:** Both halves of that mitigation are falsified; see the 2026-08-03
+> addendum.
 
 ## Addendum (2026-08-03): mechanism correction — the exception moved to a reusable default
 
@@ -130,11 +132,31 @@ since the lane went live), so this is a record defect, not an exploited one.
 
 Two corrections land with this amendment:
 
-1. Both lane callers state `skip-actors` explicitly again, so the exception is readable in the
-   repo it governs and cannot be rewritten by an upstream default change. **This is the
-   mechanism, not just the record** — an inherited default is what failed.
-2. The restored lists encode the FOUR actors currently in force, so the change is
+1. The security-review caller states `skip-actors` explicitly again, so the exception is
+   readable in the repo it governs and cannot be rewritten by an upstream default change.
+   **This is the mechanism, not just the record** — an inherited default is what failed.
+2. The restored list encodes the FOUR actors currently in force, so the change is
    behavior-preserving. Whether four is the right set is the open question below.
+
+**Deferred with a trigger — the review lane keeps its inherited default.** The same restoration
+was drafted for `claude-review.yml` and withdrawn. The pinned runner-policy contract for
+`claude-review.yml@c136b27f` permits exactly one input, `runner`, so declaring `skip-actors`
+there fails `runner-target-contract` and reds the required `ci-status` check. `runner-policy` is
+upstream-managed for this repo, so the entry cannot be edited here. The trigger to finish the
+repair: a re-pin of the review lane to a SHA whose contract lists `skip-actors`, or a
+standards-reviewed amendment to the `c136b27f` entry. Until then the review lane's skip set is
+an inherited default — recorded as a known, bounded gap rather than an unnoticed one. It is the
+advisory lane, so it carries no required check and is not the lane this ADR's ratified exception
+governs.
+
+That contract entry is itself part of the record defect, and worth stating because it sharpens
+the finding. Six other pinned `claude-review.yml` entries in `policy.json` list `skip-actors`;
+`c136b27f` is the only entry that permits `runner` while omitting it. The reviewed contract
+memorialized #1766's dropped line a second time, independently of the caller — the same accident
+recorded twice, in two places, by two mechanisms. And the mechanism that blocked the repair is
+precisely the compensating control the 2026-07-21 addendum names ("the reviewed runner-policy
+contract — an input-surface change declines auto-approval and requires a standards-reviewed
+policy entry"). It fired exactly as that addendum describes, on this amendment.
 
 `skip-actors` and the action's `allowed_bots` are different levers with different outcomes.
 Removing an actor from `skip-actors` alone does NOT restore review of its PRs: the reusable
@@ -159,9 +181,12 @@ it accurately matters, because two plausible-sounding offsets do not hold here:
   ruleset does require is `required_review_thread_resolution: true`. Any argument resting on
   "a human reviews it at merge" is unavailable here and must not be used.
 
-The complete required set on `main` is `pr-title / pr-title`, `do-not-merge / do-not-merge`,
-`ci-status` (ruleset `ci-gate`), and `security-review / security-review` (ruleset
-`security-review-gate`, which additionally grants `OrganizationAdmin` a pull-request bypass).
+The complete required STATUS-CHECK set on `main` is `pr-title / pr-title`,
+`do-not-merge / do-not-merge`, `ci-status` (ruleset `ci-gate`), and
+`security-review / security-review` (ruleset `security-review-gate`, which additionally grants
+`OrganizationAdmin` a pull-request bypass). Merge requirements beyond status checks are separate
+and unaffected by this analysis: the `signing` ruleset requires signed commits, and `base`
+requires linear history and squash-only merges.
 
 ### Correction: the caller-tamper mitigation does not hold
 
@@ -174,7 +199,7 @@ halves fail:
   default branch"), which is precisely the class of change the mitigation relies on. The step
   still reports success, so the reusable's `Fail closed on an in-scope non-run` step never
   fires and the required check goes GREEN with no review performed and no tracking comment —
-  despite `track_progress: true`. Observed on this amendment's own PR and on #1766.
+  despite `track_progress: true`. Observed on #1896 and on #1766.
 - Human review is not required (see above).
 
 So the required check does not certify a security pass on any PR that edits the caller. This
@@ -201,9 +226,21 @@ choice, not a default reached by inattention.
   Branch B is only coherent alongside the `allowed_bots` change — otherwise it converts a
   dormant record defect into a live merge block the moment either actor opens a PR.
 
-On effort: Branch A needs no edit only because this amendment restored the four-actor list to
-stay behavior-preserving. Had it restored two, Branch B would be the no-edit branch. The
-asymmetry is an artifact of drafting, not evidence for either side.
+On effort, stated so the branch that silence ratifies is not made to look cheaper than it is.
+The decision touches ONE file: the security-review caller. The review lane is deferred out of
+both branches by the runner-policy contract, so it differentiates neither.
+
+- **Branch A: no further edit.** The amendment already restored four there to stay
+  behavior-preserving.
+- **Branch B: a one-line value change** in that caller, PLUS amending correction 2 above (which
+  records four as the set in force), PLUS the upstream `allowed_bots` widening in ci-workflows,
+  which is a hard dependency and not optional sequencing — without it Branch B converts a
+  dormant record defect into a live merge block the moment either actor opens a PR.
+
+Half of that gap is a drafting artifact: had this amendment restored two, Branch B would be the
+no-edit branch and Branch A would carry the one-line change. The `allowed_bots` dependency is
+not an artifact — it is a real cost that attaches to Branch B whichever way this was drafted.
+Weigh Branch B on its affirmative case against that cost.
 
 ## Revisit triggers
 
@@ -218,12 +255,17 @@ asymmetry is an artifact of drafting, not evidence for either side.
   runs blocks the merge).
 - An actor is added to the caller's `skip-actors` list → the step-3 skip-actor exception
   widens; re-deliberate before landing, and record the rationale beside the addendum above.
-  This trigger also fires when the caller STOPS stating the list: an inherited default is an
-  undeclared exception, and it is what the 2026-08-03 amendment repairs.
+  This trigger also fires when a caller STOPS stating the list: an inherited default is an
+  undeclared exception. The 2026-08-03 amendment repairs that on the security-review caller —
+  the lane this exception actually governs. It does NOT repair the review caller, which the
+  runner-policy contract blocks; that lane's inherited default is recorded in the amendment as
+  deferred with its own trigger, so it is a declared gap rather than the undeclared drift this
+  bullet exists to catch.
 - Agent actors begin authoring substantive changes under security-sensitive paths → the skip
   stops being cheap; widen `allowed_bots` in the ci-workflows reusable so those PRs are
   reviewed rather than skipped, instead of narrowing `skip-actors` alone (which fails closed).
-- ci-workflows maps an action-side workflow-validation skip to a non-run → the caller-tamper
+- ci-workflows maps an action-side workflow-validation skip to a non-run (ci-workflows#345) →
+  the caller-tamper
   gap recorded in the 2026-08-03 addendum closes, and the required check begins certifying
   execution on caller-editing PRs. Until then, treat a green `security-review` on any PR that
   touches `.github/workflows/claude-security-review.yml` as unproven and review it by hand.

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -106,62 +106,104 @@ standards-reviewed policy entry), and standards-sync PRs materialize byte-exact 
 reviewed upstream. Bounded scope: the exception covers exactly the listed actors; adding an
 actor to `skip-actors` widens the exception and warrants the same deliberation.
 
-**Compensating controls on a skipped PR.** The skip removes the LLM pass, not all security
-coverage: `secret-scan / gitleaks` and GitGuardian both run and must pass, the `ci-status`
-aggregate gates the rest, and merge still requires human review. Those are what the exception
-above is accepted against.
-
-## Addendum (2026-08-03): mechanism correction — the exception moved to a reusable default
-
-The addendum above describes a **caller-side** `skip-actors` list. That list stopped existing
-on 2026-07-30: #1766 re-pinned the lane callers to v0.9.1 and dropped the caller's explicit
-`skip-actors` line, so the effective value silently became the reusable's own default — which
-had widened from one actor to four three days earlier. The consequence: `claude[bot]` and
-`melodic-ai[bot]` joined a required-check exception without the deliberation the revisit
-trigger below demands. Neither has exercised it (`claude[bot]` has authored no PRs in this
-org; `melodic-ai[bot]` none here since the lane went live), so this is a record defect, not
-an exploited one.
-
-Two corrections land with this amendment:
-
-1. The caller states `skip-actors` explicitly again, so the exception is readable in the repo
-   it governs and cannot be rewritten by an upstream default change. **This is the mechanism,
-   not just the record** — an inherited default is what failed.
-2. The list as restored encodes the FOUR actors currently in force, so the change is
-   behavior-preserving on its own. Whether four is the right set is the open question below.
-
-Note also that `skip-actors` and the action's `allowed_bots` are different levers with
-different outcomes. Removing an actor from `skip-actors` alone does NOT restore review of its
-PRs: the reusable passes `allowed_bots: dependabot[bot]`, and the action throws on any other
-bot actor, which this lane's fail-closed mapping turns into a required check that is red for
-a cause no push can fix. Reviewing an agent's PRs instead of skipping them requires widening
-`allowed_bots` in ci-workflows — a separate change, tracked below.
-
-### OPERATOR DECISION POINT — ratify four actors, or revert to two
-
-This amendment deliberately does NOT decide the actor set. Both branches are live options;
-pick one before this PR merges.
-
-- **Branch A — ratify the widened exception (keep four).** Accept `claude[bot]` and
-  `melodic-ai[bot]` alongside the two ratified actors, on the same rationale: agent-authored
-  changes here are either byte-exact upstream content or pass through human review at merge.
-  Costs nothing to implement — the restored line already encodes it.
-- **Branch B — revert to the ratified two.** Drop `claude[bot]` and `melodic-ai[bot]` from
-  the caller's `skip-actors`, restoring exactly the 2026-07-21 scope. Their PRs would then
-  hit the actor gate described above and fail closed, so Branch B is only coherent alongside
-  the `allowed_bots` change — otherwise it converts a dormant record defect into a live
-  merge block the moment either actor opens a PR.
-
-Evidence either way: both added actors are dormant, so the choice is cheap now and gets more
-expensive once agent authorship picks up. Branch A is a one-word confirmation; Branch B is an
-edit to the restored line plus an upstream dependency.
-
 Two structural bounds on what the required check proves: it evidences that the workflow-side
 gate ran (or judged not-applicable) — and because `pull_request` workflows execute the PR
 branch's caller file, a PR can alter its own `paths` input or `skip-actors` on its head; the
 mitigation is that workflow-file diffs are themselves security-review surface and the caller
 file is human-reviewed. This is the consensus-accepted bound of Actions-based required checks,
 not a defect introduced here.
+<!-- Both halves of that mitigation are falsified; see the 2026-08-03 addendum. -->
+
+## Addendum (2026-08-03): mechanism correction — the exception moved to a reusable default
+
+Supersedes the 2026-07-21 addendum's description of WHERE the exception lives and WHICH actors
+it covers. That addendum describes a **caller-side** `skip-actors` list naming two actors;
+neither remained true.
+
+The list stopped existing on 2026-07-30: #1766 re-pinned the lane callers to v0.9.1 and
+dropped the caller's explicit `skip-actors` line, so the effective value silently became the
+reusable's own default — which had widened from one actor to four three days earlier
+(ci-workflows `cf666f67`, 2026-07-27). `claude[bot]` and `melodic-ai[bot]` thereby joined a
+required-check exception without the deliberation the revisit trigger below demands. Neither
+has exercised it (`claude[bot]` has authored no PRs in this org; `melodic-ai[bot]` none here
+since the lane went live), so this is a record defect, not an exploited one.
+
+Two corrections land with this amendment:
+
+1. Both lane callers state `skip-actors` explicitly again, so the exception is readable in the
+   repo it governs and cannot be rewritten by an upstream default change. **This is the
+   mechanism, not just the record** — an inherited default is what failed.
+2. The restored lists encode the FOUR actors currently in force, so the change is
+   behavior-preserving. Whether four is the right set is the open question below.
+
+`skip-actors` and the action's `allowed_bots` are different levers with different outcomes.
+Removing an actor from `skip-actors` alone does NOT restore review of its PRs: the reusable
+passes `allowed_bots: dependabot[bot]`, and the action throws on any other bot actor, which
+this lane's fail-closed mapping turns into a required check red for a cause no push can fix.
+Reviewing an agent's PRs instead of skipping them requires widening `allowed_bots` in
+ci-workflows — a separate change, tracked below.
+
+### Correction: what a skipped PR is actually still checked by
+
+The 2026-07-21 addendum accepts the exception without naming the offsetting coverage. Naming
+it accurately matters, because two plausible-sounding offsets do not hold here:
+
+- **gitleaks does gate.** It is a STEP (`id: gitleaks`) in `ci.yml`'s `hygiene` job, not a
+  check context of its own; its outcome is aggregated fail-closed into `hygiene`, which
+  `ci-status` requires. It blocks merge under the name `ci-status`.
+- **GitGuardian runs but does NOT gate.** `GitGuardian Security Checks` reports on every PR
+  and is in no ruleset. A failing GitGuardian check does not block merge.
+- **Human approval is NOT required.** The `base` ruleset sets
+  `required_approving_review_count: 0`; the repo has a single collaborator, so author and
+  reviewer are the same person and merges routinely carry zero approving reviews. What the
+  ruleset does require is `required_review_thread_resolution: true`. Any argument resting on
+  "a human reviews it at merge" is unavailable here and must not be used.
+
+The complete required set on `main` is `pr-title / pr-title`, `do-not-merge / do-not-merge`,
+`ci-status` (ruleset `ci-gate`), and `security-review / security-review` (ruleset
+`security-review-gate`, which additionally grants `OrganizationAdmin` a pull-request bypass).
+
+### Correction: the caller-tamper mitigation does not hold
+
+The 2026-07-21 addendum names "workflow-file diffs are themselves security-review surface and
+the caller file is human-reviewed" as the mitigation for a PR editing its own caller. Both
+halves fail:
+
+- The action refuses to run when the calling workflow file differs from the default branch
+  ("Workflow validation failed… must have identical content to the version on the repository's
+  default branch"), which is precisely the class of change the mitigation relies on. The step
+  still reports success, so the reusable's `Fail closed on an in-scope non-run` step never
+  fires and the required check goes GREEN with no review performed and no tracking comment —
+  despite `track_progress: true`. Observed on this amendment's own PR and on #1766.
+- Human review is not required (see above).
+
+So the required check does not certify a security pass on any PR that edits the caller. This
+is a real gap in what the gate proves, recorded here rather than papered over; the fix belongs
+upstream in the ci-workflows outcome mapping and is filed as a revisit trigger below.
+
+### OPERATOR DECISION POINT — ratify four actors, or revert to two
+
+This amendment deliberately does NOT decide the actor set. **If the amendment lands without an
+explicit pick, Branch A is what merges** — silence ratifies four. Stating that so it is a
+choice, not a default reached by inattention.
+
+- **Branch A — ratify the widened exception (keep four).** The affirmative case: both added
+  actors are dormant, so the exception costs nothing observable today; and the lane's value on
+  agent-authored chore PRs (dependency re-pins, sync materializations, doc-queue churn) is low
+  relative to its spend. Note the 2026-07-21 rationales do NOT extend here — "byte-exact
+  upstream content" is specific to `melodic-standards-sync[bot]`, and "human review at merge"
+  is unavailable in this repo. Branch A must stand on dormancy and cost, not on those.
+- **Branch B — revert to the ratified two.** The affirmative case: the required check's entire
+  claim is that a security pass ran, and `claude[bot]` is precisely the actor whose output an
+  independent pass is most useful against; two actors entered the exception with no
+  deliberation, and the conservative repair is to restore the scope that was actually ratified
+  rather than bless the accident. Cost: their PRs would hit the actor gate and fail closed, so
+  Branch B is only coherent alongside the `allowed_bots` change — otherwise it converts a
+  dormant record defect into a live merge block the moment either actor opens a PR.
+
+On effort: Branch A needs no edit only because this amendment restored the four-actor list to
+stay behavior-preserving. Had it restored two, Branch B would be the no-edit branch. The
+asymmetry is an artifact of drafting, not evidence for either side.
 
 ## Revisit triggers
 
@@ -181,3 +223,7 @@ not a defect introduced here.
 - Agent actors begin authoring substantive changes under security-sensitive paths → the skip
   stops being cheap; widen `allowed_bots` in the ci-workflows reusable so those PRs are
   reviewed rather than skipped, instead of narrowing `skip-actors` alone (which fails closed).
+- ci-workflows maps an action-side workflow-validation skip to a non-run → the caller-tamper
+  gap recorded in the 2026-08-03 addendum closes, and the required check begins certifying
+  execution on caller-editing PRs. Until then, treat a green `security-review` on any PR that
+  touches `.github/workflows/claude-security-review.yml` as unproven and review it by hand.

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -106,6 +106,56 @@ standards-reviewed policy entry), and standards-sync PRs materialize byte-exact 
 reviewed upstream. Bounded scope: the exception covers exactly the listed actors; adding an
 actor to `skip-actors` widens the exception and warrants the same deliberation.
 
+**Compensating controls on a skipped PR.** The skip removes the LLM pass, not all security
+coverage: `secret-scan / gitleaks` and GitGuardian both run and must pass, the `ci-status`
+aggregate gates the rest, and merge still requires human review. Those are what the exception
+above is accepted against.
+
+## Addendum (2026-08-03): mechanism correction — the exception moved to a reusable default
+
+The addendum above describes a **caller-side** `skip-actors` list. That list stopped existing
+on 2026-07-30: #1766 re-pinned the lane callers to v0.9.1 and dropped the caller's explicit
+`skip-actors` line, so the effective value silently became the reusable's own default — which
+had widened from one actor to four three days earlier. The consequence: `claude[bot]` and
+`melodic-ai[bot]` joined a required-check exception without the deliberation the revisit
+trigger below demands. Neither has exercised it (`claude[bot]` has authored no PRs in this
+org; `melodic-ai[bot]` none here since the lane went live), so this is a record defect, not
+an exploited one.
+
+Two corrections land with this amendment:
+
+1. The caller states `skip-actors` explicitly again, so the exception is readable in the repo
+   it governs and cannot be rewritten by an upstream default change. **This is the mechanism,
+   not just the record** — an inherited default is what failed.
+2. The list as restored encodes the FOUR actors currently in force, so the change is
+   behavior-preserving on its own. Whether four is the right set is the open question below.
+
+Note also that `skip-actors` and the action's `allowed_bots` are different levers with
+different outcomes. Removing an actor from `skip-actors` alone does NOT restore review of its
+PRs: the reusable passes `allowed_bots: dependabot[bot]`, and the action throws on any other
+bot actor, which this lane's fail-closed mapping turns into a required check that is red for
+a cause no push can fix. Reviewing an agent's PRs instead of skipping them requires widening
+`allowed_bots` in ci-workflows — a separate change, tracked below.
+
+### OPERATOR DECISION POINT — ratify four actors, or revert to two
+
+This amendment deliberately does NOT decide the actor set. Both branches are live options;
+pick one before this PR merges.
+
+- **Branch A — ratify the widened exception (keep four).** Accept `claude[bot]` and
+  `melodic-ai[bot]` alongside the two ratified actors, on the same rationale: agent-authored
+  changes here are either byte-exact upstream content or pass through human review at merge.
+  Costs nothing to implement — the restored line already encodes it.
+- **Branch B — revert to the ratified two.** Drop `claude[bot]` and `melodic-ai[bot]` from
+  the caller's `skip-actors`, restoring exactly the 2026-07-21 scope. Their PRs would then
+  hit the actor gate described above and fail closed, so Branch B is only coherent alongside
+  the `allowed_bots` change — otherwise it converts a dormant record defect into a live
+  merge block the moment either actor opens a PR.
+
+Evidence either way: both added actors are dormant, so the choice is cheap now and gets more
+expensive once agent authorship picks up. Branch A is a one-word confirmation; Branch B is an
+edit to the restored line plus an upstream dependency.
+
 Two structural bounds on what the required check proves: it evidences that the workflow-side
 gate ran (or judged not-applicable) — and because `pull_request` workflows execute the PR
 branch's caller file, a PR can alter its own `paths` input or `skip-actors` on its head; the
@@ -126,3 +176,8 @@ not a defect introduced here.
   runs blocks the merge).
 - An actor is added to the caller's `skip-actors` list → the step-3 skip-actor exception
   widens; re-deliberate before landing, and record the rationale beside the addendum above.
+  This trigger also fires when the caller STOPS stating the list: an inherited default is an
+  undeclared exception, and it is what the 2026-08-03 amendment repairs.
+- Agent actors begin authoring substantive changes under security-sensitive paths → the skip
+  stops being cheap; widen `allowed_bots` in the ci-workflows reusable so those PRs are
+  reviewed rather than skipped, instead of narrowing `skip-actors` alone (which fails closed).

--- a/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
+++ b/docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md
@@ -145,13 +145,20 @@ there fails `runner-target-contract` and reds the required `ci-status` check. `r
 upstream-managed for this repo, so the entry cannot be edited here. The trigger to finish the
 repair: a re-pin of the review lane to a SHA whose contract lists `skip-actors`, or a
 standards-reviewed amendment to the `c136b27f` entry. Until then the review lane's skip set is
-an inherited default — recorded as a known, bounded gap rather than an unnoticed one. It is the
-advisory lane, so it carries no required check and is not the lane this ADR's ratified exception
-governs.
+an inherited default — recorded as a known, bounded gap rather than an unnoticed one.
+
+Scope, stated precisely rather than conveniently: before #1766 BOTH callers carried the ratified
+`dependabot[bot],melodic-standards-sync[bot]` list, so the review lane's inherited default is an
+unrepaired half of the same ratified declaration, not an adjacent unrelated gap. What differs is
+consequence, not provenance. The review lane is advisory and has no required check, so its
+inherited default cannot let a PR satisfy a required gate with no review — which is the harm the
+2026-07-21 exception was ratified against. That bounds the deferral; it does not make the review
+lane out of scope.
 
 That contract entry is itself part of the record defect, and worth stating because it sharpens
-the finding. Six other pinned `claude-review.yml` entries in `policy.json` list `skip-actors`;
-`c136b27f` is the only entry that permits `runner` while omitting it. The reviewed contract
+the finding. `policy.json` holds eight pinned `claude-review.yml` entries; six list
+`skip-actors`, one (`1d3762c2`) permits no inputs at all, and `c136b27f` is the only
+`claude-review.yml` entry that permits `runner` while omitting it. The reviewed contract
 memorialized #1766's dropped line a second time, independently of the caller — the same accident
 recorded twice, in two places, by two mechanisms. And the mechanism that blocked the repair is
 precisely the compensating control the 2026-07-21 addendum names ("the reviewed runner-policy
@@ -227,8 +234,9 @@ choice, not a default reached by inattention.
   dormant record defect into a live merge block the moment either actor opens a PR.
 
 On effort, stated so the branch that silence ratifies is not made to look cheaper than it is.
-The decision touches ONE file: the security-review caller. The review lane is deferred out of
-both branches by the runner-policy contract, so it differentiates neither.
+Only ONE workflow file is in play — the security-review caller; the review lane is deferred out
+of both branches by the runner-policy contract, so it differentiates neither. That does not make
+the branches equal in reach: Branch B additionally touches this ADR and a second repository.
 
 - **Branch A: no further edit.** The amendment already restored four there to stay
   behavior-preserving.
@@ -237,10 +245,11 @@ both branches by the runner-policy contract, so it differentiates neither.
   which is a hard dependency and not optional sequencing — without it Branch B converts a
   dormant record defect into a live merge block the moment either actor opens a PR.
 
-Half of that gap is a drafting artifact: had this amendment restored two, Branch B would be the
-no-edit branch and Branch A would carry the one-line change. The `allowed_bots` dependency is
-not an artifact — it is a real cost that attaches to Branch B whichever way this was drafted.
-Weigh Branch B on its affirmative case against that cost.
+The first two rows are a drafting artifact: had this amendment restored two, Branch B would be
+the no-edit branch and Branch A would carry the one-line change and the ADR touch. The
+`allowed_bots` dependency is NOT an artifact — it is a real cost that attaches to Branch B
+whichever way this was drafted, and it is the row that makes Branch B a cross-repo change rather
+than a one-line edit. Weigh Branch B on its affirmative case against that cost.
 
 ## Revisit triggers
 
@@ -257,15 +266,15 @@ Weigh Branch B on its affirmative case against that cost.
   widens; re-deliberate before landing, and record the rationale beside the addendum above.
   This trigger also fires when a caller STOPS stating the list: an inherited default is an
   undeclared exception. The 2026-08-03 amendment repairs that on the security-review caller —
-  the lane this exception actually governs. It does NOT repair the review caller, which the
-  runner-policy contract blocks; that lane's inherited default is recorded in the amendment as
-  deferred with its own trigger, so it is a declared gap rather than the undeclared drift this
-  bullet exists to catch.
+  the lane where an undeclared exception can satisfy a required gate with no review. It does
+  NOT repair the review caller, which the runner-policy contract blocks; that lane's inherited
+  default is recorded in the amendment as deferred with its own trigger, so it is a declared
+  gap rather than the undeclared drift this bullet exists to catch.
 - Agent actors begin authoring substantive changes under security-sensitive paths → the skip
   stops being cheap; widen `allowed_bots` in the ci-workflows reusable so those PRs are
   reviewed rather than skipped, instead of narrowing `skip-actors` alone (which fails closed).
 - ci-workflows maps an action-side workflow-validation skip to a non-run (ci-workflows#345) →
-  the caller-tamper
-  gap recorded in the 2026-08-03 addendum closes, and the required check begins certifying
+  the caller-tamper gap recorded in the 2026-08-03 addendum closes, and the required check
+  begins certifying
   execution on caller-editing PRs. Until then, treat a green `security-review` on any PR that
   touches `.github/workflows/claude-security-review.yml` as unproven and review it by hand.


### PR DESCRIPTION
## Summary

ADR 0002 records a skip-actor exception scoped to **two** actors and living in **the caller's** `skip-actors` list. Neither is true today.

[#1766](https://github.com/melodic-software/claude-code-plugins/pull/1766) re-pinned the lane callers to v0.9.1 and dropped the explicit `skip-actors` line from **both** callers. The effective value silently became the reusable's own default — which had widened from one actor to four three days earlier (ci-workflows `cf666f67`). So `claude[bot]` and `melodic-ai[bot]` entered a required-check exception without the deliberation ADR 0002's own revisit trigger demands.

Neither has exercised it (`claude[bot]` has authored no PRs in this org; `melodic-ai[bot]` none here since the lane went live), so this is a **record defect, not an exploited one**.

What this changes:

1. **Mechanism** — the **security-review caller** states `skip-actors` explicitly again, so the exception is readable in the repo it governs and cannot be rewritten by an upstream default change. The inherited default is what failed, so the fix is the mechanism, not just the prose. The review lane's matching half is **deferred with a trigger** — see below.
2. **Compensating controls, stated accurately** — see the correction note below; the first draft of this PR got them wrong.
3. **Lever confusion** — records that `skip-actors` and the action's `allowed_bots` are different levers. Narrowing `skip-actors` alone does NOT restore review; the reusable passes `allowed_bots: dependabot[bot]`, the action throws on any other bot actor, and this lane's fail-closed mapping turns that into a required check red for a cause no push can fix.

## 🟡 Half the repair is deferred — the runner-policy contract blocks the review lane

**This PR originally edited both callers, and that red-lined a required check.** Disclosing it, because the episode is itself evidence for the ADR's thesis.

Declaring `skip-actors` on `claude-review.yml` failed `runner-target-contract`, which fails required `ci-status`:

```
.github/workflows/claude-review.yml#review: runner-target-contract:
the reusable workflow call has inputs absent from its reviewed contract: skip-actors
```

Cause, from `.github/standards/runner-policy/policy.json`:

| pinned target | `allowedInputs` | `skip-actors` permitted |
|---|---|---|
| `claude-review.yml@c136b27f` | `["runner"]` | **no** |
| `claude-security-review.yml@c136b27f` | `["runner","paths-file","skip-actors"]` | yes |

`runner-policy` is **upstream-managed** for this repo — `distribution/sync-manifest.yml` lists it under `melodic-software/claude-code-plugins` → `managed`, and `components/runner-policy/policy.json` is owned in `melodic-software/standards` — so the contract entry cannot be edited here.

**Resolution taken:** `.github/workflows/claude-review.yml` is restored to its pre-PR state — byte-identical to `origin/main`. `ci-status` is green again. Only the security caller, whose contract permits the input, keeps the explicit list. The review lane's inherited default is recorded in the ADR as **deferred with a trigger** (re-pin to a review-lane SHA whose contract lists `skip-actors`, or a standards-reviewed amendment to the `c136b27f` entry) rather than dropped silently. The ADR's revisit trigger for a caller that *stops* stating the list is amended so this reads as a declared gap, not the undeclared drift that bullet exists to catch.

Scope stated precisely, since it would be easy to overclaim here: before #1766 **both** callers carried the ratified `dependabot[bot],melodic-standards-sync[bot]` list, so the review lane's inherited default is an *unrepaired half of the same ratified declaration*, not an unrelated gap. What differs is consequence, not provenance — the review lane is advisory with no required check, so its inherited default cannot let a PR satisfy a required gate with no review, which is the harm the 2026-07-21 exception was ratified against. That bounds the deferral; it does not put the review lane out of scope.

Two findings from the episode, now in the ADR because they strengthen the record:

- **The contract entry is a second, independent memorialization of the same #1766 drift.** Six other pinned `claude-review.yml` entries in `policy.json` list `skip-actors`; `c136b27f` is the only entry that permits `runner` while omitting it. The reviewed contract recorded the accident too, separately from the caller.
- **The control that blocked the repair is the one ADR 0002 already credits.** The 2026-07-21 addendum cites "the reviewed runner-policy contract — an input-surface change declines auto-approval and requires a standards-reviewed policy entry" as a compensating control. That is exactly what fired here, as designed.

## 🔴 Gap this surfaced — the required check does not certify a pass on caller-editing PRs

Independent review of this PR found, and I confirmed on this PR's own run:

- The action refuses to run when the caller workflow file differs from the default branch (`Workflow validation failed… must have identical content to the version on the repository's default branch`) — precisely the class of change ADR 0002 names as its tamper mitigation.
- The step nonetheless reports **success**, so `Fail closed on an in-scope non-run` never fires.
- Result: `security-review / security-review` goes **green with no review performed and no tracking comment**, despite `track_progress: true`. Same signature on #1766 (12s run; the security lane posted no tracking comment).

Recorded in the ADR as a real bound plus a revisit trigger pointing at ci-workflows#345. **The fix belongs upstream in the ci-workflows outcome mapping** (an action-side validation skip on an in-scope PR should map to a non-run, not a pass) — not in this PR. Until then, a green security check on any PR touching the caller should be treated as unproven and reviewed by hand — **including this one**.

## ✅ OPERATOR DECISION — Branch A ratified (2026-08-04)

The restored list encodes the **four** actors currently in force, so **this PR is behavior-preserving as drafted** (byte-equal to the v0.9.1 default the security caller already inherits). Whether four is right was deliberately left to the operator, and the ADR carries an affirmative case for each branch:

- **Branch A — ratify four.** Stands on dormancy and review cost. (The 2026-07-21 rationales do *not* extend to these two actors — see the correction note.)
- **Branch B — revert to the ratified two.** Stands on the required check's claim that a pass actually ran, and on repairing the accident rather than blessing it.

**The operator picked Branch A on 2026-08-04**, so the silence default was never exercised. Recorded in the ADR as a dated addendum; per the doc's append-only supersession style the scaffolding paragraph that named silence as the ratifying default keeps its text and gains a superseded marker, and both branches' presented cases stay byte-untouched as the record of what was weighed. Branch B is recorded as outweighed while its premises hold, **not refuted** — the existing revisit trigger for agent actors beginning to author substantive changes under security-sensitive paths is the condition that reopens it. Four is now the ratified baseline the `skip-actors` trigger measures additions against.

No workflow edit accompanies the decision: Branch A is the no-further-edit branch by construction, so the merged diff is unchanged from what was already verified.

Cost model as weighed (the earlier draft understated Branch B, and the review lane is out of both branches so it differentiates neither):

| | Branch A (**chosen**) | Branch B |
|---|---|---|
| security caller | no further edit | one-line value change |
| ADR | no further edit | amend correction 2 (records four as in force) |
| upstream | none | `allowed_bots` widening in ci-workflows — **hard dependency**, not sequencing |

Branch A's zero-edit position is half a drafting artifact: had this PR restored two, Branch B would be the no-edit branch. The `allowed_bots` dependency is **not** an artifact — without it, Branch B converts a dormant record defect into a live merge block the moment either actor opens a PR.

## Correction note (second commit)

The first commit asserted three compensating controls without verifying them **in this repo**. Cold-read review falsified all three; they are now corrected in the ADR:

| Claimed | Actual |
|---|---|
| `secret-scan / gitleaks` runs and must pass | No such check context. gitleaks is a STEP in `ci.yml`'s `hygiene` job, aggregated fail-closed and gated transitively as `ci-status`. |
| GitGuardian must pass | Runs on every PR, but is in **no** ruleset — cannot block merge. |
| Merge still requires human review | **False.** `base` ruleset sets `required_approving_review_count: 0`; single collaborator; merges routinely carry zero approving reviews. Only `required_review_thread_resolution: true` applies. |

The third was load-bearing twice — offered as a compensating control *and* as half of Branch A's rationale. Both uses are withdrawn.

## Test plan

- [x] `markdownlint-cli2` clean on the amended ADR (0 errors)
- [x] `.github/workflows/claude-review.yml` restored: blob hash byte-identical to `origin/main`'s (`8be2703d`), so the file is absent from this PR's diff entirely
- [x] Security caller's YAML parses; `skip-actors` resolves to `dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]`
- [x] Behavior-preserving: the restored list is byte-equal to the v0.9.1 reusable default the security caller currently inherits, so the effective skip set is unchanged on both lanes
- [x] No other behavioral change: triggers, permissions, SHA pins, concurrency, `runner`/`paths-file`, and the named secret are untouched
- [x] `policy.json` `allowedInputs` for both pinned targets read directly from the repo, not restated from review notes
- [x] Ownership confirmed before editing — `standards/distribution/sync-manifest.yml` lists `claude-security-review-caller` under `melodic-software/claude-code-plugins` → `locally-owned`, so the caller is the sanctioned local seam. The claim now matches the diff exactly, since the security caller is the only workflow this PR touches. Cited by key rather than by line number as a drift guard only — the earlier `:325` citation was and remains correct on live `standards` main (an intermediate revision of this body wrongly said it had drifted; that came from checking a stale local clone, and is withdrawn).
- [x] Append-only convention: zero pre-existing ADR lines deleted against the merge base
- [x] `ci-status` green at head (was red while the review caller carried the input)
- [x] Operator picked Branch A on 2026-08-04; recorded as a dated ADR addendum, append-only preserved (187 insertions, 0 deletions against the merge base) and no workflow edit needed
- [ ] Manual security review of this diff — the automated pass cannot certify it (see the gap above)

## Related

- ADR 0002 `docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md` — the record being repaired
- #1766 — the PR that dropped the caller-side lists while re-pinning to v0.9.1
- ci-workflows#345 — the upstream fix for the workflow-validation-skip gap
- Diagnosis this PR implements: `ci-workflows/.work/agent-returns/skip-actors-premise.md`. It also refutes the "agent PRs are pinned red by the security lane" premise that motivated a narrowing proposal — narrowing would have *caused* that condition, not cured it.

Closes #1897.
