### PR TITLE
fix(dometrain): scope the headless marketplace registration and drop the no-op -y

### DIFF
--- a/plugins/dometrain/.claude-plugin/plugin.json
+++ b/plugins/dometrain/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dometrain",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Dometrain course-content grounding over a third-party remote MCP server (Dometrain-hosted, Bearer auth): search lessons, pull curated lesson documents with on-screen code, and cite timestamped deep links. Requires an active Dometrain Pro subscription. Credential entered once through Claude Code's native masked userConfig prompt and stored in secure credential storage. Ships with a grounding usage skill kept in sync with Dometrain's own official Claude Code plugin.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/dometrain/CHANGELOG.md
+++ b/plugins/dometrain/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to the `dometrain` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.1.3]
+
+### Fixed
+
+- Setup skill's headless bootstrap registers the marketplace at the chosen scope:
+  `claude plugin marketplace add <source> --scope <scope>`. The bare form writes the registration to
+  *user* settings while the `install`/`enable` steps below it carry `-s <scope>`, so a `project`
+  bootstrap left a fresh clone or CI agent with the enabled plugin and no marketplace to resolve it
+  from (`docs/MIGRATION-PLAYBOOK.md` "Fresh-consumer onboarding"). The prose now also names the flag
+  asymmetry: `marketplace add` accepts `--scope` only, while `install` and `enable` also take `-s`.
+- Setup skill no longer claims all three rotation commands "default to `user`". `enable`
+  auto-detects the scope, which the same file already said forty lines above — the page
+  contradicted itself. Corrected to name each command's real default.
+- Setup skill's headless rotation drops the no-op `-y` from `claude plugin uninstall` and the false
+  rationale attached to it. `-y` skips only `uninstall`'s `--prune` confirmation; the recipe never
+  passes `--prune`, so the flag changed nothing and the claimed CI hang could not occur. Completes
+  the same correction 0.21.2/0.17.2/0.3.1 landed for `claude-ops`, `session-flow`, and
+  `rate-limit-guard`, and 0.2.3 landed for `miro`.
+
 ## [0.1.2]
 
 ### Fixed

--- a/plugins/dometrain/skills/setup/SKILL.md
+++ b/plugins/dometrain/skills/setup/SKILL.md
@@ -66,15 +66,20 @@ For a non-interactive install — CI, a fleet bootstrap, a scripted machine setu
 on the initial install instead of the interactive `/plugin` prompt. Three steps, all required:
 
 ```shell
-claude plugin marketplace add <source>
+claude plugin marketplace add <source> --scope <scope>
 claude plugin install dometrain@<marketplace> -s <scope> --config dometrain_api_key=<your-key>
 claude plugin enable dometrain -s <scope>
 ```
 
 Both placeholders are bootstrap inputs, not lookups: before the first install there is no record
 to read them from. `<marketplace>` is the name the catalog registers under when it is added, and
-`<scope>` is the scope the bootstrap chooses — `user`, `project`, or `local`; `install` defaults
-to `user` when the flag is omitted. Use the same `<scope>` in every command of the sequence.
+`<scope>` is the scope the bootstrap chooses — `user`, `project`, or `local`; `marketplace add`
+and `install` default to `user` when the flag is omitted, while `enable` auto-detects. Carry the
+same `<scope>` through all three. Note the asymmetry: `marketplace add` spells it `--scope` only,
+while `install` and `enable` also accept the `-s` short form. Registering at `user` while
+installing at `project` leaves the marketplace declaration out of the project's checked-in
+settings, so a fresh clone or CI agent carries the enabled plugin with no registered marketplace
+to resolve it from.
 
 **The enable step is not optional.** This plugin ships `defaultEnabled: false`, so it installs
 DISABLED — the install seeds the key but leaves the MCP server, and therefore every `dometrain`
@@ -89,23 +94,24 @@ later, use `/plugin configure dometrain` (interactive, any time), or headlessly:
 
 ```shell
 claude plugin list                                          # read the CURRENT scope for dometrain
-claude plugin uninstall dometrain -s <scope> -y
+claude plugin uninstall dometrain -s <scope>
 claude plugin install dometrain@<marketplace> -s <scope> --config dometrain_api_key=<new-key>
 claude plugin enable dometrain -s <scope>
 ```
 
 Never re-run `install --config` against an existing install expecting it to take effect. Read the
-scope from `claude plugin list` and carry that SAME `-s <scope>` through all three commands — they
-default to `user`, so omitting it against a `project`- or `local`-scope install removes a
-different record than the one that is loading and reinstalls at a scope that does not load,
-leaving the old key in use. For a `project`- or `local`-scope install, run every command from
-that project directory, since those scopes resolve against the current project.
+scope from `claude plugin list` and carry that SAME `-s <scope>` through all three commands —
+`uninstall` and `install` default to `user` and `enable` auto-detects, so omitting it against a
+`project`- or `local`-scope install removes a different record than the one that is loading and
+reinstalls at a scope that does not load, leaving the old key in use. For a `project`- or
+`local`-scope install, run every command from that project directory, since those scopes resolve
+against the current project.
 
-`-y` on the uninstall is required whenever stdin or stdout is not a TTY — without it a rotation
-run from CI stops at the confirmation prompt with the plugin already uninstalled. The reinstall
-needs its own `enable` for the same reason the initial bootstrap does: uninstalling can drop the
-`enabledPlugins` entry, and a fresh install of a `defaultEnabled: false` plugin lands disabled, so
-a rotation that ends at `install` completes with the new key stored and no tools available.
+`-y` only skips `uninstall`'s `--prune` confirmation; this recipe never passes `--prune`, so `-y`
+has no effect here and should not be added. The reinstall needs its own `enable` for the same
+reason the initial bootstrap does: uninstalling can drop the `enabledPlugins` entry, and a fresh
+install of a `defaultEnabled: false` plugin lands disabled, so a rotation that ends at `install`
+completes with the new key stored and no tools available.
 
 Full detail, including the command-line-exposure caveat, is in the README's
 [Rotating or clearing the key](../../README.md#rotating-or-clearing-the-key) section.


### PR DESCRIPTION
## Summary

Three corrections to `plugins/dometrain/skills/setup/SKILL.md`'s headless recipes, mirroring the
shape merged for `miro` in #2070.

1. **`claude plugin marketplace add <source>` took no scope** (L69). It registers at `user` while
   the `install` and `enable` steps beside it carry `-s <scope>`, so a `project` bootstrap left a
   fresh clone or CI agent holding an enabled plugin with no marketplace to resolve it from. Now
   `--scope <scope>`, and the surrounding prose names the flag asymmetry — `marketplace add` accepts
   `--scope` only, with no `-s` short form (L76-77).
2. **The rotation prose claimed all three commands "default to `user`"** (L98-99). `enable`
   auto-detects. This same file already said so at L82, so the page contradicted itself. Each
   command's real default is now named.
3. **`-y` on the uninstall was a no-op carrying a false rationale** (L92, L104-105). `-y` skips only
   `uninstall`'s `--prune` confirmation and this recipe never passes `--prune`, so the flag changed
   nothing and the CI hang its rationale described could not occur.

## Verification — what is executed, and what is documentary

**Executed** (read-only `--help` on this machine, `claude 2.1.225`):

| Command | Observed |
| --- | --- |
| `marketplace add` | `--scope <scope>  Where to declare the marketplace: user (default), project, or local` — **no `-s` alias** |
| `install` | `-s, --scope <scope>  Installation scope: user, project, or local (default: "user")` |
| `enable` | `-s, --scope <scope>  Installation scope: user, project, local (default: auto-detect)` |
| `uninstall` | `-y, --yes  Skip the --prune confirmation prompt (required when stdin or stdout is not a TTY)` and `--prune  … (requires -y in non-interactive contexts)` |

Each of the three corrections above follows directly from those four outputs, and the L82/L98
self-contradiction is visible in the file itself.

**Documentary, NOT executed** — that a non-TTY `claude plugin uninstall` passing neither `--prune`
nor `-y` completes without prompting. It was deliberately not run here: it mutates installed-plugin
state on this machine. The basis is (a) the joint reading of the two help entries above, where the
`-y` requirement attaches to `--prune` rather than to `uninstall` generally, and (b) main commit
`7b109db` (verified an ancestor of `origin/main`), which records exactly that empirical run against
`claude 2.1.220` — throwaway local marketplace, dummy plugin, non-TTY, no `--prune`, no `-y` →
exit 0, no prompt — and landed the same correction for `claude-ops` 0.21.2, `session-flow` 0.17.2,
and `rate-limit-guard` 0.3.1. #2070 then carried it to `miro` 0.2.3.

**Gates**, from the worktree root against `origin/main`: `check-changed-skills.sh` (PASS),
`check-changelog-parity.sh` (`--check-bump`; `--check-order` — all 73 changelogs newest-first, no
duplicate versions), `check-skill-portability.sh` (no unexcused coupling tokens),
`markdownlint-cli2` over `plugins/dometrain/**/*.md` (7 files, 0 errors). `SKILL.md` is 141 lines,
well under the 500-line cap.

`dometrain` 0.1.2 → 0.1.3. Docs-only; no runtime behavior change, and no installed-plugin state on
this machine was touched.

## Related

Mirrors #2070 (`miro` 0.2.3) and completes the `-y` correction line from #1443
(`claude-ops` 0.21.2, `session-flow` 0.17.2, `rate-limit-guard` 0.3.1).

No linked issue
