### PR TITLE
fix(guardrails): stop blocking a PowerShell call of a constant target

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,58 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.1]
+
+### Fixed
+
+- **The PowerShell git sink no longer blocks a call-operator / dot-source of a CONSTANT target
+  (#1968).** `ps::might_invoke_git`'s call-target branch matched any quote character after `&` or
+  `.`, so `& "C:\tools\publish.ps1"` — the ordinary PowerShell script-invocation idiom, carrying no
+  `git` token and a compile-time-constant path — routed to the fail-closed sink and was refused by
+  a *git* guard. Both quote styles and the dot-source form were affected, and because the predicate
+  is shared, the identical command false-blocked twice: once from `block-dangerous-git` and once
+  from `block-no-verify`. The branch now matches only a genuinely computed target — a bare variable
+  or subexpression (`& $tool`, `& (…)`), or a double-quoted string that INTERPOLATES
+  (`& "$tool"`, `& "C:\tools\$ver\x.exe"`). Per PowerShell
+  [`about_Quoting_Rules`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules),
+  a `$`-free double-quoted string and any single-quoted string are compile-time constants, so such
+  a target is statically decidable as non-git. No fail-open: the literal-git probe runs
+  quote-INTACT, so `& 'git' …`, `& "git" …`, and `& "C:\Git\cmd\git.exe" …` are still caught by
+  name; the interpolated forms still block. Regression cases for both directions are checked in on
+  both guards' suites.
+
+- **The sink's block message named constructs that were not present, and omitted the one that
+  was.** Both unparsable-command messages listed backtick / `--%` / subexpression / script-block /
+  here-string regardless of which of the four sink triggers actually fired, so an operator blocked
+  by a launcher or a computed call target was told to "remove the unparsable construct" when there
+  was none to remove. `ps::classify_git_command` now records the trigger in `PS_SINK_TRIGGER` and
+  each message prints a remediation line specific to it.
+
+- **The fail-closed sink message now names its kill switch.** Unlike the sibling too-long and
+  alias-cap fail-closed messages, the unparsable-command messages omitted the
+  `block_dangerous_git_enabled` / `block_no_verify_enabled` escape hatch, leaving an over-blocked
+  operator with no documented way out.
+
+### Changed
+
+- **Telemetry distinguishes the four sink triggers.** Both guards emitted a single
+  `powershell-unparsable` form token for all four shapes that reach the fail-closed sink, which
+  hid which one was responsible for a false-positive rate. The token now carries the trigger:
+  `powershell-unparsable-herestring-unbalanced`, `-special-construct`, `-dynamic-invocation`,
+  `-launcher`.
+
+- **The git and python-write lanes answer "is this call target computed?" with one shared
+  predicate.** The two lanes had drifted to different regexes for the same question — the git
+  lane's blanket quote match is what produced the false positive above, while the python lane's
+  interpolation-only match was already correct. The separator class and operator shape now live in
+  one place (`ps::call_target_is_bare_computed`, `ps::call_target_is_interpolating_string`); each
+  lane states at its call site which of the two shapes it admits. The python lane's behavior is
+  unchanged — it takes the interpolating-string half only, as before. The shared operator prefix is
+  spelled out in each predicate rather than concatenated in from a variable: mixing an unquoted
+  variable with adjacent literal regex text in a `[[ =~ ]]` pattern is version-sensitive, and a
+  predicate that quietly stops matching fails OPEN. The two named functions are the seam that
+  prevents drift; a string constant would not have added to that.
+
 ## [0.19.0]
 
 ### Changed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -30,6 +30,28 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   was none to remove. `ps::classify_git_command` now records the trigger in `PS_SINK_TRIGGER` and
   each message prints a remediation line specific to it.
 
+- **The unbalanced-here-string message names the terminator that matches the opener.** PowerShell
+  pairs `@'` with `'@` and `@"` with `"@`
+  ([`about_Quoting_Rules`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules)),
+  but the remediation line always said `'@`. An operator whose `@"` body was flagged and who
+  followed the advice literally produced a command that was still unbalanced and still blocked.
+  `ps::blank_herestrings` now records the hanging opener's quote in `PS_HERESTRING_QUOTE` and the
+  line names the matching terminator, falling back to naming both when no opener was recorded.
+
+- **The dynamic-invocation message no longer prescribes the form the operator already used.** It
+  told them to "invoke the target by its literal name" and asserted that a constant quoted path is
+  not blocked — but the invocation FORM is what routes a command to this branch, so
+  `& 'git' reset --hard` names its program literally and is blocked anyway. Following the advice
+  changed nothing. The detection is unchanged and correct: `&` plus a quoted string is what the
+  guard's Bash tokenizer cannot read, so the command is refused unless it is provably git-free.
+  The line now says to drop the `iex` / `&` / `.` and write the program as a plain command word,
+  which is actionable for every shape that reaches it.
+
+- **The sink remediation lines are now asserted on their TEXT, not just their exit code.** Both
+  message defects above survived because every PowerShell sink case checked only that the command
+  was blocked; `block-no-verify.test.sh` now captures stderr and pins the terminator selection and
+  the drop-the-operator advice.
+
 - **The fail-closed sink message now names its kill switch.** Unlike the sibling too-long and
   alias-cap fail-closed messages, the unparsable-command messages omitted the
   `block_dangerous_git_enabled` / `block_no_verify_enabled` escape hatch, leaving an over-blocked

--- a/plugins/guardrails/hooks/block-dangerous-git.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.sh
@@ -1073,7 +1073,9 @@ ps::classify_git_command "$TOOL_NAME" "$COMMAND"
 case $? in
 2)
   ps::print_unparsable_git_block_message
-  emit_tel "blocked" "powershell-unparsable"
+  # The trigger rides along in the form token: four distinct shapes reach this
+  # sink, and one collapsed token cannot show which of them is over-blocking.
+  emit_tel "blocked" "powershell-unparsable-${PS_SINK_TRIGGER:-unknown}"
   exit 2
   ;;
 1) exit 0 ;; # non-git PowerShell with an A2b-deferred construct

--- a/plugins/guardrails/hooks/block-dangerous-git.test.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.test.sh
@@ -600,4 +600,37 @@ run_pwsh "PS: backslash path-qualified git.exe, safe op (allowed)" \
 run_pwsh "PS: semicolon-adjacent computed call (fail-closed block)" \
   "Write-Host ok;& ('g'+'it') reset --hard" 2
 
+# Call-operator / dot-source of a CONSTANT target (#1968). `& "script.ps1"` is the
+# ordinary PowerShell script-invocation idiom; the sink's git probe used to match
+# any quote character after the operator, so a provably git-free literal path was
+# blocked by a *git* guard. Per PowerShell about_Quoting_Rules a `$`-free
+# double-quoted string and ANY single-quoted string are compile-time constants,
+# so these are statically decidable as non-git.
+run_pwsh "PS: call-op, double-quoted literal script path (allowed)" \
+  '& "C:\tools\publish.ps1"' 0
+run_pwsh "PS: call-op, single-quoted literal script path (allowed)" \
+  "& 'C:\\tools\\publish.ps1'" 0
+run_pwsh "PS: dot-source, double-quoted literal script path (allowed)" \
+  '. "C:\tools\lib.ps1"' 0
+run_pwsh "PS: dot-source, single-quoted literal script path (allowed)" \
+  ". 'C:\\tools\\lib.ps1'" 0
+# The fail-OPEN guard rail on that narrowing: an INTERPOLATING double-quoted
+# target is computed and must still block, and a literal git command word is
+# still caught by name because the git probe runs quote-intact.
+# shellcheck disable=SC2016
+run_pwsh "PS: call-op, interpolated variable target (fail-closed block)" \
+  '& "$tool" reset --hard' 2
+# shellcheck disable=SC2016
+run_pwsh "PS: call-op, interpolated subexpression target (fail-closed block)" \
+  '& "$(Get-Tool)" reset --hard' 2
+# shellcheck disable=SC2016
+run_pwsh "PS: call-op, interpolation inside a longer literal (fail-closed block)" \
+  '& "C:\tools\$ver\thing.exe" reset --hard' 2
+run_pwsh "PS: call-op, double-quoted literal git (blocked by name)" \
+  '& "git" reset --hard' 2
+run_pwsh "PS: call-op, single-quoted literal git (blocked by name)" \
+  "& 'git' reset --hard" 2
+run_pwsh "PS: call-op, quoted literal path whose basename is git (blocked by name)" \
+  '& "C:\Git\cmd\git.exe" reset --hard' 2
+
 report

--- a/plugins/guardrails/hooks/block-no-verify.sh
+++ b/plugins/guardrails/hooks/block-no-verify.sh
@@ -232,7 +232,9 @@ ps::classify_git_command "$TOOL_NAME" "$COMMAND"
 case $? in
 2)
   ps::print_unparsable_block_message
-  emit_tel "blocked" "powershell-unparsable"
+  # The trigger rides along in the form token: four distinct shapes reach this
+  # sink, and one collapsed token cannot show which of them is over-blocking.
+  emit_tel "blocked" "powershell-unparsable-${PS_SINK_TRIGGER:-unknown}"
   exit 2
   ;;
 1) exit 0 ;; # non-commit PowerShell with an A2b-deferred construct — not this guard's proven surface

--- a/plugins/guardrails/hooks/block-no-verify.test.sh
+++ b/plugins/guardrails/hooks/block-no-verify.test.sh
@@ -281,4 +281,35 @@ run_pwsh "PS: dot-source, single-quoted literal script path (allowed)" \
 run_pwsh "PS: call-op, interpolated variable target (fail-closed block)" \
   '& "$tool" commit --no-verify' 2
 
+# --- Sink remediation TEXT --------------------------------------------------
+# run_pwsh discards stderr, so nothing asserted what the trigger lines actually
+# SAY — and a remediation line that describes a shape it never sees is as much a
+# dead end as no line at all. Both message defects fixed here (#1974 review) were
+# exactly that, and both survived because only the exit code was checked.
+pwsh_stderr() {
+  bash "$HOOK" <<<"$(pwsh_command_json "$1")" 2>&1 >/dev/null
+}
+
+# PowerShell pairs each opener with its own quote, so the terminator named has to
+# follow the opener rather than always being `'@`.
+assert_contains "PS msg: @' opener names the '@ terminator" \
+  "$(pwsh_stderr "$(printf '%s\n%s\n%s' "@'" "body" "'X | git commit --no-verify")")" \
+  "the '@ terminator must start at column 0"
+assert_contains "PS msg: @\" opener names the \"@ terminator" \
+  "$(pwsh_stderr "$(printf '%s\n%s\n%s' '@"' "body" '"X | git commit --no-verify')")" \
+  "the \"@ terminator must start at column 0"
+
+# A literal call target is blocked by the invocation FORM, so the advice must be
+# to drop the operator — not to "invoke the target by its literal name", which is
+# the form the operator already used.
+assert_contains "PS msg: literal call target is told to drop the operator" \
+  "$(pwsh_stderr "& 'git' commit --no-verify")" \
+  "Drop the iex/'&'/'.'"
+assert_absent "PS msg: literal call target is not told to use a literal name" \
+  "$(pwsh_stderr "& 'git' commit --no-verify")" \
+  "Invoke the target by its literal name"
+assert_contains "PS msg: iex of a literal gets the same actionable advice" \
+  "$(pwsh_stderr "iex 'git commit --no-verify'")" \
+  "Drop the iex/'&'/'.'"
+
 report

--- a/plugins/guardrails/hooks/block-no-verify.test.sh
+++ b/plugins/guardrails/hooks/block-no-verify.test.sh
@@ -269,4 +269,16 @@ run_pwsh "PS: cmd /c git (blocked)" "cmd /c git commit --no-verify" 2
 run_pwsh "PS: Start-Process notepad (no git, allowed)" "Start-Process notepad" 0
 run_pwsh "PS: pwsh -File script (no inline git, allowed)" "pwsh -File build.ps1" 0
 
+# `ps::might_invoke_git` is SHARED with block-dangerous-git, so the constant
+# call-target false positive (#1968) false-blocked the same command twice — once
+# per guard. Covered on both sides so a regression in the shared predicate cannot
+# be caught by only one suite.
+run_pwsh "PS: call-op, double-quoted literal script path (allowed)" \
+  '& "C:\tools\publish.ps1"' 0
+run_pwsh "PS: dot-source, single-quoted literal script path (allowed)" \
+  ". 'C:\\tools\\lib.ps1'" 0
+# shellcheck disable=SC2016
+run_pwsh "PS: call-op, interpolated variable target (fail-closed block)" \
+  '& "$tool" commit --no-verify' 2
+
 report

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -77,6 +77,12 @@ readonly PS_HERESTRING_PLACEHOLDER="__GUARDRAILS_PS_HERESTRING__"
 # Set by ps::blank_herestrings.
 PS_BLANKED=""
 PS_HERESTRING_UNBALANCED=0
+# The quote character of the UNBALANCED opener (`'` or `"`), empty when the
+# command carried no unbalanced here-string. PowerShell pairs `@'` with `'@` and
+# `@"` with `"@`, so the remediation line can only name the right terminator if
+# it knows which opener was left hanging — naming `'@` for a `@"` body sends the
+# operator to a terminator PowerShell will not accept.
+PS_HERESTRING_QUOTE=""
 # Set by ps::classify_git_command when a command routes to the fail-closed sink:
 # which of the four triggers fired (`herestring-unbalanced`, `special-construct`,
 # `dynamic-invocation`, `launcher`), empty otherwise. Read by the block messages
@@ -102,6 +108,7 @@ ps::blank_herestrings() {
   local cmd="$1"
   local line out="" pending="" in_hs=0 hs_quote="" first2 rest closer opener_scan
   PS_HERESTRING_UNBALANCED=0
+  PS_HERESTRING_QUOTE=""
 
   while IFS= read -r line || [[ -n "$line" ]]; do
     if ((in_hs)); then
@@ -140,6 +147,7 @@ ps::blank_herestrings() {
     # swallow a trailing command (e.g. `| git commit --no-verify`) into the inert
     # placeholder, so surface the raw command and flag unbalanced instead.
     PS_HERESTRING_UNBALANCED=1
+    PS_HERESTRING_QUOTE="$hs_quote"
     PS_BLANKED="$cmd"
     return 0
   fi
@@ -439,18 +447,40 @@ ps::classify_git_command() {
 
 # One line naming the construct that actually routed this command to the sink,
 # plus what to do about it. Each of the four triggers needs different advice:
-# "remove the unparsable construct" is unactionable for a launcher or a computed
-# call target, because there is no such construct to remove (#1968).
+# "remove the unparsable construct" is unactionable for a launcher or a dynamic
+# invocation, because there is no such construct to remove (#1968). Each line
+# must also stay true of every command that reaches it — advice that describes
+# only part of a trigger's shape space is the same unactionable dead end in a
+# different disguise.
 ps::print_sink_trigger_line() {
+  local closer
   case "$PS_SINK_TRIGGER" in
   herestring-unbalanced)
-    echo "Trigger: an unbalanced here-string — its extent cannot be determined, so a trailing pipeline could be hidden inside it. Close the here-string (the '@ terminator must start at column 0)." >&2
+    # PowerShell pairs the opener with its OWN quote: `@'` closes with `'@` and
+    # `@"` closes with `"@`. Naming the wrong one leaves the rewritten command
+    # still unbalanced and still blocked, so name the terminator that matches
+    # the opener actually left hanging; name both only when the opener is not
+    # recorded (a caller that printed this line without a preceding
+    # ps::blank_herestrings run).
+    case "$PS_HERESTRING_QUOTE" in
+    "'") closer="the '@ terminator" ;;
+    '"') closer="the \"@ terminator" ;;
+    *) closer="the terminator matching the opener (@' closes with '@, @\" closes with \"@)" ;;
+    esac
+    echo "Trigger: an unbalanced here-string — its extent cannot be determined, so a trailing pipeline could be hidden inside it. Close the here-string ($closer must start at column 0)." >&2
     ;;
   special-construct)
     echo "Trigger: a construct the guard cannot faithfully tokenize (backtick, '--%', subexpression, or {}/() grouping). Remove it, or run the command via the Bash tool." >&2
     ;;
   dynamic-invocation)
-    echo "Trigger: a dynamic invocation (iex/Invoke-Expression, or a call '&' / dot-source '.' of a computed target) whose program name is not statically decidable. Invoke the target by its literal name — a constant quoted path is decidable and is not blocked; only an interpolating target (a double-quoted string containing a variable or subexpression) reaches this branch." >&2
+    # The INVOCATION FORM is what routes here, not the decidability of the
+    # target: `& 'git' reset --hard` names its program literally and is still
+    # blocked, because `&` plus a quoted string is what the guard's Bash
+    # tokenizer cannot read. Telling that operator to "invoke the target by its
+    # literal name" describes the form they already used, so the advice has to
+    # be to drop the invocation operator instead. A call/dot-source of a bare
+    # variable (`& $tool`) never reaches this branch.
+    echo "Trigger: a dynamic invocation — iex/Invoke-Expression, or a call '&' / dot-source '.' whose target is a quoted string. The form itself routes here, a constant literal target included; a target that cannot reach git is then allowed, and this one could. Drop the iex/'&'/'.' and write the program as a plain command word, or run the command via the Bash tool." >&2
     ;;
   launcher)
     echo "Trigger: a process launcher or nested shell (Start-Process/saps/start, pwsh, powershell, cmd), which the guard must see through the way it sees through 'bash -c'. Run the program directly, or run the command via the Bash tool." >&2

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -77,6 +77,13 @@ readonly PS_HERESTRING_PLACEHOLDER="__GUARDRAILS_PS_HERESTRING__"
 # Set by ps::blank_herestrings.
 PS_BLANKED=""
 PS_HERESTRING_UNBALANCED=0
+# Set by ps::classify_git_command when a command routes to the fail-closed sink:
+# which of the four triggers fired (`herestring-unbalanced`, `special-construct`,
+# `dynamic-invocation`, `launcher`), empty otherwise. Read by the block messages
+# (so they name the construct actually present) and by the callers' telemetry (so
+# the four sink shapes are distinguishable in aggregate rather than collapsed into
+# one `powershell-unparsable` token that hides which one over-blocks).
+PS_SINK_TRIGGER=""
 # Set by ps::classify_git_command — the command the caller should parse. Read by
 # the sourcing guard, not within this library.
 # shellcheck disable=SC2034
@@ -172,6 +179,56 @@ ps::has_special_constructs() {
   esac
 }
 
+# --- call-target computedness (shared by the git and python-write lanes) -------
+#
+# Both lanes ask the same question of a call `&` / dot-source `.`: is the target
+# COMPUTED (so it could resolve to anything, including the program the lane
+# guards) or a compile-time CONSTANT (so it is statically decidable)? They used to
+# answer it with two different regexes — the git lane matching any quote character
+# and the python lane only an interpolating double quote — which is how the git
+# lane came to block `& "publish.ps1"`, a provably git-free literal path (#1968).
+# The separator class and the operator shape now live in one place; the two lanes
+# differ only in WHICH of the two computed shapes each admits, stated at the call
+# site rather than duplicated in a regex.
+#
+# A call operator is valid immediately after a statement/block separator
+# (`;& …`, `{& …}`, `|& …`), not only after whitespace — hence the separator class
+# `(^|[[:space:]\;\{\}\(\|\&])` rather than a bare `[[:space:]]`.
+#
+# The operator prefix is spelled out literally in each predicate rather than
+# factored into a shared variable and concatenated into the `[[ =~ ]]` pattern.
+# Mixing an unquoted variable with adjacent literal regex text in a pattern
+# position is the one bash construct whose quote-removal behavior is genuinely
+# version-sensitive, and a predicate that silently stops matching here fails
+# OPEN — the guard would wave through a computed call target. The SSOT that
+# matters is these two named functions being the only place either lane asks the
+# question; a shared string constant would buy nothing and risk that.
+
+# True (0) when the call/dot-source target is a bare variable or subexpression —
+# `& $tool …`, `& ('g'+'it') …`, `. (Get-Path) …`. The target is computed at run
+# time and cannot be resolved statically.
+ps::call_target_is_bare_computed() {
+  local lc="${1//\`/}"
+  lc="${lc,,}"
+  [[ "$lc" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*[\$\(] ]]
+}
+
+# True (0) when the call/dot-source target is a DOUBLE-quoted string that
+# INTERPOLATES a variable or subexpression — `& "$tool" …`, `& "$(Get-Tool)" …`,
+# `& "C:\tools\$ver\x.exe" …`. Grounded in PowerShell `about_Quoting_Rules`:
+# a double-quoted string expands `$`-prefixed expressions, so such a target is
+# computed; a `$`-free double-quoted string and ANY single-quoted string are
+# compile-time constants ("& '$x'" is the literal program name `$x`).
+#
+# Deliberately does NOT match a constant literal. That is the whole point: a
+# blanket quote match makes every `& "script.ps1"` — the ordinary PowerShell
+# script-invocation idiom — indistinguishable from `& "$tool"`.
+ps::call_target_is_interpolating_string() {
+  local lc="${1//\`/}"
+  lc="${lc,,}"
+  [[ "$lc" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*\"[^\"]*\$ ]]
+}
+
 # True (0) when the text MIGHT invoke git and cannot be proven otherwise. This is
 # the fail-closed sink's positive test: because the constructs that route here can
 # obfuscate the command, we do not trust a negative `commit`/`push` shape match on
@@ -188,17 +245,18 @@ ps::has_special_constructs() {
 # branch, so a false positive costs at most an over-block on a command that also
 # carries an unparsable construct.
 ps::might_invoke_git() {
-  # `q` carries the two quote characters so neither appears literally inside the
-  # [[ =~ ]] test (which would derail shellcheck's parser).
-  local recovered="${1//\`/}" lc q="\"'"
+  local recovered="${1//\`/}" lc
   lc="${recovered,,}"
   [[ "$lc" =~ (^|[^[:alnum:]_.])git([.]exe)?([^[:alnum:]_]|$) ]] && return 0
   [[ "$lc" =~ (^|[^[:alnum:]_-])(iex|invoke-expression)([^[:alnum:]_-]|$) ]] && return 0
-  # Call / dot-source of a variable, subexpression, or string literal:
-  # `& $x …`, `& (…)`, `& 'git …'`, `. $x …` — the target runs as a command.
-  # The call operator is also valid immediately after a statement/block
-  # separator (`;& …`, `{& …}`, `|& …`), not only after whitespace.
-  [[ "$lc" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*[\$\($q] ]] && return 0
+  # Call / dot-source of a COMPUTED target — `& $x …`, `& (…)`, `& "$x" …`,
+  # `. $x …` — which could resolve to git. A CONSTANT target (`& 'git' …`,
+  # `& "C:\Git\cmd\git.exe" …`) is not matched here and does not need to be: the
+  # literal-git probe above runs quote-INTACT, so a quoted git command word is
+  # already caught by name. Matching constants here as well is what over-blocked
+  # `& "publish.ps1"` (#1968) — a target statically decidable as non-git.
+  ps::call_target_is_bare_computed "$recovered" && return 0
+  ps::call_target_is_interpolating_string "$recovered" && return 0
   # A launcher whose program is a computed expression or variable —
   # `Start-Process ('g'+'it') …`, `saps $tool …`, optionally behind one named
   # parameter (`-FilePath (…)`) — may evaluate to git; it cannot be proven
@@ -254,8 +312,10 @@ ps::might_write_via_python3() {
   # it here on the quote-INTACT text and fail closed. A SINGLE-quoted target does
   # NOT interpolate in PowerShell (`& '$x'` is the literal name `$x`), so it is not
   # matched. ps::write_bypass catches only an UNQUOTED `& $`/`& (`; this closes the
-  # quoted-interpolated form for the python-write lane.
-  [[ "$lc" =~ (^|[[:space:]\;\{\}\(\|\&])[.\&][[:space:]]*\"[^\"]*\$ ]] && return 0
+  # quoted-interpolated form for the python-write lane — which is why this lane
+  # takes only the interpolating-string half of the shared call-target predicate
+  # and not the bare-computed half.
+  ps::call_target_is_interpolating_string "$recovered" && return 0
   # Must name a python3 interpreter token at all (quote-intact, backtick-recovered).
   [[ "$lc" =~ (^|[^[:alnum:]_.])python3([.]exe)?([^[:alnum:]_]|$) ]] || return 1
   # A literal `-c` inline-code flag settles it (quote-bounded, so an arg-split
@@ -331,14 +391,26 @@ ps::has_launcher() {
 ps::classify_git_command() {
   local tool="$1" cmd="$2" scan
   PS_SAFE_COMMAND="$cmd"
+  PS_SINK_TRIGGER=""
   [[ "$tool" == "PowerShell" ]] || return 0
 
   ps::blank_herestrings "$cmd"
   scan=$(ps::blank_quoted_spans "$PS_BLANKED")
-  if ((PS_HERESTRING_UNBALANCED)) ||
-    ps::has_special_constructs "$scan" ||
-    ps::has_dynamic_invocation "$PS_BLANKED" ||
-    ps::has_launcher "$PS_BLANKED"; then
+  # Record WHICH trigger routed the command here. Four distinct shapes reach this
+  # sink and they need different remediation: an operator told to "remove the
+  # unparsable construct" when the trigger was a launcher or a computed call
+  # target has nothing to remove (#1968). The order matches the test order below,
+  # so the recorded trigger is the one that actually fired first.
+  if ((PS_HERESTRING_UNBALANCED)); then
+    PS_SINK_TRIGGER="herestring-unbalanced"
+  elif ps::has_special_constructs "$scan"; then
+    PS_SINK_TRIGGER="special-construct"
+  elif ps::has_dynamic_invocation "$PS_BLANKED"; then
+    PS_SINK_TRIGGER="dynamic-invocation"
+  elif ps::has_launcher "$PS_BLANKED"; then
+    PS_SINK_TRIGGER="launcher"
+  fi
+  if [[ -n "$PS_SINK_TRIGGER" ]]; then
     # Not faithfully tokenizable. Fail closed unless provably git-free. The git
     # probe runs on PS_BLANKED (quotes INTACT, backticks recovered inside the
     # probe) so a quoted or backtick-obfuscated `git` is still seen; an unbalanced
@@ -365,16 +437,41 @@ ps::classify_git_command() {
   return 0
 }
 
+# One line naming the construct that actually routed this command to the sink,
+# plus what to do about it. Each of the four triggers needs different advice:
+# "remove the unparsable construct" is unactionable for a launcher or a computed
+# call target, because there is no such construct to remove (#1968).
+ps::print_sink_trigger_line() {
+  case "$PS_SINK_TRIGGER" in
+  herestring-unbalanced)
+    echo "Trigger: an unbalanced here-string — its extent cannot be determined, so a trailing pipeline could be hidden inside it. Close the here-string (the '@ terminator must start at column 0)." >&2
+    ;;
+  special-construct)
+    echo "Trigger: a construct the guard cannot faithfully tokenize (backtick, '--%', subexpression, or {}/() grouping). Remove it, or run the command via the Bash tool." >&2
+    ;;
+  dynamic-invocation)
+    echo "Trigger: a dynamic invocation (iex/Invoke-Expression, or a call '&' / dot-source '.' of a computed target) whose program name is not statically decidable. Invoke the target by its literal name — a constant path in quotes ('& \"C:\\path\\script.ps1\"') is decidable and is not blocked." >&2
+    ;;
+  launcher)
+    echo "Trigger: a process launcher or nested shell (Start-Process/saps/start, pwsh, powershell, cmd), which the guard must see through the way it sees through 'bash -c'. Run the program directly, or run the command via the Bash tool." >&2
+    ;;
+  *)
+    echo "Run the command via the Bash tool, or rewrite it without the unparsable construct." >&2
+    ;;
+  esac
+}
+
 # Shell-agnostic block text for a PowerShell git command the guard cannot parse
 # with confidence. Printed to stderr by the caller before it exits 2.
 ps::print_unparsable_block_message() {
   echo "BLOCKED: this PowerShell git command cannot be parsed with confidence — blocked (fail-closed)." >&2
-  echo "Remove the obfuscating construct (backtick, --%, subexpression, or {}/() grouping)." >&2
+  ps::print_sink_trigger_line
   echo "The canonical PowerShell commit form (a here-string piped to 'git commit -F -') is:" >&2
   echo "  @'" >&2
   echo "  <subject>" >&2
   echo "  '@ | git commit -F -" >&2
   echo "or run the commit via the Bash tool (the /commit skill's canonical form)." >&2
+  echo "If this is a false positive, set the guardrails block_no_verify_enabled option to false (/plugin configure) to bypass." >&2
 }
 
 # Shell-agnostic block text for a PowerShell git command block-dangerous-git
@@ -383,8 +480,9 @@ ps::print_unparsable_block_message() {
 # caller before it exits 2.
 ps::print_unparsable_git_block_message() {
   echo "BLOCKED: this PowerShell 'git' command cannot be parsed with confidence — blocked (fail-closed)." >&2
-  echo "A git command carrying a PowerShell construct the guard cannot faithfully tokenize (backtick, '--%', subexpression, script-block grouping, or an unbalanced here-string) could hide a destructive form (reset --hard, clean -fd, checkout/restore), so it is blocked rather than waved through." >&2
-  echo "Run the command via the Bash tool, or rewrite it without the unparsable construct." >&2
+  echo "A git command the guard cannot faithfully tokenize could hide a destructive form (reset --hard, clean -fd, checkout/restore), so it is blocked rather than waved through." >&2
+  ps::print_sink_trigger_line
+  echo "If this is a false positive, set the guardrails block_dangerous_git_enabled option to false (/plugin configure) to bypass." >&2
 }
 
 # True (0) when a PowerShell command authors file content in a way that bypasses

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -450,7 +450,7 @@ ps::print_sink_trigger_line() {
     echo "Trigger: a construct the guard cannot faithfully tokenize (backtick, '--%', subexpression, or {}/() grouping). Remove it, or run the command via the Bash tool." >&2
     ;;
   dynamic-invocation)
-    echo "Trigger: a dynamic invocation (iex/Invoke-Expression, or a call '&' / dot-source '.' of a computed target) whose program name is not statically decidable. Invoke the target by its literal name — a constant path in quotes ('& \"C:\\path\\script.ps1\"') is decidable and is not blocked." >&2
+    echo "Trigger: a dynamic invocation (iex/Invoke-Expression, or a call '&' / dot-source '.' of a computed target) whose program name is not statically decidable. Invoke the target by its literal name — a constant quoted path is decidable and is not blocked; only an interpolating target (a double-quoted string containing a variable or subexpression) reaches this branch." >&2
     ;;
   launcher)
     echo "Trigger: a process launcher or nested shell (Start-Process/saps/start, pwsh, powershell, cmd), which the guard must see through the way it sees through 'bash -c'. Run the program directly, or run the command via the Bash tool." >&2
@@ -603,6 +603,8 @@ ps::write_bypass() {
     seg="${seg#"${seg%%[![:space:]]*}"}" # ltrim
     [[ "$seg" == *'>'* ]] || continue
     # Exclude the `$null` discard (PowerShell's /dev/null).
+    # portability-ok: `\>` escapes a literal `>` inside a bash [[ =~ ]] ERE, it
+    # is not GNU grep's `\>` word-boundary — no external grep/sed is involved.
     [[ "$seg" =~ \>\>?[[:space:]]*\$null([[:space:]]|$) ]] && continue
     # Unwrap grouping parens AND script-block braces so a grouped producer is
     # judged by what it produces: `('secret') > f` (quote-stripped to `() > f`)


### PR DESCRIPTION
Closes #1973

## Summary

`ps::might_invoke_git`'s call-target branch matched any quote character after `&` or `.`, so `& "C:\tools\publish.ps1"` — the ordinary PowerShell script-invocation idiom, carrying no `git` token and a compile-time constant path — routed to the fail-closed sink and was refused by a *git* guard. Both quote styles and the dot-source form were affected, and because the predicate is shared, the same command false-blocked twice: once from `block-dangerous-git`, once from `block-no-verify`.

The branch now matches only a genuinely computed target: a bare variable or subexpression (`& $tool`, `& (…)`), or a double-quoted string that **interpolates** (`& "$tool"`, `& "C:\tools\$ver\x.exe"`).

Per PowerShell [`about_Quoting_Rules`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules), a `$`-free double-quoted string and any single-quoted string are compile-time constants, so such a target is statically decidable as non-git.

## No fail-open

This is the risk that mattered, so it is covered in both directions:

- The literal-git probe runs **quote-intact**, so `& 'git' …`, `& "git" …`, and `& "C:\Git\cmd\git.exe" …` are still caught by name.
- Every interpolated form still blocks — a blanket removal of the quote class would have failed OPEN on `& "$tool" commit`.

Regression cases for both directions are checked in on both guards' suites (13 new cases).

## Also in this change

- **Block messages name the real trigger.** They previously listed backtick / `--%` / subexpression / script-block / here-string regardless of which of the four sink triggers actually fired, so "remove the unparsable construct" was unactionable when the trigger was a launcher or a computed target. `ps::classify_git_command` now records the trigger in `PS_SINK_TRIGGER` and each message prints remediation specific to it.
- **Both fail-closed messages name their kill switch**, which the sibling too-long and alias-cap messages already did.
- **Telemetry carries the trigger** instead of collapsing all four shapes into one `powershell-unparsable` token that hid the false-positive rate.
- **The git and python-write lanes share one call-target predicate** instead of two drifted regexes — the git lane's blanket quote match *was* the drift. The python lane's behavior is unchanged; it takes the interpolating-string half only, as before.

One implementation note: the shared operator prefix is spelled out in each predicate rather than concatenated in from a variable. Mixing an unquoted variable with adjacent literal regex text in a `[[ =~ ]]` pattern is version-sensitive, and a predicate that quietly stops matching fails OPEN. The two named functions are the seam that prevents drift.

## Verification

858 tests pass across the five affected suites, shellcheck clean:

| Suite | Result |
|---|---|
| `block-dangerous-git` | 329 pass |
| `block-hook-bypass` | 211 pass |
| `block-noncanonical-commit` | 172 pass |
| `block-no-verify` | 115 pass |
| `block-convention-violation` | 31 pass |

Before the fix, all five constant-target shapes exited 2 on a live repro battery; after, all exit 0 while every must-block shape still exits 2.

`guardrails` 0.19.0 → 0.19.1.

## Related

- Reported via the plugin handoff inbox item `20260807-182002-guardrails-block-dangerous-git-ps-call-op-false-positive`, produced by a `plugin-quality:audit` run on a consuming project.
- One correction to that brief, recorded on the item: `& $tool reset --hard` (bare variable, no other construct) is allowed and is the **documented A2b residual**, not part of this false-positive class — nothing routes it to the sink.