### PR TITLE
docs(knowledge): add the tag-exempt class to the applicability filter

### DIFF
--- a/plugins/knowledge/.claude-plugin/plugin.json
+++ b/plugins/knowledge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "knowledge",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "description": "Ingest external knowledge into durable, synthesized artifacts. Ships a book-distillation pipeline (PDF/EPUB into concept-organized, author-attributed skill reference files), a YouTube pipeline (watch, transcript, link harvest, and repo-applicability synthesis), a course-digest pipeline (extract and synthesize online video courses — Dometrain, Teachable — into repo-applicable recommendations), and a docpage-digest pipeline (single online documentation page into a verified knowledge slice with dual verification — one cross-vendor verifier — and an interview handoff), plus a re-runnable setup action; a configurable library directory governs where synthesized artifacts land in the consuming repo.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/knowledge/CHANGELOG.md
+++ b/plugins/knowledge/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the `knowledge` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.10.23]
+
+### Added
+
+- **Anthropic profile's applicability filter gains the `tag-exempt (<sub-shape>)` class.** The
+  vocabulary (`cc-applicable` / `mixed` / `api-only`) adjudicates API-vs-harness guidance, but some
+  rows carry no guidance for any surface it adjudicates — consumer-surface material, an archive's
+  own apparatus, metadata, or a navigation pointer — and the closest negative tag misdescribes what
+  such material is. The new class is one disposition with those four documented sub-shapes, the
+  sub-shape named at the row. It describes the material's genre and asserts nothing about harness
+  applicability — not a positive tag, not a negative claim — so it owes no live-doc citation and no
+  absence basis, and the near-miss disclosure burden never attaches; `api-only` remains reserved
+  for rows that DO assert a harness absence for their own specific assertion. Consistent with the
+  co-decided positive-tag rule (a positive tag asserts harness applicability and requires a
+  live-doc citation): the class carries neither assertion, so neither evidence obligation.
+
 ## [0.10.22]
 
 ### Changed

--- a/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
+++ b/plugins/knowledge/skills/docpage-digest/context/anthropic-docs-profile.md
@@ -71,8 +71,9 @@ archive wrong in a way its own verification cannot catch:
 ## Claude-Code-applicability filter (with teeth)
 
 Anthropic docs mix API-surface guidance with harness-relevant guidance. Every digest tags each
-claim's applicability (`cc-applicable` / `api-only` / `mixed`), with evidence scaled to what
-the tag asserts:
+claim's applicability (`cc-applicable` / `api-only` / `mixed`, or the tag-exempt disposition
+below for material the vocabulary does not adjudicate), with evidence scaled to what the tag
+asserts:
 
 - **`cc-applicable` / `mixed` (positive claims):** verified against live code.claude.com docs at
   tag time — cite the URL consulted in the digest row. A positive tag assigned by inference,
@@ -123,6 +124,16 @@ the tag asserts:
   **one** attested instance against that two-instance base, and is enumerated no wider than that: a
   doc line describing some *other* model's tier is not harness-internal behavior toward the subject,
   fails (3)'s own test, and is disclosed as a near-miss without entering this list.
+- **`tag-exempt (<sub-shape>)` — material the vocabulary does not adjudicate.** One disposition
+  for rows carrying no guidance for ANY surface the applicability vocabulary adjudicates, with the
+  sub-shape named at the row. Four sub-shapes: `consumer-surface` (a different product surface,
+  e.g. claude.ai web/mobile), `archive-descriptive` (an archive's own apparatus and entry
+  structure), `metadata` (dates, titles, version labels), `navigation-pointer` (links and
+  cross-references). The disposition describes the material's genre and asserts nothing about
+  harness applicability — it is not a positive tag and not a negative claim — so it owes no
+  live-doc citation and no absence basis, and the near-miss disclosure burden never attaches.
+  `api-only` remains reserved for rows that DO assert a harness absence for their own specific
+  assertion.
 - **`cc-applicable`/`mixed` boundary:** a claim that names an API surface (parameter, endpoint,
   SDK call, model ID) tags `mixed` even when its guidance transfers to the harness;
   `cc-applicable` is reserved for claims naming no API surface. **Bare names are not API


### PR DESCRIPTION
## Summary

Implements the PA-H interview decision (locked 2026-08-02) in the Anthropic docs profile: the
applicability filter gains one `tag-exempt (<sub-shape>)` disposition for rows carrying no
guidance for ANY surface the vocabulary adjudicates, with four documented sub-shapes
(consumer-surface, archive-descriptive, metadata, navigation-pointer), the sub-shape named at the
row. The class describes the material's genre and asserts nothing about harness applicability -
not a positive tag, not a negative claim - so it owes no live-doc citation and no absence basis,
and the near-miss disclosure burden never attaches. `api-only` remains reserved for rows that DO
assert a harness absence for their own specific assertion. Consistent with the co-decided PA-AI
Reading 1 (a positive tag asserts harness applicability and requires a live-doc citation).

- `anthropic-docs-profile.md`: vocabulary intro mentions the tag-exempt disposition; new bullet in
  the applicability-filter section defines the class
- knowledge plugin `0.10.22` -> `0.10.23` + CHANGELOG entry

The memory-tier retag sweep over the system-prompts slice (the decision's implementation cost) is
performed separately in `.work/` and is never committed.

No linked issue

## Related

- PR #1898 (archive-reading conventions, knowledge 0.10.20) - same profile, same campaign
- PR #1928 (model-matching table alignment, knowledge 0.10.22) - most recent edit to this profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)