### PR TITLE
docs(philosophy): state the availableModels dispatch-seam consequence the tier ladder lacked

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -616,6 +616,21 @@ recheck list: the trigger above re-audits **every** agent-frontmatter `model` va
 repository, which `git grep -n '^model:' -- 'plugins/*/agents/*.md'` enumerates rather than any
 list restated here.
 
+That floor is the consumer's to lose. An enterprise `availableModels` allowlist applies "everywhere
+a user can specify a model" — frontmatter pins included — and a pin naming a family it excludes
+"falls back to the inherited or default model rather than failing the request". Which of those two
+branches applies is **unresolved upstream, and stated here as such**; what is documented is that
+`enforceAvailableModels` resolves a Default falling outside the list to the *first* allowed,
+available allowlist entry, and that this reaches
+"the fallback used when an excluded selection is dropped" — an ordering nothing ties to this
+ladder. So a blocked pin can land **below** the session, and the tier invariant above is not
+self-enforcing: under an allowlist a lane may not depend on its pin in either direction, neither
+that it is at least its tier nor that it is cheap, and no error is raised either way. A design
+whose correctness needs a tier needs a mechanism that is not a frontmatter pin
+([model config: restrict model selection](https://code.claude.com/docs/en/model-config#restrict-model-selection),
+verified 2026-08-04; recheck trigger: that section's fallback sentence for a blocked subagent,
+skill, or command override changing, or `enforceAvailableModels`' enforced-Default scope changing).
+
 ### Effort tiers
 
 Effort routes per lane the way model does. Skill and subagent frontmatter `effort` overrides the


### PR DESCRIPTION
## Summary

Doc-alignment roster row 9: **Choosing the right model** (live page byte-identical to the archived slice — MD5 confirmed by producer and verifier independently against both the capture and today's live page).

Row dispositions:

- **IA-6 (vet-delta triggers): closed, nothing owed here.** Its mechanism half already shipped as criteria I21/I22 via the Q8 ownership carve-out (I22 carries all four trigger shapes, the delta-not-re-run discipline, and consumer-supplies-baseline); the instance half is dotfiles-owned. The targeted delta check was run anyway against the executed 2026-07-29 vet (issue #1697): no trigger fired.
- **DOC-40 (four-question second lens): not shipped, correctly still routed to the dotfiles routing-doctrine seam** per its recorded disposition.
- **OQ-6 (fast mode): deferral holds** — zero latency-first lanes exist, and model-config now documents `/fast` refusing to toggle under an allowlist that excludes the target, one more availability constraint on a research preview.

**What ships (+15 lines, `docs/PLUGIN-PHILOSOPHY.md` only, no version bump per this file's precedent):** an enterprise `availableModels` dispatch-seam consequence the Model-tiers section lacked. Upstream (model-config, quoted character-exact): the allowlist reaches subagent/skill/command `model` frontmatter; a pin naming an excluded model "falls back to the inherited or default model rather than failing the request"; under `enforceAvailableModels` the Default remaps to the first *allowed, available* allowlist entry, and that remap reaches "the fallback used when an excluded selection is dropped". Consequence: a blocked pin can silently land **below** the session tier — the section's own invariant (consequential verdict at session tier or above) is not self-enforcing under an allowlist, and no error is raised. The paragraph states the failure mode, the operator action, and a non-vacuous recheck trigger. This is a dispatch-seam consequence, not a second selection checklist — DOC-40's declined shape.

## Test plan

- Single file, +15/−0; markdownlint clean; parity scripts green; merge-tree clean vs current main.
- Producer ran a two-round adversarial loop before handoff: a fresh Fable verifier falsified an advisor-recall claim (the paragraph's first draft asserted the *opposite* direction) against the primary source, and caught a vacuous recheck trigger; both fixed, then a second adversarial pass returned SHIP with one precision fix (the "allowed, available" qualifiers restored).
- Orchestrator-commissioned Fable verifier: live-page sentence fidelity (three quotes character-exact, qualifiers present, anchor resolves), step-by-step reconstruction of the invariant-breakage scenario including the alias-resolution subtlety, IA-6 closure evidence (I21/I22 on main; carve-out record; delta-check spot-checks), contested-call boundary (no factor checklist restated), OQ-6 spot-checks, hygiene — **6/6 PASS, empty defect list**.

## Related

- No linked issue.
- Doc-alignment loop, roster row 9. Predecessors: #1908–#1915. Recorded for later: playbooks:boris transcribes "fast mode 3× cheaper" (Opus 4.8-era third-party claim) while this page's era has it premium-priced — third-party transcription, exempt from first-party staleness detection by I22's own fence; noted on the roster row, not patched inside a vendor mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
