### PR TITLE
fix(songwriting): adjudicate worksheets.md against Writing Better Lyrics chapters 2, 4, 5

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.7.4]
+
+A source-fidelity pass over `object-writing.md` (Chapter 2), `worksheets.md`
+(Chapter 4), and `cliche.md` (Chapter 5) against *Writing Better Lyrics* (2009),
+all three read in full with their figures. Paraphrase only; no chapter prose,
+example writes, or student work reaches this public repository.
+
+### Fixed
+
+- **The worksheet layout sorted rhymes into per-type buckets; Chapter 4's does
+  not.** The file gave every core word five labelled rows — perfect, family,
+  additive/subtractive, assonance, consonance. The chapter's own worksheet is
+  ten numbered core words, each heading ONE undifferentiated column with every
+  rhyme type mixed together. The mixing is the point: a single field is scanned
+  and compared on meaning, where five labelled rows turn one choice into five
+  sub-choices and invite filling each to a quota — the opposite of generating a
+  surplus in order to reject most of it. Rhyme type is a placement decision,
+  which is `rhyme-strategy.md`'s job, after the column exists.
+
 ## [0.7.3]
 
 A source-fidelity pass over `prosody.md` against *Writing Better Lyrics* (2009)

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -24,10 +24,12 @@ example writes, or student work reaches this public repository.
   are recorded together; type matters again only when placing a survivor, which
   is `rhyme-strategy.md`'s job.
 - **The template carried keep/maybe/reject and notes fields the chapter's
-  worksheet does not have.** Its only annotation is parentheses, marking a word
-  kept as an alternate rather than a first choice — `freeze (wheel, shield)`,
-  `guarantee(s)`. Rejection happens by not writing the word down. The workflow
-  step that told the model to mark each word now matches the page it writes on.
+  worksheet does not have.** Its only annotation is parentheses, doing two jobs:
+  holding an alternate word behind a first choice that shares its vowel
+  (`freeze (wheel, shield)`), and marking an optional morpheme that records two
+  candidates in one entry (`(re)born`, `guarantee(s)`). Rejection happens by not
+  writing the word down. The workflow step that told the model to mark each word
+  now matches the page it writes on.
 
 ## [0.7.3]
 

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -19,8 +19,15 @@ example writes, or student work reaches this public repository.
   rhyme type mixed together. The mixing is the point: a single field is scanned
   and compared on meaning, where five labelled rows turn one choice into five
   sub-choices and invite filling each to a quota — the opposite of generating a
-  surplus in order to reject most of it. Rhyme type is a placement decision,
-  which is `rhyme-strategy.md`'s job, after the column exists.
+  surplus in order to reject most of it. The per-type SEARCH still runs — each
+  type is a different lookup and skipping one loses candidates — but its results
+  are recorded together; type matters again only when placing a survivor, which
+  is `rhyme-strategy.md`'s job.
+- **The template carried keep/maybe/reject and notes fields the chapter's
+  worksheet does not have.** Its only annotation is parentheses, marking a word
+  kept as an alternate rather than a first choice — `freeze (wheel, shield)`,
+  `guarantee(s)`. Rejection happens by not writing the word down. The workflow
+  step that told the model to mark each word now matches the page it writes on.
 
 ## [0.7.3]
 

--- a/plugins/songwriting/context/pat-pattison/research/worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/worksheets.md
@@ -151,28 +151,30 @@ rhymes belong inside a section.
 
 ## Worksheet layout
 
-A practical lyric worksheet can use this structure:
+Chapter 4's own worksheet is ten numbered core words, each heading a single
+undifferentiated column of rhymes:
 
 ```text
 Title / working idea:
 Angle:
 Objective correlative:
 
-Core words:
-1.
-2.
-3.
-...
-
-For each core word:
-- perfect:
-- family:
-- additive/subtractive:
-- assonance:
-- consonance:
-- image/idea notes:
-- keep / maybe / reject:
+1. <core word>     2. <core word>     3. <core word>
+   <rhyme>            <rhyme>            <rhyme>
+   <rhyme>            <rhyme>            <rhyme>
+   ...                ...                ...
 ```
+
+**Do not sort the column by rhyme type.** Perfect, family, additive,
+subtractive, assonance, and consonance candidates sit side by side, and the
+mixing is the point: the eye scans one field and compares candidates on what
+they *mean* for this lyric. Splitting the column into labelled per-type rows
+turns one choice into five sub-choices and invites filling each row to a quota
+— which is the opposite of generating a surplus in order to reject most of it.
+
+Rhyme type is a placement decision, not a generation one. It matters when
+choosing which candidate lands in which position, which is
+[rhyme strategy](rhyme-strategy.md)'s job, after the column exists.
 
 Keep the page flexible. Add, remove, and swap core words as the lyric clarifies.
 
@@ -187,7 +189,7 @@ Exercise 9 - Focus and worksheet seed:
 - Save strong idea-words on a separate list.
 - Expand those words with a thesaurus or concept map.
 - Trim to ten or twelve core words with useful stressed vowels.
-- Build rhyme columns for each core word.
+- Build one mixed rhyme column under each core word.
 
 ## Skill workflow
 
@@ -199,6 +201,7 @@ When applying this file:
 4. Select an objective correlative.
 5. Build a core idea-word list.
 6. Trim the list for vowels, stress, and relevance.
-7. Expand rhyme options across perfect and imperfect types.
+7. Expand rhyme options across perfect and imperfect types into one mixed
+   column per core word, unsorted.
 8. Mark each word as keep, maybe, or reject.
 9. Draft only after the worksheet contains enough options to say no.

--- a/plugins/songwriting/context/pat-pattison/research/worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/worksheets.md
@@ -161,20 +161,29 @@ Objective correlative:
 
 1. <core word>     2. <core word>     3. <core word>
    <rhyme>            <rhyme>            <rhyme>
-   <rhyme>            <rhyme>            <rhyme>
+   <rhyme>            (<alternate>)      <rhyme>
    ...                ...                ...
 ```
 
-**Do not sort the column by rhyme type.** Perfect, family, additive,
-subtractive, assonance, and consonance candidates sit side by side, and the
-mixing is the point: the eye scans one field and compares candidates on what
-they *mean* for this lyric. Splitting the column into labelled per-type rows
-turns one choice into five sub-choices and invites filling each row to a quota
-— which is the opposite of generating a surplus in order to reject most of it.
+The chapter's only annotation is parentheses, used for a word kept as an
+alternate rather than a first choice — `freeze (wheel, shield)` in the core-word
+list, `(re)born` and `guarantee(s)` in the columns. There is no keep / maybe /
+reject field and no notes field: rejection happens by not writing the word down,
+or by crossing it out later. Keep that convention rather than adding columns the
+worksheet does not have.
 
-Rhyme type is a placement decision, not a generation one. It matters when
-choosing which candidate lands in which position, which is
-[rhyme strategy](rhyme-strategy.md)'s job, after the column exists.
+**Search by type; record unsorted.** Stage 3 above still runs a separate search
+per rhyme type — each one is a different lookup and skipping any of them loses
+candidates. What the worksheet does not do is keep those searches apart on the
+page. Perfect, family, additive, subtractive, assonance, and consonance results
+land in one column together, and the mixing is the point: the eye scans a single
+field and compares candidates on what they *mean* for this lyric.
+
+Labelled per-type rows turn one choice into five sub-choices and invite filling
+each row to a quota — the opposite of generating a surplus in order to reject
+most of it. Which type a surviving candidate belongs to matters again when
+deciding where it lands, and that stability question is
+[rhyme strategy](rhyme-strategy.md)'s, after the column exists.
 
 Keep the page flexible. Add, remove, and swap core words as the lyric clarifies.
 
@@ -201,7 +210,9 @@ When applying this file:
 4. Select an objective correlative.
 5. Build a core idea-word list.
 6. Trim the list for vowels, stress, and relevance.
-7. Expand rhyme options across perfect and imperfect types into one mixed
-   column per core word, unsorted.
-8. Mark each word as keep, maybe, or reject.
+7. Search each rhyme type separately — perfect, family, additive, subtractive,
+   assonance, consonance — and record every survivor into one mixed, unsorted
+   column per core word.
+8. Parenthesise anything kept only as an alternate; drop the rest by leaving it
+   off the page.
 9. Draft only after the worksheet contains enough options to say no.

--- a/plugins/songwriting/context/pat-pattison/research/worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/worksheets.md
@@ -165,11 +165,17 @@ Objective correlative:
    ...                ...                ...
 ```
 
-The chapter's only annotation is parentheses, used for a word kept as an
-alternate rather than a first choice — `freeze (wheel, shield)` in the core-word
-list, `(re)born` and `guarantee(s)` in the columns. There is no keep / maybe /
-reject field and no notes field: rejection happens by not writing the word down,
-or by crossing it out later. Keep that convention rather than adding columns the
+Parentheses are the chapter's only annotation, and they do two jobs:
+
+- **Alternates** — a whole word held behind a first choice sharing its vowel
+  sound, as in the core-word list's `freeze (wheel, shield)`. This is Stage 2's
+  duplicate-vowel rule written on the page.
+- **Optional morphemes** — a prefix or ending that may or may not be used, as in
+  the columns' `(re)born` and `guarantee(s)`, which record two rhyme candidates
+  in one entry.
+
+There is no keep / maybe / reject field and no notes field. Rejection happens by
+not writing the word down. Keep that convention rather than adding columns the
 worksheet does not have.
 
 **Search by type; record unsorted.** Stage 3 above still runs a separate search
@@ -213,6 +219,6 @@ When applying this file:
 7. Search each rhyme type separately — perfect, family, additive, subtractive,
    assonance, consonance — and record every survivor into one mixed, unsorted
    column per core word.
-8. Parenthesise anything kept only as an alternate; drop the rest by leaving it
-   off the page.
+8. Parenthesise alternates and optional morphemes; drop everything else by
+   leaving it off the page.
 9. Draft only after the worksheet contains enough options to say no.


### PR DESCRIPTION
No linked issue — the defect this PR fixes was found by the pass itself, not
filed ahead of it.

Sixth session of the chapter-by-chapter source-fidelity pass. *Writing Better
Lyrics* (2009) Chapters 2 (Rusty's Collar), 4 (Learning to Say No: Building
Worksheets), and 5 (Clichés) read in full, all eight figures rendered, against
`object-writing.md`, `worksheets.md`, and `cliche.md`. Plugin 0.7.3 → 0.7.4.

Paraphrase only — no chapter prose, no example writes, no student work. Chapter
3 was audited in an earlier session, so this closes the book's opening block.

## Two of the three files were already correct

Worth stating plainly, because it is the first time in this pass that a chapter
read produced no change at all:

- **`object-writing.md` vs Chapter 2** — faithful on every load-bearing point:
  the Sister Mary Elizabeth rule, the collar as the concrete thing held up
  first, the dye-drips-downward mechanic, the placement consequence (colors drip
  down, not up, so a late collar leaves the opening under-coloured), and the
  cliché-substitution warning drawn from the chapter's own beige-rewrite
  demonstration.
- **`cliche.md` vs Chapter 5** — its four families map to the chapter's four
  sections exactly and in order, the universal-is-not-generic distinction is the
  chapter's own, and friendly clichés, draft-stage placeholders, and
  "most cliché rhymes are perfect rhymes, so stretch into imperfect types" all
  land. Its inventories are described as territories rather than copied, which
  is the licensing constraint working as intended.

## The worksheet layout was invented

`worksheets.md` told the reader to give every core word five labelled rows:

```text
For each core word:
- perfect:
- family:
- additive/subtractive:
- assonance:
- consonance:
```

Chapter 4's own worksheet — figures `ATW` and `ATX`, two full pages — is ten
numbered core words, each heading **one undifferentiated column** with every
rhyme type mixed together. Under `risk`: cliff, fist, kissed, stiff, itch,
pitch, drift, switch, shift, pinched, chips. Perfect, family, additive and
assonance candidates sit side by side, unlabelled.

**This is not cosmetic, and it works against what the chapter is for.** The
worksheet exists to produce enough options that the writer can say no — the
chapter's framing is a musician with enough gigs to turn down the bad ones. A
single field is scanned once and the candidates compete on what they *mean* for
this lyric. Five labelled rows turn one choice into five sub-choices and invite
filling each row to a quota, which is generating to a target rather than
generating a surplus in order to discard most of it.

The type labels are also downstream information. Which rhyme type a candidate is
matters when deciding *where it lands* — the stability question `rhyme-strategy.md`
owns — not while the column is being built. Sorting at generation time front-loads
a decision that belongs after.

Fixed by carrying the chapter's actual shape, stating why the mixing matters, and
pointing the placement question at the file that owns it. The
`worksheet-prompt.md` template was checked and never had the bucketed shape, so
the defect was isolated to this one file.

## Verified correct and worth recording

- **The consonant-family chart** (`ATS` — plosives / fricatives / nasals, split
  voiced and unvoiced, with the companions relationship) is carried faithfully
  in `rhyme-types.md`.
- **The chord-voicing analogy for rhyme stability** — C in the bass, C/G, C/E,
  the chord with no C in the right hand, then E minor as "only a suggestion of
  home" — is carried in `rhyme-types.md` voicing by voicing, mapped onto the
  five rhyme types. `worksheets.md` correctly keeps only the resulting scale and
  points onward rather than restating it.
- **Chapter 5 is already bound at generation time.** `response-filter` §1 runs a
  cliché-pair scan with an inline flag list; §2 runs a cliché scan and a
  friendly-cliché test. Nothing to add.

## Step 5 — evals

Not empty this time, but nothing asserts the defect. `object-writing`'s eval set
contains no collar, show-before-tell, worksheet, or cliché claim at all. Four
other sets reference cliché — `co-write`, `diagnose`, `metaphor`, `rhyme` — and
every one is consistent with Chapter 5, which this pass found correct. **No eval
encodes a worksheet-shape claim**, so the layout fix asserts nothing back.

One observation for the remaining passes: the file whose chapter was audited
here owns an eval set that says nothing about that chapter, while the chapter
that *is* encoded (Chapter 5's cliché material) is encoded across four skills
that do not own it. Eval coverage does not track file ownership.

## Scope warning

`worksheets.md` is audited against 2009 Chapter 4 only. `object-writing.md`
carries material from Chapter 1 (audited earlier) and from sources beyond the
books; `cliche.md` is Chapter 5 throughout. As with `meter.md` and `prosody.md`,
none of these files is "audited" full stop.

## Verification

- `typos --config _typos.toml` — clean
- `markdownlint-cli2` — 0 errors over 103 files
- `lychee --offline --include-fragments` — 0 errors, 692 OK
- `check-changelog-parity.sh` `--check` / `--check-bump origin/main` /
  `--check-order` — all clean
- `validate-plugins.sh` — passed
- No skill body changed, so the skill-quality gate is unaffected

## Related

- PR #2071 — the Chapters 18-19 pass, merged as 0.7.3, which this builds on.
- Issue #2061 — the plugin cache is keyed by version number. Reproduced
  precisely this session: the installed `0.7.3/` cache directory holds a
  snapshot of an intermediate commit, carrying the first prosody commit and
  neither the `response-filter` binding nor the review fixes that replaced it. A
  version bump alone does not deliver final content when the version was
  installed mid-branch. Not closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
