### PR TITLE
fix(discovery): strike a coverage claim the ledger case cannot back

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — discovery plugin
 
+## [0.12.2]
+
+### Fixed
+
+- **The coverage-ledger case no longer advertises coverage it does not have — the same defect 0.12.1
+  was written to remove.** Both 0.12.1's entry above and the block comment at
+  `scripts/check-dispatch-artifact.test.sh` claimed the case fails against a harvest that "globs the
+  directory instead of reading the index". It does not. Found by an independent verification pass
+  that ran exactly that mutation: a directory-glob harvest emits `sidecars=1 missing=0`, exit 0 —
+  byte-identical to the correct gate, so the assertion cannot tell them apart.
+
+  **The stated mechanism was wrong in principle, not merely here.** The comment reasoned that a glob
+  "picks it up on any case-insensitive filesystem — which is what this repo is developed on". Bash
+  matches a glob against the DIRENT STRING, so how the filesystem compares names for *lookup* never
+  enters. Probed on this platform: `shopt -s nullglob; echo RESEARCH-*.md` yields only
+  `RESEARCH-tiers.md`, while `test -f RESEARCH-checklist.md` succeeds.
+
+  Both claims are struck. The two legs that ARE real — a dropped `RESEARCH-` anchor and a
+  case-insensitive `grep -oiE` harvest — were verified by mutation and are unchanged. A glob rewrite
+  is still caught, by the named-but-missing sidecar cases it cannot satisfy; that is now stated where
+  the wrong claim used to be. No behavior changes: the gate, the fixture, and all 103 cases are
+  untouched.
+
 ## [0.12.1]
 
 ### Fixed
@@ -17,9 +40,8 @@
   **text** — so no implementation of the current design could have counted it, and the case asserted
   something its label implied but did not test. The index now mentions the ledger the way a real run's
   restatement or handoff does, with the file still on disk beside it, so the case fails against a
-  harvest that drops the `RESEARCH-` anchor, matches case-insensitively, or globs the directory
-  instead of reading the index. Verified by mutation: under a `grep -oiE` harvest the case fails,
-  where the previous fixture passed.
+  harvest that drops the `RESEARCH-` anchor or matches case-insensitively. Verified by mutation:
+  under a `grep -oiE` harvest the case fails, where the previous fixture passed.
 
 ### Changed
 

--- a/plugins/discovery/scripts/check-dispatch-artifact.test.sh
+++ b/plugins/discovery/scripts/check-dispatch-artifact.test.sh
@@ -364,12 +364,17 @@ run_raw 0 "the same slice is usable under --index-name EXPLORE.md" \
 #     `RESEARCH-` anchor for a bare `[A-Za-z0-9._-]+\.md`, or that matched
 #     case-insensitively (`research-checklist.md` matches `RESEARCH-…` under
 #     `grep -oiE`), counts it and reports sidecars=2.
-#   - ON DISK BESIDE THE INDEX. A rewrite that globbed the directory for
-#     `RESEARCH-*.md` instead of reading the index picks it up on any
-#     case-insensitive filesystem — which is what this repo is developed on.
+#   - ON DISK BESIDE THE INDEX, which keeps the fixture realistic but is NOT
+#     what this case discriminates on. A directory-glob rewrite does not fail
+#     here: bash matches a glob against the DIRENT STRING, so `RESEARCH-*.md`
+#     never picks up `research-checklist.md` regardless of how the filesystem
+#     compares names for lookup. Probed on this platform — `shopt -s nullglob;
+#     echo RESEARCH-*.md` yields only `RESEARCH-tiers.md` while
+#     `test -f RESEARCH-checklist.md` succeeds. A glob rewrite is caught
+#     instead by the named-but-missing sidecar cases, which it cannot satisfy.
 #
-# Either way the count inflates and the assertion below fails, which is the
-# point of having it.
+# So the anchor and the case-fold inflate the count and fail the assertion
+# below, which is the point of having it.
 ledgered="$(slice ledgered)"
 index "$ledgered" 'RESEARCH-tiers.md' \
   'Corpus coverage is tracked in research-checklist.md beside this index.'


### PR DESCRIPTION
No linked issue

Post-merge follow-up from an independent verification pass on #2090. Documentation only — no behavior change.

## The defect #2090 shipped is the one it existed to remove

#2090 fixed a coverage-ledger test case that could not fail by construction: its fixture wrote `research-checklist.md` to disk but never named it in the index, and the gate harvests sidecar names from the index **text**. That fix is real and stands.

But the same commit advertised a third discriminating leg it does not have. Both `plugins/discovery/CHANGELOG.md` (0.12.1) and the block comment above the fixture claimed the case fails against a harvest that **"globs the directory instead of reading the index"**.

A verifier ran exactly that mutation:

```text
directory-glob harvest → ... sidecars=1 missing=0 ... status=usable   exit 0
correct gate           → ... sidecars=1 missing=0 ... status=usable   exit 0
```

Byte-identical. The assertion cannot separate them.

## The stated mechanism was wrong in principle, not just here

The comment reasoned that a glob "picks it up on any case-insensitive filesystem — which is what this repo is developed on." That confuses two different things: **bash matches a glob against the dirent string**, so how the filesystem compares names for *lookup* never enters the match.

Probed on this platform:

```console
$ shopt -s nullglob; echo RESEARCH-*.md
RESEARCH-tiers.md

$ test -f RESEARCH-checklist.md && echo YES
YES
```

The file is findable by that name, and the glob still does not match it.

## What changed

Both claims are struck — one line in `CHANGELOG.md`, one bullet in the test's block comment.

The two legs that **are** real are unchanged and were verified by mutation:

| mutation | ledger case |
|---|---|
| `grep -oE` → `grep -oiE` (case-insensitive harvest) | **FAIL** — `sidecars=2` |
| drop the `RESEARCH-` anchor → `[A-Za-z0-9._-]+\.md` | **FAIL** — `sidecars=2` |
| glob the directory instead of reading the index | `ok` — **survives** |

A glob rewrite is still caught by the suite, just not by this case: the named-but-missing sidecar cases fail under it in both artifact families, because a glob harvest cannot detect a sidecar that is named but never written. That is now stated where the wrong claim used to be, so the next reader knows which case carries which claim.

## Verification

| Check | Result |
|---|---|
| `check-dispatch-artifact.test.sh` | **103 ok, 0 FAIL** (unchanged — comment-only) |
| `shellcheck -x` | clean |
| `markdownlint-cli2` | 0 issues |
| `check-changelog-parity.sh --check-bump origin/main` | pass |

`discovery` 0.12.1 → **0.12.2**. The correction is recorded as its own entry rather than only editing the shipped text, so the record shows what was claimed and what was withdrawn.

## Related

- #2090 — introduced the claim being struck; its other four fixes are sound and untouched here.
- #2074 — the acceptance gate both PRs build on.
