### PR TITLE
fix(ci): deploy linkage parser v0.10.2

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   pr-issue-linkage:
     permissions: {}
-    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@d7734df8c557084edc2df7cf578cf62ad2f261e4 # d7734df 2026-07-20
+    uses: melodic-software/ci-workflows/.github/workflows/pr-issue-linkage.yml@e94438746c300b02385a7f8a2a2dcd19a7f4ad4a # v0.10.2
     with:
       runner: ubuntu-24.04
       # dependabot PR bodies cannot carry the closing-keyword + `## Related`


### PR DESCRIPTION
No linked issue

## Summary

Move the locally owned PR-linkage caller to the reviewed `ci-workflows` v0.10.2 release. This deploys the Markdown-aware parser that ignores linkage-like text inside inline, fenced, and indented code while preserving real HTML-comment metadata and the existing exact Dependabot exemption.

The exact reusable-workflow SHA is approved by the synced runner policy from `standards@0d0c144`.

## Verification

- `actionlint .github/workflows/pr-issue-linkage.yml`
- `node .github/standards/runner-policy/runner-policy.mjs --root .`
- `git diff --check`

## Related

- melodic-software/ci-workflows#355
- melodic-software/standards#328
- melodic-software/claude-code-plugins#1957
- claude-code-plugins#1933