### PR TITLE
docs(plugin-quality): cover plugin-shipped harness config in the config lens

### DIFF
--- a/plugins/plugin-quality/.claude-plugin/plugin.json
+++ b/plugins/plugin-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "plugin-quality",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Post-use behavioral audit of Claude Code plugin components: a six-step audit workflow (evidence capture, grounded mapping in a fresh subagent, blindspot pass, interactive contract lock, presence-gated review seams, work-item emit with draft+confirm) over any skill, agent, hook, command, or config you have actually used — zone-informed by context-guard snapshots when present, conservative when not.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the `plugin-quality` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-04
+
+### Added
+
+- **Config lens covers plugin-shipped harness config files.** The plugins guide
+  (<https://code.claude.com/docs/en/plugins>, fetched 2026-08-04) specifies three plugin-root
+  config surfaces the lens predated, each with a silent failure mode worth auditing:
+  `settings.json` (only `agent` and `subagentStatusLine` supported; unknown keys silently ignored;
+  wins over `settings` in `plugin.json`), `.lsp.json` (an invalid entry is skipped — only
+  `claude --debug` says why; a failed start surfaces in the `/plugin` Errors tab), and
+  `monitors/monitors.json` (auto-start; every stdout line reaches Claude as a notification).
+  `config.md` now names the surfaces and their checks, and the hub's index row routes them there.
+
 ## [0.4.0] - 2026-07-31
 
 ### Added

--- a/plugins/plugin-quality/CHANGELOG.md
+++ b/plugins/plugin-quality/CHANGELOG.md
@@ -15,7 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `settings.json` (only `agent` and `subagentStatusLine` supported; unknown keys silently ignored;
   wins over `settings` in `plugin.json`), `.lsp.json` (an invalid entry is skipped — only
   `claude --debug` says why; a failed start surfaces in the `/plugin` Errors tab), and
-  `monitors/monitors.json` (auto-start; every stdout line reaches Claude as a notification).
+  `monitors/monitors.json` (start governed by the `when` trigger — `"always"` default vs
+  `"on-skill-invoke:<skill-name>"`; every stdout line reaches Claude as a notification).
   `config.md` now names the surfaces and their checks, and the hub's index row routes them there.
 
 ## [0.4.0] - 2026-07-31

--- a/plugins/plugin-quality/skills/audit/SKILL.md
+++ b/plugins/plugin-quality/skills/audit/SKILL.md
@@ -488,7 +488,7 @@ cross-platform, escape hatches, observability).
 | `references/component-types/skill.md` | Auditing a skill (frontmatter, disclosure, triggering). |
 | `references/component-types/agent.md` | Auditing an agent/subagent definition. |
 | `references/component-types/command.md` | Auditing a slash command (merged into skills). |
-| `references/component-types/config.md` | Auditing plugin config / settings / userConfig surfaces. |
+| `references/component-types/config.md` | Auditing plugin config / settings / userConfig surfaces, incl. plugin-shipped `settings.json` / `.lsp.json` / `monitors.json`. |
 
 ## Extending this skill
 

--- a/plugins/plugin-quality/skills/audit/references/component-types/config.md
+++ b/plugins/plugin-quality/skills/audit/references/component-types/config.md
@@ -8,6 +8,8 @@ convention/config files the plugin reads.
 - The plugin's `plugin.json` `userConfig` schema (keys, defaults, `sensitive` flags).
 - Any config files the plugin resolves (paths, layer/merge order).
 - How defaults are inferred when unset.
+- Plugin-shipped harness config at the plugin root: `settings.json`, `.lsp.json`,
+  `monitors/monitors.json`.
 
 ## Check
 
@@ -26,6 +28,16 @@ convention/config files the plugin reads.
   settings value.
 - **Machine-readable format** — for data other tools must read, prefer flat-scalar YAML (shell-grep
   friendly) over frontmatter-in-markdown or a value trapped in a tool-specific language.
+- **Silent no-op keys (`settings.json`)** — a plugin-root `settings.json` supports only the `agent`
+  and `subagentStatusLine` keys, silently ignores unknown keys, and takes priority over `settings`
+  in `plugin.json`. An unsupported key reads as configuration but does nothing — flag it.
+- **Silent-skip LSP entries (`.lsp.json`)** — an entry with an invalid configuration is skipped
+  (only `claude --debug` says why); a server that fails to start surfaces in the `/plugin` Errors
+  tab. The server binary is a user-machine prerequisite — check it is documented for installers.
+- **Monitor noise & portability (`monitors/monitors.json`)** — monitors auto-start while the plugin
+  is active and every stdout line from `command` reaches Claude as a notification; check volume and
+  that the command runs on the consumer's platform. (All three per
+  <https://code.claude.com/docs/en/plugins>, fetched 2026-08-04.)
 
 ## Reproduce
 

--- a/plugins/plugin-quality/skills/audit/references/component-types/config.md
+++ b/plugins/plugin-quality/skills/audit/references/component-types/config.md
@@ -34,10 +34,13 @@ convention/config files the plugin reads.
 - **Silent-skip LSP entries (`.lsp.json`)** — an entry with an invalid configuration is skipped
   (only `claude --debug` says why); a server that fails to start surfaces in the `/plugin` Errors
   tab. The server binary is a user-machine prerequisite — check it is documented for installers.
-- **Monitor noise & portability (`monitors/monitors.json`)** — monitors auto-start while the plugin
-  is active and every stdout line from `command` reaches Claude as a notification; check volume and
-  that the command runs on the consumer's platform. (All three per
-  <https://code.claude.com/docs/en/plugins>, fetched 2026-08-04.)
+- **Monitor noise & portability (`monitors/monitors.json`)** — inspect each monitor's `when`
+  trigger before assessing runtime volume: the default `"always"` starts it at session start and on
+  plugin reload, while `"on-skill-invoke:<skill-name>"` keeps it dormant until that skill is first
+  dispatched. Every stdout line from `command` reaches Claude as a notification; check volume for
+  the trigger's actual lifetime and that the command runs on the consumer's platform. (All three
+  surfaces per <https://code.claude.com/docs/en/plugins> and
+  <https://code.claude.com/docs/en/plugins-reference#monitors>, fetched 2026-08-04.)
 
 ## Reproduce
 


### PR DESCRIPTION
No linked issue.

## Summary

Doc-alignment (ROSTER row 141, "Create plugins", <https://code.claude.com/docs/en/plugins>, fetched 2026-08-04). The plugins guide specifies three plugin-root config surfaces the audit skill's config lens predated, each carrying a silent failure mode worth auditing:

- **`settings.json`** — only `agent` and `subagentStatusLine` are supported; unknown keys are silently ignored; takes priority over `settings` in `plugin.json`. An unsupported key reads as configuration but does nothing.
- **`.lsp.json`** — an entry with an invalid configuration is silently skipped (only `claude --debug` says why); a server that fails to start surfaces in the `/plugin` Errors tab.
- **`monitors/monitors.json`** — monitors auto-start while the plugin is active and every stdout line from `command` reaches Claude as a notification (volume/portability concerns).

Changes:

- `references/component-types/config.md`: name the three surfaces in "Read first" and add one doc-grounded check bullet per surface.
- `SKILL.md`: widen the config lens index row so these surfaces route there.
- plugin-quality `0.4.0` → `0.5.0` + CHANGELOG entry (Added → minor, per this plugin's precedent).

Repo-conformance audit for the same row found no defect: all 61 plugin manifests conform (name matches directory, description and version present, documented-schema keys only), structure conforms (only `plugin.json` under `.claude-plugin/`, hooks in `hooks/hooks.json` with a top-level `hooks` key, no `commands/` dirs), and `claude plugin validate` passes for all 61 plugins plus `--strict` on the marketplace catalog, zero warnings (Claude Code 2.1.221, 2026-08-04).

## Related

- `.work/doc-alignment/ROSTER.md` row 141 (memory-tier, not committed)
- Sibling roster rows 139/142 own the marketplace and plugins-reference pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
