### PR TITLE
chore: pilot two report-only self-maintenance routines

### DIFF
--- a/.github/recurring-schedule.json
+++ b/.github/recurring-schedule.json
@@ -11,6 +11,30 @@
       "next_due": "2026-11-06",
       "notes": "On each frontier model release (primary trigger), run /claude-config:audit-instructions and /claude-config:unhobble over this repository's session surfaces to re-test which standing instructions the new model still needs. No automation observes the release event: the trigger's consumer is the standing OPEN [Maintenance] issue (#2019) — kept open continuously so /work-items:work can select it the moment an operator or agent notices a release, ahead of next_due. The quarterly cadence is a backstop only, guaranteeing the pass happens even when a release goes unnoticed (docs/PLUGIN-PHILOSOPHY.md, Instruction economy). Tier-4 caveat (known limitation, unenforced): last-resort selection can pick the open issue when no release has occurred, and neither the work skill's tier-4 step nor recheck's close step consults any precondition — the issue body instructs the claimant (no frontier release since last_checked: unclaim, leave open, never recheck-close), but honoring that depends on the claimant reading the body and deviating from the unconditional close step. If a premature close drains the item before a real release, re-open or re-create it from this row. Session surfaces only, never the shipped plugin components.",
       "close_previous": true
+    },
+    {
+      "id": "listing-budget-watch",
+      "title": "Listing-budget watch: report the shared aggregate and drift",
+      "cadence": "quarterly",
+      "area": [],
+      "category": "general",
+      "triggers": [],
+      "last_checked": "2026-08-08",
+      "next_due": "2026-11-06",
+      "notes": "Report-only self-maintenance routine (digest menu #9 pilot). Run skill-quality's check-listing-budget.sh pooled over plugins/*/skills from a current main checkout; record aggregate, skill count, delta vs prior cycle, and top-10 contributors on the open [Maintenance] issue (#2023 is the first instance). Baseline and the pending target decision live in #2022. Never edits descriptions — findings route to issues.",
+      "close_previous": true
+    },
+    {
+      "id": "stale-doc-drift-watch",
+      "title": "Stale-doc drift watch: report doc references that no longer hold",
+      "cadence": "quarterly",
+      "area": [],
+      "category": "general",
+      "triggers": [],
+      "last_checked": "2026-08-08",
+      "next_due": "2026-11-06",
+      "notes": "Report-only self-maintenance routine (digest menu #9 pilot). Sweep docs/ and top-level repo docs for references to files/checks/skills that no longer exist, stale version claims, and moved OFFICIAL-DOCS.md pages (review:doc-drift-detector or docs-hygiene audits); verify generated CATALOG/SKILL-CHEAT-SHEET freshness on a scratch branch. File one issue per confirmed drift cluster or comment no-drift on the open [Maintenance] issue (#2024 is the first instance). Never edits docs directly from the routine.",
+      "close_previous": true
     }
   ]
 }


### PR DESCRIPTION
No linked issue

## Summary

Lands the deferred half of the Boris-talk digest's menu #9 (marketplace self-maintenance routines), now that the schedule seam carries its first row (#2020) and the analyses these routines watch have baselines (#2021, #2022): two quarterly, report-only recurring rows in `.github/recurring-schedule.json`.

## Fix

- `listing-budget-watch` — re-run skill-quality's pooled `check-listing-budget.sh` over `plugins/*/skills`, record aggregate/delta/top-10 on the `[Maintenance]` instance. Backing issue #2023; baseline and the pending target decision in #2022.
- `stale-doc-drift-watch` — sweep repo docs for references that no longer hold (missing files/checks/skills, stale versions, moved OFFICIAL-DOCS.md pages) plus a generated-doc freshness check on a scratch branch. Backing issue #2024.

Both are report-only by contract: findings become issues or comments; the routines never edit descriptions or docs directly. Both rows carry `next_due` 2026-11-06 (quarterly from today), matching the exact `[Maintenance] {title}` convention `recheck` requires for close-matching.

## Verification

- `jq -e '.items | length'` → 3; file parses clean and preserves the merged `frontier-release-instruction-ablation` row untouched.
- Backing issues #2023/#2024 created through the work-item-tracker seam with `recurring` label and titles exactly matching the rows.

## Related

- Refs #2023, #2024 — the recurring backing issues (not closed; they are the recurring instances)
- Refs #2022 — listing-budget baseline + pending decision the first routine watches
- Refs #2021 — hook classification report (same digest follow-through batch)
- Refs #2020 — the schedule row this stacks after

🤖 Generated with [Claude Code](https://claude.com/claude-code)