### PR TITLE
docs(dometrain): align setup's unreportable-connection bullet with the MCP page

### DIFF
--- a/plugins/dometrain/.claude-plugin/plugin.json
+++ b/plugins/dometrain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dometrain",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Dometrain course-content grounding over a third-party remote MCP server (Dometrain-hosted, Bearer auth): search lessons, pull curated lesson documents with on-screen code, and cite timestamped deep links. Requires an active Dometrain Pro subscription. Credential entered once through Claude Code's native masked userConfig prompt and stored in secure credential storage. Ships with a grounding usage skill kept in sync with Dometrain's own official Claude Code plugin.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/dometrain/CHANGELOG.md
+++ b/plugins/dometrain/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the `dometrain` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-## [VERSION_PLACEHOLDER]
+## [0.1.2]
 
 ### Fixed
 

--- a/plugins/dometrain/CHANGELOG.md
+++ b/plugins/dometrain/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `dometrain` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [VERSION_PLACEHOLDER]
+
+### Fixed
+
+- Setup skill's unreportable-connection bullet now matches the MCP page it cites. Amazon Bedrock,
+  Google Cloud's Agent Platform, and Microsoft Foundry form their own group alongside configurations
+  without tool search rather than members of it — upstream's "and on" clause makes them additional,
+  and tool search is on by default for Claude 4.5-generation models on Agent Platform. Microsoft
+  Foundry was missing entirely, and the platform names now match upstream's. The bullet also no
+  longer instructs a check the skill cannot run: it may not inspect the environment, so it reports
+  the state and routes to `/mcp` rather than naming which configuration is in effect
+  (<https://code.claude.com/docs/en/mcp#automatic-reconnection>).
+
 ## [0.1.1]
 
 ### Added

--- a/plugins/dometrain/skills/setup/SKILL.md
+++ b/plugins/dometrain/skills/setup/SKILL.md
@@ -51,11 +51,12 @@ Official contracts:
 4. When the plugin is enabled but no `dometrain`-scoped tool resolves, report **failed or
    unverified**:
    - If `ToolSearch` returned a connection error for the `dometrain` server, quote it verbatim.
-   - If this environment has tool search disabled (custom `ANTHROPIC_BASE_URL`,
-     `ENABLE_TOOL_SEARCH=false`, Bedrock, GCP Agent Platform, or a non-tool-search model), say so
-     explicitly and direct the user to run `/mcp` themselves — Claude Code does not report failed
-     connections to Claude in that configuration, and this skill must not claim knowledge it
-     doesn't have.
+   - Otherwise do not assert why: Claude Code does not report failed connections to Claude in a
+     configuration without tool search (custom `ANTHROPIC_BASE_URL`, `ENABLE_TOOL_SEARCH=false`, or
+     a model that doesn't support tool search), and on Amazon Bedrock, Google Cloud's Agent
+     Platform, and Microsoft Foundry — and this skill cannot inspect the environment to tell which
+     is in effect. Direct the user to run `/mcp` themselves rather than claim knowledge it doesn't
+     have.
    - After the user reconfigures the key, require `/reload-plugins` or a new session before
      rechecking tool availability.
 


### PR DESCRIPTION
No linked issue.

Doc-alignment roster row(s) 125 (dometrain/mcp.md residues). Version claim: dometrain 0.1.1 -> 0.1.2.

Both residues reproduced and fixed: the setup skill's unreportable-connection bullet now matches the MCP page it cites — Amazon Bedrock, Google Cloud's Agent Platform, and Microsoft Foundry form their own group alongside configurations without tool search rather than members of it (upstream's "and on" clause makes them additional).

Awaiting an orchestrator-commissioned fresh-context gate verifier before merge, per the campaign's producer-never-self-certifies rule.

## Related

- Campaign ledger: #1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVbP5JXnEaieMgKBRV1PS7