### PR TITLE
docs(prompts): date the lane rationales that restate overview-owned model facts

### DIFF
--- a/prompts/loops/loop-lane-prompts.md
+++ b/prompts/loops/loop-lane-prompts.md
@@ -339,8 +339,17 @@ IDs — the alias tracks the current recommended model and a pinned ID rots.
 - **Conflict and security subagents — `fable`.** Frontier tier, which
   babysit-loop requires for conflict workers unconditionally.
 - **Mechanical greps and log pulls — `haiku`.** Per-dispatch override
-  only: 200k context and an old cutoff, never for a question about
-  current harness behavior.
+  only: the smallest context window and the oldest cutoff of the four,
+  never for a question about current harness behavior.
+
+The per-model figures behind those two rationales — context window and
+knowledge cutoff — are upstream-owned
+([models overview](https://platform.claude.com/docs/en/about-claude/models/overview))
+and are not restated here. Both orderings resolved as written against that
+page on 2026-08-04. Both are *derived* comparisons rather than quoted
+figures, so either can flip while every underlying number still reads
+correctly: re-resolve them when a new Claude model family reaches GA, or
+when one of the aliases above starts resolving to a different model.
 
 **The implementer tier is enforced structurally at the dispatch seam
 (#1649).** `/implementation:implement-dispatch` dispatches workers and


### PR DESCRIPTION
## Summary

Doc-alignment roster row 8: **Models overview** — the docpage-digest profile's canonical model-fact freshness source. First repo capture of the page (29,119 bytes, MD5 recorded); systematic ten-dimension sweep of every repo surface stating a fact this page owns.

Sweep verdict: the repo is clean — pointer-not-copy holds everywhere except one surface. The single fix: `prompts/loops/loop-lane-prompts.md` justified two lane assignments with bare, undated page-owned facts (`opus` freshest-cutoff; `haiku` 200k/oldest-cutoff). Both were *true*; the defect was discipline. The rationales now carry the sanctioned dated-matrix shape already used by `docs/PLUGIN-PHILOSOPHY.md`'s tier table: figures upstream-owned and not restated, a dated resolution (2026-08-04), and a recheck trigger naming the derived-ordering failure mode (either comparison can flip while every underlying figure stays correct). Operational instructions unchanged.

Also verified in passing: the profile's canonical-freshness claim is structurally true (current matrix + legacy accordion in one fetch); #1911's three enqueue negatives re-confirmed against the live page; all agent `model:` frontmatter still aliases; legacy placements and tier orderings consistent repo-wide. Component opportunity (a stored capture-and-diff freshness probe) declined: no upstream sync path for a hand-copied materialization, a one-consumer count, and the lightweight trigger shape already proved itself by producing #1912 — deferred with a trigger recorded on the roster row.

## Test plan

- Single file, +11/−2, no plugin/changelog touched (parity script is plugin-scoped — confirmed by reading it); markdownlint clean.
- Independent fresh-context Fable verifier: its own live fetch and scripted ordering checks (both derived orderings true), three sweep spot-checks (all holds), positional-wording check, `git merge-tree` conflict-free against current main, decline-soundness and scope-call review — **all PASS, empty defect list**.

## Related

- No linked issue.
- Doc-alignment loop, roster row 8. Predecessors: #1908–#1914 (rows 1–6 + row-5 follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
