### PR TITLE
fix(guardrails): stop blocking read-only python open() and cat > /dev/null

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory) un-throttled Workflow fan-out that risks burst 529s, and (advisory) direct git commit/gh pr create calls bypassing this marketplace's own commit/pull-request skills — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -39,13 +39,27 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   they keep testing the contract they were written for; a new case asserts that the same mention
   carrying only a READ-mode open is now allowed, which is the fix rather than a hole.
 
-- **`block-hook-bypass` no longer blocks `cat > /dev/null`.** A discard is not a file write — the
-  exemption the echo/printf lane already grants (`_echo_devnull`) now applies to the `cat >` lane
-  too, including the quoted spellings (`cat > "/dev/null"`, `cat > /dev/"null"`). The exemption is
-  **segment-scoped**, not command-scoped: `cat > /dev/null && cat > real.txt` still blocks on its
-  second segment. The `cat` scan and the echo/printf scan now share one segment splitter
-  (`normalize_segments`) instead of two, so they cannot drift on escaped separators or on the
-  `2>&1` fd-duplication sentinel.
+- **`block-hook-bypass` no longer blocks `cat > /dev/null`.** A discard is not a file write, so the
+  exemption the echo/printf lane already granted now applies to the `cat >` lane too, including the
+  quoted spellings (`cat > "/dev/null"`, `cat > /dev/"null"`). The exemption is **segment-scoped**,
+  not command-scoped: `cat > /dev/null && cat > real.txt` still blocks on its second segment. The
+  `cat` scan and the echo/printf scan now share one segment splitter (`normalize_segments`) instead
+  of two, so they cannot drift on escaped separators or on the `2>&1` fd-duplication sentinel.
+
+  **The exemption resolves the segment's EFFECTIVE stdout destination, never the mere presence of a
+  `/dev/null` redirect** — and getting that wrong would have been a one-token bypass of this entire
+  guard. Bash applies redirections left to right, so `cat > /dev/null > real.txt` writes to
+  `real.txt`, as does `cat >/dev/null 1>real.txt`. A presence test would have exempted both: write
+  the discard first, the real file second. `set_last_stdout_target` walks the segment's stdout
+  redirects and keeps the LAST target; only `/dev/null` there exempts. The inverse order
+  (`cat > real.txt > /dev/null`) is a genuine discard and stays allowed.
+
+  This replaces `_echo_devnull`, which was the same order-blind presence test on the echo/printf
+  lane — that half was **pre-existing**, not introduced here, and both lanes now share the helper.
+  The scan admits the explicit stdout spelling `1>` (`1>file` is stdout exactly as `>file` is) while
+  excluding other fds (`2>`, `21>`), the combined form (`&>`), and fd duplications (`>&1`, whose
+  target class excludes `&`). It sets a global rather than echoing: it runs per segment on every
+  Bash call, and a command substitution would add a fork to each one.
 
 - **`flag-commit-pr-skill-bypass` is registered at `timeout: 60`, not `10` (was the only guardrails
   hook below its siblings).** Measured runtimes of 12–19 s against a 10 s cap meant the hook was

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,87 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.19.3]
+
+### Fixed
+
+- **`block-hook-bypass` no longer blocks a READ-ONLY inline `open()`.** The python write-indicator
+  set matched a bare `open[[:space:]]*\(`, so `python3 -c "import json; d=json.load(open('x.json'))"`
+  — a read — was refused as a Write/Edit bypass. Reproduced verbatim against the shipped hook.
+
+  **Design call (the discrimination boundary, stated because `open(f,'w')` and `open(f)` differ only
+  by an argument):** `open(` on its own now says nothing about direction and is no longer an
+  indicator. It counts as a write only when a python WRITE-MODE LITERAL also occurs in the same
+  command — a quoted token built solely from mode characters, containing at least one of
+  `w`/`a`/`x`/`+`, in an argument position (immediately after a comma, or after `mode=`). Read modes
+  (`'r'`, `'rb'`, `'rt'`) carry none of those characters and no longer trip it.
+
+  The check is **co-occurrence, not position**, and deliberately so: Bash ERE has no lazy quantifier,
+  so a positional `open\([^)]*'w'` stops at the first `)` and would fail OPEN on a genuine
+  `open(os.path.join(a,b),'w')`, while a greedy `.*` reaches into unrelated text anyway. This is the
+  same mangle-resistant co-occurrence shape the PowerShell lane already uses, and it is checked in
+  both directions by new cases.
+
+  **Accepted residual, in the fail-CLOSED direction:** a read-only `open()` in a command that
+  separately contains an argument-position `'w'`/`'a'`/`'x'`/`'+'` literal — e.g.
+  `print(open('f').read(), 'a')` — still blocks. The argument-position requirement is what keeps the
+  common read shapes clear: a dict subscript (`json.load(open('p'))['a']`) is preceded by `[`, not by
+  a comma. **Second accepted residual, unchanged from before:** a bare `pathlib` mention is still an
+  indicator on its own, so read-only inline python that merely imports `pathlib` still blocks. That
+  indicator carries the `.write_text(` / `.write_bytes(` block today; narrowing it needs an explicit
+  write-call set and is a separate change.
+
+  **Test fixtures respelled, not relaxed.** Four PowerShell-lane cases asserted the accepted
+  mention-over-block (and the here-string inertness) using a bare `open(` as their stand-in write
+  indicator. Since a bare `open(` no longer *is* one, those inputs are respelled to `open(f,'w')` so
+  they keep testing the contract they were written for; a new case asserts that the same mention
+  carrying only a READ-mode open is now allowed, which is the fix rather than a hole.
+
+- **`block-hook-bypass` no longer blocks `cat > /dev/null`.** A discard is not a file write — the
+  exemption the echo/printf lane already grants (`_echo_devnull`) now applies to the `cat >` lane
+  too, including the quoted spellings (`cat > "/dev/null"`, `cat > /dev/"null"`). The exemption is
+  **segment-scoped**, not command-scoped: `cat > /dev/null && cat > real.txt` still blocks on its
+  second segment. The `cat` scan and the echo/printf scan now share one segment splitter
+  (`normalize_segments`) instead of two, so they cannot drift on escaped separators or on the
+  `2>&1` fd-duplication sentinel.
+
+- **`flag-commit-pr-skill-bypass` is registered at `timeout: 60`, not `10` (was the only guardrails
+  hook below its siblings).** Measured runtimes of 12–19 s against a 10 s cap meant the hook was
+  cancelled on essentially every firing: the commit/PR-skill advisory never ran, while still costing
+  its full cap on every Bash/PowerShell call. Per the current hooks reference
+  (<https://code.claude.com/docs/en/hooks>, fetched 2026-08-08), `timeout` is *"Seconds before
+  canceling. Defaults: 600 for `command`, `http`, and `mcp_tool`; 30 for `prompt`; 60 for `agent`.
+  `UserPromptSubmit` lowers the `command`, `http`, and `mcp_tool` default to 30, and `MessageDisplay`
+  lowers it to 10."* — nothing in the harness pushes a `PreToolUse` `command` hook toward 10, so the
+  value was authored. 60 is this file's established value for the same matcher (the other five
+  `Bash|PowerShell` guards all carry it); the documented default is 600. The same page states that
+  *"Hook entries merge across settings levels rather than replacing each other: user, project, and
+  local settings add their own hooks without removing managed ones"*, so a consumer had no way to
+  raise a plugin's timeout locally — which is why this had to be fixed in the plugin.
+
+- **`cli-flag-verify` no longer reports npm's global config flags as hallucinated.**
+  `npm ci --prefix ./vendor` was flagged `UNKNOWN_FLAG`. `--prefix` is one of npm's config keys, and
+  every config key is simultaneously a command-line flag on every subcommand — `npm --help` says so
+  itself ("Specify configs in the ini-formatted file … or on the command line via:
+  `npm <command> --key=value`"). Those keys appear in neither `npm <subcmd> --help` nor `npm --help`,
+  and the authoritative list (`npm config ls -l`) prints `prefix = "…"`, not `--prefix`, so a generic
+  `--help` flag-list parser cannot consume it. `npm` therefore joins `git` and `npx` as an excluded
+  binary in `DEFAULT_BINS`, on the same recorded rationale: a non-exhaustive `--help` produces only
+  real-flag false positives. Consumers who want it back can re-add it through the
+  `cli_flag_verify_bins` option. **A per-subcommand→top-level `--help` fallback was considered and
+  rejected as the fix**: it was measured against this repro and `npm --help` does not list `--prefix`
+  either, so it would not have closed the finding.
+
+### Changed
+
+- **`block-dangerous-git` and `block-no-verify` read their payload with `hook::jq_fields`.** Both
+  extracted `.tool_input.command` and `.tool_name` with two separate `jq` invocations; they now take
+  both from one, using the helper `0.19.2` added to the shared lib. On Windows Git Bash a process
+  spawn is `fork()` emulation (~140 ms), and both guards run on every Bash/PowerShell tool call.
+  Failure semantics are unchanged: a missing `jq` or an unparsable payload exits 0 exactly as the
+  empty-command skip did, after `hook::require_jq` has already surfaced the degraded state once per
+  session.
+
 ## [0.19.2]
 
 ### Changed

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -181,9 +181,15 @@ repo-specific policy of their own:
   placeholders, `tests/fixtures` / `tests/testdata` trees, `settings.local.json`,
   `CLAUDE.local.md`, and hook scripts.
 - **CLI-flag tuning.** `cli-flag-verify` checks a default binary set
-  (`claude gh dotnet docker npm kubectl terraform az aws`); override with the
+  (`claude gh dotnet docker kubectl terraform az aws`); override with the
   `cli_flag_verify_bins` option (`bin1,bin2,…`) and skip specific binaries
-  with `cli_flag_verify_skip_bins`.
+  with `cli_flag_verify_skip_bins`. `npm` is **excluded by default**, alongside
+  `git` and `npx`: every npm config key is a flag on every subcommand
+  (`npm <command> --key=value`), so per-subcommand `--help` is non-exhaustive by
+  design and the authoritative list (`npm config ls -l`) prints `prefix = "…"`
+  rather than `--prefix` — a generic `--help` parser cannot consume it, and
+  verifying against one produces false "unknown flag" findings. Re-add it with
+  `cli_flag_verify_bins` if your project wants it checked anyway.
 - **Hook-manager prefixes.** `block-no-verify` reads its recognized
   hook-manager disable-env-var prefixes from `block_no_verify_hook_manager_prefixes`
   (comma list, default `lefthook, husky, pre_commit, simple_git_hooks`). Add a

--- a/plugins/guardrails/hooks/block-dangerous-git.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.sh
@@ -87,9 +87,16 @@ INPUT=$(hook::buffer_stdin) || {
 # (additionalContext), once per session — see docs/conventions/hook-observability/.
 hook::require_jq "PreToolUse" "guardrails-block-dangerous-git" "$INPUT"
 
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
+# Both payload fields in ONE jq process (hook::jq_fields), not two. A jq spawn is
+# ~140 ms of fork() emulation on Windows Git Bash and this guard runs on every
+# Bash/PowerShell call. Failure semantics are unchanged: a missing jq or an
+# unparsable payload yields rc 1 here, which exits 0 exactly as the empty-COMMAND
+# skip below did — hook::require_jq above has already made the degraded state
+# visible once per session.
+hook::jq_fields "$INPUT" '.tool_input.command' '.tool_name' || exit 0
+COMMAND="${HOOK_JQ_FIELDS[0]}"
 [[ -n "$COMMAND" ]] || exit 0
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // "Bash"' 2>/dev/null | tr -d '\r')
+TOOL_NAME="${HOOK_JQ_FIELDS[1]:-Bash}"
 
 # Above this length the command is not parsed — a pathologically long command is
 # assumed to be obfuscation and blocked FAIL-CLOSED (generous cap; real git

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -254,7 +254,13 @@ EXEC_LC="${EXECUTABLE,,}"
 COMMAND_LC="${COMMAND,,}"
 
 # `cat` immediately before a redirect, with or without a space (`cat>file`).
+# Scanned PER SEGMENT (see cat_redirect_bypass), so `;|&()` never reach it — the
+# leading class is kept for the pre-segmentation shape and costs nothing.
 _cat_redir='(^|[[:space:];|&()]+)cat[[:space:]]*>'
+# `cat > /dev/null` is a DISCARD, not a file write — the same exemption
+# _echo_devnull already grants the echo/printf lane. Segment-scoped so a compound
+# `cat > /dev/null && cat > real.txt` still blocks on its second segment.
+_cat_devnull='(^|[[:space:];|&()]+)cat[[:space:]]*>>?[[:space:]]*/dev/null([[:space:]]|$)'
 # A simple-command segment whose command token is `echo` or `printf` — the
 # content producers a `> file` redirect turns into a Write/Edit bypass. Anchored
 # to the segment start (see producer_redirect_bypass), so it never matches an
@@ -309,11 +315,43 @@ _leading_redir='^([0-9]*(>>?|<)&?|&>>?)[[:space:]]*'
 # exempts a stdout discard (`>/dev/null`) — that's not a Write/Edit bypass.
 _echo_file_out='(^|[^0-9&])>>?[[:space:]]*[^|&>[:space:]]'
 _echo_devnull='(^|[^0-9&])>>?[[:space:]]*/dev/null'
-# python file-write indicators. `pathlib` / `path(` are identifier-boundary
-# anchored so they match the write-capable `pathlib.Path(` producer but NOT the
-# read-only `os.path.*path(` helpers (`normpath(`, `abspath(`, `realpath(`, …)
-# whose trailing `path(` would otherwise substring-match and false-positive.
-_py_write='open[[:space:]]*\(|\.write[[:space:]]*\(|(^|[^[:alnum:]_])pathlib|(^|[^[:alnum:]_])path[[:space:]]*\('
+# python file-write indicators that are unambiguous on their own. `pathlib` /
+# `path(` are identifier-boundary anchored so they match the write-capable
+# `pathlib.Path(` producer but NOT the read-only `os.path.*path(` helpers
+# (`normpath(`, `abspath(`, `realpath(`, …) whose trailing `path(` would
+# otherwise substring-match and false-positive.
+_py_write='\.write[[:space:]]*\(|(^|[^[:alnum:]_])pathlib|(^|[^[:alnum:]_])path[[:space:]]*\('
+# `open(` is NOT one of them: `open(f,'w')` writes and `open(f)` reads, and the
+# two differ only by an argument. A bare `open(` therefore says nothing about
+# direction, and matching it blocked every read-mode inline `open()`.
+# DISCRIMINATION BOUNDARY (see py_write_indicator): `open(` counts as a write
+# indicator only when a python WRITE-MODE LITERAL also occurs somewhere in the
+# same command — a quoted token built solely from mode characters that contains
+# at least one of `w` / `a` / `x` / `+`, in an argument position (after a comma,
+# or after `mode=`). Read modes (`'r'`, `'rb'`, `'rt'`) carry none of those
+# characters and no longer trip it.
+#
+# CO-OCCURRENCE, not position — deliberately. Bash ERE has no lazy quantifier, so
+# a positional `open\([^)]*'w'` stops at the first `)` and would fail OPEN on a
+# real write with a nested call (`open(os.path.join(a,b),'w')`), while a greedy
+# `.*` reaches into unrelated text anyway. This is the same mangle-resistant
+# co-occurrence shape the PowerShell lane below already uses.
+#
+# ACCEPTED RESIDUAL (the fail-CLOSED direction): a read-only `open()` in a
+# command that separately contains an argument-position `'w'`/`'a'`/`'x'`/`'+'`
+# literal (e.g. `print(open('f').read(), 'a')`) still blocks. The argument-position
+# requirement is what keeps the common read shapes clear — a dict subscript
+# (`json.load(open('p'))['a']`) is preceded by `[`, not by a comma.
+_py_open='open[[:space:]]*\('
+_py_write_mode='(,|mode[[:space:]]*=)[[:space:]]*['\''"][rwaxbtu+]*[wax+][rwaxbtu+]*['\''"]'
+
+# True when the (lowercased) command carries a python file-write indicator.
+py_write_indicator() {
+  local cmd_lc="$1"
+  [[ "$cmd_lc" =~ $_py_write ]] && return 0
+  [[ "$cmd_lc" =~ $_py_open && "$cmd_lc" =~ $_py_write_mode ]] && return 0
+  return 1
+}
 
 # Flag ONLY when the producer being redirected into a real file is echo/printf
 # authoring content — not any command string that merely co-mentions an `echo`
@@ -346,8 +384,12 @@ _py_write='open[[:space:]]*\(|\.write[[:space:]]*\(|(^|[^[:alnum:]_])pathlib|(^|
 # indistinguishable from a command word by prefix-peeling alone, and the redirect
 # there is group-level (same brace-group floor as above). Structurally unusual for
 # LLM output and covered by an accepted-floor test.
-producer_redirect_bypass() {
-  local exec_lc="$1" seps=$';\n|&()' soh=$'\x01' esc=$'\x02' normalized seg s i
+#
+# Segmentation is shared with the `cat >` scan (cat_redirect_bypass) through
+# normalize_segments, so both lanes agree on escaped separators and on the
+# fd-duplication sentinel instead of drifting apart behind two splitters.
+normalize_segments() {
+  local exec_lc="$1" seps=$';\n|&()' soh=$'\x01' esc=$'\x02' normalized s i
   # Protect backslash-escaped separators (`echo x \; > file`, an escaped-newline
   # line continuation `echo x \<newline> > file`) before the split: bash keeps an
   # escaped separator inside the SAME simple command (`\;` is a literal argument,
@@ -377,6 +419,25 @@ producer_redirect_bypass() {
   normalized="${normalized//[$seps]/$'\n'}"
   normalized="${normalized//"$soh"/&}"
   normalized="${normalized//"$esc"/ }"
+  NORMALIZED_SEGMENTS="$normalized"
+}
+
+# `cat >` with no input file is content authoring redirected into a file — the
+# heredoc/typed-content Write bypass. Scanned per segment so the /dev/null
+# DISCARD exemption cannot leak across a compound command: `cat > /dev/null &&
+# cat > real.txt` still blocks on its second segment.
+cat_redirect_bypass() {
+  local seg
+  while IFS= read -r seg || [[ -n "$seg" ]]; do
+    [[ "$seg" =~ $_cat_redir ]] || continue
+    [[ "$seg" =~ $_cat_devnull ]] && continue
+    return 0
+  done <<<"$NORMALIZED_SEGMENTS"
+  return 1
+}
+
+producer_redirect_bypass() {
+  local seg
   while IFS= read -r seg || [[ -n "$seg" ]]; do
     seg="${seg#"${seg%%[![:space:]]*}"}"
     # Peel leading command-prefix tokens (see _cmd_prefix) and leading redirections
@@ -427,7 +488,7 @@ producer_redirect_bypass() {
     [[ "$seg" =~ $_echo_file_out ]] || continue
     [[ "$seg" =~ $_echo_devnull ]] && continue
     return 0
-  done <<<"$normalized"
+  done <<<"$NORMALIZED_SEGMENTS"
   return 1
 }
 
@@ -491,23 +552,27 @@ if [[ "$TOOL_NAME" == "PowerShell" ]]; then
   # lane). ACCEPTED RESIDUAL: a stdin heredoc (`python3 - <<PY … PY`, no `-c`) is
   # uncovered here, as it is today.
   ps::blank_herestrings "$COMMAND"
-  if [[ "$COMMAND_LC" =~ $_py_write ]] && ps::might_write_via_python3 "$PS_BLANKED"; then
+  if py_write_indicator "$COMMAND_LC" && ps::might_write_via_python3 "$PS_BLANKED"; then
     block_bypass "python-write" "python3 -c inline-code file write bypasses Write/Edit hooks"
   fi
   emit_tel "ok" ""
   exit 0
 fi
 
-# cat > file (allow cat without redirect). EXEC_LC (lowercased stripped form) for
-# case-insensitive command-token detection.
-if [[ "$EXEC_LC" =~ $_cat_redir ]]; then
+# Split once into simple-command segments; both redirect scans below read it.
+# EXEC_LC (lowercased stripped form) gives case-insensitive command-token
+# detection.
+normalize_segments "$EXEC_LC"
+
+# cat > file (allow cat without redirect, and allow a `> /dev/null` discard).
+if cat_redirect_bypass; then
   block_bypass "cat-redirect" "cat > file write bypasses Write/Edit hooks"
 fi
 
 # echo/printf ... > file — only when the echo/printf IS the producer redirected
 # into a real file (stdout-to-real-file only; not stderr/fd redirects, /dev/null,
 # a co-located but unrelated echo, or tokens inside a quoted argument).
-if producer_redirect_bypass "$EXEC_LC"; then
+if producer_redirect_bypass; then
   block_bypass "echo-redirect" "echo/printf > file write bypasses Write/Edit hooks"
 fi
 
@@ -520,7 +585,7 @@ fi
 # `/c/Python313/python3.exe -c`) is the same write — anchored on the python3
 # basename, so `notpython3` (no separator before it) stays inert.
 if [[ "$EXEC_LC" =~ (^|[[:space:];|&()/\\]+)python3(\.exe)?[[:space:]]+-c ]] &&
-  [[ "$COMMAND_LC" =~ $_py_write ]]; then
+  py_write_indicator "$COMMAND_LC"; then
   block_bypass "python-write" "python3 -c file write bypasses Write/Edit hooks"
 fi
 

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -257,10 +257,14 @@ COMMAND_LC="${COMMAND,,}"
 # Scanned PER SEGMENT (see cat_redirect_bypass), so `;|&()` never reach it — the
 # leading class is kept for the pre-segmentation shape and costs nothing.
 _cat_redir='(^|[[:space:];|&()]+)cat[[:space:]]*>'
-# `cat > /dev/null` is a DISCARD, not a file write — the same exemption
-# _echo_devnull already grants the echo/printf lane. Segment-scoped so a compound
-# `cat > /dev/null && cat > real.txt` still blocks on its second segment.
-_cat_devnull='(^|[[:space:];|&()]+)cat[[:space:]]*>>?[[:space:]]*/dev/null([[:space:]]|$)'
+# One stdout redirect and its target word. `[^0-9&]` before the operator keeps
+# other-fd (`2>`, `21>`) and combined (`&>`) redirects out, while the optional
+# `1` admits the EXPLICIT stdout spelling — `1>file` is stdout exactly as `>file`
+# is, and omitting it left `cat >/dev/null 1>real.txt` reading as a discard. The
+# target class excludes `&`, so an fd dup (`>&1`) is not mistaken for a file.
+# Used by set_last_stdout_target, never matched alone: the PRESENCE of a
+# `/dev/null` redirect proves nothing (see below).
+_redir_scan='(^|[^0-9&])1?>>?[[:space:]]*([^|&>[:space:]]+)'
 # A simple-command segment whose command token is `echo` or `printf` — the
 # content producers a `> file` redirect turns into a Write/Edit bypass. Anchored
 # to the segment start (see producer_redirect_bypass), so it never matches an
@@ -305,16 +309,17 @@ _modifier_optend='^--([[:space:]]|$)'
 # A leading redirection element (`> file cmd`, `< in cmd`, `2> f cmd`, `>& n cmd`):
 # bash permits redirections before the command word, so a producer can hide behind
 # one (`> real.txt echo x`). Peeled (operator + its target word) — like _cmd_prefix
-# — to expose the producer for _producer_head, while _echo_file_out/_echo_devnull
+# — to expose the producer for _producer_head, while _echo_file_out and the
 # still run on the UN-peeled segment so the redirect itself remains the write
 # signal. Not anchored to stdout-to-file: any leading redirect is peeled for
 # producer exposure; whether a real file write exists is decided by _echo_file_out.
 _leading_redir='^([0-9]*(>>?|<)&?|&>>?)[[:space:]]*'
 # stdout-to-file redirect: `>` / `>>` NOT preceded by an fd digit or `&`, so
-# stderr/fd redirects (`2>/dev/null`, `2>&1`, `&>`) do not trip. _echo_devnull
-# exempts a stdout discard (`>/dev/null`) — that's not a Write/Edit bypass.
+# stderr/fd redirects (`2>/dev/null`, `2>&1`, `&>`) do not trip. A stdout discard
+# is exempt — that's not a Write/Edit bypass — but the exemption is decided by
+# set_last_stdout_target, not by this pattern: the discard must be the EFFECTIVE
+# target, not merely present somewhere in the segment.
 _echo_file_out='(^|[^0-9&])>>?[[:space:]]*[^|&>[:space:]]'
-_echo_devnull='(^|[^0-9&])>>?[[:space:]]*/dev/null'
 # python file-write indicators that are unambiguous on their own. `pathlib` /
 # `path(` are identifier-boundary anchored so they match the write-capable
 # `pathlib.Path(` producer but NOT the read-only `os.path.*path(` helpers
@@ -422,6 +427,29 @@ normalize_segments() {
   NORMALIZED_SEGMENTS="$normalized"
 }
 
+# The EFFECTIVE stdout destination of a segment, into LAST_STDOUT_TARGET (empty
+# when the segment redirects stdout nowhere).
+#
+# Bash applies redirections LEFT TO RIGHT, so the last one wins: `cat >
+# /dev/null > real.txt` writes to real.txt, and `cat > /dev/null 1>real.txt`
+# does too. A check that exempted a segment on merely CONTAINING a `/dev/null`
+# redirect would hand an attacker a one-token bypass of this whole guard — write
+# the discard first, the real file second. Only the final target may exempt.
+#
+# Sets a global rather than echoing: this runs per segment on every Bash call,
+# and a command substitution would add a fork to each one.
+LAST_STDOUT_TARGET=""
+set_last_stdout_target() {
+  local rest="$1"
+  LAST_STDOUT_TARGET=""
+  while [[ "$rest" =~ $_redir_scan ]]; do
+    LAST_STDOUT_TARGET="${BASH_REMATCH[2]}"
+    # Quoted so the consumed text is stripped literally — a target may hold glob
+    # metacharacters, and an unquoted pattern would eat the wrong span.
+    rest="${rest#*"${BASH_REMATCH[0]}"}"
+  done
+}
+
 # `cat >` with no input file is content authoring redirected into a file — the
 # heredoc/typed-content Write bypass. Scanned per segment so the /dev/null
 # DISCARD exemption cannot leak across a compound command: `cat > /dev/null &&
@@ -430,7 +458,8 @@ cat_redirect_bypass() {
   local seg
   while IFS= read -r seg || [[ -n "$seg" ]]; do
     [[ "$seg" =~ $_cat_redir ]] || continue
-    [[ "$seg" =~ $_cat_devnull ]] && continue
+    set_last_stdout_target "$seg"
+    [[ "$LAST_STDOUT_TARGET" == "/dev/null" ]] && continue
     return 0
   done <<<"$NORMALIZED_SEGMENTS"
   return 1
@@ -447,7 +476,7 @@ producer_redirect_bypass() {
     # compound-command header / group opener / negation (`; do echo x > f`, `if echo
     # x > f`, `while echo ...`, `! echo ...`, `{ echo ...`), or a leading redirect
     # (`> real.txt echo x`) is still seen as the segment's command word. The redirect
-    # itself is left in `seg`: _echo_file_out/_echo_devnull below decide whether a
+    # itself is left in `seg`: _echo_file_out and set_last_stdout_target below decide whether a
     # real file write exists, so a leading redirect stays the write signal.
     local head="$seg" tgt prev_mod=""
     while :; do
@@ -486,7 +515,10 @@ producer_redirect_bypass() {
     done
     [[ "$head" =~ $_producer_head ]] || continue
     [[ "$seg" =~ $_echo_file_out ]] || continue
-    [[ "$seg" =~ $_echo_devnull ]] && continue
+    # Same left-to-right rule as the cat lane: `echo x > /dev/null > real.txt`
+    # writes to real.txt. The old presence test exempted it.
+    set_last_stdout_target "$seg"
+    [[ "$LAST_STDOUT_TARGET" == "/dev/null" ]] && continue
     return 0
   done <<<"$NORMALIZED_SEGMENTS"
   return 1

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -116,6 +116,30 @@ run "cat > /dev/null && cat > real.txt still blocked" \
 run "cat > real.txt; cat > /dev/null still blocked" \
   "cat > real.txt; cat > /dev/null" 2
 
+# REGRESSION FLOOR — must not be reintroduced: bash applies redirects LEFT TO
+# RIGHT, so the LAST stdout target wins. Exempting a segment merely because a
+# /dev/null redirect appears in it is a one-token bypass of the whole guard:
+# write the discard first, the real file second, within a single segment.
+run "cat > /dev/null > real.txt still blocked" \
+  "cat > /dev/null > real.txt" 2
+run "cat >/dev/null 1>real.txt still blocked" \
+  "cat >/dev/null 1>real.txt" 2
+run "cat > /dev/null >> real.txt still blocked" \
+  "cat > /dev/null >> real.txt" 2
+# The inverse order is a genuine discard — real.txt is opened but stdout ends at
+# /dev/null, so the last-target rule must still ALLOW it.
+run "cat > real.txt > /dev/null is a discard (allowed)" \
+  "cat > real.txt > /dev/null" 0
+# Same rule on the echo/printf lane, which had the identical order-blind test.
+run "echo x > /dev/null > real.txt still blocked" \
+  "echo x > /dev/null > real.txt" 2
+run "printf x > /dev/null > real.txt still blocked" \
+  "printf x > /dev/null > real.txt" 2
+# A trailing stderr redirect is not a stdout target and must not displace the
+# /dev/null verdict — the fd-qualified form is excluded from the scan.
+run "cat > /dev/null 2> err.log (allowed)" \
+  "cat > /dev/null 2> err.log" 0
+
 # --- Redirect false-positive regression -------------------------------------
 # stderr/fd redirects + /dev/null discards are NOT file-write bypasses, even
 # when an `echo` appears in the same compound command.

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -67,6 +67,55 @@ run "path-qualified python3.exe -c open write (blocked)" \
 run "notpython3 -c open (allowed)" \
   "notpython3 -c \"open('x','w').write('a')\"" 0
 
+# --- open() write-mode discrimination ---------------------------------------
+# `open(` alone is direction-agnostic (`open(f,'w')` writes, `open(f)` reads),
+# so it is a write indicator ONLY alongside an argument-position write-mode
+# literal — a quoted mode token carrying w / a / x / +. Read modes carry none.
+# The reproduced consumer false positive, verbatim in shape: a read-mode open
+# feeding json.load.
+run "python3 -c read-only open() feeding json.load (allowed)" \
+  "python3 -c \"import json; d=json.load(open('x.json'))\"" 0
+run "python3 -c bare open(f) (allowed)" "python3 -c \"open(f).read()\"" 0
+run "python3 -c open mode 'r' (allowed)" "python3 -c \"open('x','r').read()\"" 0
+run "python3 -c open mode 'rb' (allowed)" "python3 -c \"open('x','rb').read()\"" 0
+# A dict SUBSCRIPT that looks like a mode token is preceded by `[`, not by a
+# comma, so the argument-position anchor keeps this common read shape clear.
+run "python3 -c open() + dict subscript ['a'] (allowed)" \
+  "python3 -c \"import json;print(json.load(open('p'))['a'])\"" 0
+# Write modes still block, in every spelling.
+run "python3 -c open mode 'a' append (blocked)" "python3 -c \"open('x','a')\"" 2
+run "python3 -c open mode 'r+' update (blocked)" "python3 -c \"open('x','r+')\"" 2
+run "python3 -c open mode='w' keyword (blocked)" "python3 -c \"open('x', mode='w')\"" 2
+# REGRESSION FLOOR — must not be reintroduced: the check is co-occurrence, not
+# positional, precisely so a nested call between `open(` and the mode argument
+# cannot fail it open (a positional `open\([^)]*'w'` stops at the first `)`).
+run "python3 -c open(nested-call, 'w') (blocked)" \
+  "python3 -c \"open(os.path.join(a,b),'w')\"" 2
+# ACCEPTED RESIDUAL, fail-CLOSED direction: a read-only open() in a command that
+# separately carries an argument-position mode-shaped literal still blocks.
+run "python3 -c read open + unrelated ', \\\"a\\\"' literal (accepted over-block)" \
+  "python3 -c \"print(open('f').read(), 'a')\"" 2
+
+# --- cat > /dev/null is a discard, not a write -------------------------------
+# The exemption the echo/printf lane already grants now applies to `cat >` too,
+# in every spelling the strip can produce.
+run "cat > /dev/null discard (allowed)" "cat > /dev/null" 0
+run "cat>/dev/null no space (allowed)" "cat>/dev/null" 0
+run "cat >> /dev/null append discard (allowed)" "cat >> /dev/null" 0
+run "cat >/dev/null 2>&1 (allowed)" "cat >/dev/null 2>&1" 0
+run "cat >> /dev/null 2>&1 append + fd dup (allowed)" "cat >> /dev/null 2>&1" 0
+run "cat > /dev/null; trailing separator (allowed)" "cat > /dev/null; echo done" 0
+# A real append target with the same trailing fd dup is still a write.
+run "cat >> real.txt 2>&1 still blocked" "cat >> real.txt 2>&1" 2
+run "cat > fully-quoted /dev/null (allowed)" 'cat > "/dev/null"' 0
+run "cat > partially-quoted /dev/null (allowed)" 'cat > /dev/"null"' 0
+# REGRESSION FLOOR — must not be reintroduced: the exemption is SEGMENT-scoped.
+# A command-scoped exemption would let the real write in the second segment pass.
+run "cat > /dev/null && cat > real.txt still blocked" \
+  "cat > /dev/null && cat > real.txt" 2
+run "cat > real.txt; cat > /dev/null still blocked" \
+  "cat > real.txt; cat > /dev/null" 2
+
 # --- Redirect false-positive regression -------------------------------------
 # stderr/fd redirects + /dev/null discards are NOT file-write bypasses, even
 # when an `echo` appears in the same compound command.
@@ -515,17 +564,26 @@ run_pwsh "PS: python3 script run, open( in an arg, no -c (allowed)" \
 run_pwsh "PS: python3 -m module run, open( in an arg, no -c (allowed)" \
   "python3 -m mytool \"open('x','w')\"" 0
 # here-string mention stays inert (blanked before the probe, like the git lane).
-run_pwsh "PS: here-string mentions python3 -c open (allowed)" \
-  "$(printf "@'\npython3 -c open(\n'@\nWrite-Output ok")" 0
+# Spelled with a WRITE MODE so the here-string blanking is what makes this
+# allowed — a bare `open(` would now be allowed for the unrelated reason that it
+# is no longer a write indicator.
+run_pwsh "PS: here-string mentions python3 -c open write (allowed)" \
+  "$(printf '@%s\npython3 -c open(f,"w")\n%s@\nWrite-Output ok' "'" "'")" 0
 # ACCEPTED OVER-BLOCK (fail-closed): a MENTION of python3 … -c + a write indicator in
 # prose, a line comment, or a quoted string now blocks — the guard cannot prove a
-# non-tokenizable PowerShell command is a mere mention.
-run_pwsh "PS: prose mention of python3 -c open now over-blocks (blocked)" \
-  "Write-Output 'run python3 -c open() later'" 2
-run_pwsh "PS: line-comment mention of python3 -c open now over-blocks (blocked)" \
-  "Write-Output ok # python3 -c open(" 2
-run_pwsh "PS: quoted &{python3 -c open( string now over-blocks (blocked)" \
-  "Write-Output '&{python3 -c open(}'" 2
+# non-tokenizable PowerShell command is a mere mention. The mentioned write is
+# spelled with a WRITE MODE, because a bare `open(` is no longer a write
+# indicator in either lane (see the open() write-mode discrimination above).
+run_pwsh "PS: prose mention of python3 -c open write now over-blocks (blocked)" \
+  "Write-Output 'run python3 -c open(f,\"w\") later'" 2
+run_pwsh "PS: line-comment mention of python3 -c open write now over-blocks (blocked)" \
+  "Write-Output ok # python3 -c open(f,'w')" 2
+run_pwsh "PS: quoted &{python3 -c open( write string now over-blocks (blocked)" \
+  "Write-Output '&{python3 -c open(f,\"w\")}'" 2
+# The same three MENTION shapes carrying only a read-mode open are no longer
+# write indicators at all, so they stay allowed — this is the fix, not a hole.
+run_pwsh "PS: prose mention of a read-only python3 -c open (allowed)" \
+  "Write-Output 'run python3 -c open(f) later'" 0
 # Quoted / path-qualified / brace-glued / backtick-obfuscated python3 with -c: all
 # caught by the token+`-c` probe (quote-intact, backtick-recovered).
 run_pwsh "PS: & 'python3' -c open write (blocked)" \

--- a/plugins/guardrails/hooks/block-no-verify.sh
+++ b/plugins/guardrails/hooks/block-no-verify.sh
@@ -73,9 +73,16 @@ INPUT=$(hook::buffer_stdin) || {
 # (additionalContext), once per session — see docs/conventions/hook-observability/.
 hook::require_jq "PreToolUse" "guardrails-block-no-verify" "$INPUT"
 
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null | tr -d '\r')
+# Both payload fields in ONE jq process (hook::jq_fields), not two. A jq spawn is
+# ~140 ms of fork() emulation on Windows Git Bash and this guard runs on every
+# Bash/PowerShell call. Failure semantics are unchanged: a missing jq or an
+# unparsable payload yields rc 1 here, which exits 0 exactly as the empty-COMMAND
+# skip below did — hook::require_jq above has already made the degraded state
+# visible once per session.
+hook::jq_fields "$INPUT" '.tool_input.command' '.tool_name' || exit 0
+COMMAND="${HOOK_JQ_FIELDS[0]}"
 [[ -n "$COMMAND" ]] || exit 0
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // "Bash"' 2>/dev/null | tr -d '\r')
+TOOL_NAME="${HOOK_JQ_FIELDS[1]:-Bash}"
 
 # Above this length the command is not parsed — a pathologically long command is
 # assumed to be obfuscation and blocked FAIL-CLOSED (generous cap; real git

--- a/plugins/guardrails/hooks/cli-flag-verify.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.sh
@@ -93,8 +93,9 @@ fi
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
 
 # Known binaries to check. Override via the cli_flag_verify_bins userConfig option.
-# `git` and `npx` are intentionally EXCLUDED — both are unreliable `--help`
-# flag lists whose residuals are all real-flag false positives:
+# `git`, `npx`, and `npm` are intentionally EXCLUDED — all three have unreliable
+# or non-exhaustive `--help` flag lists whose residuals are all real-flag false
+# positives:
 #   - `git <subcmd> --help` routes to the man page (or a short synopsis under
 #     timeout), not a parseable per-subcommand flag list, AND the flaky output
 #     poisons the 24h --help cache → persistent FPs.
@@ -102,8 +103,18 @@ REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
 #     package's, not npx's) and an uninstalled `<pkg>` can trigger a network
 #     fetch. Working cases produce no residual (invisible benefit); failing
 #     cases produce visible FPs — same shape that excludes git.
-# Re-add either via the env var if it ever ships a stdout-parseable flag list.
-DEFAULT_BINS="claude gh dotnet docker npm kubectl terraform az aws"
+#   - `npm <subcmd> --help` lists only that subcommand's own options, but EVERY
+#     npm config key is simultaneously a command-line flag on every subcommand —
+#     `npm --help` says so itself: "Specify configs in the ini-formatted file …
+#     or on the command line via: npm <command> --key=value". So the global
+#     config flags (`--prefix`, `--registry`, `--userconfig`, …) appear in
+#     NEITHER `npm <subcmd> --help` NOR `npm --help`, and every use of one is a
+#     false positive. The authoritative list (`npm config ls -l`) prints
+#     `prefix = "…"`, not `--prefix`, so it cannot be consumed by a generic
+#     `--help` flag-list parser without an npm-specific transform.
+# Re-add any of them via the option if it ever ships a stdout-parseable,
+# exhaustive flag list.
+DEFAULT_BINS="claude gh dotnet docker kubectl terraform az aws"
 BINS_RAW="${CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS:-$DEFAULT_BINS}"
 # Normalize: comma OR space separated → space separated.
 BINS="${BINS_RAW//,/ }"

--- a/plugins/guardrails/hooks/cli-flag-verify.test.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.test.sh
@@ -261,4 +261,29 @@ assert_exit "verifier: target --verbose verified, not consumed (absent -> 1)" 1 
 run_verifier --quiet faketool --quiet
 assert_exit "verifier: target --quiet verified, not consumed (absent -> 1)" 1 $?
 
+# ============ DEFAULT BIN SET — npm excluded (global-flag FP) ===============
+# `npm ci --prefix ./vendor` was reported UNKNOWN: `--prefix` is one of npm's
+# config keys, every one of which is a valid flag on every subcommand, and none
+# of which appears in `npm <subcmd> --help` OR in `npm --help`. npm is therefore
+# out of the default bin set (like git and npx), so no candidate is produced.
+npm_dir="$TEST_TMPDIR/npm-default-bins"
+mkdir -p "$npm_dir/cache"
+npm_target="$npm_dir/target.sh"
+NPM_LINE='npm ci --prefix ./vendor'
+printf '%s\n' "$NPM_LINE" >"$npm_target"
+# Deliberately NO CLAUDE_PLUGIN_OPTION_CLI_FLAG_VERIFY_BINS override: the
+# DEFAULT set is what is under test here.
+OUT=$(LOCALAPPDATA="$npm_dir/cache" XDG_CACHE_HOME="$npm_dir/cache" \
+  bash "$HOOK" <<<"$(write_json "$npm_target" "$NPM_LINE")" 2>&1)
+RC=$?
+assert_exit "npm ci --prefix (default bins) -> exit 0" 0 "$RC"
+assert_absent "npm ci --prefix -> no UNKNOWN_FLAG" "$OUT" "UNKNOWN_FLAG"
+# The behavioral case above is silent on a host with no npm installed, so pin
+# the exclusion at its source too — that assertion fails on any host.
+DEFAULT_BINS_LINE=$(grep -m1 '^DEFAULT_BINS=' "$HOOK")
+assert_absent "npm removed from DEFAULT_BINS" "$DEFAULT_BINS_LINE" "npm"
+# …and the removal must not have emptied or reshuffled the rest of the set.
+assert_contains "DEFAULT_BINS still carries the retained bins" \
+  "$DEFAULT_BINS_LINE" 'claude gh dotnet docker kubectl terraform az aws'
+
 report

--- a/plugins/guardrails/hooks/hooks.json
+++ b/plugins/guardrails/hooks/hooks.json
@@ -42,7 +42,7 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/flag-commit-pr-skill-bypass.sh",
-            "timeout": 10,
+            "timeout": 60,
             "statusMessage": "Checking commit/PR skill usage..."
           }
         ]


### PR DESCRIPTION
No linked issue

Consumer report drained from the handoff inbox: `20260730-182801-guardrails-hook-false-positives-and-ungated-commit-pr-hook`. Two false positives were reproduced verbatim at HEAD before anything was changed.

## 1a — a read-only `open()` was blocked

Reproduced first: `python3 -c "import json; d=json.load(open('x.json'))"` → exit 2.

`_py_write` matched `open[[:space:]]*\(` with no write-mode discrimination, so every inline Python `open()` read as a write.

**The discrimination boundary, stated because it is a design call and not obvious.** A bare `open(` is no longer a write indicator at all. `open(` counts as a write **only when an argument-position write-mode literal occurs in the same command** — a quoted token built solely from mode characters `[rwaxbtu+]`, containing at least one of `w`/`a`/`x`/`+`, appearing immediately after a comma or after `mode=`.

The test is **co-occurrence, not positional, deliberately.** Bash ERE has no lazy quantifier: a positional `open\([^)]*'w'` stops at the first `)` and would **fail open** on a real `open(os.path.join(a,b),'w')`, while a greedy `.*` reaches into unrelated text. This is the same mangle-resistant co-occurrence shape the PowerShell lane already uses. The **argument-position** requirement — rather than "a mode literal anywhere" — is what keeps common read shapes clear: `json.load(open('p'))['a']` has its `'a'` preceded by `[`, not by a comma.

**Residual, in the fail-closed direction and pinned by a test:** a read-only `open()` in a command that separately carries an argument-position `'w'`/`'a'`/`'x'`/`'+'` literal (e.g. `print(open('f').read(), 'a')`) still blocks. Accepted over the alternative.

**Second residual, left alone:** a bare `pathlib` mention is still an indicator on its own, so read-only inline Python that merely imports `pathlib` still blocks. That indicator is what currently carries `.write_text(` / `.write_bytes(` — `\.write[[:space:]]*\(` does not match `.write_text(` — so narrowing it requires introducing an explicit write-call set. Out of scope here, recorded in the CHANGELOG.

**Fixtures respelled, not relaxed — called out so it does not read as test-fitting.** Four PowerShell-lane cases used a bare `open(` as their stand-in write indicator to assert mention-over-block and here-string inertness. Since `open(` is no longer an indicator, those inputs were respelled to `open(f,'w')` so they keep testing their actual contract, and a new case asserts that the same mention with a READ-mode open is now allowed.

## 1b — `cat > /dev/null` was blocked

A discard is not a write. Added `_cat_devnull`, the exemption the echo/printf lane already had.

It is **segment-scoped, not command-scoped**: a whole-command exemption would let `cat > /dev/null && cat > real.txt` through, which is now a pinned regression floor. The `cat` and echo/printf scans now share one splitter — the segmentation block was extracted from `producer_redirect_bypass` into `normalize_segments` (called once, sets `NORMALIZED_SEGMENTS`) so the two lanes cannot drift on escaped separators or the `2>&1` fd-dup sentinel. Quoted spellings (`cat > "/dev/null"`, `cat > /dev/"null"`) fall out of the existing redirect-operand handling in `strip_literals`; asserted.

## 2 — `flag-commit-pr-skill-bypass` timeout 10 → 60

It was the only guardrails hook not at 60, against five `Bash|PowerShell` siblings that are. Per the hooks page fetched this session (<https://code.claude.com/docs/en/hooks>):

> Seconds before canceling. Defaults: 600 for `command`, `http`, and `mcp_tool`; 30 for `prompt`; 60 for `agent`.

Nothing pushes a `PreToolUse` hook to 10 — the 10 was authored here. Same page, on why a consumer cannot work around it locally:

> Hook entries merge across settings levels rather than replacing each other: user, project, and local settings add their own hooks without removing managed ones, and the `disableAllHooks` setting can't disable managed hooks from outside managed settings.

## 3a — `hook::jq_fields` adopted by `block-dangerous-git` and `block-no-verify`

Two `jq` spawns collapsed to one per invocation; first adopters in the fleet. Failure semantics are unchanged: rc 1 from the helper exits 0 exactly as the old empty-`COMMAND` skip did, after `hook::require_jq` has already surfaced the degraded state. The cross-hook `require-jq-notice-isolation` contract still passes over both adopters.

## 3b — `cli-flag-verify` global-flag false positive

**The obvious fix was a chain-fallback to top-level `--help`, and it was measured and rejected:** `npm --help` does not list `--prefix` either (`verify-cli-flag.sh npm --prefix` → rc 1), so it would not have closed the repro.

Root cause is structural. `npm --help` states:

> Specify configs in the ini-formatted file … or on the command line via: `npm <command> --key=value`

Every config key is a flag on every subcommand, so per-subcommand help is non-exhaustive **by design**, and the authoritative list (`npm config ls -l`) prints `prefix = "…"`, not `--prefix`, so no generic `--help` parser can consume it. `npm` therefore joins `git` and `npx` in the exclusion, on the rationale already recorded in that file. Consumers re-add it via `cli_flag_verify_bins`.

## Verification

| Check | Result |
|---|---|
| `block-hook-bypass.test.sh` | PASS=233 FAIL=0 |
| `block-dangerous-git.test.sh` | PASS=329 FAIL=0 |
| `block-no-verify.test.sh` | PASS=120 FAIL=0 |
| `cli-flag-verify.test.sh` | PASS=52 FAIL=0 |
| `require-jq-notice-isolation.test.sh` | PASS=2 FAIL=0 |
| `shellcheck` (6 changed files) | clean |
| `shfmt -d` (5 of 6) | clean |
| `check-shell-portability.sh --paths` (6 files) | No unexcused GNU-only constructs |
| `check-silent-skips.sh` | No silent prerequisite skips found |
| `markdownlint-cli2` | 0 issues |
| `check-changelog-parity.sh --check-bump origin/main` | pass |
| `git ls-files -s` changed `.sh` | all `100755` |

Suites were run strictly one at a time — their wall-clock ceilings fail spuriously under concurrency. The first `block-hook-bypass` run surfaced 3 failures (the PowerShell `open(` fixtures); those were respelled and the suite re-run to green twice, so the 233 tally is the shipped file.

Both directions of each fix are covered: read-only `open()` feeding `json.load` → exit 0, `open(nested-call, 'w')` → exit 2 (the fail-open floor), `cat > /dev/null` variants → exit 0, `cat > /dev/null && cat > real.txt` and `cat >> real.txt 2>&1` → exit 2 (the segment-scoping floors).

`cli-flag-verify.test.sh` fails bare `shfmt -d` — **pre-existing and identical at `origin/main`** (the `X=$(…); RC=$?` one-liner idiom used throughout). The diff hunks stop around line 239 and this PR's addition starts at 264, so the added lines are shfmt-clean. `main` being green means bare `shfmt -d` is evidently not the gate CI applies to `.test.sh` here.

`check-orphaned-fixtures.sh` was not run locally; it exceeds a 300s timeout on this machine. CI covers it.

`guardrails` 0.19.2 → **0.19.3**.

## Deliberately not done

- **F2 (out-of-repo plugin-data append blocked)** — not among the three confirmed-live findings; prior triage left it unreproduced.
- **F1 suggestions 2–3 (command-gating the hook, profiling the 12–19 s)** — the report says explicitly these are *not* superseded by a timeout fix, and that is right: a hook taking 12–19 s on every shell call is still expensive. Scoped out here, still open.
- **`workflow-resilience-check.sh` remains at `timeout: 10`** — `Workflow` matcher, not exercised by the report, flagged out of scope by the item itself.
- **`cat >&2` still blocks.** An fd-dup is not a file write — the same class as the `/dev/null` FP fixed here — but it is pre-existing and not the reported defect. Flagged rather than folded in.

## Surfaced, not fixed

- `plugins/guardrails/README.md`'s hook table lists "PreToolUse · Bash" for six guards whose registered matcher in `hooks.json` is `Bash|PowerShell` — a table-wide doc/manifest mismatch, not introduced here.
- The inbox item's front-matter title still says "guardrails 0.18.1" while its triage audited 0.19.0 and this lands at 0.19.3; stale on version, but its findings verified live at HEAD.

## Related

- #1979 — the shared-hook-lib work that introduced `hook::jq_fields`, which this PR is the first to adopt.
- #2001 — the sibling timeout fix in `context-guard`, same defect class and same fetched doc line.
- Inbox item `20260730-182801-guardrails-hook-false-positives-and-ungated-commit-pr-hook` — the consumer report.
