### PR TITLE
docs: index the auto-mode configuration page in OFFICIAL-DOCS

### DIFF
--- a/docs/OFFICIAL-DOCS.md
+++ b/docs/OFFICIAL-DOCS.md
@@ -97,6 +97,7 @@ SDK-based host.
 | The `.claude` directory | <https://code.claude.com/docs/en/claude-directory> | 2026-08-06 |
 | Permissions | <https://code.claude.com/docs/en/permissions> | 2026-08-06 |
 | Permission modes | <https://code.claude.com/docs/en/permission-modes> | 2026-08-06 |
+| Configure auto mode (`autoMode`, `claude auto-mode`) | <https://code.claude.com/docs/en/auto-mode-config> | 2026-08-09 |
 | Environment variables | <https://code.claude.com/docs/en/env-vars> | 2026-08-06 |
 
 ## Prompting doctrine (platform docs)


### PR DESCRIPTION
No linked issue

## Summary

`docs/OFFICIAL-DOCS.md` indexes Permissions, Permission modes, Settings, and Server-managed settings, but not `auto-mode-config` — the page that owns the `autoMode` settings block and the `claude auto-mode` subcommands.

## Fix

One row added to the Configuration / settings table, placed next to Permission modes:

```
| Configure auto mode (`autoMode`, `claude auto-mode`) | <https://code.claude.com/docs/en/auto-mode-config> | 2026-08-09 |
```

That page is the only source for the `environment` / `allow` / `soft_deny` / `hard_deny` schema, the `"$defaults"` splice semantics, `classifyAllShell`, and the scope rule that the classifier ignores `autoMode` in project and local settings. CLAUDE.md's fresh-docs mandate names this index as the canonical entry point for plugin-relevant official pages, so until now a contract change touching auto mode had no indexed page to fetch.

## Verification

- Page fetched during the session that authored this change; the `2026-08-09` verified date reflects that fetch, not a copied stamp.
- Gap confirmed by grep against the pre-change file: `auto-mode-config` appeared nowhere in `docs/OFFICIAL-DOCS.md`.
- Row placement and column shape match the four existing rows in the same table.
- No content from the page is copied into the repository — the row is a pointer, per the pointer-not-copy posture the index exists to serve.

## Related

N/A
