### PR TITLE
docs(ci): say why the skip-actors line must survive a re-pin

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -41,6 +41,23 @@ jobs:
       # rewrites the exception whenever ci-workflows changes it — which is how
       # `claude[bot]` and `melodic-ai[bot]` entered it (#1766 dropped this line
       # while re-pinning to a version whose default had widened).
+      #
+      # DO NOT delete this line at a re-pin, and do not "simplify" it away.
+      # Deleting it is not a no-op even when the value matches the upstream
+      # default of the moment: the four actors here are ADR 0002's 2026-08-04
+      # ratified baseline, and inheriting instead re-delegates that decision to
+      # whatever ci-workflows ships next. Every actor in an inherited default
+      # satisfies this repo's REQUIRED `security-review / security-review`
+      # check with no review run, on security-sensitive paths.
+      #
+      # The failure directions are asymmetric, which is why explicit wins here
+      # and not everywhere: a stale explicit list fails CLOSED (an actor gets a
+      # review it may not have needed — visible, cheap), while a stale
+      # inherited default fails OPEN (an actor this repo never deliberated
+      # skips review silently — exactly what #1766 did). runner-policy rejects
+      # inputs outside the reviewed contract but cannot REQUIRE one, so
+      # dropping this line re-widens the exception with CI green and nothing
+      # said. That residual gap is standards#308.
       skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
     # One named secret (least privilege), never `secrets: inherit`.
     secrets:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -51,13 +51,19 @@ jobs:
       # check with no review run, on security-sensitive paths.
       #
       # The failure directions are asymmetric, which is why explicit wins here
-      # and not everywhere: a stale explicit list fails CLOSED (an actor gets a
-      # review it may not have needed — visible, cheap), while a stale
-      # inherited default fails OPEN (an actor this repo never deliberated
-      # skips review silently — exactly what #1766 did). runner-policy rejects
-      # inputs outside the reviewed contract but cannot REQUIRE one, so
-      # dropping this line re-widens the exception with CI green and nothing
-      # said. That residual gap is standards#308.
+      # and not everywhere. A stale explicit list fails CLOSED and LOUD: for an
+      # actor the reusable's `allowed_bots` does not permit, the action throws
+      # and this lane's fail-closed mapping turns that into a RED required
+      # check no push can fix — a merge block, not an extra review (ADR 0002,
+      # "skip-actors and the action's allowed_bots are different levers").
+      # Un-skipping such an actor for real means widening `allowed_bots`
+      # upstream, which is why removing a name here is never a one-line change.
+      # A stale inherited default fails OPEN and SILENT: an actor this repo
+      # never deliberated skips review with CI green — exactly what #1766 did.
+      # Loud-and-blocking is the direction to fail in; silent-and-permissive is
+      # not. runner-policy rejects inputs outside the reviewed contract but
+      # cannot REQUIRE one, so dropping this line re-widens the exception with
+      # nothing said. That residual gap is standards#308.
       skip-actors: dependabot[bot],claude[bot],melodic-ai[bot],melodic-standards-sync[bot]
     # One named secret (least privilege), never `secrets: inherit`.
     secrets:


### PR DESCRIPTION
No linked issue — this closes nothing. #1767 stays open deliberately: its residual gap is
structural (`runner-policy` cannot *require* an input), and a comment guards against a careful
reviewer, not an inattentive one. Closing it on a documentation change would record the gap as
fixed when it is not.

## What

Seventeen lines of comment above `skip-actors` in
`.github/workflows/claude-security-review.yml`. No value changes; the actor list stays at the
ratified four.

## Why

The existing comment says the list is stated explicitly rather than inherited, and records how
#1766 widened it. It does not say why deleting the line is unsafe **when its value matches the
upstream default of the moment** — which is the only state in which a reviewer is tempted to delete
it, and precisely the state #1766 was in.

Two things the re-pin reviewer needs and the comment did not carry:

- **Deleting is not a no-op at parity.** The four actors are ADR 0002's 2026-08-04 ratified
  baseline. Inheriting re-delegates that ratification to whatever `ci-workflows` ships next, and
  every actor in an inherited default satisfies this repo's REQUIRED
  `security-review / security-review` check with no review run, on security-sensitive paths.

- **The failure directions are asymmetric**, which is what makes explicit correct here without
  contradicting the fleet's inheritance-over-explicit-list default elsewhere. A stale explicit list
  fails CLOSED and LOUD — for an actor the reusable's `allowed_bots` does not permit, the action
  throws and the fail-closed mapping turns that into a red required check no push can fix. A stale
  inherited default fails OPEN and SILENT — an actor this repo never deliberated skips review with
  CI green. Loud-and-blocking is the direction to fail in; silent-and-permissive is not.

  The first draft of this comment described the closed direction as "an actor gets a review it may
  not have needed — visible, cheap." That was wrong, and review caught it: ADR 0002's
  `skip-actors`-vs-`allowed_bots` section records that removing an actor from `skip-actors` alone
  does not restore review of its PRs — it blocks the merge. Corrected in the second commit, which
  also notes that un-skipping an actor for real requires widening `allowed_bots` upstream, so
  removing a name here is never a one-line change.

The comment also names standards#308 at the point of use: `runner-policy` rejects inputs outside the
reviewed contract but cannot *require* one, so dropping this line re-widens the exception with CI
green and nothing said.

## Provenance

Salvaged from PR #1845, which I closed as superseded. That branch re-narrowed the exception to two
actors on 2026-07-31; the 2026-08-04 addendum records an explicit operator decision ratifying four
and names four as the baseline future additions are measured against, having weighed the two-actor
case on its merits. The narrowing is therefore correctly dead — but the branch's comment block was
the better explanation of an invariant that survives the ruling either way, so it is ported here
with the actor list left alone.

## Verification

- `actionlint` clean on the changed file.
- The `skip-actors` value is byte-identical before and after — confirmed by reading the parsed line
  back, not by eye.
- Comment-only diff: 17 insertions, 0 deletions.

## Related

- #1767 — the re-deliberation issue this comment serves; left open, since the residual
  `requiredInputs` gap is not closed by a comment.
- #1845 — the superseded branch this is salvaged from.
- #1766 — the re-pin that dropped the line and silently widened the exception.
- `docs/adr/0002-default-on-ai-review-advisory-with-earned-promotion.md` — the 2026-08-04 addendum
  that ratified four actors.
- melodic-software/standards#308 — the `requiredInputs`-style contract field that would make this
  structurally enforced rather than comment-enforced.
