### PR TITLE
fix(guardrails): correct a measured claim about inline alias fork cost

### DIFF
--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -505,14 +505,22 @@ fi
 # An inline HOP is free: it sets inline_alias_handled and skips the config
 # lookup, and effective_dir is pure string composition. Measured with the shim
 # below, the 20-hop dual-spelling and 60-hop single-spelling inline chains to
-# `commit -F -` cost ZERO spawns. But an inline chain is not uniformly free —
-# its TERMINAL subcommand has no inline definition, so the walk still pays one
-# persisted_alias lookup for it: a 12-hop divergent chain to `status` costs 1,
-# as does the dual-spelling chain's blocked `commit -m` variant.
-# That single fork is not nothing — it moves 1 -> 40 under the same cache
-# regression this section pins. The inline cases are still the wrong fixtures
-# here, not because they cannot move, but because one fork cannot express a
-# per-hop ceiling, and because none of them carries a spawn assertion.
+# `commit -F -` cost ZERO spawns. But an inline chain is not uniformly free: its
+# TERMINAL subcommand can still fork, by either of two DISTINCT routes that must
+# not be conflated.
+#   - An alias lookup, when the subcommand is not `commit` — the persisted probe
+#     at block-noncanonical-commit.sh:683 excludes `commit` by name. A 12-hop
+#     divergent inline chain to `status` costs 1 this way, and that one IS
+#     cache-sensitive: it moves 1 -> 40 under the same regression this section
+#     pins.
+#   - The sequencer probe, for a blocked multi-line `commit -m` — one
+#     `rev-parse --absolute-git-dir` from sequencer_in_progress (:443, called at
+#     :827 behind saw_commit + msg_newline). The dual-spelling chain's blocked
+#     variant costs 1 this way. It is NOT an alias lookup and NOT cache-
+#     sensitive, so it says nothing about the cost this section pins.
+# The inline cases are still the wrong fixtures here, not because they cannot
+# move, but because one fork cannot express a per-hop ceiling, and because none
+# of them carries a spawn assertion.
 #
 # The shim LOGS AND DELEGATES. This hook genuinely needs git to answer, so a
 # log-only stub would change the very verdicts being measured. The real binary is

--- a/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
+++ b/plugins/guardrails/hooks/block-noncanonical-commit.test.sh
@@ -500,12 +500,19 @@ fi
 # noise.
 #
 # Only the PERSISTED branch forks, so these fixtures — not the inline chains
-# earlier in this file — are where the cost lives. Measured with the shim below,
-# the 20-hop dual-spelling, 60-hop single-spelling and 12-hop divergent INLINE
-# chains cost ZERO `git` spawns each: an inline expansion sets
-# inline_alias_handled and skips the config lookup entirely, and effective_dir is
-# pure string composition. Those traversal cases could never have caught a
-# fork-cost regression, which is why this section builds persisted fixtures.
+# earlier in this file — are where the cost lives, and a persisted chain is the
+# only shape that gives one fork PER HOP for the linear ceilings below.
+# An inline HOP is free: it sets inline_alias_handled and skips the config
+# lookup, and effective_dir is pure string composition. Measured with the shim
+# below, the 20-hop dual-spelling and 60-hop single-spelling inline chains to
+# `commit -F -` cost ZERO spawns. But an inline chain is not uniformly free —
+# its TERMINAL subcommand has no inline definition, so the walk still pays one
+# persisted_alias lookup for it: a 12-hop divergent chain to `status` costs 1,
+# as does the dual-spelling chain's blocked `commit -m` variant.
+# That single fork is not nothing — it moves 1 -> 40 under the same cache
+# regression this section pins. The inline cases are still the wrong fixtures
+# here, not because they cannot move, but because one fork cannot express a
+# per-hop ceiling, and because none of them carries a spawn assertion.
 #
 # The shim LOGS AND DELEGATES. This hook genuinely needs git to answer, so a
 # log-only stub would change the very verdicts being measured. The real binary is
@@ -612,7 +619,8 @@ if [[ -n "$FORK_REAL_GIT" && -d "$FORK10/.git" && -d "$FORK20/.git" ]]; then
   # Guarded on BOTH shapes, not just one: the divergent case carries the load-
   # bearing ceiling, and it can go vacuous on its own. If `alias.d` ever falls out
   # of the fixture, or the chain stops reaching it, the walk still exhausts the
-  # budget and still exits 2 while forking nothing — and a 0 <= 16 ceiling would
+  # budget and still exits 2 while forking far below the ceiling — measured at 1,
+  # the terminal `alias.status` lookup alone — and a `1 <= 16` ceiling would
   # report green over a fixture that had quietly stopped testing anything. Two is
   # the measured floor: `alias.d`, then `alias.status`.
   if ((FORKS_10 > 0)); then


### PR DESCRIPTION
No linked issue

Post-merge follow-up from an independent verification pass on #2101. **Comments only** — no fixture, assertion, or ceiling changes.

## The claim that was wrong

The fork-pin section states, prefaced "**Measured** with the shim below", that the 20-hop dual-spelling, 60-hop single-spelling **and 12-hop divergent** inline chains cost **zero** `git` spawns each.

The third is false. Measured through the section's own `run_shimmed` against the pristine hook, twice:

```text
INLINE 20-hop dual-spelling -> commit -F -            rc=0 spawns=0
INLINE 20-hop dual-spelling -> multi-line commit -m   rc=2 spawns=1
INLINE 60-hop single-spelling -> commit -F -          rc=0 spawns=0
INLINE 12-hop divergent -> status                     rc=2 spawns=1
```

## Why

The mechanism sentence was right as far as it went: an inline **hop** does set `inline_alias_handled` (`block-noncanonical-commit.sh:646`) and skip the lookup at `:683`, and `effective_dir` is pure string composition.

It omitted the **terminal subcommand**. `status` has no inline definition, so the walk still pays one `persisted_alias(dir, "status")` — the very `git config` fork this section counts. Same for the dual-spelling chain's blocked `commit -m` variant.

## Why it matters, rather than being a nit

That single fork is not inert. Against a hook copy with the `_persisted_alias` cache guard removed — the exact regression this section exists to pin — the same pre-existing inline chain moves:

```text
INLINE 12-hop divergent -> status    1 -> 40 spawns
```

So the shipped inference that those traversal cases "could never have caught a fork-cost regression" does not hold as written. It survives only in the trivial sense that none of them carries a spawn assertion.

The comment now gives the reason that actually holds: **one fork cannot express a per-hop ceiling**, which is what the 10/20/40 linear shapes need, and none of the inline cases asserts on spawns at all. The persisted fixtures remain correct and necessary.

## Second correction

The vacuity-guard rationale illustrated a rotted fixture as exiting 2 "while forking nothing", with a `0 <= 16` ceiling reporting green. Measured, that case forks **1**, not 0. The `>= 2` threshold still fires — the guard was sound and is unchanged — but the illustrative number was off by one.

## Scope

Nothing executable changed. The eleven `fork pin:` assertions, their fixtures, and their measured counts (10 at 10 hops, 20 at 20, 2 divergent) are untouched, as are both vacuity guards and the branching ceiling that carries the discriminating claim.

| Check | Result |
|---|---|
| `shellcheck -x` | clean |
| `bash -n` | clean |

## Related

- #2101 — introduced the claim being corrected; its pin, guards, and ceilings all verified sound and are untouched here.
- #2080 — converted the wall-clock ceilings to hang guards, which is why the spawn-count pin exists.
