### PR TITLE
ci: verify the shared hook lib on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,12 @@ jobs:
   # Keep this job SMALL. Adding a platform-agnostic suite here buys no coverage
   # and pays Windows' process-creation cost (~140ms/spawn vs ~3ms on Linux),
   # which is the whole reason the full suite is unusable on a Windows dev box.
+  # Pinned, not `windows-latest`: the runner policy forbids the floating
+  # `*-latest` labels outright (policy.json forbiddenHostedRunnerLabels), for the
+  # same reason the Linux lanes pin ubuntu-24.04 — an image roll must be a
+  # reviewed commit, not a silent Tuesday.
   hook-utils-windows:
-    runs-on: windows-latest
+    runs-on: windows-2025
     timeout-minutes: 20
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,39 @@ jobs:
       paths: .
       fail-on-severity: low
 
+  # The ONLY job on a Windows runner, and deliberately so. Every other suite in
+  # this repository is platform-agnostic bash string logic that a Linux runner
+  # exercises identically — `lib/powershell/ps-command.sh`, for instance, carries
+  # zero `OSTYPE`/`cygpath`/`uname` branches despite classifying PowerShell
+  # commands, so Linux tests it faithfully.
+  #
+  # `lib/hook-utils.sh` is the exception: it carries OSTYPE-gated branches that a
+  # Linux runner NEVER EXECUTES — case-insensitive path folding for the Windows
+  # filesystem, and `cygpath` short-name (8.3) resolution. Those branches were
+  # previously verified only by whatever a maintainer happened to run on a dev
+  # box. This job is what makes them a gate.
+  #
+  # Free: GitHub Actions is free for public repositories on standard
+  # GitHub-hosted runners, Windows included; only larger runners are charged.
+  # https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions
+  #
+  # Keep this job SMALL. Adding a platform-agnostic suite here buys no coverage
+  # and pays Windows' process-creation cost (~140ms/spawn vs ~3ms on Linux),
+  # which is the whole reason the full suite is unusable on a Windows dev box.
+  hook-utils-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run shared lib tests on Windows
+        run: bash lib/hook-utils.test.sh
+
   hook-utils-sync:
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,11 @@ jobs:
   # Linux runner NEVER EXECUTES — case-insensitive path folding for the Windows
   # filesystem, and `cygpath` short-name (8.3) resolution. Those branches were
   # previously verified only by whatever a maintainer happened to run on a dev
-  # box. This job is what makes them a gate.
+  # box. This job is what makes them a gate — but only because it is also listed
+  # in the `ci-status` needs graph below. `ci-status` is the single required merge
+  # check, so a lane missing from that list is informational no matter how loudly
+  # a comment here calls it a gate: the aggregate would report success while this
+  # lane was red.
   #
   # Free: GitHub Actions is free for public repositories on standard
   # GitHub-hosted runners, Windows included; only larger runners are charged.
@@ -997,6 +1001,7 @@ jobs:
     needs:
       - hygiene
       - hook-utils-sync
+      - hook-utils-windows
       - parse-concern-value-sync
       - resolve-convention-pattern-sync
       - standards-contract-sync


### PR DESCRIPTION
No linked issue

## Summary

Every CI job in this repository runs on `ubuntu-24.04`. `lib/hook-utils.sh` carries `OSTYPE`-gated branches that a Linux runner **never executes**:

- case-insensitive path folding for the Windows filesystem
- `cygpath` short-name (8.3) resolution

Those branches have only ever been exercised by whatever a maintainer happened to run on a dev box. This adds the job that makes them a gate.

## Why only one suite

This is deliberately narrow, and the narrowness is the point.

I checked which code is genuinely platform-dependent rather than assuming. `lib/hook-utils.sh` has 18 platform-conditional sites with explicit `OSTYPE` branches. `lib/powershell/ps-command.sh` — which classifies *PowerShell* commands, and is therefore the intuitive candidate for a Windows job — has **zero**. It is pure bash string manipulation and behaves identically on both platforms, so Linux already tests it faithfully.

Adding platform-agnostic suites to a Windows runner would buy no coverage while paying Windows' process-creation cost. Measured on a Windows dev box: **~140ms per process spawn**, against ~3ms on Linux. A hook invocation spawns 7 externals, so it costs ~2.0s on Windows; the largest suite has 319 cases and takes ~11 minutes there. That cost is exactly why the full suite is unusable locally on Windows, and why it should not be replicated in CI.

The comment block on the job states this rule so the job does not accrete suites over time.

## Cost

Free. GitHub Actions is free for public repositories on standard GitHub-hosted runners, Windows included; only *larger* runners are charged — per [GitHub's billing docs](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions), fetched for this change:

> GitHub Actions usage is free for self-hosted runners and for public repositories that use standard GitHub-hosted runners.

## Verification

`actionlint` clean. The job's real verification is its first run on this PR — if `lib/hook-utils.test.sh` has latent Windows assumptions, this is where we find out, which is the point of adding it.

## Related

- Came out of investigating why the guardrails hook suites take ~50 minutes to run serially on a Windows dev box. Two follow-ups are queued from the same investigation: cutting `lib/hook-utils.sh`'s per-invocation subprocess spawns from 7 to ~1 (which also addresses two open hook-timeout reports from a consuming project), and an affected-suite selector so a local run does not mean running all 60 suites.
- Related finding, not addressed here: `block-noncanonical-commit.test.sh` uses hard `timeout 30` wall-clock ceilings, which fail spuriously when the box is loaded. Surfaced while running suites in parallel.