### PR TITLE
docs(claude-memory): re-align auto-memory reference facts with live memory doc

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -16,9 +16,13 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   that project settings are not accepted no longer matches the docs. M1's measurement now mirrors
   the documented limit check: YAML frontmatter and block-level HTML comments are stripped before
   the MEMORY.md index loads, so they don't count toward the 200-line/25KB limits (backing quote
-  added to `official-guidance.md`). Also: the `audit` SKILL.md scope table states the 25KB limb of
-  the MEMORY.md load limit alongside the 200-line one, and a quote attribution names the page's
-  current "Set up a project CLAUDE.md" section (formerly "Project memory").
+  added to `official-guidance.md`). The deterministic spine follows the same rule:
+  `memory-dir-stats.sh --memory-lines` now measures post-strip content instead of raw `wc -l`, a
+  new `--memory-bytes` mode covers the 25KB limb, and the SKILL.md pre-computed context reports
+  both figures so M1 never disagrees with its own injected stats. Also: the `audit` SKILL.md scope
+  table states the 25KB limb of the MEMORY.md load limit alongside the 200-line one, and a quote
+  attribution names the page's current "Set up a project CLAUDE.md" section (formerly
+  "Project memory").
 
 ## [0.5.4]
 

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.5]
+
+### Fixed
+
+- **Re-align auto-memory and CLAUDE.md reference facts with the live memory doc**
+  (claude-memory 0.5.4 → 0.5.5; criteria 1.5.0 → 1.5.1), verified against
+  code.claude.com/docs/en/memory on 2026-08-04. Two drifted facts in
+  `audit`'s `reference/official-guidance.md` corrected: `@import` recursion depth is 4 hops, not 5;
+  and `autoMemoryDirectory` is read from any settings scope (user, project, local, policy,
+  `--settings`) with project/local values gated behind the workspace trust dialog — the prior claim
+  that project settings are not accepted no longer matches the docs. M1's measurement now mirrors
+  the documented limit check: YAML frontmatter and block-level HTML comments are stripped before
+  the MEMORY.md index loads, so they don't count toward the 200-line/25KB limits (backing quote
+  added to `official-guidance.md`). Also: the `audit` SKILL.md scope table states the 25KB limb of
+  the MEMORY.md load limit alongside the 200-line one, and a quote attribution names the page's
+  current "Set up a project CLAUDE.md" section (formerly "Project memory").
+
 ## [0.5.4]
 
 ### Changed

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -22,7 +22,14 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   both figures so M1 never disagrees with its own injected stats. Also: the `audit` SKILL.md scope
   table states the 25KB limb of the MEMORY.md load limit alongside the 200-line one, and a quote
   attribution names the page's current "Set up a project CLAUDE.md" section (formerly
-  "Project memory").
+  "Project memory"). The strip counts an unterminated block as content rather than swallowing the
+  rest of the file: a leading thematic break or frontmatter clipped mid-file previously reported
+  zero, and since M1 is a `[FAIL]`-severity size gate that zero always passes, the gate could not
+  fire. A fenced block inside a comment no longer toggles fence state, and text sharing a line with
+  a comment's open or close is counted as the loaded content it is. `criteria.md` M1 now records
+  the four readings the strip applies and marks them as this plugin's reading, not doc-derived —
+  the memory doc states the fenced-code carve-out for CLAUDE.md only and is silent on it for
+  MEMORY.md.
 
 ## [0.5.4]
 

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -33,7 +33,7 @@ the `audit` and `automation-gaps` skills in the `claude-config` plugin).
 | Project instructions | `CLAUDE.md` | Every session, full | Yes |
 | Local overrides | `CLAUDE.local.md` | Every session, full | Yes |
 | Rules | `.claude/rules/**/*.md` | Every session (unconditional) or on-demand (path-scoped) | Yes |
-| Auto-memory | `~/.claude/projects/<project>/memory/` | First 200 lines of MEMORY.md | Yes |
+| Auto-memory | `~/.claude/projects/<project>/memory/` | First 200 lines / 25KB of MEMORY.md | Yes |
 | Settings, hooks, MCP, agents, skills | Various | Various | No — use `claude-config`'s `audit` / `automation-gaps` |
 
 ## Scope boundary (route out)

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -13,7 +13,8 @@ metadata:
 ## Pre-computed context
 
 Memory files: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --md-count 2>/dev/null || echo "0"`
-MEMORY.md lines: !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --memory-lines 2>/dev/null || echo "0"`
+MEMORY.md loaded lines (200 cap): !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --memory-lines 2>/dev/null || echo "0"`
+MEMORY.md loaded bytes (25KB cap): !`bash "${CLAUDE_PLUGIN_ROOT}/skills/audit/scripts/memory-dir-stats.sh" --memory-bytes 2>/dev/null || echo "0"`
 Rules files: !`find .claude/rules -name "*.md" 2>/dev/null | wc -l | tr -d '\r' || echo "0"`
 CLAUDE.md lines: !`test -f CLAUDE.md && wc -l < CLAUDE.md | tr -d '\r' || echo "0"`
 CLAUDE.local.md exists: !`test -f CLAUDE.local.md && echo "yes" || echo "no"`

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -1,6 +1,6 @@
 # Memory Health Criteria
 
-Version: 1.5.0
+Version: 1.5.1
 Last updated: 2026-08-04
 Source: Official Claude Code docs (code.claude.com/docs/en/memory, code.claude.com/docs/en/best-practices, code.claude.com/docs/en/sub-agents, code.claude.com/docs/en/skills)
 
@@ -307,8 +307,10 @@ matching-file Read, so being unreferenced costs nothing per session. WARN per or
 
 **What**: Is MEMORY.md under 200 lines / 25KB?
 
-**How to check**: Count lines and file size. Only the first 200 lines (or 25KB) load at session start
-— anything beyond is silently dropped.
+**How to check**: Count lines and file size on the content that loads — strip YAML frontmatter and
+block-level HTML comments first, since they are removed before the index is loaded and don't count
+toward the limits. Only the first 200 loaded lines (or 25KB) load at session start — anything beyond
+is silently dropped.
 
 ### M2: Stale Entries [WARN]
 

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -324,9 +324,8 @@ Four readings the strip applies, so a hand count matches the reported figures:
    than a frontmatter close, and without both bounds the entire span between the two would be
    stripped. A leading thematic break, or frontmatter clipped mid-file, must not blank the count.
 2. A block-level comment occupies whole lines. Text sharing a line with the comment's open or
-   close loads, and is counted. Only the first comment on a line is stripped — a close match ends
-   at the first `-->`, not the last — so a second complete comment on that same line counts as
-   content rather than blanking the text between the two.
+   close loads, and is counted — including text between two comments on one line, since each
+   comment ends at the first `-->` after its own opener.
 3. Comments inside fenced code blocks are preserved: a comment inside a fence is code, not
    block-level markdown.
 4. Byte counts measure LF-normalized content, so a CRLF index reports about one byte per line

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -314,6 +314,24 @@ toward the limits. The SKILL.md pre-computed context already reports both post-s
 file. Only the first 200 loaded lines (or 25KB) load at session start — anything beyond is silently
 dropped.
 
+Four readings the strip applies, so a hand count matches the reported figures:
+
+1. A block counts only once it closes. An opening `---` or `<!--` with no closing delimiter is
+   ordinary content and is counted — a leading thematic break, or frontmatter clipped mid-file,
+   must not blank the count.
+2. A block-level comment occupies whole lines. Text sharing a line with the comment's open or
+   close loads, and is counted.
+3. Comments inside fenced code blocks are preserved: a comment inside a fence is code, not
+   block-level markdown.
+4. Byte counts measure LF-normalized content, so a CRLF index reports about one byte per line
+   under its on-disk size — well under 1% of the 25KB cap.
+
+**Provenance**: the strip rule itself is doc-derived (code.claude.com/docs/en/memory, "How it
+works"). The four readings are not. The doc states the fenced-code carve-out for CLAUDE.md only and
+is silent on it for MEMORY.md, and says nothing about unterminated blocks, partial lines, or line
+endings. They are this plugin's reading, chosen so that no input silently reports 0 and leaves this
+`[FAIL]` gate unable to fire — the `update` action must not overwrite them.
+
 ### M2: Stale Entries [WARN]
 
 **What**: Do any memory entries reference files, features, or decisions that no longer exist?

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -309,8 +309,10 @@ matching-file Read, so being unreferenced costs nothing per session. WARN per or
 
 **How to check**: Count lines and file size on the content that loads — strip YAML frontmatter and
 block-level HTML comments first, since they are removed before the index is loaded and don't count
-toward the limits. Only the first 200 loaded lines (or 25KB) load at session start — anything beyond
-is silently dropped.
+toward the limits. The SKILL.md pre-computed context already reports both post-strip figures
+(`memory-dir-stats.sh --memory-lines` / `--memory-bytes`); use them rather than re-measuring the raw
+file. Only the first 200 loaded lines (or 25KB) load at session start — anything beyond is silently
+dropped.
 
 ### M2: Stale Entries [WARN]
 

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -324,7 +324,9 @@ Four readings the strip applies, so a hand count matches the reported figures:
    than a frontmatter close, and without both bounds the entire span between the two would be
    stripped. A leading thematic break, or frontmatter clipped mid-file, must not blank the count.
 2. A block-level comment occupies whole lines. Text sharing a line with the comment's open or
-   close loads, and is counted.
+   close loads, and is counted. Only the first comment on a line is stripped — a close match ends
+   at the first `-->`, not the last — so a second complete comment on that same line counts as
+   content rather than blanking the text between the two.
 3. Comments inside fenced code blocks are preserved: a comment inside a fence is code, not
    block-level markdown.
 4. Byte counts measure LF-normalized content, so a CRLF index reports about one byte per line

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -316,9 +316,13 @@ dropped.
 
 Four readings the strip applies, so a hand count matches the reported figures:
 
-1. A block counts only once it closes. An opening `---` or `<!--` with no closing delimiter is
-   ordinary content and is counted — a leading thematic break, or frontmatter clipped mid-file,
-   must not blank the count.
+1. A block counts only once it closes, and a leading `---` opens frontmatter only for as long as
+   what follows is shaped like frontmatter. An opening `---` or `<!--` with no closing delimiter is
+   ordinary content and is counted. So is a leading `---` whose block reaches a line that is
+   neither blank, a comment, nor a `key:` mapping entry, or that runs past 20 lines — markdown
+   carries thematic breaks freely, so the next `---` in a file is usually another break rather
+   than a frontmatter close, and without both bounds the entire span between the two would be
+   stripped. A leading thematic break, or frontmatter clipped mid-file, must not blank the count.
 2. A block-level comment occupies whole lines. Text sharing a line with the comment's open or
    close loads, and is counted.
 3. Comments inside fenced code blocks are preserved: a comment inside a fence is code, not
@@ -328,9 +332,11 @@ Four readings the strip applies, so a hand count matches the reported figures:
 
 **Provenance**: the strip rule itself is doc-derived (code.claude.com/docs/en/memory, "How it
 works"). The four readings are not. The doc states the fenced-code carve-out for CLAUDE.md only and
-is silent on it for MEMORY.md, and says nothing about unterminated blocks, partial lines, or line
-endings. They are this plugin's reading, chosen so that no input silently reports 0 and leaves this
-`[FAIL]` gate unable to fire — the `update` action must not overwrite them.
+is silent on it for MEMORY.md, and says nothing about unterminated blocks, unbounded blocks,
+partial lines, or line endings. They are this plugin's reading, chosen so that no input silently
+under-reports and leaves this `[FAIL]` gate unable to fire. Where a reading has to guess, it guesses
+toward counting: an over-count can only make the gate fire early on a file near its limit, while an
+under-count stops it firing at all. The `update` action must not overwrite them.
 
 ### M2: Stale Entries [WARN]
 

--- a/plugins/claude-memory/skills/audit/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/audit/reference/official-guidance.md
@@ -69,7 +69,7 @@ Official include/exclude table (code.claude.com/docs/en/best-practices):
 ## Build and test commands
 
 > "Create this file and add instructions that apply to anyone working on the project: build and test commands, coding standards, architectural decisions, naming conventions, and common workflows."
-> — code.claude.com/docs/en/memory, "Project memory"
+> — code.claude.com/docs/en/memory, "Set up a project CLAUDE.md"
 
 Build and test commands lead the list of what project memory is for. The inference cost of omitting
 them is stated on the same page, in what `/init` does instead:
@@ -88,7 +88,7 @@ than read. Backs C9.
 Key details:
 
 - Both relative and absolute paths allowed. Relative paths resolve relative to the file containing the import
-- Imported files can recursively import other files, max depth 5 hops
+- Imported files can recursively import other files, max depth 4 hops
 - First-time approval dialog for external imports; if declined, stays disabled
 - Use for README, package.json, personal preferences (`@~/.claude/my-project-instructions.md`)
 
@@ -178,12 +178,17 @@ Caveats that do survive, each verified:
 > "This limit applies only to `MEMORY.md`. CLAUDE.md files are loaded in full regardless of length, though shorter files produce better adherence."
 > — code.claude.com/docs/en/memory
 
+<!-- -->
+
+> "The check measures only the content that loads: YAML frontmatter and block-level HTML comments are stripped before the index is loaded, so they don't count toward the limits."
+> — code.claude.com/docs/en/memory (limit check on writes to MEMORY.md; before v2.1.211, the raw file was measured)
+
 ## Auto-memory storage
 
 > "Each project gets its own memory directory at `~/.claude/projects/<project>/memory/`. The `<project>` path is derived from the git repository, so all worktrees and subdirectories within the same repo share one auto memory directory."
 > — code.claude.com/docs/en/memory
 
-**`autoMemoryDirectory` setting:** Override default location in user or local settings. Not accepted from project settings (security — prevents shared projects redirecting memory writes).
+**`autoMemoryDirectory` setting:** Override default location; read from any settings scope — user, project, local, policy, or `--settings`. From a project's `.claude/settings.json` or `.claude/settings.local.json`, the value is honored only after you accept the workspace trust dialog for that folder (the same gate that governs hooks).
 
 ## Subagent persistent memory
 

--- a/plugins/claude-memory/skills/audit/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/audit/reference/official-guidance.md
@@ -1,6 +1,7 @@
 # Official Claude Code Guidance on CLAUDE.md
 
-Last researched: 2026-06-20
+Last researched: 2026-06-20; code.claude.com/docs/en/memory re-verified 2026-08-04 (the other
+sources below were not re-checked on that date)
 Sources: [Steering Claude Code (June 18, 2026)](https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more), code.claude.com/docs/en/memory, code.claude.com/docs/en/hooks, code.claude.com/docs/en/best-practices, code.claude.com/docs/en/sub-agents, howborisusesclaudecode.com
 
 Refresh this file from current official docs via the skill's `update` action.

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -42,7 +42,9 @@ Usage: memory-dir-stats.sh (--md-count|--memory-lines|--memory-bytes|--help)
 
 The MEMORY.md stats measure the content that loads: YAML frontmatter and block-level
 HTML comments are stripped before the index is loaded, so they don't count toward the
-200-line/25KB limits. Resolves the memory dir via the sibling resolve-memory-dir.sh.
+200-line/25KB limits. A block that never closes is counted as content, comments inside
+fenced code blocks are kept, and byte counts are of LF-normalized content — criteria.md
+M1 records these readings. Resolves the memory dir via the sibling resolve-memory-dir.sh.
 Every stat mode prints exactly one integer and always exits 0; a bad or missing mode
 exits 2.
 EOF
@@ -90,19 +92,50 @@ fi
 
 # The 200-line/25KB limits measure only the content that loads: YAML frontmatter and
 # block-level HTML comments are stripped before the index is loaded (memory doc), so
-# both MEMORY.md stats measure that stripped content — matching criteria.md M1. HTML
-# comments inside fenced code blocks are preserved, per the documented comment
-# behavior. tr guards Git Bash CRLF; the arithmetic expansion strips the leading
+# both MEMORY.md stats measure that stripped content — matching criteria.md M1.
+#
+# A block only counts as one once it closes. An opening `---` or `<!--` that never
+# closes is ordinary content, so those lines are held and flushed at EOF instead of
+# swallowed: a leading thematic break or a clipped frontmatter block would otherwise
+# report 0, and M1 is a [FAIL]-severity size gate that 0 always passes — it could
+# never fire. MEMORY.md carries frontmatter by design (Claude Code stamps a `modified`
+# field into any memory file that has it), so this is a live shape, not a corner case.
+#
+# A block-level comment occupies whole lines; text sharing a line with the comment's
+# open or close is loaded content and survives. Comments inside fenced code blocks are
+# preserved — a comment inside a fence is code, not block-level markdown. The memory
+# doc states that explicitly for CLAUDE.md and says nothing either way for MEMORY.md;
+# criteria.md M1 records the reading rather than claiming it as documented.
+#
+# tr guards Git Bash CRLF, so both counts measure LF-normalized content (see the
+# assumption recorded in criteria.md M1); the arithmetic expansion strips the leading
 # padding BSD `wc` emits on macOS.
 strip_unloaded() {
   tr -d '\r' <"$index" | awk '
-    NR == 1 && $0 == "---" { fm = 1; next }
-    fm == 1 { if ($0 == "---") fm = 2; next }
+    NR == 1 && $0 == "---" { pending = $0 "\n"; fm = 1; next }
+    fm == 1 {
+      pending = pending $0 "\n"
+      if ($0 == "---") { fm = 2; pending = "" }
+      next
+    }
+    incomment {
+      pending = pending $0 "\n"
+      if (!sub(/^.*-->/, "")) next
+      incomment = 0; pending = ""
+      if ($0 ~ /[^[:space:]]/) print
+      next
+    }
     /^[[:space:]]*```/ { fence = !fence; print; next }
     fence { print; next }
-    incomment { if (/-->/) incomment = 0; next }
-    /^[[:space:]]*<!--/ { if (!/-->/) incomment = 1; next }
+    /^[[:space:]]*<!--/ {
+      pending = $0 "\n"
+      if (!sub(/^[[:space:]]*<!--.*-->/, "")) { incomment = 1; next }
+      pending = ""
+      if ($0 ~ /[^[:space:]]/) print
+      next
+    }
     { print }
+    END { printf "%s", pending }
   '
 }
 

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -116,10 +116,17 @@ fi
 # while the under-count they replace stopped it firing at all.
 #
 # A block-level comment occupies whole lines; text sharing a line with the comment's
-# open or close is loaded content and survives. Comments inside fenced code blocks are
-# preserved — a comment inside a fence is code, not block-level markdown. The memory
-# doc states that explicitly for CLAUDE.md and says nothing either way for MEMORY.md;
-# criteria.md M1 records the reading rather than claiming it as documented.
+# open or close is loaded content and survives. Both close matches stop at the FIRST
+# `-->` on the line rather than the last: awk's ERE has no lazy quantifier, and a
+# `.*-->` would run to the last one, blanking the text between two comments on one
+# line — `([^-]|-[^-]|--+[^->])*` is that bound spelled as a body that cannot itself
+# contain `-->`. Only the first comment on a line is stripped, so a second one counts
+# as content: an over-count, the direction every other bound here also fails toward.
+#
+# Comments inside fenced code blocks are preserved — a comment inside a fence is code,
+# not block-level markdown. The memory doc states that explicitly for CLAUDE.md and says
+# nothing either way for MEMORY.md; criteria.md M1 records the reading rather than
+# claiming it as documented.
 #
 # tr guards Git Bash CRLF, so both counts measure LF-normalized content (see the
 # assumption recorded in criteria.md M1); the arithmetic expansion strips the leading
@@ -144,7 +151,7 @@ strip_unloaded() {
     }
     incomment {
       pending = pending $0 "\n"
-      if (!sub(/^.*-->/, "")) next
+      if (!sub(/^([^-]|-[^-]|--+[^->])*--+>/, "")) next
       incomment = 0; pending = ""
       if ($0 ~ /[^[:space:]]/) print
       next
@@ -153,7 +160,7 @@ strip_unloaded() {
     fence { print; next }
     /^[[:space:]]*<!--/ {
       pending = $0 "\n"
-      if (!sub(/^[[:space:]]*<!--.*-->/, "")) { incomment = 1; next }
+      if (!sub(/^[[:space:]]*<!--([^-]|-[^-]|--+[^->])*--+>/, "")) { incomment = 1; next }
       pending = ""
       if ($0 ~ /[^[:space:]]/) print
       next

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -23,7 +23,8 @@
 #
 # Usage:
 #   memory-dir-stats.sh --md-count      # count of *.md files in the memory dir
-#   memory-dir-stats.sh --memory-lines  # line count of MEMORY.md (0 when absent)
+#   memory-dir-stats.sh --memory-lines  # loaded-content line count of MEMORY.md (0 when absent)
+#   memory-dir-stats.sh --memory-bytes  # loaded-content byte count of MEMORY.md (0 when absent)
 #   memory-dir-stats.sh --help
 
 set -uo pipefail
@@ -32,14 +33,18 @@ usage() {
   cat <<'EOF'
 memory-dir-stats.sh — emit one auto-memory statistic as a single integer.
 
-Usage: memory-dir-stats.sh (--md-count|--memory-lines|--help)
+Usage: memory-dir-stats.sh (--md-count|--memory-lines|--memory-bytes|--help)
 
   --md-count       print the number of *.md files in the current project's memory dir
-  --memory-lines   print the line count of that dir's MEMORY.md (0 when absent)
+  --memory-lines   print the loaded-content line count of that dir's MEMORY.md (0 when absent)
+  --memory-bytes   print the loaded-content byte count of that dir's MEMORY.md (0 when absent)
   --help           this message
 
-Resolves the memory dir via the sibling resolve-memory-dir.sh. Both stat modes print
-exactly one integer and always exit 0; a bad or missing mode exits 2.
+The MEMORY.md stats measure the content that loads: YAML frontmatter and block-level
+HTML comments are stripped before the index is loaded, so they don't count toward the
+200-line/25KB limits. Resolves the memory dir via the sibling resolve-memory-dir.sh.
+Every stat mode prints exactly one integer and always exits 0; a bad or missing mode
+exits 2.
 EOF
 }
 
@@ -49,7 +54,7 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
 fi
 
 mode="${1:-}"
-if [[ "$mode" != "--md-count" && "$mode" != "--memory-lines" ]]; then
+if [[ "$mode" != "--md-count" && "$mode" != "--memory-lines" && "$mode" != "--memory-bytes" ]]; then
   usage >&2
   exit 2
 fi
@@ -83,8 +88,27 @@ if [[ ! -f "$index" ]]; then
   exit 0
 fi
 
-# `wc -l` (newline count) is kept deliberately — the semantics the audit checklist's
-# line budget has always been measured against. tr guards Git Bash CRLF; the
-# arithmetic expansion strips the leading padding BSD `wc` emits on macOS.
-lines=$(wc -l <"$index" | tr -d '\r')
-printf '%s\n' "$((lines))"
+# The 200-line/25KB limits measure only the content that loads: YAML frontmatter and
+# block-level HTML comments are stripped before the index is loaded (memory doc), so
+# both MEMORY.md stats measure that stripped content — matching criteria.md M1. HTML
+# comments inside fenced code blocks are preserved, per the documented comment
+# behavior. tr guards Git Bash CRLF; the arithmetic expansion strips the leading
+# padding BSD `wc` emits on macOS.
+strip_unloaded() {
+  tr -d '\r' <"$index" | awk '
+    NR == 1 && $0 == "---" { fm = 1; next }
+    fm == 1 { if ($0 == "---") fm = 2; next }
+    /^[[:space:]]*```/ { fence = !fence; print; next }
+    fence { print; next }
+    incomment { if (/-->/) incomment = 0; next }
+    /^[[:space:]]*<!--/ { if (!/-->/) incomment = 1; next }
+    { print }
+  '
+}
+
+if [[ "$mode" == "--memory-lines" ]]; then
+  n=$(strip_unloaded | wc -l)
+else
+  n=$(strip_unloaded | wc -c)
+fi
+printf '%s\n' "$((n))"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -98,8 +98,9 @@ fi
 # closes is ordinary content, so those lines are held and flushed at EOF instead of
 # swallowed: a leading thematic break or a clipped frontmatter block would otherwise
 # report 0, and M1 is a [FAIL]-severity size gate that 0 always passes — it could
-# never fire. MEMORY.md carries frontmatter by design (Claude Code stamps a `modified`
-# field into any memory file that has it), so this is a live shape, not a corner case.
+# never fire. A MEMORY.md that has frontmatter keeps it stamped (Claude Code writes a
+# `modified` field into any memory file that already has frontmatter, and never adds
+# frontmatter to one that has none), so this is a live shape, not a corner case.
 #
 # Closing is necessary but not sufficient: a leading `---` only opens frontmatter if
 # what follows is shaped like frontmatter. Markdown carries thematic breaks freely, so
@@ -116,12 +117,14 @@ fi
 # while the under-count they replace stopped it firing at all.
 #
 # A block-level comment occupies whole lines; text sharing a line with the comment's
-# open or close is loaded content and survives. Both close matches stop at the FIRST
-# `-->` on the line rather than the last: awk's ERE has no lazy quantifier, and a
-# `.*-->` would run to the last one, blanking the text between two comments on one
-# line — `([^-]|-[^-]|--+[^->])*` is that bound spelled as a body that cannot itself
-# contain `-->`. Only the first comment on a line is stripped, so a second one counts
-# as content: an over-count, the direction every other bound here also fails toward.
+# open or close is loaded content and survives. Each comment ends at the FIRST `-->`
+# after its opener and the line is then re-scanned, because one line can carry several:
+# matching to the last `-->` swallows the text between two of them, and stopping after
+# the first leaves the rest counted as content. `index`/`substr` walk the line instead
+# of a regex — awk's ERE has no lazy quantifier, and spelling "up to the first close"
+# as a bounded complement reads far worse than the scan. Only whole `<!-- ... -->`
+# spans are removed, so a residue still holding text always survives; only a line that
+# is entirely comment disappears.
 #
 # Comments inside fenced code blocks are preserved — a comment inside a fence is code,
 # not block-level markdown. The memory doc states that explicitly for CLAUDE.md and says
@@ -134,6 +137,19 @@ fi
 strip_unloaded() {
   tr -d '\r' <"$index" | awk '
     BEGIN { fmcap = 20 }
+    function emit(s) { if (s ~ /[^[:space:]]/) print s }
+    # Remove every complete comment from s, each ending at the first `-->` after its
+    # own opener. An opener with no close takes the rest of s and arms `incomment`,
+    # holding the raw remainder so an unterminated block still counts at EOF.
+    function uncomment(s,   p, q, out) {
+      while ((p = index(s, "<!--")) > 0) {
+        out = out substr(s, 1, p - 1)
+        q = index(substr(s, p + 4), "-->")
+        if (q == 0) { incomment = 1; pending = substr(s, p) "\n"; return out }
+        s = substr(s, p + q + 6)
+      }
+      return out s
+    }
     NR == 1 && $0 == "---" { pending = $0 "\n"; fm = 1; next }
     fm == 1 {
       if ($0 == "---") { fm = 2; pending = ""; next }
@@ -151,18 +167,22 @@ strip_unloaded() {
     }
     incomment {
       pending = pending $0 "\n"
-      if (!sub(/^([^-]|-[^-]|--+[^->])*--+>/, "")) next
+      close_at = index($0, "-->")
+      if (close_at == 0) next
       incomment = 0; pending = ""
-      if ($0 ~ /[^[:space:]]/) print
+      emit(uncomment(substr($0, close_at + 3)))
       next
     }
     /^[[:space:]]*```/ { fence = !fence; print; next }
     fence { print; next }
     /^[[:space:]]*<!--/ {
-      pending = $0 "\n"
-      if (!sub(/^[[:space:]]*<!--([^-]|-[^-]|--+[^->])*--+>/, "")) { incomment = 1; next }
-      pending = ""
-      if ($0 ~ /[^[:space:]]/) print
+      residue = uncomment($0)
+      # An unterminated opener holds its own raw text. Whitespace that loaded ahead of
+      # it belongs to that held block too, so an indented opener keeps its indent.
+      # Real text is emitted instead of held: folding it into pending would lose it
+      # outright once the comment closes and the held block is dropped.
+      if (incomment && residue !~ /[^[:space:]]/) pending = residue pending
+      emit(residue)
       next
     }
     { print }

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -101,6 +101,20 @@ fi
 # never fire. MEMORY.md carries frontmatter by design (Claude Code stamps a `modified`
 # field into any memory file that has it), so this is a live shape, not a corner case.
 #
+# Closing is necessary but not sufficient: a leading `---` only opens frontmatter if
+# what follows is shaped like frontmatter. Markdown carries thematic breaks freely, so
+# a file opening with `---` and carrying any later `---` would otherwise have the whole
+# span between them stripped — a 253-line index reporting one loaded line, disarming
+# the very gate the flush-at-EOF rule above exists to arm. Frontmatter mode is
+# therefore bounded twice, and abandoning it re-emits the held lines as content:
+#   * grammar — the block ends at the first line that is not blank, a comment, or a
+#     `key:` mapping entry, which is all YAML a memory index's frontmatter holds;
+#   * length — `fmcap` lines, because grammar alone still swallows a runaway whose
+#     every line happens to be a `#` heading or a `Label: value` pair, a plausible
+#     shape for a hand-written index.
+# Both bounds fail toward counting: an over-count can only make this gate fire early,
+# while the under-count they replace stopped it firing at all.
+#
 # A block-level comment occupies whole lines; text sharing a line with the comment's
 # open or close is loaded content and survives. Comments inside fenced code blocks are
 # preserved — a comment inside a fence is code, not block-level markdown. The memory
@@ -112,11 +126,21 @@ fi
 # padding BSD `wc` emits on macOS.
 strip_unloaded() {
   tr -d '\r' <"$index" | awk '
+    BEGIN { fmcap = 20 }
     NR == 1 && $0 == "---" { pending = $0 "\n"; fm = 1; next }
     fm == 1 {
-      pending = pending $0 "\n"
-      if ($0 == "---") { fm = 2; pending = "" }
-      next
+      if ($0 == "---") { fm = 2; pending = ""; next }
+      if (++fmlines <= fmcap && ($0 ~ /^[[:space:]]*$/ ||
+                                 $0 ~ /^[[:space:]]*#/ ||
+                                 $0 ~ /^[[:space:]]*[A-Za-z_][A-Za-z0-9_-]*:/)) {
+        pending = pending $0 "\n"
+        next
+      }
+      # Not frontmatter after all: re-emit the held lines as content and let this one
+      # fall through to the rules below, which still owe it fence and comment handling.
+      fm = 0
+      printf "%s", pending
+      pending = ""
     }
     incomment {
       pending = pending $0 "\n"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -181,6 +181,35 @@ assert_eq "content after a single-line comment survives" "1" "$(run "$H3" --memo
 printf -- "<!-- a\nb --> TAIL\nreal\n" >"$M3/MEMORY.md"
 assert_eq "content after a multi-line comment's close survives" "2" "$(run "$H3" --memory-lines)"
 
+# --- Case 4f: a `-->` match must stop at the FIRST close on the line. awk's ERE has no
+# lazy quantifier, so a `.*-->` runs to the LAST `-->` and blanks everything between two
+# comments on one line — an UNDER-count on this [FAIL]-severity gate, the one direction
+# the strip must never take. Only the first comment on a line is stripped, so a second
+# one counts as content. Byte expectations below are the measured post-strip size. ---
+printf -- "<!-- a --> KEPT TEXT <!-- b -->\n" >"$M3/MEMORY.md"
+assert_eq "text between two comments on one line survives" "1" "$(run "$H3" --memory-lines)"
+assert_eq "text between two comments keeps its bytes" "22" "$(run "$H3" --memory-bytes)"
+
+# The close path shows the same rule in bytes rather than lines: the line prints either
+# way, so only its byte count reveals whether the text before a reopened comment survived.
+printf -- "<!-- open\nmid\n--> KEPT ONE <!-- again --> KEPT TWO\nplain\n" >"$M3/MEMORY.md"
+assert_eq "a close followed by a reopen counts both texts" "2" "$(run "$H3" --memory-lines)"
+assert_eq "a close followed by a reopen keeps its bytes" "40" "$(run "$H3" --memory-bytes)"
+
+# The bound must not cost an ordinary block comment its strip, on either limb.
+printf -- "# H\n<!--\nsecret\n-->\nvisible\n" >"$M3/MEMORY.md"
+assert_eq "a plain block comment still strips" "2" "$(run "$H3" --memory-lines)"
+assert_eq "a plain block comment still strips its bytes" "12" "$(run "$H3" --memory-bytes)"
+
+# Idiom guards: the bounded-complement body must still close on an empty comment, on a
+# body holding a lone dash, and on a closer padded with extra dashes.
+printf -- "<!---->\nreal\n" >"$M3/MEMORY.md"
+assert_eq "an empty comment strips" "1" "$(run "$H3" --memory-lines)"
+printf -- "<!-- a - b --> tail\n" >"$M3/MEMORY.md"
+assert_eq "a lone dash in a comment body does not close it" "6" "$(run "$H3" --memory-bytes)"
+printf -- "<!-- a ---->\ntail\n" >"$M3/MEMORY.md"
+assert_eq "a multi-dash closer still closes" "1" "$(run "$H3" --memory-lines)"
+
 # --- Case 5: fresh project — no memory dir at all: both modes report 0, exit 0 ---
 H5="$TEST_TMPDIR/h5"
 mkdir -p "$H5"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -115,6 +115,60 @@ assert_eq "leading thematic break is not frontmatter" "4" "$(run "$H3" --memory-
 printf -- "<!-- note\na\nb\nc\n" >"$M3/MEMORY.md"
 assert_eq "unclosed comment counts the whole file" "4" "$(run "$H3" --memory-lines)"
 
+# --- Case 4c2: closing is not enough — a leading thematic break must not open a
+# frontmatter block that runs to whatever `---` appears next. Markdown carries thematic
+# breaks freely, so the whole span between them would be stripped and an index that is
+# over the limit would report a single loaded line, leaving this [FAIL] gate unable to
+# fire. Both limbs of M1 are covered: the line limit and the 25KB byte limit.
+#
+# The expectation is the file's own raw size: none of these fixtures holds frontmatter,
+# so nothing may be stripped from any of them. ---
+raw_lines() { printf '%s' "$(($(wc -l <"$M3/MEMORY.md")))"; }
+raw_bytes() { printf '%s' "$(($(wc -c <"$M3/MEMORY.md")))"; }
+# repeat_lines <count> <prefix> <suffix> — <count> distinct lines of "<prefix><n><suffix>".
+repeat_lines() {
+  local i=0
+  while [[ "$i" -lt "$1" ]]; do
+    printf '%s%d%s\n' "$2" "$i" "$3"
+    i=$((i + 1))
+  done
+}
+
+{
+  printf -- '---\n# Title\n'
+  repeat_lines 249 'content line ' ''
+  printf -- '---\ntail\n'
+} >"$M3/MEMORY.md"
+assert_eq "leading break + later --- counts every line" "$(raw_lines)" "$(run "$H3" --memory-lines)"
+
+# Byte limb: content long enough to blow the 25KB limit on its own.
+PAD=$(printf '%200s' '' | tr ' ' 'x')
+{
+  printf -- '---\n# Title\n'
+  repeat_lines 150 'content ' " $PAD"
+  printf -- '---\ntail\n'
+} >"$M3/MEMORY.md"
+if [[ "$(raw_bytes)" -gt 25600 ]]; then
+  pass "byte-limb fixture is genuinely over the 25KB limit"
+else
+  fail "byte-limb fixture is genuinely over the 25KB limit" "only $(raw_bytes) bytes"
+fi
+assert_eq "leading break + later --- counts every byte" "$(raw_bytes)" "$(run "$H3" --memory-bytes)"
+
+# Grammar alone cannot bound the block: every line here is a well-formed `key: value`
+# mapping entry, a plausible hand-written index shape. Only the length cap ends it.
+{
+  printf -- '---\n'
+  repeat_lines 250 'Label' ': value'
+  printf -- '---\ntail\n'
+} >"$M3/MEMORY.md"
+assert_eq "a key:-shaped runaway is bounded by length" "$(raw_lines)" "$(run "$H3" --memory-lines)"
+
+# --- Case 4c3: the bound must not cost real frontmatter its strip. A well-formed block
+# is still stripped even when a thematic break appears later in the file. ---
+printf -- "---\ntype: index\nmodified: 2026-01-01\n---\n# A\none\n---\ntwo\n" >"$M3/MEMORY.md"
+assert_eq "real frontmatter still strips despite a later ---" "4" "$(run "$H3" --memory-lines)"
+
 # --- Case 4d: a fence inside a comment must not toggle fence state — otherwise the
 # commented-out fence body leaks back into the count ---
 printf -- "<!-- note\n\`\`\`bash\nLEAKED\n\`\`\`\n-->\nreal\n" >"$M3/MEMORY.md"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -101,7 +101,7 @@ assert_eq "--memory-lines counts MEMORY.md lines" "3" "$OUT"
 # --- Case 4b: MEMORY.md stats measure loaded content only — frontmatter and
 # block-level HTML comments are stripped (they don't count toward the limits),
 # while a comment inside a fenced code block is preserved ---
-printf -- '---\ntype: index\n---\n# Index\n<!-- hidden\nstill hidden -->\nreal\n```\n<!-- kept -->\n```\n' >"$M3/MEMORY.md"
+printf -- "---\ntype: index\n---\n# Index\n<!-- hidden\nstill hidden -->\nreal\n\`\`\`\n<!-- kept -->\n\`\`\`\n" >"$M3/MEMORY.md"
 assert_eq "--memory-lines counts post-strip lines" "5" "$(run "$H3" --memory-lines)"
 assert_eq "--memory-bytes counts post-strip bytes" "35" "$(run "$H3" --memory-bytes)"
 

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -181,34 +181,70 @@ assert_eq "content after a single-line comment survives" "1" "$(run "$H3" --memo
 printf -- "<!-- a\nb --> TAIL\nreal\n" >"$M3/MEMORY.md"
 assert_eq "content after a multi-line comment's close survives" "2" "$(run "$H3" --memory-lines)"
 
-# --- Case 4f: a `-->` match must stop at the FIRST close on the line. awk's ERE has no
-# lazy quantifier, so a `.*-->` runs to the LAST `-->` and blanks everything between two
-# comments on one line — an UNDER-count on this [FAIL]-severity gate, the one direction
-# the strip must never take. Only the first comment on a line is stripped, so a second
-# one counts as content. Byte expectations below are the measured post-strip size. ---
+# --- Case 4f: one line can carry several comments. Each ends at the FIRST `-->` after
+# its own opener, and the line is re-scanned for the next: matching to the LAST `-->`
+# blanks the text between two comments, an UNDER-count on this [FAIL]-severity gate and
+# the one direction the strip must never take. Only whole comment spans are removed, so
+# text always survives. Byte expectations below are the measured post-strip size. ---
 printf -- "<!-- a --> KEPT TEXT <!-- b -->\n" >"$M3/MEMORY.md"
 assert_eq "text between two comments on one line survives" "1" "$(run "$H3" --memory-lines)"
-assert_eq "text between two comments keeps its bytes" "22" "$(run "$H3" --memory-bytes)"
+assert_eq "text between two comments keeps its bytes" "12" "$(run "$H3" --memory-bytes)"
 
-# The close path shows the same rule in bytes rather than lines: the line prints either
-# way, so only its byte count reveals whether the text before a reopened comment survived.
+# The close path re-scans too: a line closing one comment may open and close another.
 printf -- "<!-- open\nmid\n--> KEPT ONE <!-- again --> KEPT TWO\nplain\n" >"$M3/MEMORY.md"
 assert_eq "a close followed by a reopen counts both texts" "2" "$(run "$H3" --memory-lines)"
-assert_eq "a close followed by a reopen keeps its bytes" "40" "$(run "$H3" --memory-bytes)"
+assert_eq "a close followed by a reopen keeps its bytes" "26" "$(run "$H3" --memory-bytes)"
 
-# The bound must not cost an ordinary block comment its strip, on either limb.
+# Both texts on an open line, with and without a tail after the second comment.
+printf -- "<!-- a --> mid <!-- b --> tail\n" >"$M3/MEMORY.md"
+assert_eq "two comments plus a tail keep every fragment" "11" "$(run "$H3" --memory-bytes)"
+printf -- "<!-- a --> mid <!-- b -->\n" >"$M3/MEMORY.md"
+assert_eq "two comments with no tail keep the middle" "6" "$(run "$H3" --memory-bytes)"
+
+# A close line that reopens and re-closes, and one whose text is followed by a stray
+# close: the second must keep its whole line rather than reporting nothing.
+printf -- "<!-- a\nb --> mid <!-- c -->\nreal\n" >"$M3/MEMORY.md"
+assert_eq "a close line that reopens and recloses counts both" "2" "$(run "$H3" --memory-lines)"
+assert_eq "a close line that reopens and recloses keeps bytes" "11" "$(run "$H3" --memory-bytes)"
+printf -- "<!-- a\nb --> real content -->\n" >"$M3/MEMORY.md"
+assert_eq "text before a stray close is not dropped" "1" "$(run "$H3" --memory-lines)"
+assert_eq "text before a stray close keeps its bytes" "18" "$(run "$H3" --memory-bytes)"
+
+# The re-scan must not cost an ordinary block comment its strip, on either limb.
 printf -- "# H\n<!--\nsecret\n-->\nvisible\n" >"$M3/MEMORY.md"
 assert_eq "a plain block comment still strips" "2" "$(run "$H3" --memory-lines)"
 assert_eq "a plain block comment still strips its bytes" "12" "$(run "$H3" --memory-bytes)"
 
-# Idiom guards: the bounded-complement body must still close on an empty comment, on a
-# body holding a lone dash, and on a closer padded with extra dashes.
+# Scan guards: the walk must still close on an empty comment, on a body holding a lone
+# dash, and on a closer padded with extra dashes.
 printf -- "<!---->\nreal\n" >"$M3/MEMORY.md"
 assert_eq "an empty comment strips" "1" "$(run "$H3" --memory-lines)"
 printf -- "<!-- a - b --> tail\n" >"$M3/MEMORY.md"
 assert_eq "a lone dash in a comment body does not close it" "6" "$(run "$H3" --memory-bytes)"
 printf -- "<!-- a ---->\ntail\n" >"$M3/MEMORY.md"
 assert_eq "a multi-dash closer still closes" "1" "$(run "$H3" --memory-lines)"
+
+# A line can close one comment and open an unterminated one. What loaded before the
+# opener is emitted at once and only the unterminated fragment is held, so that text is
+# neither counted twice when the flush lands nor lost if the comment closes later.
+printf -- "<!-- a --> KEEP <!-- open\nnext\n" >"$M3/MEMORY.md"
+assert_eq "text before an unterminated opener counts once" "3" "$(run "$H3" --memory-lines)"
+assert_eq "text before an unterminated opener keeps its bytes" "22" "$(run "$H3" --memory-bytes)"
+
+# The same shape with the comment closing further down. The held block is dropped on
+# close, and the text that loaded before the opener must survive that drop — folding it
+# into the held block instead of emitting it would lose it outright here.
+printf -- "<!-- a --> KEEP <!-- open\nstill\n--> tail\n" >"$M3/MEMORY.md"
+assert_eq "text before an opener survives a later close" "2" "$(run "$H3" --memory-lines)"
+assert_eq "text before an opener keeps bytes past a close" "13" "$(run "$H3" --memory-bytes)"
+
+# Only whitespace ahead of the opener joins the held block: an indented opener keeps its
+# indent, while a comment already stripped off the line is not counted a second time.
+printf -- "  <!-- note\na\n" >"$M3/MEMORY.md"
+assert_eq "an indented unterminated opener keeps its indent" "2" "$(run "$H3" --memory-lines)"
+assert_eq "an indented unterminated opener counts its bytes" "14" "$(run "$H3" --memory-bytes)"
+printf -- "<!-- a --><!-- open\nnext\n" >"$M3/MEMORY.md"
+assert_eq "a stripped comment is not re-counted by the hold" "15" "$(run "$H3" --memory-bytes)"
 
 # --- Case 5: fresh project — no memory dir at all: both modes report 0, exit 0 ---
 H5="$TEST_TMPDIR/h5"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -105,6 +105,28 @@ printf -- "---\ntype: index\n---\n# Index\n<!-- hidden\nstill hidden -->\nreal\n
 assert_eq "--memory-lines counts post-strip lines" "5" "$(run "$H3" --memory-lines)"
 assert_eq "--memory-bytes counts post-strip bytes" "35" "$(run "$H3" --memory-bytes)"
 
+# --- Case 4c: an unterminated block is content, not a block. M1 is a [FAIL]-severity
+# size gate and 0 always passes it, so a block that swallows the file to EOF would
+# disarm the gate outright. Each input below must report its whole line count. ---
+printf -- "---\ntype: index\n# Title\nreal\n" >"$M3/MEMORY.md"
+assert_eq "unclosed frontmatter counts the whole file" "4" "$(run "$H3" --memory-lines)"
+printf -- "---\n# Title\nreal one\nreal two\n" >"$M3/MEMORY.md"
+assert_eq "leading thematic break is not frontmatter" "4" "$(run "$H3" --memory-lines)"
+printf -- "<!-- note\na\nb\nc\n" >"$M3/MEMORY.md"
+assert_eq "unclosed comment counts the whole file" "4" "$(run "$H3" --memory-lines)"
+
+# --- Case 4d: a fence inside a comment must not toggle fence state — otherwise the
+# commented-out fence body leaks back into the count ---
+printf -- "<!-- note\n\`\`\`bash\nLEAKED\n\`\`\`\n-->\nreal\n" >"$M3/MEMORY.md"
+assert_eq "fence inside a comment stays stripped" "1" "$(run "$H3" --memory-lines)"
+
+# --- Case 4e: a block-level comment occupies whole lines; real text sharing a line
+# with the comment's open or close still loads ---
+printf -- "<!-- x --> KEPT\n" >"$M3/MEMORY.md"
+assert_eq "content after a single-line comment survives" "1" "$(run "$H3" --memory-lines)"
+printf -- "<!-- a\nb --> TAIL\nreal\n" >"$M3/MEMORY.md"
+assert_eq "content after a multi-line comment's close survives" "2" "$(run "$H3" --memory-lines)"
+
 # --- Case 5: fresh project — no memory dir at all: both modes report 0, exit 0 ---
 H5="$TEST_TMPDIR/h5"
 mkdir -p "$H5"

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -98,6 +98,13 @@ OUT=$(run "$H3" --memory-lines) || rc=$?
 assert_exit "--memory-lines exits 0" 0 "$rc"
 assert_eq "--memory-lines counts MEMORY.md lines" "3" "$OUT"
 
+# --- Case 4b: MEMORY.md stats measure loaded content only — frontmatter and
+# block-level HTML comments are stripped (they don't count toward the limits),
+# while a comment inside a fenced code block is preserved ---
+printf -- '---\ntype: index\n---\n# Index\n<!-- hidden\nstill hidden -->\nreal\n```\n<!-- kept -->\n```\n' >"$M3/MEMORY.md"
+assert_eq "--memory-lines counts post-strip lines" "5" "$(run "$H3" --memory-lines)"
+assert_eq "--memory-bytes counts post-strip bytes" "35" "$(run "$H3" --memory-bytes)"
+
 # --- Case 5: fresh project — no memory dir at all: both modes report 0, exit 0 ---
 H5="$TEST_TMPDIR/h5"
 mkdir -p "$H5"
@@ -115,9 +122,10 @@ H6="$TEST_TMPDIR/h6"
 mem_dir_for "$H6" >/dev/null
 assert_eq "empty memory dir --md-count == 0" "0" "$(run "$H6" --md-count)"
 assert_eq "empty memory dir --memory-lines == 0" "0" "$(run "$H6" --memory-lines)"
+assert_eq "empty memory dir --memory-bytes == 0" "0" "$(run "$H6" --memory-bytes)"
 
 # --- Case 7: output contract — a single bare integer, nothing else, for every stat mode ---
-for m in --md-count --memory-lines; do
+for m in --md-count --memory-lines --memory-bytes; do
   OUT=$(run "$H3" "$m")
   if [[ "$OUT" =~ ^[0-9]+$ ]]; then
     pass "$m emits exactly one bare integer"


### PR DESCRIPTION
## Summary

Row-127 doc-alignment pass: every shipped `claude-memory` assertion about the auto-memory / project-memory page was verified against the live doc (https://code.claude.com/docs/en/memory, fetched 2026-08-04, 35,136 bytes, sha256 `7440c455…`). Most claims are current; this PR corrects the ones that drifted.

- `skills/audit/reference/official-guidance.md`
  - `@import` recursion depth: 5 hops → 4 hops (live: "maximum depth of four hops").
  - `autoMemoryDirectory`: replaced the stale "user or local settings only; not accepted from project settings" claim with the live behavior — read from any settings scope (user, project, local, policy, `--settings`), with project/local values honored only after the workspace trust dialog.
  - Quote attribution: "Project memory" section no longer exists; now cites "Set up a project CLAUDE.md".
  - Added the backing quote for the MEMORY.md limit check measuring stripped content.
- `skills/audit/reference/criteria.md` (1.5.0 → 1.5.1): M1 now measures the content that loads — YAML frontmatter and block-level HTML comments are stripped before the index loads and don't count toward the 200-line/25KB limits.
- `skills/audit/scripts/memory-dir-stats.sh`: `--memory-lines` measures post-strip loaded content instead of raw `wc -l`, and a new `--memory-bytes` mode covers the 25KB limb; covered by `memory-dir-stats.test.sh`.
- `skills/audit/SKILL.md`: scope table now states the 25KB limb of the MEMORY.md load limit alongside the 200-line one, and the pre-computed context reports both post-strip figures so M1 never disagrees with its own injected stats.
- Version: claude-memory 0.5.4 → 0.5.5, with CHANGELOG entry.

Serialization note: this PR was rebased onto current `main` after the row-60 work landed. Row 60 shipped as #1932 at claude-memory 0.5.4 / criteria 1.5.0 (commit `f668526f7`), which is the `main` this branch now sits on, so this PR takes the next free literals — 0.5.5 / criteria 1.5.1. #1947 (row 74, `stateless` skill) is the only other open claude-memory PR and already claims 0.5.6; it is now rebased on top of this branch and does not touch `skills/audit/reference/criteria.md`.

## Post-rebase CI fix (`8664a65647`)

The rebased head failed the `hygiene` check. Root cause: the post-strip test fixture wrote its literal markdown code fence inside a single-quoted `printf` format, and ShellCheck reads backticks in single quotes as an unexpanded command substitution (SC2016). The repo's gate invokes ShellCheck with an empty severity setting — ShellCheck's default `style` level — so the info-level finding failed CI rather than being advisory.

Fixed by writing the fixture with double quotes and escaped backticks, which produces byte-identical output (verified by md5) and keeps the file's existing `printf` convention rather than introducing a second fixture-writing mechanism. No `# shellcheck disable` was added.

Verified locally on the final head:

- `shellcheck --rcfile=.shellcheckrc` over both scripts — exit 0, no findings.
- `bash memory-dir-stats.test.sh` — **all 23 checks passed**, including the post-strip line and byte assertions. Both earlier review passes noted they could not execute this suite in the CI sandbox and asked for a local run; this is that run.

## Strip correctness fix (`e597abcd95`) — the M1 gate could not fire

An independent verifier pass found that the post-strip measurement shipped earlier in this PR had a hole that inverted the check it was meant to sharpen.

`strip_unloaded()` treated a line-1 `---` as opening YAML frontmatter and skipped every line until a closing `---`. When no closing `---` exists, the whole file was discarded:

```
"---\ntype: index\n# Title\nreal\n"    ->  lines=0 bytes=0
"---\n# Title\nreal one\nreal two\n"   ->  lines=0 bytes=0
```

M1 is a `[FAIL]`-severity size gate and **0 always passes it**, so any index with frontmatter clipped mid-file — or a leading `---` used as a thematic break — silently disarmed the gate. The memory doc notes Claude Code stamps a `modified` frontmatter field into any memory file that already has frontmatter, so MEMORY.md is frontmatter-bearing by design; this is a live shape. An unclosed `<!--` swallowed the file the same way.

Fixed by holding an opening delimiter's lines and flushing them at EOF when it never closes, so an unterminated block is counted as the content it is — matching what a reader following `criteria.md` counts. One mechanism covers both block kinds.

Two further defects in the same function, found while fixing the first:

- The fence rules ran before the comment rule, so a fence **inside** a comment toggled fence state and leaked the commented-out body back into the count.
- A line sharing space with a comment's open or close was dropped whole, losing real content.

**Provenance correction.** The fenced-code carve-out was justified in the script header as "per the documented comment behavior". Re-fetching the live page shows that sentence sits under **How CLAUDE.md files load**, while the MEMORY.md limit paragraph under **How it works** says only that frontmatter and block-level HTML comments are stripped — the doc is silent on the carve-out for MEMORY.md. The behavior is kept (a comment inside a fence is code, not block-level markdown), but `criteria.md` M1 now records it, together with the unterminated-block rule, the partial-line rule, and the `--memory-bytes` LF-normalization assumption, under a `**Provenance**:` note marking them as this plugin's reading rather than doc-derived.

Also: `official-guidance.md`'s `Last researched` line now scopes the 2026-08-04 re-verify to the memory page, the only source this PR re-checked, instead of implying the whole source list was refreshed.

**Version stays 0.5.5 / criteria 1.5.1.** 0.5.5 is unmerged and its CHANGELOG entry is this PR's own, so amending it is not a version event; #1947 keeps 0.5.6 and no re-stack is needed.

Verified on `e597abcd95`: ShellCheck exit 0, **29/29 tests pass** (a regression test per defect), markdownlint clean, all 32 CI checks green and `MERGEABLE` / `CLEAN`.

No linked issue

## Related

- Source of truth: https://code.claude.com/docs/en/memory ("How Claude remembers your project")
- Doc-alignment campaign roster row 127 (claude-memory vs the memory page); supporting facts cross-checked against the live settings, env-vars, and claude-directory pages the reference files cite.
- Serialization predecessor: #1932 (roster row 60, claude-memory 0.5.4 / criteria 1.5.0), now on `main`.
- Stacked successor: #1947 (roster row 74, claude-memory 0.5.6), based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- linkage revalidated under v0.10.2 -->
