### PR TITLE
feat(playbooks): carry the Opus 5 guide's correction-narration delta and re-verify its sources

### DIFF
--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.6.11]
+
+### Added
+
+- **`opus-5.md`: the half of the guide's "Self-correction" section the chapter never carried.**
+  `reference/model-adaptation/opus-5.md` took that section's first paragraph — you already
+  self-correct, so instructed re-checks are cost with no gain — into §"Verification", and stopped
+  there. The section's second half describes a distinct behavior: Opus 5 *narrates* corrections to
+  its earlier statements more than prior models do. That is the same shape as the chapter's other
+  deltas (a behavior that runs hotter than prior models and needs a counter-steer), so its absence
+  was a gap by the chapter's own inclusion standard, not payload discipline. New §"Correction
+  narration: fix the slip, announce only what changes a decision" states the counter-steer: correct
+  an earlier statement when the error would change the user's code, conclusions, or decisions; for a
+  slip that changes nothing, make the fix and move on.
+
+  Tagged `[CC: direct]` on a verification rather than an assumption. The chapter's neighbouring
+  narration-*cadence* bullet is `[CC: harness-covered]`, so the same check ran here against a live
+  session system prompt: Claude Code states update cadence, outcome-first ordering, and faithful
+  outcome reporting, but carries no rule about narrating corrections — so this one is not covered
+  and does not restate the harness.
+
+  **The section is fenced against the reading that would make it harmful.** Suppressing a
+  correction is licensed only where the correction changes nothing for the user; faithful reporting
+  explicitly outranks it, and a failed test, a skipped step, a wrong result already acted on, or a
+  false claim all still get said. The authoring half is split out as `[CC: prompt-authoring]` and
+  scoped to user-facing products, keeping the guide's suppression instruction off surfaces where
+  the user is the operator of the work.
+
+- **A re-verification line on `opus-5.md`'s Sources block**, scoped to the Opus 5 prompting guide
+  only: re-fetched 2026-08-03 through the raw-`.md` channel, byte-identical to the 2026-07-25
+  capture (11,225 bytes, identical MD5). It states its own limits rather than letting one date
+  cover five sources — the system card and the three live-fetched harness/model pages have not been
+  re-read and still stand at 2026-07-26.
+
 ## [0.6.10]
 
 ### Changed

--- a/plugins/playbooks/reference/model-adaptation/opus-5.md
+++ b/plugins/playbooks/reference/model-adaptation/opus-5.md
@@ -57,8 +57,10 @@ about narrating corrections (verified against a live session system prompt, 2026
 method the cadence bullet records).
 
 This governs self-corrections that change nothing, and nothing else. Faithful reporting outranks
-it: a wrong result the user already acted on, a failed test, a skipped step, or a claim you made
-that turned out false all still get said — those change conclusions by definition. When you author
+it: a wrong result the user already acted on, a failed test, a skipped step, or a false claim the
+user may have relied on — anything they heard, used, or built on — all still get said, because
+those change conclusions. The silent branch is only the slip already defined above: an error
+nothing rests on yet, where the corrected work is the first thing the user will actually consume. When you author
 prompts for user-facing products, the guide's suppression instruction is the lever; do not add one
 to surfaces where the user is the operator of the work. `[CC: prompt-authoring]`
 

--- a/plugins/playbooks/reference/model-adaptation/opus-5.md
+++ b/plugins/playbooks/reference/model-adaptation/opus-5.md
@@ -43,6 +43,25 @@ corpus digests and three interview validators, accepted as plausible by both cor
 but never stated by the source. If Anthropic reconciles differently, this section and the audit rows built on it move
 together. This paragraph is the landing spot for that clarification.
 
+## Correction narration: fix the slip, announce only what changes a decision
+
+**Your default:** you narrate corrections to your own earlier statements more than prior models do
+(guide, "Self-correction"). This is the other half of that section — the half about what you *say*,
+not the instructed re-checks the section above removes. **Correction:** only correct an earlier
+statement when the error would change the user's code, conclusions, or decisions; state such a
+correction plainly and briefly and continue, and for a slip that changes nothing for the user, make
+the fix and move on without noting it. `[CC: direct]` — not harness-covered, unlike the narration
+*cadence* bullet below: Claude Code's system prompt states update cadence, outcome-first ordering,
+and faithful outcome reporting (failures, skipped steps, verified results), but carries no rule
+about narrating corrections (verified against a live session system prompt, 2026-08-03, the same
+method the cadence bullet records).
+
+This governs self-corrections that change nothing, and nothing else. Faithful reporting outranks
+it: a wrong result the user already acted on, a failed test, a skipped step, or a claim you made
+that turned out false all still get said — those change conclusions by definition. When you author
+prompts for user-facing products, the guide's suppression instruction is the lever; do not add one
+to surfaces where the user is the operator of the work. `[CC: prompt-authoring]`
+
 ## Scope: deliver what was asked
 
 **Your default:** you can expand task scope — adding unrequested steps, re-deciding what the task
@@ -191,6 +210,11 @@ Live fetches at authoring time (2026-07-26):
 - <https://code.claude.com/docs/en/settings> — `alwaysThinkingEnabled`, `MAX_THINKING_TOKENS`, `effortLevel`.
 - <https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5> — thinking-on default,
   400 constraint, behavior changes.
+
+The Opus 5 prompting guide was re-fetched 2026-08-03 through the same raw-`.md` channel and is
+byte-identical to the 2026-07-25 capture above (11,225 bytes, identical MD5). That date covers that
+one page and nothing else on this list: the Opus 5 system card has not been re-read, and neither
+have the three live-fetch pages immediately above, which still stand at their 2026-07-26 reading.
 
 Quotation note: this repository is public. The verbatim upstream sentences in this file — the
 deliverable-length calibration sentence and the quoted effort-guidance sentences and clause in


### PR DESCRIPTION
## Summary

Doc-alignment roster row 3: re-check of **Prompting Claude Opus 5** (platform.claude.com) against the shipped chapter `plugins/playbooks/reference/model-adaptation/opus-5.md`.

Re-check result: the live page is byte-identical to the repo's 2026-07-25 capture (11,225 bytes, MD5 `8579d63f…` — confirmed independently by producer and verifier), and every existing chapter claim re-verified against it holds, including four precise source-line citations and the truncated-effort-ladder claim. The Fable 5 launch moved nothing on this page.

The re-check surfaced one gap byte-identity hid — **playbooks 0.6.11**:

- The guide's "Self-correction" section has two halves; the chapter carried only the first (self-verify default → remove instructed re-checks). The second — Opus 5 **narrates corrections to earlier statements** more than prior models, undesirable in user-facing products — was absent from the whole plugin. Shipped as `opus-5.md` §"Correction narration: fix the slip, announce only what changes a decision", tagged `[CC: direct]` (verified empirically: Claude Code's own rules state update cadence, outcome-first ordering, and faithful outcome reporting, but no correction-narration rule). Hard-fenced: suppression licensed only where the correction changes nothing for the user; faithful reporting explicitly outranks it — failed tests, skipped steps, results already acted on, and false claims always get said.
- Sources block gains a scoped re-verification line (mirrors #1908's `opus-4-8.md` treatment), stating its own limits.

Deliberately not shipped: an audit-instructions criteria row — zero in-repo instructions request correction narration, and the audit lane targets instructions to remove, not guidance to add in user-facing products.

Positive finding kept visible: the chapter's recorded "Residual tension" (upstream endorses writer-verifier patterns while advising removal of verification instructions) remains unresolved upstream — byte-identity means no reconciliation shipped, so that section and the audit rows built on it correctly stay put.

## Test plan

- Docs-only (chapter prose, changelog, version bump); markdownlint clean; skill-quality gate on fable-5 PASS 0 errors, warnings identical to base.
- Producer-side fresh-context Fable verifier (rationale withheld, 8 binary criteria): 8/8 PASS.
- Second, orchestrator-commissioned Fable verifier post-rebase (6 criteria incl. its own live fetch + MD5, traceability to the page's Self-correction text, adversarial fence-reading, `[CC: direct]` empirical check, rebase content-loss diff via reflog): content 6/6 PASS; its one defect (stale version-chain paragraph in the commit message) fixed by message-only amend before push (tree hash unchanged: `0e37455e…`).
- Rebased onto main after #1909; changelog stack asserted 0.6.11 > 0.6.10 > 0.6.9.

## Related

- No linked issue.
- Doc-alignment per-document loop, roster row 3. Predecessors: #1908 (row 1), #1909 (row 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
