### PR TITLE
docs: note claude-code-security-review default model is retired

### DIFF
--- a/docs/topics/ai-adoption-ladder/design/RESEARCH-product-surface.md
+++ b/docs/topics/ai-adoption-ladder/design/RESEARCH-product-surface.md
@@ -101,7 +101,7 @@ Every one of the 12 linked docs resolves to a **real, live** feature page, and *
 ### 12. claude-code-security-review (github.com/anthropics/claude-code-security-review)
 
 - **What / does:** Open-source GitHub Action running Claude for diff-aware semantic security review on PRs; comments findings; detects injection, authn/authz, secret exposure, crypto, TOCTOU, supply-chain, XSS, etc.; false-positive filtering.
-- **Config surface:** action inputs — `claude-api-key` (req), `comment-pr`, `upload-results`, `exclude-directories`, `claude-model` (default `claude-opus-4-1-20250805`), `claudecode-timeout` (20 min), `run-every-commit`, `custom-security-scan-instructions`, `false-positive-filtering-instructions`.
+- **Config surface:** action inputs — `claude-api-key` (req), `comment-pr`, `upload-results`, `exclude-directories`, `claude-model` (action-input default empty; effective default resolves to [`claude-opus-4-1-20250805`](https://github.com/anthropics/claude-code-security-review/blob/beb0d9bf6077d94cf6896c02fb5dbb73f33b4788/claudecode/constants.py#L8) — still unchanged upstream as of 2026-08-08, though that model [retired 2026-08-05](https://platform.claude.com/docs/en/about-claude/model-deprecations), replacement `claude-opus-4-8`), `claudecode-timeout` (20 min), `run-every-commit`, `custom-security-scan-instructions`, `false-positive-filtering-instructions`.
 - **Maturity:** **Active OSS**, MIT, ~5.6k stars. Warns: not hardened against prompt injection — review trusted PRs only.
 - **Ladder:** **1→2** — self-hosted automated (security) review in your own CI.
 

--- a/docs/topics/ai-adoption-ladder/design/RESEARCH-product-surface.md
+++ b/docs/topics/ai-adoption-ladder/design/RESEARCH-product-surface.md
@@ -101,7 +101,8 @@ Every one of the 12 linked docs resolves to a **real, live** feature page, and *
 ### 12. claude-code-security-review (github.com/anthropics/claude-code-security-review)
 
 - **What / does:** Open-source GitHub Action running Claude for diff-aware semantic security review on PRs; comments findings; detects injection, authn/authz, secret exposure, crypto, TOCTOU, supply-chain, XSS, etc.; false-positive filtering.
-- **Config surface:** action inputs — `claude-api-key` (req), `comment-pr`, `upload-results`, `exclude-directories`, `claude-model` (action-input default empty; effective default resolves to [`claude-opus-4-1-20250805`](https://github.com/anthropics/claude-code-security-review/blob/beb0d9bf6077d94cf6896c02fb5dbb73f33b4788/claudecode/constants.py#L8) — still unchanged upstream as of 2026-08-08, though that model [retired 2026-08-05](https://platform.claude.com/docs/en/about-claude/model-deprecations), replacement `claude-opus-4-8`), `claudecode-timeout` (20 min), `run-every-commit`, `custom-security-scan-instructions`, `false-positive-filtering-instructions`.
+- **Config surface:** action inputs — `claude-api-key` (req), `comment-pr`, `upload-results`, `exclude-directories`, `claude-model`, `claudecode-timeout` (20 min), `run-every-commit`, `custom-security-scan-instructions`, `false-positive-filtering-instructions`.
+  - `claude-model`: action-input default empty; effective default resolves to [`claude-opus-4-1-20250805`](https://github.com/anthropics/claude-code-security-review/blob/beb0d9bf6077d94cf6896c02fb5dbb73f33b4788/claudecode/constants.py#L8) — still unchanged upstream as of 2026-08-08, though that model [retired 2026-08-05](https://platform.claude.com/docs/en/about-claude/model-deprecations), replacement `claude-opus-4-8`.
 - **Maturity:** **Active OSS**, MIT, ~5.6k stars. Warns: not hardened against prompt injection — review trusted PRs only.
 - **Ladder:** **1→2** — self-hosted automated (security) review in your own CI.
 


### PR DESCRIPTION
## Summary

`docs/topics/ai-adoption-ladder/design/RESEARCH-product-surface.md` line 104 recorded the `claude-code-security-review` GitHub Action's `claude-model` input as defaulting to `claude-opus-4-1-20250805`, a model that retired 2026-08-05.

Verified upstream: **the default has not moved.** Two things are true at once, and the record now says both:

- `action.yml`'s `claude-model` input declares `default: ''` — so the old record's literal was structurally wrong, it was quoting the *resolved* default, not the input default.
- The effective default still resolves in `claudecode/constants.py:8` — `DEFAULT_CLAUDE_MODEL = os.environ.get('CLAUDE_MODEL') or 'claude-opus-4-1-20250805'` — last touched in commit `beb0d9b` (2025-08-06). `README.md` line 57 still documents "Defaults to Opus 4.1".

The updated bullet records the input/effective split, keeps the model id, pins the upstream citation to commit SHA `beb0d9bf6077d94cf6896c02fb5dbb73f33b4788` (a `blob/main` link would silently drift and re-create exactly the problem this row exists to fix), states the as-of date, and cites the Anthropic deprecation page for the retirement plus its `claude-opus-4-8` replacement.

Scope was held to row 246. Two adjacent facts observed but deliberately left alone: the same record's `~5.6k stars` on line 105 is now stale (upstream reports 5811), and no other line in this file cites the retired model — grep over `docs/topics/ai-adoption-ladder/` returns only line 104.

## Test plan

- Upstream evidence fetched this run via `gh api` against `anthropics/claude-code-security-review` (default branch `main`, `pushed_at` 2026-02-11): `action.yml` blob `0e10e6a`, `claudecode/constants.py` blob at commit `beb0d9b`, and `README.md` line 57.
- Retirement date verified independently against <https://platform.claude.com/docs/en/about-claude/model-deprecations>: `claude-opus-4-1-20250805`, state Retired, deprecated June 5 2026, retirement date August 5 2026, recommended replacement `claude-opus-4-8`.
- `npx markdownlint-cli2` on the changed file against the repo's `.markdownlint-cli2.jsonc`: 0 errors.
- Docs-only change; no code paths touched.

## Related

No linked issue. Context: issue #1989, row 246 (tracking only).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbtPzLRe1yBavNpsmv5Tum

