### PR TITLE
docs(autonomy): document the lane-stop gate's deliberate server-managed settings exclusion

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
 Versions 0.1.0–0.7.0 predate this file (introduced with 0.7.1); their history lives in the
 merged work-package PRs (#333, #343, #356, #372, #377, #600, #676).
 
+## [0.12.1]
+
+### Changed
+
+- **`lane-stop-gate-lib.sh`: the server-managed settings channel's exclusion from the org-veto
+  source list is documented as deliberate.** The gate reads only endpoint managed-settings paths
+  plus `managed-settings.d/` drop-ins; [server-managed
+  settings](https://code.claude.com/docs/en/server-managed-settings) surface on disk only as the
+  user-writable cache `~/.claude/remote-settings.json`, which fails the root-owned trust test the
+  veto relies on — the page itself calls the channel "a client-side control, not a security
+  boundary". Comment at the exclusion site plus a README precedence-list note directing orgs on the
+  server channel to also deliver an endpoint `managed-settings.json`; no behavior change.
+
 ## [0.12.0]
 
 ### Changed

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -109,7 +109,8 @@ merge:
    deliberately excluded — their only on-disk artifact is the user-writable cache
    `~/.claude/remote-settings.json`, which fails the root-owned trust test (the page itself calls
    the channel "a client-side control, not a security boundary") — so an org vetoing via the server
-   channel must also deliver an endpoint `managed-settings.json` to veto lanes.
+   channel must also deliver an endpoint `managed-settings.json` to veto lanes (the gate reads that
+   file directly; Claude Code itself ignores endpoint sources when server keys arrive).
 2. **The per-session arm record** — the `claude-ops` lane launcher arms a lane at launch: give the
    lane a `settings` object requesting the gate in its lanes-config entry (see that skill's
    `context/config.md`), and the launcher runs this plugin's `hooks/lane-stop-gate-arm.sh` (writing

--- a/plugins/autonomy/README.md
+++ b/plugins/autonomy/README.md
@@ -105,6 +105,11 @@ merge:
 
 1. **Managed settings** (fixed root-owned paths + `managed-settings.d/` drop-ins) — an org can veto
    with `lane_stop_gate_enabled: false`.
+   [Server-managed settings](https://code.claude.com/docs/en/server-managed-settings) are
+   deliberately excluded — their only on-disk artifact is the user-writable cache
+   `~/.claude/remote-settings.json`, which fails the root-owned trust test (the page itself calls
+   the channel "a client-side control, not a security boundary") — so an org vetoing via the server
+   channel must also deliver an endpoint `managed-settings.json` to veto lanes.
 2. **The per-session arm record** — the `claude-ops` lane launcher arms a lane at launch: give the
    lane a `settings` object requesting the gate in its lanes-config entry (see that skill's
    `context/config.md`), and the launcher runs this plugin's `hooks/lane-stop-gate-arm.sh` (writing

--- a/plugins/autonomy/hooks/lane-stop-gate-lib.sh
+++ b/plugins/autonomy/hooks/lane-stop-gate-lib.sh
@@ -137,6 +137,11 @@ gate_user_settings_file() {
 # nothing on an unrecognized platform. Platform comes from `uname -s`, never
 # `$OSTYPE` (see the header): the exemplar killswitch_config.py keys on
 # sys.platform, and this is the bash equivalent.
+# Server-managed settings (code.claude.com/docs/en/server-managed-settings) are
+# deliberately excluded: their only on-disk artifact is the user-writable cache
+# `~/.claude/remote-settings.json`, which fails this list's trust test —
+# root-owned paths a repo cannot forge — and the page itself calls the channel
+# "a client-side control, not a security boundary".
 gate_managed_settings_files() {
   local primary
   case "$(uname -s 2>/dev/null)" in


### PR DESCRIPTION
## Summary

Roster row 152 (server-managed settings) close-out. The lane-stop gate's org-veto layer
(`plugins/autonomy/hooks/lane-stop-gate-lib.sh`, `gate_managed_settings_files`) reads only endpoint
managed-settings paths plus `managed-settings.d/` drop-ins. Server-managed settings
([code.claude.com/docs/en/server-managed-settings](https://code.claude.com/docs/en/server-managed-settings))
are a second admin-controlled managed source at the same top precedence tier — and when the server
delivers any keys, endpoint sources are ignored, not merged — so an org managing exclusively via the
server channel cannot veto lanes.

The exclusion is correct, not a gap: the veto's trust rationale is root-owned paths a repo cannot
forge, and the server channel's only on-disk artifact is the user-writable cache
`~/.claude/remote-settings.json`, which fails that test. The live page itself calls the channel
"a client-side control, not a security boundary" (verified 2026-08-04). This PR makes the exclusion
documented and deliberate rather than silent:

- Comment at the exclusion site in `lane-stop-gate-lib.sh` stating the trust constraint.
- README precedence-list note with the same constraint, directing orgs on the server channel to also
  deliver an endpoint `managed-settings.json` to veto lanes.
- autonomy 0.12.1 + changelog entry. No behavior change.

No linked issue

## Related

- Roster row 152, doc-alignment campaign (batch B6 finding, orchestrator ruling: deliberate exclusion, documented)
- #1784 / #1865 (trusted-channel config resolution that established the veto's trust rationale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
