### PR TITLE
fix(planning): give the Brief template the Q<N> id its own gate matches on

### DIFF
--- a/plugins/planning/.claude-plugin/plugin.json
+++ b/plugins/planning/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "planning",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "userConfig": {
     "use_ask_user_question": {
       "type": "boolean",

--- a/plugins/planning/CHANGELOG.md
+++ b/plugins/planning/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to the `planning` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.28.1]
+
+### Fixed
+
+- **`interview`: the Brief template now carries the `Q<N>` id the Step 4 gate matches on.** 0.28.0
+  added a cross-check proving every `deferred` / `blocked` register row reached the Brief's
+  `### Deferred questions`, keyed by the row's `Q<N>`. The requirement lived only in the script and
+  its fixtures — `loop.md`'s "Brief template (the literal shape)" still showed a deferred line
+  starting at `<question>`, with no id anywhere. A session writing the Brief exactly per the
+  documented template therefore failed the Step 4 cross-check with exit 2, which the skill treats
+  as a halt: **0.28.0 could block a template-conforming interview.** The template's deferred line,
+  its section guidance, the unattended ladder's step 3, and SKILL.md's Step 4 schema note now all
+  state that each deferred entry leads with its `Q<N>` id. Same failure class as the two the 0.28.0 review caught — the gate
+  blocking a run it should not — reached through the docs rather than the code.
+- **`interview`: eval 14 graded the pre-split gate contract.** It still asserted the check runs
+  "not after" persistence and that `--brief` is passed for an engineering session, both of which
+  0.28.0's two-run split reversed at Step 3. Nothing mechanical could catch this — `validate-evals`
+  checks schema and markdownlint does not read JSON — so it is called out here. Eval 13 gains the
+  `Q<N>` id in its unattended-blocker expectation for the same reason.
+
 ## [0.28.0]
 
 ### Added

--- a/plugins/planning/skills/interview/SKILL.md
+++ b/plugins/planning/skills/interview/SKILL.md
@@ -211,11 +211,11 @@ Derive `<topic-slug>` from the task or current branch name (kebab-case, ≤40 ch
 
 PLAN.md holds `## Brief` + `## Plan` sections. `/interview` writes only the Brief section; the Plan section stays empty until `/planning:plan` fills it.
 
-**Cross-check the Brief once it exists.** Immediately after writing it, re-run the register gate with `--brief <contract_dir>/<topic-slug>/PLAN.md` — this run proves every `deferred` and `blocked` row actually reached `### Deferred questions`, which the Step 3 run could not check because the file was not written yet. A non-zero exit means the Brief is missing a question the ledger retired: fix the Brief, do not retire the row. A general session writes no Brief and skips this.
+**Cross-check the Brief once it exists.** Immediately after writing it, re-run the register gate with `--brief <contract_dir>/<topic-slug>/PLAN.md` — this run proves every `deferred` and `blocked` row actually reached `### Deferred questions`, which the Step 3 run could not check because the file was not written yet. It matches on the `Q<N>` id, so each deferred entry must lead with one. A non-zero exit means the Brief is missing a question the ledger retired: fix the Brief, do not retire the row. A general session writes no Brief and skips this.
 
 If a PLAN.md Brief exists and user chose **revise**, edit the Brief in-place. If **start fresh**, append a dated scope-change note to the top of the Brief capturing why before rewriting — never silently overwrite — and let the commit message carry the pivot rationale.
 
-Section schema: write the literal `## Brief` template — TLDR / Goal / Constraints / Acceptance criteria / Captured assumptions / Out-of-scope / Deferred questions — per [`context/loop.md`](context/loop.md) "Brief template (the literal shape)". Each **Deferred question** carries an **arbiter tag** (`/planning:plan` default, or `USER-RESERVED` when its resolution could change acceptance criteria / out-of-scope / constraints) — load-bearing; loop.md covers when to use which.
+Section schema: write the literal `## Brief` template — TLDR / Goal / Constraints / Acceptance criteria / Captured assumptions / Out-of-scope / Deferred questions — per [`context/loop.md`](context/loop.md) "Brief template (the literal shape)". Each **Deferred question** leads with its **`Q<N>` id** — the tie back to its register row, and what the Step 4 gate greps this section for — and carries an **arbiter tag** (`/planning:plan` default, or `USER-RESERVED` when its resolution could change acceptance criteria / out-of-scope / constraints) — both load-bearing; loop.md covers when to use which.
 
 ### Step 5 — Hand off
 

--- a/plugins/planning/skills/interview/context/loop.md
+++ b/plugins/planning/skills/interview/context/loop.md
@@ -211,7 +211,7 @@ The ladder, in order:
 
 1. **Facts stay facts.** Resolve from the environment exactly as always — this path changes nothing about the codebase gate.
 2. **Codebase-resolvable or unambiguous-conventional decisions** resolve as they would interactively. Record the row `answered` with the basis in the resolution field, marked `auto-resolved (unattended)`.
-3. **A decision that is genuinely the user's** — real tradeoffs, no codebase answer — is NEVER assumed. Record the row `blocked`, write the question into the Brief's `### Deferred questions` with **arbiter: USER-RESERVED**, and name it as a blocker in the run's output.
+3. **A decision that is genuinely the user's** — real tradeoffs, no codebase answer — is NEVER assumed. Record the row `blocked`, write the question into the Brief's `### Deferred questions` led by its `Q<N>` id and tagged **arbiter: USER-RESERVED**, and name it as a blocker in the run's output.
 4. **Never idle-wait.** A run with nobody to answer stops on its blockers rather than holding the lane.
 5. **The confirmation gate cannot be satisfied unattended.** Report the contract as unconfirmed with its blocker list; absence of objection is not confirmation.
 
@@ -277,7 +277,7 @@ Each section in the PLAN.md Brief captures a specific shape. Keep tight.
 
 **Out-of-scope** — things raised during the interview and explicitly excluded. Distinct from non-goals (constraints up-front); these surfaced in conversation.
 
-**Deferred questions** — questions deferred-fully. Out of scope for this task but recorded so they don't silently become hidden assumptions.
+**Deferred questions** — questions deferred-fully, plus the `blocked` ones an unattended run could not put to anybody. Out of scope for this task but recorded so they don't silently become hidden assumptions. **Each entry leads with its `Q<N>` id** — that id is what ties the contract entry back to its register row, and the Step 4 gate greps this section for it; an entry written without one reads as a question the ledger retired and the contract never recorded, and halts the gate.
 
 ### Brief template (the literal shape)
 
@@ -305,7 +305,7 @@ Write this into `<contract_dir>/<topic-slug>/PLAN.md` (default `docs/topics/`; t
 - <thing the user raised and explicitly excluded>
 
 ### Deferred questions
-- <question> — defer until <when>; **arbiter: /planning:plan** (default — /planning:plan resolves unilaterally during planning) OR **arbiter: USER-RESERVED** (user must re-confirm at /planning:plan approval gate; /planning:plan proposes, user resolves)
+- Q<N> — <question> — defer until <when>; **arbiter: /planning:plan** (default — /planning:plan resolves unilaterally during planning) OR **arbiter: USER-RESERVED** (user must re-confirm at /planning:plan approval gate; /planning:plan proposes, user resolves)
 
 ## Plan
 <empty — populated by /planning:plan>

--- a/plugins/planning/skills/interview/evals/evals.json
+++ b/plugins/planning/skills/interview/evals/evals.json
@@ -167,7 +167,7 @@
       "files": [],
       "expectations": [
         "The unattended condition comes from the caller's declaration, not from the skill claiming to detect a non-interactive environment",
-        "A genuine user design decision is recorded as a named blocker (register `blocked` + Brief deferred question with arbiter USER-RESERVED), never as a silently captured assumption",
+        "A genuine user design decision is recorded as a named blocker (register `blocked` + a Brief deferred question leading with its Q<N> id and tagged arbiter USER-RESERVED), never as a silently captured assumption",
         "Codebase-resolvable or unambiguous-conventional decisions still resolve, recorded as auto-resolved",
         "The run terminates on its blockers instead of waiting indefinitely, and reports the contract as unconfirmed rather than reading absence of objection as confirmation"
       ]
@@ -176,13 +176,14 @@
       "id": 14,
       "name": "register-gate-halts-before-the-contract-locks",
       "prompt": "/planning:interview — we've covered enough, write the brief for the audit-log retention work.",
-      "expected_output": "Before persisting the contract or handing off, the skill runs scripts/check-open-questions.sh over the ledger (and the Brief when the session is engineering). A non-zero exit halts: exit 1 means a question is still `open`, exit 2 means the register could not be graded at all (missing register, gapped Q numbering, a deferred row the Brief never records). Neither is treated as a pass — the skill resolves or explicitly retires the row and re-runs rather than locking the contract over a failing check.",
+      "expected_output": "The skill runs scripts/check-open-questions.sh twice. At Step 3, before the contract is persisted, it passes --ledger ONLY — PLAN.md does not exist yet, and the gate exits 2 on a named-but-missing --brief. Then, immediately after Step 4 writes the Brief, it re-runs with --brief to prove every deferred/blocked row reached `### Deferred questions`, matched on the leading Q<N> id. A non-zero exit halts either time: exit 1 means a question is still `open`, exit 2 means the register could not be graded (missing register, malformed row, gapped or leading-zero Q numbering, a retired row the Brief never records). Neither is a pass — the skill resolves or explicitly retires the row, or fixes the Brief, and re-runs rather than locking the contract over a failing check. A run that asked no question wrote no register and skips the gate entirely.",
       "files": [],
       "expectations": [
-        "The register check runs before the contract is persisted or handed off, not after",
+        "The Step 3 run passes --ledger only; --brief is NOT named before Step 4 has written PLAN.md",
+        "The gate re-runs with --brief immediately after the Brief is written, in an engineering session",
         "Exit 1 halts the lock and the still-open question is resolved or explicitly retired first",
-        "Exit 2 (ungradeable) is treated as a halt, never as a pass",
-        "--brief is passed for an engineering session writing a PLAN.md, and omitted for a general session that writes no Brief"
+        "Exit 2 (ungradeable) is treated as a halt, never as a pass; on the Step 4 run a missing question means the Brief is fixed, not the register row retired",
+        "A general session writing no Brief runs only the ledger-only form, and a run that asked no question skips the gate rather than failing it"
       ]
     }
   ]


### PR DESCRIPTION
No linked issue

Follow-up to #1994, found reviewing that merge rather than reported.

## The defect

#1994 added a Step 4 cross-check proving every `deferred` / `blocked` open-question register row actually reached the Brief's `### Deferred questions`, matched on the row's `Q<N>` id.

**That requirement lived only in the script and its test fixtures.** `context/loop.md`'s "Brief template (the literal shape)" — the shape an authoring session is told to write — still read:

```markdown
### Deferred questions
- <question> — defer until <when>; **arbiter: /planning:plan** OR **arbiter: USER-RESERVED**
```

No id, anywhere. So a session writing the Brief exactly per the documented template fails the Step 4 cross-check with exit 2, and `SKILL.md` makes exit 2 a halt. **0.28.0 could block a template-conforming interview** — the same failure class the #1994 review round caught twice (the gate blocking a run it should not), reached through the docs instead of the code.

Four surfaces now state the leading id: the template's deferred line, the `**Deferred questions**` section guidance, the unattended ladder's step 3 (which writes a `blocked` question into that same section), and `SKILL.md`'s Step 4 schema note.

## Also: eval 14 graded the pre-split contract

#1994's first review round split the gate in two — ledger-only at Step 3, `--brief` at Step 4. `evals.json` was staged in the original commit and in neither fix commit, so eval 14 still asserted the check runs "before the contract is persisted or handed off, **not after**" and that "`--brief` is passed for an engineering session." Both were reversed at Step 3 by that split.

Nothing mechanical could have caught it: `skill-quality`'s `validate-evals` checks the schema, and markdownlint does not read JSON. Eval 14's expectations now match the two-run contract, and eval 13 gains the `Q<N>` id in its unattended-blocker expectation.

## Verification

| Check | Result |
|---|---|
| `check-open-questions.test.sh` | 34/34 pass (unchanged — the script was already correct; the docs were not) |
| `check-changelog-parity.sh --check-bump origin/main` | pass |
| `markdownlint-cli2` | 0 issues |
| `skill-quality` `check-skill.sh interview` | PASS — 0 errors, 2 pre-existing warnings |
| `evals.json` parses, 14 evals | pass |

`planning` 0.28.0 → **0.28.1**: the gate already required the id; only the documentation of it was incomplete, so no consumer obligation changes.

## Related

- #1994 — added the cross-check this PR completes the contract for.
- N/A otherwise; this is a follow-up found while reviewing the merge, not a consumer report.
