### PR TITLE
docs: characterize context-engineering source as vendor-published

### DIFF
--- a/docs/topics/context-engineering-claude-5/design/official-corroboration.md
+++ b/docs/topics/context-engineering-claude-5/design/official-corroboration.md
@@ -1,9 +1,10 @@
 # Official corroboration — each source claim against current documentation
 
-The source is one practitioner's post. Every rule it states is checked here against official
-documentation fetched 2026-07-24. Where a doc confirms the rule, the doc is the authority and the
-post is a restatement. Where no doc confirms it, the rule is `OPINION`-tier under the authority axis
-already defined in `claude-config/skills/audit-instructions/reference/criteria.md`.
+The source is a post on Anthropic's Claude blog — vendor-published, but a blog post rather than
+reference documentation. Every rule it states is checked here against official documentation fetched
+2026-07-24. Where a doc confirms the rule, the doc is the authority and the post is a restatement.
+Where no doc confirms it, the rule is `OPINION`-tier under the authority axis already defined in
+`claude-config/skills/audit-instructions/reference/criteria.md`.
 
 Pages fetched this session:
 


### PR DESCRIPTION
## Summary

`docs/topics/context-engineering-claude-5/design/official-corroboration.md` line 3 opened with "The
source is one practitioner's post." The source — [The new rules of context engineering for Claude 5
generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models)
— is published on Anthropic's own Claude blog, so calling it a practitioner's post understated the
corroboration weight the whole document is weighing.

Byline verified against the live page before editing: the page footer reads *"This article was
written by Thariq Shihipar, member of technical staff, Anthropic."*, published on the Claude blog,
dated July 24, 2026. Vendor-published, authored by Anthropic staff — not an independent practitioner.

The replacement names the publisher and keeps the distinction the rest of the paragraph depends on: a
vendor **blog post** is still not vendor **reference documentation**, which is what justifies the
document treating unconfirmed rules as `OPINION`-tier. Without that clause the swap would leave
Anthropic-published content demoted to `OPINION`-tier with no stated reason.

Scope is line 3 only, per the row. No table verdict, no tier, and no surrounding content changed.

**Same mischaracterization elsewhere, deliberately left alone** — outside row 245's named file and
line, and worth their own row against #1989 rather than a silent fix here:

- `docs/topics/context-engineering-claude-5/PLAN.md:381`
- `docs/topics/context-engineering-claude-5/design/proportionality-gate.md:453` — the severity-ceiling
  rationale ("An unconfirmed practitioner preference cannot raise an `error`") genuinely rests on the
  wrong characterization, so this one carries real weight
- `docs/topics/context-engineering-claude-5/design/proportionality-gate.md:458`
- `docs/topics/context-engineering-claude-5/design/proportionality-gate.md:474`

No plugin version bump — this is a repo docs file, not a plugin surface.

## Test plan

Gates run against the changed file, all clean:

- `markdownlint-cli2` v0.23.2 (the version this repo's `.markdownlint-cli2.jsonc` `$schema` pins) with
  the repo config — 0 issues. Note the repo has no local `markdownlint-cli2` devDependency, so this
  was run via `npx --yes markdownlint-cli2@0.23.2`; CI runs it through the
  `melodic-software/ci-workflows` markdown action.
- `typos` with `_typos.toml` — clean.
- `editorconfig-checker` — clean.

Nothing executable changed, so there is no build or test surface to exercise.

## Related

No linked issue. Context: issue #1989, row 245 (tracking only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbtPzLRe1yBavNpsmv5Tum

