### PR TITLE
fix(context-guard): raise the four hook timeouts to 60s from a measured tail

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks inject continuation guidance once per transition into a worse zone (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8]
+
+### Fixed
+
+- **All four hooks declared a 10-second timeout they could not meet on Windows, so the hook was
+  cancelled instead of run.** A consuming session on Windows/Git Bash reported
+  `zone-crossing-inject.sh` overrunning on essentially every firing across a ten-session chain
+  (10.6–21.4 s observed against `timeout: 10`), which meant the zone enforcement never took effect
+  while still charging its full wall-time cost. Every registration in `hooks/hooks.json` now
+  declares `60`.
+
+  Re-measured on Windows 11 / Git Bash after the 0.4.6 spawn reduction, 18 samples per path: the
+  typical case now fits comfortably (means 2.7–10.6 s), but the tail does not.
+  `zone-crossing-inject.sh` still reached **22.0 s**, and `post-compact-mark.sh` — whose exposure
+  the report could only infer — reached **12.4 s**, both over the old cap. `zone-gate.sh` peaked at
+  2.8 s and showed no overrun; it is raised for uniformity and tail-safety, not because it was
+  failing. The tail is environmental, not payload-driven: a small `UserPromptSubmit` payload took
+  22.0 s while a 150 KB `PostToolBatch` payload took 6.7 s, on a host with Defender real-time
+  protection enabled. Sizing has to survive an antivirus-stalled process spawn, not just the median.
+
+  Why 60 and not 30: the measurement times the script alone and excludes the harness's own
+  hook-launch overhead, so 22.0 s is a floor rather than a p100 — 30 would leave under 8 s of margin
+  on an already-optimistic number. 60 is ~2.7x the observed floor while staying an order of
+  magnitude below the harness's own 600 s `command` default, so a genuinely hung hook still cannot
+  stall a session for ten minutes. `guardrails` and `disk-hygiene` already declare 60 in this
+  marketplace.
+
+  Contract note, verified against <https://code.claude.com/docs/en/hooks> (fetched 2026-08-08):
+  `timeout` is *"Seconds before canceling. Defaults: 600 for `command`, `http`, and `mcp_tool`; 30
+  for `prompt`; 60 for `agent`. `UserPromptSubmit` lowers the `command`, `http`, and `mcp_tool`
+  default to 30, and `MessageDisplay` lowers it to 10."* So 10 was never a harness default here — it
+  was authored, narrowing the `PostToolBatch`, `PreToolUse`, and `PostCompact` budgets to 1/60th of
+  what the harness allows. The 30 documented for `UserPromptSubmit` is stated as a *default*; the
+  page does not say whether it also caps an explicit larger value, so 60 is declared there on the
+  understanding that a clamp to 30 would still clear the measurement. The page likewise says only
+  "Seconds before canceling" about exceeding the budget — what a cancelled hook reports, and whether
+  sibling hooks continue, is not documented and is not assumed here.
+
+  This is the immediate remedy, not the durable one: the underlying per-invocation cost on Windows
+  is still real, and a 60 s cap only stops a slow hook from becoming an absent one. Consumers who
+  want the overrun visible can point `HOOK_TELEMETRY_SINK` at a sink — every hook already emits
+  `duration_ms` per invocation.
+
 ## [0.4.7]
 
 ### Fixed

--- a/plugins/context-guard/hooks/hooks.json
+++ b/plugins/context-guard/hooks/hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/zone-crossing-inject.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking for a context-zone crossing..."
           }
         ]
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/zone-crossing-inject.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking for a context-zone crossing..."
           }
         ]
@@ -31,7 +31,7 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/zone-gate.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking the context-zone gate..."
           }
         ]
@@ -43,7 +43,7 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/post-compact-mark.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Recording the compaction marker..."
           }
         ]


### PR DESCRIPTION
No linked issue

Consumer report drained from the handoff inbox: `20260730-182801-context-guard-zone-crossing-hook-times-out-100-percent`. The zone-crossing hook was reported timing out 100% of the time; all four registrations sat at `timeout: 10`.

## The number was authored here, not inherited

Per the hooks page fetched this session (<https://code.claude.com/docs/en/hooks>):

> `timeout` | no | Seconds before canceling. Defaults: 600 for `command`, `http`, and `mcp_tool`; 30 for `prompt`; 60 for `agent`. `UserPromptSubmit` lowers the `command`, `http`, and `mcp_tool` default to 30, and `MessageDisplay` lowers it to 10.

Unit is **seconds**. The applicable defaults are 600 (`PostToolBatch`, `PreToolUse`, `PostCompact`) and 30 (`UserPromptSubmit`). So `10` was a deliberate narrowing to 1/60th of the default, not something inherited — and it is below what the hooks actually take on Windows.

## Measured, post-#1979

The prior per-invocation saving (`9b90e351`) is on `main`, so the report's timings were stale. Re-measured with a harness invoking each script exactly as the hook would — real payload on stdin, `HOME` / `CLAUDE_PLUGIN_DATA` / `CLAUDE_PLUGIN_ROOT` set, snapshot present so the resolver does real work. Two runs, 18 samples per path:

| Path | min | max |
|---|---|---|
| `zone-crossing-inject.sh` — PostToolBatch, 150 KB payload | 2.21 s | 6.68 s |
| `zone-crossing-inject.sh` — UserPromptSubmit, small payload | 2.24 s | **22.01 s** |
| `zone-gate.sh` — PreToolUse | 0.45 s | 2.83 s |
| `post-compact-mark.sh` — PostCompact | 1.27 s | **12.37 s** |

**These are noisy and are presented as such.** CPU load was 14% before run 1 and 68% during run 2; 523 processes; Defender real-time protection enabled. Identical work spanned 3.3 s → 22.0 s, so the means are unreliable and only the maxima carry the decision.

Three things the measurement establishes:

1. **`post-compact-mark.sh` reached 12.4 s — over the old 10 s cap.** The report flagged this one as *inferred, not measured*, and as the most consequential, since sibling plugins read its marker. It is now measured fact.
2. **`zone-gate.sh` peaked at 2.83 s with no observed overrun.** It is raised for uniformity and tail-safety, not because it was failing — stated plainly rather than folded into a "they were all broken" claim.
3. **The tail is environmental, not payload-scaling.** The *small* UserPromptSubmit payload (22.0 s) beat the 150 KB PostToolBatch one (6.7 s). Sizing has to survive an AV-stalled process spawn, not just the median.

## Why 60 and not the report's suggested 30

22.0 s is a **floor, not a p100**: the harness times the script alone, excluding the harness's own hook-launch overhead, and it never sets `HOOK_TELEMETRY_SINK`, so `hook::emit_telemetry` short-circuits and its per-invocation `jq -n` + sink exec are excluded too (spawns cost ~140 ms each here, per the 0.4.6 entry). 30 would leave under 8 s of margin on an already-optimistic number. 60 gives ~2.7× while staying an order of magnitude under the 600 s default, so a genuinely hung hook still cannot stall a session for ten minutes. `guardrails` and `disk-hygiene` already declare 60 in this marketplace. A timeout is a cap, not a cost.

## What #1988 changed about the edit surface

`.claude-plugin/plugin.json` no longer carries a `hooks` key at all — #1988 removed the redeclaration of the default-discovered path. The manifest was re-read at HEAD rather than trusted from the report. Consequence: `hooks/hooks.json` is now unambiguously the single declaration site for a timeout, so this change touches one file plus the version bump. The report's four-registration table is still accurate.

## Deliberately not asserted

The page says only "Seconds before canceling" — what a cancelled hook reports, whether partial output is discarded, and whether sibling hooks continue are **not documented**, so none of it is claimed here. Likewise the page states 30 as `UserPromptSubmit`'s *default* and does not say whether it also **caps** a larger explicit value; 60 is declared regardless, which is harmless if clamped, since 22.0 s still clears 30.

## Verification

| Check | Result |
|---|---|
| `zone-crossing-inject.test.sh` | PASS=18 FAIL=0 |
| `zone-gate.test.sh` | PASS=24 FAIL=0 |
| `post-compact-mark.test.sh` | PASS=16 FAIL=0 |
| `hooks.json` parses | OK — timeouts `[60, 60, 60, 60]` |
| `plugin.json` parses | OK — 0.4.8, no `hooks` key |
| `markdownlint-cli2` | 0 issues |
| `check-changelog-parity.sh --check-bump origin/main` | pass |
| shellcheck / shfmt / shell-portability / exec-bit | N/A — no `.sh` changed (2 JSON + 1 MD) |

`check-orphaned-fixtures.sh` was not run locally; it exceeds a 300s timeout on this machine. CI covers it.

`context-guard` 0.4.7 → **0.4.8**.

## Out of scope, surfaced not fixed

- Profiling the hot path (the report's suggestions 2–3) is the durable fix for the *cost*; this PR fixes the *cap*. The Windows per-invocation cost is still real and still open.
- A timeout-observability notice is already served: every hook emits `duration_ms` via `hook::emit_telemetry`, opt-in through `HOOK_TELEMETRY_SINK`.
- Same defect class elsewhere, unmeasured: `rate-limit-guard` declares `timeout: 10`, `guardrails` has two entries at `10`, and `claude-ops` declares `timeout: 5` on **eight** registrations — the tightest in the marketplace, notable given the spawn tail measured above.
- `plugins/context-guard/CHANGELOG.md` cites `(#1985)` for 0.4.7 and `(#1978)` for 0.4.6, but those landed as `6b5c1b96 (#1988)` and `9b90e351 (#1979)`. Consistent pattern, likely issue-vs-PR numbering; unverified and not touched.

## Related

- #1988 — removed the manifest's hooks redeclaration; the reason the manifest was re-read at HEAD rather than trusted from the report.
- #1979 — the per-invocation saving that made the report's original timings stale and forced a re-measure.
- Inbox item `20260730-182801-context-guard-zone-crossing-hook-times-out-100-percent` — the consumer report.
