### PR TITLE
docs(visualization): note connector-backed live data in the artifact tier

### DIFF
--- a/plugins/visualization/.claude-plugin/plugin.json
+++ b/plugins/visualization/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "visualization",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "On-demand visualization router: infers what in the current conversation should be shown visually, then decides the best FORM (a mermaid diagram, a markdown table, a hand-authored SVG/CSS chart, ASCII/Unicode art, or a rich rendered page) and the best MEDIUM (inline terminal, a local HTML file, or a published Artifact) via a decision matrix over content shape, complexity, and a configurable medium preference. Renders good defaults and asks only when the target is genuinely ambiguous and no form was named. A form-and-medium decision layer in front of the craft capabilities — it routes chart craft and artifact-design fundamentals to those capabilities when installed and never restates them.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/visualization/CHANGELOG.md
+++ b/plugins/visualization/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `visualization` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.2]
+
+### Changed
+
+- **Decision matrix covers connector-backed live data on published Artifacts.**
+  The published-Artifact tier now notes that from Claude Code v2.1.209 a
+  published page can call declared MCP connectors at view time — through
+  claude.ai (the CSP still holds; the page itself makes no network call), via
+  each viewer's own approved connector account, never shareable to a public
+  link, and gated on Team/Enterprise by the org Owner "Enable artifact
+  connectors" toggle. Previously the matrix presented published pages as
+  build-time snapshots with no path to outside data.
+
 ## [0.1.1]
 
 ### Changed

--- a/plugins/visualization/skills/visualize/context/decision-matrix.md
+++ b/plugins/visualization/skills/visualize/context/decision-matrix.md
@@ -30,6 +30,13 @@ against those sources before relying on a time-sensitive detail; the platform mo
 - **Theme-aware** (light/dark), **responsive**, and **favicon required** — this is
   the Artifact tool's own contract; an artifact-design capability, when installed,
   owns the craft on top of it.
+- **Connector-backed live data** (Claude Code v2.1.209+): a published page can
+  call declared MCP connectors at view time, showing current data rather than a
+  build-time snapshot. The CSP above still holds — the page itself makes no
+  network call; it hands each call to claude.ai. Calls run through each viewer's
+  own connector account after that viewer approves; a connector-backed page can
+  never be shared to a public link; and on Team/Enterprise an org Owner toggle
+  ("Enable artifact connectors") gates the capability.
 
 ### Availability gating (why the surface is often absent)
 
@@ -141,7 +148,8 @@ before relying on a time-sensitive detail.
 - Mermaid emitted as source, not terminal-rendered —
   `https://code.claude.com/docs/en/output-styles.md`.
 - Artifact CSP (no external requests, inline CSS/JS, `data:` images, ~16 MiB,
-  self-contained), HTML+Markdown types, and availability gating —
+  self-contained), HTML+Markdown types, availability gating, and connector-backed
+  live data (verified 2026-08-04) —
   `https://code.claude.com/docs/en/artifacts`.
 - Artifact native mermaid, favicon requirement, theme-awareness
   (`prefers-color-scheme` / `data-theme`), and responsive rules — the Artifact


### PR DESCRIPTION
## Summary

The live artifacts doc (https://code.claude.com/docs/en/artifacts) now documents MCP-connector-backed published pages (Claude Code v2.1.209+): a published page can call declared MCP connectors at view time through claude.ai, via each viewer's own approved connector account; connector-backed pages can never be shared to a public link; on Team/Enterprise an org Owner "Enable artifact connectors" toggle gates the capability.

The visualization decision matrix presented published Artifacts as build-time snapshots with no path to outside data. This adds the capability note to the published-Artifact tier and grounds it in the sources section. The strict-CSP claim is unchanged and remains accurate: the page itself still makes no network call — connector calls are handed to claude.ai, which makes them.

Plugin version 0.1.1 → 0.1.2 with changelog entry.

No linked issue.

## Related

- Doc-alignment roster row 57 (batch B3 escalation, solo re-dispatch); live page double-fetched 2026-08-04 with matching MD5s.
- Fresh-context Fable verifier: PASS 4/4 (capability verbatim-grounded, CSP untouched and reconciled, v2.1.209 exact, version/changelog consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)