### PR TITLE
docs: align row-245 sibling characterizations with vendor-published status

### DIFF
--- a/docs/topics/context-engineering-claude-5/PLAN.md
+++ b/docs/topics/context-engineering-claude-5/PLAN.md
@@ -378,8 +378,9 @@ dispositions accordingly:
   `OPINION` authority value but has never used it — all eleven seeds are `ANTHROPIC-DOCS` — so no
   consumer has ever had to decide what an `OPINION` finding means. This work is the first to populate
   the tier, and therefore owns defining its default enablement, its severity ceiling, and how a
-  consumer turns it on. Shipping `OPINION` rules enabled would let one practitioner's unconfirmed
-  preference mutate a consumer's instruction corpus under the same banner as documented doctrine.
+  consumer turns it on. Shipping `OPINION` rules enabled would let vendor blog advice that no
+  documentation confirms mutate a consumer's instruction corpus under the same banner as documented
+  doctrine.
 
 **If only D1 survives as a detector, stop and re-derive the deliverable's shape** before Phase 3
 builds a catalog. A versioned cross-plugin catalog, its convention-registry owner doc, a re-run

--- a/docs/topics/context-engineering-claude-5/design/proportionality-gate.md
+++ b/docs/topics/context-engineering-claude-5/design/proportionality-gate.md
@@ -450,13 +450,16 @@ placement rule, the S10 artifacts claim.
 - **Default enablement: off.** An emitting `OPINION` rule produces no finding on bare invocation.
 - **Opt-in is explicit** — a named argument or configuration key, never a side effect of another
   setting.
-- **Severity ceiling: `info`.** An unconfirmed practitioner preference cannot raise an `error` or a
-  `warning` against a consumer's instruction corpus.
+- **Severity ceiling: `info`.** The source is a post on Anthropic's Claude blog — vendor-published,
+  but a blog post rather than reference documentation — and a rule sits in this tier precisely
+  because the corroboration pass found no official doc that confirms it. `error` and `warning`
+  assert a breach of documented doctrine, a force vendor blog advice that documentation does not
+  corroborate cannot carry against a consumer's instruction corpus.
 - **Never fix-applied.** `OPINION` findings are reported, never mutated automatically, regardless of
   the sweep's apply posture.
 
-Rationale: shipping them enabled would let one practitioner's unconfirmed preference mutate a
-consumer's instruction corpus under the same banner as documented doctrine. Dropping them instead
+Rationale: shipping them enabled would let vendor blog advice that no documentation confirms mutate
+a consumer's instruction corpus under the same banner as documented doctrine. Dropping them instead
 would violate the Brief's settled scope, which keeps every rule and marks the unbacked ones.
 
 **Advice attached to a backed finding — the case the two-way split missed.** D2 is `OPINION`-tier
@@ -471,7 +474,7 @@ is told to do about a finding that was going to be reported anyway. So:
 - **The finding's enablement and severity follow the host check**, because the detection is the
   host's and is backed.
 - **The `OPINION`-derived remediation is labelled inline as such**, so an operator can see which part
-  of the advice rests on a practitioner's preference rather than on documentation.
+  of the advice rests on uncorroborated vendor blog guidance rather than on documentation.
 - **It is never fix-applied**, which is the one clause of the emitting-rule policy that does carry
   over, and the one that actually protects the consumer's corpus.
 

--- a/docs/topics/context-engineering-claude-5/design/proportionality-gate.md
+++ b/docs/topics/context-engineering-claude-5/design/proportionality-gate.md
@@ -453,8 +453,8 @@ placement rule, the S10 artifacts claim.
 - **Severity ceiling: `info`.** The source is a post on Anthropic's Claude blog — vendor-published,
   but a blog post rather than reference documentation — and a rule sits in this tier precisely
   because the corroboration pass found no official doc that confirms it. `error` and `warning`
-  assert a breach of documented doctrine, a force vendor blog advice that documentation does not
-  corroborate cannot carry against a consumer's instruction corpus.
+  assert a breach of documented doctrine — a force that vendor blog advice, uncorroborated by
+  documentation, cannot carry against a consumer's instruction corpus.
 - **Never fix-applied.** `OPINION` findings are reported, never mutated automatically, regardless of
   the sweep's apply posture.
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2036, which corrected the primary characterization of the context-engineering source (a post on Anthropic's Claude blog — vendor-published, but a blog post rather than reference documentation — not "one practitioner's post"). Four sibling instances still carried the old characterization:

- `docs/topics/context-engineering-claude-5/design/proportionality-gate.md` severity-ceiling bullet (load-bearing): the `info` ceiling's rationale rested on "an unconfirmed practitioner preference". Re-derived honestly against the vendor-published status: the ceiling holds because an emitting rule sits in the `OPINION` tier precisely when the corroboration pass found no official doc confirming it, and `error`/`warning` assert a breach of documented doctrine — a force vendor blog advice without documentation behind it cannot carry. No verdict changes (ceiling stays `info`; default-off, explicit opt-in, never fix-applied all stand).
- `proportionality-gate.md` emitting-rule rationale ("one practitioner's unconfirmed preference" → "vendor blog advice that no documentation confirms").
- `proportionality-gate.md` D2 remediation-labelling bullet ("a practitioner's preference" → "uncorroborated vendor blog guidance").
- `PLAN.md` Phase 2.5 `OPINION` clause (same rationale sentence, wording aligned).

A sweep of `docs/topics/context-engineering-claude-5/` for "practitioner", "unconfirmed preference", and similar found no further instances; the primary in `design/official-corroboration.md` line 3 is owned by open PR #2036 and deliberately untouched here. No version bump — repo docs, not a plugin.

## Test plan

- `npx markdownlint-cli2` on both changed files: 0 errors.
- Grep sweep of the topic tree confirms no remaining old-characterization wording outside #2036's file.

## Related

No linked issue — docs follow-up to PR #2036 row-245 fix, umbrella tracking only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbtPzLRe1yBavNpsmv5Tum
