### PR TITLE
docs(adr): record that plugins-reference now documents body-text placeholder substitution

### DIFF
--- a/docs/adr/0007-host-per-model-doctrine-outside-skill-private-surfaces.md
+++ b/docs/adr/0007-host-per-model-doctrine-outside-skill-private-surfaces.md
@@ -113,6 +113,10 @@ bodies. The verification record above carries the recheck trigger, and the relat
 attested, so a regression is recoverable rather than silent — but the dependency is real and is the
 price of the model-neutral host.
 
+*Update (2026-08-04, live fetch):* superseded by the update under Context — the substitution is a
+documented contract for skill and agent content, so the dependency is on documented behavior and the
+per-upgrade recheck it prescribed is retired. The relative-path fallback stays attested.
+
 Chapter paths in `fable-5`'s `SKILL.md` are no longer uniform: twelve chapters resolve under
 `context/` by bare filename while the adaptation chapters carry a full interpolated path. The routing
 table's preamble states the exception rather than leaving a reader to infer it.

--- a/docs/adr/0007-host-per-model-doctrine-outside-skill-private-surfaces.md
+++ b/docs/adr/0007-host-per-model-doctrine-outside-skill-private-surfaces.md
@@ -63,6 +63,12 @@ from a model normalizing paths on its own. **As of:** 2026-08-03. **Recheck trig
 upgrade, since body-text substitution is not a documented contract. A relative-path form remains the
 attested fallback if the behavior ever regresses.
 
+*Update (2026-08-04, live fetch):* the current
+[plugins reference](https://code.claude.com/docs/en/plugins-reference#environment-variables) lists
+skill and agent content as substituting the placeholder anywhere it appears, so body-text
+substitution is a documented contract and the recheck trigger's "not documented" premise no longer
+holds; the probes above stand as corroboration.
+
 ## Decision
 
 Per-version model-adaptation chapters live at


### PR DESCRIPTION
No linked issue.

## Summary

Doc-alignment campaign, roster row 142 (upstream page: [Plugins reference](https://code.claude.com/docs/en/plugins-reference), fetched live via the raw-markdown channel `plugins-reference.md` on 2026-08-04).

ADR-0007's `${CLAUDE_PLUGIN_ROOT}` interpolation paragraph claimed upstream documents substitution "for hook commands, MCP and LSP server configuration, monitor commands, and `allowed-tools` frontmatter — not for prose body text", and keyed its recheck trigger on body-text substitution being undocumented. The current page's Environment-variables substitution table lists **"Skill and agent content — Anywhere the placeholder appears"**, so body-text substitution is a documented contract. This PR appends a dated update note to the ADR — the original record and its empirical probes are preserved as corroboration; no decision changes.

## Alignment sweep result (row 142)

All other repo surfaces citing plugins-reference facts verified **aligned** against the live page, no change owed there: `plugins/plugin-quality/skills/audit/SKILL.md` (+ spokes, auditor.md), `plugins/skill-quality/skills/check/SKILL.md` (+ spokes, check-skill.sh), `docs/PLUGIN-PHILOSOPHY.md`, `docs/OFFICIAL-DOCS.md`, `docs/MIGRATION-PLAYBOOK.md`, `docs/conventions/hook-config-delivery/README.md`, `docs/conventions/permission-rule-hygiene/README.md`, repo `CLAUDE.md`, and the per-plugin citation sites (miro, dometrain, knowledge, discipline, bug-report, claude-ops, disk-hygiene, context-guard, typos-format, markdown-format, source-control, visualization, repo-fleet-hygiene, work-items/guardrails changelogs).

## Related

- ADR-0007 (`docs/adr/0007-host-per-model-doctrine-outside-skill-private-surfaces.md`) — the amended record
- plugin-quality CHANGELOG #1808 entry — the earlier in-repo correction that already cited the "anywhere the placeholder appears" row (fetched 2026-07-31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4WKk84pYqZs75H4gmgUfc
