### PR TITLE
docs(conventions): align permission-rule-hygiene quotes with current skills page (row 156 dependency pass)

### DIFF
--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -97,7 +97,7 @@ Three official constraints mean the operative allow-rule cannot be shipped by th
 
 - **Skill `allowed-tools` is turn-scoped and (per anti-pattern 1) ineffective for auto-mode-gated
   action classes.** It "grants permission for the listed tools during the turn that invokes the
-  skill." "The grant clears when you send your next message." It "does not restrict which tools
+  skill"; "The grant clears when you send your next message." It "does not restrict which tools
   are available" —
   [skills](https://code.claude.com/docs/en/skills) — but auto mode still drops the broad/interpreter
   shapes.

--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -79,9 +79,9 @@ anchors for the file tools, not shell-command expansion). A rule like
 Two substitutions *are* expanded in `allowed-tools`: per
 [skills](https://code.claude.com/docs/en/skills#available-string-substitutions), Claude Code
 substitutes `${CLAUDE_SKILL_DIR}` and `${CLAUDE_PROJECT_DIR}` in the skill's markdown content and in
-Bash rules in `allowed-tools` (version floors: `${CLAUDE_SKILL_DIR}` v2.1.129+,
-`${CLAUDE_PROJECT_DIR}` v2.1.196+; below the floor the rule stays a literal string and never
-matches). `${CLAUDE_PLUGIN_ROOT}` is **not** among them — it does not appear anywhere on that page —
+Bash rules in `allowed-tools` (the `${CLAUDE_PROJECT_DIR}` substitution requires Claude Code
+v2.1.196 or later; below that floor the rule stays a literal string and never matches).
+`${CLAUDE_PLUGIN_ROOT}` is **not** among them — it does not appear anywhere on that page —
 so a rule written with it stays a literal string, never matches, and the grant is inert.
 
 `${CLAUDE_SKILL_DIR}` is therefore the correct token for a rule that must match a skill's own bundled
@@ -95,9 +95,10 @@ written.
 
 Three official constraints mean the operative allow-rule cannot be shipped by the skill or plugin:
 
-- **Skill `allowed-tools` is skill-scoped and (per anti-pattern 1) ineffective for auto-mode-gated
-  action classes.** It "grants permission for the listed tools while the skill is active … It does not
-  restrict which tools are available" —
+- **Skill `allowed-tools` is turn-scoped and (per anti-pattern 1) ineffective for auto-mode-gated
+  action classes.** It "grants permission for the listed tools during the turn that invokes the
+  skill", "The grant clears when you send your next message", and "It does not restrict which tools
+  are available" —
   [skills](https://code.claude.com/docs/en/skills) — but auto mode still drops the broad/interpreter
   shapes.
 - **A plugin cannot ship permission rules.** A plugin's `settings.json` supports "Only the `agent` and

--- a/docs/conventions/permission-rule-hygiene/README.md
+++ b/docs/conventions/permission-rule-hygiene/README.md
@@ -97,7 +97,7 @@ Three official constraints mean the operative allow-rule cannot be shipped by th
 
 - **Skill `allowed-tools` is turn-scoped and (per anti-pattern 1) ineffective for auto-mode-gated
   action classes.** It "grants permission for the listed tools during the turn that invokes the
-  skill", "The grant clears when you send your next message", and "It does not restrict which tools
+  skill." "The grant clears when you send your next message." It "does not restrict which tools
   are available" —
   [skills](https://code.claude.com/docs/en/skills) — but auto mode still drops the broad/interpreter
   shapes.


### PR DESCRIPTION
## Summary

Executes row 156's owed dependency pass (the optional follow-up on #1989): the page-level DONE close of the [Extend Claude with skills](https://code.claude.com/docs/en/skills) roster row had checked only `plugins/playbooks/skills/fable-5/context/verification.md`, owing a pass over the other citing files.

**Enumeration:** re-derived by `git grep -E 'code\.claude\.com/docs/en/skills([^a-z-]|$)'` at origin/main `958f9579` — 36 files / 59 citing lines (the row's count of 34 was taken at `81c0297d87`; main has moved). The live page was re-fetched raw (HTTP 200, 82,668 B) and **has changed since the row's 2026-08-06 baseline** (78,513 B, MD5 differs), so every citation was checked against the current page.

**Result: 35 of 36 files conformant; 2 stale claims, both in `docs/conventions/permission-rule-hygiene/README.md`, fixed here:**

- **`${CLAUDE_SKILL_DIR}` v2.1.129 floor dropped** — the sentence attributed both substitution version floors to the skills page; the live page now documents only the `${CLAUDE_PROJECT_DIR}` floor ("The `${CLAUDE_PROJECT_DIR}` substitution requires Claude Code v2.1.196 or later"). The 2.1.129 claim is no longer supported by its cited source.
- **`allowed-tools` grant quote re-quoted** — the page no longer says the grant holds "while the skill is active"; it now reads "grants permission for the listed tools during the turn that invokes the skill" and "The grant clears when you send your next message". Semantic upstream change (turn-scoped, not skill-active-scoped); the anti-pattern-3 argument survives strengthened. Bullet lead re-worded "skill-scoped" → "turn-scoped" to match.

Notable conformant checks (representative): namespace claim verbatim at live page (3 citing files); invocation-control table "Description not in context" (skill-quality scripts/tests/CHANGELOG, discipline, claude-config criteria); 1,536-char truncation verbatim; `context: fork` / `agent` / lifecycle / 5,000-token compaction quotes verbatim; `${CLAUDE_PLUGIN_ROOT}` still absent from the page (the convention's negative claim holds); v2.1.145 / v2.1.215 / v2.1.216 bundled-skill claims verbatim (testing, verification, review, playbooks). The spec-validation absence claim in `verification.md` still holds: the commands page now has 14 `[Skill]` rows and one `[Workflow]` row (`/deep-research`); none is spec-validation, so the row's recheck trigger has not fired. A repo-wide sweep for the two stale phrases found no other live occurrence (remaining hits are `disallowed-tools` prose matching the live page, historical CHANGELOG entries, and one unrelated `docs/PLUGIN-PHILOSOPHY.md` sentence that is the repo's own prose, not a docs quote).

No plugin versioned surface is touched — repo docs only, no version bump.

## Test plan

- [x] Live page re-fetched raw and each of the 59 citing lines checked against it (quotes grepped verbatim; anchors resolved against the live heading list)
- [x] Repo-wide `git grep` sweep for `2\.1\.129` and `while the skill is active` — no other live occurrence
- [x] `markdownlint-cli2` on the changed file — 0 errors
- [x] Both retained quotes verified verbatim substrings of the live page

## Related

No linked issue — this is the optional row-156 dependency pass tracked under umbrella #1989 (kept open deliberately; no closing keyword).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbtPzLRe1yBavNpsmv5Tum
