### PR TITLE
docs(planning): give the two-knob digest its source, its prior step, and its fences

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.27.3]
+
+### Added
+
+- **`session-config.md`: the step the source post puts *ahead* of both knobs, and the
+  ambiguity signal it attaches to the model dial.** The "Two orthogonal knobs" section is a
+  faithful digest of
+  [Choosing a Claude model and effort level in Claude Code](https://claude.com/blog/claude-model-and-effort-level-in-claude-code)
+  — "confidently wrong despite full context" tracks the post's "confidently wrong no matter
+  how much context you give it" — but it carried the two branches without the post's prior
+  step and without its own citation, so a reader could not tell the doctrine from the live
+  values listed two sections below. Three gaps closed. **The prior step**: the post's first
+  instruction on a wrong answer is not to turn a dial at all — "your first instinct shouldn't
+  be to adjust a knob, but to examine the context you have provided" — and it names the
+  surfaces where the real fix usually lives (context, `CLAUDE.md`, task scoping). That step is
+  this skill's own product, which is why its absence mattered here specifically: the Brief
+  **is** the context fix, so a knob recommendation is now scoped to what a sharper Brief would
+  not have caught. **The fence**: the post's figure caption calls the try-versus-know
+  discriminator "a starting point, not a hard rule" — provenance disclosed in the section,
+  since a caption is authorial text but not body prose — and it scopes raising effort to "most
+  relevant if you selected an
+  effort level below the model's default" — neither qualifier was present, leaving the section
+  reading as a hard rule at every level. **The ambiguity signal**: the post pairs the larger
+  model with handling ambiguity and the smaller model with "specific instructions directing
+  execution", which is directly actionable for a skill whose rounds exist to retire ambiguity
+  — ambiguity that survived them argues up, a Brief precise enough to execute from argues
+  down.
+- **Why a vendor post is cited here for doctrine.** `playbooks`' calibration rule is that the
+  reference page defines and a post corroborates. It does not fire here, on two grounds the
+  section now records rather than leaving a later reader to re-derive. First, the harness docs
+  delegate this guidance to the post outright:
+  [model configuration](https://code.claude.com/docs/en/model-config) says "For guidance on
+  which model and effort level fit different kinds of work, see [the post] on the blog"
+  (verified 2026-08-04) — a reference page pointing AT the post is the strongest possible
+  ground for citing it. Second, no reference page states the try-versus-know **diagnostic**
+  itself. The claim is deliberately narrow, because two pages discriminate something adjacent:
+  [choosing a model](https://platform.claude.com/docs/en/about-claude/models/choosing-a-model)
+  orders the levers — "Tuning effort is often a better lever than switching models" — and the
+  [effort page](https://platform.claude.com/docs/en/build-with-claude/effort) pairs effort
+  against *prompting* ("raise effort rather than prompting around it"). Ordering a lever is not
+  diagnosing which failure you have, so the post owns the diagnostic while those pages own the
+  ordering.
+
 ## [0.27.2]
 
 ### Fixed

--- a/plugins/planning/skills/interview/context/session-config.md
+++ b/plugins/planning/skills/interview/context/session-config.md
@@ -20,7 +20,10 @@ are not interchangeable:
   **confidently wrong despite full context** — the failure is a reasoning ceiling,
   not missing information. Signals from the interview: the task turned on subtle
   correctness, dense cross-module invariants, or tradeoffs the user themselves found
-  hard to adjudicate.
+  hard to adjudicate. Residual ambiguity is its own signal in this direction —
+  upstream pairs the larger model with handling ambiguity and the smaller model with
+  "specific instructions directing execution", so ambiguity the rounds could not
+  retire argues up, and a Brief precise enough to execute from argues down.
 - **Effort level (thoroughness).** Raise effort when the assistant would
   **under-explore or under-verify** — it can reach the right answer but tends to stop
   short. Signals: broad surface area, many files, a verification-heavy acceptance
@@ -28,6 +31,33 @@ are not interchangeable:
 
 A task can want both, one, or neither. State which knob each recommendation turns and
 why, in the interview's own evidence terms.
+
+**Neither knob is the first move.** Upstream puts a prior step ahead of both: when
+Claude gets something wrong, "your first instinct shouldn't be to adjust a knob, but
+to examine the context you have provided" — vague prompt, wrong tools, missing
+skills. The corollary names the surfaces: "If you're increasing effort on a task that
+*shouldn't* need it, the fix is often upstream, in your context, your CLAUDE.md, or
+how the task is scoped." That prior step is this skill's own product: the Brief **is**
+the context fix, so recommend a knob only for what a sharper Brief would not have
+caught. The discriminator between the two — "did it not *try* hard enough, or did it
+not *know* enough?" — is upstream's, and its own figure caption fences it: "a starting
+point, not a hard rule". Raising effort is sharpest below the default, where upstream
+scopes it: "most relevant if you selected an effort level below the model's default"
+([choosing a Claude model and effort level in Claude Code](https://claude.com/blog/claude-model-and-effort-level-in-claude-code),
+verified 2026-08-04).
+
+A post is cited here for doctrine, not only for the live values below, and the harness
+docs authorize it outright: `model-config` delegates this guidance to the post — "For
+guidance on which model and effort level fit different kinds of work, see [the post]
+on the blog"
+([model configuration](https://code.claude.com/docs/en/model-config), verified
+2026-08-04). What no reference page states is the try-versus-know **diagnostic**
+itself. The nearest sentences discriminate something else: [choosing a
+model](https://platform.claude.com/docs/en/about-claude/models/choosing-a-model) orders
+the levers — "Tuning effort is often a better lever than switching models" — and the
+effort page's "raise effort rather than prompting around it" pairs effort against
+*prompting*. Ordering a lever is not diagnosing which failure you have, so the post
+owns the diagnostic rather than corroborating a page that states it.
 
 ## Advisor pairing
 


### PR DESCRIPTION
## Summary

Doc-alignment roster row 241: **Choosing a Claude model and effort level in Claude Code** (claude.com blog) — the post the owner's model-routing lane and two main-tree surfaces cite for the model-vs-effort dial discrimination. First custody baseline taken (article-body-only hash, so site chrome can't fake drift). The roster's premise was corrected en route: the post was *not* "digested nowhere" — planning's session-config already carried a faithful two-knob digest; what it lacked was custody and the post's own qualifiers.

**planning 0.27.3** — the "Two orthogonal knobs" section gains:

- Its citation, led by the strongest ground available: model-config's own delegation sentence ("For guidance on which model and effort level fit different kinds of work, see [the post] on the blog") — the reference page points *at* the post; the narrowed negative is the supporting ground: no reference page states the try-versus-know **diagnostic** (choosing-a-model *orders* the levers — "Tuning effort is often a better lever than switching models" — and the effort page pairs effort against prompting; ordering a lever is not diagnosing which failure you have).
- The post's **context-first prior step** neither knob had: on a wrong answer, examine the provided context before touching a dial — sharpened here because the step is this skill's own product (the Brief *is* the context fix).
- Two missing fences: the discriminator is "a starting point, not a hard rule" (the post's figure caption, disclosed as such), and raising effort is sharpest below the model's default.
- The ambiguity signal: ambiguity the rounds could not retire argues up; a Brief precise enough to execute from argues down.

Both pre-existing main-tree citations verified holding against the live post. Owner-facing findings routed to the dotfiles ledger (not this repo's to edit): the CLAUDE.md lane's dropped "clearly tried" (making the two branches overlap), the Fable-reservation grounds contradiction, the missing context-first step — with one earlier finding partially withdrawn after the verifier surfaced the choosing-a-model source.

## Test plan

- Docs-only; markdownlint 0 errors; check-skill PASS identical to base; scripted quote fidelity across four live sources (post, effort, model-config, choosing-a-model) — after the producer caught and fixed its own circular self-match, all spans verbatim with one disclosed editorial elision.
- Independent fresh-context Fable verifier (rationale withheld, 8 binary criteria incl. an adversarial test of the load-bearing negative): 7/8 PASS; its one FAIL (the negative stated too broadly) fixed with its prescribed wording, the fix cross-verified verbatim against both live pages before amending.

## Related

- No linked issue.
- Doc-alignment loop, roster row 241. Predecessors: #1908–#1920, #1922, #1923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gaVX25Txd6GXdiu9HEH3X
