### PR TITLE
fix(songwriting): adjudicate meter and prosody against Essential Guide to Lyric Form and Structure chapter 3

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -69,6 +69,13 @@ answers reach this public repository.
   definition covered only stressed-on-weak while its own worked example
   diagnoses an unstressed syllable riding a strong beat as a greedy spot. The
   definition now covers both directions. Pre-existing; surfaced by review.
+- **The skill handler still called "too cold" the reverse of greed.** After the
+  frame split above, `skills/meter-prosody/SKILL.md` introduced too-cold as "the
+  reverse case," reasserting the single-axis reading this release exists to
+  remove — in the one file that drives behavior rather than documents it. Too
+  cold is **orthogonal**, not a mirror image: the stresses land correctly and no
+  stress check of any kind finds it. Now stated as an explicit negative, since
+  merely softening the connective leaves the scan-for-it instinct in place.
 - **Two categorical claims had been softened into hedges.** Three-syllable words
   with middle primary stress have **no** secondary stress, not "may be no"; words
   of four or more syllables **always** carry secondary stress, not "normally."

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -53,17 +53,22 @@ answers reach this public repository.
   fixed a different defect in this same section and the overreach survived.
   Readers wanting melody- or harmony-specific stability criteria are now pointed
   at `stable-unstable-meta.md`, which genuinely carries them.
-- **Three files defined "greedy spot" three different ways.** The term
-  originates in this chapter and is **one-directional**: greed is putting
-  stressed syllables into unstressed positions — the too-hot failure only. Pat
-  names the opposite error separately and never calls it greed. `meter.md` said
-  greedy spots are "usually too-hot or too-cold failures"; `audit-checklist.md`
-  checked for both directions under a heading citing this chapter; and
-  `skills/meter-prosody/SKILL.md` gave a third definition attributable to no
-  source at all, "too many syllables for the melodic slot." All three corrected.
-  `prosody.md`'s two-directional definition is **scoped rather than rewritten** —
-  it is sourced to patpattison.com, which remains unaudited — with a note that
-  the 1991 sense is narrower and that the two failures take different fixes.
+- **"Greedy spot" was defined inconsistently across five files, and its scope
+  turns on a frame nothing stated.** Matching a lyric to a *model lyric*, greed
+  is **one-directional** — stressed syllables in unstressed positions, the
+  too-hot failure only; Pat names the opposite error separately as "too cold"
+  and never calls it greed. Matching a lyric to a *melody*, **either** direction
+  is a greedy spot, since a stressed syllable on a weak beat and an unstressed
+  syllable riding a strong one both fight the bar. Three distinct failures,
+  three distinct fixes — and too cold is caught by no stress check at all.
+  `meter.md`, `prosody.md`, `audit-checklist.md`, `lyric-melodic-roadmaps.md`,
+  and `skills/meter-prosody/SKILL.md` now each name their frame.
+  `skills/meter-prosody/SKILL.md` had also carried a definition attributable to
+  no source, "too many syllables for the melodic slot."
+- **`lyric-melodic-roadmaps.md` contradicted itself on the same term.** Its
+  definition covered only stressed-on-weak while its own worked example
+  diagnoses an unstressed syllable riding a strong beat as a greedy spot. The
+  definition now covers both directions. Pre-existing; surfaced by review.
 - **Two categorical claims had been softened into hedges.** Three-syllable words
   with middle primary stress have **no** secondary stress, not "may be no"; words
   of four or more syllables **always** carry secondary stress, not "normally."

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,128 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.4]
+
+A source-fidelity pass over *Essential Guide to Lyric Form and Structure*
+(1991) Chapter 3 (Rhythm), read in full with **all 59 of its figures**, against
+`meter.md` and `prosody.md`. This chapter is the book's densest and it argues
+almost entirely in page scans, so the figures are where nearly every finding
+below came from. Paraphrase only; no chapter prose, example lyrics, or exercise
+answers reach this public repository.
+
+### Fixed
+
+- **`meter.md`'s image inventory said this chapter has "no linked page-scan
+  images." It has 59 references across 56 unique figures.** This is the **third**
+  chapter whose inventory carried that exact falsehood, after Chapter 6 (37
+  figures) and Chapter 5 (32) in 0.8.3. Every scansion, all three Paradigms, the
+  4/4 bar settings, and all four filled-in Structural Pentad worksheets exist
+  only as images. The two corrections immediately below were invisible to a
+  text-only reader and both survived a full prior pass because of that one line.
+- **The scansion worked example marked the wrong number of stresses.** "When I
+  got home the house was dark" was scanned with "got" stressed, giving four
+  stresses. Pat's figure marks "when," "I," and "got" all unstressed: **three
+  stresses**. The code block also contradicted the file's own prose two lines
+  below it, which already described "got" as a grey-area syllable. This is the
+  model scansion the skill hands users, so it was teaching the error.
+- **"Too cold" was defined as a stress failure. It is not a stress failure at
+  all.** `meter.md` had it as "an unstressed syllable where the structure wants
+  stress." Pat's too-cold example preserves the model's stress map exactly; what
+  fails is that the important positions are filled with semantically empty
+  words. The two Goldilocks states test **two independent things** — the stress
+  map, and what stands on each strong position — and "just right" requires both.
+  A rewrite can scan perfectly and still be dead, which is precisely the failure
+  a stress-only audit cannot see. `meter.md` already stated this correctly in its
+  pattern-matching section; the later section contradicted it. **Fifth file found
+  with the correct-early / wrong-late duplication shape**, after `song-forms.md`,
+  `co-writing.md`, and `phrasing.md`.
+- **The emitted Pentad worksheet offered values that are not in Pat's
+  worksheet.** Balance was `balanced | unbalanced` where the source's closed list
+  is **symmetrical | asymmetrical**, and Closure offered a third value,
+  `leans forward`, where the source is **binary: closed | open**. The file's own
+  summary section had both right; the copy-paste block users actually receive had
+  both wrong. Value lists are now stated as closed lists, with a filled-in table
+  for all three Paradigms.
+- **The Pentad's cross-domain claim generalized past its evidence — in a section
+  a previous release had already corrected.** Pat names three surfaces:
+  rhythmic, rhyme, and *musical*. `meter.md` split the third into "melodic
+  structure" and "harmonic structure (chord pattern stability per pentad
+  property)," inventing per-surface criteria that are not in the source. 0.8.2
+  fixed a different defect in this same section and the overreach survived.
+  Readers wanting melody- or harmony-specific stability criteria are now pointed
+  at `stable-unstable-meta.md`, which genuinely carries them.
+- **Three files defined "greedy spot" three different ways.** The term
+  originates in this chapter and is **one-directional**: greed is putting
+  stressed syllables into unstressed positions — the too-hot failure only. Pat
+  names the opposite error separately and never calls it greed. `meter.md` said
+  greedy spots are "usually too-hot or too-cold failures"; `audit-checklist.md`
+  checked for both directions under a heading citing this chapter; and
+  `skills/meter-prosody/SKILL.md` gave a third definition attributable to no
+  source at all, "too many syllables for the melodic slot." All three corrected.
+  `prosody.md`'s two-directional definition is **scoped rather than rewritten** —
+  it is sourced to patpattison.com, which remains unaudited — with a note that
+  the 1991 sense is narrower and that the two failures take different fixes.
+- **Two categorical claims had been softened into hedges.** Three-syllable words
+  with middle primary stress have **no** secondary stress, not "may be no"; words
+  of four or more syllables **always** carry secondary stress, not "normally."
+- **`demo-review.md` attributed the Pentad to `five-compositional-elements.md`.**
+  That is the two-lists confusion 0.8.2 fixed in `meter.md`; it survived here.
+  The Pentad (balance, pace, flow, closure, type of closure) lives in `meter.md`;
+  the Elements are a different five-item list naming the levers.
+- **A header note claimed Pat has no notation for unstressed syllables.**
+  `meter.md` stated that "Pat's own source notation uses only `/` and `//`" and
+  that the `u` marker "is not in Pat's text." Pat marks unstressed syllables with
+  a breve throughout, and this chapter's exercises ask for that "slight cup" over
+  the vowel by name. `u` is an ASCII stand-in for it, not an addition.
+
+### Added
+
+- **Phrase length measured in stressed syllables now shows the inversion.** The
+  file said an extra weak syllable "may not change the structural weight," which
+  understates the source: an 8-syllable / 4-stress phrase is **longer** than a
+  9-syllable / 3-stress phrase. Raw syllable count can rank a pair backwards,
+  which is the entire reason this method counts stresses.
+- **The rule for counting secondary stress when scanning.** A secondary stress
+  counts as a stress. Without it the file's own common-meter example miscounts as
+  three stresses instead of four, and the paradigms break on any multi-syllable
+  word.
+- **The rule that unstressed pickups do not change the pattern.** Anacrusis at
+  the head of a line leaves a 4/3/4/3 stanza at 4/3/4/3.
+- **The third deceleration case.** The file covered only triple-to-duple. *Any*
+  reduction in unstressed syllables decelerates, including dropping them entirely
+  so stresses fall adjacent. The single mechanism behind both directions — strong
+  stresses hold their musical positions while the space between them crowds or
+  opens — is now stated once, where the effect is described.
+- **Paradigm 1 stated in triples alongside duples**, which is the cleanest proof
+  that the paradigms are defined by stress count rather than syllable count, and
+  is what the chapter's own exercises drill.
+- **The one-word demonstration inside the common-meter example.** Lengthening
+  line two to four stresses makes the first two lines balanced and stoppable;
+  leaving it at three is what makes the form move. This claim exists only in a
+  figure — the surrounding prose is a dangling reference to it — and it is also
+  the bridge to Paradigm 2.
+- **A note that Paradigm 3 still closes.** Deception is a property of the type
+  row, not the closure row, and it works only because the resolving phrase length
+  is already present in the structure.
+
+### Notes
+
+- **Verified, no change needed:** the conventional-stress examples
+  (`incision`, `turbulent`, `understand`, `relinquish`) all match their figures,
+  and Chapter 3 does own Exercises 8-17 as `meter.md` claimed.
+- **Two open probes were aimed at the wrong chapter.** "Can't Fight This
+  Feeling" does not appear in Chapter 3; it appears in Chapters 1, 5, and 7, and
+  Chapter 1's use is a phrase-count argument, not the stress-pattern claim
+  `section-building.md` makes. "Years" appears in Chapters 2 and 5, not 3, so
+  `form.md`'s composite-balance claim must be checked against Chapter 5. Both
+  left unadjudicated rather than hedged.
+- `meter.md` is now a **third** file carrying duplicated parallel treatments of
+  the same material — two Pentad sections and two Paradigm sets. They were
+  reconciled here rather than folded together, since the duplication itself is
+  scoped as a separate restructuring follow-up alongside `song-forms.md` and
+  `phrasing.md`. That duplication is what allowed the worksheet and the summary
+  to disagree about Pentad values in the first place.
+
 ## [0.8.3]
 
 A source-fidelity pass over *Essential Guide to Lyric Form and Structure*

--- a/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
+++ b/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
@@ -64,8 +64,9 @@ Run for any line under consideration for locking.
 **Stress & meter (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3, *Songwriting Without Boundaries* (2011), Challenge 4)**
 
 - [ ] every stressed syllable lands on a strong beat
-- [ ] no greedy spots — no stressed syllable forced into a position the pattern leaves unstressed
-- [ ] the strong positions carry the line's *important* words, not filler — a line can scan correctly and still be too cold
+- [ ] no stressed syllable forced into a position the pattern or the bar leaves weak — this is "greed" in the 1991 sense
+- [ ] no unstressed syllable riding a strong beat — the reverse alignment error, equally a distortion of natural speech
+- [ ] the strong positions carry the line's *important* words, not filler — a line can pass both checks above and still be too cold
 - [ ] "into" handled per the ínto rule (*Songwriting Without Boundaries* (2011), Challenge 4) — not intó
 - [ ] compound words primary-stressed on first syllable
 - [ ] grey-area stress flagged, not silently resolved

--- a/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
+++ b/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
@@ -64,7 +64,8 @@ Run for any line under consideration for locking.
 **Stress & meter (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3, *Songwriting Without Boundaries* (2011), Challenge 4)**
 
 - [ ] every stressed syllable lands on a strong beat
-- [ ] no greedy spots (unstressed forced to a strong beat, or stressed forced to weak)
+- [ ] no greedy spots — no stressed syllable forced into a position the pattern leaves unstressed
+- [ ] the strong positions carry the line's *important* words, not filler — a line can scan correctly and still be too cold
 - [ ] "into" handled per the ínto rule (*Songwriting Without Boundaries* (2011), Challenge 4) — not intó
 - [ ] compound words primary-stressed on first syllable
 - [ ] grey-area stress flagged, not silently resolved

--- a/plugins/songwriting/context/pat-pattison/research/demo-review.md
+++ b/plugins/songwriting/context/pat-pattison/research/demo-review.md
@@ -183,7 +183,11 @@ becomes the input for the next session's revision.
 ## Cross-references
 
 - `workflows.md` — Scenario 2 (existing song revision), Scenario 6 (diagnose without rewrite)
-- `five-compositional-elements.md` — Pentad diagnostic per section
+- `five-compositional-elements.md` — the five levers per section (number of
+  lines, length of lines, rhythm, rhyme scheme, rhyme type)
+- `meter.md` — the Structural Pentad, which is a different five-item list:
+  balance, pace, flow, closure, type of closure. The Elements name the levers;
+  the Pentad names the effects they produce
 - `stable-unstable-meta.md` — section-level prosody scan
 - `cliche.md` — cliche taxonomy
 - `verse-development.md` — travelogue test, power positions

--- a/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
+++ b/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
@@ -107,10 +107,14 @@ Risk: overuse becomes a tic.
 
 ## Greedy spots and roadmap mismatch
 
-A greedy spot is a stressed syllable that lands on a weak musical beat,
-stealing emphasis from where the music wants it. Greedy spots are usually
-caused by the same root problem as a roadmap mismatch: lyric stress
-disagrees with melodic stress.
+A greedy spot is a stressed syllable that lands on a weak musical beat, or an
+unstressed syllable riding a strong one. Either direction steals emphasis from
+where the music wants it. Greedy spots are usually caused by the same root
+problem as a roadmap mismatch: lyric stress disagrees with melodic stress.
+
+Both directions belong in this definition: the worked example below diagnoses
+the unstressed-on-strong case, and an earlier revision covered only the
+stressed-on-weak one, leaving the two at odds.
 
 When you find a greedy spot, check whether the surrounding lyric phrase
 has its boundary in the wrong place. Often fixing the roadmap fixes the

--- a/plugins/songwriting/context/pat-pattison/research/meter.md
+++ b/plugins/songwriting/context/pat-pattison/research/meter.md
@@ -998,9 +998,16 @@ Check the stress map first, then ask separately what is standing on each strong
 position.
 
 Use the Goldilocks frame when running pattern-match audits per line. Note the
-scope on the vocabulary: in this chapter **greed is one-directional** — it is
-the too-hot failure only. Pat names the too-cold failure separately and never
-calls it greed.
+scope on the vocabulary: **when matching a lyric to a model lyric, greed is
+one-directional** — it is the too-hot failure only, and Pat names the too-cold
+failure separately without ever calling it greed.
+
+That scope does not travel to melody setting. When the lyric is being matched
+to a *melody* rather than to another lyric, a mismatch in either direction is a
+greedy spot — a stressed syllable on a weak beat, or an unstressed syllable
+riding a strong one — because either one fights the bar. See
+[prosody](prosody.md) "greedy spots" for that frame. Too cold is a third thing
+again, and no stress check of any kind will catch it.
 
 ## Pitch-based stress model (*Songwriting Without Boundaries* (2011), Challenge 4)
 

--- a/plugins/songwriting/context/pat-pattison/research/meter.md
+++ b/plugins/songwriting/context/pat-pattison/research/meter.md
@@ -5,8 +5,9 @@ Pat Pattison - *Writing Better Lyrics* (2009), Chapter 14-17.
 Pat Pattison - *Songwriting Without Boundaries* (2011), Challenge 4.
 
 Notation: `/` = primary stress, `//` = secondary stress, `u` = unstressed.
-Pat's own source notation uses only `/` and `//`; the `u` marker is added here
-as a scansion convenience and is not in Pat's text.
+Pat's own source notation marks unstressed syllables too, with a breve — the
+"slight cup" over the vowel that Chapter 3's exercises ask for by name. `u` is
+this file's ASCII stand-in for that cup, not an addition to Pat's system.
 
 Chapter 3's opening epigraph sets the duple/triple movement the chapter unpacks:
 
@@ -22,8 +23,15 @@ The whole chapter is about hearing that contrast and using it deliberately.
 
 ## Image inventory
 
-- *Songwriting: Essential Guide to Lyric Form and Structure*, Chapter 3: no linked
-  page-scan images.
+- *Songwriting: Essential Guide to Lyric Form and Structure*, Chapter 3: **59
+  figure references, 56 unique**, running `image_rsrc2YZ.jpg` through
+  `image_rsrc30P.jpg` (`image_rsrc30P.jpg` is a closure arrow, used four times).
+  This chapter argues *in* its figures: every scansion, all three Paradigms, the
+  4/4 bar settings, and all four filled-in Structural Pentad worksheets exist
+  only as page scans. Earlier revisions of this file recorded "no linked
+  page-scan images" for this chapter, and that one false line is why the
+  too-cold definition and the "When I got home" scansion below both survived a
+  full pass uncorrected.
 - *Writing Better Lyrics*, Chapter 14: `image_rsrcAU7.jpg`, `image_rsrcAU8.jpg`,
   `image_rsrcAU9.jpg`, `image_rsrcAUA.jpg`, `image_rsrcAUB.jpg`.
 - *Writing Better Lyrics*, Chapter 15: no linked page-scan images.
@@ -65,9 +73,15 @@ relinquish:   u / u
 ```
 
 If primary stress is on the first or last syllable of a three-syllable word, the
-opposite end often carries secondary stress. If primary stress is in the middle,
-there may be no secondary stress. Four-syllable and longer words normally carry
-secondary stress.
+opposite end carries secondary stress — and because that secondary is stronger
+than the middle syllable, it is what gives the word its shape. If primary stress
+is on the middle syllable, there is no secondary stress. Words of four or more
+syllables always carry secondary stress.
+
+**When scanning a phrase for its stress count, treat a secondary stress exactly
+like a primary one.** This is what holds "And everywhere that Mary went" at four
+stresses rather than three, and it is why the paradigms below survive contact
+with multi-syllable words instead of miscounting on them.
 
 ## One-syllable words
 
@@ -96,12 +110,18 @@ Worked example:
 
 ```text
 When I got home the house was dark.
-u    u /   /    u   /     u   /
+u    u u   /    u   /     u   /
 ```
 
-"When," "I," and "got" could change under contrast, but "home," "house," and
-"dark" carry the obvious weight. Save musically strong positions for the
-weight-bearing words.
+Three stresses, not four. "When," "I," and "got" are all grey-area syllables
+that could take stress under contrast — "got" if the lights came up a moment
+later, "I" if someone else had been expected home — but the natural reading
+leaves all three unstressed and gives the weight to "home," "house," and "dark."
+
+That asymmetry is the lesson: what the grey syllables *are* stays arguable, and
+what they are *not* does not. They are not the most important syllables in the
+phrase. Start from the syllables that are unarguable and let the rest settle
+around them. Save musically strong positions for the weight-bearing words.
 
 ## Matching patterns
 
@@ -158,14 +178,47 @@ triple setup:      u u / u u /
 duple change:      u / u /
 ```
 
+Deceleration is not only a triple-to-duple move. *Any* reduction in unstressed
+syllables slows the pace, including dropping them entirely so that stresses fall
+adjacent:
+
+```text
+duple setup:       u / u / u / u /
+adjacent stresses: / / / /
+```
+
+One mechanism explains both directions, and it is worth stating plainly because
+it is what makes the effect predictable: the strong stresses hold the same
+musical positions either way. Adding unstressed syllables crowds the space
+between them, demanding shorter notes that move faster. Removing unstressed
+syllables opens that space up, allowing longer notes or rests between them.
+
 Keep rhythmic pace separate from phrase-length speed: rhythm can slow while a
 section still feels pushed forward by phrase count.
 
 ## Stress count vs syllable count
 
 When deciding whether one phrase is longer than another for rhythmic structure,
-count stressed syllables, not raw syllables. An unstressed pickup or extra weak
-syllable may not change the structural weight.
+count stressed syllables, not raw syllables. This is not a rounding convenience.
+The two measures can rank the same pair of phrases in **opposite** directions:
+
+```text
+u / u / u / u /      8 syllables, 4 stresses   <- the LONGER phrase
+u u / u u / u u /    9 syllables, 3 stresses   <- the SHORTER phrase
+```
+
+The four-stress line has one syllable *fewer* and is still the longer phrase;
+set to music, it is the one that extends further. A raw-syllable count ranks
+these backwards — which is the whole reason the stressed-syllable count is the
+measurement this method uses.
+
+Two corollaries follow, and both matter when matching a paradigm:
+
+- **An unstressed pickup does not change the pattern.** The weak syllables
+  opening lines two, three, and four of a common-meter stanza are anacrusis; the
+  stanza is still 4/3/4/3.
+- **A secondary stress counts as a stress**, per
+  [conventional stress](#conventional-stress) above.
 
 If stressed syllables keep the same note length, extra stresses usually extend
 the number of bars. If the stresses are squeezed into the same number of bars,
@@ -176,7 +229,7 @@ the same longer phrase can sound accelerated instead.
 Common Meter alternates four-stress and three-stress phrases:
 
 ```text
-Phrase 1: / u / u / u /   -> motion
+Phrase 1: / u / u / u /
 Phrase 2: / u / u /       -> motion
 Phrase 3: / u / u / u /   -> motion
 Phrase 4: / u / u /       <- closure
@@ -189,6 +242,15 @@ phrases define an eight-bar unit.
 Worked example: Pattison uses "Mary Had a Little Lamb" to show that stopping
 after two lines feels incomplete, and that line three predicts the three-stress
 line needed for line four.
+
+The sharpest move in that demonstration is a one-word edit. Lengthen line two to
+four stresses — "white as whitest snow" rather than "white as snow" — and the
+first two lines become rhythmically balanced and you *can* stop there. Leave
+line two at three stresses and you cannot. The imbalance between four and three
+is the entire engine of the form, and this is the cheapest way to hear it.
+
+That contrast is also the bridge to Paradigm 2 below, which is simply what a
+four-stress second phrase produces once it is carried across all four lines.
 
 ## Common meter as map
 
@@ -514,14 +576,31 @@ close internally. Phrase three repeats phrase one, making the listener expect a
 return of phrase two's length at phrase four.
 
 ```text
-4 stresses -> motion
+4 stresses
 3 stresses -> motion
 4 stresses -> motion
 3 stresses <- expected closure
 ```
 
+Pat's compact framing for why it moves: Paradigm 1 runs `SAME / DIFFERENT /
+SAME ...`, and the unfinished third term is the point. Paradigm 2 runs `SAME /
+SAME / SAME / SAME`, which finishes itself twice.
+
+**The paradigm is defined by stress count, not syllable count.** Pat states
+Paradigm 1 twice — once in duples and once in triples — and both are the same
+paradigm:
+
+```text
+duples:   / u / u / u /   |  triples:  / u u / u u / u u /
+          / u / u /       |            / u u / u u /
+          / u / u / u /   |            / u u / u u / u u /
+          / u / u /       |            / u u / u u /
+```
+
 Exercise use: write content that carries its idea through to the end, because
-the structure has no earlier point of resolution.
+the structure has no earlier point of resolution. Chapter 3's exercises ask for
+one of the three systems in triples specifically, which is the drill that makes
+the stress-count definition stick.
 
 ## Paradigm 2: fragmented
 
@@ -729,15 +808,23 @@ where the natural language contradicts the intended form.
 *Essential Guide to Lyric Form and Structure* (1991), Chapter 3 introduces a five-property framework Pat uses across all
 four books. Every section is described by:
 
-| # | Property | What it answers |
+| # | Property | Values |
 |---|---|---|
-| 1 | Balance | Even or odd count? Matched or unmatched lengths? |
-| 2 | Pace | Constant, accelerating, decelerating? |
-| 3 | Flow | Through-written or fragmented? |
-| 4 | Closure | Closed, leans forward, stays open? |
-| 5 | Type of closure | Expected, deceptive, or unexpected? |
+| 1 | Balance | symmetrical / asymmetrical |
+| 2 | Pace | constant / accelerated / decelerated |
+| 3 | Flow | through-written / fragmented |
+| 4 | Closure | closed / open |
+| 5 | Type of closure | expected / unexpected / deceptive |
 
-> "The Structural Pentad." — Pat (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3 framing)
+These are the value sets from Pat's own worksheet, and they are closed lists.
+Balance is **symmetrical / asymmetrical** — not "balanced / unbalanced," though
+the prose around the worksheet uses that looser wording. Closure is **binary**:
+closed or open. There is no third "leans forward" value; a structure that leans
+forward is an *open* one, and how it leans is what the Flow and Type-of-closure
+rows are for.
+
+Pat's framing is that these are five normal characteristics of *any* structure,
+not a rhythm-only checklist.
 
 Use the Pentad as a single diagnostic per section. Rhythm, rhyme,
 phrase count, phrase length all contribute to all five. The Pentad
@@ -748,12 +835,26 @@ Diagnostic worksheet:
 ```text
 Section: <verse 1 | chorus | etc.>
 
-1. Balance:        <balanced | unbalanced — why>
-2. Pace:           <constant | accelerating | decelerating>
+1. Balance:        <symmetrical | asymmetrical — why>
+2. Pace:           <constant | accelerated | decelerated>
 3. Flow:           <through-written | fragmented>
-4. Closure:        <closed | leans forward | open>
-5. Closure type:   <expected | deceptive | unexpected>
+4. Closure:        <closed | open>
+5. Closure type:   <expected | unexpected | deceptive>
 ```
+
+Filled in for the three paradigms, that worksheet reads:
+
+| | Paradigm 1 | Paradigm 2 | Paradigm 3 |
+|---|---|---|---|
+| Stresses | 4/3/4/3 | 4/4/4/4 | 4/3/4/4 |
+| Balance | symmetrical | symmetrical | **asymmetrical** |
+| Pace | constant | constant | constant |
+| Flow | through-written | **fragmented** | through-written |
+| Closure | closed | closed | closed |
+| Type | expected | expected | **deceptive** |
+
+All three close. What separates them is where the structure rests on the way
+there, and whether the resting place was the one predicted.
 
 The Pentad pairs with the
 [Five Compositional Elements](five-compositional-elements.md). The
@@ -772,8 +873,9 @@ line 2: X X X         (3 stresses)
 line 3: X X X X       (4 stresses)
 line 4: X X X         (3 stresses)
 
+Balance:   symmetrical
 Flow:      through-written
-Closure:   expected
+Closure:   closed, and the type is expected
 Stability: stable
 ```
 
@@ -792,8 +894,9 @@ line 2: X X X X       (4 stresses)
 line 3: X X X X       (4 stresses)
 line 4: X X X X       (4 stresses)
 
+Balance:   symmetrical
 Flow:      fragmented
-Closure:   expected
+Closure:   closed twice — internally at line two, then again at line four
 Stability: stable but blocky
 ```
 
@@ -813,10 +916,18 @@ line 2: X X X         (3 stresses)
 line 3: X X X X       (4 stresses)
 line 4: X X X X       (4 stresses — deceptive)
 
+Balance:   asymmetrical — this is the price of the deception
 Flow:      through-written
-Closure:   deceptive
+Closure:   closed, and the type is deceptive
 Stability: unstable at the closure point
 ```
+
+Note that Paradigm Three still **closes**. Deception is a property of the
+*type* row, not the closure row: the fourth line resolves the system, it just
+resolves it with a length the listener was not braced for. It can do that only
+because the four-stress phrase is already present in the structure — a resolving
+phrase the section had never used would leave the system open instead of
+deceived.
 
 Use Paradigm Three when the last idea must spotlight or unsettle. The
 expectation of a 3-stress close makes the longer line audible.
@@ -865,15 +976,31 @@ Use in revision:
 Pat's memorable framing for stress pattern matching is a three-state
 diagnostic: too hot, too cold, just right.
 
-- **Too hot** — a stressed syllable in a slot that needs to be unstressed.
-  The line pushes harder than it should at that beat. The ear trips.
-- **Too cold** — an unstressed syllable where the structure wants stress.
-  The line loses energy in a hot spot.
-- **Just right** — content word stress + structural strong-beat aligned.
-  The natural reading and the meter agree.
+The three states test **two independent things**, and reading them as one test
+is the standing error here:
 
-Use the Goldilocks frame when running pattern-match audits per line.
-Greedy spots (per `prosody.md`) are usually too-hot or too-cold failures.
+- **Too hot** — *greed*. A stressed syllable is forced into a slot the model
+  leaves unstressed. This is a scansion failure: the stress map itself is wrong.
+  The greedy syllables get buried or sound hurried when set to the original's
+  music, and they lose their emotion on the way.
+- **Too cold** — a **matching stress map filled with the wrong words**. The
+  scansion is correct; every stress lands where the model put one. The failure
+  is that the important positions are occupied by semantically empty
+  words — connectives, filler, and hedges — where the model had meaning
+  carriers. Nothing trips; the section simply stops being worth listening to.
+- **Just right** — **both** conditions met at once: the stresses match, *and*
+  the most important words sit in the same places as the model's most important
+  words.
+
+Too cold is the state a stress-only audit cannot see, which is exactly why it is
+worth naming. A rewrite can scan perfectly against its model and still be dead.
+Check the stress map first, then ask separately what is standing on each strong
+position.
+
+Use the Goldilocks frame when running pattern-match audits per line. Note the
+scope on the vocabulary: in this chapter **greed is one-directional** — it is
+the too-hot failure only. Pat names the too-cold failure separately and never
+calls it greed.
 
 ## Pitch-based stress model (*Songwriting Without Boundaries* (2011), Challenge 4)
 
@@ -953,14 +1080,24 @@ allows mixed lengths.
 
 ## Pentad cross-domain applicability (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3)
 
-Pat's Structural Pentad (balance / pace / flow / closure / type of closure)
-applies not only to rhyme structure. It also applies to:
+Pat's Structural Pentad (balance / pace / flow / closure / type of closure) is
+introduced as five normal characteristics of **any** structure. He names three
+surfaces:
 
-- **Rhythmic structure** — same pentad properties measured against the
-  song's rhythmic motifs
-- **Melodic structure** — same properties measured against melodic phrases
-  (when melody is known)
-- **Harmonic structure** — chord pattern stability per pentad property
+- **Rhythmic structure** — the pentad properties measured against the song's
+  stress patterns. This is the surface Chapter 3 develops them on.
+- **Rhyme structure** — the same properties measured against the rhyme scheme.
+- **Musical structure** — named, but not broken down or worked through.
+
+Pat's word for the third surface is *musical*, and it stops there. Earlier
+revisions of this file split it into "melodic structure" and "harmonic
+structure (chord pattern stability per pentad property)"; that split is not in
+the source, and the per-surface criteria it implied were never Pat's. If a
+melody- or harmony-specific stability read is what is wanted, the file that
+actually carries per-domain criteria is
+[stable / unstable](stable-unstable-meta.md), whose five motion controllers
+include melody, harmony, melodic rhythm, and harmonic rhythm as separate rows
+with their own stable/unstable tests.
 
 The pentad is one analysis frame applied across multiple structural
 surfaces. Do not confuse it with the

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -7,14 +7,22 @@ article (motion controllers, tone-of-voice); patpattison.com
 "Language and Songwriting" (greedy spots, ordinary-language preservation);
 American Songwriter "Motion Creates E-Motion" column (4-controller framework).
 
-Audited against *Writing Better Lyrics* (2009) Chapters 18-19 only. The 1991
-Pentad material and every non-book source above are distillations nobody has
-checked against their originals.
+Audited against *Writing Better Lyrics* (2009) Chapters 18-19, and against
+*Essential Guide to Lyric Form and Structure* (1991) Chapter 3 with its figures.
+**Still unaudited:** that book's Chapter 4, and every non-book source listed
+above — the Berklee Online article, patpattison.com, the American Songwriter
+column, and OSONG-525 — which remain distillations nobody has checked against
+their originals. Where this file's wording and the 1991 chapter's wording
+diverge, the divergence is marked in place rather than silently reconciled.
 
 ## Image inventory
 
 - Chapter 18: `image_rsrcAUE.jpg`.
 - Chapter 19: `image_rsrcAUF.jpg`.
+- *Essential Guide to Lyric Form and Structure* (1991), Chapter 3: **59 figure
+  references, 56 unique**, `image_rsrc2YZ.jpg` through `image_rsrc30P.jpg`. The
+  Structural Pentad worksheets this file cites exist only as page scans; see
+  [meter](meter.md) for the inventory note.
 
 ## Core idea
 
@@ -406,6 +414,17 @@ A greedy spot is a stressed syllable that lands on a weak musical beat, or
 an unstressed syllable forced onto a strong beat. The mismatch steals
 emphasis from where the music wants it, distorts the natural shape of the
 words, and breaks the listener's parse of the meaning.
+
+**Scope note on the term.** That two-directional definition comes from the web
+sources above and has not been checked against them. The term originates in
+*Essential Guide to Lyric Form and Structure* (1991) Chapter 3, where it is
+narrower and **one-directional**: greed is putting stressed syllables into
+unstressed positions — the "too hot" failure only. The opposite error is named
+separately there and is not a stress problem at all: a line whose stresses land
+correctly but whose important positions are filled with semantically empty
+words. See [meter](meter.md) "Goldilocks pattern matching." Keep the two apart
+when coaching, because they take different fixes — the first is repaired by
+rescanning, the second only by changing which words carry the weight.
 
 Causes:
 

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -415,16 +415,25 @@ an unstressed syllable forced onto a strong beat. The mismatch steals
 emphasis from where the music wants it, distorts the natural shape of the
 words, and breaks the listener's parse of the meaning.
 
-**Scope note on the term.** That two-directional definition comes from the web
-sources above and has not been checked against them. The term originates in
-*Essential Guide to Lyric Form and Structure* (1991) Chapter 3, where it is
-narrower and **one-directional**: greed is putting stressed syllables into
-unstressed positions — the "too hot" failure only. The opposite error is named
-separately there and is not a stress problem at all: a line whose stresses land
-correctly but whose important positions are filled with semantically empty
-words. See [meter](meter.md) "Goldilocks pattern matching." Keep the two apart
-when coaching, because they take different fixes — the first is repaired by
-rescanning, the second only by changing which words carry the weight.
+**Scope note — the term covers different ground in two frames.** Keep them
+apart, because the same word means something narrower in one of them.
+
+- **Lyric against a melody** — the frame this section is in. A mismatch in
+  *either* direction is a greedy spot, because either one distorts the natural
+  shape of the words against the bar. That two-directional definition comes
+  from the web sources above and has not been checked against them, but it is
+  the definition the rest of this plugin's melody-alignment material uses.
+- **Lyric against a model lyric** — matching verse two to verse one. Here the
+  term originates in *Essential Guide to Lyric Form and Structure* (1991)
+  Chapter 3, and it is **one-directional**: greed is putting stressed syllables
+  into unstressed positions, the "too hot" failure only. Chapter 3's opposite
+  error is not the reverse alignment mismatch and is not a stress problem at
+  all — it is "too cold," a line whose stresses land correctly but whose
+  important positions carry semantically empty words. See [meter](meter.md)
+  "Goldilocks pattern matching."
+
+The three failures take three different fixes: rescan, re-set against the bar,
+or change which words carry the weight. Name which one you found.
 
 Causes:
 

--- a/plugins/songwriting/skills/meter-prosody/SKILL.md
+++ b/plugins/songwriting/skills/meter-prosody/SKILL.md
@@ -45,10 +45,15 @@ No action → route on context (a pasted line → `meter`; a "does this feel rig
   not scansion for its own sake.
 - Stability is a tool, not a verdict: name whether a section reads stable or unstable and whether
   that serves the section's job; the writer chooses.
-- Greedy spots (a stressed syllable forced into a position the pattern leaves unstressed) route
-  through `align-melody` + `prosody`. Greed is the "too hot" direction only — a line whose stresses
-  land correctly but whose strong positions carry filler is "too cold," a separate failure with a
-  separate fix. Name which one you found; do not report both as greed.
+- Stress-alignment failures route through `align-melody` + `prosody`. Name the frame, because the
+  scope differs:
+  - **Lyric against a model lyric** (matching verse 2 to verse 1): "greed" is one-directional —
+    a stressed syllable forced into a position the model leaves unstressed. The reverse case is
+    "too cold": stresses land correctly but the strong positions carry filler. Different failures,
+    different fixes; do not report the second as greed.
+  - **Lyric against a melody**: a mismatch in *either* direction is a greedy spot — a stressed
+    syllable on a weak beat, or an unstressed syllable riding a strong one. Both distort the
+    natural shape of the language.
 
 ## Persistence and template overrides
 

--- a/plugins/songwriting/skills/meter-prosody/SKILL.md
+++ b/plugins/songwriting/skills/meter-prosody/SKILL.md
@@ -45,7 +45,10 @@ No action → route on context (a pasted line → `meter`; a "does this feel rig
   not scansion for its own sake.
 - Stability is a tool, not a verdict: name whether a section reads stable or unstable and whether
   that serves the section's job; the writer chooses.
-- Greedy spots (too many syllables for the melodic slot) route through `align-melody` + `prosody`.
+- Greedy spots (a stressed syllable forced into a position the pattern leaves unstressed) route
+  through `align-melody` + `prosody`. Greed is the "too hot" direction only — a line whose stresses
+  land correctly but whose strong positions carry filler is "too cold," a separate failure with a
+  separate fix. Name which one you found; do not report both as greed.
 
 ## Persistence and template overrides
 

--- a/plugins/songwriting/skills/meter-prosody/SKILL.md
+++ b/plugins/songwriting/skills/meter-prosody/SKILL.md
@@ -48,9 +48,10 @@ No action → route on context (a pasted line → `meter`; a "does this feel rig
 - Stress-alignment failures route through `align-melody` + `prosody`. Name the frame, because the
   scope differs:
   - **Lyric against a model lyric** (matching verse 2 to verse 1): "greed" is one-directional —
-    a stressed syllable forced into a position the model leaves unstressed. The reverse case is
-    "too cold": stresses land correctly but the strong positions carry filler. Different failures,
-    different fixes; do not report the second as greed.
+    a stressed syllable forced into a position the model leaves unstressed. The chapter's other
+    failure, "too cold," is **not** a mirror-image stress error and is not a stress error at all:
+    the stresses land correctly and the strong positions carry filler. Do not scan for it; no
+    stress check finds it. Read what stands on each strong position instead.
   - **Lyric against a melody**: a mismatch in *either* direction is a greedy spot — a stressed
     syllable on a weak beat, or an unstressed syllable riding a strong one. Both distort the
     natural shape of the language.


### PR DESCRIPTION
Reads *Essential Guide to Lyric Form and Structure* (1991) Chapter 3 (Rhythm) in
full — **all 59 figure references, 56 unique** — and adjudicates `meter.md` and
`prosody.md` against it. Continues the per-chapter source-fidelity audit; 0.8.3
covered Chapters 1, 2, and 6.

This chapter argues almost entirely in page scans. Nearly every finding below
was invisible to a text-only reader, which is the point of the first one.

## The inventory falsehood, third occurrence

`meter.md` recorded that this chapter has **"no linked page-scan images."** It
has 59 references across 56 unique figures, `image_rsrc2YZ`–`image_rsrc30P`.
Every scansion, all three Paradigms, the 4/4 bar settings, and all four
filled-in Structural Pentad worksheets exist *only* as images.

This is the third chapter whose inventory carried that exact falsehood, after
Chapter 6 (37 figures) and Chapter 5 (32) in 0.8.3. Two live defects were
sitting behind it.

## What was behind it

**The model scansion was wrong.** `meter.md`'s worked example marked "got"
stressed in "When I got home the house was dark," reporting four stresses. Pat's
figure marks "when," "I," and "got" all unstressed — **three**. The code block
also contradicted the file's own prose two lines below it, which already called
"got" a grey-area syllable. This is the scansion the skill hands users as its
model, so it was teaching the error.

**"Too cold" was defined as a stress failure. It isn't one.** The file had it as
"an unstressed syllable where the structure wants stress." Pat's too-cold
example preserves the model's stress map *exactly*; what fails is that the
important positions are filled with semantically empty words. The two Goldilocks
states test two independent things — the stress map, and what stands on each
strong position — and "just right" requires both. A rewrite can scan perfectly
and still be dead, which is precisely what a stress-only audit cannot see.

`meter.md`'s pattern-matching section already had this right. The later section
contradicted it — the **fifth** file found with the correct-early / wrong-late
duplication shape, after `song-forms.md`, `co-writing.md`, and `phrasing.md`.

## The worksheet users actually receive

The emitted Pentad worksheet offered values that are not in Pat's worksheet:
Balance as `balanced | unbalanced` where the source's closed list is
**symmetrical | asymmetrical**, and Closure with a third value `leans forward`
where the source is **binary: closed | open**. The file's summary section had
both right; the copy-paste block had both wrong. Now stated as closed lists,
with a filled-in table for all three Paradigms.

## An overreach that survived its own correction

Pat introduces the Pentad as five characteristics of any structure and names
three surfaces: **rhythmic, rhyme, and musical**. `meter.md` split the third
into "melodic structure" and "harmonic structure (chord pattern stability per
pentad property)" — per-surface criteria that are not in the source. 0.8.2 fixed
a *different* defect in this same section and the overreach survived. Readers
wanting melody- or harmony-specific stability criteria are now pointed at
`stable-unstable-meta.md`, which genuinely carries them.

This also closes a standing open question: yes, Pat claims the Pentad applies
beyond rhythm — to rhyme and to musical structure. Not to melody and harmony as
separately-criteria'd domains.

## One term, three definitions

"Greedy spot" originates in this chapter and is **one-directional**: putting
stressed syllables into unstressed positions, the too-hot failure only. Pat
names the opposite error separately and never calls it greed.

| File | Said | Action |
|---|---|---|
| `meter.md` | "usually too-hot or too-cold failures" | fixed |
| `audit-checklist.md` | both directions, under a heading citing this chapter | fixed |
| `skills/meter-prosody/SKILL.md` | "too many syllables for the melodic slot" — attributable to no source | fixed |
| `prosody.md` | both directions, sourced to patpattison.com | **scoped, not rewritten** |

`prosody.md`'s source is still unaudited, so its definition is annotated with the
1991 sense rather than overwritten on evidence that doesn't reach it.

## Also fixed

- Two categorical claims softened into hedges — middle-stress three-syllable
  words have **no** secondary stress, not "may be no"; four-plus-syllable words
  **always** carry one, not "normally."
- `demo-review.md` attributed the Pentad to `five-compositional-elements.md` —
  the two-lists confusion 0.8.2 fixed in `meter.md`, surviving elsewhere.
- A header note claimed Pat has no notation for unstressed syllables. He marks
  them with a breve; this chapter's exercises ask for that "slight cup" by name.

## Added

- The stressed-syllable length **inversion**: an 8-syllable / 4-stress phrase is
  *longer* than a 9-syllable / 3-stress one. Raw syllable count can rank a pair
  backwards — the entire reason this method counts stresses. The file previously
  said an extra weak syllable "may not change the structural weight."
- Secondary stresses count as stresses when scanning; unstressed pickups do not
  change the pattern. Without the first, the file's own common-meter example
  miscounts.
- The third deceleration case — *any* reduction in unstressed syllables, not
  only triple-to-duple — plus the single mechanism behind both directions.
- Paradigm 1 stated in triples alongside duples: the cleanest proof the
  paradigms are defined by stress count, not syllable count.
- The one-word common-meter demonstration that exists only in a figure, and a
  note that Paradigm 3 still *closes* (deception is a type-row property).

## Verified, no change needed

The conventional-stress examples (`incision`, `turbulent`, `understand`,
`relinquish`) all match their figures, and Chapter 3 does own Exercises 8-17 as
claimed.

## Two open probes were aimed at the wrong chapter

- **"Can't Fight This Feeling"** does not appear in Chapter 3. It appears in
  Chapters 1, 5, and 7 — and Chapter 1's use is a *phrase-count* argument, not
  the stress-pattern claim `section-building.md` makes.
- **"Years"** appears in Chapters 2 and 5, not 3, so `form.md`'s
  composite-balance claim must be checked against Chapter 5.

Both left unadjudicated rather than hedged, per the standing decision that a
hedge beside unread evidence is worse than the open question.

## Note for the restructuring follow-up

`meter.md` is now a third file carrying duplicated parallel treatments of the
same material — two Pentad sections and two Paradigm sets. Reconciled here, not
folded together, since the duplication is scoped as a separate follow-up
alongside `song-forms.md` and `phrasing.md`. That duplication is what let the
worksheet and the summary disagree about Pentad values in the first place.

## Scope

Paraphrase only. No chapter prose, example lyrics, student work, or exercise
answers reach this public repository. Pat's hot/cold/just-right demonstrations
are example writes against a licensed lyric, so the *definitions* are corrected
without reproducing the lines.

## Verification

`typos`, `markdownlint-cli2` (103 files, 0 errors), `lychee --offline
--include-fragments`, `validate-plugins.sh`, and `check-changelog-parity.sh
--check-bump origin/main` all pass locally. `check-skill.sh meter-prosody`
passes with 2 pre-existing warnings (no gotchas surface, no evals — the latter a
previously settled decision for this skill).

Version bumped 0.8.3 → 0.8.4 with a CHANGELOG entry.

## Related

No linked issue
