### PR TITLE
fix(work-items): resolve the preflight's main checkout by verification, never by path arithmetic

### DIFF
--- a/plugins/work-items/.claude-plugin/plugin.json
+++ b/plugins/work-items/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "work-items",
-  "version": "0.31.3",
+  "version": "0.32.0",
   "description": "Manages development work items through a provider-neutral tracker seam that ships with the plugin (bundled dispatcher plus github and local-markdown adapters; seam plugin-dir canonical, adapters consumer-local-first): dashboard, taxonomy-labeled creation, a race-safe assignee-plus-lease claim protocol, recurring-schedule checks, TODO scanning, stale-lease auditing, plan decomposition into vertical-slice items, raw-intake triage (issues and unsolicited PRs through raw, verified, briefed, autonomous-eligible states), plus the two work-items loop lanes of the loop-lane convention: a self-paced autonomous work-loop drain (work-class admission gate, adaptive item cap, PR-only) and an attended attend-queue escalation lane. The re-runnable setup skill binds the provider (.work-item-tracker.json), seeds the recurring-schedule seam (.github/recurring-schedule.json), and remaps canonical role labels.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/work-items/CHANGELOG.md
+++ b/plugins/work-items/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to the `work-items` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.32.0]
+
+### Changed
+
+- **The permission preflight resolves the main checkout by verification instead of path arithmetic,
+  and never claims `PREFLIGHT: OK` for a run whose main-checkout layer it could not read (#1941).**
+  0.31.3 recovered that checkout from the common git dir's path, assuming the conventional
+  `<root>/.git` spelling. Any other spelling left it unresolved, and the checkout's
+  `settings.local.json` was then dropped from **every** read, deny included — so a live main-local
+  deny went unreported while the run printed a clean `PREFLIGHT: OK`, exit 0, zero gaps. The
+  interactive path was worse than quiet: both headers that name a main checkout print only under
+  `--worktree-root` or a distinct `--project-root`, so a plain run from a linked worktree dropped
+  that deny with no output at all.
+
+  Resolution is now a ladder of candidates — the probed checkout itself, the common dir's
+  `core.worktree`, then the conventional parent-of-`.git` — each put through one three-leg predicate
+  before it is trusted: the candidate is its own toplevel, it belongs to this repository, and its git
+  dir is the common dir. A candidate that fails is discarded, never named, so no path is asserted to
+  be the main checkout unverified. `core.worktree` is what makes a submodule's
+  `<super>/.git/modules/<name>` common dir — which no parent-of-`.git` arithmetic can invert —
+  resolvable at all; a submodule's linked worktree now reports its main-local deny where it
+  previously reported nothing.
+
+  Outcomes are three, not two. A **bare** repository has no main working tree, so no main-local layer
+  can exist, nothing is missing, and the summary stays `OK` rather than raising the false alarm this
+  change exists to remove. An **unresolved** main checkout is reported on its own `UNREAD LAYER` line
+  with the reason, and the summary becomes `PREFLIGHT: INCOMPLETE …`, which outranks both `OK`
+  branches and prints in every mode including the interactive one. The report-only contract is
+  unchanged: `--count` still prints the gap integer, unread layers are not gaps, and the script still
+  always exits 0.
+
+  `--separate-git-dir <path>/.git` is documented as what it is — ambiguous in git itself, not a
+  preflight defect. Git records no back-pointer to that layout's working tree (`core.worktree` is
+  unset by `git init --separate-git-dir`, `git clone --separate-git-dir`, and the migration path
+  alike), `git worktree list` reports `<path>` as the main worktree even when run from the true tree,
+  and `<path>` satisfies the verification predicate exactly as a conventional root does. The
+  preflight resolves to git's own answer, reached by verification rather than by string arithmetic.
+
+  Internally `normalize_path` answers in a variable using only builtins: every path comparison used
+  to fork a command substitution around a `printf | tr` pipeline, and one `rev-parse` now answers all
+  three predicate legs. The added verification is more than paid for — a run takes 1.7s against the
+  previous 4.7s on the same fixture.
+
 ## [0.31.3]
 
 ### Fixed

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -158,8 +158,10 @@ that worktree. Two cases:
   of the whole common dir turns up only `worktrees/<name>/gitdir` entries, which point at *linked*
   worktrees; `core.worktree` is unset by every creation path (`git init --separate-git-dir` on a
   fresh directory, `git clone --separate-git-dir`, and `git init --separate-git-dir` over an existing
-  repository). Git's own `git worktree list` therefore reports `<path>` — the `.git` file's parent —
-  as the main worktree, and reports it identically when run *from* the true working tree. `<path>`
+  repository). Git's own `git worktree list` therefore reports `<path>` — the parent of the separate
+  git *directory*, not of the `.git` file, which lives in the true working tree and is the very link
+  git does not record in reverse — as the main worktree, and reports it identically when run *from*
+  that true working tree. `<path>`
   also satisfies all three legs of the verification predicate, byte for byte, exactly as a
   conventional `<root>` does; any test strong enough to reject it also rejects the conventional
   layout. So the preflight resolves to `<path>`: **git's own answer**, arrived at by verification

--- a/plugins/work-items/reference/permission-preflight.md
+++ b/plugins/work-items/reference/permission-preflight.md
@@ -99,27 +99,50 @@ that repository — every linked worktree included, however the worktree was cre
 ([permissions](https://code.claude.com/docs/en/permissions#permission-system),
 [worktrees](https://code.claude.com/docs/en/worktrees); both fetched 2026-08-04). The main
 checkout's local file is therefore part of a fresh worker worktree's effective settings, and the
-preflight reads it in **every** mode. It identifies that checkout by comparing the probed
-checkout's own git dir against the common one — the probed checkout being `--project-root` when
-given, else the cwd: equal means that checkout *is* the main one — whatever its git dir is
-named, so the **main checkout of** a `--separate-git-dir` or submodule layout resolves correctly —
-and only from a linked worktree is the main checkout recovered from the common dir's path, which
-assumes the conventional `<root>/.git` spelling and misfires when that assumption does not hold —
-leaving the main checkout unresolved, or resolving it to a foreign directory (second residual
-below). What a fresh worker does **not** inherit is a local
-file living inside some *other* linked worktree — a pre-2.1.211 save, or a hand-placed file — which
-applies only to sessions started in that worktree. Two cases:
+preflight reads it in **every** mode — but only once it has **verified** which directory that is.
+
+**Resolving the main checkout.** Candidates are proposed cheapest-first and each is put through one
+predicate before it is trusted; a candidate that fails is discarded, never named. The predicate has
+three legs, all required: the candidate's `--show-toplevel` is the candidate itself (it is a
+toplevel, not a subdirectory of one), its `--git-common-dir` is our common dir (it belongs to *this*
+repository), and its `--git-dir` is also our common dir (it is the **main** worktree, not a linked
+one). The candidates:
+
+1. **The probed checkout itself** — its own git dir *is* the common dir. True whatever the git dir
+   is named, so the **main checkout of** a `--separate-git-dir` or submodule layout resolves here.
+   The probed checkout is `--project-root` when given, else the cwd.
+2. **`core.worktree`** in the common dir's config, resolved relative to that dir. Git writes it for
+   submodules, which is what makes a submodule's `<super>/.git/modules/<name>` common dir — which no
+   parent-of-`.git` arithmetic can invert — resolvable at all.
+3. **The conventional `<root>/.git` spelling** — the parent of the common dir.
+
+Resolution has three outcomes, and the report distinguishes them:
+
+- **Verified** — a candidate passed. Only then is a path named as the main checkout, and only then
+  is its `settings.local.json` read. The header prints git's own spelling of the verified toplevel.
+- **Bare** — the repository has no main working tree, so no main-local layer can exist. Nothing is
+  missing and the summary stays `OK`.
+- **Unresolved** — no candidate passed. The layer is **UNREAD**, the report says so on its own line
+  with the reason, and the summary is `PREFLIGHT: INCOMPLETE …`, never a bare `OK`. It is printed in
+  **every** mode, the interactive one included — the two headers that name a main checkout print
+  only under `--worktree-root` or a distinct `--project-root`, so a plain run from a linked worktree
+  would otherwise drop a main-local deny with no output at all. The exit code is still `0`: the
+  script is report-only and findings never fail the run.
+
+What a fresh worker does **not** inherit is a local file living inside some *other* linked
+worktree — a pre-2.1.211 save, or a hand-placed file — which applies only to sessions started in
+that worktree. Two cases:
 
 - **Pre-dispatch** — `--worktree-root` is passed but no distinct `--project-root` (the worker is not
   yet created). The **coverage** reads (allow + `additionalDirectories`) span user-global + tracked
   project settings + the main checkout's local file; only a linked-worktree cwd's *own* local file
   is dropped, since the fresh worker would not inherit it and reading it would mask a worker-side
-  gap. Run from the main checkout, nothing is dropped. The report header says which — naming
-  whatever `main_root` resolved to, right or wrong (see the second residual).
+  gap. Run from the main checkout, nothing is dropped. The report header says which — naming the
+  main checkout only when resolution verified it.
 - **A named worker** — `--project-root <worker-worktree>` resolves to a checkout whose toplevel
   differs from the cwd. That is a real, existing checkout, so the preflight reads **its own**
   `settings.local.json` (legacy rules saved there still apply to sessions started there) plus the
-  main checkout's shared local file; the header names the sources, under the same caveat.
+  main checkout's shared local file; the header names the sources, under the same condition.
 
 **Two residual limits apply to BOTH modes above.**
 
@@ -129,37 +152,29 @@ applies only to sessions started in that worktree. Two cases:
   the *harness*, not on the repository layout — so wherever the installed Claude Code is v2.1.211 or
   later it is a documentation-completeness matter rather than a live defect (v2.1.222 on the machine
   this was verified against).
-- **Main checkout unresolved or wrongly resolved — MASKING is reachable in both shapes.** From a linked
-  worktree the main checkout is recovered from the common dir's path, and that recovery fails two
-  ways. **Unresolved** (`main_root` empty): that checkout's local file goes unread in **every** read,
-  deny included — a covered verb is over-reported as a gap (noisy), *and* a deny living only in that
-  file is not reported at all, so the run can print `PREFLIGHT: OK` (exit 0, zero gaps) while a
-  main-local deny is live. The err-wide deny posture cannot widen a layer never read.
-  **Wrongly resolved**: `main_root` names a directory that is not this repository's working tree, and
-  that foreign `.claude/settings.local.json` is unioned into every read — a foreign allow masks a
-  real gap, a foreign deny yields a false DENIED. The header treats the two shapes differently, and
-  neither treatment is safe. **Unresolved** is indistinguishable from a repository that simply has no
-  main-local file. **Wrongly resolved** is worse than indistinguishable: the header **names the
-  foreign directory as the main checkout** — `coverage read includes the main checkout's
-  settings.local.json ('<foreign path>', applies in every worktree since Claude Code v2.1.211)` —
-  in wording identical to a correct resolution, so the output asserts something false about which
-  file was read rather than merely omitting it. Both header lines that print a resolved path (the
-  pre-dispatch one and the named-worker one) carry it. Three ways in:
-  - A linked worktree of a repo created with `--separate-git-dir <path>/.git`: the common dir is
-    `<path>/.git`, so the `*/.git` recovery yields `main_root=<path>` — **wrongly resolved**, with
-    foreign rules flowing in both directions (`--separate-git-dir "$HOME/.git"` unions the
-    operator's own `~/.claude` local file into the run).
-  - A linked worktree whose common dir is spelled otherwise — a separate git dir under any other
-    name, or a submodule's `<super>/.git/modules/<name>` — **unresolved**.
-  - A `--project-root` naming a path that is not a checkout — **unresolved**.
-
-  The **main checkout of** either layout resolves correctly, by the own-git-dir comparison above; the
-  defect is confined to the linked-worktree recovery. Correcting that recovery is a deferred
-  follow-up, so this reference states the behaviour rather than claiming it fixed.
+- **`--separate-git-dir` is ambiguous in git itself — NOT a preflight defect, and not maskable in
+  silence.** For a repository created with `--separate-git-dir <path>/.git`, the main working tree is
+  the directory holding the `.git` *file* — but git records no back-pointer to it. A recursive search
+  of the whole common dir turns up only `worktrees/<name>/gitdir` entries, which point at *linked*
+  worktrees; `core.worktree` is unset by every creation path (`git init --separate-git-dir` on a
+  fresh directory, `git clone --separate-git-dir`, and `git init --separate-git-dir` over an existing
+  repository). Git's own `git worktree list` therefore reports `<path>` — the `.git` file's parent —
+  as the main worktree, and reports it identically when run *from* the true working tree. `<path>`
+  also satisfies all three legs of the verification predicate, byte for byte, exactly as a
+  conventional `<root>` does; any test strong enough to reject it also rejects the conventional
+  layout. So the preflight resolves to `<path>`: **git's own answer**, arrived at by verification
+  rather than by string arithmetic. Where the operator intended a different directory to be the
+  working tree, the layout is ambiguous at the git level and no consumer of git can do better.
+  Two consequences worth knowing: `--separate-git-dir "$HOME/.git"` makes `$HOME` the main checkout
+  by git's reckoning, so the operator's own `~/.claude/settings.local.json` is genuinely in scope for
+  that repository; and a spelling that is *not* `<something>/.git` (a separate git dir under any
+  other name) yields no candidate at all — that is the **unresolved** outcome above, which is
+  reported loudly rather than passed over.
 
 The interactive/default path (no `--worktree-root`) keeps the cwd checkout's local settings in
-scope. Deny always reads every local layer it resolves, in every mode — the same err-wide rationale,
-bounded by the second residual above.
+scope. Deny always reads every local layer it resolves, in every mode — the same err-wide rationale;
+an unresolved main checkout is the one layer it cannot widen, which is why that case is reported
+rather than absorbed.
 
 ## The trusted worktree root — `additionalDirectories`
 
@@ -223,8 +238,14 @@ It is report-only and always exits `0`. Each output line is one of:
   operator-side: resolve the deny rule, add the open glob, or compose the standards floor in (above).
 - `GAP (c) …` — the worktree root is not covered by `additionalDirectories`. Add the entry (above).
 - `NOTE (c) …` — no worktree root was passed, so coverage was not checked.
+- `PREFLIGHT: UNREAD LAYER …` — the main checkout could not be verified, so its `settings.local.json`
+  was not read and the findings are incomplete: a grant there is not credited (a verb may be
+  over-reported) and a deny there is not reported at all. The summary is then
+  `PREFLIGHT: INCOMPLETE …` rather than `OK`. Re-run from the main checkout, or pass `--project-root`
+  naming it, to read that layer.
 
-`--count` prints just the integer GAP count (NOTEs excluded) for a scripted gate. Surface any gap
+`--count` prints just the integer GAP count (NOTEs excluded) for a scripted gate. An unread layer is
+not a gap, so the count is unchanged by it — read the summary line, not only the count. Surface any gap
 **once, at loop start**, with the exact remediation, then proceed or degrade per the lane's
 report-only posture — never rediscover the gap as per-operation prompts mid-cycle.
 

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -281,9 +281,12 @@ resolve_main_root() {
   # 3. core.worktree in the common dir's config points at the working tree,
   #    relative to the common dir. Git sets it for submodules, which is what
   #    makes a submodule's <super>/.git/modules/<name> shape resolvable at all.
-  #    Read the file directly: `git --git-dir=<dir> rev-parse --show-toplevel`
-  #    silently falls back to the PROCESS cwd when core.worktree is unset.
-  cand="$(git config -f "$main_gitdir/config" --get core.worktree 2>/dev/null | tr -d '\r')"
+  #    Read it with GIT_DIR context rather than `git config -f`, so a value
+  #    defined through [include]/[includeIf] is honored — includeIf's gitdir
+  #    conditions need a git dir to evaluate against, which -f never supplies.
+  #    (`git --git-dir=<dir> rev-parse --show-toplevel` stays unusable here: it
+  #    silently falls back to the PROCESS cwd when core.worktree is unset.)
+  cand="$(GIT_DIR="$main_gitdir" git config --get core.worktree 2>/dev/null | tr -d '\r')"
   if [[ -n "$cand" ]]; then
     case "$cand" in
       /* | [A-Za-z]:[/\\]*) ;;

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -25,7 +25,11 @@
 #   main-local  : <main-checkout>/.claude/settings.local.json — since Claude Code
 #                 v2.1.211 "don't ask again" approvals save here (resolved through
 #                 worktrees to the main checkout) and apply in every worktree of
-#                 the repository, so this file is read in every mode.
+#                 the repository, so this file is read in every mode — but only
+#                 when the main checkout is VERIFIED. When it cannot be
+#                 determined the layer goes unread and the run reports
+#                 PREFLIGHT: INCOMPLETE rather than an unqualified OK; no path is
+#                 ever named as the main checkout unverified.
 # The cwd probed for (a) is $PREFLIGHT_FIXTURE_DIR (tests) else $PWD. Project
 # settings are read from --project-root (default: the cwd checkout) resolved to
 # its git toplevel; pass the worker worktree the lane dispatches into so its own
@@ -58,15 +62,17 @@ Usage: preflight.sh [--worktree-root <path>] [--project-root <path>] [--count] [
   --project-root P  read project settings from P's checkout instead of the cwd's
                     (also read from PREFLIGHT_PROJECT_ROOT) — pass the dispatched
                     worker worktree so ITS OWN grants (incl. its settings.local.json)
-                    are checked rather than the cwd checkout's; the main checkout's
-                    settings.local.json is read in every mode
+                    are checked rather than the cwd checkout's; a VERIFIED main
+                    checkout's settings.local.json is read in every mode
   --count           print the integer GAP count only (NOTEs excluded); exit 0
   --help            this message
 
 Reports three conditions from the effective settings — (a) cwd not a git repo,
 (b) a probed git/gh verb denied or missing from permissions.allow, (c) the
-worktree root not covered by additionalDirectories. Report-only: never edits
-settings, always exits 0. Remediation is operator-side (see reference/permission-preflight.md).
+worktree root not covered by additionalDirectories. When the main checkout
+cannot be verified its settings.local.json goes unread and the summary is
+PREFLIGHT: INCOMPLETE, never a bare OK. Report-only: never edits settings,
+always exits 0. Remediation is operator-side (see reference/permission-preflight.md).
 Requires jq (exit 2 when absent).
 EOF
 }
@@ -138,30 +144,182 @@ user_settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 # .claude/settings.local.json at the repository root, resolved through worktrees
 # to the MAIN checkout, and the rule applies to sessions anywhere in the
 # repository — every linked worktree included (docs/en/permissions#permission-system).
-# A checkout whose OWN git dir is the common one is itself the main checkout, so
-# its toplevel is the answer whatever the git dir is named (--separate-git-dir, a
-# submodule). Only from a linked worktree must the main checkout be recovered from
-# the common dir's path, which assumes the conventional "<root>/.git" spelling.
-# That recovery misfires two ways, both of which can MASK a gap rather than
-# merely over-report one, and neither of which this script yet corrects:
-#   - main_root stays EMPTY when proj_src is not a repo, or when the common dir
-#     is spelled otherwise (a submodule's <super>/.git/modules/<name>, a
-#     separate git dir under another name). Every read then falls back to the
-#     project layer alone, so a main-local deny goes unreported entirely.
-#   - main_root resolves WRONGLY when the common dir is <path>/.git for a <path>
-#     that is not this working tree (--separate-git-dir <path>/.git): the arm
-#     below yields <path>, and that foreign settings.local.json is unioned into
-#     every read — a foreign allow masks a real gap, a foreign deny false-DENIES.
+# Resolving that checkout has three outcomes, and the report distinguishes them:
+#   verified  — main_root names a directory PROVEN to be this repository's main
+#               working tree (main_state=verified).
+#   bare      — the repository has no main working tree at all, so no main-local
+#               layer can exist and nothing is missing (main_state=bare).
+#   unresolved— the main working tree cannot be determined; the layer is UNREAD
+#               and the report says so loudly (main_state=unresolved + reason).
+# Only "verified" may be named as the main checkout, and only it is read.
 main_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-common-dir 2>/dev/null | tr -d '\r')"
 own_gitdir="$(git -C "$proj_src" rev-parse --path-format=absolute --git-dir 2>/dev/null | tr -d '\r')"
-main_root=""
-if [[ -n "$main_gitdir" && "$main_gitdir" == "$own_gitdir" ]]; then
-  main_root="$proj_base"
-else
-  case "$main_gitdir" in
-    */.git) main_root="${main_gitdir%/.git}" ;;
+
+norm_path() {
+  # Fold a path to one comparable form: expand a leading ~, backslashes →
+  # slashes, lower-case and de-colon a leading Windows drive (D:\repos →
+  # /d/repos, matching the git-bash /d/repos spelling), strip a trailing slash.
+  # Literal only — no symlink resolution, since permission rules match the
+  # command string literally. Also folds git's native "C:/…" answers against the
+  # shell's "/c/…" spelling, so the resolution predicates below compare equal.
+  #
+  # Answers in $NORM_OUT rather than on stdout, and uses only builtins: this runs
+  # on every path comparison, and on Windows a fork per call (the command
+  # substitution, plus a printf|tr pipeline inside it) dominates the runtime.
+  # normalize_path wraps it for the call sites that want a value.
+  local p="$1" home="${HOME:-${USERPROFILE:-}}"
+  # A leading ~ (~ alone, or ~/… / ~\… — both separators, since a Windows entry
+  # may be written ~\…) expands to the user home so a tilde-form
+  # additionalDirectories entry compares equal to the absolute probed root the
+  # harness derives from that same home. HOME first, then USERPROFILE (its
+  # backslashes, and any in the stripped remainder, are folded by the tr below);
+  # neither set leaves ~ literal.
+  if [[ -n "$home" ]]; then
+    # Strip one trailing separator (either form — HOME=/, USERPROFILE=…\) so the
+    # join below cannot double it; normalize_path does not collapse an internal
+    # //, so //.worktrees would never match an absolute /.worktrees/… root.
+    home="${home%/}"
+    home="${home%\\}"
+    # shellcheck disable=SC2088  # the literal ~ arms are patterns being matched, not paths to expand
+    case "$p" in
+      "~") p="$home" ;;
+      "~/"* | "~\\"*) p="$home/${p:2}" ;;
+      *) ;;
+    esac
+  fi
+  p="${p//\\//}"
+  case "$p" in
+    [A-Za-z]:/*)
+      # Windows filesystems are case-insensitive: fold the WHOLE path, not just
+      # the drive letter, so D:/Repos/.Worktrees and /d/repos/.worktrees compare
+      # equal. Non-drive (POSIX) paths stay case-sensitive.
+      p="${p,,}"
+      p="/${p%%:*}${p#*:}"
+      ;;
+    /[A-Za-z]/*)
+      # Git-bash drive spelling (/d/Repos/…) is the same case-insensitive
+      # Windows filesystem — fold it too. A true POSIX single-letter root
+      # directory is the accepted (rare, documented) collision.
+      p="${p,,}"
+      ;;
     *) ;;
   esac
+  case "$p" in
+    ?*/) p="${p%/}" ;;
+    *) ;;
+  esac
+  NORM_OUT="$p"
+}
+
+normalize_path() {
+  norm_path "$1"
+  printf '%s' "$NORM_OUT"
+}
+
+is_main_worktree() {
+  # is_main_worktree <candidate> — true when <candidate> is THE main working
+  # tree of the repository whose common dir is $main_gitdir. All three legs are
+  # required: the candidate is a toplevel (not a subdirectory of one), it belongs
+  # to THIS repository, and its own git dir is the common dir (so it is the main
+  # worktree, not a linked one). One rev-parse answers all three; paths are
+  # normalized because git answers in native "C:/…" spelling while shell paths
+  # arrive as "/c/…", and an unnormalized compare would silently never match.
+  local cand="$1" facts top cdir gdir want
+  [[ -n "$cand" && -d "$cand" ]] || return 1
+  facts="$(git -C "$cand" rev-parse --path-format=absolute \
+    --show-toplevel --git-common-dir --git-dir 2>/dev/null | tr -d '\r')"
+  [[ -n "$facts" ]] || return 1
+  { read -r top && read -r cdir && read -r gdir; } <<<"$facts" || return 1
+  norm_path "$cand"
+  want="$NORM_OUT"
+  norm_path "$top"
+  [[ "$NORM_OUT" == "$want" ]] || return 1
+  norm_path "$cdir"
+  [[ "$NORM_OUT" == "$main_gitdir_n" ]] || return 1
+  norm_path "$gdir"
+  [[ "$NORM_OUT" == "$main_gitdir_n" ]] || return 1
+  return 0
+}
+
+resolve_main_root() {
+  # Sets main_root / main_state / main_reason. Candidates are proposed cheapest
+  # first and each is put through is_main_worktree before being trusted; a
+  # candidate that fails verification is discarded, never named.
+  local cand own_n
+  main_root=""
+  main_state="unresolved"
+  main_reason=""
+
+  if [[ -z "$main_gitdir" ]]; then
+    main_reason="'$proj_src' is not a git repository"
+    return
+  fi
+  norm_path "$main_gitdir"
+  main_gitdir_n="$NORM_OUT"
+
+  # 1. The probed checkout is itself the main checkout (own git dir IS the common
+  #    one) — true whatever the git dir is named, so a --separate-git-dir or
+  #    submodule MAIN checkout resolves here.
+  norm_path "$own_gitdir"
+  own_n="$NORM_OUT"
+  if [[ "$own_n" == "$main_gitdir_n" ]] && is_main_worktree "$proj_base"; then
+    main_root="$proj_base"
+    main_state="verified"
+    return
+  fi
+
+  # 2. A bare repository has no main working tree, so there is no main-local
+  #    layer to read and nothing is being missed.
+  if [[ "$(git --git-dir="$main_gitdir" rev-parse --is-bare-repository 2>/dev/null | tr -d '\r')" == "true" ]]; then
+    main_state="bare"
+    return
+  fi
+
+  # 3. core.worktree in the common dir's config points at the working tree,
+  #    relative to the common dir. Git sets it for submodules, which is what
+  #    makes a submodule's <super>/.git/modules/<name> shape resolvable at all.
+  #    Read the file directly: `git --git-dir=<dir> rev-parse --show-toplevel`
+  #    silently falls back to the PROCESS cwd when core.worktree is unset.
+  cand="$(git config -f "$main_gitdir/config" --get core.worktree 2>/dev/null | tr -d '\r')"
+  if [[ -n "$cand" ]]; then
+    case "$cand" in
+      /* | [A-Za-z]:[/\\]*) ;;
+      *) cand="$main_gitdir/$cand" ;;
+    esac
+    cand="$(cd "$cand" 2>/dev/null && pwd)"
+    if is_main_worktree "$cand"; then
+      main_root="$cand"
+      main_state="verified"
+      return
+    fi
+  fi
+
+  # 4. The conventional "<root>/.git" spelling: the parent of the common dir.
+  case "$main_gitdir" in
+    */.git)
+      cand="${main_gitdir%/.git}"
+      if is_main_worktree "$cand"; then
+        main_root="$cand"
+        main_state="verified"
+        return
+      fi
+      ;;
+    *) ;;
+  esac
+
+  main_reason="the common git dir '$main_gitdir' names no verifiable working tree"
+}
+
+resolve_main_root
+# main_root and proj_base come from different producers (git's native "C:/…"
+# answers, a config-relative path, the shell's own spelling), so the identity
+# test between them goes through the normalized forms.
+main_is_proj_base=""
+if [[ "$main_state" == "verified" ]]; then
+  norm_path "$main_root"
+  main_root_n="$NORM_OUT"
+  norm_path "$proj_base"
+  [[ "$main_root_n" == "$NORM_OUT" ]] && main_is_proj_base="yes"
 fi
 
 read_array() {
@@ -183,22 +341,23 @@ collect() {
   # in the pre-dispatch autonomous (--worktree-root) path a worktree cwd's local
   # grants would mask a worker-side gap; the coverage reads drop that file there.
   # Deny always keeps it: erring wide on deny cannot mask a gap among the layers
-  # actually read — but see main_root above, which can leave a layer unread or
-  # substitute a foreign one.
+  # actually read. Only a VERIFIED main checkout is read — an unresolved one
+  # contributes nothing and is reported as an unread layer instead of being
+  # guessed at.
   local path="$1" local_mode="$2"
   read_array "$user_settings" "$path"
   read_array "$proj_base/.claude/settings.json" "$path"
-  if [[ -n "$main_root" && "$main_root" != "$proj_base" ]]; then
+  if [[ "$main_state" == "verified" && -z "$main_is_proj_base" ]]; then
     read_array "$main_root/.claude/settings.local.json" "$path"
   fi
-  if [[ "$local_mode" == "with-local" || "$proj_base" == "$main_root" ]]; then
+  if [[ "$local_mode" == "with-local" || -n "$main_is_proj_base" ]]; then
     read_array "$proj_base/.claude/settings.local.json" "$path"
   fi
 }
 
 # Checkout-own local-settings scope for the COVERAGE reads (allow +
-# additionalDirectories); the main checkout's local file is in scope regardless
-# — whichever file main_root resolved to, including the wrong one (see above):
+# additionalDirectories); a VERIFIED main checkout's local file is in scope
+# regardless:
 #   - A DISTINCT --project-root (a worker worktree whose toplevel differs from this
 #     checkout) names a real, existing checkout — read ITS OWN settings.local.json
 #     (legacy rules saved there still apply to sessions started there).
@@ -209,8 +368,8 @@ collect() {
 #     checkout this exclusion is a no-op — its local file follows the worker.
 #   - The interactive/default path keeps local.
 # Deny always reads every local layer that resolves; erring wide on deny cannot
-# mask a gap among those layers, but it cannot widen a layer main_root left
-# unresolved, nor unwind one it resolved to a foreign directory.
+# mask a gap among those layers, but it cannot widen a main checkout that never
+# resolved — which is why an unresolved one is reported rather than passed over.
 distinct_project_root=""
 if [[ -n "$project_root" && "$proj_base" != "$repo_root" ]]; then
   distinct_project_root="yes"
@@ -277,59 +436,6 @@ RULES
 verb_covered() { verb_in_rules "$1" "$ALL_ALLOW" "open-glob-only"; }
 verb_denied() { verb_in_rules "$1" "$ALL_DENY" "bare"; }
 verb_bare_exact() { verb_in_rules "$1" "$ALL_ALLOW" "bare-exact-only"; }
-
-normalize_path() {
-  # Fold a path to one comparable form: expand a leading ~, backslashes →
-  # slashes, lower-case and de-colon a leading Windows drive (D:\repos →
-  # /d/repos, matching the git-bash /d/repos spelling), strip a trailing slash.
-  # Literal only — no symlink resolution, since permission rules match the
-  # command string literally.
-  local p="$1" drive rest home="${HOME:-${USERPROFILE:-}}"
-  # A leading ~ (~ alone, or ~/… / ~\… — both separators, since a Windows entry
-  # may be written ~\…) expands to the user home so a tilde-form
-  # additionalDirectories entry compares equal to the absolute probed root the
-  # harness derives from that same home. HOME first, then USERPROFILE (its
-  # backslashes, and any in the stripped remainder, are folded by the tr below);
-  # neither set leaves ~ literal.
-  if [[ -n "$home" ]]; then
-    # Strip one trailing separator (either form — HOME=/, USERPROFILE=…\) so the
-    # join below cannot double it; normalize_path does not collapse an internal
-    # //, so //.worktrees would never match an absolute /.worktrees/… root.
-    home="${home%/}"
-    home="${home%\\}"
-    # shellcheck disable=SC2088  # the literal ~ arms are patterns being matched, not paths to expand
-    case "$p" in
-      "~") p="$home" ;;
-      "~/"* | "~\\"*) p="$home/${p:2}" ;;
-      *) ;;
-    esac
-  fi
-  # shellcheck disable=SC1003  # '\\' is tr's escaped backslash (one char), not a quote escape
-  p="$(printf '%s' "$p" | tr '\\' '/')"
-  case "$p" in
-    [A-Za-z]:/*)
-      # Windows filesystems are case-insensitive: fold the WHOLE path, not just
-      # the drive letter, so D:/Repos/.Worktrees and /d/repos/.worktrees compare
-      # equal. Non-drive (POSIX) paths stay case-sensitive.
-      p="$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')"
-      drive="${p%%:*}"
-      rest="${p#*:}"
-      p="/$drive$rest"
-      ;;
-    /[A-Za-z]/*)
-      # Git-bash drive spelling (/d/Repos/…) is the same case-insensitive
-      # Windows filesystem — fold it too. A true POSIX single-letter root
-      # directory is the accepted (rare, documented) collision.
-      p="$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')"
-      ;;
-    *) ;;
-  esac
-  case "$p" in
-    ?*/) p="${p%/}" ;;
-    *) ;;
-  esac
-  printf '%s' "$p"
-}
 
 dir_covered() {
   # dir_covered <path> — true when some additionalDirectories entry equals the
@@ -405,29 +511,46 @@ if [[ "$mode" == "count" ]]; then
   exit 0
 fi
 
+# A path is named as "the main checkout" only when resolution VERIFIED it. When
+# it did not, the layer is UNREAD and every mode says so — including the
+# interactive one, which prints no header otherwise and would otherwise drop a
+# main-local deny in silence.
+main_unread=""
+if [[ "$main_state" == "unresolved" ]]; then
+  main_unread="yes"
+fi
+
 if [[ -n "$local_excluded" ]]; then
-  if [[ "$proj_base" == "$main_root" ]]; then
+  if [[ -n "$main_is_proj_base" ]]; then
     echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read includes this main checkout's settings.local.json: since Claude Code v2.1.211 its rules apply in every worktree, the fresh worker included."
-  elif [[ -n "$main_root" ]]; then
+  elif [[ "$main_state" == "verified" ]]; then
     echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read includes the main checkout's settings.local.json ('$main_root', applies in every worktree since Claude Code v2.1.211) but excludes this worktree's own local file, which a fresh worker would not inherit; deny rules still include it."
   else
     echo "PREFLIGHT: autonomous mode (--worktree-root, no distinct --project-root) — coverage read excludes this checkout's gitignored settings.local.json, which a fresh worktree would not carry; deny rules still include it."
   fi
 elif [[ -n "$distinct_project_root" ]]; then
-  if [[ -n "$main_root" && "$main_root" != "$proj_base" ]]; then
+  if [[ "$main_state" == "verified" && -z "$main_is_proj_base" ]]; then
     echo "PREFLIGHT: reading project settings (incl. settings.local.json) from --project-root '$proj_base', plus the main checkout's shared settings.local.json ('$main_root')."
   else
     echo "PREFLIGHT: reading project settings (incl. settings.local.json) from --project-root '$proj_base'."
   fi
 fi
 
-if [[ "${#findings[@]}" -eq 0 ]]; then
-  echo "PREFLIGHT: OK — cwd is a git repo, probed grants present, worktree root covered."
-  exit 0
+if [[ -n "$main_unread" ]]; then
+  echo "PREFLIGHT: UNREAD LAYER — the main checkout's settings.local.json was NOT read: $main_reason. Its rules apply in every worktree since Claude Code v2.1.211, so a grant there is not credited (a verb may be over-reported as a gap) and, worse, a DENY there is not reported at all. Findings below are incomplete. Run the preflight from the main checkout, or pass --project-root naming it, to read that layer."
 fi
 
-printf '%s\n' "${findings[@]}"
-if [[ "$gapcount" -eq 0 ]]; then
+if [[ "${#findings[@]}" -gt 0 ]]; then
+  printf '%s\n' "${findings[@]}"
+fi
+
+# INCOMPLETE outranks BOTH OK branches: an unread main-checkout layer means the
+# probe never saw every rule, so "OK" would assert more than the run checked.
+if [[ -n "$main_unread" ]]; then
+  echo "PREFLIGHT: INCOMPLETE — main-checkout layer unread ($main_reason); $gapcount gap(s) found among the layers that were read. Report-only: exit 0 regardless (see reference/permission-preflight.md)."
+elif [[ "${#findings[@]}" -eq 0 ]]; then
+  echo "PREFLIGHT: OK — cwd is a git repo, probed grants present, worktree root covered."
+elif [[ "$gapcount" -eq 0 ]]; then
   echo "PREFLIGHT: OK — ${#findings[@]} note(s), 0 gap(s)."
 else
   echo "PREFLIGHT: $gapcount gap(s) — remediate operator-side before the unattended loop; the assistant cannot self-apply (see reference/permission-preflight.md)."

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -224,6 +224,8 @@ is_main_worktree() {
   # worktree, not a linked one). One rev-parse answers all three; paths are
   # normalized because git answers in native "C:/…" spelling while shell paths
   # arrive as "/c/…", and an unnormalized compare would silently never match.
+  # On success MAIN_TOP carries git's own spelling of the verified toplevel, so
+  # every arm below reports one consistent form whatever the candidate's origin.
   local cand="$1" facts top cdir gdir want
   [[ -n "$cand" && -d "$cand" ]] || return 1
   facts="$(git -C "$cand" rev-parse --path-format=absolute \
@@ -238,6 +240,7 @@ is_main_worktree() {
   [[ "$NORM_OUT" == "$main_gitdir_n" ]] || return 1
   norm_path "$gdir"
   [[ "$NORM_OUT" == "$main_gitdir_n" ]] || return 1
+  MAIN_TOP="$top"
   return 0
 }
 
@@ -263,7 +266,7 @@ resolve_main_root() {
   norm_path "$own_gitdir"
   own_n="$NORM_OUT"
   if [[ "$own_n" == "$main_gitdir_n" ]] && is_main_worktree "$proj_base"; then
-    main_root="$proj_base"
+    main_root="$MAIN_TOP"
     main_state="verified"
     return
   fi
@@ -286,9 +289,12 @@ resolve_main_root() {
       /* | [A-Za-z]:[/\\]*) ;;
       *) cand="$main_gitdir/$cand" ;;
     esac
+    # core.worktree is spelled with ".." segments ("../../../sub"), which the
+    # is-this-a-toplevel leg compares as a literal string — canonicalize first
+    # or that leg rejects the true working tree.
     cand="$(cd "$cand" 2>/dev/null && pwd)"
     if is_main_worktree "$cand"; then
-      main_root="$cand"
+      main_root="$MAIN_TOP"
       main_state="verified"
       return
     fi
@@ -299,7 +305,7 @@ resolve_main_root() {
     */.git)
       cand="${main_gitdir%/.git}"
       if is_main_worktree "$cand"; then
-        main_root="$cand"
+        main_root="$MAIN_TOP"
         main_state="verified"
         return
       fi

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -457,6 +457,36 @@ assert_contains "non-checkout project-root reports the unread layer" "$OUT" "UNR
 assert_contains "non-checkout project-root summary is INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
 assert_not_contains "non-checkout project-root claims no shared main checkout" "$OUT" "plus the main checkout's shared settings.local.json"
 
+# --- Case 16k: a candidate that no longer exists is rejected, not named -------
+# Removing a submodule's working tree leaves core.worktree pointing at a dead
+# path. Without the verification predicate that path would be named as the main
+# checkout and read straight through — a directory that is not there.
+git -C "$SUPER/sub" worktree add -q --detach "$TEST_TMPDIR/res-dead-wt"
+DEADPATH="$(git -C "$SUPER/sub" rev-parse --show-toplevel | tr -d '\r')"
+rm -rf "$SUPER/sub"
+OUT=$(run "$TEST_TMPDIR/res-dead-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "a vanished main checkout is reported unread" "$OUT" "UNREAD LAYER"
+assert_contains "a vanished main checkout makes the run INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_not_contains "a vanished main checkout is never named" "$OUT" "$DEADPATH"
+
+# --- Case 16l: the conventional parent is rejected when it is not the tree ----
+# "<X>/.git is the common dir" does not by itself make <X> the working tree. Here
+# the common dir's core.worktree names somewhere else, so <X>'s own toplevel
+# disagrees and the candidate must be discarded — the old arithmetic returned <X>
+# unconditionally, which is what let a non-checkout be named as the main one.
+CONV2="$TEST_TMPDIR/res-conv2"
+git init -q "$CONV2"
+commit_empty "$CONV2"
+plant_main_deny "$CONV2"
+git -C "$CONV2" worktree add -q --detach "$TEST_TMPDIR/res-conv2-wt"
+mkdir -p "$TEST_TMPDIR/res-elsewhere"
+git config -f "$CONV2/.git/config" core.worktree "$TEST_TMPDIR/res-elsewhere"
+OUT=$(run "$TEST_TMPDIR/res-conv2-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "a parent that is not the tree is reported unread" "$OUT" "UNREAD LAYER"
+assert_contains "a parent that is not the tree makes the run INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_not_contains "a parent that is not the tree is never named as the main checkout" "$OUT" \
+  "includes the main checkout's settings.local.json ('"
+
 # --- Case 17: a distinct --project-root reads the worker's OWN local settings -
 # When --project-root names a real worker worktree (toplevel differs from cwd),
 # read ITS OWN settings.local.json — the worker's file, present in that checkout —

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -345,6 +345,118 @@ assert_contains "main-local deny reaches a worktree run" "$OUT" "'git push'"
 assert_contains "main-local deny carries the DENIED message" "$OUT" "is DENIED"
 assert_eq "main-local deny → exactly one gap" "1" "$(run "$WT16" "$CFG16D" --count --worktree-root "$POSIX_CHILD")"
 
+# --- Main-checkout resolution across git-dir spellings (cases 16e–16j) --------
+# The recovery used to be path arithmetic on the common dir, so any spelling but
+# "<root>/.git" left the main checkout unresolved and its local file dropped from
+# EVERY read, deny included — silently, under a "PREFLIGHT: OK". Each case below
+# plants a real main-local DENY and asserts it is either reported (the layer was
+# read) or that the run says loudly that the layer was NOT read. Deny is the
+# probe because it is the masking direction: a dropped deny under-reports.
+#
+# commit_empty <repo> — a commit so `worktree add` has a HEAD to detach from.
+commit_empty() {
+  git -C "$1" -c user.name=t -c user.email=t@t commit -q --allow-empty -F - --cleanup=verbatim <<'MSG'
+init
+MSG
+}
+# plant_main_deny <checkout> — the main checkout's local file carries a deny and
+# nothing else, so any report of 'git push' proves that file was read.
+plant_main_deny() {
+  mkdir -p "$1/.claude"
+  jq -n '{permissions:{deny:["Bash(git push *)"]}}' >"$1/.claude/settings.local.json"
+}
+# CFGRES allows all five verbs and trusts the filesystem root, so ONLY a deny can
+# produce a gap — a nonzero count means the main-local layer reached the read.
+CFGRES="$TEST_TMPDIR/cfg-res"
+mkdir -p "$CFGRES"
+MSYS_NO_PATHCONV=1 jq -n '{permissions:{allow:["Bash(git add *)","Bash(git commit *)","Bash(git push *)","Bash(gh pr create *)","Bash(gh issue comment *)"],additionalDirectories:["/"]}}' >"$CFGRES/settings.json"
+RESROOT="$TEST_TMPDIR/res-wtroot"
+
+# --- Case 16e: conventional linked worktree still resolves (no regression) ----
+CONV="$TEST_TMPDIR/res-conv"
+git init -q "$CONV"
+commit_empty "$CONV"
+plant_main_deny "$CONV"
+git -C "$CONV" worktree add -q --detach "$TEST_TMPDIR/res-conv-wt"
+OUT=$(run "$TEST_TMPDIR/res-conv-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "conventional worktree reports the main-local deny" "$OUT" "is DENIED"
+assert_not_contains "conventional worktree is not INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_eq "conventional worktree → one gap" "1" "$(run "$TEST_TMPDIR/res-conv-wt" "$CFGRES" --count --worktree-root "$RESROOT")"
+
+# --- Case 16f: a submodule's linked worktree resolves via core.worktree -------
+# A submodule's common dir is <super>/.git/modules/<name>, which no parent-of-.git
+# arithmetic can invert. Git records the working tree in that dir's core.worktree,
+# which is what makes the shape resolvable at all.
+SUPER="$TEST_TMPDIR/res-super"
+SUBSRC="$TEST_TMPDIR/res-subsrc"
+git init -q "$SUPER"
+commit_empty "$SUPER"
+git init -q "$SUBSRC"
+commit_empty "$SUBSRC"
+git -C "$SUPER" -c protocol.file.allow=always -c user.name=t -c user.email=t@t \
+  submodule add -q "$SUBSRC" sub 2>/dev/null
+git -C "$SUPER" -c user.name=t -c user.email=t@t commit -q -F - --cleanup=verbatim <<'MSG'
+add submodule
+MSG
+plant_main_deny "$SUPER/sub"
+git -C "$SUPER/sub" worktree add -q --detach "$TEST_TMPDIR/res-sub-wt"
+OUT=$(run "$TEST_TMPDIR/res-sub-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "submodule worktree reports the main-local deny" "$OUT" "is DENIED"
+# The header prints git's own spelling of the toplevel, which on Windows is the
+# native "C:/…" form rather than the shell's "/tmp/…" — compare against git.
+assert_contains "submodule worktree names the submodule checkout" "$OUT" \
+  "$(git -C "$SUPER/sub" rev-parse --show-toplevel | tr -d '\r')"
+assert_not_contains "submodule worktree is not INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_eq "submodule worktree → one gap" "1" "$(run "$TEST_TMPDIR/res-sub-wt" "$CFGRES" --count --worktree-root "$RESROOT")"
+
+# --- Case 16g: an unresolvable spelling is LOUD, never "PREFLIGHT: OK" --------
+# --separate-git-dir under a name that is not "<something>/.git" leaves the main
+# working tree genuinely unrecoverable (git records no back-pointer to it). The
+# planted deny therefore cannot be read — so the run must say the layer is unread
+# instead of reporting a clean bill of health.
+SEP2="$TEST_TMPDIR/res-sep2"
+git init -q --separate-git-dir "$TEST_TMPDIR/res-sep2-gitdir" "$SEP2"
+commit_empty "$SEP2"
+plant_main_deny "$SEP2"
+git -C "$SEP2" worktree add -q --detach "$TEST_TMPDIR/res-sep2-wt"
+OUT=$(run "$TEST_TMPDIR/res-sep2-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "unresolvable spelling reports the layer as unread" "$OUT" "UNREAD LAYER"
+assert_contains "unresolvable spelling summary is INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_not_contains "unresolvable spelling never claims OK" "$OUT" "PREFLIGHT: OK"
+assert_not_contains "unresolvable spelling names no main checkout" "$OUT" "includes the main checkout's settings.local.json ('"
+assert_exit "unresolvable spelling still exits 0 (report-only)" 0 "$(
+  run "$TEST_TMPDIR/res-sep2-wt" "$CFGRES" --worktree-root "$RESROOT" >/dev/null
+  echo $?
+)"
+assert_eq "unresolvable spelling leaves the gap count untouched" "0" "$(run "$TEST_TMPDIR/res-sep2-wt" "$CFGRES" --count --worktree-root "$RESROOT")"
+
+# --- Case 16h: the INTERACTIVE path is loud too -------------------------------
+# Both headers that name a main checkout print only under --worktree-root or a
+# distinct --project-root, so a plain run from an unresolvable linked worktree
+# used to drop a main-local deny with no output whatsoever.
+OUT=$(run "$TEST_TMPDIR/res-sep2-wt" "$CFGRES")
+assert_contains "interactive path reports the unread layer" "$OUT" "UNREAD LAYER"
+assert_contains "interactive path summary is INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_not_contains "interactive path never claims OK" "$OUT" "PREFLIGHT: OK"
+
+# --- Case 16i: a bare repository has no main checkout — not an unread layer ---
+# Nothing is missing (a bare repo holds no working tree, so no main-local file can
+# exist), so INCOMPLETE here would be the same false alarm this change removes.
+git clone -q --bare "$CONV" "$TEST_TMPDIR/res-bare.git" 2>/dev/null
+git -C "$TEST_TMPDIR/res-bare.git" worktree add -q --detach "$TEST_TMPDIR/res-bare-wt"
+OUT=$(run "$TEST_TMPDIR/res-bare-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "bare repo's worktree reports OK" "$OUT" "PREFLIGHT: OK"
+assert_not_contains "bare repo's worktree is not INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+
+# --- Case 16j: --project-root naming a non-checkout is unresolved, not named --
+# The old arithmetic would happily name a directory it never verified.
+NOTAREPO="$TEST_TMPDIR/res-notarepo"
+mkdir -p "$NOTAREPO"
+OUT=$(run "$TEST_TMPDIR/res-conv-wt" "$CFGRES" --project-root "$NOTAREPO" --worktree-root "$RESROOT")
+assert_contains "non-checkout project-root reports the unread layer" "$OUT" "UNREAD LAYER"
+assert_contains "non-checkout project-root summary is INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+assert_not_contains "non-checkout project-root claims no shared main checkout" "$OUT" "plus the main checkout's shared settings.local.json"
+
 # --- Case 17: a distinct --project-root reads the worker's OWN local settings -
 # When --project-root names a real worker worktree (toplevel differs from cwd),
 # read ITS OWN settings.local.json — the worker's file, present in that checkout —

--- a/plugins/work-items/skills/work/scripts/preflight.test.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.test.sh
@@ -409,6 +409,18 @@ assert_contains "submodule worktree names the submodule checkout" "$OUT" \
 assert_not_contains "submodule worktree is not INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
 assert_eq "submodule worktree → one gap" "1" "$(run "$TEST_TMPDIR/res-sub-wt" "$CFGRES" --count --worktree-root "$RESROOT")"
 
+# --- Case 16f2: core.worktree defined through [include] is honored ------------
+# A config may hold core.worktree only via an include directive; `git config -f`
+# never processes includes, so the resolution must read with GIT_DIR context.
+SUBGITDIR="$(git -C "$SUPER/sub" rev-parse --git-common-dir | tr -d '\r')"
+INCWT="$(git config -f "$SUBGITDIR/config" --get core.worktree | tr -d '\r')"
+git config -f "$SUBGITDIR/config" --unset core.worktree
+printf '[core]\n\tworktree = %s\n' "$INCWT" > "$SUBGITDIR/worktree.inc"
+printf '[include]\n\tpath = worktree.inc\n' >> "$SUBGITDIR/config"
+OUT=$(run "$TEST_TMPDIR/res-sub-wt" "$CFGRES" --worktree-root "$RESROOT")
+assert_contains "include-defined core.worktree still reports the deny" "$OUT" "is DENIED"
+assert_not_contains "include-defined core.worktree is not INCOMPLETE" "$OUT" "PREFLIGHT: INCOMPLETE"
+
 # --- Case 16g: an unresolvable spelling is LOUD, never "PREFLIGHT: OK" --------
 # --separate-git-dir under a name that is not "<something>/.git" leaves the main
 # working tree genuinely unrecoverable (git records no back-pointer to it). The


### PR DESCRIPTION
`preflight.sh` recovered the main checkout from the common git dir's path, assuming the conventional `<root>/.git` spelling. Any other spelling left it unresolved, and that checkout's `settings.local.json` was dropped from **every** read, deny included — so a live main-local deny went unreported while the run printed a clean `PREFLIGHT: OK`, exit 0, zero gaps. The interactive path was worse than quiet: both headers that name a main checkout print only under `--worktree-root` or a distinct `--project-root`, so a plain run from a linked worktree dropped that deny with no output at all.

## What changed

Resolution is now a ladder of candidates — the probed checkout itself, the common dir's `core.worktree`, then the conventional parent-of-`.git` — each put through one three-leg predicate before it is trusted: the candidate is its own toplevel, it belongs to this repository, and its git dir is the common dir. A candidate that fails is discarded, never named, so no path is asserted to be the main checkout unverified. `core.worktree` is what makes a submodule's `<super>/.git/modules/<name>` common dir — which no parent-of-`.git` arithmetic can invert — resolvable at all.

Outcomes are three, not two. A **bare** repository has no main working tree, so no main-local layer can exist, nothing is missing, and the summary stays `OK` rather than raising the false alarm this change exists to remove. An **unresolved** main checkout gets its own `UNREAD LAYER` line with the reason, and the summary becomes `PREFLIGHT: INCOMPLETE …`, which outranks both `OK` branches and prints in every mode. The report-only contract is unchanged: `--count` still prints the gap integer, unread layers are not gaps, and the script still always exits 0.

## Before / after, same fixtures

| shape | before | after |
|---|---|---|
| conventional linked worktree | deny reported | deny reported (no regression) |
| submodule linked worktree | `PREFLIGHT: OK`, deny **masked** | deny reported, true tree named |
| separate-git-dir, other name | `PREFLIGHT: OK`, deny **masked** | `INCOMPLETE`, no path named |
| main checkout not the parent of `.git` | named unverified | rejected, `INCOMPLETE` |
| `--project-root` naming a non-checkout | `PREFLIGHT: OK` | `INCOMPLETE` |
| bare repo's linked worktree | `OK` | `OK` (correctly not an alarm) |
| interactive path, unresolvable | `OK — 1 note(s), 0 gap(s)` | `INCOMPLETE` |

## `--separate-git-dir` is documented as what it is

Not a preflight defect but an ambiguity in git itself. Git records no back-pointer to that layout's working tree: `core.worktree` is unset by `git init --separate-git-dir`, `git clone --separate-git-dir`, and the migration path alike; `git worktree list` reports the separate git dir's parent as the main worktree *even when run from the true working tree*; and that parent satisfies all three predicate legs byte for byte, exactly as a conventional root does — any test strong enough to reject it also rejects the conventional layout. The preflight resolves to git's own answer, reached by verification rather than string arithmetic, and the reference says so with the evidence.

## Verification

- Suite: **97 checks, all passing** (70 pre-existing, 27 new). Six new case families turn the previously documented residual shapes into real ones, each planting a genuine main-local **deny** — the masking direction — and asserting it is either reported or loudly declared unread.
- **Mutation-checked.** Reverting the `core.worktree` arm, the verification predicate, the INCOMPLETE summary, the `UNREAD LAYER` line, or the whole resolution back to the base approach each breaks named checks; no mutation leaves the suite green.
- Independent fresh-context verifier, rationale withheld, built its own fixtures and re-derived every git claim in the docs from scratch: **PASS on all nine criteria**. It caught one imprecise phrase ("the `.git` file's parent"), fixed in the final commit.
- Performance improved despite the added verification — `normalize_path` answers in a variable using only builtins instead of forking a command substitution around a `printf | tr` pipeline, and one `rev-parse` answers all three predicate legs. 1.7s against the previous 4.7s on the same fixture.
- `markdownlint` and `shellcheck` clean.

No linked issue.

## Related

- #1941
- Completes the resolution follow-up deferred in #1948, which stated the behaviour truthfully rather than claiming it fixed.
