### PR TITLE
fix(work-items): count main checkout local settings in worktree preflight coverage

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.31.3]
+
+### Fixed
+
+- **The permission preflight counts the main checkout's `settings.local.json` as worktree
+  coverage, so the autonomous path stops over-reporting gaps a fresh worker would not have.**
+  Since Claude Code v2.1.211, choosing "Yes, don't ask again" saves the rule to
+  `.claude/settings.local.json` at the repository root, resolved through worktrees to the MAIN
+  checkout, and the rule applies to sessions anywhere in that repository — every linked worktree
+  included. The preflight modelled the pre-v2.1.211 behaviour instead: it dropped the local file
+  wholesale on the `--worktree-root` path, on the reasoning that a gitignored file cannot follow a
+  fresh worktree. That reasoning now holds only for a local file living inside some *other* linked
+  worktree, so a grant the worker would genuinely inherit was reported as a missing-allow gap. The
+  script resolves the main checkout through the git common dir and reads its local file in every
+  mode; only a linked-worktree cwd's *own* local file is still dropped pre-dispatch, since a
+  pre-v2.1.211 save (or a hand-placed file) applies solely to sessions started in that worktree.
+  The exclusion is a no-op when the run starts from the main checkout, and the report header now
+  names which files the coverage read spanned. Deny rules keep reading every local layer — erring
+  wide on deny never masks a gap. On a pre-v2.1.211 harness a main-local-only grant is still a real
+  worker-side gap this report would miss; `reference/permission-preflight.md` states that residual
+  limit rather than leaving it implied.
+
 ## [0.31.2]
 
 ### Fixed

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -16,14 +16,19 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   wholesale on the `--worktree-root` path, on the reasoning that a gitignored file cannot follow a
   fresh worktree. That reasoning now holds only for a local file living inside some *other* linked
   worktree, so a grant the worker would genuinely inherit was reported as a missing-allow gap. The
-  script resolves the main checkout through the git common dir and reads its local file in every
-  mode; only a linked-worktree cwd's *own* local file is still dropped pre-dispatch, since a
-  pre-v2.1.211 save (or a hand-placed file) applies solely to sessions started in that worktree.
-  The exclusion is a no-op when the run starts from the main checkout, and the report header now
-  names which files the coverage read spanned. Deny rules keep reading every local layer — erring
-  wide on deny never masks a gap. On a pre-v2.1.211 harness a main-local-only grant is still a real
-  worker-side gap this report would miss; `reference/permission-preflight.md` states that residual
-  limit rather than leaving it implied.
+  script now reads the main checkout's local file in every mode; only a linked-worktree cwd's *own*
+  local file is still dropped pre-dispatch, since a pre-v2.1.211 save (or a hand-placed file)
+  applies solely to sessions started in that worktree. The exclusion is a no-op when the run starts
+  from the main checkout, and the report header now names which files the coverage read spanned.
+  Deny rules keep reading every local layer — erring wide on deny never masks a gap.
+- **That main checkout is identified by comparing the checkout's own git dir against the common
+  one, not by assuming the git dir is spelled `<root>/.git`.** Equal dirs mean the checkout *is*
+  the main one, so `--separate-git-dir` and submodule layouts — where the common dir lives outside
+  the working tree entirely — resolve to the right root instead of resolving to nothing and
+  re-reporting the very gap this release removes. Only from a linked worktree is the main checkout
+  recovered from the common dir's path. `reference/permission-preflight.md` states the two residual
+  over-reporting cases rather than leaving them implied: a pre-v2.1.211 harness, and a linked
+  worktree whose common dir is not spelled `<root>/.git`. Both are noisy, never masking.
 
 ## [0.31.2]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -19,7 +19,8 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   script now reads the main checkout's local file in every mode; only a linked-worktree cwd's *own*
   local file is still dropped pre-dispatch, since a pre-v2.1.211 save (or a hand-placed file)
   applies solely to sessions started in that worktree. The exclusion is a no-op when the run starts
-  from the main checkout, and the report header now names which files the coverage read spanned.
+  from the main checkout, and the report header now names which files the coverage read spanned —
+  whichever path the main-checkout resolution produced, including a wrong one (below).
   Deny rules keep reading every local layer they resolve — erring wide on deny cannot mask a gap
   *within the layers actually read*, though it cannot widen a layer that never resolves (below).
 - **That main checkout is identified by comparing the checkout's own git dir against the common
@@ -38,7 +39,9 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   repository's working tree at all, and a foreign `.claude/settings.local.json` is unioned into every
   read: a foreign allow **masks** a real gap, and a foreign deny yields a false DENIED (point the
   separate git dir at `$HOME/.git` and the foreign layer is the operator's own `~/.claude` local
-  file). Correcting the resolution itself is deferred; this release states the behaviour truthfully.
+  file). The header then names that foreign directory **as** the main checkout, in wording identical
+  to a correct resolution, so it asserts something false rather than merely omitting it. Correcting
+  the resolution itself is deferred; this release states the behaviour truthfully.
   `reference/permission-preflight.md` carries the residual cases rather than leaving them implied,
   scoped to both the pre-dispatch and named-worker modes. A pre-v2.1.211 harness, where a worktree
   session loads its own local file rather than the main checkout's, **masks** a gap the worker really

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -20,21 +20,30 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   local file is still dropped pre-dispatch, since a pre-v2.1.211 save (or a hand-placed file)
   applies solely to sessions started in that worktree. The exclusion is a no-op when the run starts
   from the main checkout, and the report header now names which files the coverage read spanned.
-  Deny rules keep reading every local layer they resolve — erring wide on deny never masks a gap.
+  Deny rules keep reading every local layer they resolve — erring wide on deny cannot mask a gap
+  *within the layers actually read*, though it cannot widen a layer that never resolves (below).
 - **That main checkout is identified by comparing the checkout's own git dir against the common
   one, not by assuming the git dir is spelled `<root>/.git`.** Equal dirs mean the checkout *is*
   the main one, so the **main checkout of** a `--separate-git-dir` or submodule layout — where the
   common dir lives outside the working tree entirely — resolves to the right root instead of
   resolving to nothing and re-reporting the very gap this release removes. From a linked worktree the
   main checkout is still recovered from the common dir's path, so a linked worktree *of* such a repo
-  resolves to nothing and keeps over-reporting. `reference/permission-preflight.md` states the two
-  residual cases rather than leaving them implied, scoped to both the pre-dispatch and named-worker
-  modes. A pre-v2.1.211 harness, where a worktree session loads its own local file rather than the
-  main checkout's, **masks** a gap the worker really hits, and this report cannot self-detect it
-  since it never probes the running Claude Code version — a documentation-completeness matter rather
-  than a live defect on any v2.1.211-or-later install. An unresolvable main checkout runs in **both**
-  directions: its local file goes unread in every read, so a covered verb is over-reported as a gap
-  (noisy) while a deny living only in that file is not reported at all (masking).
+  lands in one of two wrong states, neither of them merely noisy. When the common dir is not spelled
+  `<root>/.git` — a submodule's `<super>/.git/modules/<name>`, or a separate git dir named anything
+  else — the main checkout stays unresolved and its local file goes unread in **every** read: a
+  covered verb is over-reported as a gap (noisy), *and* a deny living only in that file is not
+  reported at all, so the run can print a clean `PREFLIGHT: OK` (exit 0, zero gaps) while a
+  main-local deny is live. When the common dir *is* spelled that way — `--separate-git-dir
+  <path>/.git` — the main checkout resolves **wrongly**, to `<path>`, a directory that is not this
+  repository's working tree at all, and a foreign `.claude/settings.local.json` is unioned into every
+  read: a foreign allow **masks** a real gap, and a foreign deny yields a false DENIED (point the
+  separate git dir at `$HOME/.git` and the foreign layer is the operator's own `~/.claude` local
+  file). Correcting the resolution itself is deferred; this release states the behaviour truthfully.
+  `reference/permission-preflight.md` carries the residual cases rather than leaving them implied,
+  scoped to both the pre-dispatch and named-worker modes. A pre-v2.1.211 harness, where a worktree
+  session loads its own local file rather than the main checkout's, **masks** a gap the worker really
+  hits, and this report cannot self-detect it since it never probes the running Claude Code version —
+  a documentation-completeness matter rather than a live defect on any v2.1.211-or-later install.
 
 ## [0.31.2]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -20,19 +20,21 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   local file is still dropped pre-dispatch, since a pre-v2.1.211 save (or a hand-placed file)
   applies solely to sessions started in that worktree. The exclusion is a no-op when the run starts
   from the main checkout, and the report header now names which files the coverage read spanned.
-  Deny rules keep reading every local layer — erring wide on deny never masks a gap.
+  Deny rules keep reading every local layer they resolve — erring wide on deny never masks a gap.
 - **That main checkout is identified by comparing the checkout's own git dir against the common
   one, not by assuming the git dir is spelled `<root>/.git`.** Equal dirs mean the checkout *is*
-  the main one, so `--separate-git-dir` and submodule layouts — where the common dir lives outside
-  the working tree entirely — resolve to the right root instead of resolving to nothing and
-  re-reporting the very gap this release removes. Only from a linked worktree is the main checkout
-  recovered from the common dir's path. `reference/permission-preflight.md` states the two residual
-  cases rather than leaving them implied, and they run in opposite directions: a linked worktree
-  whose common dir is not spelled `<root>/.git` leaves the main checkout's file unread, which is
-  merely noisy; a pre-v2.1.211 harness, where a worktree session loads its own local file rather
-  than the main checkout's, instead **masks** a gap the worker really hits. That masking case is the
-  one direction this report cannot self-detect, since it never probes the running Claude Code
-  version.
+  the main one, so the **main checkout of** a `--separate-git-dir` or submodule layout — where the
+  common dir lives outside the working tree entirely — resolves to the right root instead of
+  resolving to nothing and re-reporting the very gap this release removes. From a linked worktree the
+  main checkout is still recovered from the common dir's path, so a linked worktree *of* such a repo
+  resolves to nothing and keeps over-reporting. `reference/permission-preflight.md` states the two
+  residual cases rather than leaving them implied, scoped to both the pre-dispatch and named-worker
+  modes. A pre-v2.1.211 harness, where a worktree session loads its own local file rather than the
+  main checkout's, **masks** a gap the worker really hits, and this report cannot self-detect it
+  since it never probes the running Claude Code version — a documentation-completeness matter rather
+  than a live defect on any v2.1.211-or-later install. An unresolvable main checkout runs in **both**
+  directions: its local file goes unread in every read, so a covered verb is over-reported as a gap
+  (noisy) while a deny living only in that file is not reported at all (masking).
 
 ## [0.31.2]
 

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -27,8 +27,12 @@ All notable changes to the `work-items` plugin are documented here. Format follo
   the working tree entirely — resolve to the right root instead of resolving to nothing and
   re-reporting the very gap this release removes. Only from a linked worktree is the main checkout
   recovered from the common dir's path. `reference/permission-preflight.md` states the two residual
-  over-reporting cases rather than leaving them implied: a pre-v2.1.211 harness, and a linked
-  worktree whose common dir is not spelled `<root>/.git`. Both are noisy, never masking.
+  cases rather than leaving them implied, and they run in opposite directions: a linked worktree
+  whose common dir is not spelled `<root>/.git` leaves the main checkout's file unread, which is
+  merely noisy; a pre-v2.1.211 harness, where a worktree session loads its own local file rather
+  than the main checkout's, instead **masks** a gap the worker really hits. That masking case is the
+  one direction this report cannot self-detect, since it never probes the running Claude Code
+  version.
 
 ## [0.31.2]
 

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -114,11 +114,12 @@ applies only to sessions started in that worktree. Two cases:
   yet created). The **coverage** reads (allow + `additionalDirectories`) span user-global + tracked
   project settings + the main checkout's local file; only a linked-worktree cwd's *own* local file
   is dropped, since the fresh worker would not inherit it and reading it would mask a worker-side
-  gap. Run from the main checkout, nothing is dropped. The report header says which.
+  gap. Run from the main checkout, nothing is dropped. The report header says which — naming
+  whatever `main_root` resolved to, right or wrong (see the second residual).
 - **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
   differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
   `settings.local.json` (legacy rules saved there still apply to sessions started there) plus the
-  main checkout's shared local file; the header names the sources.
+  main checkout's shared local file; the header names the sources, under the same caveat.
 
 **Two residual limits apply to BOTH modes above.**
 
@@ -136,8 +137,14 @@ applies only to sessions started in that worktree. Two cases:
   main-local deny is live. The err-wide deny posture cannot widen a layer never read.
   **Wrongly resolved**: `main_root` names a directory that is not this repository's working tree, and
   that foreign `.claude/settings.local.json` is unioned into every read — a foreign allow masks a
-  real gap, a foreign deny yields a false DENIED. The autonomous header distinguishes neither shape
-  from a repository that simply has no main-local file. Three ways in:
+  real gap, a foreign deny yields a false DENIED. The header treats the two shapes differently, and
+  neither treatment is safe. **Unresolved** is indistinguishable from a repository that simply has no
+  main-local file. **Wrongly resolved** is worse than indistinguishable: the header **names the
+  foreign directory as the main checkout** — `coverage read includes the main checkout's
+  settings.local.json ('<foreign path>', applies in every worktree since Claude Code v2.1.211)` —
+  in wording identical to a correct resolution, so the output asserts something false about which
+  file was read rather than merely omitting it. Both header lines that print a resolved path (the
+  pre-dispatch one and the named-worker one) carry it. Three ways in:
   - A linked worktree of a repo created with `--separate-git-dir <path>/.git`: the common dir is
     `<path>/.git`, so the `*/.git` recovery yields `main_root=<path>` — **wrongly resolved**, with
     foreign rules flowing in both directions (`--separate-git-dir "$HOME/.git"` unions the

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -92,22 +92,31 @@ wildcard spanning it) is not caught here. That conservatism never false-flags th
 floor, whose destructive-verb rules are flag-scoped (`git push --force …`) rather than the bare
 `git push` / `git commit` / `git add` shape.
 
-**`settings.local.json` scope on the autonomous path.** `settings.local.json` is gitignored, so a
-fresh linked worktree the lane dispatches a worker into carries this checkout's tracked
-`.claude/settings.json` but **not** its local file. Two cases:
+**`settings.local.json` scope on the autonomous path.** Since Claude Code v2.1.211, choosing
+"Yes, don't ask again" saves the rule to `.claude/settings.local.json` at the repository root,
+**resolved through worktrees to the main checkout**, and the rule applies to sessions anywhere in
+that repository — every linked worktree included, however the worktree was created
+([permissions](https://code.claude.com/docs/en/permissions#permission-system),
+[worktrees](https://code.claude.com/docs/en/worktrees); both fetched 2026-08-04). The main
+checkout's local file is therefore part of a fresh worker worktree's effective settings, and the
+preflight reads it in **every** mode, resolved through the git common dir. What a fresh worker does
+**not** inherit is a local file living inside some *other* linked worktree — a pre-2.1.211 save, or
+a hand-placed file — which applies only to sessions started in that worktree. Two cases:
 
 - **Pre-dispatch** — `--worktree-root` is passed but no distinct `--project-root` (the worker is not
-  yet created). A grant living only in this checkout's local file would be absent in the fresh
-  worktree, and reading it would mask a worker-side gap, so the **coverage** reads (allow +
-  `additionalDirectories`) drop local — user-global + tracked project settings only — and the report
-  header says so.
+  yet created). The **coverage** reads (allow + `additionalDirectories`) span user-global + tracked
+  project settings + the main checkout's local file; only a linked-worktree cwd's *own* local file
+  is dropped, since the fresh worker would not inherit it and reading it would mask a worker-side
+  gap. Run from the main checkout, nothing is dropped. The report header says which. (On a
+  pre-2.1.211 harness the main checkout's local rules do not reach a worktree either, so there a
+  main-local-only grant is still a real worker-side gap the report would miss.)
 - **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
   differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
-  `settings.local.json` (the worker's file, not this parent's); nothing is masked, and the header
-  names the source.
+  `settings.local.json` (legacy rules saved there still apply to sessions started there) plus the
+  main checkout's shared local file; nothing is masked, and the header names the sources.
 
-The interactive/default path (no `--worktree-root`) keeps local settings in scope. Deny always reads
-local regardless — the same err-wide rationale.
+The interactive/default path (no `--worktree-root`) keeps the cwd checkout's local settings in
+scope. Deny always reads every local layer regardless — the same err-wide rationale.
 
 ## The trusted worktree root — `additionalDirectories`
 
@@ -145,11 +154,11 @@ The `work` skill invokes the script at loop start; run it directly to preview th
 "${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/preflight.sh" --worktree-root <configured-worktree-root>
 ```
 
-**Check the worktree the lane actually runs in.** Project `.claude/settings(.local).json` is
-per-checkout, so a fresh linked worktree can carry different grants than the main checkout — and the
-main checkout's grants would otherwise mask a worker-side gap. When the orchestrator dispatches a
-worker into a worktree, pass that worktree as `--project-root` so its own project settings are the
-ones probed:
+**Check the worktree the lane actually runs in.** A checkout's tracked `.claude/settings.json` can
+differ per worktree (a different branch), so a fresh linked worktree can carry different grants than
+the checkout the orchestrator runs in — and the cwd checkout's grants would otherwise mask a
+worker-side gap. When the orchestrator dispatches a worker into a worktree, pass that worktree as
+`--project-root` so its own project settings are the ones probed:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/preflight.sh" \
@@ -158,8 +167,9 @@ ones probed:
 
 `--project-root` defaults to the current checkout. A distinct one (a different toplevel) re-points
 the project layer to that worker checkout and reads its own `settings.local.json`; without it, the
-autonomous path drops this checkout's local file (see the `settings.local.json` scope note above).
-User-global settings apply everywhere and are read regardless.
+autonomous path drops a worktree cwd's own local file (see the `settings.local.json` scope note
+above). User-global settings and the main checkout's shared `settings.local.json` apply everywhere
+and are read regardless.
 
 It is report-only and always exits `0`. Each output line is one of:
 

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -104,7 +104,9 @@ checkout's own git dir against the common one — the probed checkout being `--p
 given, else the cwd: equal means that checkout *is* the main one — whatever its git dir is
 named, so the **main checkout of** a `--separate-git-dir` or submodule layout resolves correctly —
 and only from a linked worktree is the main checkout recovered from the common dir's path, which
-assumes the conventional `<root>/.git` spelling. What a fresh worker does **not** inherit is a local
+assumes the conventional `<root>/.git` spelling and misfires when that assumption does not hold —
+leaving the main checkout unresolved, or resolving it to a foreign directory (second residual
+below). What a fresh worker does **not** inherit is a local
 file living inside some *other* linked worktree — a pre-2.1.211 save, or a hand-placed file — which
 applies only to sessions started in that worktree. Two cases:
 
@@ -126,14 +128,27 @@ applies only to sessions started in that worktree. Two cases:
   the *harness*, not on the repository layout — so wherever the installed Claude Code is v2.1.211 or
   later it is a documentation-completeness matter rather than a live defect (v2.1.222 on the machine
   this was verified against).
-- **Main checkout unresolvable — noisy on the allow reads, MASKING on the deny read.** When
-  `main_root` does not resolve, that checkout's local file goes unread in **every** read, deny
-  included: a covered verb is over-reported as a gap (noisy), and a deny living only in that file is
-  not reported at all (masking). The err-wide deny posture cannot widen a layer never read, and the
-  autonomous header does not distinguish this from a repository that simply has no main-local file.
-  Two ways in: a linked worktree whose common dir is not spelled `<root>/.git` — a
-  `--separate-git-dir` or submodule repo — and a `--project-root` naming a path that is not a
-  checkout.
+- **Main checkout unresolved or wrongly resolved — MASKING is reachable in both shapes.** From a linked
+  worktree the main checkout is recovered from the common dir's path, and that recovery fails two
+  ways. **Unresolved** (`main_root` empty): that checkout's local file goes unread in **every** read,
+  deny included — a covered verb is over-reported as a gap (noisy), *and* a deny living only in that
+  file is not reported at all, so the run can print `PREFLIGHT: OK` (exit 0, zero gaps) while a
+  main-local deny is live. The err-wide deny posture cannot widen a layer never read.
+  **Wrongly resolved**: `main_root` names a directory that is not this repository's working tree, and
+  that foreign `.claude/settings.local.json` is unioned into every read — a foreign allow masks a
+  real gap, a foreign deny yields a false DENIED. The autonomous header distinguishes neither shape
+  from a repository that simply has no main-local file. Three ways in:
+  - A linked worktree of a repo created with `--separate-git-dir <path>/.git`: the common dir is
+    `<path>/.git`, so the `*/.git` recovery yields `main_root=<path>` — **wrongly resolved**, with
+    foreign rules flowing in both directions (`--separate-git-dir "$HOME/.git"` unions the
+    operator's own `~/.claude` local file into the run).
+  - A linked worktree whose common dir is spelled otherwise — a separate git dir under any other
+    name, or a submodule's `<super>/.git/modules/<name>` — **unresolved**.
+  - A `--project-root` naming a path that is not a checkout — **unresolved**.
+
+  The **main checkout of** either layout resolves correctly, by the own-git-dir comparison above; the
+  defect is confined to the linked-worktree recovery. Correcting that recovery is a deferred
+  follow-up, so this reference states the behaviour rather than claiming it fixed.
 
 The interactive/default path (no `--worktree-root`) keeps the cwd checkout's local settings in
 scope. Deny always reads every local layer it resolves, in every mode — the same err-wide rationale,

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -102,34 +102,42 @@ checkout's local file is therefore part of a fresh worker worktree's effective s
 preflight reads it in **every** mode. It identifies that checkout by comparing the probed
 checkout's own git dir against the common one — the probed checkout being `--project-root` when
 given, else the cwd: equal means that checkout *is* the main one — whatever its git dir is
-named, so `--separate-git-dir` and submodule layouts resolve correctly — and only from a linked
-worktree is the main checkout recovered from the common dir's path. What a fresh worker does
-**not** inherit is a local file living inside some *other* linked worktree — a pre-2.1.211 save, or
-a hand-placed file — which applies only to sessions started in that worktree. Two cases:
+named, so the **main checkout of** a `--separate-git-dir` or submodule layout resolves correctly —
+and only from a linked worktree is the main checkout recovered from the common dir's path, which
+assumes the conventional `<root>/.git` spelling. What a fresh worker does **not** inherit is a local
+file living inside some *other* linked worktree — a pre-2.1.211 save, or a hand-placed file — which
+applies only to sessions started in that worktree. Two cases:
 
 - **Pre-dispatch** — `--worktree-root` is passed but no distinct `--project-root` (the worker is not
   yet created). The **coverage** reads (allow + `additionalDirectories`) span user-global + tracked
   project settings + the main checkout's local file; only a linked-worktree cwd's *own* local file
   is dropped, since the fresh worker would not inherit it and reading it would mask a worker-side
-  gap. Run from the main checkout, nothing is dropped. The report header says which. Two residual
-  cases remain, and they run in **opposite** directions:
-  - **Pre-2.1.211 harness — MASKING, the dangerous direction.** There a worktree session loads its
-    own local file, not the main checkout's, so crediting a main-local-only grant suppresses a gap
-    the worker really hits. This is the one place the report can under-report; it is a floor on the
-    harness, not on the repository layout, and nothing in the preflight can detect it (it never
-    probes the running Claude Code version).
-  - **Common dir not spelled `<root>/.git`, seen from a linked worktree — noisy only.** The main
-    checkout cannot be recovered from that path, so its local file goes unread and a covered verb
-    is reported as a gap.
+  gap. Run from the main checkout, nothing is dropped. The report header says which.
 - **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
   differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
   `settings.local.json` (legacy rules saved there still apply to sessions started there) plus the
-  main checkout's shared local file; on a v2.1.211-or-later harness nothing is masked, and the
-  header names the sources. The pre-2.1.211 masking case above applies here too, for the same
-  reason: on that harness the shared file's rules never reach the worker's worktree.
+  main checkout's shared local file; the header names the sources.
+
+**Two residual limits apply to BOTH modes above.**
+
+- **Pre-2.1.211 harness — MASKING.** There a worktree session loads its own local file, not the main
+  checkout's, so crediting a main-local-only grant suppresses a gap the worker really hits. Nothing
+  in the preflight detects it: it never probes the running Claude Code version. This is a floor on
+  the *harness*, not on the repository layout — so wherever the installed Claude Code is v2.1.211 or
+  later it is a documentation-completeness matter rather than a live defect (v2.1.222 on the machine
+  this was verified against).
+- **Main checkout unresolvable — noisy on the allow reads, MASKING on the deny read.** When
+  `main_root` does not resolve, that checkout's local file goes unread in **every** read, deny
+  included: a covered verb is over-reported as a gap (noisy), and a deny living only in that file is
+  not reported at all (masking). The err-wide deny posture cannot widen a layer never read, and the
+  autonomous header does not distinguish this from a repository that simply has no main-local file.
+  Two ways in: a linked worktree whose common dir is not spelled `<root>/.git` — a
+  `--separate-git-dir` or submodule repo — and a `--project-root` naming a path that is not a
+  checkout.
 
 The interactive/default path (no `--worktree-root`) keeps the cwd checkout's local settings in
-scope. Deny always reads every local layer regardless — the same err-wide rationale.
+scope. Deny always reads every local layer it resolves, in every mode — the same err-wide rationale,
+bounded by the second residual above.
 
 ## The trusted worktree root — `additionalDirectories`
 

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -99,8 +99,9 @@ that repository — every linked worktree included, however the worktree was cre
 ([permissions](https://code.claude.com/docs/en/permissions#permission-system),
 [worktrees](https://code.claude.com/docs/en/worktrees); both fetched 2026-08-04). The main
 checkout's local file is therefore part of a fresh worker worktree's effective settings, and the
-preflight reads it in **every** mode. It identifies that checkout by comparing the cwd's own git
-dir against the common one: equal means this checkout *is* the main one — whatever its git dir is
+preflight reads it in **every** mode. It identifies that checkout by comparing the probed
+checkout's own git dir against the common one — the probed checkout being `--project-root` when
+given, else the cwd: equal means that checkout *is* the main one — whatever its git dir is
 named, so `--separate-git-dir` and submodule layouts resolve correctly — and only from a linked
 worktree is the main checkout recovered from the common dir's path. What a fresh worker does
 **not** inherit is a local file living inside some *other* linked worktree — a pre-2.1.211 save, or
@@ -111,15 +112,21 @@ a hand-placed file — which applies only to sessions started in that worktree. 
   project settings + the main checkout's local file; only a linked-worktree cwd's *own* local file
   is dropped, since the fresh worker would not inherit it and reading it would mask a worker-side
   gap. Run from the main checkout, nothing is dropped. The report header says which. Two residual
-  cases still over-report — both noisy rather than masking: on a pre-2.1.211 harness the main
-  checkout's local rules do not reach a worktree either, so there a main-local-only grant is a real
-  worker-side gap this report would miss; and from a linked worktree whose common dir is not spelled
-  `<root>/.git`, the main checkout cannot be recovered from that path, so its local file goes
-  unread.
+  cases remain, and they run in **opposite** directions:
+  - **Pre-2.1.211 harness — MASKING, the dangerous direction.** There a worktree session loads its
+    own local file, not the main checkout's, so crediting a main-local-only grant suppresses a gap
+    the worker really hits. This is the one place the report can under-report; it is a floor on the
+    harness, not on the repository layout, and nothing in the preflight can detect it (it never
+    probes the running Claude Code version).
+  - **Common dir not spelled `<root>/.git`, seen from a linked worktree — noisy only.** The main
+    checkout cannot be recovered from that path, so its local file goes unread and a covered verb
+    is reported as a gap.
 - **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
   differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
   `settings.local.json` (legacy rules saved there still apply to sessions started there) plus the
-  main checkout's shared local file; nothing is masked, and the header names the sources.
+  main checkout's shared local file; on a v2.1.211-or-later harness nothing is masked, and the
+  header names the sources. The pre-2.1.211 masking case above applies here too, for the same
+  reason: on that harness the shared file's rules never reach the worker's worktree.
 
 The interactive/default path (no `--worktree-root`) keeps the cwd checkout's local settings in
 scope. Deny always reads every local layer regardless — the same err-wide rationale.

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -99,7 +99,10 @@ that repository — every linked worktree included, however the worktree was cre
 ([permissions](https://code.claude.com/docs/en/permissions#permission-system),
 [worktrees](https://code.claude.com/docs/en/worktrees); both fetched 2026-08-04). The main
 checkout's local file is therefore part of a fresh worker worktree's effective settings, and the
-preflight reads it in **every** mode, resolved through the git common dir. What a fresh worker does
+preflight reads it in **every** mode. It identifies that checkout by comparing the cwd's own git
+dir against the common one: equal means this checkout *is* the main one — whatever its git dir is
+named, so `--separate-git-dir` and submodule layouts resolve correctly — and only from a linked
+worktree is the main checkout recovered from the common dir's path. What a fresh worker does
 **not** inherit is a local file living inside some *other* linked worktree — a pre-2.1.211 save, or
 a hand-placed file — which applies only to sessions started in that worktree. Two cases:
 
@@ -107,9 +110,12 @@ a hand-placed file — which applies only to sessions started in that worktree. 
   yet created). The **coverage** reads (allow + `additionalDirectories`) span user-global + tracked
   project settings + the main checkout's local file; only a linked-worktree cwd's *own* local file
   is dropped, since the fresh worker would not inherit it and reading it would mask a worker-side
-  gap. Run from the main checkout, nothing is dropped. The report header says which. (On a
-  pre-2.1.211 harness the main checkout's local rules do not reach a worktree either, so there a
-  main-local-only grant is still a real worker-side gap the report would miss.)
+  gap. Run from the main checkout, nothing is dropped. The report header says which. Two residual
+  cases still over-report — both noisy rather than masking: on a pre-2.1.211 harness the main
+  checkout's local rules do not reach a worktree either, so there a main-local-only grant is a real
+  worker-side gap this report would miss; and from a linked worktree whose common dir is not spelled
+  `<root>/.git`, the main checkout cannot be recovered from that path, so its local file goes
+  unread.
 - **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
   differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
   `settings.local.json` (legacy rules saved there still apply to sessions started there) plus the

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -22,10 +22,14 @@
 # Effective settings (union of permissions.allow / additionalDirectories):
 #   user-global : ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json (applies everywhere)
 #   project     : <project-root>/.claude/settings.json, .../settings.local.json
+#   main-local  : <main-checkout>/.claude/settings.local.json — since Claude Code
+#                 v2.1.211 "don't ask again" approvals save here (resolved through
+#                 worktrees to the main checkout) and apply in every worktree of
+#                 the repository, so this file is read in every mode.
 # The cwd probed for (a) is $PREFLIGHT_FIXTURE_DIR (tests) else $PWD. Project
 # settings are read from --project-root (default: the cwd checkout) resolved to
 # its git toplevel; pass the worker worktree the lane dispatches into so its own
-# project settings are checked rather than the main checkout's, which could
+# project settings are checked rather than the cwd checkout's, which could
 # otherwise mask a worker-side gap. $PREFLIGHT_PROJECT_ROOT is the env fallback.
 #
 # Requires jq (exits 2 when absent).
@@ -47,12 +51,15 @@ Usage: preflight.sh [--worktree-root <path>] [--project-root <path>] [--count] [
   --worktree-root P check that some permissions.additionalDirectories entry covers P
                     (also read from PREFLIGHT_WORKTREE_ROOT); omitted → NOTE, not checked.
                     The autonomous signal: unless a distinct --project-root is given,
-                    coverage reads exclude this checkout's gitignored settings.local.json
-                    (a not-yet-created worktree lacks it)
+                    coverage reads keep the MAIN checkout's settings.local.json (its
+                    rules apply in every worktree since Claude Code v2.1.211) and
+                    exclude only a linked-worktree cwd's own local file, which a
+                    fresh worker would not inherit
   --project-root P  read project settings from P's checkout instead of the cwd's
                     (also read from PREFLIGHT_PROJECT_ROOT) — pass the dispatched
                     worker worktree so ITS OWN grants (incl. its settings.local.json)
-                    are checked, not the main checkout's
+                    are checked rather than the cwd checkout's; the main checkout's
+                    settings.local.json is read in every mode
   --count           print the integer GAP count only (NOTEs excluded); exit 0
   --help            this message
 
@@ -127,6 +134,18 @@ proj_src="${project_root:-$CHECK_DIR}"
 proj_toplevel="$(git -C "$proj_src" rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
 proj_base="${proj_toplevel:-$proj_src}"
 user_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+# Since Claude Code v2.1.211, "Yes, don't ask again" saves the rule to
+# .claude/settings.local.json at the repository root, resolved through worktrees
+# to the MAIN checkout, and the rule applies to sessions anywhere in the
+# repository — every linked worktree included (docs/en/permissions#permission-system).
+# Resolve that checkout through the git common dir; empty when proj_src is not a
+# repo (or the common dir is not a ".git" directory), which degrades to the
+# project-layer reads alone.
+main_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')"
+main_root=""
+case "$main_gitdir" in
+  */.git) main_root="${main_gitdir%/.git}" ;;
+esac
 
 read_array() {
   # read_array <file> <jq-path> — one element per line; silent on a missing or
@@ -139,27 +158,37 @@ read_array() {
 
 collect() {
   # collect <jq-path> <local-mode> — union the path across user-global + tracked
-  # project settings, plus the gitignored project settings.local.json only when
-  # <local-mode> is "with-local". A fresh linked worktree carries the tracked
-  # .claude/settings.json but NOT the gitignored settings.local.json, so in the
-  # autonomous (--worktree-root) path this checkout's local grants would mask a
-  # worker-side gap; the coverage reads drop local there. Deny always keeps local
-  # (erring wide on deny never masks a gap).
+  # project settings + the MAIN checkout's settings.local.json (always: its rules
+  # apply in every worktree since v2.1.211, a fresh worker included), plus the
+  # project checkout's OWN settings.local.json only when <local-mode> is
+  # "with-local". A rule saved inside a linked worktree by a pre-2.1.211 harness
+  # (or hand-placed there) applies only to sessions started in that worktree, so
+  # in the pre-dispatch autonomous (--worktree-root) path a worktree cwd's local
+  # grants would mask a worker-side gap; the coverage reads drop that file there.
+  # Deny always keeps it (erring wide on deny never masks a gap).
   local path="$1" local_mode="$2"
   read_array "$user_settings" "$path"
   read_array "$proj_base/.claude/settings.json" "$path"
-  [[ "$local_mode" == "with-local" ]] && read_array "$proj_base/.claude/settings.local.json" "$path"
+  if [[ -n "$main_root" && "$main_root" != "$proj_base" ]]; then
+    read_array "$main_root/.claude/settings.local.json" "$path"
+  fi
+  if [[ "$local_mode" == "with-local" || "$proj_base" == "$main_root" ]]; then
+    read_array "$proj_base/.claude/settings.local.json" "$path"
+  fi
 }
 
-# Local-settings scope for the COVERAGE reads (allow + additionalDirectories):
+# Checkout-own local-settings scope for the COVERAGE reads (allow +
+# additionalDirectories); the main checkout's local file is in scope regardless:
 #   - A DISTINCT --project-root (a worker worktree whose toplevel differs from this
 #     checkout) names a real, existing checkout — read ITS OWN settings.local.json
-#     (the worker's file, not this parent's); nothing is masked.
+#     (legacy rules saved there still apply to sessions started there).
 #   - Otherwise, --worktree-root (the autonomous signal) is pre-dispatch: the worker
-#     is not yet created, so exclude this checkout's gitignored settings.local.json,
-#     which a fresh worktree would not carry, lest a local-only grant mask a gap.
+#     is not yet created, so exclude a worktree cwd's own gitignored
+#     settings.local.json, which a fresh worker would not inherit, lest a
+#     worktree-local-only grant mask a gap. When the cwd checkout IS the main
+#     checkout this exclusion is a no-op — its local file follows the worker.
 #   - The interactive/default path keeps local.
-# Deny always reads local (erring wide on deny never masks a gap).
+# Deny always reads every local layer (erring wide on deny never masks a gap).
 distinct_project_root=""
 if [[ -n "$project_root" && "$proj_base" != "$repo_root" ]]; then
   distinct_project_root="yes"
@@ -355,9 +384,19 @@ if [[ "$mode" == "count" ]]; then
 fi
 
 if [[ -n "$local_excluded" ]]; then
-  echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read excludes this checkout's gitignored settings.local.json, which a fresh worktree would not carry; deny rules still include it."
+  if [[ "$proj_base" == "$main_root" ]]; then
+    echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read includes this main checkout's settings.local.json: since Claude Code v2.1.211 its rules apply in every worktree, the fresh worker included."
+  elif [[ -n "$main_root" ]]; then
+    echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read includes the main checkout's settings.local.json ('$main_root', applies in every worktree since Claude Code v2.1.211) but excludes this worktree's own local file, which a fresh worker would not inherit; deny rules still include it."
+  else
+    echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read excludes this checkout's gitignored settings.local.json, which a fresh worktree would not carry; deny rules still include it."
+  fi
 elif [[ -n "$distinct_project_root" ]]; then
-  echo "PREFLIGHT: reading project settings (incl. settings.local.json) from --project-root '$proj_base'."
+  if [[ -n "$main_root" && "$main_root" != "$proj_base" ]]; then
+    echo "PREFLIGHT: reading project settings (incl. settings.local.json) from --project-root '$proj_base', plus the main checkout's shared settings.local.json ('$main_root')."
+  else
+    echo "PREFLIGHT: reading project settings (incl. settings.local.json) from --project-root '$proj_base'."
+  fi
 fi
 
 if [[ "${#findings[@]}" -eq 0 ]]; then

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -142,9 +142,16 @@ user_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 # its toplevel is the answer whatever the git dir is named (--separate-git-dir, a
 # submodule). Only from a linked worktree must the main checkout be recovered from
 # the common dir's path, which assumes the conventional "<root>/.git" spelling.
-# main_root stays empty when proj_src is not a repo, or when a linked worktree's
-# common dir is spelled otherwise; the coverage reads then fall back to the
-# project layer alone — over-reporting a gap, never hiding one.
+# That recovery misfires two ways, both of which can MASK a gap rather than
+# merely over-report one, and neither of which this script yet corrects:
+#   - main_root stays EMPTY when proj_src is not a repo, or when the common dir
+#     is spelled otherwise (a submodule's <super>/.git/modules/<name>, a
+#     separate git dir under another name). Every read then falls back to the
+#     project layer alone, so a main-local deny goes unreported entirely.
+#   - main_root resolves WRONGLY when the common dir is <path>/.git for a <path>
+#     that is not this working tree (--separate-git-dir <path>/.git): the arm
+#     below yields <path>, and that foreign settings.local.json is unioned into
+#     every read — a foreign allow masks a real gap, a foreign deny false-DENIES.
 main_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')"
 own_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-dir 2>/dev/null | tr -d '\r')"
 main_root=""
@@ -175,7 +182,9 @@ collect() {
   # (or hand-placed there) applies only to sessions started in that worktree, so
   # in the pre-dispatch autonomous (--worktree-root) path a worktree cwd's local
   # grants would mask a worker-side gap; the coverage reads drop that file there.
-  # Deny always keeps it (erring wide on deny never masks a gap).
+  # Deny always keeps it: erring wide on deny cannot mask a gap among the layers
+  # actually read — but see main_root above, which can leave a layer unread or
+  # substitute a foreign one.
   local path="$1" local_mode="$2"
   read_array "$user_settings" "$path"
   read_array "$proj_base/.claude/settings.json" "$path"
@@ -188,7 +197,8 @@ collect() {
 }
 
 # Checkout-own local-settings scope for the COVERAGE reads (allow +
-# additionalDirectories); the main checkout's local file is in scope regardless:
+# additionalDirectories); the main checkout's local file is in scope regardless
+# — whichever file main_root resolved to, including the wrong one (see above):
 #   - A DISTINCT --project-root (a worker worktree whose toplevel differs from this
 #     checkout) names a real, existing checkout — read ITS OWN settings.local.json
 #     (legacy rules saved there still apply to sessions started there).
@@ -198,7 +208,9 @@ collect() {
 #     worktree-local-only grant mask a gap. When the cwd checkout IS the main
 #     checkout this exclusion is a no-op — its local file follows the worker.
 #   - The interactive/default path keeps local.
-# Deny always reads every local layer (erring wide on deny never masks a gap).
+# Deny always reads every local layer that resolves; erring wide on deny cannot
+# mask a gap among those layers, but it cannot widen a layer main_root left
+# unresolved, nor unwind one it resolved to a foreign directory.
 distinct_project_root=""
 if [[ -n "$project_root" && "$proj_base" != "$repo_root" ]]; then
   distinct_project_root="yes"

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -145,6 +145,7 @@ main_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-common-
 main_root=""
 case "$main_gitdir" in
   */.git) main_root="${main_gitdir%/.git}" ;;
+  *) ;;
 esac
 
 read_array() {

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -138,15 +138,24 @@ user_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 # .claude/settings.local.json at the repository root, resolved through worktrees
 # to the MAIN checkout, and the rule applies to sessions anywhere in the
 # repository — every linked worktree included (docs/en/permissions#permission-system).
-# Resolve that checkout through the git common dir; empty when proj_src is not a
-# repo (or the common dir is not a ".git" directory), which degrades to the
-# project-layer reads alone.
+# A checkout whose OWN git dir is the common one is itself the main checkout, so
+# its toplevel is the answer whatever the git dir is named (--separate-git-dir, a
+# submodule). Only from a linked worktree must the main checkout be recovered from
+# the common dir's path, which assumes the conventional "<root>/.git" spelling.
+# main_root stays empty when proj_src is not a repo, or when a linked worktree's
+# common dir is spelled otherwise; the coverage reads then fall back to the
+# project layer alone — over-reporting a gap, never hiding one.
 main_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')"
+own_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-dir 2>/dev/null | tr -d '\r')"
 main_root=""
-case "$main_gitdir" in
-  */.git) main_root="${main_gitdir%/.git}" ;;
-  *) ;;
-esac
+if [[ -n "$main_gitdir" && "$main_gitdir" == "$own_gitdir" ]]; then
+  main_root="$proj_base"
+else
+  case "$main_gitdir" in
+    */.git) main_root="${main_gitdir%/.git}" ;;
+    *) ;;
+  esac
+fi
 
 read_array() {
   # read_array <file> <jq-path> — one element per line; silent on a missing or

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -279,10 +279,11 @@ assert_contains "deny-only verb is a gap" "$OUT" "'git add'"
 assert_contains "deny-only gap has the DENIED message" "$OUT" "is DENIED"
 assert_eq "deny-only verb → exactly one gap" "1" "$(run "$REPO" "$CFG15" --count)"
 
-# --- Case 16: --worktree-root excludes settings.local.json from coverage -----
-# A grant present ONLY in this checkout's gitignored settings.local.json is not
-# carried by a fresh worktree. The interactive path reads local (gap closed); the
-# autonomous path (--worktree-root) drops local, so the worker-side gap surfaces.
+# --- Case 16: the main checkout's settings.local.json follows the worker -----
+# Since Claude Code v2.1.211, "don't ask again" approvals save to the MAIN
+# checkout's settings.local.json and apply in every worktree of the repository —
+# so a grant there is real coverage for a fresh worker, and the autonomous path
+# reads it instead of dropping it.
 REPO3="$TEST_TMPDIR/local-mask"
 git init -q "$REPO3"
 PROJ3="$(git -C "$REPO3" rev-parse --show-toplevel)"
@@ -295,9 +296,28 @@ write_settings "$CFG16" \
 jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$PROJ3/.claude/settings.local.json"
 assert_eq "interactive path reads local grant → no gap" "0" "$(run "$REPO3" "$CFG16" --count)"
 OUT=$(run "$REPO3" "$CFG16" --worktree-root "$POSIX_CHILD")
-assert_contains "autonomous path drops local → gh pr create gap surfaces" "$OUT" "'gh pr create'"
-assert_contains "report header notes the local exclusion" "$OUT" "settings.local.json"
-assert_eq "autonomous path drops local grant → one gap" "1" "$(run "$REPO3" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
+assert_contains "header states the main-local inclusion basis" "$OUT" "v2.1.211"
+assert_eq "autonomous path reads the main checkout's local grant → no gap" "0" "$(run "$REPO3" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
+
+# --- Case 16b: a linked worktree's OWN local file is still excluded ----------
+# A rule saved inside a worktree (pre-2.1.211 harness, or hand-placed) applies
+# only to sessions started there, so a fresh worker would not inherit it. From a
+# worktree cwd the autonomous path keeps the main checkout's local file but
+# drops the worktree's own.
+git -C "$REPO3" -c user.name=t -c user.email=t@t commit -q --allow-empty -m init
+WT16="$TEST_TMPDIR/local-mask-wt"
+git -C "$REPO3" worktree add -q --detach "$WT16"
+# Main-local grant (case 16's file) reaches a worktree cwd's autonomous run.
+assert_eq "main checkout's local grant covers from a worktree cwd → no gap" "0" "$(run "$WT16" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
+# Move the grant into the worktree's own local file only.
+rm "$PROJ3/.claude/settings.local.json"
+mkdir -p "$WT16/.claude"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$WT16/.claude/settings.local.json"
+assert_eq "interactive path in the worktree reads its own local → no gap" "0" "$(run "$WT16" "$CFG16" --count)"
+OUT=$(run "$WT16" "$CFG16" --worktree-root "$POSIX_CHILD")
+assert_contains "autonomous path drops the worktree's own local → gap surfaces" "$OUT" "'gh pr create'"
+assert_contains "header notes the worktree-local exclusion" "$OUT" "excludes this worktree's own local file"
+assert_eq "worktree-local-only grant → one gap" "1" "$(run "$WT16" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
 
 # --- Case 17: a distinct --project-root reads the worker's OWN local settings -
 # When --project-root names a real worker worktree (toplevel differs from cwd),

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -320,6 +320,17 @@ assert_contains "autonomous path drops the worktree's own local → gap surfaces
 assert_contains "header notes the worktree-local exclusion" "$OUT" "excludes this worktree's own local file"
 assert_eq "worktree-local-only grant → one gap" "1" "$(run "$WT16" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Case 16c: a main checkout whose git dir is not spelled "<root>/.git" -----
+# --separate-git-dir (and a submodule checkout) put the common dir elsewhere. The
+# checkout is still the MAIN one, so its local file still reaches a fresh worker
+# and must not be dropped on the autonomous path.
+SEPCO="$TEST_TMPDIR/sep-main"
+git init -q --separate-git-dir "$TEST_TMPDIR/sep-gitdir" "$SEPCO"
+SEPTOP="$(git -C "$SEPCO" rev-parse --show-toplevel)"
+mkdir -p "$SEPTOP/.claude"
+jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$SEPTOP/.claude/settings.local.json"
+assert_eq "separate-git-dir main checkout's local grant counts → no gap" "0" "$(run "$SEPCO" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
+
 # --- Case 17: a distinct --project-root reads the worker's OWN local settings -
 # When --project-root names a real worker worktree (toplevel differs from cwd),
 # read ITS OWN settings.local.json — the worker's file, present in that checkout —

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -296,7 +296,8 @@ write_settings "$CFG16" \
 jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$PROJ3/.claude/settings.local.json"
 assert_eq "interactive path reads local grant → no gap" "0" "$(run "$REPO3" "$CFG16" --count)"
 OUT=$(run "$REPO3" "$CFG16" --worktree-root "$POSIX_CHILD")
-assert_contains "header states the main-local inclusion basis" "$OUT" "v2.1.211"
+assert_contains "header states the main-local inclusion basis" "$OUT" \
+  "includes this main checkout's settings.local.json: since Claude Code v2.1.211"
 assert_eq "autonomous path reads the main checkout's local grant → no gap" "0" "$(run "$REPO3" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
 
 # --- Case 16b: a linked worktree's OWN local file is still excluded ----------

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -331,6 +331,20 @@ mkdir -p "$SEPTOP/.claude"
 jq -n '{permissions:{allow:["Bash(gh pr create *)"]}}' >"$SEPTOP/.claude/settings.local.json"
 assert_eq "separate-git-dir main checkout's local grant counts → no gap" "0" "$(run "$SEPCO" "$CFG16" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Case 16d: the main checkout's local DENY reaches a worktree run ---------
+# Deny reads the main checkout's local file too. Every other deny case writes to
+# user-global only, so without this, dropping main-local from the deny path would
+# narrow deny silently and leave the suite green.
+CFG16D="$TEST_TMPDIR/cfg16d"
+write_settings "$CFG16D" \
+  '["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"]' \
+  "$WIN_ROOT"
+jq -n '{permissions:{deny:["Bash(git push *)"]}}' >"$PROJ3/.claude/settings.local.json"
+OUT=$(run "$WT16" "$CFG16D" --worktree-root "$POSIX_CHILD")
+assert_contains "main-local deny reaches a worktree run" "$OUT" "'git push'"
+assert_contains "main-local deny carries the DENIED message" "$OUT" "is DENIED"
+assert_eq "main-local deny → exactly one gap" "1" "$(run "$WT16" "$CFG16D" --count --worktree-root "$POSIX_CHILD")"
+
 # --- Case 17: a distinct --project-root reads the worker's OWN local settings -
 # When --project-root names a real worker worktree (toplevel differs from cwd),
 # read ITS OWN settings.local.json — the worker's file, present in that checkout —


### PR DESCRIPTION
No linked issue.

Doc-alignment roster row(s) 189. Version claim: `work-items` 0.31.2 → 0.31.3.

`preflight.sh` excluded `.claude/settings.local.json` from its coverage reads on the
`--worktree-root` (autonomous) path, reasoning that a gitignored file cannot follow a fresh linked
worktree. Since Claude Code v2.1.211 that reasoning is only half true: choosing "Yes, don't ask
again" saves the rule to `.claude/settings.local.json` at the repository root, **resolved through
worktrees to the main checkout**, and the rule applies to sessions anywhere in that repository —
every linked worktree included. A grant the dispatched worker would genuinely inherit was therefore
reported as a missing-allow gap.

The preflight now reads the main checkout's local file in every mode. What is still dropped
pre-dispatch is only a **linked-worktree cwd's own** local file — a pre-v2.1.211 save, or a
hand-placed one — which applies solely to sessions started in that worktree. Run from the main
checkout the exclusion is a no-op, and the report header names which files the coverage read
spanned — whichever path the main-checkout resolution produced, including a wrong one (see the
residuals below). Deny rules keep reading every local layer that resolves; erring wide on deny cannot mask a
gap among the layers actually read — but it cannot widen a layer the main-checkout resolution leaves
unread, nor unwind one it resolves to the wrong directory (see the residuals below).

That main checkout is identified by comparing the checkout's own git dir against the common one,
rather than assuming the git dir is spelled `<root>/.git` — a Codex P2 on this PR, confirmed
empirically. Equal dirs mean the checkout *is* the main one, so `--separate-git-dir` and submodule
layouts resolve correctly instead of resolving to nothing and re-reporting the very gap this PR
removes. Layout coverage, direction stated per layout:

| layout | resolves to | direction |
| --- | --- | --- |
| ordinary repo, main checkout | toplevel | correct |
| ordinary repo, linked worktree | main checkout | correct |
| `--separate-git-dir`, main checkout | toplevel | correct (was the P2) |
| `--separate-git-dir <path>/.git`, linked worktree | `<path>` — a foreign dir | **resolves wrongly**: a foreign local file is unioned in, so a foreign allow masks a real gap and a foreign deny false-DENIES |
| separate git dir named otherwise, or a submodule, linked worktree | empty | over-reports a covered verb, **and** drops a main-local deny entirely |

The main checkout of every layout resolves correctly; the two wrong outcomes are confined to the
linked-worktree recovery, which still reads the common dir's path. That recovery is **not** fixed
here — this PR corrects what the docs and comments claim about it, and the behavioural fix is a
tracked follow-up on its own version. The wrong resolution was established by a standalone repro, not
by `preflight.test.sh`, which covers the main-checkout side (cases 16c/16d) and has no
linked-worktree-of-`--separate-git-dir` case.

Sources (both re-fetched via the `.md` channel and double-fetched byte-identical on 2026-08-04):
[permissions](https://code.claude.com/docs/en/permissions#permission-system),
[worktrees](https://code.claude.com/docs/en/worktrees).

`reference/permission-preflight.md` states the two residual cases rather than leaving them implied.
Both can **mask** a gap:

- **The linked-worktree main-checkout recovery.** Resolved wrongly (`--separate-git-dir
  <path>/.git`), a
  foreign directory's local file is unioned into every read: a foreign allow masks a real gap, a
  foreign deny yields a false DENIED — point the separate git dir at `$HOME/.git` and that foreign
  layer is the operator's own `~/.claude` local file — and the header names that foreign directory
  **as** the main checkout, worded identically to a correct resolution, so it asserts a falsehood
  rather than merely omitting a source. Unresolved (a separate git dir under any other
  name, or a submodule's `<super>/.git/modules/<name>`), the main-local layer goes unread in every
  read: a covered verb is over-reported as a gap, **and** a main-local deny is dropped, so the run
  can print a clean `PREFLIGHT: OK` (exit 0, zero gaps) with that deny live.
- **A pre-v2.1.211 harness** loads the worktree's *own* local file rather than the main checkout's,
  so crediting a main-local-only grant **masks** a gap the worker really hits. The report cannot
  self-detect it, because it never probes the running Claude Code version. It is a floor on the
  harness, not on the repository layout.

Verification: `preflight.test.sh` passes 70/70, including cases built on a real `git worktree add`
so the resolution is genuinely exercised rather than inert, and a `--separate-git-dir` regression
case that is red against the prior resolution and green after. `shellcheck -S info` is clean on both
scripts, `markdownlint-cli2` is clean on both docs, and
`scripts/check-changelog-parity.sh --check-bump origin/main` passes.

## Related

- Campaign save-point and remaining-work ledger: #1941
- Merge runbook for the already-verified queue: `.work/doc-alignment/MERGE-RUNBOOK-2026-08-04.md` (memory-tier, machine-local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
