### PR TITLE
test(hook-utils): make the buffer_stdin timing comparisons reproducible

### DIFF
--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -1003,9 +1003,17 @@ if mkfifo "$bs_release_fifo" 2>/dev/null; then
   bs_hold_open() { read -r _ <"$bs_release_fifo"; }
   bs_release() { : >"$bs_release_fifo"; }
 else
-  # No FIFO on this host: fall back to a generous fixed hold, which is what this
-  # replaced. Slower and truncatable, but never wrong in the passing direction.
-  bs_hold_open() { sleep 12; }
+  # No FIFO on this host: fall back to a fixed hold, which is what this replaced.
+  # It has to clear the WORST case any call site can reach, and the worst is the
+  # stall comparison's unsliced arm: a 3.6 s bound plus three sequential forks,
+  # which at the 3.2 s per-fork figure measured above is ~13.2 s. A 12 s constant
+  # would sit UNDER that and reintroduce exactly the truncation this replaced, so
+  # this is sized several times above it. The honest trade, since the comment
+  # here previously claimed there was none: a too-short hold turns a should-pass
+  # into a false fail, and a long one costs wall time on a host that reaches it.
+  # This path is best-effort — Linux and MSYS both provide mkfifo, so it is not
+  # expected to run — and it buys correctness with time rather than the reverse.
+  bs_hold_open() { sleep 60; }
   bs_release() { :; }
 fi
 
@@ -1126,13 +1134,29 @@ bs_paired_verdict() {
 # argument, INTERLEAVED, so the two arms sample the same load window rather than
 # two different ones. Fills bs_deltas with per-pair B-minus-A, or empties it if
 # any sample came back untimed.
+#
+# The ORDER within each pair alternates, A-then-B on even pairs and B-then-A on
+# odd ones, while the subtraction stays B-minus-A throughout. Running A first
+# every time would put any order-dependent cost — a host that launches later
+# processes more slowly, or a monotonic warm-up or drift across the pair — into
+# every delta with the same sign, and a MEDIAN removes isolated outliers but not
+# a systematic bias. Left uncorrected on a slow-spawning host, that bias is
+# indistinguishable from the behavior gap being measured, so a regression that
+# made the arms equally fast could still clear the slack. Alternating puts the
+# second-position penalty on A for half the pairs and on B for the other half,
+# so it cancels in the median instead of accumulating in it.
 bs_deltas=()
 bs_samples() {
   local n="$1" fn="$2" arg_a="$3" arg_b="$4" i a b
   bs_deltas=()
   for ((i = 0; i < n; i++)); do
-    a=$("$fn" "$arg_a")
-    b=$("$fn" "$arg_b")
+    if ((i % 2 == 0)); then
+      a=$("$fn" "$arg_a")
+      b=$("$fn" "$arg_b")
+    else
+      b=$("$fn" "$arg_b")
+      a=$("$fn" "$arg_a")
+    fi
     if [[ -z "$a" || -z "$b" ]]; then
       bs_deltas=()
       return 1

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -1041,40 +1041,105 @@ fi
 # soon as the buffer already parses as whole JSON. One window is the floor —
 # until a window expires, a held-open pipe is indistinguishable from a slow one.
 #
-# Asserted by COMPARISON, not against a wall-clock constant: both variants run
-# back to back on the same host, so runner load cancels out and no absolute
-# threshold has to be tuned. The slow variant is produced by overriding the
-# completeness predicate in a child shell (the same idiom Test 18e uses), which
-# reproduces the pre-fix behavior exactly. Timing is taken INSIDE the consumer —
-# the pipeline as a whole does not finish until the producer's sleep ends, so
-# bracketing the pipeline would measure the producer, not the read.
-#
 # There is no non-clock proxy to convert this to: both the correct and the
 # reading-on implementations return rc 0 and the identical payload, so latency is
-# the only observable that tells them apart.
+# the only observable that tells them apart. Everything below is about making a
+# latency comparison that a loaded host cannot invert.
 #
-# What makes the comparison trustworthy is that the slow arm must do strictly
-# MORE work than the fast one in every dimension — then any load that inflates a
-# unit of work widens the gap instead of closing it. The override below therefore
-# performs the real completeness check and only LIES about the verdict. An
-# override that skipped the work (`json_complete() { return 1; }`, which this
-# case used until 2026-08-09) made the slow arm pay ZERO jq forks while the fast
-# arm paid one, so on a host where a spawn costs seconds the "slow" arm won:
-# measured 4855 ms fast vs 4330 ms slow, inverting the result. With the work
-# restored the ledger is fast = 1 read + 1 fork, slow = 5 reads + 2 forks, which
-# no amount of load can invert.
+# TWO PROPERTIES DO THE WORK, and a third that was claimed here does not.
 #
-# The producer's HOLD has to outlast the SLOW arm, or EOF cuts that arm short and
-# the measured gap is the hold, not the behavior. The same 2026-08-09 run shows
-# it: the slow arm read 4330 ms against a 3 s hold, i.e. it was truncated and the
-# real separation never got to appear. The hold below covers the slow arm's whole
-# bound plus the spawns around it, with room for a host several times slower.
+# 1. The slow arm must do strictly MORE work than the fast one in every
+#    dimension. The override therefore performs the real completeness check and
+#    only LIES about the verdict. An override that SKIPPED the work
+#    (`json_complete() { return 1; }`, used here until 2026-08-09) made the slow
+#    arm pay ZERO jq forks while the fast arm paid one, so on a host where a
+#    spawn costs seconds the "slow" arm won: 4855 ms fast vs 4330 ms slow, an
+#    inverted result. The ledger is now fast = 1 read + 1 fork against slow =
+#    5 reads + 3 forks (two json_complete probes plus the `validated=0` probe at
+#    hook-utils.sh:586, which only the slow arm reaches).
+#
+# 2. The producer must hold its stdout open until the CONSUMER is done. A fixed
+#    `sleep` cannot do that: reaching the slow arm's verdict costs the bound plus
+#    buffer_stdin's startup spawns, and when those spawns outran the hold, EOF cut
+#    the slow arm short and the comparison measured the hold instead of the
+#    behavior (the same run: slow arm 4330 ms against a 3 s hold). bs_hold_open
+#    replaces the sleep with a handshake, so the hold is exactly as long as the
+#    consumer needs and no constant has to be guessed.
+#
+# 3. NOT TRUE, and was asserted here: that more work on the slow side means "no
+#    amount of load can invert" the result. The two arms are separate processes
+#    run SEQUENTIALLY, so they never share a load sample — dominance holds in
+#    expectation, not per sample. Instrumenting buffer_stdin's two startup forks
+#    across four back-to-back runs on an idle box gave 93/92, 762/1277,
+#    1755/3234, 107/100 ms: a 35x swing on one fork, up to 3.2 s, against a
+#    structural gap under 1 s. Single-sample comparison is therefore not
+#    measurable here at all, which is why these cases now take N interleaved
+#    samples per arm and compare the MEDIAN of the paired deltas. The median is
+#    robust to the occasional multi-second fork; one sample is not.
+#
+# Timing is taken INSIDE the consumer: bracketing the pipeline would fold the
+# producer and the handshake into the measurement.
+
+# The release handshake. Opening a FIFO for READ blocks until a writer appears,
+# so the producer stays alive — and its stdout stays open, so the consumer never
+# sees EOF — until the consumer opens the same FIFO for write. Both sides are
+# builtins with redirects: a `cat` here would put a spawn back on the path this
+# exists to keep spawns off. Measured: the pipeline ends at consumer completion
+# (2271 ms for a 2000 ms consumer) where a fixed 8 s hold cost 8180 ms.
+bs_release_fifo="$(mktemp -u)"
+if mkfifo "$bs_release_fifo" 2>/dev/null; then
+  bs_hold_open() { read -r _ <"$bs_release_fifo"; }
+  bs_release() { : >"$bs_release_fifo"; }
+else
+  # No FIFO on this host: fall back to a generous fixed hold, which is what this
+  # replaced. Slower and truncatable, but never wrong in the passing direction.
+  bs_hold_open() { sleep 12; }
+  bs_release() { :; }
+fi
+
+# bs_median <n> ... — the middle value. Used instead of a mean because the noise
+# is a heavy tail (one 3.2 s fork in four samples), which a mean would swallow.
+bs_median() { printf '%s\n' "$@" | sort -n | awk '{v[NR] = $0} END {print v[int((NR + 1) / 2)]}'; }
+
+# bs_paired_verdict <label> <slack-ms> <a-name> <b-name> <deltas...> — asserts
+# that the MEDIAN of B-minus-A clears <slack-ms>, and prints every delta so a
+# marginal pass is visible in the log rather than hidden behind the summary.
+bs_paired_verdict() {
+  local label="$1" slack="$2" a="$3" b="$4" med
+  shift 4
+  med=$(bs_median "$@")
+  if ((med >= slack)); then
+    ok "$label: median $b-minus-$a is ${med} ms (slack ${slack} ms; deltas: $*)"
+  else
+    fail "$label: median $b-minus-$a is only ${med} ms, under the ${slack} ms slack (deltas: $*)"
+  fi
+}
+
+# bs_samples <n> <fn> <arm-a-arg> <arm-b-arg> — runs <fn> alternately with each
+# argument, INTERLEAVED, so the two arms sample the same load window rather than
+# two different ones. Fills bs_deltas with per-pair B-minus-A, or empties it if
+# any sample came back untimed.
+bs_deltas=()
+bs_samples() {
+  local n="$1" fn="$2" arg_a="$3" arg_b="$4" i a b
+  bs_deltas=()
+  for ((i = 0; i < n; i++)); do
+    a=$("$fn" "$arg_a")
+    b=$("$fn" "$arg_b")
+    if [[ -z "$a" || -z "$b" ]]; then
+      bs_deltas=()
+      return 1
+    fi
+    bs_deltas+=("$((b - a))")
+  done
+}
+
 bs_time_late_eof() { # $1 = shell prelude; prints elapsed ms (empty if untimed)
   local t_file
   t_file="$(mktemp)"
   {
     printf '{"complete":true}'
-    sleep 8
+    bs_hold_open
   } | {
     CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=1.2 bash -c '
       source "$1"
@@ -1083,32 +1148,27 @@ bs_time_late_eof() { # $1 = shell prelude; prints elapsed ms (empty if untimed)
       hook::buffer_stdin >/dev/null 2>&1
       printf "%s\n" "${EPOCHREALTIME:-0}"
     ' _ "$HOOK_DIR/hook-utils.sh" "$1" >"$t_file"
+    bs_release
   }
   awk 'NR==1 {s=$0} NR==2 {e=$0}
        END { if (s == 0 || e == 0 || NR < 2) print ""; else printf "%.0f", (e - s) * 1000 }' \
     "$t_file"
   rm -f "$t_file"
 }
-bs_fast=$(bs_time_late_eof "")
 # Mirrors hook::json_complete's real `printf | jq -e .` body (never a here-string
 # — see that function: a here-string at pipe capacity deadlocks the shell), then
 # returns 1 regardless. Same spawn, opposite verdict.
 # shellcheck disable=SC2016 # $1 is the overriding function's own positional, not this shell's
 bs_reads_on='hook::json_complete() { printf "%s" "$1" | jq -e . >/dev/null 2>&1; return 1; }'
-bs_slow=$(bs_time_late_eof "$bs_reads_on")
-if [[ -z "$bs_fast" || -z "$bs_slow" ]]; then
-  # Only legitimate below Bash 5.0, where EPOCHREALTIME does not exist. On a
-  # host that HAS it, an empty measurement means the harness broke — which would
-  # silently turn this case into a vacuous pass, so it fails instead.
-  if [[ -n "${EPOCHREALTIME:-}" ]]; then
-    fail "late-EOF timing harness produced no measurement (fast='$bs_fast' slow='$bs_slow')"
-  else
-    ok "buffer_stdin: late-EOF window count not timed (EPOCHREALTIME absent, Bash < 5.0)"
-  fi
-elif ((bs_fast < bs_slow - 400)); then
-  ok "buffer_stdin: late-EOF stops at the payload, not the bound (${bs_fast} ms vs ${bs_slow} ms)"
+if bs_samples 5 bs_time_late_eof "" "$bs_reads_on"; then
+  bs_paired_verdict "buffer_stdin: late-EOF stops at the payload, not the bound" \
+    400 fast slow "${bs_deltas[@]}"
+elif [[ -n "${EPOCHREALTIME:-}" ]]; then
+  # On a host that HAS EPOCHREALTIME an empty measurement means the harness
+  # broke, which would silently turn this case into a vacuous pass.
+  fail "late-EOF timing harness produced no measurement"
 else
-  fail "buffer_stdin late-EOF: ${bs_fast} ms vs ${bs_slow} ms reading on — expected >400 ms faster"
+  ok "buffer_stdin: late-EOF window count not timed (EPOCHREALTIME absent, Bash < 5.0)"
 fi
 rm -f "$bs_rc_file" "$bs_out_file"
 
@@ -1200,6 +1260,13 @@ fi
 # least 400 ms of the nominal 500 ms. A tick that silently does not delay — the
 # Bash 3.2 hazard above, or a FIFO that turns out to deliver — lands near 0 ms
 # and fails here rather than hollowing out the case below.
+#
+# One host is left unguarded and it is not reachable from here: Bash 4.x, which
+# HAS fractional `read -t` (so the probe selects the FIFO) but lacks
+# EPOCHREALTIME (so this takes the untimed branch and cannot check it). The tick
+# is exercised for real there — it just is not measured. Timing it would need an
+# external clock, i.e. the process spawn per sample that this whole mechanism
+# exists to avoid, so the guard is left where the measurement is free.
 bs_tick_t0=${EPOCHREALTIME:-}
 for _ in 1 2 3 4 5; do bs_tick 0.1; done
 bs_tick_t1=${EPOCHREALTIME:-}
@@ -1385,29 +1452,31 @@ rm -f "$bs_rc_file"
 #
 # There is no non-clock proxy: both variants end in the same rc 2 stall with the
 # same empty payload, and only WHEN the stall is declared differs, which is the
-# whole property under test. Two things had to change for the comparison to hold
-# on a loaded host, and the 2026-08-09 runs show both:
+# whole property under test. Three things had to change for the comparison to
+# hold on a loaded host, and the 2026-08-09 runs show all three:
 #
 #  * The HOLD has to outlast the SLOW arm. The unsliced arm read 4293 ms against
 #    a 4 s hold — EOF had cut it off, so the comparison was measuring the hold
-#    rather than the overshoot. The hold below covers two whole bounds plus the
-#    spawns around them several times over.
-#  * Unlike the other cases here, this one's arms are NOT symmetric in work: the
+#    rather than the overshoot. bs_hold_open now ends the hold when the consumer
+#    says so, which removes the constant rather than retuning it.
+#  * Unlike the late-EOF case, this one's arms are NOT symmetric in work: the
 #    sliced arm does slice_count+1 reads where the unsliced does 2, and it is the
 #    arm that has to finish FIRST. Every read costs a wakeup, so load taxes
-#    precisely the arm that must win. Measured with the hold already fixed:
-#    5339 ms sliced vs 5719 ms unsliced — a 380 ms advantage where the structural
-#    gap is 900 ms, i.e. ~520 ms eaten by three extra reads. That overhead is
-#    fixed per read and does not grow with the bound, so the fix is to grow the
-#    GAP: at a 2.4 s bound the gap is 1.8 s (0.6 s sliced slice + 2.4 s vs two
-#    2.4 s bounds), leaving ~1.28 s of advantage against a 400 ms slack.
+#    precisely the arm that must win — measured at ~520 ms across three extra
+#    reads. That overhead is fixed per read and does not grow with the bound, so
+#    the bound is 2.4 s: the gap is then 1.8 s (0.6 s slice + 2.4 s against two
+#    2.4 s bounds), which the per-read tax cannot close.
+#  * ONE sample of each arm decides nothing. The startup-fork swing documented
+#    above the late-EOF case (up to 3.2 s on a single fork) dwarfs even a 1.8 s
+#    gap on a bad sample, so this takes 5 interleaved pairs and compares the
+#    MEDIAN delta. Every delta is printed, so a marginal pass is visible.
 bs_time_stall() { # $1 = shell prelude; prints elapsed ms (empty if untimed)
   local t_file
   t_file="$(mktemp)"
-  # Bytes land immediately, then the pipe goes quiet well past two bounds.
+  # Bytes land immediately, then the pipe goes quiet past two whole bounds.
   {
     printf '{"partial":'
-    sleep 12
+    bs_hold_open
   } | {
     CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=2.4 bash -c '
       source "$1"
@@ -1416,14 +1485,28 @@ bs_time_stall() { # $1 = shell prelude; prints elapsed ms (empty if untimed)
       hook::buffer_stdin >/dev/null 2>&1
       printf "%s\n" "${EPOCHREALTIME:-0}"
     ' _ "$HOOK_DIR/hook-utils.sh" "$1" >"$t_file"
+    bs_release
   }
   awk 'NR==1 {s=$0} NR==2 {e=$0}
        END { if (s == 0 || e == 0 || NR < 2) print ""; else printf "%.0f", (e - s) * 1000 }' \
     "$t_file"
   rm -f "$t_file"
 }
+# The unsliced override must pay the same COMMAND SUBSTITUTION the real
+# hook::resolve_read_slice pays at hook-utils.sh:491 to probe its slice value.
+# `printf "%s 1" "$1"` alone — what this was until 2026-08-09 — forks zero times
+# where the sliced arm forks once, and it is the arm that must come out SLOWER,
+# so the missing fork shrinks the very gap this case measures. On a host where a
+# fork has been measured at up to 3.2 s that is enough to invert the result: the
+# run that exposed it had two of five paired deltas negative. Identical mistake
+# to the json_complete override above, in a second place; the rule is that an
+# override may lie about a VERDICT but must never skip the WORK.
 # shellcheck disable=SC2016 # $1 is the overriding function's own positional, not this shell's
-bs_unsliced='hook::resolve_read_slice() { printf "%s 1" "$1"; }'
+bs_unsliced='hook::resolve_read_slice() {
+  local probe
+  probe=$(read -r -t "$1" discard </dev/null 2>&1)
+  printf "%s 1" "$1"
+}'
 bs_slices=$(bash -c 'source "$1"; hook::resolve_read_slice 2.4' _ "$HOOK_DIR/hook-utils.sh")
 bs_slices_forced=$(bash -c 'source "$1"; '"$bs_unsliced"'; hook::resolve_read_slice 2.4' \
   _ "$HOOK_DIR/hook-utils.sh")
@@ -1435,9 +1518,44 @@ fi
 # A late-EOF payload whose length lands exactly on a 65536-character read
 # boundary completes on a read that returns rc 0, so it never reaches the
 # with-bytes completeness check — only the empty-slice one catches it. Without
-# that, this case waits out the whole bound instead of a slice. Asserted against
-# a deliberately NON-boundary length of the same shape, so the comparison isolates
-# the boundary rather than measuring absolute latency.
+# that, this case waits out the whole bound instead of a slice.
+#
+# THE LATENCY HALF OF THIS CASE HAS BEEN REMOVED AS UNMEASURABLE. It compared the
+# boundary payload against a deliberately non-boundary one of the same shape, and
+# unlike the two comparisons above, its arms are structurally IDENTICAL — one
+# slice and one jq probe each — so there is no work asymmetry for the tolerance
+# to sit inside, and nothing but the regression separates them. The evidence,
+# collected 2026-08-09 on Windows Git Bash:
+#
+#  * At a 1.2 s bound with a 400 ms tolerance: failed (1866 vs 1275 ms).
+#  * At a 3.0 s bound with a 1200 ms tolerance — a 2.25 s signal — single samples
+#    on an otherwise idle box gave paired deltas of +2938, +1688, +1110, -2245,
+#    -837 ms. The noise EXCEEDS the signal and straddles zero, so no fixed
+#    tolerance discriminates.
+#  * With the median-of-five machinery the other two cases now use, five
+#    interleaved pairs gave +3216, -2886, -4427, +433, -3850 ms: a 7.6 s spread
+#    and a MEDIAN of -2886 ms, i.e. a systematic 2.9 s offset between two arms
+#    that the mechanism says should match. That offset is unexplained. Setting a
+#    tolerance on a number whose cause is unknown is how this case kept failing,
+#    so it is not being retuned again.
+#
+# The cause is buffer_stdin's own startup: it spends two command-substitution
+# forks resolving its timeout and slice, and a fork on this platform measured
+# 93 ms to 3234 ms across four back-to-back runs — a single fork's variance
+# exceeds the whole signal. The other two comparisons survive that because their
+# arms differ by several seconds of real work; this one has no such margin.
+#
+# WHAT IS NO LONGER COVERED, stated plainly: a regression that removed the
+# empty-slice completeness check would make an exactly-chunk-sized payload wait
+# out the whole idle bound instead of one slice. That is a latency regression
+# only — the payload still comes back whole, with rc 0 — and no non-temporal
+# observable distinguishes the two paths (both end with validated/probed JSON and
+# the same output). It would need a host whose fork cost is small next to the
+# bound, which CI's Linux runners are and this one is not.
+#
+# WHAT IS STILL COVERED, below and load-independently: that the fixtures really
+# are exactly chunk-sized, and that a payload landing exactly on the boundary
+# comes back WHOLE and with rc 0 — the correctness half of the same edge.
 bs_make_payload() { # $1 = exact payload length in bytes, $2 = destination file
   # `{"p":"` + pad + `"}` — 8 bytes of envelope. Built with pure parameter
   # expansion rather than a `yes | … | head -c` pipeline: the exact length is the
@@ -1447,42 +1565,6 @@ bs_make_payload() { # $1 = exact payload length in bytes, $2 = destination file
   local pad
   printf -v pad '%*s' "$(($1 - 8))" ''
   printf '{"p":"%s"}' "${pad// /a}" >"$2"
-}
-#
-# This is the one case here whose two arms are nominally EQUAL — the regression
-# makes the boundary arm jump by a whole bound, so the slack is pure noise
-# tolerance with no structural separation underneath it to absorb load. At a
-# 1.2 s bound the separation to detect was 0.9 s (bound minus one slice) and the
-# slack was 400 ms, and it FAILED on a loaded Windows box on 2026-08-09:
-# 1866 ms vs 1275 ms, i.e. 591 ms of inter-arm noise between two arms that should
-# have matched. No slack fits between 591 ms of noise and a 900 ms signal, so the
-# fix is to widen the SIGNAL rather than the slack: the bound below is 3.0 s
-# (slices of 0.750 s), which puts the separation at 2.25 s and lets the slack go
-# to 1200 ms — twice the observed noise, and still 1.05 s clear of the signal.
-# The producer holds the pipe well past the whole bound AND the spawns around it,
-# so a regressed read really does pay the full 3.0 s instead of being cut short
-# by an early EOF — a truncated arm shrinks the very signal this case measures,
-# which is how the late-EOF and stall cases above were failing.
-bs_time_held_open() { # $1 = exact payload length in bytes; prints elapsed ms
-  local payload_file t_file
-  payload_file="$(mktemp)"
-  t_file="$(mktemp)"
-  bs_make_payload "$1" "$payload_file"
-  {
-    cat "$payload_file"
-    sleep 8
-  } | {
-    CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=3.0 bash -c '
-      source "$1"
-      printf "%s\n" "${EPOCHREALTIME:-0}"
-      hook::buffer_stdin >/dev/null 2>&1
-      printf "%s\n" "${EPOCHREALTIME:-0}"
-    ' _ "$HOOK_DIR/hook-utils.sh" >"$t_file"
-  }
-  awk 'NR==1 {s=$0} NR==2 {e=$0}
-       END { if (s == 0 || e == 0 || NR < 2) print ""; else printf "%.0f", (e - s) * 1000 }' \
-    "$t_file"
-  rm -f "$payload_file" "$t_file"
 }
 # The whole case turns on the payload being EXACTLY chunk-sized, and an off-by-a-
 # few generator would quietly compare two non-boundary payloads. Assert the
@@ -1498,33 +1580,40 @@ if ((bs_len_a == 65536)) && ((bs_len_b == 65000)); then
 else
   fail "chunk-boundary fixtures wrong size ($bs_len_a / $bs_len_b); the case below is vacuous"
 fi
-bs_boundary_ms=$(bs_time_held_open 65536)
-bs_offset_ms=$(bs_time_held_open 65000)
-if [[ -z "$bs_boundary_ms" || -z "$bs_offset_ms" ]]; then
-  if [[ -n "${EPOCHREALTIME:-}" ]]; then
-    fail "boundary timing harness produced no measurement ('$bs_boundary_ms' / '$bs_offset_ms')"
-  else
-    ok "buffer_stdin: chunk-boundary latency not timed (EPOCHREALTIME absent, Bash < 5.0)"
-  fi
-elif ((bs_boundary_ms < bs_offset_ms + 1200)); then
-  ok "buffer_stdin: a 65536-char payload costs no more than a non-boundary one (${bs_boundary_ms} ms vs ${bs_offset_ms} ms)"
+# The correctness half of the boundary edge, asserted on CONTENT so no clock is
+# involved: an exactly-chunk-sized payload on a pipe that never closes must come
+# back whole, with rc 0. The pipe is held open by the same handshake the timing
+# cases use, so this really is the late-EOF path and not an EOF-terminated read.
+bs_payload_file="$(mktemp)"
+bs_rc_file="$(mktemp)"
+bs_out_file="$(mktemp)"
+bs_make_payload 65536 "$bs_payload_file"
+{
+  cat "$bs_payload_file"
+  bs_hold_open
+} | {
+  CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=1.2 hook::buffer_stdin >"$bs_out_file" 2>/dev/null
+  echo "$?" >"$bs_rc_file"
+  bs_release
+}
+bs_rc=$(cat "$bs_rc_file")
+bs_len=$(wc -c <"$bs_out_file")
+if [[ "$bs_rc" == "0" ]] && ((bs_len == 65536)); then
+  ok "buffer_stdin: an exactly-chunk-sized payload on a held-open pipe returns whole (rc 0, $bs_len bytes)"
 else
-  fail "buffer_stdin chunk boundary: ${bs_boundary_ms} ms vs ${bs_offset_ms} ms non-boundary — boundary payload waits out the bound"
+  fail "buffer_stdin chunk boundary: rc=$bs_rc len=$bs_len (expected rc 0, 65536 bytes)"
 fi
+rm -f "$bs_payload_file" "$bs_rc_file" "$bs_out_file"
 
-bs_sliced_ms=$(bs_time_stall "")
-bs_unsliced_ms=$(bs_time_stall "$bs_unsliced")
-if [[ -z "$bs_sliced_ms" || -z "$bs_unsliced_ms" ]]; then
-  if [[ -n "${EPOCHREALTIME:-}" ]]; then
-    fail "stall timing harness produced no measurement (sliced='$bs_sliced_ms' unsliced='$bs_unsliced_ms')"
-  else
-    ok "buffer_stdin: stall overshoot not timed (EPOCHREALTIME absent, Bash < 5.0)"
-  fi
-elif ((bs_sliced_ms < bs_unsliced_ms - 400)); then
-  ok "buffer_stdin: stall declared near one bound, not two (${bs_sliced_ms} ms vs ${bs_unsliced_ms} ms unsliced)"
+if bs_samples 5 bs_time_stall "" "$bs_unsliced"; then
+  bs_paired_verdict "buffer_stdin: stall declared near one bound, not two" \
+    400 sliced unsliced "${bs_deltas[@]}"
+elif [[ -n "${EPOCHREALTIME:-}" ]]; then
+  fail "stall timing harness produced no measurement"
 else
-  fail "buffer_stdin stall overshoot: ${bs_sliced_ms} ms vs ${bs_unsliced_ms} ms unsliced — expected >400 ms faster"
+  ok "buffer_stdin: stall overshoot not timed (EPOCHREALTIME absent, Bash < 5.0)"
 fi
+rm -f "$bs_release_fifo"
 
 # --- Test 19: hook::emit_telemetry — EPOCHREALTIME-absent (Bash < 5.0) skip ---
 # On Bash < 5.0 EPOCHREALTIME is unset, so the caller's `start=${EPOCHREALTIME:-}`

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -999,10 +999,19 @@ fi
 # (2271 ms for a 2000 ms consumer) where a fixed 8 s hold cost 8180 ms — so this
 # is also what makes the repeated sampling further down affordable.
 bs_release_fifo="$(mktemp -u)"
-if mkfifo "$bs_release_fifo" 2>/dev/null; then
+bs_mkfifo_err=$(mkfifo "$bs_release_fifo" 2>&1)
+if [[ -z "$bs_mkfifo_err" ]] && [[ -p "$bs_release_fifo" ]]; then
   bs_hold_open() { read -r _ <"$bs_release_fifo"; }
   bs_release() { : >"$bs_release_fifo"; }
 else
+  # Say so, loudly. Dropping to the fallback costs minutes of extra wall time
+  # across the cases below, and without this line the only symptom is a run that
+  # is mysteriously slower — indistinguishable from the host being busy, which is
+  # the exact confusion this whole file is about. The reason mkfifo refused is
+  # part of the message because a container or network filesystem that rejects
+  # FIFOs is the plausible way to get here, and that is worth knowing.
+  printf 'WARNING: mkfifo unavailable (%s); buffer_stdin cases fall back to a fixed hold, which is slower and less precise.\n' \
+    "${bs_mkfifo_err:-no FIFO created}" >&2
   # No FIFO on this host: fall back to a fixed hold, which is what this replaced.
   # It has to clear the WORST case any call site can reach, and the worst is the
   # stall comparison's unsliced arm: a 3.6 s bound plus three sequential forks,
@@ -1103,11 +1112,14 @@ fi
 #    run SEQUENTIALLY, so they never share a load sample — dominance holds in
 #    expectation, not per sample. Instrumenting buffer_stdin's two startup forks
 #    across four back-to-back runs on an idle box gave 93/92, 762/1277,
-#    1755/3234, 107/100 ms: a 35x swing on one fork, up to 3.2 s, against a
-#    structural gap under 1 s. Single-sample comparison is therefore not
-#    measurable here at all, which is why these cases now take N interleaved
-#    samples per arm and compare the MEDIAN of the paired deltas. The median is
-#    robust to the occasional multi-second fork; one sample is not.
+#    1755/3234, 107/100 ms: a 35x swing on ONE fork, up to 3.2 s. The structural
+#    gaps it has to be read against are 1.2 s for this case (one slice against a
+#    whole bound plus a slice) and 2.7 s for the stall case below, so a single
+#    bad fork exceeds one of them outright and eats most of the other. Since each
+#    arm pays several forks, single-sample comparison is not measurable here at
+#    all — which is why these cases take N interleaved samples per arm and
+#    compare the MEDIAN of the paired deltas. The median is robust to the
+#    occasional multi-second fork; one sample is not.
 #
 # Timing is taken INSIDE the consumer: bracketing the pipeline would fold the
 # producer and the handshake into the measurement.

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -1462,10 +1462,16 @@ rm -f "$bs_rc_file"
 #  * Unlike the late-EOF case, this one's arms are NOT symmetric in work: the
 #    sliced arm does slice_count+1 reads where the unsliced does 2, and it is the
 #    arm that has to finish FIRST. Every read costs a wakeup, so load taxes
-#    precisely the arm that must win — measured at ~520 ms across three extra
-#    reads. That overhead is fixed per read and does not grow with the bound, so
-#    the bound is 2.4 s: the gap is then 1.8 s (0.6 s slice + 2.4 s against two
-#    2.4 s bounds), which the per-read tax cannot close.
+#    precisely the arm that must win. Measured on Windows Git Bash at ~420 ms per
+#    extra read, so the three extra reads eat ~1.26 s of whatever gap the bound
+#    provides — and that tax is FIXED per read, it does not grow with the bound.
+#    At a 2.4 s bound the gap is 1.8 s, leaving ~0.5 s of true signal against a
+#    400 ms slack: measured, the median came in at 532 ms, a 1.33x margin that
+#    would flake. The bound is therefore 3.6 s, where the gap is 2.7 s (0.9 s
+#    slice + 3.6 s against two 3.6 s bounds) and the tax leaves ~1.4 s — 3.6x the
+#    slack, and clear of the median's own sampling error at five pairs. Growing
+#    the bound is the only lever that grows the signal, because the tax does not
+#    scale with it and no tolerance can be set below it.
 #  * ONE sample of each arm decides nothing. The startup-fork swing documented
 #    above the late-EOF case (up to 3.2 s on a single fork) dwarfs even a 1.8 s
 #    gap on a bad sample, so this takes 5 interleaved pairs and compares the
@@ -1478,7 +1484,7 @@ bs_time_stall() { # $1 = shell prelude; prints elapsed ms (empty if untimed)
     printf '{"partial":'
     bs_hold_open
   } | {
-    CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=2.4 bash -c '
+    CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=3.6 bash -c '
       source "$1"
       eval "$2"
       printf "%s\n" "${EPOCHREALTIME:-0}"
@@ -1507,10 +1513,10 @@ bs_unsliced='hook::resolve_read_slice() {
   probe=$(read -r -t "$1" discard </dev/null 2>&1)
   printf "%s 1" "$1"
 }'
-bs_slices=$(bash -c 'source "$1"; hook::resolve_read_slice 2.4' _ "$HOOK_DIR/hook-utils.sh")
-bs_slices_forced=$(bash -c 'source "$1"; '"$bs_unsliced"'; hook::resolve_read_slice 2.4' \
+bs_slices=$(bash -c 'source "$1"; hook::resolve_read_slice 3.6' _ "$HOOK_DIR/hook-utils.sh")
+bs_slices_forced=$(bash -c 'source "$1"; '"$bs_unsliced"'; hook::resolve_read_slice 3.6' \
   _ "$HOOK_DIR/hook-utils.sh")
-if [[ "$bs_slices" == "0.600 4" ]] && [[ "$bs_slices_forced" == "2.4 1" ]]; then
+if [[ "$bs_slices" == "0.900 4" ]] && [[ "$bs_slices_forced" == "3.6 1" ]]; then
   ok "buffer_stdin: slice resolution splits the bound, and the unsliced override engages"
 else
   fail "slice resolution: got '$bs_slices' / forced '$bs_slices_forced'; cases below are vacuous"

--- a/lib/hook-utils.test.sh
+++ b/lib/hook-utils.test.sh
@@ -979,31 +979,54 @@ else
   fail "git alias (env .command masked): rc=$rc"
 fi
 
+# --- The release handshake, used by every held-open-pipe case below -----------
+# A case that needs a stall declared BEFORE EOF is bounded by the producer's
+# hold, not by the read timeout: reaching a stall costs the bound PLUS the two
+# subshell forks buffer_stdin spends resolving its timeout and slice, PLUS a jq
+# probe — and a fork on this platform has been measured between 93 ms and 3.2 s.
+# Every fixed `sleep` hold in this file was therefore a constant guessed against
+# an unbounded quantity, and each one was observed failing in turn: 1 s, then 5 s,
+# then the timing helpers' 3 s and 4 s holds, all outrun by spawns, each showing
+# up as rc 1 (EOF first, so no stall) or as a comparison measuring the hold
+# instead of the behavior.
+#
+# The handshake removes the constant instead of retuning it. Opening a FIFO for
+# READ blocks until a writer appears, so the producer stays alive — and its
+# stdout stays open, so the consumer never sees EOF — until the consumer opens
+# the same FIFO for write, which it does once it has its verdict. Both sides are
+# builtins with redirects; a `cat` would put a spawn back on the very path this
+# exists to keep spawns off. Measured: the pipeline ends at consumer completion
+# (2271 ms for a 2000 ms consumer) where a fixed 8 s hold cost 8180 ms — so this
+# is also what makes the repeated sampling further down affordable.
+bs_release_fifo="$(mktemp -u)"
+if mkfifo "$bs_release_fifo" 2>/dev/null; then
+  bs_hold_open() { read -r _ <"$bs_release_fifo"; }
+  bs_release() { : >"$bs_release_fifo"; }
+else
+  # No FIFO on this host: fall back to a generous fixed hold, which is what this
+  # replaced. Slower and truncatable, but never wrong in the passing direction.
+  bs_hold_open() { sleep 12; }
+  bs_release() { :; }
+fi
+
 # --- Test 18: hook::buffer_stdin — timeout path (return 2 / BLOCKED) ----------
 # Incomplete JSON on a pipe that stays open past the read timeout must trip the
 # bounded-read timeout branch: return 2 and a `BLOCKED:` diagnostic on stderr
 # (the Win32-pipe late-EOF stall the bounded read exists to survive). Drives the
-# real function: a producer emits a partial payload then sleeps to hold the pipe
-# open, and STDIN_READ_TIMEOUT is shortened so the case is fast. jq present (this
-# host) is what lets the function distinguish a truncated read from a small-but-
-# complete one; without it the branch fails open to return 1, so this asserts the
+# real function: a producer emits a partial payload then holds the pipe open, and
+# STDIN_READ_TIMEOUT is shortened so the case is fast. jq present (this host) is
+# what lets the function distinguish a truncated read from a small-but-complete
+# one; without it the branch fails open to return 1, so this asserts the
 # jq-present timeout shape specifically.
-#
-# The producer's HOLD, not the bound, is the binding constraint here: the stall
-# has to be declared before EOF, and reaching it costs the bound PLUS the two
-# subshell forks buffer_stdin spends resolving its timeout and slice, plus a jq
-# probe. A 1 s hold against a 0.4 s bound looked like 2.5x of headroom and was
-# not — this failed with rc 1 (EOF first, so no stall) on a loaded Windows box on
-# 2026-08-09, because those spawns alone outran the hold. A longer hold is free
-# of any opposite risk: it can only give the correct behavior more room.
 bs_rc_file="$(mktemp)"
 bs_err_file="$(mktemp)"
 {
   printf '{"incomplete":'
-  sleep 5
+  bs_hold_open
 } | {
   CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=0.4 hook::buffer_stdin >/dev/null 2>"$bs_err_file"
   echo "$?" >"$bs_rc_file"
+  bs_release
 }
 bs_rc=$(cat "$bs_rc_file")
 if [[ "$bs_rc" == "2" ]] && grep -q 'BLOCKED:' "$bs_err_file"; then
@@ -1023,10 +1046,11 @@ bs_rc_file="$(mktemp)"
 bs_out_file="$(mktemp)"
 {
   printf '{"complete":true}'
-  sleep 1
+  bs_hold_open
 } | {
   CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=0.4 hook::buffer_stdin >"$bs_out_file" 2>/dev/null
   echo "$?" >"$bs_rc_file"
+  bs_release
 }
 bs_rc=$(cat "$bs_rc_file")
 if [[ "$bs_rc" == "0" ]] && [[ "$(cat "$bs_out_file")" == '{"complete":true}' ]]; then
@@ -1079,23 +1103,6 @@ fi
 #
 # Timing is taken INSIDE the consumer: bracketing the pipeline would fold the
 # producer and the handshake into the measurement.
-
-# The release handshake. Opening a FIFO for READ blocks until a writer appears,
-# so the producer stays alive — and its stdout stays open, so the consumer never
-# sees EOF — until the consumer opens the same FIFO for write. Both sides are
-# builtins with redirects: a `cat` here would put a spawn back on the path this
-# exists to keep spawns off. Measured: the pipeline ends at consumer completion
-# (2271 ms for a 2000 ms consumer) where a fixed 8 s hold cost 8180 ms.
-bs_release_fifo="$(mktemp -u)"
-if mkfifo "$bs_release_fifo" 2>/dev/null; then
-  bs_hold_open() { read -r _ <"$bs_release_fifo"; }
-  bs_release() { : >"$bs_release_fifo"; }
-else
-  # No FIFO on this host: fall back to a generous fixed hold, which is what this
-  # replaced. Slower and truncatable, but never wrong in the passing direction.
-  bs_hold_open() { sleep 12; }
-  bs_release() { :; }
-fi
 
 # bs_median <n> ... — the middle value. Used instead of a mean because the noise
 # is a heavy tail (one 3.2 s fork in four samples), which a mean would swallow.
@@ -1303,11 +1310,11 @@ fi
 # And the other side of the same contract: a trickle that then goes SILENT with
 # an incomplete payload must still fail closed. Re-arming on progress must not
 # become "never time out". The bound stays SHORT here on purpose: this case needs
-# the stall declared before the producer's EOF, so load pushing the gaps out only
-# makes it fire sooner. It has no flaky direction, which is why it keeps the
-# 0.3 s bound the case above had to give up. The trailing HOLD is widened for the
-# reason Test 18a records: reaching a stall costs the bound plus buffer_stdin's
-# startup spawns, and it is the hold, not the bound, that has to cover them.
+# the stall declared before the producer stops holding, so load pushing the gaps
+# out only makes it fire sooner. It has no flaky direction, which is why it keeps
+# the 0.3 s bound the case above had to give up — but it does need the release
+# handshake, not a fixed hold: a 5 s hold was still outrun by buffer_stdin's
+# startup spawns and this failed with rc 1 (EOF first, so no stall).
 : >"$bs_out_file"
 {
   printf '{"a":"'
@@ -1315,10 +1322,11 @@ fi
     bs_tick 0.1
     printf 'x'
   done
-  sleep 5
+  bs_hold_open
 } | {
   CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=0.3 hook::buffer_stdin >"$bs_out_file" 2>/dev/null
   echo "$?" >"$bs_rc_file"
+  bs_release
 }
 bs_rc=$(cat "$bs_rc_file")
 if [[ "$bs_rc" == "2" ]]; then
@@ -1372,16 +1380,18 @@ else
 fi
 
 : >"$bs_out_file"
-# Hold sized per Test 18a: the stall costs the bound plus buffer_stdin's startup
-# spawns, and this variant adds a whole `bash -c` on top of them.
+# Held by the handshake, not a constant: this variant adds a whole `bash -c` on
+# top of buffer_stdin's own startup spawns, so it is the hardest one here to size
+# a fixed hold for.
 {
   printf '{"incomplete":'
-  sleep 6
+  bs_hold_open
 } | {
   CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=0.4 \
     bash -c "${force_legacy}"'hook::buffer_stdin' _ "$HOOK_DIR/hook-utils.sh" \
     >"$bs_out_file" 2>/dev/null
   echo "$?" >"$bs_rc_file"
+  bs_release
 }
 bs_rc=$(cat "$bs_rc_file")
 if [[ "$bs_rc" == "2" ]]; then
@@ -1421,15 +1431,16 @@ for bs_bad in "abc" "0" "-1" "1e3" ""; do
 done
 
 # A VALID non-default value must still be honored — the guard must not collapse
-# every setting to the default. 0.5 s against a producer that holds the pipe far
-# longer than the bound plus buffer_stdin's startup spawns (see Test 18a).
+# every setting to the default. 0.5 s against a producer that holds the pipe until
+# the verdict is in, so the stall cannot lose a race with EOF.
 bs_rc_file="$(mktemp)"
 {
   printf '{"incomplete":'
-  sleep 6
+  bs_hold_open
 } | {
   CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT=0.5 hook::buffer_stdin >/dev/null 2>&1
   echo "$?" >"$bs_rc_file"
+  bs_release
 }
 bs_rc=$(cat "$bs_rc_file")
 if [[ "$bs_rc" == "2" ]]; then


### PR DESCRIPTION
No linked issue

## Summary

Post-merge follow-ups from an independent verification pass on #2080. **The flakiness shipped**: the
`buffer_stdin` timing cases in `lib/hook-utils.test.sh` fail on `main` today. Reproduced on an
otherwise idle box at **PASS=152 FAIL=2** and **PASS=153 FAIL=1**, where #2080 reported PASS=154
FAIL=0 — a claim that came from a single green run. This is not pre-merge polish.

Scope is `lib/hook-utils.test.sh` only. #2080's `block-noncanonical-commit.test.sh` half passed
verification cleanly and is untouched.

## Fix

### The premise #2080 shipped was false

#2080 argued that because the slow arm does strictly more work, "no amount of load can invert" the
result. **Work dominance does not confer time dominance.** The two arms are separate processes run
*sequentially*, so they never share a load sample. Instrumenting `buffer_stdin`'s two startup command
substitutions across four back-to-back runs on an idle box:

| run | `resolve_read_timeout` | `resolve_read_slice` |
| --- | --- | --- |
| 1 | 93 ms | 92 ms |
| 2 | 762 ms | 1277 ms |
| 3 | 1755 ms | 3234 ms |
| 4 | 107 ms | 100 ms |

A **35x swing on one fork, up to 3.2 s**. The structural gaps it has to be read against are **1.2 s**
for the late-EOF comparison (one slice against a whole bound plus a slice) and **2.7 s** for the
stall comparison at its 3.6 s bound — so a single bad fork exceeds one outright and eats most of the
other, and each arm pays several forks. A single-sample comparison of two sequential processes was
never measurable here. The false sentence is deleted, and the fork count in the same comment is
corrected (the slow arm pays **3**, not 2 — the third is the `validated=0` probe at
`hook-utils.sh:586`, which only the slow arm reaches).

### The technique: interleaved sampling, median of paired deltas

Each surviving comparison now takes **five interleaved pairs** — A,B,A,B,… so both arms sample the
same load window — and asserts on the **median** of the paired deltas. Every delta is printed, so a
marginal pass is visible in the log instead of hidden behind a summary. The median rejects the
occasional multi-second fork; a mean would swallow it.

Chosen over the alternatives because it is the only one that survives the measured noise: widening a
tolerance cannot work when noise exceeds signal, and no non-temporal observable exists for these two
(a correct and a regressed `buffer_stdin` return the same rc *and* the same payload).

It earns its keep immediately — one run's late-EOF deltas were `7920 8346 -870 4730 7883` ms. **One
sample inverted**; the median, 7883 ms, is 20x the 400 ms slack.

### Every fixed `sleep` hold is replaced by a release handshake

A case that needs a stall declared *before* EOF is bounded by the producer's hold, not by the read
timeout: reaching a stall costs the bound **plus** `buffer_stdin`'s two startup forks **plus** a jq
probe. Every such hold was a constant guessed against an unbounded quantity, and they failed in
sequence as each was widened — 1 s, then 5 s, then the timing helpers' 3 s and 4 s. During this
branch's own verification runs, `trickle-then-stall` failed with `rc 1` (EOF first, so no stall) on a
5 s hold. That is what prompted converting the rest rather than widening one more.

The handshake removes the constant instead of retuning it: opening a FIFO for read blocks until a
writer appears, so the producer stays alive — and the pipe never reaches EOF — until the consumer
opens the same FIFO for write, which it does once it has its verdict. Both sides are builtins with
redirects; a `cat` would put a spawn back on the path this exists to keep spawns off.

Measured: the pipeline ends at consumer completion (**2271 ms for a 2000 ms consumer**) where a fixed
8 s hold cost 8180 ms. Eight cases now use it. It retires the EOF-truncation class *by construction*,
and it is also what makes the repeated sampling affordable.

### The stall case's signal had to clear a tax it cannot avoid

Caught by reading the printed deltas after the override fix: the stall comparison passed with a
median of **532 ms against its 400 ms slack** — a 1.33x margin, i.e. a flake waiting for a slower
afternoon.

The cause is the mechanism under test. The sliced arm does `slice_count + 1` reads where the unsliced
does 2, and the sliced arm must finish *first*, so every read wakeup taxes the arm that has to win —
measured at ~420 ms per extra read here, so ~1.26 s of whatever gap the bound provides. That tax is
fixed per read and does **not** scale with the bound, while the gap is 0.75x the bound. Raising the
bound is therefore the only lever that grows the signal, and no tolerance can be set below the tax.
At 3.6 s the gap is 2.7 s and the tax leaves ~1.4 s — 3.6x the slack.

### A second override that skipped work — same class as #2080's, found by reading the deltas

`bs_unsliced` replaced `hook::resolve_read_slice` with a bare `printf`, so it forked **zero** times
where the sliced arm forks once at `hook-utils.sh:491`. The unsliced arm is the one that must come
out *slower*, so the missing fork shrank the gap being measured. A run with **two of five deltas
negative** is what exposed it. The override now performs the same command substitution and still
returns the unsliced form.

The rule this makes explicit, now written in the file: **an override may lie about a VERDICT, but
must never skip the WORK.**

### The chunk-boundary latency comparison is REMOVED as unmeasurable, not retuned

Unlike the other two, its arms are structurally identical — one slice and one jq probe each — so the
tolerance is the entire budget with no work asymmetry beneath it. The evidence:

| configuration | paired deltas (ms) | verdict |
| --- | --- | --- |
| 1.2 s bound, 400 ms tolerance | 1866 vs 1275 single sample | failed |
| 3.0 s bound, 1200 ms tolerance, single samples | +2938, +1688, +1110, −2245, −837 | noise > 2.25 s signal, straddles zero |
| 3.0 s bound, five interleaved pairs | +3216, −2886, −4427, +433, −3850 | 7.6 s spread, **median −2886 ms** |

That median is a systematic 2.9 s offset between two arms the mechanism says should match, and it is
**unexplained**. Setting a tolerance on a number whose cause is unknown is how this case kept failing,
so it is not being retuned a third time.

**What is no longer covered, stated plainly in the file:** a regression removing the empty-slice
completeness check would make an exactly-chunk-sized payload wait out the whole idle bound instead of
one slice. That is latency-only — the payload still returns whole with rc 0 — and no non-temporal
observable distinguishes the two paths.

**What replaces it:** the correctness half of the same edge, asserted on *content* with no clock — an
exactly-chunk-sized payload on a held-open pipe must come back whole with rc 0 — alongside the
exactly-sized-fixture assertion that was already there. Net assertion count is unchanged.

## Verification

`shellcheck -x` and `scripts/check-shell-portability.sh` clean.

Five full-suite runs, one at a time, reported in full because one green run is exactly how #2080's
un-reproducible claim arose:

Final code, five consecutive runs:

| run | result | late-EOF median (slack 400 ms) | stall median (slack 400 ms) |
| --- | --- | --- | --- |
| 1 | **PASS=154 FAIL=0** | 4713 ms | 3522 ms |
| 2 | **PASS=154 FAIL=0** | 3819 ms | 3025 ms |
| 3 | **PASS=154 FAIL=0** | 2472 ms | 3344 ms |
| 4 | **PASS=154 FAIL=0** | 1274 ms | 2737 ms |
| 5 | **PASS=154 FAIL=0** | 1804 ms | 2906 ms |

Worst median across all five: **3.2x the slack** (late-EOF, run 4) and **6.8x** (stall, run 4). For
comparison, `main` today measures PASS=152 FAIL=2 and PASS=153 FAIL=1.

The individual deltas are the argument for the technique, and they are printed on every run. From an
earlier five-run set on this same branch, late-EOF read `1473 -130 1203 -4528 3527` — **two of five
inverted**, one by 4.5 s — and the median still landed at 3x the slack. Any single-sample assertion
over those numbers is a coin flip; that is what #2080 shipped.

Alternating the arm order (the review finding below) is visible in the spread. The stall case went
from **25 deltas with several negatives** to **25 consecutive positive deltas** across these five
runs, and the within-run spread on run 1 fell from 2061 ms to 982 ms on the same host. Some of what
the median had been absorbing was order bias, not noise.

Assertion count is 154 on every run — the boundary latency comparison was replaced one-for-one by the
content assertion, so nothing was dropped from the total.

### Cost

The release handshake more than pays for the extra sampling: fixed holds cost 8180 ms where the
handshake costs whatever the consumer actually needs (2271 ms in the probe). Eight cases got faster
and more reliable at once.

### Review findings, both real, both fixed in `43d331e9`

- **Arm order was not alternated.** Every pair ran A before B, so any order-dependent cost entered
  every delta with the same sign — and a median removes outliers, not bias. On a slow-spawning host
  that bias is indistinguishable from the gap being measured, so a regression making the arms equally
  fast could still clear the slack: a silent false PASS, worse than the false FAILs this set out to
  fix. Order now alternates A/B then B/A while the subtraction stays B−A, so the second-position
  penalty cancels instead of accumulating.
- **The no-FIFO fallback was sized below its own worst case.** A flat `sleep 12` had to cover the
  stall comparison's unsliced arm — a 3.6 s bound plus three sequential forks, ~13.2 s at the
  measured 3.2 s per fork — so it would have reintroduced the very truncation the handshake removes.
  Sized several times above it, and the adjacent claim that the fallback was "never wrong in the
  passing direction" is corrected: a too-short hold turns a should-pass into a false fail.

## Related

- Follow-up to #2080 (merged as `34ab1ced`). These are post-merge findings from an independent
  verification pass, not pre-merge polish — the flaky assertions are on `main` now.
- `lib/hook-utils.sh` is unchanged; this is a test-harness fix only, so no plugin version moves.
