### PR TITLE
fix(ci): stop has_heading's early exit from SIGPIPE-failing the parity gate

### DIFF
--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -429,10 +429,19 @@ for manifest in "${manifests[@]}"; do
   # — or falsely pre-exists — the release entry, and SemVer metacharacters
   # (1.0.1+build.1) never leak into a regex. A same-line "<!-- ## [x] -->" can
   # never match anyway (the heading is not at column one).
+  #
+  # The reader must consume ALL of its input, never exit on first match: this
+  # script runs under pipefail, and a reader that exits while rendered_lines is
+  # still writing kills the writer with SIGPIPE (exit 141), which pipefail then
+  # reports as the pipeline's failure — a FOUND heading misread as missing. A
+  # real changelog puts the newest heading near the top of a file larger than
+  # one stdio buffer, exactly the shape that loses the race (#2130 failed CI on
+  # a correctly documented bump); the small fixtures in the test suite fit in
+  # one buffer and can never trip it.
   heading="## [${head_version}]"
   has_heading() {
     rendered_lines - | awk -v h="$heading" '
-      index($0, h) == 1 { found = 1; exit }
+      index($0, h) == 1 { found = 1 }
       END { exit !found }
     '
   }

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -217,6 +217,47 @@ git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
 if (cd "$repo" && bash scripts/check-changelog-parity.sh --check-bump "$base" >/dev/null 2>&1); then ok "bump + '## [x.y.z]' entry passes --check-bump"; else fail "bump+entry wrongly failed"; fi
 rm -rf "$repo"
 
+# LARGE CHANGELOG (SIGPIPE regression, #2130): the new entry sits near the top
+# of a changelog far larger than the pipe buffer — the shape every mature
+# changelog has. A has_heading reader that exits on first match kills
+# rendered_lines mid-write with SIGPIPE, and pipefail turns the FOUND heading
+# into a false UNDOCUMENTED BUMP. The small fixtures above fit in one buffer
+# and cannot catch this; the padding here (~260 KB) exceeds the pipe CAPACITY,
+# so against an early-exiting reader the writer blocks mid-write and the
+# SIGPIPE is deterministic, not a winnable race — but only under gawk (the CI
+# runner's awk): mawk survives the closed pipe and passes regardless, so on a
+# machine where `awk` resolves to mawk this guard would silently prove
+# nothing. The run below therefore FORCES gawk via a PATH shim, and skips
+# loudly when gawk is absent rather than reporting a pass that exercised
+# nothing. The fix itself is engine-independent — the reader consumes to EOF,
+# so no writer can ever take SIGPIPE under any awk.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+{
+  printf '# Changelog\n\n## [1.1.0]\n\n'
+  for ((i = 0; i < 4000; i++)); do
+    printf '%s\n' '- a release note line padding the file well past any pipe or stdio buffer'
+  done
+  printf '\n## [1.0.0]\n'
+} >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
+if command -v gawk >/dev/null 2>&1; then
+  mkdir -p "$repo/bin"
+  printf '#!/bin/sh\nexec gawk "$@"\n' >"$repo/bin/awk"
+  chmod +x "$repo/bin/awk"
+  out="$(cd "$repo" && PATH="$repo/bin:$PATH" bash scripts/check-changelog-parity.sh --check-bump "$base" 2>&1)"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then ok "large changelog with the new entry near the top passes under gawk (no SIGPIPE misread under pipefail)"; else fail "large-changelog bump wrongly failed under gawk: rc=$rc out='$out'"; fi
+else
+  echo "SKIP: SIGPIPE regression fixture requires gawk; under mawk an early-exiting reader survives the closed pipe, so without gawk this case cannot distinguish fixed from unfixed." >&2
+fi
+rm -rf "$repo"
+
 # SYNTHETIC MALFORMED ENTRY: version present but as an UNBRACKETED heading
 # (## 1.1.0) -> FORMAT error naming the found heading, NOT "UNDOCUMENTED BUMP".
 repo="$(mk_repo)"


### PR DESCRIPTION
Closes #2158

## Problem

`changelog-parity-gate` failed PR #2130 twice with `UNDOCUMENTED BUMP: markdown-format went 0.11.3 -> 0.11.4 ...` even though `plugins/markdown-format/CHANGELOG.md` carries `## [0.11.4]` at line 6, column one — a required merge gate confidently asserting the opposite of the truth, while the same command passed locally. PR #2135 then failed the same gate on **every one of its sixteen bumped plugins** (smallest flagged changelog: 15 KB). The regression landed on `main` at 15:19:19Z in #2154 and blocks **every PR that bumps a plugin whose changelog exceeds roughly one stdio buffer (~4 KB)** — which newest-first ordering makes essentially all of them.

## Blast radius — precisely

Confined to the `--check-bump` path: `has_heading` is defined inside that branch and called in exactly two places (the head-side check and the base-side `git show "$base:$changelog" | has_heading`). `--check` and `--check-order` read changelogs through `changelog_versions`, whose `grep -oE` stages drain stdin with no early exit and cannot take SIGPIPE. So the failure class is exactly "PRs that bump a manifest version"; both failing call sites go through the one function this PR fixes.

## Root cause

`has_heading` runs a pipeline under `set -o pipefail` whose reader `exit`s on first match:

```bash
rendered_lines - | awk -v h="$heading" 'index($0, h) == 1 { found = 1; exit } END { exit !found }'
```

The newest heading sits near the top, so the reader exits while `rendered_lines` is still writing; the writer dies of SIGPIPE (141) and pipefail reports the pipeline — the FOUND heading — as a failure. Reproduced deterministically in an `ubuntu:24.04` container at the exact CI merge commit `ba4b72fb`: `PIPESTATUS=141 0` and the byte-identical CI error under **gawk** (what the `ubuntu-24.04` runner resolves `/usr/bin/awk` to — gawk outranks mawk in the alternatives system, and only the gawk mechanism explains CI failing 15 KB files). mawk survives the closed pipe and passes at every size tested, and Windows/MSYS process timing lets the writer finish first — which is why the failure existed only in CI. The suite's 55 fixtures all fit in one buffer — hence `PASS=55` in the very job that then failed on the real file.

## Fix

The reader consumes to EOF; `END { exit !found }` decides. Correct **by construction**: no reader exits early, so no writer can ever take SIGPIPE, under any awk — the failure is impossible, not rarer. Chosen over restoring the pre-#2154 single-awk form because it preserves the one-tracker-three-modes property (`rendered_lines` shared by all modes, so they cannot drift). Both `has_heading` call sites are covered (same function); the script has no other early-exiting reader downstream of a pipe (`changelog_versions` greps drain stdin; the `grep -m1` format probe reads a file directly, not a pipe).

## Regression fixture — with its fails-against-unfixed proof, per engine

New `--check-bump` case: ~260 KB changelog, new `## [1.1.0]` entry near the top, expected pass. 260 KB deliberately exceeds the 64 KB pipe **capacity**, so against the unfixed script the writer blocks mid-write and the SIGPIPE is deterministic, not a winnable race.

| script | gawk | mawk |
|---|---|---|
| unfixed | **FAIL=1** (exact #2130 error text) | PASS (mawk survives the closed pipe) |
| fixed | 56/56 | 56/56 |

The fixture's guard is therefore **engine-conditional — it discriminates only where `awk` resolves to gawk**, which is what the runner resolves; this is recorded in the fixture comment. The fix itself is engine-independent. Windows local: 56/56 fixed.

## Related

- #2158 — the defect issue this closes
- #2154 — shipped the early-exit reader; this is its first contact with a production-size changelog
- #2130, #2135, #2155 — blocked by this regression; once this lands, their recomputed merge refs carry the fixed gate and need no branch-side changes
- Known adjacent gap, tracked separately and deliberately NOT fixed here: the gate cannot see a **deleted** predecessor heading — a change set that renames the top heading in place (rather than adding a new one above it) destroys a shipped release section while `--check` and `--check-order` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)