### PR TITLE
chore(claude-lanes): re-pin the review lanes to ci-workflows v0.10.2

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
     concurrency:
       group: claude-review-${{ github.repository }}
       queue: max
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@e94438746c300b02385a7f8a2a2dcd19a7f4ad4a # v0.10.2
     with:
       runner: ubuntu-24.04
     # Pass only the one named secret (least privilege) rather than `secrets:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@c136b27f404dd32ce3873f39a6f3443891d1c16e # v0.9.1
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@e94438746c300b02385a7f8a2a2dcd19a7f4ad4a # v0.10.2
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths


### PR DESCRIPTION
> [!WARNING]
> **Do not merge before melodic-software/standards#337 has merged AND its sync
> PR has landed here.** CI on this branch is expected RED until then — see
> "Ordering" below. The `do-not-merge` label is applied deliberately.

## Summary

Re-pins both Claude lane callers from ci-workflows v0.9.1 (`c136b27f`) to
v0.10.2 (`e94438746c300b02385a7f8a2a2dcd19a7f4ad4a`).

These two callers are `locally-owned` in the standards sync manifest, not
managed — this is the org's one PUBLIC caller target, and runner-policy forbids
a public repository from referencing the governed `select-runner` indirection —
so the pins are bumped here rather than arriving by sync.

Neither reusable changes its input names, secret key set, `runs-on`, or
caller-permission surface against v0.9.1, so no caller edit beyond the pin is
required.

## Ordering — this PR is blocked

`.github/standards/runner-policy/policy.json` is a MANAGED materialization and
is deliberately **not** touched here. It still approves only `c136b27f`, and
the gate fails closed on the new SHA. Measured locally on this branch:

```
$ node .github/standards/runner-policy/runner-policy.mjs --root .
.github/workflows/claude-review.yml#review: runner-target-contract: the reusable
  workflow path@SHA has no reviewed runner-input contract (auto-approval
  declined: inputs changed since the previously reviewed ...@1d3762c2)
.github/workflows/claude-security-review.yml#security-review: runner-target-contract:
  the reusable workflow path@SHA has no reviewed runner-input contract
  (auto-approval declined: inputs changed since the previously reviewed ...@66073e58)
exit 1
```

The same command on the unmodified base exits `0`, so this is caused by the pin
bump and not pre-existing.

melodic-software/standards#337 adds the v0.10.2 contracts to the policy source.
Merging it triggers the sync cascade (`sync.yml` runs on `push` to `main`),
which delivers the updated `policy.json` here. Once that sync PR merges, re-run
CI on this branch and it goes green.

## Test plan

- `node .github/standards/runner-policy/runner-policy.mjs --root .` — currently
  exits 1 by design (above); expected to exit 0 after the policy sync lands.
- No other repository check is affected: the change is two `uses:` pin lines.

## Related

No linked issue.

This PR closes nothing. Related, not closed:

- melodic-software/standards#337 — the policy approval and component re-pin
  this PR depends on.
- melodic-software/ci-workflows#355 — the change released as v0.10.2.
- melodic-software/claude-lane-sandbox#3 — the hand-wired fixture bump
  (independent; no policy dependency).
