### PR TITLE
docs(knowledge): align model-matching table with dateless model-ID scheme

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.22]
+
+### Changed
+
+- **Anthropic profile's model-matching table catches up with the dateless model-ID scheme.** The
+  table's model-pin cell warned "never a bare family alias, which resolves to the current family
+  model" and demanded "a full model ID" — vocabulary from the dated-snapshot era. The live
+  model-IDs-and-versioning page now states that since the 4.6 generation the canonical model ID is
+  dateless (`claude-{name}-{major}[-{minor}]`) and "is not an alias. It is the snapshot", so the
+  old wording would misclassify exactly the correct pin for a current-generation model guide as a
+  forbidden alias and fall through to the session default. The cell now pins "its pinned model ID
+  — never an alias that can move to a newer snapshot", and a sentence under the table routes the
+  generation-dependent pinned-vs-alias resolution to the live page at spawn time
+  (pointer-not-copy; verified against the live page 2026-08-04, raw `.md` channel, 3836 bytes).
+
 ## [0.10.21]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -172,9 +172,14 @@ behavioral descriptions:
 
 | Doc subject | Digest-agent model |
 |---|---|
-| Guide/card about a specific Claude model | The exact model version the doc describes, resolved to a full model ID — never a bare family alias, which resolves to the current family model and would digest a historical guide on the wrong version. When no exact-version ID is resolvable, omit the override (session default) |
+| Guide/card about a specific Claude model | The exact model version the doc describes, resolved to its pinned model ID — never an alias that can move to a newer snapshot, which would digest a historical guide on the wrong version. When no pinned ID is resolvable, omit the override (session default) |
 | Cross-model or harness doc (best practices, effort, guardrails) | Session default (no override) |
 | Non-Claude subject | Session default (no override) |
+
+Pinned-vs-alias semantics are generation-dependent — since the 4.6 generation the dateless ID is
+itself the pinned snapshot, while earlier models pin a dated snapshot and their dateless aliases
+move — resolve them at spawn time against the live
+[model IDs and versioning page](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions).
 
 Every model-pinned spawn brief uses the conditional framing contract from `SKILL.md` Phase 3
 ("this brief assumes model X; if you are not X, note the mismatch and continue").


### PR DESCRIPTION
No linked issue.

## Summary

Doc-alignment campaign row 228 ("Model IDs and versioning",
<https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions>).

The Anthropic profile's digest-agent model-matching table pinned model-specific guides to
"a full model ID — never a bare family alias, which resolves to the current family model".
The live page now documents that since the 4.6 generation the canonical model ID is dateless
(`claude-{name}-{major}[-{minor}]`) and "is not an alias. It is the snapshot" — so the old
wording would misclassify exactly the correct pin for a current-generation model guide as a
forbidden alias and wrongly fall through to the session default.

## Changes

- Reword the table cell to "its pinned model ID — never an alias that can move to a newer
  snapshot", dropping the stale dated-era vocabulary.
- Add one sentence under the table routing the generation-dependent pinned-vs-alias
  resolution to the live page at spawn time (pointer-not-copy — no model-ID tables copied).
- Bump knowledge plugin 0.10.21 → 0.10.22 with changelog entry.

## Evidence

- Live fetch 2026-08-04, raw-markdown channel (`.md` appended), 3836 bytes / 83 lines,
  channel re-verified working for this doc.
- Page: "This guarantee covers model IDs, not the convenience aliases that the Claude API
  accepts for some earlier models" (pinning guarantee); "A 4.6-generation ID such as
  `claude-sonnet-4-6` is not an alias. It is the snapshot" (drift trigger).

## Related

- Doc-alignment close-out campaign roster row 228 (`.work/doc-alignment/ROSTER.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
