### PR TITLE
docs(claude-memory): run the C2 deletion test per line and codify C1's symptom-first diagnostic

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.4]
+
+### Changed
+
+- **`audit`'s C2 deletion test now runs per line, as the official docs state it** (claude-memory
+  0.5.3 → 0.5.4; criteria 1.4.0 → 1.5.0). The check evaluated whole H1/H2 sections — "Would Claude
+  make mistakes without this section?" — but the source it quotes tests each line: "For each line,
+  ask: 'Would removing this cause Claude to make mistakes?' If not, cut it." A section-level pass
+  let keep-worthy lines shield surplus neighbors in the same section. Sections remain as the
+  report's grouping unit only: findings are per line, and a section whose every line flags
+  collapses into one section-level finding. `context/fix.md`'s C2 fix pattern follows.
+
+### Added
+
+- **`audit`'s C1 carries the official symptom-first diagnostic for over-long files.** C1's
+  rationale already stated the causal claim (long files reduce adherence); it now also codifies the
+  reverse tell as detect guidance — "If Claude keeps doing something you don't want despite having
+  a rule against it, the file is probably too long and the rule is getting lost" — so an audit
+  prompted by a rule being ignored cites the tell and reports the length finding even below the
+  WARN threshold. The sourced quote lands in `reference/official-guidance.md` per the determinism
+  contract.
+
 ## [0.5.3]
 
 ### Added

--- a/plugins/claude-memory/skills/audit/context/fix.md
+++ b/plugins/claude-memory/skills/audit/context/fix.md
@@ -39,9 +39,9 @@ Present specific sections that are candidates for each approach.
 
 ### C2 (Deletion Test) fixes
 
-For sections flagged as potentially removable:
+For lines flagged as potentially removable:
 
-1. Present the section
+1. Present the flagged lines, grouped by section
 2. Explain why flagged (Claude can infer from code, standard practice, etc.)
 3. Suggest: delete, move to rules/skills, or keep with justification
 4. If kept, document justification in an HTML comment

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -1,6 +1,6 @@
 # Memory Health Criteria
 
-Version: 1.4.0
+Version: 1.5.0
 Last updated: 2026-08-04
 Source: Official Claude Code docs (code.claude.com/docs/en/memory, code.claude.com/docs/en/best-practices, code.claude.com/docs/en/sub-agents, code.claude.com/docs/en/skills)
 
@@ -29,26 +29,31 @@ To refresh this file against current official guidance, run the skill's `update`
 **Why**: Official docs: "Target under 200 lines per CLAUDE.md file. Longer files consume more context
 and reduce adherence." Files over 200 lines cause Claude to ignore instructions.
 
+**Diagnostic**: The symptom-first tell for this check: "If Claude keeps doing something you don't
+want despite having a rule against it, the file is probably too long and the rule is getting lost"
+(code.claude.com/docs/en/best-practices). When the audit was prompted by a rule being ignored, cite
+this tell and report the length finding even below the WARN threshold.
+
 **Allowances**: Complex monorepos using `.claude/rules/` extensively may justify overages, and a repo
 may document a deliberate exemption in its own rules (see SKILL.md "Consumer-convention extension
 seam"). Report overage and justification together.
 
-### C2: Deletion Test [WARN per section]
+### C2: Deletion Test [WARN per line]
 
-**What**: For each top-level section (H1/H2), ask: "Would Claude make mistakes without this section?"
+**What**: For each line, ask: "Would removing this cause Claude to make mistakes?" If not, cut it.
 
 **How to check**:
 
-1. Parse the file into sections by H1/H2 headers
-2. For each section, evaluate:
-   - Does this contain commands Claude can't guess? → KEEP
-   - Does this contain gotchas or non-obvious patterns? → KEEP
-   - Does this contain project-specific conventions? → KEEP
+1. For each line, evaluate:
+   - A command Claude can't guess? → KEEP
+   - A gotcha or non-obvious pattern? → KEEP
+   - A project-specific convention? → KEEP
    - Could Claude figure this out by reading the code? → FLAG
-   - Is this a standard convention any senior engineer knows? → FLAG
-   - Is this detailed reference material better suited to a skill? → FLAG
-3. WARN for each section that fails the deletion test
-4. Include the reason ("could infer from code", "standard practice", "move to skill")
+   - A standard convention any senior engineer knows? → FLAG
+   - Detailed reference material better suited to a skill? → FLAG
+2. WARN per flagged line, with the reason ("could infer from code", "standard practice", "move to
+   skill"); group findings by H1/H2 section, and collapse a section whose every line flags into one
+   section-level finding
 
 **Why**: Official docs: "For each line, ask: 'Would removing this cause Claude to make mistakes?' If
 not, cut it. Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -31,8 +31,10 @@ and reduce adherence." Files over 200 lines cause Claude to ignore instructions.
 
 **Diagnostic**: The symptom-first tell for this check: "If Claude keeps doing something you don't
 want despite having a rule against it, the file is probably too long and the rule is getting lost"
-(code.claude.com/docs/en/best-practices). When the audit was prompted by a rule being ignored, cite
-this tell and report the length finding even below the WARN threshold.
+(code.claude.com/docs/en/best-practices). When the audit was prompted by a rule being ignored, add a
+C1 WARN citing this tell even when steps 4-6 pass. The branch is prompt-conditioned, so it belongs
+to the judgment tier — label it "judgment candidate" in the report; steps 1-6 remain the
+deterministic spine, unaffected.
 
 **Allowances**: Complex monorepos using `.claude/rules/` extensively may justify overages, and a repo
 may document a deliberate exemption in its own rules (see SKILL.md "Consumer-convention extension
@@ -44,14 +46,17 @@ seam"). Report overage and justification together.
 
 **How to check**:
 
-1. For each line, evaluate:
+1. Strip HTML comment blocks (human-only reference, as in C1) and skip blank and purely structural
+   lines (headers, separators, table/list scaffolding) — only substantive instruction lines enter
+   the loop
+2. For each remaining line, evaluate:
    - A command Claude can't guess? → KEEP
    - A gotcha or non-obvious pattern? → KEEP
    - A project-specific convention? → KEEP
    - Could Claude figure this out by reading the code? → FLAG
    - A standard convention any senior engineer knows? → FLAG
    - Detailed reference material better suited to a skill? → FLAG
-2. WARN per flagged line, with the reason ("could infer from code", "standard practice", "move to
+3. WARN per flagged line, with the reason ("could infer from code", "standard practice", "move to
    skill"); group findings by H1/H2 section, and collapse a section whose every line flags into one
    section-level finding
 

--- a/plugins/claude-memory/skills/audit/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/audit/reference/official-guidance.md
@@ -24,6 +24,11 @@ Refresh this file from current official docs via the skill's `update` action.
 
 <!-- -->
 
+> "If Claude keeps doing something you don't want despite having a rule against it, the file is probably too long and the rule is getting lost."
+> — code.claude.com/docs/en/best-practices
+
+<!-- -->
+
 > "Less than 300 lines is best, and shorter is even better."
 > — humanlayer.dev/blog/writing-a-good-claude-md
 


### PR DESCRIPTION
## Summary

- `audit`'s C2 deletion test now runs per line, matching the official wording: "For each line, ask: *'Would removing this cause Claude to make mistakes?'* If not, cut it." It previously evaluated whole H1/H2 sections, letting keep-worthy lines shield surplus neighbors. Sections remain only as the report's grouping unit; a section whose every line flags collapses into one finding. `context/fix.md`'s C2 fix pattern follows.
- C1 codifies the official symptom-first diagnostic as detect guidance: "If Claude keeps doing something you don't want despite having a rule against it, the file is probably too long and the rule is getting lost." An audit prompted by an ignored rule cites the tell and reports the length finding even below the WARN threshold. The sourced quote is added to `reference/official-guidance.md` per the skill's determinism contract.
- Deliberately NOT codified: the sibling diagnostic "a question is re-asked → phrasing is ambiguous" — its input is a session transcript, which this file-reading audit never sees (routed to the retro surface per the adopted IA-9 disposition).

Versions: claude-memory 0.5.3 → 0.5.4; criteria.md 1.4.0 → 1.5.0.

No linked issue

## Related

- Official source (fetched live 2026-08-04): <https://code.claude.com/docs/en/best-practices> — CLAUDE.md section, per-line deletion test and misbehavior diagnostics.
- Doc-alignment campaign row 60: the IA-9 residue ("CLAUDE.md hygiene criteria refinements", adopted 2026-08-03) remaining for the claude-memory plugin after the 2026-08-04 recheck found criteria 1.4.0 already covers the include/exclude rubric (C4/C5), skills routing (C3), and hook conversion (C8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
