### PR TITLE
fix(ci): close the reverse direction of the changelog-parity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,9 +483,10 @@ jobs:
       - name: Check for orphaned eval fixtures
         run: scripts/check-orphaned-fixtures.sh --check
 
-  # CHANGELOG parity: a versioned plugin must keep a CHANGELOG.md (static
-  # --check), and a PR that changes a plugin's manifest version must update that
-  # plugin's CHANGELOG.md in the same diff (--check-bump, PR-only). Existing
+  # CHANGELOG parity: a versioned plugin must keep a CHANGELOG.md whose newest
+  # version heading does not outrun the manifest (static --check), and a PR that
+  # changes a plugin's manifest version must update that plugin's CHANGELOG.md in
+  # the same diff (--check-bump, PR-only). Existing
   # "versioned but changelog-less" debt is grandfathered by name in
   # scripts/changelog-parity-baseline.txt with a stale guard; the bump gate is
   # never relaxed by the baseline. The self-test runs unconditionally so a broken
@@ -502,7 +503,7 @@ jobs:
           fetch-depth: 0
       - name: Test the changelog-parity gate
         run: bash scripts/check-changelog-parity.test.sh
-      - name: Verify every versioned plugin keeps a CHANGELOG.md
+      - name: Verify every versioned plugin keeps a CHANGELOG.md at or below its manifest version
         run: scripts/check-changelog-parity.sh --check
       - name: Verify a version bump updates the plugin's CHANGELOG.md
         if: github.event_name == 'pull_request'

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [0.10.0]
 
+### Changed
+
+- **`audit-derivability`: listing description tightened (1,161 → 876 chars)** — trimmed the
+  explanatory prose from the frontmatter `description` toward the shared skill-listing budget
+  (claude-code-plugins#2022, option 2). Every single-quoted trigger phrase is preserved verbatim
+  (skill-quality check 3); the four-factor rubric and verdict classes are unchanged in the body.
+
 ### Removed
 
 - **The bare `/<skill>` alias for this plugin's skills.** Their `SKILL.md` files no longer
@@ -9,15 +16,6 @@
   declaring it only restated the path while registering a second, unnamespaced command — which
   the slash-command picker then echoed back as `/plugin:skill (skill)`. Invoke a skill by its
   namespaced command; the command itself is unchanged.
-
-## [0.9.7]
-
-### Changed
-
-- **`audit-derivability`: listing description tightened (1,161 → 876 chars)** — trimmed the
-  explanatory prose from the frontmatter `description` toward the shared skill-listing budget
-  (claude-code-plugins#2022, option 2). Every single-quoted trigger phrase is preserved verbatim
-  (skill-quality check 3); the four-factor rubric and verdict classes are unchanged in the body.
 
 ## [0.9.6]
 

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -3,7 +3,11 @@
 #
 #   scripts/check-changelog-parity.sh --check             fail if a versioned
 #                                                         plugin has no sibling
-#                                                         CHANGELOG.md
+#                                                         CHANGELOG.md, or that
+#                                                         CHANGELOG's newest
+#                                                         version heading is
+#                                                         ABOVE the manifest
+#                                                         `version`
 #   scripts/check-changelog-parity.sh --check-bump <ref>  fail if a plugin's
 #                                                         manifest version
 #                                                         changed vs <ref> but
@@ -20,7 +24,16 @@
 #   * --check is the static repo-wide invariant: a plugins/<name>/.claude-plugin/
 #     plugin.json carrying a `version` must ship a plugins/<name>/CHANGELOG.md.
 #     It catches a plugin that has bumped versions but never kept a changelog at
-#     all (autonomy shipped 5 minor bumps with none).
+#     all (autonomy shipped 5 minor bumps with none). It also owns the REVERSE
+#     direction of the parity pair: the changelog's newest version heading must
+#     not exceed the manifest `version`. Nothing else covers that direction —
+#     --check-bump fires only when the manifest version CHANGED, and
+#     --check-order is satisfied by a correctly ordered heading list — so a
+#     release note written ahead of its bump reaches main unseen, which is how
+#     docs-hygiene shipped a `## [0.9.7]` the manifest went 0.9.6 -> 0.10.0
+#     straight past (claude-code-plugins#2131). A manifest ABOVE the newest
+#     heading stays legal: a bump with no consumer-visible change need not write
+#     a release note.
 #   * --check-bump is the go-forward PR discipline: a version change must ADD a
 #     `## [<version>]` entry for the new version — present in the plugin's
 #     CHANGELOG.md at head AND absent from it at <ref>. Two failure classes the
@@ -98,9 +111,10 @@ version_of() { jq -r '.version // empty' "$1" 2>/dev/null; }
 # at them at all.
 # A fixed-width key so a lexical comparison orders versions NUMERICALLY. Five
 # digits per field is far beyond any version this repo will reach. --check-order
-# feeds digits-only versions (its regex admits nothing else); --check-bump feeds
-# manifest SemVer, so a `+build`/`-prerelease` suffix is stripped before the
-# split to keep every field numeric. Stripping build metadata is SemVer-exact
+# and --check's heading extraction feed digits-only versions (the shared regex
+# admits nothing else); --check and --check-bump feed manifest SemVer, so a
+# `+build`/`-prerelease` suffix is stripped before the split to keep every field
+# numeric. Stripping build metadata is SemVer-exact
 # (it carries no precedence); pre-release ORDERING is deliberately not modeled —
 # no manifest in this repo uses it — so an equal-core pre-release keys equal to
 # its release.
@@ -111,6 +125,19 @@ version_sort_key() {
   printf '%05d.%05d.%05d' "$((10#${1:-0}))" "$((10#${2:-0}))" "$((10#${3:-0}))"
 }
 
+# The version headings a changelog declares, in file order. Every heading form
+# this repo actually uses: `## [1.2.3]` (plugins, Keep a Changelog),
+# `## 1.2.3 — date` (conventions), and the two-component `## 1.2` several
+# convention changelogs use. Requiring a patch component would make the gates
+# built on this silently check NOTHING in those files — worse than not covering
+# them, because the pass would be indistinguishable. Shared by --check-order and
+# --check so the two directions of the parity pair cannot read a changelog
+# differently.
+changelog_versions() {
+  grep -oE '^##[[:space:]]+\[?[0-9]+\.[0-9]+(\.[0-9]+)?\]?([[:space:]]|$)' "$1" |
+    grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?'
+}
+
 if [[ "$mode" == "--check-order" ]]; then
   changelogs=(plugins/*/CHANGELOG.md docs/conventions/*/CHANGELOG.md)
   misordered=0
@@ -119,13 +146,7 @@ if [[ "$mode" == "--check-order" ]]; then
   for changelog in "${changelogs[@]}"; do
     [[ -f "$changelog" ]] || continue
     checked=$((checked + 1))
-    # Every heading form this repo actually uses: `## [1.2.3]` (plugins, Keep a
-    # Changelog), `## 1.2.3 — date` (conventions), and the two-component
-    # `## 1.2` several convention changelogs use. Requiring a patch component
-    # would make this gate silently check NOTHING in those files — worse than
-    # not covering them, because the pass would be indistinguishable.
-    mapfile -t versions < <(grep -oE '^##[[:space:]]+\[?[0-9]+\.[0-9]+(\.[0-9]+)?\]?([[:space:]]|$)' "$changelog" |
-      grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?')
+    mapfile -t versions < <(changelog_versions "$changelog")
     ((${#versions[@]} > 1)) || continue
 
     dupes="$(printf '%s\n' "${versions[@]}" | sort | uniq -d)"
@@ -163,16 +184,35 @@ fi
 if [[ "$mode" == "--check" ]]; then
   declare -A saw_debt
   missing=0
+  ahead=0
   for manifest in "${manifests[@]}"; do
     plugin_dir="${manifest%/.claude-plugin/plugin.json}"
     name="${plugin_dir##*/}"
-    [[ -n "$(version_of "$manifest")" ]] || continue
+    version="$(version_of "$manifest")"
+    [[ -n "$version" ]] || continue
     if [[ -f "$plugin_dir/CHANGELOG.md" ]]; then
       if [[ -n "${grandfathered[$name]:-}" ]]; then
         echo "STALE BASELINE: '$name' in $BASELINE now has a CHANGELOG.md — remove it." >&2
         missing=$((missing + 1))
         # Mark handled so the second stale-scan loop does not re-report it.
         saw_debt["$name"]=1
+      fi
+      # Reverse parity: the newest heading must not outrun the manifest. Only the
+      # NEWEST is compared — an older heading naming a version the manifest never
+      # took is invisible from the tree alone, but it can only get there by first
+      # being the newest, which this catches in the change set that writes it.
+      mapfile -t headings < <(changelog_versions "$plugin_dir/CHANGELOG.md")
+      newest="${headings[0]:-}"
+      if [[ -n "$newest" ]]; then
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$ ]]; then
+          echo "check-changelog-parity: $name carries a non-SemVer manifest version '$version'; refusing to pass without a comparable version." >&2
+          exit 2
+        fi
+        if [[ "$(version_sort_key "$newest")" > "$(version_sort_key "$version")" ]]; then
+          echo "CHANGELOG AHEAD OF MANIFEST: $plugin_dir/CHANGELOG.md documents $newest but $manifest carries $version." >&2
+          echo "  Bump the manifest to $newest, or fold that entry into the version that actually ships." >&2
+          ahead=$((ahead + 1))
+        fi
       fi
       continue
     fi
@@ -191,10 +231,11 @@ if [[ "$mode" == "--check" ]]; then
       missing=$((missing + 1))
     fi
   done
-  if ((missing > 0)); then
+  if ((missing > 0 || ahead > 0)); then
+    ((ahead > 0)) && echo "A changelog entry must not name a version the manifest has not reached; the manifest may sit above the newest heading, never below it." >&2
     exit 1
   fi
-  echo "Every versioned plugin has a CHANGELOG.md (or a stale-guarded baseline entry)."
+  echo "Every versioned plugin has a CHANGELOG.md (or a stale-guarded baseline entry), and none documents a version above its manifest."
   exit 0
 fi
 
@@ -240,7 +281,7 @@ declare -A bumped_candidate
 # candidate) and fork_version equals head_version (so it reads as not-bumped).
 # When HEAD has that shape, use the branch's own tip.
 head_commit=HEAD
-if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1    && git merge-base --is-ancestor 'HEAD^1' "$base" 2>/dev/null; then
+if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1 && git merge-base --is-ancestor 'HEAD^1' "$base" 2>/dev/null; then
   head_commit='HEAD^2'
 fi
 if ! merge_base="$(git merge-base "$base" "$head_commit")"; then

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -109,15 +109,14 @@ version_of() { jq -r '.version // empty' "$1" 2>/dev/null; }
 # Convention changelogs are in scope precisely because that is where it shipped:
 # they are unversioned by any manifest, so --check and --check-bump never look
 # at them at all.
+
 # A fixed-width key so a lexical comparison orders versions NUMERICALLY. Five
-# digits per field is far beyond any version this repo will reach. --check-order
-# and --check's heading extraction feed digits-only versions (the shared regex
-# admits nothing else); --check and --check-bump feed manifest SemVer, so a
-# `+build`/`-prerelease` suffix is stripped before the split to keep every field
-# numeric. Stripping build metadata is SemVer-exact
-# (it carries no precedence); pre-release ORDERING is deliberately not modeled —
-# no manifest in this repo uses it — so an equal-core pre-release keys equal to
-# its release.
+# digits per field is far beyond any version this repo will reach. Every caller —
+# the shared heading extractor and both manifest-version paths — may carry a
+# SemVer `+build`/`-prerelease` tail, which is stripped before the split to keep
+# every field numeric. Stripping build metadata is SemVer-exact (it carries no
+# precedence); pre-release ORDERING is deliberately not modeled — no manifest in
+# this repo uses it — so an equal-core pre-release keys equal to its release.
 version_sort_key() {
   local IFS='.'
   # shellcheck disable=SC2086  # deliberate word-split of the dotted version on IFS
@@ -125,17 +124,81 @@ version_sort_key() {
   printf '%05d.%05d.%05d' "$((10#${1:-0}))" "$((10#${2:-0}))" "$((10#${3:-0}))"
 }
 
+# The lines of a markdown file that RENDER as markdown — everything outside
+# fenced code blocks and multi-line HTML comments. Every mode reads a changelog
+# through this, so a `## [1.2.3]` shown as an EXAMPLE can neither satisfy
+# --check-bump's release-entry requirement nor masquerade as a real heading to
+# --check and --check-order. One tracker, not three, so the modes cannot drift.
+#
+# Fence tracking follows CommonMark: a fence line is a run of >=3 backticks or
+# tildes indented at most three SPACES (four-plus, or a tab, is indented code);
+# an opening backtick fence rejects an info string containing a backtick; a CLOSE
+# requires the same delimiter char, a run at least as long as the opener, and
+# nothing but whitespace after it — so a ~~~ line, a ```not-a-close line, or an
+# indented would-be closer inside a ``` block never prematurely re-opens the
+# content. Comment markers inside fenced code are content; fence markers inside a
+# comment are suppressed. A line that BEGINS inside a comment is suppressed whole
+# even when the comment closes on it: what follows `-->` can never be a
+# column-one heading anyway. Reads $1, or stdin when $1 is `-`.
+rendered_lines() {
+  awk '
+    {
+      if (!infence && inhtml) {
+        p = index($0, "-->")
+        if (p == 0) next
+        inhtml = 0
+        rem = substr($0, p + 3)
+        while ((q = index(rem, "<!--")) > 0) {
+          rem = substr(rem, q + 4)
+          r = index(rem, "-->")
+          if (r == 0) { inhtml = 1; break }
+          rem = substr(rem, r + 3)
+        }
+        next
+      }
+      if (match($0, /^ {0,3}`+/) || match($0, /^ {0,3}~+/)) {
+        seg = substr($0, RSTART, RLENGTH)
+        sub(/^ +/, "", seg)
+        mchar = substr(seg, 1, 1)
+        mlen = length(seg)
+        rest = substr($0, RSTART + RLENGTH)
+        if (mlen >= 3) {
+          if (!infence) {
+            # opening fence; a backtick info string must not contain a backtick
+            if (!(mchar == "`" && rest ~ /`/)) { infence = 1; fchar = mchar; flen = mlen; next }
+          } else if (mchar == fchar && mlen >= flen && rest ~ /^[ \t]*$/) {
+            infence = 0; next
+          }
+        }
+      }
+      if (infence) next
+      print
+      rem = $0
+      while ((q = index(rem, "<!--")) > 0) {
+        rem = substr(rem, q + 4)
+        r = index(rem, "-->")
+        if (r == 0) { inhtml = 1; break }
+        rem = substr(rem, r + 3)
+      }
+    }
+  ' "$1"
+}
+
 # The version headings a changelog declares, in file order. Every heading form
 # this repo actually uses: `## [1.2.3]` (plugins, Keep a Changelog),
 # `## 1.2.3 — date` (conventions), and the two-component `## 1.2` several
 # convention changelogs use. Requiring a patch component would make the gates
 # built on this silently check NOTHING in those files — worse than not covering
-# them, because the pass would be indistinguishable. Shared by --check-order and
-# --check so the two directions of the parity pair cannot read a changelog
-# differently.
+# them, because the pass would be indistinguishable. The optional
+# `+build`/`-prerelease` tail is admitted for the same reason: manifests and
+# --check-bump both accept those forms, so dropping such a heading would leave
+# exactly that class unchecked. version_sort_key strips the tail before
+# comparing. Shared by --check-order and --check so the two directions of the
+# parity pair cannot read a changelog differently.
 changelog_versions() {
-  grep -oE '^##[[:space:]]+\[?[0-9]+\.[0-9]+(\.[0-9]+)?\]?([[:space:]]|$)' "$1" |
-    grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?'
+  rendered_lines "$1" |
+    grep -oE '^##[[:space:]]+\[?[0-9]+\.[0-9]+(\.[0-9]+)?([+-][0-9A-Za-z][0-9A-Za-z.-]*)?\]?([[:space:]]|$)' |
+    grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?([+-][0-9A-Za-z][0-9A-Za-z.-]*)?'
 }
 
 if [[ "$mode" == "--check-order" ]]; then
@@ -197,22 +260,25 @@ if [[ "$mode" == "--check" ]]; then
         # Mark handled so the second stale-scan loop does not re-report it.
         saw_debt["$name"]=1
       fi
+      # Validated for EVERY plugin that keeps a changelog, not only one with a
+      # heading to compare against: an uncomparable manifest version is a defect
+      # in its own right, and --check-bump refuses it unconditionally for every
+      # plugin in its scope. Gating it on an unrelated precondition would let a
+      # malformed version ride through behind a not-yet-written release note.
+      if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$ ]]; then
+        echo "check-changelog-parity: $name carries a non-SemVer manifest version '$version'; refusing to pass without a comparable version." >&2
+        exit 2
+      fi
       # Reverse parity: the newest heading must not outrun the manifest. Only the
       # NEWEST is compared — an older heading naming a version the manifest never
       # took is invisible from the tree alone, but it can only get there by first
       # being the newest, which this catches in the change set that writes it.
       mapfile -t headings < <(changelog_versions "$plugin_dir/CHANGELOG.md")
       newest="${headings[0]:-}"
-      if [[ -n "$newest" ]]; then
-        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$ ]]; then
-          echo "check-changelog-parity: $name carries a non-SemVer manifest version '$version'; refusing to pass without a comparable version." >&2
-          exit 2
-        fi
-        if [[ "$(version_sort_key "$newest")" > "$(version_sort_key "$version")" ]]; then
-          echo "CHANGELOG AHEAD OF MANIFEST: $plugin_dir/CHANGELOG.md documents $newest but $manifest carries $version." >&2
-          echo "  Bump the manifest to $newest, or fold that entry into the version that actually ships." >&2
-          ahead=$((ahead + 1))
-        fi
+      if [[ -n "$newest" && "$(version_sort_key "$newest")" > "$(version_sort_key "$version")" ]]; then
+        echo "CHANGELOG AHEAD OF MANIFEST: $plugin_dir/CHANGELOG.md documents $newest but $manifest carries $version." >&2
+        echo "  Bump the manifest to $newest, or fold that entry into the version that actually ships." >&2
+        ahead=$((ahead + 1))
       fi
       continue
     fi
@@ -357,65 +423,16 @@ for manifest in "${manifests[@]}"; do
 
   # Require the bumped version's own entry at head, not merely that the file
   # changed: an unrelated edit (whitespace, title, an old release) must not
-  # satisfy the gate. The match is a FIXED-STRING heading anchored to line
-  # start (awk index()==1) and OUTSIDE fenced code, so the version string
-  # appearing in prose, an indented line, or a fenced example never satisfies —
-  # or falsely pre-exists — the release entry, and SemVer metacharacters
-  # (1.0.1+build.1) never leak into a regex. Fence tracking follows CommonMark:
-  # a fence line is a run of >=3 backticks or tildes indented at most three
-  # SPACES (four-plus, or a tab, is indented code); an opening backtick fence
-  # rejects an info string containing a backtick; a CLOSE requires the same
-  # delimiter char, a run at least as long as the opener, and nothing but
-  # whitespace after it — so a ~~~ line, a ```not-a-close line, or an indented
-  # would-be closer inside a ``` block never prematurely re-opens the heading.
-  # HTML raw blocks are tracked alongside fences: a heading inside a multi-line
-  # <!-- --> comment is not rendered Markdown, so it neither satisfies nor
-  # pre-exists the release entry. A same-line "<!-- ## [x] -->" can never match
-  # anyway (the heading is not at column one). Comment markers inside fenced
-  # code are content; fence markers inside a comment are suppressed.
+  # satisfy the gate. The match is a FIXED-STRING heading anchored to line start
+  # (awk index()==1) over rendered_lines only, so the version string appearing in
+  # prose, an indented line, a fenced example, or an HTML comment never satisfies
+  # — or falsely pre-exists — the release entry, and SemVer metacharacters
+  # (1.0.1+build.1) never leak into a regex. A same-line "<!-- ## [x] -->" can
+  # never match anyway (the heading is not at column one).
   heading="## [${head_version}]"
   has_heading() {
-    awk -v h="$heading" '
-      {
-        if (!infence && inhtml) {
-          p = index($0, "-->")
-          if (p == 0) next
-          inhtml = 0
-          rem = substr($0, p + 3)
-          while ((q = index(rem, "<!--")) > 0) {
-            rem = substr(rem, q + 4)
-            r = index(rem, "-->")
-            if (r == 0) { inhtml = 1; break }
-            rem = substr(rem, r + 3)
-          }
-          next
-        }
-        if (match($0, /^ {0,3}`+/) || match($0, /^ {0,3}~+/)) {
-          seg = substr($0, RSTART, RLENGTH)
-          sub(/^ +/, "", seg)
-          mchar = substr(seg, 1, 1)
-          mlen = length(seg)
-          rest = substr($0, RSTART + RLENGTH)
-          if (mlen >= 3) {
-            if (!infence) {
-              # opening fence; a backtick info string must not contain a backtick
-              if (!(mchar == "`" && rest ~ /`/)) { infence = 1; fchar = mchar; flen = mlen; next }
-            } else if (mchar == fchar && mlen >= flen && rest ~ /^[ \t]*$/) {
-              infence = 0; next
-            }
-          }
-        }
-        if (!infence && index($0, h) == 1) { found = 1; exit }
-        if (!infence) {
-          rem = $0
-          while ((q = index(rem, "<!--")) > 0) {
-            rem = substr(rem, q + 4)
-            r = index(rem, "-->")
-            if (r == 0) { inhtml = 1; break }
-            rem = substr(rem, r + 3)
-          }
-        }
-      }
+    rendered_lines - | awk -v h="$heading" '
+      index($0, h) == 1 { found = 1; exit }
       END { exit !found }
     '
   }

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -77,6 +77,72 @@ stale_count="$(printf '%s\n' "$out" | grep -c 'STALE BASELINE')"
 if [[ $rc -ne 0 && "$stale_count" == "1" ]]; then ok "stale baseline entry fails --check (reported exactly once)"; else fail "stale baseline: rc=$rc count=$stale_count out='$out'"; fi
 rm -rf "$repo"
 
+# ------------------- --check reverse parity (#2131) ----------------------
+# The direction no other mode covers: a `## [x.y.z]` heading the manifest never
+# reached. --check-bump fires only on a CHANGED manifest version and
+# --check-order is satisfied by a correctly ordered list, so a release note
+# written ahead of its bump reached main unseen.
+
+# newest heading EQUALS the manifest version -> passes
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check >/dev/null 2>&1); then ok "newest heading equal to the manifest version passes --check"; else fail "equal newest heading wrongly failed"; fi
+rm -rf "$repo"
+
+# manifest ABOVE the newest heading -> passes: a bump with no consumer-visible
+# change need not write a release note. Locks the check to one direction.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.1.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check >/dev/null 2>&1); then ok "manifest above the newest heading passes --check (a bump need not write a note)"; else fail "manifest-ahead wrongly failed"; fi
+rm -rf "$repo"
+
+# SYNTHETIC AHEAD-OF-MANIFEST: the docs-hygiene shape — a `## [0.9.7]` entry
+# above a 0.9.6 manifest -> fails, naming both versions.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 0.9.6 yes
+printf '# Changelog\n\n## [0.9.7]\n\n## [0.9.6]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"CHANGELOG AHEAD OF MANIFEST"*"alpha"* && "$out" == *"0.9.7"* && "$out" == *"0.9.6"* ]]; then ok "a heading above the manifest version fails --check (synthetic #2131 shape caught)"; else fail "ahead-of-manifest not caught: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# NUMERIC, NOT LEXICAL: 0.9.0 sorts above 0.10.0 as a string. A manifest at
+# 0.10.0 with a 0.9.0 heading must pass, not red-line.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 0.10.0 yes
+printf '# Changelog\n\n## [0.9.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check >/dev/null 2>&1); then ok "reverse parity compares numerically, not lexically (0.10.0 manifest, 0.9.0 heading)"; else fail "lexical comparison leaked into --check"; fi
+rm -rf "$repo"
+
+# UNBRACKETED heading form: the shared extractor reads `## 1.1.0 — date` too, so
+# dropping the brackets cannot smuggle a heading past the reverse check.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## 1.1.0 — 2026-08-10\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"CHANGELOG AHEAD OF MANIFEST"*"alpha"* ]]; then ok "an unbracketed heading above the manifest is still caught"; else fail "unbracketed ahead-heading missed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# A changelog with no version heading at all has nothing to compare -> passes.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\nNo releases yet.\n' >"$repo/plugins/alpha/CHANGELOG.md"
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check >/dev/null 2>&1); then ok "a changelog with no version heading passes --check"; else fail "heading-less changelog wrongly failed"; fi
+rm -rf "$repo"
+
+# NON-SEMVER MANIFEST VERSION: must refuse loudly (exit 2) rather than feed
+# garbage to the arithmetic sort key, same as --check-bump.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.two.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"non-SemVer"*"1.two.0"* ]]; then ok "--check refuses a non-SemVer manifest version loudly (exit 2)"; else fail "--check did not refuse malformed version: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
 # ============================ --check-bump (diff) =========================
 
 # version changed AND changelog has the new version's entry -> passes

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -143,6 +143,66 @@ rc=$?
 if [[ $rc -eq 2 && "$out" == *"non-SemVer"*"1.two.0"* ]]; then ok "--check refuses a non-SemVer manifest version loudly (exit 2)"; else fail "--check did not refuse malformed version: rc=$rc out='$out'"; fi
 rm -rf "$repo"
 
+# ...and refuses it EVEN WITH NO HEADING to compare against: an uncomparable
+# manifest version is a defect in its own right, so the guard must not hide
+# behind the presence of a release note.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.two.0 yes
+printf '# Changelog\n\nNo releases yet.\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"non-SemVer"*"1.two.0"* ]]; then ok "--check refuses a non-SemVer manifest version with a heading-less changelog too"; else fail "malformed version rode through behind a missing heading: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# SEMVER BUILD METADATA above the manifest -> caught. Manifests and --check-bump
+# both accept `1.0.1+build.1`, so a heading extractor that dropped the tail would
+# leave exactly that class unchecked — a gate that silently checks nothing.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.1+build.1]\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -ne 0 && "$out" == *"CHANGELOG AHEAD OF MANIFEST"*"1.0.1+build.1"* ]]; then ok "a build-metadata heading above the manifest is caught"; else fail "build-metadata heading slipped past the reverse check: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# ...and the matching manifest passes: the tail is stripped before comparing, so
+# an equal-core pair is not a false failure.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.1+build.1 yes
+printf '# Changelog\n\n## [1.0.1+build.1]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check >/dev/null 2>&1); then ok "a build-metadata heading equal to the manifest passes --check"; else fail "equal build-metadata pair wrongly failed"; fi
+rm -rf "$repo"
+
+# FENCED EXAMPLE: a column-zero heading with a high version inside a ``` block is
+# not rendered markdown, so it must not be read as the newest release. Without
+# fence tracking this is a false FAIL in a required gate with no baseline escape.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+# shellcheck disable=SC2016  # single quotes are deliberate: the backtick fence and \n are literal changelog bytes
+printf '# Changelog\n\nHeadings look like this:\n\n```\n## [9.9.9]\n```\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a fenced example heading is not read as the newest release"; else fail "fenced example wrongly red-lined --check: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# HTML-COMMENT EXAMPLE: same, inside a multi-line <!-- --> block.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n<!--\n## [9.9.9]\n-->\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a heading inside an HTML comment is not read as the newest release"; else fail "commented heading wrongly red-lined --check: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# ...and the same suppression applies to --check-order, which reads changelogs
+# through the same tracker: a fenced out-of-order example must not be misordered.
+repo="$(mk_repo)"
+mk_plugin "$repo" alpha 1.0.0 yes
+# shellcheck disable=SC2016  # single quotes are deliberate: the backtick fence and \n are literal changelog bytes
+printf '# Changelog\n\n## [2.0.0]\n\n```\n## [0.1.0]\n```\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-order >/dev/null 2>&1); then ok "a fenced example heading is invisible to --check-order too"; else fail "fenced example wrongly red-lined --check-order"; fi
+rm -rf "$repo"
+
 # ============================ --check-bump (diff) =========================
 
 # version changed AND changelog has the new version's entry -> passes


### PR DESCRIPTION
Closes #2131

## Summary

`scripts/check-changelog-parity.sh` reasoned about the manifest/changelog pair in one direction
only, so a `## [X.Y.Z]` heading naming a version the manifest never reached passed every mode.
`--check-bump` fires only when a manifest version CHANGED; `--check-order` is satisfied by any
correctly ordered heading list. `docs-hygiene` reached `main` documenting a `0.9.7` the manifest
went `0.9.6 -> 0.10.0` straight past — 63 plugins' worth of bumping in #2104 hit the gap once, and
only by accident.

## Fix

- `--check` — already the static repo-wide invariant — now also asserts that a plugin's newest
  changelog heading is at or below its manifest `version`. A manifest ABOVE the newest heading
  stays legal: a bump with no consumer-visible change need not write a release note. No fourth
  mode, so the CI job gains no step.
- The heading extractor `--check-order` already carried is factored into `changelog_versions()`
  and shared, so the two directions of the parity pair cannot read a changelog differently. It
  matches the bracketed and unbracketed forms alike — and the SemVer `+build`/`-prerelease` tail
  that manifests and `--check-bump` both accept — so neither dropping the brackets nor carrying a
  build tail can smuggle a heading past the new check.
- **All three modes now read changelogs through one `rendered_lines()` tracker** — the CommonMark
  fence and HTML-comment tracking `--check-bump`'s `has_heading` had spent 40 lines of awk
  establishing. A column-zero `## [9.9.9]` shown as an *example* is not a release in any mode.
  Without this, a fail-closed gate with no baseline escape hatch would hard-FAIL on a documented
  example. `has_heading` collapses to a fixed-string match over that output, so the modes cannot
  drift.
- A non-SemVer manifest version refuses loudly (exit 2) instead of reaching the arithmetic sort
  key — the posture `--check-bump` already takes — and the guard runs for every plugin that keeps
  a changelog, not only one that already has a heading to compare against.
- The check lands **fail-closed with no baseline entry**: all 63 versioned plugins on `main`
  satisfy it today (probed with the shipped matcher, not an approximation of it).
- `plugins/docs-hygiene/CHANGELOG.md`'s orphan `## [0.9.7]` entry is folded verbatim under
  `## [0.10.0]`, which is the version consumers actually received it in. The manifest history
  confirms the orphan: `86406fbb` 0.9.6 -> `a013d204` 0.10.0, never 0.9.7.

Note the reverse check compares only the NEWEST heading. An older heading naming a version the
manifest never took is invisible from the tree alone — but it can only get there by first being
the newest, which this catches in the change set that writes it.

## Test plan

- `bash scripts/check-changelog-parity.test.sh` — `PASS=55 FAIL=0`, with thirteen new cases:
  equal passes, manifest-ahead passes, the synthetic #2131 shape fails naming both versions,
  numeric-not-lexical, an unbracketed ahead-heading is caught, a build-metadata ahead-heading is
  caught, an equal build-metadata pair passes, a heading-less changelog passes, a non-SemVer
  manifest exits 2 both with and without a heading present, and a fenced or HTML-commented
  example heading is invisible to `--check` and `--check-order` alike.
- The pre-existing `--check-bump` fence, mismatched-delimiter, non-closing-fence, and
  HTML-comment cases pass unchanged — that is the evidence the `has_heading` refactor onto the
  shared tracker is faithful rather than merely green.
- `scripts/check-changelog-parity.sh --check` — passes across all 63 versioned plugins.
- `scripts/check-changelog-parity.sh --check-order` — passes across all 73 changelogs.
- `shellcheck --rcfile=.shellcheckrc` on both scripts — clean. `shfmt -d` — clean; this also
  corrects a pre-existing `shfmt -d` diff (stray whitespace in the `head_commit` condition).
- `bash scripts/check-shell-portability.test.sh` and `scripts/check-shell-portability.sh
  origin/main` — both green.
- `markdownlint-cli2` on the changed CHANGELOG — 0 issues.
- `--check-bump` is not exercised by this PR's own diff by design: it scopes on the MANIFEST path
  and this change set touches no plugin manifest.

## Review findings addressed

All three bot findings on the first commit were real, and all three were latent rather than live —
probed across all 73 tracked changelogs, none carries a fenced, HTML-commented, or build-tailed
version heading today. Fixed in `7220f43b` rather than deferred, because each one makes a
fail-closed required gate either check nothing or fail wrongly:

- **Codex, `check-changelog-parity.sh:138`** — SemVer suffix headings dropped by the extractor.
  Fixed; the tail is admitted and stripped before comparison.
- **Codex, `check-changelog-parity.sh:204`** — fenced / HTML-commented example headings read as
  real releases. Fixed by hoisting `has_heading`'s tracker into a shared `rendered_lines()` that
  every mode reads through.
- **Claude, `check-changelog-parity.sh:210`** — the non-SemVer guard was contingent on a heading
  being present. Fixed by hoisting it out of that branch, with a test for the untested
  malformed-version + heading-less combination.

## Related

- Refs #2104 — the all-plugin change that surfaced the gap.
- Refs #2022 — the listing-budget work whose citation the folded `0.9.7` entry carries.
