### PR TITLE
refactor(markdown-format,typos-format): trim model-coaching prose from injected hook reports

### DIFF
--- a/plugins/markdown-format/.claude-plugin/plugin.json
+++ b/plugins/markdown-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "markdown-format",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Auto-format and lint Markdown on edit via markdownlint-cli2 — only in repos that carry their own markdownlint config.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/markdown-format/CHANGELOG.md
+++ b/plugins/markdown-format/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the `markdown-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.1]
+
+### Changed
+
+- **Conduct-coaching prose trimmed from the hook's injected reports (#2021, remediation line 3).**
+  The hook-surface classification pass marked markdown-format a hybrid whose only ablatable surface
+  is the behavioral coaching text riding on its reports. Two strings are trimmed: the delta-gate
+  repeat line drops its "a rule firing in bulk is configured away once in this repository's
+  markdownlint config" lecture (now just the fact — unchanged from the previous run, detail
+  omitted), and the truncation hint shrinks to a terse `(cap: markdown_format_max_findings)`
+  pointer instead of instructing what to raise or configure. Everything policy-class is untouched:
+  the deterministic `--fix` transform, the markdownlint finding relay (counts, rule histogram,
+  per-finding lines), the rewrite disclosure on both channels, and the fail-closed code-execution
+  trust gate on `.cjs`/`.mjs` configuration.
+
 ## [0.10.0]
 
 ### Added

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -951,7 +951,7 @@ if ((FINDING_COUNT > 0)); then
 
   CTX+="markdown-format: $BASE has $FINDING_COUNT markdownlint finding(s)${RULE_SUMMARY:+ — $RULE_SUMMARY}."$'\n'
   if ((SAME_AS_LAST == 1)); then
-    CTX+="  Unchanged from the previous run on this file; per-finding detail omitted. A rule firing in bulk here (a house style markdownlint does not know about) is configured away once in this repository's markdownlint config, not re-read every edit."$'\n'
+    CTX+="  Unchanged from the previous run on this file; per-finding detail omitted."$'\n'
   else
     shown=0
     while IFS= read -r line; do
@@ -961,7 +961,7 @@ if ((FINDING_COUNT > 0)); then
       shown=$((shown + 1))
     done <<<"$findings_raw"
     if ((FINDING_COUNT > shown)); then
-      CTX+="  ... and $((FINDING_COUNT - shown)) more finding(s), omitted to bound context. Raise markdown_format_max_findings to see them, or configure the dominant rule in this repository's markdownlint config."$'\n'
+      CTX+="  ... and $((FINDING_COUNT - shown)) more finding(s) (cap: markdown_format_max_findings)."$'\n'
     fi
   fi
 elif ((LINT_RC != 0)) && [[ -n "$FIX_OUTPUT" ]]; then

--- a/plugins/typos-format/.claude-plugin/plugin.json
+++ b/plugins/typos-format/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "typos-format",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Spell-check on edit via typos-cli, unconditionally — report-only by default, honoring the consuming repo's own typos configuration when one is present.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/typos-format/CHANGELOG.md
+++ b/plugins/typos-format/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `typos-format` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.5.2]
+
+### Changed
+
+- **Wrapper coaching prose trimmed from the hook's injected reports (#2021, remediation line 3).**
+  The hook-surface classification pass marked typos-format a hybrid whose wired surface is mostly
+  injected wrapper prose around the report-only findings. The per-finding remediation tail ("if
+  intentional, add it to extend-words…"), formerly repeated on every residual line, is replaced by
+  one trailing pointer for the whole list; the applied-path disclosure keeps its facts (dictionary
+  source, no-memory re-correction, allow-list route) at less than half the length; and the
+  report-only header drops its option-explainer parenthetical. The finding lists themselves —
+  residual findings with the tool's suggested corrections, and applied rewrites disclosed on both
+  channels — are policy-class ground truth and are unchanged.
+
 ## [0.5.1]
 
 ### Changed

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -344,7 +344,7 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
         appliedInline: ([limit($max; $a[])] | map("\"\(tok)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("; ")),
         residualText: ([limit($max; $r[])] | map(
             if .corrections == null then
-              "  \"\(tok)\" (line \(.line_num // 0)): disallowed, no known correction."
+              "  \"\(tok)\" (line \(.line_num // 0)) is disallowed, no known correction."
             else
               "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corr1)\"."
             end) | join("\n"))
@@ -406,7 +406,7 @@ if ((APPLIED_COUNT > 0)); then
   if ((APPLIED_COUNT > MAX_REPORT)); then
     SYSMSG+="; ... and $((APPLIED_COUNT - MAX_REPORT)) more"
   fi
-  SYSMSG+=". Add any wrong rewrite to extend-words / extend-identifiers in your typos config, or set the typos_format_write_changes option back to false (the default) for report-only mode."
+  SYSMSG+=". Add any wrong rewrite to extend-words / extend-identifiers in the repo's typos config, or set the typos_format_write_changes option back to false (the default) for report-only mode."
 elif [[ "$WRITE_CHANGES" != "true" ]]; then
   CTX+="typos-format is report-only — $BASE was NOT modified. Findings:"$'\n'
 fi

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -344,9 +344,9 @@ CLASSIFIED=$(printf '%s\n@@typos-format-split@@\n%s\n' "$SCAN_OUTPUT" "$RESIDUAL
         appliedInline: ([limit($max; $a[])] | map("\"\(tok)\" -> \"\(corr1)\" (line \(.line_num // 0))") | join("; ")),
         residualText: ([limit($max; $r[])] | map(
             if .corrections == null then
-              "  \"\(tok)\" (line \(.line_num // 0)) is disallowed with no known correction — if intentional, add it to extend-words / extend-identifiers (or an extend-ignore-re pattern) in your typos config."
+              "  \"\(tok)\" (line \(.line_num // 0)): disallowed, no known correction."
             else
-              "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corr1)\" — if intentional, add it to extend-words / extend-identifiers in your typos config."
+              "  \"\(tok)\" (line \(.line_num // 0)) should be \"\(corr1)\"."
             end) | join("\n"))
       }' 2>/dev/null) || CLASSIFIED=""
 
@@ -398,7 +398,7 @@ if ((APPLIED_COUNT > 0)); then
   if ((APPLIED_COUNT > MAX_REPORT)); then
     CTX+="  ... and $((APPLIED_COUNT - MAX_REPORT)) more."$'\n'
   fi
-  CTX+="  These come from typos' built-in dictionary, not from this repository. If any is wrong here (an acronym, an identifier, a proper noun), add it to extend-words / extend-identifiers in your typos config; for a region quoted verbatim — a Markdown code fence, a transcript, a signature block — use an extend-ignore-re pattern instead, which typos documents for exactly that case. The autocorrect has no memory, so repairing the word by hand alone gets it rewritten again on the next edit."$'\n'
+  CTX+="  Corrections come from typos' built-in dictionary; the autocorrect has no memory, so a hand repair alone is re-corrected on the next edit. A wrong rewrite is allow-listed via extend-words / extend-identifiers (or an extend-ignore-re pattern) in the repo's typos config."$'\n'
   # The person whose file was just changed is the one who has to judge whether
   # the change was correct, and they never asked for it. This is a content
   # mutation, not a lint finding, so it goes to the user channel too.
@@ -408,7 +408,7 @@ if ((APPLIED_COUNT > 0)); then
   fi
   SYSMSG+=". Add any wrong rewrite to extend-words / extend-identifiers in your typos config, or set the typos_format_write_changes option back to false (the default) for report-only mode."
 elif [[ "$WRITE_CHANGES" != "true" ]]; then
-  CTX+="typos-format is report-only (typos_format_write_changes is off — the shipped default) — $BASE was NOT modified. Findings:"$'\n'
+  CTX+="typos-format is report-only — $BASE was NOT modified. Findings:"$'\n'
 fi
 
 if ((RESIDUAL_COUNT > 0)); then
@@ -421,6 +421,8 @@ if ((RESIDUAL_COUNT > 0)); then
   if ((RESIDUAL_COUNT > MAX_REPORT)); then
     CTX+="  ... and $((RESIDUAL_COUNT - MAX_REPORT)) more."$'\n'
   fi
+  # One remediation pointer for the whole list (it used to ride on every line).
+  CTX+="  Intentional terms are allow-listed via extend-words / extend-identifiers (or an extend-ignore-re pattern) in the repo's typos config."$'\n'
 fi
 
 # Trim the trailing newline the same way hook::ctx_flush does.


### PR DESCRIPTION
No linked issue

## Summary

Executes issue #2021's remediation line (3): trims the model-conduct coaching prose from the two formatter plugins that classification pass marked as hybrids — markdown-format and typos-format. Facts the tools measured (findings, counts, applied rewrites, file names) stay; sentences that instruct the model how to behave are removed or shortened. The classification's keep-list is untouched: the deterministic transforms, the lint/typo finding relays, both-channel mutation disclosure, and markdown-format's fail-closed code-execution trust gate on `.cjs`/`.mjs` configs.

## Fix

**markdown-format 0.10.0 → 0.10.1** (`hooks/markdown-format.sh`):

- Delta-gate repeat line drops the "a rule firing in bulk here (a house style markdownlint does not know about) is configured away once in this repository's markdownlint config, not re-read every edit" lecture; the fact stays ("Unchanged from the previous run on this file; per-finding detail omitted.").
- Truncation hint "… more finding(s), omitted to bound context. Raise markdown_format_max_findings to see them, or configure the dominant rule in this repository's markdownlint config." shrinks to "… more finding(s) (cap: markdown_format_max_findings)." — the count and a terse config pointer, no instruction.

**typos-format 0.5.1 → 0.5.2** (`hooks/typos-format.sh`):

- The per-finding remediation tail ("— if intentional, add it to extend-words / extend-identifiers … in your typos config"), formerly repeated on every residual finding line (up to 10× per report), is replaced by finding facts only plus ONE trailing pointer line for the whole list.
- The applied-path (write-mode) disclosure paragraph is cut roughly in half: keeps the facts (built-in dictionary source, no-memory re-correction, allow-list route — the test-pinned disclosure deliverable), drops the exemplifying lecture.
- The report-only header drops its option-explainer parenthetical ("(typos_format_write_changes is off — the shipped default)"); the report-only statement and "NOT modified" fact stay.

Both `plugin.json` versions bumped patch with matching CHANGELOG entries. Patch is correct per the current official manifest reference: `version` is "Optional. Semantic version. Setting this pins the plugin to that version string, so users only receive updates when you bump it", and "If you use explicit versions, follow semantic versioning (MAJOR.MINOR.PATCH) … Document changes in a CHANGELOG.md" (<https://code.claude.com/docs/en/plugins-reference>, fetched 2026-08-08).

## Verification

- `bash plugins/typos-format/hooks/typos-format.test.sh` — PASS=79 FAIL=2; the two failures are wall-clock performance assertions (`stub/scale` / `stub/scale-residual`, 15s handler-budget checks) that fail identically on an unmodified checkout of main on the same machine (65s/60s baseline vs 59s/75s here) — pre-existing environment-speed failures, not introduced by this change. Every content assertion passes, including the ones pinning kept strings: extend-words remediation present on both the applied and residual paths, `report-only` + `NOT modified` mode statement, applied-rewrite disclosure on both channels.
- `bash plugins/markdown-format/hooks/markdown-format.test.sh` — locally PASS=129 FAIL=1; the single failure is `telemetry/slow-sink`, a wall-clock fd1-leak detector whose measured delta varied 5269ms → 12118ms across two local runs (threshold-based timing assertion). The measured path is byte-identical to main — `hooks/hook-utils.sh` and the test file are unchanged, and the diff touches only two CTX string literals in the report composer. All string-pinning assertions pass, including `Unchanged from the previous run` and the `and N more finding` remainder count the trimmed strings still carry.
- **CI is the authoritative run**: the `plugin-gate` lane executes every `plugins/**/*.test.sh` (both suites, timing assertions included) on ubuntu-24.04 and passes on this PR — the local failures above are Windows machine-speed artifacts.
- `shellcheck -x` and `shfmt -d` clean on both edited hooks.
- `node scripts/generate-catalog.mjs` / `node scripts/generate-cheatsheet.mjs`: both already in sync, no diff, nothing to commit.

## Related

- Refs #2021 — hook-surface classification (formatter-family section; remediation line 3: "trim coaching strings in markdown-format/typos-format")
- docs/PLUGIN-PHILOSOPHY.md "Instruction economy" — generation-triggered ablation of behavior-coaching prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)
