### PR TITLE
feat(markdown-format): stop rewriting and reporting gitignored scratch files

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 — only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",
@@ -21,6 +21,12 @@
       "title": "markdown-format hook",
       "description": "Auto-format and lint Markdown on Write/Edit of .md/.mdc files (runs only when the repo carries a markdownlint config)",
       "default": true
+    },
+    "markdown_format_lint_gitignored": {
+      "type": "boolean",
+      "title": "Lint files git ignores",
+      "description": "By default the hook leaves gitignored files alone — a scratch tier the repo excludes is neither rewritten nor reported on. Set true to lint them anyway.",
+      "default": false
     },
     "markdown_format_max_findings": {
       "type": "number",

--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -25,7 +25,7 @@
     "markdown_format_lint_gitignored": {
       "type": "boolean",
       "title": "Lint files git ignores",
-      "description": "By default the hook leaves gitignored files alone — a scratch tier the repo excludes is neither rewritten nor reported on. Set true to lint them anyway.",
+      "description": "By default the hook leaves gitignored files alone — a scratch tier the repo excludes is neither rewritten nor reported on. Set true to bypass THIS HOOK's git check; markdownlint-cli2's own ignores/gitignore config still applies downstream, so a path your markdownlint config also excludes stays untouched.",
       "default": false
     },
     "markdown_format_max_findings": {

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -7,13 +7,15 @@ All notable changes to the `markdown-format` plugin are documented here. Format 
 
 ### Added
 
-- **A gitignored file is neither rewritten nor reported on (#1809 follow-up).** The 0.9.0
-  config gate spared repositories that carry no markdownlint config, but a repository that HAS
+- **A gitignored file is neither rewritten nor reported on.** The 0.9.0 config gate (#1809)
+  spared repositories that carry no markdownlint config, but a repository that HAS
   one still had its gitignored scratch tier formatted and linted on every edit — one reported
   session took ~35,000 characters of MD013 findings on `.work/**` working notes that are deleted
-  at the end of the task and never reviewed. The hook now consults the repository's own
-  `.gitignore` (via `git check-ignore`) and skips such a file before invoking `markdownlint-cli2`,
-  so the rewrite and the report both stop. Same doctrine as `bash-format`'s `--apply-ignore` work
+  at the end of the task and never reviewed. The hook now asks `git check-ignore` and skips such
+  a file before invoking `markdownlint-cli2`, so the rewrite and the report both stop. That is
+  git's full exclude machinery, not `.gitignore` alone: every `.gitignore` up to the repository
+  root, `$GIT_DIR/info/exclude`, and the user's global `core.excludesFile`. Same doctrine as
+  `bash-format`'s `--apply-ignore` work
   (#1817): the consumer's existing declarative scope statement is honored on the hook's
   direct-file invocation rather than a plugin-specific ignore-glob key being invented. The
   mechanism differs because the tools do — `shfmt` needs a flag to apply `.editorconfig`

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,56 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.0]
+
+### Added
+
+- **A gitignored file is neither rewritten nor reported on (#1809 follow-up).** The 0.9.0
+  config gate spared repositories that carry no markdownlint config, but a repository that HAS
+  one still had its gitignored scratch tier formatted and linted on every edit — one reported
+  session took ~35,000 characters of MD013 findings on `.work/**` working notes that are deleted
+  at the end of the task and never reviewed. The hook now consults the repository's own
+  `.gitignore` (via `git check-ignore`) and skips such a file before invoking `markdownlint-cli2`,
+  so the rewrite and the report both stop. Same doctrine as `bash-format`'s `--apply-ignore` work
+  (#1817): the consumer's existing declarative scope statement is honored on the hook's
+  direct-file invocation rather than a plugin-specific ignore-glob key being invented. The
+  mechanism differs because the tools do — `shfmt` needs a flag to apply `.editorconfig`
+  `ignore = true` to a named file, whereas `markdownlint-cli2` needs no flag and instead has no
+  ignore vocabulary at all in six of its ten discoverable config names (the rule-only
+  `.markdownlint.*` family), which is exactly the case that stayed broken.
+
+  A **tracked** file is never treated as ignored, even when a pattern matches it: `git
+  check-ignore` consults the index, and a file under version control is part of the reviewable
+  artifact whatever the patterns say. The question is asked from the file's **own directory**
+  with a bare `./name` — on Windows Git Bash an absolute path can arrive in POSIX-mount form that
+  `git.exe` rejects with exit 128, and reading that as "not ignored" would have left the reported
+  platform broken while Linux CI passed; a relative name has no drive letter to translate.
+  Resolving it that way also costs no path normalization, so the check adds one process to a
+  Markdown edit rather than the three a `cygpath`-normalized repo-root prefix strip would have
+  (the existing telemetry spawn-budget tests hold that line). Git's repository-selection and
+  discovery environment is cleared for the check, as `in_git_working_tree` already does: an
+  inherited `GIT_DIR` from a session wrapper would let the PARENT repository answer, and a
+  session inside a linked worktree under an ignored path (`.claude/worktrees/**`) would then read
+  every file it edits as ignored.
+
+  The check **fails toward linting**: git absent, the path outside the working tree, or
+  `check-ignore` erroring leaves the run alone rather than skipping it. A scope check that fails
+  closed disables the hook invisibly and repo-wide, with no output to notice it by.
+
+- **`markdown_format_lint_gitignored` (boolean, default `false`)** — set `true` to lint
+  gitignored files anyway. Read from the `CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_LINT_GITIGNORED`
+  hook-process mirror, since shell-form hook commands reject `${user_config.*}` substitution
+  (Plugins reference, "User configuration", https://code.claude.com/docs/en/plugins-reference,
+  fetched 2026-08-08); a value that is not `true`/`false` falls back to the default and is never
+  interpolated.
+
+### Changed
+
+- README documents the path-scope rule, its opt-out, and `markdownlint-cli2`'s own
+  `ignores`/`gitignore` keys as the finer-grained lever for tracked files;
+  `/markdown-format:setup check` gained a path-scope step that reports the repository's ignored
+  Markdown as out of scope and the effective opt-out value.
+
 ## [0.9.1]
 
 ### Changed

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -21,6 +21,16 @@ config has chosen no Markdown style, so the hook does not run there at all
   `bash-format`'s shfmt gate. A `package.json` `markdownlint-cli2` property
   does not open the gate: markdownlint-cli2 honors it only under an explicit
   `--config` flag, not by discovery.
+- **Gitignored paths are out of scope.** A file your repository's `.gitignore`
+  excludes — a scratch tier such as `.work/**`, build output, a vendored tree —
+  is neither rewritten nor reported on. Your `.gitignore` already says which
+  paths are not part of the reviewable artifact, so the hook reads that rather
+  than asking for a second declaration. A **tracked** file is never treated as
+  ignored, even when a pattern matches it. Set
+  `markdown_format_lint_gitignored` to `true` to lint ignored files anyway. When
+  the verdict cannot be determined (no `git` on `PATH`, no working tree,
+  `git check-ignore` erroring), the hook lints — a scope check that failed
+  closed would disable the plugin invisibly.
 - **Auto-fix on edit.** Fixable violations (final newline, list-marker style,
   trailing spaces, …) are corrected in place, and the count of fixes written is
   reported to Claude and to you — a run that changed your file never passes
@@ -118,11 +128,20 @@ The rules themselves are never configured here — the plugin's only rule source
 the markdownlint config already in your repository, which it reads automatically.
 To change the rules, edit your repo's markdownlint config.
 
-Two `userConfig` options tune the hook itself:
+Which paths are in scope is also not configured here: the hook reads your
+repository's own `.gitignore` and leaves the paths it excludes alone. To exempt
+a path that git tracks, use `markdownlint-cli2`'s own `ignores` (or `gitignore`)
+key in a `.markdownlint-cli2.*` config — the hook passes the edited file to
+`markdownlint-cli2`, which applies those itself (verified against
+markdownlint-cli2 v0.23.2; the tool's documentation does not state the behavior
+for an explicitly named file, so confirm it against your own version).
+
+Three `userConfig` options tune the hook itself:
 
 | Option | Type | Default | Effect |
 |--------|------|---------|--------|
 | `markdown_format_enabled` | boolean | `true` | Toggle the markdown-format hook; set `false` for a clean no-op. |
+| `markdown_format_lint_gitignored` | boolean | `false` | Lint files git ignores. Off by default: an excluded path is neither rewritten nor reported on. |
 | `markdown_format_max_findings` | number | `20` | How many individual violations are listed per run. The total count and the leading rule codes are always reported regardless. `0` = unlimited. |
 
 Set them interactively with `/plugin configure markdown-format`, or headless on

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -21,16 +21,18 @@ config has chosen no Markdown style, so the hook does not run there at all
   `bash-format`'s shfmt gate. A `package.json` `markdownlint-cli2` property
   does not open the gate: markdownlint-cli2 honors it only under an explicit
   `--config` flag, not by discovery.
-- **Gitignored paths are out of scope.** A file your repository's `.gitignore`
-  excludes — a scratch tier such as `.work/**`, build output, a vendored tree —
-  is neither rewritten nor reported on. Your `.gitignore` already says which
-  paths are not part of the reviewable artifact, so the hook reads that rather
-  than asking for a second declaration. A **tracked** file is never treated as
-  ignored, even when a pattern matches it. Set
-  `markdown_format_lint_gitignored` to `true` to lint ignored files anyway. When
-  the verdict cannot be determined (no `git` on `PATH`, no working tree,
-  `git check-ignore` erroring), the hook lints — a scope check that failed
-  closed would disable the plugin invisibly.
+- **Gitignored paths are out of scope.** A file git excludes — a scratch tier
+  such as `.work/**`, build output, a vendored tree — is neither rewritten nor
+  reported on. Your ignore rules already say which paths are not part of the
+  reviewable artifact, so the hook reads them rather than asking for a second
+  declaration. The verdict comes from `git check-ignore`, so it is git's full
+  exclude machinery, not `.gitignore` alone: every `.gitignore` between the file
+  and the repository root, `$GIT_DIR/info/exclude`, and your global
+  `core.excludesFile`. A **tracked** file is never treated as ignored, even when
+  a pattern matches it. Set `markdown_format_lint_gitignored` to `true` to lint
+  ignored files anyway. When the verdict cannot be determined (no `git` on
+  `PATH`, no working tree, `git check-ignore` erroring), the hook lints — a
+  scope check that failed closed would disable the plugin invisibly.
 - **Auto-fix on edit.** Fixable violations (final newline, list-marker style,
   trailing spaces, …) are corrected in place, and the count of fixes written is
   reported to Claude and to you — a run that changed your file never passes
@@ -128,10 +130,12 @@ The rules themselves are never configured here — the plugin's only rule source
 the markdownlint config already in your repository, which it reads automatically.
 To change the rules, edit your repo's markdownlint config.
 
-Which paths are in scope is also not configured here: the hook reads your
-repository's own `.gitignore` and leaves the paths it excludes alone. To exempt
-a path that git tracks, use `markdownlint-cli2`'s own `ignores` (or `gitignore`)
-key in a `.markdownlint-cli2.*` config — the hook passes the edited file to
+Which paths are in scope is also not configured here: the hook asks
+`git check-ignore` and leaves the paths git excludes alone — that means your
+`.gitignore` files, `$GIT_DIR/info/exclude`, and your global `core.excludesFile`
+together. To exempt a path that git tracks, use `markdownlint-cli2`'s own
+`ignores` (or `gitignore`) key in a `.markdownlint-cli2.*` config — the hook
+passes the edited file to
 `markdownlint-cli2`, which applies those itself (verified against
 markdownlint-cli2 v0.23.2; the tool's documentation does not state the behavior
 for an explicitly named file, so confirm it against your own version).

--- a/plugins/markdown-format/README.md
+++ b/plugins/markdown-format/README.md
@@ -29,8 +29,11 @@ config has chosen no Markdown style, so the hook does not run there at all
   exclude machinery, not `.gitignore` alone: every `.gitignore` between the file
   and the repository root, `$GIT_DIR/info/exclude`, and your global
   `core.excludesFile`. A **tracked** file is never treated as ignored, even when
-  a pattern matches it. Set `markdown_format_lint_gitignored` to `true` to lint
-  ignored files anyway. When the verdict cannot be determined (no `git` on
+  a pattern matches it. Set `markdown_format_lint_gitignored` to `true` to bypass
+  **this hook's** git check. That is the only thing it bypasses:
+  markdownlint-cli2 applies its own `ignores` / `gitignore` config downstream, so
+  a path your markdownlint config also excludes stays untouched even with the
+  option on. When the verdict cannot be determined (no `git` on
   `PATH`, no working tree, `git check-ignore` erroring), the hook lints — a
   scope check that failed closed would disable the plugin invisibly.
 - **Auto-fix on edit.** Fixable violations (final newline, list-marker style,
@@ -145,7 +148,7 @@ Three `userConfig` options tune the hook itself:
 | Option | Type | Default | Effect |
 |--------|------|---------|--------|
 | `markdown_format_enabled` | boolean | `true` | Toggle the markdown-format hook; set `false` for a clean no-op. |
-| `markdown_format_lint_gitignored` | boolean | `false` | Lint files git ignores. Off by default: an excluded path is neither rewritten nor reported on. |
+| `markdown_format_lint_gitignored` | boolean | `false` | Bypass this hook's git-ignore check. Off by default: an excluded path is neither rewritten nor reported on. Turning it on does not override markdownlint-cli2's own `ignores` / `gitignore` config, which still applies. |
 | `markdown_format_max_findings` | number | `20` | How many individual violations are listed per run. The total count and the leading rule codes are always reported regardless. `0` = unlimited. |
 
 Set them interactively with `/plugin configure markdown-format`, or headless on

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -243,13 +243,15 @@ if ! markdownlint_config_discoverable "$FILE" "$REPO_ROOT"; then
   exit 0
 fi
 
-# Path-scope escape (#1809 follow-up): a file the repository's own .gitignore
-# excludes is not part of the reviewable artifact — a scratch/working tier such
+# Path-scope escape, the half the 0.9.0 config gate (#1809) did not cover: a
+# file git excludes is not part of the reviewable artifact — a scratch tier such
 # as `.work/**` holds notes that are deleted at the end of a task and never
 # reviewed — so rewriting it produces a diff nobody reads, and REPORTING on it
-# spends context on a file whose style nobody chose. The gitignore declaration
-# the repository already carries is the scope statement; this hook reads it
-# rather than asking for a second one.
+# spends context on a file whose style nobody chose. The exclude rules the
+# consumer already carries are the scope statement; this hook reads them rather
+# than asking for a second one. `git check-ignore` is the whole of git's exclude
+# machinery, not `.gitignore` alone: every `.gitignore` up to the repository
+# root, $GIT_DIR/info/exclude, and the user's global core.excludesFile.
 #
 # Asked from the FILE'S OWN directory, with a bare relative name. Two reasons,
 # both load-bearing:

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -243,6 +243,86 @@ if ! markdownlint_config_discoverable "$FILE" "$REPO_ROOT"; then
   exit 0
 fi
 
+# Path-scope escape (#1809 follow-up): a file the repository's own .gitignore
+# excludes is not part of the reviewable artifact — a scratch/working tier such
+# as `.work/**` holds notes that are deleted at the end of a task and never
+# reviewed — so rewriting it produces a diff nobody reads, and REPORTING on it
+# spends context on a file whose style nobody chose. The gitignore declaration
+# the repository already carries is the scope statement; this hook reads it
+# rather than asking for a second one.
+#
+# Asked from the FILE'S OWN directory, with a bare relative name. Two reasons,
+# both load-bearing:
+#
+#   * Path form. markdownlint-cli2 is a Node process that takes any spelling of
+#     a path; git.exe is not. On Windows Git Bash FILE can arrive in POSIX mount
+#     form (`/c/repo/x.md`) where git wants a Win32/drive-letter path, and the
+#     wrong one yields exit 128 — which this must never read as "not ignored".
+#     `./name` carries no drive letter to translate, so both agree on it. Doing
+#     this by stripping a REPO_ROOT prefix instead would need cygpath to put the
+#     two paths in one representation, i.e. two extra process spawns on every
+#     Markdown edit (~140 ms each on Git Bash, the cost 0.9.1 went to some
+#     trouble to remove); `cd` + `${FILE%/*}` costs none.
+#   * Correctness. git resolves the rest itself, so every .gitignore between the
+#     file and the repository root applies, and a pattern excluding an ANCESTOR
+#     directory (`.work/`) is honored for a file nested arbitrarily below it.
+#     Verified 2026-08-08 against git's check-ignore behavior for a child, a
+#     grandchild, and both path spellings.
+#
+# FAILS TOWARD LINTING, deliberately. Any inability to decide — git absent, the
+# directory gone, check-ignore erroring (128) — leaves the run alone rather than
+# skipping it. The other direction is the dangerous one: a skip that fires on an
+# error condition disables this hook invisibly and repo-wide, with no output to
+# notice it by. Do not "fix" this into a fail-closed check.
+#
+# Git's repository-selection and discovery environment is cleared for the same
+# reason in_git_working_tree clears it: an inherited GIT_DIR/GIT_WORK_TREE from
+# a wrapper that launched the session would make some OTHER repository answer
+# the question. A session running inside a linked worktree under a path the
+# parent repository ignores (`.claude/worktrees/**` is a common one) would then
+# read every file it edits as ignored.
+file_is_gitignored() {
+  local dir="${FILE%/*}" base="${FILE##*/}"
+
+  command -v git >/dev/null 2>&1 || return 1
+  [[ -n "$base" && "$dir" != "$FILE" ]] || return 1
+
+  # `git check-ignore` consults the index unless --no-index is passed, so a
+  # TRACKED file that happens to match an exclude pattern is reported as not
+  # ignored — which is the wanted answer: a file under version control is part
+  # of the reviewable artifact whatever the patterns say. Exit 0 = ignored,
+  # 1 = not ignored, 128 = error; only 0 skips.
+  # https://git-scm.com/docs/git-check-ignore (fetched 2026-08-08)
+  (
+    unset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_CEILING_DIRECTORIES \
+      GIT_DISCOVERY_ACROSS_FILESYSTEM
+    cd "$dir" 2>/dev/null || exit 1
+    git check-ignore -q -- "./$base" 2>/dev/null
+  )
+}
+
+# Opt-out for the scope escape above, read from the CLAUDE_PLUGIN_OPTION_<KEY>
+# environment mirror rather than a `${user_config.*}` placeholder — shell-form
+# hook commands reject that substitution outright, and every option is exported
+# to hook processes as CLAUDE_PLUGIN_OPTION_<KEY> anyway (Plugins reference,
+# "User configuration", https://code.claude.com/docs/en/plugins-reference,
+# fetched 2026-08-08). Booleans arrive as the strings "true"/"false"; anything
+# else falls back to the manifest default rather than being interpolated.
+LINT_GITIGNORED=0
+[[ "${CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_LINT_GITIGNORED:-false}" == "true" ]] &&
+  LINT_GITIGNORED=1
+
+if ((LINT_GITIGNORED == 0)) && file_is_gitignored; then
+  # silent-skip-ok: this is a path-scope policy verdict, not a missing-tool
+  # verdict — the repository declared this path out of scope in its own
+  # .gitignore, and announcing the skip on every scratch-file edit would spend
+  # the context the skip exists to save. The skip is still observable: the
+  # telemetry envelope below records it, and README documents the rule and its
+  # markdown_format_lint_gitignored opt-out.
+  emit_tel "skipped" '[]'
+  exit 0
+fi
+
 # Resolve the consuming repository's pinned npm binary without invoking a
 # package runner. npm creates an extensionless POSIX shim in node_modules/.bin
 # alongside its Windows .cmd launcher; Git Bash executes the POSIX shim. Follow

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -1837,6 +1837,156 @@ else
   fail "bounded/fixes: no-op run emitted output: $OUT_F0"
 fi
 
+# --- Path-scope escape: a gitignored file is neither rewritten nor reported --
+# The 0.9.0 config gate spared repositories that carry NO markdownlint config;
+# a repository that HAS one still had its gitignored scratch tier (`.work/**`)
+# rewritten and reported on every edit. These cases pin both halves of that
+# acceptance criterion, and pin them with a config present — without one the
+# older gate stops the run first and the assertion would pass for the wrong
+# reason.
+SCOPE="$WORK/scope"
+mkdir -p "$SCOPE/.work"
+git -C "$SCOPE" init -q
+git -C "$SCOPE" config user.email t@t.t
+git -C "$SCOPE" config user.name t
+# Hermetic ignore rules: a developer's global core.excludesFile must not decide
+# what this suite sees as ignored.
+git -C "$SCOPE" config core.excludesFile /dev/null
+printf '.work/\n' >"$SCOPE/.gitignore"
+cat >"$SCOPE/.markdownlint-cli2.jsonc" <<'JSONC'
+{
+  "config": {
+    "MD004": { "style": "dash" },
+    "MD024": { "siblings_only": true },
+    "MD013": false
+  }
+}
+JSONC
+
+# Same shape as fixtureB: `* star item` is a FIXABLE MD004 (the rewrite signal)
+# and the duplicate sibling `## S` an UNFIXABLE MD024 (the report signal), so a
+# single run answers both "was it rewritten" and "was it reported".
+SCOPE_BODY='# Doc
+
+## S
+
+text
+
+## S
+
+* star item
+'
+run_scope() {
+  local file_path="$1"
+  shift
+  (cd "$UNRELATED" && printf '{"session_id":"scope-1","tool_input":{"file_path":"%s"},"tool_name":"Write"}' "$file_path" |
+    env -u CLAUDE_PROJECT_DIR CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_ENABLED=true "$@" bash "$HOOK")
+}
+
+SC_IGN="$SCOPE/.work/scratch.md"
+printf '%s' "$SCOPE_BODY" >"$SC_IGN"
+OUT_SI=$(run_scope "$SC_IGN")
+if [[ -z "$OUT_SI" ]]; then
+  ok "scope: gitignored file (config present) is not reported"
+else
+  fail "scope: gitignored file still reported: $OUT_SI"
+fi
+if grep -q '^\* star item$' "$SC_IGN"; then
+  ok "scope: gitignored file (config present) is not rewritten"
+else
+  fail "scope: gitignored file was rewritten: $(cat "$SC_IGN")"
+fi
+
+# The other side of the same gate: an ordinary repository file keeps its
+# rewrite and its report. A scope escape that swallowed everything would pass
+# the two assertions above.
+SC_TRK="$SCOPE/tracked.md"
+printf '%s' "$SCOPE_BODY" >"$SC_TRK"
+OUT_ST=$(run_scope "$SC_TRK")
+CTX_ST=$(printf '%s' "$OUT_ST" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if grep -q '^- star item$' "$SC_TRK"; then
+  ok "scope: a non-ignored file is still rewritten"
+else
+  fail "scope: non-ignored file was not rewritten: $(cat "$SC_TRK")"
+fi
+if printf '%s' "$CTX_ST" | grep -q 'MD024'; then
+  ok "scope: a non-ignored file is still reported"
+else
+  fail "scope: non-ignored file lost its report: $OUT_ST"
+fi
+
+# `git check-ignore` consults the index, so a TRACKED file that matches an
+# exclude pattern is NOT ignored — a file under version control is part of the
+# reviewable artifact whatever the patterns say. `git add -f` (no commit
+# needed) puts it in the index.
+SC_FORCED="$SCOPE/.work/tracked-scratch.md"
+printf '%s' "$SCOPE_BODY" >"$SC_FORCED"
+git -C "$SCOPE" add -f .work/tracked-scratch.md
+OUT_SF=$(run_scope "$SC_FORCED")
+if grep -q '^- star item$' "$SC_FORCED" &&
+  printf '%s' "$OUT_SF" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null |
+  grep -q 'MD024'; then
+  ok "scope: a tracked file under an ignored path is still linted"
+else
+  fail "scope: tracked-but-ignore-matching file was skipped: $(cat "$SC_FORCED")"
+fi
+
+# Opt-out: markdown_format_lint_gitignored=true restores the old behavior,
+# reaching the hook as the CLAUDE_PLUGIN_OPTION_<KEY> mirror.
+SC_OPT="$SCOPE/.work/optin.md"
+printf '%s' "$SCOPE_BODY" >"$SC_OPT"
+OUT_SO=$(run_scope "$SC_OPT" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_LINT_GITIGNORED=true)
+if grep -q '^- star item$' "$SC_OPT" &&
+  printf '%s' "$OUT_SO" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null |
+  grep -q 'MD024'; then
+  ok "scope: markdown_format_lint_gitignored=true lints the ignored file anyway"
+else
+  fail "scope: opt-out did not restore linting: $OUT_SO"
+fi
+SC_GARB="$SCOPE/.work/garbage-opt.md"
+printf '%s' "$SCOPE_BODY" >"$SC_GARB"
+OUT_SG=$(run_scope "$SC_GARB" CLAUDE_PLUGIN_OPTION_MARKDOWN_FORMAT_LINT_GITIGNORED="yes; rm -rf /")
+if [[ -z "$OUT_SG" ]] && grep -q '^\* star item$' "$SC_GARB"; then
+  ok "scope: a non-boolean opt-out value falls back to the default, never interpolated"
+else
+  fail "scope: garbage opt-out value was honored: $OUT_SG"
+fi
+
+# Windows path forms: the hook hands git a REPO-RELATIVE path precisely so a
+# POSIX-mount spelling (/c/...) and a drive-letter spelling (C:/...) reach the
+# same verdict. Only meaningful where both spellings exist.
+if command -v cygpath >/dev/null 2>&1; then
+  SC_WIN="$SCOPE/.work/winform.md"
+  printf '%s' "$SCOPE_BODY" >"$SC_WIN"
+  SC_WIN_M="$(cygpath -m -- "$SC_WIN")"
+  OUT_SW=$(run_scope "$SC_WIN_M")
+  if [[ -z "$OUT_SW" ]] && grep -q '^\* star item$' "$SC_WIN"; then
+    ok "scope: drive-letter path spelling reaches the same ignored verdict"
+  else
+    fail "scope: drive-letter spelling was linted: $OUT_SW / $(cat "$SC_WIN")"
+  fi
+else
+  ok "scope: drive-letter path spelling case not applicable (no cygpath)"
+fi
+
+# A repository with NO markdownlint config and a gitignored file is untouched
+# too — but by the pre-existing config gate, which stops the run before the
+# scope check. Recorded so the pairing is complete, not as evidence for the
+# scope escape.
+NOCFG="$WORK/scope-noconfig"
+mkdir -p "$NOCFG/.work"
+git -C "$NOCFG" init -q
+git -C "$NOCFG" config core.excludesFile /dev/null
+printf '.work/\n' >"$NOCFG/.gitignore"
+NC_IGN="$NOCFG/.work/scratch.md"
+printf '%s' "$SCOPE_BODY" >"$NC_IGN"
+OUT_NC=$(run_scope "$NC_IGN")
+if [[ -z "$OUT_NC" ]] && grep -q '^\* star item$' "$NC_IGN"; then
+  ok "scope: gitignored file in a config-less repo is untouched (config gate)"
+else
+  fail "scope: config-less repo touched a gitignored file: $OUT_NC"
+fi
+
 echo
 echo "PASS=$PASS FAIL=$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/plugins/markdown-format/hooks/markdown-format.test.sh
+++ b/plugins/markdown-format/hooks/markdown-format.test.sh
@@ -1921,7 +1921,7 @@ fi
 # needed) puts it in the index.
 SC_FORCED="$SCOPE/.work/tracked-scratch.md"
 printf '%s' "$SCOPE_BODY" >"$SC_FORCED"
-git -C "$SCOPE" add -f .work/tracked-scratch.md
+git -C "$SCOPE" add -f .work/tracked-scratch.md 2>/dev/null
 OUT_SF=$(run_scope "$SC_FORCED")
 if grep -q '^- star item$' "$SC_FORCED" &&
   printf '%s' "$OUT_SF" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null |

--- a/plugins/markdown-format/skills/setup/SKILL.md
+++ b/plugins/markdown-format/skills/setup/SKILL.md
@@ -56,9 +56,17 @@ restores the FAIL semantics.
    and that is the whole reason formatting is not happening. Name the remediation in the
    same line rather than leaving the reader to infer it. Never report markdownlint's own
    default rules as the fallback — an unconfigured repo gets no rules, not the defaults.
-5. **Hook toggle** — report the effective `markdown_format_enabled` value:
+5. **Path scope — the repository's `.gitignore`** — INFO: the hook leaves a gitignored
+   file alone, neither rewriting nor reporting on it, because a path the repository
+   excludes is not part of the reviewable artifact. List the ignored Markdown the
+   repository carries as out of scope — `git ls-files --others --ignored
+   --exclude-standard -- '*.md' '*.mdc'` — and note that a tracked file is never treated
+   as ignored even when a pattern matches it. Report the effective
+   `${user_config.markdown_format_lint_gitignored}` value (unexpanded or empty means
+   default `false`, i.e. gitignored files are skipped); `true` restores linting there.
+6. **Hook toggle** — report the effective `markdown_format_enabled` value:
    `${user_config.markdown_format_enabled}` (unexpanded or empty means default `true`).
-6. **Hook registration** — INFO: confirm the plugin is enabled for this project
+7. **Hook registration** — INFO: confirm the plugin is enabled for this project
    (`/plugin` → Installed) rather than parsing settings files.
 
 ## `apply` (idempotent)


### PR DESCRIPTION
No linked issue

No GitHub issue exists for this defect — searched `markdown-format gitignore`, `markdown-format scratch repeat findings`, and `markdown-format in:title` across all states. #1589 (closed) covers the repeat-findings symptom and #1809 the 0.9.0 config gate; neither covers path scope.

Consumer report drained from the handoff inbox: `20260730-182801-markdown-format-no-scratch-path-ignore-and-repeat-findings-spam`. The dedup and bounded-reporting halves already landed; this closes the residual — a repo **with** a root markdownlint config still had its gitignored `.work/**` scratch rewritten and reported.

## Mirroring bash-format, where the doctrine transfers and the mechanism doesn't

The brief was to mirror `bash-format`'s apply-ignore work (`9edf79ca`). That commit keeps `shfmt --apply-ignore` on the direct-file pass behind a capability probe, because shfmt ignores `.editorconfig` `ignore = true` for an explicitly named file unless the flag is passed; it falls back to plain `-w` only on the specific unknown-flag error, and skips formatting on any other probe failure so a consumer's opt-out is never discarded. It introduced no `userConfig`.

**markdownlint-cli2 does not have that gap.** Probed v0.23.2 directly: with a config carrying `ignores` or `gitignore: true`, an explicitly named absolute path is already excluded (`Finding: …/.work/scratch.md !.work/**` → `Summary: 0 issues`, file byte-identical). A literal mirror would have been dead code.

What is actually broken is a different gap: the six **rule-only** config names (`.markdownlint.json`, `.markdownlint.yaml`, …) have **no ignore vocabulary at all**. A `plain-json` probe reported the MD013 finding on the gitignored file — those consumers had no escape whatever they wrote.

So the four doctrinal points carry over and the mechanism changes: read the consumer's **existing** declarative scope statement rather than invent an ignore-glob key — here that is git's exclude rules, via `git check-ignore`; bias toward not touching the file; keep the skip attributable; use the same three-surface documentation pattern.

**One bias is deliberately inverted.** bash-format fails *closed* (skip) when uncertain; this fails *toward linting*. A scope skip firing on an error condition would disable the hook invisibly and repo-wide, whereas shfmt's failure mode was discarding an explicit opt-out. The source comment says not to "fix" this into a fail-closed check.

## Three load-bearing details

- **Repo-relative, from the file's own directory.** An absolute path can reach `git.exe` in POSIX-mount form on Windows Git Bash and return exit 128; reading that as "not ignored" would have left the reported platform broken while Linux CI stayed green. `./name` has no drive letter. Both spellings are covered by a test.
- **Tracked files are never skipped.** `git check-ignore` consults the index, so a `git add -f`'d file under an ignored path still lints. Also a test.
- **Runs in a subshell with `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_CEILING_DIRECTORIES`, `GIT_DISCOVERY_ACROSS_FILESYSTEM` unset**, so an inherited git environment cannot redirect the verdict.

## A regression the existing tests caught

The first implementation normalized paths through `cygpath -lm` to build the repo-relative path. The telemetry spawn-budget tests failed it: two extra process spawns per Markdown edit, ~140 ms each on Git Bash — precisely the cost 0.9.1 was released to remove. Rewriting to `cd "${FILE%/*}"` + `./name` removed them and is also more correct, since git resolves ancestor-directory patterns itself. The scope check now adds no `cygpath` and no `jq` spawn, only one `git` process per edit.

## Consumer configuration — three layers, none touching the plugin

1. **Default** — put the path in your own `.gitignore` (or `$GIT_DIR/info/exclude`, or your global `core.excludesFile`) and the hook stops touching it.
2. **Finer-grained, for tracked paths** — markdownlint-cli2's own `ignores` / `gitignore` keys in a `.markdownlint-cli2.*` config, applied by the tool itself.
3. **Opt back in** — `markdown_format_lint_gitignored=true` via `/plugin configure markdown-format`.

The hook reads the value only from the `CLAUDE_PLUGIN_OPTION_<KEY>` environment mirror, because shell-form hook commands reject `${user_config.*}` — [Plugins reference](https://code.claude.com/docs/en/plugins-reference), "User configuration", fetched 2026-08-08. A test pins that a hostile non-boolean value falls back to the default and is never interpolated. No `${CLAUDE_PLUGIN_ROOT}` reach-outs, no hardcoded paths.

The `userConfig` boolean is an addition bash-format has no counterpart for. It earns its place because the failure mode of a default-on path skip is silent repo-wide disablement, and `markdown_format_enabled=false` is too blunt an escape.

## Verification

| Check | Result |
|---|---|
| `markdown-format.test.sh` | **PASS=130 FAIL=0** (was 122; 8 new `scope:` cases) |
| `shellcheck` both `.sh` | rc=0, no output |
| `shfmt -d` hook script | clean |
| `check-shell-portability.sh --paths` | No unexcused GNU-only constructs in 2 files |
| `check-silent-skips.sh` | No silent prerequisite skips found |
| `markdownlint-cli2` | 0 issues in 3 files |
| `check-changelog-parity.sh --check-bump origin/main` | pass |
| `git ls-files -s` both `.sh` | `100755` |

New cases: gitignored file not reported / not rewritten; non-ignored file still rewritten and still reported; tracked file under an ignored path still linted; `lint_gitignored=true` lints it anyway; non-boolean opt-out falls back and is never interpolated; drive-letter spelling reaches the same verdict; gitignored file in a config-less repo untouched by the config gate. The telemetry spawn-budget cases (zero `cygpath -lm`, exactly 2 `jq`) still pass.

**Test-run provenance, stated plainly:** two earlier suite runs overlapped each other and one crossed a mid-session rewrite of the hook, so their counts are contaminated and are not cited. `PASS=130 FAIL=0` comes from two uncontaminated serial runs, the last against the exact committed tree.

`check-orphaned-fixtures.sh` was not run locally; it exceeds a 300s timeout on this machine. CI covers it.

`markdown-format` 0.9.1 → **0.10.0** — minor, not patch: unlike `9edf79ca`, which narrowed behavior and added no surface, this adds a manifest `userConfig` key.

## Deliberately not done

- **No `markdown_format_ignore_globs` key.** Inventing a third ignore vocabulary alongside git's and markdownlint-cli2's is the thing bash-format's doctrine exists to avoid.
- **No `#`-negative-glob CLI arguments** (probed, they work): the suite's stub asserts an exact argv shape so extra arguments would be untestable, and it would not help rule-only-config repos — the actual gap.
- **No text-parsing of the consumer's `gitignore: false`** as the opt-out signal, though it is the more elegant "consumer's own vocabulary" answer: unparseable for `.cjs`/`.mjs` configs, and a permissive misread would override an explicit consumer request.

## Surfaced, not fixed

- `shfmt` version conflict: local `v3.13.1` rewrites `…esac; }` → `…esac }` at `markdown-format.test.sh:1690`, in code this PR does not touch; `main` is green, so CI's shfmt accepts it. Reproduced identically from `origin/main`'s copy in the same directory, so it is pre-existing. Any local `shfmt -w` sweep will produce a spurious diff there.
- `markdown-format.test.sh:57` carries a `# portability-ok:` excuse for an unsuffixed `sed -i` pointing at #1540 as still-tracked; worth re-checking on the next pass.
- The inbox item's front matter still reads `status: open` / `priority: medium` with a 2026-07-30 stamp despite a 2026-08-07 triage verdict in its body.

## Related

- #1589 — the repeat-findings symptom from the same consumer report, already closed; this PR closes the path-scope half.
- #1809 — the 0.9.0 config gate this check is sequenced after.
- `bash-format` commit `9edf79ca` — the apply-ignore work whose doctrine this mirrors and whose mechanism it deliberately does not.
- Inbox item `20260730-182801-markdown-format-no-scratch-path-ignore-and-repeat-findings-spam` — the consumer report.
