### PR TITLE
docs(claude-memory): point stateless purge at the official project-purge command

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -20,16 +20,27 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
 ### Fixed
 
 - **The `stateless` scope table answered for four entities with one verdict, and was wrong for
-  three of them.** A single `Transcripts / history / sessions / snapshots` row claimed
-  `cleanupPeriodDays` auto-cleans all of them, and an immediate full wipe via
-  `claude project purge`. Per code.claude.com/docs/en/claude-directory (verified 2026-08-04),
-  only transcripts match that verdict: `history.jsonl` sits among the paths "not covered by
-  automatic cleanup" that "persist indefinitely"; `sessions/` "isn't part of the age-based
-  sweep" and the command's deletion list never names it; and the command "leaves
-  `shell-snapshots/` and `backups/` alone because those are not project-scoped". Split so every
-  verdict is true of every subject in its row. Also retires two counted re-fetch pointers ("the
-  two source pages", "both pages") that the file family had grown past — they now point at the
-  source list rather than counting it.
+  two of them.** A single `Transcripts / history / sessions / snapshots` row claimed
+  `cleanupPeriodDays` auto-cleans all four. Per code.claude.com/docs/en/claude-directory
+  (verified 2026-08-04) it auto-cleans transcripts and shell snapshots, but not the other two:
+  `history.jsonl` sits among the paths "not covered by automatic cleanup" that "persist
+  indefinitely", and `sessions/` "isn't part of the age-based sweep", being cleared when each
+  session exits. The row also gave one location for all four and said nothing about
+  `claude project purge`, whose scope cuts across it — the command deletes this project's
+  transcripts, filters its `history.jsonl` lines, never names `sessions/`, and "leaves
+  `shell-snapshots/` and `backups/` alone because those are not project-scoped". Now four rows,
+  each carrying its own path, sweep behavior, and purge behavior, so every verdict is true of
+  every subject in its row. The same correction applies to `reference/official-guidance.md`'s
+  out-of-scope section, which stated the sweep for all four as one fact. Also retires two
+  counted re-fetch pointers ("the two source pages", "both pages") that the file family had
+  grown past — they now point at the source list rather than counting it.
+
+- **The instruction-layer row claimed a user scope `CLAUDE.local.md` does not have.** One
+  `CLAUDE.md / CLAUDE.local.md / .claude/rules/` row gave the location as `repo + user`, true
+  of `CLAUDE.md` (`~/.claude/CLAUDE.md`) and of `.claude/rules/` (`~/.claude/rules/`, which
+  code.claude.com/docs/en/memory calls "Personal rules ... apply to every project on your
+  machine") but not of `CLAUDE.local.md`, which that page scopes to "Just you (current
+  project)" with no user-scope equivalent. Split so the location is true of its own subject.
 
 ## [0.5.5]
 

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -11,10 +11,11 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   0.5.5 → 0.5.6). Wherever the skill states that purge is auto-memory-only — the SKILL.md scope
   statement and table, `context/purge.md`'s pre-gate presentation and follow-through, and
   `reference/official-guidance.md`'s out-of-scope section — it now names `claude project purge`
-  (Claude Code v2.1.124+). The command's deletion scope is quoted verbatim in
-  `reference/official-guidance.md` and nowhere else, so the skill holds one copy of an upstream
-  list instead of one per call site; every other mention points there, and
-  code.claude.com/docs/en/claude-directory stays the source for the deletion plan and flags.
+  (Claude Code v2.1.124+). The command's scope — what it deletes, what it leaves alone, and that
+  it confirms first — is quoted verbatim in `reference/official-guidance.md` and nowhere else, so
+  the skill holds one copy of an upstream list instead of one per call site; every other mention
+  points there, and code.claude.com/docs/en/claude-directory stays the source for the deletion
+  plan and flags.
   Also retires the reference file's now-false "there is no built-in purge command" claim.
 
 ### Fixed
@@ -26,14 +27,26 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   `history.jsonl` sits among the paths "not covered by automatic cleanup" that "persist
   indefinitely", and `sessions/` "isn't part of the age-based sweep", being cleared when each
   session exits. The row also gave one location for all four and said nothing about
-  `claude project purge`, whose scope cuts across it — the command deletes this project's
-  transcripts, filters its `history.jsonl` lines, never names `sessions/`, and "leaves
-  `shell-snapshots/` and `backups/` alone because those are not project-scoped". Now four rows,
+  `claude project purge`, whose scope cuts across it and lands differently on each of the four
+  (quoted in `reference/official-guidance.md`). Now four rows,
   each carrying its own path, sweep behavior, and purge behavior, so every verdict is true of
   every subject in its row. The same correction applies to `reference/official-guidance.md`'s
   out-of-scope section, which stated the sweep for all four as one fact. Also retires two
   counted re-fetch pointers ("the two source pages", "both pages") that the file family had
   grown past — they now point at the source list rather than counting it.
+
+- **Three `stateless` reference quotes attributed to the settings doc were paraphrase, not
+  quotation.** `reference/official-guidance.md` presents block quotes as verbatim, but its
+  settings-precedence list, `env` description, and `cleanupPeriodDays` description used wording
+  absent from code.claude.com/docs/en/settings — the precedence list invented every item label
+  ("Local" for "Local project settings", "Project" for "Shared project settings") and the
+  bracketing "(highest priority)" / "lowest priority", the `env` description was a rewrite, and
+  the `cleanupPeriodDays` one stitched invented wording around real fragments with ellipses. The
+  substance was right in all three cases; only the fidelity was wrong, which is
+  the defect that matters in a file whose contract is verbatim quotation. All three now carry the
+  page's own words, verified 2026-08-05, with the precedence list quoted as the structured list it
+  is and its omissions marked. Managed settings' "cannot be overridden" property, previously
+  stitched into the precedence quote, is now quoted from the nested bullet that states it.
 
 - **The instruction-layer row claimed a user scope `CLAUDE.local.md` does not have.** One
   `CLAUDE.md / CLAUDE.local.md / .claude/rules/` row gave the location as `repo + user`, true

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.6]
+
+### Changed
+
+- **`stateless`'s purge scope boundary now points at the official full wipe** (claude-memory
+  0.5.5 → 0.5.6). Wherever the skill states that purge is auto-memory-only — the SKILL.md scope
+  statement and table, `context/purge.md`'s pre-gate presentation and follow-through, and
+  `reference/official-guidance.md`'s out-of-scope section — it now names `claude project purge`
+  (Claude Code v2.1.124+), the official per-project wipe covering transcripts and auto memory
+  under `projects/`, per-session `tasks/`, `debug/`, and `file-history/` entries, matching
+  `history.jsonl` lines, and the project's `~/.claude.json` entry, linking
+  code.claude.com/docs/en/claude-directory as the single source for the deletion plan and
+  flags. Also retires the reference file's now-false "there is no built-in purge command"
+  claim.
+
 ## [0.5.5]
 
 ### Fixed

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -11,12 +11,25 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   0.5.5 → 0.5.6). Wherever the skill states that purge is auto-memory-only — the SKILL.md scope
   statement and table, `context/purge.md`'s pre-gate presentation and follow-through, and
   `reference/official-guidance.md`'s out-of-scope section — it now names `claude project purge`
-  (Claude Code v2.1.124+), the official per-project wipe covering transcripts and auto memory
-  under `projects/`, per-session `tasks/`, `debug/`, and `file-history/` entries, matching
-  `history.jsonl` lines, and the project's `~/.claude.json` entry, linking
-  code.claude.com/docs/en/claude-directory as the single source for the deletion plan and
-  flags. Also retires the reference file's now-false "there is no built-in purge command"
-  claim.
+  (Claude Code v2.1.124+). The command's deletion scope is quoted verbatim in
+  `reference/official-guidance.md` and nowhere else, so the skill holds one copy of an upstream
+  list instead of one per call site; every other mention points there, and
+  code.claude.com/docs/en/claude-directory stays the source for the deletion plan and flags.
+  Also retires the reference file's now-false "there is no built-in purge command" claim.
+
+### Fixed
+
+- **The `stateless` scope table answered for four entities with one verdict, and was wrong for
+  three of them.** A single `Transcripts / history / sessions / snapshots` row claimed
+  `cleanupPeriodDays` auto-cleans all of them, and an immediate full wipe via
+  `claude project purge`. Per code.claude.com/docs/en/claude-directory (verified 2026-08-04),
+  only transcripts match that verdict: `history.jsonl` sits among the paths "not covered by
+  automatic cleanup" that "persist indefinitely"; `sessions/` "isn't part of the age-based
+  sweep" and the command's deletion list never names it; and the command "leaves
+  `shell-snapshots/` and `backups/` alone because those are not project-scoped". Split so every
+  verdict is true of every subject in its row. Also retires two counted re-fetch pointers ("the
+  two source pages", "both pages") that the file family had grown past — they now point at the
+  source list rather than counting it.
 
 ## [0.5.5]
 

--- a/plugins/claude-memory/skills/stateless/SKILL.md
+++ b/plugins/claude-memory/skills/stateless/SKILL.md
@@ -21,14 +21,14 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/stateless/scripts/scope-report.sh" || echo "(
 Inspect and disable Claude Code **auto memory** — the store Claude writes for itself, one
 directory per repo (`~/.claude/projects/<project>/memory/`, relocatable via
 `autoMemoryDirectory`). Governs auto-memory only. Not in scope: CLAUDE.md / CLAUDE.local.md /
-`.claude/rules/` (use `/claude-memory:audit`), transcripts, history, or shell snapshots — for
-the official full per-project wipe (transcripts and auto memory under `projects/`, per-session
-`tasks/` / `debug/` / `file-history/` entries, matching `history.jsonl` lines, and the project's
-`~/.claude.json` entry), use `claude project purge` (Claude Code v2.1.124+;
-[claude-directory doc](https://code.claude.com/docs/en/claude-directory)).
+`.claude/rules/` (use `/claude-memory:audit`), transcripts, history, or shell snapshots — for the
+official full per-project wipe, use `claude project purge` (Claude Code v2.1.124+). What it does
+and does not delete is quoted verbatim in
+[reference/official-guidance.md](reference/official-guidance.md); the deletion plan and flags live
+in the [claude-directory doc](https://code.claude.com/docs/en/claude-directory).
 
 Criteria and exact doc quotes live in [reference/official-guidance.md](reference/official-guidance.md);
-re-fetch the two source pages if a fact is load-bearing before you act.
+re-fetch the source pages listed there if a fact is load-bearing before you act.
 
 ## Scope
 
@@ -38,7 +38,10 @@ re-fetch the two source pages if a fact is load-bearing before you act.
 | `autoMemoryEnabled` setting | any settings scope | Yes — reads & writes |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | OS env or settings `env` block | Yes — reads & writes |
 | CLAUDE.md / CLAUDE.local.md / `.claude/rules/` | repo + user | No — use `/claude-memory:audit` |
-| Transcripts / history / sessions / snapshots | `~/.claude/...` | No — auto-cleaned by `cleanupPeriodDays`; immediate full wipe: `claude project purge` (v2.1.124+) |
+| Transcripts | `~/.claude/projects/<project>/` | No — auto-cleaned by `cleanupPeriodDays`; `claude project purge` (v2.1.124+) deletes this project's now |
+| Prompt history | `~/.claude/history.jsonl` | No — persists indefinitely, not swept by `cleanupPeriodDays`; `claude project purge` filters this project's lines |
+| Session files | `~/.claude/sessions/` | No — one file per running session, cleared when the session exits rather than age-swept; not in `claude project purge`'s deletion list |
+| Shell snapshots / backups | `~/.claude/shell-snapshots/`, `~/.claude/backups/` | No — swept by `cleanupPeriodDays`, but not project-scoped, so `claude project purge` leaves them untouched |
 | Claude Desktop / claude.ai memory | server-side account | Direction only — [context/desktop.md](context/desktop.md) |
 
 ## Argument parsing

--- a/plugins/claude-memory/skills/stateless/SKILL.md
+++ b/plugins/claude-memory/skills/stateless/SKILL.md
@@ -21,7 +21,11 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/stateless/scripts/scope-report.sh" || echo "(
 Inspect and disable Claude Code **auto memory** — the store Claude writes for itself, one
 directory per repo (`~/.claude/projects/<project>/memory/`, relocatable via
 `autoMemoryDirectory`). Governs auto-memory only. Not in scope: CLAUDE.md / CLAUDE.local.md /
-`.claude/rules/` (use `/claude-memory:audit`), transcripts, history, or shell snapshots.
+`.claude/rules/` (use `/claude-memory:audit`), transcripts, history, or shell snapshots — for
+the official full per-project wipe (transcripts and auto memory under `projects/`, per-session
+`tasks/` / `debug/` / `file-history/` entries, matching `history.jsonl` lines, and the project's
+`~/.claude.json` entry), use `claude project purge` (Claude Code v2.1.124+;
+[claude-directory doc](https://code.claude.com/docs/en/claude-directory)).
 
 Criteria and exact doc quotes live in [reference/official-guidance.md](reference/official-guidance.md);
 re-fetch the two source pages if a fact is load-bearing before you act.
@@ -34,7 +38,7 @@ re-fetch the two source pages if a fact is load-bearing before you act.
 | `autoMemoryEnabled` setting | any settings scope | Yes — reads & writes |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | OS env or settings `env` block | Yes — reads & writes |
 | CLAUDE.md / CLAUDE.local.md / `.claude/rules/` | repo + user | No — use `/claude-memory:audit` |
-| Transcripts / history / sessions / snapshots | `~/.claude/...` | No — auto-cleaned by `cleanupPeriodDays` |
+| Transcripts / history / sessions / snapshots | `~/.claude/...` | No — auto-cleaned by `cleanupPeriodDays`; immediate full wipe: `claude project purge` (v2.1.124+) |
 | Claude Desktop / claude.ai memory | server-side account | Direction only — [context/desktop.md](context/desktop.md) |
 
 ## Argument parsing

--- a/plugins/claude-memory/skills/stateless/SKILL.md
+++ b/plugins/claude-memory/skills/stateless/SKILL.md
@@ -37,7 +37,8 @@ re-fetch the source pages listed there if a fact is load-bearing before you act.
 | Auto-memory store | `~/.claude/projects/<project>/memory/` (or `autoMemoryDirectory`) | Yes — status / disable / purge |
 | `autoMemoryEnabled` setting | any settings scope | Yes — reads & writes |
 | `CLAUDE_CODE_DISABLE_AUTO_MEMORY` | OS env or settings `env` block | Yes — reads & writes |
-| CLAUDE.md / CLAUDE.local.md / `.claude/rules/` | repo + user | No — use `/claude-memory:audit` |
+| CLAUDE.md / `.claude/rules/` | repo + user | No — use `/claude-memory:audit` |
+| CLAUDE.local.md | repo only — no user-scope equivalent | No — use `/claude-memory:audit` |
 | Transcripts | `~/.claude/projects/<project>/` | No — auto-cleaned by `cleanupPeriodDays`; `claude project purge` (v2.1.124+) deletes this project's now |
 | Prompt history | `~/.claude/history.jsonl` | No — persists indefinitely, not swept by `cleanupPeriodDays`; `claude project purge` filters this project's lines |
 | Session files | `~/.claude/sessions/` | No — one file per running session, cleared when the session exits rather than age-swept; not in `claude project purge`'s deletion list |

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -62,7 +62,8 @@ Present to the user:
   it could point at an unrelated directory.
 - That this deletes auto-memory notes only — **not** CLAUDE.md, rules, transcripts, or history.
   If the intent is the full per-project wipe, point to `claude project purge` (Claude Code
-  v2.1.124+) instead, and state its scope to the user from the verbatim quote in
+  v2.1.124+) instead, and state its scope to the user (what it deletes and what it leaves alone)
+  from the verbatim quotes in
   [reference/official-guidance.md](../reference/official-guidance.md) rather than from memory —
   <https://code.claude.com/docs/en/claude-directory> owns the deletion plan and flags.
 - If `$manifest` is empty, report that there is nothing to purge and stop (no-op).

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -61,6 +61,11 @@ Present to the user:
   can set — confirm the user intends to delete from that absolute path before proceeding, since
   it could point at an unrelated directory.
 - That this deletes auto-memory notes only — **not** CLAUDE.md, rules, transcripts, or history.
+  If the intent is the full per-project wipe (transcripts and auto memory under `projects/`,
+  per-session `tasks/` / `debug/` / `file-history/` entries, matching `history.jsonl` lines, and
+  the project's `~/.claude.json` entry), point to
+  `claude project purge` (Claude Code v2.1.124+;
+  <https://code.claude.com/docs/en/claude-directory>) instead.
 - If `$manifest` is empty, report that there is nothing to purge and stop (no-op).
 
 ## Step 3: Confirmation gate (with backup offer)
@@ -156,6 +161,9 @@ otherwise leaving the empty directory is harmless.
 - Purge removes existing notes but does **not** stop new ones. If the user wants to stay
   stateless, point to `disable` (or run it now if they ask) so Claude doesn't immediately
   re-accumulate memory.
+- If the intent was wiping everything Claude holds for this repo, point to
+  `claude project purge` (Step 2's pointer) — it covers the full per-project scope enumerated
+  there, not auto memory alone.
 - If the user wants to be stateless everywhere, summarize the Claude Desktop / claude.ai
   account store steps in [desktop.md](desktop.md) — that store is server-side and cannot be
   deleted from here.

--- a/plugins/claude-memory/skills/stateless/context/purge.md
+++ b/plugins/claude-memory/skills/stateless/context/purge.md
@@ -61,11 +61,10 @@ Present to the user:
   can set — confirm the user intends to delete from that absolute path before proceeding, since
   it could point at an unrelated directory.
 - That this deletes auto-memory notes only — **not** CLAUDE.md, rules, transcripts, or history.
-  If the intent is the full per-project wipe (transcripts and auto memory under `projects/`,
-  per-session `tasks/` / `debug/` / `file-history/` entries, matching `history.jsonl` lines, and
-  the project's `~/.claude.json` entry), point to
-  `claude project purge` (Claude Code v2.1.124+;
-  <https://code.claude.com/docs/en/claude-directory>) instead.
+  If the intent is the full per-project wipe, point to `claude project purge` (Claude Code
+  v2.1.124+) instead, and state its scope to the user from the verbatim quote in
+  [reference/official-guidance.md](../reference/official-guidance.md) rather than from memory —
+  <https://code.claude.com/docs/en/claude-directory> owns the deletion plan and flags.
 - If `$manifest` is empty, report that there is nothing to purge and stop (no-op).
 
 ## Step 3: Confirmation gate (with backup offer)
@@ -162,8 +161,8 @@ otherwise leaving the empty directory is harmless.
   stateless, point to `disable` (or run it now if they ask) so Claude doesn't immediately
   re-accumulate memory.
 - If the intent was wiping everything Claude holds for this repo, point to
-  `claude project purge` (Step 2's pointer) — it covers the full per-project scope enumerated
-  there, not auto memory alone.
+  `claude project purge` (Step 2's pointer) — its scope is the full per-project one quoted in
+  [reference/official-guidance.md](../reference/official-guidance.md), not auto memory alone.
 - If the user wants to be stateless everywhere, summarize the Claude Desktop / claude.ai
   account store steps in [desktop.md](desktop.md) — that store is server-side and cannot be
   deleted from here.

--- a/plugins/claude-memory/skills/stateless/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/stateless/reference/official-guidance.md
@@ -1,7 +1,8 @@
 # Official Claude Code Guidance on Auto Memory State
 
-Last researched: 2026-07-22; code.claude.com/docs/en/claude-directory verified 2026-08-04 (the
-other sources below were not re-checked on that date)
+Last researched: 2026-07-22; code.claude.com/docs/en/claude-directory and
+code.claude.com/docs/en/settings verified 2026-08-05 (the other sources below were not
+re-checked on that date)
 Sources: [code.claude.com/docs/en/memory](https://code.claude.com/docs/en/memory),
 [code.claude.com/docs/en/settings](https://code.claude.com/docs/en/settings),
 [code.claude.com/docs/en/env-vars](https://code.claude.com/docs/en/env-vars),
@@ -105,17 +106,25 @@ per-project wipe (see "Out of scope" below).
 
 ## Settings scopes and precedence
 
-> "1. Managed (highest priority) — cannot be overridden 2. Command-line arguments 3. Local
-> (`.claude/settings.local.json`) 4. Project (`.claude/settings.json`) 5. User
-> (`~/.claude/settings.json`) — lowest priority"
-> — code.claude.com/docs/en/settings
+> "Settings apply in order of precedence. From highest to lowest:
+>
+> 1. **Managed settings** (…)
+> 2. **Command line arguments**
+> 3. **Local project settings** (`.claude/settings.local.json`)
+> 4. **Shared project settings** (`.claude/settings.json`)
+> 5. **User settings** (`~/.claude/settings.json`)"
+> — code.claude.com/docs/en/settings (verified 2026-08-05; each item's nested detail is omitted,
+> and item 1's parenthetical list of managed sources is elided at the ellipsis)
+
+Managed settings "Cannot be overridden by any other level, including command line arguments"
+(same page, a nested bullet under item 1).
 
 Managed settings live outside the repo (macOS `/Library/Application Support/ClaudeCode/`,
 Linux/WSL `/etc/claude-code/`, Windows registry `HKLM`/`HKCU\SOFTWARE\Policies\ClaudeCode`).
 
-> "Environment variables defined in the `settings.json` `env` object are applied to every
-> session and passed to all subprocesses Claude Code spawns."
-> — code.claude.com/docs/en/settings
+> "Environment variables applied to every session and to subprocesses Claude Code spawns from
+> it."
+> — code.claude.com/docs/en/settings (the `env` setting's description, verified 2026-08-05)
 
 So `CLAUDE_CODE_DISABLE_AUTO_MEMORY` can be set as a real OS environment variable **or**
 inside a settings file's `env` block; the docs bless the `env`-block form explicitly.
@@ -126,20 +135,21 @@ inside a settings file's `env` block; the docs bless the `env`-block form explic
   auto-cleaned at startup by `cleanupPeriodDays` (default 30, minimum 1). The other two are
   not: `history.jsonl` persists until deleted, and `sessions/` is cleared per session rather
   than by age. Purging any of them is a different concern — the official per-project wipe is
-  `claude project purge`, quoted in full below (confirm-gated; the deletion plan and flags live
-  in the doc, not here).
-  > "cleanupPeriodDays ... Default: 30 days (minimum: 1) ... Age threshold for deleting
-  > session files and application data at startup"
-  > — code.claude.com/docs/en/settings
+  `claude project purge`, quoted in full below (the deletion plan and flags live in the doc,
+  not here).
+  > "**Default**: `30` days, minimum `1`. Claude Code deletes session files and other
+  > application data older than this period at startup."
+  > — code.claude.com/docs/en/settings (the `cleanupPeriodDays` setting's description, verified
+  > 2026-08-05; the page links "session files and other application data" to claude-directory)
 
   > "The following paths are not covered by automatic cleanup and persist indefinitely."
   > — code.claude.com/docs/en/claude-directory, heading the table whose first row is
-  > `history.jsonl` (verified 2026-08-04)
+  > `history.jsonl` (verified 2026-08-05)
 
   > "`sessions/` holds one small file per running session, used to detect concurrent sessions
   > and crashes. It isn't part of the age-based sweep: Claude Code removes each file when its
   > session exits and clears crash leftovers on the next launch."
-  > — code.claude.com/docs/en/claude-directory (verified 2026-08-04)
+  > — code.claude.com/docs/en/claude-directory (verified 2026-08-05)
 
   > "Run `claude project purge` to delete the state Claude Code holds for one project. The
   > command requires Claude Code v2.1.124 or later. It deletes:
@@ -148,7 +158,22 @@ inside a settings file's `env` block; the docs bless the `env`-block form explic
   > - Per-session `tasks/`, `debug/`, and `file-history/` entries
   > - Matching prompt lines in `history.jsonl`
   > - The project's entry in `~/.claude.json`"
-  > — code.claude.com/docs/en/claude-directory (verified 2026-08-04)
+  > — code.claude.com/docs/en/claude-directory (verified 2026-08-05)
+
+  What it leaves alone, from the same page:
+
+  > "The command leaves `shell-snapshots/` and `backups/` alone because those are not
+  > project-scoped, and warns about them in the plan output."
+  > — code.claude.com/docs/en/claude-directory (verified 2026-08-05)
+
+  `sessions/` appears nowhere in the deletion list above — this plugin's reading of that list,
+  not a separate upstream statement.
+
+  It also does not delete unprompted:
+
+  > "The command prints the full deletion plan and asks for confirmation before removing
+  > anything."
+  > — code.claude.com/docs/en/claude-directory (verified 2026-08-05)
 
   `CLAUDE_CODE_SKIP_PROMPT_HISTORY` skips "writing transcripts and prompt history in any mode"
   (code.claude.com/docs/en/claude-directory) — the true "no session persistence" lever, and the

--- a/plugins/claude-memory/skills/stateless/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/stateless/reference/official-guidance.md
@@ -122,13 +122,24 @@ inside a settings file's `env` block; the docs bless the `env`-block form explic
 
 ## Out of scope for this skill (verified, deliberate)
 
-- **Transcripts / history / shell snapshots / sessions.** Session files are auto-cleaned at
-  startup by `cleanupPeriodDays` (default 30, minimum 1). Purging those is a different
-  concern — the official per-project wipe is `claude project purge`, quoted in full below
-  (confirm-gated; the deletion plan and flags live in the doc, not here).
+- **Transcripts / history / shell snapshots / sessions.** Transcripts and shell snapshots are
+  auto-cleaned at startup by `cleanupPeriodDays` (default 30, minimum 1). The other two are
+  not: `history.jsonl` persists until deleted, and `sessions/` is cleared per session rather
+  than by age. Purging any of them is a different concern — the official per-project wipe is
+  `claude project purge`, quoted in full below (confirm-gated; the deletion plan and flags live
+  in the doc, not here).
   > "cleanupPeriodDays ... Default: 30 days (minimum: 1) ... Age threshold for deleting
   > session files and application data at startup"
   > — code.claude.com/docs/en/settings
+
+  > "The following paths are not covered by automatic cleanup and persist indefinitely."
+  > — code.claude.com/docs/en/claude-directory, heading the table whose first row is
+  > `history.jsonl` (verified 2026-08-04)
+
+  > "`sessions/` holds one small file per running session, used to detect concurrent sessions
+  > and crashes. It isn't part of the age-based sweep: Claude Code removes each file when its
+  > session exits and clears crash leftovers on the next launch."
+  > — code.claude.com/docs/en/claude-directory (verified 2026-08-04)
 
   > "Run `claude project purge` to delete the state Claude Code holds for one project. The
   > command requires Claude Code v2.1.124 or later. It deletes:
@@ -139,8 +150,10 @@ inside a settings file's `env` block; the docs bless the `env`-block form explic
   > - The project's entry in `~/.claude.json`"
   > — code.claude.com/docs/en/claude-directory (verified 2026-08-04)
 
-  `CLAUDE_CODE_SKIP_PROMPT_HISTORY` disables transcript writes entirely — the true
-  "no session persistence" lever, recorded here for that future skill, not acted on by this one.
+  `CLAUDE_CODE_SKIP_PROMPT_HISTORY` skips "writing transcripts and prompt history in any mode"
+  (code.claude.com/docs/en/claude-directory) — the true "no session persistence" lever, and the
+  complement to deleting the files after the fact. Recorded for that contrast; this skill acts
+  on neither.
 
 - **Claude Desktop / claude.ai account memory.** That is a server-side account store, not
   local files — this skill cannot delete it and only gives direction (see

--- a/plugins/claude-memory/skills/stateless/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/stateless/reference/official-guidance.md
@@ -3,7 +3,8 @@
 Last researched: 2026-07-22
 Sources: [code.claude.com/docs/en/memory](https://code.claude.com/docs/en/memory),
 [code.claude.com/docs/en/settings](https://code.claude.com/docs/en/settings),
-[code.claude.com/docs/en/env-vars](https://code.claude.com/docs/en/env-vars)
+[code.claude.com/docs/en/env-vars](https://code.claude.com/docs/en/env-vars),
+[code.claude.com/docs/en/claude-directory](https://code.claude.com/docs/en/claude-directory)
 
 Refresh this file from current official docs before relying on it (re-fetch both pages).
 
@@ -96,7 +97,9 @@ code.claude.com/docs/en/memory):
 > "Auto memory files are plain markdown you can edit or delete at any time."
 > — code.claude.com/docs/en/memory
 
-There is no built-in purge command — deletion is manual removal of these files.
+There is no auto-memory-only built-in command — selective deletion is manual removal of these
+files. `claude project purge` (v2.1.124+) deletes the store only as part of the full
+per-project wipe (see "Out of scope" below).
 
 ## Settings scopes and precedence
 
@@ -119,10 +122,20 @@ inside a settings file's `env` block; the docs bless the `env`-block form explic
 
 - **Transcripts / history / shell snapshots / sessions.** Session files are auto-cleaned at
   startup by `cleanupPeriodDays` (default 30, minimum 1). Purging those is a different
-  concern and is deferred to a future skill.
+  concern — the official per-project wipe is `claude project purge`, quoted in full below
+  (confirm-gated; the deletion plan and flags live in the doc, not here).
   > "cleanupPeriodDays ... Default: 30 days (minimum: 1) ... Age threshold for deleting
   > session files and application data at startup"
   > — code.claude.com/docs/en/settings
+
+  > "Run `claude project purge` to delete the state Claude Code holds for one project. The
+  > command requires Claude Code v2.1.124 or later. It deletes:
+  >
+  > - Transcripts and auto memory under `projects/`
+  > - Per-session `tasks/`, `debug/`, and `file-history/` entries
+  > - Matching prompt lines in `history.jsonl`
+  > - The project's entry in `~/.claude.json`"
+  > — code.claude.com/docs/en/claude-directory (verified 2026-08-04)
 
   `CLAUDE_CODE_SKIP_PROMPT_HISTORY` disables transcript writes entirely — the true
   "no session persistence" lever, recorded here for that future skill, not acted on by this one.

--- a/plugins/claude-memory/skills/stateless/reference/official-guidance.md
+++ b/plugins/claude-memory/skills/stateless/reference/official-guidance.md
@@ -1,12 +1,14 @@
 # Official Claude Code Guidance on Auto Memory State
 
-Last researched: 2026-07-22
+Last researched: 2026-07-22; code.claude.com/docs/en/claude-directory verified 2026-08-04 (the
+other sources below were not re-checked on that date)
 Sources: [code.claude.com/docs/en/memory](https://code.claude.com/docs/en/memory),
 [code.claude.com/docs/en/settings](https://code.claude.com/docs/en/settings),
 [code.claude.com/docs/en/env-vars](https://code.claude.com/docs/en/env-vars),
 [code.claude.com/docs/en/claude-directory](https://code.claude.com/docs/en/claude-directory)
 
-Refresh this file from current official docs before relying on it (re-fetch both pages).
+Refresh this file from current official docs before relying on it (re-fetch every source listed
+above).
 
 ---
 


### PR DESCRIPTION
## Summary

Roster row 74. The `stateless` skill governs auto memory only, and said so without naming the official route for the broader ask ("wipe everything Claude saved about this repo"). Claude Code now ships that route: `claude project purge` (v2.1.124+). This PR names it wherever the skill states its own scope boundary — the SKILL.md scope statement and table, `context/purge.md`'s pre-gate presentation and follow-through, and `reference/official-guidance.md`'s out-of-scope section — and retires the reference file's now-false "there is no built-in purge command" claim.

Pointer, not a copy: the deletion plan and flags stay in https://code.claude.com/docs/en/claude-directory.

No executable step changes. The bash fences driving Steps 2–4 (manifest capture, backup, delete) and the confirmation gate are byte-identical to the base branch; the additions are narrative bullets outside any executable block, and nothing causes the skill to invoke `claude project purge` itself.

## Review finding fixed — full deletion scope

Codex flagged (P2, `official-guidance.md:127`) that the summarized deletion scope omitted a category. Re-fetching the live page on 2026-08-04 confirmed it: the command deletes **four** categories, and the PR's original prose listed three, dropping per-session `tasks/`, `debug/`, and `file-history/` entries — checkpoint/restore and debug history. That matters because this text is read to a user deciding whether to run a destructive wipe; the omission would have led them to believe checkpoint history survives.

Sweeping the diff found the same omission in **five** places, not the one flagged. All are corrected:

| Location | Treatment |
|---|---|
| `reference/official-guidance.md` out-of-scope section | No longer paraphrases; the verbatim quote block now carries the doc's complete bullet list |
| `SKILL.md` scope statement | Lists all four categories |
| `context/purge.md` Step 2 (pre-gate text) | Lists all four categories |
| `context/purge.md` Step 5 | Was a second hand-maintained copy; now points at Step 2's enumeration |
| `CHANGELOG.md` 0.5.6 entry | Lists all four categories |

Two authoritative enumerations now remain (the reference file's verbatim quote and Step 2's pre-gate text), down from five independently-maintained paraphrases.

## Stacking and version

Rebased onto `main` after #1933 merged, so the diff contains only this PR's five files. `0.5.6` sits directly above #1933's `0.5.5` in both `plugin.json` and the CHANGELOG, with no gap.

Fresh-context verification completed 2026-08-05 after the rebase: the five-file diff was reviewed against the live official `claude-directory` page; `claude project purge` version, deletion scope, exclusions, confirmation behavior, session cleanup, and history persistence all match. `markdownlint` (14 files), JSON parsing, changelog/version parity, and `git diff --check` pass locally; the repository-wide skill gate exceeded the local 60-second observation window, so protected CI remains authoritative for that lane.

No linked issue

## Related

- Source of truth: https://code.claude.com/docs/en/claude-directory (`claude project purge`, v2.1.124+)
- Campaign save-point and remaining-work ledger: #1941
- Stacked on: #1933 (roster row 127, claude-memory 0.5.5 / criteria 1.5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
