### PR TITLE
ci(scripts): flag a bare & in a ${var//pat/repl} replacement

### DIFF
--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -1180,7 +1180,7 @@ scan_file() {
     }
     # ---- bash-5.2 `&`-in-replacement class (!subst-replacement-ampersand) ----
     # skip_frame <line> <at> <limit> — the offset just PAST the nested frame
-    # opening at <at> (`$(`, `$((`, `${`, or a backquote). Its body is not part
+    # opening at <at> (any opener opens_frame() recognizes). Its body is not part
     # of the enclosing pattern or replacement text: a `/` inside `${x:-a/b}` is
     # data belonging to the inner expansion and never the separator, and a `&`
     # inside `$(a && b)` is inner command syntax, never a match reference.
@@ -1188,6 +1188,26 @@ scan_file() {
     # it early. An UNTERMINATED frame runs to <limit>, which ends the scan with
     # no hit — the under-flag direction, and unreachable in practice because the
     # record loop only calls this once every frame the mask opened has closed.
+    # opens_frame <line> <at> — does a nested frame open at <at>? A backquote,
+    # a `$(` / `$((` / `${`, or a PROCESS substitution `<(` / `>(`.
+    #
+    # The process-substitution body is a COMMAND LIST, so an `&` or `&&` in it
+    # is shell syntax and never a match reference, and the whole construct is
+    # version-INdependent: verified on 5.3.15 that `v=aXb; "${v//X/<(a && b)}"`
+    # yields `a/dev/fd/63b` with patsub_replacement both on AND off. Leaving it
+    # out of the opener set walked into the body and reported the `&&` — a false
+    # POSITIVE on portable code, the direction this class must not take. (This
+    # is the one paren the collapse_subs() layer above deliberately keeps
+    # verbatim, for the opposite reason: there it is not its own word. Here it
+    # is not its own text.)
+    function opens_frame(l, at,   c, n) {
+      c = substr(l, at, 1)
+      if (c == BT) return 1
+      n = substr(l, at + 1, 1)
+      if (c == "$" && (n == "(" || n == "{")) return 1
+      if ((c == "<" || c == ">") && n == "(") return 1
+      return 0
+    }
     function skip_frame(l, at, limit,   c, o, cl, depth, st) {
       c = substr(l, at, 1)
       if (c == BT) {
@@ -1276,21 +1296,36 @@ scan_file() {
     #   - a substitution assembled from fragments before use, exactly as the
     #     script header records for the ERE classes;
     #   - a parameter spelling this walk does not recognize (a name that is not
-    #     an identifier, a digit run, or one of `@ * ? $ ! -`) is skipped.
-    function amp_in_frame(l, s, e,   i, c, st, sep) {
+    #     an identifier, a digit run, or one of `@ * ? $ ! - #`) is skipped.
+    function amp_in_frame(l, s, e,   i, c, st, sep, named) {
       i = s + 2
       if (i > e - 1) return 0
       c = substr(l, i, 1)
-      if (c == "#") return 0
-      if (c == "!") i++
-      c = substr(l, i, 1)
-      if (c ~ /[A-Za-z_]/) {
-        while (i < e && substr(l, i, 1) ~ /[A-Za-z0-9_]/) i++
-      } else if (c ~ /[0-9]/) {
-        while (i < e && substr(l, i, 1) ~ /[0-9]/) i++
-      } else if (c ~ /[@*?$!-]/) {
+      # A `#` straight after `${` is USUALLY the length operator — but `#` is
+      # also the special parameter holding the positional-argument count, and
+      # bash resolves the ambiguity by what FOLLOWS it. When that is a `/`, no
+      # parameter name can be starting, so the `#` is the parameter itself and
+      # the rest is a real pattern substitution. Measured on 5.3.15 with two
+      # positional parameters: `${#//2/&}` yields `2` with patsub_replacement on
+      # and `&` with it off — the exact divergence this class exists for, which
+      # an unconditional bail reported clean. `${#}`, `${##}`, `${#v}` and
+      # `${#arr[@]}` all keep a non-`/` successor and stay length expansions.
+      named = 1
+      if (c == "#") {
+        if (substr(l, i + 1, 1) != "/") return 0
         i++
-      } else return 0
+        named = 0
+      } else if (c == "!") i++
+      if (named) {
+        c = substr(l, i, 1)
+        if (c ~ /[A-Za-z_]/) {
+          while (i < e && substr(l, i, 1) ~ /[A-Za-z0-9_]/) i++
+        } else if (c ~ /[0-9]/) {
+          while (i < e && substr(l, i, 1) ~ /[0-9]/) i++
+        } else if (c ~ /[@*?$!-]/) {
+          i++
+        } else return 0
+      }
       if (substr(l, i, 1) == "[") {
         sep = 1
         i++
@@ -1325,7 +1360,7 @@ scan_file() {
           i++
           continue
         }
-        if (c == BT || (c == "$" && (substr(l, i + 1, 1) == "(" || substr(l, i + 1, 1) == "{"))) {
+        if (opens_frame(l, i)) {
           i = skip_frame(l, i, e - 1)
           continue
         }
@@ -1351,7 +1386,7 @@ scan_file() {
           i++
           continue
         }
-        if (c == BT || (c == "$" && (substr(l, i + 1, 1) == "(" || substr(l, i + 1, 1) == "{"))) {
+        if (opens_frame(l, i)) {
           i = skip_frame(l, i, e - 1)
           continue
         }
@@ -1465,10 +1500,11 @@ scan_file() {
         report_hit(line, lineno, patterns[i], annotated_above,
           has_unguarded(cline, qline, patterns[i], mask, 1), cline, qline, mask, "ere")
       }
-      # The script-implemented class reads the ORIGINAL record text — the `&` it
-      # looks for is blanked on both derived views — and sits INSIDE this
-      # escapes of this function on purpose: hoisting it above the comment-skip
-      # annotation returns above would silently lose every one of them.
+      # The script-implemented class reads the ORIGINAL record text, because the
+      # `&` it looks for is blanked on both derived views. It runs HERE, below
+      # the comment-skip and annotation returns above, so that it inherits every
+      # escape this function applies to the ERE classes; hoisting it above those
+      # returns would silently lose all of them.
       if (CLS_AMP)
         report_hit(line, lineno, AMPTOK, annotated_above,
           subst_amp_hit(line, 1), line, qline, mask, "amp")
@@ -1477,6 +1513,9 @@ scan_file() {
     # stepping past any the annotation on that line covers. Returns 1 if
     # anything was printed, so the second view is only consulted when the first
     # found nothing (one report per pattern per record, as before).
+    # (Definition below; next_hit() has to be declared first because report_hit()
+    # advances through it.)
+    #
     # next_hit — the next occurrence at or after <from>, dispatched by CLASS
     # KIND. awk has no function references, so the kind is passed explicitly at
     # every call site rather than defaulted: a dropped argument arrives as the
@@ -1487,6 +1526,7 @@ scan_file() {
       if (kind == "amp") return subst_amp_hit(view, from)
       return has_unguarded(view, q, p, m, from)
     }
+    # report_hit — see the doc block above next_hit().
     function report_hit(line, lineno, p, annotated_above, off, view, q, m, kind,   k) {
       # A backslash continuation removes the newline, so its physical lines are
       # one line in the strongest sense: the record is reported whole, at its

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -1249,12 +1249,19 @@ scan_file() {
     #     single-quoted one are each a literal ampersand on 5.3.15 — the manual
     #     says "Quoting any part of string inhibits replacement in the
     #     expansion of the quoted portion" — and none of them is flagged. `\&`
-    #     is the spelling the failure message recommends: it is literal under
-    #     every BASH_COMPAT level this repo could meet (32/42/44/50/51 and
-    #     default), whereas the QUOTED spellings carry a separate pre-4.3 quirk
-    #     (compat42: "The replacement string in double-quoted pattern
-    #     substitution does not undergo quote removal, as it does in versions
-    #     after bash-4.2"), which leaves the quote characters in the output.
+    #     is the spelling the failure message recommends, and the evidence for
+    #     that is worth separating from what was inferred. BASH_COMPAT is NOT a
+    #     pre-5.2 oracle for this rule — a bare `&` still expanded at every
+    #     level down to 32 on 5.3.15, so the option is not compat-gated. What
+    #     the ladder DOES establish is that the backslash before an `&` is
+    #     removed even under the pre-4.3 quote-removal regime (tested at 32, 42,
+    #     44, 50, 51 and the default); the manual supplies the rest, stating the
+    #     backslash is removed in order to permit a literal `&`. The QUOTED
+    #     spellings are the ones with a version quirk of their own (compat42:
+    #     "The replacement string in double-quoted pattern substitution does not
+    #     undergo quote removal, as it does in versions after bash-4.2"), which
+    #     leaves the quote characters in the output on the older regime — a
+    #     reason to prefer `\&`, not a reason to flag them.
     #
     # KNOWN LIMITS, all in the under-flag direction and all the same indirection
     # class this gate declares out of scope throughout (#1513):
@@ -1632,6 +1639,11 @@ scan_file() {
 }
 
 violations=0
+# Whether any reported hit belongs to the bash-version class, so its remediation
+# paragraph is printed to the developer who actually hit it and to nobody else.
+# Printed unconditionally it followed every `grep -P` and `sed -i` failure with
+# advice about an ampersand the developer never wrote.
+amp_violation=0
 for file in "${files[@]}"; do
   if [[ ! -f "$file" ]]; then
     printf 'Error: no such file: %s\n' "$file" >&2
@@ -1648,6 +1660,10 @@ for file in "${files[@]}"; do
     while IFS= read -r v; do
       echo "PORTABILITY: ${file}:${v}" >&2
       violations=$((violations + 1))
+      case "$v" in
+      *"!subst-replacement-ampersand"*) amp_violation=1 ;;
+      *) ;;
+      esac
     done <<<"$out"
   fi
 done
@@ -1661,15 +1677,20 @@ if ((violations > 0)); then
     echo "undetected. Resolve the construct with a POSIX-portable form, or —"
     echo "when the use is legitimate and reviewed — add a"
     echo "'portability-ok: <reason>' comment at the site."
-    echo
-    echo "!subst-replacement-ampersand names the one class that is a bash"
-    echo "VERSION divergence rather than a utility one: since bash 5.2 an"
-    echo "unquoted '&' in the replacement half of \${var//pat/repl} expands to"
-    echo "the text the pattern just matched, so the same line means two things"
-    echo "on macOS (bash 3.2) and on this repo's runners (5.2+). Spell a literal"
-    echo "ampersand '\\&' — the backslash is removed on every bash, and the"
-    echo "quoted spellings carry their own pre-4.3 quote-removal divergence."
   } >&2
+  if ((amp_violation > 0)); then
+    {
+      echo
+      echo "!subst-replacement-ampersand names the one class above that is a bash"
+      echo "VERSION divergence rather than a utility one: since bash 5.2 an"
+      echo "unquoted '&' in the replacement half of \${var//pat/repl} expands to"
+      echo "the text the pattern just matched, so the same line means two things"
+      echo "on macOS (bash 3.2) and on this repo's runners (5.2+). Spell a literal"
+      echo "ampersand '\\&': the manual states the backslash is removed to permit"
+      echo "a literal '&', and the quoted spellings carry their own pre-4.3"
+      echo "quote-removal divergence."
+    } >&2
+  fi
   exit 1
 fi
 echo "No unexcused GNU-only constructs in ${#files[@]} shell file(s)."

--- a/scripts/check-shell-portability.sh
+++ b/scripts/check-shell-portability.sh
@@ -18,6 +18,44 @@
 # re-catch is a one-line data edit. HOW a legitimate hit is excused is this
 # script's job.
 #
+# A token line beginning with `!` names a class this script implements in CODE
+# rather than as an ERE, and ACTIVATION stays data even there: the class runs
+# only while its `!name` line is active in the token list, so a class-scoped
+# unit fixture enables exactly one class the same way `one_token_list` does for
+# an ERE. An unrecognized `!name` exits 2 rather than being ignored — a typo
+# that silently disabled a class is the fail-open this gate is tuned against.
+# Today there is one such class, and it is script-implemented for a reason the
+# ERE layer cannot work around:
+#
+#   !subst-replacement-ampersand — an UNQUOTED `&` in the REPLACEMENT half of a
+#   `${var/pat/repl}` / `${var//pat/repl}` expansion. Since bash 5.2 that `&`
+#   expands to the text the pattern just matched (the `sed` rule), under the
+#   `patsub_replacement` shell option which is ON by default; before 5.2 the
+#   same character was an ordinary literal. GNU Bash Reference Manual, Shell
+#   Parameter Expansion: "Any unquoted instances of '&' in string are replaced
+#   with the matching portion of pattern", and "Backslash escapes '&' in
+#   string; the backslash is removed in order to permit a literal '&' in the
+#   replacement string"
+#   <https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html>.
+#   Introduced in bash-5.2 ("New shell option: patsub_replacement", bash NEWS
+#   <https://tiswww.case.edu/php/chet/bash/NEWS>); verified locally on bash
+#   5.3.15, where `shopt -u patsub_replacement` restores the pre-5.2 literal.
+#   This lands on the gate's EXISTING uncovered-platform axis rather than a new
+#   one: macOS — the one platform no runner here covers — ships bash 3.2, while
+#   every runner in this repo ships 5.2 or later, so the same line silently
+#   means two different things on the two platforms. It shipped a real defect
+#   in this repo (#2008): a sentinel restored to itself became a no-op and
+#   produced a live false positive in a guardrails hook, on bash >=5.2 only.
+#
+#   It cannot be an ERE token. Matching runs on the `qline`/`cline` views, and
+#   `neutralize()` replaces every SEPS character — `&` among them — inside a
+#   masked run with a filler; a `${…}` body is masked in its entirety, which is
+#   exactly right for every other class (a `;` in an expansion body is data,
+#   not an operator) and leaves this one nothing to match on. The class is
+#   instead decided by subst_amp_hit(), which reads the ORIGINAL record text
+#   inside the `${…}` extents mask_quotes() already tracks, so the one
+#   authority on quote/frame structure stays the one authority.
+#
 # Changed-FILE scoping (not a whole-repo scan on every push) mirrors
 # check-skill-portability.sh exactly: a PR is responsible only for the files it
 # touches, so enabling a token class never red-lines main — main's push event
@@ -208,6 +246,11 @@ scan_file() {
     # single-quoted shell word, where a literal quote cannot appear.
     BEGIN {
       SQ = "\047"; DQ = "\042"; BS = "\134"; BT = "\140"; NL = "\012"
+      # The label a script-implemented class reports under. It is the token
+      # line that activates it, verbatim, so a reported hit greps straight back
+      # to the data line that turned the class on — the same relationship an
+      # ERE hit has with its own token.
+      AMPTOK = "!subst-replacement-ampersand"
       # A newline is a separator too, and it reaches a record only through a
       # quote-continued join. Inside a QUOTED run it is ordinary data, so
       # neutralizing it is what lets a token gap span the join: a `stat` whose
@@ -377,10 +420,19 @@ scan_file() {
     # original text, so `# see date -d` still reports, the same over-flag
     # direction that the comment-skip in scan_logical — not this mask — is what
     # exempts a comment-ONLY line from.
+    #
+    # It also RECORDS the extent of every `${…}` parameter expansion it closes,
+    # into VS/VE (NV of them). The bash-5.2 `&`-in-replacement class needs the
+    # one thing an ERE cannot have and this walk already computes: where an
+    # expansion begins and ends, with its own quoting and nesting honored. A
+    # second quote tracker written beside this one is the matched-pair shape
+    # that has already produced two defects in this corpus — one side widened,
+    # the other not — so the class reads these extents instead.
     function mask_quotes(l,   i, c, m, st, top, len) {
       m = ""
       DANGLING_BS = 0
       DANGLING_QUOTE = 0
+      NV = 0
       st = "U"
       len = length(l)
       for (i = 1; i <= len; i++) {
@@ -437,6 +489,7 @@ scan_file() {
         if (c == "$" && substr(l, i + 1, 1) == "{") {
           m = m "QQ"
           st = st "V"
+          VOPEN[length(st)] = i
           i++
           continue
         }
@@ -466,7 +519,15 @@ scan_file() {
           m = m "Q"
           if (c == SQ) st = st "S"
           else if (c == DQ) st = st "D"
-          else if (c == "}") st = substr(st, 1, length(st) - 1)
+          else if (c == "}") {
+            # The frame is recorded only where it CLOSES, so an expansion left
+            # open at end of record contributes nothing — the record loop joins
+            # the next physical line and this walk runs again over the whole.
+            NV++
+            VS[NV] = VOPEN[length(st)]
+            VE[NV] = i
+            st = substr(st, 1, length(st) - 1)
+          }
           continue
         }
         if (top == "D") {
@@ -1117,6 +1178,196 @@ scan_file() {
       }
       return 0
     }
+    # ---- bash-5.2 `&`-in-replacement class (!subst-replacement-ampersand) ----
+    # skip_frame <line> <at> <limit> — the offset just PAST the nested frame
+    # opening at <at> (`$(`, `$((`, `${`, or a backquote). Its body is not part
+    # of the enclosing pattern or replacement text: a `/` inside `${x:-a/b}` is
+    # data belonging to the inner expansion and never the separator, and a `&`
+    # inside `$(a && b)` is inner command syntax, never a match reference.
+    # Quoting inside the frame is tracked so a `)`/`}` in a string cannot close
+    # it early. An UNTERMINATED frame runs to <limit>, which ends the scan with
+    # no hit — the under-flag direction, and unreachable in practice because the
+    # record loop only calls this once every frame the mask opened has closed.
+    function skip_frame(l, at, limit,   c, o, cl, depth, st) {
+      c = substr(l, at, 1)
+      if (c == BT) {
+        at++
+        while (at <= limit && substr(l, at, 1) != BT) at++
+        return at + 1
+      }
+      o = substr(l, at + 1, 1)
+      if (o == "(") cl = ")"
+      else cl = "}"
+      at += 2
+      depth = 1
+      st = "U"
+      while (at <= limit && depth > 0) {
+        c = substr(l, at, 1)
+        if (st == "S") {
+          if (c == SQ) st = "U"
+        } else if (c == BS) {
+          at++
+        } else if (c == SQ) {
+          st = "S"
+        } else if (c == DQ) {
+          if (st == "D") st = "U"
+          else st = "D"
+        } else if (c == o) {
+          depth++
+        } else if (c == cl) {
+          depth--
+        }
+        at++
+      }
+      return at
+    }
+    # amp_in_frame <line> <start> <end> — the offset of the first UNQUOTED `&`
+    # in the replacement half of the `${…}` expansion spanning [start, end], or
+    # 0 when the frame is not a pattern substitution or its replacement holds no
+    # such `&`. <start> is the `$`, <end> the closing `}`.
+    #
+    # Grammar, verified against bash 5.3.15 rather than assumed:
+    #   - the expansion is a substitution only when the character after the
+    #     parameter name (and its optional `[…]` subscript) is `/`. That is what
+    #     keeps `${var:-a/b/&}`, `${var#*/}`, `${var%/*}` and `${var:0:1}` out:
+    #     their operator is not `/`, so every `/` and `&` in them is ordinary
+    #     word text. `${#var}` is a length and can never be a substitution;
+    #   - one optional `/` (global) or `#`/`%` (anchored) may follow the
+    #     operator before the pattern begins;
+    #   - the pattern ends at the FIRST `/` that is unquoted, unescaped and not
+    #     inside a nested frame — not the last. `v=aXbXc; "${v//X/Y/Z}"` yields
+    #     `aY/ZbY/Zc`, so the pattern is `X` and the replacement is `Y/Z`; a
+    #     last-slash reading would have missed the `&` in `${v//X/b&/c}`. A
+    #     quoted or backslash-escaped slash is NOT the separator
+    #     (`s=a/b; "${s//"/"/-}"` and `"${s//\//-}"` both yield `a-b`), while a
+    #     `[…]` bracket expression does NOT protect one (`"${p//[/]/-}"` leaves
+    #     `a/b` untouched, so the pattern was `[`);
+    #   - a frame with NO separator is the DELETION form `${var//pat}` and has
+    #     no replacement to flag;
+    #   - inside the replacement, only an `&` in the UNQUOTED state is a match
+    #     reference. A backslash-escaped `\&`, a double-quoted one and a
+    #     single-quoted one are each a literal ampersand on 5.3.15 — the manual
+    #     says "Quoting any part of string inhibits replacement in the
+    #     expansion of the quoted portion" — and none of them is flagged. `\&`
+    #     is the spelling the failure message recommends: it is literal under
+    #     every BASH_COMPAT level this repo could meet (32/42/44/50/51 and
+    #     default), whereas the QUOTED spellings carry a separate pre-4.3 quirk
+    #     (compat42: "The replacement string in double-quoted pattern
+    #     substitution does not undergo quote removal, as it does in versions
+    #     after bash-4.2"), which leaves the quote characters in the output.
+    #
+    # KNOWN LIMITS, all in the under-flag direction and all the same indirection
+    # class this gate declares out of scope throughout (#1513):
+    #   - an `&` that ARRIVES by expansion is undetectable here. The rule is
+    #     applied after the replacement expands, so an `&` held in a variable
+    #     and an `&` in the OUTPUT of a `$(…)` inside the replacement both
+    #     reference the match at run time (verified on 5.3.15: for `v=aXb`, a
+    #     replacement of `$(printf p&q)` — the ampersand produced by the
+    #     substitution — yields `apXqb`). The manual says the same thing from
+    #     the quoting side: quoting inhibits replacement "including replacement
+    #     strings stored in shell variables";
+    #   - a substitution assembled from fragments before use, exactly as the
+    #     script header records for the ERE classes;
+    #   - a parameter spelling this walk does not recognize (a name that is not
+    #     an identifier, a digit run, or one of `@ * ? $ ! -`) is skipped.
+    function amp_in_frame(l, s, e,   i, c, st, sep) {
+      i = s + 2
+      if (i > e - 1) return 0
+      c = substr(l, i, 1)
+      if (c == "#") return 0
+      if (c == "!") i++
+      c = substr(l, i, 1)
+      if (c ~ /[A-Za-z_]/) {
+        while (i < e && substr(l, i, 1) ~ /[A-Za-z0-9_]/) i++
+      } else if (c ~ /[0-9]/) {
+        while (i < e && substr(l, i, 1) ~ /[0-9]/) i++
+      } else if (c ~ /[@*?$!-]/) {
+        i++
+      } else return 0
+      if (substr(l, i, 1) == "[") {
+        sep = 1
+        i++
+        while (i < e && sep > 0) {
+          c = substr(l, i, 1)
+          if (c == "[") sep++
+          else if (c == "]") sep--
+          i++
+        }
+        if (sep > 0) return 0
+        sep = 0
+      }
+      if (substr(l, i, 1) != "/") return 0
+      i++
+      c = substr(l, i, 1)
+      if (c == "/" || c == "#" || c == "%") i++
+      # Pattern half: walk to the separator.
+      st = "U"
+      sep = 0
+      while (i <= e - 1) {
+        c = substr(l, i, 1)
+        if (st == "S") {
+          if (c == SQ) st = "U"
+          i++
+          continue
+        }
+        if (c == BS) { i += 2; continue }
+        if (c == SQ) { st = "S"; i++; continue }
+        if (c == DQ) {
+          if (st == "D") st = "U"
+          else st = "D"
+          i++
+          continue
+        }
+        if (c == BT || (c == "$" && (substr(l, i + 1, 1) == "(" || substr(l, i + 1, 1) == "{"))) {
+          i = skip_frame(l, i, e - 1)
+          continue
+        }
+        if (st == "U" && c == "/") { sep = i; break }
+        i++
+      }
+      if (sep == 0) return 0
+      # Replacement half: the first unquoted `&`.
+      i = sep + 1
+      st = "U"
+      while (i <= e - 1) {
+        c = substr(l, i, 1)
+        if (st == "S") {
+          if (c == SQ) st = "U"
+          i++
+          continue
+        }
+        if (c == BS) { i += 2; continue }
+        if (c == SQ) { st = "S"; i++; continue }
+        if (c == DQ) {
+          if (st == "D") st = "U"
+          else st = "D"
+          i++
+          continue
+        }
+        if (c == BT || (c == "$" && (substr(l, i + 1, 1) == "(" || substr(l, i + 1, 1) == "{"))) {
+          i = skip_frame(l, i, e - 1)
+          continue
+        }
+        if (st == "U" && c == "&") return i
+        i++
+      }
+      return 0
+    }
+    # subst_amp_hit <line> <from> — the SMALLEST offset at or after <from> at
+    # which an unquoted replacement `&` sits, or 0. An offset rather than a
+    # yes/no for the same reason has_unguarded() returns one: a joined record
+    # spans physical lines, and both the reported line number and the annotation
+    # scope are decided by WHERE the hit sits. Frames are recorded in closing
+    # order, so the minimum is taken rather than the first found — a nested
+    # expansion closes before the one containing it.
+    function subst_amp_hit(l, from,   f, at, best) {
+      best = 0
+      for (f = 1; f <= NV; f++) {
+        at = amp_in_frame(l, VS[f], VE[f])
+        if (at >= from && at > 0 && (best == 0 || at < best)) best = at
+      }
+      return best
+    }
     # A HEREDOC body is not shell code, so it can neither continue a command nor
     # leave a quote open for the next line to inherit. It still gets SCANNED —
     # this corpus writes real scripts through heredocs and the gate deliberately
@@ -1167,12 +1418,23 @@ scan_file() {
       if (k >= nphys) return substr(logical, physoff[k])
       return substr(logical, physoff[k], physoff[k + 1] - physoff[k] - 1)
     }
-    # Pass 1: collect active ERE patterns from the token list.
+    # Pass 1: collect active ERE patterns from the token list, plus the `!name`
+    # lines that activate a script-implemented class (see the script header).
+    # An UNRECOGNIZED `!name` fails closed: ignoring it would let a typo in the
+    # shipped list, or in a caller override, silently disable a whole class
+    # while the run still reported clean — the one outcome the contract of this
+    # gate forbids everywhere else.
     FNR == NR {
       line = $0
       sub(/^[[:space:]]+/, "", line)
       sub(/[[:space:]]+$/, "", line)
       if (line == "" || line ~ /^#/) next
+      if (substr(line, 1, 1) == "!") {
+        if (line == AMPTOK) { CLS_AMP = 1; ncls++; next }
+        printf "Error: unknown script-implemented class in token list: %s\n", line > "/dev/stderr"
+        FATAL = 1
+        exit 2
+      }
       patterns[++np] = line
       next
     }
@@ -1192,16 +1454,33 @@ scan_file() {
       if (!joined && (is_annotated(line) || annotated_above)) return
       for (i = 1; i <= np; i++) {
         if (report_hit(line, lineno, patterns[i], annotated_above,
-          has_unguarded(qline, qline, patterns[i], mask, 1), qline, qline, mask)) continue
+          has_unguarded(qline, qline, patterns[i], mask, 1), qline, qline, mask, "ere")) continue
         report_hit(line, lineno, patterns[i], annotated_above,
-          has_unguarded(cline, qline, patterns[i], mask, 1), cline, qline, mask)
+          has_unguarded(cline, qline, patterns[i], mask, 1), cline, qline, mask, "ere")
       }
+      # The script-implemented class reads the ORIGINAL record text — the `&` it
+      # looks for is blanked on both derived views — and sits INSIDE this
+      # escapes of this function on purpose: hoisting it above the comment-skip
+      # annotation returns above would silently lose every one of them.
+      if (CLS_AMP)
+        report_hit(line, lineno, AMPTOK, annotated_above,
+          subst_amp_hit(line, 1), line, qline, mask, "amp")
     }
     # report_hit — print the first hit whose OWN physical line is unexcused,
     # stepping past any the annotation on that line covers. Returns 1 if
     # anything was printed, so the second view is only consulted when the first
     # found nothing (one report per pattern per record, as before).
-    function report_hit(line, lineno, p, annotated_above, off, view, q, m,   k) {
+    # next_hit — the next occurrence at or after <from>, dispatched by CLASS
+    # KIND. awk has no function references, so the kind is passed explicitly at
+    # every call site rather than defaulted: a dropped argument arrives as the
+    # empty string, and a kind that defaulted to the ERE finder would make the
+    # script-implemented class report its first hit and then stop looking, with
+    # the suite still green.
+    function next_hit(kind, view, q, p, m, from) {
+      if (kind == "amp") return subst_amp_hit(view, from)
+      return has_unguarded(view, q, p, m, from)
+    }
+    function report_hit(line, lineno, p, annotated_above, off, view, q, m, kind,   k) {
       # A backslash continuation removes the newline, so its physical lines are
       # one line in the strongest sense: the record is reported whole, at its
       # first line number, exactly as before. Only a quote-joined record, whose
@@ -1223,7 +1502,7 @@ scan_file() {
           hits[++nhits] = sprintf("%d: %s -> %s", physno[k], p, phys_text(k))
           return 1
         }
-        off = has_unguarded(view, q, p, m, off + 1)
+        off = next_hit(kind, view, q, p, m, off + 1)
       }
       return 0
     }
@@ -1335,8 +1614,11 @@ scan_file() {
     # checked. Reporting clean in that state is the silent skip the contract
     # forbids, so it fails closed instead.
     END {
+      # A pass-1 fatal (an unknown `!name`) reaches END through the awk `exit`;
+      # re-reporting it as an empty pattern set would bury the real diagnostic.
+      if (FATAL) exit 2
       if (pending) scan_logical(logical, logical_line, logical_mask)
-      if (np == 0) {
+      if (np == 0 && ncls == 0) {
         print "Error: token list loaded no active patterns" > "/dev/stderr"
         exit 2
       }
@@ -1379,6 +1661,14 @@ if ((violations > 0)); then
     echo "undetected. Resolve the construct with a POSIX-portable form, or —"
     echo "when the use is legitimate and reviewed — add a"
     echo "'portability-ok: <reason>' comment at the site."
+    echo
+    echo "!subst-replacement-ampersand names the one class that is a bash"
+    echo "VERSION divergence rather than a utility one: since bash 5.2 an"
+    echo "unquoted '&' in the replacement half of \${var//pat/repl} expands to"
+    echo "the text the pattern just matched, so the same line means two things"
+    echo "on macOS (bash 3.2) and on this repo's runners (5.2+). Spell a literal"
+    echo "ampersand '\\&' — the backslash is removed on every bash, and the"
+    echo "quoted spellings carry their own pre-4.3 quote-removal divergence."
   } >&2
   exit 1
 fi

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1295,6 +1295,29 @@ else
 fi
 rm -f "$f" "$BADCLS"
 
+# --- the class remediation paragraph is SCOPED to a hit of this class. Printed
+# unconditionally it followed every `grep -P` / `sed -i` failure with advice
+# about an ampersand the developer never wrote — the mirror of the inertness
+# case above, and asserted in both directions for the same reason.
+f="$(tmpsh 'v="${v//X/&}"')"
+out="$(scan_paths "$amptok" "$f" 2>&1)"
+if [[ "$out" == *"!subst-replacement-ampersand names the one class"* ]]; then
+  ok "an & hit prints the bash-version remediation paragraph"
+else
+  fail "an & hit must carry its own remediation paragraph, got: $out"
+fi
+rm -f "$f"
+
+tok="$(one_token_list 'grep[^\n]*[[:space:]]-[A-Za-z]*P([[:space:]]|$)')"
+f="$(tmpsh 'grep -P foo "$file"')"
+out="$(scan_paths "$tok" "$f" 2>&1)"
+if [[ "$out" == *"PORTABILITY:"* && "$out" != *"!subst-replacement-ampersand names the one class"* ]]; then
+  ok "an unrelated class failure does not print the bash-version paragraph"
+else
+  fail "the & remediation paragraph leaked onto an unrelated failure, got: $out"
+fi
+rm -f "$f" "$tok"
+
 # --- the SHIPPING token list has the class active, not just the mechanism ---
 f="$(tmpsh 'normalized="${normalized//"$soh"/&}"')"
 if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1103,6 +1103,210 @@ fi
 rm -f "$f" "$tok"
 
 # =============================================================================
+# !subst-replacement-ampersand — an UNQUOTED `&` in the REPLACEMENT half of a
+# `${var/pat/repl}` / `${var//pat/repl}` expansion.
+#
+# Since bash 5.2 that `&` expands to the text the pattern just matched, under
+# the `patsub_replacement` option that is on by default; macOS ships bash 3.2,
+# where the same character is an ordinary literal — the gate's own uncovered
+# platform, reached through a version rather than a utility. Every grammar
+# expectation below was measured against bash 5.3.15 before it was encoded,
+# never recalled; the first fixture is the real defect #2008 fixed in
+# plugins/guardrails/hooks/block-hook-bypass.sh, where a sentinel restored to
+# itself became a no-op and produced a live guardrails false positive.
+#
+# The class is implemented in the script rather than as an ERE (the `&` is
+# neutralized on both matching views before a pattern could see it), so these
+# fixtures activate it through its `!name` token line exactly as an ERE fixture
+# activates a pattern — activation stays data either way, which the inertness
+# case at the end of this section pins.
+# =============================================================================
+
+amptok="$(one_token_list '!subst-replacement-ampersand')"
+
+# amp_fires <label> <fixture-body> — the body is one line and must be reported
+# by THIS class, at file:line, so a silently inert rule cannot pass.
+amp_fires() {
+  local label="$1" body="$2" f out
+  f="$(tmpsh "$body")"
+  if out="$(scan_paths "$amptok" "$f" 2>&1)"; then
+    fail "$label should fire, got success: $out"
+  elif echo "$out" | grep -q "PORTABILITY: ${f}:1: !subst-replacement-ampersand"; then
+    ok "$label fires"
+  else
+    fail "$label: expected the & class at file:line, got: $out"
+  fi
+  rm -f "$f"
+}
+# amp_clean <label> <fixture-body> — the body must be reported by nothing.
+amp_clean() {
+  local label="$1" body="$2" f out
+  f="$(tmpsh "$body")"
+  if out="$(scan_paths "$amptok" "$f" 2>&1)"; then
+    ok "$label does not fire"
+  else
+    fail "$label must not fire: $out"
+  fi
+  rm -f "$f"
+}
+
+# --- the exact shape that shipped the defect ------------------------------
+amp_fires 'the #2008 defect shape (quoted pattern, bare & replacement)' \
+  'normalized="${normalized//"$soh"/&}"'
+# --- the non-global spelling is the same expansion -------------------------
+amp_fires 'the single-substitution ${var/pat/&} spelling' 'v="${v/X/&}"'
+# --- the `&` need not be the whole replacement, nor sit last ---------------
+amp_fires 'a bare & in the middle of a replacement' 'v="${v//X/p&q}"'
+amp_fires 'a doubled && replacement' 'v="${v//X/&&}"'
+# --- the replacement runs to the closing brace, so a `/` AFTER the separator
+# is replacement text. Bash ends the PATTERN at the FIRST unquoted, unescaped
+# `/` (`v=aXbXc; "${v//X/Y/Z}"` yields `aY/ZbY/Zc`), so a last-slash reading of
+# the grammar would report this line clean.
+amp_fires 'a replacement containing its own slash' 'v="${v//X/b&/c}"'
+# --- a correctly escaped or quoted ampersand EARLIER on the line does not
+# excuse a bare one after it: each occurrence is decided on its own.
+amp_fires 'a bare & after an escaped one' 'v="${v//X/\&&}"'
+amp_fires 'a bare & after a double-quoted one' 'v="${v//X/"&"&}"'
+amp_fires 'a bare & after a nested expansion' 'v="${v//X/${r}&}"'
+# --- nasty patterns: the separator search must survive a nested expansion, a
+# quoted slash and an escaped slash inside the pattern half.
+amp_fires 'a nested expansion in the pattern half' 'v="${v//${pat}/&}"'
+amp_fires 'a double-quoted slash inside the pattern' 'v="${v//"a/b"/&}"'
+amp_fires 'a backslash-escaped slash as the pattern' 'v="${v//\//&}"'
+# --- parameter spellings other than a plain name ---------------------------
+amp_fires 'an anchored ${var/#pat/&} substitution' 'v="${v/#X/&}"'
+amp_fires 'an array element substitution' 'v="${arr[@]//X/&}"'
+amp_fires 'a positional-parameter substitution' 'v="${1//X/&}"'
+amp_fires 'an unquoted expansion context' 'v=${v//X/&}'
+
+# --- the CORRECT form. `\&` is what the failure message recommends: the
+# backslash is removed on every bash (verified across BASH_COMPAT 32/42/44/50/
+# 51 and the default on 5.3.15), so it is a literal ampersand on both sides of
+# the 5.2 boundary.
+amp_clean 'a backslash-escaped \& replacement' 'n="${n//"$soh"/\&}"'
+# --- quoting also inhibits the replacement ("Quoting any part of string
+# inhibits replacement in the expansion of the quoted portion" — GNU Bash
+# Reference Manual, Shell Parameter Expansion), verified on 5.3.15 for both
+# quote characters. Neither is flagged; the failure message still steers to
+# `\&`, because the quoted spellings carry their own pre-4.3 quote-removal
+# divergence.
+amp_clean 'a double-quoted "&" replacement' 'v="${v//X/"&"}"'
+amp_clean 'a single-quoted &-replacement' "v=\"\${v//X/'&'}\""
+# --- the DELETION form has no replacement at all ---------------------------
+amp_clean 'the ${var//pat} deletion form' 'v="${v//X}"'
+amp_clean 'an empty replacement' 'v="${v//X/}"'
+# --- expansions whose operator is not `/` are not substitutions, however many
+# slashes and ampersands their word carries.
+amp_clean 'a :- default-value word containing a slash and an &' 'v="${v:-a/b/&}"'
+amp_clean 'a := assign-default word containing an &' 'v="${v:=a/b/&}"'
+amp_clean 'a # prefix-strip pattern' 'v="${v#*/}"'
+amp_clean 'a % suffix-strip pattern' 'v="${v%/*}"'
+amp_clean 'a substring expansion' 'v="${v:0:1}"'
+amp_clean 'a length expansion' 'v="${#v}"'
+# --- an `&` that is not in a substitution at all ---------------------------
+amp_clean 'an && control operator' 'a && b'
+amp_clean 'a backgrounding &' 'cmd &'
+amp_clean 'a 2>&1 file-descriptor duplication' 'printf x 2>&1'
+amp_clean 'a quoted & in ordinary text' 'echo "a & b"'
+amp_clean 'an & in the PATTERN half' 'v="${v//&/X}"'
+# --- a nested command substitution in the replacement is command text, where
+# `&` is ordinary shell syntax rather than a match reference.
+amp_clean 'an && inside a nested substitution in the replacement' 'v="${v//X/$(a && b)}"'
+# --- a single-quoted expansion is literal text: no expansion, no rule -------
+amp_clean 'the construct inside single quotes (no expansion at all)' "printf '%s' '\${v//X/&}'"
+
+# --- the class honours the SAME escapes every other class does -------------
+f="$(tmpsh 'v="${v//X/&}" # portability-ok: the sed-rule expansion is what this line wants')"
+if scan_paths "$amptok" "$f" >/dev/null 2>&1; then
+  ok "a same-line portability-ok excuses an & hit"
+else
+  fail "an annotated & hit must be excused: $(scan_paths "$amptok" "$f" 2>&1)"
+fi
+rm -f "$f"
+
+f="$(tmpsh '# portability-ok: bash >= 5.2 is guaranteed here
+v="${v//X/&}"')"
+if scan_paths "$amptok" "$f" >/dev/null 2>&1; then
+  ok "a portability-ok comment block above excuses an & hit"
+else
+  fail "a block-annotated & hit must be excused: $(scan_paths "$amptok" "$f" 2>&1)"
+fi
+rm -f "$f"
+
+f="$(tmpsh '# portability-scope: this fixture IS a bash-5.2-construct corpus, on purpose
+v="${v//X/&}"')"
+if scan_paths "$amptok" "$f" >/dev/null 2>&1; then
+  ok "a whole-file portability-scope excuses an & hit"
+else
+  fail "a file-scoped & hit must be excused: $(scan_paths "$amptok" "$f" 2>&1)"
+fi
+rm -f "$f"
+
+# --- a comment-only line naming the construct is prose, not code -----------
+amp_clean 'a comment-only line naming the construct' '# never write ${var//pat/&} here'
+
+# --- a QUOTE-JOINED record spans physical lines, and the hit is attributed to
+# the physical line it actually sits on — the same per-line attribution the ERE
+# classes get, reached through the shared report path.
+f="$(mktemp --suffix=.sh)"
+printf 'msg="opened here\nv=${v//X/&}"\n' >"$f"
+if out="$(scan_paths "$amptok" "$f" 2>&1)"; then
+  fail "an & hit on the second physical line should fire, got success: $out"
+elif echo "$out" | grep -q "PORTABILITY: ${f}:2: !subst-replacement-ampersand"; then
+  ok "an & hit inside a joined record is attributed to its own physical line"
+else
+  fail "expected the & hit at line 2 of the joined record, got: $out"
+fi
+rm -f "$f"
+
+# --- ACTIVATION IS DATA: with the `!name` line absent the class is inert, so a
+# fixture scoped to another class is never coupled to this one.
+tok="$(one_token_list '\\b')"
+f="$(tmpsh 'v="${v//X/&}"')"
+if scan_paths "$tok" "$f" >/dev/null 2>&1; then
+  ok "the & class is inert while its token line is absent"
+else
+  fail "the & class fired without its token line: $(scan_paths "$tok" "$f" 2>&1)"
+fi
+rm -f "$f" "$tok"
+
+# --- and a token list holding ONLY the directive is a loaded config, not the
+# empty pattern set the gate fails closed on.
+f="$(tmpsh 'v="${v//X/y}"')"
+out="$(scan_paths "$amptok" "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+  ok "a directive-only token list is a loaded config, not an empty pattern set"
+else
+  fail "a directive-only token list failed closed: rc=$rc out=$out"
+fi
+rm -f "$f"
+
+# --- an UNRECOGNIZED `!name` fails the run closed. Ignoring it would let one
+# typo silently disable a whole class while the run still reported clean.
+BADCLS="$(one_token_list '!no-such-class')"
+f="$(tmpsh 'v="${v//X/&}"')"
+out="$(scan_paths "$BADCLS" "$f" 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"unknown script-implemented class"* ]]; then
+  ok "an unknown script-implemented class fails closed"
+else
+  fail "an unknown !name did not fail closed: rc=$rc out=$out"
+fi
+rm -f "$f" "$BADCLS"
+
+# --- the SHIPPING token list has the class active, not just the mechanism ---
+f="$(tmpsh 'normalized="${normalized//"$soh"/&}"')"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "the shipped token list must flag the & class, got success: $out"
+elif echo "$out" | grep -q "!subst-replacement-ampersand"; then
+  ok "the shipped token list has the & class active"
+else
+  fail "expected the & class from the shipped list, got: $out"
+fi
+rm -f "$f" "$amptok"
+
+# =============================================================================
 # Opt-out annotation
 # =============================================================================
 

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -1215,6 +1215,39 @@ amp_clean 'an && inside a nested substitution in the replacement' 'v="${v//X/$(a
 # --- a single-quoted expansion is literal text: no expansion, no rule -------
 amp_clean 'the construct inside single quotes (no expansion at all)' "printf '%s' '\${v//X/&}'"
 
+# --- `#` straight after `${` is the LENGTH operator only while what follows it
+# could start a parameter name. A `/` cannot, so `${#//2/&}` is a substitution
+# on the positional-argument COUNT and is exactly this class. Measured on 5.3.15
+# with two positional parameters: `2` with patsub_replacement on, `&` with it
+# off. Review round on #2097 — the earlier unconditional bail on `#` reported
+# this shape clean, a false PASS on a literal `${var//pat/&}`.
+amp_fires 'a substitution on the ${#} positional-argument count' 'v="${#//2/&}"'
+amp_fires 'a single substitution on ${#}' 'v="${#/2/&}"'
+amp_clean 'a plain ${#} count' 'v="${#}"'
+amp_clean 'a ${##} length-of-$# expansion' 'v="${##}"'
+amp_clean 'a ${#arr[@]} array length' 'v="${#arr[@]}"'
+
+# --- a PROCESS SUBSTITUTION body is a command list, so its `&`/`&&` is shell
+# syntax and never a match reference. Measured on 5.3.15: `v=aXb;
+# "${v//X/<(a && b)}"` yields `a/dev/fd/63b` with patsub_replacement BOTH on and
+# off — zero version divergence, so flagging it was a false POSITIVE on portable
+# code, the direction this hard-error class must never take. Review round on
+# #2097.
+amp_clean 'an && inside a <( ) process substitution in the replacement' \
+  'v="${v//X/<(cmd1 && cmd2)}"'
+amp_clean 'an && inside a >( ) process substitution in the replacement' \
+  'v="${v//X/>(cmd1 && cmd2)}"'
+amp_clean 'a single & inside a process substitution in the replacement' \
+  'v="${v//X/<(cmd1 & cmd2)}"'
+amp_clean 'a process substitution in the PATTERN half' \
+  'v="${v//<(cmd1 && cmd2)/y}"'
+# ...and skipping the frame must not swallow a real hit that follows it, in
+# either half — the frame is stepped over, not treated as end of scan.
+amp_fires 'a bare & after a process substitution in the replacement' \
+  'v="${v//X/<(cmd1 && cmd2)&}"'
+amp_fires 'a bare & replacement after a process substitution in the pattern' \
+  'v="${v//<(cmd1 && cmd2)/&}"'
+
 # --- the class honours the SAME escapes every other class does -------------
 f="$(tmpsh 'v="${v//X/&}" # portability-ok: the sed-rule expansion is what this line wants')"
 if scan_paths "$amptok" "$f" >/dev/null 2>&1; then

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -482,6 +482,43 @@ readlink[[:space:]]+(-[A-Za-z]*f|--canonicalize)
 (^|[[:space:]'"`;&|()<>/])mktemp['"]?([[:space:]][^;&|()`\n]*)?[[:space:]]-[A-Za-z]*p
 (^|[[:space:]'"`;&|()<>/])mktemp['"]?([[:space:]][^;&|()`\n]*)?[[:space:]]--tmpdir([[:space:]|&;()<>]|=|$)
 
+# --- SCRIPT-IMPLEMENTED CLASSES ---
+#
+# A line beginning with `!` activates a class check-shell-portability.sh
+# implements in CODE rather than as an ERE. Activation stays data — the class
+# runs only while its line is active here, so a class-scoped unit fixture
+# enables exactly one class exactly as it does for an ERE — and an unrecognized
+# `!name` fails the run closed rather than being ignored.
+#
+# `${var//pat/&}` — an UNQUOTED `&` in the REPLACEMENT half of a pattern
+# substitution. Since bash 5.2 it expands to the text the pattern just matched
+# (the `sed` rule), under the `patsub_replacement` option that is ON by
+# default; before 5.2 it was an ordinary literal. The GNU Bash Reference
+# Manual's Shell Parameter Expansion section states both halves — "Any
+# unquoted instances of '&' in string are replaced with the matching portion of
+# pattern" and "Backslash escapes '&' in string; the backslash is removed in
+# order to permit a literal '&' in the replacement string" — and bash NEWS
+# records the option as new in bash-5.2.
+#
+# It belongs to this gate rather than to a new one because it lands on the
+# gate's EXISTING uncovered-platform axis: macOS, the one platform no runner
+# here covers, ships bash 3.2, while every runner ships 5.2 or later. Same
+# shape as the `mktemp -p` class above — the construct is accepted on both
+# platforms and silently means something different on each, with no error
+# either way — and it is a hard error for the same reason that one is. It has
+# already shipped a defect in this repo (#2008): a sentinel restored to itself
+# became a no-op and produced a live guardrails false positive on bash >=5.2
+# only.
+#
+# It cannot be an ERE token, which is why it is here as a `!name` rather than
+# as a pattern. Matching runs on views in which every separator inside a
+# masked run — `&` among them — has been neutralized, and a `${…}` body is
+# masked in its entirety, so there is nothing left for a pattern to match. See
+# the subst_amp_hit()/amp_in_frame() block in check-shell-portability.sh for the
+# grammar it implements, the spellings it deliberately does NOT flag (`\&`,
+# `"&"`, `'&'`, and the deletion form `${var//pat}`), and its known limits.
+!subst-replacement-ampersand
+
 # --- STAGED (commented until enabled) ---
 #
 # No class is staged today: `date -d` and `stat -c` went active in #1544 and


### PR DESCRIPTION
No linked issue

## Summary

Adds one class to the shell-portability gate: an **unquoted `&` in the replacement
half of `${var/pat/repl}` / `${var//pat/repl}`**.

Since bash 5.2 that `&` expands to the text the pattern just matched — the `sed`
rule — under the `patsub_replacement` shell option, which is **on by default**.
Before 5.2 the same character was an ordinary literal. The construct is accepted
on both sides and silently means something different on each, with no error
either way.

This is not a new axis for the gate. Its stated exposure is macOS — the one
platform no runner here covers — and macOS ships bash 3.2 while every runner in
this repo ships 5.2 or later. Same shape as the existing `mktemp -p` class, whose
token comment already describes a silent precedence divergence rather than an
absent flag, and it is a **hard error** for the same reason that one is (there is
no warning channel; a hit is exit 1, escapable per site with
`portability-ok: <reason>`).

## Repro

Verified on bash 5.3.15:

```bash
soh=$'\x01'; n="cat 1>${soh}2"; n="${n//"$soh"/&}"; printf '%q\n' "$n"
# $'cat 1>\0012'   -- the replacement was a NO-OP
```

```bash
v=aXb
shopt -u patsub_replacement; printf '%q\n' "${v//X/&}"   # a\&b   (pre-5.2 behaviour)
shopt -s patsub_replacement; printf '%q\n' "${v//X/&}"   # aXb    (5.2+ default)
```

## Historical-detection proof

The class shipped a real defect in this repo, fixed by #2008. Run the new rule
against the pre-fix file:

```console
$ git show 32add0fa:plugins/guardrails/hooks/block-hook-bypass.sh > /tmp/prefix.sh
$ scripts/check-shell-portability.sh --paths /tmp/prefix.sh
PORTABILITY: /tmp/prefix.sh:425: !subst-replacement-ampersand ->   normalized="${normalized//"$soh"/&}"
```

`32add0fa` is the pre-fix parent of #2008's fix on `main`, so this reproduces for
anyone. One hit, at the exact line #2008 fixed, and nothing else in that file. That
no-op restore produced a live guardrails false positive (`echo x >&2` blocked as
a file write) on bash >=5.2 only.

## Repo sweep

`--all` audit over every in-scope shell file, with **only** this class active:

```console
$ SHELL_PORTABILITY_TOKENS=<amp-only list> scripts/check-shell-portability.sh --all
No unexcused GNU-only constructs in 418 shell file(s).
```

**ZERO occurrences of the class on current `main`** (434 tracked `*.sh`, 418 in
scope after the gate's existing `vendor/` and cross-plugin-sync exclusions — no
new exclusion was added). Nothing to fix; no live bug found.

The full `--all` run with the shipped token list reports 14 hits, all from the
pre-existing regex-escape classes (`\b`/`\s`/`\w`/`\S`) in four files this change
does not touch. Confirmed pre-existing by scanning those same four files with
`origin/main`'s unmodified gate and token list in a throwaway tree — byte-identical
output. `--all` is an audit mode; CI gates changed files only.

The stale pre-fix copy under `.claude/worktrees/agent-ac8ee00680b8101e3/` that a
sweep would legitimately hit **does not exist in this worktree** (it is untracked
in another session's worktree), so nothing was excluded for it, and nothing needed
to be: CI runs changed-file mode, where an untracked nested checkout can never
appear in a `git diff`.

## Why it is script-implemented, not a token ERE

The gate keeps *what* is detected in `scripts/shell-portability-tokens.txt`. This
class cannot live there as a pattern: matching runs on the `qline`/`cline` views,
and `neutralize()` replaces every `SEPS` character — `&` among them — inside a
masked run, while a `${…}` body is masked in its entirety. That is exactly right
for every other class (a `;` in an expansion body is data, not an operator) and
leaves this one nothing to match on.

Activation stays data anyway: a token line beginning with `!` names a class the
script implements in code, it runs only while that line is active, an
**unrecognized `!name` fails the run closed**, and a class-scoped unit fixture
enables exactly this class the way `one_token_list` does for an ERE. The extent of
each `${…}` comes from `mask_quotes()` — the one existing authority on quote and
frame structure — rather than from a second tracker written beside it.

## Grammar, measured not recalled

Every expectation below was probed against bash 5.3.15 before it was encoded.

- The pattern ends at the **FIRST** unquoted, unescaped `/`, not the last:
  `v=aXbXc; "${v//X/Y/Z}"` yields `aY/ZbY/Zc`, so the pattern is `X` and the
  replacement is `Y/Z`. (The task brief said *last*; that is measurably wrong, and
  a last-slash reading would miss the `&` in `${v//X/b&/c}` — there is a test for
  exactly that line.)
- A quoted or backslash-escaped `/` in the pattern is **not** the separator
  (`s=a/b; "${s//"/"/-}"` and `"${s//\//-}"` both yield `a-b`), while a `[...]`
  bracket expression does **not** protect one (`"${p//[/]/-}"` leaves `a/b`
  untouched).
- `\&`, `"&"` and `'&'` are each a literal ampersand — the manual's "Quoting any
  part of string inhibits replacement in the expansion of the quoted portion" —
  and **none of them is flagged**. The failure message steers to `\&`, and it is
  worth separating measurement from inference there: `BASH_COMPAT` is **not** a
  pre-5.2 oracle for this rule — a bare `&` still expanded at every level down to
  32 on 5.3.15, so the option is not compat-gated. What the ladder does establish
  is that the backslash before an `&` is removed even under the pre-4.3
  quote-removal regime (tested at 32/42/44/50/51 and the default); the manual
  supplies the rest ("the backslash is removed in order to permit a literal
  '&'"). The quoted spellings are the ones with a version quirk of their own
  (compat42: "The replacement string in double-quoted pattern substitution does
  not undergo quote removal, as it does in versions after bash-4.2"), which
  leaves the quote characters in the output on the older regime — a reason to
  prefer `\&`, not a reason to flag them.
- `${var//pat}` (deletion) and an empty replacement have nothing to flag; an
  expansion whose operator is not `/` (`${v:-a/b/&}`, `${v#*/}`, `${v%/*}`,
  `${v:0:1}`, `${#v}`) is not a substitution at all.
- `&` outside any substitution — `a && b`, `cmd &`, `2>&1`, `echo "a & b"` — is
  never flagged.

Sources: GNU Bash Reference Manual, [Shell Parameter
Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)
("Any unquoted instances of '&' in string are replaced with the matching portion
of pattern"; "Backslash escapes '&' in string; the backslash is removed in order
to permit a literal '&' in the replacement string") and [Shell Compatibility
Mode](https://www.gnu.org/software/bash/manual/html_node/Shell-Compatibility-Mode.html);
bash [NEWS](https://tiswww.case.edu/php/chet/bash/NEWS) records
`patsub_replacement` as new in bash-5.2.

## Known limits (stated, not overclaimed)

1. An `&` that **arrives by expansion** is undetectable statically. The rule is
   applied after the replacement expands, so an `&` held in a variable, or in the
   output of a `$(...)` inside the replacement, is a live match reference. Verified:
   for `v=aXb`, a replacement of `$(printf 'p&q')` yields `apXqb`. Same indirection
   class the gate already declares out of scope (#1513).
2. A literal `&` inside a nested `$(...)`/backquote in the replacement is skipped,
   because there it is ordinary command syntax (`&&`, backgrounding). Its runtime
   *output* is limit 1.
3. A substitution assembled from fragments before use — the same limit the ERE
   classes carry.
4. A parameter spelling the walk does not recognise (a name that is not an
   identifier, a digit run, or one of `@ * ? $ ! -`) is skipped rather than guessed.

All four are in the **under-flag** direction; none produces a false pass on a
literal `${var//pat/&}`.

## Review round (both findings real, both reproduced before accepting)

Review caught that the limits list was incomplete **in both directions**. Both
are now **fixed**, not documented away, so the sentence above is true again.

**Over-flag — process substitution.** `<(`/`>(` was not treated as a nested
frame, so `${v//X/<(cmd1 && cmd2)}` was reported. Measured on 5.3.15:

```
patsub_replacement on : a/dev/fd/63b
patsub_replacement off: a/dev/fd/63b
```

Identical — zero version divergence, so a hard error was red-lining portable
code. `<(`/`>(` now open a frame (`skip_frame` already handled the shape; the
opener test is factored into `opens_frame()` and shared by both halves).

**Under-flag — `$#` as the special parameter.** `#` after `${` was taken to be
the length operator unconditionally. It is the length operator only while what
follows could start a parameter name; `/` cannot, so `${#//2/&}` is a
substitution on the positional-argument count. Measured with two positional
parameters:

```
$ bash -c 'set -- 1 2; printf "%s\n" "${#//2/&}"'                              → 2
$ bash -c 'set -- 1 2; shopt -u patsub_replacement; printf "%s\n" "${#//2/&}"' → &
```

A genuine false pass on the literal shape. Fixed; `${#}`, `${##}`, `${#v}` and
`${#arr[@]}` keep a non-`/` successor and stay length expansions.

Ten cases added, including both halves of the frame skip proving a real hit
*after* a skipped process substitution is still found.

## Tests

New section in `scripts/check-shell-portability.test.sh` covering: the #2008 defect
shape (asserted with the exact `PORTABILITY: file:line:` prefix, so a silently
inert rule cannot pass), the first-slash grammar, escaped/quoted/nested-expansion
forms mixed with a bare one, quoted and escaped slashes in the pattern, array and
positional and anchored parameter spellings, the correct `\&` form, both quoted
forms, the deletion and empty-replacement forms, non-substitution operators, `&`
outside any substitution, all three excuse mechanisms (same-line
`portability-ok:`, the comment block above, whole-file `portability-scope:`),
per-physical-line attribution inside a quote-joined record, class inertness when
the `!name` line is absent, a directive-only token list not tripping the
fail-closed empty-pattern check, an unrecognised `!name` failing closed, and the
class remediation paragraph appearing on an `&` failure while staying off an
unrelated one.

`shell-portability-lint` on CI: **PASS=312 FAIL=0** (268 before this change), and
the changed-file gate reports the two touched shell files clean. The job is
`ubuntu-24.04` only, so this class — like every other class in this gate — has no
Windows CI coverage.

## Related

- #2008 — the merged fix whose defect this rule makes non-recurrable; the sweep
  proof runs against its pre-fix parent `2b60bf0b`.
- #1491 — the issue this gate was built for.
- #1513 — the variable-indirection limit this class inherits.
- #1544 — the quote-aware masking layer whose `${…}` frame tracking this class reuses.
