### PR TITLE
fix(ruff): pin the rule set so an upstream default change cannot break the repo

### DIFF
--- a/plugins/disk-hygiene/skills/setup/scripts/python3_alias_probe.py
+++ b/plugins/disk-hygiene/skills/setup/scripts/python3_alias_probe.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-import stat
 import sys
 from pathlib import Path
 

--- a/plugins/ruff-format/hooks/ruff-format.test.sh
+++ b/plugins/ruff-format/hooks/ruff-format.test.sh
@@ -284,9 +284,12 @@ fi
 # hook's fix pass passes --no-unsafe-fixes so the unattended edit-time pass
 # never applies fixes Ruff labels as possibly not intent-preserving. E712's
 # fix (x == True -> x) is such a fix: the comparison must survive and the
-# finding surface as advisory instead.
+# finding surface as advisory instead. The fixture selects E712 rather than
+# relying on it being a default rule — Ruff 0.16.0 dropped it from the default
+# set, and a case that asserts on one rule's fix safety must name that rule.
 REPO_UNSAFE="$WORK/unsafe-fixes"
-new_ruff_repo "$REPO_UNSAFE" 'unsafe-fixes = true'
+new_ruff_repo "$REPO_UNSAFE" 'unsafe-fixes = true
+lint.select = ["E712"]'
 printf 'x = 1\nif x == True:\n    pass\n' >"$REPO_UNSAFE/u.py"
 OUT=$(run_hook "$REPO_UNSAFE/u.py")
 RC=$?

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,29 @@
+# Repository-local Ruff policy, registered as `locally-owned` for this repo in
+# melodic-software/standards `distribution/sync-manifest.yml`. The managed
+# `ruff` component's canonical policy reports 385 findings against this tree
+# (melodic-software/standards#335); adopting it is a migration, not a config
+# flip. Re-adopt as `managed` there when that migration is scheduled.
+#
+# What this file is for: without it every ruff invocation in this repo lints
+# against whatever upstream's default selection happens to be that release.
+# Ruff 0.16.0 moved that default from 59 rules to 413 and dropped 18 `E`/`F`
+# rules from it, which turned two contract suites red on an unmodified `main`.
+# An explicit `select` makes the rule set a decision recorded here, so a version
+# bump can no longer change WHICH rules run.
+#
+# The selection is the pre-0.16 default set: Pyflakes plus the `E` groups that
+# flag real errors. It is deliberately a floor, not an aspiration — raise it
+# toward the managed policy with `extend-select` as each category is cleared.
+# Ref: https://docs.astral.sh/ruff/configuration/
+
+# Eval fixtures are input specimens, not code: an audit skill's fixture holds
+# the defect its eval asserts on, so linting it fails by construction.
+extend-exclude = ["**/evals/fixtures/**"]
+
+[lint]
+select = [
+  "E4", # pycodestyle — import errors
+  "E7", # pycodestyle — statement errors
+  "E9", # pycodestyle — syntax/IO errors
+  "F",  # Pyflakes — correctness
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,7 +17,11 @@
 # Ref: https://docs.astral.sh/ruff/configuration/
 
 # Eval fixtures are input specimens, not code: an audit skill's fixture holds
-# the defect its eval asserts on, so linting it fails by construction.
+# the defect its eval asserts on, so linting it fails by construction. Exclusion
+# governs directory traversal, which is what every invocation here does
+# (`ruff check plugins/ scripts/`, the engine suite's `ruff check . tests`). A
+# path handed to ruff DIRECTLY is still linted unless the caller also passes
+# `--force-exclude`, as the ruff-format hook does.
 extend-exclude = ["**/evals/fixtures/**"]
 
 [lint]

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,13 +8,24 @@
 # against whatever upstream's default selection happens to be that release.
 # Ruff 0.16.0 moved that default from 59 rules to 413 and dropped 18 `E`/`F`
 # rules from it, which turned two contract suites red on an unmodified `main`.
-# An explicit `select` makes the rule set a decision recorded here, so a version
-# bump can no longer change WHICH rules run.
+# An explicit `select` makes the rule set a decision recorded here rather than
+# one inherited from upstream.
+#
+# These are PREFIXES, not an enumeration, and that is the deliberate half of the
+# tradeoff: a future release adding a rule under `E4`, `E7`, `E9`, or `F` enables
+# it here automatically. What the selection buys is immunity to DEFAULT-SET
+# churn — a category moving in or out of upstream's defaults, which is the
+# failure that actually happened. The remaining exposure is closed by version
+# parity, not by config: the pin in `.github/requirements-ci.txt` is held equal
+# to the fleet inventory (melodic-software/dotfiles `.chezmoidata/uv-tools.yaml`)
+# so a new rule cannot reach CI before a developer, or the reverse. Enumerating
+# exact codes was the alternative; it trades a reviewable statement of intent for
+# a list nobody can read, and still needs the version pin.
 #
 # The selection is the pre-0.16 default set: Pyflakes plus the `E` groups that
 # flag real errors. It is deliberately a floor, not an aspiration — raise it
 # toward the managed policy with `extend-select` as each category is cleared.
-# Ref: https://docs.astral.sh/ruff/configuration/
+# Ref: https://docs.astral.sh/ruff/settings/#lint_select
 
 # Eval fixtures are input specimens, not code: an audit skill's fixture holds
 # the defect its eval asserts on, so linting it fails by construction. Exclusion


### PR DESCRIPTION
Closes #1972

## Summary

The repo had no ruff configuration, so every ruff invocation in it linted
against whatever upstream's default selection happened to be that release. Ruff
0.16.0 moved that default from 59 rules to 413 and removed eighteen `E`/`F`
rules from it — *"E401, E402, E701, E702, E703, E711, E712, E713, E714, E721,
E731, E741, E742, E743, F403, F405, F406, and F722"*
([0.16.0 release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.0)).
That single change is behind both failures in #1972: the expansion brought the
`TRY` category into the default set, and the removals took `E712` out of it.

## Fix

- **`ruff.toml`** selects `E4`, `E7`, `E9`, and `F` — the pre-0.16 default set.
  The rule set is now a decision recorded in the repo rather than one inherited
  from upstream. It is deliberately a floor: raise it toward the managed policy
  with `extend-select` as each category is cleared.
  Registered as `locally-owned` for this repo in
  melodic-software/standards#336 (merged), which is what keeps it from being a
  second unregistered lint policy.
- **Eval fixtures are excluded.** An audit skill's fixture holds the defect its
  eval asserts on, so linting it fails by construction. The comment records that
  exclusion governs *traversal*: Ruff's settings reference states *"Typically,
  Ruff will lint any paths passed in directly, even if they would typically be
  excluded"*, and that `force-exclude` *"will cause Ruff to respect these
  exclusions unequivocally"*. Every invocation here passes directories; the
  ruff-format hook passes a file explicitly and already sets `--force-exclude`.
  Verified both ways against the fixture path.
- **`ruff-format.test.sh` case 4e selects `E712` in its fixture** instead of
  relying on it being a default rule. A case asserting on one rule's fix safety
  must name that rule; this is version-agnostic rather than re-pinned.
- **Drops an unused `import stat`** in `python3_alias_probe.py` — a real `F401`
  the pinned set surfaces (line 90 calls `path.stat()`, the method, not the
  module).

## The TRY004 decision, recorded

#1972 asked for this on its merits rather than by config, so both halves:

- **On merits: the rule does not fit these sites.** All six raise on a decoded
  payload or a persisted state file failing an `isinstance` guard —
  `babysit_gh.py:603,699,728` on a GraphQL response, `babysit_lease.py:114`,
  `manage_feedback_ledger.py:176`, and `refresh_pr_branch.py:112` on state files
  this code wrote itself. None is a caller passing the wrong type to a function.

  That distinction is the whole argument, so it is worth being explicit that it
  is a judgment rather than something upstream states. TRY004's own rationale is
  "the Python documentation states that `TypeError` should be raised upon
  encountering an inappropriate type"; the Python docs' operative sentence is
  *"Passing arguments of the wrong type … should result in a `TypeError`"*,
  which is a caller-contract rule, and they define `RuntimeError` as "an error
  is detected that doesn't fall in any of the other categories." The broader
  opening sentence ("an operation or function is applied to an object of
  inappropriate type") could be read to cover these; the reading taken here is
  that data-integrity validation of a payload is not argument passing. Anything
  catching `RuntimeError` at these sites would change behavior if they were
  retyped. No `noqa` is needed; the sites stand as written.
- **Separately: `TRY` is not in the selected set**, so they are not findings
  today regardless. Recorded so a future `extend-select = ["TRY"]` knows the
  category was examined and rejected on merits, not merely left unselected.

## What the prefix selection does not buy

Review raised that `E4`/`E7`/`E9`/`F` are prefixes, so a later release adding a
rule inside one of those categories enables it here automatically — the original
wording of this PR overstated the invariant, and the file now says so at the
selection.

That exposure is real and is closed by version parity rather than by config. The
pin in `.github/requirements-ci.txt` is held equal to the fleet inventory
(melodic-software/dotfiles `.chezmoidata/uv-tools.yaml`), so a newly-added rule
cannot reach CI before a developer or the reverse; melodic-software/dotfiles#416
adds the check that keeps those two equal, and #1953 is the bump that makes them
equal today.

Enumerating the exact pre-0.16 codes was the alternative. It trades a reviewable
statement of intent for a list no reader can evaluate, freezes the policy against
genuinely useful new correctness rules inside `F`, and still needs the version
pin to be trustworthy — so it buys the appearance of the invariant rather than
the invariant.

## Verification

- `ruff check --no-cache --statistics plugins/ scripts/` → **0 findings**
  (166 under bare 0.16.0 defaults before this change).
- `bash plugins/ruff-format/hooks/ruff-format.test.sh` → `PASS=52 FAIL=0`
  (was `PASS=51 FAIL=1`).
- `bash plugins/source-control/skills/babysit-prs/scripts/engine.test.sh` →
  exit 0; `Ran 597 tests ... OK`, ruff section clean (83 findings under bare
  0.16.0 defaults before this change).
- `bash scripts/run-plugin-tests.sh` → complete sweep of all 170 suites, exit 0,
  `All plugin tests passed or were skipped.` Those two are also the only suites
  that invoke ruff at all (`grep -rl 'ruff check\|ruff format' --include=*.sh`
  finds `plugins/ruff-format/hooks/ruff-format.sh` and `engine.test.sh`), so no
  other suite could be affected by a lint config.
- The ruff-format fixtures build their own repos under `mktemp -d`, which
  resolves outside the worktree, so they do not inherit this config — case 4e's
  pass is real evidence about the fixture's own `select`, not about this file.
- Local ruff is 0.16.0, matching the fleet pin in `dotfiles`
  `.chezmoidata/uv-tools.yaml`, so these runs reproduce what a developer sees.
  CI still installs 0.15.22; #1953 is what closes that half.

## Related

- melodic-software/standards#336 — registers the `ruff` component as
  `locally-owned` for this repo; closes melodic-software/standards#335.
- Refs #1953 — the Dependabot bump to ruff 0.16.0. This makes it safe against
  the failure that happened: with `select` explicit, the bump cannot change
  which CATEGORIES run.
- Refs #1871 — resolves ruff from the pin file rather than PATH; it reads the
  pin dynamically, so it needs no value change once #1953 lands.
