### PR TITLE
docs(knowledge): enqueue whats-new-opus-5 on custody grounds

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.20",
+  "version": "0.10.21",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.21]
+
+### Changed
+
+- **`whats-new-opus-5` moves from deferred to the Anthropic profile's Models queue, on grounds its
+  own trigger never supplied.** The deferral read "release notes for a model the models `overview`
+  page already covers canonically; enqueue when Opus 5 enters or materially changes a fleet lane",
+  and that trigger has not fired. What moved the entry is custody: the `playbooks` Opus 5
+  model-adaptation chapter already cites this page as **sole authority** for three shipped claims —
+  thinking on by default, the 400 the API returns when thinking is disabled above effort `high`, and
+  the live effort-level enumeration that establishes the upstream Opus 5 prompting guide's own ladder
+  statement as truncated (all three re-verified live 2026-08-03) — and the `overview` page carries
+  none of them. The deferral's premise is therefore
+  false for exactly the facts already in use: doctrine ships on a page with no digest slice and no
+  custody record. Scope is this one page, not a reopened release-notes lane — `whats-new-sonnet-5`
+  carries no such citations and keeps its identical trigger.
+
 ## [0.10.20]
 
 ### Added

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -220,6 +220,15 @@ Models:
 - <https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5>
   — the launch source the corpus's own Fable 5 / Mythos 5 positioning claims rest on, and linked
   from the harness model-config doc's "Work with Fable 5"
+- <https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5>
+  — enqueued on custody grounds, not on a fleet-lane trigger that has not fired: the `playbooks`
+  Opus 5 model-adaptation chapter cites this page as sole authority for three shipped claims —
+  thinking on by default, the 400 returned when thinking is disabled above effort `high`, and the
+  live effort-level enumeration that establishes the upstream Opus 5 prompting guide's own ladder
+  statement as truncated — none of which the models `overview` page carries, so "the overview covers
+  it canonically" is false for exactly the facts already cited. A custody fact about this one page,
+  not a decision to start a release-notes corpus; `whats-new-sonnet-5` carries no such citations and
+  stays deferred
 
 Claude Code companion docs (digest in this order):
 
@@ -256,9 +265,6 @@ Deferred with trigger (not queued):
 - <https://platform.claude.com/docs/en/build-with-claude/fallback-credit> — the two API-side claims
   it would settle carry a weak, openly disclosed absence basis that nothing is built on; enqueue
   when an artifact actually depends on fallback-credit behavior
-- <https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5> — release notes for a
-  model the models `overview` page already covers canonically; enqueue when Opus 5 enters or
-  materially changes a fleet lane
 - <https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5> — release notes for a
   model the models `overview` page already covers canonically; enqueue when Sonnet 5 enters or
   materially changes a fleet lane


### PR DESCRIPTION
## Summary

**knowledge 0.10.21** — moves `whats-new-opus-5` from "Deferred with trigger (not queued)" to the Models queue in the docpage-digest Anthropic docs profile, on custody grounds rather than the (unfired) fleet-lane trigger:

- The playbooks Opus 5 model-adaptation chapter cites the page as **sole authority** for three shipped claims — thinking on by default; the 400 returned when thinking is disabled above effort `high`; and the live effort-level enumeration that establishes the upstream Opus 5 prompting guide's own ladder statement as truncated.
- The models `overview` page carries none of those facts ("Adaptive thinking: Yes" is a capability flag, not a default-on statement; no 400 constraint; no ladder enumeration) — so the deferral's premise, "the overview covers it canonically", is false for exactly the facts already cited.
- Scoped as a custody fact about this one page, not a decision to start a release-notes corpus: `whats-new-sonnet-5` carries no such citations and stays deferred with its trigger unchanged.

The original trigger text is preserved verbatim in the changelog entry and commit body (the profile format keeps no history). The fleet-lane trigger itself was independently evaluated and has NOT fired (Opus 5 GA and the fleet pin both predate the deferral's own recording).

## Test plan

- Docs-only (profile entry move, changelog, version bump).
- `scripts/check-changelog-parity.sh` `--check`, `--check-bump origin/main`, `--check-order` all pass; markdownlint clean; both plugin.json parse.
- Independent fresh-context Fable verifier, 4 binary criteria — its own live fetches of both pages (confirming the three facts live on `whats-new-opus-5` and absent from `overview`), citation-attribution check (including the corrected truncation attribution), entry-format and scope checks, changelog verbatim-trigger check, parity scripts re-run — **4/4 PASS, empty defect list**.

## Related

- No linked issue.
- Doc-alignment loop, roster row 5 follow-up (independent-grounds enqueue; the row's own trigger evaluation stands as NOT FIRED). Related rows: #1910 (row 3, whose chapter carries the citations needing custody).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
