### PR TITLE
chore(claude-lanes): re-pin the review lanes to ci-workflows v0.12.0

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,7 +32,7 @@ jobs:
     concurrency:
       group: claude-review-${{ github.repository }}
       queue: max
-    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@ee96bd28a43eebfa06b61aee8b518cc5b1b195b3 # v0.11.0
+    uses: melodic-software/ci-workflows/.github/workflows/claude-review.yml@734158c4cb6e67b0b99fd703045ac0f7f9f042d5 # v0.12.0
     with:
       runner: ubuntu-24.04
     # Pass only the one named secret (least privilege) rather than `secrets:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read         # checkout + read the diff
       pull-requests: write   # post the security review
       id-token: write        # OIDC — mints the Claude GitHub App token
-    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@ee96bd28a43eebfa06b61aee8b518cc5b1b195b3 # v0.11.0
+    uses: melodic-software/ci-workflows/.github/workflows/claude-security-review.yml@734158c4cb6e67b0b99fd703045ac0f7f9f042d5 # v0.12.0
     with:
       runner: ubuntu-24.04
       paths-file: .github/claude-security-paths


### PR DESCRIPTION
Re-pins both locally-owned lane callers from v0.11.0 (`ee96bd28`) to v0.12.0 (`734158c4cb6e67b0b99fd703045ac0f7f9f042d5`) — the two-tier availability ruling (red only for caller-drift validation skips; classified external failures conclude green with the alarm chain intact). No caller-facing contract change between the tags; the runner-policy allowlist for the new revision arrives via the standards sync (standards#345).

Note: this PR edits the security caller workflow, so its own security check is expected red (validation skip, fail-closed by design) until merge.

## Related

No linked issue. For reference: melodic-software/standards#345, melodic-software/ci-workflows v0.12.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCJfVqDNYt92YRyvKUMgYW