### PR TITLE
docs(playbooks): assign each loop term its actual owning page (0.6.20)

### DIFF
--- a/plugins/playbooks/.claude-plugin/plugin.json
+++ b/plugins/playbooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "playbooks",
-  "version": "0.6.17",
+  "version": "0.6.20",
   "description": "Doctrine and knowledge playbooks as on-demand skills, plus a maintainer-facing update skill. boris — Boris Cherny's Claude Code workflow tips (howborisusesclaudecode.com); skill-authoring — Anthropic's internal skill-authoring playbook; fable-5 — Claude Fable 5's operating doctrine (self-authored, no upstream). The boris and skill-authoring packs vendor a verbatim upstream baseline; /playbooks:update drift-checks and syncs those baselines centrally (maintainers).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/playbooks/CHANGELOG.md
+++ b/plugins/playbooks/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the `playbooks` plugin are recorded here. The `version` i
 `.claude-plugin/plugin.json` is the delivery vehicle — a consumer receives a change
 only after that version increases.
 
+## [0.6.20]
+
+### Fixed
+
+- **`fable-5`: the channel-authority worked instance assigned two terms three owning pages**
+  (playbooks 0.6.17 → 0.6.20). The section "The reference page defines; a vendor post corroborates"
+  says "the reference page that owns the term" and "the owning page" four times, all
+  singular-definite — and then its worked instance listed one plural set of three pages for two
+  terms, which no reading of the surrounding rule supports. Verified against the live pages
+  2026-08-05: the glossary carries the only heading-plus-definition of "verification loop"
+  (`### Verification loop`), which "How Claude Code works" does not mention at all; "How Claude Code
+  works" carries `## The agentic loop` and its three-phase definition, and the glossary's own
+  `Agentic loop` entry defers to it rather than restating it in full. "Best practices" owns neither
+  term — it has no loop heading, uses "verification loop" once descriptively, and points at "How
+  Claude Code works" twice — so it is dropped from the instance rather than rewritten. The worked
+  instance now assigns each term to the page that actually defines it.
+
 ## [0.6.17]
 
 ### Changed

--- a/plugins/playbooks/skills/fable-5/context/calibration.md
+++ b/plugins/playbooks/skills/fable-5/context/calibration.md
@@ -50,7 +50,7 @@ A vendor's own blog, launch announcement, or engineering post is first-party and
 - RULE: cite the owning page and treat the post as corroborating voice. Pointer, never copy: a restatement of a definition freezes at the moment you wrote it, and the page is what a reader needs when the behavior moves.
 - RULE: read the owning page even when the post's definition looks complete, because omission is invisible from inside the post — you cannot tell a summary from a whole from the summary alone.
 
-> Worked instance, verified 2026-08-03. "Verification loop" and "agentic loop" both have owning pages: the [glossary](https://code.claude.com/docs/en/glossary), [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works), and [Best practices](https://code.claude.com/docs/en/best-practices).
+> Worked instance, verified 2026-08-05. "Verification loop" is owned by the [glossary](https://code.claude.com/docs/en/glossary), "agentic loop" by [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works) — which the glossary's own entry points to rather than restating in full.
 > The glossary's verification-loop entry carries what a post-length definition drops: a verification loop is the **prerequisite** for `/goal`, unattended runs, and dynamic workflows. A reader who took the short definition would have the concept right and still not know that three capabilities depend on it.
 
 ## Point at a per-model matrix; never copy one


### PR DESCRIPTION
## Summary

One line in `plugins/playbooks/skills/fable-5/context/calibration.md` claimed two terms shared
three owning pages. The section it sits in says "the reference page that owns the term" / "the
owning page" four times, all singular-definite; that blockquote was the section's only plural. The
worked instance now assigns each term to the page that actually defines it.

Before:

> Worked instance, verified 2026-08-03. "Verification loop" and "agentic loop" both have owning pages: the [glossary](https://code.claude.com/docs/en/glossary), [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works), and [Best practices](https://code.claude.com/docs/en/best-practices).

After:

> Worked instance, verified 2026-08-05. "Verification loop" is owned by the [glossary](https://code.claude.com/docs/en/glossary), "agentic loop" by [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works) — which the glossary's own entry points to rather than restating in full.

## Evidence (all three pages fetched live as raw `.md`, 2026-08-05, HTTP 200)

- **"Verification loop" → glossary.** `glossary.md:319` `### Verification loop` is the only
  heading-plus-definition of the term across the three pages. `how-claude-code-works.md` has zero
  occurrences (positive control on the same file and command shape: `agentic loop` → 7 hits).
  `best-practices.md` has one descriptive use at L33 ("you become the verification loop") and no
  loop heading at all.
- **"Agentic loop" → How Claude Code works.** `how-claude-code-works.md:13` `## The agentic loop`
  plus its three-phase definition at L15. The glossary's own `### Agentic loop` entry (L31) closes
  with `Learn more: [How Claude Code works](/docs/en/how-claude-code-works#the-agentic-loop)` — a
  deep anchor to the section named for the term, which is what the new trailing clause records.
- **"Best practices" is dropped, not rewritten.** It owns neither term and defers to
  "How Claude Code works" twice (L15, L607). Keeping it with a qualifying clause would have
  widened the section's post-vs-owning-page rule into reference-page-vs-reference-page deference —
  a new proposition smuggled into the instance that illustrates the old one.

The replacement line is 302 bytes against the 310 it replaces, both counted mechanically rather
than estimated.

Not changed, deliberately: `plugins/playbooks/skills/fable-5/SKILL.md:48` carries the distilled
doctrine, but it is singular and names no pages, so it is already correct.
`plugins/playbooks/CHANGELOG.md:470` restates the old claim as dated history and is not
retroactively edited.

## Verification

Fresh-context verifier, rationale withheld, four binary criteria — **PASS 4/4**: ownership
assignments re-derived from its own live fetches of all three pages (including a symmetry
objection it raised and resolved on the bytes); singular-definite vocabulary consistent with the
section's four other uses; version and CHANGELOG ordering correct with no residue; diff exactly the
one line plus the version files. `markdownlint-cli2` over both changed markdown files: 0 errors.

## Version serialization

`main` is at playbooks **0.6.17**. This PR claims **0.6.20** because 0.6.18 and 0.6.19 are already
claimed by unmerged PRs — 0.6.19 by #1950. The resulting `## [0.6.20]` → `## [0.6.17]` gap in the
CHANGELOG is expected and closes when those merge; it is not residue. Version allocation for this
campaign is held centrally by the lane manager, not read from the PR chain by producers.

## Related

No linked issue.

Doc-alignment campaign #1941, roster row 114 ([How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works)).
