### PR TITLE
fix(guardrails): scope block-convention-violation's effective_dir to git's own globals

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
+  "version": "0.25.2",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.25.1",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+### Fixed
+
+- **`block-convention-violation` read the wrong repository's git config, so a commit whose
+  subject violates the team convention passed unblocked.** Its `effective_dir` scanned EVERY word of
+  the command for `-C` — no `[git, subcommand)` slice and no wrapper replay, the shape the shared
+  parser from #1785 replaced, and that #2100 removed from `block-dangerous-git`. It failed
+  in the opposite direction from that sibling: not blind to a chdir, but inventing chdirs that were
+  never there. In `env -u -C git <alias> …`, GNU env's `-u NAME` consumes `-C` as the variable to
+  unset, so git never moves — yet the every-word scan composed `<cwd>/git` and looked for the alias
+  there. The consumer that matters is the gitconfig alias lookup, which has neither a stdin-form
+  gate nor an exemption gate and fails OPEN: reading the wrong repository's config silently misses
+  the expansion, the guard never learns the real subcommand is `commit`, and the convention goes
+  unenforced. `effective_dir` now takes git's own globals only — the slice from the resolved git
+  token to the subcommand — preceded by any genuine wrapper chdir replayed from
+  `HOOK_GIT_RESOLVED_WRAPPER_DIRS`, which is the one parser that can tell a real `env -C <dir>`
+  from the `-C` in `env -u -C git`. The sequencer probe at the same call site is corrected with it.
+
+  A post-subcommand `-C` is `--reuse-message`, not a directory, and the distinction is purely
+  positional. Note that `git commit -C HEAD` cannot itself demonstrate this: `-C` sets the
+  reuse-message exemption and the hook returns before `effective_dir` is ever called, so that
+  invocation answered "allowed" both before and after and would read as already fixed. The
+  positional case is covered through the alias lookup instead, where no exemption applies.
+
+  **Acceptance behavior changes** (hence a minor bump): a wrapped alias invocation whose expansion
+  is `commit` is now content-gated where it was waved through, and one whose alias exists only in
+  an unrelated directory the scan used to compose is no longer blocked on an expansion git would
+  never perform.
+
 ## [0.25.1]
 
 ### Changed

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -33,7 +33,6 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   an unrelated directory the scan used to compose is no longer blocked on an expansion git would
   never perform.
 
-
 - **A `!` shell alias lost the directory its invocation resolved to, so a prepared merge commit was
   blocked instead of exempted.** Found in review of the above. A `!` alias body re-parses as a NEW
   top-level command, and that fresh argv carries neither the wrapper that moved git nor git's own

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.25.2]
+
 ### Fixed
 
 - **`block-convention-violation` read the wrong repository's git config, so a commit whose
@@ -30,6 +32,24 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   is `commit` is now content-gated where it was waved through, and one whose alias exists only in
   an unrelated directory the scan used to compose is no longer blocked on an expansion git would
   never perform.
+
+
+- **A `!` shell alias lost the directory its invocation resolved to, so a prepared merge commit was
+  blocked instead of exempted.** Found in review of the above. A `!` alias body re-parses as a NEW
+  top-level command, and that fresh argv carries neither the wrapper that moved git nor git's own
+  globals — so `env -C <dir> git <alias>` resolved the alias in `<dir>` and then evaluated the alias
+  body's sequencer probe against the payload cwd. With a merge in progress in `<dir>`, the commit
+  git was about to make carries a prepared message and the guard documents an exemption for exactly
+  that; it was gated instead. `effective_dir` now falls back to `HOOK_EFFECTIVE_BASE`, which the
+  caller sets to the resolved directory around each `!` reparse and restores after — the mechanism
+  `block-noncanonical-commit.sh` already uses. Pre-existing, not introduced by the scoping fix above;
+  the fix simply made the path reachable enough to demonstrate.
+
+  What this composes is the caller's directory, where the sibling asks git for the alias's real
+  launch directory (git starts a `!` body at the work tree's top level). For this guard's two
+  consumers the two agree — `config --get` and `rev-parse --absolute-git-dir` answer identically from
+  anywhere inside one repository. They diverge only when a separate repository is nested below the
+  composed path, which is deliberately not modelled here.
 
 ## [0.25.1]
 

--- a/plugins/guardrails/hooks/block-convention-violation.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.sh
@@ -190,6 +190,24 @@ block_title() {
 
 # Same repo-dir/sequencer helpers as block-noncanonical-commit — an in-progress
 # sequencer commit carries a prepared message and is never content-gated.
+#
+# CALLERS MUST PASS GIT'S OWN GLOBALS ONLY — the slice from the resolved git token
+# (`gi`) up to the subcommand, preceded by any wrapper chdir replayed as leading
+# `-C` words. The full reasoning for that contract, and for why the wrapper replay
+# is a separate input rather than something this walk could find for itself, is in
+# `block-noncanonical-commit.sh`'s docblock on its own `effective_dir`; the sibling
+# mechanic guard `block-dangerous-git.sh` binds `collect_git_locating_opts` to the
+# same boundary. In short: a 0-based scan reads `-C` words that are not git's, and
+# a slice that starts at `gi` cannot see a relocation a wrapper really performed,
+# so the caller must supply both halves.
+#
+# This guard was the last caller still scanning the WHOLE argv, which invented
+# chdirs that were not there — the opposite failure from the sibling's. `env -u -C
+# git <alias> …` moves nothing (GNU env's `-u` consumes `-C` as the variable name),
+# yet the every-word scan composed `<cwd>/git` and read that directory's aliases;
+# the guard then never learned the real subcommand and the convention went
+# unenforced. A post-subcommand `-C` is `--reuse-message`, not a directory, and the
+# distinction is purely positional.
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 effective_dir() {
   local base="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}" i n=$# arg
@@ -279,6 +297,18 @@ check_segment() {
   w=("${HOOK_GIT_RESOLVED_WORDS[@]}")
   nseg=${#w[@]}
 
+  # A wrapper's chdir happens before git starts, so it composes ahead of git's
+  # own globals — spelled as leading `-C` words so the one path-composition rule
+  # in effective_dir covers both. hook::git_resolve_index is the only parser that
+  # can tell a real `env -C <dir>` from the `-C` in `env -u -C git`, which moves
+  # nothing; the slice below deliberately cannot see either, so this replays what
+  # the resolver found.
+  local -a wrapper_cd=()
+  local wdir
+  for wdir in ${HOOK_GIT_RESOLVED_WRAPPER_DIRS[@]+"${HOOK_GIT_RESOLVED_WRAPPER_DIRS[@]}"}; do
+    wrapper_cd+=(-C "$wdir")
+  done
+
   hook::git_resolve_subcommand "$gi" "${w[@]}" || return 0
   sub=$HOOK_GIT_SUB
   sub_idx=$HOOK_GIT_SUB_IDX
@@ -315,7 +345,8 @@ check_segment() {
     fi
     if ((inline_alias_handled == 0)) && [[ "$sub" != "commit" ]]; then
       local pexp
-      pexp=$(git -C "$(effective_dir "${w[@]}")" config --get "alias.$sub" 2>/dev/null)
+      pexp=$(git -C "$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")" \
+        config --get "alias.$sub" 2>/dev/null)
       if [[ -n "$pexp" ]]; then
         if [[ "$pexp" == '!'* ]]; then
           local preparse pa
@@ -357,7 +388,8 @@ check_segment() {
 
   ((stdin_form)) || return 0
   ((exempt)) && return 0
-  sequencer_in_progress "$(effective_dir "${w[@]}")" && return 0
+  sequencer_in_progress \
+    "$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")" && return 0
 
   local subj=""
   if [[ "$TOOL_NAME" == "PowerShell" ]]; then

--- a/plugins/guardrails/hooks/block-convention-violation.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.sh
@@ -208,9 +208,26 @@ block_title() {
 # the guard then never learned the real subcommand and the convention went
 # unenforced. A post-subcommand `-C` is `--reuse-message`, not a directory, and the
 # distinction is purely positional.
+#
+# The base is HOOK_EFFECTIVE_BASE, not the payload cwd directly, because a `!`
+# shell alias's body re-parses as a NEW top-level command whose argv no longer
+# carries the wrapper that moved git. Without the fallback, `env -C <dir> git
+# <alias>` resolved the alias in <dir> and then evaluated the alias body's
+# sequencer probe against the payload cwd — so a prepared merge subject in <dir>
+# was BLOCKED where the docblock below promises an exemption. The caller
+# save/sets/restores it around each reparse.
+#
+# What this composes is the caller's directory, where the sibling
+# `block-noncanonical-commit.sh` asks git for the alias's real LAUNCH directory
+# (its `alias_launch_dir`, since git starts a `!` body at the work tree's top
+# level). For this guard's two consumers the two agree: both `config --get` and
+# `rev-parse --absolute-git-dir` answer identically from any directory inside one
+# repository. They diverge only when a SEPARATE repository is nested below the
+# composed path, which is the narrower case the sibling's extra probe exists for
+# and which is deliberately not modelled here.
 # shellcheck disable=SC2329  # reached via the hook::bash_parse_segments callback chain
 effective_dir() {
-  local base="${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}" i n=$# arg
+  local base="${HOOK_EFFECTIVE_BASE:-${HOOK_CWD:-${CLAUDE_PROJECT_DIR:-.}}}" i n=$# arg
   local -a a=("$@")
   for ((i = 0; i < n; i++)); do
     arg="${a[i]}"
@@ -313,6 +330,12 @@ check_segment() {
   sub=$HOOK_GIT_SUB
   sub_idx=$HOOK_GIT_SUB_IDX
 
+  # The directory this segment's git actually runs in. Computed ONCE: it is the
+  # same answer for the alias lookup and the sequencer probe, and each call is a
+  # subshell this hook pays on every git command it sees.
+  local seg_dir
+  seg_dir="$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")"
+
   # Alias-expanded commits must be content-gated too (`git -c alias.c=commit c
   # -F - <<EOF` and persisted `git qc` aliases create commits) — mirror the
   # sibling mechanic guard's expansion: re-check every inline spelling, then
@@ -333,7 +356,13 @@ check_segment() {
         if [[ "$exp" == '!'* ]]; then
           reparse="${exp#!}"
           for a in "${w[@]:sub_idx+1}"; do reparse+=" $(printf '%q' "$a")"; done
+          # The body is a fresh top-level parse, so it carries no wrapper and no
+          # git globals. Hand it the directory this invocation resolved to, or
+          # the reparse silently restarts from the payload cwd.
+          local saved_base="${HOOK_EFFECTIVE_BASE:-}"
+          HOOK_EFFECTIVE_BASE="$seg_dir"
           hook::bash_parse_segments "$reparse" check_segment
+          HOOK_EFFECTIVE_BASE="$saved_base"
         else
           hook::env_s_split "$exp"
           expw=(${HOOK_ENV_S_WORDS[@]+"${HOOK_ENV_S_WORDS[@]}"})
@@ -345,14 +374,17 @@ check_segment() {
     fi
     if ((inline_alias_handled == 0)) && [[ "$sub" != "commit" ]]; then
       local pexp
-      pexp=$(git -C "$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")" \
-        config --get "alias.$sub" 2>/dev/null)
+      pexp=$(git -C "$seg_dir" config --get "alias.$sub" 2>/dev/null)
       if [[ -n "$pexp" ]]; then
         if [[ "$pexp" == '!'* ]]; then
           local preparse pa
           preparse="${pexp#!}"
           for pa in "${w[@]:sub_idx+1}"; do preparse+=" $(printf '%q' "$pa")"; done
+          # Same reason as the inline `!` branch above.
+          local psaved_base="${HOOK_EFFECTIVE_BASE:-}"
+          HOOK_EFFECTIVE_BASE="$seg_dir"
           hook::bash_parse_segments "$preparse" check_segment
+          HOOK_EFFECTIVE_BASE="$psaved_base"
         else
           local -a pexpw=()
           hook::env_s_split "$pexp"
@@ -388,8 +420,7 @@ check_segment() {
 
   ((stdin_form)) || return 0
   ((exempt)) && return 0
-  sequencer_in_progress \
-    "$(effective_dir ${wrapper_cd[@]+"${wrapper_cd[@]}"} "${w[@]:gi:sub_idx-gi}")" && return 0
+  sequencer_in_progress "$seg_dir" && return 0
 
   local subj=""
   if [[ "$TOOL_NAME" == "PowerShell" ]]; then

--- a/plugins/guardrails/hooks/block-convention-violation.test.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.test.sh
@@ -184,6 +184,36 @@ run "env -C <dir> git <alias>: wrapper chdir is replayed (blocked)" "$r" \
 run "env -C <dir> git <alias>: conforming subject still allowed" "$r" \
   $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
 
+# --- a `!` shell alias must inherit the directory its invocation resolved to ---
+# Review finding on #2152. A `!` alias body re-parses as a NEW top-level command,
+# so its argv carries neither the wrapper that moved git nor git's own globals.
+# The wrapper's chdir was therefore dropped on the way in, and the alias body's
+# sequencer probe ran against the payload cwd: a prepared merge subject in the
+# moved-to repository was BLOCKED where the guard documents an exemption.
+#
+# Every case here pairs with one that must answer differently, because "exempt"
+# and "no sequencer" are indistinguishable if only the exempting case is asserted.
+r="$(newrepo "$TICKET")"
+d="$(subrepo "$r" inner)"
+git -C "$d" config alias.qc '!git commit -F - --cleanup=verbatim'
+git -C "$d" commit -q --allow-empty -F - --cleanup=verbatim <<'EOF'
+ABC-1: seed
+EOF
+touch "$(git -C "$d" rev-parse --absolute-git-dir)/MERGE_HEAD"
+run "! alias through a wrapper chdir sees the moved-to sequencer" "$r" \
+  $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 0
+
+# The discriminator: same command, same wrapper, same `!` alias — no MERGE_HEAD.
+# Without this, the case above passes for any reason that makes `!` aliases
+# unreachable, which is exactly how a dead fixture reads as a green one.
+r2="$(newrepo "$TICKET")"
+d2="$(subrepo "$r2" inner)"
+git -C "$d2" config alias.qc '!git commit -F - --cleanup=verbatim'
+run "! alias through a wrapper chdir, no sequencer: still gated" "$r2" \
+  $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 2
+run "! alias through a wrapper chdir, conforming subject allowed" "$r2" \
+  $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
+
 # --- kill switch ---------------------------------------------------------------
 r="$(newrepo "$TICKET")"
 json=$(jq -n --arg c "$BAD_COMMIT" --arg d "$r" \

--- a/plugins/guardrails/hooks/block-convention-violation.test.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.test.sh
@@ -124,6 +124,66 @@ run "configured alias commit: violating subject blocked" "$r" \
 run "configured alias commit: conforming subject allowed" "$r" \
   $'git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
 
+# --- effective_dir is git's own slice, plus the wrapper's replayed chdir -------
+# The alias lookup is the reachable consumer: it has no stdin-form gate and no
+# exemption gate, and it fails OPEN — reading the wrong repository's config
+# misses the expansion, so the guard never learns the subcommand is `commit`.
+#
+# `git commit -C HEAD` is deliberately NOT the control here. `-C` sets exempt=1
+# and the hook returns before effective_dir is ever called, so that invocation
+# answers "allowed" on both the old and the new code and would read as already
+# fixed. The positional case is probed through the alias lookup instead.
+
+# A real git repo nested at <parent>/<name>, with a team convention of its own.
+subrepo() {
+  local d="$1/$2"
+  mkdir -p "$d"
+  git -C "$d" init -q -b main
+  mkdir -p "$d/.claude"
+  printf '%s\n' "$TICKET" >"$d/.claude/source-control.md"
+  printf '%s' "$d"
+}
+
+# GNU env's `-u NAME` consumes the next word, so in `env -u -C git …` the `-C` is
+# the variable to unset and git never moves. Scanning every word composed
+# <cwd>/git and read that directory's aliases instead of the real repository's.
+r="$(newrepo "$TICKET")"
+git -C "$r" config alias.qc commit
+run "env -u -C git <alias>: alias resolves in the TRUE repo (blocked)" "$r" \
+  $'env -u -C git qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 2
+run "env -u -C git <alias>: conforming subject still allowed" "$r" \
+  $'env -u -C git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
+
+# The mirror, flipping the other way: the alias exists ONLY in a real repository
+# at <cwd>/git. Composing that directory blocked on an alias git would never
+# expand; reading the true repository is correctly silent.
+r="$(newrepo "$TICKET")"
+d="$(subrepo "$r" git)"
+git -C "$d" config alias.qc commit
+run "env -u -C git <alias>: decoy repo at <cwd>/git is not read" "$r" \
+  $'env -u -C git qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 0
+
+# A `-C` AFTER the subcommand is an argument, not a chdir. The alias ends in `--`
+# so the trailing `-C dec` git appends to the expansion cannot re-trigger the
+# reuse-message exemption in the recursed frame — without that, the case answers
+# "allowed" on both trees for a reason unrelated to effective_dir.
+r="$(newrepo "$TICKET")"
+d="$(subrepo "$r" dec)"
+git -C "$d" config alias.qs 'commit -F - --cleanup=verbatim --'
+run "post-subcommand -C is not a chdir (decoy repo not read)" "$r" \
+  $'git qs -C dec <<\'EOF\'\njunk subject\nEOF' 0
+
+# A genuine wrapper chdir IS a relocation, and the slice cannot see it — so it is
+# replayed from HOOK_GIT_RESOLVED_WRAPPER_DIRS, matching what #2100 established
+# for block-dangerous-git. The alias lives only in the moved-to repository.
+r="$(newrepo "$TICKET")"
+d="$(subrepo "$r" inner)"
+git -C "$d" config alias.qc commit
+run "env -C <dir> git <alias>: wrapper chdir is replayed (blocked)" "$r" \
+  $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 2
+run "env -C <dir> git <alias>: conforming subject still allowed" "$r" \
+  $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
+
 # --- kill switch ---------------------------------------------------------------
 r="$(newrepo "$TICKET")"
 json=$(jq -n --arg c "$BAD_COMMIT" --arg d "$r" \

--- a/plugins/guardrails/hooks/block-convention-violation.test.sh
+++ b/plugins/guardrails/hooks/block-convention-violation.test.sh
@@ -184,6 +184,37 @@ run "env -C <dir> git <alias>: wrapper chdir is replayed (blocked)" "$r" \
 run "env -C <dir> git <alias>: conforming subject still allowed" "$r" \
   $'env -C inner git qc -F - --cleanup=verbatim <<\'EOF\'\nABC-5: fine\nEOF' 0
 
+# The `-C <dir>` spelling above answers 2 on BOTH trees — the old every-word scan
+# catches that particular `-C inner` by accident — so it proves the replay is
+# load-bearing only under mutation, not against the unfixed hook. `--chdir=` is
+# the spelling that scan does NOT recognize (it matched the literal word `-C`
+# only), so this one genuinely fails before the fix and passes after. Keep the
+# `-C` case too: it is what catches a DOUBLE application of the replay, which
+# composes `<cwd>/inner/inner` and drops to 0 — and keep its directory RELATIVE,
+# because an absolute wrapper dir makes a double-apply idempotent and the guard
+# silently evaporates.
+run "env --chdir=<dir> git <alias>: attached long form is replayed" "$r" \
+  $'env --chdir=inner git qc -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 2
+
+# The OTHER effective_dir consumer: sequencer_in_progress. Every pre-existing
+# `sequencer:` case probes the payload cwd's own repo with no wrapper at all, so
+# nothing reached this call site through a wrapper chdir. `--chdir=` again, so the
+# case discriminates rather than being caught by the old scan.
+r3="$(newrepo "$TICKET")"
+d3="$(subrepo "$r3" inner)"
+git -C "$d3" commit -q --allow-empty -F - --cleanup=verbatim <<'EOF'
+ABC-1: seed
+EOF
+touch "$(git -C "$d3" rev-parse --absolute-git-dir)/MERGE_HEAD"
+run "wrapper chdir reaches the sequencer probe (exempt mid-merge)" "$r3" \
+  $'env --chdir=inner git commit -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 0
+# Its discriminator: identical command, no MERGE_HEAD anywhere. Without this the
+# case above passes for any reason that makes the commit unreachable.
+r4="$(newrepo "$TICKET")"
+subrepo "$r4" inner >/dev/null
+run "wrapper chdir, no sequencer: still content-gated" "$r4" \
+  $'env --chdir=inner git commit -F - --cleanup=verbatim <<\'EOF\'\njunk subject\nEOF' 2
+
 # --- a `!` shell alias must inherit the directory its invocation resolved to ---
 # Review finding on #2152. A `!` alias body re-parses as a NEW top-level command,
 # so its argv carries neither the wrapper that moved git nor git's own globals.


### PR DESCRIPTION
## What changed

`block-convention-violation.sh`'s `effective_dir` scanned **every word** of the command for `-C` —
no `[git, subcommand)` slice, no wrapper replay. That is the pre-#1785 shape, and this hook was the
last un-migrated caller after #2100 finished the sibling in `block-dangerous-git.sh`.

It failed in the **opposite direction** from that sibling. #2100's hole was blindness to a chdir
that really happened. This one is indiscriminate: it invents chdirs that are not there. In
`env -u -C git <alias> …` GNU env's `-u NAME` consumes `-C` as the *variable to unset*, so git never
moves — yet the every-word scan composed `<cwd>/git` and read that directory's aliases.

The reachable consumer is the **gitconfig alias lookup** (`:310`), which has neither a stdin-form
gate nor an exemption gate, and which fails **open**: reading the wrong repository's config silently
misses the expansion, so the guard never learns the real subcommand is `commit` and the team
convention goes unenforced. The `sequencer_in_progress` probe at the same call site is corrected
with it.

`effective_dir` now receives git's own globals only — the slice from the resolved git token (`gi`)
to the subcommand — preceded by any genuine wrapper chdir replayed from
`HOOK_GIT_RESOLVED_WRAPPER_DIRS`. That resolver is the one parser able to tell a real `env -C <dir>`
from the `-C` in `env -u -C git`. This is exactly the shape `block-noncanonical-commit.sh` and
`block-dangerous-git.sh` already use; the docblock points at the sibling's rationale rather than
restating it.

## Verification

Every case was written as a standalone fixture and **run against a pristine `origin/main` worktree
before the fix existed**, so both columns below are measured, not reasoned about. The controls flip
in **opposite directions**, which a single-direction fixture cannot fake.

| case | pre | post | expected | discriminates? |
|---|---|---|---|---|
| `env -u -C git qc`, alias in the **true** repo | 0 | **2** | 2 | yes — fails pre-fix |
| `env -u -C git qc`, alias only in a **decoy** `<cwd>/git` | 2 | **0** | 0 | yes — fails pre-fix, opposite direction |
| `git qs -C dec` (post-subcommand `-C`) | 2 | **0** | 0 | yes — fails pre-fix |
| `env -C inner git qc` (genuine wrapper chdir) | 2 | 2 | 2 | no — must not regress |
| `git qc` (no wrapper; machinery liveness) | 2 | 2 | 2 | no — proves the fixture is real |

**Liveness.** The `git qc` baseline row is the proof the alias machinery is actually wired and the
fixture repositories are real git repos with a real `.claude/source-control.md` — without it, a
uniformly silent hook would read as "all controls pass". The decoy/true pair is the second liveness
proof: the hook speaks when the alias sits in the composed directory and goes quiet when it does
not, which can only happen if it genuinely read a repository rather than echoing the payload.

**`git commit -C HEAD` is deliberately NOT the control**, per the issue's reachability section.
`-C` sets `exempt=1` at `:343-345` and `:350-351` returns before `effective_dir` is ever called, so
that invocation answers "allowed" on both trees and reads as already fixed. The positional case runs
through the alias lookup instead, with an alias ending in `--` so the `-C dec` git appends to the
expansion cannot re-trigger the reuse-message exemption in the recursed frame. Without that `--`,
the case answered 0 on both trees for a reason unrelated to `effective_dir` — that first draft was
caught and discarded.

`HOOK_GIT_RESOLVED_WRAPPER_DIRS` was printed and confirmed **empty** for `env -u -C git`, so the
lead control passes because the slice is right, not because the resolver invented a compensating
wrapper directory.

Suite: **37 pass, 0 fail**; all 3 affected suites green (`scripts/affected-tests.sh --run`).

## Scope

A relative `-C` inside a `!`-shell-alias body still composes from the payload cwd here, because this
hook has no `HOOK_EFFECTIVE_BASE` tracking the way `block-noncanonical-commit.sh` does. That is a
distinct pre-existing gap, not this defect, and is deliberately left alone.

## Adversarial verification status

A fresh-context adversarial verifier was spawned for this PR and did **not** return a verdict before
the authoring session ended — the machine was saturated by concurrent agents and every spawned
verifier stalled inside a long test sweep. Treat this PR as carrying the author's own evidence only.

What partially substitutes for it, and why it is not nothing: the PRE column in the table above was
produced by running the **shipped test file** against the **unmodified `origin/main` hook** in a
pristine worktree, which is precisely the headline check such a verifier performs. What is still
unverified by a second party is the "can you break it" attack surface and the payload-supply
question called out below.

Closes #2113

## Related

- #2100 — the sibling fix in `block-dangerous-git.sh`, and where this was found
- #1785 — built the shared parser in `hooks/hook-utils.sh` and migrated the first caller
- #2129 — the other guardrails defect from this sweep, shipped separately
- Another agent is concurrently bumping `guardrails` for #2124; this branch bumps 0.23.1 → 0.24.0
  and the second of the two to merge will need to re-bump.
