### PR TITLE
refactor: apply /simplify quality pass across all plugin and CI code

### DIFF
--- a/.claude/hooks/hook-telemetry-sink.sh
+++ b/.claude/hooks/hook-telemetry-sink.sh
@@ -57,20 +57,31 @@ STATUS="${FIELDS[6]}"
 # Translate the envelope status to the record shape the skill reads. Known
 # values pass through (ok → success); an unrecognized value is treated as a
 # catch-all error, never a hard fail (forward-compat rule).
+#
+# exit_code is derived from the SAME status in the same pass: the skill's
+# error/failed-then-fixed analysis keys on exit_code != 0. A clean/no-op run is 0;
+# error and blocked are non-clean (2).
 case "$STATUS" in
-ok) STATUS_OUT=success ;;
-error) STATUS_OUT=error ;;
-skipped) STATUS_OUT=skipped ;;
-blocked) STATUS_OUT=blocked ;;
-*) STATUS_OUT=error ;;
-esac
-
-# Derive exit_code: the skill's error/failed-then-fixed analysis keys on
-# exit_code != 0. A clean/no-op run is 0; error and blocked are non-clean (2).
-case "$STATUS" in
-error | blocked) EXIT_CODE=2 ;;
-ok | skipped) EXIT_CODE=0 ;;
-*) EXIT_CODE=2 ;;
+ok)
+  STATUS_OUT=success
+  EXIT_CODE=0
+  ;;
+skipped)
+  STATUS_OUT=skipped
+  EXIT_CODE=0
+  ;;
+error)
+  STATUS_OUT=error
+  EXIT_CODE=2
+  ;;
+blocked)
+  STATUS_OUT=blocked
+  EXIT_CODE=2
+  ;;
+*)
+  STATUS_OUT=error
+  EXIT_CODE=2
+  ;;
 esac
 
 project_dir=$(hook::repo_root "${CLAUDE_PROJECT_DIR:-.}")

--- a/plugins/actionlint/hooks/actionlint-check.sh
+++ b/plugins/actionlint/hooks/actionlint-check.sh
@@ -27,12 +27,15 @@ hook::check_enabled "ACTIONLINT"
 # under `set -u` would abort before the advisory exit 0.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# lints on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still lints rather
+# than aborting) and the sink opt-in. The data payload costs a jq subprocess,
+# so it is built here after both guards — never on the unwired path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "actionlint-check" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -72,7 +75,13 @@ case "$FILE_NORM" in
 *) exit 0 ;;
 esac
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+# Telemetry-only. Parsed behind the sink opt-in so the unwired default path
+# spawns zero telemetry-only subprocesses (FILE_REL below is NOT gated — it is
+# the path actionlint itself is invoked with).
+TOOL=""
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+fi
 
 # Resolve repo root early — used to compute the schema-required repo-relative
 # path in data.file.
@@ -121,8 +130,7 @@ build_data_json() {
 # both channels (agent + user). Telemetry (opt-in) also records a "skipped"
 # status so a consumer sink can observe the coverage gap.
 if ! command -v actionlint >/dev/null 2>&1; then
-  data_json=$(build_data_json '[]')
-  emit_tel "actionlint-check" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   if hook::notice_once "actionlint-missing" "$INPUT"; then
     hook::emit_skip_notice PostToolUse "actionlint: 'actionlint' not found on PATH — workflow lint skipped for this session. Install: https://github.com/rhysd/actionlint/blob/main/docs/install.md"
   fi
@@ -140,8 +148,7 @@ fi
 # clean-workflow telemetry (status ok, findings []), indistinguishable from a
 # real pass. Changing this process's cwd is safe -- the hook exits below.
 if ! cd "$REPO_ROOT" 2>/dev/null; then
-  data_json=$(build_data_json '[]')
-  emit_tel "actionlint-check" "PostToolUse" "error" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "error" '[]'
   exit 0
 fi
 AL_OUTPUT=$(actionlint -shellcheck= -pyflakes= -- "$FILE_REL" 2>&1)
@@ -155,8 +162,7 @@ if [[ "$AL_STATUS" -ge 2 ]]; then
   if [[ -n "$AL_OUTPUT" ]]; then
     FINDINGS_JSON=$(printf '%s' "$AL_OUTPUT" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
-  data_json=$(build_data_json "$FINDINGS_JSON")
-  emit_tel "actionlint-check" "PostToolUse" "error" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "error" "$FINDINGS_JSON"
   exit 0
 fi
 
@@ -175,12 +181,10 @@ if [[ -n "$AL_OUTPUT" ]]; then
   if [[ -n "$findings_raw" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
-  data_json=$(build_data_json "$FINDINGS_JSON")
-  emit_tel "actionlint-check" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" "$FINDINGS_JSON"
   exit 0
 fi
 
 # Clean workflow.
-data_json=$(build_data_json '[]')
-emit_tel "actionlint-check" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "ok" '[]'
 exit 0

--- a/plugins/bash-format/hooks/bash-format.sh
+++ b/plugins/bash-format/hooks/bash-format.sh
@@ -29,12 +29,16 @@ hook::check_enabled "BASH_FORMAT"
 # `set -u` would abort before the advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# lints and formats on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still lints and
+# formats rather than aborting) and the sink opt-in. The data payload costs a
+# jq subprocess, so it is built here after both guards — never on the unwired
+# path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "bash-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -58,26 +62,35 @@ case "$FILE" in
 *) exit 0 ;;
 esac
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-
 # Resolve repo root early — used to bound the .editorconfig opt-in walk and to
 # compute the schema-required repo-relative path in data.file.
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
-# Repo-relative path: schema requires "relative to the consuming repo root".
-# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
-# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
-# (long name, forward-slash mixed form) when available so the prefix strip
-# compares the same representation. On Linux/macOS, cygpath is absent and both
-# paths are already POSIX. Falls back to raw FILE on any normalization error.
+
+# TOOL and FILE_REL feed the telemetry data object and nothing else, so both are
+# resolved only when a sink is wired: the unwired default path spawns zero
+# telemetry-only subprocesses (the tool_name jq parse, and 2× cygpath on
+# Windows).
+#
+# FILE_REL is the repo-relative path: schema requires "relative to the consuming
+# repo root". On Windows Git Bash, git rev-parse --show-toplevel returns a
+# drive-letter path while FILE may be in POSIX mount form. Normalize both
+# through cygpath -lm (long name, forward-slash mixed form) when available so
+# the prefix strip compares the same representation. On Linux/macOS, cygpath is
+# absent and both paths are already POSIX. Falls back to raw FILE on any
+# normalization error.
+TOOL=""
 FILE_REL="$FILE"
-if command -v cygpath >/dev/null 2>&1; then
-  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
-  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
-  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
-    FILE_REL="${_file_lm#"$_root_lm"/}"
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  if command -v cygpath >/dev/null 2>&1; then
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+      FILE_REL="${_file_lm#"$_root_lm"/}"
+    fi
+  else
+    FILE_REL="${FILE#"$REPO_ROOT"/}"
   fi
-else
-  FILE_REL="${FILE#"$REPO_ROOT"/}"
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
@@ -277,6 +290,5 @@ fi
 
 status="ok"
 [[ $ran_any -eq 0 ]] && status="skipped"
-data_json=$(build_data_json "$FINDINGS_JSON")
-emit_tel "bash-format" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "$status" "$FINDINGS_JSON"
 exit 0

--- a/plugins/biome-format/hooks/biome-format.sh
+++ b/plugins/biome-format/hooks/biome-format.sh
@@ -33,12 +33,15 @@ hook::check_enabled "BIOME_FORMAT"
 # `set -u` would abort before the advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# formats and lints on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still formats and
+# lints rather than aborting) and the sink opt-in. The data payload costs a jq
+# subprocess, so it is built here after both guards — never on the unwired path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "biome-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -62,26 +65,36 @@ case "$FILE" in
 *) exit 0 ;;
 esac
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-
 # Resolve repo root early — used to bound the biome-config opt-in walk and to
 # compute the schema-required repo-relative path in data.file.
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
-# Repo-relative path: schema requires "relative to the consuming repo root".
-# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
-# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
-# (long name, forward-slash mixed form) when available so the prefix strip
-# compares the same representation. On Linux/macOS, cygpath is absent and both
-# paths are already POSIX. Falls back to raw FILE on any normalization error.
+
+# TOOL and FILE_REL feed the telemetry data object and nothing else (Biome is
+# invoked with a CONFIG_DIR-relative path computed below), so both are resolved
+# only when a sink is wired: the unwired default path spawns zero
+# telemetry-only subprocesses (the tool_name jq parse, and 2× cygpath on
+# Windows).
+#
+# FILE_REL is the repo-relative path: schema requires "relative to the consuming
+# repo root". On Windows Git Bash, git rev-parse --show-toplevel returns a
+# drive-letter path while FILE may be in POSIX mount form. Normalize both
+# through cygpath -lm (long name, forward-slash mixed form) when available so
+# the prefix strip compares the same representation. On Linux/macOS, cygpath is
+# absent and both paths are already POSIX. Falls back to raw FILE on any
+# normalization error.
+TOOL=""
 FILE_REL="$FILE"
-if command -v cygpath >/dev/null 2>&1; then
-  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
-  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
-  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
-    FILE_REL="${_file_lm#"$_root_lm"/}"
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  if command -v cygpath >/dev/null 2>&1; then
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+      FILE_REL="${_file_lm#"$_root_lm"/}"
+    fi
+  else
+    FILE_REL="${FILE#"$REPO_ROOT"/}"
   fi
-else
-  FILE_REL="${FILE#"$REPO_ROOT"/}"
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
@@ -101,9 +114,7 @@ build_data_json() {
 }
 
 emit_skipped() {
-  local data_json
-  data_json=$(build_data_json '[]')
-  emit_tel "biome-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 }
 
@@ -197,8 +208,7 @@ fi
 # config authoritative — consistent with the in-tree opt-in this plugin is built
 # on (an out-of-tree config has no in-tree biome.json, so the gate skips anyway).
 if OUTPUT=$(cd "$CONFIG_DIR" && env -u BIOME_CONFIG_PATH "$BIOME_BIN" check --write --error-on-warnings --reporter=github "$BIOME_ARG" 2>&1); then
-  data_json=$(build_data_json '[]')
-  emit_tel "biome-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" '[]'
   exit 0
 fi
 
@@ -224,8 +234,7 @@ if [[ -n "$FINDINGS" ]]; then
   if [[ -n "$findings_raw" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
-  data_json=$(build_data_json "$FINDINGS_JSON")
-  emit_tel "biome-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" "$FINDINGS_JSON"
   exit 0
 fi
 
@@ -250,6 +259,5 @@ while IFS= read -r line; do
   hook::ctx_append "  $line"
 done <<<"$OUTPUT"
 hook::ctx_flush PostToolUse
-data_json=$(build_data_json '[]')
-emit_tel "biome-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "skipped" '[]'
 exit 0

--- a/plugins/claude-ops/hooks/hook-telemetry-sink.sh
+++ b/plugins/claude-ops/hooks/hook-telemetry-sink.sh
@@ -54,20 +54,31 @@ STATUS="${FIELDS[6]}"
 # Translate the envelope status to the record shape the skill reads. Known
 # values pass through (ok → success); an unrecognized value is treated as a
 # catch-all error, never a hard fail (forward-compat rule).
+#
+# exit_code is derived from the SAME status in the same pass: the skill's
+# error/failed-then-fixed analysis keys on exit_code != 0. A clean/no-op run is 0;
+# error and blocked are non-clean (2).
 case "$STATUS" in
-ok) STATUS_OUT=success ;;
-error) STATUS_OUT=error ;;
-skipped) STATUS_OUT=skipped ;;
-blocked) STATUS_OUT=blocked ;;
-*) STATUS_OUT=error ;;
-esac
-
-# Derive exit_code: the skill's error/failed-then-fixed analysis keys on
-# exit_code != 0. A clean/no-op run is 0; error and blocked are non-clean (2).
-case "$STATUS" in
-error | blocked) EXIT_CODE=2 ;;
-ok | skipped) EXIT_CODE=0 ;;
-*) EXIT_CODE=2 ;;
+ok)
+  STATUS_OUT=success
+  EXIT_CODE=0
+  ;;
+skipped)
+  STATUS_OUT=skipped
+  EXIT_CODE=0
+  ;;
+error)
+  STATUS_OUT=error
+  EXIT_CODE=2
+  ;;
+blocked)
+  STATUS_OUT=blocked
+  EXIT_CODE=2
+  ;;
+*)
+  STATUS_OUT=error
+  EXIT_CODE=2
+  ;;
 esac
 
 project_dir=$(hook::repo_root "${CLAUDE_PROJECT_DIR:-.}")

--- a/plugins/claude-ops/hooks/instructions-loaded-audit.sh
+++ b/plugins/claude-ops/hooks/instructions-loaded-audit.sh
@@ -30,8 +30,13 @@ START=${EPOCHREALTIME:-}
 
 INPUT=$(hook::buffer_stdin) || exit 0
 
-FILE_PATH=$(hook::jq_field "$INPUT" '.file_path' || true)
-LOAD_REASON=$(hook::jq_field "$INPUT" '.load_reason' || true)
+# Both payload fields in ONE jq process (hook::jq_fields), not two. A jq spawn is
+# ~140 ms of fork() emulation on Windows Git Bash. Failure semantics are
+# unchanged: a missing jq or an unparsable payload yields rc 1 here, which exits 0
+# exactly as the both-fields-empty skip below did.
+hook::jq_fields "$INPUT" '.file_path' '.load_reason' || exit 0
+FILE_PATH="${HOOK_JQ_FIELDS[0]}"
+LOAD_REASON="${HOOK_JQ_FIELDS[1]}"
 
 # Need at least one of the two; a pure missing payload is a silent skip.
 [[ -n "$FILE_PATH$LOAD_REASON" ]] || exit 0

--- a/plugins/claude-ops/hooks/permission-denied-audit.sh
+++ b/plugins/claude-ops/hooks/permission-denied-audit.sh
@@ -25,8 +25,15 @@ START=${EPOCHREALTIME:-}
 
 INPUT=$(hook::buffer_stdin) || exit 0
 
-TOOL=$(hook::jq_field "$INPUT" '.tool_name') || exit 0
-CMD=$(hook::jq_field "$INPUT" '.tool_input.command' || true)
+# Both payload fields in ONE jq process (hook::jq_fields), not two. A jq spawn is
+# ~140 ms of fork() emulation on Windows Git Bash. Failure semantics are
+# unchanged: a missing jq or an unparsable payload yields rc 1 here, which exits 0
+# exactly as the absent-tool_name skip did, and an absent `.tool_input.command`
+# still arrives as the empty string the subject helper already tolerates.
+hook::jq_fields "$INPUT" '.tool_name' '.tool_input.command' || exit 0
+TOOL="${HOOK_JQ_FIELDS[0]}"
+[[ -n "$TOOL" ]] || exit 0
+CMD="${HOOK_JQ_FIELDS[1]}"
 SUBJECT=$(hook::extract_bash_subject "$TOOL" "$CMD")
 
 DATA=$(jq -nc --arg subject "$SUBJECT" --arg tool "$TOOL" '{subject: $subject, tool: $tool}')

--- a/plugins/claude-ops/hooks/tool-failure-audit.sh
+++ b/plugins/claude-ops/hooks/tool-failure-audit.sh
@@ -22,8 +22,15 @@ START=${EPOCHREALTIME:-}
 
 INPUT=$(hook::buffer_stdin) || exit 0
 
-TOOL=$(hook::jq_field "$INPUT" '.tool_name') || exit 0
-CMD=$(hook::jq_field "$INPUT" '.tool_input.command' || true)
+# Both payload fields in ONE jq process (hook::jq_fields), not two. A jq spawn is
+# ~140 ms of fork() emulation on Windows Git Bash. Failure semantics are
+# unchanged: a missing jq or an unparsable payload yields rc 1 here, which exits 0
+# exactly as the absent-tool_name skip did, and an absent `.tool_input.command`
+# still arrives as the empty string the subject helper already tolerates.
+hook::jq_fields "$INPUT" '.tool_name' '.tool_input.command' || exit 0
+TOOL="${HOOK_JQ_FIELDS[0]}"
+[[ -n "$TOOL" ]] || exit 0
+CMD="${HOOK_JQ_FIELDS[1]}"
 SUBJECT=$(hook::extract_bash_subject "$TOOL" "$CMD")
 
 DATA=$(jq -nc --arg subject "$SUBJECT" --arg tool "$TOOL" '{subject: $subject, tool: $tool}')

--- a/plugins/claude-ops/skills/known-issues/scripts/registry_manager.py
+++ b/plugins/claude-ops/skills/known-issues/scripts/registry_manager.py
@@ -155,6 +155,29 @@ def find_by_query(
     return [i for i in issues if query_lower in _searchable_text(i)]
 
 
+def _is_stale(
+    issue: dict[str, Any],
+    today: date,
+    days: int,
+    *,
+    missing_is_stale: bool,
+) -> bool:
+    """Has this issue gone unchecked for `days` or more?
+
+    An unparsable `last_checked` always counts as stale — the check date cannot
+    be trusted. A MISSING one is the callers' one disagreement, so it stays a
+    parameter: `list --stale` reports it (nothing proves it was ever checked)
+    while `stats` does not count it.
+    """
+    checked = issue.get("last_checked")
+    if not checked:
+        return missing_is_stale
+    try:
+        return (today - date.fromisoformat(checked)).days >= days
+    except (ValueError, TypeError):
+        return True
+
+
 # ── Validation helpers ──────────────────────────────────────────
 
 
@@ -276,19 +299,11 @@ def action_list(
         filtered = [i for i in filtered if feat in (i.get("feature", "")).lower()]
     if stale_days is not None:
         today = date.today()
-        stale: list[dict[str, Any]] = []
-        for i in filtered:
-            checked = i.get("last_checked")
-            if checked:
-                try:
-                    checked_date = date.fromisoformat(checked)
-                    if (today - checked_date).days >= stale_days:
-                        stale.append(i)
-                except (ValueError, TypeError):
-                    stale.append(i)
-            else:
-                stale.append(i)
-        filtered = stale
+        filtered = [
+            i
+            for i in filtered
+            if _is_stale(i, today, stale_days, missing_is_stale=True)
+        ]
 
     msg = f"Found {len(filtered)} issues"
     return _ok(
@@ -480,18 +495,10 @@ def action_stats(
     """Summary dashboard."""
     by_category: Counter[str] = Counter(i.get("category", "unknown") for i in issues)
     by_status: Counter[str] = Counter(i.get("status", "unknown") for i in issues)
-    stale_count = 0
     today = date.today()
-
-    for issue in issues:
-        checked = issue.get("last_checked")
-        if checked:
-            try:
-                checked_date = date.fromisoformat(checked)
-                if (today - checked_date).days >= 7:
-                    stale_count += 1
-            except (ValueError, TypeError):
-                stale_count += 1
+    stale_count = sum(
+        1 for i in issues if _is_stale(i, today, 7, missing_is_stale=False)
+    )
 
     blocking = [
         {

--- a/plugins/claude-ops/skills/lanes/scripts/machine-behavior.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/machine-behavior.sh
@@ -205,7 +205,9 @@ plugin_versions() {
   fi
 
   local want_json='[]'
-  ((${#WANT_PLUGINS[@]})) && want_json="$(printf '%s\n' "${WANT_PLUGINS[@]}" | jq -R . | jq -cs .)"
+  # One jq process, not two: `-Rn` makes `inputs` yield each line as a raw
+  # string, which is what `jq -R . | jq -cs .` spelled with a second spawn.
+  ((${#WANT_PLUGINS[@]})) && want_json="$(printf '%s\n' "${WANT_PLUGINS[@]}" | jq -Rcn '[inputs]')"
 
   local rows
   rows="$(jq -r --argjson want "$want_json" '

--- a/plugins/claude-ops/skills/morning-brief/scripts/morning-brief.sh
+++ b/plugins/claude-ops/skills/morning-brief/scripts/morning-brief.sh
@@ -86,6 +86,16 @@ require_file() {
   }
 }
 
+# Same shape as require_value above, for the three numeric flags. Callers then
+# assign with `$((10#$2))`, which forces base-10 so a leading-zero value is not
+# misread as octal (08 errors outright, 010 would evaluate as 8).
+require_uint() {
+  [[ "$2" =~ ^[0-9]+$ ]] || {
+    printf 'morning-brief: %s requires a non-negative integer\n' "$1" >&2
+    exit 3
+  }
+}
+
 while (($# > 0)); do
   case "$1" in
   -h | --help) usage ;;
@@ -101,33 +111,19 @@ while (($# > 0)); do
     ;;
   --stale-hours)
     require_value "$1" "${2:-}"
-    [[ "$2" =~ ^[0-9]+$ ]] || {
-      printf 'morning-brief: --stale-hours requires a non-negative integer\n' >&2
-      exit 3
-    }
-    # 10# forces base-10 so a leading-zero value (e.g. 08) is not later misread
-    # as octal in the staleness arithmetic (08 errors, 010 would evaluate as 8).
+    require_uint "$1" "$2"
     STALE_HOURS="$((10#$2))"
     shift 2
     ;;
   --rec-maxlen)
     require_value "$1" "${2:-}"
-    [[ "$2" =~ ^[0-9]+$ ]] || {
-      printf 'morning-brief: --rec-maxlen requires a non-negative integer\n' >&2
-      exit 3
-    }
-    # 10# forces base-10 so a leading-zero value (e.g. 010) is not later misread
-    # as octal in the truncation length (010 would evaluate as 8, not 10).
+    require_uint "$1" "$2"
     REC_MAXLEN="$((10#$2))"
     shift 2
     ;;
   --stranded-days)
     require_value "$1" "${2:-}"
-    [[ "$2" =~ ^[0-9]+$ ]] || {
-      printf 'morning-brief: --stranded-days requires a non-negative integer\n' >&2
-      exit 3
-    }
-    # 10# forces base-10 so a leading-zero value is not misread as octal.
+    require_uint "$1" "$2"
     STRANDED_DAYS="$((10#$2))"
     shift 2
     ;;

--- a/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
+++ b/plugins/claude-ops/skills/plugins/scripts/fleet-state.sh
@@ -256,20 +256,28 @@ if [[ -n "$PROJECT_ROOT" ]]; then
     local_map=$(jq -c '.enabledPlugins // {}' "$PROJECT_ROOT/.claude/settings.local.json")
 fi
 
+# The three scope maps feed three jq programs below. Route each one through the
+# filesystem ONCE and reuse the path: jq_slurp_tmpfile is a mktemp + write per
+# call, and re-deriving the same three payloads for every program paid that nine
+# times for three distinct values.
+user_map_f="$(jq_slurp_tmpfile "$user_map")"
+project_map_f="$(jq_slurp_tmpfile "$project_map")"
+local_map_f="$(jq_slurp_tmpfile "$local_map")"
+
 # Union of every id ever mentioned in any scope (raw, unmerged) — used to
 # distinguish "never mentioned anywhere" (missing_from_enabled) from
 # "explicitly false somewhere" (deliberate opt-out, never flipped by sync).
 known_ids=$(jq -cn \
-  --slurpfile u "$(jq_slurp_tmpfile "$user_map")" \
-  --slurpfile p "$(jq_slurp_tmpfile "$project_map")" \
-  --slurpfile l "$(jq_slurp_tmpfile "$local_map")" \
+  --slurpfile u "$user_map_f" \
+  --slurpfile p "$project_map_f" \
+  --slurpfile l "$local_map_f" \
   '($u[0] + $p[0] + $l[0]) | keys')
 
 # Effective value per id: local > project > user.
 effective_map=$(jq -cn \
-  --slurpfile u "$(jq_slurp_tmpfile "$user_map")" \
-  --slurpfile p "$(jq_slurp_tmpfile "$project_map")" \
-  --slurpfile l "$(jq_slurp_tmpfile "$local_map")" \
+  --slurpfile u "$user_map_f" \
+  --slurpfile p "$project_map_f" \
+  --slurpfile l "$local_map_f" \
   '$u[0] + $p[0] + $l[0]')
 
 # ids explicitly set to false in ANY scope — a deliberate opt-out, even for a
@@ -277,10 +285,14 @@ effective_map=$(jq -cn \
 # this" in project settings before anyone runs install). "Missing" (needing
 # an install prompt) excludes these; sync never installs over an opt-out.
 explicit_false_ids=$(jq -cn \
-  --slurpfile u "$(jq_slurp_tmpfile "$user_map")" \
-  --slurpfile p "$(jq_slurp_tmpfile "$project_map")" \
-  --slurpfile l "$(jq_slurp_tmpfile "$local_map")" \
+  --slurpfile u "$user_map_f" \
+  --slurpfile p "$project_map_f" \
+  --slurpfile l "$local_map_f" \
   '[($u[0], $p[0], $l[0]) | to_entries[] | select(.value == false) | .key] | unique')
+
+# Marketplace-invariant, so it is routed once here rather than twice per
+# marketplace inside emit_marketplace (which an --all sweep runs per entry).
+explicit_false_ids_f="$(jq_slurp_tmpfile "$explicit_false_ids")"
 
 # --- Normalized current-project root, for the `currentProject` install flag
 current_project_norm=""
@@ -357,11 +369,16 @@ emit_marketplace() {
   auto_update=$(jq -r '.autoUpdate // false' <<<"$mp_entry")
   last_updated=$(jq -r '.lastUpdated // ""' <<<"$mp_entry")
   install_location=$(jq -r '.installLocation // ""' <<<"$mp_entry")
+  # `auto_update` is jq's own `true`/`false` text; normalize it to a JSON literal
+  # once here rather than re-running the same `$([[ … ]] && echo …)` subshell at
+  # each of the four --argjson call sites below.
+  local auto_update_json=false
+  [[ "$auto_update" == "true" ]] && auto_update_json=true
 
   if [[ -n "${FLEET_STATE_CATALOG_DIR:-}" ]]; then
     local fixture="$FLEET_STATE_CATALOG_DIR/$name.json"
     if [[ ! -f "$fixture" ]]; then
-      jq -cn --arg n "$name" --argjson au "$([[ "$auto_update" == "true" ]] && echo true || echo false)" --arg lu "$last_updated" \
+      jq -cn --arg n "$name" --argjson au "$auto_update_json" --arg lu "$last_updated" \
         '{marketplace: {name: $n, autoUpdate: $au, lastUpdated: $lu, error: "no catalog fixture"}}'
       return 1
     fi
@@ -369,7 +386,7 @@ emit_marketplace() {
   else
     catalog_json="$install_location/.claude-plugin/marketplace.json"
     if [[ ! -f "$catalog_json" ]]; then
-      jq -cn --arg n "$name" --argjson au "$([[ "$auto_update" == "true" ]] && echo true || echo false)" --arg lu "$last_updated" \
+      jq -cn --arg n "$name" --argjson au "$auto_update_json" --arg lu "$last_updated" \
         '{marketplace: {name: $n, autoUpdate: $au, lastUpdated: $lu, error: "marketplace.json not found at installLocation"}}'
       return 1
     fi
@@ -381,15 +398,18 @@ emit_marketplace() {
   # the branches above — report it inline and return 1 so one corrupt clone
   # doesn't abort an --all sweep of every other marketplace.
   if ! jq empty "$catalog_json" 2>/dev/null; then
-    jq -cn --arg n "$name" --argjson au "$([[ "$auto_update" == "true" ]] && echo true || echo false)" --arg lu "$last_updated" \
+    jq -cn --arg n "$name" --argjson au "$auto_update_json" --arg lu "$last_updated" \
       '{marketplace: {name: $n, autoUpdate: $au, lastUpdated: $lu, error: "marketplace.json is not valid JSON"}}'
     return 1
   fi
   local catalog
   catalog=$(jq -c '[.plugins[]?.name // empty] | unique' "$catalog_json")
 
-  local catalog_ids
+  local catalog_ids catalog_ids_f
   catalog_ids=$(jq -c --arg mp "$name" '[.[] | . + "@" + $mp]' <<<"$catalog")
+  # Routed once: both the all-scope and the user-scope completeness programs
+  # below read the same catalog id list.
+  catalog_ids_f="$(jq_slurp_tmpfile "$catalog_ids")"
 
   # Ids the marketplace entry ships with defaultEnabled:false — a publisher's
   # deliberate opt-in-required default (takes precedence over the plugin's own
@@ -430,9 +450,9 @@ emit_marketplace() {
   # scope, even one never installed at all.
   local missing_from_install
   missing_from_install=$(jq -cn \
-    --slurpfile catalog "$(jq_slurp_tmpfile "$catalog_ids")" \
+    --slurpfile catalog "$catalog_ids_f" \
     --slurpfile installed "$(jq_slurp_tmpfile "$installed_ids")" \
-    --slurpfile falseIds "$(jq_slurp_tmpfile "$explicit_false_ids")" \
+    --slurpfile falseIds "$explicit_false_ids_f" \
     '($catalog[0] - $installed[0]) - $falseIds[0]')
 
   # User-scope completeness, distinct from all-scope missing_from_install: a
@@ -445,13 +465,15 @@ emit_marketplace() {
 
   local missing_from_user_install
   missing_from_user_install=$(jq -cn \
-    --slurpfile catalog "$(jq_slurp_tmpfile "$catalog_ids")" \
+    --slurpfile catalog "$catalog_ids_f" \
     --slurpfile userInstalled "$(jq_slurp_tmpfile "$user_installed_ids")" \
-    --slurpfile falseIds "$(jq_slurp_tmpfile "$explicit_false_ids")" \
+    --slurpfile falseIds "$explicit_false_ids_f" \
     '($catalog[0] - $userInstalled[0]) - $falseIds[0]')
 
-  local known_at_mp
+  local known_at_mp known_at_mp_f
   known_at_mp=$(jq -c --arg suffix "@$name" '[.[] | select(endswith($suffix))]' <<<"$known_ids")
+  # Routed once: both the missing_from_enabled and enabled_at_mp programs read it.
+  known_at_mp_f="$(jq_slurp_tmpfile "$known_at_mp")"
 
   # missing_from_enabled can only be computed for ids whose enabledPlugins
   # this invocation can actually read: user scope (global) and the current
@@ -467,13 +489,13 @@ emit_marketplace() {
   local missing_from_enabled
   missing_from_enabled=$(jq -cn \
     --slurpfile verifiable_ids "$(jq_slurp_tmpfile "$verifiable_ids")" \
-    --slurpfile known "$(jq_slurp_tmpfile "$known_at_mp")" \
+    --slurpfile known "$known_at_mp_f" \
     --slurpfile defaultDisabled "$(jq_slurp_tmpfile "$default_disabled_ids")" \
     '($verifiable_ids[0] - $known[0]) - $defaultDisabled[0]')
 
   local enabled_at_mp
   enabled_at_mp=$(jq -cn \
-    --slurpfile known "$(jq_slurp_tmpfile "$known_at_mp")" \
+    --slurpfile known "$known_at_mp_f" \
     --slurpfile eff "$(jq_slurp_tmpfile "$effective_map")" \
     'reduce $known[0][] as $id ({}; . + {($id): $eff[0][$id]})')
 
@@ -494,7 +516,7 @@ emit_marketplace() {
 
   jq -cn \
     --arg name "$name" \
-    --argjson autoUpdate "$([[ "$auto_update" == "true" ]] && echo true || echo false)" \
+    --argjson autoUpdate "$auto_update_json" \
     --arg lastUpdated "$last_updated" \
     --slurpfile catalog "$(jq_slurp_tmpfile "$catalog")" \
     --slurpfile installed "$(jq_slurp_tmpfile "$installed")" \

--- a/plugins/context-guard/scripts/statusline-tee.sh
+++ b/plugins/context-guard/scripts/statusline-tee.sh
@@ -89,10 +89,39 @@ tee_snapshot() {
   [[ -n "${HOME:-}" ]] || return 0
   command -v jq >/dev/null 2>&1 || return 0 # visible notice emitted by the caller
 
-  # Extract + sanitize the session id BEFORE any filesystem work: it becomes
-  # the snapshot filename, so only [A-Za-z0-9_-] is accepted.
-  local sid
-  sid=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || return 0
+  local ts payload sid out
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || return 0
+  # ONE jq pass for both the snapshot body and the session id — this runs on
+  # every statusline refresh, so a second spawn here is a second spawn per
+  # refresh. Framing is payload-FIRST and is airtight because `jq -c` emits an
+  # object on exactly one line (JSON escapes any newline inside a string),
+  # while a raw session id may legally carry newlines: the first line is
+  # always the payload, everything after it is the id, and a multi-line id
+  # simply fails the character-class gate below like any other bad value.
+  #
+  # cli_version carries the payload's top-level `version` (the Claude Code
+  # version — statusline reference, verified 2026-07-26). The reader needs it
+  # because `total_input_tokens` / `total_output_tokens` mean current context
+  # occupancy only from 2.1.132 and were CUMULATIVE session totals before it:
+  # a cumulative total below the window size is indistinguishable from a real
+  # occupancy, so without a version there is no sound way to trust the token
+  # bands. Copied only when it is a string; absent leaves the reader on the
+  # percentage shape alone.
+  out=$(printf '%s' "$INPUT" | jq -rc --arg ts "$ts" '
+    ({captured_at: $ts, session_id: .session_id}
+     + (if (.version? // null | type) == "string" then {cli_version: .version} else {} end)
+     + (if has("context_window") then {context_window} else {} end)),
+    (.session_id // "")
+  ' 2>/dev/null) || return 0
+  payload=${out%%$'\n'*}
+  sid=""
+  # No second line at all (absent/null session_id) leaves sid empty, which the
+  # character-class gate rejects — never the payload text read as an id.
+  [[ "$out" == *$'\n'* ]] && sid=${out#*$'\n'}
+  [[ -n "$payload" ]] || return 0
+
+  # Sanitize the session id BEFORE any filesystem work: it becomes the
+  # snapshot filename, so only [A-Za-z0-9_-] is accepted.
   [[ "$sid" =~ ^[A-Za-z0-9_-]+$ ]] || return 0
 
   local dir="$HOME/.claude/context-guard/context"
@@ -102,23 +131,6 @@ tee_snapshot() {
   # symlinks or reading the snapshots. Best-effort (no-op on filesystems
   # without POSIX modes, e.g. Windows ACL volumes under Git Bash).
   chmod 700 "$dir" 2>/dev/null || true
-
-  local ts payload
-  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || return 0
-  # cli_version carries the payload's top-level `version` (the Claude Code
-  # version — statusline reference, verified 2026-07-26). The reader needs it
-  # because `total_input_tokens` / `total_output_tokens` mean current context
-  # occupancy only from 2.1.132 and were CUMULATIVE session totals before it:
-  # a cumulative total below the window size is indistinguishable from a real
-  # occupancy, so without a version there is no sound way to trust the token
-  # bands. Copied only when it is a string; absent leaves the reader on the
-  # percentage shape alone.
-  payload=$(printf '%s' "$INPUT" | jq -c --arg ts "$ts" '
-    {captured_at: $ts, session_id: .session_id}
-    + (if (.version? // null | type) == "string" then {cli_version: .version} else {} end)
-    + (if has("context_window") then {context_window} else {} end)
-  ' 2>/dev/null) || return 0
-  [[ -n "$payload" ]] || return 0
 
   # Prune stale sibling snapshots (14 days ≫ the reader contract's 10-minute
   # staleness window — a live-but-idle session survives). Pattern *.json

--- a/plugins/disk-hygiene/lib/killswitch_config.py
+++ b/plugins/disk-hygiene/lib/killswitch_config.py
@@ -209,7 +209,7 @@ def probe(settings_path: Path, plugin_id: str | None = None) -> dict[str, object
             "indeterminate",
             True,
             "A configured value is not a recognizable boolean "
-            f"({json.dumps({k: e['value'] for k, e in zip(interpreted, entries)})}); "
+            f"({json.dumps({entry['key']: entry['value'] for entry in entries})}); "
             "assuming the default (enabled). This is an assumption, not the "
             "configured value.",
             settings_path,

--- a/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/destructive_guard.py
@@ -173,6 +173,23 @@ _PLUGIN_DATA_DIRNAME = "data"
 _PLUGIN_ID_DISALLOWED = re.compile(r"[^A-Za-z0-9_-]")
 
 
+def _plugins_cache_index(parts: tuple[str, ...]) -> int | None:
+    """Index of the ``cache`` segment of a ``<plugins>/cache/...`` layout, or None.
+
+    The single place the marketplace-install marker is located. Every derivation
+    that anchors on it (data root, user settings path, plugin id, cached-version
+    family) shares this one scan, so they cannot drift apart on what counts as a
+    marketplace install. The FIRST match wins, as each derivation did alone.
+    """
+    for index in range(1, len(parts)):
+        if (
+            parts[index].casefold() == _PLUGIN_CACHE_DIRNAME
+            and parts[index - 1].casefold() == _PLUGINS_DIRNAME
+        ):
+            return index
+    return None
+
+
 def _plugin_data_root_from_root(plugin_root: str) -> str | None:
     """Derive the persistent data root from the plugin's installation root.
 
@@ -194,21 +211,15 @@ def _plugin_data_root_from_root(plugin_root: str) -> str | None:
     instead of trusting a guessed path.
     """
     parts = Path(plugin_root).parts
-    for index in range(1, len(parts)):
-        if not (
-            parts[index].casefold() == _PLUGIN_CACHE_DIRNAME
-            and parts[index - 1].casefold() == _PLUGINS_DIRNAME
-        ):
-            continue
-        if index + 2 >= len(parts):
-            return None
-        marketplace, name = parts[index + 1], parts[index + 2]
-        if not marketplace or not name:
-            return None
-        plugin_id = _PLUGIN_ID_DISALLOWED.sub("-", f"{name}@{marketplace}")
-        plugins_dir = Path(*parts[:index])
-        return os.fspath(plugins_dir / _PLUGIN_DATA_DIRNAME / plugin_id)
-    return None
+    index = _plugins_cache_index(parts)
+    if index is None or index + 2 >= len(parts):
+        return None
+    marketplace, name = parts[index + 1], parts[index + 2]
+    if not marketplace or not name:
+        return None
+    plugin_id = _PLUGIN_ID_DISALLOWED.sub("-", f"{name}@{marketplace}")
+    plugins_dir = Path(*parts[:index])
+    return os.fspath(plugins_dir / _PLUGIN_DATA_DIRNAME / plugin_id)
 
 
 _MODE_FLAG = "--mode"
@@ -242,16 +253,10 @@ def _plugin_cache_family_root() -> str | None:
     there would gate a contributor's work on their own checkout.
     """
     parts = Path(__file__).resolve().parts
-    for index in range(1, len(parts)):
-        if not (
-            parts[index].casefold() == _PLUGIN_CACHE_DIRNAME
-            and parts[index - 1].casefold() == _PLUGINS_DIRNAME
-        ):
-            continue
-        if index + 2 >= len(parts):
-            return None
-        return os.path.normcase(os.fspath(Path(*parts[: index + 3])))
-    return None
+    index = _plugins_cache_index(parts)
+    if index is None or index + 2 >= len(parts):
+        return None
+    return os.path.normcase(os.fspath(Path(*parts[: index + 3])))
 
 
 def _within_plugin_cache_family(value: str) -> bool:
@@ -440,7 +445,7 @@ def _engine_gate_relevant(command: str, tool_name: str = "Bash") -> bool:
         base = Path(word.casefold()).name
         return base.startswith("python") or base in {"py", "py.exe"}
 
-    bundled = Path(__file__).resolve().with_name("hygiene.py")
+    bundled = _engine_script_path()
 
     def _samefile(word: str) -> bool:
         try:
@@ -644,6 +649,18 @@ def _argv_authorized_data_root(argv: list[str]) -> str | None:
     return _argv_flag_value(argv, _AUTHORIZED_DATA_ROOT_FLAG)
 
 
+def _plugin_root_argument() -> str | None:
+    """The substituted ``--plugin-root`` value, or None when it carries nothing.
+
+    A literal, unexpanded ``${CLAUDE_PLUGIN_ROOT}`` is not a path, and all three
+    derivations that anchor on this argument (data root, user settings path,
+    plugin id) treat it as absent — so the placeholder check lives here once
+    rather than at each of them.
+    """
+    value = _argv_flag_value(sys.argv[1:], _PLUGIN_ROOT_FLAG)
+    return value if value and value != _PLUGIN_ROOT_PLACEHOLDER else None
+
+
 def resolve_authorized_data_root() -> str | None:
     """Resolve the authoritative data root a skill-frontmatter hook can supply.
 
@@ -661,11 +678,11 @@ def resolve_authorized_data_root() -> str | None:
     every channel the guard has no authority and every ``--data-root`` engine call
     fails closed.
     """
-    direct = _argv_flag_value(sys.argv[1:], _AUTHORIZED_DATA_ROOT_FLAG)
+    direct = _argv_authorized_data_root(sys.argv[1:])
     if direct and direct != _AUTHORIZED_DATA_ROOT_PLACEHOLDER:
         return direct
-    plugin_root = _argv_flag_value(sys.argv[1:], _PLUGIN_ROOT_FLAG)
-    if plugin_root and plugin_root != _PLUGIN_ROOT_PLACEHOLDER:
+    plugin_root = _plugin_root_argument()
+    if plugin_root:
         derived = _plugin_data_root_from_root(plugin_root)
         if derived:
             return derived
@@ -685,14 +702,11 @@ def _user_settings_path_from_root(plugin_root: str) -> str | None:
     falls back to the environment.
     """
     parts = Path(plugin_root).parts
-    for index in range(1, len(parts)):
-        if (
-            parts[index].casefold() == _PLUGIN_CACHE_DIRNAME
-            and parts[index - 1].casefold() == _PLUGINS_DIRNAME
-        ):
-            plugins_dir = Path(*parts[:index])
-            return os.fspath(plugins_dir.parent / "settings.json")
-    return None
+    index = _plugins_cache_index(parts)
+    if index is None:
+        return None
+    plugins_dir = Path(*parts[:index])
+    return os.fspath(plugins_dir.parent / "settings.json")
 
 
 def _plugin_id_from_root(plugin_root: str) -> str | None:
@@ -707,18 +721,13 @@ def _plugin_id_from_root(plugin_root: str) -> str | None:
     falls back to matching any ``disk-hygiene`` entry.
     """
     parts = Path(plugin_root).parts
-    for index in range(1, len(parts)):
-        if (
-            parts[index].casefold() == _PLUGIN_CACHE_DIRNAME
-            and parts[index - 1].casefold() == _PLUGINS_DIRNAME
-        ):
-            if index + 2 >= len(parts):
-                return None
-            marketplace, name = parts[index + 1], parts[index + 2]
-            if not marketplace or not name:
-                return None
-            return f"{name}@{marketplace}"
-    return None
+    index = _plugins_cache_index(parts)
+    if index is None or index + 2 >= len(parts):
+        return None
+    marketplace, name = parts[index + 1], parts[index + 2]
+    if not marketplace or not name:
+        return None
+    return f"{name}@{marketplace}"
 
 
 def _resolve_user_settings_path() -> Path | None:
@@ -736,8 +745,8 @@ def _resolve_user_settings_path() -> Path | None:
     ``None``; the caller then relies on managed settings (fixed system paths) and
     otherwise fails closed to enabled.
     """
-    plugin_root = _argv_flag_value(sys.argv[1:], _PLUGIN_ROOT_FLAG)
-    if plugin_root and plugin_root != _PLUGIN_ROOT_PLACEHOLDER:
+    plugin_root = _plugin_root_argument()
+    if plugin_root:
         derived = _user_settings_path_from_root(plugin_root)
         if derived:
             return Path(derived)
@@ -773,12 +782,8 @@ def resolve_disk_hygiene_enabled() -> bool:
     both run ``main()``, and both receive ``--plugin-root ${CLAUDE_PLUGIN_ROOT}`` —
     so the belt needs no environment channel it does not have.
     """
-    plugin_root = _argv_flag_value(sys.argv[1:], _PLUGIN_ROOT_FLAG)
-    plugin_id = (
-        _plugin_id_from_root(plugin_root)
-        if plugin_root and plugin_root != _PLUGIN_ROOT_PLACEHOLDER
-        else None
-    )
+    plugin_root = _plugin_root_argument()
+    plugin_id = _plugin_id_from_root(plugin_root) if plugin_root else None
     return killswitch_config.resolve_effective(
         _resolve_user_settings_path(),
         killswitch_config.managed_settings_path(),
@@ -866,30 +871,22 @@ def classify_exact_engine_command(command: str, authority: str | None) -> str | 
         ):
             return None
         return "scan"
-    if tokens[2] == "preview":
+    # preview and handoff-verify share one grammar — `--snapshot <path>` plus a
+    # subcommand-specific second required pair — so they are checked once and
+    # differ only in that pair's flag name.
+    second_flag = {"preview": "--plan", "handoff-verify": "--paths"}.get(tokens[2])
+    if second_flag is not None:
         valid = (
             len(tokens) in {7, 9}
             and tokens[3] == "--snapshot"
             and _argument(tokens[4])
-            and tokens[5] == "--plan"
+            and tokens[5] == second_flag
             and _argument(tokens[6])
             and _consume_optional_pairs(
                 tokens[7:], frozenset({"--data-root"}), authority
             )
         )
-        return "preview" if valid else None
-    if tokens[2] == "handoff-verify":
-        valid = (
-            len(tokens) in {7, 9}
-            and tokens[3] == "--snapshot"
-            and _argument(tokens[4])
-            and tokens[5] == "--paths"
-            and _argument(tokens[6])
-            and _consume_optional_pairs(
-                tokens[7:], frozenset({"--data-root"}), authority
-            )
-        )
-        return "handoff-verify" if valid else None
+        return tokens[2] if valid else None
     if tokens[2] == "apply":
         if len(tokens) not in {14, 16}:
             return None

--- a/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
+++ b/plugins/disk-hygiene/skills/clean/scripts/hygiene.py
@@ -18,6 +18,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -303,19 +304,32 @@ def has_protected_path_component(path: Path, exact_names: set[str]) -> bool:
     )
 
 
+def _windows_env_roots() -> list[Path]:
+    """The OS-install roots the environment names, absolute, skipping the unset.
+
+    Shared by system_roots() and os_drive_markers(): the two disagree about the
+    per-volume metadata names, never about which environment variables point at
+    the OS install, so naming them once keeps that half from drifting.
+    """
+    return [
+        Path(value).absolute()
+        for value in (
+            os.environ.get("SystemRoot"),
+            os.environ.get("ProgramFiles"),
+            os.environ.get("ProgramFiles(x86)"),
+            os.environ.get("ProgramData"),
+        )
+        if value
+    ]
+
+
 def system_roots(
     platform_key: str | None = None, windows_roots: list[Path] | None = None
 ) -> list[Path]:
     roots: list[Path] = []
     current_platform = platform_key or os_key()
     if current_platform == "windows":
-        candidates = [
-            os.environ.get("SystemRoot"),
-            os.environ.get("ProgramFiles"),
-            os.environ.get("ProgramFiles(x86)"),
-            os.environ.get("ProgramData"),
-        ]
-        roots.extend(Path(value).absolute() for value in candidates if value)
+        roots.extend(_windows_env_roots())
         drive_roots = windows_roots if windows_roots is not None else windows_drive_roots()
         for drive_root in drive_roots:
             roots.extend(drive_root / name for name in WINDOWS_VOLUME_SYSTEM_NAMES)
@@ -362,13 +376,7 @@ def os_drive_markers(
     if current_platform != "windows":
         return system_roots(current_platform)
     markers: list[Path] = []
-    env_roots = (
-        os.environ.get("SystemRoot"),
-        os.environ.get("ProgramFiles"),
-        os.environ.get("ProgramFiles(x86)"),
-        os.environ.get("ProgramData"),
-    )
-    markers.extend(Path(value).absolute() for value in env_roots if value)
+    markers.extend(_windows_env_roots())
     drive_roots = windows_roots if windows_roots is not None else windows_drive_roots()
     for drive_root in drive_roots:
         markers.extend(drive_root / name for name in WINDOWS_OS_DRIVE_MARKERS)
@@ -1114,6 +1122,53 @@ def entry_map(snapshot: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return result
 
 
+def subtree_names(relative: str, names: Iterable[str]) -> set[str]:
+    """The snapshot paths that ARE ``relative`` or sit beneath it.
+
+    One containment rule for every lane that asks "what did the scan record for
+    this candidate" — the preview's and handoff-verify's expected-path sets and
+    the apply lane's removal list — so the three cannot disagree about a
+    candidate's extent. Prefix matching is on the "/"-terminated name, so a
+    sibling like ``cache-old`` is never read as a child of ``cache``.
+    """
+    return {
+        name for name in names if name == relative or name.startswith(relative + "/")
+    }
+
+
+def overlaps_truncated(relative: str, truncated_paths: set[str]) -> bool:
+    """Whether ``relative`` is, contains, or lives under a truncated scan path.
+
+    Either direction disqualifies: a truncated ancestor means this path's own
+    subtree was never inventoried, and a truncated descendant means part of it
+    was not. Shared by preview and handoff-verify, which must agree on which
+    candidates the snapshot cannot speak for.
+    """
+    return any(
+        name == relative
+        or name.startswith(relative + "/")
+        or relative.startswith(name + "/")
+        for name in truncated_paths
+    )
+
+
+def snapshot_protection_globs(snapshot: dict[str, Any]) -> list[str]:
+    """Consumer protection globs a snapshot's policy recorded, strings only.
+
+    Read from the snapshot rather than from live policy on purpose: an approved
+    snapshot must stay previewable under the protections it was scanned with.
+    Non-string members are dropped here so the three validation lanes cannot
+    differ on how they tolerate a hand-edited policy block.
+    """
+    return [
+        pattern
+        for pattern in snapshot.get("policy", {}).get(
+            "additional_protected_path_globs", []
+        )
+        if isinstance(pattern, str)
+    ]
+
+
 def validate_plan(
     plan: dict[str, Any], entries: dict[str, dict[str, Any]]
 ) -> list[dict[str, Any]]:
@@ -1268,8 +1323,7 @@ def same_identity(path: Path, entry: dict[str, Any]) -> bool:
 def same_stat_identity(info: os.stat_result, entry: dict[str, Any]) -> bool:
     kind = (
         "link"
-        if stat.S_ISLNK(info.st_mode)
-        or bool(getattr(info, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT)
+        if is_linkish_stat(info)
         else "directory"
         if stat.S_ISDIR(info.st_mode)
         else "file"
@@ -1595,6 +1649,7 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
     exact_names = baseline_exact_names | set(
         snapshot.get("policy", {}).get("protected_exact_names", [])
     )
+    globs = snapshot_protection_globs(snapshot)
     results = []
     blocked = False
     for candidate in candidates:
@@ -1604,18 +1659,9 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
         blockers.extend(execution_blockers())
         if candidate["owner"] != "unmanaged":
             blockers.append("native-managed-report-only")
-        if any(
-            name == relative
-            or name.startswith(relative + "/")
-            or relative.startswith(name + "/")
-            for name in truncated_paths
-        ):
+        if overlaps_truncated(relative, truncated_paths):
             blockers.append("truncated-not-inventoried")
-        expected_paths = {
-            name
-            for name in entries
-            if name == relative or name.startswith(relative + "/")
-        }
+        expected_paths = subtree_names(relative, entries)
         if "truncated-not-inventoried" in blockers:
             # A truncated candidate is already hard-blocked from planning above;
             # walking its live subtree here would be the same unbounded
@@ -1640,13 +1686,7 @@ def preview(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
                 blockers.append("changed-since-scan")
             blockers.extend(hard_protection(current, target, exact_names, known_mounts))
             relative_current = current.relative_to(target).as_posix()
-            if any(
-                glob_matches(relative_current, pattern)
-                for pattern in snapshot.get("policy", {}).get(
-                    "additional_protected_path_globs", []
-                )
-                if isinstance(pattern, str)
-            ):
+            if any(glob_matches(relative_current, pattern) for pattern in globs):
                 blockers.append("consumer-protected-path")
         if "truncated-not-inventoried" in blockers:
             # Same rationale as the current_descendants short-circuit above: a
@@ -1722,13 +1762,7 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
         for value in snapshot.get("truncated_paths", [])
         if isinstance(value, str)
     }
-    globs = [
-        pattern
-        for pattern in snapshot.get("policy", {}).get(
-            "additional_protected_path_globs", []
-        )
-        if isinstance(pattern, str)
-    ]
+    globs = snapshot_protection_globs(snapshot)
     verdicts: list[dict[str, Any]] = []
     for relative in approved:
         path = target.joinpath(*PurePosixPath(relative).parts)
@@ -1760,17 +1794,8 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
             )
             continue
         contested.update(hard_protection(path, target, exact_names, known_mounts))
-        truncated = any(
-            name == relative
-            or name.startswith(relative + "/")
-            or relative.startswith(name + "/")
-            for name in truncated_paths
-        )
-        expected_paths = {
-            name
-            for name in entries
-            if name == relative or name.startswith(relative + "/")
-        }
+        truncated = overlaps_truncated(relative, truncated_paths)
+        expected_paths = subtree_names(relative, entries)
         if truncated:
             # A truncated path has no captured descendant set, so no live walk
             # can prove anything about it — never clear (same rationale as the
@@ -1813,9 +1838,7 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
                 hard_protection(current, target, exact_names, known_mounts)
             )
             relative_current = current.relative_to(target).as_posix()
-            if any(
-                glob_matches(relative_current, pattern) for pattern in globs
-            ):
+            if any(glob_matches(relative_current, pattern) for pattern in globs):
                 contested.add("consumer-protected-path")
         if not truncated:
             # A hung git (TimeoutExpired) must degrade to this one path's
@@ -1871,11 +1894,8 @@ def handoff_verify(snapshot: dict[str, Any], approved: list[str]) -> dict[str, A
 
 
 def removal_entries(relative: str, entries: dict[str, dict[str, Any]]) -> list[str]:
-    selected = [
-        name for name in entries if name == relative or name.startswith(relative + "/")
-    ]
     return sorted(
-        selected,
+        subtree_names(relative, entries),
         key=lambda value: (len(PurePosixPath(value).parts), value),
         reverse=True,
     )
@@ -2015,6 +2035,7 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
     if mount_error:
         os.close(target_fd)
         raise HygieneError(mount_error)
+    globs = snapshot_protection_globs(snapshot)
     for candidate in candidates:
         candidate_path = target.joinpath(*PurePosixPath(candidate["path"]).parts)
         candidate_blockers = hard_protection(
@@ -2061,13 +2082,7 @@ def apply_plan(snapshot: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]
                 baseline_protected_names(),
                 fresh_mounts,
             )
-            if any(
-                glob_matches(relative, pattern)
-                for pattern in snapshot.get("policy", {}).get(
-                    "additional_protected_path_globs", []
-                )
-                if isinstance(pattern, str)
-            ):
+            if any(glob_matches(relative, pattern) for pattern in globs):
                 fresh_protections.append("consumer-protected-path")
             fresh_vcs = tracked_blocker(path, target)
             if fresh_vcs:

--- a/plugins/eol-normalizer/hooks/eol-normalizer.sh
+++ b/plugins/eol-normalizer/hooks/eol-normalizer.sh
@@ -31,12 +31,17 @@ hook::check_enabled "EOL_NORMALIZER"
 # advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# normalizes on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 action taken.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still normalizes
+# rather than aborting) and the sink opt-in. The data payload costs a jq
+# subprocess, so it is built here after both guards — never on the unwired
+# path. This hook's matcher is every file write, so that is the hottest path in
+# the fleet.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "eol-normalizer" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 # The bundled EOL library (normalize_eol_file).
@@ -51,28 +56,36 @@ INPUT=$(hook::buffer_stdin) || exit 0
 hook::require_jq PostToolUse eol-normalizer "$INPUT"
 
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 
 # Resolve the repo root that anchors `git check-attr` (CWD-independent — the hook
 # process CWD is not guaranteed to be the repo root). File-anchored so it is
 # correct for clones, linked worktrees, and bare-hub clones.
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
 
-# Repo-relative path for the telemetry data.file. On Windows Git Bash,
-# git rev-parse --show-toplevel returns a drive-letter path while FILE may be in
-# POSIX mount form; normalize both through cygpath -lm (long, forward-slash mixed
-# form) when available so the prefix strip compares the same representation. On
-# Linux/macOS cygpath is absent and both paths are already POSIX. Falls back to
-# raw FILE on any normalization error.
+# TOOL and FILE_REL feed the telemetry data object and nothing else, so both are
+# resolved only when a sink is wired: the unwired default path spawns zero
+# telemetry-only subprocesses (the tool_name jq parse, and 2× cygpath on
+# Windows).
+#
+# FILE_REL is the repo-relative path for the telemetry data.file. On Windows Git
+# Bash, git rev-parse --show-toplevel returns a drive-letter path while FILE may
+# be in POSIX mount form; normalize both through cygpath -lm (long,
+# forward-slash mixed form) when available so the prefix strip compares the same
+# representation. On Linux/macOS cygpath is absent and both paths are already
+# POSIX. Falls back to raw FILE on any normalization error.
+TOOL=""
 FILE_REL="$FILE"
-if command -v cygpath >/dev/null 2>&1; then
-  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
-  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
-  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
-    FILE_REL="${_file_lm#"$_root_lm"/}"
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  if command -v cygpath >/dev/null 2>&1; then
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+      FILE_REL="${_file_lm#"$_root_lm"/}"
+    fi
+  else
+    FILE_REL="${FILE#"$REPO_ROOT"/}"
   fi
-else
-  FILE_REL="${FILE#"$REPO_ROOT"/}"
 fi
 
 # Build the telemetry data object. jq is authoritative; the fallback is a fixed
@@ -98,6 +111,5 @@ lf | crlf) status="ok" ;;
 *) status="skipped" ;;
 esac
 
-data_json=$(build_data_json "$ACTION")
-emit_tel "eol-normalizer" "PostToolUse" "$status" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "$status" "$ACTION"
 exit 0

--- a/plugins/go-format/hooks/go-format.sh
+++ b/plugins/go-format/hooks/go-format.sh
@@ -48,12 +48,15 @@ hook::check_enabled "GO_FORMAT"
 # `set -u` would abort before the advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# formats on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still formats rather
+# than aborting) and the sink opt-in. The data payload costs a jq subprocess,
+# so it is built here after both guards — never on the unwired path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "go-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -77,26 +80,35 @@ case "$FILE" in
 *) exit 0 ;;
 esac
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-
 # Resolve repo root early — used to compute the schema-required repo-relative
 # path in data.file.
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
-# Repo-relative path: schema requires "relative to the consuming repo root".
-# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
-# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
-# (long name, forward-slash mixed form) when available so the prefix strip
-# compares the same representation. On Linux/macOS, cygpath is absent and both
-# paths are already POSIX. Falls back to raw FILE on any normalization error.
+
+# TOOL and FILE_REL feed the telemetry data object and nothing else (goimports
+# is invoked with the absolute $FILE), so both are resolved only when a sink is
+# wired: the unwired default path spawns zero telemetry-only subprocesses (the
+# tool_name jq parse, and 2× cygpath on Windows).
+#
+# FILE_REL is the repo-relative path: schema requires "relative to the consuming
+# repo root". On Windows Git Bash, git rev-parse --show-toplevel returns a
+# drive-letter path while FILE may be in POSIX mount form. Normalize both
+# through cygpath -lm (long name, forward-slash mixed form) when available so
+# the prefix strip compares the same representation. On Linux/macOS, cygpath is
+# absent and both paths are already POSIX. Falls back to raw FILE on any
+# normalization error.
+TOOL=""
 FILE_REL="$FILE"
-if command -v cygpath >/dev/null 2>&1; then
-  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
-  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
-  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
-    FILE_REL="${_file_lm#"$_root_lm"/}"
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  if command -v cygpath >/dev/null 2>&1; then
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+      FILE_REL="${_file_lm#"$_root_lm"/}"
+    fi
+  else
+    FILE_REL="${FILE#"$REPO_ROOT"/}"
   fi
-else
-  FILE_REL="${FILE#"$REPO_ROOT"/}"
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
@@ -113,9 +125,7 @@ build_data_json() {
 }
 
 emit_skipped() {
-  local data_json
-  data_json=$(build_data_json '[]')
-  emit_tel "go-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 }
 
@@ -232,8 +242,7 @@ RC=$?
 if [[ $RC -eq 0 ]]; then
   # Clean, or fixed silently (formatting/import changes carry no advisory
   # noise — same posture as a successful ruff/typos autofix pass).
-  data_json=$(build_data_json '[]')
-  emit_tel "go-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" '[]'
   exit 0
 fi
 
@@ -255,8 +264,7 @@ if [[ $RC -eq 2 && -n "$STDERR" ]]; then
   if [[ -n "$findings_raw" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
-  data_json=$(build_data_json "$FINDINGS_JSON")
-  emit_tel "go-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" "$FINDINGS_JSON"
   exit 0
 fi
 
@@ -271,6 +279,5 @@ while IFS= read -r line; do
   hook::ctx_append "  $line"
 done <<<"$STDERR"
 hook::ctx_flush PostToolUse
-data_json=$(build_data_json '[]')
-emit_tel "go-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "skipped" '[]'
 exit 0

--- a/plugins/guardrails/hooks/cli-flag-verify.sh
+++ b/plugins/guardrails/hooks/cli-flag-verify.sh
@@ -379,7 +379,7 @@ emit_tel() {
       [[ -n "$chainstr" ]] && disp="$bin $chainstr $flag" || disp="$bin $flag"
       raw+="$disp"$'\n'
     done
-    findings_json=$(printf '%s' "$raw" | jq -R . | jq -s . 2>/dev/null) || findings_json="[]"
+    findings_json=$(printf '%s' "$raw" | jq -Rn '[inputs]' 2>/dev/null) || findings_json="[]"
   fi
   local data
   data=$(jq -n --arg file "$file_rel" --argjson findings "$findings_json" \

--- a/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
+++ b/plugins/guardrails/hooks/flag-commit-pr-skill-bypass.sh
@@ -126,7 +126,7 @@ emit_tel() {
   hook::telemetry_enabled || return 0
   local forms_json="[]"
   if ((${#FORMS[@]} > 0)); then
-    forms_json=$(printf '%s\n' "${FORMS[@]}" | jq -R . | jq -s . 2>/dev/null) || forms_json="[]"
+    forms_json=$(printf '%s\n' "${FORMS[@]}" | jq -Rn '[inputs]' 2>/dev/null) || forms_json="[]"
   fi
   local data
   data=$(jq -n --arg tool "$TOOL_NAME" --arg subject "$SUBJECT" --argjson forms "$forms_json" \
@@ -224,7 +224,9 @@ strip_literals() {
       line="${line%%<<*}${line#*"${BASH_REMATCH[0]}"}"
       in_heredoc=1
     fi
-    line=$(printf '%s' "$line" | sed "s/'[^']*'//g" | sed -E 's/"([^"\\]|\\.)*"//g')
+    # One `sed` per line, not two: the expressions apply in order, so the
+    # double-quote strip still sees the single-quote-stripped line.
+    line=$(printf '%s' "$line" | sed -E -e "s/'[^']*'//g" -e 's/"([^"\\]|\\.)*"//g')
     result+="${line}"$'\n'
   done < <(printf '%s\n' "$cmd") # not <<<: a >=64KiB here-string deadlocks (see hardcoded-path-patterns.sh)
   printf '%s' "${result%$'\n'}"

--- a/plugins/guardrails/hooks/hardcoded-path-check.sh
+++ b/plugins/guardrails/hooks/hardcoded-path-check.sh
@@ -223,7 +223,7 @@ if [[ -n "$VIOLATIONS" ]]; then
   # (see lib/path-detection/hardcoded-path-patterns.sh), and it would deadlock
   # HERE, on the blocked path, after the stderr message but before `exit 2` —
   # turning a detected violation into a hook the harness cancels at its timeout.
-  labels_json=$(grep -E 'detected:$' < <(printf '%s' "$VIOLATIONS") 2>/dev/null | sed 's/:$//' | jq -R . | jq -s . 2>/dev/null) || labels_json='[]'
+  labels_json=$(grep -E 'detected:$' < <(printf '%s' "$VIOLATIONS") 2>/dev/null | sed 's/:$//' | jq -Rn '[inputs]' 2>/dev/null) || labels_json='[]'
   emit_tel "blocked" "$labels_json"
   exit 2
 fi

--- a/plugins/guardrails/hooks/secret-pattern-detection.sh
+++ b/plugins/guardrails/hooks/secret-pattern-detection.sh
@@ -248,7 +248,7 @@ if [[ -n "$VIOLATIONS" ]]; then
     printf 'in secret-pattern-detection.sh. Never commit real secrets — use\n'
     printf 'environment variables, settings.local.json, or a secret manager.\n'
   } >&2
-  labels_json=$(printf '%s\n' "${LABELS[@]}" | jq -R . | jq -s . 2>/dev/null) || labels_json='[]'
+  labels_json=$(printf '%s\n' "${LABELS[@]}" | jq -Rn '[inputs]' 2>/dev/null) || labels_json='[]'
   emit_tel "blocked" "$labels_json"
   exit 2
 fi

--- a/plugins/guardrails/hooks/skill-reference-verify.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.sh
@@ -573,7 +573,7 @@ emit_tel() {
   if ((${#UNRESOLVED[@]} > 0)); then
     local r raw_list=""
     for r in "${UNRESOLVED[@]}"; do raw_list+="$r"$'\n'; done
-    findings_json=$(printf '%s' "$raw_list" | jq -R . | jq -s . 2>/dev/null) || findings_json="[]"
+    findings_json=$(printf '%s' "$raw_list" | jq -Rn '[inputs]' 2>/dev/null) || findings_json="[]"
   fi
   local data
   data=$(jq -n --arg file "$file_rel" --argjson findings "$findings_json" \

--- a/plugins/guardrails/hooks/stale-path-verify.sh
+++ b/plugins/guardrails/hooks/stale-path-verify.sh
@@ -338,8 +338,11 @@ TRACKED_BUILT=0
 moved_hint() {
   local base="${1##*/}" matches=()
   if ((TRACKED_BUILT == 0)); then
-    TRACKED_BUILT=1
-    TRACKED_FILES=$(git -C "$REPO_ROOT" ls-files 2>/dev/null | tr -d '\r')
+    local out
+    if out=$(git -C "$REPO_ROOT" ls-files 2>/dev/null); then
+      TRACKED_FILES=${out//$'\r'/}
+      TRACKED_BUILT=1
+    fi
   fi
   [[ -n "$TRACKED_FILES" ]] || return 1
   mapfile -t matches < <(printf '%s\n' "$TRACKED_FILES" | awk -F/ -v b="$base" '$NF == b')

--- a/plugins/guardrails/hooks/stale-path-verify.sh
+++ b/plugins/guardrails/hooks/stale-path-verify.sh
@@ -329,10 +329,20 @@ build_deleted_set() {
 # too weak to trigger on — `README.md` and `SKILL.md` match hundreds of paths —
 # but once history has established the path was removed, a UNIQUE surviving
 # basename is very likely where it went.
+#
+# The tracked-file list is read at most once per run and reused for every
+# finding: it is identical for all of them, and re-listing a large repo per
+# finding is the one place this guard's rare path re-does whole-repo I/O.
+TRACKED_FILES=""
+TRACKED_BUILT=0
 moved_hint() {
   local base="${1##*/}" matches=()
-  mapfile -t matches < <(git -C "$REPO_ROOT" ls-files 2>/dev/null | tr -d '\r' |
-    awk -F/ -v b="$base" '$NF == b')
+  if ((TRACKED_BUILT == 0)); then
+    TRACKED_BUILT=1
+    TRACKED_FILES=$(git -C "$REPO_ROOT" ls-files 2>/dev/null | tr -d '\r')
+  fi
+  [[ -n "$TRACKED_FILES" ]] || return 1
+  mapfile -t matches < <(printf '%s\n' "$TRACKED_FILES" | awk -F/ -v b="$base" '$NF == b')
   ((${#matches[@]} == 1)) && printf '%s' "${matches[0]}"
 }
 
@@ -422,7 +432,7 @@ emit_tel() {
   if ((${#MISSING[@]} > 0)); then
     local m raw_list=""
     for m in "${MISSING[@]}"; do raw_list+="$m"$'\n'; done
-    findings_json=$(printf '%s' "$raw_list" | jq -R . | jq -s . 2>/dev/null) || findings_json="[]"
+    findings_json=$(printf '%s' "$raw_list" | jq -Rn '[inputs]' 2>/dev/null) || findings_json="[]"
   fi
   local data
   data=$(jq -n --arg file "$file_rel" --argjson findings "$findings_json" \

--- a/plugins/guardrails/lib/powershell/ps-command.sh
+++ b/plugins/guardrails/lib/powershell/ps-command.sh
@@ -132,7 +132,9 @@ ps::blank_herestrings() {
     # would swallow following code lines into a phantom here-string body).
     # Distinguish by stripping PAIRED quote spans first: a real opener's quote
     # is unpaired, so its `@'` survives, while `'@'` / `'foo@'` disappear.
-    opener_scan=$(printf '%s' "$line" | sed "s/'[^']*'//g" | sed -E 's/"([^"\\]|\\.)*"//g')
+    # One `sed` per line, not two: the expressions apply in order, so the
+    # double-quote strip still sees the single-quote-stripped line.
+    opener_scan=$(printf '%s' "$line" | sed -E -e "s/'[^']*'//g" -e 's/"([^"\\]|\\.)*"//g')
     if [[ "$opener_scan" == *"@'" || "$opener_scan" == *'@"' ]]; then
       hs_quote="${line: -1}" # ' or "
       pending="${line%??}${PS_HERESTRING_PLACEHOLDER}"
@@ -160,8 +162,10 @@ ps::blank_herestrings() {
 # already forces the fail-closed branch, so this crudeness cannot open a gap.
 ps::blank_quoted_spans() {
   local text="$1"
-  text=$(printf '%s' "$text" | sed "s/'[^']*'//g")
-  text=$(printf '%s' "$text" | sed -E 's/"[^"]*"//g')
+  # One `sed` for both spans: expressions apply in order per line, so the
+  # double-quote strip still sees the single-quote-stripped text — same result
+  # as the two chained passes, at half the process cost on a hot classifier path.
+  text=$(printf '%s' "$text" | sed -e "s/'[^']*'//g" -e 's/"[^"]*"//g')
   printf '%s' "$text"
 }
 

--- a/plugins/guardrails/lib/verification/verify-cli-flag.sh
+++ b/plugins/guardrails/lib/verification/verify-cli-flag.sh
@@ -120,7 +120,7 @@ fi
 
 HELP_OUTPUT=""
 if $USE_CACHE; then
-  HELP_OUTPUT=$(cat "$CACHE_FILE")
+  HELP_OUTPUT=$(<"$CACHE_FILE")
 else
   # Run `<bin> [<subcmds>...] --help` with timeout 5s. 2>&1 catches binaries
   # that print --help to stderr (e.g. some legacy tools).

--- a/plugins/knowledge/skills/course-digest/extraction/adapters/dometrain.js
+++ b/plugins/knowledge/skills/course-digest/extraction/adapters/dometrain.js
@@ -14,7 +14,7 @@ import { fail, ok, timed } from "@melodic/video-digestion/shared/result";
 import { writeStdout } from "@melodic/video-digestion/shared/terminal";
 
 import { login as clerkLogin } from "../lib/auth/clerk.js";
-import { promptManualLogin } from "../lib/auth/manual-login.js";
+import { loginOrPromptManual } from "../lib/auth/manual-login.js";
 import { getHlsUrl } from "../lib/players/mux.js";
 import {
   DESCRIPTION_META_SELECTOR,
@@ -367,17 +367,14 @@ export async function authenticate({ context, page, course, storageStatePath, pl
     return { baseUrl };
   }
 
-  const email = process.env[`${envPrefix}_EMAIL`];
-  const password = process.env[`${envPrefix}_PASSWORD`];
-
-  if (email && password && loginUrl) {
-    writeStdout("  Logging in automatically...");
-    await clerkLogin(page, email, password, loginUrl);
-    await context.storageState({ path: storageStatePath });
-    writeStdout("  Logged in and saved auth state.\n");
-  } else {
-    await promptManualLogin(context, storageStatePath, envPrefix);
-  }
+  await loginOrPromptManual({
+    context,
+    page,
+    storageStatePath,
+    envPrefix,
+    loginUrl,
+    login: clerkLogin,
+  });
 
   return { baseUrl };
 }

--- a/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.js
+++ b/plugins/knowledge/skills/course-digest/extraction/adapters/teachable.js
@@ -19,7 +19,7 @@
 import { fail, ok, timed } from "@melodic/video-digestion/shared/result";
 import { writeStdout } from "@melodic/video-digestion/shared/terminal";
 
-import { promptManualLogin } from "../lib/auth/manual-login.js";
+import { loginOrPromptManual } from "../lib/auth/manual-login.js";
 import { login as teachableLogin } from "../lib/auth/teachable-sso.js";
 import {
   extractFrames as extractHotmartFrames,
@@ -174,16 +174,17 @@ async function scrapeCodeSnippets(page, codeDisplaySelector) {
   );
 }
 
-async function scrapeDownloadLinks(page, fileSelector) {
+/** Collect every `a[href]` under an attachment selector as `{ label, href }`. */
+async function scrapeAttachmentLinks(page, attachmentSelector) {
   return page.evaluate((selector) => {
-    const downloads = [];
+    const links = [];
     for (const el of document.querySelectorAll(selector)) {
       for (const link of el.querySelectorAll("a[href]")) {
-        downloads.push({ label: link.textContent?.trim(), href: link.href });
+        links.push({ label: link.textContent?.trim(), href: link.href });
       }
     }
-    return downloads;
-  }, fileSelector);
+    return links;
+  }, attachmentSelector);
 }
 
 async function scrapeTextAttachments(page, textSelector) {
@@ -205,18 +206,6 @@ async function scrapeTextAttachments(page, textSelector) {
   }, textSelector);
 }
 
-async function scrapePdfLinks(page, pdfSelector) {
-  return page.evaluate((selector) => {
-    const pdfLinks = [];
-    for (const el of document.querySelectorAll(selector)) {
-      for (const link of el.querySelectorAll("a[href]")) {
-        pdfLinks.push({ label: link.textContent?.trim(), href: link.href });
-      }
-    }
-    return pdfLinks;
-  }, pdfSelector);
-}
-
 export async function extractResources(page, platformCfg) {
   return timed("extract-resources", null, async () => {
     const selectors = {
@@ -226,9 +215,9 @@ export async function extractResources(page, platformCfg) {
 
     const [codeSnippets, downloads, textData, pdfLinks] = await Promise.all([
       scrapeCodeSnippets(page, selectors.codeDisplay),
-      scrapeDownloadLinks(page, selectors.file),
+      scrapeAttachmentLinks(page, selectors.file),
       scrapeTextAttachments(page, selectors.text),
-      scrapePdfLinks(page, selectors.pdfEmbed),
+      scrapeAttachmentLinks(page, selectors.pdfEmbed),
     ]);
 
     return {
@@ -307,18 +296,14 @@ export async function authenticate({ context, page, course, storageStatePath, pl
     return;
   }
 
-  const email = process.env[`${envPrefix}_EMAIL`];
-  const password = process.env[`${envPrefix}_PASSWORD`];
-  const loginUrl = platformCfg.loginUrl;
-
-  if (email && password && loginUrl) {
-    writeStdout("  Logging in automatically...");
-    await teachableLogin(page, email, password, loginUrl);
-    await context.storageState({ path: storageStatePath });
-    writeStdout("  Logged in and saved auth state.\n");
-  } else {
-    await promptManualLogin(context, storageStatePath, envPrefix);
-  }
+  await loginOrPromptManual({
+    context,
+    page,
+    storageStatePath,
+    envPrefix,
+    loginUrl: platformCfg.loginUrl,
+    login: teachableLogin,
+  });
 }
 
 /**

--- a/plugins/knowledge/skills/course-digest/extraction/classify-frames.js
+++ b/plugins/knowledge/skills/course-digest/extraction/classify-frames.js
@@ -36,7 +36,12 @@ const args = parseCliArgs({
 
 const log = createLogger(resolveLogLevel(args));
 
-function forEachLesson(courseDir, course, fn) {
+/**
+ * Yield every lesson that has screenshots on disk, with its PNG paths.
+ *
+ * @returns {Generator<{ module: object, lesson: object, pngs: string[] }>}
+ */
+function* eachLessonWithFrames(courseDir, course) {
   const modulesDir = join(courseDir, "modules");
   for (const module of course.modules) {
     for (const lesson of module.lessons) {
@@ -49,7 +54,7 @@ function forEachLesson(courseDir, course, fn) {
       );
       const pngs = walkPngs(lDir);
       if (pngs.length === 0) continue;
-      fn(module, lesson, pngs);
+      yield { module, lesson, pngs };
     }
   }
 }
@@ -60,8 +65,7 @@ async function generateContactSheets(courseDir, course) {
 
   let generated = 0;
 
-  for (const entry of collectLessons(courseDir, course)) {
-    const { module, lesson, pngs } = entry;
+  for (const { module, lesson, pngs } of eachLessonWithFrames(courseDir, course)) {
     const label = `M${module.position}L${lesson.position}`;
     const outFile = join(outDir, `${label}-${lessonDirName(lesson.position, lesson.title)}.jpg`);
 
@@ -84,21 +88,12 @@ async function generateContactSheets(courseDir, course) {
   log.info(`\n  Generated: ${generated} contact sheets → ${outDir}`);
 }
 
-function collectLessons(courseDir, course) {
-  /** @type {{ module: object, lesson: object, pngs: string[] }[]} */
-  const lessons = [];
-  forEachLesson(courseDir, course, (module, lesson, pngs) => {
-    lessons.push({ module, lesson, pngs });
-  });
-  return lessons;
-}
-
 async function computeDedup(courseDir, course) {
   let totalFrames = 0;
   let totalDups = 0;
   const results = {};
 
-  for (const { module, lesson, pngs } of collectLessons(courseDir, course)) {
+  for (const { module, lesson, pngs } of eachLessonWithFrames(courseDir, course)) {
     const key = `M${module.position}L${lesson.position}`;
     // biome-ignore lint/performance/noAwaitInLoops: lesson dedup runs sequentially to cap memory on large courses
     const frameSet = await deduplicateFrames(pngs, {}, { log });
@@ -144,7 +139,7 @@ function printSummary(courseDir, course) {
 
   let grandTotal = 0;
 
-  forEachLesson(courseDir, course, (module, lesson, pngs) => {
+  for (const { module, lesson, pngs } of eachLessonWithFrames(courseDir, course)) {
     const sizes = pngs.map((p) => statSync(p).size);
     const avgKB = Math.round(sizes.reduce((a, b) => a + b, 0) / sizes.length / 1024);
     const method = detectFrameMethod(pngs.map((p) => basename(p)));
@@ -153,7 +148,7 @@ function printSummary(courseDir, course) {
       `  M${module.position}L${String(lesson.position).padStart(2)}  ${lesson.title.substring(0, 44).padEnd(46)} ${String(pngs.length).padStart(4)}  ${method.padEnd(10)} ${String(avgKB).padStart(4)}`,
     );
     grandTotal += pngs.length;
-  });
+  }
 
   log.info(`  ${"-".repeat(78)}`);
   log.info(`  Grand total: ${grandTotal} frames`);

--- a/plugins/knowledge/skills/course-digest/extraction/lib/auth/manual-login.js
+++ b/plugins/knowledge/skills/course-digest/extraction/lib/auth/manual-login.js
@@ -28,3 +28,38 @@ export async function promptManualLogin(context, storageStatePath, envPrefix) {
   await context.storageState({ path: storageStatePath });
   writeStdout("  Saved auth state for future runs.\n");
 }
+
+/**
+ * Log in with `{envPrefix}_EMAIL`/`{envPrefix}_PASSWORD` when both — and a login URL —
+ * are available, otherwise fall back to {@link promptManualLogin}. Shared by every
+ * adapter's `authenticate()`; the provider-specific form flow is injected as `login`.
+ *
+ * @param {object} input
+ * @param {import('playwright').BrowserContext} input.context
+ * @param {import('playwright').Page} input.page
+ * @param {string} input.storageStatePath
+ * @param {string} input.envPrefix — e.g. "COURSE" or "TEACHABLE"
+ * @param {string|undefined} input.loginUrl
+ * @param {(page: import('playwright').Page, email: string, password: string, loginUrl: string) => Promise<void>} input.login
+ */
+export async function loginOrPromptManual({
+  context,
+  page,
+  storageStatePath,
+  envPrefix,
+  loginUrl,
+  login,
+}) {
+  const email = process.env[`${envPrefix}_EMAIL`];
+  const password = process.env[`${envPrefix}_PASSWORD`];
+
+  if (!(email && password && loginUrl)) {
+    await promptManualLogin(context, storageStatePath, envPrefix);
+    return;
+  }
+
+  writeStdout("  Logging in automatically...");
+  await login(page, email, password, loginUrl);
+  await context.storageState({ path: storageStatePath });
+  writeStdout("  Logged in and saved auth state.\n");
+}

--- a/plugins/knowledge/skills/youtube-digest/extraction/acquisition/preflight-metadata.js
+++ b/plugins/knowledge/skills/youtube-digest/extraction/acquisition/preflight-metadata.js
@@ -113,17 +113,29 @@ function normalizeField(value) {
 }
 
 /**
+ * First non-blank line of a multi-line stream capture, trimmed.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function firstNonEmptyLine(text) {
+  return (
+    (text ?? "")
+      .split(/\r?\n/)
+      .map((entry) => entry.trim())
+      .find((entry) => entry.length > 0) ?? ""
+  );
+}
+
+/**
  * Parse the first non-empty `--print` line into its component fields.
  *
  * @param {string} stdout
  * @returns {{ id: string, title: string, channel: string, handle: string }}
  */
 export function parsePreflightLine(stdout) {
-  const line = (stdout ?? "")
-    .split(/\r?\n/)
-    .map((entry) => entry.trim())
-    .find((entry) => entry.length > 0);
-  const [id = "", title = "", channel = "", handle = ""] = (line ?? "").split(PREFLIGHT_FIELD_SEP);
+  const line = firstNonEmptyLine(stdout);
+  const [id = "", title = "", channel = "", handle = ""] = line.split(PREFLIGHT_FIELD_SEP);
   return {
     id: normalizeField(id),
     title: normalizeField(title),
@@ -167,11 +179,7 @@ export function buildPreflightArgs(url, { env = process.env, authOverride = {} }
  * @returns {string}
  */
 function summarizeDetail(detail) {
-  const firstLine = (detail ?? "")
-    .split(/\r?\n/)
-    .map((entry) => entry.trim())
-    .find((entry) => entry.length > 0);
-  const cleaned = (firstLine ?? "").replace(/^ERROR:\s*/i, "");
+  const cleaned = firstNonEmptyLine(detail).replace(/^ERROR:\s*/i, "");
   return cleaned.length > 120 ? `${cleaned.slice(0, 119)}…` : cleaned;
 }
 

--- a/plugins/knowledge/skills/youtube-digest/extraction/evals/check-watch-outcomes.js
+++ b/plugins/knowledge/skills/youtube-digest/extraction/evals/check-watch-outcomes.js
@@ -24,7 +24,7 @@ import {
   validateTriageManifestForSlice,
   validateWatchChecklistForCompleteSlice,
 } from "../lib/watch-vision-validation.js";
-import { resolveSourceFile } from "../watch/rebuild-visual-frames.js";
+import { readPromotionMap, resolveSourceFile } from "../watch/rebuild-visual-frames.js";
 
 /** @typedef {{ id: string, pass: boolean, actual: string, expected: string, severity: 'fail'|'warn' }} OutcomeCheck */
 
@@ -69,8 +69,7 @@ export function loadPromotedTimestampsSec(sliceDir) {
 
   const selection = JSON.parse(fs.readFileSync(selectionPath, "utf8"));
   const byFile = Object.fromEntries(selection.selectedFrames.map((f) => [f.file, f]));
-  const mapPath = lanePath(absSlice, LANES.keyFrames, "promotion-map.json");
-  const promotionMap = fs.existsSync(mapPath) ? JSON.parse(fs.readFileSync(mapPath, "utf8")) : {};
+  const promotionMap = readPromotionMap(absSlice);
 
   const timestamps = [];
   for (const file of fs.readdirSync(synthesisDir)) {
@@ -260,6 +259,7 @@ function loadWatchOutcomeSlice(sliceDir) {
     ? fs.readFileSync(claimInventoryPath, "utf8")
     : "";
   const sessions = parseSessionsFromClaimInventory(claimBody);
+  const triageBody = fs.existsSync(triageLogPath) ? fs.readFileSync(triageLogPath, "utf8") : "";
 
   return {
     sliceDir,
@@ -273,10 +273,8 @@ function loadWatchOutcomeSlice(sliceDir) {
     contentClass,
     sessions,
     floors: outcomeFloors(contentClass, durationSec, sessions.length || 1),
-    triageBody: fs.existsSync(triageLogPath) ? fs.readFileSync(triageLogPath, "utf8") : "",
-    triageSheets: countTriageSheetsLogged(
-      fs.existsSync(triageLogPath) ? fs.readFileSync(triageLogPath, "utf8") : "",
-    ),
+    triageBody,
+    triageSheets: countTriageSheetsLogged(triageBody),
     promotedTs: loadPromotedTimestampsSec(sliceDir),
     visualGapsBody: fs.existsSync(visualGapsPath) ? fs.readFileSync(visualGapsPath, "utf8") : "",
     claimInventoryPath,
@@ -418,10 +416,17 @@ function pushSessionCoverageChecks(checks, slice) {
 function pushTriageManifestChecks(checks, slice) {
   const { sliceDir, triageBody, triageManifestPath } = slice;
   const triageJson = validateTriageManifestForSlice(sliceDir, { requireIndexMatch: true });
+  const triageManifestExists = fs.existsSync(triageManifestPath);
+  // Parsed once and shared by the agentic/batch-file checks below — both only
+  // read it on the same manifest-present-and-valid branch.
+  const triageManifestUsable = triageManifestExists && triageJson.valid;
+  const triageManifest = triageManifestUsable
+    ? JSON.parse(fs.readFileSync(triageManifestPath, "utf8"))
+    : null;
   checks.push({
     id: "triage-json-present",
-    pass: fs.existsSync(triageManifestPath) && triageJson.valid,
-    actual: fs.existsSync(triageManifestPath)
+    pass: triageManifestUsable,
+    actual: triageManifestExists
       ? triageJson.valid
         ? "valid manifest"
         : triageJson.errors.slice(0, 2).join("; ")
@@ -430,8 +435,7 @@ function pushTriageManifestChecks(checks, slice) {
     severity: "fail",
   });
 
-  const triageCellComplete =
-    triageJson.valid && fs.existsSync(triageManifestPath) && triageJson.errors.length === 0;
+  const triageCellComplete = triageManifestUsable && triageJson.errors.length === 0;
   checks.push({
     id: "triage-cell-completeness",
     pass: triageCellComplete,
@@ -440,10 +444,9 @@ function pushTriageManifestChecks(checks, slice) {
     severity: "fail",
   });
 
-  const triageAgenticErrors =
-    fs.existsSync(triageManifestPath) && triageJson.valid
-      ? validateTriageAgentic(JSON.parse(fs.readFileSync(triageManifestPath, "utf8")))
-      : ["manifest missing or invalid"];
+  const triageAgenticErrors = triageManifestUsable
+    ? validateTriageAgentic(triageManifest)
+    : ["manifest missing or invalid"];
   checks.push({
     id: "triage-agentic-required",
     pass: triageAgenticErrors.length === 0,
@@ -455,10 +458,9 @@ function pushTriageManifestChecks(checks, slice) {
     severity: "fail",
   });
 
-  const triageBatchErrors =
-    fs.existsSync(triageManifestPath) && triageJson.valid
-      ? validateTriageBatchFiles(sliceDir, JSON.parse(fs.readFileSync(triageManifestPath, "utf8")))
-      : ["manifest missing or invalid"];
+  const triageBatchErrors = triageManifestUsable
+    ? validateTriageBatchFiles(sliceDir, triageManifest)
+    : ["manifest missing or invalid"];
   checks.push({
     id: "triage-batch-files-present",
     pass: triageBatchErrors.length === 0,
@@ -471,7 +473,7 @@ function pushTriageManifestChecks(checks, slice) {
   });
 
   const hasMarkdownTriage = triageBody.length > 100;
-  const hasJsonTriage = fs.existsSync(triageManifestPath);
+  const hasJsonTriage = triageManifestExists;
   checks.push({
     id: "heuristic-triage-forbidden",
     pass: !hasMarkdownTriage || hasJsonTriage,
@@ -523,8 +525,7 @@ function pushPromotionChecks(checks, slice) {
   let traceabilityActual = "no synthesis pngs";
   if (synthesisPngs.length > 0 && fs.existsSync(promotionDecisionsPath)) {
     const decisions = JSON.parse(fs.readFileSync(promotionDecisionsPath, "utf8"));
-    const mapPath = lanePath(sliceDir, LANES.keyFrames, "promotion-map.json");
-    const promotionMap = fs.existsSync(mapPath) ? JSON.parse(fs.readFileSync(mapPath, "utf8")) : {};
+    const promotionMap = readPromotionMap(sliceDir);
     const promoteByDest = new Map(
       (decisions.decisions ?? [])
         .filter((d) => d.verdict === "promote")
@@ -565,14 +566,16 @@ function pushQualityAuditChecks(checks, slice) {
   } = slice;
   const qualityAuditJsonPath = lanePath(sliceDir, LANES.keyFrames, "key-frame-quality-audit.json");
   const qualityAuditValidation = validateQualityAuditForSlice(sliceDir);
-  const auditFailures =
+  const auditFiles =
     // biome-ignore lint/suspicious/noUnnecessaryConditions: validateQualityAuditForSlice() returns without `doc` on the missing-audit branch, so `doc` may be undefined; Biome models only the doc-present shape.
     qualityAuditValidation.doc && Array.isArray(qualityAuditValidation.doc.files)
-      ? qualityAuditValidation.doc.files.filter((f) => !f.pass)
+      ? qualityAuditValidation.doc.files
       : [];
+  const auditFailures = auditFiles.filter((f) => !f.pass);
 
   let manifestRowCount = 0;
-  if (fs.existsSync(manifestPath)) {
+  const manifestExists = fs.existsSync(manifestPath);
+  if (manifestExists) {
     manifestRowCount = fs
       .readFileSync(manifestPath, "utf8")
       .split("\n")
@@ -581,11 +584,7 @@ function pushQualityAuditChecks(checks, slice) {
       ).length;
   }
 
-  const auditRowCount =
-    // biome-ignore lint/suspicious/noUnnecessaryConditions: same as the auditFailures guard — validateQualityAuditForSlice() can return without `doc` (missing audit JSON), so `doc` may be undefined.
-    qualityAuditValidation.doc && Array.isArray(qualityAuditValidation.doc.files)
-      ? qualityAuditValidation.doc.files.length
-      : 0;
+  const auditRowCount = auditFiles.length;
   const parityPass =
     synthesisPngs.length === 0 ||
     (manifestRowCount === synthesisPngs.length &&
@@ -609,17 +608,15 @@ function pushQualityAuditChecks(checks, slice) {
     expected: "delete or fix frames with pass:false in key-frame-quality-audit.json",
     severity: "fail",
   });
+  const auditMdExists = fs.existsSync(qualityAuditPath);
+  const auditJsonExists = fs.existsSync(qualityAuditJsonPath);
   checks.push({
     id: "quality-audit",
-    pass:
-      fs.existsSync(qualityAuditPath) &&
-      fs.existsSync(manifestPath) &&
-      fs.existsSync(qualityAuditJsonPath) &&
-      qualityAuditValidation.valid,
+    pass: auditMdExists && manifestExists && auditJsonExists && qualityAuditValidation.valid,
     actual: [
-      fs.existsSync(manifestPath) ? "manifest" : "no-manifest",
-      fs.existsSync(qualityAuditPath) ? "audit-md" : "no-audit-md",
-      fs.existsSync(qualityAuditJsonPath) ? "audit-json" : "no-audit-json",
+      manifestExists ? "manifest" : "no-manifest",
+      auditMdExists ? "audit-md" : "no-audit-md",
+      auditJsonExists ? "audit-json" : "no-audit-json",
     ].join(", "),
     expected: "manifest + key-frame-quality-audit.md + .json after promotion",
     severity: "fail",
@@ -674,7 +671,7 @@ function writeWatchOutcomeReport(sliceDir, checks, pass) {
   const verificationDir = lanePath(sliceDir, LANES.verification);
   fs.mkdirSync(verificationDir, { recursive: true });
   // Latest report is authoritative: clear prior outcome reports before writing this run's.
-  for (const name of fs.existsSync(verificationDir) ? fs.readdirSync(verificationDir) : []) {
+  for (const name of fs.readdirSync(verificationDir)) {
     if (/-watch-outcomes\.md$/.test(name)) {
       fs.rmSync(path.join(verificationDir, name));
     }

--- a/plugins/knowledge/skills/youtube-digest/extraction/watch/rebuild-visual-frames.js
+++ b/plugins/knowledge/skills/youtube-digest/extraction/watch/rebuild-visual-frames.js
@@ -35,6 +35,17 @@ export function resolveSourceFile(destFile, promotionMap) {
 }
 
 /**
+ * A slice's key-frames/promotion-map.json, or `{}` when the slice has none yet.
+ *
+ * @param {string} sliceDir
+ * @returns {Record<string, { sourceFile?: string } | string>}
+ */
+export function readPromotionMap(sliceDir) {
+  const mapPath = lanePath(path.resolve(sliceDir), LANES.keyFrames, "promotion-map.json");
+  return fs.existsSync(mapPath) ? JSON.parse(fs.readFileSync(mapPath, "utf8")) : {};
+}
+
+/**
  * @param {string} sliceDir
  */
 export function rebuildVisualFrames(sliceDir) {
@@ -43,8 +54,7 @@ export function rebuildVisualFrames(sliceDir) {
     fs.readFileSync(lanePath(absSlice, LANES.keyFrames, "selection.json"), "utf8"),
   );
   const byFile = Object.fromEntries(sel.selectedFrames.map((f) => [f.file, f]));
-  const mapPath = lanePath(absSlice, LANES.keyFrames, "promotion-map.json");
-  const promotionMap = fs.existsSync(mapPath) ? JSON.parse(fs.readFileSync(mapPath, "utf8")) : {};
+  const promotionMap = readPromotionMap(absSlice);
 
   const synDir = lanePath(absSlice, LANES.keyFrames, "frames");
   const files = fs

--- a/plugins/knowledge/skills/youtube-digest/extraction/watch/recover-watch-bootstrap.js
+++ b/plugins/knowledge/skills/youtube-digest/extraction/watch/recover-watch-bootstrap.js
@@ -66,14 +66,22 @@ function loadFramesFromDir(framesDir) {
 
 /**
  * @param {string} contactSheetsDir
- * @param {import('../watching/models.js').SelectedFrame[][]} batches
- * @returns {import('@melodic/video-digestion/frames/models.js').ContactSheet[]}
+ * @returns {string[]} sorted `sheet_NNN.jpg` names already on disk
  */
-function loadExistingContactSheets(contactSheetsDir, batches) {
-  const sheetFiles = fs
+function listExistingSheetFiles(contactSheetsDir) {
+  return fs
     .readdirSync(contactSheetsDir)
     .filter((name) => /^sheet_\d+\.jpg$/i.test(name))
     .sort();
+}
+
+/**
+ * @param {string} contactSheetsDir
+ * @param {string[]} sheetFiles
+ * @param {import('../watching/models.js').SelectedFrame[][]} batches
+ * @returns {import('@melodic/video-digestion/frames/models.js').ContactSheet[]}
+ */
+function loadExistingContactSheets(contactSheetsDir, sheetFiles, batches) {
   return sheetFiles.map((file, index) => {
     const batch = batches[index] ?? [];
     return {
@@ -158,9 +166,7 @@ export async function recoverWatchBootstrapCli(argv) {
     densificationWindowCount: windows.length,
   });
 
-  const sheetFiles = fs
-    .readdirSync(contactSheetsDir)
-    .filter((name) => /^sheet_\d+\.jpg$/i.test(name));
+  const sheetFiles = listExistingSheetFiles(contactSheetsDir);
   const expectedSheetCount = sheetFiles.length;
   const expectedFrameCount = expectedSheetCount * 16;
 
@@ -181,7 +187,7 @@ export async function recoverWatchBootstrapCli(argv) {
   }
 
   const batches = batchFramesForContactSheets(selection.selected, 16);
-  const contactSheets = loadExistingContactSheets(contactSheetsDir, batches);
+  const contactSheets = loadExistingContactSheets(contactSheetsDir, sheetFiles, batches);
 
   const highVolume = summarizeFrameSelection(selection.selected, {
     targetMinFrames: coveragePlan.targetMinFrames,

--- a/plugins/knowledge/skills/youtube-digest/extraction/watch/repair-synthesis-promotions.js
+++ b/plugins/knowledge/skills/youtube-digest/extraction/watch/repair-synthesis-promotions.js
@@ -34,26 +34,45 @@ function sessionSlugFromName(sessionName) {
 }
 
 /**
- * @param {string} sliceDir
- * @param {string} sourceFile
- * @returns {string}
+ * @typedef {{ selectedFrames: { file: string, timestampSec?: number }[], sessions: ReturnType<typeof parseSessionsFromClaimInventory> }} SessionIndex
  */
-function resolveSessionForSource(sliceDir, sourceFile) {
+
+/**
+ * Read the frame/session lookup a slice needs to re-derive session slugs.
+ * Loaded once per repair run — {@link repairPromotionRows} would otherwise
+ * re-parse selection.json and claim-inventory.md for every fixed row.
+ *
+ * @param {string} sliceDir
+ * @returns {SessionIndex|null} null when either artifact is missing
+ */
+function loadSessionIndex(sliceDir) {
   const selectionPath = lanePath(sliceDir, LANES.keyFrames, "selection.json");
   const claimPath = lanePath(sliceDir, LANES.research, "claim-inventory.md");
   if (!fs.existsSync(selectionPath) || !fs.existsSync(claimPath)) {
-    return "misc";
+    return null;
   }
   const selection = JSON.parse(fs.readFileSync(selectionPath, "utf8"));
-  const frame = (selection.selectedFrames ?? []).find(
-    (/** @type {{ file: string }} */ f) => f.file === sourceFile,
-  );
+  return {
+    selectedFrames: selection.selectedFrames ?? [],
+    sessions: parseSessionsFromClaimInventory(fs.readFileSync(claimPath, "utf8")),
+  };
+}
+
+/**
+ * @param {SessionIndex|null} index
+ * @param {string} sourceFile
+ * @returns {string}
+ */
+function resolveSessionForSource(index, sourceFile) {
+  if (!index) {
+    return "misc";
+  }
+  const frame = index.selectedFrames.find((f) => f.file === sourceFile);
   if (!frame || frame.timestampSec == null) {
     return "misc";
   }
-  const sessions = parseSessionsFromClaimInventory(fs.readFileSync(claimPath, "utf8"));
   const ts = frame.timestampSec;
-  for (const session of sessions) {
+  for (const session of index.sessions) {
     if (ts >= session.startSec && (session.endSec === null || ts < session.endSec)) {
       return sessionSlugFromName(session.name);
     }
@@ -208,6 +227,9 @@ function repairPromotionRows(doc, reserved, absSlice) {
   let sessionsFixed = 0;
   /** @type {[string, string][]} */
   const renamePairs = [];
+  // Loaded on the first row that needs a session fix, then reused.
+  /** @type {SessionIndex|null|undefined} */
+  let sessionIndex;
 
   for (const row of doc.decisions) {
     if (row.verdict !== "promote") {
@@ -226,7 +248,10 @@ function repairPromotionRows(doc, reserved, absSlice) {
     }
 
     if (typeof row.session === "string" && isForbiddenPipelineSessionSlug(row.session)) {
-      row.session = resolveSessionForSource(absSlice, row.sourceFile);
+      if (sessionIndex === undefined) {
+        sessionIndex = loadSessionIndex(absSlice);
+      }
+      row.session = resolveSessionForSource(sessionIndex, row.sourceFile);
       sessionsFixed += 1;
     }
   }

--- a/plugins/knowledge/vendor/video-digestion/transcript/vtt-parser.js
+++ b/plugins/knowledge/vendor/video-digestion/transcript/vtt-parser.js
@@ -220,14 +220,17 @@ export function formatTranscript(cues) {
   let paragraphStart = cues[0].startSec;
   let cuesInParagraph = 0;
 
+  const closeParagraph = () => {
+    paragraphs.push(
+      `[${formatTimestamp(paragraphStart)}] ${currentParagraphText}`,
+    );
+    currentParagraphText = "";
+    cuesInParagraph = 0;
+  };
+
   for (const cue of cues) {
     if (currentParagraphText && cue.startSec - paragraphStart > 30) {
-      paragraphs.push(
-        `[${formatTimestamp(paragraphStart)}] ${currentParagraphText}`,
-      );
-      currentParagraphText = "";
-      cuesInParagraph = 0;
-      paragraphStart = cue.startSec;
+      closeParagraph();
     }
 
     if (!currentParagraphText) {
@@ -243,18 +246,12 @@ export function formatTranscript(cues) {
     }
 
     if (SENTENCE_ENDING.test(cue.text) && cuesInParagraph >= 2) {
-      paragraphs.push(
-        `[${formatTimestamp(paragraphStart)}] ${currentParagraphText}`,
-      );
-      currentParagraphText = "";
-      cuesInParagraph = 0;
+      closeParagraph();
     }
   }
 
   if (currentParagraphText) {
-    paragraphs.push(
-      `[${formatTimestamp(paragraphStart)}] ${currentParagraphText}`,
-    );
+    closeParagraph();
   }
 
   return paragraphs.join("\n\n");

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-Drivers.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-Drivers.ps1
@@ -142,13 +142,10 @@ function Invoke-DriversCheck {
         $severity = 'OK'
         if ($ciEvents.Count -gt 0) {
             $severity = 'CRIT'
-        } elseif ($unsignedInStore.Count -gt 0) {
+        } elseif ($unsignedInStore.Count -gt 0 -or $problemDevices.Count -gt 0) {
             $severity = 'WARN'
-        } elseif ($problemDevices.Count -gt 0) {
-            $severity = 'WARN'
-        } elseif ($null -ne $pendingDriverUpdates -and $pendingDriverUpdates.Count -gt 0) {
-            $severity = 'INFO'
-        } elseif ($oldSignedCount -gt 0) {
+        } elseif (($null -ne $pendingDriverUpdates -and $pendingDriverUpdates.Count -gt 0) -or
+            $oldSignedCount -gt 0) {
             $severity = 'INFO'
         }
 

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-WindowsUpdate.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-WindowsUpdate.ps1
@@ -126,11 +126,8 @@ try {
         # Escalate INFO -> WARN -> CRIT based on how long the reboot has been
         # pending (proxied by hotfix install age since the reboot flag persists
         # until the machine reboots).
-        if ($null -ne $hotfixAgeDays -and $hotfixAgeDays -gt 14) {
-            $severity = 'CRIT'
-            $summary = "Reboot pending for $hotfixAgeDays days (last hotfix install age)."
-        } elseif ($null -ne $hotfixAgeDays -and $hotfixAgeDays -gt 7) {
-            $severity = 'WARN'
+        if ($null -ne $hotfixAgeDays -and $hotfixAgeDays -gt 7) {
+            $severity = $hotfixAgeDays -gt 14 ? 'CRIT' : 'WARN'
             $summary = "Reboot pending for $hotfixAgeDays days (last hotfix install age)."
         } else {
             $severity = 'INFO'

--- a/plugins/machine-health/skills/audit/scripts/windows/checks/Test-WingetUpgrades.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/checks/Test-WingetUpgrades.ps1
@@ -145,11 +145,9 @@ try {
         if ($kevMatches.Count -gt 0) {
             $severity = 'CRIT'
             $summary = "$($kevMatches.Count) upgrade(s) match CISA KEV."
-        } elseif ($upgrades.Count -gt 10) {
-            $severity = 'WARN'
-            $summary = "$($upgrades.Count) apps behind on winget upgrades."
         } elseif ($upgrades.Count -gt 0) {
-            $severity = 'INFO'
+            # >10 behind is the WARN threshold; anything behind at all is INFO.
+            $severity = $upgrades.Count -gt 10 ? 'WARN' : 'INFO'
             $summary = "$($upgrades.Count) apps behind on winget upgrades."
         }
 

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/ConvertTo-AppendixMarkdown.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/ConvertTo-AppendixMarkdown.ps1
@@ -60,30 +60,65 @@ function ConvertTo-AppendixMarkdown {
     return ($sections -join "`n`n")
 }
 
+function Get-AppendixInventory {
+    <#
+    .SYNOPSIS
+    Items stored under one detail key, or an empty array when the key is absent.
+    #>
+    param(
+        [Parameter(Mandatory)] $Detail,
+        [Parameter(Mandatory)] [string] $Key
+    )
+    if ($Detail.PSObject.Properties[$Key]) { return @($Detail.$Key) }
+    return @()
+}
+
+function Format-AppendixDetail {
+    <#
+    .SYNOPSIS
+    The one collapsed <details> + markdown-table shape every inventory renders.
+
+    .DESCRIPTION
+    Column headers and the row strings are the only thing the per-check
+    renderers below actually differ in; the block scaffolding (details/summary,
+    header row, alignment divider, blank-line spacing) is identical for all of
+    them and lives here so a table that renders in one appendix section renders
+    the same way in every other.
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $Summary,
+        [Parameter(Mandatory)] [string[]] $Column,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Row
+    )
+    $divider = '|' + (($Column | ForEach-Object { '---' }) -join '|') + '|'
+    return @"
+<details>
+<summary>$Summary</summary>
+
+| $($Column -join ' | ') |
+$divider
+$($Row -join "`n")
+
+</details>
+"@
+}
+
 function Get-WingetUpgradeAppendix {
     param([Parameter(Mandatory)] $Detail)
-    $items = if ($Detail.PSObject.Properties['upgrades']) { @($Detail.upgrades) } else { @() }
+    $items = @(Get-AppendixInventory -Detail $Detail -Key 'upgrades')
     if ($items.Count -eq 0) { return $null }
 
     $rows = foreach ($u in $items) {
         "| $($u.name) | ``$($u.id)`` | $($u.current_version) | $($u.available_version) |"
     }
 
-    @"
-<details>
-<summary>winget upgrades ($($items.Count))</summary>
-
-| Name | Id | Installed | Available |
-|---|---|---|---|
-$($rows -join "`n")
-
-</details>
-"@
+    return Format-AppendixDetail -Summary "winget upgrades ($($items.Count))" `
+        -Column @('Name', 'Id', 'Installed', 'Available') -Row @($rows)
 }
 
 function Get-DriverAppendix {
     param([Parameter(Mandatory)] $Detail)
-    $items = if ($Detail.PSObject.Properties['oldest_drivers']) { @($Detail.oldest_drivers) } else { @() }
+    $items = @(Get-AppendixInventory -Detail $Detail -Key 'oldest_drivers')
     if ($items.Count -eq 0) { return $null }
 
     $rows = foreach ($d in $items) {
@@ -93,59 +128,31 @@ function Get-DriverAppendix {
 
     $totalCount = $Detail.PSObject.Properties['total_drivers'] ? $Detail.total_drivers : $items.Count
 
-    @"
-<details>
-<summary>oldest drivers ($($items.Count) of $totalCount)</summary>
-
-| Device | Manufacturer | Version | Date |
-|---|---|---|---|
-$($rows -join "`n")
-
-</details>
-"@
+    return Format-AppendixDetail -Summary "oldest drivers ($($items.Count) of $totalCount)" `
+        -Column @('Device', 'Manufacturer', 'Version', 'Date') -Row @($rows)
 }
 
 function Get-ServicesAppendix {
     param([Parameter(Mandatory)] $Detail)
     $sections = [System.Collections.Generic.List[string]]::new()
 
-    if ($Detail.PSObject.Properties['stopped_auto_services']) {
-        $items = @($Detail.stopped_auto_services)
-        if ($items.Count -gt 0) {
-            $rows = foreach ($s in $items) {
-                $delayed = $s.delayed_auto_start ? 'delayed' : 'auto'
-                "| ``$($s.name)`` | $($s.display_name) | $delayed |"
-            }
-            $sections.Add(@"
-<details>
-<summary>stopped automatic services ($($items.Count))</summary>
-
-| Name | Display | StartType |
-|---|---|---|
-$($rows -join "`n")
-
-</details>
-"@)
+    $stopped = @(Get-AppendixInventory -Detail $Detail -Key 'stopped_auto_services')
+    if ($stopped.Count -gt 0) {
+        $rows = foreach ($s in $stopped) {
+            $delayed = $s.delayed_auto_start ? 'delayed' : 'auto'
+            "| ``$($s.name)`` | $($s.display_name) | $delayed |"
         }
+        $sections.Add((Format-AppendixDetail -Summary "stopped automatic services ($($stopped.Count))" `
+                    -Column @('Name', 'Display', 'StartType') -Row @($rows)))
     }
 
-    if ($Detail.PSObject.Properties['startup_inventory']) {
-        $items = @($Detail.startup_inventory)
-        if ($items.Count -gt 0) {
-            $rows = foreach ($s in $items) {
-                "| $($s.Name) | $($s.User) | $($s.Location) |"
-            }
-            $sections.Add(@"
-<details>
-<summary>startup items ($($items.Count))</summary>
-
-| Name | User | Location |
-|---|---|---|
-$($rows -join "`n")
-
-</details>
-"@)
+    $startup = @(Get-AppendixInventory -Detail $Detail -Key 'startup_inventory')
+    if ($startup.Count -gt 0) {
+        $rows = foreach ($s in $startup) {
+            "| $($s.Name) | $($s.User) | $($s.Location) |"
         }
+        $sections.Add((Format-AppendixDetail -Summary "startup items ($($startup.Count))" `
+                    -Column @('Name', 'User', 'Location') -Row @($rows)))
     }
 
     if ($sections.Count -eq 0) { return $null }
@@ -154,7 +161,7 @@ $($rows -join "`n")
 
 function Get-EventLogAppendix {
     param([Parameter(Mandatory)] $Detail)
-    $items = if ($Detail.PSObject.Properties['top_sources']) { @($Detail.top_sources) } else { @() }
+    $items = @(Get-AppendixInventory -Detail $Detail -Key 'top_sources')
     if ($items.Count -eq 0) { return $null }
 
     $rows = foreach ($e in $items) {
@@ -163,21 +170,13 @@ function Get-EventLogAppendix {
         "| ``$($e.provider_and_id)`` | $($e.count) | $first | $last |"
     }
 
-    @"
-<details>
-<summary>event-log top sources ($($items.Count))</summary>
-
-| Provider/Id | Count | First seen | Last seen |
-|---|---|---|---|
-$($rows -join "`n")
-
-</details>
-"@
+    return Format-AppendixDetail -Summary "event-log top sources ($($items.Count))" `
+        -Column @('Provider/Id', 'Count', 'First seen', 'Last seen') -Row @($rows)
 }
 
 function Get-HotfixAppendix {
     param([Parameter(Mandatory)] $Detail)
-    $items = if ($Detail.PSObject.Properties['recent_hotfixes']) { @($Detail.recent_hotfixes) } else { @() }
+    $items = @(Get-AppendixInventory -Detail $Detail -Key 'recent_hotfixes')
     if ($items.Count -eq 0) { return $null }
 
     $rows = foreach ($h in $items) {
@@ -186,14 +185,6 @@ function Get-HotfixAppendix {
         "| $($h.hotfix_id) | $desc | $date |"
     }
 
-    @"
-<details>
-<summary>recent hotfixes ($($items.Count))</summary>
-
-| KB | Description | Installed |
-|---|---|---|
-$($rows -join "`n")
-
-</details>
-"@
+    return Format-AppendixDetail -Summary "recent hotfixes ($($items.Count))" `
+        -Column @('KB', 'Description', 'Installed') -Row @($rows)
 }

--- a/plugins/machine-health/skills/audit/scripts/windows/lib/Invoke-TrendAnalysis.ps1
+++ b/plugins/machine-health/skills/audit/scripts/windows/lib/Invoke-TrendAnalysis.ps1
@@ -66,22 +66,25 @@ function Invoke-TrendAnalysis {
         # against it reads the recovered difference as growth and upgrades a WARN to
         # CRIT on nothing. checks_ran is already the repo's authority for "this check
         # produced a usable result"; Get-CheckLastRun reads it the same way.
-        $priorMetricValues = [System.Collections.Generic.List[object]]::new()
-        foreach ($h in $HistoryTail) {
-            if (-not $relevantKey) { continue }
-            if (-not $h.PSObject.Properties['checks_ran']) { continue }
-            if (@($h.checks_ran) -notcontains $r.id) { continue }
-            if ($h.PSObject.Properties['top_metrics']) {
-                $fullKey = "$($r.id).$relevantKey"
+        #
+        # Only the most recent qualifying value is ever compared against, so the
+        # walk overwrites rather than accumulating: the tail is in file order
+        # (oldest -> newest), so the last assignment is the newest baseline. An
+        # earlier version collected every value into a list and read [-1]; the
+        # list was never used for anything else. Reading [0] would compare today
+        # against the STALEST entry, which is the bug the ordering note guards.
+        $lastMetric = $null
+        if ($relevantKey) {
+            $fullKey = "$($r.id).$relevantKey"
+            foreach ($h in $HistoryTail) {
+                if (-not $h.PSObject.Properties['checks_ran']) { continue }
+                if (@($h.checks_ran) -notcontains $r.id) { continue }
+                if (-not $h.PSObject.Properties['top_metrics']) { continue }
                 if ($h.top_metrics.PSObject.Properties[$fullKey]) {
-                    $priorMetricValues.Add($h.top_metrics.$fullKey)
+                    $lastMetric = $h.top_metrics.$fullKey
                 }
             }
         }
-
-        # The most recent prior run is the LAST element, not [0]. With >=2
-        # entries using [0] would compare today against stale data.
-        $lastMetric = $priorMetricValues.Count -gt 0 ? $priorMetricValues[-1] : $null
 
         # last_run is the run in which this check actually ran (per-check, from
         # checks_ran) -- NOT "the most recent run overall", which diverges once

--- a/plugins/markdown-format/hooks/markdown-format.sh
+++ b/plugins/markdown-format/hooks/markdown-format.sh
@@ -917,22 +917,17 @@ FIX_OUTPUT="${FIX_OUTPUT//$'\r'/}"
 # that this hook changed the file, so it is reported rather than dropped; the
 # clean-after-fix path used to emit nothing at all, which made a rewrite of the
 # user's file indistinguishable from the hook not running.
+#
+# Split in the SAME pass: the output is also divided into violation lines and
+# everything else. The banner lines markdownlint-cli2 always prints (its
+# version, the resolved `Finding:` glob list, `Linting: N files`, `Summary: N
+# issues`) carry no information about the file being edited and cost context on
+# every single edit, so they do not enter the report — the counts below are
+# derived here instead. Violation lines are identified by the " MD<digits>/"
+# rule-code pattern, matching what the telemetry schema calls a finding. Neither
+# classification depends on the other, and a lint run over a large file emits
+# thousands of lines, so they share one walk rather than each taking their own.
 FIXES_LINE=""
-while IFS= read -r line; do
-  case "$line" in
-  "Attempted: 0 fixes"*) ;;
-  "Attempted:"*) FIXES_LINE="$line" ;;
-  *) ;;
-  esac
-done <<<"$FIX_OUTPUT"
-
-# Split the output into violation lines and everything else. The banner lines
-# markdownlint-cli2 always prints (its version, the resolved `Finding:` glob
-# list, `Linting: N files`, `Summary: N issues`) carry no information about the
-# file being edited and cost context on every single edit, so they do not enter
-# the report — the counts below are derived here instead. Violation lines are
-# identified by the " MD<digits>/" rule-code pattern, matching what the
-# telemetry schema calls a finding.
 findings_raw=""
 FINDING_COUNT=0
 RULE_TALLY=""
@@ -942,6 +937,11 @@ while IFS= read -r line; do
     FINDING_COUNT=$((FINDING_COUNT + 1))
     RULE_TALLY+="${BASH_REMATCH[1]}"$'\n'
   fi
+  case "$line" in
+  "Attempted: 0 fixes"*) ;;
+  "Attempted:"*) FIXES_LINE="$line" ;;
+  *) ;;
+  esac
 done <<<"$FIX_OUTPUT"
 
 hook::ctx_reset

--- a/plugins/powershell-format/hooks/powershell-format.sh
+++ b/plugins/powershell-format/hooks/powershell-format.sh
@@ -39,12 +39,15 @@ hook::check_enabled "POWERSHELL_FORMAT"
 # `set -u` would abort before the advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# formats and lints on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still formats and
+# lints rather than aborting) and the sink opt-in. The data payload costs a jq
+# subprocess, so it is built here after both guards — never on the unwired path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "powershell-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -69,26 +72,35 @@ case "$FILE" in
 *) exit 0 ;;
 esac
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
-
 # Resolve repo root early — used to bound the settings opt-in walk and to compute
 # the schema-required repo-relative path in data.file.
 REPO_ROOT="$(hook::repo_root "$(dirname "$FILE")")"
-# Repo-relative path: schema requires "relative to the consuming repo root".
-# On Windows Git Bash, git rev-parse --show-toplevel returns a drive-letter path
-# while FILE may be in POSIX mount form. Normalize both through cygpath -lm
-# (long name, forward-slash mixed form) when available so the prefix strip
-# compares the same representation. On Linux/macOS, cygpath is absent and both
-# paths are already POSIX. Falls back to raw FILE on any normalization error.
+
+# TOOL and FILE_REL feed the telemetry data object and nothing else (pwsh is
+# handed the to_pwsh_path form of $FILE), so both are resolved only when a sink
+# is wired: the unwired default path spawns zero telemetry-only subprocesses
+# (the tool_name jq parse, and 2× cygpath on Windows).
+#
+# FILE_REL is the repo-relative path: schema requires "relative to the consuming
+# repo root". On Windows Git Bash, git rev-parse --show-toplevel returns a
+# drive-letter path while FILE may be in POSIX mount form. Normalize both
+# through cygpath -lm (long name, forward-slash mixed form) when available so
+# the prefix strip compares the same representation. On Linux/macOS, cygpath is
+# absent and both paths are already POSIX. Falls back to raw FILE on any
+# normalization error.
+TOOL=""
 FILE_REL="$FILE"
-if command -v cygpath >/dev/null 2>&1; then
-  _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
-  _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
-  if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
-    FILE_REL="${_file_lm#"$_root_lm"/}"
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+  if command -v cygpath >/dev/null 2>&1; then
+    _file_lm=$(cygpath -lm "$FILE" 2>/dev/null)
+    _root_lm=$(cygpath -lm "$REPO_ROOT" 2>/dev/null)
+    if [[ -n "$_file_lm" && -n "$_root_lm" ]]; then
+      FILE_REL="${_file_lm#"$_root_lm"/}"
+    fi
+  else
+    FILE_REL="${FILE#"$REPO_ROOT"/}"
   fi
-else
-  FILE_REL="${FILE#"$REPO_ROOT"/}"
 fi
 
 # Build the telemetry data object for the current TOOL/FILE_REL. $1 is the
@@ -108,9 +120,7 @@ build_data_json() {
 }
 
 emit_skipped() {
-  local data_json
-  data_json=$(build_data_json '[]')
-  emit_tel "powershell-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 }
 
@@ -607,8 +617,7 @@ PWSH_EXIT=$?
 case $PWSH_EXIT in
 0)
   # Clean — the analyzer ran to judgment with no findings.
-  data_json=$(build_data_json '[]')
-  emit_tel "powershell-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" '[]'
   exit 0
   ;;
 1)
@@ -629,8 +638,7 @@ case $PWSH_EXIT in
   if [[ -n "$findings_raw" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
-  data_json=$(build_data_json "$FINDINGS_JSON")
-  emit_tel "powershell-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" "$FINDINGS_JSON"
   exit 0
   ;;
 3)
@@ -717,8 +725,7 @@ case $PWSH_EXIT in
     hook::ctx_append "  $line"
   done <<<"$PSSA_OUTPUT"
   hook::ctx_flush PostToolUse
-  data_json=$(build_data_json '[]')
-  emit_tel "powershell-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
   ;;
 esac

--- a/plugins/rate-limit-guard/scripts/statusline-tee.sh
+++ b/plugins/rate-limit-guard/scripts/statusline-tee.sh
@@ -163,23 +163,31 @@ tee_snapshot() {
   # without POSIX modes, e.g. Windows ACL volumes under Git Bash).
   chmod 700 "$dir" 2>/dev/null || true
 
-  local ts payload
+  local ts payload has_windows out
   ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) || return 0
-  payload=$(printf '%s' "$INPUT" | jq -c --arg ts "$ts" '
-    {captured_at: $ts}
-    + (to_entries
-       | map(select(.key == "rate_limits" or .key == "session_id"
-                    or .key == "session_name" or (.key | test("account"; "i"))))
-       | from_entries)
-  ' 2>/dev/null) || return 0
-  [[ -n "$payload" ]] || return 0
-
+  # ONE jq pass for the snapshot body AND the window-bearing verdict — this
+  # runs on every statusline refresh, so a second spawn here is a second spawn
+  # per refresh. Both lines are single-line by construction (`jq -c` escapes
+  # any newline inside a string; the verdict is `true`/`false`), so the split
+  # below is exact.
+  #
   # Window-bearing is a structural property — jq's has(), never a substring
   # test: a forwarded value that merely contains the string "rate_limits"
   # (e.g. "session_name":"rate_limits") must not count as window-bearing and
-  # overwrite a snapshot holding real windows.
-  local has_windows=false
-  jq -e 'has("rate_limits")' >/dev/null 2>&1 <<<"$payload" && has_windows=true
+  # overwrite a snapshot holding real windows. It is asked of the BUILT payload,
+  # exactly as the separate call it replaces was.
+  out=$(printf '%s' "$INPUT" | jq -rc --arg ts "$ts" '
+    ({captured_at: $ts}
+     + (to_entries
+        | map(select(.key == "rate_limits" or .key == "session_id"
+                     or .key == "session_name" or (.key | test("account"; "i"))))
+        | from_entries)) as $p
+    | $p, ($p | has("rate_limits"))
+  ' 2>/dev/null) || return 0
+  payload=${out%%$'\n'*}
+  has_windows=false
+  [[ "${out##*$'\n'}" == true ]] && has_windows=true
+  [[ -n "$payload" ]] || return 0
 
   # Sweep before any early return: a machine where only windowless sessions
   # remain active would otherwise skip below on every refresh and never

--- a/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
+++ b/plugins/repo-fleet-hygiene/skills/audit/scripts/audit-fleet.sh
@@ -329,7 +329,7 @@ while [[ $# -gt 0 ]]; do
     [[ "$pair" == *=* ]] || fail "invalid --canonical value: $pair"
     key="${pair%%=*}"
     value="${pair#*=}"
-    key="$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')"
+    key="$(lower "$key")"
     [[ "$key" =~ ^github\.com/[^/]+/[^/]+$ && -n "$value" ]] ||
       fail "invalid --canonical value: $pair"
     OVERRIDE_KEYS+=("$key")
@@ -773,13 +773,13 @@ parse_github_url() {
   else
     return 1
   fi
-  host="$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')"
+  host="$(lower "$host")"
   path="${path#/}"
   path="${path%/}"
   path="${path%.git}"
   [[ "$host" == "github.com" && "$path" =~ ^[^/]+/[^/]+$ ]] || return 1
   PARSED_SLUG="$path"
-  PARSED_KEY="github.com/$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')"
+  PARSED_KEY="github.com/$(lower "$path")"
 }
 
 lookup_override() {
@@ -805,7 +805,7 @@ lookup_override() {
         value="${entry#*$'\n'}"
         name="${name#canonical.}"
         name="${name%.path}"
-        if [[ "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" == "$key" ]]; then
+        if [[ "$(lower "$name")" == "$key" ]]; then
           configured="$value"
           break
         fi

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-build.sh
@@ -104,10 +104,7 @@ if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
     echo "clean-build.sh: manifest not readable: $MANIFEST_ARG" >&2
     exit 1
   fi
-  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG" "$ALLOWED_CLASSES"
-  printf 'Summary: removed=%s failed=%s bytes=%s\n' \
-    "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
-  [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
+  clean_apply_and_report "$REPO_ROOT" "$MANIFEST_ARG" "$ALLOWED_CLASSES" || exit 1
   exit 0
 fi
 
@@ -129,8 +126,5 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
   exit 0
 fi
 
-clean_apply_manifest "$REPO_ROOT" "$MANIFEST" "$ALLOWED_CLASSES"
-printf 'Summary: removed=%s failed=%s bytes=%s\n' \
-  "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
-[[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
+clean_apply_and_report "$REPO_ROOT" "$MANIFEST" "$ALLOWED_CLASSES" || exit 1
 exit 0

--- a/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/clean-caches.sh
@@ -80,10 +80,7 @@ if [[ "$DRY_RUN" -eq 0 && -n "$MANIFEST_ARG" ]]; then
     echo "clean-caches.sh: manifest not readable: $MANIFEST_ARG" >&2
     exit 1
   fi
-  clean_apply_manifest "$REPO_ROOT" "$MANIFEST_ARG" "caches"
-  printf 'Summary: removed=%s failed=%s bytes=%s\n' \
-    "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
-  [[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
+  clean_apply_and_report "$REPO_ROOT" "$MANIFEST_ARG" "caches" || exit 1
   exit 0
 fi
 
@@ -99,8 +96,5 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
   exit 0
 fi
 
-clean_apply_manifest "$REPO_ROOT" "$MANIFEST" "caches"
-printf 'Summary: removed=%s failed=%s bytes=%s\n' \
-  "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
-[[ "$CLEAN_FAILED_COUNT" -eq 0 ]] || exit 1
+clean_apply_and_report "$REPO_ROOT" "$MANIFEST" "caches" || exit 1
 exit 0

--- a/plugins/repo-hygiene/skills/clean/scripts/git-branch-audit.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-branch-audit.sh
@@ -37,11 +37,7 @@ if [[ -z "$REPO_ROOT" ]]; then
   exit 0
 fi
 
-DEFAULT_BRANCH="$(git -C "$REPO_ROOT" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' | tr -d '\r')"
-if [[ -z "$DEFAULT_BRANCH" ]] && command -v gh >/dev/null 2>&1; then
-  DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null | tr -d '\r')"
-fi
-DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+DEFAULT_BRANCH="$(clean_default_branch "$REPO_ROOT")"
 
 CURRENT_BRANCH="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null | tr -d '\r')"
 

--- a/plugins/repo-hygiene/skills/clean/scripts/git-stash-audit.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-stash-audit.sh
@@ -51,11 +51,7 @@ COMMON_DIR="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-
 [[ -z "$COMMON_DIR" ]] && COMMON_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null | tr -d '\r')"
 printf 'StashStore: %s\n' "${COMMON_DIR:-unknown}"
 
-DEFAULT_BRANCH="$(git -C "$REPO_ROOT" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' | tr -d '\r')"
-if [[ -z "$DEFAULT_BRANCH" ]] && command -v gh >/dev/null 2>&1; then
-  DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null | tr -d '\r')"
-fi
-DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+DEFAULT_BRANCH="$(clean_default_branch "$REPO_ROOT")"
 
 # PR map (best-effort): source-branch → state, so a stash whose source branch was
 # merged can be flagged likely-superseded. Same batched gh call as the branch audit.

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset-batch.sh
@@ -49,8 +49,8 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/clean-common.sh
-source "$SCRIPT_DIR/lib/clean-common.sh"
+# shellcheck source=lib/batch-common.sh
+source "$SCRIPT_DIR/lib/batch-common.sh"
 TREE_RESET="$SCRIPT_DIR/git-tree-reset.sh"
 
 usage() {
@@ -113,24 +113,6 @@ fail_usage() {
   exit 2
 }
 
-read_lines_into() {
-  # read_lines_into <array-name> <file|->  — append non-empty trimmed lines.
-  local -n _dest="$1"
-  local src="$2" line
-  if [[ "$src" == "-" ]]; then
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      line="${line%$'\r'}"
-      [[ -n "$line" ]] && _dest+=("$line")
-    done
-  else
-    [[ -f "$src" ]] || fail_usage "file not found: $src"
-    while IFS= read -r line || [[ -n "$line" ]]; do
-      line="${line%$'\r'}"
-      [[ -n "$line" ]] && _dest+=("$line")
-    done <"$src"
-  fi
-}
-
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --dry-run) DRY_RUN=1 ;;
@@ -158,7 +140,8 @@ while [[ $# -gt 0 ]]; do
     ;;
   --repos-from)
     [[ $# -ge 2 ]] || fail_usage "--repos-from requires a file or -"
-    read_lines_into REPO_INPUTS "$2"
+    [[ "$2" == "-" || -f "$2" ]] || fail_usage "file not found: $2"
+    batch_read_lines_into REPO_INPUTS "$2"
     shift
     ;;
   --skip)
@@ -168,7 +151,8 @@ while [[ $# -gt 0 ]]; do
     ;;
   --skip-from)
     [[ $# -ge 2 ]] || fail_usage "--skip-from requires a file"
-    read_lines_into SKIP_INPUTS "$2"
+    [[ -f "$2" ]] || fail_usage "file not found: $2"
+    batch_read_lines_into SKIP_INPUTS "$2"
     shift
     ;;
   -h | --help)
@@ -248,13 +232,6 @@ CHILD_PASS=()
 # unpushed gate; a no-op when a repo is not ahead of its upstream.
 [[ "$INCLUDE_DIRTY" -eq 1 ]] && CHILD_PASS+=(--allow-unpushed)
 
-emit() {
-  printf 'Repo: %s\n' "$1"
-  printf 'Outcome: %s\n' "$2"
-  printf 'Reason: %s\n' "$3"
-  printf '%s\n' '---'
-}
-
 COUNT_RESET=0
 COUNT_SKIPPED=0
 COUNT_BLOCKED=0
@@ -279,7 +256,7 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
     fi
   done
   if [[ -n "$matched" ]]; then
-    emit "$top" skipped "skip-list ($matched)"
+    batch_emit "$top" skipped "skip-list ($matched)"
     COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
     continue
   fi
@@ -288,7 +265,7 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
   if [[ "$INCLUDE_DIRTY" -eq 0 ]]; then
     dirty="$(repo_dirty_reason "$top")"
     if [[ -n "$dirty" ]]; then
-      emit "$top" skipped "$dirty (pass --include-dirty to reset anyway)"
+      batch_emit "$top" skipped "$dirty (pass --include-dirty to reset anyway)"
       COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
       continue
     fi
@@ -323,7 +300,7 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
       [[ -n "$discards" ]] && reason="$discards"
     fi
     if [[ "$DRY_RUN" -eq 1 ]]; then
-      emit "$top" would-reset "$reason"
+      batch_emit "$top" would-reset "$reason"
     else
       unremovable="$(printf '%s\n' "$out" | sed -n 's/^Unremovable: //p' | head -1)"
       if [[ "${unremovable:-0}" -gt 0 ]]; then
@@ -331,27 +308,27 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
         if [[ "$reason" == none ]]; then reason="$note"; else reason="$reason; $note"; fi
         printf '%s\n' "$out" | grep -E 'could not be removed|failed to remove' >&2 || true
       fi
-      emit "$top" "done" "$reason"
+      batch_emit "$top" "done" "$reason"
     fi
     COUNT_RESET=$((COUNT_RESET + 1))
     ;;
   2)
-    emit "$top" skipped "no upstream tracking branch"
+    batch_emit "$top" skipped "no upstream tracking branch"
     COUNT_SKIPPED=$((COUNT_SKIPPED + 1))
     ;;
   3)
-    emit "$top" blocked "default-branch (pass --force-default-branch)"
+    batch_emit "$top" blocked "default-branch (pass --force-default-branch)"
     COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
     ;;
   4)
     # Reachable only without --include-dirty (which passes --allow-unpushed): the
     # child re-gates unpushed after its fetch, so a repo that looked not-ahead at
     # the batch dirty-check can become ahead once fetch advances the upstream.
-    emit "$top" blocked "unpushed commits after fetch (pass --include-dirty)"
+    batch_emit "$top" blocked "unpushed commits after fetch (pass --include-dirty)"
     COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
     ;;
   5)
-    emit "$top" failed "reset --hard failed mid-apply (child output below)"
+    batch_emit "$top" failed "reset --hard failed mid-apply (child output below)"
     printf '%s\n' "$out" >&2
     COUNT_FAILED=$((COUNT_FAILED + 1))
     ;;
@@ -361,16 +338,16 @@ for ((i = 0; i < ${#REPO_TOPS[@]}; i++)); do
     # the child reports non-zero. Treat it as failed like exit 5 so the batch
     # summary and exit status never report a repo that was only partly realigned
     # as a completed reset.
-    emit "$top" failed "clean failed after a successful reset -- partial apply, tree not fully cleaned (child output below)"
+    batch_emit "$top" failed "clean failed after a successful reset -- partial apply, tree not fully cleaned (child output below)"
     printf '%s\n' "$out" >&2
     COUNT_FAILED=$((COUNT_FAILED + 1))
     ;;
   6)
-    emit "$top" blocked "upstream-unresolved"
+    batch_emit "$top" blocked "upstream-unresolved"
     COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
     ;;
   *)
-    emit "$top" blocked "tree-reset error (child exit $rc)"
+    batch_emit "$top" blocked "tree-reset error (child exit $rc)"
     COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
     ;;
   esac
@@ -378,7 +355,7 @@ done
 
 # Invalid inputs reported as blocked outcomes.
 for ((i = 0; i < ${#INVALID_INPUTS[@]}; i++)); do
-  emit "${INVALID_INPUTS[$i]}" blocked "${INVALID_REASONS[$i]}"
+  batch_emit "${INVALID_INPUTS[$i]}" blocked "${INVALID_REASONS[$i]}"
   COUNT_BLOCKED=$((COUNT_BLOCKED + 1))
 done
 

--- a/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/git-tree-reset.sh
@@ -137,11 +137,7 @@ UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-origin}"
 # Resolve the default branch from the tracked remote's HEAD, not a hardcoded
 # origin — a repo whose default branch lives on a non-origin remote (or is not
 # named main) would otherwise slip past the default-branch guard below.
-DEFAULT_BRANCH="$(git symbolic-ref "refs/remotes/${UPSTREAM_REMOTE}/HEAD" 2>/dev/null | sed "s|^refs/remotes/${UPSTREAM_REMOTE}/||" | tr -d '\r')"
-if [[ -z "$DEFAULT_BRANCH" ]] && command -v gh >/dev/null 2>&1; then
-  DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null | tr -d '\r')"
-fi
-DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+DEFAULT_BRANCH="$(clean_default_branch "$REPO_ROOT" "$UPSTREAM_REMOTE")"
 
 TRACKED_DIRTY="$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
 IGNORED_COUNT="$(git status --ignored --porcelain 2>/dev/null | wc -l | tr -d ' ')"

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/batch-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/batch-common.sh
@@ -3,10 +3,11 @@
 # directly. Reuses clean_path_key / clean_skip_matches from clean-common.sh —
 # the separator-agnostic normalization + skip matching proven out by tree-batch.
 #
-# tree-batch (git-tree-reset-batch.sh) predates this module and still carries its
-# own inline copies of read-lines / resolve-dedup / emit. This is the canonical
-# home for that plumbing; migrating tree-batch onto it is a deferred follow-up,
-# kept out of scope here so this change stays off tree-batch's large test suite.
+# tree-batch (git-tree-reset-batch.sh) predates this module and now reads lines
+# and emits per-repo records through it. Its resolve-dedup loop is still inline:
+# batch_resolve_repos additionally runs each input through batch_normalize_input
+# (backslash folding), which tree-batch's loop does not, so adopting it there is a
+# behavior change rather than a lift — a deferred follow-up.
 
 # shellcheck source=clean-common.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/clean-common.sh"

--- a/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/lib/clean-common.sh
@@ -16,6 +16,22 @@ clean_repo_root() {
   printf '%s' "$root"
 }
 
+# clean_default_branch <repo_root> [<remote>] — echo the repository's default
+# branch: the remote's HEAD symref (default remote `origin`; the tree tier passes
+# the remote the current branch actually tracks), else gh's view of it, else the
+# `main` fallback. One spelling for the three git tiers that need it, so a repo
+# whose default branch is neither `main` nor on `origin` cannot be classified one
+# way by the branch/stash audits and another by the tree reset.
+clean_default_branch() {
+  local repo_root="$1" remote="${2:-origin}" branch
+  branch="$(git -C "$repo_root" symbolic-ref "refs/remotes/${remote}/HEAD" 2>/dev/null |
+    sed "s|^refs/remotes/${remote}/||" | tr -d '\r')"
+  if [[ -z "$branch" ]] && command -v gh >/dev/null 2>&1; then
+    branch="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null | tr -d '\r')"
+  fi
+  printf '%s' "${branch:-main}"
+}
+
 # Normalize a filesystem path to a comparison key: backslashes -> forward
 # slashes, collapse trailing slashes, and lowercase on case-insensitive
 # platforms (Windows via MSYS/Cygwin). This is the exact fix for the multi-repo
@@ -642,6 +658,18 @@ clean_apply_manifest() {
       CLEAN_FAILED_COUNT=$((CLEAN_FAILED_COUNT + 1))
     fi
   done 3<"$manifest"
+}
+
+# clean_apply_and_report ROOT MANIFEST ALLOWED_CLASSES — consume a manifest and
+# print the tier's `Summary:` line; returns 1 when any entry failed (the caller's
+# exit status). Each selective tier reaches this on BOTH of its apply paths
+# (resume-from-a-prebuilt-manifest and build-then-apply), so the summary's shape
+# and the fail-closed exit rule have one home rather than four copies.
+clean_apply_and_report() {
+  clean_apply_manifest "$1" "$2" "$3"
+  printf 'Summary: removed=%s failed=%s bytes=%s\n' \
+    "$CLEAN_REMOVED_COUNT" "$CLEAN_FAILED_COUNT" "$CLEAN_REMOVED_BYTES"
+  [[ "$CLEAN_FAILED_COUNT" -eq 0 ]]
 }
 
 # Return 0 when PATH is safe to (re)write as a manifest: absent, or an existing

--- a/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.sh
+++ b/plugins/repo-hygiene/skills/clean/scripts/resolve-clean-action.sh
@@ -120,9 +120,9 @@ has_reset_intent() {
 # falls through to the normal conflict path.
 sel=""
 for token in "$@"; do
-  case "$(resolve_one "$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')")" in
+  t="$(resolve_one "$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')")"
+  case "$t" in
   caches | build | git)
-    t="$(resolve_one "$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')")"
     if [[ -z "$sel" ]]; then
       sel="$t"
     elif [[ "$sel" != "$t" ]]; then

--- a/plugins/ruff-format/hooks/ruff-format.sh
+++ b/plugins/ruff-format/hooks/ruff-format.sh
@@ -41,12 +41,15 @@ hook::check_enabled "RUFF_FORMAT"
 # `set -u` would abort before the advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# formats and lints on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 findings JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still formats and
+# lints rather than aborting) and the sink opt-in. The data payload costs a jq
+# subprocess, so it is built here after both guards — never on the unwired path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "ruff-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -70,7 +73,13 @@ case "$FILE" in
 *) exit 0 ;;
 esac
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+# Telemetry-only. Parsed behind the sink opt-in so the unwired default path
+# spawns zero telemetry-only subprocesses (FILE_REL below is NOT gated — it is
+# also the path Ruff itself is invoked with).
+TOOL=""
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+fi
 
 # Resolve repo root early — used to bound the config opt-in walk and to compute
 # the schema-required repo-relative path in data.file.
@@ -109,9 +118,7 @@ build_data_json() {
 }
 
 emit_skipped() {
-  local data_json
-  data_json=$(build_data_json '[]')
-  emit_tel "ruff-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 }
 
@@ -234,8 +241,7 @@ OUTPUT=$(cd "$RUN_DIR" && "$RUFF_BIN" check --no-fix --output-format concise "${
 RC=$?
 
 if [[ $RC -eq 0 ]]; then
-  data_json=$(build_data_json '[]')
-  emit_tel "ruff-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" '[]'
   exit 0
 fi
 
@@ -254,11 +260,10 @@ if [[ $RC -eq 1 && -n "$OUTPUT" ]]; then
   if [[ -n "$findings_raw" ]]; then
     FINDINGS_JSON=$(printf '%s' "$findings_raw" | jq -R . | jq -s . 2>/dev/null) || FINDINGS_JSON='[]'
   fi
-  data_json=$(build_data_json "$FINDINGS_JSON")
   # Status "ok" — the linter RAN and produced a judgment (findings live in
   # data.findings), mirroring the sibling formatter plugins where status
   # reflects whether the tool ran, not whether it was clean.
-  emit_tel "ruff-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" "$FINDINGS_JSON"
   exit 0
 fi
 
@@ -274,6 +279,5 @@ while IFS= read -r line; do
   hook::ctx_append "  $line"
 done <<<"$OUTPUT"
 hook::ctx_flush PostToolUse
-data_json=$(build_data_json '[]')
-emit_tel "ruff-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "skipped" '[]'
 exit 0

--- a/plugins/session-flow/skills/running-retro/scripts/arm_observer.py
+++ b/plugins/session-flow/skills/running-retro/scripts/arm_observer.py
@@ -147,7 +147,7 @@ def main() -> int:
     except Exception as e:  # noqa: BLE001 -- any spawn-time failure must degrade gracefully
         print(f"observer: failed to spawn: {e}")
         return 0
-    print(f"observer: armed for session {args.session_id or transcript.stem} (pid {pid})")
+    print(f"observer: armed for session {sid} (pid {pid})")
     return 0
 
 

--- a/plugins/skill-quality/scripts/check-skill.sh
+++ b/plugins/skill-quality/scripts/check-skill.sh
@@ -166,6 +166,18 @@ note() {
   printf 'INFO: %s\n' "$*"
 }
 
+# Sorted-unique trigger phrases in a frontmatter block's LISTING text — the
+# description + when_to_use pair the harness assembles into one listing entry.
+# Reads the frontmatter as a string so every caller (working tree, base ref,
+# sibling skill) derives triggers the same way.
+fm_listing_triggers() {
+  local fm="$1"
+  printf '%s\n%s\n' \
+    "$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field description <<<"$fm")")" \
+    "$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field when_to_use <<<"$fm")")" |
+    skill_frontmatter::extract_triggers
+}
+
 if [[ ! -d "$SKILL_DIR" ]]; then
   # A `plugin:skill` argument is a common miss: the operator wants to gate a
   # marketplace-INSTALLED skill, but this checker resolves a bare skill name
@@ -267,9 +279,7 @@ fi
 
 if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; then
   BASE_FM_3="$(git -C "$REPO_ROOT" show "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
-  BASE_DESC="$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field description <<<"$BASE_FM_3")")"
-  BASE_WTU="$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field when_to_use <<<"$BASE_FM_3")")"
-  BASE_TRIG="$(printf '%s\n%s\n' "$BASE_DESC" "$BASE_WTU" | skill_frontmatter::extract_triggers)"
+  BASE_TRIG="$(fm_listing_triggers "$BASE_FM_3")"
   CUR_TRIG="$(printf '%s\n%s\n' "$CUR_DESC" "$CUR_WTU" | skill_frontmatter::extract_triggers)"
   if [[ -n "$BASE_TRIG" ]]; then
     MISSING="$(comm -23 <(printf '%s\n' "$BASE_TRIG") <(printf '%s\n' "$CUR_TRIG"))"
@@ -287,28 +297,30 @@ if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$SKILL_REL/SKILL.md" 2>/dev/null; 
       # repo root), so sibling base-ref lookups address the right tree entry.
       SKILLS_REL_PARENT=""
       [[ "$SKILL_REL" == */* ]] && SKILLS_REL_PARENT="${SKILL_REL%/*}"
+      # A sibling's working-tree listing text is the same for every missing
+      # phrase, so read and parse each SKILL.md once here rather than once per
+      # phrase (the per-phrase scan below then only walks the cached arrays).
+      # Glob order is preserved, so the first-genuine-host tie-break is unchanged.
+      SIB_NAMES=()
+      SIB_TRIGS=()
+      for other_md in "$SKILLS_ROOT"/*/SKILL.md; do
+        [[ -f "$other_md" ]] || continue
+        [[ "$other_md" == "$SKILL_MD" ]] && continue
+        OTHER_NAME="${other_md%/SKILL.md}"
+        SIB_NAMES+=("${OTHER_NAME##*/}")
+        SIB_TRIGS+=("$(fm_listing_triggers "$(skill_frontmatter::extract <"$other_md")")")
+      done
       LOST=""
       while IFS= read -r phrase; do
         [[ -n "$phrase" ]] || continue
         MOVE_HOST=""
-        for other_md in "$SKILLS_ROOT"/*/SKILL.md; do
-          [[ -f "$other_md" ]] || continue
-          [[ "$other_md" == "$SKILL_MD" ]] && continue
-          OTHER_FM="$(skill_frontmatter::extract <"$other_md")"
-          OTHER_TRIG="$(printf '%s\n%s\n' \
-            "$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field description <<<"$OTHER_FM")")" \
-            "$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field when_to_use <<<"$OTHER_FM")")" |
-            skill_frontmatter::extract_triggers)"
-          printf '%s\n' "$OTHER_TRIG" | grep -qxF -- "$phrase" || continue
-          OTHER_NAME="${other_md%/SKILL.md}"
-          OTHER_NAME="${OTHER_NAME##*/}"
+        for ((sib_i = 0; sib_i < ${#SIB_NAMES[@]}; sib_i++)); do
+          printf '%s\n' "${SIB_TRIGS[$sib_i]}" | grep -qxF -- "$phrase" || continue
+          OTHER_NAME="${SIB_NAMES[$sib_i]}"
           OTHER_REL="${SKILLS_REL_PARENT:+$SKILLS_REL_PARENT/}$OTHER_NAME"
           if git -C "$REPO_ROOT" cat-file -e "$BASE_REF:$OTHER_REL/SKILL.md" 2>/dev/null; then
-            OTHER_BASE_FM="$(git -C "$REPO_ROOT" show "$BASE_REF:$OTHER_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)"
-            OTHER_BASE_TRIG="$(printf '%s\n%s\n' \
-              "$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field description <<<"$OTHER_BASE_FM")")" \
-              "$(skill_frontmatter::strip_quotes "$(skill_frontmatter::field when_to_use <<<"$OTHER_BASE_FM")")" |
-              skill_frontmatter::extract_triggers)"
+            OTHER_BASE_TRIG="$(fm_listing_triggers \
+              "$(git -C "$REPO_ROOT" show "$BASE_REF:$OTHER_REL/SKILL.md" 2>/dev/null | skill_frontmatter::extract)")"
             # Sibling already carried the phrase at BASE_REF: coincidental
             # overlap, not a move — keep looking for a genuine host.
             printf '%s\n' "$OTHER_BASE_TRIG" | grep -qxF -- "$phrase" && continue

--- a/plugins/source-control/scripts/fetch-all-pr-comments.sh
+++ b/plugins/source-control/scripts/fetch-all-pr-comments.sh
@@ -123,14 +123,34 @@ if [[ -z "$OWNER" || -z "$REPO" ]]; then
   exit 2
 fi
 
-# --- Surface 1: General PR comments (issue-level) ----------------------------
+# --- Surface fetch -----------------------------------------------------------
 
-GENERAL_RAW=$(gh api --paginate "repos/$OWNER/$REPO/issues/$PR_NUMBER/comments" 2>/dev/null) || {
-  printf 'fetch-all-pr-comments: gh api issues/%s/comments failed\n' "$PR_NUMBER" >&2
-  exit 2
+# fetch_surface <endpoint> <jq-projection> — page one API surface and project it
+# into the shared schema, leaving the JSONL in SURFACE_JSON. Every surface has
+# the same two failure modes (the fetch, then the parse) and the same fail-loud
+# response to each, so they live here once rather than per surface.
+#
+# The result comes back through a GLOBAL rather than stdout: both guards must
+# terminate the SCRIPT, and an `exit 2` inside a `$( )` capture kills only the
+# subshell — the caller would sail on with an empty surface, which is exactly
+# the shape of a PR with no comments there.
+SURFACE_JSON=""
+fetch_surface() {
+  local endpoint="$1" projection="$2" raw
+  SURFACE_JSON=""
+  raw=$(gh api --paginate "repos/$OWNER/$REPO/$endpoint" 2>/dev/null) || {
+    printf 'fetch-all-pr-comments: gh api %s failed\n' "$endpoint" >&2
+    exit 2
+  }
+  SURFACE_JSON=$(printf '%s' "$raw" | jq -c "$projection" 2>/dev/null) || {
+    printf 'fetch-all-pr-comments: jq failed parsing %s response\n' "$endpoint" >&2
+    exit 2
+  }
 }
 
-if ! GENERAL=$(printf '%s' "$GENERAL_RAW" | jq -c '
+# --- Surface 1: General PR comments (issue-level) ----------------------------
+
+fetch_surface "issues/$PR_NUMBER/comments" '
   if type == "array" then .[] else . end
   | {
       id: .id,
@@ -142,19 +162,12 @@ if ! GENERAL=$(printf '%s' "$GENERAL_RAW" | jq -c '
       created_at: .created_at,
       in_reply_to_id: null
     }
-' 2>/dev/null); then
-  printf 'fetch-all-pr-comments: jq failed parsing issues/%s/comments response\n' "$PR_NUMBER" >&2
-  exit 2
-fi
+'
+GENERAL="$SURFACE_JSON"
 
 # --- Surface 2: Review-level comments ----------------------------------------
 
-REVIEWS_RAW=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" 2>/dev/null) || {
-  printf 'fetch-all-pr-comments: gh api pulls/%s/reviews failed\n' "$PR_NUMBER" >&2
-  exit 2
-}
-
-if ! REVIEWS=$(printf '%s' "$REVIEWS_RAW" | jq -c '
+fetch_surface "pulls/$PR_NUMBER/reviews" '
   if type == "array" then .[] else . end
   | select(.body != null and .body != "")
   | {
@@ -167,19 +180,12 @@ if ! REVIEWS=$(printf '%s' "$REVIEWS_RAW" | jq -c '
       created_at: (.submitted_at // .created_at),
       in_reply_to_id: null
     }
-' 2>/dev/null); then
-  printf 'fetch-all-pr-comments: jq failed parsing pulls/%s/reviews response\n' "$PR_NUMBER" >&2
-  exit 2
-fi
+'
+REVIEWS="$SURFACE_JSON"
 
 # --- Surface 3: Inline review comments (line-anchored) -----------------------
 
-INLINE_RAW=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" 2>/dev/null) || {
-  printf 'fetch-all-pr-comments: gh api pulls/%s/comments failed\n' "$PR_NUMBER" >&2
-  exit 2
-}
-
-if ! INLINE=$(printf '%s' "$INLINE_RAW" | jq -c '
+fetch_surface "pulls/$PR_NUMBER/comments" '
   if type == "array" then .[] else . end
   | {
       id: .id,
@@ -191,10 +197,8 @@ if ! INLINE=$(printf '%s' "$INLINE_RAW" | jq -c '
       created_at: .created_at,
       in_reply_to_id: .in_reply_to_id
     }
-' 2>/dev/null); then
-  printf 'fetch-all-pr-comments: jq failed parsing pulls/%s/comments response\n' "$PR_NUMBER" >&2
-  exit 2
-fi
+'
+INLINE="$SURFACE_JSON"
 
 # --- Merge and sort by created_at --------------------------------------------
 

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_checks.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_checks.py
@@ -28,6 +28,9 @@ CHECK_FAILURE_STATES = {
     "TIMED_OUT",
 }
 CHECK_SUCCESS_STATES = {"NEUTRAL", "SKIPPED", "SUCCESS"}
+# Documentation of GitHub's pending vocabulary rather than a lookup table:
+# `check_category` treats every state that is neither failing nor success as
+# pending, so adding a value here does not change any classification.
 CHECK_PENDING_STATES = {
     "EXPECTED",
     "IN_PROGRESS",
@@ -43,8 +46,8 @@ def check_category(state: str) -> str:
         return "failing"
     if state in CHECK_SUCCESS_STATES:
         return "success"
-    if state in CHECK_PENDING_STATES or not state:
-        return "pending"
+    # Pending, empty, and any state GitHub adds later all land here: an
+    # unrecognized state must never read as success or failure.
     return "pending"
 
 

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_delta.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_delta.py
@@ -193,32 +193,28 @@ class ClassifyConfig:
 DEFAULT_CLASSIFY_CONFIG = ClassifyConfig()
 
 
-def validated_max_quiet_recheck_seconds(value: float) -> float:
+def _validated_positive_seconds(value: float, flag: str) -> float:
+    """Coerce one seconds-valued override, refusing anything not finite/positive.
+
+    Shared by the per-flag validators below so the two cannot drift; `flag`
+    names the CLI option in the refusal so the message stays specific.
+    """
+    message = f"{flag} must be a finite number greater than zero"
     try:
         seconds = float(value)
     except (TypeError, ValueError) as error:
-        raise ValueError(
-            "--max-quiet-recheck-seconds must be a finite number greater than zero"
-        ) from error
+        raise ValueError(message) from error
     if not math.isfinite(seconds) or seconds <= 0:
-        raise ValueError(
-            "--max-quiet-recheck-seconds must be a finite number greater than zero"
-        )
+        raise ValueError(message)
     return seconds
+
+
+def validated_max_quiet_recheck_seconds(value: float) -> float:
+    return _validated_positive_seconds(value, "--max-quiet-recheck-seconds")
 
 
 def validated_stuck_check_age_seconds(value: float) -> float:
-    try:
-        seconds = float(value)
-    except (TypeError, ValueError) as error:
-        raise ValueError(
-            "--stuck-check-age-seconds must be a finite number greater than zero"
-        ) from error
-    if not math.isfinite(seconds) or seconds <= 0:
-        raise ValueError(
-            "--stuck-check-age-seconds must be a finite number greater than zero"
-        )
-    return seconds
+    return _validated_positive_seconds(value, "--stuck-check-age-seconds")
 
 
 def compute_branch_freshness(pr: dict[str, Any]) -> dict[str, Any]:
@@ -319,6 +315,23 @@ def head_repository_scope(
     }
 
 
+def _ledgered_comment_ids(prior: dict[str, Any]) -> set[str]:
+    """Every review-trigger comment id our own mutation ledger recorded.
+
+    The two same-login arms below ask opposite questions of the same evidence --
+    `detect_foreign_activity` looks for a trigger comment that is NOT in here,
+    `detect_attribution_drift` for one that IS -- so the ledger read is shared:
+    a divergence between the two would silently change which comments each arm
+    considers accounted for.
+    """
+    recorded: set[str] = set()
+    for history_key in ("request_history", "request_attempt_history"):
+        for entry in json_object(prior.get(history_key)).values():
+            if is_json_object(entry) and entry.get("comment_id") is not None:
+                recorded.add(str(entry["comment_id"]))
+    return recorded
+
+
 def detect_foreign_activity(
     pr: dict[str, Any],
     previous: dict[str, Any] | None,
@@ -340,11 +353,7 @@ def detect_foreign_activity(
     if recognizer is None or not self_logins:
         return {"detected": False, "evidence": []}
     prior = json_object((previous or {}).get("review_trigger"))
-    known_comment_ids: set[str] = set()
-    for history_key in ("request_history", "request_attempt_history"):
-        for entry in json_object(prior.get(history_key)).values():
-            if is_json_object(entry) and entry.get("comment_id") is not None:
-                known_comment_ids.add(str(entry["comment_id"]))
+    known_comment_ids = _ledgered_comment_ids(prior)
     evidence: list[dict[str, str]] = []
     for comment in json_array(pr.get("comments")):
         if not is_json_object(comment):
@@ -398,11 +407,7 @@ def detect_attribution_drift(
     if not intended or not self_logins:
         return {"detected": False, "evidence": []}
     prior = json_object((previous or {}).get("review_trigger"))
-    recorded_comment_ids: set[str] = set()
-    for history_key in ("request_history", "request_attempt_history"):
-        for entry in json_object(prior.get(history_key)).values():
-            if is_json_object(entry) and entry.get("comment_id") is not None:
-                recorded_comment_ids.add(str(entry["comment_id"]))
+    recorded_comment_ids = _ledgered_comment_ids(prior)
     if not recorded_comment_ids:
         return {"detected": False, "evidence": []}
     evidence: list[dict[str, str]] = []

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_gh.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_gh.py
@@ -69,17 +69,23 @@ def gh_timeout_seconds() -> float:
     return _default_timeout_seconds
 
 
-def run_gh(args: list[str], *, timeout_seconds: float | None = None) -> str:
-    """Run a gh command, raising on timeout or nonzero exit; returns stdout."""
-    proc = run_command(
+def _run_gh(
+    args: list[str], *, timeout_seconds: float | None, check: bool
+) -> subprocess.CompletedProcess[str]:
+    """The one gh invocation seam; `None` means the process-wide default timeout."""
+    return run_command(
         ["gh", *args],
         allowed_executables=("gh",),
         timeout_seconds=(
             timeout_seconds if timeout_seconds is not None else _default_timeout_seconds
         ),
-        check=True,
+        check=check,
     )
-    return proc.stdout
+
+
+def run_gh(args: list[str], *, timeout_seconds: float | None = None) -> str:
+    """Run a gh command, raising on timeout or nonzero exit; returns stdout."""
+    return _run_gh(args, timeout_seconds=timeout_seconds, check=True).stdout
 
 
 def gh_capture(
@@ -87,14 +93,7 @@ def gh_capture(
 ) -> subprocess.CompletedProcess[str]:
     """Run a gh command capturing stdout/stderr/returncode without raising on
     nonzero exit -- for callers that inspect the returncode themselves."""
-    return run_command(
-        ["gh", *args],
-        allowed_executables=("gh",),
-        timeout_seconds=(
-            timeout_seconds if timeout_seconds is not None else _default_timeout_seconds
-        ),
-        check=False,
-    )
+    return _run_gh(args, timeout_seconds=timeout_seconds, check=False)
 
 
 def gh_json(args: list[str]) -> Any:

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_lease.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_lease.py
@@ -54,11 +54,10 @@ def normalize_scope_repos(value: Any) -> tuple[str, ...]:
     if value is None:
         return ()
     if isinstance(value, str):
-        raw = [part for part in value.split(",")]
+        raw = value.split(",")
     else:
         raw = [str(part) for part in value]
-    repos = sorted({parse_repo(part) for part in raw if part.strip()})
-    return tuple(repos)
+    return tuple(sorted({parse_repo(part) for part in raw if part.strip()}))
 
 
 def active_workers_dir(state_dir: str | Path) -> Path:

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_merge.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_merge.py
@@ -179,9 +179,7 @@ def split_owner(repo: str) -> str:
 
 
 def parse_allowed_owners(raw: str | None) -> set[str]:
-    if not raw:
-        return set()
-    return {part.strip().casefold() for part in raw.split(",") if part.strip()}
+    return {owner.casefold() for owner in parse_csv_set(raw)}
 
 
 def unresolved_threads(repo: str, number: int) -> list[dict[str, object]]:
@@ -870,12 +868,11 @@ def evaluate(
 
     # Reconcile each required status-check context against the deduped rollup.
     required_contexts = rules.get("requiredContexts")
+    required_context_list = (
+        cast(list[Any], required_contexts) if isinstance(required_contexts, list) else []
+    )
     required_check_status: list[dict[str, object]] = []
-    for raw_context in (
-        cast(list[Any], required_contexts)
-        if isinstance(required_contexts, list)
-        else []
-    ):
+    for raw_context in required_context_list:
         ctx = str(raw_context)
         match = next(
             (
@@ -896,9 +893,6 @@ def evaluate(
         )
 
     required_reviews = rules.get("requiredApprovingReviews") or 0
-    required_context_list = (
-        required_contexts if isinstance(required_contexts, list) else []
-    )
     base_is_unprotected = not required_reviews and not required_context_list
 
     blockers: list[str] = []

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_state.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_state.py
@@ -485,7 +485,7 @@ def save_state(
             cycles_since_full_sweep = (
                 int(current.get("cycles_since_full_sweep") or 0) + 1
             )
-# An unscoped queue run owns the whole error map; scoped and single
+        # An unscoped queue run owns the whole error map; scoped and single
         # runs replace only the keys they observed and preserve the rest.
         if mode == "queue" and scope is None:
             merged_errors: dict[str, Any] = {}

--- a/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/pr_queue_snapshot.py
@@ -41,14 +41,12 @@ from babysit_review_trigger import ReviewTriggerConfig
 from babysit_util import configure_stdio, json_object
 
 
-def _csv(value: str | None) -> frozenset[str]:
-    return frozenset(
-        part.strip() for part in (value or "").split(",") if part.strip()
-    )
-
-
 def _csv_list(value: str | None) -> list[str]:
     return [part.strip() for part in (value or "").split(",") if part.strip()]
+
+
+def _csv(value: str | None) -> frozenset[str]:
+    return frozenset(_csv_list(value))
 
 
 def build_config(args: argparse.Namespace) -> delta.ClassifyConfig:

--- a/plugins/source-control/skills/babysit-prs/scripts/request_review.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/request_review.py
@@ -381,11 +381,12 @@ def run_locked(
         repo, number, expected_head_sha, config, allowed_owners, review_trigger
     )
 
-    history = json_object(review_trigger.get("request_history"))
-    attempts = json_object(review_trigger.get("request_attempt_history"))
+    # `request_history` / `attempt_history` above are the ledger-merged maps
+    # already written back onto `review_trigger`, so re-reading them off it here
+    # would only re-copy the same entries.
     known_comment_ids = {
         str(entry.get("comment_id"))
-        for entry in (*history.values(), *attempts.values())
+        for entry in (*request_history.values(), *attempt_history.values())
         if is_json_object(entry) and entry.get("comment_id") is not None
     }
     if review_trigger.get("request_comment_id") is not None:

--- a/plugins/source-control/skills/pull-request/scripts/fetch-annotations.sh
+++ b/plugins/source-control/skills/pull-request/scripts/fetch-annotations.sh
@@ -128,7 +128,9 @@ if [[ "$FAILED_ONLY" -eq 1 ]]; then
   FILTERED=$(printf '%s\n' "$CHECK_RUNS_JSON" |
     jq -c 'select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled")')
 else
-  FILTERED=$(printf '%s\n' "$CHECK_RUNS_JSON" | jq -c '.')
+  # No filter: the records are already the one-per-line compact form the walk
+  # below reads, so passing them through `jq -c '.'` was an identity round trip.
+  FILTERED="$CHECK_RUNS_JSON"
 fi
 
 if [[ -z "$FILTERED" ]]; then

--- a/plugins/source-control/skills/pull-request/scripts/fetch-failed-logs.sh
+++ b/plugins/source-control/skills/pull-request/scripts/fetch-failed-logs.sh
@@ -329,53 +329,59 @@ fi
 # Errors appear in the top-level consolidated files. Walk all *.txt recursively
 # rather than per-job dirs (the prior fixture-only logic missed real layouts).
 
+# Enumerated ONCE and reused by every walk below (markers, --raw, the three
+# audit sections, the no-marker fallback). Each of those used to re-run `find`,
+# so an --audit pass re-walked the extracted tree five times. NUL-delimited to
+# survive filenames with spaces (real ZIPs have them — e.g. "shell _ Bash").
+TXT_FILES=()
+while IFS= read -r -d '' f; do
+  TXT_FILES+=("$f")
+done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0 | sort -z)
+
+# per_file_section <banner> <extractor>... — run <extractor> <file> over every
+# extracted log and print each non-empty result under one shared banner. The
+# three audit sections differ only in their extractor, so the walk and the
+# per-file header live here once. Each extractor owns its own stderr handling.
+per_file_section() {
+  local banner="$1" f rel out
+  shift
+  printf '\n===== %s =====\n' "$banner"
+  for f in ${TXT_FILES[@]+"${TXT_FILES[@]}"}; do
+    rel="${f#"$EXTRACT_DIR"/}"
+    out=$("$@" "$f") || true
+    [[ -n "$out" ]] && printf '\n--- %s ---\n%s\n' "$rel" "$out"
+  done
+  return 0
+}
+
+# shellcheck disable=SC2329  # invoked as a per_file_section extractor
+grep_group_markers() { grep -E '##\[(group|endgroup)\]' "$1" 2>/dev/null; }
+# shellcheck disable=SC2329  # invoked as a per_file_section extractor
+grep_suspicious() { grep -iE "$SUSPICIOUS_RE" "$1" 2>/dev/null; }
+
 if [[ "$RAW" -eq 1 ]]; then
-  # Dump every text file with a header for orientation. NUL-delimited to
-  # survive filenames with spaces (real ZIPs have them — e.g. "shell _ Bash").
-  while IFS= read -r -d '' f; do
+  # Dump every text file with a header for orientation.
+  for f in ${TXT_FILES[@]+"${TXT_FILES[@]}"}; do
     rel="${f#"$EXTRACT_DIR"/}"
     printf '\n===== %s =====\n' "$rel"
     cat "$f"
-  done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0 | sort -z)
+  done
 else
-  # Walk every .txt file recursively, grep for markers, group output by file.
+  # Walk every .txt file, grep for markers, group output by file.
   found_any=0
-  while IFS= read -r -d '' f; do
+  for f in ${TXT_FILES[@]+"${TXT_FILES[@]}"}; do
     rel="${f#"$EXTRACT_DIR"/}"
     matches=$(grep -E "$MARKER_RE" "$f" 2>/dev/null || true)
     if [[ -n "$matches" ]]; then
       printf '\n===== %s =====\n%s\n' "$rel" "$matches"
       found_any=1
     fi
-  done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0 | sort -z)
+  done
 
   # --- Audit-flag sections (when requested) ---
-  if [[ "$SHOW_GROUPS" -eq 1 ]]; then
-    printf '\n===== groups (step structure) =====\n'
-    while IFS= read -r -d '' f; do
-      rel="${f#"$EXTRACT_DIR"/}"
-      g=$(grep -E '##\[(group|endgroup)\]' "$f" 2>/dev/null || true)
-      [[ -n "$g" ]] && printf '\n--- %s ---\n%s\n' "$rel" "$g"
-    done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0 | sort -z)
-  fi
-
-  if [[ "$TIMING" -eq 1 ]]; then
-    printf '\n===== timing (per group, ms) =====\n'
-    while IFS= read -r -d '' f; do
-      rel="${f#"$EXTRACT_DIR"/}"
-      timing=$(emit_group_timing "$f")
-      [[ -n "$timing" ]] && printf '\n--- %s ---\n%s\n' "$rel" "$timing"
-    done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0 | sort -z)
-  fi
-
-  if [[ "$SUSPICIOUS" -eq 1 ]]; then
-    printf '\n===== suspicious patterns =====\n'
-    while IFS= read -r -d '' f; do
-      rel="${f#"$EXTRACT_DIR"/}"
-      sus=$(grep -iE "$SUSPICIOUS_RE" "$f" 2>/dev/null || true)
-      [[ -n "$sus" ]] && printf '\n--- %s ---\n%s\n' "$rel" "$sus"
-    done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0 | sort -z)
-  fi
+  [[ "$SHOW_GROUPS" -eq 1 ]] && per_file_section "groups (step structure)" grep_group_markers
+  [[ "$TIMING" -eq 1 ]] && per_file_section "timing (per group, ms)" emit_group_timing
+  [[ "$SUSPICIOUS" -eq 1 ]] && per_file_section "suspicious patterns" grep_suspicious
 
   if [[ "$found_any" -eq 0 ]]; then
     # No marker found — surface tail of the largest non-system log file. Use
@@ -383,15 +389,15 @@ else
     # BSD find rejects it).
     largest=""
     largest_size=0
-    while IFS= read -r -d '' f; do
-      [[ "$(basename "$f")" == "system.txt" ]] && continue
+    for f in ${TXT_FILES[@]+"${TXT_FILES[@]}"}; do
+      [[ "${f##*/}" == "system.txt" ]] && continue
       size=$(wc -c <"$f" 2>/dev/null | tr -d ' \r\n')
       [[ -z "$size" ]] && continue
       if [[ "$size" -gt "$largest_size" ]]; then
         largest="$f"
         largest_size="$size"
       fi
-    done < <(find "$EXTRACT_DIR" -type f -name '*.txt' -print0)
+    done
 
     if [[ -n "$largest" ]]; then
       printf 'fetch-failed-logs: no ##[error]/##[warning] markers found. Tail of %s:\n' \

--- a/plugins/typos-format/hooks/typos-format.sh
+++ b/plugins/typos-format/hooks/typos-format.sh
@@ -79,12 +79,16 @@ hook::check_enabled "TYPOS_FORMAT"
 # `set -u` would abort before the advisory exit 0, failing every edit.
 start=${EPOCHREALTIME:-}
 
-# Telemetry needs the high-res start stamp. When EPOCHREALTIME is unavailable
-# (Bash < 5.0) the stamp is empty and telemetry is skipped, so the hook still
-# fixes typos on older bash rather than aborting.
+# Emit this run's telemetry envelope: $1 status, $2 residual-findings JSON
+# array, optional $3 applied-corrections JSON array.
+# Two guards: the high-res start stamp (EPOCHREALTIME is Bash 5.0+; on older
+# bash it is empty and telemetry is skipped, so the hook still fixes typos
+# rather than aborting) and the sink opt-in. The data payload costs a jq
+# subprocess, so it is built here after both guards — never on the unwired path.
 emit_tel() {
   [[ -n "$start" ]] || return 0
-  hook::emit_telemetry "$@"
+  hook::telemetry_enabled || return 0
+  hook::emit_telemetry "typos-format" "PostToolUse" "$1" "$start" "$(build_data_json "$2" "${3:-[]}")" "$REPO_ROOT"
 }
 
 INPUT=$(hook::buffer_stdin) || exit 0
@@ -100,7 +104,13 @@ hook::require_jq PostToolUse typos-format "$INPUT"
 
 FILE=$(printf '%s' "$INPUT" | hook::read_file_path) || exit 0
 
-TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+# Telemetry-only. Parsed behind the sink opt-in so the unwired default path
+# spawns zero telemetry-only subprocesses (FILE_REL below is NOT gated — it is
+# also the path typos itself is invoked with).
+TOOL=""
+if hook::telemetry_enabled; then
+  TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+fi
 
 # Resolve repo root early — used as the CWD typos runs in and to compute
 # the schema-required repo-relative path in data.file.
@@ -147,9 +157,7 @@ build_data_json() {
 }
 
 emit_skipped() {
-  local data_json
-  data_json=$(build_data_json '[]')
-  emit_tel "typos-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 }
 
@@ -236,17 +244,14 @@ emit_tool_break() {
     hook::ctx_append "  $line"
   done <<<"$1"
   hook::ctx_flush PostToolUse
-  local data_json
-  data_json=$(build_data_json '[]')
-  emit_tel "typos-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 }
 
 if [[ $SCAN_RC -eq 0 ]]; then
   # Clean, or excluded by the repo's own typos config. Nothing was changed and
   # there is nothing to disclose.
-  data_json=$(build_data_json '[]')
-  emit_tel "typos-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "ok" '[]'
   exit 0
 fi
 
@@ -406,29 +411,46 @@ if [[ -z "$CLASSIFIED" ]]; then
   hook::ctx_reset
   hook::ctx_append "typos-format ran on $(basename "$FILE") and its findings could not be summarized (internal parse failure). If the file was rewritten, review it — this run cannot say what changed."
   hook::ctx_flush PostToolUse
-  data_json=$(build_data_json '[]')
-  emit_tel "typos-format" "PostToolUse" "skipped" "$start" "$data_json" "$REPO_ROOT"
+  emit_tel "skipped" '[]'
   exit 0
 fi
 
-read_field() { printf '%s' "$CLASSIFIED" | jq -r "$1" 2>/dev/null; }
-APPLIED_COUNT=$(read_field '.appliedCount')
-RESIDUAL_COUNT=$(read_field '.residualCount')
-APPLIED_LINES=$(read_field '.appliedText')
-APPLIED_INLINE=$(read_field '.appliedInline')
-RESIDUAL_LINES=$(read_field '.residualText')
-APPLIED_JSON=$(printf '%s' "$CLASSIFIED" | jq -c '.applied' 2>/dev/null) || APPLIED_JSON='[]'
-FINDINGS_JSON=$(printf '%s' "$CLASSIFIED" | jq -c '.findings' 2>/dev/null) || FINDINGS_JSON='[]'
+# Unpack the classification in ONE jq process (hook::jq_fields), not seven. The
+# same spawn cost the classifier above was built to avoid applies here: reading
+# these seven values with a jq call apiece paid seven forks over a document jq
+# had just produced, charged against the handler's 15-second budget on exactly
+# the typo-heavy runs that already spent the most of it. hook::jq_fields exists
+# for this shape and records the cost it removes (three forks over one envelope
+# measured at ~840 ms on Windows Git Bash). The array fields come back
+# via `tostring`, which is the same compact JSON `jq -c` emitted. jq_fields also
+# strips every CR (its documented contract): the Windows jq build writes stdout
+# in text mode, so a multi-line value would otherwise arrive with a CR embedded
+# before every newline and carry a literal \r into the emitted context.
+#
+# The failure arm is near-unreachable — jq is a hard prerequisite
+# (hook::require_jq above) and CLASSIFIED is jq's own output — but it must not
+# leave the display strings unset under `set -u`.
+if hook::jq_fields "$CLASSIFIED" \
+  '.appliedCount' '.residualCount' '.appliedText' '.appliedInline' '.residualText' \
+  '.applied' '.findings'; then
+  APPLIED_COUNT="${HOOK_JQ_FIELDS[0]}"
+  RESIDUAL_COUNT="${HOOK_JQ_FIELDS[1]}"
+  APPLIED_LINES="${HOOK_JQ_FIELDS[2]}"
+  APPLIED_INLINE="${HOOK_JQ_FIELDS[3]}"
+  RESIDUAL_LINES="${HOOK_JQ_FIELDS[4]}"
+  APPLIED_JSON="${HOOK_JQ_FIELDS[5]}"
+  FINDINGS_JSON="${HOOK_JQ_FIELDS[6]}"
+else
+  APPLIED_COUNT=0
+  RESIDUAL_COUNT=0
+  APPLIED_LINES=""
+  APPLIED_INLINE=""
+  RESIDUAL_LINES=""
+  APPLIED_JSON='[]'
+  FINDINGS_JSON='[]'
+fi
 [[ "$APPLIED_COUNT" =~ ^[0-9]+$ ]] || APPLIED_COUNT=0
 [[ "$RESIDUAL_COUNT" =~ ^[0-9]+$ ]] || RESIDUAL_COUNT=0
-# jq writes stdout in text mode on Windows, so a multi-line value comes back
-# with CRLF line endings; command substitution strips only the trailing one and
-# leaves a CR embedded before every remaining newline, which then survives
-# JSON-escaping into the emitted context as a literal \r. These strings are
-# display text with no meaningful carriage returns of their own.
-APPLIED_LINES="${APPLIED_LINES//$'\r'/}"
-APPLIED_INLINE="${APPLIED_INLINE//$'\r'/}"
-RESIDUAL_LINES="${RESIDUAL_LINES//$'\r'/}"
 [[ -n "$APPLIED_LINES" ]] && APPLIED_LINES="$APPLIED_LINES"$'\n'
 [[ -n "$RESIDUAL_LINES" ]] && RESIDUAL_LINES="$RESIDUAL_LINES"$'\n'
 
@@ -506,10 +528,9 @@ CTX=$(truncate_to "$CTX" 12000)
 
 hook::emit_channels PostToolUse "$CTX" "$SYSMSG"
 
-data_json=$(build_data_json "$FINDINGS_JSON" "$APPLIED_JSON")
 # Status "ok" — typos RAN and produced a judgment (findings live in
 # data.findings, applied rewrites in data.applied), mirroring the sibling
 # formatter plugins where status reflects whether the tool ran, not whether it
 # was clean.
-emit_tel "typos-format" "PostToolUse" "ok" "$start" "$data_json" "$REPO_ROOT"
+emit_tel "ok" "$FINDINGS_JSON" "$APPLIED_JSON"
 exit 0

--- a/plugins/work-items/skills/work/scripts/preflight.sh
+++ b/plugins/work-items/skills/work/scripts/preflight.sh
@@ -334,10 +334,14 @@ fi
 read_array() {
   # read_array <file> <jq-path> — one element per line; silent on a missing or
   # non-JSON file (a settings file may legitimately not exist).
-  local file="$1" path="$2"
+  # Read + CR-strip ONCE: `collect` calls this for every settings layer on every
+  # one of the three permission paths, so a second read-and-tr per file is pure
+  # per-layer overhead (worst on Windows, where each fork is expensive).
+  local file="$1" path="$2" json
   [[ -f "$file" ]] || return 0
-  tr -d '\r' <"$file" | jq -e . >/dev/null 2>&1 || return 0
-  tr -d '\r' <"$file" | jq -r "$path // [] | .[]" 2>/dev/null | tr -d '\r'
+  json="$(tr -d '\r' <"$file")" || return 0
+  jq -e . <<<"$json" >/dev/null 2>&1 || return 0
+  jq -r "$path // [] | .[]" <<<"$json" 2>/dev/null | tr -d '\r'
 }
 
 collect() {

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/common.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/common.sh
@@ -99,6 +99,22 @@ wit_item_exists() {
   [[ -f "$(wit_item_file "$1")" ]]
 }
 
+# wit_item_numbers — every item number in the store, ascending. One spelling of the
+# whole-store walk for the verbs that enumerate it (list-items, list-sub-items), so
+# the file-name filter and the numeric ordering cannot drift between them. Basename
+# splitting is pure-bash: this runs once per stored file, and a `basename` fork per
+# item is the dominant cost of a large-store list on Windows/MSYS.
+wit_item_numbers() {
+  local f base
+  shopt -s nullglob
+  for f in "$WIT_STORAGE_DIR"/*.md; do
+    base="${f##*/}"
+    base="${base%.md}"
+    [[ "$base" =~ ^[0-9]+$ ]] || continue
+    printf '%s\n' "$base"
+  done | sort -n
+}
+
 # wit_next_number — max existing item file number + 1 (single-writer store).
 wit_next_number() {
   local max=0 f base n

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-items.sh
@@ -34,17 +34,9 @@ esac
 wit_need_storage
 limit="$(jq -r '.limits.list_items_max' "$WIT_LOCAL_ADAPTER_DIR/capabilities.json")"
 
-numbers=()
-shopt -s nullglob
-for f in "$WIT_STORAGE_DIR"/*.md; do
-  base="$(basename "$f" .md)"
-  [[ "$base" =~ ^[0-9]+$ ]] || continue
-  numbers+=("$base")
-done
-
 emitted=0
 {
-  for n in $(printf '%s\n' "${numbers[@]+"${numbers[@]}"}" | sort -n); do
+  for n in $(wit_item_numbers); do
     ((emitted < limit)) || break
     item_state="$(wit_fm_field "$(wit_item_file "$n")" state)"
     case "$state" in

--- a/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.sh
+++ b/plugins/work-items/tools/work-item-tracker/adapters/local-markdown/list-sub-items.sh
@@ -37,16 +37,8 @@ wit_need_storage
 # compare against the quoted form, never the bare id.
 parent_quoted="$(jq -cn --arg p "$id" '$p')"
 
-numbers=()
-shopt -s nullglob
-for f in "$WIT_STORAGE_DIR"/*.md; do
-  base="$(basename "$f" .md)"
-  [[ "$base" =~ ^[0-9]+$ ]] || continue
-  numbers+=("$base")
-done
-
 {
-  for n in $(printf '%s\n' "${numbers[@]+"${numbers[@]}"}" | sort -n); do
+  for n in $(wit_item_numbers); do
     file="$(wit_item_file "$n")"
     [[ "$(wit_fm_field "$file" parent)" == "$parent_quoted" ]] || continue
     item_state="$(wit_fm_field "$file" state)"

--- a/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/e2e-probe.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TRACKER="$SCRIPT_DIR/../work-item-tracker.sh"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../tests/lib.sh"
+source "$SCRIPT_DIR/../tests/lib.sh"
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   echo "usage: e2e-probe.sh [--evidence <file>]  (drives the full lifecycle — map, typed items, edge, frontier, claim/lease, renew, close, graduation — against a live GitHub sandbox; target required: WIT_CONFORMANCE_GITHUB_REPO=owner/name)"

--- a/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
+++ b/plugins/work-items/tools/work-item-tracker/conformance/run-conformance.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TRACKER="$SCRIPT_DIR/../work-item-tracker.sh"
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../tests/lib.sh"
+source "$SCRIPT_DIR/../tests/lib.sh"
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
   echo "usage: run-conformance.sh --binding <name>  (runs the abstract seam conformance suite through the core CLI against the named adapter binding under bindings/<name>.sh)"

--- a/scripts/check-contract-slice-prune.sh
+++ b/scripts/check-contract-slice-prune.sh
@@ -265,7 +265,7 @@ if [[ "$mode" == "--check" ]]; then
     echo "A baseline entry outliving its slice would silently re-open the exemption for a future slice reusing that slug." >&2
     exit 1
   fi
-  echo "Every $BASELINE entry still names an existing slice under $CONTRACT_DIR/ ($(("${#grandfathered[@]}")) grandfathered)."
+  echo "Every $BASELINE entry still names an existing slice under $CONTRACT_DIR/ (${#grandfathered[@]} grandfathered)."
   exit 0
 fi
 

--- a/scripts/check-orphaned-fixtures.sh
+++ b/scripts/check-orphaned-fixtures.sh
@@ -63,10 +63,14 @@ if [[ -f "$BASELINE" ]]; then
   mapfile -t entries < <(sed -E 's/#.*//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$BASELINE" | grep -v '^$')
 fi
 
-is_grandfathered() {
+# matched_baseline <fixture-path> -> print the baseline entry that grandfathers
+# it and return 0, or return 1 when none does. Callers that only need the
+# yes/no answer discard stdout.
+matched_baseline() {
   local path="$1" entry
   for entry in "${entries[@]}"; do
     if [[ "$path" == "$entry" ]]; then
+      printf '%s' "$entry"
       return 0
     fi
   done
@@ -84,6 +88,7 @@ plugin_root_of() {
 consumed() {
   local fixture="$1"
   local fixtures_dir evals_dir skill_dir evals_json rel base plugin plugin_rel files_values
+  local esc_base base_re
 
   fixtures_dir="${fixture%/*}"
   # walk up to the nearest 'fixtures' segment (fixtures may nest a subdir)
@@ -158,23 +163,13 @@ fi
 
 # Track which baseline entries actually shadow an orphan, to flag stale ones.
 declare -A entry_used
-matched_baseline() {
-  local path="$1" entry
-  for entry in "${entries[@]}"; do
-    if [[ "$path" == "$entry" ]]; then
-      printf '%s' "$entry"
-      return 0
-    fi
-  done
-  return 1
-}
 
 orphans=0
 if [[ "$mode" == "discover" ]]; then
   for f in "${fixtures[@]}"; do
     if consumed "$f"; then
       printf '%-14s %s\n' "CONSUMED" "$f"
-    elif is_grandfathered "$f"; then
+    elif matched_baseline "$f" >/dev/null; then
       printf '%-14s %s\n' "GRANDFATHERED" "$f"
     else
       printf '%-14s %s\n' "ORPHAN" "$f"

--- a/scripts/validate-plugin-contracts.mjs
+++ b/scripts/validate-plugin-contracts.mjs
@@ -29,6 +29,14 @@ function fail(path, message) {
 
 const pluginRoot = join(root, "plugins");
 const pluginFiles = filesUnder(pluginRoot);
+
+// Every plugin file under `directory`, taken from the single plugins/ walk
+// above rather than walking the subtree again — same set, same order, one
+// traversal instead of one per checked subtree.
+function filesIn(directory) {
+  return pluginFiles.filter((path) => path.startsWith(directory + sep));
+}
+
 const setupSkills = pluginFiles.filter((path) =>
   /[\\/]skills[\\/]setup[\\/]SKILL\.md$/.test(path),
 );
@@ -99,7 +107,7 @@ for (const plugin of ["discovery", "planning", "implementation"]) {
   if (existsSync(manifest) && /"notes_dir"\s*:/.test(read(manifest))) {
     fail(manifest, "shared project artifact locations cannot use personal userConfig");
   }
-  for (const path of filesUnder(join(pluginRoot, plugin, "skills"))) {
+  for (const path of filesIn(join(pluginRoot, plugin, "skills"))) {
     if (path.endsWith(".md") && /\$\{user_config\.notes_dir\}/.test(read(path))) {
       fail(path, "lifecycle skills must use the shared repository artifact protocol");
     }
@@ -132,12 +140,14 @@ for (const legacyPath of [
   join(aiBriefingRoot, "skills", "generate", "scripts"),
   join(aiBriefingRoot, "skills", "generate", "seed"),
 ]) {
+  // filesUnder, not filesIn: this probes paths that must NOT exist, so it has
+  // to look at the filesystem rather than at a walk that already excluded them.
   if (filesUnder(legacyPath).length > 0) {
     fail(legacyPath, "legacy automated-X collectors must not be shipped");
   }
 }
 
-const aiBriefingFiles = filesUnder(aiBriefingRoot);
+const aiBriefingFiles = filesIn(aiBriefingRoot);
 const automatedXTokens =
   /--refresh-following|--grok-preload|following-list\.json|chrome-extract|per-profile-runner|grok-capture|mcp__claude-in-chrome/i;
 for (const path of aiBriefingFiles.filter((path) => /\.(?:js|json|md|sh)$/.test(path))) {
@@ -179,7 +189,7 @@ const aiBriefingBuildRoot = join(
   "output",
   "build",
 );
-for (const path of filesUnder(aiBriefingBuildRoot).filter((path) => path.endsWith(".js"))) {
+for (const path of filesIn(aiBriefingBuildRoot).filter((path) => path.endsWith(".js"))) {
   if (/fonts\.googleapis|fonts\.gstatic|cdn\.jsdelivr\.net|simple-icons@latest|networkidle/i.test(read(path))) {
     fail(path, "deterministic local rendering must not depend on remote assets or networkidle");
   }
@@ -221,7 +231,7 @@ if (existsSync(autonomyRoot)) {
   const fleetTokens = /melodic-software|ci-workflows|github-iac/i;
   const vendorTokens = /github|gitlab|bitbucket|slack|anthropic|claude|openai|copilot|cursor|devin/i;
   const autonomyReference = join(autonomyRoot, "reference") + sep;
-  for (const path of filesUnder(autonomyRoot)) {
+  for (const path of filesIn(autonomyRoot)) {
     let content = read(path);
     if (path.endsWith(`${sep}.claude-plugin${sep}plugin.json`)) {
       // Only the author block is exempt — description/keywords/etc. stay gated.


### PR DESCRIPTION
Repo-wide **/simplify quality pass** over every tracked code file (834 files, ~215k lines of bash/PowerShell/Python/JS/TS), executed by a 10-agent workflow (Opus 5), one agent per logical file group. Each agent reviewed its group through the four /simplify angles — **reuse, simplification, efficiency, altitude** — applied only behavior-preserving fixes, and ran the sibling test suite for every file it touched before finishing.

**Net result: 89 fixes across 78 files (+1,252 / −1,006 lines).**

## Group breakdown

| Group | Files changed | Fixes | Verification |
|---|---|---|---|
| source-control: babysit-prs | 8 | 10 | full 607-test suite green |
| source-control (rest) + lib/ | 3 | 5 | sibling suites green |
| knowledge | 10 | 12 | 381 tests green (vitest + shell) |
| claude-ops + .claude/hooks | 9 | 10 | 9/10 suites green; 10th = pre-existing load flake, reproduced on unmodified HEAD |
| scripts/ (CI tooling) + .github | 3 | 4 | sibling suites green |
| guardrails + rate-limit-guard + context-guard | 10 | 11 | 13 suites green |
| machine-health + disk-hygiene | 8 | 16 | 676 tests green |
| autonomy + repo-hygiene + work-items + session-flow | 16 | 9 | 24 suites green |
| formatter plugins (9) | 9 | 9 | all 9 suites green (run serially) |
| remaining small plugins (26) | 2 | 3 | suites green; audit-fleet flakes reproduced identically on pristine HEAD |

## What the fixes look like

- Dead branches / unreachable returns removed (e.g. `babysit_checks.py` guard that could never change the result).
- Byte-identical copy-paste helpers collapsed into one shared function within the same module (validators in `babysit_delta.py`, CSV splitters, telemetry emitters, frontmatter trigger extraction in `check-skill.sh`).
- Redundant recomputation hoisted out of loops (per-phrase sibling SKILL.md re-parsing in `check-skill.sh`, duplicate `isinstance` derivations in `babysit_merge.py`, repeated host normalization).
- Identity comprehensions, single-use temps, and useless pipeline stages reduced (`lower()` helper reused at four call sites in `audit-fleet.sh`).

## Deliberately not touched

- **Synced cross-plugin copies** (`hook-utils.sh`, `parse-concern-value.sh`, etc.) — duplication is by design, enforced by `sync-*.sh --check` and `check-cross-plugin-source-drift.sh`.
- **Generated artifacts** (`plugins/miro/dist`), **eval fixtures** whose defects are the test input, and **templates** marked do-not-hand-edit.
- Findings whose fix would be behavior-visible (e.g. `parse_github_timestamp` offset preservation, SSRF-gate restructuring in `url-policy.js`, policy-divergent for-each-ref loops in `audit-fleet.sh`) were skipped and recorded by the agents rather than risked.

## Verification (local, on this branch)

- Per-file sibling suites run by each agent during the pass (see table).
- `check-changelog-parity` (`--check`, `--check-bump origin/main`, `--check-order`) ✅
- `check-cross-plugin-source-drift --check`, all three `sync-*.sh --check` gates ✅
- `check-shell-portability origin/main`, `check-skill-portability origin/main` ✅
- `check-silent-skips`, `check-orphaned-fixtures --check`, `check-hook-userconfig-argv`, `check-contract-slice-prune --check`, `check-contract-clause-coverage.py` ✅
- `validate-plugins.sh` (manifests + catalog) ✅
- npm suites: course-digest 91/91, youtube-digest 270/270, vendored video-digestion 10/10 ✅
- Full serial `run-plugin-tests.sh` was additionally started locally (extremely slow on Windows git-bash; 35+/175 suites green, zero failures at time of PR) — CI is the authoritative run for the rest.

Two suites showed failures during the pass (`audit-fleet.test.sh`, one claude-ops suite); both were **reproduced byte-identically against unmodified HEAD** under the same load and are timing/environment flakes, not regressions — details in the agent reports.

## Related

No linked issue — repo-wide code-quality pass requested interactively via Claude Code (/simplify over all code files); no tracking issue exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012UQr3XT3AuHtZGFRsZf3XA
