### PR TITLE
feat(claude-config): audit the model-configuration settings the harness accepts but declines to honor

### DIFF
--- a/docs/conventions/loop-lane/README.md
+++ b/docs/conventions/loop-lane/README.md
@@ -354,7 +354,7 @@ recommended model for the provider and update over time; a dated model name is a
 is never written into a lane body. Aliases are the only handle guaranteed under subscription OAuth,
 so they are the runtime path; the Models API list endpoint is the **build/audit-time** verification
 path, since it may require an API key a loop session lacks. No lane hard-codes a model ID. (Alias
-semantics verified against <https://code.claude.com/docs/en/model-config> on 2026-07-23.)
+semantics verified against <https://code.claude.com/docs/en/model-config> on 2026-08-04.)
 
 Tier tables are built from a live official-docs fetch at authoring time, never from recall. Any new
 model release re-audits the tier table — the trigger is recorded in this convention's

--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.21.6",
+  "version": "0.21.7",
   "description": "Five audit skills for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), and audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -24,7 +24,22 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
 
   Three rows are `warning`. The `enforceAvailableModels` pairing is `error`, because this skill's own
   severity guide rates an enforcement bypass that way and that is what the finding is: an
-  administrator who set the key believes the Default option is constrained when it is not.
+  administrator who set the key believes the Default option is constrained when it is not. That row
+  fires only on `enforceAvailableModels: true` with the list unset or empty — an explicit `false` is
+  someone disabling enforcement deliberately, so the check gates on the value rather than the key's
+  presence.
+
+  **`check-structure.sh` now reports the four keys by value for `settings.local.json`.** Category H
+  can read `settings.json` and `~/.claude/settings.json` directly, but the safe-read rule routes the
+  local file through this helper, and the helper emitted only environment, permission, and plugin
+  counts — so a key living only in `settings.local.json` was invisible and its defect silently
+  missed. Counts could not have closed that: the allowlist wildcard rule turns on which family each
+  entry names, and the fallback cap turns on entry order. The four values are configuration
+  identifiers — level names, model names, a boolean — not credentials, so emitting them leaves the
+  secret guard untouched, and a test asserts env values and env key names still never appear.
+  `unset` and `(empty list)` are reported distinctly because they are different findings. Existing
+  output lines are unchanged; the new lines are appended, and the script's own suite covers the
+  addition (10 checks before, 24 after).
 
   **How loudly each surfaces differs, and the rows say so individually.** An earlier draft claimed a
   blanket runtime silence; that is false for the allowlist row, where a narrowed alias shows a

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,78 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.21.7]
+
+### Added
+
+- **`audit`: category H, the model and effort settings no category reached.** The skill advertises
+  settings-file and environment-variable correctness "against current official docs", and categories
+  A–G reach schema, permissions, MCP servers, hooks, plugins, environment variables, and the
+  skill-listing budget. None reached the model-configuration keys, so `effortLevel`,
+  `fallbackModel`, `availableModels`, and `enforceAvailableModels` went unaudited in a skill whose
+  stated scope includes them. Phase 2's enumeration, `validation-categories.md`, and a mandatory
+  Phase 3 model-config fetch all move with it, so the category is reachable by the skill's own flow
+  rather than stranded in the checklist.
+
+  The four rows share one shape: each names a value the harness accepts into the file and then does
+  not apply as its author expects. `effortLevel: max` is not the level that persists; a fourth
+  `fallbackModel` entry risks being ignored; a specific model listed beside its own family wildcard
+  narrows the allowlist to that one version; `enforceAvailableModels` without a non-empty
+  `availableModels` does nothing at all.
+
+  Three rows are `warning`. The `enforceAvailableModels` pairing is `error`, because this skill's own
+  severity guide rates an enforcement bypass that way and that is what the finding is: an
+  administrator who set the key believes the Default option is constrained when it is not.
+
+  **How loudly each surfaces differs, and the rows say so individually.** An earlier draft claimed a
+  blanket runtime silence; that is false for the allowlist row, where a narrowed alias shows a
+  substitution notice naming both models. Two rows also have an authoring-time path — the declared
+  schema constrains `effortLevel` by `enum` and `fallbackModel` by `maxItems` — so a schema-aware
+  editor catches them first. They stay because the schema is advisory and the harness reads a file
+  that violates it. Where the two authorities disagree they are reported separately: `maxItems` caps
+  RAW array length while the page caps the chain after deduplication, so a four-entry chain holding
+  one duplicate fails the schema and satisfies the harness.
+
+  Rows were admitted on one test: the key must appear in a file this skill actually opens. That
+  excluded the managed-source placement rule for the `availableModels` pair, which no local file can
+  decide, and it is carried as guidance in the verify column instead of a verdict. `modelOverrides`
+  key validation is excluded for a different reason and stated as a closing note: deciding whether a
+  key is a real model ID means resolving it against Models overview, and that page's own restatement
+  deferral governs new consumers of the facts it owns.
+
+  **The frontmatter-`effort` lint stays deferred and untouched.** That separate item would lint the
+  `effort` frontmatter field in this repository's own agents and skills; it has no host, and the
+  value list it would need is deliberately not restated in this repo. Category H is a different item
+  on three counts — a different key (`effortLevel`, not `effort`), a different file (a consumer's
+  settings, not this repo's component frontmatter), and a host that already exists. Its deferral
+  permits exactly this: a new item with a chosen host, rather than the deferral being lifted.
+
+  The rows do restate the session-only effort semantics rather than citing this repo's philosophy
+  doc, deliberately: this checklist ships into consumer repositories where that doc is not present,
+  so a citation would resolve to nothing and the row would lose its detection. Note the rows also
+  quote the upstream page verbatim where categories A–F restate their sources inline instead. That
+  is a deliberate departure — these findings turn on exact wording a reader will want to check
+  against the page — and the Phase 3.3 fetch is what keeps the quotes honest as the page moves.
+
+  Verified 2026-08-04 against <https://code.claude.com/docs/en/model-config>, fetched as raw
+  markdown (82,975 B), and against the declared settings schema at
+  <https://json.schemastore.org/claude-code-settings.json>. Recheck trigger: the `effortLevel`
+  accepted-value set changing, the three-model fallback-chain cap changing, the wildcard-disabling
+  rule for a specific family entry changing, or the schema's `enum`/`maxItems` constraints diverging
+  further from the page.
+
+### Fixed
+
+- **`audit-instructions`: `I17`'s `effortLevel: max` carve-out justified itself with a false claim**
+  (criteria 1.15.0). It read that the settings schema "accepts `low`, `medium`, `high`, `xhigh`
+  only, so that string is unreachable there". The schema is advisory JSON Schema: the value is
+  writable, the file merely fails validation, and the harness reads it anyway — which is precisely
+  why the new `audit` category H checks for it. Left as written, one plugin asserted both that the
+  value cannot appear in a settings file and that a sibling category hunts it there. The carve-out
+  itself is unchanged and still correct — an instruction-text catalog should not hunt the literal —
+  but it now rests on the editor-catches-it-at-authoring-time reason rather than an impossibility
+  that does not hold, and points at the category that does own the file-level check.
+
 ## [0.21.6]
 
 ### Changed

--- a/plugins/claude-config/skills/audit-instructions/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-instructions/reference/criteria.md
@@ -1,5 +1,5 @@
 ---
-version: 1.14.0
+version: 1.15.0
 last-updated: 2026-08-04
 ---
 
@@ -733,9 +733,12 @@ fails only at the top of the effort ladder, and a disable that fails at every le
   scanned settings files would claim authority a sibling already holds. Instruction text that
   happens to *live* in a settings file, such as a prompt-type hook's injected text, stays here: the
   discriminator is whether the content instructs, not which file holds it.
-- **Must NOT flag:** `effortLevel: max` as a literal to hunt — the settings schema accepts `"low"`,
-  `"medium"`, `"high"`, `"xhigh"` only, so that string is unreachable there and an auditor sent
-  after it finds nothing and learns nothing. **A document that states either arm in order to
+- **Must NOT flag:** `effortLevel: max` as a literal to hunt **in instruction text** — the settings
+  schema's `enum` accepts `"low"`, `"medium"`, `"high"`, `"xhigh"` only, so a schema-aware editor
+  flags the value where it is actually written, and an instruction-text auditor sent after the
+  literal finds nothing and learns nothing. The value is writable, not unreachable: the schema is
+  advisory and the harness reads a file that violates it, which is why the settings-file check is
+  `claude-config:audit` category H rather than absent. **A document that states either arm in order to
   describe or forbid it** — this row, a model-adaptation delta chapter, a verification record
   quoting it — on the same audience test I8-b applies: either arm prescribed inside an operative
   directive is a finding; a document *about* it is not. **The bare `ultracode` prompt

--- a/plugins/claude-config/skills/audit/SKILL.md
+++ b/plugins/claude-config/skills/audit/SKILL.md
@@ -115,7 +115,7 @@ Load the audit checklist: [audit-checklist.md](reference/audit-checklist.md)
 
 Run each category's checks. Record findings with severity ratings.
 
-Seven categories — names + the question each answers below; **full per-check criteria in
+Eight categories — names + the question each answers below; **full per-check criteria in
 [context/validation-categories.md](context/validation-categories.md)** (read it when running Phase 2).
 
 - **A — Schema & Structure**: `$schema` present, no unknown keys, `mcpServers` not in `settings.local.json`
@@ -125,6 +125,7 @@ Seven categories — names + the question each answers below; **full per-check c
 - **E — Plugins**: static checks (marketplace membership) + live upstream drift detection (`scripts/check-plugin-drift.sh` — ORPHAN/NEW/RENAME modes, auto-fix policy table in the context file)
 - **F — Environment Variables**: documented/justified vars, secrets in `settings.local.json` only, forward-slash paths
 - **G — Skill-listing budget**: `/doctor` overflow check and trim levers (description trimming, `skillOverrides`, budget settings)
+- **H — Model and effort settings**: `effortLevel`, `fallbackModel`, `availableModels`, `enforceAvailableModels` — values the harness accepts into the file but does not apply as written
 
 ---
 
@@ -148,7 +149,15 @@ Claude Code issue-tracking skill if it has one). For any issue whose upstream fi
 below the installed Claude Code version, confirm the settings-specific workaround is still needed and
 recommend retiring it if not.
 
-### 3.3 Permission syntax verification
+### 3.3 Model configuration verification
+
+**MANDATORY** for any category H finding: fetch
+[code.claude.com/docs/en/model-config](https://code.claude.com/docs/en/model-config) and confirm the
+behavior the finding rests on. Do NOT report a category H finding from this checklist's wording
+alone — the accepted `effortLevel` values, the fallback-chain cap, and the allowlist wildcard rule
+are all upstream-owned and move with the harness.
+
+### 3.4 Permission syntax verification
 
 Fetch [code.claude.com/docs/en/permissions](https://code.claude.com/docs/en/permissions) and verify:
 

--- a/plugins/claude-config/skills/audit/context/validation-categories.md
+++ b/plugins/claude-config/skills/audit/context/validation-categories.md
@@ -122,8 +122,10 @@ Row-by-row criteria are in [audit-checklist.md](../reference/audit-checklist.md)
 effort settings". What governs the category:
 
 - **Scope** — `effortLevel`, `fallbackModel`, `availableModels`, `enforceAvailableModels` in the
-  settings files this skill already opens. `modelOverrides` values are deliberately not validated;
-  the checklist says why
+  settings files this skill already opens, `settings.local.json` included: `check-structure.sh`
+  reports those four by value while keeping env and permission entries as counts, so a local-only
+  misconfiguration is checkable without dumping the secrets beside it. `modelOverrides` values are
+  deliberately not validated; the checklist says why
 - **Fetch before reporting** — every row rests on upstream-owned behavior, so a finding requires the
   Phase 3.3 model-config fetch, not this file's wording
 - **Two authorities, and they can disagree** — the declared settings schema constrains `effortLevel`

--- a/plugins/claude-config/skills/audit/context/validation-categories.md
+++ b/plugins/claude-config/skills/audit/context/validation-categories.md
@@ -1,6 +1,6 @@
 # audit — Phase 2 validation categories
 
-Detailed checks for each Phase 2 category (A–G). SKILL.md Phase 2 names the categories + points here;
+Detailed checks for each Phase 2 category (A–H). SKILL.md Phase 2 names the categories + points here;
 this file carries the per-check criteria. Run each category's checks and record findings with severity
 ratings.
 
@@ -115,3 +115,25 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/fix-plugin-drift.sh" --yes
   `SLASH_COMMAND_TOOL_CHAR_BUDGET` in project settings as a last resort (costs context every turn)
 - **Recommend, don't apply the list** — `skillOverrides` is contributor-scoped; surface the candidate
   least-invoked skills, leave the actual name-only list to the developer
+
+## Category H: Model and effort settings
+
+Row-by-row criteria are in [audit-checklist.md](../reference/audit-checklist.md) "H. Model and
+effort settings". What governs the category:
+
+- **Scope** — `effortLevel`, `fallbackModel`, `availableModels`, `enforceAvailableModels` in the
+  settings files this skill already opens. `modelOverrides` values are deliberately not validated;
+  the checklist says why
+- **Fetch before reporting** — every row rests on upstream-owned behavior, so a finding requires the
+  Phase 3.3 model-config fetch, not this file's wording
+- **Two authorities, and they can disagree** — the declared settings schema constrains `effortLevel`
+  by `enum` and `fallbackModel` by `maxItems` (raw array length), while the harness caps the
+  fallback chain after deduplication. Report a schema violation and a harness-behavior finding as
+  the separate things they are
+- **Per-row visibility, not a blanket claim** — some of these are silent and some announce
+  themselves (a narrowed alias shows a substitution notice). Each row states which, because it
+  changes what the finding is worth to the reader
+- **Placement is out of reach** — `availableModels` and `enforceAvailableModels` belong in the
+  highest-precedence managed source, and admin-deployed managed sources do not merge. Nothing in the
+  files this skill reads decides whether that holds, so report the value-level finding and leave
+  placement to the administrator

--- a/plugins/claude-config/skills/audit/reference/audit-checklist.md
+++ b/plugins/claude-config/skills/audit/reference/audit-checklist.md
@@ -2,6 +2,10 @@
 
 Validation rules organized by category. Each check has a severity, what to look for, and how to verify.
 
+Category G (skill-listing budget) has no table here — its checks are procedural and live in
+[context/validation-categories.md](../context/validation-categories.md), which carries every
+category's criteria.
+
 ## A. Schema & Structure
 
 | Check | Severity | How to verify |
@@ -104,3 +108,32 @@ additional ask-gates) get those checked at the same severities.
 | No secrets in settings.json (tokens, keys, passwords) | error | Scan for patterns: `ghp_`, `eyJ`, `sk-`, `AKIA`, common token prefixes |
 | Secrets are in settings.local.json only | error | settings.local.json is gitignored |
 | Path-based env vars use forward slashes | info | Windows compatibility |
+
+## H. Model and effort settings
+
+Each check reads a settings file this skill already opens, and each detects a value the harness
+accepts into the file and then does not apply the way its author expects. How loudly that surfaces
+differs per row, so each row says so rather than the section claiming a blanket silence.
+
+Two of these rows also have an authoring-time path: the declared schema section A checks for
+constrains `effortLevel` by `enum` and `fallbackModel` by `maxItems`, so an editor validating
+against it flags them before the file is ever loaded. The rows stay, because the schema is advisory
+— the harness still reads a file that violates it — and because section A checks that `$schema` is
+present, not what the values are. Where the schema and the harness disagree, the row says which is
+which.
+
+Apply `jq` recipes to `settings.json` and `~/.claude/settings.json`. For `settings.local.json`,
+follow this skill's safe-read rule and go through `check-structure.sh` rather than dumping values.
+Resolve current behavior from <https://code.claude.com/docs/en/model-config> when the audit runs,
+the way section F resolves environment variables against their own page.
+
+| Check | Severity | How to verify |
+| --- | --- | --- |
+| `effortLevel` is not `max` or `ultracode` | warning | `jq '.effortLevel'`. Model configuration states both are session-only and "are not accepted here"; the declared schema's `enum` omits them too, so a schema-aware editor already flags this. Report what the author loses — the level they asked for is not the one that persists — without asserting which level runs instead, which the page does not state. `CLAUDE_CODE_EFFORT_LEVEL` is the durable route to `max` |
+| `fallbackModel` satisfies both the declared `maxItems: 3` and the documented post-dedup cap | warning | These are two different tests and can disagree: the schema caps RAW array length at 3, while the page caps the chain "after duplicate removal", so `["sonnet","haiku","sonnet","opus"]` fails the schema at 4 entries but leaves exactly 3 after dedup. Report raw length over 3 as a schema violation, then dedupe in place with `jq '.fallbackModel \| reduce .[] as $m ([]; if index($m) then . else . + [$m] end)'` — `unique` would sort away the order the chain is tried in — and name any entry past the third as at risk of being ignored. Not "dead": allowlist-excluded entries are also dropped when the chain is read, and the page does not state whether that dropping happens before or after the cap |
+| `availableModels` does not mix a family wildcard with a specific entry of that family | warning | An entry naming a specific model "disables that family's wildcard entry": `["sonnet", "claude-sonnet-4-5"]` permits only Sonnet 4.5, not every Sonnet. Reached the same way by a Mantle ID and by an `ANTHROPIC_CUSTOM_MODEL_OPTION` value embedding a family name. This one is not silent — an alias narrowed to an older permitted version shows "a notice naming both the requested and substituted models" — so the finding is that the allowlist is narrower than its author meant, not that nothing surfaces. Report the models they most likely still expect to be selectable |
+| `enforceAvailableModels` is paired with a non-empty `availableModels` | error | `jq '.enforceAvailableModels, .availableModels'`. The key "has no effect when `availableModels` is unset or empty", so an administrator who set it believes the Default option is constrained when it is not — an enforcement bypass, which this skill's severity guide rates `error`. Both keys belong in the highest-precedence managed source, and managed sources do not merge; that placement is not decidable from the files this skill reads, so report the pairing, not the placement |
+
+Model IDs in `modelOverrides` are not validated here: unknown keys are ignored rather than
+rejected, and deciding whether a key is a real Anthropic model ID means resolving it against
+[Models overview](https://platform.claude.com/docs/en/about-claude/models/overview).

--- a/plugins/claude-config/skills/audit/reference/audit-checklist.md
+++ b/plugins/claude-config/skills/audit/reference/audit-checklist.md
@@ -123,16 +123,20 @@ present, not what the values are. Where the schema and the harness disagree, the
 which.
 
 Apply `jq` recipes to `settings.json` and `~/.claude/settings.json`. For `settings.local.json`,
-follow this skill's safe-read rule and go through `check-structure.sh` rather than dumping values.
-Resolve current behavior from <https://code.claude.com/docs/en/model-config> when the audit runs,
-the way section F resolves environment variables against their own page.
+follow this skill's safe-read rule and go through `check-structure.sh`, which reports these keys by
+value — `Effort level`, `Fallback chain` (raw and post-dedup counts), `Fallback entries` in order,
+`Available models`, and `Enforce available models` — distinguishing `unset` from `(empty list)`
+because those are different findings. Env and permission entries stay counts there, so a key that
+lives only in the local file is still checkable without dumping the secrets beside it. Resolve
+current behavior from <https://code.claude.com/docs/en/model-config> when the audit runs, the way
+section F resolves environment variables against their own page.
 
 | Check | Severity | How to verify |
 | --- | --- | --- |
 | `effortLevel` is not `max` or `ultracode` | warning | `jq '.effortLevel'`. Model configuration states both are session-only and "are not accepted here"; the declared schema's `enum` omits them too, so a schema-aware editor already flags this. Report what the author loses — the level they asked for is not the one that persists — without asserting which level runs instead, which the page does not state. `CLAUDE_CODE_EFFORT_LEVEL` is the durable route to `max` |
 | `fallbackModel` satisfies both the declared `maxItems: 3` and the documented post-dedup cap | warning | These are two different tests and can disagree: the schema caps RAW array length at 3, while the page caps the chain "after duplicate removal", so `["sonnet","haiku","sonnet","opus"]` fails the schema at 4 entries but leaves exactly 3 after dedup. Report raw length over 3 as a schema violation, then dedupe in place with `jq '.fallbackModel \| reduce .[] as $m ([]; if index($m) then . else . + [$m] end)'` — `unique` would sort away the order the chain is tried in — and name any entry past the third as at risk of being ignored. Not "dead": allowlist-excluded entries are also dropped when the chain is read, and the page does not state whether that dropping happens before or after the cap |
 | `availableModels` does not mix a family wildcard with a specific entry of that family | warning | An entry naming a specific model "disables that family's wildcard entry": `["sonnet", "claude-sonnet-4-5"]` permits only Sonnet 4.5, not every Sonnet. Reached the same way by a Mantle ID and by an `ANTHROPIC_CUSTOM_MODEL_OPTION` value embedding a family name. This one is not silent — an alias narrowed to an older permitted version shows "a notice naming both the requested and substituted models" — so the finding is that the allowlist is narrower than its author meant, not that nothing surfaces. Report the models they most likely still expect to be selectable |
-| `enforceAvailableModels` is paired with a non-empty `availableModels` | error | `jq '.enforceAvailableModels, .availableModels'`. The key "has no effect when `availableModels` is unset or empty", so an administrator who set it believes the Default option is constrained when it is not — an enforcement bypass, which this skill's severity guide rates `error`. Both keys belong in the highest-precedence managed source, and managed sources do not merge; that placement is not decidable from the files this skill reads, so report the pairing, not the placement |
+| `enforceAvailableModels: true` is paired with a non-empty `availableModels` | error | `jq 'select(.enforceAvailableModels == true) \| .availableModels'` — the finding requires the flag to be `true` AND the list unset or empty. An explicit `false` is someone turning enforcement off on purpose and is never a finding, so gate on the value rather than the key's presence. When it does fire: the key "has no effect when `availableModels` is unset or empty", so an administrator who set it believes the Default option is constrained when it is not — an enforcement bypass, which this skill's severity guide rates `error`. Both keys belong in the highest-precedence managed source, and managed sources do not merge; that placement is not decidable from the files this skill reads, so report the pairing, not the placement |
 
 Model IDs in `modelOverrides` are not validated here: unknown keys are ignored rather than
 rejected, and deciding whether a key is a real Anthropic model ID means resolving it against

--- a/plugins/claude-config/skills/audit/scripts/check-structure.sh
+++ b/plugins/claude-config/skills/audit/scripts/check-structure.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Secret-safe config structure facts for the audit skill.
 #
-# Output: per-file validity and key counts. Never prints env values.
+# Output: per-file validity and key counts, plus the model and effort values
+# audit category H needs from settings.local.json. Never prints env values.
 # Exit: 0 parseable; 1 invalid JSON; 2 jq missing.
 #
 # Env:
@@ -93,12 +94,24 @@ emit_file_facts() {
       '
     ;;
   local)
+    # Model and effort values are emitted in full, unlike env and permission
+    # entries which stay counts. They are configuration identifiers — level
+    # names, model names, a boolean — not credentials, and the audit's category
+    # H cannot decide its findings from counts: the allowlist wildcard rule
+    # turns on which family each entry names, and the fallback cap turns on
+    # entry order. Counting them here would leave a local-only misconfiguration
+    # invisible. The env-value and secret-field guard above is unchanged.
     tr -d '\r' <"$path" | jq -r '
         "Env keys: \((.env // {} | keys | length))",
         "Deny count: \((.permissions.deny // []) | length)",
         "Ask count: \((.permissions.ask // []) | length)",
         "Allow count: \((.permissions.allow // []) | length)",
-        "Plugin keys: \((.enabledPlugins // {} | keys | length))"
+        "Plugin keys: \((.enabledPlugins // {} | keys | length))",
+        "Effort level: \(if has("effortLevel") then (.effortLevel | tostring) else "unset" end)",
+        "Fallback chain: \(if has("fallbackModel") then "\(.fallbackModel | length) raw, \(.fallbackModel | reduce .[] as $m ([]; if index($m) then . else . + [$m] end) | length) after dedup" else "unset" end)",
+        "Fallback entries: \(if has("fallbackModel") then (if (.fallbackModel | length) == 0 then "(empty list)" else (.fallbackModel | join(", ")) end) else "unset" end)",
+        "Available models: \(if has("availableModels") then (if (.availableModels | length) == 0 then "(empty list)" else (.availableModels | join(", ")) end) else "unset" end)",
+        "Enforce available models: \(if has("enforceAvailableModels") then (.enforceAvailableModels | tostring) else "unset" end)"
       '
     ;;
   mcp)

--- a/plugins/claude-config/skills/audit/scripts/check-structure.test.sh
+++ b/plugins/claude-config/skills/audit/scripts/check-structure.test.sh
@@ -95,6 +95,46 @@ else
 fi
 chmod 600 "$fixture_dir/.claude/settings.local.json" 2>/dev/null
 
+# --- Case 5: category-H facts from settings.local.json -------------------------
+# The audit's category H checks keys that can live only in settings.local.json,
+# which the safe-read rule bars from a direct dump. The helper must surface those
+# values — and must still refuse to surface env values sitting beside them.
+fixture_dir="$TEST_TMPDIR/category-h"
+mkdir -p "$fixture_dir/.claude"
+printf '{"permissions":{"deny":[]}}\n' >"$fixture_dir/.claude/settings.json"
+printf '%s\n' '{"env":{"TOKEN":"sk-not-a-real-secret"},"effortLevel":"max","fallbackModel":["sonnet","haiku","sonnet","opus"],"availableModels":["sonnet","claude-sonnet-4-5"],"enforceAvailableModels":true}' >"$fixture_dir/.claude/settings.local.json"
+rc=0
+out=$(
+  SETTINGS_AUDIT_STRUCTURE_FIXTURE_DIR="$fixture_dir" \
+    bash "$SCRIPT" 2>/dev/null
+) || rc=$?
+assert_exit "case 5: exit 0 on valid local settings" 0 "$rc"
+assert_contains "case 5: effort level surfaced" "$out" "Effort level: max"
+assert_contains "case 5: raw and dedup counts differ" "$out" "Fallback chain: 4 raw, 3 after dedup"
+assert_contains "case 5: fallback order preserved" "$out" "Fallback entries: sonnet, haiku, sonnet, opus"
+assert_contains "case 5: allowlist entries surfaced" "$out" "Available models: sonnet, claude-sonnet-4-5"
+assert_contains "case 5: enforce flag surfaced" "$out" "Enforce available models: true"
+assert_contains "case 5: env still counted not dumped" "$out" "Env keys: 1"
+assert_not_contains "case 5: no secret leaked" "$out" "sk-"
+assert_not_contains "case 5: no env key name leaked" "$out" "TOKEN"
+
+# --- Case 6: category-H keys absent report unset, empty list is distinct --------
+# "unset" and "(empty list)" are different findings: an empty availableModels
+# never engages Default enforcement, while an absent one was never configured.
+fixture_dir="$TEST_TMPDIR/category-h-absent"
+mkdir -p "$fixture_dir/.claude"
+printf '%s\n' '{"availableModels":[],"permissions":{"allow":[]}}' >"$fixture_dir/.claude/settings.local.json"
+rc=0
+out=$(
+  SETTINGS_AUDIT_STRUCTURE_FIXTURE_DIR="$fixture_dir" \
+    bash "$SCRIPT" 2>/dev/null
+) || rc=$?
+assert_exit "case 6: exit 0" 0 "$rc"
+assert_contains "case 6: absent effortLevel is unset" "$out" "Effort level: unset"
+assert_contains "case 6: absent fallbackModel is unset" "$out" "Fallback chain: unset"
+assert_contains "case 6: empty allowlist is distinct from unset" "$out" "Available models: (empty list)"
+assert_contains "case 6: absent enforce flag is unset" "$out" "Enforce available models: unset"
+
 # --- Case 3: missing jq exits 2 -------------------------------------------------
 # Run the script under an EMPTY PATH so its `command -v jq` resolves nothing. The
 # script exits at the jq gate before invoking any external tool, so an empty PATH


### PR DESCRIPTION
## Summary

Doc-alignment roster row 18 — the priority head's final row: **Model configuration** (code.claude.com/docs/en/model-config), the corpus's most-cited harness page, first formally captured here (82,975 B, MD5 `5c9e06c5…`) with a **semantic-stability proof**: normalized token streams of the live page and the frozen 2026-07-31 snapshot are identical (10,222 tokens each, control-probed) — retroactively confirming seven earlier rows' model-config-dependent work ran against an unchanged page.

**claude-config 0.21.7 / criteria 1.15.0**:

- The audit skill advertised settings auditing yet had zero coverage of the model-configuration keys. New **category H (Model and effort settings)** — four rows, each a value the harness accepts into a settings file and then declines to honor: `effortLevel: max/ultracode` (not accepted there), `fallbackModel` beyond three after dedup (with the raw-`maxItems:3` schema test reported separately — the two tests genuinely diverge, verified empirically), a specific entry disabling its family wildcard (including the Mantle-ID and custom-model-option arms), and `enforceAvailableModels` against an unset/empty list (rated **error** per the skill's own enforcement-bypass rubric). Visibility stated per row from the page's own text (row 3's substitution notice; row 2's documented silence). Category H is wired into the skill's phase flow: "Eight categories", a Category H section, and a MANDATORY Phase 3.3 live model-config fetch gating every H finding. `settings.local.json` routed through the safe-read path.
- **criteria I17's carve-out justification corrected** (1.15.0): it claimed the schema makes `effortLevel: max` "unreachable" in settings — false (JSON Schema is advisory; the harness reads a violating file). The directive is unchanged; the justification now states the true reason and points at the sibling that owns the file-level check, making the two halves of one plugin cohere.
- Loop-lane alias stamp refreshed in place (prescribed by that convention's own no-drift rule; claim re-verified against today's bytes). CLOSE-2 re-confirmed discharged. The roster's named component (dotfiles pin audit) declined — machine-scope, not this repo's to own.

Recorded upstream: schemastore's `effortLevel` description omits Opus 5/Sonnet 5 from its effort-support list — stale against the live page; their fix, flagged because this PR now cites that schema.

## Test plan

- markdownlint 0 errors; changelog parity all modes; `instruction-scan.test.sh` 46/46; `conflict-scan.test.sh` 41/41; scripted quote fidelity (6 literals exact, 3 near-miss control probes absent); schema constraints script-verified including the no-`uniqueItems` fact the divergence rests on.
- Two full independent passes converged: the producer's reviewer (found the blocking category-letter collision that made the section unreachable, plus 8 accuracy/coherence defects — all fixed) and an orchestrator-commissioned Fable verifier (upstream fidelity, the stability-proof reproduction, IA-10-boundary and quote-vs-cite adjudications, then a delta re-verify of the fix round: **every item PASS, empty defect list**, both its residual observations non-blocking).
- Producer self-caught one defect pre-review (a sorted dedup misidentifying dead chain entries) and corrected one of its own premises when tested (A–F never quote upstream; the quote call stands on the consumer-repo ground instead, disclosed as a deliberate departure).

## Related

- No linked issue.
- Doc-alignment loop, roster row 18 — completes the 18-row priority head. Predecessors: #1908–#1920, #1922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
