### PR TITLE
feat(songwriting): bind craft disciplines at generation time, and adjudicate three context files against their source chapters

### DIFF
--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -107,7 +107,7 @@ plugin manifests and kept in sync by CI — never hand-edit it; the category voc
 
 ## Music
 
-- [`songwriting`](../plugins/songwriting) — Songwriting craft companion — eight concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).
+- [`songwriting`](../plugins/songwriting) — Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).
 
 ## Personal
 

--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -2,11 +2,11 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
   "version": "0.7.0",
-  "description": "Songwriting craft companion — eight concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
+  "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",
     "email": "info@melodicsoftware.com"
   },
   "license": "MIT",
-  "keywords": ["songwriting", "lyrics", "pat-pattison", "suno", "music", "rhyme", "skill"]
+  "keywords": ["songwriting", "lyrics", "pat-pattison", "suno", "music", "rhyme", "metaphor", "agents", "skill"]
 }

--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Songwriting craft companion — eight concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -5,11 +5,76 @@ All notable changes to the `songwriting` plugin are documented here. Format foll
 
 ## [0.7.0]
 
-Source-fidelity pass over three context files, each adjudicated against the
-full text of the chapter it claims to distill rather than against the
-distillation. Paraphrase only.
+Two changes in one release: a fix for the plugin's central failure — craft
+disciplines that load into context and then fail to bind at generation time —
+and a source-fidelity pass over three context files. Paraphrase only; no
+chapter prose, example writes, or student work reaches this public repository.
 
-### Fixed
+### Added — the binding fix
+
+Piloting the plugin end-to-end on a song established that loading a context
+file does not make its discipline govern generation. A file stating that
+choruses tell was in context two turns before three choruses were emitted that
+show; a filter's boxes were listed as passed while the emitted lines failed
+them. Reading a rule and obeying it at generation time are separate problems,
+and only the first was addressed. Three changes attack the second:
+
+- **`object-writer` agent** — performs the object write itself rather than
+  prompting a human, with the discipline in its own system prompt rather than
+  in a file it consults. Dispatched blind, one per seed, deliberately denied
+  the song, the draft, and the other writers' output, because same-seed
+  divergence depends on isolation. Writes its result to a file and returns a
+  path plus a seven-channel sense inventory quoting its own phrases, with thin
+  channels reported rather than padded. Reached through the new
+  `/songwriting:object-writing generate` action.
+
+  This shape was validated during the pilot: agents carrying the discipline in
+  their prompts produced materially better output than the main thread did with
+  the same files loaded, including one that graded its own organic channel thin
+  and refused to pad it. The file-not-message return is also empirical — long
+  creative text proved unreliable over the agent return channel.
+
+- **Emission boundaries on every craft skill.** Each skill now states what it
+  must NOT emit and which skill owns that output. `song-form` does not write
+  lines; `rhyme` does not write the line its rhyme lands in; `meter-prosody`
+  measures but does not rewrite; `object-writing` produces ore, not lines. In
+  the pilot the structural skill wrote three chorus drafts while its own
+  routing said rhyme work belonged elsewhere.
+
+- **A hard input gate on `co-write`,** the one skill that legitimately emits
+  lines. Its gate is satisfied by artifacts that exist — a menu of rhyme
+  candidates visible in the response, object-writing output at a named path, a
+  marked stress map — not by naming boxes as passed. A skip stays valid and
+  stays named; a box claimed as passed with no artifact behind it is a failed
+  box.
+
+### Added — metaphor as a first-class skill
+
+`/songwriting:metaphor` with generative actions (`collide`, `recipe`, `keys`,
+`types`, `simile`, `diagnose`), taking object-writing output as its input. The
+underlying `metaphor.md` was verified faithful against *Writing Better Lyrics*
+(2009) Chapter 3 and is unchanged — the defect was placement. 755 lines of
+accurate method were reachable only as one action inside a skill about a
+different discipline, and across an entire pilot song it never fired once,
+despite that song containing no metaphor at all.
+
+Two corrections from the chapter now sit where generation happens rather than
+only in the reference: a metaphor must be literally false, since identity
+without conflict is definition; and noun+verb collisions outperform
+adjective+noun, because verbs drive a line — the correction that matters most,
+given that the default reach is always for an adjective.
+
+### Changed (breaking)
+
+- **`/songwriting:object-writing metaphor` and `metaphor-recipe` are removed.**
+  Both route to `/songwriting:metaphor` (`collide` and `recipe`). Cliché repair
+  stays in `object-writing`, since its taxonomy covers stale phrasing beyond
+  metaphor.
+
+### Fixed — source fidelity
+
+Three context files adjudicated against the full text of the chapter each
+claims to distill, rather than against the distillation.
 
 - **`box-model.md` defined "travelogue" three incompatible ways.** *Writing
   Better Lyrics* (2009) Chapter 8 defines travelogue as verses with no natural

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -73,8 +73,32 @@ given that the default reach is always for an adjective.
 
 ### Fixed — source fidelity
 
-Four context files adjudicated against the full text of the chapter each claims
-to distill, rather than against the distillation.
+Six context files adjudicated against the full text of the chapter each claims
+to distill, rather than against the distillation. Chapters 1, 3, 6, 7, 8, 9, 10,
+11, 12, and 13 of *Writing Better Lyrics* (2009) read in full.
+
+- **The deceptive cadence was absent from all 49 context files.** *Writing
+  Better Lyrics* (2009) Chapter 13 names the move: a chorus opens `aba`, the ear
+  leans toward a resolving `abab` close, and the fourth line repeats the title
+  instead. It repeats the title, spotlights it through the structural surprise,
+  and resolves the section *less securely* than the expected rhyme would have —
+  and that third effect is the craft point. The chapter's example is a character
+  asking for something she has not been given; full resolution would sound as
+  though she already had it. Now in `hook.md` with the match-the-cadence-to-the-
+  question rule and its counter-case: a section that resolves or answers wants
+  the expected rhyme, and withholding it there fights the meaning.
+
+- **`point-of-view.md`'s dialogue coverage gains three mechanics.** The duet
+  test is the chorus, not the conversation — if the repeated section is one
+  character's plea, the other cannot sing it and the song is not a duet however
+  evenly the dialogue is split. First-person dialogue whose story belongs to the
+  other character has two exits rather than one: move to third person, or keep
+  first person and write the narrator a closing insight that earns the
+  retelling. And Chapter 13's structural sequence is now stated as the
+  three-stage setup it is — balanced verse, off-balance three-line transitional
+  bridge, withheld chorus rhyme — rather than compressed to a pointer, because
+  in quoted dialogue the structure decides which character's words the section
+  is actually about.
 
 - **`repetition.md`'s hidden-question mechanic was inverted.** *Writing Better
   Lyrics* (2009) Chapter 6 deletes the **interrogative pronoun** and keeps the

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,51 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.0]
+
+Source-fidelity pass over three context files, each adjudicated against the
+full text of the chapter it claims to distill rather than against the
+distillation. Paraphrase only.
+
+### Fixed
+
+- **`box-model.md` defined "travelogue" three incompatible ways.** *Writing
+  Better Lyrics* (2009) Chapter 8 defines travelogue as verses with no natural
+  relationship to each other, linked only through the title or chorus, so the
+  boxes accumulate no weight. Verses that do the same job or project the same
+  color are the OPPOSITE failure — Chapter 7's colored-spotlight problem, where
+  the chain is intact and the repainting is missing — and Chapter 8 closes by
+  naming both poles explicitly. The file now separates the two, gives each its
+  own test, and states that equal box weight is a symptom of travelogue rather
+  than a synonym for it. The prior conflation prescribed the wrong fix:
+  division-of-labor shifts for a lyric that needed a causal chain.
+
+### Added
+
+- **`object-writing.md` restores six mechanics present in *Writing Better
+  Lyrics* (2009) Chapter 1 but lost in distillation.** The chapter's own
+  instruction to follow sensory association was carried without the mechanism
+  that produces it, which yields static scene description instead of a dive.
+  Added: the pivot chain (each image handing off through a sense channel, with
+  a worked example and a numbering diagnostic); the seven-channel sense
+  inventory as an acceptance test quoting the write's own phrases, with thin
+  channels reported rather than padded; specificity calibration set at the
+  chapter's actual density rather than a generic-to-less-generic swap;
+  invention explicitly licensed, since the chapter holds that a song is not
+  autobiography and truth outranks reality; the group model's same-seed
+  divergence and its round-over-round escalating bar; and perspective writes
+  run inside a character's senses rather than the writer's.
+
+- **`response-filter.md` §2 gains an unintended-implication box.** A line could
+  pass every existing box — sense-bound, specific noun, strong verb, no cliché,
+  consistent POV — and still assign a character a motive the writer never
+  chose. The check is grounded in Chapter 1's own account of why sense-bound
+  language works: the listener fills the writer's words with their own
+  associations, and that mechanism is not selective, so a more concrete line
+  carries more unintended implication rather than less. Paired with a
+  "nothing without its purpose" box carrying Chapter 10's invocation of
+  Ibsen's rule about the gun in Act I.
+
 ## [0.6.1]
 
 ### Changed

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -73,8 +73,47 @@ given that the default reach is always for an adjective.
 
 ### Fixed — source fidelity
 
-Three context files adjudicated against the full text of the chapter each
-claims to distill, rather than against the distillation.
+Four context files adjudicated against the full text of the chapter each claims
+to distill, rather than against the distillation.
+
+- **`repetition.md`'s hidden-question mechanic was inverted.** *Writing Better
+  Lyrics* (2009) Chapter 6 deletes the **interrogative pronoun** and keeps the
+  auxiliary, which is what leaves the fragment a question — "Who do you love?"
+  becomes "Do you love?". Four of the file's seven table rows deleted the
+  auxiliary instead ("Can you remember?" → "You remember?"), which destroys the
+  effect rather than producing it. The rewritten table also states the semantic
+  payoff the original omitted: the full question presupposes the action and asks
+  for its object, while the fragment asks whether the action happens at all.
+
+  Two adjacent corrections in the same section: with past- or future-tense
+  verbs the command hides inside the **infinitive phrase**, not the main verb,
+  and the isolation can be staged twice, each pass landing harder; and Chapter
+  6 frames the whole technique's payoff as the **change of sentence type** —
+  statement to question, statement to command — so a fragment that repeats
+  without changing type is an echo, not productive repetition.
+
+- **`repetition.md` gains eight mechanics** present in Chapters 6 and 9 and
+  absent from the distillation: stagnant boxes *lose* weight rather than merely
+  flattening, because boredom amplifies; polished language cannot fix a
+  development problem, which fixes the diagnostic order; the per-line box-weight
+  test, where one chorus line is read after each verse (Chapter 6's own example
+  moves an image from observer to witness to prophet on identical words); the
+  drafting constraint that every chorus line must be *able* to gain weight; a
+  box may span more than one section, so boxes are counted by idea movement, not
+  section count; Box 3 as the song's *why*; both named formulas carrying
+  Chapter 6's own warning that a formula can take the freshness out of writing,
+  making them repairs rather than defaults; and thinking in boxes from the
+  moment an idea arrives as the *prevention* for second-verse hell, where
+  reordering is only the rescue.
+
+  Also corrected: "verses show, chorus tells" now carries the instruction
+  Chapter 9 attaches to it — keep the verses specific and interesting — and
+  states that neutral means grammatically neutral, not vague, since the
+  chapter's own demonstration chorus is built from concrete images while
+  committing to no tense and no pronoun. Plus the working consequence of a
+  chorus being many people singing together: change the words and no one can
+  sing along, which is why the fix for a stagnant chorus is always to develop
+  the verses.
 
 - **`box-model.md` defined "travelogue" three incompatible ways.** *Writing
   Better Lyrics* (2009) Chapter 8 defines travelogue as verses with no natural
@@ -112,6 +151,15 @@ claims to distill, rather than against the distillation.
   carries more unintended implication rather than less. Paired with a
   "nothing without its purpose" box carrying Chapter 10's invocation of
   Ibsen's rule about the gun in Act I.
+
+- **`song-form`'s stagnation eval asserted the defect this release fixes.** Its
+  prompt is the same-color case verbatim — a second verse repeating the first,
+  same scene, same speaker, same time — while its expectations required the
+  model to name a *travelogue*. A model following the corrected `box-model.md`
+  would have failed the eval, and a model passing it would reproduce the
+  conflation. Now expects the same-color diagnosis and explicitly forbids the
+  travelogue label, with a new companion case covering the genuine travelogue so
+  the two failures are pinned apart rather than merely relabeled.
 
 ## [0.6.1]
 

--- a/plugins/songwriting/agents/object-writer.md
+++ b/plugins/songwriting/agents/object-writer.md
@@ -1,0 +1,145 @@
+---
+name: object-writer
+description: "Performs one timed Pat Pattison object write itself — sense-bound, pivoting through the seven senses, stopping mid-word at the buzzer — then writes the result to a file and returns the path plus a seven-channel sense inventory quoting its own phrases. Dispatched blind, one per seed, by /songwriting:object-writing generate; deliberately given no access to the song, the draft, or the other writers. Not intended for direct ad-hoc use."
+tools: "Write"
+model: inherit
+effort: high
+---
+You are an object writer. You perform the exercise yourself — you do not coach anyone through it,
+issue a prompt, or hand it back. Your dispatch prompt names a seed and an output path. Everything
+below is your discipline; it is in your prompt rather than in a file you consult because a
+discipline you read is a discipline you override.
+
+**You know nothing about the song this feeds.** Not the title, not the draft, not the other
+writers' pages, not the diagnosis. That is deliberate and is not a gap in your briefing — do not
+ask for it and do not try to write toward it. A group of writers produces unrecognizably different
+dives on one seed precisely because none of them can see the others. Writing toward a song you
+cannot see produces a worse write and destroys the divergence you exist to create.
+
+## What you produce
+
+One continuous sense-bound write on the seed, at the length your dispatched timer implies:
+
+| Timer | Target |
+|---|---|
+| 90 seconds ("Kami-kazi") | 80-150 words |
+| 5 minutes | 250-400 words |
+| 10 minutes | 500-800 words |
+
+These stand in for elapsed time, which you have no way to feel. Hitting the range is not the
+exercise — the mid-word stop is (see below).
+
+Not lines. Not verses. Not rhyme, meter, or full sentences. No story arc, no explanation of what it
+means, no closing reflection. You are producing ore, and someone else does the mining.
+
+## The seven senses
+
+Sight, hearing, smell, taste, touch, **organic**, **kinesthetic**.
+
+Organic is inner-body awareness: heartbeat, pulse, muscle tension, held breath, a stomach turning,
+the tightening of a throat. Kinesthetic is your relation to the space around you: balance, tilt,
+speed, spatial orientation, the vertigo of moving without moving.
+
+Sight and hearing fill themselves. Smell, taste, organic, and kinesthetic are the channels that go
+missing, and they are the ones that move a write from description into a body. Watch them.
+
+## The pivot chain — this is the mechanism, not a suggestion
+
+Do not describe one scene. Each image hands off to the next **through a shared sense channel** —
+never through topic, logic, or narrative. A texture suggests a taste; the taste puts you somewhere
+else entirely; that place makes a sound; the sound produces a flinch; the flinch tilts the floor.
+
+Six pivots in and you should be nowhere near where you started. **Loyalty to the seed is a
+failure mode, not a virtue.** The seed is a diving board. If you are still describing it at the end
+of the write, the exercise did not happen.
+
+Before you finish, check your own handoffs. A handoff phrased as "and also there was…" is topical
+and is the failure. A handoff where the sense channel changes is the mechanism running.
+
+## Specificity — calibrated
+
+"Be specific" is uncalibrated and produces writing that satisfies every rule and reads as nothing
+in particular. The target density is **five or six independent specifics inside a single sentence,
+spread across more than one sense channel**: the named street, the named town, an exact age, the
+particular garment, what that garment smelled like, the sound its hardware made.
+
+Test any image you are about to keep: swap in the generic version. If nothing is lost, it was never
+specific. `the diner` → `the Moonlight` is the floor, not the target.
+
+## Invention is licensed — write, do not decline
+
+You have no childhood, no sense memory, and no autobiography. **This does not disqualify you from
+the exercise and is not a reason to hand it back to a human.** A song is not a deposition; truth
+outranks reality. Invent the street, the weather, the garment, the age, the person. Concrete,
+sense-bound, specific invention IS the exercise performed correctly.
+
+Abstraction, hedging, disclaiming your lack of experience, or writing about the difficulty of the
+exercise are the exercise refused. If your dispatch prompt names a character to write as, get
+inside that person's body and use their senses, their vocabulary, and what they would notice —
+never a narrator commenting on them from outside.
+
+## The mid-word stop
+
+End the write mid-word. Not at the end of a sentence, not on a resolved image, not on a line that
+sounds like an ending — mid-word, with the fragment left broken:
+
+```text
+…and the whole platform tilts the way a dock does when someone heavy steps of
+```
+
+This is not decoration. A finished thought closes and resists later mining; a broken one invites
+it. The stop is also the only evidence available that you ran the exercise instead of composing
+something shaped like its output. Never write a concluding sentence.
+
+## The sense inventory — your own acceptance test
+
+After the write, break it into seven headed lists, **quoting your own phrases back verbatim**. A
+summary ("I covered smell") is not evidence and will be rejected.
+
+- A phrase may appear under more than one channel. One image often carries two senses at once.
+- **Report thin and empty channels. Never pad one to fill a row.** A write honestly short on taste
+  is more useful than a write with a taste line bolted on, and a self-graded thin channel is the
+  most valuable thing you can return. You are the generator and the grader here; the inventory only
+  works if you are willing to fail yourself.
+
+## Output contract
+
+1. `Write` the object write and its sense inventory to the exact path in your dispatch prompt. **The
+   file is the deliverable.** Do not put the write in your return message — long creative text is
+   unreliable over the return channel and belongs on disk regardless.
+2. Return **only**: the file path, then the seven channel names each marked `strong` / `thin` /
+   `absent`, then one sentence on where the pivot chain took you and how far from the seed.
+
+File format:
+
+```markdown
+# Object write — <seed>
+
+**Seed:** <seed> · **Timer:** <90 seconds | 5 minutes | 10 minutes> · **Category:** <What | Who | When | Where>
+
+<the write, one continuous block, ending mid-word>
+
+## Sense inventory
+
+**Sight:** <phrases, verbatim>
+**Hearing:** <phrases>
+**Smell:** <phrases>
+**Taste:** <phrases>
+**Touch:** <phrases>
+**Organic:** <phrases>
+**Kinesthetic:** <phrases>
+
+**Thin or absent channels:** <name them honestly, or "none">
+```
+
+## What disqualifies a write
+
+Any one of these means you did not run the exercise. Fix it before writing the file.
+
+- It stayed on the seed the whole way.
+- It reads as a scene description rather than a chain.
+- It has a concluding sentence, or stops on a complete word.
+- Its specifics are generic-plus-one-adjective.
+- It names emotions instead of producing the body that carries them.
+- An inventory channel is filled with a line written to fill it.
+- It asks the human to do the writing, or explains why you cannot.

--- a/plugins/songwriting/agents/object-writer.md
+++ b/plugins/songwriting/agents/object-writer.md
@@ -45,9 +45,10 @@ missing, and they are the ones that move a write from description into a body. W
 
 ## The pivot chain — this is the mechanism, not a suggestion
 
-Do not describe one scene. Each image hands off to the next **through a shared sense channel** —
-never through topic, logic, or narrative. A texture suggests a taste; the taste puts you somewhere
-else entirely; that place makes a sound; the sound produces a flinch; the flinch tilts the floor.
+Do not describe one scene. Each image hands off to the next **through a sense** — never through
+topic, logic, or narrative — and it lands in a DIFFERENT channel from the one it left. A texture
+suggests a taste; the taste puts you somewhere else entirely; that place makes a sound; the sound
+produces a flinch; the flinch tilts the floor.
 
 Six pivots in and you should be nowhere near where you started. **Loyalty to the seed is a
 failure mode, not a virtue.** The seed is a diving board. If you are still describing it at the end

--- a/plugins/songwriting/context/pat-pattison/research/action-routing.md
+++ b/plugins/songwriting/context/pat-pattison/research/action-routing.md
@@ -13,7 +13,8 @@ content under `context/pat-pattison/`.
 | --- | --- |
 | `/songwriting:workflow` | situation routing (11 scenarios), coaching dialog, blank-page/idea/fragment starts, response-filter diagnostic, going-deeper resources |
 | `/songwriting:rhyme` | rhyme generation, rhyme types, mosaic, worksheets, Datamuse lookup |
-| `/songwriting:object-writing` | object writing, metaphor, cliche repair, point of view |
+| `/songwriting:object-writing` | object writing (including the agent that performs it), cliche repair, point of view |
+| `/songwriting:metaphor` | metaphor generation and diagnosis, collisions, playing in keys, simile focus |
 | `/songwriting:meter-prosody` | scansion/meter, prosody, phrasing, stability, lyric-melody fit |
 | `/songwriting:song-form` | form, song forms, hook, repetition, verse, bridge, box model |
 | `/songwriting:co-write` | co-write protocol, Title Game, titles, high-volume line/section dumps |
@@ -41,9 +42,13 @@ content under `context/pat-pattison/`.
 | "Why does this rhyme feel weak?" | `/songwriting:rhyme` |
 | "Make this verse less abstract." | `/songwriting:object-writing` + `/songwriting:diagnose rewrite` |
 | "Give me a 90-second writing prompt." | `/songwriting:object-writing` or `/songwriting:practice` |
-| "I need a metaphor for trust." | `/songwriting:object-writing metaphor` or `metaphor-recipe` |
-| "Generate eight metaphor options for X." | `/songwriting:object-writing metaphor-recipe` |
-| "Should this be like or is?" | `/songwriting:object-writing metaphor` |
+| "You do the object writing — I don't want to." | `/songwriting:object-writing generate` (dispatches the `object-writer` agent) |
+| "I need a metaphor for trust." | `/songwriting:metaphor collide` |
+| "Generate eight metaphor options for X." | `/songwriting:metaphor recipe` |
+| "Should this be like or is?" | `/songwriting:metaphor simile` |
+| "Sustain this image across the whole song." | `/songwriting:metaphor keys` |
+| "Is this metaphor dead / grounded / too strained?" | `/songwriting:metaphor diagnose` |
+| "This song has no metaphor at all." | `/songwriting:metaphor collide`, seeded from `/songwriting:object-writing` material |
 | "Scan this line." | `/songwriting:meter-prosody meter` |
 | "Can this be common meter?" | `/songwriting:meter-prosody meter` |
 | "My chorus does not land." | `/songwriting:song-form hook` + `/songwriting:meter-prosody` |
@@ -88,7 +93,12 @@ content under `context/pat-pattison/`.
 /songwriting:rhyme worksheet "last call at the Moonlight"
 /songwriting:rhyme datamuse syllables disappointment
 /songwriting:object-writing 90 seconds hotel bar
-/songwriting:object-writing metaphor-recipe trust
+/songwriting:object-writing generate "hotel bar"
+/songwriting:metaphor collide trust
+/songwriting:metaphor recipe trust
+/songwriting:metaphor keys tide
+/songwriting:metaphor simile "my love is an engine"
+/songwriting:metaphor diagnose "<paste metaphor in context>"
 /songwriting:meter-prosody meter "I woke up under a borrowed sky"
 /songwriting:meter-prosody stability chorus
 /songwriting:meter-prosody align-melody "<lyric>" "<melody description>"

--- a/plugins/songwriting/context/pat-pattison/research/box-model.md
+++ b/plugins/songwriting/context/pat-pattison/research/box-model.md
@@ -15,7 +15,9 @@ boxes lacked.
 > Put separate ideas in separate boxes.
 
 This is Pat's division-of-labor principle: every verse system has its own
-exclusive job. Two verses with the same job = travelogue (*Writing Better Lyrics* (2009), Chapter 8).
+exclusive job. Two verses doing the same job is a **same-color** failure
+(*Writing Better Lyrics* (2009), Chapter 7) — NOT a travelogue. The two are
+opposite poles; see [Travelogue vs same-color](#travelogue-vs-same-color).
 
 ## Box weight rule
 
@@ -83,27 +85,65 @@ that made verse 1's situation possible?" Often the answer becomes verse 2,
 and verse 1 becomes verse 3 — the chronology was wrong but the material was
 right.
 
-## Travelogue test (*Writing Better Lyrics* (2009), Chapter 8)
+## Travelogue vs same-color
+
+Two verse failures sit at OPPOSITE ends of one axis, and Chapter 8 closes by
+naming both poles: verse ideas that sit too close together make the repeated
+chorus static and boring, and verse ideas that sit too far apart become a
+travelogue. Diagnosing one as the other prescribes the wrong fix.
+
+| | **Travelogue** (Chapter 8) | **Same-color** (Chapter 7) |
+|---|---|---|
+| Verse ideas are | too far apart | too close together |
+| What links the verses | nothing but the title / refrain / chorus | they say the same thing twice |
+| What breaks | accumulation — each box starts a separate avalanche instead of one rolling downhill | repainting — each verse shines the same colored light, so the chorus never looks new |
+| Box symptom | boxes gain no weight; all the same size | Box 2 = Box 1 |
+| Fix | find the chain — what in verse 1 CAUSES verse 2, what verse 2 makes inevitable | shift the job via You-I-We, Past-Present-Future, or another division axis |
+
+Chapter 8's own image for the difference: three avalanches started separately
+a third of the way up a mountain do less damage than one snowball rolled from
+the top. Travelogue is three separate avalanches.
+
+### Travelogue test (*Writing Better Lyrics* (2009), Chapter 8)
 
 Remove the chorus and read only the verses in sequence.
 
-- Do the verses tell a coherent story without the chorus glue?
-- Does each verse have its own job that the others don't share?
-- Or do they project the same color in different words?
+- Without the title's glue, would a listener know what is going on?
+- Does each verse carry information forward into the next, or does each one
+  start over?
+- Does verse 2 gain any weight from verse 1 having happened?
 
 If the verses are independent observations linked only by the title /
 refrain / chorus, the song is a **travelogue**. Pat's diagnosis: verse
 development should mean verse relationship.
 
+### Same-color test (*Writing Better Lyrics* (2009), Chapter 7)
+
+Read each verse, then read the chorus that follows it, and name the color the
+verse just cast on it.
+
+- Does each verse have its own job the others don't share?
+- Do two verses project the same color in different words?
+- Say the chorus's meaning after verse 1 and again after verse 2 — if the two
+  statements match, the verses are the same color.
+
+Verses connected but same-colored is NOT a travelogue; the chain is intact and
+the repainting is missing.
+
 ## Box weight failure modes
 
 | Failure | Symptom | Fix |
 |---|---|---|
-| Box 2 = Box 1 | second verse feels redundant | apply You-I-We or Past-Present-Future shift |
+| Box 2 = Box 1 | second verse feels redundant; chorus never repaints | same-color (Chapter 7) — apply You-I-We or Past-Present-Future shift |
 | Box 3 ≤ Box 2 | song sags at the end | promote bridge or final verse to carry "why" |
 | All boxes same weight | song feels flat / no destination | redistribute via division-of-labor axis |
 | Box 1 too heavy | listener lost in detail before chorus | move heavy material to Box 2 or Box 3 |
-| Boxes unconnected | travelogue (*Writing Better Lyrics* (2009), Chapter 8) | find the chain — what causes / what consequences link them |
+| Boxes unconnected | travelogue (Chapter 8) — verses share only the title | find the chain — what causes / what consequences link them |
+
+Equal box weight is a symptom of travelogue, not a synonym for it: a
+travelogue always leaves the boxes the same size, but boxes can also flatten
+inside a properly chained lyric. Diagnose the connection first, the weight
+second.
 
 ## Repaintable chorus across boxes
 

--- a/plugins/songwriting/context/pat-pattison/research/hook.md
+++ b/plugins/songwriting/context/pat-pattison/research/hook.md
@@ -202,6 +202,43 @@ hook arrival:      / / /
 Do not regularize a distinctive hook just because the verse is easier to write
 that way. Use the irregularity as a structural feature.
 
+## Deceptive cadence — spotlight the title by withholding the rhyme
+
+Pat's borrowed term (*Writing Better Lyrics* (2009), Chapter 13) for a chorus
+that sets up an expected rhyme and then repeats the title instead.
+
+The setup: an `aba` chorus opening leaves one word unrhymed, and the ear
+actively wants a fourth line rhyming with it — an `abab` close, fully resolved.
+Give the ear that resolution and the chorus lands securely. Repeat the title in
+the fourth position instead (`abaa`) and three things happen at once:
+
+1. The title repeats — the commercially useful move.
+2. The structural surprise spotlights the title, because the ear was leaning
+   toward a different sound and got the title instead.
+3. The chorus still resolves, but **less securely** than the expected rhyme
+   would have resolved it.
+
+That third effect is the craft point, not a side cost. The worked example in
+Chapter 13 is a chorus whose character is asking for something she has not yet
+been given. A fully resolved `abab` close would sound as though she already had
+it; the deceptive cadence leaves the section slightly unsettled, which is what
+the emotional situation actually is. **Match the security of the cadence to
+whether the song's question is answered.**
+
+When to reach for it:
+
+- The title deserves a spotlight and the section is running toward a rhyme that
+  would upstage it.
+- The section's emotional state is unresolved, wanting, or asking — full
+  resolution would contradict the content.
+- The chorus already repeats the title and a plain repetition would feel inert.
+
+When NOT to: the section resolves something, arrives, or answers. There, the
+expected rhyme *is* the prosody, and withholding it fights the meaning.
+
+Diagnose an existing chorus by naming its scheme, then asking what the ear was
+promised and whether the section's emotional state deserves that promise kept.
+
 ## Strategic positions can shift
 
 A phrase may look like the strategic position early in a section and then be

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -163,13 +163,13 @@ process.
 chain is the mechanism, and without it a write becomes a static description of
 one scene instead of a dive.
 
-Each image hands off to the next **through a shared sense channel**, not
-through topic, logic, or narrative. Chapter 1 demonstrates it as an unbroken
-run: a physical sensation in one setting suggests a texture, the texture
-suggests a taste, the taste relocates the writer somewhere else entirely, the
-new place produces a sound, the sound produces a body reaction, and so on —
-each link a sense, not an idea. The write ends somewhere the seed could never
-have predicted.
+Each image hands off to the next **through a sense**, not through topic, logic,
+or narrative — and the channel it lands in is a different one from the channel
+it left. Chapter 1 demonstrates it as an unbroken run: a physical sensation in
+one setting suggests a texture, the texture suggests a taste, the taste
+relocates the writer somewhere else entirely, the new place produces a sound,
+the sound produces a body reaction, and so on — each link a sense, not an idea.
+The write ends somewhere the seed could never have predicted.
 
 Worked example of the shape (the chain, not Pat's):
 

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -108,6 +108,39 @@ Organic and kinesthetic details are often the fastest way to move a lyric from
 general description into embodiment. Use them when the draft explains emotion
 from the outside instead of letting the listener feel it.
 
+### Sense inventory — the acceptance test on a finished write
+
+Chapter 1 does not stop at naming the channels. It takes a completed write and
+breaks it into seven headed lists, each one quoting the write's own phrases
+back. That inventory is the check: a channel with nothing under it was not
+covered, whatever the writer believes.
+
+Run it on every completed write, whoever produced it:
+
+```text
+Sight:         <phrases from the write, verbatim>
+Hearing:       <phrases>
+Smell:         <phrases>
+Taste:         <phrases>
+Touch:         <phrases>
+Organic:       <phrases>
+Kinesthetic:   <phrases>
+```
+
+Rules that make it an acceptance test rather than a formality:
+
+- Quote the write's own words. A summary ("I covered smell") is not evidence.
+- A phrase may appear under more than one channel — Chapter 1's own inventory
+  does exactly this, because one image can carry two senses at once.
+- A thin or empty channel is **reported, never padded**. Sight and hearing fill
+  themselves; smell, taste, organic, and kinesthetic are the channels that go
+  missing, and a write honestly short on one is more useful than a write with a
+  line bolted on to fill the row.
+
+This inventory is what converts "the write covered the senses" from a claim
+into checkable evidence — which matters most when the write was machine-
+generated and the generator is also the grader.
+
 ## Ten-minute practice
 
 The basic practice is strict:
@@ -116,13 +149,48 @@ The basic practice is strict:
 2. Set a timer for ten minutes, preferably first thing in the morning.
 3. Write continuously in sensory language.
 4. Move through all seven senses.
-5. Follow sensory associations wherever they lead.
+5. Pivot from image to image through the senses — see below.
 6. Stop immediately when the timer ends.
 7. Mine the page later for images, phrases, titles, and emotional turns.
 
 Stopping on time matters. The short container trains speed, access, and trust.
 Object writing is a warmup and a source of material, not the whole songwriting
 process.
+
+## The pivot chain — the mechanism behind "follow the senses"
+
+"Follow sensory associations wherever they lead" is the instruction. The pivot
+chain is the mechanism, and without it a write becomes a static description of
+one scene instead of a dive.
+
+Each image hands off to the next **through a shared sense channel**, not
+through topic, logic, or narrative. Chapter 1 demonstrates it as an unbroken
+run: a physical sensation in one setting suggests a texture, the texture
+suggests a taste, the taste relocates the writer somewhere else entirely, the
+new place produces a sound, the sound produces a body reaction, and so on —
+each link a sense, not an idea. The write ends somewhere the seed could never
+have predicted.
+
+Worked example of the shape (the chain, not Pat's):
+
+```text
+seed: laundromat
+  dryer heat on the forearms          [touch]
+  → the smell of scorched lint        [smell]
+  → burnt-toast mornings              [taste]
+  → the toaster's spring-loaded bang  [hearing]
+  → flinch at the shoulders           [organic]
+  → the floor tilting on a boat deck  [kinesthetic]
+```
+
+Six pivots, six channels, and the write left the laundromat by link three. That
+is working. A write that is still describing the laundromat at ten minutes has
+been staying loyal to the seed.
+
+Diagnostic when a write reads flat: number the images and name the sense
+carrying each handoff. Handoffs carried by topic ("and also in the laundromat
+there was…") are the failure. Handoffs where the sense channel changes are the
+mechanism running.
 
 ## Loyalty to the object
 
@@ -145,6 +213,42 @@ If a story appears because the senses pull the writer there, let it appear. If
 it appears because the writer is trying to control the exercise, return to
 specific sensory detail.
 
+## Specificity calibration
+
+"Be specific" is uncalibrated advice, and an underweight benchmark produces
+underweight writing. Chapter 1's own demonstration passages set the bar much
+higher than the usual generic-to-slightly-less-generic swap: a single short
+recollection carries the named street, the named city, the speaker's exact age,
+the specific garment, what that garment smelled like, and the sound its
+hardware made when the speaker walked.
+
+That is the target density — **five or six independent specifics inside one
+sentence, spread across more than one sense channel.**
+
+Calibration check on any line claiming to be specific:
+
+- Could a stranger name the street, the year, the age, or the brand from this?
+- Does the specificity land on more than one sense, or is it all sight?
+- Is a proper noun doing work, or is it decoration on a generic image?
+- Swap in the generic version — is anything actually lost? If not, the "specific"
+  version was not specific.
+
+Weak calibration is the most common cause of a write that satisfies every rule
+and still reads as nothing in particular.
+
+## Invention is licensed
+
+Chapter 1 is explicit: a song does not have to be accurate autobiography, and
+truth outranks reality. Object writing draws on sense memory, but the write is
+not a deposition — the writer may invent the street, the garment, the age, and
+the weather, so long as the result is sense-bound and specific.
+
+This matters most when the writer is an AI, which has no autobiography to draw
+on. The absence of personal sense memory is **not** grounds to decline the
+exercise or hand it back to the human. Invention that is concrete, sense-bound,
+and specific is the exercise being performed correctly; abstraction and hedging
+are the exercise being refused.
+
 ## What object writing is not
 
 Object writing is not journaling. Journaling can explain, evaluate, remember,
@@ -162,6 +266,23 @@ Group object writing can build range because every writer enters the same word
 through different sense memory. Use shorter rounds for larger groups and longer
 rounds for small groups. Read aloud for image and sensory discovery, not
 critique.
+
+**Same seed, no shared context.** Chapter 1 prints several writers' dives on a
+single common seed word and they are unrecognizable as responses to the same
+prompt. The divergence is the product: each writer enters the word through
+sense memory no one else has. Isolation is what produces it — writers who have
+seen each other's pages converge instead.
+
+**The bar escalates between rounds.** In the documented Sunday-group format the
+strongest write of a round sets the standard the next round writes against.
+Rounds are not independent repetitions; each one raises the floor. Run the
+rounds in sequence and name what made the best write of each round work before
+starting the next.
+
+Both mechanisms transfer directly to multi-agent generation: fan several
+writers out over one seed with none of them seeing the others' output or the
+song in progress, then feed the round's strongest result forward as the
+standard for the next round.
 
 Object-writing parties can use:
 
@@ -301,6 +422,30 @@ Use "who" writing to support point of view and character work. Ask:
 Observation games in public places are useful, but keep them ethical and
 craft-focused. The point is to notice posture, pace, tension, gesture, objects,
 distance, and implied want, then invent responsibly.
+
+### Perspective writes — through the character's senses
+
+Chapter 1 goes further than observing a character: it directs the writer to run
+the object write **inside the character's body**, using that character's senses
+rather than the writer's own. A flight attendant working a short hop, a shelter
+volunteer at closing time — the seven channels stay the same, but every image
+must be one that person could have had.
+
+Pat cites his own examples from Sting's catalog: songs written from a car
+thief's perspective and from a male prostitute's. Neither is autobiography, and
+both are sense-bound throughout.
+
+The discipline:
+
+- Name the character and their situation before the timer starts.
+- Every sensory detail must be reachable from where that character's body is.
+- Their vocabulary, not the writer's — what they would notice, and what they
+  would fail to notice.
+- No narrator commentary on the character from outside.
+
+Perspective writes are the bridge from object writing to
+[point of view](point-of-view.md), and the fastest route out of a catalog of
+writes that all sound like the same speaker.
 
 ## Cataloging the good stuff
 

--- a/plugins/songwriting/context/pat-pattison/research/point-of-view.md
+++ b/plugins/songwriting/context/pat-pattison/research/point-of-view.md
@@ -313,6 +313,12 @@ not automatically a duet. A duet needs equal characters who can share or answer
 the repeated material. If only one character owns the chorus, one singer can
 tell the conversation with quoted speech.
 
+**The duet test is the chorus, not the conversation.** Ask who can sing the
+repeated section. If the chorus is one character's request, plea, or claim, the
+other character cannot sing it and the song is not a duet however evenly the
+dialogue is distributed. Sung dialogue with two genuinely equal speakers is
+opera; a lyric hands the whole conversation to one singer, in quotes.
+
 Test dialogue through three POV setups:
 
 - First-person narrative: `I asked her...` or `He asked me...`
@@ -337,6 +343,22 @@ Use first-person dialogue when:
 
 If the singer merely reports what someone else said, ask why the microphone is
 in that singer's hand.
+
+**The repair when the answer is "no reason": give the singer a final insight.**
+Chapter 13 does not treat first-person dialogue as unusable when the story
+belongs to the other character — it adds a closing line in which the narrator
+says what the conversation cost or taught them, which retroactively earns the
+whole retelling. Pat's cited model is a well-known gambler song whose narrator
+spends the entire lyric quoting someone else and then, in the final line, names
+what he took from it.
+
+So the diagnostic has two exits, not one:
+
+- Move to third person, letting the scene speak without a narrator, **or**
+- keep first person and write the narrator an ending that justifies the telling.
+
+Choose the second when the narrator genuinely changed; the first when they did
+not.
 
 ## Direct-address dialogue
 
@@ -368,12 +390,23 @@ Use third-person dialogue when:
 
 ## Dialogue structure note
 
-Chapter 13 also shows how dialogue sections can use structure to support emotion:
-balanced verse setup, an off-balance transitional bridge, and a chorus whose
-rhyme pattern withholds full resolution. This belongs primarily to
-[form](form.md), [meter](meter.md), and [prosody](prosody.md), but it matters
-for POV because the structural surprise can spotlight the line the speaking
-character most needs to say.
+Chapter 13 also shows how dialogue sections use structure to support emotion,
+in a deliberate three-stage sequence:
+
+1. **A balanced verse lulls the listener** — four lines of common meter, `xaxa`.
+   The stability is a setup, not the point.
+2. **A three-line transitional bridge topples that balance** — an odd line count
+   after an even one leaves the ear reaching for a landing, which is exactly
+   what a transitional bridge is for.
+3. **The chorus withholds the rhyme the ear was promised**, repeating the title
+   in the fourth position instead. See
+   [deceptive cadence](hook.md#deceptive-cadence--spotlight-the-title-by-withholding-the-rhyme).
+
+This belongs primarily to [form](form.md), [meter](meter.md), and
+[prosody](prosody.md), but it matters for POV because the structural surprise
+spotlights the line the speaking character most needs to say — and in quoted
+dialogue, that line is inside quotation marks. The structure decides which
+character's words the section is actually about.
 
 When dialogue has a quoted chorus, check whether the structure makes that
 quote feel inevitable.

--- a/plugins/songwriting/context/pat-pattison/research/repetition.md
+++ b/plugins/songwriting/context/pat-pattison/research/repetition.md
@@ -88,9 +88,28 @@ Use this carefully. It does not mean choruses should become generic. It means
 verses usually carry specific situation, image, and action, while the chorus or
 refrain can make a broader statement that the verses keep recoloring.
 
+The chapter attaches an instruction to the rule in the same breath: keep the
+verses specific and interesting. The rule constrains the CHORUS's grammar, not
+its imagination — the chapter's own demonstration chorus is built from concrete
+images (a fall from grace, a dot in space) while committing to no tense and no
+pronoun. **Neutral means grammatically neutral, not vague.**
+
 If the chorus tells too specifically, it may block the verses. If it tells too
 generically, it may become cliche. Strip tense and POV without stripping image,
 sound, or emotional pressure.
+
+**A chorus is many people singing together.** Chapter 6 draws a working
+consequence from that definition rather than leaving it as etymology: change the
+words each time and no one else can sing it on the second pass — one person
+singing alone is a soloist, not a chorus. Change a refrain's words each time and
+it is not a refrain, just additional material. This is why the fix for a
+stagnant chorus is always to develop the verses, never to rewrite the chorus
+first.
+
+Changing the repeat IS available as a last resort when a refrain proves
+color-resistant and cannot be neutralized — the chapter changes one to fit a
+tense before showing the better repair — but it costs the singalong, so
+neutralize first.
 
 ## Productive ambiguity
 
@@ -138,6 +157,30 @@ Ask:
 - If the chorus comes back unchanged, has the listener changed enough to hear
   it differently?
 
+Box 3 is usually the song's **why** — why the speaker is saying any of this —
+which is what makes it the heaviest rather than merely the last.
+
+**A box is not always one section.** Chapter 6 analyzes a lyric whose boxes are
+each two verses plus a chorus. Count boxes by idea movement, not by section
+count: two verses that share one angle are one box, and diagnosing them as two
+hides the stagnation.
+
+### Test one chorus line at a time
+
+The chapter's sharpest box-weight test works on a single line rather than the
+whole chorus: take one line and write what it means after each verse. In its
+worked example, an image that merely observes in box 1 becomes a witness in box
+2 and a prophet in box 3 — the same words, three sizes.
+
+Run it on the line carrying the most weight. If that line means the same thing
+after every verse, the boxes are not growing whatever the summaries suggest.
+
+**Every chorus line carries this obligation.** The chapter states it as a
+drafting constraint, not just a diagnostic: when writing a chorus, each line
+must be *able* to gain weight. A line too specific or too closed to mean more
+later is a line that will flatten the repeat no matter how well the verses
+develop.
+
 ## Stagnant repetition
 
 Repetition is stagnant when each verse says essentially the same thing in
@@ -155,6 +198,21 @@ Symptoms:
 
 Fix stagnant repetition by changing the development, not by changing the
 chorus words first.
+
+**Stagnation does not merely flatten the boxes — it can shrink them.** Chapter 6
+is explicit that stagnant boxes are the same size at best, and more likely lose
+weight, because boredom amplifies across repeats. A second chorus that merely
+repeats does not land neutrally; it lands weaker than the first.
+
+**Polished language cannot fix it.** The chapter demonstrates the failure in
+deliberately bland prose summaries, then fixes it while leaving the language
+just as bland — because development is what changed. Strong imagery on stagnant
+boxes only decorates the problem. This is the diagnostic order: check whether
+the verse summaries move before touching a single word of the lines.
+
+The one-sentence summary test is the fastest form of this. If the verse
+summaries are interchangeable, the song has a development problem no rewrite of
+the lines will reach.
 
 ## Separate jobs
 
@@ -180,6 +238,20 @@ Where did I get here from?
 
 The verse first written may belong in the middle or end. Try moving boxes
 around before assuming the song must continue forward from the first draft.
+
+Chapter 6's framing: just because you wrote a verse first does not make it the
+first verse — give yourself two chances at every stuck point.
+
+**The stronger move is upstream of the stuck point.** The chapter names thinking
+in boxes from the moment an idea arrives as by far the best remedy for
+second-verse hell. Reordering is the rescue; planning the boxes is the
+prevention. When a writer arrives with an idea and no verses yet, sketch the box
+summaries before drafting — that is the intervention, and it is unavailable once
+the verses exist.
+
+Six questions are the chapter's named tool for filling a box that will not
+open: who, what, where, when, why, how — with `when` and `where` singled out as
+the most productive.
 
 ## Chorus and refrain weight
 
@@ -213,7 +285,22 @@ Use this when:
 - the bridge supplies contrast and new weight,
 - the final chorus becomes stronger because the weak middle chorus is gone.
 
-This is a formal risk, but Chapter 6 treats it as a valid toolbox move.
+This is a formal risk, but Chapter 6 treats it as a valid toolbox move — and
+records it as a real-world one: a well-known recording drops its second chorus
+and goes straight to the bridge, an unusual move in commercial music, after the
+writers found the conventional layout made the song feel too long. "Too long" is
+the audible symptom of a sagging box.
+
+The chapter names a second gain beyond removing the sag: keeping the bridge
+gives the music room to breathe when verse lines are long and the tempo is slow.
+The cut buys contrast and interest at once.
+
+**Diagnose the sag before cutting.** The alternative repair is to give the weak
+verse the missing information — in that same example, reintroducing a character
+the listener had forgotten lets a two-verse layout work with both choruses
+landing, no cut required. Cutting a chorus and developing the verse are two
+answers to one diagnosis; run the box-weight test first and decide which the
+song needs.
 
 ## Productive repetition inside lines
 
@@ -347,6 +434,22 @@ The two formulas can stack: verse 1 = You/Past, verse 2 = I/Present, verse
 3 = We/Future. The combined matrix lets one short distribution carry the
 song's full emotional arc.
 
+### Formulas are tools, and they cut both ways
+
+Chapter 6 attaches its own warning to both formulas, in the same paragraph that
+introduces them: sometimes one is exactly what a song needs, and other times a
+formula takes the freshness out of the writing. Be aware of the techniques;
+beware of letting them become a habit.
+
+Two consequences for how these get applied:
+
+- **Do not reach for a formula first.** The chapter's own preferred case is an
+  idea that carries the DNA of its own development, or a plot that does the
+  development work — the formulas are the repair when an idea does not.
+- **Name the formula as a candidate, not a prescription.** Proposing You-I-We
+  because the boxes are stagnant is the tool working. Proposing it because a
+  song has three verses is the habit the chapter warns against.
+
 Cross-ref [box-model](box-model.md) for full division-of-labor framework.
 
 ## Hidden questions and hidden commands (*Writing Better Lyrics* (2009), Chapter 6) — grammatical detail
@@ -357,22 +460,40 @@ isolates the question or command underneath.
 
 ### Hidden questions — full grammatical matrix
 
-A question with an auxiliary verb can be reduced to a hidden sub-question
-by deleting the auxiliary:
+**Delete the interrogative pronoun, and KEEP the auxiliary.** The auxiliary is
+what makes the remaining fragment a question; deleting it destroys the effect
+rather than producing it. The deleted word is `who`, `what`, `when`, `where`,
+`why`, or `how`.
 
-| Original (full question) | Hidden (auxiliary deleted) | Effect |
+The change in meaning is the point. The full question presupposes the action
+happens and asks for its object, place, reason, or method. The isolated
+fragment asks whether the action exists at all — a genuinely different and
+usually more exposed question.
+
+| Original (full question) | Hidden (interrogative pronoun deleted) | Effect |
 |---|---|---|
-| Who do you love? | Do you love? | Sub-question isolates the verb |
-| Where did you go? | Did you go? | Tense + question, narrowed |
-| What will you say? | Will you say? | Future modal, narrowed |
-| Can you remember? | You remember? | Modal stripped, declarative emerges |
-| Should I leave? | I leave? | First-person modal stripped |
-| Could she stay? | She stay? | Third-person modal stripped |
-| Would they listen? | They listen? | Conditional → declarative |
+| Who do you love? | Do you love? | Asks whether loving happens at all |
+| Where did you go? | Did you go? | Asks whether the leaving happened |
+| What will you try? | Will you try? | Asks whether the attempt will be made |
+| When will I know? | Will I know? | Asks whether knowing ever arrives |
+| Why do you laugh? | Do you laugh? | Asks whether the laughter is real |
+| How did you know? | Did you know? | Asks whether the knowledge existed |
 
-The technique scales across tenses (do/did/will), modals (can/could/should/would),
-and persons (1st/2nd/3rd). The deletion creates a fragment that the listener
-hears as both repetition AND new content.
+The technique scales across tenses via the auxiliary — `do` / `did` / `will` —
+and across the subjunctive modals `can` / `could` / `should` / `would`:
+
+| Original | Hidden |
+|---|---|
+| Who can you love? | Can you love? |
+| Who could you love? | Could you love? |
+| Who should you love? | Should you love? |
+| Who would you love? | Would you love? |
+
+The deletion creates a fragment the listener hears as both repetition AND new
+content. Chapter 6's worked instance is a declarative that hides a question:
+a line ending in "can you win" becomes the question `Can you win?` simply by
+isolating and repeating that fragment, turning a statement of the terms into
+the character's uncertainty about whether the terms can be met.
 
 ### Hidden commands — subject deletion
 
@@ -386,21 +507,39 @@ the subject:
 | You hold me. | Hold me. | Imperative + intimacy |
 
 Note: **third-person cannot generate commands** because English third-
-person verbs take an -s ("he/she tells"). The deletion only works in
-first/second person where the verb base is bare.
+person verbs take an -s ("he/she tells"). Deleting the subject there yields
+only simple repetition — `She tells me` reduces to `Tells me`, which is a
+fragment, not an imperative. The technique needs the bare verb base, which
+first and second person supply and third person does not.
+
+A second-person question hides a command the same way: `Will you love me?`
+reduces to `Love me.`
 
 ### Infinitive isolation — past and future
 
-Pat's extension: the technique works with infinitive verb phrases too.
+Pat's extension: with a past- or future-tense verb, the command hides inside the
+INFINITIVE phrase, not the main verb. Isolate the infinitive and drop its `to`.
 
 | Original | Infinitive isolation | Tense effect |
 |---|---|---|
 | Did you want to win my heart? | Win my heart. | Past → present command |
-| Will you say it out loud? | Say it out loud. | Future → present command |
-| Did you mean to leave? | Mean to leave? | Past → present sub-question |
+| He loved to walk alone. | Walk alone. | Past → present command |
+| Won't you try to walk alone? | Try to walk alone. → Walk alone. | Future → present, two-stage |
 
-The infinitive form lets the same surface fragment work across tenses —
-useful when a chorus must remain tense-neutral while verses change tense.
+The third row shows the staging the chapter demonstrates: the fragment can be
+isolated once, then isolated again, each pass shedding another layer and landing
+harder.
+
+This is why the main verb's tense stops mattering — the infinitive carries no
+tense of its own, so the same surface fragment works after a past verse and a
+future one alike. That makes it the line-level counterpart of the chorus-level
+tense-neutralization above.
+
+**Moving between sentence types is itself the payoff.** Chapter 6 frames the
+gain as an energy boost: statement → question, or statement → command, lifts the
+emotion to a new level. The repetition is the vehicle; the change of sentence
+type is the cargo. A fragment that repeats without changing sentence type is
+just an echo.
 
 ### When to use
 

--- a/plugins/songwriting/context/pat-pattison/research/response-filter.md
+++ b/plugins/songwriting/context/pat-pattison/research/response-filter.md
@@ -174,11 +174,38 @@ any prose lyric line.
 - [ ] **Vowel awareness** — the line's stressed vowels chosen, not
       defaulted; bright vowels (long-ē, long-ā) feel sharp; dark vowels
       (long-ō, long-ū) feel weighted
+- [ ] **Unintended implication** — read the line as a stranger with no
+      access to the writer's intent, and NAME what it implies about each
+      character: their motive, their status, their history, their
+      relationship. If any implication contradicts the song's premise,
+      REWRITE. A line can pass every box above and still assign a
+      character a motive the writer never chose.
+- [ ] **Nothing without its purpose** — every element the line introduces
+      (an object, a second character, a place, a time marker) does a job
+      the song needs. Pat invokes Ibsen's rule about the gun in Act I:
+      have a reason for each element, and no duplication of function
+      (*Writing Better Lyrics* (2009), Chapter 10). An unused element is
+      not neutral — the listener will assign it meaning.
 
-**Fail signature:** about-to-emit line like *"My broken heart is lonely in
-the dark, waiting for your love to make me whole"* — every box fails:
-abstract telling, three cliches, generic nouns, no senses, weak verbs.
-STOP. Rebuild from a concrete sense-bound image.
+**Fail signature 1 — generic abstraction:** about-to-emit line like
+*"My broken heart is lonely in the dark, waiting for your love to make me
+whole"* — every box fails: abstract telling, three cliches, generic nouns,
+no senses, weak verbs. STOP. Rebuild from a concrete sense-bound image.
+
+**Fail signature 2 — clean line, wrong implication:** a line like *"she
+watched me from the window sill"* passes sense-bound, specific noun, strong
+verb, no cliche, and consistent POV — and still reads as surveillance,
+casting a chance-encounter character as a stalker or a thief sizing up a
+mark. The premise is destroyed by a line with no defective box.
+
+Why this box is not optional: Chapter 1's account of why sense-bound
+language works is that the listener fills the writer's words with their OWN
+sense memories and associations. That mechanism is what makes showing
+powerful, and it is not selective — the listener supplies implication the
+writer never placed there. Specificity increases the pull, so a MORE
+concrete line carries MORE unintended implication, not less. The check runs
+after the other §2 boxes pass, precisely because passing them is what makes
+the risk live.
 
 **Anchor quote:**
 

--- a/plugins/songwriting/skills/co-write/SKILL.md
+++ b/plugins/songwriting/skills/co-write/SKILL.md
@@ -19,7 +19,7 @@ Collaborative generation: running a co-write with feedback discipline, generatin
 the Title Game), and dumping high-volume labeled options for a single line or section so the writer
 has raw material to choose from.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's method plugs in
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's method plugs in
 at `context/<author>/` without changing this skill.
 
 ## Action Router
@@ -52,8 +52,49 @@ to `variations/` or `worksheets/` as a labeled menu (not inline). Before loading
 `templates/<name>.md`, check `${CLAUDE_PROJECT_DIR}/songwriting/templates/pat-pattison/<name>.md`
 first — a project-level override wins over the bundled default.
 
+## Boundary — this skill owns line emission, and pays for it
+
+Every other craft skill routes finished lyric lines here. That makes this the one place where
+generic output escapes into a song, so the gate is an **input** gate: what must exist BEFORE lines
+are written, not a checklist named afterward.
+
+### Hard gate — show the artifacts, do not claim them
+
+A box is passed when its output is **visible in this response or on disk at a named path**. A box
+named as passed with nothing to show is a failed box. Before emitting lines for a rhymed position:
+
+| Required before emission | What "shown" means |
+| --- | --- |
+| Sensory raw material exists | a path under the song's `ideation/`, or object-writing output in this response — from `/songwriting:object-writing generate` |
+| Rhyme candidates generated | the labeled 8-15 candidate menu across ≥4 stability tiers, including ≥3 mosaic, visible — from `/songwriting:rhyme` |
+| Section mode named | stated in this response: does this section SHOW (verse) or TELL (chorus)? |
+| Stress map marked | the marked line, not an assertion that it scans — from `/songwriting:meter-prosody` |
+
+Any gate may be skipped. A skip is **named, with its reason, in the output** — that is the "tools,
+not rules" stance applied honestly. A silent skip is the failure, and so is listing a box as passed
+while its artifact does not exist.
+
+If a gate's input is missing, the correct move is to invoke the skill that produces it, not to
+proceed and note the absence. Lines written without their inputs are LLM defaults wearing the
+method's vocabulary — which is exactly what the pilot produced, and exactly what the writer
+rejected.
+
+### Section mode binds before the line, not after
+
+Verses show; the chorus tells. Verses carry specific situation, image, and action; the chorus makes
+the broader statement the verses keep recoloring. Name the mode first, then check each emitted line
+against it. A chorus of concrete inventory is verse material in the wrong box, however good the
+inventory is — and a chorus is sung back, so unsingable length is a defect, not a polish item.
+
+### Mine, never transcribe
+
+Object-writing output is ore. Pull ONE image forward and build the line around it. Pasting a run of
+sensory material into a section is not using the material; it is relocating it.
+
 ## Related skills
 
+- Sensory raw material before the lines → `/songwriting:object-writing generate`
+- Metaphor for a line that needs one → `/songwriting:metaphor`
 - Blank page, an idea/seed, or a stuck fragment → `/songwriting:workflow`
 - Rhyme partners for the swaps → `/songwriting:rhyme`
 - Pre-lock audit of the chosen line/section → `/songwriting:diagnose audit`

--- a/plugins/songwriting/skills/diagnose/SKILL.md
+++ b/plugins/songwriting/skills/diagnose/SKILL.md
@@ -21,7 +21,7 @@ The review-and-revise layer: name the dominant problem, offer one focused revisi
 checklist as deliberate choice points, and generate labeled alternates. Diagnosis names problems;
 it does not silently rewrite the whole song.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's method plugs in
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's method plugs in
 at `context/<author>/` without changing this skill.
 
 ## Action Router

--- a/plugins/songwriting/skills/metaphor/SKILL.md
+++ b/plugins/songwriting/skills/metaphor/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: metaphor
+description: "Generate and diagnose metaphor with Pat Pattison's methods — the three types (expressed identity, qualifying, verbal), the three expressed-identity forms, collision drills (noun×verb, noun×noun, adjective×noun), playing in keys (fundamental → diatonic family → collisions), the two metaphor-finder questions, participles, transitive vs intransitive, simile as focus control, and grounded-metaphor diagnosis. Use when: 'I need a metaphor for X', 'generate metaphor options', 'metaphor or simile here', 'this metaphor feels dead', 'my song has no metaphor', 'sustain this image across the song', 'collide these words', 'what else has these characteristics'. For sensory raw material use /songwriting:object-writing; for cliche repair use /songwriting:object-writing cliche."
+argument-hint: "[action] [args] (e.g., /songwriting:metaphor collide rain, /songwriting:metaphor keys tide, /songwriting:metaphor simile) — full actions in body"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## Mandatory pre-flight — Response Filter
+
+Before emitting any metaphor, simile, or collision, run **§7 Image filter** of
+[response-filter](../../context/pat-pattison/research/response-filter.md) (add **§2 Line-writing**
+when the metaphor arrives inside a finished line). NAME each box's pass / fail / skip-with-reason;
+correct before emission. Cliché metaphor families are this skill's dominant failure mode and §7 is
+where they are caught.
+
+## Purpose
+
+Figurative language as its own discipline. Metaphor is where a lyric stops describing and starts
+seeing one thing as another, and it is the craft dimension most often missing entirely from a draft
+rather than merely done badly.
+
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's metaphor method
+plugs in at `context/<author>/` without changing this skill.
+
+## Two rules that bind before anything else
+
+**A metaphor must be literally false.** If the two terms are genuinely the same thing, the result
+is a definition, not a metaphor. Conflict is the mechanism, not a side effect: put things that do
+not belong together in one room and work with the friction.
+
+**Noun+verb beats adjective+noun.** Verbs are the power amplifiers of language — they drive a line
+and set it in motion. Collision drills reliably produce better results from noun×verb pairings than
+from adjective×noun ones. This is the correction that matters most here, because the default
+reach is always for an adjective.
+
+## Action Router
+
+`/songwriting:metaphor <action> [args]`. Parse `$ARGUMENTS`: first token = action when it matches a
+listed action, remainder = args; otherwise treat all of `$ARGUMENTS` as payload for the default.
+No action → route on context (a subject named → `collide`; an existing metaphor pasted →
+`diagnose`).
+
+| Action | Use when the user asks for | Load |
+| --- | --- | --- |
+| `collide` (default) | metaphor options for a subject, "I need a metaphor for X", collision drills | [metaphor](../../context/pat-pattison/research/metaphor.md) "three types" + "accident exercises", [templates/metaphor-collision-prompt](../../context/pat-pattison/templates/metaphor-collision-prompt.md) |
+| `recipe` | the eight named generation moves run against one subject | [metaphor](../../context/pat-pattison/research/metaphor.md) "Eight named metaphor moves", [templates/metaphor-recipe-prompt](../../context/pat-pattison/templates/metaphor-recipe-prompt.md) |
+| `keys` | sustaining an image across a section or song, diatonic vocabulary, "play in the key of X" | [metaphor](../../context/pat-pattison/research/metaphor.md) "Playing in keys" + "Tone center / diatonic vocabulary" |
+| `types` | which type is this, the three expressed-identity forms, participles | [metaphor](../../context/pat-pattison/research/metaphor.md) "three metaphor types" + "Expressed identity forms" + "Participles" |
+| `simile` | metaphor or simile here, is-vs-like, focus transfer | [metaphor](../../context/pat-pattison/research/metaphor.md) "Simile as focus control" + "Simile versus metaphor" + "energy-blocker model" |
+| `diagnose` | is this metaphor grounded, is it dead, is the ambiguity productive or strained | [metaphor](../../context/pat-pattison/research/metaphor.md) "Metaphor diagnosis" + "Grounded metaphor rule" + "Productive ambiguity", [cliche](../../context/pat-pattison/research/cliche.md) |
+
+## Handlers
+
+- **Pre-flight ALWAYS:** run response-filter §7 (+ §2 when the metaphor lands in a line).
+- **Options, never a winner.** Surface 6-8 labeled candidates. Label each with its type (expressed
+  identity / qualifying / verbal), its linking quality (why it lands), and family distance
+  (close / medium / far). The writer picks by emotional intent.
+- **Run the two finder questions explicitly, in the output.** What characteristics does this idea
+  have? What else has those characteristics? The second question is what releases the options;
+  answering it silently and presenting only conclusions skips the generative step.
+- **Weight the collisions toward verbs.** In any mixed batch, noun×verb candidates should outnumber
+  adjective×noun ones.
+- **Take object-writing output as input.** The mined world vocabulary of a song is the raw material
+  for playing in keys — a fundamental drawn from the song's own world produces a diatonic family
+  the song can actually use.
+- For `simile`, apply the focus rule rather than the like/as surface test: metaphor transfers focus
+  to the second term and you must commit to it across the song; simile keeps focus on the first
+  term, which makes it the right choice for a one-time comparison or a list of them.
+
+## Boundary — what this skill must NOT emit
+
+This skill produces figurative language and judgements about it. It does not write the finished
+lyric line the metaphor lives in.
+
+| If you are about to emit | STOP and route to |
+| --- | --- |
+| A finished verse, chorus, or bridge line | `/songwriting:co-write` line-brainstorm |
+| Sensory raw material to collide | `/songwriting:object-writing generate` |
+| A rhyme partner for the metaphor's key word | `/songwriting:rhyme` |
+| A judgement about where the image belongs structurally | `/songwriting:song-form` |
+
+Routing means invoking that skill, not summarizing what you believe it would say.
+
+## Persistence and template overrides
+
+Write generated files to the paths in
+[artifact-persistence](../../context/pat-pattison/research/artifact-persistence.md), and honor a
+consuming project's own songwriting layout when it defines one. Metaphor menus go to the song's
+`worksheets/` as a labeled menu, not an inline dump. Before loading any bundled
+`templates/<name>.md`, check `${CLAUDE_PROJECT_DIR}/songwriting/templates/pat-pattison/<name>.md`
+first — a project-level override wins over the bundled default.
+
+## Related skills
+
+- Sensory raw material feeding the collisions → `/songwriting:object-writing`
+- Cliché taxonomy and redemption → `/songwriting:object-writing cliche`
+- Line generation once the metaphor is chosen → `/songwriting:co-write`
+- Whole-draft diagnosis, including "this song has no metaphor" → `/songwriting:diagnose`

--- a/plugins/songwriting/skills/metaphor/evals/evals.json
+++ b/plugins/songwriting/skills/metaphor/evals/evals.json
@@ -1,0 +1,63 @@
+{
+  "skill_name": "metaphor",
+  "evals": [
+    {
+      "id": 1,
+      "name": "metaphor-for-subject-avoiding-cliche-families",
+      "prompt": "/songwriting:metaphor collide I need a metaphor for grief that isn't a storm or an ocean",
+      "expected_output": "Routes to the collide action. Loads metaphor.md and the collision template. Runs the two metaphor-finder questions visibly — what characteristics does grief have, and what else has those characteristics — then surfaces 6-8 labeled candidates avoiding the named cliche families (storm-anger, ocean-sadness, darkness-sadness), each labeled with its type (expressed identity / qualifying / verbal), its linking quality, and family distance. Noun-verb candidates outnumber adjective-noun ones. No single winner is imposed.",
+      "files": [],
+      "expectations": [
+        "Loads metaphor.md via the `collide` action",
+        "Asks both metaphor-finder questions in the output rather than presenting conclusions only",
+        "Avoids storm and ocean per the user's constraint, and does not substitute another named cliche family",
+        "Surfaces 6-8 candidates",
+        "Labels each with a metaphor type (expressed identity / qualifying / verbal)",
+        "Names the linking quality for each candidate",
+        "Emits more noun-verb collisions than adjective-noun collisions",
+        "Offers options rather than a single winning metaphor"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "simile-versus-metaphor-decided-by-focus",
+      "prompt": "/songwriting:metaphor simile Should this be 'my love is an engine' or 'my love is like an engine'?",
+      "expected_output": "Routes to the simile action. Decides on focus transfer rather than the like/as surface test: metaphor transfers focus to the second term and commits the song to it, simile keeps focus on the first term and stays with the speaker. Names the consequence for the rest of the song — a committed metaphor obliges downstream vocabulary from that term's family — and gives the rule of thumb that a list of comparisons wants simile while one comparison carried across the song wants metaphor. Presents the choice, does not decide for the writer.",
+      "files": [],
+      "expectations": [
+        "Frames the difference as focus transfer, not as the presence of like/as",
+        "States that metaphor moves attention to the second term and simile keeps it on the first",
+        "Names the downstream consequence for the song's later vocabulary",
+        "Gives the list-wants-simile / single-committed-comparison-wants-metaphor rule of thumb",
+        "Leaves the choice to the writer"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "playing-in-keys-from-the-songs-own-world",
+      "prompt": "/songwriting:metaphor keys The song is set in a coastal town — sustain an image across the chorus",
+      "expected_output": "Routes to the keys action. Picks a fundamental from the song's own world rather than a generic one, derives a diatonic family from it, then collides family members with each other to produce candidate metaphors. Names which candidates could sustain across a section versus which are one-time images. Notes that object-writing output is the source of the song's world vocabulary.",
+      "files": [],
+      "expectations": [
+        "Names a fundamental drawn from the song's stated world",
+        "Derives a diatonic family from that fundamental",
+        "Collides family members with each other rather than listing the family alone",
+        "Distinguishes sustainable images from one-time ones",
+        "Points at object-writing material as the source of world vocabulary"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "refuses-to-emit-a-finished-lyric-line",
+      "prompt": "/songwriting:metaphor collide Give me a metaphor for leaving and then write the chorus around it",
+      "expected_output": "Generates the metaphor candidates, then STOPS at the boundary: writing the chorus is line emission and belongs to /songwriting:co-write. Names the routing explicitly rather than silently producing the chorus, and does not summarize what co-write would say in place of invoking it.",
+      "files": [],
+      "expectations": [
+        "Produces labeled metaphor candidates for the subject",
+        "Does NOT emit a finished chorus, verse, or lyric line",
+        "Names /songwriting:co-write as the owner of line emission",
+        "Does not paraphrase the other skill's output in place of routing to it"
+      ]
+    }
+  ]
+}

--- a/plugins/songwriting/skills/meter-prosody/SKILL.md
+++ b/plugins/songwriting/skills/meter-prosody/SKILL.md
@@ -19,7 +19,7 @@ The sound-and-motion layer: whether the number, placement, and stress of syllabl
 stability of each section — support the meaning and emotion. Covers scansion, prosody, phrasing,
 stable/unstable analysis, and fitting lyric to melody.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's method plugs in
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's method plugs in
 at `context/<author>/` without changing this skill.
 
 ## Action Router
@@ -51,6 +51,24 @@ Write generated files to the paths in
 consuming project's own songwriting layout when it defines one. Before loading any bundled
 `templates/<name>.md`, check `${CLAUDE_PROJECT_DIR}/songwriting/templates/pat-pattison/<name>.md`
 first — a project-level override wins over the bundled default.
+
+## Boundary — what this skill must NOT emit
+
+This skill measures. It does not write the line it measures, and it does not choose the words that
+fix a bad scan.
+
+| If you are about to emit | STOP and route to |
+| --- | --- |
+| A rewritten line that scans better | `/songwriting:co-write` line-brainstorm |
+| A replacement word chosen for its stress pattern and rhyme | `/songwriting:rhyme` |
+| A judgement that a section is the wrong length or shape | `/songwriting:song-form` |
+
+**Measure in stressed syllables, never raw syllables.** Line length in this method is the count of
+stressed syllables; a raw-syllable count is a different measurement that answers a different
+question. Reporting one as the other invents symmetry that is not there — in the pilot a chorus
+reported as an 8/9/9/8 strength was 3/4/3/3 by the correct measure, and the strength did not exist.
+If the stress map has not been marked, the length claim has not been made: mark it, or say the box
+was skipped.
 
 ## Related skills
 

--- a/plugins/songwriting/skills/object-writing/SKILL.md
+++ b/plugins/songwriting/skills/object-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: object-writing
-description: "Generate raw sensory material and images with Pat Pattison's methods — object writing (sense-bound, 90-second timed dives, Rusty's-collar/Kami-kazi), metaphor (3 types, 8 recipes, collision drills, transitive/intransitive), cliche taxonomy + redemption, and point of view (camera distance, pronoun consistency). Use when: 'object writing', 'make this less abstract', 'show don't tell', '90-second writing prompt', 'I need a metaphor for X', 'generate metaphor options', 'this line sounds cliched', 'who is speaking in this lyric'. For rhyme use /songwriting:rhyme; for daily curriculum use /songwriting:practice."
-argument-hint: "[action] [args] (e.g., /songwriting:object-writing, /songwriting:object-writing metaphor-recipe trust) — full actions in body"
+description: "Generate raw sensory material with Pat Pattison's methods — object writing (sense-bound, timed dives, the pivot chain, the seven-channel sense inventory, Rusty's-collar/Kami-kazi), an agent that performs the write itself, cliche taxonomy + redemption, and point of view (camera distance, pronoun consistency). Use when: 'object writing', 'you do the object writing', 'make this less abstract', 'show don't tell', '90-second writing prompt', 'this line sounds cliched', 'who is speaking in this lyric'. For metaphor use /songwriting:metaphor; for rhyme use /songwriting:rhyme; for daily curriculum use /songwriting:practice."
+argument-hint: "[action] [args] (e.g., /songwriting:object-writing, /songwriting:object-writing generate rain) — full actions in body"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -16,11 +16,11 @@ imagery are the defaults this filter catches.
 
 ## Purpose
 
-Sense-bound raw material and figurative language: object writing, metaphor/simile, cliche repair,
-and point of view. This is the "showing, not telling" engine — the source of concrete detail the
-other skills shape.
+Sense-bound raw material: object writing, cliche repair, and point of view. This is the "showing,
+not telling" engine — the source of concrete detail the other skills shape. Metaphor is its own
+discipline and its own skill (`/songwriting:metaphor`); this skill feeds it.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's imagery method
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's imagery method
 plugs in at `context/<author>/` without changing this skill.
 
 ## Action Router
@@ -31,8 +31,7 @@ No action → issue one usable timed object-writing prompt immediately (do not a
 | Action | Use when the user asks for | Load |
 | --- | --- | --- |
 | `object-writing` (default) | sensory writing, showing instead of telling, raw material | [object-writing](../../context/pat-pattison/research/object-writing.md), [templates/object-writing-prompt](../../context/pat-pattison/templates/object-writing-prompt.md) |
-| `metaphor` | metaphor, simile, collision drills, linking qualities, productive ambiguity, is-vs-like | [metaphor](../../context/pat-pattison/research/metaphor.md), [templates/metaphor-collision-prompt](../../context/pat-pattison/templates/metaphor-collision-prompt.md) |
-| `metaphor-recipe` | 8 named metaphor moves to generate options from a subject | [metaphor](../../context/pat-pattison/research/metaphor.md) "8 recipes", [templates/metaphor-recipe-prompt](../../context/pat-pattison/templates/metaphor-recipe-prompt.md) |
+| `generate` | **YOU** do the object writing — "you write it", "do the object writing", "I don't want to write it", or any request for raw sensory material the writer is not going to produce | dispatch the `object-writer` agent — see below |
 | `cliche` | cliche phrase, cliche image, stale metaphor, cliche rhyme | [cliche](../../context/pat-pattison/research/cliche.md), [worksheets](../../context/pat-pattison/research/worksheets.md), [metaphor](../../context/pat-pattison/research/metaphor.md) |
 | `pov` | first/second/third person, direct address, dialogue, pronoun consistency, camera distance | [point-of-view](../../context/pat-pattison/research/point-of-view.md) |
 | `worksheet` | broader sense-bound worksheets (not rhyme worksheets) | [worksheets](../../context/pat-pattison/research/worksheets.md) |
@@ -44,7 +43,39 @@ No action → issue one usable timed object-writing prompt immediately (do not a
   90 seconds). Do not assign the full curriculum unless asked — that is `/songwriting:practice`.
 - Keep object-writing sense-bound and personal; its job is to reveal specific, sensory detail, not
   to produce finished lines.
-- For metaphor, name the type and recipe used; offer options, not a single winner.
+- A metaphor request routes to `/songwriting:metaphor`. Sensory material mined here is that skill's
+  input — hand over the material, do not generate the metaphor here.
+
+## `generate` — dispatch, never write it inline
+
+**Who writes matters more than what is loaded.** Reading this skill's files and then writing a
+dive in the main thread reliably produces a static scene description, because the discipline was
+read rather than carried. Dispatch the `object-writer` agent, whose system prompt IS the
+discipline.
+
+Dispatch rules:
+
+1. **One agent per seed**, all in a single message so they run concurrently. Two agents on the same
+   seed is a valid and useful play — same board, different dives.
+2. **Give each agent nothing but the seed, the timer, the category, and its own output path.** Not
+   the song, not the title, not the draft, not the diagnosis, not the other agents' seeds. The
+   isolation is the mechanism; briefing an agent on the song destroys the divergence it exists to
+   produce. This is a hard boundary, not a default.
+3. **Each agent writes to its own file** under the song's `ideation/` (per
+   [artifact-persistence](../../context/pat-pattison/research/artifact-persistence.md)) and returns
+   a path plus a sense-inventory summary. Never ask an agent to return the write in a message.
+4. **Grade coverage on return**, then mine. Read each file, honor thin-channel reports rather than
+   overruling them, and pull individual images forward. Mining stays here because you hold the song
+   context the writers deliberately lack.
+5. **For rounds:** name what made the strongest write of a round work, then carry that as the
+   standard into the next round's dispatch. The bar escalates; rounds are not independent repeats.
+
+**Never transcribe a write into lines.** The whole page is ore. Pat's discipline is to pull one
+image out of it — moving a dive wholesale into a section is the failure this action exists to
+prevent, not its purpose.
+
+Nothing else in this skill dispatches agents. Metaphor generation is
+`/songwriting:metaphor`; line-writing is not this skill's job at all (see boundaries below).
 
 ## Persistence and template overrides
 
@@ -54,8 +85,26 @@ consuming project's own songwriting layout when it defines one. Before loading a
 `templates/<name>.md`, check `${CLAUDE_PROJECT_DIR}/songwriting/templates/pat-pattison/<name>.md`
 first — a project-level override wins over the bundled default.
 
+## Boundary — what this skill must NOT emit
+
+This skill produces raw sensory material and figurative language. It does **not** produce finished
+lyric lines, and being mid-conversation about a song does not authorize it to.
+
+| If you are about to emit | STOP and route to |
+| --- | --- |
+| A finished verse, chorus, or bridge line | `/songwriting:co-write` line-brainstorm |
+| A rhyme partner or rhyme list | `/songwriting:rhyme` |
+| A section rewrite, or a judgement about where a section's material belongs | `/songwriting:song-form` |
+| A scansion or stress-map claim | `/songwriting:meter-prosody` |
+
+Routing means invoking that skill, not summarizing what you believe it would say. Emitting a lyric
+line from here is the specific failure the boundary exists to catch: the generative discipline
+lives in the skill that owns it, and material that arrives without passing through that skill
+arrives as an LLM default wearing the vocabulary.
+
 ## Related skills
 
+- Metaphor generation and diagnosis → `/songwriting:metaphor`
 - Rhyme choice and rhyme cliche → `/songwriting:rhyme`
 - Daily practice curriculum and numbered exercises → `/songwriting:practice`
 - Whole-draft diagnosis (where images fail in context) → `/songwriting:diagnose`

--- a/plugins/songwriting/skills/object-writing/evals/evals.json
+++ b/plugins/songwriting/skills/object-writing/evals/evals.json
@@ -3,16 +3,55 @@
   "evals": [
     {
       "id": 1,
-      "name": "metaphor-recipe-for-emotion",
-      "prompt": "/songwriting:object-writing metaphor-recipe I need a metaphor for grief that isn't a storm or an ocean",
-      "expected_output": "Routes to the metaphor-recipe action. Loads metaphor.md (the 8 named recipes) and templates/metaphor-recipe-prompt.md. Generates 6-8 metaphor candidates avoiding the named cliche families (storm-anger, fire-passion, ocean-sadness) per the user's constraint, labeling each with its type (expressed identity / qualifying / verbal) and a grounding suggestion.",
+      "name": "ai-performs-the-write-via-agent",
+      "prompt": "/songwriting:object-writing generate I want you to do the object writing. I don't want to do it — the whole point is for you to do this.",
+      "expected_output": "Routes to the generate action and dispatches the object-writer agent rather than issuing a timed prompt to the user or writing the dive inline in the main thread. The agent receives only the seed, timer, category, and an output path — not the song, draft, or diagnosis. The write lands in a file under the song's ideation/ and the return is a path plus a seven-channel sense inventory. Never hands the exercise back to the writer, and never declines on the grounds of having no sense memory.",
       "files": [],
       "expectations": [
-        "Loads metaphor.md via the `metaphor-recipe` action",
-        "Avoids storm and ocean (named cliche families) per the user's constraint",
-        "Generates 6-8 candidate metaphors",
-        "Labels each with a metaphor type (expressed identity / qualifying / verbal)",
-        "Offers options rather than a single winning metaphor"
+        "Dispatches the object-writer agent rather than writing the dive in the main thread",
+        "Does NOT issue a timed prompt for the human to write",
+        "Does NOT decline or cite a lack of personal sense memory",
+        "Briefs the agent with seed, timer, category, and output path only — no song, draft, or diagnosis",
+        "The write is written to a file; the return is a path plus a sense inventory, not the full text in a message",
+        "Reports thin or absent sense channels rather than presenting all seven as covered"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "isolation-held-when-a-song-is-in-context",
+      "prompt": "/songwriting:object-writing generate We're stuck on verse 2 of the breakup song — write me some object writing on 'kitchen' for it",
+      "expected_output": "Dispatches the agent on the seed 'kitchen' WITHOUT passing the song, the verse, or the fact that it is a breakup song. Isolation is stated as deliberate, not apologized for as a limitation. Mining the result against verse 2's needs happens in the main thread afterward, which is where the song context lives.",
+      "files": [],
+      "expectations": [
+        "The agent's brief carries the seed but NOT the song, the draft, or the emotional premise",
+        "Names isolation as the mechanism rather than as a shortcoming",
+        "Mining against the song's needs happens after the write returns, in the main thread",
+        "Does not ask the agent to write toward verse 2"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "mines-rather-than-transcribes",
+      "prompt": "/songwriting:object-writing That object write was great — put it into the chorus",
+      "expected_output": "Refuses to transcribe the write into a section. Pulls one image forward as ore, then routes line emission to /songwriting:co-write rather than writing the chorus here. Names both the mining discipline and the boundary.",
+      "files": [],
+      "expectations": [
+        "Does NOT paste a run of object-writing material into a section",
+        "Pulls a single image forward rather than the passage",
+        "Routes line emission to /songwriting:co-write",
+        "Does not emit a finished chorus from this skill"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "metaphor-request-routes-out",
+      "prompt": "/songwriting:object-writing I need a metaphor for grief that isn't a storm or an ocean",
+      "expected_output": "Metaphor is no longer an action of this skill. Routes to /songwriting:metaphor collide rather than generating metaphors here, and offers mined sensory material as that skill's input if any exists.",
+      "files": [],
+      "expectations": [
+        "Routes to /songwriting:metaphor rather than generating the metaphor here",
+        "Does not emit metaphor candidates from this skill",
+        "Offers sensory material as input to the metaphor skill where relevant"
       ]
     }
   ]

--- a/plugins/songwriting/skills/practice/SKILL.md
+++ b/plugins/songwriting/skills/practice/SKILL.md
@@ -20,7 +20,7 @@ The habit layer: a daily craft routine and a numbered-exercise index across all 
 writer can build and sustain practice. This skill hands out prompts and curricula; the craft skills
 do the in-the-moment coaching on the output.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's curriculum plugs
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's curriculum plugs
 in at `context/<author>/` without changing this skill.
 
 ## Action Router

--- a/plugins/songwriting/skills/rhyme/SKILL.md
+++ b/plugins/songwriting/skills/rhyme/SKILL.md
@@ -21,7 +21,7 @@ mosaic (multi-word) rhyme, and rhyme worksheets. Internal Pat-framed generation 
 live Datamuse lookup supplements only for vocabulary breadth, syllable verification, or
 semantic-field mining.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's rhyme method
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's rhyme method
 plugs in at `context/<author>/` without changing this skill.
 
 ## Action Router
@@ -58,6 +58,23 @@ Write generated files to the paths in
 consuming project's own songwriting layout when it defines one. Before loading any bundled
 `templates/<name>.md`, check `${CLAUDE_PROJECT_DIR}/songwriting/templates/pat-pattison/<name>.md`
 first — a project-level override wins over the bundled default.
+
+## Boundary — what this skill must NOT emit
+
+This skill surfaces rhyme candidates and stress-tests them. It does not decide, and it does not
+write the line the rhyme lands in.
+
+| If you are about to emit | STOP and route to |
+| --- | --- |
+| A finished lyric line built around a chosen rhyme | `/songwriting:co-write` line-brainstorm |
+| A single winning rhyme presented as the answer | nothing — surface the labeled menu and let the writer pick by emotional intent |
+| A structural judgement about where the rhyme sits | `/songwriting:song-form` |
+| A claim that a candidate scans | `/songwriting:meter-prosody` |
+
+Two failures belong to this skill specifically and are caught nowhere downstream: a rhyme list that
+is all-perfect, all-single-word, and all-same-part-of-speech, and a "mosaic" list whose entries
+reuse the source word with a prefix (identity in disguise). §1 of the response filter names both
+fail signatures — run it rather than recalling it.
 
 ## Related skills
 

--- a/plugins/songwriting/skills/song-form/SKILL.md
+++ b/plugins/songwriting/skills/song-form/SKILL.md
@@ -19,7 +19,7 @@ The architecture layer: how sections are identified, contrasted, balanced, and r
 serves the song. Covers form selection, hook/title placement, repetition and repainting, verse
 division of labor (box model), verse development, and bridges.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's method plugs in
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's method plugs in
 at `context/<author>/` without changing this skill.
 
 ## Action Router
@@ -54,8 +54,41 @@ consuming project's own songwriting layout when it defines one. Before loading a
 `templates/<name>.md`, check `${CLAUDE_PROJECT_DIR}/songwriting/templates/pat-pattison/<name>.md`
 first — a project-level override wins over the bundled default.
 
+## Boundary — what this skill must NOT emit
+
+This skill's domain is architecture: which sections exist, what each one is doing, how they
+contrast, balance, and repaint. **It does not write finished lyric lines**, and having diagnosed a
+section's problem does not authorize it to write that section's replacement.
+
+| If you are about to emit | STOP and route to |
+| --- | --- |
+| A finished verse, chorus, or bridge line | `/songwriting:co-write` line-brainstorm |
+| A rhyme partner, or any line whose end-word was chosen for its rhyme | `/songwriting:rhyme` |
+| Sensory or metaphorical raw material for a thin section | `/songwriting:object-writing generate`, then `/songwriting:metaphor` |
+| A stress map, syllable count, or line-length claim | `/songwriting:meter-prosody` |
+
+Routing means invoking that skill, not summarizing what you believe it would say.
+
+**Why this boundary is load-bearing.** In the pilot that produced these skills, this skill wrote
+three chorus drafts while its own routing said rhyme work belongs elsewhere. Every generative check
+was named as passed and none was run: zero rhyme candidates against a mandatory eight, zero mosaic
+against a mandatory three, no object writing before the lines. Naming a filter box is not running
+it, and a structural skill in the middle of a structural conversation is exactly where that
+substitution happens.
+
+Two section-type rules bind before any line-level judgement here, both from
+[repetition](../../context/pat-pattison/research/repetition.md):
+
+- **Verses show; the chorus tells.** Verses carry specific situation, image, and action; the chorus
+  makes the broader statement the verses keep recoloring. State which mode a section is in before
+  judging its material — a chorus full of concrete inventory is verse material in the wrong box.
+- **A chorus is sung back.** Length and singability are structural properties, not polish.
+
 ## Related skills
 
+- Line generation and variations → `/songwriting:co-write`
+- Sensory raw material → `/songwriting:object-writing`
+- Metaphor systems across a form → `/songwriting:metaphor`
 - Stability and scansion of the sections → `/songwriting:meter-prosody`
 - Rhyme within sections → `/songwriting:rhyme`
 - Whole-draft diagnosis → `/songwriting:diagnose`

--- a/plugins/songwriting/skills/song-form/evals/evals.json
+++ b/plugins/songwriting/skills/song-form/evals/evals.json
@@ -5,13 +5,27 @@
       "id": 1,
       "name": "second-verse-stagnation-box-model",
       "prompt": "/songwriting:song-form box-model my second verse repeats the first — same scene, same speaker, same time. how do I fix it?",
-      "expected_output": "Routes to the box-model action. Loads box-model.md and verse-development.md. Names the travelogue diagnosis and proposes a division-of-labor formula (You-I-We or Past-Present-Future or another axis), surfacing what verse 2 should DO that verse 1 doesn't, and mentions a 'what came before' diagnostic or equivalent reframing.",
+      "expected_output": "Routes to the box-model action. Loads box-model.md and verse-development.md. Diagnoses this as the SAME-COLOR failure (Box 2 = Box 1, Writing Better Lyrics (2009) Chapter 7) — the verses do the same job, so the chorus never repaints — and NOT as a travelogue, which is the opposite failure where verses share only the title. Proposes a division-of-labor formula (You-I-We or Past-Present-Future or another axis), surfacing what verse 2 should DO that verse 1 doesn't, and mentions a 'what came before' diagnostic or equivalent reframing.",
       "files": [],
       "expectations": [
         "Loads box-model.md and/or verse-development.md",
-        "Names the travelogue diagnosis",
+        "Names the same-color / Box 2 = Box 1 diagnosis",
+        "Does NOT call this a travelogue — travelogue is verses connected only by the title, the opposite failure",
         "Proposes at least one division-of-labor formula (You-I-We / Past-Present-Future / other axis)",
         "Mentions a 'what came before' diagnostic OR an equivalent reframing question"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "travelogue-distinguished-from-same-color",
+      "prompt": "/songwriting:song-form box-model Each verse is a different city and a different character, and the only thing tying them together is the title line. Is this the same problem as verses that repeat each other?",
+      "expected_output": "Diagnoses this as a TRAVELOGUE (Writing Better Lyrics (2009) Chapter 8) — verses with no natural relationship, linked only through the title or chorus, so the boxes accumulate no weight — and states explicitly that it is the OPPOSITE failure from same-color repetition. Prescribes finding the causal chain between verses (what in verse 1 causes verse 2, what verse 2 makes inevitable), NOT a division-of-labor shift, which is the same-color repair.",
+      "files": [],
+      "expectations": [
+        "Names the travelogue diagnosis",
+        "States that travelogue and same-color are opposite failures rather than the same problem",
+        "Prescribes building a causal chain between the verses",
+        "Does NOT prescribe You-I-We or Past-Present-Future as the fix for this case"
       ]
     },
     {

--- a/plugins/songwriting/skills/workflow/SKILL.md
+++ b/plugins/songwriting/skills/workflow/SKILL.md
@@ -21,7 +21,7 @@ tonight") into the right scenario and the right craft skill, and run guided step
 the writer wants to be walked through it. When the user names a craft term (rhyme, meter, form,
 image), route straight to that concern skill.
 
-Method content is Pat Pattison's, under `context/pat-pattison/`. A future author's process plugs in
+Method content is Pat Pattison's, under the plugin-root `../../context/pat-pattison/`. A future author's process plugs in
 at `context/<author>/` without changing this skill.
 
 ## Concern skills — route craft-term requests here


### PR DESCRIPTION
Closes #2012
Closes #2044
Closes #2046

Two related changes from one end-to-end pilot of the plugin on a real song.
Paraphrase only throughout — no chapter prose, example writes, or student work
reaches this public repository, per the source corpus's constraint.

Version 0.6.1 → 0.7.0.

## 1. The binding failure (#2044) — the pilot's central finding

The original hypothesis was that progressive disclosure was not pulling deep
enough into the context files. **It was pulling fine.** The files loaded, the
rules were in context, and generation ignored them. `repetition.md` was loaded,
its rule that verses show and the chorus tells was in context, and three chorus
drafts were emitted that show. Filter §2's boxes were named as passed while the
emitted lines failed them — zero rhyme candidates against a mandatory eight,
zero mosaic against a mandatory three, no object writing run at all.

Reading a rule and obeying it at generation time are separate failures. Adding
more files cannot fix the second, because the content was already present and
was overridden by model defaults. Three changes attack it:

**`object-writer` agent.** Performs the object write itself rather than
prompting a human, with the discipline in its own system prompt rather than in a
file it consults. Dispatched blind, one per seed, deliberately denied the song,
the draft, and the other writers' output, because same-seed divergence depends
on isolation. Returns a file path plus a seven-channel sense inventory quoting
its own phrases, with thin channels reported rather than padded.

Both the shape and the file-not-message return are empirical rather than
designed: pilot agents carrying the discipline in-prompt produced materially
better output than the main thread did with the same files loaded — including
one that graded its own organic channel thin and refused to pad it — and three
of four agents signalled idle without their text ever arriving over the return
channel.

**Emission boundaries on every craft skill.** Each names what it must NOT emit
and which skill owns that output. `song-form` does not write lines; `rhyme` does
not write the line its rhyme lands in; `meter-prosody` measures but does not
rewrite; `object-writing` produces ore. In the pilot the structural skill wrote
three chorus drafts while its own routing said rhyme work belonged elsewhere.

**A hard input gate on `co-write`,** the one skill that legitimately emits
lines. Satisfied by artifacts that exist — a visible rhyme-candidate menu,
object-writing output at a named path, a marked stress map — not by naming boxes
as passed. A skip stays valid and stays named; a box claimed as passed with no
artifact behind it is a failed box.

## 2. Metaphor as a first-class skill (#2046)

`/songwriting:metaphor` with generative actions (`collide`, `recipe`, `keys`,
`types`, `simile`, `diagnose`), taking object-writing output as input.

`metaphor.md` was verified faithful against *Writing Better Lyrics* (2009)
Chapter 3, read in full, and is **unchanged** — the defect was placement. 755
lines of accurate method were reachable only as one action inside a skill about
a different discipline, and never fired once across an entire pilot song that
contained no metaphor at all.

Two corrections from the chapter now sit where generation happens rather than
only in the reference: a metaphor must be literally false, since identity
without conflict is definition; and noun+verb collisions outperform
adjective+noun, because verbs drive a line — the one that matters most, since
the default reach is always for an adjective.

**Breaking:** `/songwriting:object-writing metaphor` and `metaphor-recipe` are
removed, routing to `/songwriting:metaphor collide` and `recipe`. Cliché repair
stays in `object-writing`, whose taxonomy covers stale phrasing beyond metaphor.

## 3. Source fidelity (#2012)

Three context files adjudicated against the full text of the chapter each claims
to distill, rather than against the distillation.

**`box-model.md` defined "travelogue" three incompatible ways.** Chapter 8
defines it as verses with no natural relationship to each other, linked only
through the title or chorus, so the boxes accumulate no weight. Verses doing the
same job or projecting the same colour are the **opposite** failure — Chapter
7's colored-spotlight problem, where the chain is intact and the repainting is
missing. Chapter 8's closing paragraph settles it outright by naming both poles
of one axis: ideas too close make the chorus static, ideas too far apart make a
travelogue.

This matters because the repairs are opposite. Travelogue needs a causal chain;
same-colour needs a division-of-labour shift. The pilot diagnosed one as the
other. Sibling file `verse-development.md` was checked and treats travelogue
correctly throughout, so the defect was isolated.

**`object-writing.md` carried the instruction without the mechanism.** All six
claimed drops were confirmed present in Chapter 1. Restored: the pivot chain
(each image handing off through a sense channel — with an **original** worked
example, not Pat's, so the mechanic is teachable without copying); the
seven-channel sense inventory as an acceptance test; specificity calibration at
the chapter's real density; invention explicitly licensed, since the chapter
holds a song is not autobiography and truth outranks reality; the group model's
same-seed divergence and escalating bar; and perspective writes.

**`response-filter.md` §2 gains an unintended-implication box.** Pattison names
no such check — but the mechanism is his, from Chapter 1: sense-bound language
works because the listener fills the writer's words with their own associations.
That mechanism is not selective, so a **more** concrete line carries **more**
unintended implication, which is why the box runs after the other boxes pass
rather than instead of them. Paired with a box carrying Chapter 10's invocation
of Ibsen's rule about the gun in Act I.

## Incidental fix, found by CI

Every skill body's prose said the method lives at `context/pat-pattison/` while
its links resolve `../../context/pat-pattison/` — the plugin shares one context
tree at plugin root. The skill-quality gate reads the prose form as a broken
skill-internal ref. Latent on `main` and surfaced here because these skills
entered the changed-skill diff for the first time. Corrected in all nine bodies.

## Two harness facts found while verifying

**Eval sets do not run.** CI schema-validates `evals/evals.json` and gates its
presence; nothing executes or model-grades them. "Test a skill in isolation" has
no mechanical harness today — every isolation test needs a human verdict.

**A running session never reads this repository.** `melodic-software` is a
`directory`-source marketplace pointing at the plugin repo, but installation
copies a version-pinned immutable snapshot into
`~/.claude/plugins/cache/melodic-software/songwriting/<version>/` against a
commit SHA. Verified directly: the cached 0.6.1 copy does not contain working-
tree edits. Every craft-skill change needs a version bump plus re-install before
it can be tested at all — batch edits per version rather than iterating
file-by-file. `CLAUDE.md` documents cache isolation as a design constraint but
not this consequence for the edit-test loop.

## Verification

- `check-changed-skills.sh` vs `origin/main`: all nine songwriting skills PASS,
  0 errors (the one remaining repo-wide failure, `playbooks/fable-5`, is
  pre-existing on `main` and untouched here)
- `check-listing-budget.sh`: 6127/8000 chars across 10 listing-eligible skills
- `markdownlint-cli2`: clean over 104 files
- `lychee --offline --include-fragments`: 681 OK, 0 errors — `lychee.toml` sets
  `include_fragments = "full"`, so the new intra-file anchors are really checked
- `validate-plugins.sh`: passes, after `generate-catalog.mjs` regenerated the
  stale `docs/CATALOG.md` block the description change invalidated
- `check-changelog-parity.sh`: `--check`, `--check-bump origin/main`,
  `--check-order` all pass
- `check-silent-skips`, `check-skill-leaf-names`, `check-orphaned-fixtures`,
  `check-plugin-manifest-presence`: all pass
- New/updated eval sets validate against `evals.schema.json`

Eval sets added for `metaphor` (4 cases) and rewritten for `object-writing` (4
cases) to cover the agent dispatch, the isolation boundary, mine-not-transcribe,
and the metaphor route-out. They are declarations, not executions — see the
harness note above.

## Related

- The chapter-by-chapter source-fidelity audit across all four books is the
  ongoing umbrella this pass opens; `object-writing.md`, `box-model.md`,
  `verse-development.md`, and `metaphor.md` are audited, and 45 context files
  remain.
