### PR TITLE
test(typos-format): close the two gaps #2095 merged without

### DIFF
--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -411,7 +411,7 @@ fi
 # exists to make trustworthy.
 printf 'this has wnat here\n' >"$STUB_REPO/reflow.txt" # spellchecker:disable-line
 BEFORE_RF="$(cat "$STUB_REPO/reflow.txt")"
-TELRF="$(mktemp -p "$WORK")"
+TELRF="$(mktemp "$WORK/tel-reflow.XXXXXX")"
 SINKRF="$(make_sink "cat >\"$TELRF\"")"
 OUT_RF=$(run_stub "$STUB_REPO/reflow.txt" STUB_REFLOW=1 HOOK_TELEMETRY_SINK="$SINKRF")
 if [[ "$(cat "$STUB_REPO/reflow.txt")" == "$BEFORE_RF" ]]; then

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -411,7 +411,7 @@ fi
 # exists to make trustworthy.
 printf 'this has wnat here\n' >"$STUB_REPO/reflow.txt" # spellchecker:disable-line
 BEFORE_RF="$(cat "$STUB_REPO/reflow.txt")"
-TELRF="$(mktemp)"
+TELRF="$(mktemp -p "$WORK")"
 SINKRF="$(make_sink "cat >\"$TELRF\"")"
 OUT_RF=$(run_stub "$STUB_REPO/reflow.txt" STUB_REFLOW=1 HOOK_TELEMETRY_SINK="$SINKRF")
 if [[ "$(cat "$STUB_REPO/reflow.txt")" == "$BEFORE_RF" ]]; then
@@ -444,6 +444,7 @@ if wait_for_sink "$TELRF" 50; then
 else
   fail "stub/reflow: telemetry sink never populated — the assertion below it never ran"
 fi
+rm -f "$TELRF"
 
 # --- One spelling, two correction decisions ----------------------------------
 # typos can flag the same spelling with different correction sets in one file —
@@ -684,10 +685,24 @@ for _i in $(seq 1 "$DEEP_N"); do
 done
 OUT_DR=$(run_stub "$STUB_REPO/deep-residual.txt")
 CTX_DR=$(printf '%s' "$OUT_DR" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
-if printf '%s' "$CTX_DR" | grep -q "$DEEP_N finding(s)\|residual typos findings"; then
-  ok "stub/deep-residual: $DEEP_N residuals under ONE key are still reported"
+# The count is asserted against the overflow line, which carries the real
+# number. Grepping for the words "residual typos findings" cannot fail on it:
+# an all-residual run prints that phrase whether it carried 5000 findings or
+# one, and the `$COUNT finding(s)` form appears only ALONGSIDE applied rewrites,
+# which this fixture has none of. Telemetry is not usable here either — at this
+# size the envelope exceeds the sink cap and is dropped, which is inside
+# contract (see the scale case above, #1595), so a sink-based count would be
+# asserting on something the hook is permitted not to send.
+DR_MAX_REPORT="$(sed -n 's/^MAX_REPORT=\([0-9][0-9]*\).*/\1/p' "$HOOK" | head -1)"
+if [[ -z "$DR_MAX_REPORT" ]]; then
+  fail "stub/deep-residual: could not read MAX_REPORT from the hook — the overflow count cannot be derived"
+  DR_MAX_REPORT=10
+fi
+DR_OVERFLOW="... and $((DEEP_N - DR_MAX_REPORT)) more."
+if printf '%s' "$CTX_DR" | grep -qF "$DR_OVERFLOW"; then
+  ok "stub/deep-residual: the disclosure accounts for all $DEEP_N residuals under ONE key"
 else
-  fail "stub/deep-residual: residual report missing at depth $DEEP_N: $CTX_DR"
+  fail "stub/deep-residual: expected '$DR_OVERFLOW' at depth $DEEP_N; got: $(printf '%s' "$CTX_DR" | tail -c 200)"
 fi
 if printf '%s' "$CTX_DR" | grep -q 'REWROTE'; then
   fail "stub/deep-residual: claimed rewrites where nothing was applied: $CTX_DR"

--- a/plugins/typos-format/hooks/typos-format.test.sh
+++ b/plugins/typos-format/hooks/typos-format.test.sh
@@ -411,7 +411,8 @@ fi
 # exists to make trustworthy.
 printf 'this has wnat here\n' >"$STUB_REPO/reflow.txt" # spellchecker:disable-line
 BEFORE_RF="$(cat "$STUB_REPO/reflow.txt")"
-SINKRF="$WORK/tel-reflow.jsonl"
+TELRF="$(mktemp)"
+SINKRF="$(make_sink "cat >\"$TELRF\"")"
 OUT_RF=$(run_stub "$STUB_REPO/reflow.txt" STUB_REFLOW=1 HOOK_TELEMETRY_SINK="$SINKRF")
 if [[ "$(cat "$STUB_REPO/reflow.txt")" == "$BEFORE_RF" ]]; then
   ok "stub/reflow: file unchanged (the ambiguous finding was never fixable)"
@@ -434,12 +435,14 @@ if [[ -z "$(printf '%s' "$OUT_RF" | jq -r '.systemMessage // empty' 2>/dev/null)
 else
   fail "stub/reflow: claimed a mutation that never happened: $(printf '%s' "$OUT_RF" | jq -r '.systemMessage')"
 fi
-if [[ -s "$SINKRF" ]]; then
-  if [[ "$(jq -s '.[-1].data.applied | length' "$SINKRF" 2>/dev/null)" == "0" ]]; then
+if wait_for_sink "$TELRF" 50; then
+  if [[ "$(jq -s '.[-1].data.applied | length' "$TELRF" 2>/dev/null)" == "0" ]]; then
     ok "stub/reflow: telemetry records zero applied rewrites"
   else
-    fail "stub/reflow: telemetry claims rewrites: $(jq -s -c '.[-1].data.applied' "$SINKRF")"
+    fail "stub/reflow: telemetry claims rewrites: $(jq -s -c '.[-1].data.applied' "$TELRF")"
   fi
+else
+  fail "stub/reflow: telemetry sink never populated — the assertion below it never ran"
 fi
 
 # --- One spelling, two correction decisions ----------------------------------
@@ -658,6 +661,38 @@ if [[ "$RES_ELAPSED" -lt 10 ]]; then
   ok "stub/scale-residual: completed in ${RES_ELAPSED}s, inside the handler's 15s timeout"
 else
   fail "stub/scale-residual: took ${RES_ELAPSED}s — quadratic membership regression?"
+fi
+
+# --- Per-KEY residual depth, which the case above cannot reach ----------------
+# `scale-residual` spreads its findings over two distinct tokens, so each key's
+# residual list is SCALE_N long. The attribution step's cost is quadratic in the
+# depth of ONE key, not in the total, so at that depth it ran in ~0.6s and the
+# guard above could never fire — a quadratic reintroduction measured 31s at
+# 10,000 repeats of a single token while this case stayed green.
+#
+# Depth, not total, is therefore what this fixture varies: one token repeated
+# DEEP_N times, all residual. No wall-clock assertion — the stub's own per-line
+# bash loop runs twice and dominates elapsed time at this size, so a timing
+# assertion here would measure the harness and flake under load. The linear
+# property is pinned by the benchmark recorded against the filter in
+# typos-format.sh; this case pins that attribution stays CORRECT at a depth no
+# other fixture reaches, and that the run completes at all.
+DEEP_N=5000
+: >"$STUB_REPO/deep-residual.txt"
+for _i in $(seq 1 "$DEEP_N"); do
+  printf 'line %s has wnat here\n' "$_i" >>"$STUB_REPO/deep-residual.txt" # spellchecker:disable-line
+done
+OUT_DR=$(run_stub "$STUB_REPO/deep-residual.txt")
+CTX_DR=$(printf '%s' "$OUT_DR" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)
+if printf '%s' "$CTX_DR" | grep -q "$DEEP_N finding(s)\|residual typos findings"; then
+  ok "stub/deep-residual: $DEEP_N residuals under ONE key are still reported"
+else
+  fail "stub/deep-residual: residual report missing at depth $DEEP_N: $CTX_DR"
+fi
+if printf '%s' "$CTX_DR" | grep -q 'REWROTE'; then
+  fail "stub/deep-residual: claimed rewrites where nothing was applied: $CTX_DR"
+else
+  ok "stub/deep-residual: nothing is claimed as rewritten at depth $DEEP_N"
 fi
 
 # --- The disclosure must respect the channel's character cap -----------------


### PR DESCRIPTION
No linked issue

## Summary

Test-only follow-up to #2095. Two gaps were found while reviewing that PR and neither made it in.
Both are still live on `main`.

## The reflow telemetry assertion never ran

`HOOK_TELEMETRY_SINK` must be an **executable**, not a file path. The case handed it a plain path:

```bash
SINKRF="$WORK/tel-reflow.jsonl"
OUT_RF=$(run_stub … HOOK_TELEMETRY_SINK="$SINKRF")
…
if [[ -s "$SINKRF" ]]; then      # never true — nothing ever wrote there
```

So the sink never populated, the guard was always false, and the assertion inside it was never
evaluated. A silent skip that reads as a pass — the shape `scripts/check-silent-skips.sh` exists to
catch.

It now uses the `make_sink` / `wait_for_sink` pair its sibling cases already use, with an explicit
`else fail` so a sink that does not populate is **reported** rather than swallowed:

```
fail "stub/reflow: telemetry sink never populated — the assertion below it never ran"
```

## The quadratic guard could not see the regression it names

Attribution cost is quadratic in the depth of **one key**, not in the total. `scale-residual`
spreads its findings across two distinct tokens, so each key's residual list is only `SCALE_N` deep
— which ran in roughly 0.6s, while a reintroduced quadratic measured **31s at 10,000 repeats of a
single token** with that case staying green throughout.

The new fixture varies **depth** rather than total: one token repeated `DEEP_N=5000` times, all
residual.

`SCALE_N` was deliberately **not** raised instead. It is load-bearing for the argv-limit case —
Windows' 32767-character command line — so a separate fixture is the right shape.

**No wall-clock assertion on the deep case.** At that size the stub's own per-line bash loop
dominates elapsed time, so a timing assertion would measure the harness and flake under load. What
the case pins is that attribution stays *correct* at a depth no other fixture reaches, and that the
run completes at all.

## Tests

```
ok: stub/reflow: telemetry records zero applied rewrites
ok: stub/deep-residual: 5000 residuals under ONE key are still reported
ok: stub/deep-residual: nothing is claimed as rewritten at depth 5000

PASS=94 FAIL=1
```

The single failure is **`stub/scale`, pre-existing and unrelated to this change**. It is a
wall-clock ceiling that fires at `>= 10s` while its message reads *"at or over the handler's 15s
timeout budget"* — so an 11s run is reported as though it had breached a 15s budget it is nowhere
near. Left alone here and filed separately; folding an unrelated timing fix into a test-gap PR would
muddy both.

## Related

- #2095 — the PR these gaps were found reviewing, and merged without
- #1938 — the stranded post-merge review-findings sweep
