### PR TITLE
docs(prompts): add model-deprecation trigger to loop-lane re-resolve list

### DIFF
--- a/prompts/loops/loop-lane-prompts.md
+++ b/prompts/loops/loop-lane-prompts.md
@@ -348,8 +348,12 @@ knowledge cutoff — are upstream-owned
 and are not restated here. Both orderings resolved as written against that
 page on 2026-08-04. Both are *derived* comparisons rather than quoted
 figures, so either can flip while every underlying number still reads
-correctly: re-resolve them when a new Claude model family reaches GA, or
-when one of the aliases above starts resolving to a different model.
+correctly: re-resolve them when a new Claude model family reaches GA,
+when one of the aliases above starts resolving to a different model, or
+when a model one of them resolves to is announced deprecated or retired
+([model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations)
+— the announcement leads the alias move, and upstream warns deprecated
+models are likely to be less reliable than active ones).
 
 **The implementer tier is enforced structurally at the dispatch seam
 (#1649).** `/implementation:implement-dispatch` dispatches workers and


### PR DESCRIPTION
No linked issue.

## Summary

Doc-alignment roster row 227 ([Model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations)). The Models section of `prompts/loops/loop-lane-prompts.md` told operators to re-resolve its two derived per-model comparisons only when a new model family reaches GA or when a lane alias is observed resolving to a different model — both reactive triggers. A deprecation/retirement announcement for a model an alias resolves to precedes the alias move (upstream commits to at least 60 days' notice) and upstream warns deprecated models are likely to be less reliable than active ones, so it is the earliest re-check signal. This adds it as a third trigger, pointer-only: no dates, model IDs, or lifecycle tables are copied into the repo.

Resolved against the live page 2026-08-04: raw `.md` capture 12,764 B, MD5 `783f0a320e3c4a544103a8f163c8be79`.

Audited and deliberately unchanged:

- `plugins/playbooks/skills/fable-5/context/calibration.md:40` — dated archival system-prompt citation ("Claude Opus 4.1 entry, dated August 5 2025"); API retirement (requests fail) does not affect a published system-prompt archive, and the surrounding text already treats the entry as superseded.
- `docs/topics/ai-adoption-ladder/design/RESEARCH-product-surface.md:104` — frozen research record of a third-party action's then-default model ID; the action is not adopted in any workflow here.
- `plugins/playbooks/reference/model-adaptation/` — all three subject models (Opus 4.8, Opus 5, Sonnet 5) are Active on the live table; no stale references.

Repo-root `prompts/` surface — no plugin version bump.

## Related

- Live source: <https://platform.claude.com/docs/en/about-claude/model-deprecations>
- Timely context: `claude-opus-4-1-20250805` retires 2026-08-05 per the live table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
