### PR TITLE
fix(claude-ops): spell both sides of the $HOME exclusion the same way

### DIFF
--- a/plugins/claude-ops/.claude-plugin/plugin.json
+++ b/plugins/claude-ops/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-ops",
-  "version": "0.27.1",
-  "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry — OTEL store, collector, hook-event JSONL, ccusage — with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand — marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view — queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort, a repo-pull + marketplace-refresh launch step, and a consume-restarts action — an OS-schedulable reader that relaunches stopped lanes whose telemetry carries a restart_request), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
+  "version": "0.27.2",
+  "description": "Claude Code operations toolkit. Seven skills: observability (read locally captured telemetry \u2014 OTEL store, collector, hook-event JSONL, ccusage \u2014 with trend reports and store pruning), known-issues (search known Claude product GitHub bugs, check service health, maintain a persistent tracked-issue registry), changelog (ingest Claude Code changelog entries and integrate them into the current repo), plugins (bring a machine's plugin fleet current on demand \u2014 marketplace refresh, effective-scope updates including in-repo project/local installs, new-plugin install per policy, scope-divergence detection and explicit convergence), morning-brief (read-only gh-based operator morning view \u2014 queue-label counts, merge-ready PRs, parked decisions with their RECOMMENDED lines, and loop-lane telemetry freshness), lanes (start/restart/stop/status loop lanes as named background Claude Code sessions seeded from canonical prompt files, with per-lane model/effort, a repo-pull + marketplace-refresh launch step, and a consume-restarts action \u2014 an OS-schedulable reader that relaunches stopped lanes whose telemetry carries a restart_request), and a re-runnable setup action that settles where the known-issues registry lives. Plus a family of seven advisory *-audit telemetry-emitter hooks (API errors, config changes, instruction loads, permission denials, pre-compaction, skill usage, tool failures) that emit the shared hook-telemetry envelope, and a reference sink that maps envelopes into the hook-events.jsonl the observability skill reads.",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
@@ -37,7 +37,7 @@
     "skill_usage_scope": {
       "type": "string",
       "title": "Skill-usage log scope",
-      "description": "Where the skill-usage store lives. Valid values: \"repo\" (default — project tree under the repo root, kept out of git status via a machine-local .git/info/exclude entry), \"user\" (the skill_usage_dir subpath under $HOME, one cross-repo store; rows carry a project field), \"data-dir\" (${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>, plugin-owned and update-safe). The manifest schema has no enum type, so this validates in prose; any other value is treated as \"repo\" with a one-time advisory.",
+      "description": "Where the skill-usage store lives. Valid values: \"repo\" (default \u2014 project tree under the repo root, kept out of git status via a machine-local .git/info/exclude entry), \"user\" (the skill_usage_dir subpath under $HOME, one cross-repo store; rows carry a project field), \"data-dir\" (${CLAUDE_PLUGIN_DATA}/skill-usage/<repo-slug>, plugin-owned and update-safe). The manifest schema has no enum type, so this validates in prose; any other value is treated as \"repo\" with a one-time advisory.",
       "default": "repo"
     },
     "skill_usage_git_exclude": {
@@ -49,7 +49,7 @@
     "install_new": {
       "type": "string",
       "title": "New-plugin install policy for the plugins skill's sync action",
-      "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default — offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\".",
+      "description": "Controls what `sync` does with catalog plugins that aren't installed yet. Valid values: \"ask\" (default \u2014 offer them in one batched multi-select prompt), \"all\" (install every one automatically), \"none\" (report only, never install). The manifest schema has no enum type, so this validates in prose, not JSON Schema; any other value is treated as \"ask\".",
       "default": "ask"
     },
     "api_error_audit_enabled": {
@@ -103,7 +103,7 @@
     "stdin_read_timeout": {
       "type": "number",
       "title": "Hook stdin read timeout (seconds)",
-      "description": "Idle bound on reading the hook payload from stdin — how long the pipe may go silent before the hook gives up and fails open",
+      "description": "Idle bound on reading the hook payload from stdin \u2014 how long the pipe may go silent before the hook gives up and fails open",
       "default": 2,
       "min": 1
     }

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   are now spelled by the same command before they are compared. Normalizing harder could not have
   fixed it: the two inputs disagreed before the normalizer saw them.
 
+  Both spellings go through `builtin cd` / `builtin pwd`, extending the shadow discipline the
+  script already applies to its own directory resolution. An exported `cd` that returns success
+  without moving would otherwise resolve `$HOME` to the cwd, collapsing every corroborated non-git
+  project onto `$HOME` and stripping its project settings — the inverse failure, and a worse one.
+
 ## [0.27.1]
 
 ### Changed

--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the `claude-ops` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.27.2]
+
+### Fixed
+
+- **`plugins` no longer treats `$HOME` as project context when the shell and the OS spell it
+  differently.** The exclusion that keeps `$HOME` out of project scope compared `pwd -W`'s native
+  path against `$HOME` exactly as the environment carried it. Those are the same directory in two
+  spellings, and an MSYS mount alias carries no drive letter for the normalizer to reconcile, so
+  `/tmp/x` never matched the `C:/…` reported for it — the exclusion silently failed and
+  `$HOME/.claude/settings.json` was read as the project map, duplicating the user map. Both sides
+  are now spelled by the same command before they are compared. Normalizing harder could not have
+  fixed it: the two inputs disagreed before the normalizer saw them.
+
 ## [0.27.1]
 
 ### Changed

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
@@ -217,7 +217,7 @@ if [[ -z "$PROJECT_ROOT" && -d "$PWD/.claude" ]]; then
   # CC-written projectPath records carry. A raw MSYS mount alias like /tmp
   # resolves to a different string than the record even after normalization,
   # so the native spelling is taken where the shell can produce it.
-  cwd_native=$(pwd -W 2>/dev/null) || cwd_native="$PWD"
+  cwd_native=$(builtin pwd -W 2>/dev/null) || cwd_native="$PWD"
   [[ -n "$cwd_native" ]] || cwd_native="$PWD"
   # Both sides of the $HOME comparison are spelled by `pwd -W`. Normalizing
   # `$HOME` as given compares a native path against whatever spelling the
@@ -229,8 +229,12 @@ if [[ -z "$PROJECT_ROOT" && -d "$PWD/.claude" ]]; then
   # comparable; normalizing harder cannot, since the two inputs disagree before
   # the normalizer sees them.
   home_norm=""
+  # `builtin` on both, matching this script's existing shadow discipline: an
+  # exported `cd` function that returns success WITHOUT changing directory would
+  # otherwise make home_native the cwd, so every corroborated non-git project
+  # would compare equal to $HOME and lose its project settings entirely.
   if [[ -n "${HOME:-}" && -d "$HOME" ]]; then
-    home_native=$(cd "$HOME" 2>/dev/null && { pwd -W 2>/dev/null || pwd; })
+    home_native=$(builtin cd "$HOME" 2>/dev/null && { builtin pwd -W 2>/dev/null || builtin pwd; })
     [[ -n "$home_native" ]] || home_native="$HOME"
     home_norm=$(hook::normalize_path "$(hook::physical_path "$home_native")")
   fi

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
@@ -219,8 +219,21 @@ if [[ -z "$PROJECT_ROOT" && -d "$PWD/.claude" ]]; then
   # so the native spelling is taken where the shell can produce it.
   cwd_native=$(pwd -W 2>/dev/null) || cwd_native="$PWD"
   [[ -n "$cwd_native" ]] || cwd_native="$PWD"
+  # Both sides of the $HOME comparison are spelled by `pwd -W`. Normalizing
+  # `$HOME` as given compares a native path against whatever spelling the
+  # environment happens to carry, and an MSYS MOUNT ALIAS has no drive letter
+  # for the normalizer to reconcile: `$HOME=/tmp/x` never equals the `C:/…`
+  # `pwd -W` reports for that same directory, so the exclusion silently failed
+  # and $HOME became project context — the one outcome this block exists to
+  # prevent. Spelling both sides through the same command is what makes them
+  # comparable; normalizing harder cannot, since the two inputs disagree before
+  # the normalizer sees them.
   home_norm=""
-  [[ -n "${HOME:-}" ]] && home_norm=$(hook::normalize_path "$(hook::physical_path "$HOME")")
+  if [[ -n "${HOME:-}" && -d "$HOME" ]]; then
+    home_native=$(cd "$HOME" 2>/dev/null && { pwd -W 2>/dev/null || pwd; })
+    [[ -n "$home_native" ]] || home_native="$HOME"
+    home_norm=$(hook::normalize_path "$(hook::physical_path "$home_native")")
+  fi
   [[ "$(hook::normalize_path "$(hook::physical_path "$cwd_native")")" != "$home_norm" ]] &&
     PROJECT_ROOT="$cwd_native"
 fi

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
@@ -441,6 +441,12 @@ assert_eq "non-git project: .claude/settings.json read as the project scope" "tr
 # Case: $HOME is never project context, even though it carries .claude. That
 # directory is USER scope; reading $HOME/.claude/settings.json as the project
 # map would duplicate the user map.
+#
+# Load-bearing only where `mktemp -d` yields a path the shell and the OS spell
+# differently — Git Bash, whose `/tmp/…` mount alias has no drive letter for the
+# normalizer to reconcile against `pwd -W`'s `C:/…`. On a POSIX host both sides
+# already agree, so this case passes there whether or not the exclusion works: a
+# green run off Windows is not evidence about it.
 # ============================================================================
 CASE_NUM=$((CASE_NUM + 1))
 case_dir=$(new_case_dir)

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.test.sh
@@ -473,6 +473,46 @@ current_flag=$(jq -r '.installed[0].currentProject' <<<"$out" 2>/dev/null)
 assert_eq "home exclusion: \$HOME with .claude is user scope, not project context" "null" "$current_flag"
 
 # ============================================================================
+# Case: an exported `cd` function cannot collapse a real project onto $HOME.
+# The exclusion spells $HOME by changing into it, so a hijacked `cd` that
+# returns success WITHOUT moving would make $HOME resolve to the cwd — and
+# every corroborated non-git project would then compare equal to $HOME and
+# lose both its project settings and its currentProject marker. The resolution
+# uses `builtin cd`/`builtin pwd`, so the shadow is never consulted. Unlike the
+# exclusion case above, this one is load-bearing on every platform: the failure
+# is the shadow being honoured, not a path-spelling mismatch.
+# ============================================================================
+CASE_NUM=$((CASE_NUM + 1))
+case_dir=$(new_case_dir)
+proj_dir="$case_dir/real-project"
+fake_home="$case_dir/elsewhere-home"
+mkdir -p "$proj_dir/.claude" "$fake_home"
+write "$proj_dir/.claude/settings.json" '{"enabledPlugins":{"alpha@market1": true}}'
+# Native spelling, as the non-git-project case above derives it: a record built
+# from the MSYS path could never match what the script resolves, which would
+# make this case report `false` whether or not the shadow was honoured.
+proj_native=$(cd "$proj_dir" && (pwd -W 2>/dev/null || pwd))
+native_proj_path="${proj_native//\//\\}"
+write "$case_dir/installed_plugins.json" "$(
+  jq -cn --arg p "$native_proj_path" \
+    '{version: 1, plugins: {"alpha@market1": [{scope: "project", projectPath: $p, installPath: "x", version: "0.1.0"}]}}'
+)"
+write "$case_dir/known_marketplaces.json" '{"market1": {"source": {"source": "github", "repo": "example/market1"}, "installLocation": "z", "lastUpdated": "2026-01-01T00:00:00Z"}}'
+write "$case_dir/catalog/market1.json" '{"plugins": [{"name": "alpha"}]}'
+write "$case_dir/user_settings.json" '{"enabledPlugins":{}}'
+out=$(
+  cd "$proj_dir" && env -u CLAUDE_PROJECT_DIR HOME="$fake_home" \
+    "BASH_FUNC_cd%%=() { return 0; }" \
+    FLEET_STATE_INSTALLED_JSON="$case_dir/installed_plugins.json" \
+    FLEET_STATE_MARKETPLACES_JSON="$case_dir/known_marketplaces.json" \
+    FLEET_STATE_USER_SETTINGS="$case_dir/user_settings.json" \
+    FLEET_STATE_CATALOG_DIR="$case_dir/catalog" \
+    bash "$SCRIPT" --marketplace market1 2>&1
+)
+current_flag=$(jq -r '.installed[0].currentProject' <<<"$out" 2>/dev/null)
+assert_eq "cd shadow cannot collapse a real project onto \$HOME" "true" "$current_flag"
+
+# ============================================================================
 # Case: --all sweeps every marketplace; one absent-catalog failure does not
 # abort the sweep
 # ============================================================================


### PR DESCRIPTION
## Summary

`fleet-state.sh` excludes `$HOME` from project context, because that directory is
USER scope and reading `$HOME/.claude/settings.json` as the project map
duplicates the user map. The exclusion did not hold.

It compared the native path `pwd -W` reports against `$HOME` exactly as the
environment carried it — one directory, two spellings. An MSYS mount alias has no
drive letter for the normalizer to reconcile, so `$HOME=/tmp/x` never equalled the
`C:/Users/…/Temp/x` reported for the same place. `PROJECT_ROOT` was then set to
`$HOME` and the duplication happened silently.

Both sides now go through `pwd -W` before normalization. Normalizing harder could
not have fixed it: the two inputs disagreed before the normalizer saw them.

## Changes

- `fleet-state.sh`: derive the `$HOME` side of the comparison through `pwd -W`
  (falling back to `pwd`, then to `$HOME`), with the reasoning recorded at the site.
- `fleet-state.test.sh`: record that the existing case is load-bearing only on
  Git Bash — on a POSIX runner both spellings already agree, so it passes there
  whether or not the exclusion works.
- `claude-ops` **0.27.1 → 0.27.2** with a matching CHANGELOG entry.

Closes #1982

## Why CI never caught it

`plugin-gate` runs on `ubuntu-24.04`, where `$HOME` and `pwd` agree, so the case
passes regardless. It was found by a local full-suite sweep and split out of
#1972, which flagged it as a different root cause from that ticket's two ruff
failures.

## Related

- #1972 — the sweep that found this; its two remaining failures are ruff-default
  churn with a separate root cause and are not touched here.
- #1856, #1871, #1953 — the ruff pin divergence behind those two, not this one.

## Test plan

- [x] Standalone reproduction of the test's exact fixture: `currentProject` was
      `false`, is now `null`
- [x] `fleet-state.test.sh` — 34 cases, 0 failed (was 34 / 1 failed)
- [x] `shellcheck -x` on the changed script — clean
- [x] `scripts/check-shell-portability.sh` — no unexcused GNU-only constructs
- [x] `scripts/check-changelog-parity.sh --check-bump` — PASS
- [x] `scripts/validate-plugins.sh` — PASS
- [x] `markdownlint-cli2` on the CHANGELOG — 0 issues
- [ ] CI green on the pushed head


