### PR TITLE
docs: refresh OFFICIAL-DOCS verification stamps against live fetches

### DIFF
--- a/docs/OFFICIAL-DOCS.md
+++ b/docs/OFFICIAL-DOCS.md
@@ -31,54 +31,54 @@ components are declared in, not a component, so it has no row.
 
 | Component | Official doc page | Verified date |
 |---|---|---|
-| Skills (`skills/`) | <https://code.claude.com/docs/en/skills> | 2026-07-17 |
-| Commands — legacy flat-file skills (`commands/`) | <https://code.claude.com/docs/en/commands> | 2026-07-17 |
-| Agents / subagents (`agents/`) | <https://code.claude.com/docs/en/sub-agents> | 2026-07-17 |
-| Workflows (`workflows/`) | <https://code.claude.com/docs/en/workflows> | 2026-07-27 |
-| Hooks (`hooks/hooks.json`) | <https://code.claude.com/docs/en/hooks> | 2026-07-17 |
-| MCP servers (`.mcp.json`) | <https://code.claude.com/docs/en/mcp> | 2026-07-17 |
-| LSP servers (`.lsp.json`) | <https://code.claude.com/docs/en/plugins-reference#lsp-servers> | 2026-07-17 |
-| Output styles (`output-styles/`) | <https://code.claude.com/docs/en/output-styles> | 2026-07-17 |
-| Themes (`themes/`) | <https://code.claude.com/docs/en/plugins-reference#themes> | 2026-07-17 |
-| Monitors (`monitors/monitors.json`) | <https://code.claude.com/docs/en/plugins-reference#monitors> | 2026-07-17 |
-| Channels (`channels` manifest field) | <https://code.claude.com/docs/en/channels> | 2026-07-17 |
-| Executables (`bin/`) | <https://code.claude.com/docs/en/plugins-reference#file-locations-reference> | 2026-07-17 |
-| Settings (`settings.json` defaults) | <https://code.claude.com/docs/en/settings> | 2026-07-17 |
-| Dependencies (`dependencies` manifest field) | <https://code.claude.com/docs/en/plugin-dependencies> | 2026-07-17 |
+| Skills (`skills/`) | <https://code.claude.com/docs/en/skills> | 2026-08-06 |
+| Commands — legacy flat-file skills (`commands/`) | <https://code.claude.com/docs/en/commands> | 2026-08-06 |
+| Agents / subagents (`agents/`) | <https://code.claude.com/docs/en/sub-agents> | 2026-08-06 |
+| Workflows (`workflows/`) | <https://code.claude.com/docs/en/workflows> | 2026-08-06 |
+| Hooks (`hooks/hooks.json`) | <https://code.claude.com/docs/en/hooks> | 2026-08-06 |
+| MCP servers (`.mcp.json`) | <https://code.claude.com/docs/en/mcp> | 2026-08-06 |
+| LSP servers (`.lsp.json`) | <https://code.claude.com/docs/en/plugins-reference#lsp-servers> | 2026-08-06 |
+| Output styles (`output-styles/`) | <https://code.claude.com/docs/en/output-styles> | 2026-08-06 |
+| Themes (`themes/`) | <https://code.claude.com/docs/en/plugins-reference#themes> | 2026-08-06 |
+| Monitors (`monitors/monitors.json`) | <https://code.claude.com/docs/en/plugins-reference#monitors> | 2026-08-06 |
+| Channels (`channels` manifest field) | <https://code.claude.com/docs/en/channels> | 2026-08-06 |
+| Executables (`bin/`) | <https://code.claude.com/docs/en/plugins-reference#file-locations-reference> | 2026-08-06 |
+| Settings (`settings.json` defaults) | <https://code.claude.com/docs/en/settings> | 2026-08-06 |
+| Dependencies (`dependencies` manifest field) | <https://code.claude.com/docs/en/plugin-dependencies> | 2026-08-06 |
 
 ## Authoring
 
 | Page | Official doc page | Verified date |
 |---|---|---|
-| Create plugins | <https://code.claude.com/docs/en/plugins> | 2026-07-17 |
-| Plugins reference (schemas, variables, CLI) | <https://code.claude.com/docs/en/plugins-reference> | 2026-07-17 |
-| Skills | <https://code.claude.com/docs/en/skills> | 2026-07-17 |
-| Slash commands | <https://code.claude.com/docs/en/commands> | 2026-07-17 |
-| Hooks reference | <https://code.claude.com/docs/en/hooks> | 2026-07-17 |
-| Automate actions with hooks (guide) | <https://code.claude.com/docs/en/hooks-guide> | 2026-07-17 |
-| Subagents | <https://code.claude.com/docs/en/sub-agents> | 2026-07-17 |
-| Dynamic workflows — script-held orchestration, runtime agent caps | <https://code.claude.com/docs/en/workflows> | 2026-07-27 |
-| MCP | <https://code.claude.com/docs/en/mcp> | 2026-07-17 |
-| Connect to MCP servers (quickstart) | <https://code.claude.com/docs/en/mcp-quickstart> | 2026-07-17 |
-| Output styles | <https://code.claude.com/docs/en/output-styles> | 2026-07-17 |
-| Statusline | <https://code.claude.com/docs/en/statusline> | 2026-07-17 |
-| Push events into a session with channels | <https://code.claude.com/docs/en/channels> | 2026-07-17 |
-| Channels reference | <https://code.claude.com/docs/en/channels-reference> | 2026-07-17 |
-| Sandboxing the Bash tool | <https://code.claude.com/docs/en/sandboxing> | 2026-07-17 |
-| Sandbox environments | <https://code.claude.com/docs/en/sandbox-environments> | 2026-07-17 |
-| Run parallel sessions with worktrees | <https://code.claude.com/docs/en/worktrees> | 2026-07-17 |
-| Tools reference (includes the Monitor tool) | <https://code.claude.com/docs/en/tools-reference> | 2026-07-17 |
+| Create plugins | <https://code.claude.com/docs/en/plugins> | 2026-08-06 |
+| Plugins reference (schemas, variables, CLI) | <https://code.claude.com/docs/en/plugins-reference> | 2026-08-06 |
+| Skills | <https://code.claude.com/docs/en/skills> | 2026-08-06 |
+| Slash commands | <https://code.claude.com/docs/en/commands> | 2026-08-06 |
+| Hooks reference | <https://code.claude.com/docs/en/hooks> | 2026-08-06 |
+| Automate actions with hooks (guide) | <https://code.claude.com/docs/en/hooks-guide> | 2026-08-06 |
+| Subagents | <https://code.claude.com/docs/en/sub-agents> | 2026-08-06 |
+| Dynamic workflows — script-held orchestration, runtime agent caps | <https://code.claude.com/docs/en/workflows> | 2026-08-06 |
+| MCP | <https://code.claude.com/docs/en/mcp> | 2026-08-06 |
+| Connect to MCP servers (quickstart) | <https://code.claude.com/docs/en/mcp-quickstart> | 2026-08-06 |
+| Output styles | <https://code.claude.com/docs/en/output-styles> | 2026-08-06 |
+| Statusline | <https://code.claude.com/docs/en/statusline> | 2026-08-06 |
+| Push events into a session with channels | <https://code.claude.com/docs/en/channels> | 2026-08-06 |
+| Channels reference | <https://code.claude.com/docs/en/channels-reference> | 2026-08-06 |
+| Sandboxing the Bash tool | <https://code.claude.com/docs/en/sandboxing> | 2026-08-06 |
+| Sandbox environments | <https://code.claude.com/docs/en/sandbox-environments> | 2026-08-06 |
+| Run parallel sessions with worktrees | <https://code.claude.com/docs/en/worktrees> | 2026-08-06 |
+| Tools reference (includes the Monitor tool) | <https://code.claude.com/docs/en/tools-reference> | 2026-08-06 |
 
 ## Distribution / marketplace
 
 | Page | Official doc page | Verified date |
 |---|---|---|
-| Create & distribute a marketplace | <https://code.claude.com/docs/en/plugin-marketplaces> | 2026-07-17 |
-| Discover & install plugins | <https://code.claude.com/docs/en/discover-plugins> | 2026-07-17 |
-| Plugin dependencies (version constraints) | <https://code.claude.com/docs/en/plugin-dependencies> | 2026-07-17 |
-| Recommend plugins for your org (plugin relevance) | <https://code.claude.com/docs/en/plugin-relevance> | 2026-07-17 |
-| Recommend your plugin from your CLI (plugin hints) | <https://code.claude.com/docs/en/plugin-hints> | 2026-07-17 |
-| Plugins in the Agent SDK | <https://code.claude.com/docs/en/agent-sdk/plugins> | 2026-07-17 |
+| Create & distribute a marketplace | <https://code.claude.com/docs/en/plugin-marketplaces> | 2026-08-06 |
+| Discover & install plugins | <https://code.claude.com/docs/en/discover-plugins> | 2026-08-06 |
+| Plugin dependencies (version constraints) | <https://code.claude.com/docs/en/plugin-dependencies> | 2026-08-06 |
+| Recommend plugins for your org (plugin relevance) | <https://code.claude.com/docs/en/plugin-relevance> | 2026-08-06 |
+| Recommend your plugin from your CLI (plugin hints) | <https://code.claude.com/docs/en/plugin-hints> | 2026-08-06 |
+| Plugins in the Agent SDK | <https://code.claude.com/docs/en/agent-sdk/plugins> | 2026-08-06 |
 
 The Agent SDK's own skills/hooks/subagents/MCP pages (`agent-sdk/skills`, `agent-sdk/hooks`,
 `agent-sdk/subagents`, `agent-sdk/mcp`) describe those concepts for custom SDK-built agent hosts, not
@@ -90,24 +90,24 @@ SDK-based host.
 
 | Page | Official doc page | Verified date |
 |---|---|---|
-| Settings | <https://code.claude.com/docs/en/settings> | 2026-07-17 |
-| Server-managed settings | <https://code.claude.com/docs/en/server-managed-settings> | 2026-07-17 |
-| Control MCP server access for your organization | <https://code.claude.com/docs/en/managed-mcp> | 2026-07-17 |
-| Memory — CLAUDE.md, `.claude/rules/`, auto memory | <https://code.claude.com/docs/en/memory> | 2026-07-17 |
-| The `.claude` directory | <https://code.claude.com/docs/en/claude-directory> | 2026-07-17 |
-| Permissions | <https://code.claude.com/docs/en/permissions> | 2026-07-17 |
-| Permission modes | <https://code.claude.com/docs/en/permission-modes> | 2026-07-17 |
-| Environment variables | <https://code.claude.com/docs/en/env-vars> | 2026-07-17 |
+| Settings | <https://code.claude.com/docs/en/settings> | 2026-08-06 |
+| Server-managed settings | <https://code.claude.com/docs/en/server-managed-settings> | 2026-08-06 |
+| Control MCP server access for your organization | <https://code.claude.com/docs/en/managed-mcp> | 2026-08-06 |
+| Memory — CLAUDE.md, `.claude/rules/`, auto memory | <https://code.claude.com/docs/en/memory> | 2026-08-06 |
+| The `.claude` directory | <https://code.claude.com/docs/en/claude-directory> | 2026-08-06 |
+| Permissions | <https://code.claude.com/docs/en/permissions> | 2026-08-06 |
+| Permission modes | <https://code.claude.com/docs/en/permission-modes> | 2026-08-06 |
+| Environment variables | <https://code.claude.com/docs/en/env-vars> | 2026-08-06 |
 
 ## Reference / schemas
 
 | Page | Official doc page | Verified date |
 |---|---|---|
-| Docs index (discover any other page) | <https://code.claude.com/docs/llms.txt> | 2026-07-17 |
-| CLI reference | <https://code.claude.com/docs/en/cli-reference> | 2026-07-17 |
-| Error reference | <https://code.claude.com/docs/en/errors> | 2026-07-17 |
-| Glossary | <https://code.claude.com/docs/en/glossary> | 2026-07-17 |
-| Release changelog — per-version behavior changes | <https://code.claude.com/docs/en/changelog> | 2026-07-26 |
+| Docs index (discover any other page) | <https://code.claude.com/docs/llms.txt> | 2026-08-06 |
+| CLI reference | <https://code.claude.com/docs/en/cli-reference> | 2026-08-06 |
+| Error reference | <https://code.claude.com/docs/en/errors> | 2026-08-06 |
+| Glossary | <https://code.claude.com/docs/en/glossary> | 2026-08-06 |
+| Release changelog — per-version behavior changes | <https://code.claude.com/docs/en/changelog> | 2026-08-06 |
 
 **On citing the changelog.** It is indexed here because the prose pages can lag it: a behavior can
 change in a release and reach the topic page a release or more later, and when the two disagree the


### PR DESCRIPTION
## Summary

Refreshes all 51 verification stamps in `docs/OFFICIAL-DOCS.md` to `2026-08-06` after re-fetching every cited page live. **Stamps only** — no row text, URL, prose, heading, or table structure changed.

This is the designated campaign-end date pass for this file: one agent, one pass, so the stamps land once rather than drifting across lane PRs. No lane producer touched this file during the campaign.

**What was verified.** The 51 rows resolve to 37 unique URLs — 36 `code.claude.com/docs/en/*` pages plus `llms.txt`; the four `plugins-reference#<anchor>` rows share one page. Every one returned HTTP 200 with a title matching its row, and every cited page is present in the upstream `llms.txt` index, so no row is stale, renamed, or dead.

The four anchor rows were validated against the page's actual headings, not the page title alone, because a renamed heading returns HTTP 200 with a dead fragment that a title check would miss. All four still resolve: `### LSP servers`, `### Themes`, `### Monitors`, `### File locations reference`.

**Why `2026-08-06`.** [`docs/conventions/upstream-drift/README.md`](../blob/main/docs/conventions/upstream-drift/README.md) defines the as-of date as when the derivation happened, and these fetches happened today. Earlier campaign evidence for some of these pages was re-derived rather than inherited.

**No anomalies found.** No 404s, no moved pages, no dead anchors, nothing absent from `llms.txt`.

One observation outside the stamped inventory: the two SchemaStore links (`json.schemastore.org/claude-code-{marketplace,plugin-manifest}.json`) 301-redirect to `www.schemastore.org` at the same paths. This is SchemaStore's canonical-host redirect, not a moved resource — each schema body's `$id` still names the cited `json.schemastore.org` URL — so the links are left as written. These rows carry no verification stamp.

## Versioning

No changelog entry and no version bump. `docs/conventions/upstream-drift/README.md` line 92: *"refreshing a date with no verdict change is no entry and no version bump."* Confirmed independently — `docs/` has no `CHANGELOG.md`, no plugin version is keyed to it, and the changelog-parity gate reports no plugin paths in this diff.

## Test plan

- `npx markdownlint-cli2 docs/OFFICIAL-DOCS.md` — `Summary: 0 error(s)`.
- `scripts/check-changelog-parity.sh --check-bump origin/main` — pass.
- `scripts/check-contract-slice-prune.sh --check-diff origin/main` — pass.
- `scripts/check-skill-portability.sh origin/main` — pass ("No skill files in scope").
- Diff is 51 insertions / 51 deletions in one file — exactly the stamped-row count, file length unchanged at 126 lines.
- Independent fresh-context verifier subagent, rationale withheld, three binary criteria (live pages / stamps-only scope / anomaly claim). It re-fetched all URLs itself over both the raw `.md` and literal channels with a bogus-path 404 control, extracted `plugins-reference` headings and slugged them deterministically rather than grepping body text (so a fragment string inside a table cell could not produce a false pass), and proved the scope criterion by masking every date to `DATE` in both revisions and confirming the files are then byte-identical. **OVERALL: PASS** on all three.

## Related

No linked issue. Campaign tracking issue: #1941 — this is the campaign-closing `OFFICIAL-DOCS.md` date pass recorded there.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
