### PR TITLE
docs: ship DOC bundle 4 — matrix pointers, archive-reading conventions, residual-risk footer

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -17,9 +17,9 @@ only after that version increases.
   entry is not a content-change signal:** two entries five days apart are byte-identical, differing
   on zero lines across 100-line bodies, with no annotation explaining why the second exists — so a
   new dated heading licenses no inference of revision, intent, or policy movement. The rule is
-  stated in the **content-change** form, which is the narrower of the two the record carries and the
-  one the underlying finding actually supports; it bars inferring change from sameness, and leaves a
-  reader free to read an actual textual narrowing between two entries as the change it is. **(2)
+  stated in the narrower **content-change** form, which is what the finding supports: it bars
+  inferring change from sameness, and leaves a reader free to read an actual textual narrowing
+  between two entries as the change it is. **(2)
   Absence of bold does not prove absence of change:** the page states that updates between versions
   are bolded and the convention does not hold — one span carries zero bold markup across three dated
   entries differing in three sentences plus a twelve-paragraph addition, another marks one
@@ -30,9 +30,8 @@ only after that version increases.
   error, with the blog channel's two known extraction artifacts named as the standing instance
   rather than restated. Its one exception runs the other way — a downstream artifact reproducing a
   known-corrupt entry *for a reader* rather than for verification repairs the corruption and says
-  that it did. The fourth property these three refine — that dated content is scoped to its entry
-  date — is not restated here; it already ships as reader-side doctrine in the `playbooks` fable-5
-  calibration chapter, and the section carries it as the premise the three rules qualify.
+  that it did. The property all three refine — that everything inside a dated entry is scoped to that
+  entry's date — opens the section as its premise rather than as a fourth rule.
 
 - **Anthropic profile gains hedge preservation and the residual-risk footer.** A source's own hedge
   now travels with the content it qualifies: an artifact graduated from this publisher preserves the

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.20]
+
+### Added
+
+- **Anthropic profile gains archive-reading conventions.** Some pages this publisher maintains are
+  archives — dated entries accumulated over time rather than a current statement, the [published
+  system prompts](https://platform.claude.com/docs/en/release-notes/system-prompts) being the
+  standing case — and three of their properties are invisible from inside any single entry, so a
+  digest that does not know them reads the archive wrong in a way its own verification cannot catch.
+  Each was found independently by multiple digest units before it became a convention. **(1) A dated
+  entry is not a content-change signal:** two entries five days apart are byte-identical, differing
+  on zero lines across 100-line bodies, with no annotation explaining why the second exists — so a
+  new dated heading licenses no inference of revision, intent, or policy movement. The rule is
+  stated in the **content-change** form, which is the narrower of the two the record carries and the
+  one the underlying finding actually supports; it bars inferring change from sameness, and leaves a
+  reader free to read an actual textual narrowing between two entries as the change it is. **(2)
+  Absence of bold does not prove absence of change:** the page states that updates between versions
+  are bolded and the convention does not hold — one span carries zero bold markup across three dated
+  entries differing in three sentences plus a twelve-paragraph addition, another marks one
+  transition of three, and silent unbolded typo fixes and a silent removal were found the same way,
+  so deltas come from diffing entries and never from reading the markup. **(3) Note a source
+  artifact at the row; never silently repair it:** typos, escaped markup and malformed auto-links
+  are reproduced byte-exact so a verifier can tell faithful reproduction from digest transcription
+  error, with the blog channel's two known extraction artifacts named as the standing instance
+  rather than restated. Its one exception runs the other way — a downstream artifact reproducing a
+  known-corrupt entry *for a reader* rather than for verification repairs the corruption and says
+  that it did. The fourth property these three refine — that dated content is scoped to its entry
+  date — is not restated here; it already ships as reader-side doctrine in the `playbooks` fable-5
+  calibration chapter, and the section carries it as the premise the three rules qualify.
+
 ## [0.10.19]
 
 ### Changed

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -34,6 +34,24 @@ only after that version increases.
   date — is not restated here; it already ships as reader-side doctrine in the `playbooks` fable-5
   calibration chapter, and the section carries it as the premise the three rules qualify.
 
+- **Anthropic profile gains hedge preservation and the residual-risk footer.** A source's own hedge
+  now travels with the content it qualifies: an artifact graduated from this publisher preserves the
+  hedge as the source states it, neither dropped as throat-clearing nor widened past what the source
+  claims. Two instances graduate under the one convention rather than each inventing its own — the
+  residual-risk footer below, and the harness best-practices material's "starting points, not set in
+  stone" relativization. The **footer** is quoted rather than paraphrased from [Reduce
+  hallucinations](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)
+  (re-fetched 2026-08-03, HTTP 200; the sentence is byte-identical to the snapshot the corpus
+  froze): *"Remember, while these techniques significantly reduce hallucinations, they don't
+  eliminate them entirely. Always validate critical information, especially for high-stakes
+  decisions."* **Its scope is the source's own and is deliberately not broadened** — it is about
+  hallucinations, not errors or guardrail failures in general, and it names **no validator**, since
+  who or what validates critical information is unstated in the source. That exact scoping is the
+  part most likely to be lost in transit: it survived two correction rounds during the slice's
+  verification, both of which caught a widening. It attaches **at the profile rather than per
+  artifact**, because the profile is the seam every guardrail slice of this publisher flows through,
+  so a graduated chapter or template cites the footer and never restates it.
+
 ## [0.10.19]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -41,6 +41,33 @@ extraction waits for the third (Rule of Three).
   `CLAUDE_CODE_MAX_OUTPUT_TOKENS` sits at line 277 of a 451-line, 316-row page whose rendered fetch
   surfaced only roughly its first fifth.)
 
+## Archive-reading conventions
+
+Some pages this publisher maintains are archives — dated entries accumulated over time rather than a
+current statement, the [published system
+prompts](https://platform.claude.com/docs/en/release-notes/system-prompts) being the standing case.
+Everything inside a dated entry is scoped to that entry's date. Three further properties of such a
+page are invisible from inside any single entry, and a digest that does not know them reads the
+archive wrong in a way its own verification cannot catch:
+
+- **A dated entry is not a content-change signal.** Two entries can be byte-identical and here two
+  are: entries five days apart differ on zero lines across 100-line bodies, and the page carries no
+  annotation explaining why the second one exists. Record the re-publication as what it is; never
+  infer a revision, an intent, or a policy movement from the appearance of a new dated heading.
+- **Absence of bold does not prove absence of change.** The page states that updates between
+  versions are bolded, and that convention does not hold: one span of the archive carries zero bold
+  markup across three dated entries that differ in three sentences plus a twelve-paragraph addition,
+  and another entry marks one transition of three. Silent unbolded typo fixes and a silent removal
+  were found the same way. Treat an unbolded inter-entry difference as an authoritative delta of
+  equal standing to a bolded one, which means the deltas come from diffing entries, never from
+  reading the markup.
+- **Note a source artifact at the row; never silently repair it.** Typos, escaped markup and
+  malformed auto-links are reproduced byte-exact so a verifier can tell faithful reproduction from
+  digest transcription error. The two blog-channel extraction artifacts under **Fetch channel**
+  above are this rule's standing instance. One exception, and it runs the other way: a downstream
+  artifact reproducing a known-corrupt entry *for a reader* rather than for verification repairs the
+  corruption and says that it did.
+
 ## Claude-Code-applicability filter (with teeth)
 
 Anthropic docs mix API-surface guidance with harness-relevant guidance. Every digest tags each

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -284,10 +284,12 @@ widened past what the source claims. The footer below is the standing instance; 
 best-practices material's "starting points, not set in stone" relativization is the second, and both
 graduate under this one convention rather than each inventing its own.
 
-**Residual-risk footer.** Every artifact derived from a guardrail page of this publisher carries the
-source's residual-risk sentence, quoted rather than paraphrased ([Reduce
-hallucinations](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations),
-verified 2026-08-03):
+**Residual-risk footer.** Every artifact derived from a guardrail page of this publisher carries
+that page's OWN residual-risk sentence when the page states one, quoted rather than paraphrased —
+a hedge scoped to one page's techniques never transfers to an artifact derived from a different
+page. The standing instance, for artifacts derived from [Reduce
+hallucinations](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)
+(verified 2026-08-03):
 
 > Remember, while these techniques significantly reduce hallucinations, they don't eliminate them
 > entirely. Always validate critical information, especially for high-stakes decisions.

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -275,3 +275,28 @@ model-delta audit class), corpus graduation (a knowledge-corpus repository), or 
 synthesis (a cross-model artifact spanning units and slices the per-unit digest fan-out cannot
 reach — not per-model, not an audit rule row, not graduation of one slice; its host is
 undecided). The handoff records the candidate target per finding; the interview decides.
+
+## Hedge preservation, and the residual-risk footer
+
+A source's own hedge travels with the content it qualifies. An artifact graduated from this
+publisher preserves the hedge as the source states it — neither dropped as throat-clearing nor
+widened past what the source claims. The footer below is the standing instance; the harness
+best-practices material's "starting points, not set in stone" relativization is the second, and both
+graduate under this one convention rather than each inventing its own.
+
+**Residual-risk footer.** Every artifact derived from a guardrail page of this publisher carries the
+source's residual-risk sentence, quoted rather than paraphrased ([Reduce
+hallucinations](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations),
+verified 2026-08-03):
+
+> Remember, while these techniques significantly reduce hallucinations, they don't eliminate them
+> entirely. Always validate critical information, especially for high-stakes decisions.
+
+Its scope is the source's own and stays unbroadened. It is about **hallucinations**, not errors,
+regressions, or guardrail failures in general; and it names **no validator** — who or what validates
+critical information is unstated in the source and stays unstated here. Widening the failure mode or
+supplying a mechanism states something the source does not.
+
+The footer attaches at this profile, not per artifact, because the profile is the seam every
+guardrail slice of this publisher flows through. A graduated chapter or template **cites this
+footer**; it never restates it.

--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.6.7]
+
+### Added
+
+- **`fable-5` calibration gains the per-model-matrix rule.**
+  `skills/fable-5/context/calibration.md` adds "Point at a per-model matrix; never copy one",
+  triggered when a per-model table — supported values, defaults, capabilities, limits — is about to
+  be written into a chapter, rule, brief, or answer. It is a **volatility** axis, distinct from the
+  surface axis and the channel axis the neighbouring sections own: a table reads as a fact and is
+  actually a snapshot, so a copy is a fact about the day it was copied with nothing in it saying
+  which day that was. The rule is point-at-the-owning-table, and for thinking configuration that
+  table is the per-model table on [Troubleshooting
+  thinking](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting) — the
+  authority on what each model accepts, defaults to, and rejects (re-fetched 2026-08-03, HTTP 200).
+  A matrix stated anyway — because the reader cannot act without the values in front of them —
+  carries a **re-check trigger naming the next model release**, so a stale row is found by a
+  scheduled read rather than by a reader acting on it. The fourth rule connects the section to its
+  neighbour: a vendor matrix is an API-surface fact, so presence in the table is not reachability
+  where the reader is running.
+
+  The worked instance ships with it, verified 2026-08-03 on both sides. **Claude Mythos 5 has its
+  own row in that per-model table**, and in Claude Code it is a known model in the registry with
+  full gating machinery and still not selectable — no alias resolves to it, it is absent from
+  `latest_per_family`, it declares no capabilities, and it exposes no picker row; its registry entry
+  carries **exactly one non-null provider id (`first_party`) beside seven null siblings**. Reading
+  that row as an available option would be the copy error and the surface error at once, and the
+  table gives no signal that the two answers differ. The seven-null figure is stated at the
+  corrected count: an earlier reading of the same registry entry put every provider id null and
+  counted eight, which the schema disproves — `first_party` is non-nullable and exactly seven
+  siblings are nullish. `skills/fable-5/SKILL.md` carries the distilled line under core doctrine,
+  "Ground truth and checking — calibration".
+
 ## [0.6.6]
 
 ### Added

--- a/plugins/playbooks/skills/fable-5/SKILL.md
+++ b/plugins/playbooks/skills/fable-5/SKILL.md
@@ -46,6 +46,7 @@ The distillation of every chapter, grouped in operating-loop order. Each line is
 - Settled means settled: reopen a session-verified, untouched fact only on contradicting evidence, never data-free doubt.
 - A behavioral claim about Claude is a fact about the surface documenting it, and it transfers to the surface you are running on only after a per-claim check — never on vendor authority alone, which is what makes a scope slip invisible. Docs for your own surface clear that check where they stand; a claim from another surface (consumer apps, the raw API) is a hypothesis until checked, and a dated archive entry is scoped to its date on top of that.
 - Channel grades a source independently of vendor: the reference page that owns a term defines it, and a vendor blog post corroborates. Cite the owning page and read it even when the post looks complete — a post is written once and never revised, and what it omits is invisible from inside it.
+- A per-model matrix is the fastest-moving thing a vendor publishes: point at the table that owns it rather than copying it, and if you state one anyway, attach a re-check trigger on the next model release. Presence in such a table is not reachability on your surface.
 
 ### Thinking — reasoning-moves
 

--- a/plugins/playbooks/skills/fable-5/context/calibration.md
+++ b/plugins/playbooks/skills/fable-5/context/calibration.md
@@ -53,6 +53,18 @@ A vendor's own blog, launch announcement, or engineering post is first-party and
 > Worked instance, verified 2026-08-03. "Verification loop" and "agentic loop" both have owning pages: the [glossary](https://code.claude.com/docs/en/glossary), [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works), and [Best practices](https://code.claude.com/docs/en/best-practices).
 > The glossary's verification-loop entry carries what a post-length definition drops: a verification loop is the **prerequisite** for `/goal`, unattended runs, and dynamic workflows. A reader who took the short definition would have the concept right and still not know that three capabilities depend on it.
 
+## Point at a per-model matrix; never copy one
+
+Per-model tables — which configurations a model accepts, what it defaults to, which values it rejects, what its limits are — are the fastest-moving content a vendor publishes and the most tempting to paste, because a table reads as a fact rather than as a snapshot. A copied matrix is a fact about the day you copied it, and nothing in your artifact tells a later reader which day that was; a row is added or a default flips with each model release, and the copy stays confidently wrong.
+
+- TRIGGER: about to write a per-model matrix — supported values, defaults, capabilities, limits — into a chapter, rule, brief, or answer.
+- RULE: point at the vendor page that owns the table and let the reader read it there. For thinking configuration that page is [Troubleshooting thinking](https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting), whose per-model table is the authority on what each model accepts, defaults to, and rejects (verified 2026-08-03). Nothing you restate from it is more current than it is.
+- RULE: if you state a matrix anyway — because the reader cannot act without the values in front of them — attach a re-check trigger naming the next model release, so a stale row is found by a scheduled read rather than by a reader acting on it.
+- RULE: a vendor matrix is an API-surface fact, so "A claim's product surface travels with it" above applies to it row by row. Presence in the table is not reachability where you are running.
+
+> Worked instance, verified 2026-08-03. Claude Mythos 5 has its own row in that per-model table. In Claude Code it is a known model in the registry with full gating machinery and is still not selectable: no alias resolves to it, it is absent from `latest_per_family`, it declares no capabilities, and it exposes no picker row. Its registry entry carries exactly one non-null provider id — `first_party` — beside seven null siblings.
+> Reading its row as an available option would be the copy error and the surface error at once, and the table itself gives no signal that the two answers differ.
+
 ## The check / skip decision
 
 Checking is an investment, not a virtue. Decide with the rules below. Already-settled exits first: a session-verified, untouched claim is evidence, not a claim needing a check — it leaves this matrix entirely (see "Settled means settled"). Among the rest, precedence: silent-failure mandate, then the gating-and-expensive test (its ≤2-call cost cap lives inside it), then the loud-fast-free skip, then DEFAULT.


### PR DESCRIPTION
## Summary

DOC bundle 4 of the doc-corpus application campaign — the three unblocked rows (playbooks 0.6.6 → 0.6.7; knowledge 0.10.19 → 0.10.20):

- **Point at a per-model matrix; never copy one** (`fable-5/context/calibration.md` + one SKILL.md line): a third source-grading axis (volatility) beside the surface and channel axes — point at the vendor page that owns a per-model table; a stated matrix carries a re-check trigger naming the next model release; table presence is not reachability where you run. Worked instance corrected at the bytes: Claude Mythos 5 is a known registry model with full gating machinery and still not selectable — exactly one non-null provider id beside **seven** null siblings (the earlier "all eight null" figure was schema-disproven; the correction and its reason are in the CHANGELOG).
- **Archive-reading conventions** (knowledge profile): a dated entry is not a content-change signal (two byte-identical entries five days apart prove it); absence of bold does not prove absence of change — deltas come from diffing entries, never reading markup; note a source artifact at the row, never silently repair it (with the one reader-facing exception stated). Recheck against the UNC-1 ruling confirmed no premise moved — the ruling touched tags, these are page properties.
- **Residual-risk footer** (knowledge profile): the reduce-hallucinations page's own hedge, quoted verbatim (byte-compared live), scope unbroadened — hallucinations only, no validator named — with the cite-never-restate rider for graduated chapters.

Fourth commit removes a cross-plugin dependency claim and an internal-record pointer from the knowledge CHANGELOG (self-caught; disclosed).

Independently verified (fresh-context, rationale withheld): SHIP, zero findings — EC-3 seven-count, UNC-1 no-retag ruling, byte-identical-entries evidence, and the footer byte-compare all re-derived by the verifier.

No linked issue

## Related

- #1885, #1887, #1893 — DOC bundles 1-3 (same campaign, same delivery shape)
- #1895 — the doc-queue repopulation this bundle's knowledge bump follows (0.10.19 → 0.10.20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UarawwEnZQu7cB6i7WatJ
