### PR TITLE
docs: add Cursor Cloud dev-environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,51 @@ mean to commit.
 - Title pull requests with [Conventional Commits](https://www.conventionalcommits.org/).
 - Resolve every review thread before merging; an unresolved thread marks a
   finding that has not yet been addressed.
+
+## Cursor Cloud specific instructions
+
+This repo is a Claude Code plugin marketplace, not a long-running service: the
+"applications" are the CI validation scripts, the plugin contract tests, and the
+one bundled Node MCP server under `plugins/miro`. There is no server to keep
+running. The toolchain, the exact lint/test/validate/build commands, and the CI
+tool inventory are already documented — read `README.md`,
+[`docs/MIGRATION-PLAYBOOK.md`](docs/MIGRATION-PLAYBOOK.md) ("Local development
+loop"), [`docs/CLOUD-SESSIONS.md`](docs/CLOUD-SESSIONS.md), and
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml). Notes below cover only
+the non-obvious VM caveats a fresh Cursor Cloud agent needs.
+
+- **Node version / PATH shadowing (non-obvious).** The repo pins Node via
+  `.node-version` (24.18.0), installed through `nvm`. The exec-daemon prepends
+  `/exec-daemon` (Node 22) to `PATH` *after* `~/.bashrc` runs, so it shadows
+  `nvm`. The fix is a trailing `PATH` prepend in `~/.bashrc` (already applied and
+  baked into the VM snapshot) that puts the pinned Node bin — plus
+  `/workspace/node_modules/.bin` (the `claude` CLI and Biome) and `~/.local/bin`
+  (CI hygiene binaries) — ahead of `/exec-daemon`. If a fresh VM ever reverts to
+  Node 22, re-run the version-pin activation via `nvm install "$(cat
+  .node-version)" && nvm alias default "$(cat .node-version)"`.
+- **`FORCE_COLOR=0` breaks output-parsing tests (non-obvious).** The daemon sets
+  `FORCE_COLOR=0`, which the Rust `anstream` crate (used by `ruff`, hence the
+  `ruff-format` plugin) treats as "force color ON", overriding `NO_COLOR=1` and
+  injecting ANSI codes that make color-sensitive contract tests fail. `~/.bashrc`
+  `unset FORCE_COLOR`s to fix this; keep that unset when running tests.
+- **`awk` must be GNU awk (non-obvious).** `plugins/skill-quality`'s
+  `check-skill.sh` check 21 uses interval regexes (`{0,3}`) that make the VM's
+  default `mawk 1.3.4` panic (`REcompile() - panic`), silently skipping the check
+  and failing its contract test. `gawk` is installed and set as the default `awk`
+  (via update-alternatives); do not switch `awk` back to `mawk`.
+- **Full CI toolchain provisioning.** `.claude/hooks/session-start.sh` is the
+  repo's own idempotent bootstrap that installs the pinned CI tool inventory
+  (`ruff`, `shellcheck`, `shfmt`, `actionlint`, `typos`, `editorconfig-checker`,
+  `gitleaks`, `markdownlint-cli2`, `check-jsonschema`) into `~/.local/bin`. It is
+  guarded by `CLAUDE_CODE_REMOTE`; to (re)provision those tools on this VM run
+  `CLAUDE_CODE_REMOTE=true bash .claude/hooks/session-start.sh`. Its
+  `$CLAUDE_ENV_FILE` PATH step is a no-op here (that var is Claude-Code-only), so
+  PATH is handled by `~/.bashrc` instead.
+- **Running things.** Tests: `scripts/run-plugin-tests.sh` (plugin contract
+  suites; individual suites SKIP when an optional tool such as `duckdb`/`goimports`
+  is absent), the shared `lib/*.test.sh` suites, and `scripts/*.test.sh`. Manifest
+  and catalog validation (the marketplace "build") runs via
+  `scripts/validate-plugins.sh` (needs `claude` on PATH). The bundled MCP server:
+  `cd plugins/miro`, then
+  `npm ci` once, and `npm run typecheck|lint|test|verify-bundle`; smoke-run the
+  built bundle over stdio with `MIRO_API_TOKEN=... node dist/index.min.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,14 @@ the non-obvious VM caveats a fresh Cursor Cloud agent needs.
   `.node-version` (24.18.0), installed through `nvm`. The exec-daemon prepends
   `/exec-daemon` (Node 22) to `PATH` *after* `~/.bashrc` runs, so it shadows
   `nvm`. The fix is a trailing `PATH` prepend in `~/.bashrc` (already applied and
-  baked into the VM snapshot) that puts the pinned Node bin — plus
-  `/workspace/node_modules/.bin` (the `claude` CLI and Biome) and `~/.local/bin`
-  (CI hygiene binaries) — ahead of `/exec-daemon`. If a fresh VM ever reverts to
-  Node 22, re-run the version-pin activation via `nvm install "$(cat
-  .node-version)" && nvm alias default "$(cat .node-version)"`.
+  baked into the VM snapshot) that puts the pinned Node bin — plus the
+  repository's own `node_modules/.bin` (the `claude` CLI and Biome; `npm ci` at
+  the repo root creates it, and `.claude/hooks/session-start.sh` exports that
+  same `$repo_root/node_modules/.bin`, so use the checkout path rather than a
+  fixed `/workspace` one) and `~/.local/bin` (CI hygiene binaries) — ahead of
+  `/exec-daemon`. If a fresh VM ever reverts to Node 22, re-run the version-pin
+  activation via `nvm install "$(cat .node-version)" && nvm alias default "$(cat
+  .node-version)"`.
 - **`FORCE_COLOR=0` breaks output-parsing tests (non-obvious).** The daemon sets
   `FORCE_COLOR=0`, which the Rust `anstream` crate (used by `ruff`, hence the
   `ruff-format` plugin) treats as "force color ON", overriding `NO_COLOR=1` and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No linked issue

## Summary

Sets up a full Cursor Cloud development environment for this marketplace repo and
documents the non-obvious VM caveats discovered while doing so. The only tracked
change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`;
all other setup lives in the VM (nvm Node 24.18.0, `gawk`, `~/.bashrc`, `npm ci`)
and in the proposed startup update script.

## Fix

`AGENTS.md` gains a Cursor-Cloud section covering three environment gotchas that
are not otherwise discoverable, plus pointers to the existing run/test/build docs:

- **Node PATH shadowing** — the exec-daemon prepends `/exec-daemon` (Node 22)
  after `~/.bashrc`, shadowing nvm; a trailing `~/.bashrc` PATH prepend restores
  the repo-pinned Node 24.18.0 (`.node-version`) and exposes `node_modules/.bin`
  (`claude`, Biome) and `~/.local/bin`.
- **`FORCE_COLOR=0`** — the daemon sets it, and the `anstream` crate (ruff) reads
  it as "force color ON", overriding `NO_COLOR=1` and breaking output-parsing
  contract tests (`ruff-format`); `~/.bashrc` now unsets it.
- **`awk` must be GNU awk** — the VM's default `mawk 1.3.4` panics on check 21's
  interval regex in `plugins/skill-quality/check-skill.sh`; `gawk` is installed
  and set as the default `awk`.

The startup update script (proposed separately) is intentionally minimal:
activate the pinned Node via nvm and `npm ci` at the repo root. The full CI tool
inventory is provisioned by the repo's own `.claude/hooks/session-start.sh`.

## Verification

All gates run green in the configured environment (full log captured as the
`setup_verification.txt` cloud-agent artifact):

- `scripts/run-plugin-tests.sh` — 168 suites, 0 failures (optional-tool cases SKIP).
- `lib/*.test.sh` shared-helper suites — pass.
- Lint: shellcheck, editorconfig-checker, typos, actionlint, markdownlint-cli2 (1032 files) — pass.
- `scripts/validate-plugins.sh` — every plugin manifest + the catalog validate (marketplace "build").
- `plugins/miro` — typecheck, Biome lint, `verify-bundle`, 32 vitest tests pass; the bundled MCP server runs over stdio and returns 16 tools (incl. `miro_create_board`).
- Hello-world: a freshly scaffolded `hello-world` plugin passes `claude plugin validate --strict`.

## Related

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81ee224c-de66-4dcb-9db1-529212b06d3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81ee224c-de66-4dcb-9db1-529212b06d3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

