### PR TITLE
feat(claude-config): flag a leading thinking block treated as required where none is

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Five audit skills for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), and audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -34,9 +34,11 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
   documented. Severity is `warning` against I18's `error` on its own footing: wasted work plus a
   fabrication risk, not a guaranteed rejected request.
 
-  **The carve-out is upstream's own.** Models using a legacy manual thinking budget do enforce that
-  the final assistant turn of a thinking-enabled request begins with one, so text scoped to that
-  mode is correct — the finding is the missing gate, never the mention, as in `I17-c`. The row also
+  **The carve-out is upstream's own, and exactly as wide as its source.** Models using a legacy
+  manual thinking budget do enforce that the final assistant turn of a thinking-enabled request
+  begins with one, so text scoped to that mode AND that turn is correct; a legacy-scoped
+  instruction demanding the block on every assistant turn over-requires past its own source and
+  still flags — the finding is the missing gate, never the mention, as in `I17-c`. The row also
   fences itself against being read as license to drop blocks: the relaxation "is about validation,
   not about what you should send".
 

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,57 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.5]
+
+### Added
+
+- **`audit-instructions`: `I18-a`, a leading thinking block treated as required where the model does
+  not require one** (criteria 1.13.0, taking the next minor over PR #1917). I18 covered only what a
+  surface does to thinking blocks it *has* — dropping the `signature`, the `type == "thinking"`
+  filter, editing the latest turn's blocks. The opposite error had no row: believing a block must
+  be there. The Steering
+  thinking page states the relaxation outright — "Assistant turns don't need to start with a
+  thinking block" — with three consequences that become the row's three detect shapes: reinsertion
+  when assembling history from mixed sources, rewriting history on resume under a different
+  thinking configuration, and logic that reads an assistant turn's first block as though it were a
+  thinking block.
+
+  **It is a sub-row of I18 rather than a new criterion because the two are one mechanism seen from
+  both ends.** The remediation a reader reaches for once they believe a block is required is to
+  fabricate one, and a hand-built block carries no valid `signature` — which is I18's own shape 1
+  and a rejected request. So this row is the upstream *cause* of an I18 violation; both are reported
+  when a surface states the premise and acts on it. I18 gains a two-sentence lead-in naming the
+  pairing and a `Base row:` label; its detect, fences, source and stamp are unchanged.
+
+  **Reach is I18's, unchanged, for all three shapes** — a path back to the model, whatever the file
+  format. Presence-assuming logic that only ever *reads* is recorded as out of reach rather than
+  excused: the page's caution sits in the request/response frame and says nothing about stored
+  transcripts, whether a harness transcript carries thinking blocks at all is unestablished, and the
+  harm there would be the consumer's own logic rather than a 400 — a code-correctness matter this
+  catalog does not audit. The row carries a `Re-scope when` clause for the day that shape is
+  documented. Severity is `warning` against I18's `error` on its own footing: wasted work plus a
+  fabrication risk, not a guaranteed rejected request.
+
+  **The carve-out is upstream's own.** Models using a legacy manual thinking budget do enforce that
+  the final assistant turn of a thinking-enabled request begins with one, so text scoped to that
+  mode is correct — the finding is the missing gate, never the mention, as in `I17-c`. The row also
+  fences itself against being read as license to drop blocks: the relaxation "is about validation,
+  not about what you should send".
+
+  **Decisive source, with the sibling as corroboration.** The Thinking page carries the same pair
+  compressed into one sentence inside "Thinking with tool use" — extended (manual) mode "additionally
+  enforces that the final assistant turn of a thinking-enabled request begins with a thinking block",
+  and "Adaptive mode relaxes this: no assistant turn needs to start with one." Steering thinking is
+  where the relaxation is stated operatively, with the three history-shape consequences the detect
+  shapes are drawn from and the presence caution, so it is cited as decisive and the sibling as
+  corroboration. Separate from both is that page's strip claim — the API "may strip thinking blocks
+  that would create an invalid turn structure" — server-side degradation of a request rather than a
+  rule about what history a caller may send. The Steering thinking page joins Sources. Local
+  coverage measured 2026-08-04: zero
+  operative instances, on the same footing as I18, with a re-measure clause. The one transcript
+  consumer here, `session-flow`'s retro parser, selects blocks by each item's own `type` rather than
+  by position, so it is correct by construction rather than by this rule.
+
 ## [0.21.4]
 
 ### Changed

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -963,10 +963,14 @@ Tier `mechanical` · Severity `warning`.
   thinking blocks at all is unestablished; the harm there would in any case be the consumer's own
   logic rather than a rejected request, which is a code-correctness matter this catalog does not
   audit. **Re-scope when** the stored transcript's content-block shape is documented.
-- **Must NOT flag: text scoped to a legacy manual thinking budget**, where the requirement is real.
-  The page carves it out itself — those models "enforce that the final assistant turn of a
-  thinking-enabled request begins with one". The gate is the model's thinking mode, not the
-  sentence's confidence, and as in I17-c **the finding is the missing gate, never the mention.**
+- **Must NOT flag: text scoped to a legacy manual thinking budget AND to the final assistant
+  turn**, where the requirement is real. The page carves it out itself — those models "enforce that
+  the final assistant turn of a thinking-enabled request begins with one" — and the enforcement is
+  exactly that wide: the final assistant turn of a thinking-enabled request, no other turn. A
+  legacy-scoped instruction demanding a leading block on *every* assistant turn over-requires past
+  its own source and still flags. The gate is the model's thinking mode plus the turn it names, not
+  the sentence's confidence, and as in I17-c **the finding is the missing gate, never the
+  mention.**
   **The base row's own advice**, which is not this row's inverse: the relaxation "is about
   validation, not about what you should send", so an instruction to pass blocks you *have* back
   unmodified — particularly during tool use — is correct and stays correct. Reading this row as

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -1,5 +1,5 @@
 ---
-version: 1.12.0
+version: 1.13.0
 last-updated: 2026-08-04
 ---
 
@@ -108,6 +108,9 @@ I15–I22 apply to all surfaces; I13 and I14 name narrower surface sets in their
   round-trip protocol, the models that reject a thinking-disable outright, and what a thinking or
   effort change does to the cache prefix) —
   <https://platform.claude.com/docs/en/build-with-claude/thinking>
+- Steering thinking (the turn-validation relaxation, and the models that still enforce a leading
+  thinking block) —
+  <https://platform.claude.com/docs/en/build-with-claude/thinking-steering-and-cost>
 - Troubleshooting thinking (the per-request 400s, and the models the effort restriction covers) —
   <https://platform.claude.com/docs/en/build-with-claude/thinking-troubleshooting>
 - Model migration guide (the model ranges over which manual extended thinking is rejected) —
@@ -883,6 +886,11 @@ Tier `mechanical` · Authority `ANTHROPIC-DOCS` · Severity `error` · Surfaces:
 promotion gate MET: the round-trip protocol is stated on a model-agnostic feature page, not in a
 model guide.
 
+Two rows, in opposite directions: the base row is what a surface does to blocks it *has*, and I18-a
+is what a surface believes about blocks that are *not there*. They share a subject, not a citation.
+
+**Base row: blocks altered on the way back.**
+
 - **Detect:** instruction text directing an agent, a script, or a reader to handle assistant content
   blocks in a way that breaks the round-trip protocol. Three shapes:
   1. **Dropping the `signature`.** An instruction to reconstruct, summarize, re-serialize, or
@@ -927,6 +935,71 @@ model guide.
   round-trip or transcript-replay path lands here.
 - **Verified 2026-08-02** against the Thinking page, fetched as raw markdown. **Recheck trigger:** a
   content-block type joining or leaving the set the protocol requires echoed back.
+
+**Row I18-a: a leading thinking block treated as required where the model does not require one** ·
+Tier `mechanical` · Severity `warning`.
+
+- **Detect:** instruction text asserting, or directing work premised on, a validation rule that
+  assistant turns must begin with a thinking block. Three shapes:
+  1. **Reinsertion.** An instruction to insert, synthesize, or restore a leading `thinking` block
+     when assembling history from mixed sources, so that each assistant turn "starts with one".
+  2. **History rewriting on resume.** An instruction to rewrite, normalize, or discard a
+     conversation because it began without thinking or ran under a different thinking
+     configuration.
+  3. **Presence-assuming logic.** An instruction to read, index, or branch on an assistant turn's
+     first content block as though it were a `thinking` block. A turn where Claude chose not to
+     think carries none, and the same conversation can hold turns of both kinds.
+- **Why the belief is a finding and not a harmless one.** The remediation a reader reaches for is
+  fabrication, and a hand-built block carries no valid `signature` — the base row's shape 1, and a
+  rejected request. This row is therefore the upstream cause of the base row's violation, not a
+  restatement of it; report both when a surface states the premise *and* acts on it.
+- **Remediate:** pass history back in whatever shape you have it, and treat a thinking block as
+  optional per assistant turn — in tests too, where a no-thinking turn is the case the assumption
+  hides.
+- **Reach: the base row's, unchanged, and for all three shapes** — a path back to the model is what
+  puts a surface in scope, not the file format it reads. **Presence-assuming logic that only ever
+  reads is out of reach rather than excused.** The page's caution sits in the request/response
+  frame and says nothing about stored transcripts, and whether a harness transcript carries
+  thinking blocks at all is unestablished; the harm there would in any case be the consumer's own
+  logic rather than a rejected request, which is a code-correctness matter this catalog does not
+  audit. **Re-scope when** the stored transcript's content-block shape is documented.
+- **Must NOT flag: text scoped to a legacy manual thinking budget**, where the requirement is real.
+  The page carves it out itself — those models "enforce that the final assistant turn of a
+  thinking-enabled request begins with one". The gate is the model's thinking mode, not the
+  sentence's confidence, and as in I17-c **the finding is the missing gate, never the mention.**
+  **The base row's own advice**, which is not this row's inverse: the relaxation "is about
+  validation, not about what you should send", so an instruction to pass blocks you *have* back
+  unmodified — particularly during tool use — is correct and stays correct. Reading this row as
+  license to drop blocks inverts both rows at once. A document *about* the assumption, on the
+  audience test I8-b applies.
+- **Source:** Steering thinking, "Turn validation" — "Assistant turns don't need to start with a
+  thinking block" — with the three consequences stated there, one per shape above: turns where
+  Claude chose not to think "are valid history as-is"; a conversation begun without thinking, or
+  under a different thinking configuration, resumes "without rewriting its history"; and history
+  assembled from mixed sources "doesn't need thinking blocks reinserted at the start of each
+  assistant turn to pass validation". The legacy carve-out is that same "Turn validation" section's
+  own parenthetical, quoted in the fence above. The presence half is the same page, "How Claude
+  decides when to think" — "a turn where Claude chose not to think contains no thinking block. Don't
+  build application logic that assumes every assistant turn starts with one."
+- **Why this page is cited and not the sibling.** The Thinking page carries the same pair, but
+  compressed into a single sentence inside "Thinking with tool use": in extended (manual) mode the
+  API "additionally enforces that the final assistant turn of a thinking-enabled request begins with
+  a thinking block", and "Adaptive mode relaxes this: no assistant turn needs to start with one."
+  That corroborates this row; it does not carry it. Steering thinking is where the relaxation is
+  stated operatively — the three history-shape consequences the detect shapes are drawn from, plus
+  the presence caution — so it is cited as decisive and the sibling as corroboration. Separate from
+  both is that page's *strip* claim, that the API "may strip thinking blocks that would create an
+  invalid turn structure": server-side degradation of a request, not a rule about what history a
+  caller may send, and it licenses nothing here.
+- **Local coverage, measured 2026-08-04: zero operative instances here**, on the same footing as the
+  base row — nothing in this repository assembles, rewrites, or replays history back to the model.
+  The one transcript consumer, `session-flow`'s retro parser, selects blocks by testing each item's
+  own `type` rather than by position, so it is correct by construction rather than by this rule.
+  Stated as an as-of measurement, not a passed check. **Re-measure when** a history-assembly or
+  replay path lands here.
+- **Verified 2026-08-04** against the Steering thinking page, fetched as raw markdown. **Recheck
+  trigger:** the turn-validation relaxation narrowing, or the set of models that enforce a leading
+  thinking block changing.
 
 ### I19: Restated external benchmark figure with no recheck trigger
 


### PR DESCRIPTION
## Summary

Doc-alignment roster row 12: **Steering thinking** (live page byte-identical to the archived 947-line slice — MD5 confirmed by producer and verifier independently).

**criteria 1.13.0 / claude-config 0.21.5** — new sub-row **I18-a**: *a leading thinking block treated as required where the model does not require one*. I18 covered only what a surface does to blocks it has; the inverse belief — that a block must be there — had no row, and its natural remediation (fabricate one) produces exactly I18's shape 1 (a hand-built block has no valid signature), making I18-a the upstream cause of an I18 violation. Three detect shapes, one per consequence the page states: reinsertion when assembling history from mixed sources; history rewriting on resume under a different thinking configuration; logic reading an assistant turn's first block as a thinking block.

- Honest carve-out from upstream's own text: legacy manual-budget models *do* enforce the leading block — the finding is the missing gate, never the mention.
- Fence: the relaxation "is about validation, not about what you should send" — never license to drop blocks.
- Reach held to I18's line: presence-assuming read-only logic is out of reach (neither excused nor flagged), keyed to the still-unresolved question of what Claude Code transcripts carry, with a re-scope trigger.
- Sourcing: the Steering page is decisive (states the relaxation operatively with its three consequences); the Thinking page carries the pair in compressed form in its tool-use section and is cited as corroboration — with its server-side strip claim explicitly held apart as a different claim.
- I18 base gains only a two-sentence lead-in and a "Base row:" label; its detect, fences, source, and stamp are untouched.

Also verified in passing (roster corrections, not in this diff): the row's "shipped only as far as context-economy" note was stale — PLUGIN-PHILOSOPHY's Effort tiers already carries five of the slice's candidates citing this page; and the repo's one transcript consumer already selects blocks by their own `type`, correct by construction.

## Test plan

- Docs-only; markdownlint 0 errors; changelog parity all three modes; `instruction-scan.test.sh` 46/46; scripted quote fidelity 14/14 against both live pages with control probes.
- Producer's advisor overturned an over-reach in its first draft (extending shape 3 to read-only surfaces — unsupported); the producer also self-diagnosed the root cause of its one false claim (a `begin with` grep that could never match `begins with` — the absence-through-a-blind-channel trap).
- Orchestrator-commissioned Fable verifier: 5/6 first pass — caught the false "only source" custody claim against its own live fetch of the sibling page — plus an ambiguous antecedent; both fixed, rebase compose verified to preserve #1917's Sources expansion, re-check ALL PASS.
- Rebased onto post-#1917 main; stacks asserted: [0.21.5] > [0.21.4] > [0.21.3]; criteria 1.13.0.

## Related

- No linked issue.
- Doc-alignment loop, roster row 12. Predecessors: #1908–#1917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
