### PR TITLE
fix(claude-memory): count heading-shaped lines a pseudo-frontmatter block would swallow

### DIFF
--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -19,8 +19,10 @@ All notable changes to the `claude-memory` plugin are documented here. Format fo
   The cost is that a real YAML comment inside frontmatter ends the block, and ending it strips
   nothing at all — the opening `---`, every entry held so far, and the rest of the block through
   its close all count. That is an over-count, the direction M1's readings already guess toward,
-  and a rare one: Claude Code writes only the `modified` scalar and never authors comments, so it
-  takes a hand-edited index to reach. criteria.md M1 reading 1 records both halves.
+  and it takes a hand-edited index to reach, since Claude Code only stamps a `modified` scalar
+  into frontmatter a file already has. Comments join an existing class rather than opening a new
+  one: frontmatter this grammar cannot parse already ended the block before this change, and a
+  block sequence under `tags:` still does. criteria.md M1 reading 1 records both halves.
 
 ## [0.5.6]
 

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.7]
+
+### Fixed
+
+- **A pseudo-frontmatter block of markdown headings silently blanked the `audit` skill's M1
+  index-size count** (claude-memory 0.5.6 → 0.5.7, criteria 1.5.1 → 1.5.2). `memory-dir-stats.sh`
+  admitted `#` lines to its frontmatter grammar, so a `MEMORY.md` opening with a `---` thematic
+  break, carrying up to twenty heading lines, and reaching any later `---` had the whole span
+  stripped as frontmatter: a five-line index reported one loaded line. M1 is a `[FAIL]`-severity
+  size gate that a low count always passes, so the shape disarmed the gate outright. A `#` line is
+  a comment to YAML but a heading to markdown, and headings are loaded content, so the grammar now
+  accepts only blank lines and `key:` mapping entries and that shape counts every line.
+
+  The cost is that a real YAML comment inside frontmatter ends the block, and ending it strips
+  nothing at all — the opening `---`, every entry held so far, and the rest of the block through
+  its close all count. That is an over-count, the direction M1's readings already guess toward,
+  and a rare one: Claude Code writes only the `modified` scalar and never authors comments, so it
+  takes a hand-edited index to reach. criteria.md M1 reading 1 records both halves.
+
 ## [0.5.6]
 
 ### Changed

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -1,7 +1,7 @@
 # Memory Health Criteria
 
-Version: 1.5.1
-Last updated: 2026-08-04
+Version: 1.5.2
+Last updated: 2026-08-05
 Source: Official Claude Code docs (code.claude.com/docs/en/memory, code.claude.com/docs/en/best-practices, code.claude.com/docs/en/sub-agents, code.claude.com/docs/en/skills)
 
 This file defines every check the audit runs. Each check has a severity, description, and instructions
@@ -319,10 +319,13 @@ Four readings the strip applies, so a hand count matches the reported figures:
 1. A block counts only once it closes, and a leading `---` opens frontmatter only for as long as
    what follows is shaped like frontmatter. An opening `---` or `<!--` with no closing delimiter is
    ordinary content and is counted. So is a leading `---` whose block reaches a line that is
-   neither blank, a comment, nor a `key:` mapping entry, or that runs past 20 lines — markdown
-   carries thematic breaks freely, so the next `---` in a file is usually another break rather
-   than a frontmatter close, and without both bounds the entire span between the two would be
-   stripped. A leading thematic break, or frontmatter clipped mid-file, must not blank the count.
+   neither blank nor a `key:` mapping entry, or that runs past 20 lines. Markdown carries
+   thematic breaks freely, so the next `---` in a file is usually another break rather than a
+   frontmatter close, and without both bounds the entire span between the two would be stripped.
+   A leading thematic break, or frontmatter clipped mid-file, must not blank the count. A `#`
+   line ends the block: it is a comment to YAML but a heading to markdown, and headings are
+   loaded content. When the block ends this way nothing in it is stripped — the opening `---`,
+   every entry held so far, and the rest of the block through its closing `---` all count.
 2. A block-level comment occupies whole lines. Text sharing a line with the comment's open or
    close loads, and is counted — including text between two comments on one line, since each
    comment ends at the first `-->` after its own opener.

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.sh
@@ -108,13 +108,22 @@ fi
 # span between them stripped — a 253-line index reporting one loaded line, disarming
 # the very gate the flush-at-EOF rule above exists to arm. Frontmatter mode is
 # therefore bounded twice, and abandoning it re-emits the held lines as content:
-#   * grammar — the block ends at the first line that is not blank, a comment, or a
-#     `key:` mapping entry, which is all YAML a memory index's frontmatter holds;
+#   * grammar — the block ends at the first line that is not blank and not a `key:`
+#     mapping entry, which is all YAML a memory index's frontmatter holds. A `#` line
+#     is deliberately NOT frontmatter here: it is a comment to YAML but a heading to
+#     markdown, and a heading is loaded content, so admitting it would let a pseudo-
+#     frontmatter block of headings swallow them. The cost is that a real YAML comment
+#     inside frontmatter ends the block, and ending it strips nothing — the opening
+#     `---`, every entry held so far, and the rest of the block through its close all
+#     count. An over-count, and a rare one: Claude Code writes only the `modified`
+#     scalar and never authors comments, so this needs a hand-edited index;
 #   * length — `fmcap` lines, because grammar alone still swallows a runaway whose
-#     every line happens to be a `#` heading or a `Label: value` pair, a plausible
-#     shape for a hand-written index.
-# Both bounds fail toward counting: an over-count can only make this gate fire early,
-# while the under-count they replace stopped it firing at all.
+#     every line happens to be a `Label: value` pair, a plausible shape for a
+#     hand-written index.
+# Both bounds fail toward counting when they fire: an over-count can only make this gate
+# fire early, while the under-count they replace stopped it firing at all. They bound the
+# block by shape and by line count, never by bytes — a short `key:`-shaped block is
+# frontmatter under YAML grammar and is stripped whatever those entries weigh.
 #
 # A block-level comment occupies whole lines; text sharing a line with the comment's
 # open or close is loaded content and survives. Each comment ends at the FIRST `-->`
@@ -154,7 +163,6 @@ strip_unloaded() {
     fm == 1 {
       if ($0 == "---") { fm = 2; pending = ""; next }
       if (++fmlines <= fmcap && ($0 ~ /^[[:space:]]*$/ ||
-                                 $0 ~ /^[[:space:]]*#/ ||
                                  $0 ~ /^[[:space:]]*[A-Za-z_][A-Za-z0-9_-]*:/)) {
         pending = pending $0 "\n"
         next

--- a/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
+++ b/plugins/claude-memory/skills/audit/scripts/memory-dir-stats.test.sh
@@ -169,6 +169,19 @@ assert_eq "a key:-shaped runaway is bounded by length" "$(raw_lines)" "$(run "$H
 printf -- "---\ntype: index\nmodified: 2026-01-01\n---\n# A\none\n---\ntwo\n" >"$M3/MEMORY.md"
 assert_eq "real frontmatter still strips despite a later ---" "4" "$(run "$H3" --memory-lines)"
 
+# --- Case 4c4: a `#` line is a comment to YAML but a HEADING to markdown, and headings
+# are loaded content. Admitting them to the grammar let a pseudo-frontmatter block of
+# headings swallow them — the under-count this gate cannot tolerate. The cost is that a
+# real YAML comment inside frontmatter now ends the block early and counts: an
+# over-count, and a rare shape, since Claude Code writes only the `modified` scalar. ---
+printf -- "---\n# heading one\n# heading two\n---\nbody\n" >"$M3/MEMORY.md"
+assert_eq "a heading-only pseudo block counts every line" "$(raw_lines)" "$(run "$H3" --memory-lines)"
+assert_eq "a heading-only pseudo block counts every byte" "$(raw_bytes)" "$(run "$H3" --memory-bytes)"
+printf -- "---\ntype: index\n# note\nmodified: x\n---\nbody\n" >"$M3/MEMORY.md"
+assert_eq "a comment in frontmatter ends the block and counts" "$(raw_lines)" "$(run "$H3" --memory-lines)"
+printf -- "---\ntype: index\nmodified: 2026-01-01\n---\nbody\n" >"$M3/MEMORY.md"
+assert_eq "key-only frontmatter still strips" "1" "$(run "$H3" --memory-lines)"
+
 # --- Case 4d: a fence inside a comment must not toggle fence state — otherwise the
 # commented-out fence body leaks back into the count ---
 printf -- "<!-- note\n\`\`\`bash\nLEAKED\n\`\`\`\n-->\nreal\n" >"$M3/MEMORY.md"


### PR DESCRIPTION
Follow-up to #1933 (work-items row 127, campaign ledger #1941). #1933 shipped the M1 index-size measurement fixes for `memory-dir-stats.sh`; this closes the last under-count residual that surfaced during its gate review, after the PR had already merged.

No linked issue — the residual was found by #1933's own gate review rather than filed as an issue, and the campaign ledger it belongs to stays open past this PR.

## The bug

`memory-dir-stats.sh` admitted `#` lines to its frontmatter grammar. A `MEMORY.md` that opens with a `---` thematic break, carries heading lines, and reaches any later `---` therefore had the whole span stripped as frontmatter:

```
---
# heading one
# heading two
---
body
```

Raw 5 lines / 41 bytes, reported **1 line / 5 bytes**.

M1 is a `[FAIL]`-severity size gate, and a low count always passes it, so the shape disarmed the gate outright rather than merely mismeasuring it. This is the same failure species #1933 exists to eliminate — silent under-count on the gate — reached through the frontmatter grammar instead of the comment strip.

A `#` line is a comment to YAML but a **heading** to markdown, and headings are loaded content. The grammar now accepts only blank lines and `key:` mapping entries.

## Evidence

Measured against `origin/main`'s script and this branch's, same fixtures:

| fixture | 0.5.6 | 0.5.7 |
|---|---|---|
| 5-line heading pseudo-block | 1 line / 5 bytes | 5 / 41 (raw) |
| 20 headings + later `---` (23 lines) | 1 line / 5 bytes | 23 / 123 (raw) |
| genuine `key:`-only frontmatter | 1 / 5 | 1 / 5 (still strips) |
| genuine frontmatter with a `# note` | 1 / 5 | 6 / 44 (raw) |

The bound is capped at `fmcap` (20) lines, so the worst case was ~22 content lines — 11% of the 200-line budget — never a full disarm of the line limb, but enough to make a five-line index report one.

## The cost, stated plainly

A real YAML comment inside frontmatter now ends the block, and ending it strips **nothing at all**: the opening `---`, every entry held so far, and the rest of the block through its close all count. That is an over-count, the direction M1's readings already guess toward — it can make the gate fire early, never fail to fire. It takes a hand-edited index to reach, since Claude Code only stamps a `modified` scalar into frontmatter a file already has. Comments join an existing class rather than opening a new one: frontmatter this grammar cannot parse already ended the block before this change, and a block sequence under `tags:` still does.

`criteria.md` M1 reading 1 records both halves.

## Verification

- Full suite **60/60, exit 0** — run in this worktree off current `main`.
- Fresh-context verifier, rationale withheld, **PASS on all six criteria** (suite; heading fixture reports raw; `key:`-only frontmatter still strips; comment/fence behavior unregressed; no `#` alternation left in the executed awk; version + changelog hygiene). It derived every expectation from the awk before looking at output, and added its own mutation check — running `origin/main`'s pre-fix script side by side to confirm the fix is load-bearing and the numbers above reproduce.

## Versions

`claude-memory` 0.5.6 → **0.5.7** (0.5.5 → 0.5.6 landed via #1947); `criteria.md` 1.5.1 → **1.5.2**; CHANGELOG entry under `[0.5.7]`.

## Related

- #1933 — predecessor, merged. Shipped the M1 measurement fixes (frontmatter bounding, greedy-comment fix, comment re-scan) this builds on; the residual fixed here was found during its gate review. Not closed by this PR.
- #1941 — campaign ledger tracking work-items row 127 and its siblings. Stays open past this PR.
- #1947 — carried `claude-memory` 0.5.5 → 0.5.6, the version this PR bumps from. Reference only.
