### PR TITLE
feat(scripts): select and run only the test suites a change affects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,17 @@ jobs:
       - name: Run cheat-sheet generator tests
         if: steps.scope.outputs.docs_only != 'true'
         run: bash scripts/generate-cheatsheet.test.sh
+      # Same reason as the step above — run-plugin-tests.sh never reaches
+      # scripts/. This suite is wired into CI rather than left to local runs
+      # because its load-bearing cases assert against the LIVE repository: that
+      # the shared-lib copy set affected-tests.sh derives still equals what each
+      # scripts/sync-*.sh manifest declares today. That equality is what stops
+      # the selector silently under-selecting after a manifest changes shape or
+      # a new carrying plugin appears, and a check that only ever runs when
+      # someone remembers to run it is exactly the rot it guards against.
+      - name: Run affected-suite selector tests
+        if: steps.scope.outputs.docs_only != 'true'
+        run: bash scripts/affected-tests.test.sh
       - name: Validate plugin and catalog manifests
         if: steps.scope.outputs.docs_only != 'true'
         run: scripts/validate-plugins.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,15 @@ to such a file is silently lost. When one of them is wrong, fix the cause
 upstream in `melodic-software/standards` and let the sync carry the correction
 back — never patch the materialized copy here.
 
+## Run the affected suites, not all of them
+
+Running every `**/*.test.sh` is an hours-long wall on a Windows box, so it does
+not happen and regressions reach CI instead. `scripts/affected-tests.sh` prints
+(or `--run`s) the suites covering your diff; see the README's "Validate a
+change" section for the mapping rules and the flags. It exits non-zero when a
+changed file maps to no suite — that is the tool working, not a bug to route
+around, because an empty selection would otherwise read as "nothing to run".
+
 ## Stage explicit paths
 
 Stage the specific files a change touches. Never `git add -A` or `git add .`:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,39 @@ user opts in with `/plugin enable`; an existing install is never flipped by cata
 - `docs/OFFICIAL-DOCS.md` — canonical index of the official Claude Code doc pages the mandate
   sends you to.
 
+## Validate a change
+
+The shell suites here are spawn-bound, and Git Bash on Windows pays roughly
+140 ms per process spawn against roughly 3 ms on Linux — so running every
+`**/*.test.sh` locally is an hours-long wall on a Windows box and nobody does
+it. Run the suites that actually cover your change instead:
+
+```shell
+scripts/affected-tests.sh                 # list the suites covering your diff vs origin/main
+scripts/affected-tests.sh --run           # ... and run them, sequentially
+scripts/affected-tests.sh --explain       # ... and say why each one was selected
+scripts/affected-tests.sh path/to/file.sh # explicit paths instead of a diff
+```
+
+It maps a changed file to its co-located `*.test.sh`, to any suite that names
+it, and to its dependents transitively — and it fans a shared-lib change out to
+every carrying plugin by reading the `copies=(...)` array out of that lib's
+`scripts/sync-*.sh` manifest, the same manifest CI's `*-sync` lanes enforce. The
+fan-out is derived on every run, never transcribed, so a new carrying plugin is
+covered the moment it exists.
+
+A changed file that maps to nothing is an **error**, not an empty selection —
+"zero suites" must never be read as "nothing to run". Path classes that
+genuinely carry no shell suite are recorded, with the CI lane that does cover
+them, in [`scripts/affected-tests-no-suite.txt`](scripts/affected-tests-no-suite.txt);
+`--allow-unmapped` is the escape hatch for everything else.
+
+The runner is deliberately sequential: parallelising it measured sublinear
+(the suites are spawn-bound), and several guardrails suites assert wall-clock
+ceilings that fail spuriously under concurrency. Selection is the lever.
+
+CI is unaffected — it still runs everything.
+
 ## Official documentation
 
 This repo tracks policy and wiring only; authoritative behavior lives in the official docs, which must

--- a/scripts/affected-tests-no-suite.txt
+++ b/scripts/affected-tests-no-suite.txt
@@ -1,0 +1,60 @@
+# Path classes that carry NO shell test suite (**/*.test.sh), each paired with
+# the CI lane that DOES cover it. Read by scripts/affected-tests.sh, which
+# treats a changed file matching one of these as "covered, but not by a shell
+# suite" instead of the loud "I do not know what covers this" error.
+#
+# Consulted LAST — only after every selection rule has come up empty for the
+# file. A doc or manifest that a suite genuinely names is still selected by the
+# reference rule, so listing a broad pattern here never suppresses a real match.
+#
+# This list is deliberately SEPARATE from scripts/docs-only-paths.txt even
+# though the two overlap. They answer different questions: docs-only asks "can
+# this path affect ANY code lane" (a very narrow yes, because a wrong answer
+# turns CI false-green), while this asks "is there a SHELL SUITE covering this"
+# (a broader yes, because a wrong answer only costs a developer a needless
+# error). Coupling them would drag the narrow gate's answer into the wrong
+# question. Keep both; do not make one read the other.
+#
+# Format: one bash glob pattern per line, matched against the repo-relative
+# path. `*` crosses `/`. Blank lines and `#` comments are ignored. Adding an
+# entry is a claim that a named non-shell lane covers the class — write the
+# lane in the comment above it, the way every other data file in scripts/ does.
+#
+# ADDING A NEW CODE FILE? Do not reach for this list. A new .sh/.py/.mjs with
+# no coverage should FAIL here; that failure is the tool working.
+
+# Markdown prose — skills, references, conventions, design records, changelogs.
+# Covered by the hygiene lane (markdownlint-cli2, typos, comment-hygiene,
+# machine-specific-paths, lychee) and, for skill bodies, by skill-quality-gate
+# (check-skill.sh, check-listing-budget.sh). None of those is a *.test.sh.
+*.md
+
+# JSON — plugin/marketplace manifests, JSON Schemas, eval graders, registries,
+# lockfiles. Covered by the hygiene lane's four check-jsonschema steps,
+# scripts/check-manifest-duplicate-keys.py, scripts/validate-plugins.sh,
+# scripts/validate-plugin-contracts.mjs and the skill-quality-gate evals
+# validation. A JSON fixture a suite actually names is selected by the
+# reference rule before this line is ever consulted.
+*.json
+
+# Workflows and repository configuration. Covered by actionlint, zizmor, the
+# workflow check-jsonschema step, and the runner-policy lane.
+.github/*
+.gitattributes
+.gitignore
+.editorconfig
+.shellcheckrc
+.node-version
+*.yml
+*.yaml
+*.toml
+
+# Session-local working docs and this checkout's own Claude Code configuration
+# prose. Ships to no one; the hooks under .claude/hooks/ are NOT covered by
+# this line — they carry their own *.test.sh and are selected normally.
+.work/*
+docs/topics/*
+
+# Repository top-level prose and licensing, already covered by *.md above; the
+# bare LICENSE file has no extension, so it needs its own line.
+LICENSE

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -1,0 +1,524 @@
+#!/usr/bin/env bash
+# Select the shell test suites (**/*.test.sh) that cover a set of changed files,
+# so a developer can run what their change actually affects instead of the whole
+# corpus. The full corpus is tens of minutes of wall clock on a Windows box
+# (Git Bash pays ~140ms per process spawn, and these suites are spawn-bound),
+# which is long enough that nobody runs it locally and regressions reach CI.
+#
+#   scripts/affected-tests.sh                    list the suites covering the diff vs the base ref
+#   scripts/affected-tests.sh --run              ... and run them, sequentially
+#   scripts/affected-tests.sh path/a.sh path/b   ... for explicit paths instead of a diff
+#   scripts/affected-tests.sh --base <ref>       use <ref> as the diff base (default: origin/main)
+#   scripts/affected-tests.sh --explain          report WHY each suite was selected (stderr)
+#   scripts/affected-tests.sh --allow-unmapped   downgrade an unmapped file to a warning
+#   scripts/affected-tests.sh --print-fanout P   print the copy set DERIVED for shared source P
+#
+# Exit: 0 selected (or nothing to do); 1 an unmapped changed file, or a failing
+# suite under --run; 2 usage or a broken derivation.
+#
+# DIRECTION: over-selection is safe, under-selection is not. Every rule below is
+# deliberately generous — a basename match counts even when it lands in a
+# comment — because a suite that runs needlessly costs seconds, while a suite
+# that should have run and did not is the regression this tool exists to stop.
+#
+# FAIL LOUD, NOT OPEN. A changed file that maps to NO suite is an ERROR, not an
+# empty selection: "zero suites" reads as "nothing to run" when it actually
+# means "nothing here knows what covers this". The only exceptions are the path
+# classes recorded in scripts/affected-tests-no-suite.txt, each of which names
+# the non-shell CI lane that does cover it. Anything else fails, and
+# --allow-unmapped is the one-flag escape.
+#
+# SELECTION RULES
+#   R1 self          a changed *.test.sh selects itself.
+#   R2 co-located    <dir>/<stem>.<ext> selects <dir>/<stem>.test.sh when it
+#                    exists — the dominant convention in this repo (foo.sh ->
+#                    foo.test.sh, foo.py -> foo.test.sh, foo.mjs -> foo.test.sh).
+#   R3 referenced    any *.test.sh whose text contains the file's basename is a
+#                    covering suite (it names the file, so it exercises it).
+#   R4 dependents    any other *.sh whose text contains the file's basename is a
+#                    dependent; R2/R3 are then applied to IT, transitively. This
+#                    is what carries a lib change out to the hooks that source it.
+#   R5 shared-lib    a file that is the `src=` of a scripts/sync-*.sh selects
+#                    every path in that script's `copies=(...)` array, and then
+#                    R2/R3/R4 on each copy. The copy set is DERIVED from the sync
+#                    manifest on every run, never hardcoded here: the manifests
+#                    are what CI's *-sync lanes enforce, so a new carrying plugin
+#                    is picked up the moment it exists. Deriving it is the whole
+#                    point — a list copied into this file would silently rot, and
+#                    the rot would show up as an under-selection.
+#   R6 sync script   a changed scripts/sync-*.sh selects its own co-located test
+#                    plus everything its `src=` selects, since its failure mode
+#                    is the copies drifting from that source.
+#
+# R3/R4 skip STRUCTURAL basenames — README.md, SKILL.md, plugin.json and the
+# like — because those name a repo-wide role rather than one artifact, so a
+# basename match carries no coverage signal (SKILL.md alone appears in 20
+# unrelated suites). Such files fall through to R2, then to the no-suite list.
+#
+# The transitive walk has no depth cap. It terminates on the visited set, and
+# its worst case is selecting every suite — the safe direction.
+#
+# KNOWN LIMIT, in the safe direction: R3/R4 match a bare basename, so a file
+# with a GENERIC name (`common.sh`, `thing.sh`) can match text that has nothing
+# to do with it — a fixture literal inside an unrelated suite, say. That
+# over-selects, and it can also make a genuinely uncovered new file look mapped.
+# Narrowing it needs real shell/path parsing rather than a token match, which is
+# not worth the fail-open risk the narrowing itself would carry. Name new files
+# distinctively and the rule behaves.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+NO_SUITE_LIST="${AFFECTED_TESTS_NO_SUITE:-scripts/affected-tests-no-suite.txt}"
+
+# Basenames that name a structural role rather than one artifact. R3/R4 ignore
+# them; see the note above.
+STRUCTURAL_BASENAMES="README.md SKILL.md AGENTS.md CLAUDE.md CHANGELOG.md
+plugin.json marketplace.json settings.json hooks.json package.json
+package-lock.json index.md LICENSE"
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+base_ref=""
+do_run=0
+allow_unmapped=0
+explain=0
+print_fanout=""
+declare -a explicit_paths=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --run)
+    do_run=1
+    shift
+    ;;
+  --allow-unmapped)
+    allow_unmapped=1
+    shift
+    ;;
+  --explain)
+    explain=1
+    shift
+    ;;
+  --base)
+    base_ref="${2:?--base needs a ref}"
+    shift 2
+    ;;
+  --base=*)
+    base_ref="${1#--base=}"
+    shift
+    ;;
+  --print-fanout)
+    print_fanout="${2:?--print-fanout needs a path}"
+    shift 2
+    ;;
+  --)
+    shift
+    while [[ $# -gt 0 ]]; do
+      explicit_paths+=("$1")
+      shift
+    done
+    ;;
+  -*)
+    echo "error: unknown option: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  *)
+    explicit_paths+=("$1")
+    shift
+    ;;
+  esac
+done
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/affected-tests.XXXXXX")" || exit 2
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# ---------------------------------------------------------------------------
+# Sync-manifest derivation (R5/R6)
+# ---------------------------------------------------------------------------
+
+# manifest_src <sync-script> -> the `src=` value, or empty.
+manifest_src() {
+  awk '/^src=/ {
+    v = $0
+    sub(/^src=/, "", v)
+    gsub(/["\047]/, "", v)
+    sub(/[[:space:]]*#.*$/, "", v)
+    print v
+    exit
+  }' "$1"
+}
+
+# manifest_copy_patterns <sync-script> -> one raw `copies=(...)` entry per line.
+manifest_copy_patterns() {
+  awk '
+    /^copies=\(/ {
+      inarr = 1
+      line = $0
+      sub(/^copies=\(/, "", line)
+    }
+    !inarr { next }
+    inarr && line == "" && $0 !~ /^copies=\(/ { line = $0 }
+    {
+      sub(/#.*$/, "", line)
+      closed = (line ~ /\)/)
+      if (closed) sub(/\).*$/, "", line)
+      gsub(/["\047]/, "", line)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      if (line != "") print line
+      if (closed) exit
+      line = ""
+    }
+  ' "$1"
+}
+
+# SYNC_SRC_COPIES maps a sync source path to its newline-separated copy paths.
+declare -A SYNC_SRC_COPIES=()
+declare -A SYNC_SCRIPT_SRC=()
+
+build_sync_map() {
+  local script src pattern match
+  local -a patterns=()
+  local -a expanded=()
+  for script in scripts/sync-*.sh; do
+    [[ -f "$script" ]] || continue
+    case "$script" in
+    *.test.sh) continue ;;
+    *) ;;
+    esac
+    src="$(manifest_src "$script")"
+    if [[ -z "$src" ]]; then
+      echo "error: $script declares no src= — the shared-lib derivation cannot read it." >&2
+      echo "       Teach scripts/affected-tests.sh the new manifest shape; do not hardcode a copy list." >&2
+      exit 2
+    fi
+    mapfile -t patterns < <(manifest_copy_patterns "$script")
+    expanded=()
+    for pattern in ${patterns[@]+"${patterns[@]}"}; do
+      # shellcheck disable=SC2086 # a manifest entry may be a glob; splitting is
+      # the expansion, and no path in this repo contains whitespace.
+      for match in $pattern; do
+        [[ -e "$match" ]] && expanded+=("$match")
+      done
+    done
+    if [[ ${#expanded[@]} -eq 0 ]]; then
+      echo "error: $script yielded ZERO copy paths for $src." >&2
+      echo "       An empty derivation is the hardcoded-list failure mode one level up: it would" >&2
+      echo "       silently stop fanning a shared-lib change out to its carrying plugins." >&2
+      exit 2
+    fi
+    SYNC_SCRIPT_SRC["$script"]="$src"
+    printf -v SYNC_SRC_COPIES["$src"] '%s\n' "${expanded[@]}"
+  done
+  if [[ ${#SYNC_SCRIPT_SRC[@]} -eq 0 ]]; then
+    echo "error: no scripts/sync-*.sh manifests found — shared-lib fan-out would be silently empty." >&2
+    exit 2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+declare -A SUITES=()   # suite path -> reason
+declare -a UNMAPPED=() # changed paths that mapped to nothing
+
+is_structural() {
+  local b="$1" s
+  for s in $STRUCTURAL_BASENAMES; do
+    [[ "$b" == "$s" ]] && return 0
+  done
+  return 1
+}
+
+# SEED_HITS counts the suites the CURRENT seed reached, whether or not an
+# earlier seed had already selected them. Counting only NEWLY added suites was
+# wrong and wrong in the dangerous direction: the second of two changed files
+# that share a suite looked like it mapped to nothing and was reported unmapped.
+SEED_HITS=0
+add_suite() {
+  local suite="$1" reason="$2"
+  [[ -f "$suite" ]] || return 1
+  if [[ -z "${SUITES[$suite]:-}" ]]; then
+    SUITES["$suite"]="$reason"
+  fi
+  SEED_HITS=$((SEED_HITS + 1))
+  return 0
+}
+
+# colocated_suite <path> -> echo the sibling .test.sh, if any.
+colocated_suite() {
+  local p="$1" stem
+  case "$p" in
+  *.test.sh)
+    printf '%s' "$p"
+    return 0
+    ;;
+  *) ;;
+  esac
+  stem="${p%.*}"
+  [[ "$stem" == "$p" ]] && stem="$p" # extensionless
+  if [[ -f "$stem.test.sh" ]]; then
+    printf '%s' "$stem.test.sh"
+  fi
+}
+
+# select_for <changed-path> -> populate SUITES, and set SEED_HITS to the number
+# of suites THIS seed reached. The count comes back through a global rather than
+# stdout on purpose: a command substitution would run the whole walk in a
+# SUBSHELL and every SUITES mutation would be discarded with it.
+select_for() {
+  local seed="$1"
+  local -a frontier=()
+  local -a next=()
+  local p b sib copy line matched_path matched_name
+  # The visited set is PER SEED, not shared across seeds. Sharing it made a
+  # changed file that an earlier seed had already walked past look unvisited-
+  # and-unmapped, which is the fail-open direction: the file would be reported
+  # as covered because someone else's walk touched it, or as unmapped because
+  # its own walk was short-circuited. Re-walking costs one batched grep.
+  local -A VISITED=()
+  SEED_HITS=0
+
+  frontier=("$seed")
+  # R5: a sync source seeds every copy the manifest declares.
+  if [[ -n "${SYNC_SRC_COPIES[$seed]:-}" ]]; then
+    while IFS= read -r copy; do
+      [[ -n "$copy" ]] && frontier+=("$copy")
+    done <<<"${SYNC_SRC_COPIES[$seed]}"
+  fi
+  # R6: a sync script pulls in whatever its source pulls in.
+  if [[ -n "${SYNC_SCRIPT_SRC[$seed]:-}" ]]; then
+    frontier+=("${SYNC_SCRIPT_SRC[$seed]}")
+    while IFS= read -r copy; do
+      [[ -n "$copy" ]] && frontier+=("$copy")
+    done <<<"${SYNC_SRC_COPIES[${SYNC_SCRIPT_SRC[$seed]}]:-}"
+  fi
+
+  while [[ ${#frontier[@]} -gt 0 ]]; do
+    : >"$WORK_DIR/patterns"
+    next=()
+    for p in "${frontier[@]}"; do
+      [[ -n "${VISITED[$p]:-}" ]] && continue
+      VISITED["$p"]=1
+      # R1/R2
+      sib="$(colocated_suite "$p")"
+      if [[ -n "$sib" ]]; then
+        if [[ "$sib" == "$p" ]]; then
+          add_suite "$sib" "changed suite" || true
+        else
+          add_suite "$sib" "co-located with $p" || true
+        fi
+      fi
+      b="${p##*/}"
+      is_structural "$b" && continue
+      printf '%s\n' "$b" >>"$WORK_DIR/patterns"
+    done
+
+    [[ -s "$WORK_DIR/patterns" ]] || break
+
+    # R3/R4: one batched reverse lookup per level.
+    while IFS= read -r line; do
+      matched_path="${line%:*}"
+      matched_name="${line##*:}"
+      [[ -n "$matched_path" ]] || continue
+      case "$matched_path" in
+      *.test.sh) add_suite "$matched_path" "references $matched_name" || true ;;
+      *)
+        [[ -n "${VISITED[$matched_path]:-}" ]] || next+=("$matched_path")
+        ;;
+      esac
+    done < <(git grep --untracked -o -F -f "$WORK_DIR/patterns" -- '*.sh' 2>/dev/null || true)
+
+    frontier=(${next[@]+"${next[@]}"})
+  done
+}
+
+# ---------------------------------------------------------------------------
+# No-suite classification
+# ---------------------------------------------------------------------------
+
+declare -a NO_SUITE_PATTERNS=()
+load_no_suite_patterns() {
+  local line
+  if [[ ! -f "$NO_SUITE_LIST" ]]; then
+    echo "error: missing $NO_SUITE_LIST — the no-suite classification cannot be applied," >&2
+    echo "       and without it every doc and manifest change would report as unmapped." >&2
+    exit 2
+  fi
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -n "$line" ]] && NO_SUITE_PATTERNS+=("$line")
+  done <"$NO_SUITE_LIST"
+  if [[ ${#NO_SUITE_PATTERNS[@]} -eq 0 ]]; then
+    echo "error: $NO_SUITE_LIST has no active patterns." >&2
+    exit 2
+  fi
+}
+
+is_no_suite() {
+  local p="$1" pat
+  for pat in "${NO_SUITE_PATTERNS[@]}"; do
+    # shellcheck disable=SC2053 # the right-hand side is a glob pattern by design.
+    [[ "$p" == $pat ]] && return 0
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Changed-file resolution
+# ---------------------------------------------------------------------------
+
+resolve_base() {
+  local c
+  if [[ -n "$base_ref" ]]; then
+    printf '%s' "$base_ref"
+    return 0
+  fi
+  for c in origin/main origin/master main master; do
+    if git rev-parse --verify --quiet "$c^{commit}" >/dev/null 2>&1; then
+      printf '%s' "$c"
+      return 0
+    fi
+  done
+  return 1
+}
+
+changed_from_diff() {
+  local base mb
+  if ! base="$(resolve_base)"; then
+    echo "error: no diff base resolved (tried --base, origin/main, origin/master, main, master)." >&2
+    echo "       Pass --base <ref>, or give explicit paths." >&2
+    exit 2
+  fi
+  if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null 2>&1; then
+    echo "error: base ref '$base' does not resolve to a commit." >&2
+    exit 2
+  fi
+  # Compare the WORKING TREE against the merge base: a local developer wants the
+  # suites covering the work in front of them, including uncommitted edits, and
+  # not the suites for whatever else landed on the base branch meanwhile.
+  mb="$(git merge-base "$base" HEAD 2>/dev/null)" || mb="$base"
+  git diff --name-only "$mb" --
+  git ls-files --others --exclude-standard
+}
+
+# --print-fanout exists so the DERIVATION itself is inspectable and testable:
+# the copy set for a shared source must equal what the sync manifest declares
+# right now, not what someone once transcribed into this file.
+if [[ -n "$print_fanout" ]]; then
+  build_sync_map
+  print_fanout="${print_fanout#./}"
+  if [[ -z "${SYNC_SRC_COPIES[$print_fanout]:-}" ]]; then
+    echo "error: $print_fanout is not the src= of any scripts/sync-*.sh manifest." >&2
+    exit 2
+  fi
+  printf '%s' "${SYNC_SRC_COPIES[$print_fanout]}"
+  exit 0
+fi
+
+declare -a changed=()
+if [[ ${#explicit_paths[@]} -gt 0 ]]; then
+  for p in "${explicit_paths[@]}"; do
+    # Accept an absolute or ./-prefixed path; the rules are repo-relative.
+    p="${p#./}"
+    changed+=("$p")
+  done
+else
+  mapfile -t changed < <(changed_from_diff | sort -u)
+fi
+
+if [[ ${#changed[@]} -eq 0 ]]; then
+  echo "No changed files against the base ref; nothing to select." >&2
+  exit 0
+fi
+
+build_sync_map
+load_no_suite_patterns
+
+declare -a NO_SUITE_FILES=()
+for f in "${changed[@]}"; do
+  [[ -n "$f" ]] || continue
+  select_for "$f"
+  if [[ "$SEED_HITS" -eq 0 ]]; then
+    if is_no_suite "$f"; then
+      NO_SUITE_FILES+=("$f")
+    else
+      UNMAPPED+=("$f")
+    fi
+  fi
+done
+
+# `${!SUITES[@]}` cannot carry a `+` default-guard: bash parses `${!NAME...}` as
+# an indirect reference and rejects the expanded key list as a variable name.
+declare -a selected=()
+if [[ ${#SUITES[@]} -gt 0 ]]; then
+  mapfile -t selected < <(printf '%s\n' "${!SUITES[@]}" | sort -u)
+fi
+
+if [[ ${#NO_SUITE_FILES[@]} -gt 0 && "$explain" -eq 1 ]]; then
+  for f in "${NO_SUITE_FILES[@]}"; do
+    echo "no-suite: $f (recorded in $NO_SUITE_LIST; a non-shell CI lane covers it)" >&2
+  done
+fi
+
+if [[ ${#UNMAPPED[@]} -gt 0 ]]; then
+  echo "UNMAPPED: ${#UNMAPPED[@]} changed file(s) map to no test suite:" >&2
+  for f in "${UNMAPPED[@]}"; do
+    echo "  - $f" >&2
+  done
+  echo "This is NOT 'nothing to run' — it is 'this tool does not know what covers these'." >&2
+  echo "Fix one of: add a co-located <stem>.test.sh; make a suite name the file; or record the" >&2
+  echo "path class in $NO_SUITE_LIST with the CI lane that does cover it." >&2
+  if [[ "$allow_unmapped" -eq 0 ]]; then
+    echo "Re-run with --allow-unmapped to proceed anyway." >&2
+    exit 1
+  fi
+  echo "Proceeding under --allow-unmapped." >&2
+fi
+
+if [[ ${#selected[@]} -eq 0 ]]; then
+  echo "No suites selected (every changed file is a recorded no-suite class)." >&2
+  exit 0
+fi
+
+if [[ "$explain" -eq 1 ]]; then
+  for s in "${selected[@]}"; do
+    echo "select: $s  (${SUITES[$s]})" >&2
+  done
+fi
+
+if [[ "$do_run" -eq 0 ]]; then
+  printf '%s\n' "${selected[@]}"
+  exit 0
+fi
+
+# Strictly SEQUENTIAL. Two reasons, both measured rather than assumed: running
+# these suites in parallel was measured sublinear (they are spawn-bound and the
+# box saturates), and several guardrails suites assert wall-clock ceilings that
+# fail spuriously under concurrency. Selection, not parallelism, is the lever.
+echo "Running ${#selected[@]} selected suite(s) sequentially." >&2
+failed=0
+for s in "${selected[@]}"; do
+  echo "=== $s ==="
+  if bash "$s"; then
+    echo "PASS: $s"
+  else
+    echo "FAIL: $s" >&2
+    failed=1
+  fi
+done
+if [[ "$failed" -ne 0 ]]; then
+  echo "One or more selected suites failed." >&2
+  exit 1
+fi
+echo "All ${#selected[@]} selected suites passed or were skipped."

--- a/scripts/affected-tests.sh
+++ b/scripts/affected-tests.sh
@@ -408,8 +408,20 @@ changed_from_diff() {
   # suites covering the work in front of them, including uncommitted edits, and
   # not the suites for whatever else landed on the base branch meanwhile.
   mb="$(git merge-base "$base" HEAD 2>/dev/null)" || mb="$base"
-  git diff --name-only "$mb" --
-  git ls-files --others --exclude-standard
+  # Every failure here is fatal, never an empty list. An empty change set is
+  # indistinguishable from "the diff blew up" downstream, and downstream reports
+  # it as "nothing to select, exit 0" — the fail-open this whole tool exists to
+  # refuse. This function must therefore run in the CURRENT shell (see the call
+  # site): from inside a process substitution these exits would kill only the
+  # subshell and `mapfile` would happily succeed with nothing.
+  if ! git diff --name-only "$mb" --; then
+    echo "error: 'git diff --name-only $mb' failed; refusing to report an empty change set." >&2
+    exit 2
+  fi
+  if ! git ls-files --others --exclude-standard; then
+    echo "error: 'git ls-files --others' failed; refusing to report an empty change set." >&2
+    exit 2
+  fi
 }
 
 # --print-fanout exists so the DERIVATION itself is inspectable and testable:
@@ -429,12 +441,27 @@ fi
 declare -a changed=()
 if [[ ${#explicit_paths[@]} -gt 0 ]]; then
   for p in "${explicit_paths[@]}"; do
-    # Accept an absolute or ./-prefixed path; the rules are repo-relative.
     p="${p#./}"
+    # Every rule is repo-relative, and so is every sync-manifest key. An
+    # absolute path that stayed absolute would miss those keys and then fall
+    # through to a broad no-suite pattern — reporting success with no suites,
+    # which is the fail-open direction. Normalize what can be normalized and
+    # refuse the rest out loud.
+    case "$p" in
+    "$PWD"/*) p="${p#"$PWD"/}" ;;
+    /* | [A-Za-z]:[/\\]*)
+      echo "error: '$p' is absolute and does not sit under this repository as spelled." >&2
+      echo "       Pass repository-relative paths (Git Bash spells this checkout '$PWD')." >&2
+      exit 2
+      ;;
+    *) ;;
+    esac
     changed+=("$p")
   done
 else
-  mapfile -t changed < <(changed_from_diff | sort -u)
+  # Run the producer in the CURRENT shell so its fatal exits are the script's.
+  changed_from_diff >"$WORK_DIR/changed.raw"
+  mapfile -t changed < <(sort -u "$WORK_DIR/changed.raw")
 fi
 
 if [[ ${#changed[@]} -eq 0 ]]; then

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# Unit tests for affected-tests.sh. Selection only — nothing here runs a real
+# suite, because the point of the tool is that the real suites are expensive.
+#
+# Most scenarios build a throwaway git repo carrying a MINIATURE version of this
+# repo's own shape: a shared lib with a sync manifest, two carrying plugins, and
+# co-located suites. The exceptions are the two cases that must be proved
+# against the LIVE repo — the derived shared-lib copy set and the real no-suite
+# list — because a synthetic fixture cannot show that the derivation still
+# tracks reality, which is the whole failure mode this tool exists to avoid.
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+SCRIPT="$SELF_DIR/affected-tests.sh"
+NO_SUITE="$SELF_DIR/affected-tests-no-suite.txt"
+
+PASS=0
+FAIL=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+ok() {
+  echo "ok: $*"
+  PASS=$((PASS + 1))
+}
+
+# A stand-in suite that is cheap to run and records that it ran.
+# shellcheck disable=SC2016 # deliberate: the emitted file must expand these, not this shell
+suite_body() {
+  printf '#!/usr/bin/env bash\nprintf %%s "%s" >>"${MARKER_FILE:-/dev/null}"\nexit %s\n' "$1" "${2:-0}"
+}
+
+# Write a fixture script whose only job is to source its sibling widget.sh —
+# the shape that makes it a DEPENDENT of the shared lib.
+# shellcheck disable=SC2016 # deliberate: the emitted file must expand these, not this shell
+mk_widget_consumer() {
+  printf 'source "$(dirname "${BASH_SOURCE[0]}")/widget.sh"\n' >"$1"
+}
+
+mk_repo() {
+  local dir
+  dir="$(mktemp -d "${TMPDIR:-/tmp}/affected-tests-fixture.XXXXXX")"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email t@t.test
+  git -C "$dir" config user.name test
+  git -C "$dir" config commit.gpgsign false
+  git -C "$dir" config core.autocrlf false
+
+  mkdir -p "$dir/scripts" "$dir/lib" \
+    "$dir/plugins/alpha/hooks" "$dir/plugins/beta/hooks"
+  cp "$SCRIPT" "$dir/scripts/affected-tests.sh"
+  cp "$NO_SUITE" "$dir/scripts/affected-tests-no-suite.txt"
+
+  # A sync manifest in the same shape as the real ones: a `src=` line and a
+  # GLOB `copies=(...)` array. The selector must read the copy set out of this
+  # file rather than knowing the plugin names.
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '# Fixture sync manifest.\n'
+    printf 'set -euo pipefail\n'
+    printf 'src="lib/widget.sh"\n'
+    printf 'copies=(plugins/*/hooks/widget.sh)\n'
+    # shellcheck disable=SC2016 # deliberate: the fixture manifest's own body
+    printf 'echo "${src} ${copies[0]}"\n'
+  } >"$dir/scripts/sync-widget.sh"
+
+  printf 'widget_helper() { echo widget; }\n' >"$dir/lib/widget.sh"
+  suite_body lib-widget >"$dir/lib/widget.test.sh"
+
+  local p
+  for p in alpha beta; do
+    printf 'widget_helper() { echo widget; }\n' >"$dir/plugins/$p/hooks/widget.sh"
+    mk_widget_consumer "$dir/plugins/$p/hooks/$p-hook.sh"
+    suite_body "$p-hook" >"$dir/plugins/$p/hooks/$p-hook.test.sh"
+    printf '# %s plugin\n' "$p" >"$dir/plugins/$p/README.md"
+  done
+
+  # A file no suite names and no no-suite pattern covers.
+  printf 'echo orphan\n' >"$dir/scripts/zzorphan-tool.sh"
+
+  git -C "$dir" add scripts lib plugins >/dev/null
+  git -C "$dir" commit -qm base >/dev/null
+  printf '%s' "$dir"
+}
+
+# run_sel <repo> <args...> -> stdout on fd1, exit status in RC
+RC=0
+run_sel() {
+  local repo="$1"
+  shift
+  local out
+  out="$(cd "$repo" && bash scripts/affected-tests.sh "$@" 2>/dev/null)"
+  RC=$?
+  printf '%s' "$out"
+}
+
+has_line() {
+  printf '%s\n' "$1" | grep -qxF "$2"
+}
+
+# --- co-located mapping ----------------------------------------------------
+repo="$(mk_repo)"
+out="$(run_sel "$repo" plugins/alpha/hooks/alpha-hook.sh)"
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh &&
+  ! has_line "$out" plugins/beta/hooks/beta-hook.test.sh; then
+  ok "co-located: a hook selects its own suite and not a sibling plugin's"
+else
+  fail "co-located mapping (rc=$RC): $out"
+fi
+
+# --- a changed suite selects itself ----------------------------------------
+out="$(run_sel "$repo" plugins/beta/hooks/beta-hook.test.sh)"
+if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/beta/hooks/beta-hook.test.sh; then
+  ok "a changed *.test.sh selects itself"
+else
+  fail "self-selection (rc=$RC): $out"
+fi
+
+# --- shared-lib fan-out, derived from the sync manifest --------------------
+out="$(run_sel "$repo" lib/widget.sh)"
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$out" lib/widget.test.sh &&
+  has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh &&
+  has_line "$out" plugins/beta/hooks/beta-hook.test.sh; then
+  ok "shared lib fans out to every carrying plugin's suite"
+else
+  fail "shared-lib fan-out (rc=$RC): $out"
+fi
+
+# --- the fan-out is DERIVED, not transcribed -------------------------------
+# A third carrying plugin appears with NO edit to the manifest and NO edit to
+# the selector. A hardcoded copy list would miss it silently; that silent miss
+# is the exact rot this test exists to catch.
+mkdir -p "$repo/plugins/gamma/hooks"
+printf 'widget_helper() { echo widget; }\n' >"$repo/plugins/gamma/hooks/widget.sh"
+mk_widget_consumer "$repo/plugins/gamma/hooks/gamma-hook.sh"
+suite_body gamma-hook >"$repo/plugins/gamma/hooks/gamma-hook.test.sh"
+git -C "$repo" add plugins/gamma >/dev/null
+git -C "$repo" commit -qm gamma >/dev/null
+out="$(run_sel "$repo" lib/widget.sh)"
+if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/gamma/hooks/gamma-hook.test.sh; then
+  ok "a newly carrying plugin is picked up with no selector or manifest edit"
+else
+  fail "derived fan-out missed a new carrying plugin (rc=$RC): $out"
+fi
+
+# --- an empty derivation is a loud error, not an empty selection -----------
+sedless="$repo/scripts/sync-widget.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'src="lib/widget.sh"\n'
+  printf 'copies=(plugins/*/hooks/nothing-matches-this.sh)\n'
+} >"$sedless"
+out="$(cd "$repo" && bash scripts/affected-tests.sh lib/widget.sh 2>&1)"
+RC=$?
+if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'ZERO copy paths'; then
+  ok "a sync manifest that yields no copies fails loudly"
+else
+  fail "empty derivation should exit 2 (rc=$RC): $out"
+fi
+rm -rf "$repo"
+
+# --- unmapped file: fail loud, and the documented escape hatch -------------
+repo="$(mk_repo)"
+out="$(cd "$repo" && bash scripts/affected-tests.sh scripts/zzorphan-tool.sh 2>&1)"
+RC=$?
+if [[ "$RC" -eq 1 ]] && printf '%s' "$out" | grep -q 'UNMAPPED'; then
+  ok "a file covered by nothing exits non-zero and says so"
+else
+  fail "unmapped file should exit 1 with an UNMAPPED report (rc=$RC): $out"
+fi
+
+out="$(cd "$repo" && bash scripts/affected-tests.sh --allow-unmapped scripts/zzorphan-tool.sh 2>/dev/null)"
+RC=$?
+if [[ "$RC" -eq 0 ]]; then
+  ok "--allow-unmapped downgrades the failure"
+else
+  fail "--allow-unmapped should exit 0 (rc=$RC): $out"
+fi
+
+# --- a file an earlier seed already walked past is still MAPPED ------------
+# Regression: the shared lib's walk reaches alpha-hook.sh as a dependent. With
+# one visited set across seeds, alpha-hook.sh's own walk was short-circuited,
+# it contributed nothing, and it was reported unmapped — a false alarm that
+# trains people to reach for --allow-unmapped.
+out="$(cd "$repo" && bash scripts/affected-tests.sh lib/widget.sh plugins/alpha/hooks/alpha-hook.sh 2>&1)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! printf '%s' "$out" | grep -q 'UNMAPPED'; then
+  ok "a changed file reached by an earlier file's walk is not reported unmapped"
+else
+  fail "shared-walk file falsely unmapped (rc=$RC): $out"
+fi
+
+# --- a no-suite class is NOT an unmapped failure ---------------------------
+out="$(cd "$repo" && bash scripts/affected-tests.sh plugins/alpha/README.md 2>&1)"
+RC=$?
+if [[ "$RC" -eq 0 ]] && ! printf '%s' "$out" | grep -q 'UNMAPPED'; then
+  ok "a recorded no-suite path class exits 0 without an unmapped report"
+else
+  fail "no-suite class should exit 0 quietly (rc=$RC): $out"
+fi
+
+# --- explicit paths vs the default diff ------------------------------------
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# edited\n' >>"$repo/plugins/beta/hooks/beta-hook.sh"
+out="$(run_sel "$repo" --base "$base")"
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$out" plugins/beta/hooks/beta-hook.test.sh &&
+  ! has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh; then
+  ok "default mode selects from the working-tree diff against the base ref"
+else
+  fail "diff mode (rc=$RC): $out"
+fi
+
+# An UNCOMMITTED, UNTRACKED new file is part of the work in front of the
+# developer, so the diff mode must see it too.
+mk_widget_consumer "$repo/plugins/alpha/hooks/alpha-extra.sh"
+suite_body alpha-extra >"$repo/plugins/alpha/hooks/alpha-extra.test.sh"
+out="$(run_sel "$repo" --base "$base")"
+if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/alpha/hooks/alpha-extra.test.sh; then
+  ok "diff mode includes untracked files"
+else
+  fail "untracked file missed by diff mode (rc=$RC): $out"
+fi
+
+# --- --run executes the selected suites, sequentially ----------------------
+marker="$(mktemp "${TMPDIR:-/tmp}/affected-tests-marker.XXXXXX")"
+: >"$marker"
+(cd "$repo" && MARKER_FILE="$marker" bash scripts/affected-tests.sh --run lib/widget.sh >/dev/null 2>&1)
+RC=$?
+if [[ "$RC" -eq 0 ]] && grep -q 'lib-widget' "$marker" && grep -q 'beta-hook' "$marker"; then
+  ok "--run executes every selected suite"
+else
+  fail "--run did not execute the selection (rc=$RC): $(cat "$marker")"
+fi
+
+# --- --run propagates a suite failure --------------------------------------
+suite_body alpha-hook 1 >"$repo/plugins/alpha/hooks/alpha-hook.test.sh"
+(cd "$repo" && bash scripts/affected-tests.sh --run plugins/alpha/hooks/alpha-hook.sh >/dev/null 2>&1)
+RC=$?
+if [[ "$RC" -eq 1 ]]; then
+  ok "--run exits non-zero when a selected suite fails"
+else
+  fail "--run should propagate a suite failure (rc=$RC)"
+fi
+rm -rf "$repo" "$marker"
+
+# --- LIVE repo: the derived copy set equals the manifest's glob today ------
+# The synthetic cases above prove the mechanism; this one proves it is still
+# wired to THIS repository, which is what rots.
+for src in lib/hook-utils.sh lib/parse-concern-value.sh docs/conventions/standards/README.md; do
+  derived="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh --print-fanout "$src" 2>/dev/null | sort)"
+  manifest="scripts/sync-$(basename "${src%.*}").sh"
+  case "$src" in
+  docs/conventions/standards/README.md) manifest="scripts/sync-standards-contract.sh" ;;
+  *) ;;
+  esac
+  # Re-derive independently: read the manifest's own copies array with a
+  # different implementation than the selector's, then compare.
+  expected="$(cd "$REPO_ROOT" && awk '
+    /^copies=\(/ { inarr = 1; line = $0; sub(/^copies=\(/, "", line) }
+    !inarr { next }
+    { if (line == "" && $0 !~ /^copies=\(/) line = $0
+      sub(/#.*$/, "", line)
+      closed = (line ~ /\)/)
+      if (closed) sub(/\).*$/, "", line)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      if (line != "") print line
+      if (closed) exit
+      line = "" }
+  ' "$manifest" | while IFS= read -r pat; do
+    # shellcheck disable=SC2086 # the manifest entry is a glob by design.
+    for m in $pat; do [[ -e "$m" ]] && printf '%s\n' "$m"; done
+  done | sort)"
+  if [[ -n "$derived" && "$derived" == "$expected" ]]; then
+    ok "live derivation for $src matches $manifest ($(printf '%s\n' "$derived" | wc -l | tr -d ' ') copies)"
+  else
+    fail "live derivation drifted for $src: derived=[$derived] expected=[$expected]"
+  fi
+done
+
+# --- LIVE repo: a real shared-lib change reaches a real carrying plugin ----
+out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh lib/hook-utils.sh 2>/dev/null)"
+RC=$?
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$out" lib/hook-utils.test.sh &&
+  has_line "$out" plugins/guardrails/hooks/block-no-verify.test.sh &&
+  has_line "$out" plugins/eol-normalizer/hooks/eol-normalizer.test.sh; then
+  ok "live shared-lib change reaches suites in more than one carrying plugin"
+else
+  fail "live hook-utils fan-out (rc=$RC): $out"
+fi
+
+# --- LIVE repo: a co-located change stays narrow ---------------------------
+out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh plugins/eol-normalizer/hooks/eol-normalizer.sh 2>/dev/null)"
+RC=$?
+count="$(printf '%s\n' "$out" | grep -c '.')"
+if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/eol-normalizer/hooks/eol-normalizer.test.sh && [[ "$count" -lt 10 ]]; then
+  ok "live co-located change selects a narrow set ($count suites)"
+else
+  fail "live co-located selection too wide or wrong (rc=$RC, count=$count): $out"
+fi
+
+printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+((FAIL == 0))

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -294,6 +294,23 @@ else
   fail "live hook-utils fan-out (rc=$RC): $out"
 fi
 
+# --- LIVE repo: a STRUCTURAL basename that is also a sync src -------------
+# docs/conventions/standards/README.md is both. R3/R4 must ignore the basename
+# (every plugin has a README.md, so the match carries no signal) while R5 must
+# still fan the change out to the differently-named copies the manifest
+# declares — plugins/*/reference/standards-contract.md — and on to the suites
+# that bind against them. Neither the synthetic fixture nor the copy-set
+# assertions above isolate that interaction.
+out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh docs/conventions/standards/README.md 2>/dev/null)"
+RC=$?
+if [[ "$RC" -eq 0 ]] &&
+  has_line "$out" plugins/planning/tests/standards-binding.test.sh &&
+  has_line "$out" plugins/review/tests/standards-binding.test.sh; then
+  ok "a structural basename that is also a sync src still fans out"
+else
+  fail "standards-contract fan-out (rc=$RC): $out"
+fi
+
 # --- LIVE repo: a co-located change stays narrow ---------------------------
 out="$(cd "$REPO_ROOT" && bash scripts/affected-tests.sh plugins/eol-normalizer/hooks/eol-normalizer.sh 2>/dev/null)"
 RC=$?

--- a/scripts/affected-tests.test.sh
+++ b/scripts/affected-tests.test.sh
@@ -85,15 +85,18 @@ mk_repo() {
   printf '%s' "$dir"
 }
 
-# run_sel <repo> <args...> -> stdout on fd1, exit status in RC
+# run_sel <repo> <args...> -> selection in OUT, exit status in RC.
+# Both come back through globals rather than stdout: wrapping this in a command
+# substitution would run it in a subshell, and RC would silently keep whatever
+# the PREVIOUS case left behind — an assertion that reads as passing while
+# checking nothing.
 RC=0
+OUT=""
 run_sel() {
   local repo="$1"
   shift
-  local out
-  out="$(cd "$repo" && bash scripts/affected-tests.sh "$@" 2>/dev/null)"
+  OUT="$(cd "$repo" && bash scripts/affected-tests.sh "$@" 2>/dev/null)"
   RC=$?
-  printf '%s' "$out"
 }
 
 has_line() {
@@ -102,7 +105,8 @@ has_line() {
 
 # --- co-located mapping ----------------------------------------------------
 repo="$(mk_repo)"
-out="$(run_sel "$repo" plugins/alpha/hooks/alpha-hook.sh)"
+run_sel "$repo" plugins/alpha/hooks/alpha-hook.sh
+out="$OUT"
 if [[ "$RC" -eq 0 ]] &&
   has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh &&
   ! has_line "$out" plugins/beta/hooks/beta-hook.test.sh; then
@@ -112,7 +116,8 @@ else
 fi
 
 # --- a changed suite selects itself ----------------------------------------
-out="$(run_sel "$repo" plugins/beta/hooks/beta-hook.test.sh)"
+run_sel "$repo" plugins/beta/hooks/beta-hook.test.sh
+out="$OUT"
 if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/beta/hooks/beta-hook.test.sh; then
   ok "a changed *.test.sh selects itself"
 else
@@ -120,7 +125,8 @@ else
 fi
 
 # --- shared-lib fan-out, derived from the sync manifest --------------------
-out="$(run_sel "$repo" lib/widget.sh)"
+run_sel "$repo" lib/widget.sh
+out="$OUT"
 if [[ "$RC" -eq 0 ]] &&
   has_line "$out" lib/widget.test.sh &&
   has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh &&
@@ -140,7 +146,8 @@ mk_widget_consumer "$repo/plugins/gamma/hooks/gamma-hook.sh"
 suite_body gamma-hook >"$repo/plugins/gamma/hooks/gamma-hook.test.sh"
 git -C "$repo" add plugins/gamma >/dev/null
 git -C "$repo" commit -qm gamma >/dev/null
-out="$(run_sel "$repo" lib/widget.sh)"
+run_sel "$repo" lib/widget.sh
+out="$OUT"
 if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/gamma/hooks/gamma-hook.test.sh; then
   ok "a newly carrying plugin is picked up with no selector or manifest edit"
 else
@@ -206,7 +213,8 @@ fi
 # --- explicit paths vs the default diff ------------------------------------
 base="$(git -C "$repo" rev-parse HEAD)"
 printf '# edited\n' >>"$repo/plugins/beta/hooks/beta-hook.sh"
-out="$(run_sel "$repo" --base "$base")"
+run_sel "$repo" --base "$base"
+out="$OUT"
 if [[ "$RC" -eq 0 ]] &&
   has_line "$out" plugins/beta/hooks/beta-hook.test.sh &&
   ! has_line "$out" plugins/alpha/hooks/alpha-hook.test.sh; then
@@ -219,11 +227,43 @@ fi
 # developer, so the diff mode must see it too.
 mk_widget_consumer "$repo/plugins/alpha/hooks/alpha-extra.sh"
 suite_body alpha-extra >"$repo/plugins/alpha/hooks/alpha-extra.test.sh"
-out="$(run_sel "$repo" --base "$base")"
+run_sel "$repo" --base "$base"
+out="$OUT"
 if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/alpha/hooks/alpha-extra.test.sh; then
   ok "diff mode includes untracked files"
 else
   fail "untracked file missed by diff mode (rc=$RC): $out"
+fi
+
+# --- a broken diff is fatal, never an empty selection ----------------------
+# The producer used to run inside a process substitution, so its fatal exit
+# killed only the subshell: mapfile succeeded with nothing and the run reported
+# "nothing to select" and exit 0. A validation caller would read that as clean.
+out="$(cd "$repo" && bash scripts/affected-tests.sh --base definitely-not-a-ref 2>&1)"
+RC=$?
+if [[ "$RC" -eq 2 ]] && ! printf '%s' "$out" | grep -q 'nothing to select'; then
+  ok "an unresolvable base ref exits 2 instead of reporting an empty selection"
+else
+  fail "broken diff should be fatal (rc=$RC): $out"
+fi
+
+# --- an absolute path inside the repo is normalized, not silently missed ---
+abs="$repo/plugins/beta/hooks/beta-hook.sh"
+run_sel "$repo" "$abs"
+out="$OUT"
+if [[ "$RC" -eq 0 ]] && has_line "$out" plugins/beta/hooks/beta-hook.test.sh; then
+  ok "an absolute path under the repo root resolves to the same selection"
+else
+  fail "absolute path not normalized (rc=$RC): $out"
+fi
+
+# --- an absolute path from outside the repo is refused, not swallowed ------
+out="$(cd "$repo" && bash scripts/affected-tests.sh /elsewhere/lib/widget.sh 2>&1)"
+RC=$?
+if [[ "$RC" -eq 2 ]] && printf '%s' "$out" | grep -q 'absolute'; then
+  ok "an absolute path outside the repo is refused out loud"
+else
+  fail "foreign absolute path should exit 2 (rc=$RC): $out"
 fi
 
 # --- --run executes the selected suites, sequentially ----------------------


### PR DESCRIPTION
## Summary

Running every `**/*.test.sh` in this repo is an hours-long wall on a Windows box — the suites are
spawn-bound and Git Bash pays roughly 140 ms per process spawn against roughly 3 ms on Linux — so
nobody runs them locally and regressions reach CI instead. `scripts/affected-tests.sh` maps a change
set to the suites that actually cover it, prints them by default, and runs them sequentially under
`--run`.

```shell
scripts/affected-tests.sh                 # suites covering the diff vs origin/main
scripts/affected-tests.sh --run           # ... and run them
scripts/affected-tests.sh --explain       # ... and say why each was selected
scripts/affected-tests.sh path/to/file.sh # explicit paths instead of a diff
```

### Mapping rules, and where each one comes from

| Rule | Selects | Derivation |
| --- | --- | --- |
| R1 self | a changed `*.test.sh` selects itself | — |
| R2 co-located | `<dir>/<stem>.<ext>` → `<dir>/<stem>.test.sh` | the repo's dominant convention (`foo.sh`/`foo.py`/`foo.mjs` → `foo.test.sh`) |
| R3 referenced | any `*.test.sh` whose text names the file | a suite that names a file exercises it |
| R4 dependents | any other `*.sh` whose text names the file, then R2/R3 on **it**, transitively | carries a lib change out to the hooks that source it |
| R5 shared-lib | every path in the `copies=(...)` array of the `scripts/sync-*.sh` whose `src=` is the changed file, then R2/R3/R4 on each copy | **read out of the sync manifests on every run** |
| R6 sync script | a changed `scripts/sync-*.sh` selects its own test plus everything its `src=` selects | its failure mode is the copies drifting |

R5 is the point of the exercise. A change to `lib/hook-utils.sh` fans out to every plugin that
carries a copy, and the copy set is **derived** from `scripts/sync-hook-utils.sh` — the same manifest
CI's `hook-utils-sync` lane enforces — rather than transcribed into the selector. A transcribed list
rots silently, and the rot shows up as an under-selection, which is the one failure mode this tool
exists to prevent. `--print-fanout <src>` prints the derived set so the derivation is inspectable,
and the test suite pins it against the live manifests, so a manifest changing shape (or a new
carrying plugin appearing) fails in CI rather than quietly narrowing the selection.

Derived today, from the three manifests, checked in the suite:

- `lib/hook-utils.sh` → **16** copies (`plugins/*/hooks/hook-utils.sh`, a glob)
- `lib/parse-concern-value.sh` → **3** copies (an explicit list at three different paths)
- `docs/conventions/standards/README.md` → **2** copies (`plugins/*/reference/standards-contract.md`
  — a *differently named* destination, which is why R5 cannot be replaced by basename matching)

### Fails loud, not open

A changed file that maps to nothing exits non-zero with an explicit report. "Zero suites" must never
be read as "nothing to run" when it means "nothing here knows what covers this". Path classes that
genuinely carry no shell suite are recorded in `scripts/affected-tests-no-suite.txt`, each paired
with the CI lane that *does* cover it (markdown → the hygiene lane and skill-quality-gate; JSON →
the four check-jsonschema steps plus `validate-plugins.sh`; workflows → actionlint/zizmor). That list
is deliberately kept separate from `scripts/docs-only-paths.txt`: the two answer different questions
("can this affect any code lane" versus "is there a shell suite covering this"), and coupling them
would drag the narrow gate's answer into the wrong question. `--allow-unmapped` is the one-flag
escape.

### Not parallel, on purpose

Parallelising the runner was measured sublinear in a prior session (the suites are spawn-bound and
the box saturates), and several guardrails suites assert wall-clock ceilings that fail spuriously
under concurrency. Selection, not parallelism, is the lever.

## Test plan

`scripts/affected-tests.test.sh` — **PASS=22 FAIL=0**. `shellcheck -x` clean on both new `.sh` files;
`scripts/check-shell-portability.sh` clean; `actionlint` clean on the workflow; `markdownlint-cli2`
and `typos` clean on the changed docs.

Cases: co-located mapping (and *not* a sibling plugin's suite); a changed suite selecting itself;
shared-lib fan-out; **the fan-out being derived** (a third carrying plugin is added mid-test with no
manifest and no selector edit, and must be picked up); an empty derivation failing loudly; the
unmapped failure and `--allow-unmapped`; a no-suite class exiting 0; a file reached by an earlier
file's walk not being falsely reported unmapped; diff mode including untracked files; an
unresolvable `--base` being fatal rather than an empty selection; an absolute path under the repo
root normalizing, and one outside it being refused; `--run`
executing the selection and propagating a failure; and four assertions against the **live** repo —
the derived copy set equalling each manifest's glob today, a real `lib/hook-utils.sh` change reaching
suites in more than one carrying plugin, the structural-basename-that-is-also-a-sync-`src` case
(`docs/conventions/standards/README.md`), and a co-located change staying narrow.

### Measurement, and the load it was taken under

Machine: Windows 11, Git Bash, bash 5.3.15. Every number below is a wall-clock measurement on that
box — nothing is modelled or extrapolated.

**Numerator — a representative single-file change.** Editing one guardrails hook,
`plugins/guardrails/hooks/block-no-verify.sh`, selects **2 of 195** suites
(`block-no-verify.test.sh` and `flag-commit-pr-skill-bypass.test.sh`, the latter because it names the
hook). `scripts/affected-tests.sh --run` on that change: **19 m 22 s** (`real 19m22.471s`), both
suites PASS.

**Load during that measurement, stated plainly:** the box was not idle. The session ran `git commit`,
`git push`, one `gh issue list`, and a handful of file writes while it was in flight. No other test
run and no other heavy process was active. So 19 m 22 s is a real figure taken under light
concurrent I/O, not a clean-room number — treat it as an upper bound on the selected-set cost.

**Denominator — NOT measured, and that is itself a finding.** A sequential instrumented run of all
195 suites was started and did not complete. What it did produce, before it was stopped, is this:

- **18 of 195 suites (9.2%) consumed 3 523 s = 58 m 43 s.**
- Outliers in that sample: `plugins/autonomy/hooks/lane-stop-gate.test.sh` **1 133 s**,
  `plugins/bash-format/hooks/bash-format.test.sh` **488 s**,
  `plugins/biome-format/hooks/biome-format.test.sh` **368 s**,
  `plugins/claude-config/.../permission-rule-check.test.sh` **304 s**,
  `lib/hook-utils.test.sh` **298 s**.
- I am **not** extrapolating that sample to a full-corpus figure: the sample is the first 18 suites
  in path order, not a random one, and it visibly contains outliers.

What it does establish is that the **"~50 minutes" figure this repo's handoffs have carried for five
sessions is wrong, and wrong low**: the first 9.2% of the corpus alone already exceeds it. The true
local wall is hours. That makes the saving from selection larger than the tool was justified on, but
it also means the honest headline is a ratio of suites (2 of 195), not a ratio of two measured wall
clocks — I only have one side of that measured, and I am not going to present a modelled denominator
as if it were observed.

**Pre-existing local failure, not caused by this PR — verified, not asserted.** `lib/hook-utils.test.sh`
FAILED in that instrumented run. Re-run **standalone on this branch** it still fails, at
**PASS=150 FAIL=3**, and all three are wall-clock assertions:

```text
FAIL: buffer_stdin trickle: rc=2 out=
FAIL: buffer_stdin valid non-default timeout: rc=1 (expected 2)
FAIL: buffer_stdin stall overshoot: 3616 ms vs 3592 ms unsliced — expected >400 ms faster
```

The same suite is **green on this PR's `hook-utils-windows` lane** (1 m 9 s). So it is the
load-sensitive-ceiling class the separate follow-up owns, reproducing on a busy local Windows box and
not on the runner. This branch touches no shell library and no hook, so nothing here can affect it.

## Related

- Recorded as a follow-up in `.work/handoffs/20260809T082720Z-handoff-post-2008-followups.md`
  (remaining action 3), and it is the sole owner of that handoff's unmet completion criterion:
  "a developer can run the tests covering their change without a ~50-minute wall".
- The `lib/hook-utils.test.sh` failure noted above is owned by the separate wall-clock-ceilings
  follow-up (remaining action 1 in the same handoff), not by this change.
- CI scope is otherwise unchanged: the lanes still run everything. The only CI addition is this
  selector's own suite, wired into `plugin-gate` beside the cheat-sheet generator tests for the same
  documented reason — `run-plugin-tests.sh` discovers only `plugins/**`, so a suite under `scripts/`
  never runs without an explicit step.

No linked issue
