### PR TITLE
chore(deps): bump fast-uri to 3.1.5 and brace-expansion to 5.0.9

### DIFF
--- a/.github/standards/runner-policy/package-lock.json
+++ b/.github/standards/runner-policy/package-lock.json
@@ -38,9 +38,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/plugins/ai-briefing/skills/generate/output/build/package-lock.json
+++ b/plugins/ai-briefing/skills/generate/output/build/package-lock.json
@@ -101,9 +101,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Lockfile-only security bumps for the two open Dependabot alerts that had no covering Dependabot PR:

- **fast-uri** 3.1.4 → 3.1.5 in `.github/standards/runner-policy/package-lock.json` — alert #8, GHSA-7p8r-x3mc-p8w7 (high). Transitive via `ajv`; patched version satisfies ajv's `^3.0.1` range.
- **brace-expansion** 5.0.8 → 5.0.9 in `plugins/ai-briefing/skills/generate/output/build/package-lock.json` — alert #9, GHSA-rgw5-rvv9-x895 (high). Patched version within the existing range.

Both are `npm update <pkg>` results within existing semver ranges; no manifest (`package.json`) changes. Follows the precedent of prior lockfile-only dependency merges (e.g. #1373, #1374): no plugin version or changelog bumps.

No linked issue

## Related

- Dependabot alerts: [#8](https://github.com/melodic-software/claude-code-plugins/security/dependabot/8), [#9](https://github.com/melodic-software/claude-code-plugins/security/dependabot/9)
- Prior lockfile-only precedent: #1373, #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
