### PR TITLE
feat(songwriting): restore Pat Pattison's verbatim text across the research files, and adjudicate chapter 4

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -37,6 +37,10 @@ extend-ignore-re = [
 abd = "abd"
 # Business Associate Agreements (HIPAA) — provisioning.
 BAAs = "BAAs"
+# Scansion vocalization of a stressed syllable ("da DUM da DUM") — standard
+# prosody notation in Pat Pattison's craft books, quoted throughout the
+# songwriting plugin. Case-sensitive: only the all-caps stressed form.
+DUM = "DUM"
 # Features on Demand (Windows optional-feature packaging) — provisioning.
 FoD = "FoD"
 # NIC power-management registry value name — provisioning.

--- a/_typos.toml
+++ b/_typos.toml
@@ -37,10 +37,6 @@ extend-ignore-re = [
 abd = "abd"
 # Business Associate Agreements (HIPAA) — provisioning.
 BAAs = "BAAs"
-# Scansion vocalization of a stressed syllable ("da DUM da DUM") — standard
-# prosody notation in Pat Pattison's craft books, quoted throughout the
-# songwriting plugin. Case-sensitive: only the all-caps stressed form.
-DUM = "DUM"
 # Features on Demand (Windows optional-feature packaging) — provisioning.
 FoD = "FoD"
 # NIC power-management registry value name — provisioning.

--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -37,7 +37,25 @@ layer.
   system.
 - **The three labeling drills now carry their printed answer keys** (Ex 23, 24,
   25), transcribed from the page scans. Ex 24 #6 independently confirms `abba`
-  is open.
+  is open. The keys are printed rotated 180° at the foot of each scan; reading
+  them in place gets them wrong, so they were re-read from cropped, rotated,
+  4x-upscaled strips. Ex 23 #7 is `T` — consecutive rhymes do not fragment when
+  they follow an odd phrase count, which the chapter states outright.
+- **Three fabrications, not just omissions.** `rhyme-types.md`'s weak-syllable
+  examples (`mountain/certain`, `shadow/window`, `ringing/falling`) were
+  invented — the chapter names weak-syllable rhyme but never defines it.
+  `form.md`'s transitional-bridge list carried ten names where the chapter
+  prints six, adding "channel" and "runway", splitting "Climb or Lift", and
+  attaching genre and era attributions the book does not make; its heading also
+  cited *Writing Better Lyrics* (2009) Chapter 13, which is "Dialogue and Point
+  of View". `exercises.md` invented its item counts. The paraphrase rule did not
+  only omit — it produced authoritative-looking inventions.
+- **`bridge.md` attached the "four times is a lot" warning to `V/Ch/V/Ch`.**
+  *Writing Better Lyrics* (2009) Chapter 22 attaches it to `v/v/ch/v/v/ch` —
+  four verses, four trips. `song-forms.md` was right all along. Long-standing
+  known defect, now closed with the verbatim passage.
+- **`exercises.md` was missing Ex 32 and 33**, jumping 31 → 34. Both are in
+  Chapter 5. Restored; the 1991 numbering now runs 1-44 unbroken.
 - **The Marvell and Shelley passages are quoted** rather than described — both
   public domain — with the consonance-rhyme gloss Pat attaches to
   "Ozymandias."

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -5,22 +5,45 @@ All notable changes to the `songwriting` plugin are documented here. Format foll
 
 ## [0.8.5]
 
-A source-fidelity pass over *Essential Guide to Lyric Form and Structure*
-(1991) Chapter 4 (Rhyme), read in full with **all 40 of its figures** at 3x
-upscale, against `rhyme-fundamentals.md` and `rhyme-strategy.md` — the two
-files that name that chapter as their primary source. Two of the findings
-below came only from the figures: the balance-paradigm set and the printed
-exercise answer keys, neither of which exists in the text layer. Paraphrase
-only.
+**A reversal of standing policy, plus a source-fidelity pass.**
+
+Every previous release of this plugin was built under a "paraphrase only —
+never reproduce Pat's text" rule that had been propagating through eight
+handoffs. **That rule is revoked.** The repo owner owns all four books and this
+reference is for their own use, and the paraphrasing was actively destroying
+the value of the craft guidance: an exercise summarized is not an exercise, and
+a worked example described is not an example. Pat's actual text, actual
+examples, actual exercise wording and actual printed answer keys are being
+restored across the whole knowledge base.
+
+This release covers *Essential Guide to Lyric Form and Structure* (1991)
+Chapter 4 (Rhyme), read in full with **all 40 of its figures** at 3x upscale,
+plus the first wave of the verbatim restoration across the other research
+files. Two findings below came only from the figures: the balance-paradigm set
+and the printed exercise answer keys, neither of which exists in the text
+layer.
+
+### Restored — Chapter 4
+
+- **Pat's two worked `aabb` / `abab` sections are back in `rhyme-strategy.md`
+  in full**, as he wrote them, with the Exercise 27 instruction to reverse
+  them. Likewise his worked `ABACCB` plot sketch and rhyme words from Exercise
+  28, his "Ready or Not" verse and chorus, and both `abcccb` acceleration
+  examples including the feminine-rhyme comedy version.
+- **The closure sections now show Pat's actual word-schemes** rather than bare
+  letters: both deceptive continuations, both non-deceptive open contrasts,
+  both unexpected-closure cases, and the paired `aaa` illustration that
+  distinguishes looking-backward identity from a genuinely open odd-count
+  system.
+- **The three labeling drills now carry their printed answer keys** (Ex 23, 24,
+  25), transcribed from the page scans. Ex 24 #6 independently confirms `abba`
+  is open.
+- **The Marvell and Shelley passages are quoted** rather than described — both
+  public domain — with the consonance-rhyme gloss Pat attaches to
+  "Ozymandias."
 
 ### Fixed
 
-- **Eight lines of Pat's own example lyrics were reproduced verbatim in
-  `rhyme-strategy.md`,** in a public repository — the `aabb`/`abab` worked
-  contrast. Pat states in the chapter that he wrote both. Replaced with a
-  structural diagram that makes the same teaching point without the text. A
-  second instance, the chapter's worked `ABACCB` exercise answer, was replaced
-  with an equivalent built the same way.
 - **`rhyme-fundamentals.md`'s identity test asserted the opposite of the
   rule it was stating.** It said identity "matches conditions 1 and 2 and
   **also** matches 3" where condition 3 is *"different consonant sound before

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,91 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.5]
+
+A source-fidelity pass over *Essential Guide to Lyric Form and Structure*
+(1991) Chapter 4 (Rhyme), read in full with **all 40 of its figures** at 3x
+upscale, against `rhyme-fundamentals.md` and `rhyme-strategy.md` — the two
+files that name that chapter as their primary source. Two of the findings
+below came only from the figures: the balance-paradigm set and the printed
+exercise answer keys, neither of which exists in the text layer. Paraphrase
+only.
+
+### Fixed
+
+- **Eight lines of Pat's own example lyrics were reproduced verbatim in
+  `rhyme-strategy.md`,** in a public repository — the `aabb`/`abab` worked
+  contrast. Pat states in the chapter that he wrote both. Replaced with a
+  structural diagram that makes the same teaching point without the text. A
+  second instance, the chapter's worked `ABACCB` exercise answer, was replaced
+  with an equivalent built the same way.
+- **`rhyme-fundamentals.md`'s identity test asserted the opposite of the
+  rule it was stating.** It said identity "matches conditions 1 and 2 and
+  **also** matches 3" where condition 3 is *"different consonant sound before
+  the vowel."* Identity fails condition 3 — that failure is the entire
+  distinction. As written, the test passed every identity as a rhyme. Every
+  other file in the plugin states the check correctly; this was the sole
+  outlier.
+- **`abba` was listed as a balanced pattern.** The chapter uses `abba` as its
+  explicit counterexample — an opening `abb` is *not* balanced by returning to
+  `a`; it is balanced by `abbabb` or `abbacc` — and the chapter's printed
+  exercise key marks `abba` **open**. Since a balanced system is closed by
+  definition, both sources agree it is neither.
+- **`rhyme-strategy.md` contradicted itself about `abba`,** calling it
+  "encloses" in the strategy table while its own Challenge 4 table listed it
+  under floating instability. Resolved toward the source; the strategy table
+  now states it stays open.
+- **The balance-paradigm list was missing half the set.** Pat prints six
+  (`abab`, `xaxa`, `aa`, `aabb`, `abcabc`, `xxaxxa`); the file carried three
+  of them plus the counterexample.
+- **`five-compositional-elements.md` described `abba` as a "wrap"** in a list
+  where every neighbouring entry names a closure state, inviting the same
+  wrong reading. Clarified that the frame returns without closing. The
+  In Memoriam `abba` in `meter.md` is a **different frame** — Tennyson's
+  equal-tetrameter stanza from the Challenge 4 curriculum — and was left
+  untouched.
+- **`rhyme-fundamentals.md` mislabeled a feminine-rhyme example as an
+  identity** (`lonely / only`). It is a rhyme: the stressed syllables differ
+  before the vowel. Its tail is identical, which the chapter explicitly
+  permits without changing the classification.
+- **Both files' image inventories omitted this chapter.** `rhyme-strategy.md`
+  listed only its 2014 and 2011 sources; `rhyme-fundamentals.md` carried no
+  inventory line at all. This is the **fourth** consecutive Book 1 chapter
+  whose inventory concealed a defect.
+- **Bare "Chapter 4" / "Chapter 9" references in `rhyme-strategy.md`** were
+  genuinely ambiguous in a file citing three books — 2014 also has a Chapter 4,
+  which `rhyme-types.md` uses. Qualified with title and year per
+  `book-references.md`.
+
+### Added
+
+- **`rhyme-fundamentals.md` now names the chapter's five structural areas as a
+  set** — balance, pace, flow, closure, type of closure — and identifies them
+  as the Structural Pentad measured against rhyme instead of stress. The file
+  previously covered all five without ever connecting them.
+- **The through-written / fragmented pair is now linked to the rhythm
+  Paradigms** it is drawn from: `abab` is the simplest through-written system
+  "like rhythm Paradigm One," `aabb` the simplest fragmented one "like rhythm
+  Paradigm Two."
+- **Consonance rhyme is recorded as already named in 1991**, so the 2014
+  stability scale extends that vocabulary rather than introducing it.
+- The cheerleader analogy is now attributed to **both** 1991 Chapter 4 and
+  2014 Chapter 1 — it appears in both, verified by extraction. The prior
+  single-source attribution was incomplete, not wrong.
+
+### Verified — no change needed
+
+- **`prosody.md`'s "1991 Chapter 3-4 (Structural Pentad)" citation holds.**
+  Its standing "Chapter 4 still unaudited" flag is cleared: Chapter 4 opens by
+  naming all five Pentad properties and gives each a numbered section. Only
+  the non-book sources remain unaudited.
+- **`exercises.md`'s Chapter 4 block is complete** — Ex 18 through 28, no
+  numbering gap.
+- **`book-references.md`'s perfect-rhyme citation is accurate.**
+- **`rhyme-types.md`'s page-scan inventory is genuine** — every cited
+  *Essential Guide to Rhyming* (2014) filename resolves against a fresh
+  extraction. Book 4's gate passes at 139 spine items / 139 images.
+
 ## [0.8.4]
 
 A source-fidelity pass over *Essential Guide to Lyric Form and Structure*

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -96,10 +96,14 @@ the corpus and nothing was invented to fill them.
 
 ### Changed — tooling
 
-- **`_typos.toml` gains `DUM`** as a case-sensitive identifier. "da DUM da DUM"
-  is standard scansion notation and now appears verbatim in four files; the
-  spell-checker was rewriting it to "DUMB". Added at the canonical root per
-  that file's own policy note rather than as inline suppressions.
+- **Scansion strips are wrapped in the spell-checker's block directive.** Pat's
+  stressed-syllable vocalization is flagged as a misspelling of "DUMB", and it
+  now appears verbatim in `meter.md`, `prosody.md` and `daily-practice.md`. An
+  earlier revision of this branch added the exception to `_typos.toml`
+  directly; that file is synchronized from `melodic-software/standards` and a
+  local edit to it is silently dropped on the next sync, so the exception is
+  applied with the inline `spellchecker:off` / `spellchecker:on` convention
+  that config itself blesses. A permanent fix belongs upstream.
 
 ### Fixed
 
@@ -140,6 +144,22 @@ the corpus and nothing was invented to fill them.
   genuinely ambiguous in a file citing three books — 2014 also has a Chapter 4,
   which `rhyme-types.md` uses. Qualified with title and year per
   `book-references.md`.
+- **Seven remaining bare "Book N" citations retired**, in `audit-checklist.md`
+  (2), `bridge.md`, `rhyme-generation.md` (2), and
+  `templates/audit-checklist-prompt.md` (2) — constructions like "Books 1
+  Chapter 4, 2 Chapter 4, 4 Chapters 4-6" that `book-references.md` prints as
+  the counterexample. The plugin now has no bare "Book N" reference outside
+  that file. Regression test:
+  `grep -rn "Books\? [1-4]\b" context/ skills/ agents/ | grep -v book-references`
+- **`exercises.md`'s header claimed its exercises were paraphrases** while
+  carrying the restored verbatim ones — a stale notice that contradicted the
+  file's own contents.
+- **The Marvell / Shelley worked example appeared three times in
+  `rhyme-fundamentals.md`** — a paraphrase in the flow section, the restored
+  verbatim quotes, and a bullet restating Marvell a third time under a heading
+  promising two examples. The verbatim quotation was prepended rather than
+  substituted for what it replaced. Consolidated to one quotation with the
+  other two positions now referencing it.
 
 ### Added
 

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -42,6 +42,47 @@ layer.
   public domain — with the consonance-rhyme gloss Pat attaches to
   "Ozymandias."
 
+### Restored — across the knowledge base
+
+Twenty-nine research files were swept. Pat's real examples, exercise wording,
+worksheet layouts and printed answer keys replace the summaries that stood in
+for them. Highlights:
+
+- **`exercises.md` no longer advertises that its exercises are paraphrases** —
+  they were, which meant not one numbered exercise in the file was actually
+  Pat's. They are now.
+- **`rhyme-types.md`** — every stability tier now carries Pat's own definition
+  wording and his actual example word-pairs, tier by tier. This is the file the
+  rhyme skill runs on.
+- **`daily-practice.md`** — the 56-day curriculum now lists Pat's real seeds
+  and day titles with his numbering, replacing "(paraphrased shape)" stubs.
+- **`prosody.md`, `meter.md`** — Pat's actual scansion strips, motion/emotion
+  demonstrations, and worked stress examples.
+- **`five-compositional-elements.md`** — Pat's full "Some People's Lives"
+  demonstration, including the counterfactual rewrites and his commentary on
+  why the one-row change matters at song scale.
+- **`worksheets.md`, `rhyme-worksheets.md`** — real worksheet layouts and
+  Pat's numbered step text, quoted.
+- **`song-forms.md`, `song-forms-examples.md`, `form.md`, `hook.md`,
+  `bridge.md`, `phrasing.md`** — worked song analyses with their real sections
+  rather than "mechanism analyses (NOT lyric reproduction)".
+- **`metaphor.md`, `cliche.md`, `object-writing.md`, `repetition.md`,
+  `verse-development.md`, `box-model.md`, `title-game.md`, `idea-to-title.md`,
+  `mosaic-rhyme.md`, `rhyme-sonic-bonding.md`,
+  `rhyme-spotlight-connection.md`, `rhyme-dictionary-practice.md`** — real
+  collision lists, cliche examples, sample writes, and rhyme demonstrations.
+
+Web-sourced passages (Berklee Online, patpattison.com, American Songwriter,
+Coursera) stay paraphrased and stay marked unaudited — those sources are not in
+the corpus and nothing was invented to fill them.
+
+### Changed — tooling
+
+- **`_typos.toml` gains `DUM`** as a case-sensitive identifier. "da DUM da DUM"
+  is standard scansion notation and now appears verbatim in four files; the
+  spell-checker was rewriting it to "DUMB". Added at the canonical root per
+  that file's own policy note rather than as inline suppressions.
+
 ### Fixed
 
 - **`rhyme-fundamentals.md`'s identity test asserted the opposite of the

--- a/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
+++ b/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
@@ -72,7 +72,7 @@ Run for any line under consideration for locking.
 - [ ] grey-area stress flagged, not silently resolved
 - [ ] sing-check passed (read aloud / sing against melody if known)
 
-**Rhyme stability (Books 1 Chapter 4, 2 Chapter 4, 4 Chapters 4-6)**
+**Rhyme stability (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4; *Writing Better Lyrics* (2009), Chapter 4; *Essential Guide to Rhyming* (2014), Chapters 4-6)**
 
 - [ ] if line ends in a rhyme position: identity check — pre-vowel consonants DIFFER
 - [ ] stability tier chosen by emotional intent, not convenience (perfect / family / additive / assonance / consonance)
@@ -142,7 +142,7 @@ After the per-line pass, zoom out.
 
 ## Pre-lock-title checklist
 
-**Sound (Books 1 Chapter 4, 4 Chapter 3-4)**
+**Sound (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4; *Essential Guide to Rhyming* (2014), Chapters 3-4)**
 
 - [ ] stressed vowel identified
 - [ ] family rhymes plausible (run `datamuse.sh family <title>` per `ai-tools.md`)

--- a/plugins/songwriting/context/pat-pattison/research/box-model.md
+++ b/plugins/songwriting/context/pat-pattison/research/box-model.md
@@ -28,6 +28,31 @@ opposite poles; see [Travelogue vs same-color](#travelogue-vs-same-color).
 - **Box 3 (verse 3 / bridge / final verse):** heaviest. The "why" of the
   song. The emotional landing.
 
+Pat's own statement of the stack:
+
+> The first box begins the flow of ideas, introducing us to the song's world. The
+> second box continues the idea, but from a different angle, combining the weight
+> of the first box with the weight of the second. The last box builds from the
+> first two, introducing its own angle and combining its idea with the first two,
+> resulting in the heaviest box.
+
+> Box 3 combines or resolves all the information, and delivers the point of the
+> song. It's often the "why" of the song — why I'm saying all this to you. It
+> weighs the most.
+
+His worked sketch, on the title idea *I'd just like to know*, shows the same
+five words carrying three different sentences:
+
+```text
+Box 1  A greeting. "You're looking good, and you're looking really happy.
+       Are you? I hope you don't mind my asking. I'd just like to know."
+Box 2  An accusation. "When you left, did you already know you were moving in
+       with him? … I suppose it doesn't matter now, but I'd just like to know."
+Box 3  The why. "For me, a relationship is all about honesty. … You could have
+       told me about him. I wouldn't have tried to stop you.
+       I'd just like to know."
+```
+
 If Box 3 is lighter than Box 2, the song sags. If Box 2 repeats Box 1, the
 chorus picks up the entire emotional load — usually too much load.
 
@@ -49,6 +74,49 @@ Each verse takes a different relational POV.
 Or any reordering: I → You → We, We → I → You, etc. The formula is the
 distribution, not the order.
 
+Pat's demonstration starts from a stuck verse summary — one where "it feels like
+everything's been covered":
+
+```text
+You are really wonderful
+And I've been looking for someone just like you
+We should be together
+
+Love Love Love
+Love Love Love
+```
+
+All three perspectives are crammed into box 1. Split out, with the same refrain
+under each, they become (Pat's own illustration, deliberately ridiculous —
+he signs off "Okay, just kidding"):
+
+```text
+Box 1: You are amazing. And beautiful. Your blonde hair flows over your
+       milky-white complexion like chicken gravy over mashed potatoes…
+
+       Love Love Love
+       Love Love Love
+
+Box 2: I've been looking for a codependent relationship for a long time.
+       Someone who'll mother me and let me do whatever I want to…
+
+       Love Love Love
+       Love Love Love
+
+Box 3: We'll always be together. Everyone I've ever loved is still with
+       me…in the downstairs freezer…
+
+       Love Love Love
+       Love Love Love
+```
+
+> But you can see how the boxes gain weight by separating the perspectives. Call
+> it the "you-I-we" formula for lyric development: Each verse focuses from a
+> different perspective. It's a nice guideline for dividing your verses' jobs.
+
+The joke is doing real work: the boxes gain weight because each one is *about*
+something the others are not, and Pat's third box is heaviest because it turns.
+
 ### Past-Present-Future formula
 
 Each verse takes a different tense.
@@ -57,9 +125,43 @@ Each verse takes a different tense.
 - **Box 2: Present** — what is now. The current state.
 - **Box 3: Future** — what will be / could be. The projection or fear.
 
+Pat's starting verse for this one:
+
+```text
+We were so good together
+But now everything's falling apart
+What's going to happen to us?
+
+Love Love Love
+Love Love Love
+```
+
+> This idea contains three tenses: past, present, and future. Try separating them
+> into separate boxes.
+
+```text
+Box 1: We used to smile and laugh together, etc., so much in…
+Box 2: Everything's turned sour. What happened to…
+Box 3: Can we work to stay together, or drift away, only remembering how it
+       felt to be in…
+```
+
+> So tense can also provide access to verse development, just like perspective
+> can.
+
 Like You-I-We, the order is interchangeable. Reverse chronology is a strong
 play (Future → Present → Past) — letting the listener reconstruct the
 sequence backwards.
+
+**Both demonstrations share one diagnostic.** The stuck verse already contained
+every box. Neither formula invented material; each unpacked what the writer had
+compressed into box 1. When a writer says "everything's been covered," check
+first whether the covering happened all in one box.
+
+Pat's warning, attached in the same breath: "Sometimes one or the other will be
+just what you need; other times, like any formula, they could take the freshness
+out of your writing. Be aware of these techniques, just beware of letting them
+become a habit in your writing."
 
 ### Other named division axes
 
@@ -75,15 +177,54 @@ sequence backwards.
 Pick the axis that supports the song's central emotional shape, not the
 axis that's most clever.
 
+### Better than any axis: an idea that develops itself
+
+Pat's stated preference is to need no axis at all:
+
+> It's better when you find an idea that contains the DNA of its own
+> development, or when plot does the development work.
+
+His case is Gillian Welch's "One More Dollar," where plot alone drives the
+boxes: a man leaves home for orchard work and sends his wages back, promising to
+come home when the next crop pays his way; then a freeze kills the work and he
+gambles at the bar downtown; then he is on the street asking strangers for "a
+coin and a Christian prayer." The refrain never changes:
+
+```text
+One more dime to show for my day
+One more dollar and I'm on my way
+When I reach those hills, boys
+I'll never roam
+One more dollar and I'm going home
+```
+
+> Each verse moves the story forward, making chances of getting home more and
+> more remote.
+
+Reach for a division axis when the idea does *not* carry its own development.
+That ordering matters — the axes are a repair, not a starting move.
+
 ## The "what came before?" diagnostic
 
 When a writer is stuck on verse 2, the question is rarely "what's the next
-event?" — it's "what came before what we already have in verse 1?"
+event?" Pat states the move twice in Chapter 6:
 
-Pat's diagnostic: ask not "what happens next" but "what is the prior cause
-that made verse 1's situation possible?" Often the answer becomes verse 2,
-and verse 1 becomes verse 3 — the chronology was wrong but the material was
-right.
+> Just because you wrote a verse first doesn't mean it's your first verse. Give
+> yourself two chances. Don't just ask "Where do I go next?" Try asking "What
+> happened before this?"
+
+> Instead of asking "Where do I go now?" it may help to ask "Where did I get here
+> from?"
+
+What he claims is the reordering itself — the verse you wrote first may not be
+box 1 — not any particular destination for it. Try the material in each slot
+before assuming the song has to continue forward from the draft.
+
+And the stronger version of the same advice runs upstream of the stuck point
+entirely:
+
+> Thinking about boxes from the outset, the minute an idea comes, is by far the
+> best remedy for "second-verse hell."
 
 ## Travelogue vs same-color
 
@@ -114,8 +255,27 @@ Remove the chorus and read only the verses in sequence.
 - Does verse 2 gain any weight from verse 1 having happened?
 
 If the verses are independent observations linked only by the title /
-refrain / chorus, the song is a **travelogue**. Pat's diagnosis: verse
-development should mean verse relationship.
+refrain / chorus, the song is a **travelogue**. Pat's diagnosis: "Verse
+development should mean verse relationship. Your verses should have a good
+reason to hang out together."
+
+His canonical summary sets — both message songs, both well-intentioned:
+
+```text
+Verse 1: Police brutality is a common problem in large cities.
+Verse 2: Car bombs are becoming more common as a terrorist weapon.
+Verse 3: More prostitutes carry the AIDS virus every year.
+Refrain: Streets are turning deadly in the dark.
+
+Verse 1: We're screwing up our planet.
+Verse 2: We're killing each other in stupid wars.
+Verse 3: We ignore our poor and homeless.
+Refrain: We're losing the human race.
+```
+
+Nothing links the verses except the refrain. The full worked travelogue and its
+repair ("Chain Reaction") are in
+[verse-development](verse-development.md#chain-reaction-model).
 
 ### Same-color test (*Writing Better Lyrics* (2009), Chapter 7)
 
@@ -129,6 +289,27 @@ verse just cast on it.
 
 Verses connected but same-colored is NOT a travelogue; the chain is intact and
 the repainting is missing.
+
+Pat's case is "Between Fathers and Sons" (John Jarvis and Gary Nicholson). Its
+two perspectives — the son looking at his father, and the son now a father — are
+both spent inside box 1, so box 2 restates. On verse four:
+
+> Oops. I know I've been here before. It's verse two with *I* changed to *you*.
+> … The second chorus is a goner. It can't help but say exactly the same thing
+> as the first chorus.
+
+> It isn't so much that there is no advancement of the idea in verses three and
+> four, there just isn't enough to give us a new look at the chorus when we get
+> there. … Both boxes are the same size.
+
+The fix is redistribution, not rewriting: move *Now when I look at my own son*
+down into box 2 and let box 1 keep only the son's view of his father. Same
+chorus, two colors. The verses were always connected — the split was missing.
+
+Contrast the sheriff demonstration in
+[repetition](repetition.md#stagnant-repetition), where Pat repairs stagnation
+without touching the (deliberately bland) language at all. Same-color is a
+distribution problem in both cases.
 
 ## Box weight failure modes
 

--- a/plugins/songwriting/context/pat-pattison/research/bridge.md
+++ b/plugins/songwriting/context/pat-pattison/research/bridge.md
@@ -45,7 +45,8 @@ A bridge must serve **at least one**, often all three:
 Diagnose a draft bridge: which of these three does it do? If none, it isn't
 bridging — it's restating. Rewrite or remove.
 
-**Do not confuse this list with Chapter 5's.** Book 1 carries two bridge lists
+**Do not confuse this list with Chapter 5's.** *Essential Guide to Lyric Form
+and Structure* (1991) carries two bridge lists
 and they answer different questions. Chapter 6's three purposes above are what
 *adding* a bridge accomplishes for a form. Chapter 5 gives a separate
 **five-point characterization of what a bridge is**: it is a developmental

--- a/plugins/songwriting/context/pat-pattison/research/bridge.md
+++ b/plugins/songwriting/context/pat-pattison/research/bridge.md
@@ -61,11 +61,34 @@ more than that. Cite Chapter 6 for the purposes, Chapter 5 for the definition.
 | Song shape | Bridge needed? |
 |---|---|
 | V/Refrain × 3-4 | optional; bridge before final V or as alt-final-verse |
-| V/Ch/V/Ch | not strict; "four times is a lot" risk → bridge or distill |
-| V/Ch/V/Ch/V/Ch | almost always — three identical chorus visits without contrast feels endless |
+| V/V/Ch/V/V/Ch | strong candidate — "four times is a lot" (see below) |
+| V/Ch/V/Ch | not strict; this is already one of the fixes for the form above |
+| V/Ch/V/Ch/V/Ch | almost always — the third system "seems to fall a little flat, not so much for what it says, but because we've seen its structure twice before" |
 | V/Ch/V/Ch/Br/Ch | the canonical pop form |
 | AABA | yes — B section IS the bridge; A returns feel like homecoming |
 | Through-written | usually no — but a contrasting section may earn the label |
+
+### The four-times risk (*Writing Better Lyrics* (2009), Chapter 22)
+
+The "four times is a lot" warning belongs to **v/v/ch/v/v/ch**, not to v/ch/v/ch:
+
+> Simple; v / v / ch / v / v / ch repeats the same melody, chords, phrase
+> lengths, and rhyme schemes four times. Four times is a lot. You risk boring
+> your listeners when you make four trips through the same structure. Your
+> verses, especially the crucial fourth verse, had better be very interesting
+> to risk all that repetition.
+
+Chapter 22 gives three risk-avoidance techniques, only one of which is a bridge:
+
+1. **Dump a verse.** Distill two verses into one on a "best of" principle. The
+   resulting v/v/ch/v/ch "gives the second chorus a boost by seeming to get to
+   it early — a distinct advantage."
+2. **Turn one of the verses into a bridge**, giving v/v/ch/v/ch/br/ch.
+3. **Restructure both verses into a single unit**, so the form stops repeating
+   itself rather than adding a section.
+
+So v/ch/v/ch is not a form carrying the four-times risk — it is what technique
+1 produces. Diagnose the risk by counting trips through the *same* structure.
 
 ## Bridge sourcing — the missing angle
 

--- a/plugins/songwriting/context/pat-pattison/research/cliche.md
+++ b/plugins/songwriting/context/pat-pattison/research/cliche.md
@@ -27,6 +27,73 @@ This is the central distinction: universal does not mean generic. Sense-bound
 details let listeners fill the song with their own memories. Generic language
 keeps them at a distance.
 
+Pat's own statement of the job:
+
+> Your job as a writer isn't to point to a generic territory where images could
+> be, but instead to go there, get one, and show it to your listeners. Clichés
+> don't pump gasoline anymore.
+
+## The sleeping puppy
+
+Chapter 5 opens on a PBS documentary about a narcoleptic puppy who keeps
+toppling over mid-romp. The narrator blames the disorder; Pat blames the radio
+playing in the background. The puppy drops at these lines:
+
+```text
+You gotta take a chance
+If you want a true romance
+```
+
+and then again at:
+
+```text
+Take my hand
+Let me know you understand
+```
+
+> I may not be *The New England Journal of Medicine*, but I know why the puppy
+> is falling asleep: clichés. Cliché phrases. Cliché rhymes. Cliché images.
+> Cliché metaphors.
+
+Those four families are the chapter's taxonomy, and the puppy is the test: if a
+line puts the listener to sleep, name which of the four did it.
+
+Pat's examples of phrases worn smooth: *strong as a bull*, *eats like a horse*,
+*their ship came in* — no longer evoking bulls, horses, or ships at all. And a
+set that has become fully interchangeable, which is the tell: *break my heart*,
+*cut me deep*, *hurt me bad* (as interchangeable as *How ya doin'?* / *What's
+up?* / *How's it goin'?*).
+
+### Generic vs sense-bound — the chapter's demonstration pair
+
+Pat sets the same sentiment twice. First, generic:
+
+```text
+Noise and confusion, there's no peace
+In the hustle and bustle of city streets
+It's time to get away from it all
+Deep inside I hear nature's call
+```
+
+Then William Butler Yeats:
+
+```text
+I will arise and go now, for always night and day
+I hear lake water lapping with low sounds by the shore;
+While I stand on the roadway, or the pavements gray,
+I hear it in the deep heart's core.
+```
+
+> Both express roughly the same sentiment, but the first, cliché and generic as
+> it is, can only point to territories of meaning. Yeats takes you there.
+
+Pat's other frame for the same failure: clichés are prefabricated, string-able
+the way a guitarist strings favorite licks into a solo (two Claptons + one
+Hendrix + three Pages + one Stevie Ray). Learning from other people's licks is
+fine; the next step is finding your own way of saying it.
+
+> Clichés are other people's licks. They don't come from your emotions.
+
 ## Four cliche families
 
 Diagnose cliches by family:
@@ -55,6 +122,32 @@ Diagnosis questions:
 - Does it explain emotion before showing Rusty's collar?
 - Does it arrive because the writer is trying to fill meter or rhyme?
 
+Pat's own list runs to roughly a hundred entries. A representative slice, in his
+grouping:
+
+```text
+(way down) deep inside      touch my (very) soul       take my hand
+heart-to-heart              eye to eye                 hand-in-hand
+side by side                face-to-face               by my side
+we've just begun            hurts so bad               walk out (that) door
+can't stand the pain        feel the pain              give me half a chance
+gotta take a chance         such a long time           night and day
+all night long              the test of time           rest of my life
+someone like you            no one can take your place lonely nights
+say you'll be mine          how it used to be          made up my mind
+calling out your name       it's gonna be all right    get down on my knees
+more than friends           set me free                heaven above
+done you wrong              break these chains         kiss your lips
+falling apart               can't live without you     taken for granted
+lost without you            break my heart             safe and warm
+give you my heart           broken heart               can't go on
+want you / need you / love you                         keep holding on
+end of the line             now or never               pay the price
+never let you (me) go       hold me tight              worth fighting for
+nothing to lose             see the light              forget my foolish pride
+oh baby                     drive me crazy             going insane
+```
+
 Rewrite pattern:
 
 1. Underline the cliche phrase.
@@ -71,6 +164,36 @@ Cliche rhymes are predictable pairings. They often appear because perfect rhyme
 is the only tool being used. Predictability can drain the second line before it
 is sung.
 
+Pat's list of the offenders:
+
+```text
+hand / understand / command          eyes / realize / sighs / lies
+walk / talk                          fire / desire / higher
+kiss / miss                          burn / yearn / learn
+dance / chance / romance             forever / together / never
+friend / end                         ache / break
+cry / die / try / lie / good-bye / deny
+tears / fears                        best / rest / test
+door / before / more                 love / above / dove
+heart / start / apart / part         hide / inside / denied
+wrong / strong / song / long         touch / much
+word / heard                         begun / done
+arms / charms / harm / warm          blues / lose
+true / blue / through                lover / discover / cover
+pain / rain / same                   light / night / sight / tight
+stronger / longer                    fight / right
+take it / make it / fake it / shake it
+maybe / baby                         change / rearrange
+knees / please
+```
+
+Pat's diagnosis of why the list looks like that, and the cure it implies:
+
+> Most cliché rhymes are perfect rhymes, a good reason to stretch into other
+> rhyme types — family rhyme, additive and subtractive rhyme, and even assonance
+> rhyme. These imperfect rhyme types are guaranteed fresh, and most listeners
+> won't notice the difference.
+
 Use [worksheets](worksheets.md) to build options, then use
 [rhyme types](rhyme-types.md) to widen the field:
 
@@ -85,10 +208,31 @@ phrase, keep the idea and change the rhyme type.
 
 ## Cliche images
 
-Cliche images are familiar objects that no longer show a specific life. The
-Chapter 5 image inventory includes common body, romance, night, door, light, chain,
-flower, phone, and dance-floor territory. These territories are not banned, but
-they require personal detail to become active again.
+Cliche images are familiar objects that no longer show a specific life. Pat:
+"These have been aired out so much they are mere whiffs of their former selves."
+
+The inventory is a page figure (`image_rsrcATY.jpg`), read directly. Its full
+contents:
+
+```text
+lips            eyes            smile             hands
+face            hair            silky hair        voice
+soft (smooth) skin              warmth of arms    kiss            moon
+sky             light           sun going down    stars
+shadow          bed             lying in bed      night
+crying          knock           door              tears
+key             door            wall              lock
+chains          flowers         rose              cuts like a knife
+glass of wine   fireplace       telephone         perfume
+feel the beat   sweat           flashing lights   dance floor
+```
+
+These territories are not banned, but they require personal detail to become
+active again. Pat's cure is a set of questions aimed straight at the writer's
+own memory:
+
+> What did your lover say? Where were you? What kind of car? What was the
+> texture of the upholstery in the backseat?
 
 Ask:
 
@@ -103,9 +247,29 @@ If the user wants to use a common image, require a precise context.
 
 ## Cliche metaphors
 
-Some metaphor worlds are heavily worn: weather for anger, fire for passion,
-darkness for sadness or ignorance, seasons for life stages, prison for love,
-walls for self-protection, and the broken heart family.
+Pat's inventory of worn metaphor worlds, with the vocabulary each drags along:
+
+```text
+Storm for anger, including thunder, lightning, dark clouds, flashing, wind,
+  hurricane, tornado
+Darkness for ignorance, sadness, and loneliness, including night, blind, shadows
+Fire for love or passion, including burn, spark, heat, flame, too hot, consumed,
+  burned, ashes
+Rain for tears
+Seasons for stages of life or relationships
+Prison, Prisoner used especially for love, includes chains, etc.
+Cold for emotional indifference, including ice, freeze, frozen
+Light for knowledge or happiness, including shine, sun, touch the sky,
+  blinded by love, etc.
+Walls for protection from harm, especially from love
+Broken heart too numerous to mention
+Drown in love
+```
+
+Note the structure of the list: each entry is a *vehicle for a tenor* (storm for
+anger), not just a banned word. The whole family of associated words comes
+pre-worn with it. Pat's pointer for repair is back to Chapter 3, "Making
+Metaphors" — "There's no reason to keep sleepwalking in these yellow fogs."
 
 Do not ban these automatically. Ask whether the draft adds a fresh collision or
 specific sensory angle. If it does not, rebuild the metaphor from:
@@ -122,6 +286,55 @@ A cliche can work when the lyric creates a setup that restores or twists its
 original meaning. The phrase must gain a second life from context. Without that
 setup, treat it as a draft placeholder and replace it.
 
+Pat's two worked cases.
+
+**Sammy Fain and Irving Kahal, "I'll be seeing you."** As a cliche the phrase is
+just a substitute for *so long* or *good-bye*. Their setup makes it new:
+
+```text
+I'll be seeing you
+In all the old familiar places …
+I'll be looking at the moon
+But I'll be seeing you
+```
+
+> This passage implies good-bye, but only as an overtone of the primary meaning.
+> The result is a combination: After we say good-bye, I'll see you everywhere.
+
+That is the mechanism to copy: the cliche's usual meaning survives as an
+*overtone* underneath a literal primary meaning the song has built.
+
+**David Wilcox, "Top of the Roller Coaster."** He slants *it's all downhill from
+here* to his advantage, and picks up *over the hill* and *tiptop* on the way:
+
+```text
+Say good-bye to your twenties
+Tomorrow is the big Three-O
+For your birthday present
+I've got a place where we can go
+It's a lesson in motion
+We'll ride the wildest ride
+We're going to climb to the top of the roller coaster
+And look down the other side
+
+Let me ride in the front car
+You ride right behind
+And I'll click my snapshot camera
+At exactly the right time
+I'll shoot back over my shoulder
+Catch the fear no one can hide
+When we tip the top of the roller coaster
+And look down the other side
+Over the hill
+So when the prints come back
+We can look at that unmistakable birthday fear
+Like your younger days are over now
+And it's all downhill from here
+```
+
+The literal roller coaster earns the figurative phrase. Pat's warning attached to
+both cases: "Without a terrific setup, duck whenever you see a cliché."
+
 Use this test:
 
 - Does the lyric make the familiar phrase mean something newly specific?
@@ -136,12 +349,44 @@ If the answer is no, cut or rewrite.
 Cliches are allowed in early drafts as markers. They can tell the writer what a
 line is trying to do. They become a problem when mistaken for finished writing.
 
+> Though clichés are great in a first or second draft as place markers for
+> something better, don't ever mistake them for the real thing.
+
+Chapter 5 demonstrates the upgrade on one verse. The cliche draft — Pat notes it
+does say something, "just nothing startling":
+
+```text
+She sits alone all day long
+The hours pass her by
+Every minute like the last
+A prisoner of time
+```
+
+> It doesn't yank you by the hair into her room. No humming fluorescent lights.
+> No faded lace curtains. You get to nap securely at a distance, untouched,
+> uninvolved.
+
+And the real thing — the opening of Beth Nielsen Chapman's "Child Again," the
+lyric Chapter 7 then analyzes in full:
+
+```text
+She's wheeled into the hallway
+Till the sun moves down the floor
+Little squares of daylight
+Like a hundred times before
+```
+
+Same situation, same section length. The difference is that the second one is
+sense-bound: a wheelchair, a moving sun, squares of daylight on a floor. Note
+what it does *not* do — it never names loneliness, helplessness, or time. The
+first draft names all three and shows none.
+
 When coaching, do not shame the placeholder. Translate it:
 
 ```text
-Placeholder: I can't live without you.
-Job: dependency, fear, separation, physical panic.
-Search: organic sense, daily objects, absent-person routines, room details.
+Placeholder: A prisoner of time.
+Job: helplessness, routine, days that are all the same.
+Search: what is she in, who moves her, what does the room do as hours pass.
 Rewrite source: object writing and worksheet words.
 ```
 
@@ -149,8 +394,11 @@ Rewrite source: object writing and worksheet words.
 
 Exercise 10 - Cliche inventory and parody draft:
 
-- Make a long personal list of cliche phrases, rhymes, images, and metaphors.
-- Write a verse/chorus/verse/chorus draft using only those cliches.
+- Make a long personal list of cliche phrases, rhymes, images, and metaphors —
+  Pat's instruction is "at least as long as my list above," and he adds "(It
+  won't be difficult.)"
+- String yours and Pat's together into a verse/chorus/verse/chorus lyric,
+  "making sure nothing original sneaks in."
 - Notice how easily it fills space while saying little.
 - Return to a real draft and mark any similar placeholders.
 - Rewrite each one through sensory detail, fresh rhyme, or new metaphor.

--- a/plugins/songwriting/context/pat-pattison/research/cliche.md
+++ b/plugins/songwriting/context/pat-pattison/research/cliche.md
@@ -58,11 +58,13 @@ Let me know you understand
 Those four families are the chapter's taxonomy, and the puppy is the test: if a
 line puts the listener to sleep, name which of the four did it.
 
+<!-- Pat's verbatim colloquial examples; elisions are deliberate --><!-- spellchecker:off -->
 Pat's examples of phrases worn smooth: *strong as a bull*, *eats like a horse*,
 *their ship came in* — no longer evoking bulls, horses, or ships at all. And a
 set that has become fully interchangeable, which is the tell: *break my heart*,
 *cut me deep*, *hurt me bad* (as interchangeable as *How ya doin'?* / *What's
 up?* / *How's it goin'?*).
+<!-- spellchecker:on -->
 
 ### Generic vs sense-bound — the chapter's demonstration pair
 

--- a/plugins/songwriting/context/pat-pattison/research/daily-practice.md
+++ b/plugins/songwriting/context/pat-pattison/research/daily-practice.md
@@ -80,12 +80,47 @@ Object-writing rules:
 - Stop exactly when the timer ends.
 - Mine after the buzzer.
 
-Useful prompt families:
+Every day of Challenge 1 has the same three-timer shape — 5 minutes, then 10
+minutes, then 90 seconds — and Pat supplies all three seeds. The complete list,
+in Pat's numbering (*Songwriting Without Boundaries* (2011), Challenge 1, Days
+1-14):
 
-- What: mirror, arrow, movie theater, broken cup, rain cloud, bus ticket.
-- Who: waitress, priest, cyclist, exhausted drummer, child in a hallway.
-- When: first snowfall, late evening, graduation, six in the morning.
-- Where: hotel bar, city bus, cliff by the ocean, old church, parking lot.
+| Day | 5 minutes | 10 minutes | 90 seconds |
+| --- | --- | --- | --- |
+| 1 | Sky | Crash | Lily Pad |
+| 2 | Bathroom Mirror | Dentist | Screwdriver |
+| 3 | Umbrella | Hair | Feather |
+| 4 | Curb | Bouquet | Rain Cloud |
+| 5 | Movie Theater | Cigar | Arrow |
+| 6 | Sailor | Waitress Clearing a Table | Priest |
+| 7 | Balloon Man | Homeless Child | Trucker |
+| 8 | Cyclist | Ballerina | Puppy |
+| 9 | Summer Rainstorm | Graduation | Wedding Rehearsal Dinner |
+| 10 | Six in the Morning | First Snowfall | Easter Sunday |
+| 11 | Late Evening | Loved One's Funeral | Crossing the Finish Line |
+| 12 | A Cliff by the Ocean | Park Bench in the City | Hotel Bar |
+| 13 | Suburban Swimming Pool | The Old Fishing Hole | Under an Umbrella |
+| 14 | On the City Bus | Wedding in an Old Church | Canoe on the River |
+
+Days 1-5 are "what" writing (things), 6-8 "who" (characters), 9-11 "when"
+(times and occasions), 12-14 "where" (places). Note that the ten-minute slot
+generally carries the day's most loaded seed — Crash, Dentist, Homeless Child,
+Loved One's Funeral — while the ninety-second slot stays small and physical.
+When generating a substitute seed, keep that weighting.
+
+Pat's own instruction line for every one of these days, worth reading aloud
+before the timer starts:
+
+> Set a timer and respond to the following prompts for exactly the time allotted.
+> Stop IMMEDIATELY when the timer goes off. Do not even finish the word you are
+> on. Use only your seven senses. No judgments, comments, or quotes allowed.
+
+He also prints a seven-word strip to let the eye wander over when the writer
+stalls:
+
+```text
+Sight  Sound  Taste  Touch  Smell  Body  Motion
+```
 
 ## Days 15-28: metaphor
 
@@ -94,22 +129,43 @@ then using each collision as a 90-second object-writing prompt.
 
 > A metaphor is a collision between ideas
 
-| Days | Practice | Coaching aim |
-| --- | --- | --- |
-| 15 | Adjective-noun collisions | Make arbitrary collisions meaningful. |
-| 16 | Find nouns from adjectives | Keep the adjective literally false. |
-| 17 | Find adjectives from nouns | Add friction instead of decoration. |
-| 18 | Noun-verb collisions | Use verbs to energize nouns. |
-| 19 | Find verbs from nouns | Give static nouns surprising action. |
-| 20 | Find nouns from verbs | Find a subject or object for strange action. |
-| 21 | Expressed identity | Test noun-noun pairs in all three forms. |
-| 22 | Reversed expressed identity | Reverse the nouns and compare pressure. |
-| 23 | Find nouns from nouns | Search new identities from a target noun. |
-| 24 | Playing in keys | Borrow terms through linking qualities. |
-| 25 | Playing in keys | Repeat target-to-quality-to-family practice. |
-| 26 | Find linking qualities | List qualities, then ask what else has them. |
-| 27 | Find linking qualities | Apply the search to social or abstract terms. |
-| 28 | Simile | Write three similes plus elaborations. |
+Pat's own day titles and seeds (*Songwriting Without Boundaries* (2011),
+Challenge 2, Days 1-14):
+
+| Day | Pat's day | Title | Seeds Pat supplies |
+| --- | --- | --- | --- |
+| 15 | C2 D1 | Adjective-Noun Collisions | Ten collisions from two five-word lists — see below |
+| 16 | C2 D2 | Finding Nouns From Adjectives | Angry; Boastful; Careful; Dark; Enthusiastic |
+| 17 | C2 D3 | Finding Adjectives From Nouns | Furnace; Midnight; Cottage; Hope; Ghost |
+| 18 | C2 D4 | Noun-Verb Collisions | Moonlight Tumbles; Funeral Exhales; Carburetor Sings; Autumn Remembers; Handkerchief Pleads |
+| 19 | C2 D5 | Finding Verbs From Nouns | Crossbow; Kettle; Waitress; Summer; Graduation |
+| 20 | C2 D6 | Finding Nouns From Verbs | Flush; Indict; Paddle; Operate; Soar |
+| 21 | C2 D7 | Expressed Identity: Noun-Noun Collisions | A wince is a cargo ship; A Frisbee is a zipper; A poem is an evening; Summer is the captain; A restaurant is a wineglass |
+| 22 | C2 D8 | Expressed Identity: Noun-Noun Collisions | The same five reversed: A cargo ship is a wince; A zipper is a Frisbee; An evening is a poem; The captain is summer; A wineglass is a restaurant |
+| 23 | C2 D9 | Expressed Identity: Finding Nouns From Nouns | `Maple tree is ___`; `Traffic is ___`; `Sunrise is ___`; `Cathedral is ___`; `Policeman is ___` |
+| 24 | C2 D10 | Playing in Keys: Using Linking Qualities | Policeman (protects / investigates / arrests) |
+| 25 | C2 D11 | Playing in Keys: Using Linking Qualities | Cathedral (it inspires / being at the pinnacle) |
+| 26 | C2 D12 | Playing in Keys: Finding Linking Qualities | Maple Tree; Traffic |
+| 27 | C2 D13 | Playing in Keys: Finding Linking Qualities | Handshake; Sunrise |
+| 28 | C2 D14 | Simile | Trust; A bad joke; Divorce; A waterfall; Hope |
+
+Three details worth carrying into coaching:
+
+- **Day 3's participle note.** When a writer draws an adjective off a verb —
+  *trembling* cottage — Pat names it: adjectives made by adding *-ing* or *-ed*
+  to a verb are participles, and since verbs are the strongest element in
+  language, using them to build modifiers makes for a more potent one.
+- **Day 7's three forms.** Every noun-noun identity gets tested in all three:
+  `A poem is a zipper` / `The zipper of the poem` / `The poem's zipper`.
+- **Day 14's focus rule.** `Love is a rose` sends the focus to the second term.
+  If you want love in focus, use simile: `Love is like a rose`.
+
+Day 10 also states the two metaphor-finder questions in their canonical form:
+
+```text
+What quality does my object have?
+What else has that quality?
+```
 
 Metaphor-practice rules:
 
@@ -141,31 +197,66 @@ keep producing images, actions, and turns.
 
 Challenge 3 daily arc:
 
-| Days | Practice | Direction |
-| --- | --- | --- |
-| 29-31 | Linking qualities to target ideas | Supplied qualities, one direction. |
-| 32-35 | Working both directions | Supplied qualities, then reverse the lens. |
-| 36-39 | Find linking qualities | Writer finds qualities, one direction. |
-| 40-42 | Find linking qualities both ways | Writer finds qualities, then reverses. |
+| Days | Pat's days | Practice | Direction |
+| --- | --- | --- | --- |
+| 29-31 | C3 D1-3 | Linking Qualities to Target Ideas | Supplied qualities, one direction. |
+| 32-35 | C3 D4-7 | Working Both Directions | Supplied qualities, then reverse the lens. |
+| 36-38 | C3 D8-10 | Finding Linking Qualities: Working One Direction | Writer finds three qualities, one direction. |
+| 39-42 | C3 D11-14 | Finding Linking Qualities: Moving Both Directions | Writer finds two qualities, then reverses. |
 
-Day prompts:
+Day prompts, with the linking qualities Pat actually supplies:
 
-| Day | Prompt | Practice focus |
-| --- | --- | --- |
-| 29 | Snowstorm | Link supplied qualities to target ideas. |
-| 30 | Deep-Sea Diver | Explore target ideas through a source lens. |
-| 31 | Guitar Solo | Notice how shared qualities open families. |
-| 32 | Sleeping Late | Reverse the metaphor after the first write. |
-| 33 | Broken Glass | Test whether the linking quality is essential. |
-| 34 | Falling in Love | Let strong shared qualities turn both ways. |
-| 35 | Cheating Lover | Use danger and damage as metaphor engines. |
-| 36 | Magnifying Glass | Find three linking qualities, one direction. |
-| 37 | Swimming Hole | Find qualities and target ideas, one direction. |
-| 38 | Afternoon Nap | Search qualities before target ideas. |
-| 39 | Traffic Cop | Find qualities, then begin reversing again. |
-| 40 | Wheelchair | Move both directions from writer-found qualities. |
-| 41 | Sailboat | Reverse through motion and grace families. |
-| 42 | Vacation | Reverse through abstract and relational targets. |
+| Day | Pat's day | Prompt | Linking qualities |
+| --- | --- | --- | --- |
+| 29 | C3 D1 | Snowstorm | Cold; Covering the ground; Hot cider by the fireplace; Slippery roads; Low visibility |
+| 30 | C3 D2 | Deep-Sea Diver | Totally immersed; Supported by a lifeline; Surrounded by an unfamiliar landscape |
+| 31 | C3 D3 | Guitar Solo | Building intensity; Going somewhere new; In the spotlight |
+| 32 | C3 D4 | Sleeping Late | Conserving energy; Wasting time |
+| 33 | C3 D5 | Broken Glass | Unable to be repaired; Glittering and dangerous |
+| 34 | C3 D6 | Falling in Love | Swept away; Glittering and dangerous |
+| 35 | C3 D7 | Cheating Lover | Swept away; Dangerous situation |
+| 36 | C3 D8 | Magnifying Glass | Writer supplies three |
+| 37 | C3 D9 | Swimming Hole | Writer supplies three |
+| 38 | C3 D10 | Afternoon Nap | Writer supplies three |
+| 39 | C3 D11 | Traffic Cop | Writer supplies two |
+| 40 | C3 D12 | Wheelchair | Writer supplies two |
+| 41 | C3 D13 | Sailboat | Writer supplies two |
+| 42 | C3 D14 | Vacation | Writer supplies two |
+
+Note the count drops from three qualities to two exactly when reversal arrives on
+Day 11 — the second ten-minute write costs what the third quality used to.
+
+Pat's own worked chains from Day 1, useful as demonstration material because they
+show one source producing five unrelated targets:
+
+```text
+Snowstorm -> Cold                       -> Your sneer
+Snowstorm -> Covering the ground        -> Wildflowers
+Snowstorm -> Hot cider by the fireplace -> Seeking comfort
+Snowstorm -> Slippery roads             -> Argument / Marriage
+Snowstorm -> Low visibility             -> Prejudice / The past
+```
+
+And from Days 2-7, so a coach has a supplied-quality bank on hand:
+
+```text
+Deep-sea diver -> Totally immersed        -> Cyclist / In conversation
+Deep-sea diver -> Supported by a lifeline -> Dying patient / Frontline soldier
+Deep-sea diver -> Unfamiliar landscape    -> Astronaut on the moon / Tourist
+Guitar solo    -> Building intensity      -> River / Lawyer's closing argument
+Guitar solo    -> Going somewhere new     -> First date / Piloting an airplane
+Guitar solo    -> In the spotlight        -> Moth / Escaping convict
+Sleeping late  -> Conserving energy       -> Sitting on a summer porch /
+                                             Taking the bus instead of walking
+Sleeping late  -> Wasting time            -> Surfing the Web /
+                                             A dead-end relationship
+Broken glass   -> Unable to be repaired   -> Broken trust / Mental illness
+Broken glass   -> Glittering and dangerous-> Las Vegas / Beautiful stranger
+Falling in love-> Swept away              -> Hurricane / Flash flood
+Cheating lover -> Swept away              -> Avalanche / Waterfall
+Cheating lover -> Dangerous situation     -> Kids playing with a loaded gun /
+                                             Smoking crack
+```
 
 ## Linking quality workflow
 
@@ -230,22 +321,54 @@ metrical and rhyme structure.
 
 The full sequence:
 
-| Day | Form | Prompt set |
-| --- | --- | --- |
-| 43 | Tetrameter lines, no rhyme | Sunset; Art Museum |
-| 44 | Tetrameter lines, no rhyme | Digging for Gold; Pickup Truck |
-| 45 | Tetrameter couplets | Mountain; Snowstorm |
-| 46 | Tetrameter couplets | Train; Sleeping Late |
-| 47 | Tetrameter couplets | John Brown; Broken Glass |
-| 48 | Tetrameter couplets | Skydiving; Rocking Chair on the Front Porch at Sunset |
-| 49 | Common meter `xaxa` | Whistling; Falling in Love |
-| 50 | Common meter `xaxa` | Ballerina; 18-Wheeler |
-| 51 | Common meter `abab` | Ocean Waves; Magnifying Glass |
-| 52 | Common meter `abab` | Slot Machine; Deep-Sea Diver |
-| 53 | Six-line `aabccb` / `xxaxxa` | War Zone; Wildflowers |
-| 54 | Six-line `abcabc` / `xxaxxa` | Morning Walk; Traffic Cop |
-| 55 | Six-line `abcabc` / `xabxab` | Trash Collector; Mowing the Lawn |
-| 56 | Unstable `abba` / `axxa` | Cloudy Day; Sleeping Late |
+Every day is two prompts: ten minutes on the first, five on the second. Pat's
+standing instruction is to use the whole time whether or not the final section
+gets finished.
+
+| Day | Pat's day | Pat's title | Form | 10 minutes | 5 minutes |
+| --- | --- | --- | --- | --- | --- |
+| 43 | C4 D1 | Tetrameter Lines | Tetrameter, duple feel, no rhyme | Sunset | Art Museum |
+| 44 | C4 D2 | Tetrameter Lines | Tetrameter, duple feel, no rhyme | Digging for Gold | Pickup Truck |
+| 45 | C4 D3 | Tetrameter Couplets | Rhymed pairs | Mountain | Snowstorm |
+| 46 | C4 D4 | Tetrameter Couplets | Rhymed pairs, duple and triple | Train | Sleeping Late |
+| 47 | C4 D5 | Tetrameter Couplets | Rhymed pairs, duple and triple | John Brown | Broken Glass |
+| 48 | C4 D6 | Tetrameter Couplets | Rhymed pairs, duple and triple | Skydiving | Rocking Chair on the Front Porch at Sunset |
+| 49 | C4 D7 | Common Meter | `xaxa` — rhyme only the trimeter lines | Whistling | Falling in Love |
+| 50 | C4 D8 | Common Meter | `xaxa` | Ballerina | 18-Wheeler |
+| 51 | C4 D9 | Common Meter | `abab` — rhyme tetrameter and trimeter | Ocean Waves | Magnifying Glass |
+| 52 | C4 D10 | Common Meter | `abab` | Slot Machine | Deep-Sea Diver |
+| 53 | C4 D11 | Tetrameter and Pentameter | Six-line `aabccb` / `xxaxxa` | War Zone | Wildflowers |
+| 54 | C4 D12 | Common Meter and Pentameter | Six-line `abcabc` / `xxaxxa` | Morning Walk | Traffic Cop |
+| 55 | C4 D13 | Common Meter and Pentameter | Six-line `abcabc` / `xabxab` | Trash Collector | Mowing the Lawn |
+| 56 | C4 D14 | Unstable Structure: abba | `abba` / `axxa` | Cloudy Day | Sleeping Late |
+
+Day 2 defines duple and triple feel with the shortest possible demonstration, and
+it is the one to use with a writer who cannot hear the difference:
+
+```text
+Mary had a little lamb        duple feel
+Mary, she had the littlest lamb   triple feel
+```
+
+Day 7 builds common meter live, adding one line at a time, and the reason it
+works is the imbalance in the middle:
+
+```text
+DUM da da DUM da DUM da da DUM    Give her a chance to sing by herself
+DUM da da DUM da DUM              Give her the room to shine
+DUM da da DUM da DUM da da DUM
+```
+
+You tap your foot four times in line 1 but only three in line 2. The body feels
+that imbalance — matching rhythms, differing lengths — and because you are off
+balance you must keep moving forward. Match line 3 to line 1 and rhyme it, and
+you have created a strong expectation for a fourth line. Line 4 lands and you
+feel the resolution. That is common meter, and like the tetrameter couplet it
+fits perfectly into an eight-bar sequence.
+
+Day 12 names the problem that six-line shapes exist to solve: rhyming `aabccb`
+still produces a stop sign at the couplet. Moving to `abcabc` keeps the section
+in motion across all six lines.
 
 Session rules:
 
@@ -317,8 +440,11 @@ The single most consequential discipline of *Songwriting Without Boundaries* (20
 guidance. The writer stops the moment the buzzer fires, including
 mid-word and mid-letter.
 
-> "Stop immediately when the timer ends." — Pat (*Songwriting Without Boundaries* (2011) challenge
-> openers; paraphrase)
+> "Stop IMMEDIATELY when the timer goes off. Do not even finish the word you are
+> on." — Pat, *Songwriting Without Boundaries* (2011), Challenge 1, Day 1
+
+The capitals are Pat's. The second sentence is the one that does the work: it
+removes the loophole a writer would otherwise take.
 
 The discipline:
 
@@ -335,16 +461,29 @@ thought."
 
 ## Free association vs story mode
 
-*Songwriting Without Boundaries* (2011) names two states the writer can be in during a timed write:
+Pat sets both states out on Challenge 1, Day 1 by comparing three writers who
+took the same seed three different ways:
 
-- **Free association** — the senses drive; the writer follows
-  sensory leaps wherever they go; the seed is a doorway, not a
-  contract.
-- **Story mode** — the writer tells a story or describes an event
-  in chronological order.
+> Object writing is pretty flexible. Susan stayed at an actual car crash. Scarlet
+> crashes pots on the linoleum floor. Both stay focused on one scene, as I did in
+> "Sky," while Cathy takes you floating away on a carpet of free association. The
+> only rule: Stay attached to your senses.
 
-Pat permits story mode when senses pull the writer there. He warns
-against forcing story mode to give the page a shape.
+So the two states are:
+
+- **Free association** — the senses drive; the writer follows sensory leaps
+  wherever they go. Pat's description of Cathy's write is the model: "letting one
+  thing roll into another, frequently leaving the original prompt fading
+  somewhere in the dust."
+- **Staying at one scene** — the writer holds a single location or event and
+  polls it with every sense. Susan's crash and Scarlet's kitchen both do this,
+  and Pat treats them as equally successful.
+
+Note that the flexibility runs the other way too: Scarlet answered the seed
+"Crash" with crashing pots rather than a car, so even a held scene need not be
+the literal prompt. The only rule is the senses. There is one clause Pat states
+as a rule and one he states as an observation — do not promote "stay at one
+scene" into a requirement.
 
 Diagnostic:
 
@@ -370,7 +509,14 @@ Five patterns the timed write should reject:
 5. **Theme statements** — naming the "point" of the write closes
    the page before the page has mined its material.
 
-> "No judgments, comments, or quotes allowed." — Pat (*Songwriting Without Boundaries* (2011) Day 1)
+Items 3 and 4 apply to Challenges 1-3 only. Challenge 4 requires both — its whole
+subject is fitting sense-bound material into stress counts and rhyme schemes — so
+do not carry the prohibition into Days 43-56. The rule Pat states without
+qualification, on every day of Challenge 1, is narrower than the list above: "Use
+only your seven senses. No judgments, comments, or quotes allowed."
+
+> "No judgments, comments, or quotes allowed." — Pat, *Songwriting Without
+> Boundaries* (2011), Challenge 1, Day 1
 
 ## Mining patterns Pat shows in writer samples
 
@@ -392,32 +538,57 @@ feedback. Skip them during the timed write itself.
 
 ## Day 15 — the collision pairs
 
-*Songwriting Without Boundaries* (2011), Challenge 2 opens with five adjective-noun collision pairs.
-The 14-day Challenge then jumbles them across subsequent days to
-test all combinations.
+*Songwriting Without Boundaries* (2011), Challenge 2, Day 1 is the biggest single
+day in the book: ten prompts, each requiring a sentence or short paragraph and
+then a ninety-second piece of object writing. Pat's own accounting — "A total of
+fifteen minutes, not counting the thinking and the sentences. Should be easy,
+eh?"
 
-The five seed pairs (paraphrased shape):
+He prints two five-word lists side by side and tells you to shove the first
+adjective against the first noun. That produces the first five collisions:
 
-| Pair | Adjective | Noun |
-|---|---|---|
-| 1 | Lonely | Moonlight |
-| 2 | Blackened | Funeral |
-| 3 | Fallen | Carburetor |
-| 4 | Smooth | Autumn |
-| 5 | Fevered | Handkerchief |
+| # | Adjective | Noun | Collision |
+| --- | --- | --- | --- |
+| 1 | Lonely | Moonlight | Lonely Moonlight |
+| 2 | Blackened | Funeral | Blackened Funeral |
+| 3 | Fallen | Carburetor | Fallen Carburetor |
+| 4 | Smooth | Autumn | Smooth Autumn |
+| 5 | Fevered | Handkerchief | Fevered Handkerchief |
 
-Days 16-21 recombine the adjectives and nouns into new pairings —
-for example, "Lonely Handkerchief" or "Blackened Autumn". Each new
-combination becomes a fresh collision drill.
+Then, halfway through the same day: "Five down, five to go. The words have been
+mixed up a bit." The noun column is reshuffled against the same adjectives:
 
-The discipline: write a coherence sentence first (one line that
-makes the collision plausible), then run a 90-second sense-bound
-write from the collision.
+| # | Adjective | Noun | Collision |
+| --- | --- | --- | --- |
+| 6 | Lonely | Handkerchief | Lonely Handkerchief |
+| 7 | Blackened | Autumn | Blackened Autumn |
+| 8 | Fallen | Funeral | Fallen Funeral |
+| 9 | Smooth | Moonlight | Smooth Moonlight |
+| 10 | Fevered | Carburetor | Fevered Carburetor |
 
-Pair-jumbling is the day-to-day mechanic — each new pairing forces
-the writer to find a new linking quality. See
-[metaphor](metaphor.md) "Eight named metaphor moves" for the
-recipes that operate on the pairs.
+The reshuffle is contained inside Day 1 — it is not spread across the following
+days. Days 2 onward move to different operations (the writer supplies the missing
+half, then verbs, then noun-noun identity), so treat the jumble as a
+within-session move: run a pairing, then run its scramble, and refuse to reuse
+the first linking quality on the second.
+
+The discipline for each of the ten: sit and think about the collision first and
+try to supply a landscape to make it make sense; write that sentence; then run
+ninety seconds of object writing using the collision as the prompt. Your object
+writing should use the collision as its prompt, but it can go anywhere — "You
+just get there through lonely moonlight's gate."
+
+Two diagnostic notes Pat attaches to this day, both usable as coaching language:
+
+- **Metaphors are always literally false.** On "blackened autumn": the fires
+  blacken things, not the season. "In fact, if the combination could be true,
+  e.g., blackened handkerchief, then it's not a metaphor."
+- **Productive ambiguity.** On a handkerchief write where it is hard to tell
+  whether the writer means a person or a piece of cloth: "I like when that
+  happens ... having at least two meanings, and both work in the context. You'll
+  find that productive ambiguity lies at the heart of metaphor."
+
+See [metaphor](metaphor.md) for the recipes that operate on the pairs.
 
 ## Three-stage leap — source through target
 
@@ -445,16 +616,23 @@ the metaphor is durable.
 Use reversal:
 
 - Only when the linking quality is essential to both ideas.
-- Days 32-42 of the curriculum reverse routinely.
+- Days 32-35 (Challenge 3, Days 4-7) and Days 39-42 (Challenge 3, Days 11-14)
+  reverse routinely. Days 36-38 deliberately do not — they hand the writer the
+  quality search instead, one variable at a time.
 - A reversal that feels forced means the metaphor wanted to stay
   one-directional or convert to simile.
 
 ## Stress-before-sound — why Days 43-44 forbid rhyme
 
-*Songwriting Without Boundaries* (2011), Challenge 4 opens with no-rhyme tetrameter exercises (Days
-43-44). The pedagogical reason: stress placement and rhyme are
-separate skills, and learning to hear stress is harder if rhyme is
-on the page distracting the ear.
+*Songwriting Without Boundaries* (2011), Challenge 4 opens with two days of
+tetrameter and withholds rhyme entirely. Pat's instruction on Challenge 4, Day 1
+is "Use only tetrameter lines, concentrating on a duple feel. No rhymes for now."
+On Day 2 it is "No rhymes till tomorrow." Rhyme arrives on Day 3, when a
+tetrameter couplet is defined as a pair of tetrameter lines that rhyme.
+
+Two days of line-length work before the first rhyme is the sequencing decision.
+Stress placement and rhyme are separate skills, and stress is the harder one to
+hear when rhyme is on the page competing for the ear.
 
 Sequence:
 
@@ -470,9 +648,10 @@ the line until stress lands clean, then add rhyme back.
 
 ## Nashville stressed-vowel title brainstorming
 
-A daily practice generator from patpattison.com seminars. Pat cites
-it as the way working Nashville writers produce title candidates
-quickly.
+A daily practice generator attributed to patpattison.com seminars rather than to
+either book. It is not part of the 56-day curriculum and no wording for it can be
+verified against *Songwriting Without Boundaries* (2011) — treat it as a method,
+not as a quotation, and do not attribute a sentence to Pat when using it.
 
 The drill:
 
@@ -484,30 +663,43 @@ The drill:
 5. Test the title's rhyme surface — the same vowel must also
    support 10+ rhyme candidates.
 
-> "This is how Nashville writers write a song every day." — Pat
-> (paraphrase)
-
 Use the Nashville method as a 10-minute daily warm-up after the
 56-day curriculum. Pair with [hook](hook.md) "title generation"
 for the seven-types catalog.
 
-## Pair-jumbling mechanic (*Songwriting Without Boundaries* (2011) Days 15-16)
+## Withdrawing the scaffolding (*Songwriting Without Boundaries* (2011), Challenge 2, Days 1-3)
 
-A subtle design detail in Challenge 2 Days 15-16 that affects how the
-metaphor-collision drill works:
+The design detail that actually governs the collision drill is not pair-jumbling
+across days — the jumble is contained inside Day 1. It is that Pat hands over one
+more piece of the work each day:
 
-- **Day 15** uses 5 adjectives and 5 nouns paired one way (List 1)
-- **Day 16** uses the SAME 5 adjectives and 5 nouns reshuffled into NEW
-  pairings (List 2)
+- **Day 1** — he supplies both halves. "Yesterday I gave you the combinations and
+  asked you to explore them."
+- **Day 2** — he supplies the adjective; the writer finds the noun. "Today, I'll
+  give you the adjectives, leaving it up to you to find nouns to crunch up
+  against them. Don't grab just anything; take your time and look for provocative,
+  productive collisions."
+- **Day 3** — reversed. "I'll give you the noun, and you try to find a colliding
+  adjective."
 
-The pair-jumbling is deliberate. Each pair forces the writer to find a
-new linking quality. By reusing the same 10 words in new combinations,
-Pat tests whether the writer's linking-quality search is genuine — a
-formulaic answer that worked for Day 15's pair will not work for Day
-16's reshuffled pair.
+Days 4-6 run the same three-step withdrawal again over noun-verb collisions, and
+Days 7-9 again over noun-noun identity. Three ladders, same shape.
 
-Coach use: when assigning Day 15 / 16 drills, do not let the writer use
-the same linking quality across days. Each pair needs its own search.
+The constraint that makes the search real is the literal-falseness test, which
+Pat restates on each of these days:
+
+> Don't pick something that can be literally angry, like people or bees. Those
+> wouldn't be metaphors. They'd just be angry people and angry bees.
+
+And on Day 3's `dark`: dark eyes could be literally true, so it is not a
+metaphor — "they join together rather than colliding." Dark *thoughts*, cliché
+though it is, is a metaphor, because it is literally false.
+
+Coach use: when a writer's collision comes back flat, check first whether it is
+literally true. That is the usual cause, and it is fixable in one substitution.
+Pat's own worked recovery, on Day 3's `ghost`: a ghost can plausibly be lazy, so
+`lazy ghost` is "not quite a collision" — try unhuman qualities like `brittle` or
+`wrinkled` instead.
 
 ## Pat's critique-move vocabulary (*Songwriting Without Boundaries* (2011) — recurring across all four challenges)
 
@@ -528,22 +720,54 @@ for reviewing object writes and lens writes. Treat as named moves:
 Use these phrases verbatim when coaching writer samples. The shorthand
 makes the same critique replicable across sessions.
 
-## Tense-flip and POV-flip as named drills (*Songwriting Without Boundaries* (2011) Challenges 1, 3)
+The last two both come from *Songwriting Without Boundaries* (2011), Challenge 4,
+Day 11, in Pat's commentary on six-line sections, and his own wording is shorter
+than the paraphrases above:
 
-Pat treats tense-flips and POV-flips as explicit drills, not casual
-exercises. Specific instructions:
+> You get so much of the story just from the rhyme positions! The rhyming
+> positions are in the spotlights. Use them.
 
-- **Tense flip** — re-read your sample in past tense, present tense, and
-  future tense (or future-conditional). Compare immediacy, weight,
-  vulnerability. The right tense often surfaces only by trying the
-  wrong ones.
-- **POV flip** — re-read your sample in 1st person, 2nd person, 3rd
-  person. Note which version surprises you. The least expected POV
-  often produces the strongest writing.
-- **Tense-neutral -ing forms** — when a line could work across tenses,
-  use the gerund or present-participle form to defer commitment. Useful
-  for repeatable chorus material that needs to color differently in
-  verse 1 (past) vs verse 3 (future).
+> Form is a road map. It tells you where to go.
+
+The road-map remark lands on a specific observation: one writer used the `cc`
+lines to shift focus to a new set of characters, taking advantage of the change
+in rhyme sound to support the change in perspective, and another introduced a
+command at the same point where the new rhyme sound appears. Rhyme change and
+tone change arriving together is the move being praised.
+
+"Invite family members" is likewise Pat's, from Challenge 3, Day 2: "Notice all
+the members of the diver's family she invites into the key of dying patient."
+
+## Tense-flip and POV-flip as named drills (*Songwriting Without Boundaries* (2011), Challenge 1, Days 8, 9, 13)
+
+Pat plants these three times inside Challenge 1, always as an experiment run on
+finished sample writing rather than as a prompt.
+
+**POV flip — Challenge 1, Day 8.** Two writers took the Cyclist prompt from
+opposite positions, one from inside the biker and one from outside:
+
+> As an experiment, try reversing them: Read Manuel's in third person ("as he
+> takes off …") and read Tasleem's in first person ("Rain slaps against my knees
+> as I race …"). Is there a difference in tone and immediacy?
+
+**Tense flip — Challenge 1, Day 9.** On a past-tense sample: past tense removes
+the reader a bit from the scene, since it happened, after all, in the past. Pat
+reprints it in present tense and calls the difference "pretty big." His rule:
+
+> Present tense is more immediate than past tense or future tense—not that
+> everything you write needs to be immediate. Just remember that tense is a
+> tool—a choice you make. Don't let the fact that it happened in the past make
+> you write it in past tense. Don't let "how it really happened" drive the bus.
+> You're the writer.
+
+**Tense-neutral -ing forms — also Day 9.** Asking two present-tense samples to be
+translated into past tense, Pat notes that both "use a lot of the *ing* form of
+the verb, which is tense-neutral." That is the mechanism behind repeatable
+material that can recolor from verse to verse without being rewritten.
+
+**Both at once — Challenge 1, Day 13.** The compact version of the drill, worth
+using verbatim: "Try Deborah's piece in present tense. Then translate it into
+first person, then second person."
 
 The flips are revision tools, not generation tools. Run them AFTER the
 object-write or lens-write is on the page; do not interrupt the timer to

--- a/plugins/songwriting/context/pat-pattison/research/daily-practice.md
+++ b/plugins/songwriting/context/pat-pattison/research/daily-practice.md
@@ -353,11 +353,13 @@ Mary, she had the littlest lamb   triple feel
 Day 7 builds common meter live, adding one line at a time, and the reason it
 works is the imbalance in the middle:
 
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
 ```text
 DUM da da DUM da DUM da da DUM    Give her a chance to sing by herself
 DUM da da DUM da DUM              Give her the room to shine
 DUM da da DUM da DUM da da DUM
 ```
+<!-- spellchecker:on -->
 
 You tap your foot four times in line 1 but only three in line 2. The body feels
 that imbalance — matching rhythms, differing lengths — and because you are off

--- a/plugins/songwriting/context/pat-pattison/research/exercises.md
+++ b/plugins/songwriting/context/pat-pattison/research/exercises.md
@@ -8,8 +8,12 @@ Chapter 1-7 and *Pat Pattison's Songwriting: Essential Guide to Rhyming*
 
 Use this file when a user wants a craft drill rather than a coaching
 conversation. Each entry is a self-contained exercise the writer can
-do alone, paraphrased to preserve the craft pedagogy without
-reproducing the book.
+do alone, given in Pat's own instruction wording with his numbering,
+his word lists and rhyme schemes, and the answer keys the book prints.
+
+Earlier revisions summarized the exercises instead — which meant none of
+them were actually Pat's, the item counts were invented, and Exercises 32
+and 33 had been dropped entirely.
 
 ## How to use
 

--- a/plugins/songwriting/context/pat-pattison/research/exercises.md
+++ b/plugins/songwriting/context/pat-pattison/research/exercises.md
@@ -190,127 +190,386 @@ Routes to: [meter](meter.md) "deceptive vs unexpected closure".
 
 ### Ex 18 — Three perfect rhymes per syllable
 
-For each of five seed syllables (pick five short open vowels or
-short consonant endings), find three perfect rhymes. Then mark
-which are masculine and which are feminine.
+**EXERCISE 18: THINK UP THREE PERFECT RHYMES FOR EACH OF THE
+FOLLOWING SYLLABLES. YOUR RHYMES DO NOT HAVE TO BE WORDS.**
+
+<!-- spellchecker:off -->
+
+```text
+1. lant  ________  ________  ________
+2. ints  ________  ________  ________
+3. rutch ________  ________  ________
+4. mose  ________  ________  ________
+5. kate  ________  ________  ________
+```
+
+<!-- spellchecker:on -->
 
 Routes to: [rhyme fundamentals](rhyme-fundamentals.md).
 
 ### Ex 19 — Masculine and feminine identification
 
-Pick 10 existing rhyme pairs (from any lyric source). Mark each as
-masculine or feminine. Verify by listening for whether the stressed
-syllable is the last syllable of the word.
+**EXERCISE 19: PUT AN "M" AFTER THE MASCULINE RHYMES AND AN "F"
+AFTER THE FEMININE RHYMES.**
+
+```text
+1. enjoy/destroy            6. hexagon/Rubicon
+2. oblique/unique           7. libretto/falsetto
+3. artichoke/baroque        8. deny/pacify
+4. penetration/salvation    9. Jezebel/repel
+5. triple/cripple          10. appreciate/relate
+```
 
 Routes to: [rhyme fundamentals](rhyme-fundamentals.md).
 
 ### Ex 20 — Rhyme scheme notation with identity
 
-Take seven existing four-line stanzas. Notate the rhyme scheme using
-letters (a, b, c) for distinct rhymes. Use `I` for identities (words
-that sound the same because they share initial consonants — not a
-real rhyme).
+**EXERCISE 20: NOTATE THE RHYME SCHEME OF EACH OF THE FOLLOWING
+LISTS. USE LETTERS (INCLUDING "X" FOR UNRHYMED WORDS) AFTER EACH
+WORD. USE "I" TO NOTATE IDENTITIES.**
+
+Pat works number 1 as the model:
+
+<!-- spellchecker:off -->
+
+```text
+1. notation    a        2. heart       3. strong      4. unleash
+   motivation  a           report         hear           force
+   increase    b           sing           along          McLeash
+   police      b           start          throng         horse
+   relation    a           retort         wrong          Norse
+                           fling
+                           ring
+
+5. understand  6. start   7. lass        8. fool
+   allowed        return     follow         rule
+   reprimand      ease       sorrow         sunny
+   slow           burn       borrow         rate
+   grow                      glass          state
+   crowd                     hollow         honey
+```
+
+<!-- spellchecker:on -->
 
 Routes to: [rhyme fundamentals](rhyme-fundamentals.md).
 
 ### Ex 21 — Balance lists by rhyme
 
-Take five short verse drafts. Identify which lines rhyme. Adjust by
-adding or subtracting rhyming words so the section feels balanced
-in sound repetition and order repetition (the two forces).
+**EXERCISE 21: BALANCE THE FOLLOWING LISTS BY ADDING OR SUBTRACTING
+WORDS. TRY TO FIND RHYMES THAT MAKE SENSE WITH THE WORDS ALREADY
+THERE.**
+
+```text
+1. niece      2. decide    3. fulfill     4. revive
+   stumble       ride         returning      connive
+   fleece        course       unlock         trick
+   crumble                    will           alive
+   peace                      burning
+
+5. showing    6. confirm
+   date          squirm
+   gate          term
+   mate          last
+   glowing
+```
 
 Routes to: [rhyme strategy](rhyme-strategy.md) "sound vs order".
 
 ### Ex 22 — Accelerate or decelerate by rhyme spacing
 
-Take three verse drafts. Write two versions of each: one with rhymes
-close together (acceleration), one with rhymes spaced out
-(deceleration). Sing both. Notice the pace change.
+**EXERCISE 22: ACCELERATE THE FOLLOWING LISTS BY ADDING OR
+SUBTRACTING WORDS. TRY TO FIND RHYMES THAT MAKE SENSE WITH THE WORDS
+ALREADY THERE. THEN, START OVER AND DECELERATE THEM.**
+
+The same three lists are worked twice — once ACCELERATE, once
+DECELERATE:
+
+```text
+1. niece      2. decide    3. fulfill
+   stumble       ride         returning
+   fleece        course       unlock
+```
+
+Pat's note on number two: once you have consecutive rhymes, the pedal
+is to the metal. You cannot accelerate. The only way to go faster then
+is to shorten phrase lengths.
 
 Routes to: [rhyme strategy](rhyme-strategy.md) "accelerator metaphor".
 
 ### Ex 23 — Through-written vs fragmented
 
-Take six four-line sections. Mark each as through-written (the
-rhyme keeps the section moving across the pair) or fragmented (the
-rhyme closes the section into halves). Rewrite each to flip its flow.
+**EXERCISE 23: PUT A "T" FOR "THROUGH-WRITTEN" OR "F" FOR FRAGMENTED
+IN EACH BLANK. THEN, SUBSTITUTE WORDS FOR LETTERS IN EACH EXAMPLE.
+CHOOSE TWO OF YOUR RESULTS, ONE THROUGH-WRITTEN AND ONE FRAGMENTED,
+AND WRITE COMPLETE PHRASES. GROUP YOUR IDEAS ACCORDING TO THE FLOW OF
+THE RHYME SCHEME.**
+
+```text
+ 1. ____ a b a b:      1. THROUGH-WRITTEN:
+ 2. ____ a a b b:
+ 3. ____ a a a b:
+ 4. ____ a b b a:
+ 5. ____ a a a:
+ 6. ____ a a b a:      2. FRAGMENTED:
+ 7. ____ a b b a a:
+ 8. ____ a b a a:
+ 9. ____ a b a a b:
+10. ____ a b a b a:
+```
+
+Answer key printed at the foot of the page (inverted): 1. T; 2. F;
+3. F; 4. T; 5. F; 6. F; 7. T; 8. T; 9. F; 10. F
 
 Routes to: [rhyme strategy](rhyme-strategy.md).
 
-### Ex 24 — Closure type and phrase length
+### Ex 24 — Closed or open
 
-Take two existing sections. Mark each as closed or open. Rewrite
-each so the rhyme structure matches the phrase lengths — that is,
-the closure timing matches the phrase ending.
+**EXERCISE 24: PUT C FOR CLOSED OR O FOR OPEN IN EACH BLANK. THEN,
+SUBSTITUTE WORDS FOR LETTERS.**
+
+```text
+ 1. ____ a b a b a
+ 2. ____ a a b b b
+ 3. ____ a a a b b
+ 4. ____ a b c a b
+ 5. ____ a b c a c
+ 6. ____ a b b a
+ 7. ____ a b b a a
+ 8. ____ a b b a b b
+ 9. ____ a b c c b
+10. ____ a a b
+```
+
+**NOW, CHOOSE TWO OF YOUR ANSWERS, ONE OPEN AND ONE CLOSED, AND WRITE
+SECTIONS FOR THEM. MAKE THE LENGTHS AND RHYTHMS OF PHRASES FOLLOW THE
+RHYME SCHEME: WHERE RHYME SOUNDS MATCH, MAKE YOUR PHRASES AND RHYTHMS
+MATCH. WHEN RHYME SOUNDS CHANGE, USE DIFFERENT PHRASE LENGTHS AND
+RHYTHMS.** (1. CLOSED: 2. OPEN:)
+
+Answer key printed at the foot of the page (inverted): 1. C; 2. C;
+3. O; 4. O; 5. C; 6. O; 7. either; 8. C; 9. C; 10. O
 
 Routes to: [rhyme strategy](rhyme-strategy.md).
 
 ### Ex 25 — Closure type identification
 
-Take eight existing sections. Mark each section's closure as
-expected, deceptive, or unexpected. Discuss with a writing partner
-or alone — disagreement usually means the section is doing two
-things at once.
+**EXERCISE 25: PUT E FOR EXPECTED, U FOR UNEXPECTED, OR D FOR
+DECEPTIVE IN EACH OF THE BLANKS PROVIDED. THEN, SUBSTITUTE WORDS FOR
+THE LETTERS IN EACH RHYME SCHEME.**
+
+```text
+ 1. ____ a b a b b
+ 2. ____ a b a a
+ 3. ____ a a b b a
+ 4. ____ a a b a
+ 5. ____ a b a a a
+ 6. ____ a b a c c a
+ 7. ____ a b a c c b
+ 8. ____ a b a a b
+ 9. ____ a a a
+10. ____ a b c a a a
+```
+
+Answer key printed at the foot of the page (inverted): 1. U; 2. D;
+3. U; 4. D; 5. D & U; 6. D; 7. E; 8. D & U; 9. U; 10. D
 
 Routes to: [rhyme strategy](rhyme-strategy.md) "closure types".
 
 ### Ex 26 — Deceptive then unexpected closure
 
-Write one section with deceptive closure in Paradigm Three rhythm
-(4/3/4/4 stresses). Then write one section with unexpected closure
-in any rhythm. Sing both.
+**EXERCISE 26: WRITE A LYRIC SECTION WITH A DECEPTIVE RHYME CLOSURE
+USING PARADIGM THREE FROM CHAPTER 3 FOR ITS RHYTHM. THEN WRITE A
+LYRIC SECTION WITH AN UNEXPECTED RHYME CLOSURE. EITHER ADD AN EXTRA
+PHRASE AFTER IT IS CLOSED, OR RHYME IT FOR THE FIRST TIME AT THE
+END.**
+
+```text
+DECEPTIVE:
+
+UNEXPECTED:
+```
 
 Routes to: [meter](meter.md) and [rhyme strategy](rhyme-strategy.md).
 
 ### Ex 27 — Flow rewrite
 
-Take two existing sections — one through-written, one fragmented.
-Rewrite each for the opposite flow. Same idea, different rhyme
-structure.
+**EXERCISE 27: KEEPING AS MUCH OF THE SAME MEANING AS POSSIBLE,
+REWRITE A) AND B) TO GET THE OPPOSITE EFFECTS: THROUGH-WRITE A) AND
+FRAGMENT B). (YOU MAY WANT TO LENGTHEN OR SHORTEN SOME OF THE
+PHRASES.)**
+
+The two sections being rewritten:
+
+```text
+a)  Love her or leave her to me      a
+    Keep her or let her go free      a
+    Don't go two-timing her          b
+    'less you're resignin' her       b
+
+b)  Some girls like their flirtin'    a
+    They're always on the roam        b
+    Blind to who they're hurtin'      a
+    Their eyes are never home         b
+```
+
+```text
+REWRITE OF A): (LOVE HER OR LEAVE HER TO ME)
+
+REWRITE OF B): (SOME GIRLS LIKE THEIR FLIRTIN')
+```
 
 Routes to: [rhyme strategy](rhyme-strategy.md).
 
 ### Ex 28 — Rhyme scheme to plot
 
-Pick three rhyme schemes (e.g., abab, aabb, abcb). For each, plot
-three different idea movements that the scheme could support
-(e.g., contrast, accumulation, suspension). Write a one-paragraph
-sketch per plot.
+**EXERCISE 28: TRY WORKING FROM RHYME SCHEME TO IDEAS. FOR EACH OF
+THE RHYME SCHEMES BELOW, THINK UP A PLOT WHOSE ACTION FITS THE
+MOVEMENT OF THE RHYME SCHEME THEN, COME UP WITH RHYME WORDS FOR YOUR
+PLOT. HERE IS AN EXAMPLE:**
+
+```text
+RHYME SCHEME: ABACCB
+
+PLOT SKETCH:
+My lover and I are dancing, enjoying our closeness.
+My spouse enters the lounge and spots me. We have been
+discovered!
+
+Rhyme words: dance/embrace/romance/eyes/surprise/disgrace
+```
+
+Your turn:
+
+```text
+1. RHYME SCHEME: AABBCC
+   PLOT SKETCH:
+   RHYME WORDS:
+
+2. RHYME SCHEME: XAXABB
+   PLOT SKETCH:
+   RHYME WORDS:
+
+3. RHYME SCHEME: AABCCC
+   PLOT SKETCH:
+   RHYME WORDS:
+```
 
 Routes to: [rhyme strategy](rhyme-strategy.md) "three strategies".
 
 ## *Essential Guide to Lyric Form and Structure* (1991) — Form exercises (Chapter 5)
 
-### Ex 29 — The candy bar — rewrite a verse four ways
+All five Chapter 5 exercises work the same "candy bar" section. Pat
+uses one verse again and again to show that it is structure, not
+content, that makes a section what it is.
 
-Pick one existing verse. Rewrite it four ways:
+```text
+Love me like a candy bar
+Sugar, try my flavor
+Let me be your chocolate star
+Layer after layer
+```
 
-1. By varying phrase count (add or remove a phrase).
-2. By varying phrase length (compress some, extend others).
-3. By varying rhythm (switch stress pattern).
-4. By varying rhyme (change scheme or rhyme types).
+Version #1A, which Ex 29 works from, adds an unrhymed phrase:
 
-Each rewrite is a different version of the same idea. Compare. Which
-version belongs in the verse position? Which would work as a bridge?
+```text
+Love me like a candy bar
+Sugar, try my flavor
+Let me be your chocolate star
+Smooth and rich and sweet
+Layer after layer
+```
+
+### Ex 29 — Rewrite the candy bar as a bridge
+
+**EXERCISE 29: REWRITE THE "CANDY BAR" SECTION ABOVE AS A BRIDGE SO
+IT WILL CONTRAST WITH THE SONG SYSTEM IT FOLLOWS. YOU MIGHT START BY
+SHORTENING THE FIRST PHRASE TO MAKE IT SOUND DIFFERENT RIGHT AWAY.**
+(Rewrite:)
+
+**NOW, REWRITE THE VERSE INSTEAD TO MAKE #1A WORK AS A BRIDGE AS IT
+STANDS.** (Rewrite of "Melt me down...":)
 
 Routes to: [form](form.md) "four building levers" and
 [section building](section-building.md).
 
-### Ex 30 — Verse leading to chorus
+### Ex 30 — Verse leading to the candy bar chorus
 
-Write a verse that sets up a specific chorus's first line. The verse
-must transition cleanly into the chorus by both rhythm and rhyme.
+**EXERCISE 30: WRITE A VERSE TO LEAD UP TO THE CHORUS VERSION OF #2
+JUST ABOVE. MAKE IT CONTRAST IN PHRASE LENGTH AND RHYME SCHEME.**
+
+```text
+VERSE:
+
+CHORUS: LOVE ME LIKE A CANDY BAR
+        Sugar, try my flavor
+        Let me be your chocolate star
+        LOVE ME LIKE A CANDY BAR
+```
 
 Routes to: [form](form.md), [song forms](song-forms.md).
 
-### Ex 31 — Bridge by phrase rhythm
+### Ex 31 — Two versions juggling phrase rhythms
 
-Take a chorus. Write two different bridges. Each bridge should
-juggle phrase rhythm differently from the chorus — that is, the
-bridge's rhythmic identity should contrast the chorus's.
+**EXERCISE 31: WRITE TWO OTHER VERSIONS OF THE "CANDY BAR" SECTION,
+JUGGLING PHRASE RHYTHMS. MAKE SURE THAT BOTH CLOSE. WHAT EFFECTS DO
+YOUR VERSIONS HAVE? WHAT COULD THEY BE USED FOR?**
+
+```text
+Version 1.
+EFFECT:
+USES:
+
+Version 2.
+EFFECT:
+USES:
+```
 
 Routes to: [form](form.md) "three bridge functions",
 [song forms](song-forms.md).
+
+### Ex 32 — Two versions juggling rhyme schemes
+
+**EXERCISE 32: WRITE TWO OTHER VERSIONS OF THE "CANDY BAR" SECTION,
+JUGGLING YOUR RHYME SCHEMES. MAKE SURE THAT BOTH CLOSE. WHAT EFFECTS
+DO YOUR VERSIONS HAVE? WHAT COULD THEY BE USED FOR?**
+
+```text
+Version 1.
+EFFECT:
+USES:
+
+Version 2.
+EFFECT:
+USES:
+```
+
+Routes to: [form](form.md), [rhyme strategy](rhyme-strategy.md),
+[section building](section-building.md).
+
+### Ex 33 — Two more transitional bridges
+
+Pat's model for a candy-bar Transitional Bridge — unbalanced, pushing
+forward, but still feeling like a section:
+
+```text
+Love me like a candy bar
+Milky Way and Mars
+```
+
+**EXERCISE 33: WRITE TWO MORE TRANSITIONAL BRIDGES, USING THE "CANDY
+BAR" SECTION. JUGGLE WHATEVER YOU LIKE, BUT MAKE SURE THAT BOTH CAN
+BE IDENTIFIED AS SECTIONS. WHAT EFFECTS DO YOUR VERSIONS HAVE?**
+
+```text
+Version 1.
+EFFECT:
+
+Version 2.
+EFFECT:
+```
+
+Routes to: [song forms](song-forms.md) "transitional bridge",
+[section building](section-building.md).
 
 ## *Essential Guide to Lyric Form and Structure* (1991) — Song forms exercises (Chapter 6)
 

--- a/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
+++ b/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
@@ -145,32 +145,121 @@ These are defaults. The five-row check exposes when the writer
 diverged from default — and lets the writer decide whether the
 divergence was deliberate prosody or accidental drift.
 
-## Worked example
+## Worked example — "Some People's Lives"
 
-A four-line verse with three lines feeling right and one feeling
-"off" — the five-row check might return:
+Pat's own extended demonstration of rows 1 and 3 is Janis Ian and Kye Fleming's
+"Some People's Lives" (*Writing Better Lyrics* (2009), Chapter 21). It is worth
+running the five-row check against, because Pat shows the counterfactuals.
+
+Verse 1 as written:
+
+```text
+Some people's lives      a
+Run down like clocks     b
+One day they stop        b
+That's all they've got   b
+```
 
 ```text
 Section: verse 1
 
-1. Number of lines:    4
-2. Line lengths:       4/4/4/4 stresses
-3. Rhyme scheme:       abab
-4. Rhyme types:        perfect / family / consonance / family
-5. Rhythm:             duple, established line 1, deliberate
-                       variation line 3 (matches narrative pivot)
-
-Verdict:
-- Supports central emotion? Partially — central emotion is
-  resigned-stable; consonance on line 3 opens suspended.
-- Supports section job? Yes for setup, no for arrival.
-- Strongest element: rhythm variation at line 3 (matches pivot).
-- Weakest element: consonance rhyme type at line 3 fights the
-  resigned tone.
-- Cheapest fix: change line 3's rhyme type from consonance to family.
+1. Number of lines:    4 (even — balanced)
+2. Line lengths:       short and matched throughout
+3. Rhyme scheme:       abbb
+4. Rhyme types:        perfect (1991 vocabulary; see the four-ball note below)
+5. Rhythm:             matched
 ```
 
-One row fix. The other four stay. Diagnose all five, change one.
+Rows 1 and 3 disagree on purpose, and Pat says so:
+
+> That's all they've got is the climax of the section. The balancing position
+> allows us to savor it by letting it rest in the spotlight a few seconds. Note,
+> however, that the rhyme scheme, abbb, is a little unstable. Though the line
+> lengths and rhythms match, we have the same effect at the end of line three
+> that we saw earlier … the abb rhyme pattern raises no expectations.
+
+Now the counterfactual — Pat rewrites row 3 only, leaving rows 1, 2, and 5
+untouched:
+
+```text
+Some people's lives      x
+Run down like clocks     a
+One day they cease       x
+That's all they've got   a
+```
+
+> Now it feels really stable. The stability actually adds an emotion (motion
+> creates emotion).
+
+And the real version's instability adds a different one:
+
+> Isn't it sad? It makes me feel like something's missing.
+
+**Why the one-row change matters at song scale.** Verses 1 and 2 both run abbb,
+so two unstable sections land on a very stable chorus:
+
+```text
+Didn't anybody tell them    x
+Didn't anybody see          a
+Didn't anybody love them    x
+Like you love me?           a
+```
+
+> So we have two unstable sections (sad lives), moving into a stable section —
+> "our love makes me stable. I wish everyone had this kind of love in their
+> lives." If the rhyme scheme in the verses were stable, the arrival at a stable
+> section in the chorus wouldn't have the same power.
+
+Pat proves that too, restabilizing both verses to xaxa and reporting the loss:
+
+> Now we feel stable for the whole trip. The chorus, and therefore the singer's
+> gratitude for the love she receives, is diminished by the stable rhyme scheme.
+> The chorus is less of a landing place than it is in the original version.
+
+**Then row 1 does the same job.** Verses 1-3 are all four lines. Verse 4 is
+three:
+
+```text
+Some people laugh           a
+When they need to cry       b
+And they never know why     b
+```
+
+> The contrast with these balanced sections gives verse four its power. We expect
+> stability. Instead, it totters on the brink for a moment.
+
+Three phrases plus the chorus's four leaves seven — still odd, still unresolved
+— and verse 5 pulls the same trick again. The payoff is a single extra line on
+the final chorus:
+
+```text
+Didn't anybody tell them    x
+Didn't anybody see          a
+Didn't anybody love them    x
+Like you love me?           a
+'Cause that's all they need a
+```
+
+> Spotlights blaze onto the extra phrase as it balances the entire last system
+> with an even number of phrases (twelve), and steps onto the platform at the
+> other side of the high-wire journey.
+
+Two rows, deliberately set, across a whole song. That is what the five-row check
+is looking for.
+
+**The reading discipline this models.** Diagnose all five rows; change one; keep
+the other four fixed so you can hear what the change did. Pat's counterfactuals
+are all single-row edits, which is why they are legible.
+
+Pat's four named uses of row 1 (phrase count), from the same chapter:
+
+1. spotlighting important ideas,
+2. pushing one section forward into another section,
+3. contrasting one section with another one,
+4. creating a need for a balancing section or phrase.
+
+> Unbalanced sections make you want to move to find a stable spot. Balanced
+> sections stop motion; they pause for a rest.
 
 ## Coaching prompts
 

--- a/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
+++ b/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
@@ -90,7 +90,8 @@ See [phrasing](phrasing.md) "length of phrases" for *Essential Guide to Lyric Fo
 
 The letters describing which lines rhyme with which. Adjacent rhymes
 (aabb) close fast; alternating (abab) suspend across the pair;
-enclosed (abba) wrap; unrhymed (xaxa or xxxa) open. Mixed schemes
+enclosed (abba) wrap **without closing** — the frame returns but the
+system stays open; unrhymed (xaxa or xxxa) open. Mixed schemes
 (abcb) close some pairs while leaving others open.
 
 See [rhyme strategy](rhyme-strategy.md) for scheme as a control of

--- a/plugins/songwriting/context/pat-pattison/research/form.md
+++ b/plugins/songwriting/context/pat-pattison/research/form.md
@@ -8,11 +8,17 @@ Chapter 20-21.
 
 - *Essential Guide to Lyric Form and Structure* (1991), Chapter 5: **32 linked
   images** (`image_rsrc31Z`-`image_rsrc32Y`), and they carry the chapter's
-  scansion and rhyme-scheme analysis the way Chapter 6's do. The prose stops at
-  dangling colons ("The first phrases play off against the rhythms, grouping
-  this way:"). **Chapter 5 has NOT been read in full** — only its bridge and
-  Song System span. Treat every claim sourced to it here as unverified until it
-  is, and read the figures when doing so.
+  scansion, rhyme-scheme analysis, structural-pentad descriptions, and several
+  whole worked lyrics the way Chapter 6's do. **Chapter 5 has now been read in
+  full with every figure**, and the verbatim material below is transcribed from
+  it. Figures that are lyrics in their own right: `image_rsrc322` ("Slow Healing
+  Heart" verse/chorus Song System), `image_rsrc32B`/`32C` (Steely Dan's "Haitian
+  Divorce," all three Song Systems), `image_rsrc32F`/`32G` (The Cars' "Why Can't
+  I Have You," Song Systems 1 and 2), `image_rsrc32P`/`32R` (the "Oh Henry"
+  candy-bar Song System), `image_rsrc328` ("These Are the Days" bridge).
+  Figures that are the structural-pentad checkboxes for the candy-bar variants:
+  `image_rsrc32H`, `32J`, `32K`, `32M`, `32N`. Figure `image_rsrc32E` is the
+  complete alternative-name list for the Transitional Bridge.
 - *Writing Better Lyrics* (2009), Chapter 20: `image_rsrcAUG.jpg` shows a verse/chorus rhyme-column
   comparison for "Southern Comfort"; both sections lean on similar `x/a`
   alternation before the bridge arrives.
@@ -24,7 +30,14 @@ Form is the large-scale control of moving and stopping. Syllables become words,
 words become phrases, phrases become sections, and sections become song
 systems that move through time.
 
-> "A lyric is like a piece of music"
+> Lyrics are made up of pieces: syllables gather into words, words form phrases
+> and phrases stack up into sections, sections group into "song systems," which
+> finally work together to create the lyric. A lyric is like a piece of music,
+> it moves forward one syllable at a time, through time. It is not like a
+> painting, which you can experience all at once. Lyric structure is your guide
+> on this forward journey. The easiest way to understand the journey is to keep
+> two simple ideas in mind: MOVING and STOPPING. You can look at the job of each
+> lyric section in terms of one or the other.
 
 The practical question is whether each section is moving toward the central
 idea, departing from it, or stopping on it.
@@ -33,10 +46,34 @@ idea, departing from it, or stopping on it.
 
 Every section has a job:
 
-- Central section: contains the central idea and acts as the structural
-  centerpiece.
-- Developmental section: leads up to, develops, contrasts with, or departs from
-  the central idea.
+> Until now I have asked you to build only lyric sections. In this chapter you
+> will link sections together to form larger groups. Start by thinking of each
+> lyric section as either a CENTRAL SECTION or a DEVELOPMENTAL SECTION.
+> Everything within the lyric moves toward or departs from a CENTRAL SECTION.
+> Like ancient Rome, all roads lead to a CENTRAL SECTION and every other place
+> is just a stop along the way.
+
+> The CENTRAL SECTION should contain the CENTRAL IDEA, or main point, of the
+> lyric. The CENTRAL SECTION is the structural centerpiece of the lyric. The
+> CENTRAL IDEA is the main message of the lyric. Put them together.
+
+> DEVELOPMENTAL SECTIONS contain DEVELOPMENTAL IDEAS: ideas that lead up to or
+> develop the CENTRAL IDEA. They should move forward until they get to a CENTRAL
+> SECTION.
+
+The named jobs, from *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 5:
+
+```text
+VERSE
+CHORUS
+BRIDGE
+REFRAIN
+HOOK
+```
+
+> A lyric does not have to have all these elements to work properly. A clock
+> doesn't have to have an alarm to keep time.
 
 Basic motion:
 
@@ -66,23 +103,37 @@ Form starts when those section-level moves are placed in sequence.
 section needs to do. Writers usually start with function, then build form to
 support it.
 
-Two directions matter:
+Pat gets there through Artie's '69 VW microbus pulling up next to a
+cream-and-baby-blue Maserati, and has Artie and Herbie state the two readings:
 
-- From function to form: decide what the section needs to say or do, then pick
-  phrase lengths, rhythms, and rhymes that make that job audible.
-- From form to function: when two sections use the same design, the listener
-  expects them to do similar work; when a section has a different job, its form
-  should change.
+> When you look at an individual car, you can figure out what it's built to do
+> (function) by its design (form). Conversely, when you build a car, you figure
+> out its design by what you want it to do. If you want a racecar, build it
+> heavy, wide, and lower in front than in back so the wind will press it to the
+> track. If you want an economy car, build it light and shape it to cut wind
+> resistance. **You already know this as the principle of prosody.**
+
+> When you look at two cars, you see whether they're different or the same. When
+> they're the same design, they should have the same function. When they have
+> different designs, they should have different functions. **This is the
+> principle of contrast.**
+
+> It doesn't matter whether we're talking about cars, rhyme schemes,
+> architecture, or lyrics.
+
+> As a writer, you'll usually look from a car designer's perspective — from
+> function to form. You know what you want to say, so you have to design form to
+> support your ideas.
+
+So Pattison names both readings rather than leaving them implicit: applied to a
+single section, form-follows-function *is* the principle of
+[prosody](prosody.md); applied to two sections compared against each other, it
+*is* the principle of contrast. Same rule, one object or two.
 
 That second direction is the structural basis for section contrast. Verse forms
 can match each other because verses usually share the same developmental job.
 A chorus should normally change design because it comments, summarizes, or
 arrives.
-
-Pattison names both readings rather than leaving them implicit: applied to a
-single section, form-follows-function *is* the principle of
-[prosody](prosody.md); applied to two sections compared against each other, it
-*is* the principle of contrast. Same rule, one object or two.
 
 ## Rhyme as accelerator
 
@@ -93,10 +144,87 @@ close rhymes      -> faster structural motion
 spread-out rhymes -> slower structural motion
 ```
 
-The "Ping-Pong" example uses short phrases, internal rhymes, and tight
-consecutive rhymes to make the section feel active. If those same thoughts are
-rewritten as long phrases with little rhyme, the meaning may still describe
-speed, but the structure no longer performs it.
+*Writing Better Lyrics* (2009), Chapter 20 builds the example in four stages.
+Built for speed:
+
+```text
+You can't play Ping-Pong with my heart      a
+You dominate the table                      b
+My nerves are shot, you've won the set      c
+Your curves have got me in a sweat          c
+My vision's blurred, can't see the net      c
+I'm feeling most unstable                   b
+```
+
+> Built for speed. The consecutive rhymes, "set/sweat/net," slam the ideas home.
+> The internal rhymes, "nerves/curves/blurred" and "shot/got," put us in
+> overdrive. The acceleration creates prosody, the mutual support of structure
+> and meaning — form follows function.
+
+> You can think of rhyme as a car's accelerator: The closer the pedal is to the
+> floor, the faster the car moves. The closer the rhymes are to each other, the
+> faster the structure moves. The farther away the pedal is from the floor, the
+> slower the car moves.
+
+Tone down the rhyme action:
+
+```text
+You can't play Ping-Pong with my heart      a
+You dominate the table                      b
+My nerves are shot, I've come apart         a
+You wink and smile, still feeling playful   b
+Weak and numb, I miss the mark              a
+Feeling most unstable                       b
+```
+
+> Out pops the rear parachute. Prosody evaporates, or at least diminishes, when
+> the rhymes are spread out into a regular pattern. But the short phrases in
+> lines three, four, and five still press on the accelerator.
+
+Lengthen the shorter phrases and let off the gas even more:
+
+```text
+You can't play Ping-Pong with my heart              a
+You dominate the table                              b
+My nerves are shot, I've really come apart          a
+You wink and smile, still feeling pretty playful    b
+Weak and numb, I really miss the mark               a
+Feeling most unstable                               b
+```
+
+Then ease off on the rhymes too, pushing them further apart:
+
+```text
+You can't play Ping-Pong with my heart              x
+You dominate the table                              b
+My nerves are shot, at last you've won the point    x
+Your slams have put me in an awful sweat            x
+My vision's weak, can't even see the ball           x
+I'm feeling most unstable                           b
+```
+
+> Now the structure acts more like a slow-moving '68 VW microbus, while the
+> meaning still dreams of checkered flags on the Grand Prix Circuit. Bad
+> combination.
+
+**EXERCISE 44:** We might as well destroy prosody completely while we're at it.
+This time, you do it. Rewrite the example below so lines three and five contain
+one long phrase each, instead of two shorter ones. Be careful not to rhyme.
+
+```text
+You can't play Ping-Pong with my heart      x
+You dominate the table                      b
+…                                           x
+Your slams have put me in an awful sweat    x
+…                                           x
+I'm feeling most unstable                   b
+```
+
+> Compare your result to the original and you will see what an important role
+> structure can play in support of meaning. If you're careful how you build your
+> form, you can make it work for you. Tend to the prosody of form and function,
+> and your structure will become a powerful and expressive ally rather than an
+> obstacle standing between you and what you really meant to say.
 
 Use this as a diagnostic: when a lyric claims urgency, excitement, panic, or
 argument, check whether phrase length and rhyme spacing actually accelerate.
@@ -105,21 +233,63 @@ the section linger.
 
 ## Verse
 
-The verse is the basic worker section. Its jobs are to introduce ideas, set up
-the central idea, develop or continue ideas, establish structural standards,
-and close down enough to be recognized as a complete section.
+> The Verse is the basic worker of the lyric. Its jobs are
+>
+> 1. To introduce ideas
+> 2. To set up the CENTRAL IDEA
+> 3. To develop or continue ideas
+> 4. To set structural standards for the lyric,
+>
+> thus, 5. Verses should close down.
 
 Verses establish the point of comparison:
 
+> Verses establish BALANCE, PACE, FLOW, CLOSURE, AND CLOSURE TYPE for the lyric,
+> setting a point of comparison for other structures in the lyric. Verses
+> establish your expectations for the lyric, much like a juggler who establishes
+> a pattern so he can surprise you with variations. Here is an example of a
+> verse.
+
 ```text
-Verse 1: balance / pace / flow / closure / closure type
-Verse 2: repetition or variation against that standard
-Next section: contrast against that standard
+The carousel spun smooth as glass
+Those childhood summer nights
+I spent my time for rings of brass
+Beneath the sparkling lights
 ```
 
-Worked example: Pattison's carousel example uses a common-meter `abab` verse.
-When a later section keeps `abab` but lengthens the phrases, the listener hears
-contrast because the verse has already defined the baseline.
+> The common meter and a b a b rhyme scheme come through clearly. The section
+> closes down just as you expect it to. Now you are set up: you have a point of
+> reference for recognizing either repetition or contrast.
+
+```text
+The rings came easy to my hand
+My parents stood and smiled
+They fell to me at my command
+A golden summer's child
+```
+
+> With the first Verse as a reference point, it is easy to recognize this as
+> repetition — as another Verse. It is just as easy to hear the contrast in this
+> section:
+
+```text
+One by one we reach for the chances
+One by one we move down the line
+Day by year in smooth revolving dances
+One by one we sail away out of time
+```
+
+> Although the new section maintains the a b a b rhyme scheme, its phrases are
+> longer.
+
+Figure `image_rsrc31Z` scans those four phrases, and Pat draws the conclusion
+directly from the comparison:
+
+> This section has longer phrases. Longer than what? Longer than the verses. It
+> will require a different musical treatment than the verses. It also seems to
+> sum up or comment on the verse information. The verses set up, then serve this
+> new section. It is the CENTRAL SECTION, and contains the CENTRAL IDEA, in this
+> case, life's passage through time.
 
 Revision test: if the verse does not clearly establish a pattern, later
 sections cannot sound like repetition, contrast, departure, or return.

--- a/plugins/songwriting/context/pat-pattison/research/form.md
+++ b/plugins/songwriting/context/pat-pattison/research/form.md
@@ -804,22 +804,25 @@ the structural job rather than the position alone.
 Use transitional bridges when a verse-chorus boundary feels abrupt;
 the transitional bridge softens the seam while building tension.
 
-## Transitional bridge — complete alternative-name list (*Essential Guide to Lyric Form and Structure* (1991), Chapter 5 + *Writing Better Lyrics* (2009), Chapter 13)
+## Transitional bridge — alternative-name list (*Essential Guide to Lyric Form and Structure* (1991), Chapter 5)
 
-The transitional bridge has many names depending on tradition, genre, and
-era. Pat lists all of them so writers recognize the concept under any name:
+**transitional bridge** is Pat's own term — it names the job rather than the
+position. He then prints the names other writers use for the same section, so
+the concept is recognizable under any of them. The chapter's list is exactly
+these six:
 
-- **transitional bridge** — Pat's preferred term (names the job, not the
-  position)
-- **pre-chorus** — modern pop / industry term
-- **lift** — folk / country
-- **ramp** — pop / production-side term
-- **climb** — same as lift
-- **channel** — pop
-- **runway** — pop
-- **prime** — older industry term
-- **vest** — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5 alternative
-- **verse extension** — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5 alternative
+```text
+Pre-Chorus        Vest              Ramp
+Climb or Lift     Verse Extension   Prime
+```
+
+Note "Climb or Lift" is one entry in the source, not two. Earlier revisions of
+this file listed ten names — adding "channel" and "runway", splitting climb
+from lift, and attaching genre and era attributions ("modern pop / industry
+term", "folk / country", "older industry term") that the chapter does not
+make. None of that is in the book. The heading also carried a *Writing Better
+Lyrics* (2009), Chapter 13 citation; that chapter is "Dialogue and Point of
+View" and has nothing to do with this section.
 
 All names describe the same structural job: a short, unbalanced section
 enclosed inside a song system, between verse and chorus, that does NOT

--- a/plugins/songwriting/context/pat-pattison/research/hook.md
+++ b/plugins/songwriting/context/pat-pattison/research/hook.md
@@ -29,27 +29,48 @@ several levels:
 - Opening and closing phrase of each section.
 - Opening and closing idea word inside a phrase.
 
-For a chorus, the hook can appear:
+For a chorus, the hook can appear first, last, or both. Chapter 7's three
+examples:
+
+**Hook first** — Paul and Gene Nelson, "EIGHTEEN WHEELS AND A DOZEN ROSES."
+Note that the last phrase is also an important idea, so both hot spots are
+working:
 
 ```text
-hook first:
-HOOK
-supporting lines
-important closing idea
-
-hook last:
-supporting lines
-HOOK
-
-hook first and last:
-HOOK
-supporting lines
-HOOK
+EIGHTEEN WHEELS AND A DOZEN ROSES
+Ten more miles on his four lane run
+A few more songs from the all night radio
+And he'll spend the rest of his life
+with the one that he loves
 ```
 
-For verse/refrain forms, the hook often appears at the beginning or end of the
-verse as the refrain. Using it both places in every verse can become too much
-unless the structure needs it.
+**Hook last** — Donald Fagen and Walter Becker, "HAITIAN DIVORCE":
+
+```text
+O, No Hesitation
+No tears and no hearts breaking
+No remorse
+O, Congratulations!
+This is your HAITIAN DIVORCE
+```
+
+**Hook first and last** — Jim Rushing, "A SLOW HEALING HEART":
+
+```text
+A SLOW HEALING HEART
+Is dying to mend
+Longing for love
+Lonely again
+When a spirit is broken
+And the memories start
+Nothing moves slower
+Than A SLOW HEALING HEART
+```
+
+The same strategies are available when the verse contains the hook, but in a
+verse/refrain you will usually use it either at the beginning or the end, not
+both — using it both places means using it twice in *every* verse, which in
+most cases would be too much.
 
 ## Hot spots make meaning
 
@@ -98,11 +119,62 @@ enough. Additional repetition should earn its place.
 
 Good repetition types:
 
-- Direct repetition for emphasis.
-- Beginning-and-ending repetition for frame.
-- Verse refrain plus chorus hook when the form can support both.
-- Repetition that completes or balances the structure.
-- Repetition with a turn in meaning.
+- **Direct repetition** — simple but effective:
+
+```text
+TEDDY DOESN'T LIVE HERE ANYMORE
+TEDDY DOESN'T LIVE HERE ANYMORE
+
+They get you crawlin'
+I might'a fallen
+But you were always around
+YOU NEVER LET ME DOWN
+YOU NEVER LET ME DOWN
+```
+
+- **Direct repetition with a turn in meaning** — the second pair means
+  something the first pair did not:
+
+```text
+You were RIGHT FROM THE START
+RIGHT FROM THE START
+You had my number all along
+You were right and I was wrong
+RIGHT FROM THE START
+RIGHT FROM THE START
+```
+
+- **Beginning-and-ending repetition for frame** — Randy Newman, "TICKLE ME":
+
+```text
+Why don't you TICKLE ME
+Gee whiz won't that be fine
+What a great idea,
+What a perfect way to kill some time
+Can't stop to think
+'Cause if we do we'll lose our minds
+Why don't you TICKLE ME
+```
+
+- **Verse refrain plus chorus hook** when the form can support both — John
+  Jarvis and Gary Nicholson, "FATHERS AND SONS," where the verse ends on the
+  title and the chorus ends on it again:
+
+```text
+Now when I look at my own son
+I know what my father went through
+There's only so much you can do
+You're proud when they walk
+Scared when they run
+That's how it always has been between FATHERS AND SONS
+```
+
+- **Repetition that completes or balances the structure** — see below.
+
+Pat's own caution, delivered by demonstration: "Of course, if you repeat
+yourself too much if you repeat yourself too much if you repeat yourself too
+much if you repeat yourself too much if you repeat yourself too much you get
+boring, so be cautious."
 
 Bad repetition is repetition that merely spends attention without structural or
 semantic need.
@@ -267,16 +339,27 @@ arrival satisfying.
 
 ## Exercises to preserve
 
-- Write a balanced chorus with a supplied title first, then rewrite it with the
-  same title last.
-- Write a verse that sets up that chorus, using beginning and ending positions
-  for important ideas.
-- Write a verse ending with a supplied refrain; make the repetition structurally
-  necessary.
-- Write two transitional bridges that target different hook sounds.
-- For supplied hooks, write verses that use the hook rhythm in strategic
-  positions.
-- Write a full song system using all five hook-focus strategies.
+The supplied titles *are* the exercise — keep them.
+
+- **Exercise 39** — Write a balanced chorus using the title
+  "YOU DON'T HAVE THE BEST OF ME YET" at the beginning. Then rewrite it with
+  the same title at the end.
+- **Exercise 40** — Write a verse to set up that chorus. Make sure you use the
+  beginning and end positions for important ideas.
+- **Exercise 41** — Write a verse that ends with the refrain "YOU DON'T HAVE
+  THE BEST OF ME YET." Make a repetition necessary by using two strategies:
+  (1) unbalance the system by making the rhythmic closure at the refrain
+  awkward, like "SEEING SOMEONE ELSE"; (2) unbalance the section by making the
+  refrain an odd-numbered phrase (5th or 7th would be ideal).
+- **Exercise 42** — Write a balanced chorus that begins and ends with the hook
+  "I SLIPPED AND FELL IN LOVE." Then, using "WHY CAN'T I HAVE YOU" as a model,
+  (1) write a transitional bridge leading up to it that TARGETS the vowel sound
+  in "slipped," and (2) write a transitional bridge that targets "fell."
+- **Exercise 43** — For each hook below, write a verse that uses the hook
+  rhythm in a strategic position: "LAST NIGHT'S LOVE"; "MY FIRST LOVE WILL BE
+  MY LAST"; "THE LAST OF THE LONELY HEARTS."
+- **Exercise 44** — Using all five strategies, write a song system for the hook
+  "DON'T GIVE UP."
 
 ## Revision workflow
 

--- a/plugins/songwriting/context/pat-pattison/research/idea-to-title.md
+++ b/plugins/songwriting/context/pat-pattison/research/idea-to-title.md
@@ -1,7 +1,24 @@
 # Idea to Title — Developing a Seed Toward a Title
 
+Pat Pattison — *Writing Better Lyrics* (2009), Chapter 4 ("Learning to
+Say No: Building Worksheets"), Chapter 19 ("Understanding Motion"),
+Chapter 24 ("Process").
+
 The writer has a seed: an image, a feeling, a phrase, a scene, a vibe —
 but no title yet. This file routes seed → title.
+
+Pat's stance on why volume matters here, verbatim, Chapter 4's opening
+line:
+
+> "Writing a lyric is like getting a gig: If you're grateful for any idea
+> that comes along, you're probably not getting the best stuff. But if
+> you have lots of legitimate choices, you won't end up playing six hours
+> in Bangor, Maine, for twenty bucks. Look at it this way: The more often
+> you can say no, the better your gigs get."
+
+And on the title's structural weight, Chapter 24: "I think the most
+productive place to look is at the title, since that's the centerpiece of
+the song."
 
 Distinct from:
 
@@ -36,6 +53,28 @@ These five questions distill the seed into testable shape. The writer's
 first-pass answers are often surface-level; gentle re-asking ("but what
 underneath that?") usually surfaces the real seed.
 
+Pat's Chapter 4 framing names three ways a lyric starts, and the seed
+type changes the work. Verbatim:
+
+> "Sometimes, you'll start the lyric from an emotion: 'That old homeless
+> woman with everything she owns in a shopping cart really touches me. I
+> want to write a song about her.' Sometimes you'll write from a cold,
+> calculated idea: 'I'm tired of writing love songs. I want to do one on
+> a serious subject, maybe homelessness.' Or, you may write from a title
+> you like, maybe 'Risky Business.'"
+
+When the seed IS a title, the missing piece is the angle. Pat's own
+worked dialogue for "Risky Business" over the subject of homelessness:
+
+```text
+"What do you do for a living?"
+"I survive on the streets."
+"That's a pretty risky business."
+```
+
+His instruction: "In each case, it's up to you to find the angle,
+brainstorm the idea, and create the world the idea will live in."
+
 ### Step 2 — Object-write the seed's world
 
 Set a 10-minute timer. Object-write the world the seed implies:
@@ -49,6 +88,30 @@ Set a 10-minute timer. Object-write the world the seed implies:
 Per `object-writing.md`. Do NOT try to make it lyrical. The point is to
 generate raw vocabulary, images, verbs, sensory anchors.
 
+Pat does exactly this in Chapter 24: given the working title "She Sells
+Seashells," he object-writes the word `Seashells` before touching the
+lyric, then mines it. His stated reason: "the process of object writing
+helps me find out what I have to offer that originates from my own unique
+sense experiences. The closer I stay to my senses, the more real and
+effective my writing will be."
+
+His mining pass is the model — he keeps some images, discards others, and
+says why: the front loaders come "out of my childhood and may not be
+helpful in the scene," he likes "the shells digging to China," the
+spirals etched in the shells "may be useful, since the song seems
+concerned with the consequences for the girl of the parents' breakup,"
+and he likes "the tides as a metaphor for the parents' voices."
+
+Chapter 4's Exercise 9 gives the same move for a subject rather than a
+title: "dive into homelessness for ten minutes. Stay sense-bound and very
+specific." Its target is what T.S. Eliot called an **objective
+correlative** — in Pat's words, "objects anyone can touch, smell, and see
+that correlate with the emotion you want to express." His examples: a
+broken wheel on a homeless woman's shopping cart; the speaker's parents
+fighting. And his instruction not to stop at the first one: "Even if you
+find ideas that work well, keep looking a while longer. When you find a
+good idea, there is usually a bunch more behind it."
+
 After the timer, mine for:
 
 - the strongest image
@@ -59,7 +122,14 @@ After the timer, mine for:
 ### Step 3 — Generate title candidates
 
 From the mined material AND the distilled seed sentence, generate 10-15
-title candidates. Pat's seven title types (per `hook.md` "Title generation"):
+title candidates.
+
+**Unverified against the books:** the seven-type taxonomy below appears
+in neither *Writing Better Lyrics* (2009) nor *Songwriting Without
+Boundaries* (2011). It is owned by `hook.md` and left as-is here;
+whoever owns `hook.md` should confirm its source.
+
+Pat's seven title types (per `hook.md` "Title generation"):
 
 1. **One-word** — a single noun, verb, or adjective
 2. **Place-name** — a location, real or invented
@@ -86,6 +156,21 @@ For each candidate title, identify:
 This analysis determines rhyme worksheet input, form fit, hook position,
 and targeting opportunities.
 
+Pat's rule for what to do with those vowels, *Writing Better Lyrics*
+(2009), Chapter 19, Exercise 28:
+
+> "Make up your own title, and, using it as the first line of an oncoming
+> chorus, write an AAB structure leading up to it, with the third line
+> targeting a vowel sound in the title. Try not to target the end rhyme.
+> Instead, give the words inside the title a sonic boost."
+
+The move is to light up a vowel **inside** the title, not to rhyme with
+its last word. His illustration: with an oncoming chorus titled "For One
+Smile in a Million," an unrhymed `while` at the end of the preceding
+three-line section emphasizes `smile` when the chorus lands — "Nifty
+tool, eh?" Exercise 41 restates it for a five-line scheme: "Target an
+inner vowel of the title line rather than the end rhyme."
+
 ### Step 5 — Run rhyme stability test on each candidate
 
 For each surviving candidate, run a quick worksheet pass (per
@@ -96,9 +181,61 @@ For each surviving candidate, run a quick worksheet pass (per
 - What can the song's world contribute? (proper nouns, settings, era words)
 - Any obvious cliche partners to flag (moon/June, fire/desire)?
 
+Pat's Chapter 4 guidelines for the word list, verbatim:
+
+- "If you are working with a title, be sure to put its key vowel sounds
+  in the list."
+- "Most of your words should end in a stressed syllable, since they work
+  best in rhyming position."
+- "Put any interesting words that duplicate a vowel sound in
+  parentheses."
+
+He trims to "about ten or twelve words with different vowel sounds in
+their stressed syllables." His actual surviving list for the working
+title "Risky Business," looking through the lens of homelessness:
+
+```text
+risk
+business
+left out
+freeze (wheel, shield)
+storm
+dull (numb)
+night (child)
+change
+defense
+home (hope, broken, coat)
+```
+
+Note the parenthesized duplicates — they are kept but flagged as sharing
+a vowel with the headword. And his caveat: "This is not a final list.
+Don't be afraid to switch, add, or take out words as the process
+continues."
+
+Chapter 24 shows the same worksheet built from a locked title. Keywords
+`sea, shells, shore, sand, tide` yield, after Pat says no to most of what
+the rhyming dictionary offers:
+
+```text
+sea     debris, refugee, recede, weeds, bleed, deep, sleep, streaked, retreat
+shell   swell, carousel, withheld, help, chill, spilled
+shore   roar, pour, storm, outworn, torn, blur, search, submerged, curled
+sand    ran, chant, slammed, stamped, inheritance
+tide    glide, slide, inscribed, flight, harbor light, sacrifice,
+        still life, revived, rise, arise
+```
+
+His rejections are as instructive as his keeps: `free` is "overused,"
+`plea` is court-only ("Why use it in a lyric just to get a rhyme?"),
+`referee` "takes me somewhere I don't want to be in this song," `hell` is
+"too dramatic — it's one of those words that seems to mean so much more
+than it conveys. Like soul. Avoid those clunkers." Under `sand` he finds
+"nothing interesting under perfect rhyme except the tired old
+hand/understand/command nonsense."
+
 A title that can ONLY perfect-rhyme with cliche partners is a weaker title
-than one with family-rhyme + world-vocabulary options. Pat's "writing a
-lyric is like getting a gig" — more options = better choices.
+than one with family-rhyme + world-vocabulary options. More options =
+better choices.
 
 ### Step 6 — Test the title against form
 
@@ -110,6 +247,14 @@ Does this title repeat well, or live once?
 
 Per `song-forms.md`. The title's emotional shape decides — not a default
 form preference.
+
+The other half of the test is whether the verses can deliver the title.
+Pat, Chapter 24: "My first job is to make sure the verses set up the
+title. Additional lines can come along later when I'm sure the title
+works with the verses." He deliberately keeps the first-pass chorus thin
+for that reason — "I don't want to make too early a commitment to a lot
+of ideas in the chorus. It's best to keep it streamlined and simple at
+first."
 
 ### Step 7 — Choose the title (or shelve)
 
@@ -159,3 +304,5 @@ After title lock:
 - `rhyme-worksheets.md` — three-stage worksheet
 - `song-forms.md` — title repeats-well vs lives-once
 - `fragment-development.md` — if seed is already a partial line, not just a seed
+- `metaphor.md` — Chapter 24's grounded-metaphor rule; the same chapter
+  that works this title also decides where the song is set

--- a/plugins/songwriting/context/pat-pattison/research/metaphor.md
+++ b/plugins/songwriting/context/pat-pattison/research/metaphor.md
@@ -1,7 +1,9 @@
 # Metaphor
 
-Pat Pattison — *Writing Better Lyrics* (2009), Chapter 3; Pat Pattison —
-*Songwriting Without Boundaries* (2011), Challenge 2 (Days 1-14).
+Pat Pattison — *Writing Better Lyrics* (2009), Chapter 3 ("Making
+Metaphors"), Chapter 24 ("Process"); Pat Pattison — *Songwriting Without
+Boundaries* (2011), Challenge 2 ("Metaphor," Days 1-14) and Challenge 3
+("Object Writing with Metaphor," Days 1-14).
 
 ## Anchor stance
 
@@ -36,7 +38,28 @@ Metaphor is a controlled collision between ideas that do not literally belong
 together. The collision creates pressure, and the listener resolves that
 pressure by finding shared qualities between the terms.
 
-> All metaphors must be literally false.
+> "All metaphors must be literally false." — *Writing Better Lyrics*
+> (2009), Chapter 3
+
+Pat's anchor example is `an army is a rabid wolf`. The soldiers snarl,
+grow snouts, foam at the teeth; the army disappears and what is left is
+"something red-eyed and dangerous." His counter-example is `a house is a
+dwelling place` — literally true, therefore definition, not metaphor.
+
+His three friction pairs, verbatim from Chapter 3: `dog with wind`;
+`torture with car`; `cloud with river`.
+
+Pat restates the test twice on live student work in *Songwriting Without
+Boundaries* (2011), Challenge 2:
+
+- Day 1, on `blackened autumn`: fires blacken things, not the season, so
+  the phrase is literally false and therefore metaphor. `Blackened
+  handkerchief` **could** be true — so it is not a metaphor. "Again,
+  metaphors are always literally false. That's what makes them
+  interesting."
+- Day 2, on `dark`: "dark eyes could be literally true, and thus isn't a
+  metaphor. They join together rather than colliding. Dark thoughts,
+  though a cliché, is a metaphor. It's literally false."
 
 If the comparison is literally true, it is definition or description, not
 metaphor. If the terms are too far apart with no discoverable shared quality,
@@ -53,8 +76,9 @@ writer who over-explains kills the productive ambiguity.
 
 ## The two metaphor-finder questions
 
-Pat's canonical metaphor-finding move (per his *patpattison.com/pat-s-
-lyric-tips* "Making Metaphors" entry):
+Pat's canonical metaphor-finding move, from *Writing Better Lyrics*
+(2009), Chapter 3 — reprinted in *Songwriting Without Boundaries*
+(2011), Challenge 2 Day 10, and sharpened in Challenge 3's opener:
 
 1. **What characteristics does my idea have?** — list as many as possible
 2. **What else has those characteristics?** — for each characteristic,
@@ -69,31 +93,48 @@ candidate metaphor partners per quality.
 the **multi-quality target-walk** — running THREE distinct qualities
 through the two-question move per target.
 
-Worked illustrative example (paraphrased): target = `Policeman`.
+Pat's worked target is `policeman`. He supplies the three qualities as
+questions — "He protects. What else protects?", "He investigates. What
+else investigates?", "He arrests. What else arrests?" — and named
+writers answer each one, mine the answer's word-family, then apply that
+family back to `policeman` in a sentence.
 
-| Quality | Other things sharing it |
-|---|---|
-| Protects | flu vaccine, lifeguard, body armor, mother, antibiotic, dam |
-| Investigates | mechanic, X-ray, dental probe, detective, jeweler's loupe, journalist |
-| Arrests | brake pedal, oxygen, sleep, freeze frame, prison gate, cardiac arrest |
+> **Restoration blocked.** Pat's six printed answers, their family
+> word-lists, and the applied sentences could not be reproduced here;
+> the permission system refused the edit. A previous version of this
+> file filled the space with an invented table (body armor, mother,
+> antibiotic, dam, dental probe, jeweler's loupe, brake pedal, freeze
+> frame, prison gate, cardiac arrest) attributed to Pat. **None of
+> those appear in Day 10.** The fabrication has been deleted rather
+> than replaced — read Challenge 2 Day 10 directly for the real lists.
 
 The three quality-columns generate three different metaphor pools per
 target. The writer picks by emotional intent: an arrest-themed pool
 serves a different song than an investigate-themed pool.
 
-**Rule:** run ≥3 qualities per target before picking. Single-quality
-metaphor search produces shallow metaphors; multi-quality target-walk
-produces a rich pool.
+**Rule:** Pat's own instruction on Days 12 and 13 is to list **at least
+three** qualities per prompt. Single-quality metaphor search produces
+shallow metaphors; multi-quality target-walk produces a rich pool.
+
+Do not merge Day 10 with Day 9, which uses `policeman` as a plain
+expressed-identity prompt ("Policeman is") rather than a quality-walk.
 
 ## The three metaphor types
 
-Pat organizes metaphor into three working types.
+Pat organizes metaphor into three working types. The count is **three**,
+and the names are Expressed Identity, Qualifying Metaphor, and Verbal
+Metaphor — identical in *Writing Better Lyrics* (2009), Chapter 3 and
+*Songwriting Without Boundaries* (2011), Challenge 2 opener. Pat's own
+definitions and examples:
 
-| Type | Form | Use |
+| Type | Pat's definition | Pat's examples |
 | --- | --- | --- |
-| Expressed identity | noun is noun; noun's noun; noun of noun | Commits the lyric to seeing one thing as another. |
-| Qualifying | adjective-noun or adverb-verb friction | Adds charged color inside a phrase. |
-| Verbal | subject/object and verb do not normally belong together | Creates motion and often more energy than adjective work. |
+| Expressed identity | "asserts an identity between two nouns" | fear is a shadow; a cloud is a sailing ship |
+| Qualifying | "adjectives qualify nouns; adverbs qualify verbs. Friction within these relationships creates metaphor" | hasty clouds; to sing blindly |
+| Verbal | "formed by conflict between the verb and its subject and/or object" | clouds sail; he tortured his clutch; frost gobbles summer down |
+
+His extension example for expressed identity: `clouds are sailing ships on
+rivers of wind`.
 
 Expressed identity is the most explicit and structurally demanding. Qualifying
 metaphor is often compact and local. Verbal metaphor is especially powerful
@@ -114,12 +155,34 @@ the eight-recipe table as a quality-source generator.
 
 ## Expressed identity forms
 
-Run noun-noun collisions through three forms:
+There are **three** forms, and Pat numbers them the same way in both
+books. Verbatim, with his example word-pair:
 
 ```text
-x is y
-the y of x
-x's y
+1.  "x is y"        fear is a shadow
+2.  "the y of x"    the shadow of fear
+3.  "x's y"         fear's shadow
+```
+
+*Songwriting Without Boundaries* (2011), Challenge 2 Day 7 restates them
+with a second pair:
+
+```text
+1. x is y        A poem is a zipper
+2. The y of x    The zipper of the poem
+3. x's y         The poem's zipper
+```
+
+Pat refers to these by number throughout Challenges 2 and 3 ("the second
+version of expressed identity," "the third form"), so keep the numbering
+when coaching.
+
+Chapter 3's drill — run each of these through all three forms:
+
+```text
+wind = yelping dog
+wind = river
+wind = highway
 ```
 
 Each form changes the pressure and usability of the metaphor:
@@ -137,6 +200,24 @@ Words can gather around a central idea the way notes gather around a musical
 key. Pattison calls this playing in a key. Start with a fundamental word, list
 related words, then use those related words to find collisions.
 
+Pat's three worked keys, verbatim (*Writing Better Lyrics* (2009),
+Chapter 3; reprinted in *Songwriting Without Boundaries* (2011),
+Challenge 2 Day 10):
+
+```text
+key of tide  (fundamental tone: tide)
+  ocean, moon, recede, power, beach
+
+key of power (fundamental tone: power)
+  Muhammad Ali, avalanche, army, Wheaties, socket, tide
+
+key of moon  (fundamental tone: moon)
+  stars, harvest, lovers, crescent, astronauts, calendar, tide
+```
+
+Note that `tide` appears in all three. A word is not owned by one key —
+it belongs to whichever key its fundamental tone establishes.
+
 Workflow:
 
 1. Pick a fundamental word.
@@ -145,6 +226,31 @@ Workflow:
 3. Choose two terms from the list.
 4. Ask what hidden quality connects them.
 5. Turn the collision into one of the three metaphor types.
+
+Pat's own collisions drawn from those keys:
+
+```text
+key of power
+  Muhammad Ali avalanched over his opponents.
+  An avalanche is an army of snow.
+  This army is the Wheaties of our revolution.
+  Wheaties plug your morning into a socket.
+  A socket holds back tides of electricity.
+
+key of moon
+  The New Mexico sky is a rich harvest of stars.
+  Evening brings a harvest of lovers to the beach.
+  The lovers' feelings waned to a mere crescent.
+  The crescent of human knowledge grows with each astronaut's mission.
+  Astronauts' flights are a calendar of human courage.
+  A new calendar washes in a tide of opportunities.
+```
+
+Each line collides two members of the same key — which is why they cohere
+despite being literally false. Pat's gloss: "Muhammad Ali is hardly the
+first idea that comes to mind with avalanche, unless you recognize their
+linking term, power. In most contexts, Muhammad Ali and avalanche are
+nondiatonic, unrelated to each other."
 
 The key idea prevents arbitrary cleverness. The collision may look strange on
 the surface, but it has a shared underlying trait.
@@ -164,8 +270,49 @@ locked piano, bee in a jar. From there, collide.
 
 ## Accident exercises
 
-Chapter 3 uses group exercises to create accidental collisions. Preserve them as
-coaching prompts rather than as fixed examples.
+Chapter 3 uses group exercises to create accidental collisions. Pat's own
+printed lists (Exercises 4, 6, and 7):
+
+```text
+Exercise 4 — adjectives × nouns
+  smoky          conversation
+  refried        railroad
+  decaffeinated  rainbow
+  hollow         rain forest
+  understated    eyebrows
+
+Exercise 6 — nouns × verbs
+  squirrel       preaches
+  wood stove     vomits
+  surfboard      cancels
+  reef           celebrates
+  aroma          palpitates
+
+Exercise 7 — nouns × nouns
+  summer         Rolls-Royce
+  ocean          savings account
+  thesaurus      paintbrush
+  Indian         beach ball
+  shipwreck      mattress
+```
+
+Exercise 5 then jumbles the pairs — `smoky eyebrows`, `squirrel
+celebrates`, `wood stove palpitates`, `surfboard preaches`, `reef
+cancels`, `aroma vomits`, `summer mattress`, `ocean paintbrush`,
+`thesaurus beach ball`, `Indian Rolls-Royce`, `shipwreck savings
+account`. Pat's point: "overtones (linking ideas, metaphors) are
+released by this blind striking of notes. Wonderful accidents happen
+frequently."
+
+Exercise 7 shows the three expressed-identity forms on the first pair:
+
+```text
+summer is a Rolls-Royce
+the Rolls-Royce of summer
+summer's Rolls-Royce
+```
+
+Use these as coaching prompts as well as fixed examples.
 
 Adjective-noun collisions:
 
@@ -213,22 +360,36 @@ verbs, images, and playable lyric material.
 
 Challenge 2 daily arc:
 
-| Day | Practice | Writer supplies |
+Day headings as printed, with Pat's actual prompt words:
+
+| Day | Heading (as printed) | Prompts Pat supplies |
 | --- | --- | --- |
-| 1 | Adjective-noun collisions | Nothing; use given adjective/noun pairs. |
-| 2 | Finding nouns from adjectives | Nouns that cannot literally hold the adjective. |
-| 3 | Finding adjectives from nouns | Productive adjectives for given nouns. |
-| 4 | Noun-verb collisions | Nothing; use given noun/verb pairs. |
-| 5 | Finding verbs from nouns | Verbs that charge the noun with action. |
-| 6 | Finding nouns from verbs | Nouns that make the verb strange but legible. |
-| 7 | Expressed identity, noun-noun | Forms for given noun pairs. |
-| 8 | Reversed expressed identity | New pressure from reversing the noun pairs. |
-| 9 | Finding nouns from nouns | Colliding identities for given nouns. |
-| 10 | Playing in keys | Linking qualities from a given target. |
-| 11 | Playing in keys | More target-to-quality-to-family practice. |
-| 12 | Finding linking qualities | Writer lists qualities, then searches families. |
-| 13 | Finding linking qualities | More quality search with abstract and social terms. |
-| 14 | Simile | Three similes plus elaboration for each target. |
+| 1 | Adjective-Noun Collisions | adjectives: lonely, blackened, fallen, smooth, fevered; nouns: moonlight, funeral, carburetor, autumn, handkerchief — paired in order, then re-paired |
+| 2 | Finding Nouns From Adjectives | angry, boastful, careful, dark, enthusiastic |
+| 3 | Finding Adjectives From Nouns | furnace, midnight, cottage, hope, ghost |
+| 4 | Noun-Verb Collisions | nouns: moonlight, funeral, carburetor, autumn, handkerchief; verbs: tumble, exhale, sing, remembers, plead |
+| 5 | Finding Verbs From Nouns | crossbow, kettle, waitress, summer, graduation |
+| 6 | Finding Nouns From Verbs | flush, indict, paddle, operate, soar |
+| 7 | Expressed Identity: Noun-Noun Collisions | wince, Frisbee, poem, summer, restaurant × cargo ship, zipper, evening, captain, wineglass |
+| 8 | Expressed Identity: Noun-Noun Collisions | the same pairs reversed: cargo ship, zipper, evening, captain, wineglass × wince, Frisbee, poem, summer, restaurant |
+| 9 | Expressed Identity: Finding Nouns From Nouns | maple tree, traffic, sunrise, cathedral, policeman |
+| 10 | Playing in Keys: Using Linking Qualities | policeman (three qualities supplied: protects / investigates / arrests) |
+| 11 | Playing in Keys: Using Linking Qualities | cathedral (two qualities supplied: it inspires / being at the pinnacle) |
+| 12 | Playing in Keys: Finding Linking Qualities | maple tree, traffic — writer lists at least three qualities each |
+| 13 | Playing in Keys: Finding Linking Qualities | handshake, sunrise — writer lists at least three qualities each |
+| 14 | Simile | trust, a bad joke, divorce, a waterfall, hope |
+
+Note the shape of the arc: Days 1, 4, 7, and 8 supply **both** terms;
+Days 2, 3, 5, 6, and 9 supply one term and the writer finds the other;
+Days 10 and 11 supply the linking qualities; Days 12 and 13 make the
+writer find the linking qualities too. Each hand-off removes one
+scaffold.
+
+Days 1-13 use the same two-stage unit: a sentence or short paragraph
+that makes the collision make sense, then a **ninety-second** piece of
+object writing using the collision as the prompt. Day 1 states the
+budget: ten prompts, fifteen minutes of timed writing, "not counting the
+thinking and the sentences."
 
 Use this sequence when a user asks for "more metaphor" but does not yet have a
 specific image-world. Start with collision drills, then move into linking
@@ -285,7 +446,14 @@ This is useful in coaching because the user's starting material may be any part
 of speech. A flat adjective can become a noun search; a static noun can become
 a verb search; an abstract idea can become an expressed identity search.
 
-> Verbs electrify them
+Pat's ranking of the collision types, *Writing Better Lyrics* (2009),
+Chapter 3: "One thing will become clear right away: You get better
+results combining nouns and verbs than from combining adjectives and
+nouns. Verbs are the power amplifiers of language. They drive it; they
+set it in motion."
+
+His prescription there is to circle the verbs in Yeats, Frost, Sexton,
+and Eliot and see why the poems "crackle with power."
 
 Favor verb collisions when a lyric has too much description. A good verbal
 metaphor puts pressure on a noun and creates motion immediately.
@@ -323,6 +491,135 @@ Workflow:
 
 This keeps metaphor search disciplined. The metaphor may surprise the listener,
 but the writer can still explain why it belongs.
+
+## Challenge 3 — object writing with metaphor
+
+*Songwriting Without Boundaries* (2011), Challenge 3 ("Object Writing
+with Metaphor") is the second half of the metaphor curriculum, and it is
+where the linking-quality machinery actually lives. Pat hands off to it
+explicitly at Challenge 2 Day 9: "You'll become very familiar with this
+process in Challenge #3. This is the ramp to get you there safely."
+
+### The notation
+
+Pat writes the search as a three-term chain, and uses it on every day:
+
+```text
+<first idea> → Linking quality: <quality> → Target idea: <target>
+```
+
+His Day 1 walk-throughs, verbatim:
+
+```text
+Snowstorm → Linking quality: Cold → Target idea: Your sneer
+Snowstorm → Linking quality: Covering the ground → Target idea: Wildflowers
+Snowstorm → Linking quality: Hot cider by the fireplace → Target idea: Seeking comfort
+```
+
+The **first idea** is the prompt. The **linking quality** is a quality of
+that prompt. The **target idea** is whatever else has that quality — and
+the target is then written about *through the lens of* the prompt.
+
+### The opener's worked example
+
+Pat builds the challenge on Faulkner: the crowded cans of sardines on a
+country store shelf become the crowd of people watching Abner Snopes
+tried for burning a barn.
+
+```text
+What quality does a can of sardines have?   Crowded.
+What else is crowded?                       The courtroom.
+The courtroom = can of sardines
+In what respect?                            They're both crowded.
+```
+
+Having established the link, the sardine family's nouns, verbs, and
+adjectives transfer onto the courtroom. Pat's applications:
+
+```text
+The courtroom felt packed in oil
+The courtroom felt dead and gray
+The courtroom, layered in townsfolk
+The oily courtroom
+Something fishy …
+```
+
+The two questions in their Challenge 3 form: "What **interesting**
+quality does my idea have? What else has that quality?"
+
+### Timing and difference from Challenge 2
+
+Challenge 2 uses **ninety-second** writes. Challenge 3 uses **ten-minute**
+writes. Pat also loosens the constraint: the writing "stays deep in the
+senses, but the object writing in this section, unlike the writing you've
+done up to this point, can be focused on a more unified narrative
+thread."
+
+### The 14-day arc
+
+Two scaffolds come off in sequence. For Days 1-7 Pat supplies the linking
+qualities; from Day 8 the writer finds their own. Separately, Days 1-3
+work one direction only; Days 4-7 add the reversal; Days 8-11 return to
+one direction while the writer sources the qualities; Days 12-14 do both
+at once.
+
+| Day | Heading (as printed) | Prompt | Linking qualities |
+| --- | --- | --- | --- |
+| 1 | Linking Qualities to Target Ideas | Snowstorm | supplied: cold; covering the ground; hot cider by the fireplace; slippery roads; low visibility |
+| 2 | Linking Qualities to Target Ideas | Deep-Sea Diver | supplied: totally immersed; supported by a lifeline; surrounded by an unfamiliar landscape |
+| 3 | Linking Qualities to Target Ideas | Guitar Solo | supplied: building intensity; going somewhere new; in the spotlight |
+| 4 | Working Both Directions | Sleeping Late | supplied: conserving energy; wasting time |
+| 5 | Working Both Directions | Broken Glass | supplied: unable to be repaired; glittering and dangerous |
+| 6 | Working Both Directions | Falling in Love | supplied: swept away; glittering and dangerous |
+| 7 | Working Both Directions | Cheating Lover | supplied: swept away; dangerous situation |
+| 8 | Finding Linking Qualities: Working One Direction | Magnifying Glass | writer finds three |
+| 9 | Finding Linking Qualities: Working One Direction | Swimming Hole | writer finds three |
+| 10 | Finding Linking Qualities: Working One Direction | Afternoon Nap | writer finds three |
+| 11 | Finding Linking Qualities: Working One Direction | Traffic Cop | writer finds two |
+| 12 | Finding Linking Qualities: Moving Both Directions | Wheelchair | writer finds two |
+| 13 | Finding Linking Qualities: Moving Both Directions | Sailboat | writer finds two |
+| 14 | Finding Linking Qualities: Moving Both Directions | Vacation | writer finds two |
+
+Day 11's heading reads "Working One Direction" as printed, but its
+instructions add the reversal ("you'll spend another ten minutes
+reversing directions"). Reproduce the heading as printed and follow the
+instruction.
+
+### Reversibility — the Day 4-7 move
+
+The reversal is the point of Days 4-7: after writing the target idea
+through the lens of the prompt, spend another ten minutes writing the
+prompt through the lens of the target idea. Pat's own demonstration
+chain is `Sleeping late → Feeling lazy → Avoiding your homework`, written
+first as homework-seen-as-sleeping-late, then as
+sleeping-late-seen-as-homework.
+
+Reversibility is a **test of the linking quality**, not a bonus
+exercise. Pat states the criterion at Day 5: "Being able to reverse
+directions — to move in either direction through the linking quality —
+requires a linking quality that is an essential feature of your first
+idea." Day 7 repeats it: "The ability to go deep enough into your idea to
+find an essential linking quality will accelerate your search for
+effective metaphor." Day 2 gives the same guidance forward: make sure the
+qualities "are a close relation to, e.g., deep-sea diver's family, that
+they capture an essential quality. That's the key to finding an effective
+target idea."
+
+**Coaching use:** if a proposed metaphor will not run backwards, the
+linking quality is incidental rather than essential. Send the writer back
+for a deeper quality before they commit a section to the image.
+
+### When the families are too remote, use simile
+
+Challenge 3 keeps Day 14's simile lesson live. Pat's note on a wheelchair
+/ adventure-novel pairing (Day 12): the writer "accomplishes it through
+simile, not metaphor, since the relationship between the two ideas is
+pretty remote." His Day 13 gloss on `leaves are sailboats` restates the
+energy-blocker model — `like boats docked at a jetty` keeps focus on the
+leaves, whereas `are boats docked at a jetty` transfers the energy to
+boats. Challenge 2 Day 8 makes the same call on `the captain is summer`:
+when very few family members can step into the other's living room,
+simile works better.
 
 ## Simile as focus control
 
@@ -367,11 +664,25 @@ the writer from waiting passively for inspiration.
 Verbs can become vivid adjectives through participles. Use this when adjective
 lists feel stale:
 
+Pat's own example, *Writing Better Lyrics* (2009), Chapter 3, Exercise 8
+step one: "you can make vivid adjectives out of verbs: to wrinkle becomes
+the adjective wrinkled (wrinkled water) or wrinkling (the wrinkling
+hours). These are called participles."
+
 ```text
-to crack -> cracked, cracking
-to wrinkle -> wrinkled, wrinkling
-to rust -> rusted, rusting
+to wrinkle -> wrinkled water, the wrinkling hours
 ```
+
+He carries the image into step two: "Develop a habit of mind that can see
+a doe stepping through the shallows as the water wrinkles into circles
+around her."
+
+*Songwriting Without Boundaries* (2011), Challenge 2 Day 3 adds the
+reason to prefer them, on Andrea Stolpe's `trembling cottage`: "Andrea
+draws her adjective, trembling, from the verb, to tremble. Adjectives
+created in this sort of way, by adding ing or ed to the verb, are called
+participles. Since verbs are the strongest element in language, using
+them to create adjectives makes for a more potent modifier."
 
 Participles keep description near action. They often feel more alive than
 static adjectives because they imply process.
@@ -388,6 +699,34 @@ driving. The song has committed to the engine world.
 Simile keeps focus on the first term. If love is like an engine, the listener
 stays nearer the speaker's feeling and does not expect the song to keep
 developing engine logic.
+
+Pat's worked pair is a lyric by Kurt Thompson, printed twice in Chapter 3
+— once as metaphor (`My love is an engine`) and once as simile (`My
+love's like an engine`, `My heart needs to rev some / Like an old
+Chevrolet`). His verdict: "The metaphor creates a
+light, clever song. The simile is clever, too, but it's also more
+intimate, since we stay in the presence of the speaker throughout the
+song."
+
+His one-line demonstration of simile's disposability: "In a line like
+'I'm as corny as Kansas in August,' our focus stays on I. We have no
+further appetite for corn or Kansas. Good thing, since the rest of the
+song goes everywhere but Kansas. However, if the line had been 'I am
+corn in Kansas in August,' we'd expect to hear things about sun, rain,
+wind, and harvest in the upcoming lines."
+
+And his rule of thumb, verbatim — when you have a list of comparisons in
+mind, use a simile:
+
+```text
+love is like rain
+love is like planting
+love is like the summer sun
+```
+
+When you're using only one comparison (`love is a rose`) and want to
+commit to it throughout the song, use a metaphor. Pat's closing line on
+it: "It only grows when it's on the vine."
 
 Use metaphor when:
 
@@ -480,12 +819,18 @@ card when stuck on a single subject and needing options.
 | 7 | Metaphor vs Simile Focus | write both `X is Y` and `X is like Y`; pick by focus | Choose whether subject or comparator dominates |
 | 8 | Simile for Multiple Comparisons | layered simile opening 2-3 sub-comparisons | When one comparison cannot carry the load |
 
-> "Verbs electrify them." — Pat (*Writing Better Lyrics* (2009), Chapter 3)
+> "Nouns are inert. They sit there. Adjectives pile on top of them and
+> sit there. Verbs electrify them, propel them, launch them into action.
+> The difference between average and great writing: verbs."
+> — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 2
+> Day 4
 
-Two anchors from Pat's column:
+Two anchors, both printed in *Writing Better Lyrics* (2009), Chapter 3
+and repeated in *Songwriting Without Boundaries* (2011), Challenge 2
+opener:
 
-- "Fear is a shadow." — Expressed Identity.
-- "Clouds sail; frost gobbles summer down." — Verbal Metaphor.
+- "fear is a shadow" — Expressed Identity.
+- "clouds sail; frost gobbles summer down" — Verbal Metaphor.
 
 Run the recipe with the [metaphor-recipe template](../templates/metaphor-recipe-prompt.md).
 For each move:
@@ -540,9 +885,16 @@ A productive-ambiguity test:
 3. The listener does not have to "pick"; both meanings live together
    under the music.
 
-Example shape (paraphrased): "the lonely handkerchief" can mean both
-the cloth's emptiness and the person who carries it. Both readings sit
-in the same line.
+Pat's actual example is Greg Becker's `lonely handkerchief` sentence in
+Challenge 2 Day 1, where the handkerchief is "crumpling into himself,
+clutching his near empty glass." Pat's comment: "It's hard to tell in
+Greg's sentence whether he's talking about a person or a piece of cloth.
+I like when that happens: Call it 'productive ambiguity,' having at
+least two meanings, and both work in the context. You'll find that
+productive ambiguity lies at the heart of metaphor."
+
+The two readings — the cloth and the person carrying it — sit in the
+same line without either cancelling the other.
 
 When productive ambiguity appears, do not flatten it by adding context
 that picks one reading. The dual reading is the feature.
@@ -585,39 +937,47 @@ For verbal metaphors (one of Pat's three named types), the verb's
 transitivity determines where the metaphorically colliding noun appears in
 the sentence.
 
-- **Transitive verb** — takes a direct object. The metaphor-colliding noun
-  appears AFTER the verb as the object.
-  - Example shape: "[subject] [transitive-verb] [colliding-noun]"
-  - The "verb does something TO the noun" — the noun is the recipient.
-- **Intransitive verb** — does NOT take a direct object. The metaphor-
-  colliding noun appears as the subject OR in a prepositional phrase.
-  - Example shape: "[colliding-noun] [intransitive-verb]" OR
-    "[subject] [intransitive-verb] [preposition] [colliding-noun]"
-  - The "noun does something" or "subject does something near/at/through the noun."
+Pat classifies the Day 4-6 prompt verbs explicitly:
+
+| Verb | Day | Classification | Pat's consequence |
+|---|---|---|---|
+| `exhale` | Day 4 | transitive | The prompt noun can sit AFTER the verb as direct object, with a different noun as subject ("The tsunami exhaled a funeral onto the white beach") |
+| `plead` | Day 4 | intransitive | "It doesn't require a direct object, so handkerchief needs to stay in subject position. It could take an indirect object, introduced by a preposition: pleads with, pleads for" |
+| `flush` | Day 6 | transitive | "you'll have to find two nouns: x flushes y. Dusk flushes daylight" |
+| `indict` | Day 6 | transitive | "The collision is between the subject and the verb. The direct object comes along for the ride" |
+| `paddle` | Day 6 | intransitive | "No direct object necessary, but you'll probably use a prepositional phrase" — "paddles in a river of clouds" |
+| `operate` | Day 6 | intransitive | subject carries the collision |
+| `soar` | Day 6 | intransitive | subject carries the collision |
+
+The load-bearing rule, stated at Day 4: **the noun can serve either as
+subject or direct object.** That is what makes noun-verb collisions
+flexible. Pat's Day 4 note on `autumn remembers`: if autumn is instead
+the direct object, the writer looks for a collision in the form
+`___________ remembers autumn` — "Just make sure the noun you choose
+doesn't actually have the ability to remember."
 
 Same metaphor idea, different grammar. Get it wrong and the collision
-breaks (or the line becomes ungrammatical).
-
-Example — "drown" is transitive when meaning to-cause-to-drown ("the city
-drowned my voice") and intransitive when meaning to-be-drowned ("my voice
-drowned in the city"). The collision lands differently:
-
-- Transitive: the city is active; voice is passive recipient
-- Intransitive: voice is active subject; city is the surrounding medium
-
-Choose by what the metaphor should foreground.
+breaks (or the line becomes ungrammatical). Choose by what the metaphor
+should foreground.
 
 ## Tone center / diatonic vocabulary (*Songwriting Without Boundaries* (2011), Challenge 2)
 
 Pat names a musical analogy for metaphor families: words cluster in
 "keys" the way notes cluster in musical keys.
 
-- **Tone center** — the central concept the writer is exploring (e.g.
-  "winter")
-- **Diatonic** — words that fit naturally within that tone center's
-  family (snow, cold, ice, frost, bone, frozen, bare)
+- **Tone center** — the central concept the writer is exploring. Pat's
+  own demonstration in the Challenge 2 opener uses the word `collision`
+  as the tone center: think of ideas as cars, and you can then think
+  about ideas in car terms — "broken down along the roadside (flat
+  tire?)," "ticketed for speeding," "taking the scenic route," "parked
+  in the garage."
+- **Diatonic** — words that belong to that tone center's family. Pat's
+  printed families are the three keys above (`tide`, `power`, `moon`);
+  use those, not an invented family.
 - **Nondiatonic** — words that don't fit the family, used deliberately
-  for collision
+  for collision. Pat: "Two ideas collide when they are in different
+  keys, different families, like idea and collision. A third thing
+  emerges: a chord that contains them both. A metaphor."
 
 In a tone-centered passage, **everything diatonic feels natural** — words
 slide together without friction. **A single nondiatonic word collides**
@@ -652,12 +1012,20 @@ then says "sea spray on his face," the metaphor breaks unless the song
 has already established why the ocean is present. The mismatch is
 diagnostic of failure, not of style.
 
-### Three ways to ground a borrowed image
+### How Pat actually resolves it
 
-1. **Fantasy / dream** — the song's POV allows imagined locations
-2. **Memory** — the speaker has been there before, the image is recalled
-3. **Title carryover** — the title names the borrowed location; everything
-   in the song lives under that umbrella
+Not by adding a POV layer — by **deciding the setting**. The lyric under
+discussion is "She Sells Seashells," and the offending line is `Sea spray
+on his face`. Pat's own reasoning: in his mental picture the characters
+are inside a house, so there is nowhere for the spray to come from. Spray
+could stand in for tears, but with no source it is confusing. Had they
+been on the beach, the line would work — it could be "both what it
+actually is, plus more." His conclusion is a decision, not a patch:
+"Remember to ground your metaphors in reality. They must have a
+legitimate place in the context. So I've got to decide. Are they in the
+house or at the ocean? I can't just assume that my mental picture is
+everybody's mental picture. I've got to make it everybody's mental
+picture."
 
 ### When the rule applies
 
@@ -674,10 +1042,12 @@ work is the cost of the image.
 *Songwriting Without Boundaries* (2011), Challenge 2 Day 14 names the
 mechanical model for why simile works differently than metaphor:
 
-> "Like works as an energy blocker — it reflects energy back onto the
-> first term, refusing to let the energy pass to the second term."
+> "Simile doesn't transfer focus: like works as an energy blocker — it
+> reflects energy back onto the first term, refusing to let the energy
+> pass to the second term. The is of metaphor allows free passage of
+> energy to the second term, and lights it up."
 > — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 2
-> Day 14 (paraphrased ≤25w)
+> Day 14
 
 In metaphor (`Her smile IS sunlight`), the energy of `sunlight` transfers
 directly to `her smile` — the smile becomes the sunlight. In simile
@@ -707,9 +1077,16 @@ The distinction:
 | Listener does the work of completing | Writer does the work of pointing |
 | Pressure builds and resolves internally | Pressure resolves at the comparison itself |
 
-Both are valid craft moves. Pat's preference is metaphor when the
-listener should DO the work; simile when the writer wants to point at
-a quality without committing to identity.
+Both are valid craft moves. Pat does **not** adopt Coleridge's
+shared-quality test as his own decision rule. His stated criterion is
+commitment: it is "perhaps a good guideline for choosing between
+metaphor and simile, but I prefer making the choice in terms of
+commitment." His worked pair is `Love is a rose` versus `Love is like a
+rose` — if the texture, smell, and color of the rose should be in focus,
+metaphor; if love should stay in focus, simile. He runs the same test on
+`Freedom is riding a bike for the first time without help` (energy
+transfers to the bike rider) against `Freedom is like riding a bike for
+the first time without help` (focus stays on the concept of freedom).
 
 ### Five canonical simile-elaboration targets
 
@@ -731,22 +1108,37 @@ elaboration extends the shared quality into the song.
 ## Failure mode — simile-only candidate
 
 *Songwriting Without Boundaries* (2011), Challenge 2 Day 14 shows a
-failure mode via Samuel Butler's "morning is a boiled lobster" — a
-candidate that works ONLY as simile (the shared quality is black-to-red
-color change, period). The terms have one shared quality and no other
-hidden relationships. A metaphor would feel random; a simile lands as
-witty comparison.
+failure mode via Samuel Butler, quoted as a couplet:
 
-**Diagnostic:** when proposing a metaphor, the AI should test how many
-shared qualities can be found between the terms. ≥3 = metaphor candidate.
-1-2 = simile candidate. 0 = random.
+```text
+Like a lobster boil'd, the morn
+From black to red began to turn
+                    — Samuel Butler
+```
+
+Pat's reading: a boiled lobster has little in common with morning
+except that both change from black to red. So metaphor collapses —
+he prints all three expressed-identity forms to show them failing:
+
+```text
+Morning is a boiled lobster
+The boiled lobster of the morning
+Morning's boiled lobster
+```
+
+**Diagnostic:** count the shared qualities before choosing. Pat's own
+formulation of the degree test is Coleridge's, and he states it as a
+guideline rather than a rule — few shared qualities, simile; more,
+metaphor. He then declines it in favor of commitment (see below). Do
+not apply a fixed numeric cutoff; the books state none.
 
 ## Cross-references
 
 - [object writing](object-writing.md) — sense-bound material is the
   source of strong collisions
 - [daily practice](daily-practice.md) "Challenge 2" — 14-day
-  metaphor-collision curriculum
+  metaphor-collision curriculum; "Challenge 3" — 14-day
+  linking-quality / target-idea curriculum
 - [cliche](cliche.md) — stale metaphor diagnosis
 - [hook](hook.md) — title-as-metaphor and titles built from a single
   move

--- a/plugins/songwriting/context/pat-pattison/research/meter.md
+++ b/plugins/songwriting/context/pat-pattison/research/meter.md
@@ -360,12 +360,14 @@ matters less than repetition.
 
 Pat builds it from the smallest cell up, and his figures name the small one out
 loud:
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
 
 ```text
 small cell:        / u                 (DUM da)
 repeated figure:   / u / u / u / u     (DUM da DUM da DUM da DUM da)
 larger cell:       / u u /
 repeated figure:   / u u / / u u / / u u / / u u /
+<!-- spellchecker:on -->
 ```
 
 > The size of the pattern is not important. What is important is that the
@@ -549,12 +551,14 @@ are landmarks along it. The end of bar two rests, bars three and four tack into
 the wind, bars five and six return to familiar territory, and bars seven and
 eight match three and four to arrive. Marked in strong and weak notes:
 
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
 ```text
 DUM da DUM da DUM da DUM     4 stresses
 DUM da DUM da DUM            3 stresses
 DUM da DUM da DUM da DUM     4 stresses
 DUM da DUM da DUM            3 stresses
 ```
+<!-- spellchecker:on -->
 
 > The continuous voyage is organized according to a very simple principle:
 > longer / shorter / longer / shorter.
@@ -1200,6 +1204,7 @@ As with deceptive closure, use the surprise position for important content.
 
 ## Common-meter exercises
 
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
 - Grocery-list meter (Exercise 16, *Writing Better Lyrics*, Chapter 14): "Try
   doing this with your grocery list. Try one in duples — da DUM da DUM — and one
   in triples — da da DUM da da DUM." Keep the 4/3/4/3 stress relation audible
@@ -1208,6 +1213,7 @@ As with deceptive closure, use the surprise position for important content.
   Times are tough and rent is due / And I've got songs to write") and working up
   the nerve to ask for a date ("I wanna call, I wanna call / I know I'll sound
   too scared / My self-esteem is plunging fast / O do I do I dare?").
+<!-- spellchecker:on -->
 - Spotlight ladder: write one four-line common-meter stanza, then revise it
   through these versions: shortened fourth line, lengthened fourth line,
   fourth line rhyming with one/three, one added four-stress line, several added

--- a/plugins/songwriting/context/pat-pattison/research/meter.md
+++ b/plugins/songwriting/context/pat-pattison/research/meter.md
@@ -4,7 +4,8 @@ Pat Pattison - *Songwriting: Essential Guide to Lyric Form and Structure* (1991)
 Pat Pattison - *Writing Better Lyrics* (2009), Chapter 14-17.
 Pat Pattison - *Songwriting Without Boundaries* (2011), Challenge 4.
 
-Notation: `/` = primary stress, `//` = secondary stress, `u` = unstressed.
+Notation: `/` = primary stress, `//` = secondary stress, `u` = unstressed. Words
+Pat sets in *italics* inside a scansion figure are rendered here in `CAPS`.
 Pat's own source notation marks unstressed syllables too, with a breve — the
 "slight cup" over the vowel that Chapter 3's exercises ask for by name. `u` is
 this file's ASCII stand-in for that cup, not an addition to Pat's system.
@@ -20,6 +21,8 @@ Chapter 3's opening epigraph sets the duple/triple movement the chapter unpacks:
 
 The first two phrases ride a long triple figure; the last two snap into duples.
 The whole chapter is about hearing that contrast and using it deliberately.
+Pat's own scansion of that verse is reproduced under
+[matching patterns](#matching-patterns) below.
 
 ## Image inventory
 
@@ -27,11 +30,12 @@ The whole chapter is about hearing that contrast and using it deliberately.
   figure references, 56 unique**, running `image_rsrc2YZ.jpg` through
   `image_rsrc30P.jpg` (`image_rsrc30P.jpg` is a closure arrow, used four times).
   This chapter argues *in* its figures: every scansion, all three Paradigms, the
-  4/4 bar settings, and all four filled-in Structural Pentad worksheets exist
-  only as page scans. Earlier revisions of this file recorded "no linked
-  page-scan images" for this chapter, and that one false line is why the
-  too-cold definition and the "When I got home" scansion below both survived a
-  full pass uncorrected.
+  4/4 bar settings, and the Structural Pentad worksheets — one blank
+  (`image_rsrc309.jpg`) plus three filled in for Common Meter, Paradigm Two, and
+  Paradigm Three — exist only as page scans. Earlier revisions of this file
+  recorded "no linked page-scan images" for this chapter, and that one false
+  line is why the too-cold definition and the "When I got home" scansion below
+  both survived a full pass uncorrected.
 - *Writing Better Lyrics*, Chapter 14: `image_rsrcAU7.jpg`, `image_rsrcAU8.jpg`,
   `image_rsrcAU9.jpg`, `image_rsrcAUA.jpg`, `image_rsrcAUB.jpg`.
 - *Writing Better Lyrics*, Chapter 15: no linked page-scan images.
@@ -51,32 +55,101 @@ changing that expectation controls pace, flow, and closure.
 
 ## Syllables
 
-A syllable is usually one vowel sound plus consonants around it. It may be a
-whole word, part of a word, or only a vowel sound.
+> Syllables are the basic building blocks of all language. A syllable is usually
+> made up of one vowel sound and one or more consonant sounds.
 
-Diphthongs contain two vowel sounds treated as one vowel. Speech may count a
-diphthong as one syllable, but melody can stretch it across two notes.
+Pat's own examples, in his order:
 
-Use a dictionary for word division. The writer's job is not to guess syllables
-by eye; it is to hear and verify how the word actually divides.
+```text
+jo   give   set   strength   un   peace
+```
+
+> A syllable does not have be a word, but all words have to be at least one
+> syllable.
+
+Sometimes a syllable has only a vowel sound with no consonants at all:
+
+```text
+I   a   mel - o - dy
+```
+
+Diphthongs are two vowel sounds slurred together and treated as a single vowel:
+
+```text
+boil   pail   out   now
+```
+
+> Since diphthongs contain two vowel sounds, composers often use two notes to set
+> them to music. Syllables containing only one vowel sound typically are set to
+> one note.
+
+Use a dictionary for word division — Pat's instruction is blunt: "If you do not
+have a dictionary handy, stop here and go out and buy one. It is a tool of your
+trade." His rule of thumb for dividing:
+
+> A basic rule for dividing words: while there are exceptions, syllables with
+> short vowels usually attach the next consonant to the short vowel
+> (man-u-script, not ma-nu-script), while syllables with long vowels divide
+> between the long vowel and the consonant (ta-ble, not tab-le; re-lief, not
+> rel-ief).
+
+### Exercise 8 (*Essential Guide to Lyric Form and Structure*, Chapter 3)
+
+> EXERCISE 8: BREAK EACH OF THE FOLLOWING WORDS INTO SYLLABLES IN THE SPACE
+> PROVIDED.
+
+Item 1 is worked in the book; the rest are blank.
+
+```text
+1. careless: care less
+2. intimidate:
+3. relief:
+4. understatement:
+5. melodramatic:
+6. splurged:
+7. stopped:
+8. hone:
+9. flower:
+10. lease:
+```
 
 ## Conventional stress
 
-Multi-syllable English words have conventional stress. The stressed syllable is
-normally higher, louder, and longer than the syllables around it.
+Multi-syllable English words have conventional stress. Pat's three-part
+definition: a stressed syllable is higher in pitch, louder, and
+longer than the unstressed syllables around it. "In effect, words of two or more
+syllables have a little melody, with the stressed syllable 'on the beat.' That's
+how we learn them." His demonstration word is "incision" — say it five times,
+slow down, and hear that "ci" is higher, louder, and longer than the other two.
+The figure sets "ci" physically higher on the page than "in" and "sion": the
+little melody drawn rather than described.
+
+Pat's name for this is CONVENTIONAL STRESS, "because we all, as speakers of
+English, agree to organize our words in these particular ways. Our conventions
+are registered in our book of agreements, the dictionary."
+
+His four scanned words, exactly as the figures mark them:
 
 ```text
-incision:     u / u
-turbulent:    / u //
-understand:   // u /
-relinquish:   u / u
+in ci sion:       u  /  u
+tur bu lent:      /  u  //
+un der stand:     // u  /
+re lin quish:     u  /  u
+ju di cious:      u  /  u
 ```
 
 If primary stress is on the first or last syllable of a three-syllable word, the
 opposite end carries secondary stress — and because that secondary is stronger
 than the middle syllable, it is what gives the word its shape. If primary stress
-is on the middle syllable, there is no secondary stress. Words of four or more
-syllables always carry secondary stress.
+is on the middle syllable, there is no secondary stress ("relinquish,"
+"judicious"). Words of four or more syllables always carry secondary stress.
+
+Chapter 3's Exercise 9 drills this: divide ten words into syllables and mark the
+stressed syllable with a slash. Three of its ten items are verb/noun pairs —
+"present," "suspect," "perfect" — which is the point of the drill, since those
+words move their stress with their part of speech. Exercise 10 adds the
+secondary-stress mark over ten longer words; its worked first item is
+`un re lent ing`, marked `// u / u`.
 
 **When scanning a phrase for its stress count, treat a secondary stress exactly
 like a primary one.** This is what holds "And everywhere that Mary went" at four
@@ -85,18 +158,53 @@ with multi-syllable words instead of miscounting on them.
 
 ## One-syllable words
 
-One-syllable stress depends on function:
+The dictionary is silent on one-syllable words, so stress depends on what the
+word's job is in the phrase:
 
-- Meaning carriers usually stress: nouns, main verbs, adjectives, adverbs.
-- Grammar carriers usually do not: articles, prepositions, conjunctions,
-  auxiliaries, personal pronouns, relative pronouns.
+- Meaning carriers — "semantic" function: nouns, verbs, adjectives, adverbs —
+  are stressed. Pat's own list of words that will always be stressed:
+  `track list risk luck slick hard stem strip`. His name for this is **stress by
+  importance**.
+- Grammatical road signs are unstressed: prepositions, articles, conjunctions,
+  auxiliary verbs indicating tense, auxiliary verbs indicating mood, personal
+  pronouns, and relative pronouns.
+
+Pat's argument for why the unstressed words matter is the opening of Lewis
+Carroll's "Jabberwocky":
+
+> 'Twas brillig, and the slithy toves
+> Did gyre and gimble in the wabe;
+
+The lines seem to say something although "brillig," "slithy," "toves," "gimble,"
+and "wabe" are attached to no ideas at all. "So why do the lines seem to say
+something? The answer is in the unstressed syllables. They tweak our ears; tell
+us to get ready for certain kinds of words." His figure strips out the nonsense
+and leaves the frame doing the work:
+
+```text
+'Twas ______________ and the ______________
+      (predicate adjective)   (noun cluster)
+
+Did _______ and _______ in the ____________________________ ;
+    (verb)      (verb)         (place where, noun or adj.)
+```
+
+> A millisecond before we hear a word, we already know what kind of a word it
+> will be. This cuts down the odds of making a mistake.
 
 Grammar carriers can stress when contrast makes them important:
 
 ```text
-Throw the ball TO me, not AT me.
-YOU throw it to ME, not to HER.
+I asked you to throw the ball to me, not at me.
+                              /         /
+I asked you to throw the ball to me, not to her.
+                                 /           /
+I asked you to throw the ball, not him.
+        /                          /
 ```
+
+Pat's frame around those three: these are the only times unstressed
+one-syllable words are stressed to show their importance.
 
 Grey areas are normal, especially in strings of one-syllable words. Start with
 the obvious meaning carriers, then fit weaker syllables around them.
@@ -106,11 +214,14 @@ the obvious meaning carriers, then fit weaker syllables around them.
 Scanning means marking the stresses already present in natural speech. Do not
 force a pattern onto the phrase.
 
-Worked example:
+Pat works his example in two stages, and the staging is the teaching. The first
+figure marks only "home / house / dark" and the two weak syllables between them,
+leaving "When I got" bare — "Some parts are totally clear. Start with those."
+The second figure fills the grey area in with the most likely reading:
 
 ```text
 When I got home the house was dark.
-u    u u   /    u   /     u   /
+u    u  u   /   u    /    u   /
 ```
 
 Three stresses, not four. "When," "I," and "got" are all grey-area syllables
@@ -118,7 +229,15 @@ that could take stress under contrast — "got" if the lights came up a moment
 later, "I" if someone else had been expected home — but the natural reading
 leaves all three unstressed and gives the weight to "home," "house," and "dark."
 
-That asymmetry is the lesson: what the grey syllables *are* stays arguable, and
+That asymmetry is Pat's, stated outright:
+
+> Although it may not be perfectly clear what the first three syllables are, it
+> is very clear what they are not. They are not the most important syllables in
+> the phrase — typical for words in grey areas. There would be no problem setting
+> this phrase to music — just save the important places in the measures for the
+> most important words.
+
+What the grey syllables *are* stays arguable, and
 what they are *not* does not. They are not the most important syllables in the
 phrase. Start from the syllables that are unarguable and let the rest settle
 around them. Save musically strong positions for the weight-bearing words.
@@ -128,10 +247,92 @@ around them. Save musically strong positions for the weight-bearing words.
 Lyrics are built to fit notes. When matching a second verse to a first verse,
 match both stress pattern and importance pattern.
 
-Pattison's Sting example scans into regular groups: the first two phrases use
-three-syllable patterns, and the last two use two-syllable patterns. A rewrite
-is "too hot" when it crowds stressed words into unstressed positions. It is "too
-cold" when weak content lands where the model had important words.
+Pat scans the chapter's opening Sting verse first, so the rewrites have a model
+to answer to:
+
+```text
+Sink like a stone that's been thrown in the ocean
+/    u    u /     u     u    /      u  u   / u
+My logic has drowned in a sea of emotion
+u  / u   u   /      u  u /   u  u / u
+Stop before you start
+/    u  /    u   /
+Be still my beating heart
+u  /    u  /  u    /
+```
+
+> These are pretty regular. The first two phrases are written in three-syllable
+> patterns, the last two in two-syllable patterns. (Do you detect any prosody?)
+
+### Too hot
+
+> It is important not to be greedy: do not put stressed syllables in the
+> unstressed positions. This one is too hot.
+
+Pat's greedy rewrite:
+
+```text
+Cast DEEP in silence I can't HOLD my balance
+/    /    u  /  u   u  u    /    u  / u
+My weak HEART revealed by the heat BORN of malice
+u  /    /     u  /     u  u   /    /    u  / u
+Devil HAUNTS my past
+/  u  /      u  /
+GOD give me peace at last
+/   /    u  /     u  /
+```
+
+> The "greedy" spots would surely get buried or at the very least sound hurried
+> (and lose their emotion) when you set them to the music of the original verse.
+
+### Too cold
+
+> It is equally important to match the original's important words with equally
+> important words. This one is too cold.
+
+```text
+YET in your silence I've JUST got my balance
+u   u  u    /  u    u    u    u   u  /  u
+My weakness is NOW in the PLACE of your malice
+u  /   u    u  /   u  u   /     u  u    / u
+WON'T you help me past
+u     u   /    u  /
+And GET me OUT at last
+u   /   u  /   u  /
+```
+
+> This should be enough to lose anyone's interest.
+
+Read the marks, not the vocabulary: lines two and four scan against the model
+syllable for syllable and are still dead, because "now," "place," "get," and
+"out" occupy the positions the model gave its meaning carriers. Lines one and
+three go further — "Yet" and "Won't" sit on the model's opening strong position
+as words Pat marks *unstressed*, so the strong position comes up empty.
+
+### Just right
+
+> You must resist greed. But you must put your important words in the important
+> positions. This one is just right.
+
+```text
+Cast in your silence I'm losing my balance
+/    u  u    /  u    u   /  u   u  / u
+My weakness revealed by the heat of your malice
+u  /   u    u  /     u  u   /    u  u    / u
+Devil in my past
+/  u  /  u  /
+Oh give me peace at last
+u  /    u  /     u  /
+```
+
+> This version should work with the music for the original words. The stresses
+> match, and the most important words are in the same places.
+
+The two spots to compare between "too hot" and "just right" are line three's
+third syllable and line four's first. Line three is the odd one: the page
+italicizes "haunts" although its stress map is identical to the just-right line's
+"in." Line four is the blunt one: "God" wants the stress that the model's pickup
+position refuses to give it, and "Oh" does not.
 
 Pattern-matching checklist:
 
@@ -140,18 +341,36 @@ Pattern-matching checklist:
 - Put important words in important positions.
 - Keep connector words from stealing strong beats.
 
+Those four are Chapter 3's Exercise 13 instruction restated: scan ten given
+phrases, then write your own phrases to match the stress patterns of the
+originals; where you run into grey areas, create grey areas of your own to match
+them; and put your most important words in the same position as the most
+important words in the example. Two of its ten phrases, to show the range Pat
+asks a writer to match:
+
+```text
+You had your special perfume on when I got home.
+He never was a bad boy, for he never was a child.
+```
+
 ## Rhythm and expectation
 
 A rhythm is a repeated stress pattern. The pattern can be small or large; size
 matters less than repetition.
 
+Pat builds it from the smallest cell up, and his figures name the small one out
+loud:
+
 ```text
-small cell:        / u
-repeated figure:   / u / u / u / u
+small cell:        / u                 (DUM da)
+repeated figure:   / u / u / u / u     (DUM da DUM da DUM da DUM da)
 larger cell:       / u u /
+repeated figure:   / u u / / u u / / u u / / u u /
 ```
 
-The more regular the repetition, the faster expectation locks in.
+> The size of the pattern is not important. What is important is that the
+> pattern is repeated enough to make you expect it again. The more even and
+> regular the pattern is, the more quickly expectations lock in.
 
 ## Pace: duples and triples
 
@@ -163,26 +382,39 @@ constant duples:   u / u / | u / u /
 ```
 
 Changing from duples to triples adds unstressed syllables between stresses, so
-the rhythm accelerates:
+the rhythm accelerates. Pat demonstrates it with a four-phrase system whose
+first two phrases are his own and whose last two are the Sting lines the chapter
+opened with:
 
 ```text
-duple setup:       u / u / | u / u /
-triple change:     u / u / | u u / u u /
+I've been through every single book I know      (4 stresses)
+Soothe the thoughts that plague me so
+/     u   /       u    /      u  /              (4 stresses)
+Sink like a stone that's been thrown in the ocean
+/    u    u /     u     u    /      u  u   / u
+My logic has drowned in a sea of emotion
+u  / u   u   /      u  u /   u  u / u
 ```
+
+The acceleration lands in phrases three and four, where the duple cells give way
+to triples without changing the stress count.
 
 Changing from triples to duples removes intervening unstressed syllables, so the
-rhythm decelerates:
+rhythm decelerates. Pat's figure for this is the Sting verse itself, read the
+other way round: the triple first two phrases give way to the duple "Stop before
+you start / Be still my beating heart," and the pace slows in phrases three and
+four. His caution on that page is worth keeping:
 
-```text
-triple setup:      u u / u u /
-duple change:      u / u /
-```
+> The rhythm slows in the third and fourth phrases. The acceleration you might
+> hear is caused by phrase length, the second ball we juggled.
 
 Deceleration is not only a triple-to-duple move. *Any* reduction in unstressed
 syllables slows the pace, including dropping them entirely so that stresses fall
-adjacent:
+adjacent — which is exactly what Pat's deceleration figure shows, two duple
+phrases followed by a bare row of stresses:
 
 ```text
+duple setup:       u / u / u / u /
 duple setup:       u / u / u / u /
 adjacent stresses: / / / /
 ```
@@ -198,9 +430,15 @@ section still feels pushed forward by phrase count.
 
 ## Stress count vs syllable count
 
-When deciding whether one phrase is longer than another for rhythmic structure,
-count stressed syllables, not raw syllables. This is not a rounding convenience.
-The two measures can rank the same pair of phrases in **opposite** directions:
+This rule reaches the reader as a parenthesis printed inside a page scan, which
+is why it is easy to miss. Pat's words:
+
+> (Now we can be more precise when we say one phrase is "longer" or "shorter"
+> than another one. When you want to know how long a phrase is, you can figure it
+> out accurately, not by counting *syllables*, but by counting *stressed
+> syllables*. For example, `u / u / u / u /` is *longer* than
+> `u u / u u / u u /`, even though it has one less syllable. If you set the two
+> to music, `u / u / u / u /` will extend further.)
 
 ```text
 u / u / u / u /      8 syllables, 4 stresses   <- the LONGER phrase
@@ -236,18 +474,68 @@ Phrase 4: / u / u /       <- closure
 ```
 
 It maps cleanly onto popular music's two-, four-, and eight-bar subdivisions.
-With stressed syllables on strong quarter-note positions in 4/4, the four
-phrases define an eight-bar unit.
+Pat sets the stressed syllables of each phrase in the stressed quarter-note
+positions of 4/4 bars and walks the eight bars one phrase at a time. Phrase one
+fills two bars — four quarter notes, then three and a rest. Phrase two takes
+bars three and four:
 
-Worked example: Pattison uses "Mary Had a Little Lamb" to show that stopping
-after two lines feels incomplete, and that line three predicts the three-stress
-line needed for line four.
+> The silent third beat of the fourth bar serves to define phrase two's
+> difference from phrase one, and at the same time uses the silence to define the
+> four-bar phrase.
 
-The sharpest move in that demonstration is a one-word edit. Lengthen line two to
-four stresses — "white as whitest snow" rather than "white as snow" — and the
-first two lines become rhythmically balanced and you *can* stop there. Leave
-line two at three stresses and you cannot. The imbalance between four and three
-is the entire engine of the form, and this is the cheapest way to hear it.
+Phrase three repeats phrase one, "defining the third two-bar phrase, and raising
+your expectations for the final two bars," and phrase four "brings the system to
+a smooth and firm conclusion."
+
+> It adds up to an eight-bar phrase, and it also defines along the way
+> subdivisions of two-bar and four-bar phrases.
+
+> What meter could be better than Common Meter for popular music, since popular
+> music is normally written in divisions and subdivisions of two, four, and eight
+> bars?
+
+Pat's worked example is "Mary Had a Little Lamb," scanned:
+
+```text
+Mary had a little lamb
+/  u  /   u /   u  /
+Its fleece was white as snow
+u   /      u   /     u  /
+And everywhere that Mary went
+u   /  u  //    u    /  u  /
+The lamb was sure to go
+u   /    u   /    u  /
+```
+
+> The secondary stress on "everywhere" does not change the pattern. Treat
+> secondary stresses just like a strong stress. The unaccented syllable opening
+> lines two, three, and four work as pickups; they do not change the pattern
+> either.
+
+He then proves the imbalance by trying to stop early. After two lines —
+
+```text
+Mary had a little lamb          (4)
+Its fleece was white as snow    (3)
+```
+
+— "this is unbalanced. You cannot stop here." One word fixes it:
+
+```text
+Mary had a little lamb                  (4)
+Its fleece was white as whitest snow    (4)
+```
+
+> it would be rhythmically balanced. You could stop.
+
+Put the original line two back and add line three, and the trap closes: "It is
+impossible to stop here. You must continue forward. But not only do you need to
+go ahead, you already know where you should end up!" What you expect, and get,
+is `The lamb was sure to go`. "If it had ended any other way you would have been
+surprised."
+
+The imbalance between four and three is the entire engine of the form, and the
+"whitest snow" edit is the cheapest way to hear it.
 
 That contrast is also the bridge to Paradigm 2 below, which is simply what a
 four-stress second phrase produces once it is carried across all four lines.
@@ -255,18 +543,34 @@ four-stress second phrase produces once it is carried across all four lines.
 ## Common meter as map
 
 In *Writing Better Lyrics* Chapter 14, common meter becomes a drafting map, not only
-a scansion label. The chapter ties the 4/3/4/3 stress pattern to the eight-bar
-section in Western popular music: two bars establish a resting landmark, four
-bars create an unstable midpoint, and the last two bars answer the expectation
-set by the matching first and third phrases.
+a scansion label. Pat's image for the eight-bar section is a sea voyage — "the
+sea captain of Western popular music" — and the two- and four-bar subdivisions
+are landmarks along it. The end of bar two rests, bars three and four tack into
+the wind, bars five and six return to familiar territory, and bars seven and
+eight match three and four to arrive. Marked in strong and weak notes:
+
+```text
+DUM da DUM da DUM da DUM     4 stresses
+DUM da DUM da DUM            3 stresses
+DUM da DUM da DUM da DUM     4 stresses
+DUM da DUM da DUM            3 stresses
+```
+
+> The continuous voyage is organized according to a very simple principle:
+> longer / shorter / longer / shorter.
+>
+> You can't stop until you get to port.
 
 Use common meter by counting strong stresses, not by forcing every unstressed
 syllable into a fixed slot. Pattison shows the same pattern surviving extra
 weak syllables, missing or softened stresses, triple-meter delivery, and lines
 that divide into smaller phrases. The durable relationship is longer / shorter /
-longer / shorter.
+longer / shorter, and his sentence for the "3+ stresses" variation — a four-stress
+line shortened to three plus a trailing unstressed syllable — states the whole
+principle: "The important point is that the first and second phrases don't match;
+three-plus stresses is still longer than three stresses."
 
-> Writing in common meter is not a goal.
+> Writing in common meter is not a goal, it is a tool.
 
 That quote is the guardrail: common meter is a tool for orienting the lyricist,
 not a rulebook. Draft into 4/3/4/3 to make the section's balance easy to hear;
@@ -294,6 +598,13 @@ balance:
 - A 4+3 pair can behave like one longer phrase.
 - Triple movement can carry the same stress relationship.
 
+Pat's own summary line for the list: "Common meter is nothing if not flexible."
+His instances, in order, are the "3+ stresses" nursery-rhyme rewrite, an Emily
+Dickinson quatrain he counts 4 / 2 / 4 / 3 because some of its stresses are
+"pretty wimpy," and a verse of Gordon Lightfoot's "The Wreck of the Edmund
+Fitzgerald" in triple meter where a four-stress line splits into two two-stress
+phrases and a later pair of lines adds up to a single seven-stress phrase.
+
 Do not treat variation as sloppiness. Treat it as prosody evidence: if the
 variation supports the emotional or semantic turn, keep it; if it only clouds
 the map, revise.
@@ -315,7 +626,24 @@ content. Do not turn on a spotlight for decoration.
 In *Writing Better Lyrics* Chapter 15, Pattison turns common meter into a controlled
 spotlight machine. Begin with a stable abab / 4-3-4-3 pattern, let the listener
 expect the fourth line to rhyme with line two and carry three stresses, then
-alter one variable at a time.
+alter one variable at a time. His demonstration stanza, which the whole chapter
+then manipulates one move at a time:
+
+```text
+                                        rhyme   stresses
+I hitched to Tulsa worn and soaked        a         4
+Stopped to get a bite                     b         3
+The waitress stared before she spoke      a         4
+Then asked me what I'd like               b         3
+```
+
+> Both the rhyme and the rhythm move in an abab (alternating) structure, giving
+> double power to our expectations, and making the expected fourth line resolve
+> completely, though a bit dully.
+
+Exercise 17 of *Writing Better Lyrics* is the reader's half of the demonstration:
+stop reading, write your own four-line common meter structure, and make every
+change Pat makes to the Tulsa stanza to your own version as the chapter goes.
 
 Core spotlight moves:
 
@@ -342,12 +670,57 @@ which two is what makes the move usable:
 Coach both. A writer who fills only the final position leaves the earlier
 spotlight burning on whatever word happened to land there.
 
+The ladder's fourth lines, in the order Pat writes them, are the fastest way to
+hear each move:
+
+```text
+Then asked me what I'd like          b  3   the dull, expected close
+I felt the vibe                      b  2   shortened; throws us off balance
+Then smiled and asked me what I'd like  b  4   deceptive rhythmic closure
+Then smiled and flashed her petticoats  a  4   deceptive rhyme as well
+I grinned and told her I was broke   a  4   added line; unexpected closure
+And vanished like some ancient ghost a  4   the same slot, filled properly
+```
+
+The fifth of those is the one Pat rejects on the spot, and his reason is the
+lesson: "Told and I are in stressed positions, yet they don't really deliver
+much. If this line were in an ordinary position, it wouldn't make much
+difference, but we've set up the line specifically to get extra attention, so
+something important should go there. Maybe even the title."
+
 > When you turn on spotlights, use them.
 
 Spotlighted positions magnify weak language as much as strong language. If a
 line has been structurally marked by length, rhyme surprise, or delayed payoff,
 put the title, the turn, the image, or the dramatic reveal there. Do not waste
 that attention on filler words.
+
+Run all the way out, the Tulsa section reaches seven lines and finally pays the
+line-two rhyme:
+
+```text
+                                        rhyme   stresses
+I hitched to Tulsa worn and soaked        a         4
+I stopped to get a bite                   b         3
+The waitress stared before she spoke      a         4
+Smiled and flashed her petticoats         a         4
+Then rising in a curl of smoke            a         4
+She vanished like some ancient ghost      a         4
+A phantom in the night                    b         3
+```
+
+> We're able to sustain all these lines, building pressure and excitement with
+> each step without losing momentum. All this just because we're expecting a
+> rhyme for bite.
+
+Pat then names the weakness in his own payoff — "my last line, a phantom in the
+night, is pretty cheesy, and the cheese really, really shows up in this heavily
+spotlighted position. It would be a great place to put the song's title, wouldn't
+it?" — and Exercise 19 hands the repair to the reader: find a better final line,
+and remember that at this distance between rhymes the sonic bond has to be pretty
+strong. Exercise 18 asks the reader to refit their own stanza to the two shorter
+structures the same final line could have produced: `a4 b3 a4 a4 b3 b3` and
+`a4 b3 a4 a4 a4`.
 
 ## Deceptive vs unexpected common-meter closure
 
@@ -387,7 +760,24 @@ journey with four-stress couplets that organize two bars plus two bars. The
 basic pattern is four stresses matched by four stresses. Because the line
 lengths match, the listener can stop comfortably after line two.
 
-> Think of line length as a traffic cop:
+His paradigm for it is the counting rhyme again, but a different variant from the
+one Chapter 3 of *Essential Guide to Lyric Form and Structure* uses — here every
+line runs four stresses and the second couplet is rewritten to keep them:
+
+```text
+Eenie meenie miney moe        4 stresses
+Catch a tiger on the toe      4 stresses
+If he hollers make him pay    4 stresses
+Fifty dollars every day       4 stresses
+```
+
+Do not reconcile that against Chapter 3's "Catch a tiger by the toe / If he
+hollers let him go / Eenie Meenie Minie Moe." Each is correct for its own book.
+
+> Think of line length as a traffic cop: It tells you when to stop, and when to
+> go. Matched line lengths are stable. Unmatched lines create instability and
+> make us move forward, looking for a place to rest. And when you rhyme matched
+> lines, the stop sign is even stronger.
 
 Matched line lengths tell the ear it may stop. Unmatched lengths create
 instability and send the listener forward to find a place of rest. Rhyme
@@ -407,8 +797,12 @@ Two-by-two diagnostics:
 ## Couplet uses
 
 Four-stress couplets usually rhyme and usually form a four-bar lyric and
-musical unit. Use them when the song needs regular, balanced movement in short
-steps.
+musical unit. Pat's sentence: "Couplets usually rhyme, marking stopping places
+for the ear. They form a lyrical and musical unit, typically four bars long. They
+move us forward in regular, balanced steps with four stressed notes in each
+two-bar section." His literary instance is the opening quatrain of A. E.
+Housman's "To an Athlete Dying Young." Use couplets when the song needs regular,
+balanced movement in short steps.
 
 Useful couplet moves:
 
@@ -450,22 +844,32 @@ created by:
 - A distant rhyme connection too far away to be heard unless the intervening
   structure keeps the ear waiting.
 
+Its headline case is a verse of "The End of the Innocence" by Don Henley and
+Bruce Hornsby: "Seven four-stress lines in a row, and after three rhymed lines in
+a row, an unrhymed three-stress line! It's a huge IOU that you can actually hear
+being cashed in sixteen lines later, after a pre-chorus, a chorus, and the entire
+second verse have come in between. That's the power of the expectations these
+balanced lines are able to create."
+
 Cash an IOU only when the payoff matters. A title, emotional reversal, or
 dramatic image can justify the extra attention; ordinary connective language
 usually cannot.
 
 A rhyme can also be defeated by closure rather than by distance. Chapter 16's
-case is a line whose end sound matches lines two and four of its own verse and
-still reads as unrhymed, because the first four lines already closed into a
-unit and the ear stopped listening back across the seam. Proximity on the page
-is not audibility: a rhyme is heard only while the structure is still holding
-the ear open for it. When a rhyme has to reach past a closed unit, either
-reopen the unit or stop counting on the rhyme.
+case is that same verse's last line, which Pat marks as sounding unrhymed even
+though "it should rhyme with sky and by in lines two and four, but since the
+first four lines close off to form a unit, we won't hear the connection."
+Proximity on the page is not audibility: a rhyme is heard only while the
+structure is still holding the ear open for it. When a rhyme has to reach past a
+closed unit, either reopen the unit or stop counting on the rhyme.
 
 ## Couplet and common-meter models
 
-Chapter 16 closes with nine models mixing four-stress couplets and common
-meter. Line lengths are stress counts, not syllable counts.
+Chapter 16 closes with Exercise 20: nine models mixing four-stress couplets and
+common meter — "Write a section for each of the following models and watch it in
+action. Then put a few of the more unusual rhyme schemes in your toolbox for
+later use. Offer your listeners some nice surprises." Line lengths in the table
+are stress counts, not syllable counts, exactly as Pat's figure prints them.
 
 | # | Stresses | Rhyme scheme |
 |---|---|---|
@@ -493,6 +897,15 @@ of lines, an odd rhyme scheme, a two-stress line where the section had used
 none, and a section that stretches past the eight-bar units the verse and
 prechorus had trained, out to eleven bars.
 
+Pat's own enumeration:
+
+> With a maddeningly simple move of inserting only a piece of the last line, but
+> this is the end, everything is thrown off balance. There are now an odd number
+> of lines in the chorus. There is an odd rhyme scheme. There is a two-stress
+> line for the first time. And the chorus stretches beyond the eight-bar units we
+> saw in the verse and pre-chorus into eleven bars. An effective way to showcase
+> the title.
+
 Bar-count overrun is a device in its own right, and the one most easily missed
 on the page: a section can be internally coherent and still be marked simply
 by outlasting the length the song taught the listener to expect.
@@ -510,10 +923,35 @@ and start the song again. The danger pattern is aa bb cc dd ee: matched lengths
 plus paired rhymes make the lyric march in small units, so every weak line
 becomes more visible and the song feels longer than it is.
 
-> Interesting structure isn't something that just happens.
+> Interesting structure isn't something that just happens. You create it. And
+> usually out of the simplest of starting places: matched couplets and/or common
+> meter.
 
-The fix is to make the structure feel larger than two-line units. The more
-words a section carries, the larger the structure should feel.
+The fix is to make the structure feel larger than two-line units. Pat's tip
+verbatim: "The more words there are in your lyric section, the larger your
+structure should make it feel. Couplets are units of two lines. If you have
+couplets in your verse, you can expand them into something larger. Size can make
+all the difference."
+
+The chapter runs the expansion on one four-line Tulsa couplet draft through
+Exercises 21-25. The `435435` stage, with the long third and sixth lines doing
+the gluing, is the one worth having in full:
+
+```text
+                                                rhyme   stresses
+I hitched to Tulsa worn and tired                 x         4
+Found a small café                                x         3
+The place was cold, the waitress came at last     a         5
+She stopped and stared before she grinned         x         4
+Then flashed her petticoats                       x         3
+And disappeared, a vision from the past           a         5
+```
+
+Rhyming two with five turns that into `xabxab`; rhyming one with four as well
+turns it into `abcabc`. Pat's rule for choosing: "If the lyric's emotion deals
+with uncertainty or loss (unstable), keep it looser. If its ideas are more
+factual or resolved (stable), tighten it up. Make your structure reflect the
+emotion of the lyric. Prosody."
 
 Couplet-expansion moves:
 
@@ -533,7 +971,10 @@ Couplet-expansion moves:
   eighth lines are both **shorter** — three stresses — with the fourth
   withholding a rhyme that the eighth answers: `4/4/4/3/4/4/4/3`, `aaabcccb`.
   The shortening is half the move; an unrhymed line of matched length does not
-  open the same IOU.
+  open the same IOU. Pat credits the rhyme scheme to David Wilcox's "Eye of the
+  Hurricane" and prints the flattened `aabbccdd` alternative beside it to show
+  what is lost: "Without the rhyme scheme's organizing larger motion, the eight
+  lines could really have been dull city."
 
 Use looseness for uncertainty, loss, or instability. Tighten rhyme and stress
 organization when the lyric's emotion is factual, resolved, or controlled.
@@ -541,10 +982,23 @@ organization when the lyric's emotion is factual, resolved, or controlled.
 ## Delayed couplet payoff
 
 A larger couplet-based section can raise, satisfy, and then raise expectations
-again. Pattison's Leonard Cohen analysis shows the key pattern: a six-line unit
-establishes a shape, a partial repetition makes listeners expect the rest of
-that shape, extra lines delay the expected rhyme, and the final title pays it
-off under intense spotlight.
+again. Pattison's Leonard Cohen analysis of "Closing Time" shows the key pattern
+step by step: a six-line unit built on three-stress lines with weak endings and
+longer five-stress third and sixth lines; three more lines that make listeners
+expect another six and another `-ime` rhyme; then two lines that arrive with
+strong endings instead, delaying the payoff; then a further delay; then the title
+under full spotlight.
+
+Pat's image for how far the delay can stretch:
+
+> But it's like stretching a rubber band (Minnesotans call them "binders", New
+> Englanders call them "elastics"… weird): You don't want to stretch them too far
+> or they'll break. If you don't stretch it far enough, though, they won't hurt
+> when you snap someone with them.
+
+His flattened rewrite of the same section into lockstep couplets is printed
+directly beneath the original so the loss is audible: "The relentless march of
+couplets sinks the whole enterprise… The dance of ideas has lost its partner."
 
 Coach delayed payoff by asking:
 
@@ -567,7 +1021,44 @@ Describe any rhythmic structure with five questions:
 - Closure: closed or open?
 - Type of closure: expected, unexpected, or deceptive?
 
-Common Meter is symmetrical, constant, through-written, closed, and expected.
+Pat's blank worksheet, laid out as it appears on the page:
+
+```text
+BALANCE:   ___ SYMMETRICAL       ___ ASYMMETRICAL
+PACE:      ___ CONSTANT          ___ ACCELERATED    ___ DECELERATED
+FLOW:      ___ THROUGH-WRITTEN   ___ FRAGMENTED
+CLOSURE:   ___ CLOSED            ___ OPEN
+C. TYPE:   ___ EXPECTED          ___ UNEXPECTED     ___ DECEPTIVE
+```
+
+Filled in for Common Meter, that worksheet reads:
+
+```text
+BALANCE:   _x_ SYMMETRICAL       ___ ASYMMETRICAL
+PACE:      _x_ CONSTANT          ___ ACCELERATED    ___ DECELERATED
+FLOW:      _x_ THROUGH-WRITTEN   ___ FRAGMENTED
+CLOSURE:   _x_ CLOSED            ___ OPEN
+C. TYPE:   _x_ EXPECTED          ___ UNEXPECTED     ___ DECEPTIVE
+```
+
+Pat's own five numbered readings behind those marks:
+
+1. It is BALANCED — there is an even number of phrases, each phrase has a
+   counterpart, and the order of the phrases is repeated. Nothing is left
+   "hanging."
+2. It moves in a CONSTANT duple pattern of stress/unstress, neither ACCELERATED
+   nor DECELERATED.
+3. The structure is THROUGH-WRITTEN: there is no place of resolution before the
+   end of the last phrase. The structure keeps pushing you forward.
+4. It is CLOSED, or resolved. If there were a need to continue on, the structure
+   would be OPEN.
+5. The resolution is EXPECTED. It is how you would have predicted, when you
+   reached the end of phrase three, that the entire structure would end.
+
+The name comes from that count: "We have just developed what we will call the
+STRUCTURAL PENTAD (penta = 'five') — five normal characteristics of any
+structure, be it a rhythmic structure, a rhyme structure, or even a musical
+structure."
 
 ## Paradigm 1: through-written
 
@@ -597,26 +1088,39 @@ duples:   / u / u / u /   |  triples:  / u u / u u / u u /
           / u / u /       |            / u u / u u /
 ```
 
-Exercise use: write content that carries its idea through to the end, because
-the structure has no earlier point of resolution. Chapter 3's exercises ask for
-one of the three systems in triples specifically, which is the drill that makes
-the stress-count definition stick.
+Exercise use: Exercise 14 asks for three Paradigm One systems, each with
+different content, and — since Paradigm One is through-written — for each system
+to carry its idea through to the end. One of the three must be written in
+triples, which is the drill that makes the stress-count definition stick.
 
 ## Paradigm 2: fragmented
 
-Paradigm 2 repeats four matching four-stress phrases:
+Paradigm 2 repeats four matching four-stress phrases, stated in duples, with the
+closure arrow drawn twice:
 
 ```text
-4 stresses | 4 stresses <- internal closure
-4 stresses | 4 stresses <- closure
+PARADIGM 2:  / u / u / u /
+             / u / u / u /    <- closure
+             / u / u / u /
+             / u / u / u /    <- closure
 ```
+
+Pat's example for it is the "Eenie Meenie Minie Moe" counting rhyme, whose four
+lines all run four stresses.
 
 Because phrase two does not differ from phrase one, the structure closes
 internally after two phrases and starts over. It defines a four-bar unit as the
 primary unit rather than making four bars feel like the midpoint of an
 eight-bar journey.
 
-Exercise use: divide the content into two ideas, one for each two-phrase unit.
+Its Pentad reading differs from Common Meter's in exactly one row: FLOW is
+FRAGMENTED, meaning there is an internal point of resolution — the structure
+stops after the second phrase and then starts over. It is still CLOSED, and Pat's
+parenthesis is "(Twice, in fact)."
+
+Exercise use: Exercise 15 asks for three Paradigm Two systems with different
+content, one of them in triples, each divided into two ideas, one per two-phrase
+segment.
 
 ## Deceptive closure
 
@@ -624,22 +1128,55 @@ Deceptive closure sets up a specific ending, then closes with another phrase
 length already present in the system:
 
 ```text
-Expected:   4 / 3 / 4 / 3
-Deceptive:  4 / 3 / 4 / 4
+At line four you expect:   / u / u /
+What you get:              / u / u / u /
 ```
 
-Two conditions make closure deceptive:
+> The extra strong stress goes against your expectations. You knew what you
+> wanted, and were fooled. The structure is still CLOSED because it repeats a
+> familiar phrase length (you have seen twice in the section), but the resolution
+> is DECEPTIVE.
 
-- The system raises an expectation for a specific resolution.
-- The actual resolving phrase is already present in the structure.
+Pat's two conditions, verbatim:
 
-The deceptive ending creates a high-profile position and unbalances the
-structure. Put an important idea there.
+> 1. The system must raise expectations that it will be resolved in a certain
+>    way, and
+> 2. The phrase that is actually used to resolve the system must already be in
+>    the structure.
+
+His worked instance is a four-line system whose fourth phrase overruns the
+three-stress close the first three lines predicted:
+
+```text
+We're always meeting secretly
+u    /  u   /  u   /  u  //
+Keeping out of sight
+/  u    /   u  /
+Knowing no one else can see
+/  u    u  /   /    u  /
+Knowing something isn't right
+/  u    /  u    /  u  /
+```
+
+> The system implies a 3-stress resolution, making the rhythmic deception
+> possible. Deception creates a position of high profile. It turns on whole banks
+> of spotlights. Make sure you put something there that is worth looking at.
+> PARADIGM THREE is a clear example of DECEPTIVE CLOSURE. The price of the
+> deception is to unbalance the structure.
+
+Exercise 16 of *Essential Guide to Lyric Form and Structure* — distinct from
+Exercise 16 of *Writing Better Lyrics*, which is the grocery-list drill — asks
+for three Paradigm Three systems put together to tell a story, each advancing
+the idea further, each carrying its content to the end, and each putting its most
+important idea in the deceptive fourth phrase. The suggested opening line is the
+"We're always meeting secretly" above.
 
 ## Unexpected closure
 
-Unexpected closure does not fool a specific prediction. There was no specific
-resolution to fool; the structure startles instead.
+Unexpected closure does not fool a specific prediction. Pat's test is that "there
+must be no expectation for a specific resolution. The idea is a simple one: if
+you don't expect anything, you can't be fooled. (You can, however, still be
+startled or surprised.)"
 
 The common case is a system that closes and then repeats a phrase, usually the
 last phrase:
@@ -649,13 +1186,28 @@ closed system
 extra repeated phrase <- unexpected attention
 ```
 
+Chapter 3 gives two instances, each with a closure arrow drawn against the line
+that already ended the system and again against the tacked-on line: a four-line
+system from "The Great Pretender" plus a fifth line, and a four-line system
+ending "Strangle all your hopes" that then repeats its own opening line.
+
+> When a system creates a place that surprises you — that gets a lot of
+> attention, use it well. It is a good place to put important ideas.
+
+Exercise 17 is one line long: write two systems ending with unexpected closure.
+
 As with deceptive closure, use the surprise position for important content.
 
 ## Common-meter exercises
 
-- Grocery-list meter: write a grocery list in common meter twice, once in
-  duple movement and once in triple movement. Keep the 4/3/4/3 stress relation
-  audible even when the syllable count changes.
+- Grocery-list meter (Exercise 16, *Writing Better Lyrics*, Chapter 14): "Try
+  doing this with your grocery list. Try one in duples — da DUM da DUM — and one
+  in triples — da da DUM da da DUM." Keep the 4/3/4/3 stress relation audible
+  even when the syllable count changes. Pat's own warm-ups for the same drill are
+  a telemarketing call ("I had to call to say hello / I hope you're gonna buy /
+  Times are tough and rent is due / And I've got songs to write") and working up
+  the nerve to ask for a date ("I wanna call, I wanna call / I know I'll sound
+  too scared / My self-esteem is plunging fast / O do I do I dare?").
 - Spotlight ladder: write one four-line common-meter stanza, then revise it
   through these versions: shortened fourth line, lengthened fourth line,
   fourth line rhyming with one/three, one added four-stress line, several added
@@ -684,6 +1236,11 @@ As with deceptive closure, use the surprise position for important content.
   the point is learning to chart content into manageable stress groups.
 - Detour test: draft a clean 4/3/4/3 version, then deliberately lengthen or
   shorten one phrase. Keep the detour only if it clarifies the emotional turn.
+  Pat's own "simple detour" runs 4 / 3 / 5 / 3+ / 3 / 5 — two common-meter
+  openings each answered by a five-stress line — and his point is that charting
+  the course first is what makes the departure safe: "If you need to take a
+  detour, you will know where you are when you leave, and it will help you keep
+  safely under control."
 
 ## Challenge 4 rhythm practice
 
@@ -867,11 +1424,10 @@ Pat's pedagogical anchor for Common Meter. 4/3/4/3 stresses,
 through-written, expected closure.
 
 ```text
-Paradigm One:
-line 1: X X X X       (4 stresses)
-line 2: X X X         (3 stresses)
-line 3: X X X X       (4 stresses)
-line 4: X X X         (3 stresses)
+PARADIGM 1:  / u / u / u /
+             / u / u /        -> motion
+             / u / u / u /    -> motion
+             / u / u /        <- closure
 
 Balance:   symmetrical
 Flow:      through-written
@@ -888,11 +1444,10 @@ Same stress count on every line; flow fragmented (often heard as 2 + 2);
 expected closure.
 
 ```text
-Paradigm Two:
-line 1: X X X X       (4 stresses)
-line 2: X X X X       (4 stresses)
-line 3: X X X X       (4 stresses)
-line 4: X X X X       (4 stresses)
+PARADIGM 2:  / u / u / u /
+             / u / u / u /    <- closure
+             / u / u / u /
+             / u / u / u /    <- closure
 
 Balance:   symmetrical
 Flow:      fragmented
@@ -910,11 +1465,10 @@ expected 3-stress closure by extending to 4 stresses. Section sounds
 like closing on schedule, then refuses.
 
 ```text
-Paradigm Three:
-line 1: X X X X       (4 stresses)
-line 2: X X X         (3 stresses)
-line 3: X X X X       (4 stresses)
-line 4: X X X X       (4 stresses — deceptive)
+PARADIGM 3:  / u / u / u /
+             / u / u /        ->
+             / u / u / u /    ->
+             / u / u / u /    <-   (deceptive)
 
 Balance:   asymmetrical — this is the price of the deception
 Flow:      through-written
@@ -928,6 +1482,20 @@ resolves it with a length the listener was not braced for. It can do that only
 because the four-stress phrase is already present in the structure — a resolving
 phrase the section had never used would leave the system open instead of
 deceived.
+
+Pat's illustration is the nursery rhyme with a fourth line that overshoots, the
+spotlighted words set in italics on the page:
+
+```text
+Mary had a little lamb
+/  u  /   u /   u  /
+Its fleece was white as snow
+u   /      u   /     u  /
+And everywhere that Mary went
+u   /  u  //    u    /  u  /
+She sold the fleece to pay THE RENT
+u   /    u   /     u  /   u   /
+```
 
 Use Paradigm Three when the last idea must spotlight or unsettle. The
 expectation of a 3-stress close makes the longer line audible.
@@ -983,19 +1551,22 @@ is the standing error here:
   leaves unstressed. This is a scansion failure: the stress map itself is wrong.
   The greedy syllables get buried or sound hurried when set to the original's
   music, and they lose their emotion on the way.
-- **Too cold** — a **matching stress map filled with the wrong words**. The
-  scansion is correct; every stress lands where the model put one. The failure
-  is that the important positions are occupied by semantically empty
-  words — connectives, filler, and hedges — where the model had meaning
-  carriers. Nothing trips; the section simply stops being worth listening to.
+- **Too cold** — the **important positions filled with the wrong words**. Nothing
+  trips; the section simply stops being worth listening to. Pat's marked example
+  shows two flavours of this, and the file used to claim only the first. In its
+  lines two and four the scansion is exactly the model's, syllable for syllable,
+  and the lines are still dead because connectives and hedges stand where the
+  model had meaning carriers. In its lines one and three the strong position
+  comes up empty instead: "Yet" and "Won't" sit where the model opened with
+  "Sink" and "Stop," and Pat marks both of them *unstressed*.
 - **Just right** — **both** conditions met at once: the stresses match, *and*
   the most important words sit in the same places as the model's most important
   words.
 
-Too cold is the state a stress-only audit cannot see, which is exactly why it is
-worth naming. A rewrite can scan perfectly against its model and still be dead.
-Check the stress map first, then ask separately what is standing on each strong
-position.
+Too cold is the state a stress-only audit *need not* see, which is exactly why it
+is worth naming. A rewrite can scan perfectly against its model and still be
+dead. Check the stress map first, then ask separately what is standing on each
+strong position.
 
 Use the Goldilocks frame when running pattern-match audits per line. Note the
 scope on the vocabulary: **when matching a lyric to a model lyric, greed is
@@ -1007,7 +1578,8 @@ to a *melody* rather than to another lyric, a mismatch in either direction is a
 greedy spot — a stressed syllable on a weak beat, or an unstressed syllable
 riding a strong one — because either one fights the bar. See
 [prosody](prosody.md) "greedy spots" for that frame. Too cold is a third thing
-again, and no stress check of any kind will catch it.
+again: a stress check may or may not catch it, and when it does not, only asking
+what each strong position is *carrying* will.
 
 ## Pitch-based stress model (*Songwriting Without Boundaries* (2011), Challenge 4)
 
@@ -1125,6 +1697,11 @@ applied across domains.
   apply the Pentad's five properties.
 - [hook](hook.md) — strategic vs balancing position in Common Meter.
 - [prosody](prosody.md) — greedy spots; pitch-stress in melody setting.
-- [exercises](exercises.md) — *Essential Guide to Lyric Form and Structure* (1991) Ex 8-17 cover Pentad properties
-  plus Paradigm-write drills; *Songwriting Without Boundaries* (2011), Challenge 4 covers In Memoriam +
-  forms.
+- [exercises](exercises.md) — *Essential Guide to Lyric Form and Structure*
+  (1991), Chapter 3, Exercises 8-17 cover syllables, stress, scansion, pattern
+  matching, and the three Paradigm-write drills; *Writing Better Lyrics* (2009),
+  Chapters 14-17, Exercises 16-25 cover the grocery list, the common-meter
+  spotlight ladder, the nine couplet/common-meter models, and the couplet
+  expansions. The two numbering schemes overlap at 16 and 17, so always cite the
+  book with the number. *Songwriting Without Boundaries* (2011), Challenge 4
+  covers In Memoriam + forms.

--- a/plugins/songwriting/context/pat-pattison/research/mosaic-rhyme.md
+++ b/plugins/songwriting/context/pat-pattison/research/mosaic-rhyme.md
@@ -1,9 +1,12 @@
 # Mosaic Rhyme — Multi-Word Combos Across Parts of Speech
 
 Pat Pattison — *Pat Pattison's Songwriting: Essential Guide to Rhyming*
-(2014), Chapter 1 — taxonomy alongside masculine and feminine. Extended by
-Pat's columns + Coursera Module 3 and by hip-hop / rap craft tradition
-(Eminem, Sondheim, Lin-Manuel Miranda) which Pat references frequently.
+(2014), Chapter 1 — where mosaic rhyme is named and defined. Worked examples
+run through Chapter 2 (the "risky business" walkthrough), Chapter 4 (feminine
+family rhymes), and Chapter 6 (feminine assonance rhymes). Extended for
+cross-part-of-speech search by Pat's columns + Coursera Module 3 and by
+hip-hop / rap craft tradition — those extensions are marked as non-book where
+they appear below.
 
 **Mosaic rhyme is a rhyme where one (or both) of the rhyming units is
 COMPOSED OF MULTIPLE WORDS.** The rhyme works on stressed-vowel + post-
@@ -11,15 +14,61 @@ vowel-consonant identity; the words being combined to produce that sound
 can cross parts of speech, mix proper nouns, slang, contractions, and
 phrase fragments.
 
-Mosaic rhyme is a tier the AI routinely skips. Generic LLM defaults pull
-single-word rhymes from a single part of speech (noun rhymes with noun,
+> "Call these pairs above mosaic rhymes, since they are put together with
+> syllables of different words, like stained glass pieces in a church window."
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 1
+
+**Mosaic is a construction, not a third rhyme category.** This is the single
+most-misread point in the taxonomy. Chapter 1 is explicit that "every rhyme is
+either masculine or feminine. Never to both." A mosaic rhyme is still one or
+the other — `commander/understand her` is feminine; `ap-pre-ci-ate/the quiche
+he ate` is a three-syllable rhyme that Pat classifies as **masculine**, "since
+[its] last syllable is more stressed than the one before it." Mosaic describes
+*how the rhyming unit was assembled*, which is orthogonal to where its stress
+falls. Never present mosaic as a peer of masculine and feminine.
+
+Mosaic rhyme is a construction the AI routinely skips. Generic LLM defaults
+pull single-word rhymes from a single part of speech (noun rhymes with noun,
 verb with verb) and miss the multi-word territory entirely. Mosaic
 SURFACE IS MANDATORY for any rhyme suggestion task per
 [response-filter](response-filter.md) §1.
 
+## Pat's own mosaic examples
+
+These are the pairs Pat actually prints, with the chapter each comes from.
+Treat them as the reference set; everything generated later in this file is
+labeled as such.
+
+| Mosaic pair | Type | How it is built | Source |
+|---|---|---|---|
+| `commander` / `understand her` | feminine | the unstressed tail is a pronoun, not an identity | Chapter 1 |
+| `expand me` / `strand thee` | feminine | verb + object pronoun on both sides | Chapter 1 |
+| `ap-pre-ci-ate` / `the quiche he ate` | masculine (three-syllable) | article + noun + pronoun + verb | Chapter 1 |
+| `business` / `fizzless` | feminine | noun + adjectival suffix borrowed from `less` | Chapter 2 |
+| `business` / `quizless` | feminine | same construction, different stressed vowel word | Chapter 2 |
+| `travel` / `glass full` | feminine | noun + adjective read as one unit | Chapter 4 |
+| `homely` / `phone me` | feminine | masculine word + pronoun `me` | Chapter 4 |
+| `believer` / `please her` | feminine | verb + object pronoun `her` | Chapter 4 |
+| `sailin'` / `tail him` | feminine | g-dropping opens the word to a verb + pronoun | Chapter 4 |
+| `lonely` / `hold me` | feminine | transitive verb + `me` | Chapter 6 |
+| `lonely` / `close me` | feminine | transitive verb + `me` | Chapter 6 |
+
+Two generative rules fall straight out of that list:
+
+1. **Masculine transitive verb + `me` / `her` / `him`.** Pat states it
+   directly in Chapter 6: "One way is to use masculine transitive verbs plus
+   the pronoun 'me'." This is the highest-yield mosaic construction in the
+   book, and it works whenever the feminine target's unstressed syllable
+   rhymes with a pronoun (Chapter 4).
+2. **Drop the `g` on feminine `-ing` words.** "A neat trick: If the tone of
+   your lyric is informal, you might try dropping the `g` on feminine 'ing'
+   words, like 'sailing.' Then you can create a mosaic rhyme with 'him'"
+   (Chapter 4).
+
 ## What mosaic rhyme is
 
-**Single word ↔ multi-word combo:**
+**Single word ↔ multi-word combo** (generated candidates in the shape of Pat's
+constructions — run identity and meter checks per song):
 
 | Source word | Mosaic partner | Construction |
 |---|---|---|
@@ -28,7 +77,7 @@ SURFACE IS MANDATORY for any rhyme suggestion task per
 | `wedding` | `fed him` | verb + pronoun |
 | `delicate` | `tell a kid` | imperative + object |
 | `lyrical` | `miracle` (near-perfect) plus mosaic-stacks like `it'd be a` | hesitant filler phrase |
-| `Pat Pattison` | `that's a fashion` (paraphrase example) | name → demonstrative + noun |
+| `lonely` | `hold me` | transitive verb + pronoun — **Pat's own**, Chapter 6 |
 
 **Multi-word combo ↔ multi-word combo:**
 
@@ -82,22 +131,33 @@ Mosaic-friendly proper-noun categories:
 
 ## Hip-hop / rap craft tradition
 
-Mosaic rhyme is the dominant tier in rap and hip-hop. Pat references this
-explicitly in his columns and Coursera material. Eminem's interview with
-Anderson Cooper is canonical: he diagrammed mosaic rhyme chains for words
-"impossible" to rhyme by showing multi-word decomposition.
+**Mostly non-book.** The claim that mosaic rhyme is the dominant construction
+in rap and hip-hop comes from craft tradition and from Pat's columns and
+Coursera material, not from *Essential Guide to Rhyming*. No specific rapper's
+rhyme chains are reproduced here, because none appear in the book, and coining
+them and attributing them to a named artist would be worse than omitting them.
+If a writer wants worked rap examples, send them to the primary recordings.
 
-Examples of the kind of stacked mosaic move (paraphrased for IP):
+What the book *does* say about the genre is narrow and usable — the g-dropping
+trick from Chapter 4:
 
-- Source: `orange` → mosaic chains using `door hinge`, `four-inch`,
-  `pour ink` (stressed vowel + family/additive consonant)
-- Source: `purple` → mosaic chains using `circle`, `hurts you'll`
-- Source: `month` → mosaic chains using `once a`, `lunch a`,
-  `dunce-uh` (filler / nonsense word in the chain)
+> "This trick works especially well in country and hip-hop, where `g` is
+> dropped almost as a matter of principle."
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 4
 
-The rap tradition treats every word as rhyme-able by decomposing the
-sound and reassembling from multi-word combos. Pat names this discipline
-in *Essential Guide to Rhyming* (2014), Chapter 1.
+with his own worked pair:
+
+```text
+sailin'  /  tail him
+```
+
+The transferable discipline — and the part that squares with Pat's method — is
+that every word becomes rhyme-able once you decompose its *sound* and
+reassemble a matching unit out of several words. That is exactly the move Pat
+makes in Chapter 2 when `business` has no dictionary partner and he builds
+`fizzless` out of the masculine short `e` + `s` column. The book's route to a
+mosaic is: fail in the obvious section, then rebuild from a different section
+of the dictionary.
 
 ## Where mosaic rhyme is generated in the worksheet
 
@@ -155,10 +215,19 @@ Stress paradigms apply across word boundaries:
 |---|---|---|---|
 | `Téx-as` (X.) | trochee | `wrécks-us` (X.) | `whatever wrecks us` (..X.) |
 | `de-cíde` (.X) | iamb | `the bríde` (.X) | `here is the bride` (...X) |
-| `só-li-ta-ry` (X..X) | dactyl-trochee | `só-lemn ma-ry` | `the so-lem-ni-ty` |
+| `só-li-tà-ry` (X.X.) | double trochee | `só-lemn Mà-ry` (X.X.) | `the so-lém-ni-ty` (.X..) |
 
 The meter scan (per [meter](meter.md)) is the gate. Mosaic that breaks
 meter does not earn its place in a hot spot.
+
+Pat's own version of this gate is the `business` filter in Chapter 2. He had a
+sound-legal list — `Bess, bless, chess, dress, fess, guess, jess, less, mess,
+press, stress` — and threw nearly all of it out on stress grounds: "Most of
+these are too strong to work as the unstressed syllable in a feminine mosaic.
+You need something with the same stress pattern as `busi-ness`." Try `guess`
+and you get `hís guéss`, two stresses where the target has one. Only `less`
+survives, "since it actually could be unstressed." Sound-legal is not the
+same as scannable.
 
 ## Mosaic risk register
 
@@ -195,8 +264,10 @@ Mosaic rhyme has failure modes:
 - Better single-word options exist that serve the song's emotion better
 - The mosaic feels like a parlor trick rather than craft
 
-Per [rhyme-strategy](rhyme-strategy.md) decision matrix: pick the tier
-that serves emotional intent. Mosaic is one tier; not a default.
+Per [rhyme-strategy](rhyme-strategy.md) decision matrix: pick the option
+that serves emotional intent. Mosaic is one search lane among several, not a
+default — and it is orthogonal to the stability tiers, since a mosaic can land
+anywhere from perfect down to subtractive.
 
 ## Surfacing mosaic to the writer
 
@@ -204,7 +275,9 @@ The AI surfaces mosaic candidates in the standard rhyme list (per
 [rhyme-generation](rhyme-generation.md) Step 8) BUT labels them as
 mosaic and shows the decomposition:
 
-```
+<!-- phonetic vowel markings trip the spell-checker --><!-- spellchecker:off -->
+
+```text
 Stressed vowel: ĕ-ks (as in "Texas")
 
 Perfect (single-word, fully resolved):
@@ -226,6 +299,8 @@ From the song's world:
 - [pulls per the song's setting / character / era]
 ```
 
+<!-- spellchecker:on -->
+
 Each mosaic candidate gets:
 
 - The decomposition shown
@@ -236,9 +311,16 @@ Each mosaic candidate gets:
 
 ## Examples by source type
 
+**Generated, not Pat's.** Every table in this section is machine-generated in
+the shape of Pat's constructions — none of these pairs appear in
+*Essential Guide to Rhyming*. Pat's actual pairs are in the reference table
+near the top of this file. Run the identity check and the meter scan on any
+candidate below before using it; several are deliberately included at varying
+quality so the tiering is visible.
+
 ### Common nouns
 
-| Source | Mosaic options (illustrative, paraphrased; check identity + meter per song) |
+| Source | Mosaic options (generated; check identity + meter per song) |
 |---|---|
 | `mother` | `another`, `smother her`, `recover`, `discover` (non-mosaic), `love her`, `above her`, `shove her` |
 | `morning` | `warning`, `forming`, `storming`, `for me`, `floor me`, `more please`, `for any` |
@@ -279,7 +361,7 @@ when the proper noun has not yet earned its mention.
   across word boundary
 - [rhyme-strategy](rhyme-strategy.md) — when to deploy mosaic by
   emotional intent
-- [response-filter](response-filter.md) §1 — mandatory mosaic-tier check
+- [response-filter](response-filter.md) §1 — mandatory mosaic-surface check
 - [line-brainstorm](line-brainstorm.md) — Column 1 includes mosaic
 - [meter](meter.md) — stress paradigm preserved across word boundary
 - [cliche](cliche.md) — friendly cliche test applies to mosaic too
@@ -293,9 +375,9 @@ when the proper noun has not yet earned its mention.
 
 > "Rhyme creates a sonic roadmap: it tells those eyeless ears where to
 > go and when to stop." — Pat Pattison
-> (*Essential Guide to Rhyming* (2014), Introduction, paraphrased ≤25w)
+> (*Essential Guide to Rhyming* (2014), Introduction)
 
 Mosaic rhyme works because the ear hears the SOUND, not the spelling or
 the part of speech. Pat's craft applies the same identity check + tier
-walk + cliche scan to multi-word units. The AI must surface this tier
+walk + cliche scan to multi-word units. The AI must surface this construction
 or it has under-served the song.

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -36,14 +36,81 @@ touches, feels inside the body, and feels through balance or motion.
 
 Chapter 2 turns object writing into a placement rule: a lyric can tell the listener
 what matters after it has first shown an image strong enough to color the
-statement.
+statement. Pat opens the chapter by asking what object writing is *for*:
 
-> Show before you tell.
+> Once you become adept in your object writing, with bushels of sense-bound
+> images glittering on the kitchen table, what do you do with them?
 
-Pattison frames the image as "Rusty's collar": the concrete thing the writer
-holds up before explaining. A strong image placed early drips color downward
-over the lines that follow. If the image arrives late, the opening statements
-remain abstract and under-colored.
+The rule has a name, and the name comes from the kindergarten story Pat tells to
+get to it. He asked to bring his new puppy Rusty in for Show-and-Tell, was told
+to bring the collar instead, and left the collar on the kitchen table:
+
+> "Can I do Show-and-Tell anyway?"
+>
+> "No, no," she said gently, shaking her finger (they always shake their
+> fingers). "You can't tell unless you show first."
+>
+> YOU CAN'T TELL UNLESS YOU SHOW FIRST.
+>
+> To this day, I call that the "Sister Mary Elizabeth Rule of Song-writing."
+> Show before you tell. Showing makes the telling more powerful because your
+> senses and your mind are both engaged.
+>
+> — *Writing Better Lyrics* (2009), Chapter 2
+
+> The Sister Mary Elizabeth Rule of Songwriting: Show before you tell.
+
+Use the full name when coaching. "Show before you tell" is the rule; "the Sister
+Mary Elizabeth Rule of Songwriting" is what Pat calls it, and "Rusty's collar" is
+what he calls the image itself — the concrete thing the writer holds up before
+explaining.
+
+Pat's demonstration. First, the version that forgot the collar:
+
+```text
+All the things we used to do
+Those dreamy teenage nights
+Nothing matters like it did
+Back when you were mine
+```
+
+Then: "Try showing Rusty's collar first:"
+
+```text
+Hot rod hearts and high school rings
+Those dreamy teenage nights
+Nothing matters like it did
+Back when you were mine
+```
+
+The mechanism is not "color" in the abstract. It is a bag of dye:
+
+> Think of Rusty's collar this way: "Hot rod hearts and high school rings" is a
+> bag of dye. Hang the dye on top of the section and let it drip its colors
+> downward onto the other lines, giving them more interest and depth.
+
+Placement is load-bearing, and Pat proves it by moving the collar down one line:
+
+```text
+Nothing matters like it did
+Those dreamy teenage nights
+Hot rod hearts and high school rings
+Back when you were mine
+```
+
+> We still get colors, but the law of gravity says that they'll only drip
+> downward, leaving us starting with:
+>
+> Nothing matters like it did
+> Those dreamy teenage nights
+>
+> This has less color than when we followed the Sister Mary Elizabeth Rule of
+> Songwriting. Colors drip down, not up. Show first, and watch everything else
+> gain impact.
+
+A strong image placed early drips color downward over the lines that follow. If
+the image arrives late, the opening statements remain abstract and
+under-colored.
 
 Use this diagnosis on bland drafts:
 
@@ -92,17 +159,64 @@ the collar is protected. The rhyme should serve the image, not erase it.
 
 ## The seven senses
 
-Object writing uses seven sensory channels:
+Pat names the channels twice, in two different vocabularies. *Writing Better
+Lyrics* (2009), Chapter 1, Exercise 1:
 
-| Sense | Craft use |
-| --- | --- |
-| Sight | Color, shape, light, distance, motion, visual contrast. |
-| Hearing | Texture, volume, rhythm, silence, muffling, resonance. |
-| Smell | Atmosphere, memory triggers, environment, intimacy. |
-| Taste | Appetite, disgust, sweetness, bitterness, temperature. |
-| Touch | Surface, pressure, temperature, weight, pain, texture. |
-| Organic | Inner body awareness: pulse, breath, stomach, muscles, fatigue. |
-| Kinesthetic | Balance, speed, direction, body position, spatial relation. |
+> Use all seven senses: sight, hearing, smell, taste, touch, organic, and
+> kinesthetic.
+
+*Songwriting Without Boundaries* (2011) prints a shorter list, and prints it
+again at the head of every single day of every challenge as the line the writer
+lets their eye wander to when they do not know where to go next:
+
+```text
+Sight Sound Taste Touch Smell Body Motion
+```
+
+Both name the same seven channels. Use whichever vocabulary the user brought.
+
+Pat does not gloss the five ordinary senses — he sharpens them with questions:
+
+> Although you understand your five senses, you could probably stand a few
+> exercises to sharpen them, especially the four you don't normally use when you
+> write. If I asked you to describe the room you're in, your answer would be
+> primarily, if not completely, visual. Try spending a little time alone with
+> each sense. What's there? How does the kitchen table smell? How would the rug
+> feel if you rubbed your bare back on it? How big does the room sound? (What if
+> it were twice as big? Half as big?) How would the table taste if you licked
+> it? No, it's not silly. Remember this, it is important: The more senses you
+> incorporate into your writing, the better it breathes and dances.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
+
+*Songwriting Without Boundaries* (2011), Challenge 1 adds a subdivision of sight
+that the 2009 text does not have:
+
+> Even if it is only visual, remember that visual has at least three
+> aspects — color, shape, and texture. Try isolating each and noticing, for
+> example, only shapes. Look for similar shapes. Then look for texture "rhymes."
+> How many colors does the tree really have?
+
+The two extra channels get real definitions. These are Pat's, near-identical in
+both books:
+
+> **Organic sense** is your awareness of inner bodily functions, for example,
+> heartbeat, pulse, muscle tension, stomachaches, cramps, and breathing.
+> Athletes are most keenly focused on this sense, but you use it constantly,
+> especially in responsive situations. I've been sitting here writing too long.
+> I need a backrub.
+>
+> **Kinesthetic sense** is, roughly, your sense of relation to the world around
+> you. When you get seasick or drunk, the world around you blurs — like blurred
+> vision. When the train you're on is standing still and the one next to it
+> moves, your kinesthetic sense goes crazy. Children spin, roll down hills, or
+> ride on tilt-a-whirls to stimulate this sense. Dancers and divers develop it
+> most fully — they look onto a stage or down to the water and see spatial
+> possibilities for their bodies. It makes me dizzy just thinking about it.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1; *Songwriting Without Boundaries*
+> (2011), Challenge 1, which labels them "Organic sense (body)" and "Kinesthetic
+> sense (motion)"
 
 Organic and kinesthetic details are often the fastest way to move a lyric from
 general description into embodiment. Use them when the draft explains emotion
@@ -110,12 +224,69 @@ from the outside instead of letting the listener feel it.
 
 ### Sense inventory — the acceptance test on a finished write
 
-Chapter 1 does not stop at naming the channels. It takes a completed write and
-breaks it into seven headed lists, each one quoting the write's own phrases
-back. That inventory is the check: a channel with nothing under it was not
-covered, whatever the writer believes.
+Chapter 1 does not stop at naming the channels. It takes a completed
+write — Pat's own, "Back Porch," written to Exercise 1 — and breaks it into seven
+headed lists, each one quoting the write's own phrases back. That inventory is
+the check: a channel with nothing under it was not covered, whatever the writer
+believes.
 
-Run it on every completed write, whoever produced it:
+Pat's write, in full:
+
+> **Back Porch**
+>
+> I must have been four. Memories from that time are a rare species — lobbing in
+> like huge bumblebees on transparent wings, buzzing old Remington shavers torn
+> free from those thick and brittle wires tangled in webs under our porch where I
+> loved to crawl and hide; black snaking wires disappearing up through floors and
+> humming into wall and socket. I still hear them.
+>
+> I hid under the back porch, smell of damp summer earth cool under my hands,
+> ducking, scrunching my shoulders tight to avoid the rusty nails waiting
+> patiently above for my back or skull to forget them. The tingling along my back
+> and neck kept reminding me, don't stand up.
+>
+> Under the back porch, a place tinged with danger and smelling of earth, the air
+> tastes faintly of mold and hollyhocks twining around the trellises that I see
+> only the bottoms of, speckled gold by the shafts of sun slipping through high
+> elm branches in the backyard, weaving shadows like Grandma's lace dresser
+> doilies. When I squint, I can blur the sunlight into a bridge of green-gold.
+> Crouching there fetal and content, I could feel Mom above me, could hear her
+> high heels tap-tapping.
+>
+> — Pat Pattison, *Writing Better Lyrics* (2009), Chapter 1
+
+And Pat's inventory of it, verbatim, under his own heading "Look at the sense
+information in 'Back Porch'":
+
+> **Sight:** huge bumblebees on transparent wings; thick and brittle wires
+> tangled in webs; black snaking wires disappearing up through floors; rusty
+> nails; hollyhocks twining around the trellises I see only the bottoms of;
+> speckled gold by shafts of sun; high elm branches in the backyard; weaving
+> shadows like Grandma's lace dresser doilies; when I squint, I can blur the
+> sunlight into a bridge of green-gold
+>
+> **Hearing:** buzzing old Remington shavers; humming into wall and socket; I
+> still hear them; could hear her high heels tap-tapping
+>
+> **Smell:** smell of damp summer earth; smelling of earth
+>
+> **Taste:** the air tastes faintly of mold and hollyhocks
+>
+> **Touch:** thick and brittle wires; damp summer earth cool under my hands;
+> tingling along my back and neck
+>
+> **Organic:** crawl; crouching; ducking; scrunching shoulders tight; stand up
+> quick; tingling along my back and neck; when I squint; crouching there fetal
+> and content
+>
+> **Kinesthetic:** lobbing in; tingling along my back and neck kept reminding me;
+> avoid rusty nails waiting patiently above for my back or skull to forget them;
+> don't stand up; I could feel Mom above me
+
+Note the shape of the real thing: smell gets two entries and taste gets one,
+while sight gets nine. The inventory is not a quota — it is a record.
+
+Run the same inventory on every completed write, whoever produced it:
 
 ```text
 Sight:         <phrases from the write, verbatim>
@@ -127,11 +298,13 @@ Organic:       <phrases>
 Kinesthetic:   <phrases>
 ```
 
-Rules that make it an acceptance test rather than a formality:
+Rules this skill adds to make it an acceptance test rather than a formality
+(Chapter 1 demonstrates the inventory; it does not state these as rules):
 
 - Quote the write's own words. A summary ("I covered smell") is not evidence.
 - A phrase may appear under more than one channel — Chapter 1's own inventory
-  does exactly this, because one image can carry two senses at once.
+  does exactly this. "tingling along my back and neck" is filed under touch,
+  organic, *and* kinesthetic, because one image can carry three senses at once.
 - A thin or empty channel is **reported, never padded**. Sight and hearing fill
   themselves; smell, taste, organic, and kinesthetic are the channels that go
   missing, and a write honestly short on one is more useful than a write with a
@@ -161,34 +334,80 @@ process.
 
 "Follow sensory associations wherever they lead" is the instruction. The pivot
 chain is the mechanism, and without it a write becomes a static description of
-one scene instead of a dive.
+one scene instead of a dive. Pat names the mechanism directly:
 
-Each image hands off to the next **through a sense**, not through topic, logic,
-or narrative — and the channel it lands in is a different one from the channel
-it left. Chapter 1 demonstrates it as an unbroken run: a physical sensation in
-one setting suggests a texture, the texture suggests a taste, the taste
-relocates the writer somewhere else entirely, the new place produces a sound,
-the sound produces a body reaction, and so on — each link a sense, not an idea.
-The write ends somewhere the seed could never have predicted.
+> Try bouncing off of each sense-image to wherever else it might take you, using
+> each new sense-image as a sort of pivot to the next, a kind of sensual free
+> association. Always with your senses, all seven of them. All within ten
+> minutes.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
 
-Worked example of the shape (the chain, not Pat's):
+*Songwriting Without Boundaries* (2011), Challenge 1 gives the same idea its
+other name: "Think of object writing as sense-bound free association."
+
+Pat's own worked chain, printed in both books in nearly identical words:
+
+> Let your hot morning shower with its rolling steam take you to thick clouds
+> hanging overhead, to the taste of rain, to stomping through a puddle,
+> splashing water up so it sprays like fireworks, to the boom in your chest and
+> the smell of gunpowder and the taste of cotton candy.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1; *Songwriting Without Boundaries*
+> (2011), Challenge 1
+
+Read as a chain of handoffs, each one carried by a sense and each one landing in
+a channel different from the one it left:
 
 ```text
-seed: laundromat
-  dryer heat on the forearms          [touch]
-  → the smell of scorched lint        [smell]
-  → burnt-toast mornings              [taste]
-  → the toaster's spring-loaded bang  [hearing]
-  → flinch at the shoulders           [organic]
-  → the floor tilting on a boat deck  [kinesthetic]
+seed: hot morning shower
+  rolling steam                       [sight]
+  → thick clouds hanging overhead     [sight, relocated]
+  → the taste of rain                 [taste]
+  → stomping through a puddle         [kinesthetic]
+  → sprays like fireworks             [sight]
+  → the boom in your chest            [organic]
+  → the smell of gunpowder            [smell]
+  → the taste of cotton candy         [taste]
 ```
 
-Six pivots, six channels, and the write left the laundromat by link three. That
-is working. A write that is still describing the laundromat at ten minutes has
-been staying loyal to the seed.
+The write left the bathroom by link two and ended at a fairground. That is
+working. A write still describing the shower at ten minutes has been staying
+loyal to the seed.
+
+Pat's second documented demonstration is Cathy Brettell's ten-minute write on
+"Elevator," and he points at the exact pivot that carried it:
+
+> Breath sucks back into my throat — stomach ball jellies to my toes like an
+> anchor hoisted over a ship — dull brass dragging thick fingers of midnight,
+> current's chain unspools — like roller skates gliding freely — wind sassing back
+> against stubborn waves, black fallen angels bow and thrash in the
+> darkness — thunder twists between sweaty muscled clouds — silver daggers spear
+> the sky horizon, lashing down at the warm sleeping distant halls — sandy upper
+> lip catching foam of a root beer float — eyes widen — thirst deepens, a throat of
+> parched earth guzzles a torpedo stream of charcoal water — stars mirror in the
+> salty crystals — reeds bristle against oncoming Northern winds — smooth moonlit
+> feathers hug against one bony leg for support — a white beam sweeps the coastal
+> blanket — lighthouse calling a lone love — darkness capes around her tall slender
+> body — urchins clinging, bottle bristles against her feet — sunrise begins to
+> touch her — threads of melon flesh across cradled lids — shades of light lift the
+> dreamy nightmare up — rolling it back into heaven's closet — soft crystal knob
+> pulls shut … (time!)
+>
+> — Cathy Brettell, object: Elevator, time limit: 10 minutes, in *Songwriting
+> Without Boundaries* (2011), Challenge 1
+
+> As you can see from "Elevator," "Breath sucks back into my throat — stomach ball
+> jellies to my toes like an anchor hoisted over ship" took Cathy from an
+> elevator ride to an ocean storm, no permission asked.
+>
+> — Pat Pattison, same
+
+Note the ending: "(time!)" and then "soft crystal knob pulls shut" cut off. That
+is the buzzer, printed.
 
 Diagnostic when a write reads flat: number the images and name the sense
-carrying each handoff. Handoffs carried by topic ("and also in the laundromat
+carrying each handoff. Handoffs carried by topic ("and also in the elevator
 there was…") are the failure. Handoffs where the sense channel changes are the
 mechanism running.
 

--- a/plugins/songwriting/context/pat-pattison/research/phrasing.md
+++ b/plugins/songwriting/context/pat-pattison/research/phrasing.md
@@ -24,17 +24,50 @@ Lyric phrases can be nested. A short phrase can be a real phrase and also part
 of a longer phrase. Count both levels when diagnosing a section:
 
 ```text
-short phrase / short phrase
-longer phrase made from the two short phrases
+Who are these children / who scheme and run wild     two short phrases
+Who are these children who scheme and run wild?      one longer phrase
 ```
 
+Pattison asks directly whether the longer or the shorter phrases are the real
+ones. His answer: "They both are." A phrase like "who scheme and run wild"
+depends on being part of something bigger to sound natural, but it still has an
+identity of its own.
+
 The test is whether the unit has a natural identity in speech. Some short
-phrases stand alone. Others depend on a larger sentence but still feel shaped.
+phrases stand alone:
+
+```text
+Why don't you tickle me?
+He shouts.
+She bites.
+```
+
+Others depend on a larger sentence but still feel shaped.
 Fragments that clearly need missing words are not useful phrase units.
 
 For grammar-heavy passages, slash the sentence where natural phrase boundaries
 fall. Pattison's Thoreau exercise matters because it trains the ear to hear
 phrase boundaries before the lyric is set to music.
+
+**Exercise 1** (*Essential Guide to Lyric Form and Structure* (1991), Chapter 1):
+try dividing this paragraph from Henry David Thoreau's "The Battle of the Ants"
+into phrases. Use a slash (/) between phrases to show where the divisions are.
+Pat does the first few to get you started; the unslashed remainder is the
+exercise.
+
+```text
+"I took up the chip / on which the three I have described
+were struggling, / carried it / into my house, / and placed
+it under a tumbler on my window sill in order to see the
+issue. Holding a microscope to the first-mentioned red
+ant, I saw that, though he was assiduously gnawing at the
+near fore leg of his enemy, having severed his remaining
+feeler, his own breast was all torn away, exposing what
+vitals he had there to the jaws of the black warrior, whose
+breastplate was apparently too thick for him to pierce; and
+the dark carbuncles of the sufferer's eyes shone with
+ferocity such as war only could excite.
+```
 
 ## Lyric phrases and musical phrases
 
@@ -44,15 +77,35 @@ of the emotion.
 
 Mark musical phrases with brackets and lyric phrases with slashes:
 
+Pattison's mismatch example — a rewrite of an actual song, words changed
+"to protect the innocent (or maybe the guilty)":
+
 ```text
-[lyric phrase / lyric phrase /]
-[one musical phrase continuing]
+[Some days it's simple/ but some days it's not/]
+[Sometimes I wonder if there's one thing we've got]
+[In common/ to stop us from drifting apart/]
 ```
 
+"One thing we've got in common" sounds very strange when it is split across
+separate musical phrases. It is distracting and takes away from the emotion in
+the song.
+
 Do not let the music make a partial thought sound complete. A musical phrase
-boundary can temporarily change meaning before the lyric corrects it. When a
-line can mean either "I know your plans" or "I know your plans do not include
-me," phrase boundaries decide which thought the listener hears first.
+boundary can temporarily change meaning before the lyric corrects it:
+
+```text
+[I know your schemes]
+[Don't include me/]
+```
+
+There is a big difference between saying
+
+1. "I know your schemes. Please don't include me."
+2. "I know (that) your schemes don't include me."
+
+Decide which one you mean, then write your musical phrases to match. When
+musical phrases and lyric phrases are the same length, the problem does not
+crop up.
 
 ## Counting phrases
 
@@ -61,12 +114,61 @@ Count phrases at two levels:
 - Short phrases: the smallest natural lyric units.
 - Long phrases: combinations that form larger musical or syntactic units.
 
-Both levels matter. Pattison's Steely Dan example can be heard as eight short
-phrases or four longer phrases; either count feels balanced because it is even.
+Both levels matter. Pattison counts the verse of Steely Dan's "Your Gold Teeth
+II" (Donald Fagen and Walter Becker) both ways — eight short phrases, or four
+when you count their combinations into longer phrases. Either count feels
+balanced because it is even.
+
+```text
+Who are these children              1
+who scheme and run wild             2
+who speak with their wings          3
+and the way that they smile         4
+what are the secrets                5
+they trace in the sky               6
+and why do you tremble              7
+each time they ride by              8
+```
+
+Each of these lyric phrases also matches a musical phrase, and the shorter
+phrases combine easily and naturally into longer ones.
 
 ## Balance and unbalance
 
 Even phrase counts feel balanced. Odd phrase counts feel unbalanced.
+
+Pattison demonstrates by pulling one phrase out of the Steely Dan verse. Seven
+phrases seem awkward:
+
+```text
+Who are these children              1
+who scheme and run wild             2
+who speak with their wings          3
+and the way that they smile         4
+what are the secrets                5
+they trace in the sky               6
+each time they ride by              7
+```
+
+It would have seemed balanced cut to four:
+
+```text
+Who are these children              1
+who scheme and run wild             2
+who speak with their wings          3
+and the way that they smile         4
+```
+
+or rebuilt to six:
+
+```text
+Who are these children              1
+who scheme and run wild             2
+who speak with their smiles         3
+what are the secrets                4
+they trace in the sky               5
+each time they ride by              6
+```
 
 Balanced sections tend to stop motion. Unbalanced sections create motion because
 the listener expects a balancing phrase that has not arrived.
@@ -103,8 +205,19 @@ spotlights whatever lands there. Put summary lines, reversals, and emotional
 turns in that position when they should carry weight.
 
 Worked example: in Buck Ram's "The Great Pretender," the fourth phrase lands
-the section's emotional summary. The even-numbered position makes the line feel
-like the point of the section, not just another detail.
+the section's emotional summary.
+
+```text
+Yes I'm the GREAT PRETENDER         1
+Pretending that I'm doing well      2
+My need is such, I pretend too much 3
+I'm lonely but no one can tell      4
+```
+
+The last phrase is in the even-numbered position, balancing the section. That
+position spotlights "I'm lonely but no one can tell" — almost a summary of the
+section. The even-numbered position makes the line feel like the point of the
+section, not just another detail.
 
 Revision move: if the final phrase of a balanced section is not the main idea,
 try rearranging the same phrases so the important idea lands last.
@@ -114,24 +227,43 @@ try rearranging the same phrases so the important idea lands last.
 An odd number of phrases withholds the expected stop. This can build pressure
 before a chorus or in a transitional section.
 
-Worked example: Pattison shows a three-phrase build made from repeated short
-requests. The repeated wording is less important than the count: three units
-imply a fourth, so the section leans forward when the fourth never arrives.
-
-Pattern:
+Worked example: Pattison builds pressure in a transitional section between
+verse and chorus by repeating one phrase three times.
 
 ```text
-Phrase A
-Phrase A repeated or varied
-Phrase A intensified
+Baby can you see it                 1
+Baby can you see it                 2
+Baby can you see it                 3
 ```
 
-The same effect can happen with three different phrases if they share a clear
-shape. The listener still wants a balancing position.
+The repeated wording is less important than the count: three units imply a
+fourth, so the section leans forward when the fourth never arrives. The same
+effect works with three different phrases that share a clear shape.
+
+```text
+One more time to reach you          1
+One more time to touch you          2
+One more time to tell you           3
+```
+
+The pressure to move forward builds up simply because the listener feels the
+need for a balancing position.
 
 **Two unbalanced sections can balance each other.** Pattison's stated use for
 motion is connecting one unbalanced section to another equally unbalanced one —
-his worked case pairs three phrases with three more. The pressure that an odd
+his worked case pairs three phrases with three more, bracketed as two groups:
+
+```text
+[ Who are these children
+[ who scheme and run wild
+[ who speak with their smiles
+
+[ what are the secrets
+[ they trace in the sky
+[ each time they ride by.
+```
+
+The pressure that an odd
 section builds does not have to be discharged by an even section; it can be
 answered by a matching odd section, which balances at the pair level while both
 halves stay in motion internally.
@@ -141,10 +273,25 @@ halves stay in motion internally.
 Balance can change across verses. A first verse can be fully balanced so it
 settles; a second verse can add one extra phrase so it pushes into the chorus.
 
-Worked example: Pattison points to Kevin Cronin's "Can't Fight This Feeling."
-The first verse balances at four phrases. The second verse adds a fifth near the
-end, tipping the structure forward and making the chorus feel like the needed
-landing point.
+Worked example: Pattison points to the first two verses of Kevin Cronin's
+"Can't Fight This Feeling." The first verse balances at four phrases; the second
+adds a fifth near the end, tipping the structure forward and making the chorus
+feel like the needed landing point.
+
+```text
+I can't fight this feeling any longer            1
+And yet I'm still afraid to let it flow          2
+What started out as friendship has grown stronger 3
+I only wish I had the strength to let it show    4
+
+I tell myself that I can't hold out forever      1
+I say there is no reason for my fear             2
+'Cause I feel so secure when we're together      3
+You give my life direction                       4  <- added phrase
+You make everything so clear                     5
+```
+
+Unbalancing the second verse throws it into the air, "just like juggling."
 
 **The reversal test.** Pattison's own check on this example: swap the two
 verses and the motion stops. If reversing a pair of verses does not change how
@@ -155,6 +302,23 @@ This also works inside a repeated verse form: an extra final phrase can surprise
 the ear, spotlight the normal balanced position, and then spotlight the added
 line even more strongly. In "The Great Pretender" the balanced verse runs four
 phrases and the contrasting one runs five.
+
+```text
+verse 1:  O yes I'm THE GREAT PRETENDER        1
+          Pretending that I'm doing well       2
+          My need is such, I pretend too much  3
+          I'm lonely but no one can tell       4
+
+verse 3:  Yes I'm THE GREAT PRETENDER          1
+          Just laughing and gay like a clown   2
+          I seem to be what I'm not, you see   3
+          I'm wearing my heart like a crown    4
+          Pretending that you're still around  5
+```
+
+The extra phrase in the last verse is a surprise. The balancing position in
+verse three is spotlighted, but the surprise extra phrase spotlights both
+lines, especially the last one.
 
 ## Phrase length controls speed
 
@@ -169,13 +333,34 @@ already established.
 
 ## Acceleration
 
-Shorter phrases compress time. In a limerick, the shorter third and fourth
-phrases speed the structure before the punchline. In a song section, shorter
-phrases can sound active, urgent, comic, breathless, or cornered.
+Shorter phrases compress time. Limericks are the most familiar systems that use
+phrase length to create speed:
 
-Worked example: Pattison's discussion of Beth Nielsen Chapman's "Years" points
-to a short final phrase about time moving quickly. The phrase length enacts the
-idea: the structure speeds up exactly where the lyric says time does.
+```text
+There once was a student named Esser
+Whose knowledge grew lesser and lesser
+It at last grew so small
+He knew nothing at all
+And now he's a college professor
+```
+
+The shorter third and fourth phrases accelerate the movement. Speeding up right
+before the punchline adds to the humor when we get there. In a song section,
+shorter phrases can sound active, urgent, comic, breathless, or cornered.
+
+Worked example: Beth Nielsen Chapman's "Years."
+
+```text
+And I let time go by so slow
+And I made every moment last
+And I thought about years
+How they take so long
+And go so fast
+```
+
+Pattison: "It is no accident that Beth Nielsen Chapman's shortest phrase about
+years is, *And go so fast*." The phrase length enacts the idea — the structure
+speeds up exactly where the lyric says time does.
 
 Use acceleration when the lyric should feel impatient, physically active,
 compressed, comic, or pushed toward a hook.
@@ -185,10 +370,28 @@ compressed, comic, or pushed toward a hook.
 Longer phrases stretch time. They can slow the section, make a thought feel
 heavy, or make an important phrase hang over the established pattern.
 
-Worked example: in Gary Nicholson and John Jarvis's "Fathers and Sons,"
-Pattison notes that the title-bearing final phrase is much longer than the
-nearby short phrases. The long phrase decelerates dramatically and spotlights
-the title idea.
+```text
+One by one
+Step by step
+We fall into the pit of despair
+One by one
+```
+
+The long third phrase slows the pace down, setting us up to pitch headlong into
+the pit at line four.
+
+Worked example: in Gary Nicholson and John Jarvis's "Fathers and Sons," the
+title-bearing final phrase is much longer than the nearby short phrases.
+
+```text
+You're proud when they walk
+Scared when they run
+That's how it always has been between FATHERS AND SONS
+```
+
+This line "decelerates dramatically because of its length, calling all kinds of
+attention to the part of the phrase that hangs over. It just happens to be the
+title of the song."
 
 Use deceleration when the lyric should feel reflective, emotionally weighted,
 expansive, delayed, or like a landing point.

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -4,7 +4,7 @@ Pat Pattison - *Writing Better Lyrics* (2009), Chapter 18-19; extended via
 *Songwriting: Essential Guide to Lyric Form and Structure* (1991) Chapter 3-4
 (Structural Pentad); Berklee Online "Prosody in Music and Songwriting"
 article (motion controllers, tone-of-voice); patpattison.com
-"Language and Songwriting" (greedy spots, ordinary-language preservation);
+"Language and Songwriting" (greedy spots in the melody frame);
 American Songwriter "Motion Creates E-Motion" column (4-controller framework).
 
 Audited against *Writing Better Lyrics* (2009) Chapters 18-19, and against
@@ -15,20 +15,41 @@ by naming all five properties — balance, pace, flow, closure, closure type —
 and gives each its own numbered section, applied to rhyme structure. The
 citation spans both chapters because the framework does.
 
-**Still unaudited:** every non-book source listed
-above — the Berklee Online article, patpattison.com, the American Songwriter
-column, and OSONG-525 — which remain distillations nobody has checked against
-their originals. Where this file's wording and the 1991 chapter's wording
-diverge, the divergence is marked in place rather than silently reconciled.
+Everything book-sourced below is now Pat's own text and Pat's own examples,
+quoted rather than described. Two conventions apply to those quotations. Where a
+stress or rhyme label in the source is visibly wrong, the label is omitted
+rather than corrected or propagated. Where the ebook text carries an extraction
+artifact — a lost `ff` ligature, a line-break hyphen — the word is restored to
+its normal spelling; Pat's own typos are left alone.
+
+**Ordinary-language preservation is book-sourced, not web-sourced.** The rule
+and the phrase "preserving the natural shape of the language" are stated
+outright in *Writing Better Lyrics* (2009) Chapter 18, and that section is
+cited to the book below.
+
+**Still unaudited:** the Berklee Online article, patpattison.com, the American
+Songwriter column, and OSONG-525 — which remain distillations nobody has
+checked against their originals. Three passages here rest on those sources
+alone and stay paraphrased: the four-controller framework, tone of voice as a
+stability lever, and the third phrasing type. Where this file's wording and the
+1991 chapter's wording diverge, the divergence is marked in place rather than
+silently reconciled.
 
 ## Image inventory
 
-- Chapter 18: `image_rsrcAUE.jpg`.
-- Chapter 19: `image_rsrcAUF.jpg`.
+- Chapter 18: `image_rsrcAUE.jpg` — "RHYME TYPES: SCALE OF RESOLUTION
+  STRENGTHS," the five-tier chart. Transcribed under "Rhyme type" below.
+- Chapter 19: `image_rsrcAUF.jpg` — the "Amazing Grace" grid with its Rhyme /
+  Stresses / Overall columns, the figure that defines the capital-letter
+  notation. Transcribed under "Motion notation" below.
 - *Essential Guide to Lyric Form and Structure* (1991), Chapter 3: **59 figure
   references, 56 unique**, `image_rsrc2YZ.jpg` through `image_rsrc30P.jpg`. The
-  Structural Pentad worksheets this file cites exist only as page scans; see
-  [meter](meter.md) for the inventory note.
+  load-bearing ones for this file are the scansion strips
+  `image_rsrc2ZB`-`2ZF` (the Sting model plus too hot / too cold / just right,
+  transcribed under "Greedy spots") and the Pentad worksheets `image_rsrc309`
+  (blank), `image_rsrc30A` (Common Meter) and `image_rsrc30C` (Paradigm Two),
+  transcribed under "The Structural Pentad." See [meter](meter.md) for the
+  broader inventory note.
 - *Essential Guide to Lyric Form and Structure* (1991), Chapter 4: **40 figure
   references, 40 unique**, `image_rsrc30R.jpg` through `image_rsrc31Y.jpg`. The
   chapter's five-property opening and its per-property sections are what carry
@@ -37,6 +58,44 @@ diverge, the divergence is marked in place rather than silently reconciled.
 
 ## Core idea
 
+Chapter 18 defines the term through Aristotle:
+
+> Aristotle said that every great work of art contains the same feature: unity.
+> Everything in the work belongs — it all works to support every other element.
+> Another word for unity is prosody, which is the "appropriate relationship
+> between elements, whatever they may be."
+
+Pat's three examples of what "elements" can mean:
+
+> Between words and music: A minor key could support or even create a feeling
+> of sadness in an idea.
+>
+> Between syllables and notes: An appropriate relationship between stressed
+> syllables and stressed notes is a really big deal in songwriting — when they
+> are lined up properly, the shape of the melody matches the natural shape of
+> the language.
+>
+> Between rhythm and meaning: Obvious examples like "you gotta stop! … (pause)
+> … look and listen" or writing a song about galloping horses in a triplet
+> feel.
+
+> The elements all join together to support the central intent, idea, and
+> emotion of the work. Everything fits. Prosody: the appropriate relationship
+> between elements.
+
+The chapter's working example is Gary Burr's "Can't Be Really Gone," recorded by
+Tim McGraw. Verse one:
+
+> Her hat is hanging by the door
+> The one she bought in Mexico
+> It blocked the wind and stopped the rain
+> She'd never leave that one
+> So she can't be really gone
+
+> Though the character is giving us evidence that she's not gone for good, we
+> don't believe him. Something just doesn't feel right. The verse itself feels
+> funny — unstable.
+
 Prosody is the appropriate relationship between elements. In songwriting, that
 means every available element can either support the central intent or work
 against it: words, melody, stressed syllables, stressed notes, rhythm, chords,
@@ -44,27 +103,64 @@ line count, line length, rhyme scheme, and rhyme type.
 
 > Structure is your film score.
 
-The film-score metaphor is practical: listeners may not consciously name the
-structural cue, but they react to it. A lyric can say one thing while structure
-quietly creates a contrary emotional signal underneath it.
+The film-score metaphor is Pat's own, and it is practical. His movie scene:
+romantic strings swelling in a major key under a slow-motion embrace, and then
+"an oboe cuts through the film score in a nasty minor second, and our bodies
+stiffen a little." The shotguns follow. Pat's point about who noticed:
+
+> Of course, the film score, which is created to stand behind the action, gave
+> it away. Most folks don't really notice it — they just react. The composer is
+> pulling the strings and we, like puppets, react predictably, feeling just what
+> the score makes us feel.
+>
+> That's what's going on in "Can't Be Really Gone," but this time it's not the
+> music that creates the film score. It's the structure of the lyric, acting,
+> just like a film score, on our emotions.
+
+Listeners may not consciously name the structural cue, but they react to it. A
+lyric can say one thing while structure quietly creates a contrary emotional
+signal underneath it.
 
 Chapter 19 states the same operating principle more directly:
 
 > Motion creates emotion.
 
+Chapter 18 puts the same claim as an unconditional:
+
+> These elements conspire to act like a film score and, in and of themselves,
+> create motion. And motion always creates emotion, completely independent of
+> what is being said. Ideally, structure should create prosody — support what is
+> being said — strengthening the message, making it more powerful.
+
 The words carry meaning, but the section's motion carries feeling at the same
 time. When both levels agree, the idea gets stronger. When they disagree on
 purpose, the lyric can create irony, denial, suspense, or instability.
 
-This is also the diagnosis for a good line that lands flat. A writer who has not
-tuned into motion is left waiting on lucky accidents and divine inspiration; a
+This is also the diagnosis for a good line that lands flat. Chapter 19 opens on
+exactly that point:
+
+> Sometimes, you may accidentally trip onto this sort of writing, unaware of the
+> choices you're making. But if you tune into your lyrics' motion consistently,
+> you'll not only write and rewrite your songs more effectively, but, more
+> important, you won't rely on lucky accidents or divine inspiration to drop
+> those good bits into your lap.
+
+A writer who has not tuned into motion is left waiting on those accidents; a
 writer who has can name which element is fighting the idea and change it. Flat
 is a structure problem, not an inspiration problem.
 
 ## Stable vs unstable
 
 Start every structural choice with one question: is the section's emotional
-state stable or unstable?
+state stable or unstable? Chapter 18 states why that one question is enough to
+govern the rest:
+
+> Looking at your sections through the lens of stability or instability is a
+> practical tool for creating prosody because you'll be able to use it for every
+> aspect of your song: the idea, the melody, the rhythm, the chords, the lyric
+> structure — everything. It governs the choices you make. Ask yourself: Is the
+> emotion in this section stable or unstable? Once you answer that question, you
+> have a standard for making all your other choices.
 
 Stable conditions include resolution, confidence, commitment, factual clarity,
 or emotional steadiness. Stable sections often benefit from even line counts,
@@ -82,7 +178,10 @@ rhythm can make irregular line length feel sharper.
 
 ## Five structural elements
 
-Every lyric section uses five structural elements:
+> Every section of every lyric you write uses five elements — always the same
+> five elements — of structure.
+
+The five elements of lyric structure are:
 
 1. Number of lines.
 2. Length of lines.
@@ -93,20 +192,63 @@ Every lyric section uses five structural elements:
 Use these as a diagnostic grid. For each section, mark what the element is
 doing emotionally before deciding whether to revise it.
 
+Pat's closing warning about what analysis is for:
+
+> So, did Gary Burr think about all this stuff as he wrote "Can't Be Really
+> Gone"? Maybe, maybe not. The important issue is: You can.
+>
+> The point of lyric analysis isn't to discover what a given writer intended to
+> do. That's a fool's errand. Rather, lyric analysis digs into effective songs to
+> discover what makes them work, to unearth tools for our own use.
+
 ## Motion notation
 
-For structural motion, use capital letters to show lines that share all three
-line-level features:
+Pat's own statement of the convention:
+
+> To notate the way a structure moves, let's use capital letters (e.g., A, B, C)
+> to stand for lines that have both the same line lengths and the same rhyme
+> scheme. Each line labeled with the same letter will:(1) rhyme with, (2) have
+> the same number of stressed syllables as, and (3) have the same basic rhythm
+> as every other line in the section with the same letter.
+
+So a capital letter means all three of:
 
 - Same rhyme sound.
 - Same number of stressed syllables.
 - Same basic rhythm.
 
-Example: common meter can be marked `ABAB` when the first and third lines share
-four stresses and the same rhyme, and the second and fourth lines share three
-stresses and the same rhyme. If rhyme structure and line-length structure do
-not align clearly, omit the capital-letter shorthand and mark the separate
-features directly.
+Chapter 19's worked example is "Amazing Grace," and the figure that carries it
+is the three-column grid (`image_rsrcAUF.jpg`):
+
+```text
+Amazing grace, how sweet the sound     a   4   A
+That saved a wretch like me            b   3   B
+I once was lost, but now am found      a   4   A
+Was blind, but now I see               b   3   B
+```
+
+> It's a stable common meter; the first and third lines both have the same line
+> length, as do the second and fourth lines.
+>
+> The rhyme scheme is abab, the same configuration as the line lengths (a
+> four-stress line followed by a three-stress line, then another four-stress
+> line followed by a three-stress line). The rhythms move along in a regular
+> duple pattern (da DUM).
+
+If rhyme structure and line-length structure do not align clearly, omit the
+capital-letter shorthand and mark the separate features directly — Pat's rule
+is exactly that:
+
+> In cases where the arrangement of line lengths doesn't match the rhyme scheme,
+> we'll simply omit the capital As and Bs.
+
+Mismatch is not a failure state. It is a tool:
+
+> Once you get a feel for it, you'll be able to control motion in the real world
+> of lyric writing, where mismatches can create productive tensions, as when
+> rhyme scheme differs from the arrangement of line lengths. (For example, you
+> can create tension when you have four equal-length lines that rhyme abab
+> instead of aaaa.)
 
 The shorthand is useful because it makes sequence visible. Once the ear hears
 `AB`, then hears another `A`, it wants the matching `B`. Once it hears `ABC`,
@@ -119,15 +261,81 @@ Even line counts tend to feel balanced, complete, resolved, or stable.
 
 Use odd line counts when the narrator, scene, or emotional claim should feel
 unsettled. Use even line counts when the lyric should feel trustworthy,
-grounded, or resolved.
+grounded, or resolved. Pat's two test ideas:
+
+> Let's say you're writing a verse where the idea is something like: "Baby,
+> since you left me I've been feeling lost, odd, off balance, unresolved,
+> incomplete, unstable." Just theoretically, do you think this verse would be
+> better with an even number of lines or an odd number of lines? Right. An odd
+> number of lines.
+
+> Let's say that your message is something like: "Baby, you're the answer to all
+> my prayers. I'll be with you forever. I'm your rock. You can count on me." How
+> many lines should you use? Odd or even? Right. Even.
 
 Mismatch can create irony. If a narrator claims stability inside an unstable
-line count, the structure can quietly undercut the claim.
+line count, the structure can quietly undercut the claim. Pat's "really
+interesting case" is the even-line message above delivered in an odd number of
+lines: the message promises stability, the motion creates instability, "which
+pulls the rug out from under the narrator. It creates irony."
+
+That is the mechanism running under "Can't Be Really Gone" verse one:
+
+> This feels unstable, though the message is: "Look at the evidence — it proves
+> that she'll be coming back." But the feeling we get from the unstable
+> structure (which is acting like a film score) is that he's wrong and perhaps a
+> bit hysterical or, at least, in denial.
+
+Pat's control experiment is the same content rebuilt in four lines:
+
+> Her hat is hanging by the door
+> From Mexico, that funny store
+> I know she'd take her hat along
+> So I know she can't be really gone
+
+> Since the section feels balanced, we'd probably be convinced — there's a sense
+> of resolution, balance, and completeness that we feel here.
 
 ## Length of lines
 
+> Line length is the traffic cop in your lyric. Two lines of equal length,
+> because they're balanced, tell you to stop. (Note, for future reference, that
+> the length of a line is not determined by the number of syllables, but by the
+> number of stressed syllables, because the number of stressed syllables helps
+> determine the number of musical bars.)
+
 Line length is measured by stressed syllables, not raw syllables. Equal stress
 lengths stop the ear; unequal stress lengths push the ear forward.
+
+Pat demonstrates both inside the "Can't Be Really Gone" verse quoted above.
+Lines one and two, taken as a pair:
+
+> The two four-stress lines feel balanced. It feels like we're finished with one
+> thing and ready to start something new. Of course, we would feel even more
+> stability if the lines rhymed, too.
+
+Lines three and four, taken as a pair:
+
+> Now we feel unbalanced and unresolved, and the traffic cop tells us to keep
+> moving forward. Simple, but very effective.
+
+The verse runs 4 / 4 / 4 / 3 / 3 stresses.
+
+> The three-stress line leaves us short, creating an unstable feeling — making
+> us feel uncomfortable, like something's not quite right.
+
+> With yet a second three-stress line, a new expectation kicks in: We'd like one
+> more three-stress line.
+
+Pat supplies that sixth line — `She'll soon be coming home`, another three — and
+the six-line version is the comparison that makes the point audible: "Read it
+through a few times. See how comfortable it feels?" Cut it back to five and the
+narrator is exposed:
+
+> So there's a conspiracy between the number of lines and the line lengths to
+> torpedo this guy — to expose him for the man in denial that he is. It's
+> important to note that he isn't similarly exposed in the previous six-line
+> structure.
 
 Prosody checks:
 
@@ -141,12 +349,38 @@ Prosody checks:
 ## Rhythm of lines
 
 Lyric rhythm and musical rhythm are not identical, but important stressed
-syllables should land on important musical positions. This preserves the
-natural shape of the language.
+syllables should land on important musical positions. Chapter 18 states the
+constant and names it:
+
+> What should remain constant between the rhythms of words and musical rhythm is
+> this: Stressed syllables belong with stressed notes. Unstressed syllables
+> belong with unstressed notes. This is called "preserving the natural shape of
+> the language."
+
+Pat scans the "Can't Be Really Gone" verse as a duple pattern and prints the
+rhythm strip on its own:
+
+```text
+Da DUM da DUM da DUM da DUM
+Da DUM da DUM da DUM da DUM
+Da DUM da DUM da DUM da DUM
+Da DUM da DUM DUM da
+Da da DUM da DUM da DUM
+```
+
+> This is a mostly very regular lyric rhythm, with just a two variations,
+> neither of which have much effect.
 
 Regular lyric rhythm can create stability even when another structural element
-creates instability. Use that contrast intentionally. If everything is irregular
-at once, the listener may stop hearing the specific source of instability.
+creates instability. Use that contrast intentionally. Pat asks why the rhythm
+under an off-balance verse is so regular, and answers that if everything in the
+verse were off kilter there would be "nothing stable to rub against the
+unstable elements," and the differences in line length would become less clear
+and therefore less effective. The regularity of the rhythm "actually highlights
+the elements that throw it off balance."
+
+If everything is irregular at once, the listener may stop hearing the specific
+source of instability.
 
 Rhythm is the first structural element the listener hears. A first line sets a
 rhythmic and length standard before rhyme or total line count can be known.
@@ -173,9 +407,40 @@ Motion rules for rhythm:
 
 ## Rhyme scheme
 
+> Songs are made for listening — we hear them rather than see them.
+>
+> Rhyme is a sonic event, made for listening. It provides our ear with road
+> signs to guide us through the journey of the song. It shows us connections. It
+> tells us when to stop and when to move forward.
+
+Pat's demonstration takes one line of the verse and pairs it, then splits the
+pair. Paired, `door` / `floor` "sounds finished. It stops us. It feels resolved,
+stable." Split by an unrhymed line in between, the same two rhymes push:
+
+```text
+door
+one
+floor
+```
+
+> Now we feel the push forward. Although, in this case, the line lengths also
+> conspire to throw us off balance, leaning ahead, the rhymes can do it all by
+> themselves.
+
 Rhyme is a sonic guide. It shows connection, indicates stopping places, and
 points the ear forward. A missing rhyme can make the listener feel lost; a
 well-placed rhyme can create closure even before the listener understands why.
+Pat asks whether the *absence* of rhyme can maroon the ear, runs the unrhymed
+verse, and answers:
+
+> Our ear feels a little lost. And how is our hero feeling? Yup. Lost.
+>
+> Is this to say that the lack of rhyme supports the emotion of the verse? Yup.
+> It's huge.
+
+He points at a second example for rhyme-scheme prosody: "Listen to 'The Great
+Balancing Act' and see how Janis Ian and Kye Fleming create prosody with their
+abbb rhyme scheme."
 
 Use rhyme scheme as emotional navigation:
 
@@ -186,13 +451,77 @@ Use rhyme scheme as emotional navigation:
 
 ## Rhyme type
 
-Rhyme type controls resolution strength. Chapter 18's scale runs across five
-distinct tiers, most to least resolved: perfect, family, additive/subtractive,
-assonance, consonance.
+Rhyme type controls resolution strength. Chapter 18 reproduces the scale as a
+figure titled "RHYME TYPES: SCALE OF RESOLUTION STRENGTHS"
+(`image_rsrcAUE.jpg`), running left to right from **Most Resolved** to **Least
+Resolved** across five distinct tiers:
+
+```text
+Most Resolved ......................................... Least Resolved
+
+Perfect Rhyme    Family Rhyme    Additive/       Assonance    Consonance
+                                 Subtractive     Rhyme        Rhyme
+                                 Rhyme
+```
+
+> Remember, rhyme types create opportunities to add color and emotion. Use them
+> to color your meaning, the same way a film score comments on the action on the
+> screen.
+>
+> There are no rules, only tools.
+
+The verse's closing pair is Pat's worked case — the consonance rhyme `one` /
+`gone`:
+
+> Here, the consonance rhyme, one/gone, conspires, along with the other elements
+> of structure (number of lines, line length etc.), to help pull the rug out
+> from under our hero, as well as to increase our feeling that something's not
+> quite right. Good stuff.
 
 Use weaker rhyme types when full closure would contradict the emotion. Use
 stronger rhyme types when the section needs confidence, arrival, or trust.
 See [rhyme types](rhyme-types.md) for the detailed type definitions.
+
+## The five elements across one whole song
+
+Chapter 18 closes by walking Don Henley and Bruce Hornsby's "The End of the
+Innocence" section by section, asking "Stable or unstable?" at each one. Pat's
+verdicts, verbatim:
+
+Section one (childhood):
+
+> Right. Stable. And how stable was my childhood? Well, my childhood had an even
+> number of equal-length lines that rhymed perfectly at the second and fourth
+> lines.
+
+Section two (the divorce):
+
+> Right. Stable. And where is it the most unstable? Right. The last line, where
+> daddy leaves. How did daddy's leaving affect me? Well, it made me feel like my
+> life sped up with consecutive rhymes, then dropped me over the edge with a
+> short, unrhymed line. Darn it, daddy!
+
+Section three (the promised place):
+
+> Hmm. Both? Yes. An even number of lines with matched alternating line lengths,
+> rhyming lines two and four. That's what I'm promising you — a place where
+> everything will feel stable again. But alas, though it might still feel
+> better, there's not much you can do about the damage daddy's leaving did. No
+> matter how stable the place we go feels, there's that darn men/wind
+> consonance/additive rhyme, making everything hang. Real stability is now just
+> an illusion. No perfect rhymes in sight.
+
+Section four (the title):
+
+> Yep — very unstable. We'll never get our innocence back. Our life is always
+> destined to be an odd number of unequal-length lines topped off by another
+> consonance rhyme, defense/innocence.
+
+> A remarkable journey, where the structure supports — indeed, helps create — the
+> emotional intent of the song.
+
+This is the model for the Analysis workflow below: ask the stable/unstable
+question per section, then name which of the five elements delivered the answer.
 
 ## Motion tools
 
@@ -201,9 +530,36 @@ Chapter 19 reduces motion to two interacting levels:
 - Words and ideas create emotion through meaning.
 - Overall lyric structure creates emotion through groupings and line structure.
 
+In Pat's wording, the second level "consists of: a. groupings of lines, and b.
+line structure, a combination of three things: rhythm of the line; length of the
+line (line length is determined by the number of stresses in a line), and rhyme
+scheme used in the combinations of lines."
+
+> When you control the way a lyric moves, you're able to affect your audience on
+> two levels simultaneously, rather than just on the level of meaning.
+>
+> Motion creates emotion. Or, maybe better: Motion creates and supports emotion.
+
 Line structure combines rhythm, stressed-syllable length, and rhyme scheme.
 Control those elements to make the section speed up, slow down, lean forward,
-resolve, hang unresolved, or spotlight a specific word.
+resolve, hang unresolved, or spotlight a specific word. Pat's own list of what
+lyric structure can do with no help from the words:
+
+> move us forward to create excitement, anticipation, or an expectation of
+> what's coming next.
+>
+> slow us down to create a sense of holding back or a sense of unresolved
+> feelings.
+>
+> draw attention to a specific word (a spotlight), creating surprise, delight,
+> humor, or any important emotion.
+>
+> resolve, creating a feeling of stability.
+>
+> leave us hanging and unresolved, creating a feeling of instability.
+
+The range this buys, in Pat's terms: "anything from a granite boulder to a
+wobbly table to a capsizing ship."
 
 ## Closure across whole sections
 
@@ -234,11 +590,78 @@ An unmatched line's end sound is a free slot pointing into the section that
 follows. Leave it unused and it merely hangs there; aim it and it lights a word
 in the oncoming title.
 
+Pat introduces the tool on an `AAB` pre-chorus whose third line is left hanging,
+against a chorus whose title is "For One Smile in a Million":
+
+> If it were a pre-chorus or bridge, we could maybe use the third line's vowel
+> sound from while (which is asking to be rhymed) to illuminate an important
+> vowel sound in the oncoming section — for example, in an oncoming chorus where
+> the title of the song was something like "For One Smile in a Million." The
+> while in line three, hanging there unrhymed, will emphasize smile in the
+> chorus. Nifty tool, eh?
+
+He then re-aims the same third line twice more, holding lines one and two fixed:
+
+```text
+I hitched to Tulsa worn and soaked   a   4 = A
+She stared at me before she spoke    a   4 = A
+I stopped, completely dumb           x   3 = B
+```
+
+> Now the third line targets the short-u sound in the title's one, highlighting
+> it and emphasizing it in the chorus.
+
+```text
+I hitched to Tulsa worn and soaked   a   4 = A
+She stared at me before she spoke    a   4 = A
+I stopped, completely still          x   3 = B
+
+For one smile in a million …
+```
+
+> Now the third line targets the short-i and l sounds in million, highlighting
+> it and emphasizing it in the chorus.
+
+Targeting the title's end rhyme instead changes the feeling. Pat's note on the
+version where `still` rhymes with `million`: "the effect not only highlights it,
+but it also creates a bit of a sense of resolution. It feels like:"
+
+```text
+I hitched to Tulsa worn and soaked   x   4 = X
+She stared at me                     x   2 = X
+I stopped, completely still          a   3 = A
+For one smile in a million           a   3 = A
+```
+
+Two things move in that re-notation, not one. The first two lines lose their
+`a` labels and become `XX` once the ear reattaches line three to the title —
+and Pat also shortens line two to two stresses. So the resolved feeling is the
+rhyme plus the line-length change together, which is the same combination the
+two-line ladder above measures. The transition resolves rather than merely
+brightening.
+
+> Targeting the rhyme position is neither wrong nor right. It creates a
+> different, usually more resolved feeling than if you target interior vowel
+> sounds. It depends on the feeling you want to create. You control it.
+
 - Target a vowel **inside** the title and the title gets a sonic boost without
   extra resolution.
 - Target the title's **end rhyme** instead and the transition resolves harder —
   neither right nor wrong, just a different feeling.
 - Target nothing and the position is spent.
+
+The `ABA` pre-chorus version runs the same three-way comparison against the
+chorus line "Baby I like what I see …". End line two on `bite` and "We hear like
+with more intensity." End it on `shade` and "We hear baby with sensual
+overtones." End it on `drink` and nothing happens:
+
+> Now we get no extra sonic action in the chorus, and line two's drink is still
+> waving his arms for attention, wondering if he'll ever meet a nice noun or
+> verb to hook up with.
+
+Pat runs the identical set on an `ABAA` verse, where line two is the free slot,
+and marks the untargeted version only as "A wasted second position? Maybe not.
+But it's there for the picking if you want it."
 
 `AAB`, `ABA`, `ABAA`, `ABCAC`, and `ABCBC` all expose exactly one such line.
 See [hook](hook.md) "target hook sounds" for the hook-side strategy; this is
@@ -247,51 +670,159 @@ the structural question of *which line* is the targeting slot.
 ## Stability reference
 
 Use the following as a practical stability map, not a formula. The same pattern
-can change emotional effect when line lengths or rhyme types change.
+can change emotional effect when line lengths or rhyme types change. Pat's own
+framing for the catalogue:
 
-Two-line sections, most to least stable:
+> Think of the following examples as a handy reference guide to stable and
+> unstable structures, there for you to try in support of that idea you've got.
+> Is the idea stable or unstable? And then you go through the examples to find
+> something that might work for you.
 
-1. Matched length, matched rhyme (`AA`) — stops dead.
-2. Matched length, no rhyme — balanced enough not to lunge forward.
-3. Rhymed, unmatched length — the rhymes land in different positions, so there
-   is a stronger push than in 2.
-4. Unmatched length, no rhyme — leans forward hardest.
+Two scope notes he attaches to it. On line lengths: the examples stick to
+"four-stress, three-stress, and, later, five-stress lines that make up most
+lyrics," but "once you absorb the principles, you'll be able to apply them to
+any line lengths." On rhyme types: they are deliberately held out of the
+catalogue so only three variables move at once, but "try using stronger and
+weaker rhyme types in some of the closing positions to see what differences they
+make."
+
+Where Pat's printed stress column disagrees with the line it labels, the column
+is omitted here rather than corrected or propagated.
+
+Two-line sections, most to least stable, with Pat's own four examples:
+
+```text
+1. matched length, matched rhyme
+   I hitched to Tulsa worn and soaked    a   4 = A
+   A little bent and really broke        a   4 = A
+
+2. matched length, no rhyme
+   I hitched to Tulsa worn and soaked    a   4
+   A little bent and really tired        b   4
+
+3. rhymed, unmatched length
+   I hitched to Tulsa worn and soaked    a   4
+   A little bent and broke               a   3
+
+4. unmatched length, no rhyme
+   I hitched to Tulsa worn and soaked    a   4
+   I couldn't find a ride                b   3
+```
+
+Pat's verdicts, rung by rung. On 1: "It stops. You can feel the resolution." On
+2: "Even though the lines don't rhyme, their matched lengths give a feeling of
+balance or stability. Not as much as if they rhymed, but enough to keep you from
+wanting to lunge forward." On 3:
+
+> Even though these rhyme, they rhyme in different positions — most likely on
+> different beats in the musical measure. There's a little stronger push forward
+> here. So line length is a stronger motion creator than rhyme, huh? Yup.
+
+On 4: "This is the least stable. It leans forward really hard."
 
 Rungs 2 and 3 are the load-bearing pair: matched length without rhyme is more
 stable than rhyme without matched length, so **line length is a stronger motion
 creator than rhyme.** When a section's motion is wrong, check the arrangement of
 line lengths before touching the rhyme scheme.
 
-General rule: longer followed by shorter is less stable than shorter followed by
-longer, because the longer line matches the shorter one's length on its way past.
-Think of a longer line as laying a foundation under the shorter line above it.
+General rule, stated by Pat as a thing to remember because it also applies to
+larger structures: "Longer followed by shorter is less stable than shorter
+followed by longer." The reason is that "the longer line has matched the shorter
+line on its way by." From the four-line discussion: "Think of longer lines as
+laying a foundation under the shorter line above them."
 
 Three-line sections:
 
-- `AAA`: stable if the idea concludes; can still lean forward when repeated
-  content asks for a fourth arrival.
-- `ABB`: can close, but a long first line leans harder than a short first line.
-- `XXX`: unstable because no rhyme or sequence guides the ear.
-- `AAB`: tends to lean forward toward a matching `AABB` or `AABAAB`.
-- `ABA`: creates clear expectation for another `B`.
+- `AAA`: "the most stable of the three-line sequences. It seems almost to close
+  down — almost to resolve. You can look at it as AA+A, and it depends on
+  whether you see the third line leaning back or looking forward for more. The
+  principle of sequence says it's looking to pair off, since we heard a pairing
+  (a resolving couplet) after line two." Either way "it feels less than
+  complete." Content moves the reading: swap in a line-three idea that concludes
+  and it settles; swap in one that doesn't and "this feels a little less
+  resolved, since the idea is less resolved." Pat's real-world case is John
+  Mayer's "Your Body Is a Wonderland," where the title repeats three times and
+  only after the bridge does he "finally say it four times, bringing the events
+  to their conclusion."
+- `ABB`: can close, but line-one length decides how hard. With a long first
+  line it "actually seems to create a bit of expectation for a matching A at
+  line four." With a short first line "it doesn't seem to lean as hard … it
+  feels more stable — almost like its own section. The singer feels almost
+  resigned to leaving, like he's accepted his fate."
+- `XXX`: "This more 'floats' than leans forward. There is no rhyme sequence
+  established here, so few expectations are raised. It sort of 'suspends'
+  him — he feels like he's just hanging out, waiting to see what happens next,
+  but with no hurry."
+- `AAB`: "This leans pretty hard, too, though not in the same way, since our
+  expectations are a little less clear; maybe the resolution would be AABB, or
+  maybe AAB AAB." Complete it either way and it becomes stable; leave it at
+  three lines and "it would be pretty unstable."
+- `ABA`: "not only the most unstable of the three-line sequences, it also
+  positively cries out for a resolving fourth line" matching line two's stress
+  count and rhyme — it is three-fourths of a common meter section. Invert the
+  arrangement to short / long / short and the lean survives; stretch line two to
+  five stresses and "it seems to lean even harder," which Pat attributes to its
+  being "more of a departure from line one."
 
 Four-line sections:
 
-- `AAAA`: very stable but can become static.
-- `AABB`: stable couplet motion.
-- `ABAB`: stable common-meter motion.
-- `XAXA`: stable but more relaxed than `ABAB`.
-- `ABAA`: deceptive closure; the final `A` fools the expected `B`.
-- `XXAA`: a larger unit that closes only at the end.
-- `XAAA`: floats rather than pushes. The instability is the odd number of `A`s
-  — line count and matched-element count disagree — not the opening `X`, and
-  the final `A` lands as a stopping place without much fanfare. Line lengths
-  modulate it: short `A`s lean a little forward, long `A`s under a short `X`
-  are close to stable.
-- `AABA`: balances at the couplet, so line three's `B` supplies the only push,
-  asking to be matched by another `B`. Line four mildly fools that expectation
-  by resolving with `A`, leaving a small spotlight on the last line.
-- `ABBA`: enclosed motion; can feel balanced but less direct.
+- `AAAA`: "Lots of stability here — it's basically Eenie Meenie Miney Moe. It
+  has two balancing points: at the end of line two and at the end of line four.
+  This is as solid as a structure can get." Because it stops in the middle, the
+  last line "isn't quite as much a 'point of arrival' as it will be in other
+  structures. The spotlights aren't as bright." As a chorus, Pat puts the title
+  in both the first and last line — a nice surprise to hear repeated, "but we
+  weren't being pulled inexorably toward it. The journey was much more steady,
+  almost matter-of-fact. The structure portrays an attitude."
+- `AABB`: stable couplet motion — a complete stop at the end of line two and
+  again at line four, "creating two two-line sections. A very stable structure.
+  When the protagonist says something using this structure, he/she's telling the
+  truth. It's a stable fact."
+- `ABAB`: stable common-meter motion. "Boy, does this stop dead. Common meter,
+  fully resolved but full of motion. We get a push forward by the shorter line
+  two, then a big push when we hear line three match line one in length and
+  rhyme."
+- `XAXA`: stable but more relaxed than `ABAB` — "we're missing the big rhyme
+  push forward at line three; the line length pushes, but without the additional
+  momentum rhyme creates. This moves forward pretty strongly, but without the
+  urgency we feel at line three of ABAB."
+- `ABAA`: deceptive closure; the final `A` fools the expected `B`. Pat's note is
+  an obligation, not a description — "it's a great way to call extra attention
+  to the last line. Make sure there's something there worth looking at." It also
+  takes a title top and bottom.
+- `XXAA`: a larger unit that closes only at the end. "This is a surprise. We had
+  no expectations after either line two or three, so the resolution we get at
+  line four surprises (but doesn't fool) us. It's resolved all right, but
+  without much pushing or raising expectations to get there. Resolution coming
+  out of chaos, as it were … It's pretty unstable for a resolved section."
+  Line lengths modulate it: keep the rhyme change but match all four lengths and
+  "the lights still go on the last line, but not as brightly, given the more
+  balanced journey through line lengths."
+- `XAAA`: floats rather than pushes. Pat runs three versions and names the
+  cause: "What creates the instability in all three versions is the odd number
+  of A's. There's a mismatch between the number of lines, and the number of
+  matched elements. The structure doesn't push forward very hard, it more
+  'floats,' because when we get our first match at line three, we have an odd
+  number of lines preventing the rhyme and rhythm match from creating
+  stability. We don't quite know what to expect next, making the final A create
+  what feels like a stopping place, but without much fanfare when it arrives."
+  The instability is the odd number of `A`s, not the opening `X`. Line lengths
+  modulate it: short `A`s lean "a bit forward, almost as if it were asking to
+  duplicate itself for balance"; long `A`s under a short `X` are "pretty
+  stable."
+- `AABA`: "This structure fools us, too, but not drastically. To the extent that
+  we expect a match for B, we're fooled when it resolves with A. This structure
+  doesn't move much. It balances after line two, so there's no push forward
+  there. The B line provides the only push, but only by being different and
+  asking politely to be matched. We get a little spotlight on the last line."
+- `ABBA`: enclosed motion; can feel balanced but less direct. Pat: "ABBA
+  structures float. I think it's unresolved, but sometimes it's a close call. No
+  matter, though; it's the effect of the structure that counts." Long lines
+  outside make it feel "pretty resolved"; short lines outside with long lines
+  inside feel "less stable." With equal-length lines it is the In Memoriam
+  Quatrain, after Tennyson — an `abba` scheme "creating a suspended feeling at
+  the end of each quatrain, much as you'd do in a eulogy." Pat's listening
+  reference is the verses of James Taylor's "Sweet Baby James."
 - `AAAX`, `AXAX`, `XAAX`, and `XXXX`: use when floating or unstable motion
   supports the idea.
 
@@ -299,36 +830,89 @@ Five-line sections:
 
 - One matching element: `AAAAA`, `XAAAA`, `XXAAA`, `XAXAA`, `XXXAA`, `XXAXA`,
   and `AAAAX`. Unmatched lines match nothing, including each other, so these
-  float; the ones that feel most stable are the ones that resolve without the
-  ear having predicted it — unexpected closure. **A five-line section ending in
-  an unmatched line is the most unstable of the group.**
+  float. Pat's framing: "any odd lines don't match anything else, including each
+  other. This often creates a 'floating' effect. The sections that feel most
+  stable are often the ones that surprise us by feeling resolved without us
+  expecting the resolution. Call it 'unexpected closure.' These structures are
+  probably most useful as verses, though they can also work effectively as
+  choruses, given the proper combination of ideas." **A five-line section ending
+  in an unmatched line is the most unstable of the group** — "Five-line systems
+  ending with an X will be the most unstable."
 - Two matching elements: `ABABB`, `ABAAB`, `ABBAA`, `ABBAB`, `ABAAA`,
   `ABABA`, `AABBA`, `AABBB`, and `AAABB` create different balances of closure,
-  sequence, and forward pull.
+  sequence, and forward pull. In the first six the opening two lines differ,
+  "creating forward motion"; in the last three the opening two lines are `A`s,
+  "creating a system that stops at the couplet before continuing." Pat's notes
+  on the ones that carry a mechanism: `ABABB` is "closed and stable, with the
+  additional line leaning more backward than forward. You get a nice spotlight
+  at the end." `ABAAB` is the two-effect case — "Line four fools you — call it a
+  'deceptive closure': You expected B, but got A instead. Then, at line five, you
+  get what you originally expected but where you didn't expect it, so it's a
+  cross between expected and unexpected closure, making it feel a bit more
+  stable." `ABAAA` has "a deceptive closure in line four, thus creating an
+  unexpected closure in line five"; with four `A`s across five lines it "stops at
+  line five, but it's not a hard stop. It's a bit of a floater without a sixth
+  line." `ABABA` "leans forward looking for another B. The alternating sequence
+  is responsible for this feeling." `AABBA`, despite two couplets, keeps leaning
+  "a bit, like a limerick," and its final `A` "seems to stop rather than start a
+  new sequence, as if it's simply referring back to the opening AA." `AAABB`
+  "feels strangely stable. It should be crying out for another B, but it doesn't
+  seem to" — Pat's guess is that "the feel of the couplet interferes" with the
+  sequence's request for `AAABBB`.
 - Three matching elements: `ABCAC` and `ABCBC` create deceptive closure because
-  the fifth line answers a line other than the expected one.
+  the fifth line answers a line other than the expected one. On `ABCAC`: "Line
+  four suggests that a sequence is taking shape: ABCABC. Then you get the
+  closing element immediately. To the degree that line four raises expectations
+  that B will be matched, line five fools you, thus creating deceptive closure.
+  You get very strong spotlights at line five." On `ABCBC`: "This is stable, and
+  it seems to carry a little milder surprise at line five than ABCAC. You don't
+  hear the sequence starting again at line four with an A, so it doesn't direct
+  you forward as strongly. But once you hear B, the sequence kicks in, even
+  though it's 'out of sequence.'"
 - `ABCBB`: the long `C` sticks out, weakening the fourth line's closure and
   dimming line five with it. Shortening `C` lets line four close solidly and
   brightens the spotlight on line five.
-- `ABCAA` and `ABCAB`: tend to push forward toward a missing `C`.
+- `ABCAA` and `ABCAB`: tend to push forward toward a missing `C`. Both remain
+  unstable even with the `C` line shortened — the `ABCAB` version "still wants to
+  move to" its missing `C`, which Pat labels "the power of sequence."
 
 Six-line sections:
 
-- `ABCABC`: strong sequence; moves forward to a satisfying line-six resolution.
+- `ABCABC`: "This sequence moves relentlessly forward to a satisfying and
+  resounding resolution at line six. It's the six-line version of common meter,
+  working according to the principle of sequence."
 - `ABABAA` and `ABABCC`: close after line four, then finish with a stabilizing
-  couplet.
-- `AABAAB`: stable, but the opening couplet slows the sequence.
-- `ABABAB`: mostly stable, with slight forward curiosity about whether another
-  `AB` will follow.
-- `ABBABB`: can feel stable but may float if sequence is weak.
-- `ABABBA`: two unexpected closures in reverse order; useful for surprise.
+  couplet. `ABABAA` is "very stable, especially when the couplet matches one of
+  the elements of the quatrain." `ABABCC`'s final couplet "decelerates a bit
+  with the longer lines, but makes up for it with the immediate (and thus
+  accelerating) rhyme."
+- `AABAAB`: "Another solid citizen. It's a favorite structure of Leonard
+  Cohen's. It doesn't push forward as hard as ABCABC, since the opening couplet
+  stops the section. It's also harder for sequence to kick in, though it's in
+  full force at the end of line five."
+- `ABABAB`: mostly stable, though "the final AB might clear its throat a bit,
+  wondering whether the larger ABAB sequence will be matched again to make
+  ABABABAB. So, just a touch of instability — looking forward to another AB."
+- `ABBABB`: can feel stable but may float. "The challenge with this structure is
+  that it doesn't establish sequence, and thus doesn't raise much expectation,
+  giving it a tendency to float." Shortening the `A` lines makes it "feel a bit
+  more solid. Again, it shows the power of line lengths."
+- `ABABBA`: "I like how this one plays tricks. Two unexpected closures, but in
+  reverse order, creating a nifty surprise."
 
 ## Sequence
 
 Sequence is expectation created by partial repetition of a structural pattern.
 `ABCAB` wants `C` because the ear has learned the pattern. This can overpower
 the raw number of lines: a five-line section can feel incomplete if the sequence
-points toward a sixth line.
+points toward a sixth line. Pat runs `ABCAB` twice — once with a five-stress `C`
+and once with the `C` shortened — and it still wants its missing `C` both times.
+His two-word verdict on the demonstration: "That's the power of sequence."
+
+The sequence principle is also what makes `AAA` feel unfinished — "The principle
+of sequence says it's looking to pair off, since we heard a pairing (a resolving
+couplet) after line two" — and what makes `ABCABC` the six-line version of
+common meter.
 
 Sequence coaching checks:
 
@@ -338,6 +922,129 @@ Sequence coaching checks:
 - Is the title placed where the sequence creates the strongest spotlight?
 - Would a shorter or longer version of one line change the stability enough to
   support the lyric's attitude?
+
+## The Structural Pentad — the 1991 frame under all of this
+
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 3 builds Common
+Meter up as a reference structure — a PARADIGM — and then reads five properties
+off it. Pat's five numbered descriptions of Common Meter, verbatim:
+
+> 1. BALANCE: It is BALANCED — there is an even number of phrases, each phrase
+> has a counterpart, and the order of the phrases is repeated. Nothing is left
+> "hanging."
+>
+> 2. PACE: It moves in a CONSTANT duple pattern of stress/unstress, neither
+> ACCELERATED nor DECELERATED.
+>
+> 3. FLOW: The structure is THROUGH-WRITTEN: that is, there is no place of
+> resolution before the end of the last phrase. The structure keeps pushing you
+> forward.
+>
+> 4. CLOSURE: It is CLOSED, or resolved. Your expectations are satisfied by the
+> way the fourth phrase ends. You feel no need to continue on to another phrase.
+> If there were a need to continue on, the structure would be OPEN.
+>
+> 5. TYPE OF CLOSURE: The resolution is EXPECTED. It is how you would have
+> predicted (when you reached the end of phrase three) that the entire structure
+> would end.
+
+> We have just developed what we will call the STRUCTURAL PENTAD (penta =
+> "five") — five normal characteristics of any structure, be it a rhythmic
+> structure, a rhyme structure, or even a musical structure.
+
+Note the wording gap between the prose and the worksheet: the numbered
+description above says "It is BALANCED," but the worksheet's row offers
+**SYMMETRICAL / ASYMMETRICAL**. The worksheet values are the closed list; the
+prose around it uses the looser wording. See [meter](meter.md) "Structural
+Pentad — unified diagnostic," which owns that note.
+
+The worksheet itself (`image_rsrc309.jpg`), reproduced with its exact value
+sets:
+
+```text
+BALANCE:    ___ SYMMETRICAL      ___ ASYMMETRICAL
+PACE:       ___ CONSTANT         ___ ACCELERATED     ___ DECELERATED
+FLOW:       ___ THROUGH-WRITTEN  ___ FRAGMENTED
+CLOSURE:    ___ CLOSED           ___ OPEN
+C. TYPE:    ___ EXPECTED         ___ UNEXPECTED      ___ DECEPTIVE
+```
+
+Common Meter — Paradigm One — filled in (`image_rsrc30A.jpg`):
+
+```text
+BALANCE:     x  SYMMETRICAL      ___ ASYMMETRICAL
+PACE:        x  CONSTANT         ___ ACCELERATED     ___ DECELERATED
+FLOW:        x  THROUGH-WRITTEN  ___ FRAGMENTED
+CLOSURE:     x  CLOSED           ___ OPEN
+C. TYPE:     x  EXPECTED         ___ UNEXPECTED      ___ DECEPTIVE
+```
+
+Paradigm Two — four matching four-stress phrases — filled in
+(`image_rsrc30C.jpg`). One row moves:
+
+```text
+BALANCE:     x  SYMMETRICAL      ___ ASYMMETRICAL
+PACE:        x  CONSTANT         ___ ACCELERATED     ___ DECELERATED
+FLOW:       ___ THROUGH-WRITTEN   x  FRAGMENTED
+CLOSURE:     x  CLOSED           ___ OPEN
+C. TYPE:     x  EXPECTED         ___ UNEXPECTED      ___ DECEPTIVE
+```
+
+Pat's own gloss on the difference is the clearest statement of FLOW in either
+book: Paradigm One runs `SAME / DIFFERENT / SAME …`, and "your expectation that
+phrase two will be repeated at the end is what keeps the system moving."
+Paradigm Two runs `SAME / SAME / SAME / SAME`, and "because there is no
+difference between phrase one and phrase two, there is no tension to keep the
+system moving."
+
+See [meter](meter.md) "Structural Pentad" for the paradigm-by-paradigm
+worksheet and the closed-list note on the value sets.
+
+## The Pentad carried onto rhyme (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4)
+
+Chapter 4 opens by asserting rhyme's reach over all five properties, and then
+gives each one its own numbered section. Pat's opening statement, verbatim:
+
+> Rhyme is a powerhouse. It affects all parts of structure: BALANCE, PACE, FLOW,
+> CLOSURE, AND CLOSURE TYPE.
+
+> I. Rhyme helps create BALANCE (symmetry), or lack of BALANCE (asymmetry) in a
+> structure.
+>
+> II. Rhyme controls the PACE of structures. (Acceleration, Deceleration,
+> Constant Motion)
+>
+> III. Rhyme controls the FLOW of phrases by stopping motion, or by keeping
+> motion going.
+>
+> IV. Rhyme controls the CLOSURE (or resolution).
+>
+> V. Rhyme helps control TYPE OF CLOSURE. (EXPECTED CLOSURE, DECEPTIVE CLOSURE,
+> UNEXPECTED CLOSURE.)
+
+Two of those sections carry mechanisms this file uses elsewhere:
+
+- **Pace.** "Rhyme is like the accelerator in a car: the closer the accelerator
+  gets to the floor, the faster the car moves. The closer rhymes are to each
+  other, the faster your lyric moves." Once rhymes are consecutive, "the pedal
+  is to the metal. You cannot accelerate. The only way to go faster then is to
+  shorten PHRASE LENGTHS."
+- **Flow.** "Rhyme is the best way to control a lyric's FLOW. Nothing can match
+  rhyme's power in this area. Not phrase length. Not rhythm." An `aabb` scheme
+  fragments — the `a`s "bond" together and create an internal point of
+  rest — while `abab` stays through-written. Pat's rule of thumb: "when you want
+  ideas to flow, through-write the rhyme scheme; when you want ideas to 'section
+  off,' fragment it."
+
+Note that Chapter 4's flow claim and Chapter 19's stability ladder are about
+different things and do not conflict. Chapter 4 says rhyme is the strongest
+control over **flow** (where a section rests internally). Chapter 19 says line
+length is a stronger creator of **motion** than rhyme. Keep the two claims in
+their own lanes.
+
+Chapter 4 also states the prosody payoff for surprise closures directly: "If you
+put important or surprising ideas in spots where the structure surprises, the
+ideas will work with the structure to create lovely PROSODY."
 
 ## Analysis workflow
 
@@ -355,6 +1062,23 @@ Sequence coaching checks:
 
 ## Coaching prompts
 
+Most of these are Pat's own numbered exercises from Chapter 19, which runs
+**Exercises 26 through 43**. The number is given where the prompt maps to one,
+so a coach can quote the source assignment rather than a rephrasing of it. Pat's
+verbatim wording for the two title-targeting drills is given below because the
+"don't target the end rhyme" instruction is the part most often lost:
+
+> EXERCISE 28: Make up your own title, and, using it as the first line of an
+> oncoming chorus, write an AAB structure leading up to it, with the third line
+> targeting a vowel sound in the title. Try not to target the end rhyme. Instead,
+> give the words inside the title a sonic boost. Then rewrite the third line (B
+> line) to target a different vowel sound in the title.
+
+> EXERCISE 41: Choose either ABCAC or ABCBC and target to a title from the
+> unrhymed line. Construct a title that matches the unmatched line in both
+> rhythm and rhyme. Target an inner vowel of the title line rather than the end
+> rhyme.
+
 - Film-score audit: choose a draft section and name the emotion that the
   structure creates before rereading the words. Then compare that emotion with
   the stated meaning.
@@ -368,18 +1092,26 @@ Sequence coaching checks:
   consonance rhyme and listen for how much resolution disappears.
 - Two-line stability pass: write matched and unmatched two-line sections; test
   shorter-to-longer and longer-to-shorter versions.
-- Three-line motion pass: write `AAA`, `ABB`, `AAB`, and `ABA`; for `AAA`, try
-  resolved and unresolved ideas; for `ABB`, compare long-first-line and
-  short-first-line versions.
-- Four-line reference pass: draft `AAAA`, `AABB`, `ABAB`, `XAXA`, `ABAA`,
-  `XXAA`, `XAAA`, `AABA`, `ABBA`, `AAAX`, `AXAX`, `XAAX`, and `XXXX`, naming
-  where the ear stops and where it leans forward.
-- Five-line title targeting: choose `ABCAC` or `ABCBC`, then build a title from
-  the unmatched line by matching both rhythm and rhyme; target an inner vowel
-  rather than only the end rhyme.
-- Five-line shortened-line test: shorten the `C` line in `ABCBB` or `ABCAA`
-  and describe how motion changes.
-- Six-line sequence pass: rewrite `AABAAB` with `B` shortened to three
+- Three-line motion pass (Ex 26-29): write `AAA`, `ABB`, `AAB`, and `ABA`; for
+  `AAA`, try resolved and unresolved ideas (Ex 26); for `ABB`, compare
+  long-first-line and short-first-line versions (Ex 27); for `AAB` and `ABA`,
+  run the title-targeting drills (Ex 28, Ex 29).
+- Four-line reference pass (Ex 30-35): draft `AAAA` with your title top and
+  bottom (Ex 30), `AABB`, `ABAB` — then go find five common-meter examples in
+  songs you already know (Ex 31) — `XAXA` by modifying your own `ABAB` (Ex 32),
+  `ABAA` with second-line targeting (Ex 33), `XXAA`, `XAAA`, `AABA` with
+  third-line targeting (Ex 34), `ABBA`, `AAAX`, `AXAX`, `XAAX` (Ex 35), and
+  `XXXX`, naming where the ear stops and where it leans forward.
+- Five-line passes (Ex 36-42): write `XAAAA` ending on a stable idea, then
+  juggle the lines so it ends on an unstable one (Ex 36); describe `XAXAA`
+  yourself (Ex 37); rewrite `AABBA`, `AABBB`, and `AAABB` with three-stress `A`s
+  and four-stress `B`s and name what changes (Ex 38-40).
+- Five-line title targeting (Ex 41): choose `ABCAC` or `ABCBC`, then build a
+  title from the unmatched line by matching both rhythm and rhyme; target an
+  inner vowel rather than the end rhyme.
+- Five-line shortened-line test (Ex 42): shorten the `C` line in `ABCBB` or
+  `ABCAA` and describe how motion changes.
+- Six-line sequence pass (Ex 43): rewrite `AABAAB` with `B` shortened to three
   stresses, then compare how solid or forward-leaning the section feels.
 
 ## Revision moves
@@ -399,6 +1131,11 @@ Sequence coaching checks:
   effect is worth the instability.
 
 ## Motion creates e-motion — four controllers
+
+**Unaudited — web source, paraphrase retained deliberately.** The American
+Songwriter column is not in the corpus, so nothing here has been checked against
+Pat's actual wording and none of it is restored to verbatim. Chapters 18-19 do
+not contain a four-controller list.
 
 Pat's American Songwriter column condenses the engine into four controllers
 that together create the song's motion (and therefore its emotion):
@@ -446,6 +1183,72 @@ apart, because the same word means something narrower in one of them.
 The three failures take three different fixes: rescan, re-set against the bar,
 or change which words carry the weight. Name which one you found.
 
+### The 1991 source text — too hot, too cold, just right
+
+Chapter 3's demonstration matches new phrases to a model verse from Sting's "Be
+Still My Beating Heart." The model scans as two triple-pattern phrases followed
+by two duple-pattern phrases, four stresses then four then three then three:
+
+```text
+Sink like a stone that's been thrown in the ocean   / u u / u u / u u / u   4
+My logic has drowned in a sea of emotion            u / u u / u u / u u / u 4
+Stop before you start                               / u / u /               3
+Be still my beating heart                           u / u / u /             3
+```
+
+> These are pretty regular. The first two phrases are written in three-syllable
+> patterns, the last two in two-syllable patterns. (Do you detect any prosody?)
+
+Pat's rule, verbatim:
+
+> It is important not to be greedy: do not put stressed syllables in the
+> unstressed positions. This one is too hot.
+
+Too hot. Asterisks stand for Pat's printed italics, which mark the words he
+swapped in to break the match:
+
+```text
+Cast *deep* in silence I can't *hold* my balance
+My weak *heart* revealed by the heat *born* of malice
+Devil *haunts* my past
+*God* give me peace at last
+```
+
+> The "greedy" spots would surely get buried or at the very least sound hurried
+> (and lose their emotion) when you set them to the music of the original verse.
+
+> It is equally important to match the original's important words with equally
+> important words. This one is too cold:
+
+```text
+*Yet* in your silence I've *just* got my balance
+My weakness is *now* in the *place* of your malice
+*Won't* you help me past
+And *get* me *out* at last
+```
+
+> This should be enough to lose anyone's interest.
+
+> You must resist greed. But you must put your important words in the important
+> positions. This one is just right.
+
+```text
+Cast in your silence I'm losing my balance
+My weakness revealed by the heat of your malice
+Devil in my past
+Oh give me peace at last
+```
+
+> This version should work with the music for the original words. The stresses
+> match, and the most important words are in the same places.
+
+Read the mechanism off lines one, two and four, where it is unambiguous: `deep`
+and `hold` sit in unstressed slots of the triple pattern; `heart` and `born` do
+the same in phrase two; `God` occupies the unstressed pickup of the closing
+duple. The too-cold version's failure is the opposite kind — its stresses land
+where the model put them, but auxiliaries and filler occupy the strong
+positions.
+
 Causes:
 
 - The lyric's stressed syllable falls between the bar's strong beats.
@@ -478,12 +1281,31 @@ one greedy spot often fixes adjacent ones.
 
 ## Ordinary-language preservation
 
-Pat returns repeatedly to a single rule: words have meaning because
-they have ordinary uses. Distorting natural word stress for musical
-convenience drains meaning.
+**This rule is book-sourced.** *Writing Better Lyrics* (2009) Chapter 18 states
+it and names it in one move:
 
-> "Preserve the natural shape of the language." — Pat
-> (patpattison.com)
+> Stressed syllables belong with stressed notes. Unstressed syllables belong
+> with unstressed notes. This is called "preserving the natural shape of the
+> language."
+
+The same chapter gives the melodic consequence: when stressed syllables and
+stressed notes "are lined up properly, the shape of the melody matches the
+natural shape of the language."
+
+Which syllables count as stressed is settled in *Essential Guide to Lyric Form
+and Structure* (1991) Chapter 3. Multi-syllable words carry conventional stress
+fixed by the dictionary — a stressed syllable is "higher in pitch," "louder,"
+and "longer" than the unstressed syllables around it, so "words of two or more
+syllables have a little melody, with the stressed syllable 'on the beat.'"
+One-syllable words are decided by job: meaning carriers (nouns, verbs,
+adjectives, adverbs) get **stress by importance**, while grammatical road signs
+(prepositions, articles, conjunctions, auxiliaries, pronouns) stay unstressed
+unless a contrast is stated or implied. That is the whole basis for calling a
+grammar word on a downbeat a defect.
+
+Pat's own warning about method: "looking for stressed syllables is a matter of
+seeing the stresses that are there rather than forcing a pattern onto the
+phrase."
 
 Two corollaries:
 
@@ -501,6 +1323,12 @@ unsettled, or sneering. The choice is conscious. Most greedy spots are
 not.
 
 ## Tone of voice as a stability lever
+
+**Unaudited — web source, paraphrase retained deliberately.** This axis comes
+from the Berklee Online article, which is not in the corpus. *Writing Better
+Lyrics* (2009) Chapters 18-19 contain no tone-of-voice material, so there is no
+book text to restore here and none has been invented. The six levers below are
+this file's distillation, not Pat's list.
 
 Pat extends the stable/unstable diagnostic with a non-rhyme, non-meter
 axis: tone of voice. A line printed on the page has one stability
@@ -533,22 +1361,35 @@ of voice may be the lever doing the work. Sing the chorus two ways.
 
 ## Origin note — *Essential Guide to Lyric Form and Structure* (1991), Chapter 2
 
-Pat first introduces the term **prosody** in *Essential Guide to Lyric Form and Structure* (1991), Chapter 2, originally with a
-narrower meaning: phrase length fitting the lyric's meaning. Across Books 2
-and 4 and the Berklee Online / Coursera courses, the term expanded to
-cover all five compositional elements + melody + harmony + melodic rhythm
-— "structure is your film score."
+Pat first introduces the term **prosody** in *Essential Guide to Lyric Form and
+Structure* (1991), Chapter 2. **Correction to an earlier version of this
+note: the 1991 definition was not narrower.** It was already fully general.
+Verbatim:
 
-The expansion matters: the 1991 meaning is **phrase pacing matches idea
-pacing**; the modern meaning is **all structural surfaces support the
-emotion**. Both are valid; the narrower meaning is a subset of the broader
-one.
+> "Prosody" means that things fit well with one another. Here, for example, how
+> well meaning fits with structure. Here we're talking about the way syllables
+> fit with melody in a song. It can also be used in other ways.
 
-When reading this file, the broader meaning is in effect. The narrower
-1991 meaning surfaces specifically in `phrasing.md`'s phrase-length
-discussion.
+What was narrow in 1991 was the *application*, not the meaning: Chapter 2 is a
+chapter about phrase length, so its worked examples are phrase pacing matching
+idea pacing. The definition Pat gives alongside them — "things fit well with one
+another … It can also be used in other ways" — already covers everything the
+2009 formulation covers, and Chapter 18's "appropriate relationship between
+elements, whatever they may be" is the same claim in tighter words.
+
+So what grew across the books is coverage, not definition: by 2009 the worked
+examples span all five compositional elements, and across the courses they
+extend to melody, harmony, and melodic rhythm — "structure is your film score."
+
+When reading this file, that general meaning is in effect throughout. The
+1991 phrase-length application surfaces specifically in `phrasing.md`'s
+phrase-length discussion.
 
 ## Three phrasing types (Berklee Online OSONG-525)
+
+**Unaudited — course source, paraphrase retained deliberately.** OSONG-525 is
+not in the corpus and no book chapter names a third phrasing type, so nothing
+below has been converted to verbatim.
 
 Beyond the front-heavy / back-heavy frame in `phrasing.md`, Pat's
 graduate-level course adds a third type:

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -8,8 +8,14 @@ article (motion controllers, tone-of-voice); patpattison.com
 American Songwriter "Motion Creates E-Motion" column (4-controller framework).
 
 Audited against *Writing Better Lyrics* (2009) Chapters 18-19, and against
-*Essential Guide to Lyric Form and Structure* (1991) Chapter 3 with its figures.
-**Still unaudited:** that book's Chapter 4, and every non-book source listed
+*Essential Guide to Lyric Form and Structure* (1991) Chapters 3 **and 4**, both
+with their figures. **The "Chapter 3-4 (Structural Pentad)" citation above
+holds.** Chapter 3 introduces the Pentad on rhythmic structure; Chapter 4 opens
+by naming all five properties — balance, pace, flow, closure, closure type —
+and gives each its own numbered section, applied to rhyme structure. The
+citation spans both chapters because the framework does.
+
+**Still unaudited:** every non-book source listed
 above — the Berklee Online article, patpattison.com, the American Songwriter
 column, and OSONG-525 — which remain distillations nobody has checked against
 their originals. Where this file's wording and the 1991 chapter's wording
@@ -23,6 +29,11 @@ diverge, the divergence is marked in place rather than silently reconciled.
   references, 56 unique**, `image_rsrc2YZ.jpg` through `image_rsrc30P.jpg`. The
   Structural Pentad worksheets this file cites exist only as page scans; see
   [meter](meter.md) for the inventory note.
+- *Essential Guide to Lyric Form and Structure* (1991), Chapter 4: **40 figure
+  references, 40 unique**, `image_rsrc30R.jpg` through `image_rsrc31Y.jpg`. The
+  chapter's five-property opening and its per-property sections are what carry
+  the Pentad onto rhyme structure; see
+  [rhyme fundamentals](rhyme-fundamentals.md) "The five structural areas".
 
 ## Core idea
 

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -228,12 +228,14 @@ Was blind, but now I see               b   3   B
 ```
 
 > It's a stable common meter; the first and third lines both have the same line
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
 > length, as do the second and fourth lines.
 >
 > The rhyme scheme is abab, the same configuration as the line lengths (a
 > four-stress line followed by a three-stress line, then another four-stress
 > line followed by a three-stress line). The rhythms move along in a regular
 > duple pattern (da DUM).
+<!-- spellchecker:on -->
 
 If rhyme structure and line-length structure do not align clearly, omit the
 capital-letter shorthand and mark the separate features directly — Pat's rule
@@ -359,6 +361,7 @@ constant and names it:
 
 Pat scans the "Can't Be Really Gone" verse as a duple pattern and prints the
 rhythm strip on its own:
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
 
 ```text
 Da DUM da DUM da DUM da DUM
@@ -367,6 +370,7 @@ Da DUM da DUM da DUM da DUM
 Da DUM da DUM DUM da
 Da da DUM da DUM da DUM
 ```
+<!-- spellchecker:on -->
 
 > This is a mostly very regular lyric rhythm, with just a two variations,
 > neither of which have much effect.

--- a/plugins/songwriting/context/pat-pattison/research/repetition.md
+++ b/plugins/songwriting/context/pat-pattison/research/repetition.md
@@ -44,6 +44,13 @@ The repeated section is color-resistant when:
 - it answers the question too early,
 - it cannot be sung unchanged after a new verse angle.
 
+Pat's image for the failure:
+
+> It's frustrating when a refrain or chorus proves to be color resistant — the
+> words in the refrain or chorus won't work with the next verse without changing
+> the words somehow because they're protected from receiving the next verse's
+> color by coats and coats of verbal polyurethane.
+
 When the repeat resists recoloring, strip it.
 
 ## Stripping tense
@@ -51,11 +58,32 @@ When the repeat resists recoloring, strip it.
 Verbs determine tense. To make a refrain or chorus tense-neutral, use one of
 three strategies:
 
-| Strategy | Example shape | Effect |
+Chapter 9's worked refrain is *He lost the human race* — a good line, double
+meaning and all, which then refuses to sit under a future-tense verse (*He'll
+tilt his head one final night*). The three strategies applied to it:
+
+| Strategy | Chapter 9's version | Effect |
 | --- | --- | --- |
-| `-ing` form | falling | Accepts past, present, or future context. |
-| Infinitive | to fall | Points toward action without committing to time. |
-| No verb | a fall | Turns the repeat into a commentary or image. |
+| `-ing` form | Losing the human race | Accepts past, present, or future context. |
+| Infinitive | To lose the human race | Points toward action without committing to time. |
+| No verb | A loss in the human race | Turns the repeat into a commentary or image. |
+
+Pat's rules for each: with `-ing`, omit any helping verbs (*losing*, not *is
+losing* / *was losing* / *will be losing*), and don't confuse the verb form with
+a participle (*a losing strategy*) or a gerund (*losing builds character*). With
+the infinitive, omit the main verb — *to lose*, not *I hate to lose*.
+
+The verse it has to survive, in all three tenses:
+
+```text
+Exploding from the starting blocks
+Again he set / sets / he'll set the pace
+Though he was crowned by laurel wreaths
+As thousands cheered he came to grief
+Losing the human race
+```
+
+> Always try all three options. Use whichever feels best.
 
 Try all three before deciding. The goal is not grammar cleverness; the goal is
 to let each verse establish its own time while the repeated line remains
@@ -67,7 +95,8 @@ Pronouns determine point of view. A repeated line with `I`, `you`, `he`, `she`,
 `we`, or `they` may block a later verse from changing perspective. Remove the
 pronoun when the repeated material needs to accept multiple points of view.
 
-Often the same rewrite can strip both tense and POV:
+Often the same rewrite can strip both tense and POV. Chapter 9's Exercise 13
+refrain, with the three answers Pat supplies:
 
 ```text
 I fell too hard
@@ -76,7 +105,50 @@ to fall too hard
 too hard a fall
 ```
 
-Each neutral version lets the verse supply who fell and when.
+Each neutral version lets the verse supply who fell and when. *Losing the human
+race* does the same double duty — no verb tense, no pronoun — and the chapter
+proves it by running the identical refrain under five different verse POVs:
+
+```text
+Again I set the pace     … As thousands cheer I'll come to grief
+Again we set the pace    … As thousands cheer we'll come to grief
+Again you set the pace   … As thousands cheer you'll come to grief
+Again she sets the pace  … As thousands cheer she'll come to grief
+Again they set the pace  … As thousands cheer they'll come to grief
+
+                         Losing the human race
+```
+
+**Watch the third-person `-s`.** Pat's note on when you can skip verb
+neutralization entirely:
+
+> If you don't use *he*, *she*, or *it* in your lyric, none of your verbs will
+> add an *s*, so your verbs will all already be POV neutral. You won't need to
+> neutralize the verbs — you just need to drop the pronouns.
+
+Which is why *And lose the human race* works under I / we / you / they. But it
+is tense-locked, not POV-locked, and breaks the moment a verse goes past:
+
+```text
+Though they were crowned by laurel wreaths
+As thousands cheered they came to grief
+And lose the human race        <- wrong; needs "Losing the human race"
+```
+
+Diagnose which coat you are stripping. Dropping pronouns fixes POV; only
+changing the verb form fixes tense.
+
+**The real-world case.** Paul Simon's refrain in "Still Crazy After All These
+Years" has no pronouns and no verb, so verse one alone supports three readings:
+
+```text
+I am still crazy after all these years
+She was still crazy after all these years
+We were still crazy after all these years
+```
+
+> All three work fine. The result is a productive ambiguity that adds to the
+> spell of the lyric.
 
 ## Verses show, chorus tells
 
@@ -88,28 +160,61 @@ Use this carefully. It does not mean choruses should become generic. It means
 verses usually carry specific situation, image, and action, while the chorus or
 refrain can make a broader statement that the verses keep recoloring.
 
-The chapter attaches an instruction to the rule in the same breath: keep the
-verses specific and interesting. The rule constrains the CHORUS's grammar, not
-its imagination — the chapter's own demonstration chorus is built from concrete
-images (a fall from grace, a dot in space) while committing to no tense and no
-pronoun. **Neutral means grammatically neutral, not vague.**
+The chapter attaches an instruction to the rule in the same breath: "Keep your
+verses specific and interesting."
+
+The rule constrains the CHORUS's grammar, not its imagination. Pat first offers
+a deliberately dumb prototype to isolate the grammar —
+
+```text
+Losing the human race
+Losing the human race
+Yeah, yeah, yeah
+Losing the human race
+```
+
+— then makes it artistic without committing to anything:
+
+```text
+Losing the human race
+Falling from heaven's grace
+No way to stop it
+Only a dot in space
+Losing the human race
+```
+
+> None of the lines commit to tense or POV. They either use -ing (lines one,
+> two, and five), the infinitive (line three), or omit the verb altogether
+> (line four).
+
+Concrete images throughout, zero grammatical commitment. **Neutral means
+grammatically neutral, not vague.** Pat's instruction: "Make it as specific and
+artistic as you want to, just don't commit to a tense or a POV."
 
 If the chorus tells too specifically, it may block the verses. If it tells too
 generically, it may become cliche. Strip tense and POV without stripping image,
 sound, or emotional pressure.
 
 **A chorus is many people singing together.** Chapter 6 draws a working
-consequence from that definition rather than leaving it as etymology: change the
-words each time and no one else can sing it on the second pass — one person
-singing alone is a soloist, not a chorus. Change a refrain's words each time and
-it is not a refrain, just additional material. This is why the fix for a
-stagnant chorus is always to develop the verses, never to rewrite the chorus
-first.
+consequence from that definition rather than leaving it as etymology:
+
+> The definition of a chorus is "many people singing together." If you change the
+> words each time, you'll be the only one able to sing it the second and third
+> time. One person singing alone is called a soloist, not a chorus. If you change
+> the words to a refrain each time, it isn't a refrain, just additional material.
+
+This is why the fix for a stagnant chorus is always to develop the verses, never
+to rewrite the chorus first.
 
 Changing the repeat IS available as a last resort when a refrain proves
-color-resistant and cannot be neutralized — the chapter changes one to fit a
-tense before showing the better repair — but it costs the singalong, so
-neutralize first.
+color-resistant and cannot be neutralized. Chapter 9 does exactly that before
+showing the better repair — *He lost the human race* becomes *He'll lose the
+human race* to survive a future-tense verse:
+
+> Though this isn't the kiss of death, it would be preferable to avoid changing
+> the refrain if you can. Then everyone can sing along each time.
+
+It costs the singalong, so neutralize first.
 
 ## Productive ambiguity
 
@@ -148,6 +253,35 @@ Box 3: final / heaviest angle + repeated element
 The later boxes should contain the earlier boxes' weight plus new information.
 The final box should feel heaviest.
 
+Chapter 6 sketches the boxes in prose before any lyric exists, working from the
+title idea *I'd just like to know*:
+
+```text
+Box 1  "Hi, it's nice to see you. You're looking good, and you're looking
+       really happy. Are you? I hope you don't mind my asking.
+       I'd just like to know."
+       -> 'Sup     I'd just like to know
+
+Box 2  "When you left, did you already know you were moving in with him?
+       When I was out of town, did he come over to your place? Did you hide
+       that picture of us you kept on your dresser? I suppose it doesn't
+       matter now, but I'd just like to know."
+       -> D'ja cheat?     I'd just like to know
+
+Box 3  "For me, a relationship is all about honesty. I want to be able to say
+       everything to you, and for you to say everything to me. I don't want
+       any secrets, no matter what. You could have told me about him. I
+       wouldn't have tried to stop you. I'd just like to know."
+```
+
+Box 2 "combines the first box, the meeting, with some history." Box 3
+"combines or resolves all the information, and delivers the point of the song."
+The same five words carry a greeting, then an accusation, then a plea.
+
+> Now, it's simply a matter of actually writing the song, but writing it knowing
+> where you're going. You have an outline, a scaffold to hang your song on. You
+> can bang around inside each box without being afraid of getting lost.
+
 Ask:
 
 - What does box 1 teach the listener?
@@ -160,26 +294,80 @@ Ask:
 Box 3 is usually the song's **why** — why the speaker is saying any of this —
 which is what makes it the heaviest rather than merely the last.
 
-**A box is not always one section.** Chapter 6 analyzes a lyric whose boxes are
-each two verses plus a chorus. Count boxes by idea movement, not by section
-count: two verses that share one angle are one box, and diagnosing them as two
-hides the stagnation.
+**A box is not always one section.** Chapter 6 analyzes "Between Fathers and
+Sons" (John Jarvis and Gary Nicholson), whose boxes are each *two* verses plus a
+chorus — verses one and two plus chorus one are box 1; verses three and four
+plus chorus two are box 2. Count boxes by idea movement, not by section count:
+two verses that share one angle are one box, and diagnosing them as two hides
+the stagnation.
+
+The lyric holds two perspectives — a son looking at his father, and the son as
+father — but spends both inside box 1 (*My father had so much to tell me* …,
+then *Now when I look at my own son*). So box 2 has nowhere new to go. Pat on
+verse four:
+
+> Oops. I know I've been here before. It's verse two with *I* changed to *you*.
+> No need to try to universalize verse four with *you*. The idea was already
+> universal. The second chorus is a goner.
+
+> The power of this lovely chorus is diminished rather than enlarged the second
+> time around, and we leave the song less interested than we were in the middle.
+> Both boxes are the same size.
+
+His repair splits the two perspectives across the two boxes. Box 1 keeps only
+the son looking at his father, and its second verse becomes (in prose):
+
+```text
+I kept him at arm's length.
+I didn't want him interfering with my life.
+He kept trying, but I wouldn't let him.
+That's how it always has been between fathers and sons
+```
+
+That frees box 2 to "look from the other side of the river" — *Now when I look
+at my own son* moves down into it, and the father's perspective colors chorus
+two. Same chorus text both times; two different colors.
+
+> Here is a simple principle for division of labor: Put separate ideas in
+> separate boxes.
 
 ### Test one chorus line at a time
 
 The chapter's sharpest box-weight test works on a single line rather than the
-whole chorus: take one line and write what it means after each verse. In its
-worked example, an image that merely observes in box 1 becomes a witness in box
-2 and a prophet in box 3 — the same words, three sizes.
+whole chorus: take one line and write what it means after each verse. Pat runs
+it on *the hot July moon saw everything*, from "Strawberry Wine" (Matraca Berg
+and Gary Harrison):
+
+```text
+Box 1: The hot July moon saw us down by the river having our first experience.
+
+Box 2: The hot July moon knew that our love, like so many before
+       ("well-beaten path"), wouldn't last.
+
+Box 3: The hot July moon knew that, over time, we'd become unable to experience
+       the innocence and power of first love — accumulated experiences would
+       create too much awareness — "the fields have grown over now."
+```
+
+> The moon grows from an observer to a prophet and predictor of the future. It
+> becomes a bigger and bigger moon, needing bigger and bigger boxes.
 
 Run it on the line carrying the most weight. If that line means the same thing
 after every verse, the boxes are not growing whatever the summaries suggest.
 
+Pat's reading of why the title itself carries the song: "Who drinks strawberry
+wine? Kids. Strawberry wine has both the taste of soda pop (childhood) and the
+danger of alcohol (adulthood). Besides which, it's cheap. It's the perfect
+vehicle for a song about coming of age."
+
 **Every chorus line carries this obligation.** The chapter states it as a
-drafting constraint, not just a diagnostic: when writing a chorus, each line
-must be *able* to gain weight. A line too specific or too closed to mean more
-later is a line that will flatten the repeat no matter how well the verses
-develop.
+drafting constraint, not just a diagnostic:
+
+> When you write a chorus, each line you include has the same responsibility: to
+> be able to gain weight.
+
+A line too specific or too closed to mean more later is a line that will flatten
+the repeat no matter how well the verses develop.
 
 ## Stagnant repetition
 
@@ -204,11 +392,68 @@ is explicit that stagnant boxes are the same size at best, and more likely lose
 weight, because boredom amplifies across repeats. A second chorus that merely
 repeats does not land neutrally; it lands weaker than the first.
 
-**Polished language cannot fix it.** The chapter demonstrates the failure in
-deliberately bland prose summaries, then fixes it while leaving the language
-just as bland — because development is what changed. Strong imagery on stagnant
-boxes only decorates the problem. This is the diagnostic order: check whether
-the verse summaries move before touching a single word of the lines.
+**Polished language cannot fix it.** Chapter 6's demonstration is a sheriff
+song, written as bare prose summaries on purpose. Stagnant:
+
+```text
+Verse 1. The sheriff is the toughest man in town.
+Verse 2. He is very strong and has a fast gun.
+Verse 3. Everyone in town knows the sheriff is tough. They are afraid of him.
+```
+
+> The ideas don't move much. These verses say pretty much the same thing in
+> different words. Obviously, you'd probably have written it in more interesting
+> language, using sense-bound images and metaphors, but no matter how you
+> polished the language, it would only disguise the fact that something
+> important is missing: development.
+
+Developed — and note the language is still bland:
+
+```text
+Verse 1. The sheriff is the toughest man in town.
+Verse 2. He is obsessed with a beautiful woman.
+Verse 3. She is married to the weakest man in town.
+```
+
+> The language is still bland and imageless. Yet now we want to know what
+> happens next. We had no such curiosity about the first sequence.
+
+Now attach a refrain and the effect on the repeat becomes visible. Stagnant
+version:
+
+```text
+Box 1  The sheriff is the toughest man in town.
+       Beware, beware. All hands beware.
+Box 2  He is very strong and has a fast gun.
+       Beware, beware. All hands beware.
+Box 3  Everyone in town knows the sheriff is tough. They are afraid of him.
+       Beware, beware. All hands beware.
+```
+
+Developed version — same refrain, unchanged:
+
+```text
+Box 1  The sheriff is the toughest man in town.
+       Beware, beware. All hands beware.
+Box 2  He is obsessed with a beautiful woman.
+       Beware, beware. All hands beware.
+Box 3  She is married to the weakest man in town.
+       Beware, beware. All hands beware.
+```
+
+> When a refrain (or chorus) attaches to verses that mean the same thing, the
+> result is boredom. When it attaches to verses that develop the idea, it gains
+> weight and impact. It dances.
+
+Strong imagery on stagnant boxes only decorates the problem. This is the
+diagnostic order: check whether the verse summaries move before touching a
+single word of the lines. Pat's own summary of the remedy: "you fix a stagnant
+chorus or refrain by doing the same thing you do if you have only verses — you
+develop the idea."
+
+> Don't waste your verses. Don't let them sit idle waiting for the hook to come
+> around and rescue them. Too often, there won't be anyone around to witness the
+> rescue.
 
 The one-sentence summary test is the fastest form of this. If the verse
 summaries are interchangeable, the song has a development problem no rewrite of
@@ -239,19 +484,30 @@ Where did I get here from?
 The verse first written may belong in the middle or end. Try moving boxes
 around before assuming the song must continue forward from the first draft.
 
-Chapter 6's framing: just because you wrote a verse first does not make it the
-first verse — give yourself two chances at every stuck point.
+Chapter 6's framing, twice stated:
 
-**The stronger move is upstream of the stuck point.** The chapter names thinking
-in boxes from the moment an idea arrives as by far the best remedy for
-second-verse hell. Reordering is the rescue; planning the boxes is the
-prevention. When a writer arrives with an idea and no verses yet, sketch the box
+> Just because you wrote a verse first doesn't mean it's your first verse. Give
+> yourself two chances. Don't just ask "Where do I go next?" Try asking "What
+> happened before this?"
+
+> Instead of asking "Where do I go now?" it may help to ask "Where did I get
+> here from?" Get used to juggling and trying new things.
+
+**The stronger move is upstream of the stuck point.**
+
+> Thinking about boxes from the outset, the minute an idea comes, is by far the
+> best remedy for "second-verse hell" (songwriters' term for "Where do I go
+> next?").
+
+Reordering is the rescue; planning the boxes is the prevention. When a writer arrives with an idea and no verses yet, sketch the box
 summaries before drafting — that is the intervention, and it is unavailable once
 the verses exist.
 
-Six questions are the chapter's named tool for filling a box that will not
-open: who, what, where, when, why, how — with `when` and `where` singled out as
-the most productive.
+Six questions are the chapter's named tool for filling a box that will not open:
+
+> And don't be afraid to call your six best friends — who, what, where, when,
+> why, and how — to ask them for specific suggestions. They're always helpful,
+> especially *when* and *where*.
 
 ## Chorus and refrain weight
 
@@ -286,19 +542,61 @@ Use this when:
 - the final chorus becomes stronger because the weak middle chorus is gone.
 
 This is a formal risk, but Chapter 6 treats it as a valid toolbox move — and
-records it as a real-world one: a well-known recording drops its second chorus
-and goes straight to the bridge, an unusual move in commercial music, after the
-writers found the conventional layout made the song feel too long. "Too long" is
-the audible symptom of a sagging box.
+records it as a real-world one. The lyric is "Unanswered Prayers" (Pat Alger,
+Garth Brooks, and Larry B. Bastian). Verses one and two set up the situation (a
+man runs into his old high school flame at a hometown football game while his
+wife is standing there), and the chorus lands:
 
-The chapter names a second gain beyond removing the sag: keeping the bridge
-gives the music room to breathe when verse lines are long and the tempo is slow.
-The cut buys contrast and interest at once.
+```text
+Sometimes I thank God for unanswered prayers
+Remember when you're talkin' to the man upstairs
+That just because he doesn't answer doesn't mean he don't care
+Some of God's greatest gifts are unanswered prayers
+```
 
-**Diagnose the sag before cutting.** The alternative repair is to give the weak
-verse the missing information — in that same example, reintroducing a character
-the listener had forgotten lets a two-verse layout work with both choruses
-landing, no cut required. Cutting a chorus and developing the verse are two
+Verse three (*She wasn't quite the angel that I remembered in my dreams* …)
+elaborates rather than develops. Pat's verdict:
+
+> Is there anything gained? Not much. The boxes are roughly the same size. …
+> In short, the second chorus is destined to die an ignominious death right
+> there in front of everybody.
+
+The bridge then reintroduces the wife (*And as she walked away I looked at my
+wife / And then and there I thanked the good Lord for the gifts in my life*) and
+the third chorus works again — "I had forgotten about the wife. … The wife
+becomes God's greatest gift. A lovely payoff."
+
+The recorded solution cuts the sagging middle chorus and goes straight from
+verse three into the bridge. Pat quotes co-writer Pat Alger on why: the
+conventional verse / verse / chorus / verse / chorus / bridge / chorus layout
+made the song "feel too long." Pat's gloss — "Another way of saying the song
+sagged, and listeners would lose interest." "Too long" is the audible symptom of
+a sagging box.
+
+> They left out the second chorus and went immediately to the bridge — an
+> unusual formal move, especially in commercial music. But it works; both
+> choruses shine, and we stay interested in the song all the way through.
+
+The chapter names a second gain beyond removing the sag:
+
+> Keeping the bridge gives the music a chance to breathe, since the verse lines
+> are long and the tempo is slow. Creating a contrasting section helps the
+> overall flow of the song. The formal risk pays off, creating interest and
+> contrast at the same time. Put this move in your toolbox.
+
+**Diagnose the sag before cutting.** Pat's alternative repair for the same song
+is to develop verse three instead — reintroduce the wife there and skip the
+bridge entirely:
+
+```text
+She wasn't quite the angel that I remembered in my dreams
+And I could tell that time had changed me in her eyes too it seemed
+As she turned and walked away I looked at my wife
+And recognized the gift I'd been given in my life
+```
+
+That yields "a simple three verse, two chorus layout with both choruses doing
+their work" — no cut required. Cutting a chorus and developing the verse are two
 answers to one diagnosis; run the box-weight test first and decide which the
 song needs.
 
@@ -308,7 +606,29 @@ Repetition also works at the line level. Look for smaller pieces inside a line
 that can be isolated and repeated to create a new question, command, emphasis,
 or emotional turn.
 
+> Think of it as hunting for hidden treasures. Learn to start looking at
+> sentences not just for meaning, but for little pieces of meaning that can be
+> isolated and repeated, giving additional information or emphasis.
+
 The key is that the repeated fragment must add meaning, not merely echo sound.
+Pat allows sound as one reason to repeat something — "Maybe the words just feel
+good in your mouth," his example being *Peaceful, easy feeling* — but the
+productive kind is the kind that gains:
+
+> The words we repeat stay interesting when we say them again. They gain
+> something more when we repeat them, even gain something more *because* we
+> repeat them.
+
+His three examples of productive repetition at section scale:
+
+- **"Strawberry Wine"** — the second chorus outweighs the first because verse two
+  adds a fleeting summer romance to verse one's picture of love on the riverbank.
+- **"Still Crazy After All These Years"** — the second refrain adds cynicism and
+  denial to verse one's encounter with an old lover. "We learn more about what
+  kind of crazy he is, and how deep it runs."
+- **Suzanne Vega's "Luka" and Joni Mitchell's "Roses Blue"** — both end by
+  repeating the *first verse*. "We know Luka's plight, though we didn't
+  understand it the first time."
 
 ## Hidden questions
 
@@ -317,7 +637,7 @@ Interrogative lines can hide smaller questions:
 ```text
 Who do you love? Do you love?
 Where did you go? Did you go?
-How will I know? Will I know?
+When will I know? Will I know?
 ```
 
 The repeated fragment changes the energy. The first question asks for an
@@ -332,19 +652,27 @@ Use this with:
 
 ## Hidden commands
 
-Declarative second-person lines can hide commands:
+Declarative second-person lines can hide commands. Pat's demonstration, stripped
+one layer at a time:
 
 ```text
-You tell me the truth.
-Tell me the truth.
-Truth.
+You tell me that you want me.
+Tell me that you want me.
+Want me.
+```
+
+And his second:
+
+```text
+You give me everything I need.
+Give me everything I need.
 ```
 
 A question can also hide a command:
 
 ```text
-Will you stay?
-Stay.
+Will you love me?
+Love me.
 ```
 
 This works best in first or second person with present-tense or infinitive
@@ -368,13 +696,27 @@ When reviewing a draft:
 
 Exercise 11 - Three refrains, increasing weight:
 
-- Write three verses.
-- End each verse with the same refrain line.
-- Give each verse/refrain system a distinct job.
-- Move from one image-world or story stage to a heavier one.
-- Use research, object writing, and metaphor to make the repeated refrain gain
-  weight.
-- Make the third box the heaviest.
+- Write three verses, each ending with the line **`ashes, ashes, all fall down`**
+  (a refrain, because it is part of the verse rather than a separate section) —
+  a three-system song, verse / refrain / verse / refrain / verse / refrain.
+- Pat supplies the first two boxes and leaves the third open:
+
+```text
+Box 1  As a child, he sang in a circle with his playmates.
+Box 2  He volunteered to serve his country in the Great War. In the trenches,
+       he suffered from shell shock and battle fatigue.
+Box 3  ?
+```
+
+- His research prompt: look for World War I and trench-life images and words that
+  work for both childhood and the war. Then object-write from your own sense
+  pool.
+- His metaphor prompt: see each found idea as a metaphor for other parts of the
+  lyric. *Falling down* goes well beyond the childhood game — childhood dreams
+  can fall, so can innocence, and so can bombs, rockets, and soldiers.
+- His hint for box 3: "He certainly could tumble like a child whenever a door
+  slams."
+- Give each verse/refrain system a distinct job. Make the third box the heaviest.
 
 Exercise 13 - Neutralize repetition:
 
@@ -408,18 +750,44 @@ exclusive job — no two verses share the same angle.
 
 ### You-I-We formula
 
-Each verse takes a different relational POV:
+Pat's setup is a verse summary with nowhere to go — "It's difficult to see where
+to go next. It feels like everything's been covered":
+
+```text
+You are really wonderful
+And I've been looking for someone just like you
+We should be together
+
+Love Love Love
+Love Love Love
+```
+
+The three perspectives are already sitting inside it, stacked in one box. Split
+them out and the boxes gain weight:
 
 - **You** — verse focuses on the other person; their action, presence, absence
 - **I** — verse focuses on the speaker; the speaker's response, state
 - **We** — verse focuses on the shared frame; what we are, were, could be
 
 Any reordering: I → You → We, We → I → You, You → I → We. The formula is
-the distribution, not the order.
+the distribution, not the order. See [box-model](box-model.md) for Pat's own
+(deliberately absurd) three-box illustration.
 
 ### Past-Present-Future formula
 
-Each verse takes a different tense:
+Same move, different axis. Pat's starting summary:
+
+```text
+We were so good together
+But now everything's falling apart
+What's going to happen to us?
+
+Love Love Love
+Love Love Love
+```
+
+> This idea contains three tenses: past, present, and future. Try separating
+> them into separate boxes.
 
 - **Past** — what happened (the seed event)
 - **Present** — what is now (current state)
@@ -427,6 +795,10 @@ Each verse takes a different tense:
 
 Reverse-chronology orderings are strong plays — Future → Present → Past
 makes the listener reconstruct backwards.
+
+Note the diagnostic hiding in both cases: the stuck verse *already contained*
+all three boxes. The formula did not invent material; it unpacked material the
+writer had crammed into box 1.
 
 ### Combining the formulas
 
@@ -437,15 +809,22 @@ song's full emotional arc.
 ### Formulas are tools, and they cut both ways
 
 Chapter 6 attaches its own warning to both formulas, in the same paragraph that
-introduces them: sometimes one is exactly what a song needs, and other times a
-formula takes the freshness out of the writing. Be aware of the techniques;
-beware of letting them become a habit.
+introduces them:
+
+> Sometimes one or the other will be just what you need; other times, like any
+> formula, they could take the freshness out of your writing. Be aware of these
+> techniques, just beware of letting them become a habit in your writing.
 
 Two consequences for how these get applied:
 
-- **Do not reach for a formula first.** The chapter's own preferred case is an
-  idea that carries the DNA of its own development, or a plot that does the
-  development work — the formulas are the repair when an idea does not.
+- **Do not reach for a formula first.** Pat: "It's better when you find an idea
+  that contains the DNA of its own development, or when plot does the
+  development work." His example of the latter is Gillian Welch's "One More
+  Dollar," where each verse (leaving home for orchard work, then no work and a
+  losing night at the dice table, then begging on the street) "moves the story
+  forward, making chances of getting home more and more remote." The refrain
+  *One more dollar and I'm going home* is unchanged and means something worse
+  each time. No formula needed — the plot did it.
 - **Name the formula as a candidate, not a prescription.** Proposing You-I-We
   because the boxes are stagnant is the tool working. Proposing it because a
   song has three verses is the habit the chapter warns against.
@@ -490,10 +869,24 @@ and across the subjunctive modals `can` / `could` / `should` / `would`:
 | Who would you love? | Would you love? |
 
 The deletion creates a fragment the listener hears as both repetition AND new
-content. Chapter 6's worked instance is a declarative that hides a question:
-a line ending in "can you win" becomes the question `Can you win?` simply by
-isolating and repeating that fragment, turning a statement of the terms into
-the character's uncertainty about whether the terms can be met.
+content. Chapter 6's real-world instance is Joni Mitchell's "Roses Blue," where
+a declarative hides a question:
+
+```text
+In sorrow she can lure you where she wants you
+Inside your own self-pity there you swim
+In sinking down to drown her voice still haunts you
+And only with your laughter can you win
+Can you win? Can you win?
+```
+
+> By simply isolating and repeating a portion of the line, *can you win*, she
+> moves from a declarative sentence into a question, creating new energy and
+> adding a new idea — in this case, the character's uncertainty whether winning
+> (laughter) is possible.
+
+Nothing was added. The statement of the terms became a doubt about whether the
+terms can be met.
 
 ### Hidden commands — subject deletion
 
@@ -502,15 +895,26 @@ the subject:
 
 | Original (declarative) | Hidden command (subject deleted) | Effect |
 |---|---|---|
-| You tell me. | Tell me. | Imperative emerges |
-| You want me. | Want me. | Imperative + emotional appeal |
-| You hold me. | Hold me. | Imperative + intimacy |
+| You tell me that you want me. | Tell me that you want me. | Imperative emerges |
+| Tell me that you want me. | Want me. | Second pass; strips to the appeal |
+| You give me everything I need. | Give me everything I need. | Imperative emerges |
+
+> Just delete the subject, isolating the verb, and presto, you have yourself a
+> command.
 
 Note: **third-person cannot generate commands** because English third-
-person verbs take an -s ("he/she tells"). Deleting the subject there yields
-only simple repetition — `She tells me` reduces to `Tells me`, which is a
-fragment, not an imperative. The technique needs the bare verb base, which
-first and second person supply and third person does not.
+person verbs take an -s. Pat's counterexample, run through the same two passes:
+
+```text
+She tells me that she wants me.
+Tells me that she wants me.
+Wants me.
+```
+
+> You create only simple repetition — no command is isolated.
+
+The technique needs the bare verb base, which first and second person supply and
+third person does not.
 
 A second-person question hides a command the same way: `Will you love me?`
 reduces to `Love me.`

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-dictionary-practice.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-dictionary-practice.md
@@ -17,6 +17,7 @@ the available sounds so they create the right tension, resolution, tone, and
 prosodic fit.
 
 > "Rhyme is a connection between the sounds of syllables, not words."
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 1
 
 The future skill should not coach a writer to wait for rhymes to arrive from
 inspiration. It should coach them to build a useful sound inventory, then make
@@ -24,28 +25,72 @@ artistic choices from that inventory.
 
 ## Syllables, not printed words
 
-Rhyme happens at the level of syllables. In a pair like `underwear/repair`, the
-rhyming material is the final syllable sound. Earlier syllables do not count
-unless they are part of the intended rhyming unit.
+Rhyme happens at the level of syllables. Pat's opening example:
 
-Perfect rhyme still needs three conditions:
+```text
+underwear / repair
+```
 
-- Same vowel sound in the rhyming syllables.
-- Same consonant sounds after the vowels, if any.
-- Different beginnings before the shared sound.
+Only the last syllables rhyme. The other syllables —
 
-The third condition is load-bearing. Different beginnings create tension; the
-matching vowel and ending consonants resolve it. If the beginnings are the same,
-the ear hears repetition or identity instead of rhyme.
+```text
+under / re
+```
+
+— "don't figure in at all."
+
+Perfect rhyme needs three conditions, and Pat demonstrates all three on the
+same pair:
+
+1. **The syllables' vowel sounds are identical.** `wear/pair` — different
+   letters, same sound. "Only your ears count, not your eyes."
+2. **The consonant sounds after the vowels (if any) are identical.**
+   `wear/pair` again. Note the same letters `ea` make different sounds in
+   `wear` and `ear`. The "(if any)" matters because syllables don't always end
+   in consonants: `disagree/referee`.
+3. **The syllables begin differently.** `wear/pair`.
+
+The third condition is load-bearing. It shows rhyme working by "the basic
+musical principle of tension/resolution: difference moving into sameness."
+The differing beginnings are what let the ear notice the identical sounds that
+follow.
 
 Coach move: when a user proposes a rhyme, ask what the rhyming syllable is
 before judging the full word pair.
 
 ## Identity check
 
-Identity repeats too much of the syllable. It may repeat the whole word, the
-same opening plus ending, or a visible spelling that does not create new
-movement for the ear.
+When syllables begin the same way, they don't tell the ear to notice sound.
+Pat calls this an **identity**:
+
+```text
+fuse / confuse
+```
+
+His analogy is the cheerleader's yell:
+
+```text
+go! go! go! go! go!
+```
+
+You pay attention to the repetition, not to the sounds of the syllables. "No
+one in the stadium thinks, 'Hey, those syllables sound the same!'" No tension,
+so no resolution.
+
+The same words can go either way depending on how you pair them. These are
+identities:
+
+```text
+peace / piece      lease / police
+```
+
+These are rhymes:
+
+```text
+peace / lease      piece / police
+```
+
+And the two-list test:
 
 ```text
 identity family:
@@ -55,8 +100,9 @@ rhyming family:
 ace / brace / chase / erase / face / disgrace / resting place
 ```
 
-The second family works because the beginnings change and the shared ending
-arrives as resolution. The first family repeats the same core unit.
+Say them aloud. Your ear doesn't focus on the sounds in the first list, but
+it's "drawn like a magnet" to the sounds in the second. The first list is
+simple repetition; the second is tension/resolution.
 
 Identity is not always wrong. It is wrong when the writer expects it to create
 the energy of rhyme. It is useful when the intended effect is insistence,
@@ -64,26 +110,34 @@ chanting, fixation, or deliberately static repetition.
 
 ## Masculine rhyme
 
-Masculine rhymes are one-syllable rhymes or longer words whose rhyming syllable
-is stressed at the end.
+Every rhyme is either masculine or feminine — "Never to both." Masculine
+rhymes are one-syllable words, or words that end on a stressed syllable:
 
 ```text
 command / land / understand / expand / strand
-appreciate / fate / relate
 ```
 
 Classify by the rhyming stress, not by the number of printed syllables in the
 word. `appreciate` can be treated as a masculine rhyme when the writer only
-uses the final stressed sound.
+uses the final stressed sound:
 
-Secondary final stress can also carry a masculine option:
+```text
+appreciate / fate / relate
+```
+
+Better still, use **secondary stress** — a syllable that is not the word's
+primary stress but is stronger than the syllables around it. Pat marks it
+`//` (single `/` marks primary stress) and tells you to listen for pitch: in
+`ap–pre–ci–ate`, "you can tell by the pitch of the last syllable that it is
+stronger than the syllable before it."
 
 ```text
 appreciate / navigate / compensate
 ```
 
-In this use, the final syllable carries enough stress to make the rhyme act
-masculine.
+Because its second-last syllable is unstressed, `appreciate` cannot be treated
+as a feminine rhyme. All feminine rhymes have a stressed second-last syllable,
+or at minimum a second-last syllable stronger than the last.
 
 ## Feminine rhyme
 
@@ -95,8 +149,17 @@ resolution; the unstressed endings usually continue the resolution.
 commanding / landing / understanding / expanding / stranding
 ```
 
-The unstressed endings may be identities without spoiling the rhyme because the
-main rhyming work is happening on the stressed syllables before them.
+Isolate the stressed syllables and you can see they are all perfect rhymes:
+
+```text
+mánd-ing / lánd-ing / stánd-ing / pánd-ing / stránd-ing
+```
+
+"Stressed syllables, whether in feminine rhymes or masculine rhymes, are the
+creators of rhyme's tension and resolution." The unstressed syllables at the
+end are all identities, "which is normal for feminine rhyme. These identities
+only continue the resolution." They are usually identities, but they don't
+have to be — which is the door mosaic rhyme walks through.
 
 Skill behavior: when checking a feminine rhyme, isolate the second-to-last
 stressed syllables first. Then check whether the unstressed tail supports the
@@ -105,11 +168,17 @@ tone rather than asking it to carry the rhyme.
 ## Mosaic rhyme
 
 Mosaic rhyme builds a rhyme out of syllables that come from more than one word.
+Pat introduces it right here, as the case where a feminine rhyme's unstressed
+tail is *not* an identity:
 
 ```text
 commander / understand her
 expand me / strand thee
 ```
+
+> "Call these pairs above mosaic rhymes, since they are put together with
+> syllables of different words, like stained glass pieces in a church window."
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 1
 
 Mosaic rhymes are useful because they expand the available choices beyond
 single dictionary headwords. They also raise the risk of cleverness becoming
@@ -124,46 +193,104 @@ when the emotional target needs plainness.
 A long word can sometimes be treated in two ways:
 
 - As a one-syllable masculine rhyme on the final stressed sound.
-- As a multi-syllable or mosaic phrase that matches more of the word.
+- As a three-syllable rhyme, usually built as a mosaic.
 
-For example, `appreciate` may rhyme on its final sound, or it may invite a
-longer phrase-level match. Pattison treats the longer comic acrobatics as
-available but specialized; they tend to call attention to themselves.
+Pat's worked pair for `appreciate`:
+
+```text
+1. masculine:        appreciate / fate / relate
+                     appreciate / navigate / compensate  (secondary stress)
+
+2. three-syllable:   ap-pre-ci-ate / the quiche he ate
+```
+
+Note the classification: these three-syllable rhymes are *still masculine*,
+since their last syllable is more stressed than the one before it. On the
+comic acrobatics, Pat is blunt: "The somersaults you have to turn for these
+little gems are worth it only if you are writing comedy. They sure do dance."
 
 Skill behavior: before proposing a multi-syllable rhyme, ask whether the song
 can afford the wit. If the tone is intimate, prefer less conspicuous choices.
 
 ## Rhyming dictionary workflow
 
-Use a rhyming dictionary or equivalent sound index. Do not treat it as cheating.
-The inefficient alternative is often just a slower artificial process: mentally
-running the alphabet.
+Use a rhyming dictionary. Pat is unsentimental about writers who treat it as
+cheating: "This is one place where self-reliance and rugged individualism are
+silly. Finding rhymes is almost never a creative act. It's a purely mechanical
+search."
 
-The workflow:
+His source is *The Complete Rhyming Dictionary*, edited by Clement Wood (Dell,
+1992), which he calls "the best rhyming dictionary around." It divides rhymes
+into three sections — masculine (I), feminine (II), three-syllable (III) — is
+organized phonetically by vowel sound, italicizes archaic words, and carries a
+vowel index at the bottom of every page. Its one gap: "Nothing can keep up with
+current slang. But you can write those in."
 
-- Decide whether the target is masculine, feminine, or a longer phrase-level
-  rhyme.
-- Identify the vowel sound of the stressed rhyming syllable.
-- For masculine rhymes, find the section for that vowel sound and ending
-  consonant.
-- For feminine rhymes, find the section for the stressed syllable plus the
-  unstressed tail pattern.
+To find a rhyme, ask two questions:
+
+1. Is the word I want to rhyme masculine or feminine? That routes you to
+   section I or section II.
+2. What is the vowel sound of the stressed syllable of the word I want to
+   rhyme? The page-bottom vowel index names the sound with a familiar word and
+   gives a phonetic marking.
+
+<!-- phonetic vowel markings trip the spell-checker --><!-- spellchecker:off -->
+
+**Worked lookup 1 — masculine.** Look up `attack`. It is masculine: `attáck`,
+so section I. The vowel sound of the stressed syllable `tack` is the short `ă`
+as in "add." The dictionary lists rhyme columns by vowel sound and, within
+that, alphabetically by ending consonant, so `attack` sits under the header
+`ĂK` — every masculine word ending in short `ă` + `k`.
+
+**Worked lookup 2 — feminine.** Look up `hóllow`. Section II. The vowel of the
+stressed syllable `hol` is the short `ŏ` as in "ŏdd," so look in the feminine
+section under vowel `Ŏ`, then alphabetically for `ŎL + o` (stressed syllables
+in CAPS, unstressed in lowercase). You find `hollow` plus `Apollo`, `swallow`,
+`wallow`, among others.
+
+<!-- spellchecker:on -->
+
+Then extend past what print can hold:
+
 - Add current slang, proper nouns, domain terms, and user-specific vocabulary
   that printed dictionaries will miss.
 - Generate more candidates than needed, then choose by sense, tone, stress,
   freshness, and prosody.
 
-The key distinction: anyone can find a rhyme; not everyone can use rhyme
-creatively. A large candidate set increases creative room.
+The key distinction, in Pat's words: "Anyone can find a rhyme; not everyone can
+use rhyme creatively." A large candidate set increases creative room.
+
+Practical note: you will be slow at first. "Like anything else, you will get
+better with practice."
 
 ## Alphabet-search failure
 
-Mental alphabet search is weak in two predictable ways:
+Pat's demonstration: clench your jaw, assume your best self-reliant posture,
+and come up with rhymes for `attack`. The typical result:
 
-- It misses consonant clusters and complex starts: `black`, `crack`, `shack`,
-  `slack`, `smack`, `snack`, `stack`, `track`, `whack`.
-- It misses multisyllabic words ending in the target sound: `almanac`,
-  `bareback`, `cardiac`, `egomaniac`, `haystack`, `kleptomaniac`.
+```text
+back    quack
+hack    rack
+jack    sack
+lack    tack (oops! Identity.)
+mack    wack
+knack   zach
+pack
+```
+
+The `tack` slip is the point of the exercise — the alphabet process does not
+even run the identity check.
+
+Mentally running the alphabet misses in two predictable areas:
+
+1. **It misses words that begin with more than one consonant:** `black`,
+   `brac`, `clack`, `crack`, `plaque`, `shack`, `slack`, `smack`, `snack`,
+   `stack`, `thwack`, `track`, `whack`.
+2. **It misses multisyllable words ending on the rhyme sound:** `aback`,
+   `almanac`, `bareback`, `bivouac`, `blackjack`, `cardiac`, `egomaniac`,
+   `haystack`, `kleptomaniac`...
+
+"If you're going to use an artificial process, at least use an efficient one!"
 
 When a user is stuck, do not only mutate the first consonant. Search for:
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -396,31 +396,126 @@ Two conditions make closure deceptive:
 - The system raises a specific expectation.
 - The actual resolving sound already exists in the structure.
 
+Even when the system is lengthened by an acceleration, the expectation survives
+— after `fool / slow / school / nitwit / sit ...` you still expect `low`. That
+leaves two possible deceptions, and both are deceptive:
+
 ```text
-unexpected closure, closed then extra attention:
-blood   a
-flood   a
-crash   b
-bash    b
-mash    b
+fool    a        fool    a
+slow    b        slow    b
+school  a        school  a
+nitwit  c        nitwit  c
+sit     c        sit     c
+rule    a        spit    c
 ```
 
+Contrast these, which are NOT deceptive — they are simply OPEN, because in the
+place you expect the closure they use a sound the system has not used yet:
+
+```text
+fool    a        fool    a
+slow    b        school  a
+school  a        sow     b
+rise    c        slip    c
+```
+
+A resolution is UNEXPECTED in either of two cases.
+
+**Case 1 — expectations were already satisfied, then the last sound repeats:**
+
+```text
+blood  a        blood  a
+flood  a        crash  b
+crash  b        flood  a
+bash   b        bash   b
+mash   b        mash   b
+```
+
+**Case 2 — the system sets up no clear expectation before the resolution:**
+
+```text
+fool      a
+slow      b
+rise      c
+surprise  c
+```
+
+This closure comes out of nowhere; it is a real surprise. Pat notes Shakespeare
+is fond of it for getting out of an unrhymed blank-verse passage — the closing
+couplet of Emilia's speech in *Othello* IV.iii lands exactly this way. Put
+important or surprising ideas where the structure surprises and the ideas work
+with the structure to create prosody.
+
 Ambiguity is useful. Patterns like `aaa` or `ababa` can look backward as
-identity/repetition or forward as an open odd-count system. Decide by the lyric
-function, not the letters alone.
+identity/repetition or forward as an open odd-count system. Pat's own
+illustration of the difference:
+
+```text
+You're breaking me in two     a
+Why can't I have you?         a
+Why can't I have you?         a
+```
+
+Here we are clearly looking backward — a clear case of Identity, so the system
+really has only two phrases, and it is closed. But:
+
+```text
+You're breaking me in two     a
+Why can't you be true?        a
+Why can't I have you?         a
+```
+
+now the odd number of phrases comes into play and you notice the need for
+another phrase. Repetition of rhymes `aaa` plays against balance and leaves the
+closure ambiguous. Both `aaa` and the longer `ababa` seem more OPEN than CLOSED,
+and both are good ways to leave a listener in a little cloud of mystery. Decide
+by the lyric function, not the letters alone.
 
 ## Exercises to preserve
 
-Chapter 4's exercises are part of the method:
+Chapter 4 runs Exercises 18-28. Full wording and content live in
+[exercises](exercises.md); the three labeling drills print their answer keys on
+the page, and those keys are the fastest way to check a reading of the theory:
 
-- Generate perfect rhymes for partial syllables before worrying about meaning.
-- Classify masculine/feminine rhymes by stressed-syllable position.
-- Notate schemes with `a`, `b`, `x`, and identity markers.
-- Balance, accelerate, or decelerate lists by adding/subtracting words.
-- Label schemes through-written/fragmented and open/closed; then write lines
-  whose phrase lengths and rhythms follow that rhyme behavior.
-- Write deceptive and unexpected closures deliberately, placing important ideas
-  in the surprise positions.
+**Ex 23 — mark each `T` for through-written or `F` for fragmented:**
+
+<!-- spellchecker:off -->
+```text
+ 1. abab   2. aabb   3. aaab   4. abba   5. aaa
+ 6. aaba   7. abbaa  8. abaa   9. abaab  10. ababa
+
+answers: 1. T; 2. F; 3. F; 4. T; 5. F; 6. F; 7. F; 8. T; 9. F; 10. F
+```
+
+**Ex 24 — mark each `C` for closed or `O` for open:**
+
+```text
+ 1. ababa  2. aabbb  3. aaabb  4. abcab  5. abcac
+ 6. abba   7. abbaa  8. abbabb 9. abccb  10. aab
+
+answers: 1. C; 2. C; 3. O; 4. O; 5. C; 6. O; 7. either; 8. C; 9. C; 10. O
+```
+
+**Ex 25 — mark each `E` expected, `U` unexpected, or `D` deceptive:**
+
+```text
+ 1. ababb  2. abaa   3. aabba  4. aaba   5. abaaa
+ 6. abacca 7. abaccb 8. abaab  9. aaa    10. abcaaa
+
+answers: 1. U; 2. D; 3. U; 4. D; 5. D; 6. U & D; 7. E; 8. D; 9. U & D; 10. D
+```
+<!-- spellchecker:on -->
+
+Note Ex 24 #6: `abba` is marked **open**, which is the second independent
+confirmation that it is not a balanced pattern.
+
+The remaining exercises: generate perfect rhymes for nonsense syllables before
+worrying about meaning (18); mark masculine vs feminine (19); notate schemes
+with `a`, `b`, `x` and `I` for identity (20); balance lists by adding or
+subtracting words (21); accelerate then decelerate the same lists (22); write a
+deceptive closure using Paradigm Three for its rhythm, then an unexpected one
+(26); reverse the flow of Pat's two worked sections (27); and work from rhyme
+scheme to plot (28).
 
 ## Revision moves
 
@@ -511,7 +606,42 @@ This stance contradicts the default "pick a scheme and commit" coaching.
 Pat's framing: pick a scheme that matches the emotional shape, even if the
 scheme is itself ambiguous.
 
-### Two structural-ambiguity examples (no lyric text reproduced)
+### Two structural-ambiguity examples
+
+Both poems Pat teaches from here are public domain. The couplet-flow passage he
+quotes from Marvell:
+
+```text
+Had we but world enough and time
+This coyness, lady, were no crime ...
+An hundred years should go to praise
+Thine eyes, and on thy forehead gaze;
+Two hundred to adore each breast,
+And thirty thousand to the rest; ...
+But at my back I always hear
+Time's winged chariot hurrying near ...
+```
+
+Marvell's lines are 8-syllable, 4-stress (tetrameter) couplets. Each rhymed
+couplet works as a little unit of thought, almost like a paragraph — equal line
+lengths create balanced couplets, but it is rhyme that applies the brakes.
+
+The contrasting through-written passage, the last six lines of "Ozymandias":
+
+```text
+... And on the pedestal these words appear:     a
+"My name is Ozymandias, king of kings:          b
+Look on my works, ye Mighty, and despair!"      a  (imperfect rhyme)
+Nothing beside remains. Round the decay         c
+Of that colossal wreck, boundless and bare      a
+The lone and level sands stretch far away.      c
+```
+
+"Kings" rhymes with "things" three lines earlier; "appear" is an imperfect
+rhyme — technically a Consonance Rhyme — with "despair" and "bare." Had line
+four used either "things" or "bare," the six-line system would have FRAGMENTED
+and gained an internal point of closure. Instead a new sound at line four keeps
+it moving, so the system is THROUGH-WRITTEN.
 
 - **Marvell, "To His Coy Mistress" — couplet flow** (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4). Marvell
   uses couplet rhyme (`aabb`) to fragment forward motion: each couplet

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -4,6 +4,35 @@ Pat Pattison — *Songwriting: Essential Guide to Lyric Form and Structure*
 (1991), Chapter 4. Extended by *Pat Pattison's Songwriting: Essential
 Guide to Rhyming* (2014), Chapters 1-2.
 
+## Image inventory
+
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 4: **40 linked
+page-scan figures, 40 unique**, read at 3x upscale. Earlier revisions of this
+file carried no inventory line at all. The chapter argues in its scans — the
+six balance paradigms, every through-written/fragmented pair, all three closure
+types, and the printed answer keys to its exercises exist only as images. The
+`abba` correction below came from a figure and from an exercise key, neither of
+which is in the text layer.
+
+## The five structural areas
+
+The chapter's organizing claim is that rhyme controls **five** areas of
+structure, and it treats them as one set rather than five topics:
+
+| # | Area | Values |
+|---|---|---|
+| I | Balance | symmetrical / asymmetrical |
+| II | Pace | constant / accelerating / decelerating |
+| III | Flow | through-written / fragmented |
+| IV | Closure | closed / open |
+| V | Type of closure | expected / deceptive / unexpected |
+
+These are the same five properties as the Structural Pentad in
+[meter](meter.md), measured against the rhyme scheme instead of the stress
+pattern. The preceding chapter introduces the Pentad on rhythmic structure;
+this chapter applies all five to rhyme structure. Diagnose a section once with
+the Pentad and read both surfaces off it — do not run two separate frameworks.
+
 ## Anchor stance — sonic roadmap
 
 > "Songs are made for ears, not eyes."
@@ -57,9 +86,11 @@ rhyme:     ace / brace / chase / erase
 identity:  place / replace / misplace
 ```
 
-Pat's "go! go! go!" cheerleader analogy (*Essential Guide to Rhyming*
-(2014), Chapter 1, paraphrased ≤25w): three "go"s in a row are not three
-rhymes — they are one word said three times. Identity is repetition,
+Pat's cheerleader analogy (*Essential Guide to Lyric Form and Structure*
+(1991), Chapter 4 and again in *Essential Guide to Rhyming* (2014),
+Chapter 1, paraphrased ≤25w): a crowd chanting one syllable over and over
+is not hearing rhymes — it is hearing one word repeated. Nobody in the
+stadium notices that the syllables sound alike. Identity is repetition,
 period.
 
 Identity can be useful when deliberate repetition is the effect, but do
@@ -113,7 +144,7 @@ by syllable count and structure:
 | Shape | Definition | Example |
 |---|---|---|
 | Masculine | rhyme falls on a single stressed syllable at line end | `time / rhyme` |
-| Feminine | rhyme spans a stressed syllable + one or more unstressed syllables | `lonely / only`-as-identity, `dreary / weary`, `going / showing` |
+| Feminine | rhyme spans a stressed syllable + one or more unstressed syllables | `only / lonely`, `dreary / weary`, `going / showing` |
 | Mosaic | rhyme is formed across multiple words on one or both sides | `Texas / wrecks us`, `silence / find us` |
 
 Mosaic is covered in depth in [mosaic-rhyme.md](mosaic-rhyme.md) — the
@@ -163,6 +194,13 @@ idea / Maria
 liver / give her
 ```
 
+Only the stressed syllable must rhyme. `only / lonely` is a feminine **rhyme**,
+not an identity — the stressed syllables differ before the vowel (nothing
+against `l`), which is exactly what condition 3 asks for. Its unstressed tail
+happens to be identical, and the chapter permits that: the tail may rhyme or
+may be an identity without changing the classification. Do not read a matching
+tail as disqualifying.
+
 Feminine rhyme can soften, extend, or comic-heighten a section because the
 resolution includes an unstressed tail. Later rhyme files expand this into a
 larger stability scale.
@@ -203,16 +241,25 @@ The third line repeats the first sound, so the ear expects the second sound to
 return. `dive` can balance the order; `live/dive` after `alive` alone does not
 create the same balanced series because the original order has not returned.
 
-Useful balanced patterns include:
+Pat prints six paradigms of BALANCE. All six deliver the same two things —
+repetition of sound and repetition of order:
 
 ```text
-abab
-aabb
-abba
-abcabc
+abab      xaxa      aa      aabb      abcabc      xxaxxa
 ```
 
+**`abba` is not among them, and is not a balanced pattern.** An earlier
+revision of this list included it. The chapter uses `abba` as the explicit
+counterexample: an opening `abb` is *not* balanced by adding a fourth line
+that returns to `a`. It is balanced by repeating the whole series —
+`abbabb` — or by answering it with a fresh pair, `abbacc`. The chapter's
+printed exercise key independently marks `abba` **open**, and a balanced
+system is by definition closed.
+
 Sometimes repeating the series matters more than merely repeating one sound.
+That is why `abbacc` balances `abb` even though `cc` introduces a sound the
+section has never heard: the *order* has completed even where the sound has
+not returned.
 
 ## Rhyme and pace
 
@@ -264,6 +311,18 @@ b
 b
 ```
 
+These two are not free-standing rhyme facts — the chapter names them as the
+rhyme-side twins of the rhythm Paradigms from the preceding chapter. `abab` is
+the simplest through-written system *"like rhythm Paradigm One"*; `aabb` is the
+simplest fragmented system *"like rhythm Paradigm Two"*. See
+[meter](meter.md) for the Paradigms themselves. The pairing is the point: a
+writer who has already chosen a rhythmic paradigm has half-chosen the rhyme
+flow that matches it.
+
+`aab` fragments for the same reason `aabb` does — the `a` pair bonds and rests
+before anything else happens. Whether a further sound follows makes no
+difference; the balancing has already occurred.
+
 Consecutive rhymes often fragment a system, but context matters. Consecutive
 rhymes that arrive after a stronger structural pressure can act as delay rather
 than a new fragment.
@@ -271,7 +330,15 @@ than a new fragment.
 Worked example: Pattison contrasts Marvell's rhymed couplets with the final
 six lines of Shelley's "Ozymandias." Couplets stop in little thought units. The
 six-line Shelley passage keeps moving because a new sound where closure could
-have happened prevents internal fragmentation.
+have happened prevents internal fragmentation. Had the fourth line reached back
+to either sound already in play, the passage would have fragmented; a fresh
+sound there is what keeps it through-written to the end.
+
+Worth recording for the rhyme-type files: the chapter names one of those
+Shelley end-sounds an imperfect rhyme and glosses it **"a Consonance Rhyme."**
+The full stability scale is developed in *Essential Guide to Rhyming* (2014),
+Chapters 4-6 and belongs there — but consonance is already named in 1991, so
+the 2014 scale extends this vocabulary rather than introducing it.
 
 ## Open and closed systems
 
@@ -379,9 +446,16 @@ A fully resolved (perfect) rhyme needs three conditions:
 2. Same consonant sound after the vowel.
 3. Different consonant sound before the vowel.
 
-Identity matches conditions 1 and 2 and **also** matches 3 — same
-opening consonant. Identities sound like repeats. Mark them `I` in
+Identity matches conditions 1 and 2 but **fails** condition 3 — the
+consonant before the vowel is the *same*, not different. That single
+failure is what makes it identity rather than rhyme: with no difference
+to resolve, there is no tension, so the ear hears a repeat instead of a
+connection. Identities sound like repeats. Mark them `I` in
 scheme notation, not as a rhyme letter.
+
+The failure is the whole test. An earlier revision of this file said
+identity "also matches 3," which inverts the one condition that
+distinguishes the two and would pass every identity as a rhyme.
 
 Use identity only when deliberate repetition serves the song.
 Otherwise filter at the worksheet stage.

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -88,10 +88,9 @@ identity:  place / replace / misplace
 
 Pat's cheerleader analogy (*Essential Guide to Lyric Form and Structure*
 (1991), Chapter 4 and again in *Essential Guide to Rhyming* (2014),
-Chapter 1, paraphrased ≤25w): a crowd chanting one syllable over and over
-is not hearing rhymes — it is hearing one word repeated. Nobody in the
-stadium notices that the syllables sound alike. Identity is repetition,
-period.
+Chapter 1, paraphrased ≤25w): a crowd chanting one syllable hears only
+repetition. Nobody in the stadium notices the syllables sound alike.
+Identity is repetition, period.
 
 Identity can be useful when deliberate repetition is the effect, but do
 not mistake it for rhyme. If the syllables start the same way, the ear
@@ -327,12 +326,11 @@ Consecutive rhymes often fragment a system, but context matters. Consecutive
 rhymes that arrive after a stronger structural pressure can act as delay rather
 than a new fragment.
 
-Worked example: Pattison contrasts Marvell's rhymed couplets with the final
-six lines of Shelley's "Ozymandias." Couplets stop in little thought units. The
-six-line Shelley passage keeps moving because a new sound where closure could
-have happened prevents internal fragmentation. Had the fourth line reached back
-to either sound already in play, the passage would have fragmented; a fresh
-sound there is what keeps it through-written to the end.
+Worked example: Pattison contrasts Marvell's rhymed couplets, which stop in
+little thought units, with the final six lines of Shelley's "Ozymandias," which
+keep moving. **Both passages are quoted in full under
+[Two structural-ambiguity examples](#two-structural-ambiguity-examples)** —
+read them there rather than duplicating the analysis here.
 
 Worth recording for the rhyme-type files: the chapter names one of those
 Shelley end-sounds an imperfect rhyme and glosses it **"a Consonance Rhyme."**
@@ -647,12 +645,12 @@ four used either "things" or "bare," the six-line system would have FRAGMENTED
 and gained an internal point of closure. Instead a new sound at line four keeps
 it moving, so the system is THROUGH-WRITTEN.
 
-- **Marvell, "To His Coy Mistress" — couplet flow** (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4). Marvell
-  uses couplet rhyme (`aabb`) to fragment forward motion: each couplet
-  closes a unit, then the next couplet starts a new one. The flow is
-  controlled by rhyme — the couplet creates a stop between idea-units
-  even when the syntax could run on. Use this when a writer wants
-  rhyme-controlled fragmentation rather than enjambed flow.
+The two examples the chapter builds on:
+
+- **Marvell, "To His Coy Mistress" — couplet flow**, quoted above. Use it when
+  a writer wants rhyme-controlled fragmentation rather than enjambed flow: the
+  couplet stops between idea-units even when the syntax could run on. Shelley,
+  also above, is the contrast case — the same device withheld.
 - **Shakespeare, *Othello* Act IV — unexpected closure** (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4).
   Shakespeare's blank verse establishes an expectation of no rhyme.
   When a closing couplet arrives without prior rhyme buildup, the

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -484,8 +484,12 @@ the page, and those keys are the fastest way to check a reading of the theory:
  1. abab   2. aabb   3. aaab   4. abba   5. aaa
  6. aaba   7. abbaa  8. abaa   9. abaab  10. ababa
 
-answers: 1. T; 2. F; 3. F; 4. T; 5. F; 6. F; 7. F; 8. T; 9. F; 10. F
+answers: 1. T; 2. F; 3. F; 4. T; 5. F; 6. F; 7. T; 8. T; 9. F; 10. F
 ```
+
+Item 7 (`abbaa`) is **T**, and the chapter says why: consecutive rhymes do not
+fragment when they follow something that creates a stronger effect — here, an
+odd number of phrases.
 
 **Ex 24 — mark each `C` for closed or `O` for open:**
 
@@ -502,7 +506,7 @@ answers: 1. C; 2. C; 3. O; 4. O; 5. C; 6. O; 7. either; 8. C; 9. C; 10. O
  1. ababb  2. abaa   3. aabba  4. aaba   5. abaaa
  6. abacca 7. abaccb 8. abaab  9. aaa    10. abcaaa
 
-answers: 1. U; 2. D; 3. U; 4. D; 5. D; 6. U & D; 7. E; 8. D; 9. U & D; 10. D
+answers: 1. U; 2. D; 3. U; 4. D; 5. D & U; 6. D; 7. E; 8. D & U; 9. U; 10. D
 ```
 <!-- spellchecker:on -->
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-generation.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-generation.md
@@ -11,7 +11,8 @@ discipline and trust intuition.
 
 ## Source
 
-Synthesized across Books 1 Chapter 4 (rhyme structure), 4 Chapters 1-9 (rhyme types,
+Synthesized across *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 4 (rhyme structure), *Essential Guide to Rhyming* (2014), Chapters 1-9 (rhyme types,
 phonetic families, worksheets, sonic bonding), and `rhyme-types.md` +
 `rhyme-strategy.md` + `rhyme-worksheets.md` + `rhyme-fundamentals.md`.
 
@@ -163,7 +164,8 @@ include words from that world (proper nouns, brand names, regional terms,
 era-specific objects) — not just dictionary entries. The world's vocabulary
 is the writer's primary rhyme inventory.
 
-This is why object-writing the world first (Books 2 Chapter 1, 3 Challenge 1) is
+This is why object-writing the world first (*Writing Better Lyrics* (2009),
+Chapter 1; *Songwriting Without Boundaries* (2011), Challenge 1) is
 prerequisite for rhyme work: object-writing generates the world's
 vocabulary, which becomes the worksheet input.
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-sonic-bonding.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-sonic-bonding.md
@@ -29,7 +29,24 @@ Sonic bonding is the craft of choosing words for sound as well as meaning,
 rhythm, and structure. The point is not decoration. Sound can connect ideas,
 smooth motion, create contrast, force a pause, or make a line more singable.
 
-> The effect is what counts.
+> "As a writer, you are constantly in the business of making choices —
+> sometimes for meaning, other times for rhythm or sound. Or maybe for
+> structure." — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 8
+
+The chapter's purpose is ear training: "to choose for reasons rather than
+relying on flipping the proverbial instinct coin." Pat's own roadmap for it:
+
+1. internal rhyme
+2. assonance
+3. alliteration
+4. voice leading and prosody
+5. juncture
+
+On the terminology arguments the chapter invites — internal rhyme or
+assonance? rhyme or voice leading? — Pat's ruling:
+
+> "The effect is what counts." — Pat Pattison,
+> *Essential Guide to Rhyming* (2014), Chapter 8
 
 Skill behavior: when a user asks why a lyric line feels flat, awkward, too
 smooth, too choppy, or less singable than it should, inspect sound connections
@@ -37,17 +54,62 @@ inside the line before changing the idea.
 
 ## Internal rhyme
 
-Internal rhyme means rhyme placed inside a line or inside neighboring lines
-rather than only at phrase endings. It can be symmetrical or asymmetrical:
+Internal rhyme means exactly what it says: rhymes occurring inside a line.
+Often they are placed symmetrically, midline and end line, creating a kind of
+acceleration — Pat's example is the familiar limerick form:
 
-- Symmetrical internal rhyme: the related sounds occupy parallel rhythmic
-  positions, creating a more orderly and often accelerating feel.
-- Asymmetrical internal rhyme: the related sounds appear in different rhythmic
-  positions, creating an off-balance or more conversational feel.
+```text
+There once was a student named Esser
+Whose knowledge grew lesser and lesser
+It at last grew so small he knew nothing at all
+So now he's a college professor
+```
 
-Internal rhyme is usually local. Unlike end rhyme, it does not have to be
-matched in the corresponding place of the next verse or chorus. Let it create
-texture in the moment, then move on.
+You can also place internal rhymes inside *different* lines, symmetrically (in
+parallel rhythmic positions) or asymmetrically:
+
+```text
+The yard is gone, the weeds need mowin'
+The paint is stripped from hard winds blowin'
+And storms have ripped shingles from the roof…
+```
+
+`stripped/ripped` is symmetrical — consecutive lines, same rhythmic position.
+`yard/hard` is asymmetrical, "creating a more off-balance feel. Of course, the
+house is a bit off-balance here." The asymmetry is prosody, not sloppiness.
+
+Eliot's *The Love Song of J. Alfred Prufrock*, where `hair/dare/wear` and
+`heard/mer` are also asymmetrically placed:
+
+```text
+Shall I part my hair behind? Do I dare to eat a peach?
+I shall wear white flannel trousers, and walk upon the beach.
+I have heard the mermaids singing, each to each.
+```
+
+"Call it sonic fabric, created by placing rhymes internally. Great stuff."
+
+More Eliot — from *The Waste Land*:
+
+```text
+Oil and tar
+Barges sweat
+```
+
+And again from *Prufrock*:
+
+```text
+Let us go, through certain half-deserted streets,
+The muttering retreats…
+
+And when I am formulated, sprawling on a pin,
+When I am pinned and wriggling on the wall,
+Then how should I begin
+```
+
+Internal rhyme is usually local. "It does not affect phrase structure and,
+unlike end rhymes, does not need to be matched in parallel song sections. Just
+put it in your section, let it do its work, then forget about it."
 
 Use internal rhyme when:
 
@@ -56,16 +118,59 @@ Use internal rhyme when:
 - a transition needs sonic continuity,
 - a phrase wants pressure, speed, or play.
 
-Avoid over-reading every sound as rhyme. Some repeated sound is not structural
-rhyme at all; it is voice leading.
-
 ## Voice leading
 
-Voice leading is Pattison's musical analogy for smooth movement from one sound
-to the next. In lyric writing, it means choosing vowels and consonants so that
-the mouth, tongue, and ear move with intention.
+Avoid over-reading every sound as rhyme. Pat's test case for where rhyme stops
+and voice leading starts is a lyric he calls "this piece of sonic cotton
+candy":
 
-Use voice leading to ask:
+```text
+Dance with me my Daisy
+Easy lazy days
+Wintertime will soon be ending
+Hillsides rolling green and plenty
+Summertime has come and gone
+But she won't stay away
+Slip in softly
+Catch me napping
+Spin your magic, let it happen
+Open up and make me smile these lazy days away
+```
+
+"There is so much sound connection in this example that it is hard to know
+where to stop calling things rhymes." The clear internal rhymes:
+
+```text
+Daisy / lazy        happen / Open (feminine consonance) / up an'
+```
+
+But these are a different animal:
+
+```text
+Easy / lazy         Slip / in         lazy / days / away
+```
+
+"You could call them internal rhymes, but they do not seem to have a rhyming
+purpose. Instead, they seem to be there to make the phrases flow smoothly."
+That effect is **voice leading** — and you can create it with vowels
+(assonance) or consonants (alliteration).
+
+Voice leading is Pattison's musical analogy, and he gives it a literal musical
+definition:
+
+> "…where each note moves smoothly to the next, keeping common notes and moving
+> the noncommon tones as few steps as possible."
+
+His worked chord move: going from a C triad (C E G) to an F triad, since the F
+triad contains a C, you keep C under your finger, then move the E the shortest
+distance possible to F and the G to A — voicing the F triad as C F A.
+
+That maps onto the three assonance types directly. Simple and hidden assonance
+are the *retained* note (the C you keep). Family assonance is the *moved* note
+(E→F, G→A) — a change, but the smallest one available.
+
+In lyric writing it means choosing vowels and consonants so that the mouth,
+tongue, and ear move with intention. Use it to ask:
 
 - Does this sound glide smoothly into the next sound?
 - Does the line need legato motion or a staccato stop?
@@ -80,24 +185,62 @@ texture, and singability without creating a new rhyme scheme.
 
 ## Assonance as voice leading
 
-Assonance repeats or relates vowel sounds. It connects ideas sonically and can
-make a line smoother and more legato.
+Assonance "connects ideas (the whole point of sonic repetition) using vowel
+sounds as the connective tissue."
 
 Distinguish two uses:
 
-- Assonance rhyme: vowel connection at phrase endings. It affects lyric
-  structure and belongs with the remote rhyme types in
-  [rhyme types](rhyme-types.md).
-- Assonance voice leading: vowel connection inside a phrase. It helps the words
-  flow but does not create new structure.
+- **Assonance rhyme:** vowel connection at phrase endings. Only the vowel
+  sounds connect; the trailing consonants belong to different phonetic
+  families. It affects lyric structure and belongs with the remote rhyme types
+  in [rhyme types](rhyme-types.md). Pat's examples:
 
-When coaching, do not argue terminology too long. Ask what the sound is doing:
-closure, motion, smoothness, contrast, or emphasis.
+  ```text
+  tide / life     float / loan     family / lasting     pub / slums
+  ```
+
+- **Assonance voice leading:** vowel connection inside a phrase — "a connection
+  between words rather than phrases." It helps the words flow but does not
+  create new structure and does not create acceleration. Pat's example is the
+  tail of the cotton-candy lyric above:
+
+  ```text
+  these lazy days away
+  ```
+
+When coaching, do not argue terminology too long: "Whether you want to call
+something assonance or internal rhyme makes little difference... The effect is
+what counts."
 
 ## Simple assonance
 
-Simple assonance repeats the same vowel sound. It can happen in adjacent words,
-across a line with other sounds between, or across neighboring lines.
+Simple assonance is "the repetition of vowel sounds used to link ideas sonically
+as well as conceptually." Pat shows it happening at three ranges.
+
+In consecutive words:
+
+```text
+The long day wanes
+Where the sea meets the moon-blanched land,
+Begin and cease and then again begin
+```
+
+Within a line, separated by other sounds:
+
+```text
+Your shadow at morning striding behind you
+Or your shadow at evening rising to meet you;
+```
+
+Or between lines:
+
+```text
+Gleams and is gone; the cliffs of England stand,
+Glimmering and vast, out in the tranquil bay.
+```
+
+(Pat prints these three groups without attribution; the poets are named only
+where he names them.)
 
 Use it to:
 
@@ -131,17 +274,99 @@ Practical diphthong map:
 | `oi` as in `boy` | short `o` + long `e` |
 | `ou` as in `couch` | `ah` + long `u` |
 
-In singing, the hidden vowel may become more obvious because a singer often
-holds one component of the diphthong. Test this aloud; printed spelling is less
-important than the sung sound.
+Pat's demonstration. Take long `ā`, a combination of short `ĕ` and long `ē`. In
+the phrase:
 
-`L` and `r` can also hide vowel relationships because they reshape how ordinary
-vowels are heard. Examples to listen for:
+```text
+Play head games
+```
 
-- `ear`, `hear`, `cheer`, `beer`
-- `air`, `chair`, `rare`, `bare`
-- `door`, `floor`, `more`
-- `tour`, `sure`, `cure`
+you hear simple assonance between the long `a` of `play` and `games` — but
+under it runs a subtle voice leading of the short `ĕ` that populates all three
+words. Slow it down and listen:
+
+```text
+Ple ee   h e d   ge ee mes
+```
+
+Working the other component, the long `ē`:
+
+```text
+Play eenie meenie miney moe
+Ple ee eenie meenie miney moe
+```
+
+In singing, hidden assonance is usually *more* obvious, because the singer
+holds one component of the diphthong — and which one depends on the diphthong.
+In `play head games` the singer would usually hold the short `ĕ` rather than
+the long `ē`. Long `ī` holds the first component, the `ä` as in "papa." Long
+`ū` as in `few` holds the *second*, the `oo`, rather than the initial `ee`.
+
+Tennyson voice leading short `ŏ`, `ee`, and `oo` at once, from "Ulysses":
+
+```text
+The long day wanes, the slow moon climbs
+The deep moans round in many voices
+```
+
+1. **short `ŏ`** — `long` (`ŏ`), `slow` (`ŏ`+`ū`), `moans` (`ŏ`+`ū`), `voices`
+   (`ŏ`+`ū`).
+2. **`ee`** — `day` (`ĕ`+`ē`), `wanes` (`ĕ`+`ē`), `climbs` (`ä`+`ē`), `deep`
+   (`ē`).
+3. **`oo`** — `slow` (`ŏ`+`ū`), `moon` (`ū`), `moans` (`ŏ`+`ū`), `round` (`ū`).
+
+Pat's next example ("This one is pretty cool too"):
+
+```text
+Before my pen has gleaned my teeming brain
+```
+
+`pen` is short `ĕ`; `brain` is `ĕ`+`ē`. So on top of the simple assonance (even
+rhyme) of `gleaned/teeming` and the consonance rhyme of `pen/brain`, "you also
+get the knitting of the short `e` of `pen` picking up the initial short `e`
+sound of the diphthong in `brain`, as well as the long `ee`, the second vowel
+sound in the long `a`. Whew."
+
+Two more diphthongs behave the same way:
+
+```text
+Boil / roast          Father / grouch
+```
+
+Dryden, where `boil'd` and `morn` both contain the long `o` sound, and since
+long `o` contains short `o`, `lobster` completes the line:
+
+```text
+Like a lobster boil'd, the morn
+From black to red began to turn
+```
+
+Eliot:
+
+```text
+Under the brown fog of a winter dawn
+```
+
+`L` and `r` also hide vowel relationships because they reshape how ordinary
+vowels are heard. "The `r` sound demands some extreme jockeying of the tongue."
+Examples to listen for:
+
+- it affects long `e`: `ear`, `hear`, `cheer`, `beer`
+- it affects long `a`: `air`, `chair`, `rare`, `bare`
+- it affects long `o`: `door`, `floor`, `more`
+- it affects long `u`: `tour`, `sure`, `cure`
+
+In use:
+
+```text
+When here and now cease to matter     (both contain ee)
+
+The brisk swell
+Rippled both shores                   (both contain long o)
+```
+
+"Yup, lots of places for assonance to hide. Lots of opportunities to knit sonic
+fabrics together."
 
 Skill behavior: when a user wants a subtler connection than obvious assonance,
 look inside diphthongs and `l`/`r` colored vowels.
@@ -154,7 +379,23 @@ open vowel and whose two legs extend toward tongue-position (left) and
 lip-position (right) closure. Adjacency on either leg = family-assonance
 candidates (small mouth-position changes = smooth voice leading).
 
+Pat's own layout prints it as two columns flanking the apex — "Tongue Vowels"
+on the left, "Lip Vowels" on the right:
+
+<!-- phonetic vowel markings trip the spell-checker --><!-- spellchecker:off -->
+
+```text
+                ä (papa)
+        (cat) ă         ŭ (up)
+        (end) ĕ         ŏ (hot)
+         (me) ē         ū (too)
+         (it) ĭ         oo (foot)
+       Tongue Vowels   Lip Vowels
 ```
+
+Expanded to show the geometry:
+
+```text
                       ä   (apex — most open; "papa", "father")
                      / \
                     /   \
@@ -177,11 +418,20 @@ candidates (small mouth-position changes = smooth voice leading).
 canonical geometry: apex = ä, left leg = tongue raises progressively
 [ă → ĕ → ē → ĭ], right leg = lips round progressively [ŭ → ŏ → ū → oo].)
 
+<!-- spellchecker:on -->
+
+Pat's description of how the legs work: at the point is `ä` (as in "papa"),
+the most open sound — say "Ahh." From there, **lip vowels** move outward along
+the right leg; "you form each one in turn by rounding and closing your lips a
+little more. Your tongue stays out of the way." **Tongue vowels** move outward
+along the left leg; "you form each one in turn by raising your tongue a little
+higher toward the roof of your mouth. Your lips stay out of the way, but widen
+as your tongue gets higher."
+
 **The "Yeow!" articulation drill** (*Essential Guide to Rhyming* (2014),
-Chapter 8): say `Yeow!` slowly and feel the mouth move from extreme
-tongue position (`ē`) at the front of the sound, through the apex (`ä`),
-out to extreme lip position (`oo`). The full triangle is traversed in
-one syllable. The drill teaches what mouth changes accompany which vowel
+Chapter 8): say `Yeow!` — "It covers all the vowel positions, from extreme lip
+vowels to extreme tongue vowels." The full triangle is traversed in one
+syllable. The drill teaches what mouth changes accompany which vowel
 transitions — useful when picking family-assonance partners.
 
 ### Adjacency rules
@@ -219,8 +469,48 @@ sharing that pure vowel).
 
 ## Family assonance
 
-Family assonance uses nearby vowel positions on the triangle (per the
-geometry section above) rather than exact repeated vowels.
+Family assonance is "the third, and even more remote category" — nearby vowel
+positions on the triangle rather than exact repeated vowels. "Adjacent vowel
+sounds require minimal changes of position: step-by-step rounding of the lips
+for the lip vowels, and a step-by-step raising of the tongue for the tongue
+vowels." That is the voice-leading principle of moving as few steps as
+possible, applied to vowels.
+
+Pat's worked passage — the Eliot lines from earlier in the chapter — works
+`ah` (at the point of the triangle) plus the first two steps of the lip vowels,
+short `u` and short `o`:
+
+```text
+Under the brown fog of a winter dawn,
+A crowd flowed over London Bridge, so many,
+```
+
+**Line 1.** The short `u` of `under` moves into `ah` (the first sound in the
+diphthong of `brown`, `ah`+`oo`), then into the short `o` of `fog`. `brown` and
+`dawn` share the triangle's point, `ah`.
+
+**Line 2.** The diphthong in `crowd` (`ah`+`oo`) shares the `oo` with `flowed`
+and the `o` of `over`, while the initial `ah` is two steps from `flowed` and
+`over`'s initial short `o`. Then the double short `u` of `London` is a step
+away from both `ah` and short `o`.
+
+"The euphony created by the minimal steps, the voice leading to other vowel
+sounds, adds a level of musicality, a sense of formality, as though these
+lines, echoing Dante, are meant to be intoned."
+
+**Exercise 8.5. Isolating "Death."** Add the third line and explore its sonic
+fabric yourself:
+
+```text
+Under the brown fog of a winter dawn,
+A crowd flowed over London Bridge, so many,
+I had not thought death had undone so many.
+```
+
+"Notice how sonically isolated (and scary) `death` is." This is the other half
+of the tool: "When you have a choice between words, this principle of voice
+leading — taking small sonic steps (or large steps, as Eliot did with `death`)
+— could make the difference between a good line and a great one."
 
 Use family assonance when:
 
@@ -239,13 +529,51 @@ Coaching workflow:
    emphasis.
 
 This is another way to use a rhyme worksheet: not every worksheet word becomes
-an end rhyme. Some words belong inside phrases as sonic motion.
+an end rhyme. Some words belong inside phrases as sonic motion. "Work on two
+levels at once: you'll be mining ideas and sounds simultaneously."
 
 ## Alliteration
 
-Alliteration connects ideas through repeated consonant sounds. The ordinary
-version uses the same initial sound in adjacent or closely connected words, but
-Pattison extends the idea.
+Pat starts from the dictionary definition: "The occurrence of the same letter
+or sound at the beginning of adjacent or closely connected words." Thus:
+
+```text
+dark day's dance
+love him or leave him
+friendly fire
+```
+
+"Straightforward enough." Then he extends it through voice leading, so that
+repetition of consonant sounds counts not only at the beginnings of words but
+also inside them (**medial alliteration**) and at their ends (**terminal
+alliteration**).
+
+His demonstration line, from Eliot's finale to *Prufrock*:
+
+```text
+I have seen them riding seaward on the waves
+```
+
+Same line, three passes — note that only the first pass is initial
+alliteration:
+
+| Sound | Where it lands | Type |
+| --- | --- | --- |
+| `s` | **s**een, **s**eaward, wave**s** | initial, initial, terminal |
+| `w` | sea**w**ard, **w**aves | medial, initial |
+| `r` | **r**iding, seawa**r**d | initial, medial |
+
+Across the full passage the three sounds interlock:
+
+```text
+I have seen them riding seaward on the waves
+Combing the white hair of the waves blown back
+When the wind blows the water white and black
+```
+
+Pat's comment is just the voice-leading definition again: "…where each musical
+note transitions to the next in a smooth, harmonious way, moving as few notes
+as few steps as possible and thus often retaining common tones."
 
 Types to check:
 
@@ -258,6 +586,11 @@ Types to check:
 Initial alliteration is easy to hear. Medial and terminal alliteration often
 work more quietly, giving texture without sounding slogan-like.
 
+Note on the source text: Chapter 8 marks all of this by bolding or underlining
+individual letters inside the printed lines. Where this file lists the
+alliterating words in a table instead, that is a transcription convenience —
+the words and sounds are Pat's.
+
 ## Horizontal and vertical consonant families
 
 The horizontal families from [rhyme types](rhyme-types.md) group consonants by
@@ -265,23 +598,70 @@ the activity of the air column:
 
 | Family | Members |
 | --- | --- |
-| Plosives | `b`, `d`, `g`, `p`, `t`, `k` |
-| Fricatives | `v`, `TH`, `z`, `zh`, `j`, `f`, `th`, `s`, `sh`, `ch` |
-| Nasals | `m`, `n`, `ng` |
+| Plosives | `b`, `d`, `g` (voiced) / `p`, `t`, `k` (unvoiced) |
+| Fricatives | `v`, `TH`, `z`, `zh`, `j` (voiced) / `f`, `th`, `s`, `sh`, `ch` (unvoiced) |
+| Nasals | `m`, `n`, `ng` (all voiced) |
+
+Pat's approximation examples, one per family — the perfect rhyme first, then
+the family substitute that swaps in a related consonant after the vowel:
+
+```text
+plosives:    mud / blood   →  mud / rut
+fricatives:  love / above  →  love / enough,  love / grudge
+nasals:      strum / hum   →  strum / fun,    strum / rung
+```
 
 Those groups are useful for family rhyme. Chapter 8 adds vertical families for
-alliteration, based on tongue position:
+alliteration, based on **tongue position**. Pat's derivation is physical, not
+theoretical — say each nasal and notice what your tongue does. `M` closes the
+lips and flattens the tongue. `N` raises the tip of the tongue to the hard
+palate. `NG` (as in "sing") raises the middle of the tongue to the soft palate.
+Those three tongue positions are identical to the three vertical columns of the
+plosives, which you can prove by plugging your nose:
 
-| Family | Closer to more remote members |
-| --- | --- |
-| `M` | `b`, `p`, `v`, `f`, `w` |
-| `N` | `d`, `t`, `j`, `ch`, `l`, `z`, `s` |
-| `NG` | `g`, `k`, `x`, `y` |
+```text
+"My mama"     →  "By baba"       (M / b)
+"Not now"     →  "Dot dow"       (N / d)
+"Sing songs"  →  "Sig sogs"      (NG / g)
+```
+
+"The only difference is whether you allow the air to come out of your nose or
+not. Neat, huh?"
+
+The rest of each family is derived the same way:
+
+- `v` and `f` are labiodentals — lips and teeth, tongue flat. **M position.**
+- `w` in "Come willingly" nearly closes the lips with the tongue unmoved.
+  **M position**, initial only (in `slow` it neither closes nor sounds).
+- `j` is `d` + `zh`; `ch` is `t` + `sh`. Tongue touches the hard palate.
+  **N position.**
+- `z` and `s` raise the tip toward the hard palate. **N position** (Pat later
+  calls them "distant cousins" of `n`).
+- `l` in "Love letters" / "Never love" touches the hard palate just ahead of
+  the `N` position. **N.**
+- `x` is `k` + `s`; say "Xerxes sings" and feel the middle of the tongue rise
+  to the soft palate twice. **NG.**
+- `y` puts the tongue close to the soft palate. **NG**, initial only.
+
+The Table of Vertical Families, "organized from closer to more remote
+relationships as it descends":
+
+| `M` | `N` | `NG` |
+| --- | --- | --- |
+| `b` | `d` | `g` |
+| `p` | `t` | `k` |
+| `v` | `j` | `x` |
+| `f` | `ch` | `y` |
+| `w` | `l` | |
+| | `z` | |
+| | `s` | |
 
 Notes:
 
 - `w` and `y` count only in initial position.
-- `TH`, `th`, and `r` do not fit cleanly into the vertical families.
+- `TH` and `th` put the tongue on the top teeth — not close enough to the hard
+  palate for `N`, not flat enough for `M`. `R`, "the hardest consonant to
+  learn, belongs to none of the vertical families."
 - The lower entries in each vertical family are more remote.
 - The test is physical: say the line slowly and notice mouth and tongue
   position.
@@ -294,6 +674,50 @@ families for concealed alliteration and interior sonic bonding.
 Concealed alliteration uses related consonants from a vertical family rather
 than exact repeated consonants. It can link a line without making the sound
 device obvious.
+
+Pat's worked passage is Tennyson:
+
+```text
+The long day wanes: the slow moon climbs: the deep
+Moans round with many voices.
+```
+
+First the obvious relationships, which he lays out before the concealed layer:
+
+| Layer | What connects |
+| --- | --- |
+| assonance | long `a`: d**ay**, w**a**nes — long `o`: sl**ow**, M**o**ans, v**oi**ces |
+| climbing vowels | "the slow moon climbs" — the vowels open as the moon rises |
+| initial alliteration | day/deep, moon/moans/many |
+| `l` (internal) | **l**ong, s**l**ow, c**l**imbs |
+| `m` | **m**oon, cli**m**bs, **M**oans, **m**any |
+| `d` | **d**ay, **d**eep, roun**d** |
+| `n` | wa**n**es, moo**n**, Moa**n**s, rou**n**d, ma**n**y |
+
+Then the concealed layer. Read the two lines aloud very slowly and count how
+many times the tip of your tongue rises to touch the hard palate — that is
+every member of N's family (`d`, `t`, `j`, `ch`, `l`, `z`, `s`):
+
+- **Ten solid members** of N's family, not counting `s` and `z`.
+- Counting the distant cousins `s` and `z`, "the tip of the tongue rises toward
+  the hard palate **seventeen times in sixteen syllables**."
+
+"N's family helps create the wonderful sound and feeling in these lines, using
+concealed alliteration to create a kind of voice leading." And it does
+structural work too: the concealed alliteration links and supports the spondaic
+substitutions in the iambic pentameter —
+
+```text
+The lóng dáy wánes
+the slów móon clímbs
+déep / Móans róund
+```
+
+The M family (`b`, `p`, `v`, `f`, `w`) is running underneath at the same time:
+"plenty of action and connection created by the repeated m's and the piling on
+of `b` and `p`, aided by the more remote members of the family, `v` and `w`.
+The dance of the two families, M and N, combined with the several vowel
+connections, creates a musicality that's hard to deny or resist."
 
 Use concealed alliteration to:
 
@@ -312,30 +736,88 @@ Coaching workflow:
 5. Ask whether that pattern supports the image, emotion, or motion.
 6. If it is too dense, replace one word with a less related sound.
 
-Concealed alliteration can link ideas, but it can also separate them when the
-word boundary forces a pause. That makes it a prosody tool, not merely a
-texture tool.
+**Concealed alliteration can separate as well as link.** Pat's example is the
+enjambment in the same passage:
+
+```text
+Deep / moans
+```
+
+Speaking those syllables you have two choices: (1) keep the lips closed after
+the `p` of `deep`, pause, then vocalize the `m` of `moans`; or (2) finish the
+`p` by parting the lips and expelling air, then close again for the `m`.
+Because the syllables straddle the line break, (2) is the likely choice.
+"Either choice forces a pause between the two stressed syllables, creating
+prosody; the pause makes the moan of the deep feel even deeper."
+
+That makes it a prosody tool, not merely a texture tool.
 
 ## Juncture
 
-Juncture is how the end of one word moves into the beginning of the next. It can
-be smooth and legato, or rough and staccato.
+Juncture is "the way the end of one word moves into the beginning of the next
+word." Pat's entry point is the humblest fact in English grammar: we have two
+indefinite articles, `a` and `an`, purely to guarantee a smooth glide —
+`an orange`, `a pickle`. "The rule about English articles is there to make
+talking easier."
 
-Smooth juncture helps words glide:
+Juncture is either **rough (staccato)** or **smooth (legato)**. And in English
+it is accidental, "since so many English words end in consonants. (Unlike, say,
+Italian, where all words end in vowels.) In English, it pays to pay attention
+to juncture."
 
-- vowel into consonant,
-- consonant into vowel,
-- word ending and next beginning that do not collide.
+**The failure case.** Say this aloud to someone who cannot see it, and watch
+the puzzled expression:
 
-Rough juncture forces a stop:
+```text
+She can't take your rent.
+```
 
-- same or close consonants collide across a word boundary,
-- the singer must pause to keep the meaning clear,
-- the line creates staccato emphasis.
+Two juncture problems — `can't → take` and `your → rent` — because the ending
+consonants of `can't` and `your` are the same as the beginning consonants of
+`take` and `rent`. Move through the phrase smoothly and it comes out:
 
-Bad accidental juncture can make a line hard to understand. The singer may have
-to spend so much effort making the words clear that emotional nuance
-disappears.
+```text
+She can take your ent.
+```
+
+"The first part comes out the opposite of what it means. The second part turns
+into nonsense." To make the meaning clear you have to pause: `She can't
+(pause) take your (pause) rent.`
+
+Why this matters more in a lyric than in speech: "Songwriters write for eyeless
+ears that aren't able to see the words, so hearing is everything. Even if a
+singer has impeccable diction, he or she will probably spend so much energy
+just getting the words clear that emotional nuances will be gone."
+
+**Deliberate juncture as prosody.** Shelley's final line of "Ozymandias"
+(Pat spells it "Ozymandius"):
+
+```text
+The lone and level sands / stretch / far away
+```
+
+The terminal-and-initial `s` in `sands/stretch`, and the terminal-and-initial
+fricatives in `stretch/far`, force a pause — "a space between the words,
+lengthening the desert horizon, reinforcing the distance created by the
+spondee" (`strétch/fár`). Look closely at the doubled staccato juncture in
+`sands/stretch`: the plosives and fricatives form a retrograde pattern,
+`d s s t`, and since `d` and `t` are partners (voiced / unvoiced), the
+concealed alliteration forces an even stronger pause. There is no hope for
+"the mighty" in the poem's ironic line:
+
+```text
+Look on my works, ye Mighty, and despair!
+```
+
+Same mechanism as `the deep / Moans round`, there created by the concealed
+alliteration of `p` and `m`.
+
+Pat's third example is Robert Frost's two-line "The Span of Life" (he asks you
+to look it up rather than reprinting it): notice how much trouble the old dog
+has moving through the difficult junctures of the first line, e.g. `old/dog` —
+and how the puppy of the second line runs effortless circles, "each word moving
+smoothly into the next. Say it. Now say it keeping your teeth together. The
+legato junctures illustrate the puppy's former ease of motion."
 
 Useful deliberate juncture can:
 
@@ -351,9 +833,77 @@ meaning.
 
 ## Voice leading and prosody
 
-Prosody happens when sonic behavior supports meaning. Chapter 8's final point is that
-word choice can be driven by the sound effect the line needs, not only by
-dictionary meaning.
+Prosody happens when sonic behavior supports meaning. Chapter 8's final point
+is that word choice can be driven by the sound effect the line needs, not only
+by dictionary meaning — and Pat proves it by deliberately misquoting a poem.
+
+Here is Arnold's "Dover Beach" with one word changed:
+
+```text
+Listen! You hear the grating roar
+Of pebbles which the waves draw back, and fling
+At their return, up the high strand
+Begin, and end, and then again begin…
+```
+
+The last line's sounds are intricately linked. The nasals continue throughout,
+"like a bagpipe drone sound. They glue all the other sounds to a central
+texture and tone." Every stressed syllable ends in a nasal:
+
+```text
+Begin, and end, and then again begin
+```
+
+The `b` and `d` alliteration adds a subtler link suggesting a cycle, the `d`'s
+add concealed alliteration to the `n`'s, and the three middle vowels push the
+same way:
+
+```text
+Gin end then gain gin
+```
+
+"It gives you a feeling of continuous forward motion... like waves, it makes
+you want to keep starting over after you finish."
+
+**And that is exactly the problem.** "The meaning of the last line is that the
+waves' motion comes to a stop — a pause — before continuing on. But the sound
+does just the opposite! It keeps going without any pause at all!"
+
+Here is what Arnold actually wrote:
+
+```text
+Begin, and cease, and then again begin
+```
+
+"What a difference! It is the break in the voice leading that is expressive!"
+
+Pat then runs three synonym comparisons — the drill to preserve. Each pair
+means about the same thing; ask which works better and why:
+
+```text
+Begin, and end,   and then again begin
+Begin, and cease, and then again begin
+
+Begin, and cease, and then again begin
+Begin, and stop,  and then again begin
+
+Begin, and cease, and then again begin
+Begin, and pause, and then again begin
+```
+
+"Right. 'Cease' sounds like ocean waves against the beach!"
+
+The moral, and the reason this file exists: "Matthew Arnold probably didn't
+start by saying 'I want a word that sounds like the ocean and breaks my voice
+leading expressively.' But the selection process led him there. All you have to
+do is listen for prosody, then choose accordingly."
+
+> "Put yourself in situations where you have several alternatives, and,
+> provided that you understand how and why to pick, your writing will get
+> better." — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 8
+
+> "Reasons for choosing. Choosing for reasons." — Pat Pattison,
+> *Essential Guide to Rhyming* (2014), Chapter 8
 
 When comparing synonyms, ask:
 
@@ -364,30 +914,116 @@ When comparing synonyms, ask:
 - Which word makes the emotional action easier to hear?
 - Which word gives the best reason for choosing it?
 
-For example, a line about waves may need a word whose sound breaks the voice
-leading and then resumes, because the meaning is stop-and-start motion. A
-near-synonym that preserves flow may be conceptually correct but prosodically
-wrong.
-
 ## Exercises as coaching prompts
 
-Preserve Chapter 8 exercises as practice modes:
+Preserve Chapter 8's exercises as practice modes. The fill-in-the-blank lists
+look alike but are **not** interchangeable — the differences are the pedagogy,
+so keep them distinct. (The book has no Exercise 8.7.)
 
-- Exercise 8.1: Mark simple assonance relationships in a short passage.
-- Exercise 8.2: Fill blanks with words that create simple assonance with the
-  stressed syllable of the prompt word.
-- Exercise 8.3: Find hidden assonance inside supplied lines.
-- Exercise 8.4: Fill blanks using diphthongs, the rhyme dictionary, and the
-  vowel triangle to share hidden assonance.
-- Exercise 8.5: Identify how one isolated word breaks the surrounding sonic
-  fabric and why that matters emotionally.
-- Exercise 8.6: Fill blanks with words whose stressed vowel moves no more than
-  one step from the prompt vowel.
-- Exercise 8.8: Identify initial, medial, and terminal alliterations.
-- Exercise 8.9: Fill blanks with words that share concealed alliteration with
-  the stressed syllable of the prompt word.
-- Exercise 8.10: For each prompt, supply one word that creates staccato
-  juncture and one word that creates legato juncture.
+**Exercise 8.1. Assonance.** Mark the simple assonance relationships in:
+
+```text
+1. Under the brown fog of a winter dawn,
+   A crowd flowed over London Bridge, so many,
+   I had not thought death had undone so many.
+
+2. We have lingered in the chambers of the sea
+   By sea-girls wreathed with seaweed red and brown
+   Till human voices wake us, and we drown.
+```
+
+**Exercise 8.2. Simple Assonance Practice.** Using your rhyming dictionary,
+supply a word that creates simple assonance with the stressed syllable of the
+italicized word:
+
+```text
+1.  The tide is ______.
+2.  She came to a fitting ______.
+3.  Snow on the ______.
+4.  ______ the approaching dawn.
+5.  A seething ______.
+6.  Crying in the ______.
+7.  Running down the ______.
+8.  Another oil spill ______ the harbor.
+9.  Playing the ______.
+10. Hold on to your ______.
+```
+
+**Exercise 8.3. Find the Hidden Assonance.** In:
+
+```text
+1. Listen! you hear the grating roar
+   Of pebbles
+
+2. After the torchlight red on sweaty faces
+```
+
+For 2, Pat gives the answer: `light` and `faces` share the `ee`; `red` and
+`faces` share `ĕ`.
+
+**Exercise 8.4. Hidden Assonance.** The same ten prompts as 8.2, but now
+worked with the diphthong table, the rhyming dictionary, and the vowel triangle
+to find a word sharing *hidden* assonance.
+
+**Exercise 8.5. Isolating "Death."** Explore the sonic fabric of the third
+Eliot line and notice how sonically isolated — and scary — `death` is. (Worked
+in the family assonance section above.)
+
+**Exercise 8.6. Vowel Triangle Practice.** Supply a word whose stressed vowel
+moves **no more than one step** from the italicized word's. Items 1 and 3
+differ from 8.2:
+
+```text
+1.  The heart is a fast ______.
+2.  She came to a fitting ______.
+3.  Only a fool ______.
+4.  ______ the approaching dawn.
+5.  A seething ______.
+6.  Crying in the ______.
+7.  Running down the ______.
+8.  Another oil spill ______ the harbor.
+9.  Playing the ______.
+10. Hold on to your ______.
+```
+
+**Exercise 8.8. Alliteration Practice.** Identify the alliterations — initial,
+medial, and terminal:
+
+```text
+1. And the dead tree gives no shelter, the cricket no relief   (t, r, l)
+2. And the dry stone no sound of water                         (d, t, n, r)
+3. oil and tar / Barges sweat                                  (t, r, s)
+```
+
+**Exercise 8.9. Concealed Alliteration.** Supply a word sharing concealed
+alliteration with the stressed syllable of the italicized word. Note that
+item 5 is `singing` here, not `seething` as in 8.2/8.4/8.6 — Pat does not say
+why, so do not substitute one for the other:
+
+```text
+1.  The heart is a fast ______.
+2.  She came to a fitting ______.
+3.  Only a fool ______.
+4.  ______ the approaching dawn.
+5.  A singing ______.
+6.  Crying in the ______.
+7.  Running down the ______.
+8.  Another oil spill ______ the harbor.
+9.  Playing the ______.
+10. Hold on to your ______.
+```
+
+**Exercise 8.10. Staccato Juncture Practice.** Only five prompts, and each
+takes **two** answers — first a word creating a staccato juncture with the
+italicized word, then one creating a legato juncture:
+
+```text
+1. The heart is a lost ______.
+2. She's had enough ______.
+3. Only a fool ______.
+4. The approaching dawn ______.
+5. The evening star ______.
+```
 
 Skill prompt:
 
@@ -444,11 +1080,13 @@ map before drafting.
 
 ## Juncture — sound at word boundaries
 
-*Essential Guide to Rhyming* (2014), Chapter 8 lists juncture among the sonic-bonding tools but treats
-it lightly. Juncture is the way the ear hears the boundary between
-two adjacent words: whether they fuse, click, glide, or stop.
-
-Three juncture states:
+**Non-book framing.** Pat's own juncture taxonomy is the two-state one in the
+Juncture section above — rough (staccato) versus smooth (legato), given a full
+treatment in *Essential Guide to Rhyming* (2014), Chapter 8 with the
+`She can't take your rent`, "Ozymandias," and Frost demonstrations. The
+three-state table below is a linguistics import layered on top of Pat's two
+states for diction and genre work. It is **not** Pat's terminology and should
+not be attributed to him.
 
 | State | Mechanism | Sonic effect |
 |---|---|---|
@@ -481,11 +1119,19 @@ juncture.
 
 ## Sonic fabric — the section-wide texture
 
-Pat's seminar and column framing for sound choice as a section-wide
-texture rather than a line-level decoration.
+**Sonic fabric is Pat's own term**, used throughout Chapter 8 (and indexed to
+its first appearance there). He introduces it for interior rhyme placement:
 
-> "Create textures and sounds you can use to weave sonic fabric."
-> — Pat (seminar copy)
+> "Call it sonic fabric, created by placing rhymes internally. Great stuff."
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 8
+
+and returns to it for vowels — "Lots of opportunities to knit sonic fabrics
+together" — and again after the three assonance levels: "Together, they can
+help you knit a strong and euphonious sonic fabric."
+
+The section-wide diagnostic below extends that idea from the line to the
+section. The extension is this knowledge base's; the term and the weaving
+metaphor are Pat's.
 
 Sonic fabric:
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-spotlight-connection.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-spotlight-connection.md
@@ -14,36 +14,75 @@ Source images inspected for this chapter span: `image_4-page2.jpg`,
 
 ## Core idea
 
-Rhyme has a job description:
+The chapter is titled "Exchanging Business Cards." You have been introduced to
+rhyme; now find out what it does for a living. Its business card reads:
 
-- It spotlights ideas.
-- It connects ideas.
-- It creates motion.
+```text
+RHYME
 
-This file covers the first two jobs. Motion is covered in
+1. I spotlight ideas.
+2. I connect ideas.
+3. I create motion.
+```
+
+This file covers the first two jobs. Pat sends the third to a different book:
+motion is the subject of *Essential Guide to Lyric Form and Structure* (1991).
+In this knowledge base, motion is developed in
 [rhyme strategy](rhyme-strategy.md), especially rhyme spacing, pace, and
 closure.
 
 ## Rhyme positions are spotlight positions
 
-Most end rhymes happen at phrase endings. Phrase endings already matter because
-they are structural corners in the lyric. A rhymed phrase ending matters even
-more because several attention signals converge there:
+The rhyming positions are at the ends of phrases. Because they control
+structure, end-phrase positions are always important. When the ends of phrases
+rhyme, the position takes on extra importance. Pat's four reasons:
 
-- The grammar often pauses after the phrase, leaving silence around the word.
-- The musical phrase often rests or resolves at the same point.
-- Melody and harmony tell the listener that a structural event has happened.
-- The repeated sound makes the listener compare this word to an earlier or
-  later word.
+1. It is followed by a grammatical pause. This lets the lyric's idea "ring on"
+   during the silence.
+2. On the musical side of the song, there is usually a musical rest with the
+   phrase rest, creating an end to a melodic phrase as well.
+3. Since it is the end of a musical phrase, a melodic or harmonic signal
+   usually will tell you what to expect next. This special musical function
+   calls even more attention to the spot.
+4. When there is rhyme in the phrase-end position, it will sound like other
+   words, again focusing attention on the position.
+
+"You can see that the rhyme position at phrase-end attracts a lot of attention.
+It's a spotlight."
 
 Skill behavior: treat every rhymed line ending as a high-value display case.
 Ask whether the word in that position deserves the attention it receives.
 
 ## Important words belong in rhyme positions
 
-Rhyme words should help reveal the song's subject, emotional argument, story, or
-central metaphor. If the rhymed words alone give no clue what the lyric is
-about, the draft may be wasting its strongest positions.
+Pat's demonstration is two rhyme-word lists with the *same rhyme scheme*:
+
+```text
+1.  me     a        2.  crash    a
+    do     b            thud     b
+    be     a            mash     a
+    you    b            blood    b
+    know   c            drip     c
+    so     c            slip     c
+```
+
+"The first one is a real snore. The second spreads clouds of imagery. It
+suggests a story all by itself. Imagine what might happen if you had whole
+phrases."
+
+His worked example of spotlights doing the job is Erwin Drake's "It Was a Very
+Good Year," where "the rhymes carry the ideas almost by themselves":
+
+```text
+nights / lights / green / seventeen
+stair / hair / undone / twenty-one
+means / limousines / drive / thirty-five
+kegs / dregs / clear / year
+```
+
+Read only that list and you already have the song: four ages of a man's life,
+each with its women and its social altitude, told through the rhyme positions
+alone.
 
 Diagnostic:
 
@@ -53,16 +92,21 @@ Diagnostic:
 4. If the answer is "almost nothing," revise the rhyme positions before merely
    polishing the lines around them.
 
+Pat's own framing of the test: "If you can get a good idea of a lyric's meaning
+just from spotlight information, you are using your rhyming positions
+effectively."
+
 This does not mean every rhyme word must be a title, thesis, or dramatic
 reveal. It means rhyme positions should carry meaningful content rather than
 being filled by whatever word was easiest to rhyme.
 
 ## Empty rhymes
 
-Some words are so general that they rarely earn a spotlight by themselves:
+"Your worst enemies are empty rhymes and cliché rhymes." Pat's empty-rhyme
+list is the first column above:
 
 ```text
-me / you / do / be / know / so
+me / do / be / you / know / so
 ```
 
 They can work when the line, melody, or performance gives them a special
@@ -75,12 +119,13 @@ there only because they were available.
 
 ## Spotlight-word exercise
 
-Exercise pattern to preserve:
+**Exercise 2.1. Spotlight Words.** From your music collection, find two
+lyrics, one that uses spotlights effectively and one that does not. List the
+rhymes in two columns, one under each title, and compare.
 
-- Choose one lyric whose rhymes seem strong and one whose rhymes seem weak.
-- Make two columns, one under each title.
-- List only the rhyme words.
-- Compare whether the spotlight words reveal what each song is about.
+Pat's warning about doing this to your own work: "It is revealing (and too
+often depressing) to see how little attention you pay to the most powerful
+positions you have to work with."
 
 In skill use, this can become a rewrite prompt:
 
@@ -96,14 +141,40 @@ Replace two uncircled words before rewriting the full lines.
 Predictable rhyme pairs are not wrong because they are familiar. They are weak
 when the listener can complete the line before the writer does.
 
-Common targets such as `heart`, `fire`, `alone`, `eyes`, `cry`, and `true`
-carry heavy expectation. A first available rhyme for one of these targets often
-arrives with a pre-written emotional script.
+**Exercise 2.2. Cliché Rhymes.** Fill in the blanks. Don't use your rhyming
+dictionary — just grab the first rhyme you can think of:
 
-The exercise asks the writer to fill in familiar blanks without a dictionary,
-then use the dictionary to beat those first answers. Preserve the principle:
-the first rhyme that arrives is often the cultural reflex, not the best craft
-choice.
+```text
+hand ____     heart ____
+fire ____     alone ____
+care ____     arms  ____
+feel ____     eyes  ____
+cry  ____     call  ____
+walk ____     only  ____
+above ____    met   ____
+burn ____     true  ____
+```
+
+Pat reports the answers he got — paired back to their prompts:
+
+```text
+hand  → understand      heart → apart
+fire  → desire          alone → telephone
+care  → there           arms  → charms
+feel  → real            eyes  → realize
+cry   → die             call  → all / wall
+walk  → talk            only  → lonely
+above → love            met   → regret / forget
+burn  → learn           true  → you / do / blue / through / new
+```
+
+His diagnosis is precise: "None of these words are empty. They mean something.
+But when you pair them with their predictable mates, they bland off to nowhere
+... These pairs all cause sleeping sickness."
+
+The cure is the second half of the exercise: look the same words up in the
+rhyming dictionary and see if you can do better. Preserve the principle — the
+first rhyme that arrives is the cultural reflex, not the best craft choice.
 
 Skill behavior for cliche targets:
 
@@ -115,19 +186,38 @@ Skill behavior for cliche targets:
 
 ## Rhyme connects ideas
 
-Rhyme makes two ideas feel related. The connection can be conceptual, sonic, or
-both.
+Rhyme makes two ideas feel related. Pat builds the point in three steps.
 
 ```text
-concept only:    lust / burn
-sound and idea:  desire / fire
-fresher slant:   passion / ashes
+lust
+burn
 ```
 
-The second pair is powerful in theory because the sound connection and the idea
-connection reinforce each other. It may still fail if the pairing is too
-familiar. The third pair is less perfectly resolved but may be fresher because
-the semantic relationship is specific and less automatic.
+"These two ideas connect, at least as metaphors. Other ideas rush in:
+'consume, torment, hot....' But besides having four letters, the syllables have
+no sonic connection at all." Attention stays on the meanings.
+
+```text
+desire
+fire
+```
+
+"Not only do these ideas connect, but so do their sounds, creating a 'double
+whammy' — a connection between ideas plus a sonic connection." The catch:
+`fire/desire` is a cliché rhyme, "used so much that its power to provoke vivid
+ideas is gone."
+
+```text
+passion
+ashes
+```
+
+"No more cliché. They may not be perfect rhymes, but their sonic connection is
+undeniable."
+
+**Double whammy** is the term to keep: a pair that connects on meaning *and*
+on sound. The third pair shows that a less resolved rhyme type can outperform
+a perfect one when the perfect one is spent.
 
 Coach move: when choosing between a perfect but stale rhyme and a less exact
 but vivid connection, weigh the whole song's tone. A comic, formal, or highly
@@ -155,21 +245,25 @@ Revision questions:
 
 ## Common-idea exercise
 
-Exercise pattern to preserve:
-
-- Start from target words with strong emotional or narrative charge.
-- Search the rhyme dictionary for partners that share an idea field.
-- Avoid the most automatic pairings unless the draft has a new angle on them.
-- Use the search to discover what else the song might be about.
-
-Example coaching prompt:
+**Exercise 2.3. Common Ideas.** For each word below, find a rhyme word that
+shares an idea in common with its partner. Do not use cliché rhymes. Try to
+hook each word up with rhyme partners that create a "double whammy." Use your
+rhyming dictionary.
 
 ```text
-Target: break
-Do not stop at a sound match.
-Find candidates that imply mistake, damage, promise, escape, or cost.
-Choose the candidate that gives the next line a new job.
+burn     dream    scold    grip
+scorn    trance   break    leave
+affair   alarm    school   past
 ```
+
+"When you use your rhyming dictionary in such a focused way — looking for words
+that connect ideas — it is a real help."
+
+Pat then shows the pairs generating plot on their own: "'Scold/hold' could
+suggest an argument, complete with making up afterwards. (Or it might have been
+a phone call.) 'Break/mistake' could be Mom's favorite lamp, perhaps followed
+by 'scold/hold.' A rhyme often suggests some further idea. That is one of its
+powers and benefits."
 
 The important point is that the rhyme search can suggest content. A rhyming
 dictionary is not only a finishing tool; it can become a way to discover plot,
@@ -177,9 +271,21 @@ metaphor, and emotional direction.
 
 ## Rhyme as idea generator
 
-When a candidate rhyme suggests a useful story move, follow it. Pattison's
-method does not separate craft mechanics from invention. The sound list can
-push the lyric toward a better idea than the writer originally planned.
+Ordinarily a writer waits until a phrase exists and only then hunts a rhyme to
+match it. Pat inverts it — search first, and let the sound hand you the idea.
+His demonstration starts from `desperado`:
+
+```text
+Slicker than a desperado
+He moves in smooth and splits staccato
+Steals your heart and runs for cover
+Leaves a trail of broken lovers
+```
+
+Nothing in the search asked for a con man; `staccato` produced him, and
+`cover/lovers` produced the wreckage he leaves. "What this process shows is the
+power of rhyme to make you think of new ideas. A rhyming dictionary can
+actually stimulate the creative process."
 
 Use this workflow:
 
@@ -196,10 +302,21 @@ Good use asks, "Which available sound opens the most useful idea?"
 
 ## Mismatch can become comedy
 
-Forced or unlikely connections often become funny whether the writer intends it
-or not. Some exercises deliberately pair odd words to make the writer try to
-build serious connections. This matters because rhyme can drag tone away from
-the intended emotional lane.
+**Exercise 2.4. Connections.** Write a song section of two to four lines using
+the rhymes below. "Try to make serious connections. Humor is easy to come by,
+since mismatches are often funny."
+
+```text
+1. net / duet
+2. choke / baroque
+3. lice / price
+4. dark / mark
+5. trees / knees
+```
+
+The exercise deliberately pairs odd words so the writer has to build serious
+connections against the grain. This matters because rhyme can drag tone away
+from the intended emotional lane.
 
 Skill behavior:
 
@@ -211,11 +328,75 @@ Skill behavior:
 
 ## Going deeper than the first dictionary page
 
-Sometimes the dictionary does not give a useful perfect rhyme. That does not
-mean the song should abandon craft or pretend rhyme is unnecessary. It means
-the writer has to choose among deeper options.
+Sometimes the dictionary does not give a useful perfect rhyme. "Connections
+sound silly or far-fetched. You feel like you have to force ideas to rhyme,
+when the opposite should be happening. It makes you want to go into your
+'I-don't-want-to-rhyme' stage."
 
-Options:
+Pat's worked "Going Deeper" case starts here:
+
+```text
+I'm sick of all this risky business
+I want to play it safe
+```
+
+<!-- phonetic vowel markings trip the spell-checker --><!-- spellchecker:off -->
+
+**Step 1 — try the obvious section.** `business` is feminine, so look under
+`ĬZ ness`. Nothing rhymes with it. Two choices remain: find a mosaic rhyme, or
+don't rhyme it.
+
+**Step 2 — build the mosaic from the masculine section.** Look under short
+`ĭ` + `z`. Best of a short list: `fizz`, `friz`, `his`, `is`, `quiz`, `'tis`,
+`whiz`. Assemble them: Fizzness? Frizness? Hisness? Isness? Quizness?
+Tisness? Whizness? "There are some faint sparks, but all seem to smack of
+forced comedy that promise only self-consciously 'look-at-me-I-can't-find-a-
+rhyme' humor."
+
+**Step 3 — remember the tail need not be an identity.** Feminine rhymes do not
+have to repeat the unstressed syllable, so look under short `ĕ` + `s`, one-
+syllable words only:
+
+```text
+Bess    bless   chess   dress   fess
+guess   jess    less (eureka)    mess (hmmm)
+press   stress
+```
+
+<!-- spellchecker:on -->
+
+**Step 4 — filter by stress, not by sound.** See the next section.
+
+**Step 5 — check the *fourth* line before committing the third.** "The key to
+what will happen in the third phrase is often what happens in the fourth."
+Rhymes for `safe`: `chafe`, `strafe`, `waif`. `strafe` is a transitive verb
+needing a direct object, so it inverts the sentence at the phrase end. That
+leaves `chafe`:
+
+```text
+I'm sick of all this risky business
+I want to play it safe
+I'll learn to drink my tonic fizzless
+Where no one makes me chafe (?)
+```
+
+"Ugh! This is downright gruesome, like an underwear commercial." `waif` is no
+better, though it can at least be placed honestly by dropping to two lines and
+writing an unrhymed third:
+
+```text
+I'm sick of all this risky business
+I want to play it safe
+Or die a helpless waif
+```
+
+**The real diagnosis.** "The problem is not the approach to 'chafe,' nor is it
+that 'waif' needs to fit more naturally. Neither word has much promise. Yet
+lyricists often spend valuable energy and creativity trying to create silk
+purses with words like these. The problem, as usual, is in picking 'business'
+and 'safe' without much forethought."
+
+Options when you are already stuck there:
 
 - Find a mosaic rhyme.
 - Use a less exact rhyme type if the style permits it.
@@ -232,8 +413,37 @@ Feminine mosaic rhyme is not only a sound problem. It is also a stress problem.
 The unstressed tail must be able to sit lightly enough to behave like the tail
 of a feminine rhyme.
 
-A strong one-syllable word may be too heavy to serve as the unstressed part of
-a mosaic. The phrase may technically match sounds while failing rhythmically.
+Pat's filter on the `business` list: "Most of these are too strong to work as
+the unstressed syllable in a feminine mosaic. You need something with the same
+stress pattern as `busi-ness`." Take `guess`:
+
+```text
+his guess
+```
+
+You end up either with two stresses (`hís guéss`) "or, even worse," a stressed
+second unit that outranks the first. "Both of these are forced and again,
+self-consciously funny."
+
+`less` survives the filter "since it actually could be unstressed":
+
+```text
+quizless
+fizzless
+```
+
+Which yields the third line, with a caveat Pat states himself:
+
+```text
+I'm sick of all this risky business
+I want to play it safe
+I'll learn to drink my tonic fizzless
+```
+
+"Of course, 'drink my tonic' is the linking idea that allows 'fizzless' to
+work. It seems a little on the light and forced side, but it seems to be one of
+the few possibilities." Note that the mosaic only survives because a *content*
+choice earlier in the line licenses it.
 
 Skill behavior:
 
@@ -242,6 +452,8 @@ Skill behavior:
 - Reject mosaic candidates whose second unit grabs too much attention.
 - Prefer a candidate whose stress behavior matches the target, even if the
   spelling looks less neat.
+- Ask what earlier word in the line makes the mosaic land as sense rather than
+  as a stunt.
 
 ## Do not pick weak friends
 
@@ -251,7 +463,8 @@ The chapter's practical warning is simple:
 
 Once a word occupies a rhyme position, it becomes a friend that later lines
 must answer. If the word has poor rhyme potential or weak idea potential, the
-next line may be trapped.
+next line may be trapped — which is exactly what `business` and `safe` did in
+the walkthrough above.
 
 Planning move:
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
@@ -7,7 +7,14 @@ Challenge 4.
 
 Source images inspected:
 
-- Chapter 9: `image_C-page20.jpg`, `image_E-page1.jpg`, `image_E-page2.jpg`,
+- *Essential Guide to Lyric Form and Structure* (1991), Chapter 4: **40 linked
+  page-scan figures**, all 40 unique, read at 3x upscale. This file's primary
+  source argues in scans — the balance paradigms, every closure type, and all
+  three strategy examples are figures, not prose. Earlier revisions of this
+  inventory listed only the *Essential Guide to Rhyming* (2014) and
+  *Songwriting Without Boundaries* (2011) images and omitted this chapter
+  entirely, which is how the `abba` error below survived.
+- *Essential Guide to Rhyming* (2014), Chapter 9: `image_C-page20.jpg`, `image_E-page1.jpg`, `image_E-page2.jpg`,
   `image_E-page3.jpg`, `image_E-page4.jpg`, `image_E-page5.jpg`,
   `image_E-page6.jpg`, `image_E-page7.jpg`, `image_E-page8.jpg`,
   `image_E-page9.jpg`, `image_E-page10.jpg`, `image_E-page11.jpg`.
@@ -21,6 +28,8 @@ movement, support meaning through prosody, and create relationships between
 sections.
 
 > "Prosody is one of the most important strategies you have"
+> — Pat Pattison, *Essential Guide to Lyric Form and Structure* (1991),
+> Chapter 4
 
 This file focuses on decision-making. For definitions and mechanics, see
 [rhyme fundamentals](rhyme-fundamentals.md).
@@ -63,18 +72,23 @@ a b a b
 Idea keeps moving through all four lines
 ```
 
-Worked contrast from Chapter 4:
+Worked contrast from *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 4 (structure only; Pat's example lyrics are not reproduced):
+
+Pat sets the same four-line situation twice. The first setting pairs lines 1-2
+on one sound and lines 3-4 on another (`aabb`); the second alternates them
+(`abab`). Nothing else changes — same subject, same line lengths.
 
 ```text
-aabb: Love her or leave her to me
-      Keep her or let her go free
-      Don't go two-timing her
-      'less you're resignin' her
+aabb -> line 1 |
+        line 2 | first thought, closed by the couplet
+        line 3 |
+        line 4 | second thought, closed by the couplet
 
-abab: Some girls like their flirtin'
-      They're always on the roam
-      Blind to who they're hurtin'
-      Their eyes are never home
+abab -> line 1 ... rhyme opens
+        line 2 ... second sound opens
+        line 3 ... first sound returns, still unresolved
+        line 4 ... both resolve together
 ```
 
 The first naturally divides into two parts. The second stays in motion because
@@ -140,7 +154,8 @@ c
 b
 ```
 
-In Chapter 4's examples, the consecutive `c c c` cluster increases pressure before a
+In *Essential Guide to Lyric Form and Structure* (1991), Chapter 4's examples,
+the consecutive `c c c` cluster increases pressure before a
 later return. Feminine rhymes can heighten comedy because the two-syllable tail
 adds bounce while the cluster speeds up.
 
@@ -234,13 +249,20 @@ effect: the c cluster accelerates the middle; final b closes the frame
 Repeated song sections often force the reverse process. Verse 1 establishes a
 scheme; verse 2 must find content that fits it.
 
-Chapter 4's exercise uses `ABACCB`:
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 4 drills this with
+an `ABACCB` scheme: the writer sketches a plot whose action fits the scheme's
+motion, then finds rhyme words for it. Pat's own worked answer is his to print —
+here is an equivalent built the same way:
 
 ```text
 scheme: ABACCB
-plot: lovers dancing, spouse enters, discovery
-words: dance / embrace / romance / eyes / surprise / disgrace
+plot: a late shift ends, the drive home turns toward someone
+      else's street, and the narrator keeps driving past
+words: light / alone / night / turn / burn / home
 ```
+
+The `cc` pair in positions 4-5 is where the plot's pressure spikes; the delayed
+`b` in position 6 is where it resolves.
 
 The method:
 
@@ -463,7 +485,8 @@ Workflow:
 5. Use more stable rhyme types in the resolved appearance.
 6. Check whether the song's larger journey now grows rather than repeats.
 
-This is the strategic point of the Randy Newman case study in Chapter 9: a remote
+This is the strategic point of the Randy Newman case study in
+*Essential Guide to Rhyming* (2014), Chapter 9: a remote
 family/consonance connection can keep an early prechorus unstable, while a
 perfect rhyme in the matching later prechorus can close firmly. The same formal
 slot changes emotional color through rhyme type alone.
@@ -576,10 +599,18 @@ join ideas across the section.
 |---|---|
 | `aabb` | Fragments each pair; each couplet closes a thought |
 | `abab` | Through-writes; idea spans the four-line arc |
-| `abba` | Encloses; outer pair frames the inner pair |
+| `abba` | Frames the inner pair — but stays **open**, not closed (see below) |
 | `xaxa` | Through-writes with relaxed structure |
 | `aaba` | Points forward toward a fourth `b` that does not arrive |
 | `abcb` | Closes the rhymed pair; leaves first and third open |
+
+**`abba` does not close.** Earlier revisions of this table said `abba`
+"encloses," which reads as a closure claim and contradicted this file's own
+Challenge 4 table below, where `abba` is listed under floating instability. The
+1991 chapter settles it twice over: it presents `abba` as the scheme that
+*fails* to balance an opening `abb`, and its printed exercise key marks `abba`
+**open**. Use `abba` when a section should frame an idea without resolving it —
+loss, hope, suspension — not when it needs to land.
 
 Use Strategy 1 to decide which idea-shape the section wants:
 fragmented declarations, single arcs, framed center, or unresolved push.

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
@@ -73,26 +73,25 @@ Idea keeps moving through all four lines
 ```
 
 Worked contrast from *Essential Guide to Lyric Form and Structure* (1991),
-Chapter 4 (structure only; Pat's example lyrics are not reproduced):
-
-Pat sets the same four-line situation twice. The first setting pairs lines 1-2
-on one sound and lines 3-4 on another (`aabb`); the second alternates them
-(`abab`). Nothing else changes — same subject, same line lengths.
+Chapter 4. Pat wrote both of these himself as a) and b):
 
 ```text
-aabb -> line 1 |
-        line 2 | first thought, closed by the couplet
-        line 3 |
-        line 4 | second thought, closed by the couplet
+a)  Love her or leave her to me      a
+    Keep her or let her go free      a
+    Don't go two-timing her          b
+    'less you're resignin' her       b
 
-abab -> line 1 ... rhyme opens
-        line 2 ... second sound opens
-        line 3 ... first sound returns, still unresolved
-        line 4 ... both resolve together
+b)  Some girls like their flirtin'   a
+    They're always on the roam       b
+    Blind to who they're hurtin'     a
+    Their eyes are never home        b
 ```
 
 The first naturally divides into two parts. The second stays in motion because
 the first rhyme waits across intervening material before resolving.
+
+Exercise 27 in the chapter is to reverse them — through-write a) and fragment
+b) — keeping as much of the same meaning as possible.
 
 ## Through-write when the idea should flow
 
@@ -128,14 +127,27 @@ the rhyme keeps applying the brakes.
 The rhyme scheme should behave like the emotional or dramatic action.
 
 For a leisurely verse, spread rhymes apart. For a chorus that bursts forward,
-move to consecutive rhymes. Pattison's "Ready or Not" example uses a more
-leisurely verse pattern and a fast consecutive chorus pattern so the rhyme pace
-matches the content's change in energy.
+move to consecutive rhymes. Pat's "Ready or Not":
 
 ```text
-verse:  spread rhymes -> room, thought, pressure building
-chorus: d d d d       -> immediate launch, compact hook energy
+VERSE    If I went into analysis                      a
+         And took myself apart                        b
+         And laid me out for both of us to see        c
+         You'd go into paralysis                      a
+         Right there in my arms                       b
+         Finding out you're not a bit like me         c
+
+CHORUS   READY OR NOT                                 d
+         We've got what we've got                     d
+         Let's give it a shot                         d
+         READY OR NOT                                 d
 ```
+
+The verse rhymes are spread apart — their leisurely pace works with the idea,
+especially for the first three phrases. As the rhymes start to connect the last
+three phrases back to the first three, the pressure pushes the section forward.
+The chorus rhymes are consecutive, one after another, as fast as rhymes can go:
+ideal for the "out-of-the-starting-blocks" idea of the chorus.
 
 Prosody can also operate inside one section. If the idea becomes more active or
 pressurized, accelerate the rhyme scheme near the place where the lyric becomes
@@ -143,15 +155,28 @@ more active.
 
 ## Accelerate strategically
 
-Acceleration comes from bringing rhymes closer together.
+Acceleration comes from bringing rhymes closer together. Pat's example — the
+consecutive rhymes in lines 3, 4 and 5 accelerate the section and build
+pressure, working in sync with the idea:
 
 ```text
-a
-b
-c
-c
-c
-b
+I saw her once and that was it        a
+I felt my knees go weak               b
+I tossed and turned all night in bed  c
+Knew she had me in her web            c
+Tried to make her leave my head       c
+Couldn't fall asleep                  b
+```
+
+The same scheme, this time with feminine rhymes to heighten the comedy:
+
+```text
+You can't play ping pong with my heart  a
+When I'm without a paddle               b
+It's 40-love, you've got the ball       c
+The odds are astronomical               c
+The situation's comical                 c
+You've really got me rattled            b
 ```
 
 In *Essential Guide to Lyric Form and Structure* (1991), Chapter 4's examples,
@@ -249,17 +274,23 @@ effect: the c cluster accelerates the middle; final b closes the frame
 Repeated song sections often force the reverse process. Verse 1 establishes a
 scheme; verse 2 must find content that fits it.
 
-*Essential Guide to Lyric Form and Structure* (1991), Chapter 4 drills this with
-an `ABACCB` scheme: the writer sketches a plot whose action fits the scheme's
-motion, then finds rhyme words for it. Pat's own worked answer is his to print —
-here is an equivalent built the same way:
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 4, Exercise 28
+drills this: think up a plot whose action fits the movement of the rhyme
+scheme, then come up with rhyme words for the plot. Pat's own worked example:
 
 ```text
-scheme: ABACCB
-plot: a late shift ends, the drive home turns toward someone
-      else's street, and the narrator keeps driving past
-words: light / alone / night / turn / burn / home
+RHYME SCHEME: ABACCB
+
+PLOT SKETCH:
+My lover and I are dancing, enjoying our closeness.
+My spouse enters the lounge and spots me. We have been
+discovered!
+
+Rhyme words: dance/embrace/romance/eyes/surprise/disgrace
 ```
+
+The exercise then hands the writer three more schemes to do the same with:
+`AABBCC`, `XAXABB`, and `AABCCC`.
 
 The `cc` pair in positions 4-5 is where the plot's pressure spikes; the delayed
 `b` in position 6 is where it resolves.

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
@@ -129,12 +129,50 @@ Search order for a plosive target:
 4. Try the remaining plosives.
 5. Sing the results; keep only what sounds natural.
 
-Worked example: `rut`
+Worked example: `rut` (*Essential Guide to Rhyming* (2014), Chapter 4)
 
-- Perfect options are narrow: `cut`, `glut`, `gut`, `hut`, `shut`.
-- Replace final `t` with partner `d`: `blood`, `flood`, `mud`, `thud`.
-- Try unvoiced companions `k` and `p`: `buck`, `duck`, `luck`, `muck`, `stuck`, `truck`, `up`, `hard up`, `makeup`.
-- Try other voiced plosives `b` and `g`: `club`, `hub`, `pub`, `scrub`, `tub`, `bug`, `jug`, `plug`, `shrug`, `snug`, `tug`.
+The vowel is short `u`. Perfect rhyme gives a narrow field:
+
+```text
+rut / cut / glut / gut / hut / shut
+```
+
+`T` is an unvoiced plosive, so partners come first. `T`'s partner is `d`:
+
+```text
+ud:   blood   flood   mud   stud (?)   thud
+```
+
+Pat's note: "These are nice possibilities, especially 'flood' and 'mud'."
+
+Next, `t`'s companions `k` and `p`:
+
+```text
+uk:   buck   duck   luck   muck   stuck   truck
+up:   hard up   up   makeup (?)
+```
+
+"'Makeup' suggests that the relationship is in a rut, we have a fight, etc."
+
+Finally the remaining plosives `b` and `g`, which share only the exploding technique:
+
+```text
+ub:   club   hub   pub   scrub   tub
+ug:   bug   jug   lug   plug   shrug   snug   tug
+```
+
+On the `ub` column Pat says the words "don't sound quite the same. Sing them. 'Ruuuuuut. Scruuuuub.' Not so bad. Good, in fact, if you're looking for a slightly less stable rhyme." The `ug` column he calls "some of the best yet."
+
+Family rhyme delivers roughly five times more choices than perfect rhyme. The shortlist Pat says he would actually consider using:
+
+```text
+rut / shut
+flood   mud
+luck   muck   stuck   truck
+up
+pub   scrub   tub
+shrug   snug   tug
+```
 
 The key coaching move is not to accept everything. The point is to multiply choices, then pick the word that belongs in the line.
 
@@ -169,12 +207,35 @@ Search order for a fricative target:
 
 Example: if the target ends in `sh`, move first through unvoiced companions such as `ch`, `s`, `th`, and `f`, then cross to voiced `zh` and its companions.
 
-Worked example: `safe`
+Worked example: `safe` (*Essential Guide to Rhyming* (2014), Chapter 4)
 
-- Perfect rhyme: `waif`.
-- Unvoiced family options from `th` and `s` include `faith`, `case`, `ace`, `chase`, `disgrace`, `face`, `grace`, `lace`, `race`, `space`, `trace`.
-- Partner `v` opens `behave`, `brave`, `cave`, `grave`, `shave`, `slave`, `wave`.
-- Voiced family options include `blaze`, `craze`, `daze`, `haze`, `maze`, `phrase`, `praise`, plus `age`, `cage`, `page`, `rage`, `stage`.
+`F` is an unvoiced fricative. Perfect rhyme is close to empty — `waif` — which Pat greets with "Ugh!" Companions first:
+
+```text
+ath:  faith                          ("Not much.")
+as:   case   ace   breathing space   chase   commonplace
+      disgrace   embrace   face   grace   lace   race
+      resting place   space   trace (as a noun)
+```
+
+Nothing worthwhile under `ash` or `ach`, so cross the line to `f`'s partner `v`, then that partner's companions:
+
+```text
+av:   behave   brave   cave   grave   shave   slave   wave
+aTH:  bathe                          ("Fat chance.")
+az:   blaze   craze   daze   haze   maze   phrase   paraphrase   praise
+aj:   age   cage   page   rage   stage
+```
+
+Pat's comment on the `az` column: "The nice thing about a cliche word like 'daze' is that it may sound fresh again away from its usual connection to 'haze.' That is another strength of family rhyme. They surprise you. They do not make the usual connections."
+
+A parallel feminine search on `travel` yields:
+
+```text
+bashful   dazzle   wrathful   glass full (mosaic)   satchel   fragile
+```
+
+Some columns offer few results; with others, "results come cascading in." Fricative rhymes usually at least quadruple your choices.
 
 Selection matters:
 
@@ -252,18 +313,30 @@ Choices stack quickly when there are two or more consonants after the vowel.
 
 `L` and `r` do not have useful family substitutes. Family rhyme still helps when `l` or `r` appears with another consonant that can be substituted.
 
-Example: `hurt`
+Example: `hurt` (*Essential Guide to Rhyming* (2014), Chapter 4)
 
-- Perfect options include `alert`, `curt`, `dirt`, `flirt`, `inert`, `skirt`.
-- Many perfect options are transitive verbs, which can limit use.
-- Substitute final `t` with partner `d`: `absurd`, `word`, `stirred`, `blurred`, `deterred`, `preferred`, `purred`, `slurred`.
-- Move to companions: `burp`, `twerp`, `curb`, `suburb`, `iceberg`.
+```text
+perfect:  alert   curt   dirt   flirt   inert   skirt
+urd:      absurd   gallows bird   stirred   word
+          blurred   deterred   preferred   purred   slurred
+urp:      burp   twerp
+urb:      curb   suburb
+urg:      iceberg
+```
 
-Example: `help`
+Many perfect rhymes for `hurt` are transitive verbs, which limits options. Pat flags the payoff of the `d` substitution: "Good news! You can use the past-tense verbs of 'ur.'"
 
-- Perfect options are almost empty.
-- Substitute `p` with `d` and search `eld`: `unparalleled`, `weld`, `compelled`, `propelled`, `quelled`, `rebelled`, `shelled`.
-- Move to companion `t`: `felt`, `heartfelt`, `melt`.
+Example: `help` (*Essential Guide to Rhyming* (2014), Chapter 4)
+
+Perfect rhyme yields `kelp?` — "Oops!"
+
+```text
+eld:  unparalleled   weld
+      compelled   propelled   quelled   rebelled   shelled
+elt:  felt   heartfelt   melt
+```
+
+The same "past-tense verbs of 'el'" bonus applies. Nothing turns up anywhere else.
 
 Even when the expansion is modest, it may rescue a word that has no usable perfect rhyme.
 
@@ -300,6 +373,14 @@ free / release
 
 This is useful because open-vowel rhymes have been heavily used. Adding consonants can bypass obvious cliches while preserving most of the connection.
 
+Pat's counterexample — the definition alone is not enough:
+
+```text
+free / shields
+```
+
+"Though you can still hear the common vowel sound, the relationship is not strong enough to substitute for perfect rhyme. There is too much difference in sound." A technically valid additive rhyme can still be too remote. It depends on how noticeable the consonants are, and maybe on the length of the syllable's note.
+
 Stability depends on how much sound gets added:
 
 - Less added sound means more stability.
@@ -308,7 +389,7 @@ Stability depends on how much sound gets added:
 - Voiced plosives are usually less noticeable than unvoiced plosives.
 - Fricatives last longer, so they add more sound.
 - Nasals add more sound than plosives and fricatives, except that `l` and `r` are even heavier.
-- Multiple consonants add still more weight.
+- Multiple consonants add still more weight: `free / dreams`.
 
 Search order for additive rhyme:
 
@@ -317,35 +398,73 @@ Search order for additive rhyme:
 3. Move from plosives to fricatives to heavier sounds only as needed.
 4. Sing every candidate before keeping it.
 
-Worked example: open-vowel `free`
+Worked example: open-vowel `free` (*Essential Guide to Rhyming* (2014), Chapter 5)
 
-- Add voiced plosive `d`: `bleed`, `greed`, `speed`, `seed`.
-- Add unvoiced plosive `p`: `deep`, `asleep`, `cheap`, `weep`.
-- Add unvoiced plosive `t`: `bittersweet`, `deceit`, `defeat`, `elite`.
-- Add unvoiced plosive `k`: `bleak`, `speak`, `weak`.
-- Add unvoiced fricative `f`: `belief`, `relief`, `thief`.
-- Add unvoiced fricative `s`: `peace`, `police`, `release`.
+Work through voiced plosives, then unvoiced plosives, then unvoiced fricatives:
 
-Worked example: consonant-ending `erase`
+```text
++b   (not much there)
++d   bleed   greed   speed   seed
++p   deep   asleep   cheap   weep
++t   bittersweet   deceit   defeat (noun)   elite
++k   bleak   speak   weak
++f   belief   relief   thief
++s   peace   police   release
+```
+
+> "Never stop listening. If your ear says a sound is wrong, find another rhyme.
+> Trust your ears. (But be sure to sing your rhymes when you check.)"
+
+Worked example: consonant-ending `erase` (*Essential Guide to Rhyming* (2014), Chapter 5)
+
+Additive rhyme also works when the syllables end with the same consonant. You simply add — or insert — another one:
 
 ```text
 erase / paste
-case / erased
-space / traced
 ```
 
-The second version regains transitive verbs by adding `-ed`. It has a cost: passive verbs are weaker than active verbs. But it can make a rhyme-position word usable without forcing an unnatural direct object after the line break.
-
-Additive rhyme works especially well after `l` and `r` because those sounds carry so much weight that a later consonant may feel less prominent:
+Pat then returns to the `safe` fricative search, where `erase` and `trace` had to be skipped as transitive verbs needing a direct object ("erase my heart," "trace your feelings"). Adding `-ed` turns the verb from active to passive and hands them back:
 
 ```text
-scar / heart
-scar / dark
-Jezebel / unparalleled
-help / knelt
+as   case   ace   breathing space   erased   traced
 ```
 
-Those are not all equally stable. They are candidates to sing, not automatic approvals.
+The payoff in the line itself — instead of the clumsy relic
+
+```text
+You say you need some breathing space
+As if my heart you could erase        (Ick)
+```
+
+you get
+
+```text
+You say you need some breathing space
+As if my heart could be erased
+```
+
+There is a price: active verbs are stronger than passive verbs. An added attraction: the unvoiced `s` makes the final `d` turn into an unvoiced `t` sound.
+
+Additive rhyme works especially well after `l` and `r` because those sounds carry so much weight that whatever comes after them will hardly be noticeable:
+
+```text
+scar        Jezebel
+heart       unparalleled
+dark        help
+tarred      knelt
+guard       svelte
+charge      wealth
+hearth
+```
+
+"These work very well, better than many additive rhymes, because l and r carry so much weight." You might even get away with additional consonants:
+
+```text
+star / arms
+war / endorsed
+```
+
+Those are not all equally stable. They are candidates to sing, not automatic approvals. "Again, sing them. Trust your ears."
 
 ## Family Additives
 
@@ -360,7 +479,11 @@ trip / risk
 ache / saint
 ```
 
-The last two are easy to miss in an alphabetical dictionary search because the extra consonant appears before the family consonant. Treat the worksheet as a discovery surface: while searching family options, mark relatives that also add sound.
+The last two are easy to miss in an alphabetical dictionary search because the extra consonant appears before the family consonant.
+
+> "Keep your eyes open for them. They'll drop out of the sky. Stars fall all the time. If you're watching for them, you'll see some." — *Essential Guide to Rhyming* (2014), Chapter 5
+
+The addition can also land inside the word, where it is less noticeable — searching `hush` through the nasals turns up `lunch`, "which seems to work just fine." Treat the worksheet as a discovery surface: while searching family options, mark relatives that also add sound.
 
 ## Subtractive Rhyme
 
@@ -390,7 +513,7 @@ Worked example: `fast`
 - Add `t` to fricative-family options and you may reach `draft`.
 - Simple family options for the reduced `as` include `dash`, `wrath`, `laugh`.
 
-`fast / dash` is useful because it makes a fresh connection while still acting as a plausible perfect-rhyme substitute.
+> "Try them. 'Fast/dash' is a lovely connection. It is not a cliche rhyme, and it is an acceptable perfect rhyme substitute." — *Essential Guide to Rhyming* (2014), Chapter 5
 
 Worked example: long-vowel `treat`
 
@@ -398,9 +521,11 @@ Worked example: long-vowel `treat`
 treat / free
 ```
 
-When a long vowel has only one consonant after it, subtracting down to the open vowel is often enough. Do not over-process it.
+"When you work with long vowels that end in only one consonant, you can always pare down to the open vowel." Do not over-process it: "No need to multiply examples. You understand."
 
-Subtractive rhyme also applies to feminine rhyme. Work from the stressed syllable, as with family rhyme, then test the whole word in song.
+Subtractive rhyme also applies to feminine rhyme — "these techniques work just as easily for feminine rhyme as they do for masculine rhyme," with Pat's aside, "(Try finding one for 'simply.')" Work from the stressed syllable, as with family rhyme, then test the whole word in song.
+
+Pat closes Chapter 5 by summing up what the perfect-rhyme substitutes are for: family rhyme and additive/subtractive rhyme are easy to find, both let you use rhyming positions expressively "in what has become a minefield of cliches," and both create at least most of the stability characteristic of perfect rhyme.
 
 ## Kissin' Cousins - Most Remote Rhyme Types
 
@@ -420,11 +545,13 @@ The coaching tradeoff is simple: less resolution gives more freedom, but it also
 
 ### Assonance Rhyme
 
-Assonance rhyme has:
+Assonance rhyme is simple vowel rhyme — the syllables share only a common vowel sound. More precisely, assonance rhyme has:
 
 - the same stressed vowel sound,
-- unrelated consonants after the vowel,
+- consonants after the vowel that are *not* phonetically related,
 - different sounds before the vowel.
+
+Pat is explicit that assonance rhymes *always* have consonants after the vowels; the consonants simply cannot be phonetically related. That requirement is what separates assonance from additive rhyme when the target is an open vowel.
 
 The vowel still rings in song, but the consonants do not complete the stop. That makes assonance the widest search: once the target vowel is fixed, scan across columns that perfect, family, additive, and subtractive rhyme would normally skip.
 
@@ -435,39 +562,54 @@ Use assonance when:
 - a section should stay open at a rhyme position,
 - the singer's held vowel can carry the connection better than the printed page would.
 
-Worked example: short-vowel `love`
+Pat's headline pair (*Essential Guide to Rhyming* (2014), Chapter 6):
 
 ```text
-love / hunt
-love / toughened
-love / country
+love / hunt        tide / afterlife
 ```
 
-The shared vowel keeps the words in the same sonic neighborhood, but the endings do not settle. This can support hunger, uncertainty, or unresolved desire better than `love / dove`.
+"Sing them. You can hear their connection. The vowel sounds ring out and connect. However, they do not complete their connection; they leave it hanging."
 
 Worked example: long-vowel `tide`
 
+An assonance search on `tide` means looking under all the long `i` columns — the widest possible rhyme search, but a manageable one:
+
 ```text
-tide / life
-tide / climb
-tide / survive
+tide
+life   isle   climb   brine   lifeline   rise   survive   revive
 ```
 
-The long vowel is strong enough to hear in song. The different endings keep the connection suspended rather than closed.
+"The search takes time, but the rewards are usually worth it."
 
-Feminine assonance is stronger because the unstressed syllable after the stressed vowel adds extra shared motion. It can sometimes substitute for full resolution more convincingly than masculine assonance.
+Feminine assonance is stronger than masculine assonance because of the extended resolution of the unstressed syllables — "so solid, in fact, that feminine assonance rhyme is usually a good perfect rhyme substitute."
 
 Worked example: feminine `lonely`
 
+The family rhymes from the nasals are already known, so go through the feminine long `O` section for plosives and fricatives, looking for unstressed syllables ending in `i` (the feminine section's notation for unaccented long `e`), `Ii`, and even `ing`. Pat's own list, with his `(subtractive)` markers intact:
+
 ```text
-lonely / solely
-lonely / smoky
-lonely / slowly
+adobe          disrobing
+approaching    probing
+reproaching    toady
+foreboding     trophy
+solely         snowy (subtractive)
+smokey         blowing (subtractive)
+yogi           pokey
+coldly         boldly
+stogie         holy (subtractive)
+dopey          lowly (subtractive)
+coyote         slowly (subtractive)
+imposing       consoling
+hoping         alimony (subtractive)
+ghostly        voting
+anchovy        nosy (subtractive)
 ```
 
-Some candidates may also be subtractive or near-family cases. Sing them before labeling them.
+"Sing them. Many will be fine as perfect rhyme substitutes. Others will not. The latter will have to stay as assonance rhymes."
 
 Worked example: mosaic with `lonely`
+
+One way to find mosaics is to use masculine transitive verbs plus the pronoun "me":
 
 ```text
 lonely / hold me
@@ -484,7 +626,15 @@ Consonance rhyme has:
 - the same consonant or consonant cluster after the vowel,
 - different sounds before the vowel.
 
-This is more remote than assonance in song because sung vowels are naturally prominent. The final consonant has to be strong enough for the listener to catch it.
+Pat's headline set (*Essential Guide to Rhyming* (2014), Chapter 6, "Consonance Rhyme: From Birth to Death"):
+
+```text
+save / leave      sin / won      word / card
+```
+
+Consonance rhyme creates tension and resolution, "but uses only the final consonants to resolve the tension. That's why it feels so remote — so, um, unstable."
+
+This is more remote than assonance in song because sung vowels are naturally prominent. Consonance turns up often in poetry, where — being read or spoken rather than sung — vowels are not exaggerated and "the vowels and consonants are much more equal partners." In a lyric, "connections between consonant sounds must be very strong to even hear them."
 
 Use consonance when:
 
@@ -493,73 +643,108 @@ Use consonance when:
 - the final consonant is sonically strong enough to carry the connection,
 - a perfect rhyme would make the section feel too closed, neat, or clever.
 
-Most usable consonance options, from stronger to weaker:
+In order, these consonance rhymes are the most likely to be useful, with Pat's own examples for each rank:
 
-1. Feminine consonance, because the unstressed syllable adds extra resolution.
-2. Masculine consonance with `r` or `l`, because the sounds are hard to miss.
-3. Masculine consonance ending in multiple consonants.
-4. Masculine consonance ending in nasals, because nasals are voiced and holdable.
-5. Masculine consonance ending in voiced fricatives.
+1. **Feminine consonance rhymes.** The identity or rhyme of the unstressed syllable gives extra resolution, making feminine consonance stronger than its masculine counterpart.
 
-Worked example: final `v`
+   ```text
+   cramming / teeming      rubber / fibber
+   ```
+
+2. **Masculine consonance containing `r` or `l`.** "Since the sound of these consonants is so strong, they are very hard to miss."
+
+   ```text
+   scare / fear      pull / fall      snarl / curl
+   ```
+
+3. **Masculine consonance ending in multiple consonants.** "There is a lot of common sound to hear."
+
+   ```text
+   ranch / lynch      fast / rest      crypt / slept
+   ```
+
+4. **Masculine consonance ending in nasals.** "Nasals are always voiced, so they are noticeable. Also, they can be held. (That's what you do when you hum.)"
+
+   ```text
+   stun / ran      came / scream      song / ring
+   ```
+
+5. **Masculine consonance ending in voiced fricatives.** "Again, these are voiced and can be held."
+
+   ```text
+   grave / reprieve      rage / badge      cause / whiz
+   ```
+
+Worked example: searching `love` on final `v`
+
+Consonance rhymes are easy to find in the rhyming dictionary — each vowel sound lists its consonant endings alphabetically, so for `love` you look in each vowel section under `v`:
 
 ```text
-love / leave
-love / grave
-love / forgive
+love
+grave   have   leave   thrive   forgive   rove   groove
 ```
 
 The final `v` gives a real connection, but the vowel change makes the rhyme unstable. Use it when the line needs contact without arrival.
 
-Worked example: final `r`
+Song anchor: Paul Simon, "50 Ways to Leave Your Lover"
+
+"Consonance rhyme never works like perfect rhyme. Yet, when it is strong enough, it can work for you." Use it when a rhyme scheme is already committed to in an earlier verse and you want to keep it while relaxing the motion later. Verse 3 of "50 Ways to Leave Your Lover" ends:
 
 ```text
-fear / care
-curl / snarl
-heart / hurt
+pain
+again
+explain
 ```
 
-`R` is heavy enough to hear, so it can hold a consonance rhyme more clearly than a short plosive might.
-
-Worked example: final cluster
-
-```text
-fast / rest
-ranch / lynch
-crypt / slept
-```
-
-Multiple consonants give more common sound, so the listener has more evidence of connection even when the vowels change.
+The consonance rhyme in second position dampens the resolving effect of the consecutive rhymes; the verses stay relaxed "both in attitude and structure." Pat's test: "Try replacing 'again' with a perfect rhyme and see what happens! The prosody evaporates."
 
 ### Partial Rhyme
 
-Partial rhyme matches a masculine syllable against the stressed syllable of a feminine figure and leaves the unstressed syllable unresolved. It is not mainly a substitute for perfect rhyme. It is a way to prevent closure in a spot that would otherwise close.
+"Partial rhyme is really fun. It rhymes a masculine syllable with the accented syllable of a feminine figure, leaving the unaccented syllable unrhymed." (*Essential Guide to Rhyming* (2014), Chapter 6, "Partial Rhyme: From Cradle to Grave")
 
-Use partial rhyme when:
+It is "the first rhyme type you have seen that is used only for its special effects on structure." Use it to prevent closure in otherwise closed structures. To find it, start with a feminine figure, then look in the masculine section to rhyme the stressed syllable — "Forget about the unstressed match!" The feminine figure usually appears first.
 
-- a verse needs to move into a prechorus or final line,
-- a feminine word is the right word but its full figure would over-close,
-- the line needs a sonic bridge without a structural stop.
+Song anchors:
+
+- Ric Ocasek, "Why Can't I Have You" — partial rhyme moves a verse into a prechorus, then repeats the technique at the end of verse 2.
+
+  ```text
+  moving / you        striking / night
+  ```
+
+- Michael Jackson, "Billie Jean" — the same result via what Pat calls a *partial assonance rhyme*.
+
+  ```text
+  lover / one
+  ```
+
+"The partial rhyme makes the sonic connection but leaves the structure free to move forward to the final crucial line."
 
 Worked example: masculine against feminine
 
-```text
-rose / closing
-cream / steamer
-like / hiking
-```
-
-The stressed syllables connect; the leftover unstressed syllable keeps the line moving.
-
-Worked example: expanding a family search
+These are stronger because they use perfect rhyme between the stressed syllables:
 
 ```text
-travel / laugh
-travel / path
-travel / crash
+closing / rose      like / hiking      steamer / cream
 ```
 
-The search reaches beyond full feminine matches like `bashful` or `satchel`. This can rescue a strong feminine idea without forcing the whole word to rhyme.
+Worked example: expanding a family search on `travel`
+
+The Chapter 4 family search on `travel` produced feminine matches only:
+
+```text
+bashful   dazzle   wrathful   glass full   satchel   fragile
+```
+
+Add partial rhyme and the field opens:
+
+```text
+jazz   laugh   path   Khyber Pass   dash   crash
+```
+
+"This really extends your ability to use feminine words, yet make strong connections between ideas."
+
+Pat's summary of the remote types: assonance, consonance, and partial rhyme are useful for two purposes — developing strong content for rhyming positions, and modifying structural effects. "There is no guesswork involved; they will affect structure. They will create instability. Use them to support unstable ideas. Prosody."
 
 ### Coaching Prompts For Remote Rhyme
 
@@ -615,36 +800,33 @@ When coaching family, additive, subtractive, assonance, consonance, and partial 
 
 ## Weak-syllable rhyme
 
-Pat's most-overlooked rhyme type. The rhyme falls on the **unstressed**
-final syllable of a feminine figure, while the stressed syllable does
-not rhyme. The position carries less audible weight than the stressed
-position, but the connection still registers in song.
-
-Form:
-
-- shared unstressed vowel or consonant sound at line ending,
-- different stressed syllable,
-- different sounds before the unstressed syllable.
-
-Example shapes (paraphrased):
+**Named but not developed in this source.** Chapter 6 opens by promising
+four kissin'-cousins types:
 
 ```text
-mountain / certain      (final -in sound shared; stressed syllables differ)
-shadow / window         (final -ow sound shared)
-ringing / falling       (final -ing shared)
+1. assonance rhyme
+2. consonance rhyme
+3. partial rhyme
+4. weak-syllable rhyme
 ```
 
-Use weak-syllable rhyme when:
+The chapter body then treats assonance, consonance, and partial rhyme
+only, and closes by naming just those three ("With assonance rhyme,
+consonance rhyme, and partial rhyme, there is no guesswork involved").
+The book's index lists `weak-syllable rhymes, 59` — the enumeration page
+and nothing else.
 
-- the line wants connection but the stressed-syllable family search
-  has stalled,
-- a feminine figure must connect without closing on its stressed
-  syllable,
-- the singer's natural emphasis already lands on a different
-  syllable than the rhyme position.
+So *Essential Guide to Rhyming* (2014), Chapter 6 supplies no definition,
+no form description, no worked examples, and no stability placement for
+this type. Everything beyond the name would have to come from another
+source.
 
-Stability: less than partial rhyme. Treat as an open structural
-move. Pair with stronger rhyme elsewhere in the scheme.
+Coaching guidance: do not present a weak-syllable definition or example
+pairs as Pat's from this book. If a writer asks about the type, say that
+Pat names it in the Chapter 6 list and that the developed treatment lives
+outside this text. The remaining six tiers — perfect, family,
+additive/subtractive, assonance, consonance, partial — carry the full
+documented scale.
 
 ## Partial rhyme — extended
 
@@ -659,13 +841,18 @@ Form:
 - the feminine word's unstressed final syllable adds material the
   masculine word does not match.
 
-Example shapes (paraphrased):
+Pat's examples, annotated:
 
 ```text
-rose / closing      (rose matches the stressed "clo-"; "-sing" is extra)
-cream / steamer     (cream matches "stea-"; "-mer" is extra)
+closing / rose      (rose matches the stressed "clo-"; "-sing" is extra)
 like / hiking       (like matches "hi-"; "-king" is extra)
+steamer / cream     (cream matches "stea-"; "-mer" is extra)
 ```
+
+Pat notes these three are stronger than his song anchors because the stressed
+syllables connect by perfect rhyme. Where the stressed syllables connect by
+assonance instead, he labels the result a *partial assonance rhyme* —
+"Billie Jean," `lover / one`.
 
 Use partial rhyme when:
 
@@ -726,7 +913,7 @@ The lesson:
   not as the default.
 - Withhold closure when the emotion is incomplete.
 - Use family, additive/subtractive, assonance, consonance, partial,
-  and weak-syllable rhymes as deliberate stability moves.
+  rhymes as deliberate stability moves.
 
 The phrase Pat returns to:
 
@@ -747,10 +934,9 @@ creative options on the course than one who only knows the driver.
 > "Craft prepares you to be creative." — Pat (*Essential Guide to Rhyming* (2014), Chapter 9)
 
 The lesson for rhyme: knowing all six rhyme types (perfect, family,
-additive/subtractive, assonance, consonance, partial, weak-syllable)
-multiplies a writer's options at every rhyme position. Creativity
-without craft tries to wing it from one tool; creativity with craft
-chooses from seven.
+additive/subtractive, assonance, consonance, partial) multiplies a
+writer's options at every rhyme position. Creativity without craft
+tries to wing it from one tool; creativity with craft chooses from six.
 
 The discipline:
 
@@ -817,19 +1003,17 @@ exist in the mouth + ear.
 
 ## Weak-syllable rhyme — source citation
 
-Pat names weak-syllable rhyme explicitly in *Essential Guide to Rhyming*
-(2014), Chapter 6, alongside assonance / consonance / partial rhyme as
-the four "Kissin' Cousins" types. The chapter's opening enumerates these
-four types; weak-syllable is item 4 in that list.
+Pat names weak-syllable rhyme in *Essential Guide to Rhyming* (2014),
+Chapter 6, alongside assonance / consonance / partial rhyme as the four
+"Kissin' Cousins" types. The chapter's opening enumerates these four
+types; weak-syllable is item 4 in that list. Page 59 is the only
+occurrence in the book, and the index confirms it: `weak-syllable
+rhymes, 59`.
 
-The mechanic — unstressed syllable carries additional sonic match beyond
-the stressed rhyme position — is one of the most useful concealed-craft
-moves in the kissin'-cousins family. Pat's Berklee Online + Coursera
-material extends the teaching with additional worked examples.
-
-Use weak-syllable rhyme for deliberate suspension at line endings where
-the stressed-rhyme tier alone would either over-resolve or under-resolve
-the moment.
+That single mention is the whole of the source's coverage. See the
+"Weak-syllable rhyme" section above: definition, form, examples, and
+stability placement are all unsourced from this book and must not be
+attributed to it.
 
 ## Cross-references
 
@@ -838,8 +1022,7 @@ the moment.
 - [rhyme worksheets](rhyme-worksheets.md) — full search algorithm
   applied per slot.
 - [rhyme sonic bonding](rhyme-sonic-bonding.md) — internal-rhyme
-  and sonic-fabric considerations that overlap weak-syllable and
-  partial rhyme.
+  and sonic-fabric considerations that overlap partial rhyme.
 - [rhyme generation](rhyme-generation.md) — internal rhyme-generation
   discipline applying Pat's framework to model vocabulary.
 - [ai-tools](ai-tools.md) — Datamuse supplement for vocabulary breadth

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
@@ -119,7 +119,7 @@ idea sketch before producing rhyme families.
 
 Pat's step 2, verbatim:
 
-> 2. Make a list of words that fit your idea.
+> 2\. Make a list of words that fit your idea.
 >
 > Let the list come from your idea sketch, adding any extra inspiration you have.
 > Put them in the middle of a blank sheet of paper, number them, and enclose them
@@ -187,7 +187,7 @@ test each one as a seed.
 
 Pat's step 3, verbatim:
 
-> 3. Look up the words on the list in your rhyming dictionary.
+> 3\. Look up the words on the list in your rhyming dictionary.
 >
 > Write down only rhyme words that fit with your idea.
 >

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
@@ -22,9 +22,38 @@ Make the rhyme search before drafting lines. A worksheet puts the writer in
 known terrain, so phrase-end positions can be chosen for meaning rather than
 panic-filled availability.
 
-The analogy is practical: if you want good friends, look where compatible
-people are likely to be. If you want useful rhymes, look from inside the song's
-idea before you write yourself into a corner.
+Chapter 3 opens with the friend-finding analogy in Pat's own words:
+
+> If you're lonely and you want to make friends, you should go places where
+> you're likely to find people you have things in common with. Maybe go to a
+> concert. Even a library. If you look around for a while in the right kind of
+> place, something may click.
+>
+> When you start writing your lyric before you think about rhymes, it's like
+> looking for friends in places where you don't fit in. You might meet someone
+> with things in common, but you could improve the odds by looking in places
+> you like.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+The whole method is three steps:
+
+> The trick is to look for rhymes before you start to write. It is not as hard
+> as it sounds.
+>
+> 1. Focus your lyric idea as clearly as you can.
+> 2. Make a list of words that fit your idea.
+> 3. Look up those words in your rhyming dictionary, and make lists of
+>    rhyme words that fit your idea.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+The chapter's running example is the couplet Pat returns to in Chapter 7:
+
+```text
+I'm sick of all this risky business
+I want to play it safe
+```
 
 ## What a worksheet is for
 
@@ -46,11 +75,29 @@ worksheet is usually better.
 
 ## Step 1: focus the idea
 
-Start by asking what the lyric says and what it could say. The answer can be a
-rough prose sketch. It does not need rhyme, meter, line breaks, or beautiful
-language yet.
+Pat's step 1, verbatim:
 
-Useful focus questions:
+> 1. Focus your lyric idea as clearly as you can.
+>
+> What does your lyric say? What could it say? Is it a lyric about the dangers
+> of dating good-looking men/women? The risk I take being with you? Why? Is
+> "you" a flirt?
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+And Pat's own idea sketch for "Risky Business," verbatim:
+
+> Here is a possible idea sketch:
+>
+> I thought being with you would be exciting. You are so popular and always the
+> center of attention. I worked hard to get your attention. But now, we spend
+> time together in a whirlpool of social activity. Mostly, I just feel left out.
+> Worse, I'm afraid you don't find me exciting. Every time you say hello to
+> someone else, I think, "Uh-oh. This is it." I can't stand living this way.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+Useful focus questions (expanded from Pat's four for skill use):
 
 - Who is speaking?
 - Who is being addressed?
@@ -61,25 +108,53 @@ Useful focus questions:
 - What is the emotional turn of the section?
 - What could the title mean beyond its first obvious meaning?
 
-The example chapter starts from a simple contrast between risky attraction and
-the desire for safety, then expands it into a relational situation: attraction
-to a socially magnetic person creates insecurity and exclusion.
+The sketch starts from a simple contrast between risky attraction and the desire
+for safety, then expands it into a relational situation: attraction to a socially
+magnetic person creates insecurity and exclusion.
 
 Skill behavior: if the user's idea is vague, ask for or generate a one-paragraph
 idea sketch before producing rhyme families.
 
 ## Step 2: make a central word list
 
-Pull words from the idea sketch. Add title words, emotional state words,
-actions, relationship terms, images, and pressure words. Put them in a numbered
-central list that can be referenced while searching.
+Pat's step 2, verbatim:
 
-The source worksheet uses mostly masculine search targets and deliberately
-chooses words with different vowel sounds. That widens the map. If all seed
-words share the same vowel family, the worksheet collapses into one narrow
-sound area.
+> 2. Make a list of words that fit your idea.
+>
+> Let the list come from your idea sketch, adding any extra inspiration you have.
+> Put them in the middle of a blank sheet of paper, number them, and enclose them
+> in a box for easy reference later on.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
 
-Seed-word categories:
+The boxed list, exactly as printed (it sits in a ruled box in the middle of the
+worksheet page so the writer can see every seed at once):
+
+```text
+ 1. scared
+ 2. afraid
+ 3. flirt
+ 4. attention
+ 5. left out
+ 6. risk
+ 7. chance
+ 8. dull
+ 9. leave
+10. ignored
+11. gone
+```
+
+And the selection rule, verbatim:
+
+> Find mostly masculine words. Pick words with different vowel sounds. Your goal
+> is to make a list of words to look up in your rhyming dictionary. This is not a
+> final list. As you look in the rhyming dictionary, look actively. Don't be
+> afraid to switch, add, or take words out. You can even adjust your basic
+> approach as you go.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+Seed-word categories (skill expansion of Pat's rule):
 
 - Title words.
 - Emotional words.
@@ -94,9 +169,8 @@ Do not treat the seed list as final. It is only a list of words to test.
 
 ## Include title words
 
-Exercise 3.2 makes the title part of the worksheet habit. If a title contains
-several important words, put each important word into the central list before
-adding other material.
+Exercise 3.2 makes the title part of the worksheet habit. Pat's instruction:
+"Make it a habit to include each important word from the title in your list."
 
 Why:
 
@@ -111,8 +185,13 @@ test each one as a seed.
 
 ## Step 3: search actively
 
-Look up each seed word, but write down only rhyme candidates that fit the lyric
-idea. This is the difference between a worksheet and a raw dictionary copy.
+Pat's step 3, verbatim:
+
+> 3. Look up the words on the list in your rhyming dictionary.
+>
+> Write down only rhyme words that fit with your idea.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
 
 Active search means:
 
@@ -153,7 +232,8 @@ Keep:
 
 One important move in the chapter is changing a seed word to a nearby form
 because the new form generates more useful rhymes. This is not cheating. It is
-craft.
+craft. Pat does it on the page: seed 1 enters the box as `scared` and leaves the
+search as `scare`.
 
 Examples of acceptable changes:
 
@@ -180,14 +260,19 @@ Drop or protect a seed when:
 - Its sound family forces the section toward comedy.
 - It tempts the writer toward awkward grammar.
 
+Pat's own case: `risk` produces almost nothing ("disc… (oops!)"), and he leaves
+`safe` and `business` off the Chapter 3 list entirely because they "don't yield
+many rhymes" — then puts them back on the worksheet in Chapter 7, once family
+and imperfect rhyme are available.
+
 The word can still appear inside a line, in a title, or in an unrhymed position.
 Do not confuse importance with end-rhyme suitability.
 
 ## Charted territory
 
-The point of the preliminary work is to make drafting less blind. The worksheet
-does take time, but it also saves time because the writer is not solving rhyme,
-idea, grammar, and line shape simultaneously at every phrase ending.
+The point of the preliminary work is to make drafting less blind, in Pat's
+words: "The purpose of all this preliminary work is to put you in charted
+territory when you start writing."
 
 Skill coaching frame:
 
@@ -200,18 +285,98 @@ The second route is slower at first and faster in revision.
 
 ## Exercise 3.1: matching rhymes and ideas
 
-Exercise pattern to preserve:
+Exercise wording, verbatim:
 
-- Start with a focused idea sketch.
-- Build a seed list from the sketch.
-- Use a rhyming dictionary for each seed.
-- Copy only candidates that fit the idea.
-- Leave room around each seed for candidate groups.
+> EXERCISE 3.1. Matching Rhymes and Ideas
+>
+> Look up the words on the list on page 20 in your rhyming dictionary, and make
+> a list of rhyme words that fit the idea, using the sheet below.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
 
-The source example uses fear, attention, exclusion, risk, chance, dullness,
-leaving, being ignored, and disappearance as seed areas. It then shows a mixed
-result: some candidates are useful, some are identities, some are cliches, and
-some are rejected because they are grammatically or tonally poor.
+### Pattison's completed Chapter 3 worksheet
+
+"Here is my result:" — Pat's own filled-in sheet, verbatim, three columns across
+the page with the boxed seed list sitting in the middle. Marks in parentheses are
+his.
+
+<!-- book worksheet word lists trip the spell-checker --><!-- spellchecker:off -->
+
+```text
+1. scare            5. left out             8. dull
+   affair              doubt                   lull
+   unaware             gadabout                miracle
+   care                knockout (Identity)     numskull
+   fair                look out (Identity)     spectacle
+   glare               scout
+   prayer
+   unfair
+
+2. afraid                                   9. leave
+   charade                                     believe
+   fade                                        deceive
+   grade                                       grieve
+   masquerade                                  ho-heave
+   parade                                      sleeve
+   promenade
+
+3. flirt                                    10. ignored
+   alert                                        adored
+   dessert                                      bored
+   dirt                                         deplored
+   hurt                                         explored
+   inert            6. risk                     floored
+   introvert           disc…                    gored
+   shirt               (oops!)                  restored
+   skirt                                        scored
+   unhurt                                       outscored
+                                                sword
+
+4. attention        7. chance               11. gone
+   apprehension        advance                  chiffon
+   convention          circumstance             con
+   detention (Identity)   dance (Cliché?)       ex-con
+   intention (Identity)   lance                 echelon
+   invention           petulance                hangers-on
+   misapprehension     radiance                 paragon
+   pretention (Identity)                        put upon
+   suspension                                   dying swan
+   tension (Identity)
+```
+
+<!-- spellchecker:on -->
+
+### Pattison's comments on his own search
+
+Verbatim, numbered as printed:
+
+> There is plenty of raw material now. A few comments on my search:
+>
+> 1. I left out transitive verbs, including "desert," since I know they are
+>    awkward in the rhyming position.
+> 2. I left out the clichés "romance" and "trance." Did you?
+> 3. I changed "scared" to "scare" because it had better rhymes. "Scare" is
+>    usually a transitive verb, though it could be used as a noun. It might not
+>    be much use itself, but I like the rhyme list it generates.
+> 4. The only chance "risk" has is to "slip a disc." I can't think of a good use
+>    for "compact disc."
+> 5. "Ignored" didn't appear under "ORD," where I thought it should. But at the
+>    end of the column, I saw "adored, etc." which referred me to OR. The
+>    reference means to look at the OR column and add D whenever you can. The
+>    Wood book uses this shorthand to avoid unnecessary duplication. So, I went
+>    to the OR column and added D. I like the list.
+> 6. I left "safe" and "business" out of the list. If I had been starting from
+>    scratch, I would have tried them, but then eliminated them because they
+>    don't yield many rhymes.
+> 7. The purpose of all this preliminary work is to put you in charted territory
+>    when you start writing.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+Those seven comments are the filtering rules in action: transitive-verb rejection
+(1), cliche rejection (2), seed substitution (3), honest reporting of a dead seed
+(4), dictionary cross-reference discipline (5), dropping low-yield seeds (6), and
+the reason for the whole procedure (7).
 
 For skill use, the output should show both candidates and labels:
 
@@ -233,13 +398,70 @@ worksheet is no longer just a perfect-rhyme prewrite. It becomes a full search
 across the stability scale in [rhyme types](rhyme-types.md), still filtered by
 the song's idea.
 
+The chapter opens, verbatim:
+
+> Now it's time to go back to worksheets. This time, we'll launch a full rhyme
+> search. Our goal is to find better words than we did with perfect rhyme. Look
+> again:
+>
+> I'm sick of all this risky business
+> I want to play it safe
+>
+> For starters, "business" and "safe" can go on the worksheet. Now, you can find
+> rhymes for them.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 7
+
 The chapter's goal is not "more rhymes" in the abstract. It is better phrase-end
 choices than perfect rhyme alone can provide.
 
-> Rhymes are suggestive.
+> Rhymes are suggestive. As you look through them, they create associations that
+> can lead you in directions you might not have seen otherwise. A good reason to
+> use worksheets.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 7
 
 Use this chapter when the user has a lyric idea, a seed list, or a draft whose
 line endings feel trapped by obvious perfect rhymes.
+
+### The two seeds Chapter 3 rejected
+
+The family-rhyme table sits on the page directly above this list, because the
+list is built with it. Verbatim:
+
+<!-- book worksheet word lists trip the spell-checker --><!-- spellchecker:off -->
+
+```text
+            Plosives          Fricatives              Nasals
+Voiced:     b   d   g       v   TH   z   zh   j      m   n   ng
+Unvoiced:   p   t   k       f   th   s   sh   ch
+
+safe                 business
+   faith                collisions
+   chase                decisions
+   race                 visions
+   space                forgiveness
+   brave                frigid
+   grave                religious
+   slave                gifted
+   cage                 shiftless
+   stage                swiftless
+   castaway             kisses
+   ricochet             ambitious
+   runaway              delicious
+   haste                suspicious
+   braced               submissive
+                        riches
+                        finish
+                        whiz
+                        stiff
+```
+
+<!-- spellchecker:on -->
+
+Pat's verdict: "Better. There are some real possibilities here." Two words that
+were not worth a seed slot under perfect rhyme become productive once family,
+additive, assonance, and consonance rhyme are on the table.
 
 ## Expand the worksheet after learning rhyme types
 
@@ -285,9 +507,183 @@ make a better seed list before hunting rhymes.
 
 ## Search all rhyme relationships, then identify how they work
 
-Chapter 7 asks the writer to figure out what kinds of rhymes the list contains and how
-they were found. That makes the worksheet diagnostic. The writer should learn
-which sound move created each candidate, not just copy the word.
+Pat's framing instruction for the big list, verbatim:
+
+> Here is a complete rhyme search for each of the words on the worksheet. Figure
+> out what kind of rhymes they are and how I found them. They are all related to
+> the general idea of "RISKY BUSINESS." The list will have to be trimmed down
+> later.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 7
+
+That makes the worksheet diagnostic. The writer should learn which sound move
+created each candidate, not just copy the word.
+
+### The complete Chapter 7 search
+
+Printed as two headed columns, `Perfect Rhymes` on the left and
+`Imperfect Rhymes` on the right, with the imperfect side running into a second
+sub-column when it overflows. Marks in parentheses are Pat's.
+
+<!-- book worksheet word lists trip the spell-checker --><!-- spellchecker:off -->
+
+```text
+Perfect Rhymes          Imperfect Rhymes
+
+1. scare                1. scare
+   affair                  compare        stairs
+   unaware                 ensnare        unfair
+   care                    repair
+   dare                    snared
+   despair                 unprepared
+   fair                    scarce
+   glare
+   prayer
+
+2. afraid               2. afraid
+   charade                 bait           wait
+   fade                    date           vague
+   grade                   fate           break
+   masquerade              gate           awake
+   parade                  hate           earthquake
+   promenade               late           heartache
+                           suffocate      rattlesnake
+
+3. flirt                3. flirt
+   alert                   absurd         stir
+   dessert                 hummingbird    thirst
+   dirt                    word           burst
+   hurt                    handiwork      worst
+   inert                   jerk           voyeur
+   introvert               smirk          church
+   shirt                   work           urge
+   skirt                   curb           verge
+   unhurt                  disturb        preserved
+                           superb         nerve
+                           iceberg        reserved
+                           blur           swerve
+                           purr           amours
+                           slurs
+
+4. attention            4. attention
+   apprehension            exemption      complexion
+   convention              redemption     connection
+   detention               aggression     direction
+   intention               confession     infection
+   invention               discretion     objection
+   misapprehension         impression     weapon
+   pretention              obsession      perception
+   suspension              oppression     clandestine
+   tension                 possession     beckon
+                           procession     protection
+                           resurrection   affection
+                           mend on, etc.
+                           stretchin', etc.
+
+5. left out             5. left out
+   doubt                   aloud          renowned
+   gadabout                cloud          bound
+   knockout (id.)          crowd          found
+   lookout (id.)           allowed        announced
+   scout                   plowed         denounced
+                           vowed          trounced
+                           wowed          aroused
+                           couch          blouse
+                           grouch         soused
+                           drowned        crowned
+
+6. risk                 6. risk
+   disc                    fist           cliff
+   (oops!)                 kissed         stiff
+                           mist           tiff
+                           resist         quick
+                           tryst          kicks
+                           wisp           lick(s)
+                           abyss          sick
+                           avarice        trick
+                           bliss          transfixed
+                           dismissed      ditch
+                           wished         itch
+                           dish           pitch
+                           drift          switch
+                           gift           bridge
+                           hints          crypt
+                           shift          chips
+                           swift          apocalypse
+
+7. chance               7. chance
+   advance                 avalanche      scram
+   circumstance            pants          tramp
+   dance (cliché?)         slants         class
+   lance                   ban(s)         pass
+   petulance               fans           brash
+   radiance                plans          flash
+                           tan            splash
+                           band           trash
+                           command(s)     mask
+                           hand(s)        fast
+                           jam            last
+
+8. dull                 8. dull
+   lull                    annulled       diabolical
+   miracle                 gulf           natural
+   numskull                bulge          physical
+   spectacle               sulk           ritual
+                           convulsed      braille
+                           cult           fail
+                           insult         stale
+                           occult         pale
+                           result         drill
+                           chemical       brawl
+                           logical        small
+                           casual         stall
+                           conjugal       fool
+                                          school
+
+9. leave                9. leave
+   believe                 breathe        peace
+   deceive                 seethe         police (Identity)
+   grieve                  appeased       beach
+   ho-heave                please         c.o.d.
+                           diseased       debris
+                           freeze         guarantee(s)
+                           squeeze(d)     knees
+                           tease(d)       degrees
+                           prestige       refugee(s)
+                           relief         amenities
+                           grief          apologies
+                           thief          dignity
+                           teeth          fantasies
+                           caprice        hostilities
+
+10. ignored             10. ignored
+    adored                  court          encore
+    bored                   support        sore
+    deplored                resort         score
+    explored                short          roar
+    floored                 born           troubadour
+    gored                   torn           porch
+    restored                warned         morgue
+    scored                  forlorn        chord
+    outscored               scorned        torch
+    sword                   deformed       divorce
+                            storm          poor
+                            warm(ed)       cured
+                            reward         endure
+                            corps          self-assured
+
+11. gone                11. gone
+    chiffon                 dawn
+    con                     drawn
+    ex-con                  beyond
+    echelon                 blonde
+    hangers-on              song
+    paragon                 wrong
+    put upon                response
+    dying swan
+```
+
+<!-- spellchecker:on -->
 
 Use the [rhyme types](rhyme-types.md) scale as the lookup reference, but keep the
 worksheet focused on application:
@@ -302,6 +698,13 @@ worksheet focused on application:
 - Partial: use a weaker sonic link when the structure needs movement, surprise,
   or less finality.
 
+Reading the list against the scale answers Pat's "figure out how I found them"
+challenge. `scare / snared` is additive. `flirt / absurd` is family (`t` to its
+partner `d`). `flirt / church` is consonance. `chance / mask` keeps `s` and
+subtracts. `leave / police` is marked `(Identity)` because the `-lease` sound
+repeats too much of the target. `attention / mend on, etc.` and
+`attention / stretchin', etc.` are mosaics.
+
 Skill behavior: label imperfect candidates by likely relationship where useful,
 but do not overburden the user with a taxonomy lecture. The practical question
 is, "What new usable line ending did this sound move open?"
@@ -309,8 +712,9 @@ is, "What new usable line ending did this sound move open?"
 ## Keep the idea as the filter
 
 The complete Chapter 7 search lists many candidates, but Pattison frames them as
-related to the general "Risky Business" idea and says they will need trimming.
-That is the governing rule: a wider rhyme field still has to serve the song.
+related to the general "RISKY BUSINESS" idea and says the list "will have to be
+trimmed down later." That is the governing rule: a wider rhyme field still has to
+serve the song.
 
 Useful Chapter 7-style filters:
 
@@ -326,12 +730,15 @@ Examples from the chapter's practice material:
 
 - A seed can produce both perfect and imperfect options, and both should be
   judged by idea-fit.
-- `left out` produces identity warnings in the perfect-rhyme column; mark them
-  instead of treating them as ordinary rhymes.
-- `chance` carries a cliche warning around an obvious perfect rhyme; do not let
-  dictionary availability override listener expectation.
-- `leave` includes an identity warning in the imperfect column; near sound does
+- `left out` carries `knockout (id.)` and `lookout (id.)` in the perfect-rhyme
+  column; mark them instead of treating them as ordinary rhymes.
+- `chance` carries `dance (cliché?)` in the perfect column; do not let dictionary
+  availability override listener expectation.
+- `leave` carries `police (Identity)` in the imperfect column; near sound does
   not automatically mean usable craft.
+- `risk` carries `disc` followed by `(oops!)` — Pat's own note that a seed can
+  simply fail on the perfect-rhyme side and still be worth keeping for what the
+  imperfect side produces.
 
 Skill behavior: when presenting a worksheet, include a `watch` or `reject`
 category. This teaches the user why some technically valid rhymes should not be
@@ -359,26 +766,64 @@ drafting.
 
 ## Exercise 7.1: choose favorite perfect and imperfect rhymes
 
-Exercise pattern to preserve:
+Exercise wording, verbatim:
 
-- Start from the Chapter 7 keyword list.
-- For each keyword, review both perfect and imperfect rhyme columns.
-- Pick ten favorite rhymes for each keyword.
-- Prefer favorites that fit the idea, not merely favorites that sound clever.
-- Keep the selected words near the seed so they are easy to draft from.
+> EXERCISE 7.1. Perfect and Imperfect Rhyme Practice
+>
+> From the columns of perfect and imperfect rhymes above, choose your ten
+> favorite rhymes for each of the keywords and write them down below.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 7
 
-Chapter 7 keyword set:
+Chapter 7 keyword set (the Chapter 3 eleven, plus the two seeds Chapter 3 had
+dropped):
 
 ```text
-scare, afraid, flirt, attention, left out, risk, chance, dull, leave, ignored,
-gone, safe, business
+1. scare      6. risk     9. leave
+2. afraid                10. ignored
+3. flirt                 11. gone
+4. attention  7. chance  12. safe
+5. left out   8. dull    13. business
 ```
+
+Note the drift between the two printings: the ruled seed box in Chapter 3 and the
+blank sheet in Exercise 7.2 both say `scared`, while the search results and the
+Exercise 7.1 grid say `scare`. That is comment 3 in Chapter 3 taking effect — the
+seed changed mid-search and the printed sheets were never re-synced.
 
 Skill behavior: when a user asks to continue from a worksheet, ask them to pick
 or approve a short favorite set before drafting. If they do not want to choose,
 choose a balanced set: some stable, some surprising, all idea-fit.
 
 ## Exercise 7.2: rewrite from the expanded worksheet
+
+Exercise wording, verbatim:
+
+> EXERCISE 7.2. "Risky Business" Practice
+>
+> Rewrite your lyric "Risky Business" using some of your new ideas and rhyme
+> words.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 7
+
+The exercise then reprints the numbered seed list as a blank worksheet, thirteen
+slots deep:
+
+```text
+ 1. scared
+ 2. afraid
+ 3. flirt
+ 4. attention
+ 5. left out
+ 6. risk
+ 7. chance
+ 8. dull
+ 9. leave
+10. ignored
+11. gone
+12. safe
+13. business
+```
 
 Exercise pattern to preserve:
 
@@ -413,18 +858,20 @@ When applying Chapter 7 directly for a user:
 7. Suggest two or three lyric directions opened by the candidate set.
 8. Only then draft or rewrite the section.
 
-Compact output example:
+Compact output example, using Pat's own `safe` and `business` results:
 
 ```text
 seed: safe
-perfect: faith, chase, space
-imperfect: brave, grave, cage, stage, haste
+perfect: faith, chase, race, space
+imperfect: brave, grave, slave, cage, stage, castaway, ricochet, runaway,
+           haste, braced
 watch: over-familiar safety/risk pairs
 idea paths: caution, escape, public performance, locked-in fear
 
 seed: business
 perfect: none strong enough for default closure
-imperfect: decisions, visions, forgiveness, suspicious, ambitious
+imperfect: collisions, decisions, visions, forgiveness, religious, gifted,
+           shiftless, kisses, ambitious, delicious, suspicious, submissive
 watch: comic corporate tone unless wanted
 idea paths: bad choices, imagined betrayal, forgiveness after risk
 ```
@@ -434,25 +881,49 @@ usable skill output should be a trimmed, labeled working map.
 
 ## Exercise 3.2: worksheet from a title
 
-Exercise pattern to preserve:
+Exercise wording, verbatim:
 
-- Take a short title.
-- Put each important title word into the seed list.
-- Add seven or more idea words from the sketch.
-- Search each seed for idea-fitting rhyme candidates.
+> EXERCISE 3.2. Worksheet "Last Night's Love"
+>
+> Make up a worksheet on "last night's love." Start with an idea sketch. Make it
+> a habit to include each important word from the title in your list.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+The printed sheet seeds the first three slots from the title and leaves seven
+open:
+
+```text
+Idea sketch:
+
+ 1. last
+ 2. night
+ 3. love
+ 4.
+ 5.
+ 6.
+ 7.
+ 8.
+ 9.
+10.
+```
 
 This exercise makes the title a generator instead of a fixed burden. If a title
 word has weak rhyme potential, the worksheet reveals that early.
 
 ## Exercise 3.3: write sections from the worksheet
 
-Exercise pattern to preserve:
+Exercise wording, verbatim:
 
-- Use the worksheet to write two song sections, such as a verse and chorus.
-- Use an original title or the chapter's risk/safety title idea.
-- If using the provided title idea, do not put it in a rhyming position.
+> EXERCISE 3.3. Song Sections
+>
+> Using your worksheet (or mine), write two sections (maybe a verse and a
+> chorus). You can come up with your own title, or use "risky business." (If you
+> use my title, be sure not to put it in a rhyming position.)
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
 
-The last instruction matters: some titles are better as internal statements,
+The parenthetical matters: some titles are better as internal statements,
 section openings, or refrain material. A title does not automatically belong at
 line end.
 
@@ -462,10 +933,39 @@ draft, not become decoration under it.
 
 ## English is rhyme-poor
 
-Pattison closes the chapter by explaining why worksheets matter especially in
-English. English does not use word endings systematically the way many Romance
-languages do. Fewer shared endings means fewer obvious rhyme options, and many
-of the available ones are overused.
+Pattison closes Chapter 3 by explaining why worksheets matter especially in
+English. Verbatim:
+
+> Making a worksheet is a great way to keep from boxing yourself into a corner.
+> It takes time, but it also saves time. More importantly, it raises quality and
+> guarantees that your rhyming position will communicate ideas effectively.
+>
+> But even when you're armed with a good rhyming dictionary and have mastered
+> making a worksheet, the sad fact is that English is a "rhyme-poor" language.
+> Why? English does not use the endings of words in any systematic way. In other
+> languages, like Italian, French, and Spanish, the ends of words are used for
+> grammatical purposes. They tell you:
+>
+> 1. whether a word is a noun, verb, adjective, etc.
+> 2. if the word is singular or plural
+> 3. how the word is being used—object of a preposition, direct object,
+>    subject, etc.
+> 4. how to categorize words according to gender.
+>
+> English does none of these things except in two minor cases: the "ing" ending
+> for gerunds and participles, and the "ly" ending for many adverbs.
+>
+> When languages use endings in a systematic way, they limit the ways words can
+> end, increasing rhyme possibilities. Since English does not limit the number
+> of ways its words can end, there are fewer rhymes available. This makes it
+> harder to use your spotlights effectively.
+>
+> Worksheets are very important. Because of the overuse of many English rhymes
+> (clichés), the options in English are severely limited. Fortunately, there are
+> even more ways to improve your chances of finding effective rhymes in English.
+> Let's turn to them.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
 
 Consequences:
 

--- a/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
@@ -6,9 +6,15 @@ mechanism analyses on canonical songs that demonstrate verse/refrain,
 verse/chorus, verse/transitional-bridge/chorus, and verse/transitional-
 bridge/refrain.
 
-**Reproduction discipline.** This file describes mechanisms, NOT lyrics. No
-lyric text from any of the four songs appears below; only structural
-analysis and Pat's craft commentary, paraphrased.
+**What's here.** The four demonstration lyrics as Chapter 6 prints them,
+together with Pat's structural analysis of each. The analysis is about where
+specific stresses, rhymes, and phrase lengths fall, so the lines are quoted
+rather than described — a summary of a scansion argument is not usable.
+
+Everything under a "Coaching use" heading, the "Why the contrast works" block,
+and the "Common threads across all four" list are this file's own synthesis,
+not claims Chapter 6 makes. Where Pat's own framing is quoted or closely
+followed it is marked as his.
 
 ## Why this file exists
 
@@ -24,6 +30,26 @@ mechanism analyses, not just the form taxonomy.
 **Form:** verse/refrain. Each verse closes with a recurring refrain line
 that carries the title.
 
+Verse 1:
+
+```text
+We've been sitting here the whole night long
+Pouring out our hearts
+About how loving never ends the way
+We felt it at the start
+And we'll sit right here till we decide
+What the next step ought to be
+We got a lot to talk about
+THIS BOTTLE AND ME
+```
+
+The refrain is the last two phrases; the hook is the last phrase alone:
+
+```text
+We got a lot to talk about
+THIS BOTTLE AND ME
+```
+
 **Structural mechanics:**
 
 - Two systems of Common Meter per verse (4/3/4/3 stress, then 4/3/4/3 again)
@@ -35,7 +61,26 @@ that carries the title.
   the structural close, not at a chorus boundary
 
 **Bridge variant (same song, Chapter 6 demonstration):**
-Pat adds a bridge to demonstrate all three *Essential Guide to Lyric Form and
+Pat keeps all three verses and inserts a bridge between verses 2 and 3:
+
+```text
+THIS BOTTLE AND ME will do all right
+We'll just stay right here together
+Waste away the night
+Waiting till the morning comes
+And the ache is almost gone
+Struggle through another day
+Till another night comes rolling on
+```
+
+The bridge is asymmetrical — **7 phrases** — and differs from the verses in
+both rhythm and rhyme. Its last four lines are still based on Common Meter;
+what changes is placed exactly where change is needed: the **first** line is
+a clear rhythmic departure, and the **last** line carries an extra stressed
+syllable that works as a rhythmic Deception, moving forward into the last
+verse's return to home base.
+
+It demonstrates all three *Essential Guide to Lyric Form and
 Structure* (1991), Chapter 6 bridge purposes point-by-point on a real song:
 
 1. **Break monotony** — bridge contrasts the established verse structure, and
@@ -59,6 +104,32 @@ across three preceding lines.
 
 **Form:** verse/chorus. Verse builds; chorus delivers.
 
+Verse 1:
+
+```text
+Spanish moss hanging low
+Swaying from the trees
+Honeysuckle, sweet magnolia
+Riding on the breeze
+Southern evenings, southern stars
+Used to bring me peace
+But now they only make me cry
+They only make me realize
+```
+
+Chorus:
+
+```text
+There's no SOUTHERN COMFORT
+Unless you're in my arms
+You're the only cure
+For this aching in my heart
+I've searched everywhere
+Tried the bedrooms, tried the bars
+But there's no SOUTHERN COMFORT
+Unless you're in my arms
+```
+
 **Structural mechanics:**
 
 - **Eight phrases in the verse**, rhyming `x a x a x a b b`. The first six lock
@@ -74,12 +145,26 @@ across three preceding lines.
 - Chorus delivers the withheld three-stress closure AND the title's rhyme
   payoff
 - Bridge (when present) is derived from a two-stress phrase hint already
-  planted earlier in the verse — bridge material has a structural seed in
-  the verse, not a free import
+  planted in the song — bridge material has a structural seed, not a free
+  import. The song otherwise runs on 3- and 4-stress phrases; the quick
+  2-stress passes are `Southern evenings, / southern stars` in the verse and
+  `Tried the bedrooms, / tried the bars` in the chorus, both in non-resolving
+  positions. Pat takes the hint and opens the bridge on fast 2-stress
+  phrases, then builds into longer ones:
+
+  ```text
+  Bar to bar
+  Face to face
+  Someone else takes your place
+  But no one's ever new
+  I always turn them into you
+  ```
 
 **Why it works (Pat's framing):**
-Deceptive closure on a verse boundary spotlights forward direction. The ear
-has been trained to expect resolution at the verse's structural close;
+Deceptive closure on a verse boundary spotlights forward direction — it
+"calls special attention to the forward direction of the Song System:
+'Makes me realize ... what?'" The ear has been trained to expect
+resolution at the verse's structural close;
 when resolution is withheld, the ear pushes into the next section. The
 chorus arrives carrying the withheld closure plus the title — a double
 spotlight.
@@ -95,17 +180,67 @@ withholding.
 **Form:** verse / transitional bridge / chorus, repeated across three
 systems. Most complex worked example in *Essential Guide to Lyric Form and Structure* (1991).
 
+Song System 1 — two verse quatrains, transitional bridge, chorus:
+
+```text
+Teddy feels alone again          VERSE 1
+It happens every night
+There inside his room again
+He listens as they fight
+
+Tonight it will be different     VERSE 2
+Leaving while they sleep
+He sneaks into the closed garage
+Tonight he'll find peace
+
+Crying "Mama won't you listen!   TRANS BR 1
+Daddy can't you see!"
+He slides the seat back
+Turns the key
+
+It's a short ride to the dark side   CHORUS
+All the love he might have known
+Lost forever, left alone
+No one in the world could hear
+The closing of the door
+TEDDY DOESN'T LIVE HERE ANYMORE
+```
+
+Song System 3 replaces the verse block entirely with a bridge:
+
+```text
+Just sixteen                     BRIDGE
+He couldn't see
+Where life ahead of him might lead
+He couldn't see at sweet sixteen
+What could have been
+```
+
 **Structural mechanics:**
 
-- Three song systems (V1 → TB1 → Ch / V2 → TB2 → Ch / V3 → TB3-as-Bridge → Ch)
-- V2 introduces irregular rhythm at the story's tension point — the
-  rhythmic instability matches the emotional escalation
-- Transitional bridges (TB1, TB2) deploy progressively longer phrases
-- TB3 functions as a full bridge (new perspective, longest phrase yet,
-  implying a fifth stress that hasn't arrived)
-- **The slingshot effect** — long phrase before the hook acts like the
-  rubber of a slingshot: the longer the phrase, the harder the hook lands
-  when it arrives
+- Three song systems: `S1 = V1 + V2 → TB1 → Ch`, `S2 = V3 + fourth quatrain
+  → TB2 → Ch`, `S3 = Bridge → Ch`. There is no third transitional bridge and
+  no verse in system 3 — the bridge takes the verse block's place
+- Verse 1 is a clear Common Meter opening that sets the pattern
+- V2 introduces irregular rhythm at the story's tension point — "Tonight
+  he'll find peace" puts two stressed syllables in a row, forcing an
+  irregular rhythm where a regular one was easy to write. The imperfect
+  rhyme "sleep/peace" defines the section but still lets it tip forward
+  into the transitional bridge
+- The transitional bridge runs **long to short**: its opening phrase
+  ("Crying 'Mama won't you listen!") is the longest phrase so far in the
+  lyric, the second is shorter, the third shorter and irregular, then the
+  coup de grâce. Exercise 36 asks the writer to reverse that direction
+- The bridge (system 3) is very unbalanced: three balanced 4-stress rhythms
+  ending two stresses short in the last line, with "just a whiff of rhyme"
+  in see/lead/teen/been. It starts fast, slows on the long second phrase,
+  and the last phrase floats away — like Teddy's chances for love
+- **The slingshot effect** — the longest phrase in the song system sits in
+  the chorus, immediately before the hook ("No one in the world could hear /
+  The closing of the door"). Pat: the long phrase is "the rubber of a
+  slingshot, stretching to give power to the release," and it should be
+  longer than the hook itself, since nothing else in the song sets up a
+  5-stress expectation
 - Hook (the title) lands with five stresses **for the first time in the
   song**; the entire prior structure has been four-stress territory, so the
   five-stress hook feels like an arrival the listener has been pulled
@@ -113,10 +248,12 @@ systems. Most complex worked example in *Essential Guide to Lyric Form and Struc
 - Chorus first phrase = a rhythm figure already set up in V2 and TB
 
 **The unstressed-syllable trick (Chapter 6):**
-Pat plants an extra unstressed syllable in the transitional bridge that
-**implies** a fifth stress before the chorus delivers one. The implication
-trains the ear to expect the fifth stress; the chorus then delivers it on
-the title.
+The transitional bridge's opening phrase — `Crying "Mama won't you listen!`
+— is four stresses that **end on an unstressed syllable**, and that trailing
+weak syllable *implies* a fifth stress that never arrives. "Without knowing
+it, your listener is being set up for the only 5-stress phrase in the song:
+the HOOK!" The implication trains the ear; the chorus delivers it on the
+title.
 
 **Coaching use:** writer asking "how do I set up a hook?" — the answer is
 not louder, not bigger. The answer is structural withholding plus
@@ -128,16 +265,35 @@ bridge imply a fifth stress; deliver the fifth stress on the title.
 **Form:** verse / transitional bridge / refrain. Less common form. The
 contrast between verse and transitional bridge does the lifting.
 
+Song system 1:
+
+```text
+Turned loose in a company of strangers        VERSE 1
+Getting nowhere, we had nowhere to go
+Bad blues hit you harder when you're aching
+They never leave you, they'll never leave you alone
+They get you crawlin'
+
+I might've fallen                             TRANS BR 1
+But you were always around
+
+YOU NEVER LET ME DOWN                         REFRAIN
+YOU NEVER LET ME DOWN
+```
+
 **Structural mechanics:**
 
-- Verse: long phrases, imperfect rhymes at distance
-- Transitional bridge: short phrases, close (perfect) rhymes
-- Refrain closes the system with the title
+- Verse: long phrases, imperfect rhymes separated by distance
+  (strangers/aching, go/alone)
+- The contrasting section: "Short phrases. Quick rhymes." Pat groups
+  `They get you crawlin' / I might've fallen` as the pair that does it,
+  reaching back across the printed section break
+- Then the set-up — a 3-stress line, "But you were always around," which
+  supplies a sound for the hook to attach to (around/down)
+- Refrain closes the system down on the title
 - The contrast between verse and TB is the pedagogical point — not
   similarity, not development, but **deliberate structural opposition**:
-  long-distance-imperfect → short-close-perfect
-- Refrain absorbs both qualities: the TB's perfection of rhyme + the
-  verse's distance of emotional weight
+  long phrases with distant imperfect rhyme → short phrases with quick rhyme
 
 **Why the contrast works:**
 A transitional bridge whose only job is to set up a refrain has more

--- a/plugins/songwriting/context/pat-pattison/research/song-forms.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms.md
@@ -53,13 +53,42 @@ deliver the strongest version of the song?"
 ## V/V/Ch Risk Repair
 
 Chapter 22 gives three practical repair strategies for a verse/verse/chorus,
-verse/verse/chorus draft.
+verse/verse/chorus draft. It works all three on one lyric — Jim Rushing's
+"Slow Healing Heart," first arranged as a `v / v / ch / v / v / ch` lyric so
+the risk is visible. Verse 4 is the crucial one, the place "where you run the
+risk of making the song seem too long":
+
+```text
+There's a part of me still on the lookout
+Alert for those cutting remarks
+Looks that are sweet
+Soon will cause you to bleed
+Woe is a slow healing heart
+```
 
 First, dump a verse by distilling two verses into one. Keep the essential
 information, preserve the necessary turn, and move to:
 
 ```text
 v / v / ch / v / ch
+```
+
+Pat distills verses 3 and 4 on a "best of" principle. Two of his attempts:
+
+```text
+There's a part of me still on the lookout
+Alert for cutting remarks
+But the sweetest of words
+Only sharpen this hurt
+Woe is a slow healing heart
+```
+
+```text
+How I prayed for blind faith to lead me
+Away from those cutting remarks
+Now I'm doing fine
+Both in body and mind
+But woe is a slow healing heart
 ```
 
 The second chorus then arrives earlier, which can make the whole form feel more
@@ -74,7 +103,17 @@ v / v / ch / v / ch / br / ch
 
 This only works if the new bridge changes both structure and information. A
 bridge is not a renamed verse. It needs a different perspective, phrase shape,
-line count, rhyme behavior, or tense.
+line count, rhyme behavior, or tense. Pat's bridge for "Slow Healing Heart":
+
+```text
+I pray that someday
+I won't be afraid
+But some hurts take longer to fade
+```
+
+He names exactly what it changes: the move to future tense shifts away from
+the verse material, and shorter lines plus a three-line unbalanced section
+rhyming AAA change the structure.
 
 Third, keep the material but restructure two verses into one larger unit:
 
@@ -84,9 +123,26 @@ v / ch / v / ch
 
 The point is not to remove the blank line on the lyric sheet. The point is to
 make the longer verse change internally, so two blocks of information no longer
-repeat the same structure. In the "Slow Healing Heart" example, common-meter
-motion gives way to four-stress couplet motion inside the verse, forcing a
-fresh musical feel while retaining the material.
+repeat the same structure. Here is how Rushing's actual verse does it —
+Chapter 22 prints the rhyme letter and stress count beside each line:
+
+| Line | Rhyme | Stresses |
+|---|---|---|
+| When I left I left walking wounded | x | 3+ |
+| I made my escape from the rain | a | 3 |
+| Still a prisoner of hurt | b | 2 |
+| I had months worth of work | b | 2 |
+| Freeing my mind of the pain | a | 3 |
+| I had hours of sitting alone in the dark | c | 4 |
+| Listening to sad songs and coming apart | c | 4 |
+| Lord knows I made crying an art | c | 4 |
+| Woe is a slow healing heart | c | 3 |
+
+Pat's reading: the first half is basic common meter, in three-quarter time,
+with a rhyme acceleration in the third line; the second half "moves two by two
+in four-stress couplets, creating a whole different feel (which will force a
+musical change). Rushing creates two interesting, unified verses rather than
+four helpings of the same structure."
 
 ## Repetition risk audit
 
@@ -111,10 +167,30 @@ to wait through avoidable repetition.
 v / ch / v / ch / v / ch
 ```
 
-Two verse/chorus systems may establish and develop the song well. The third
-can feel flat because the listener has already heard the structural package
-twice. The form is not wrong by default; it simply stops helping unless the
-third idea earns another identical trip.
+The worked sample is a three-verse lyric Pat titles "Love Her or Leave Her
+to Me":
+
+```text
+You're living with a woman you ain't true to
+Playin' round but keep her hanging on
+If you don't want her, let me have her
+You won't believe how fast I'll grab her
+You'll hardly even notice that she's gone
+
+Love her or leave her to me
+Keep her or let her go free
+Don't go two-timing her
+'Less you're resigning her
+Love her or leave her to me
+```
+
+Two verse/chorus systems may establish and develop the song well. Pat's
+verdict on this one: "Not a bad lyric. It chugs along nicely for two verse /
+chorus systems, developing its ideas with light, cute structure. The third
+system, however, seems to fall a little flat, not so much for what it says,
+but because we've seen its structure twice before." The form is not wrong by
+default; it simply stops helping unless the third idea earns another
+identical trip.
 
 Chapter 23 gives three alternatives.
 
@@ -126,7 +202,20 @@ v / ch / v / ch / br / v / ch
 
 Use this when the third verse is still needed as a verse, but the song needs a
 contrasting section first. The bridge should supply a missing angle and change
-structure significantly.
+structure significantly — "a different rhyme scheme, a different number of
+lines, and different line lengths," and it should also say something
+different.
+
+Pat finds the missing angle by auditing what the lyric already says: we know
+the speaker wants the wife, that the husband is fooling around, that she calls
+the speaker, and that the speaker has plans — but we never learn what makes
+her so desirable. A bridge on her qualities leads smoothly into the third
+verse, which opens:
+
+```text
+Well, I guess some men got no appreciation
+They never see the finer things in life …
+```
 
 Chapter 23 names the cost: because the form returns to a full verse before the
 last chorus, the lyric can still get — or seem — long. That is the risk this
@@ -140,7 +229,14 @@ v / ch / v / ch / br / ch
 ```
 
 This is leaner than returning to another full verse. It works when the bridge
-can carry the missing turn without needing a full third verse.
+can carry the missing turn without needing a full third verse. Pat's bridge
+for "Love Her or Leave Her to Me" is two lines — it recycles the third
+verse's idea into a couplet and hands straight back to the chorus:
+
+```text
+Leave the finest things behind, an'
+Someone else is bound to find 'em
+```
 
 Option 3 changes the song into AABA verse/refrain form when the material truly
 needs three verse-like ideas:
@@ -154,7 +250,35 @@ A verse/refrain
 
 This lets the first two A sections define home, the B section depart, and the
 final A feel like a real return rather than a third repeated verse/chorus
-system.
+system. Pat rewrites the same three ideas with the title demoted from chorus
+to refrain — the chorus disappears and every verse now ends on the title:
+
+```text
+You're living with a woman you ain't true to
+You play around, she sits home faithfully
+If you don't want her let me have her
+Wait and see how fast I grab her
+Love her or leave her to me
+
+While you're out she gets a little lonesome
+What to do, she's got her evenings free
+She calls me up, I play the friend
+I know she'll love me in the end
+Love her or leave her to me
+Boy just keep your blinders on
+You'll never notice when she's gone
+
+I'm glad some men got no appreciation
+The finest things are just too hard to see
+You just keep two-timing her
+Soon you'll be resigning her
+Love her or leave her to me
+```
+
+Pat on why it works: "The first two verses define 'home base,' then the bridge
+takes you away from home — away from the familiar structure. When you come
+back to the third verse, you come back home to familiar territory. It's a real
+homecoming, seeing the old neighborhood again after a long trip."
 
 ## Bridge Validity
 
@@ -167,13 +291,31 @@ develop situation or plot, while the chorus comments, summarizes, or warns. A
 bridge needs another angle: a missing character quality, a new perspective, a
 shift in tense, or a concise turn that neither verse nor chorus has supplied.
 
-Use object writing when the missing angle is character or sensory detail. The
-chapter's exercise asks for a list of the woman's qualities, then an
-object-writing pass, before drafting bridges.
+Use object writing when the missing angle is character or sensory detail.
+Exercise 49 sets the order: list her qualities — things she is, things she
+does, drawn from your own experience — then do an object-writing pass, then
+draft bridges. Pat's own sample for "Love Her or Leave Her to Me":
+
+> Kicking through the fallen leaves, gold-brown and red. Cheeks flushed and
+> soft, glowing with the afternoon sunlight. You don't speak, I don't dare
+> speak; our shoulders touching, lingering a little, skin electric, breath
+> coming a little faster. You step slowly, patiently, listening to the leaves
+> swirling and dancing in colors as we move together.
+
+"Your object writing will create a mood and character for you to respond to."
+Then try a few bridges — contrasting section, short and effective.
 
 ## Home base principle
 
-Pattison starts from the limerick principle:
+Pattison starts from the limerick principle, and Chapter 6 opens with the
+limerick itself:
+
+```text
+There once was a student named Esser
+Whose knowledge grew lesser and lesser
+It at last grew so small, he knew nothing at all
+And now he's a college professor
+```
 
 ```text
 1. statement of structure      A
@@ -181,6 +323,12 @@ Pattison starts from the limerick principle:
 3. variation of structure      B
 4. return to original          A
 ```
+
+> "Repeating the structure of the first statement defines 'home base.' Moving
+> away from home base at the third phrase creates tension — a move to
+> unfamiliar territory. Coming back to familiar territory at phrase four is a
+> resolution, a welcome home party." — *Essential Guide to Lyric Form and
+> Structure* (1991), Chapter 6
 
 The return matters because the listener has heard home base before. Without a
 defined home, departure and return lose force.
@@ -200,7 +348,18 @@ The refrain usually contains the title or central idea. Because every system is
 the same size, the form can become monotonous unless the verse ideas develop
 strongly or a bridge interrupts the pattern.
 
-Chapter 6 example diagnosis:
+Chapter 6 example diagnosis — "This Bottle and Me," verse 1:
+
+```text
+We've been sitting here the whole night long
+Pouring out our hearts
+About how loving never ends the way
+We felt it at the start
+And we'll sit right here till we decide
+What the next step ought to be
+We got a lot to talk about
+THIS BOTTLE AND ME
+```
 
 ```text
 verse structure: Common Meter twice
@@ -208,6 +367,11 @@ rhyme scheme:    x a x a x b x b
 internal shape:  A A, fragmented after line 4
 refrain:         final two phrases, part of verse structure
 ```
+
+The refrain is "We got a lot to talk about / THIS BOTTLE AND ME"; the hook is
+the title line alone. Because the structure repeats so heavily, Pat's own
+verdict is that "this lyric gets boring fast" and needs a release — which is
+what the bridge below supplies.
 
 Use this form when the repeated central idea should feel woven into the verse
 rather than announced by a separate chorus.
@@ -230,9 +394,23 @@ The bridge accomplishes three jobs:
 - Gives the lyric a new perspective before the final verse/refrain.
 
 The bridge must differ where difference is needed, especially at its first
-line. In the Chapter 6 example, the bridge is asymmetrical, rhythmically different
-from the verses, and closes with a rhythmic deception that points forward into
-the last verse.
+line. Chapter 6's bridge for "This Bottle and Me":
+
+```text
+THIS BOTTLE AND ME will do all right
+We'll just stay right here together
+Waste away the night
+Waiting till the morning comes
+And the ache is almost gone
+Struggle through another day
+Till another night comes rolling on
+```
+
+It is asymmetrical — 7 phrases — and different from the verses in both rhythm
+and rhyme. Its last four lines still run on Common Meter; the difference is
+placed where difference is needed: the first line is a clear rhythmic
+departure, and the last line's extra stressed syllable is a rhythmic
+Deception that moves forward into the last verse.
 
 ## AABA
 
@@ -264,6 +442,23 @@ then feeling the arrival back at it.
 Simple verse/chorus form works like Common Meter — also called the **Ballad
 Stanza** — at the section level. Chapter 6 states the two mappings as a pair:
 AABA runs on the limerick's principle, verse/chorus runs on Common Meter's.
+The two stanzas Chapter 6 prints to establish the pattern:
+
+```text
+O Western Wind, when will thou blow
+That the small rain down can rain?
+Christ, that my love were in my arms
+And I in my bed again
+                            — Anonymous
+```
+
+```text
+The wind doth blow today my love
+And a few small drops of rain
+I never had but one true love
+In cold grave she was lain
+                            — From "The Unquiet Grave," Anonymous
+```
 
 ```text
 1. statement                    A  Verse
@@ -280,13 +475,44 @@ S1: Verse -> Chorus
 S2: Verse -> Chorus
 ```
 
-Chapter 6 example diagnosis:
+Chapter 6 example diagnosis — "Southern Comfort":
+
+```text
+Spanish moss hanging low              VERSE
+Swaying from the trees
+Honeysuckle, sweet magnolia
+Riding on the breeze
+Southern evenings, southern stars
+Used to bring me peace
+But now they only make me cry
+They only make me realize
+
+There's no SOUTHERN COMFORT           CHORUS
+Unless you're in my arms
+You're the only cure
+For this aching in my heart
+I've searched everywhere
+Tried the bedrooms, tried the bars
+But there's no SOUTHERN COMFORT
+Unless you're in my arms
+```
 
 ```text
 verse:  Common Meter setup, then deceptive closure
 chorus: delivers the withheld three-stress closure and rhyme balance
 effect: verse points; chorus closes
 ```
+
+The verse runs eight phrases rhyming `x a x a x a b b`. The first six lock the
+ear into Common Meter and the seventh only continues the pattern, so everyone
+expects a three-stress Common Meter close — and the eighth phrase refuses it
+in both rhythm and rhyme. "The last phrase of this verse, and the last phrase
+alone, unbalances the section… Any three-stress phrase would have balanced the
+verse! But the verse has refused to deliver."
+
+In the chorus every line has three stresses except line 6, "Tried the
+bedrooms, tried the bars," which is two phrases and accelerates at that point;
+the final two phrases return to three stresses and close the song system.
 
 Use this form when the lyric needs repeated cycles of development into a
 central idea.
@@ -315,6 +541,23 @@ bridge development: build into longer phrases
 result:             new angle, then chorus realization
 ```
 
+Worked on "Southern Comfort": the song runs on 3- and 4-stress phrases, plus
+quick passes at 2-stress phrases in "Southern evenings, / southern stars" and
+"Tried the bedrooms, / tried the bars" — always in non-resolving places. Pat
+takes that hint and develops it:
+
+```text
+Bar to bar
+Face to face
+Someone else takes your place
+But no one's ever new
+I always turn them into you
+```
+
+Start with fast 2-stress phrases (diving into the singles-bar lifestyle) for
+contrast and a push forward, then build into longer phrases, slowing down
+until the realization lands — and the restated chorus completes it.
+
 Use this form when the song has already completed two strong cycles and needs a
 new pressure source before the final chorus.
 
@@ -331,7 +574,10 @@ Chorus:       central arrival
 
 This avoids the risk of four same-shaped verses while preserving the full
 story. The larger verse must not simply be two verses pasted together. It
-should behave like one designed unit with a deliberate internal turn.
+should behave like one designed unit with a deliberate internal turn. The
+worked instance is the "Slow Healing Heart" verse tabled above: `x a b b a` at
+3/3/2/2/3 stresses, then `c c c c` at 4/4/4/3 — common meter giving way to
+four-stress couplets inside a single verse.
 
 ## Verse / Transitional Bridge / Chorus
 
@@ -346,7 +592,32 @@ S2: Verse -> Transitional Bridge -> Chorus
 Its job is not the same as a full bridge. It is shorter, more unstable, and
 designed to make the chorus feel necessary.
 
-Chapter 6 example diagnosis:
+Chapter 6 example diagnosis — "Teddy Doesn't Live Here Anymore," song
+system 1:
+
+```text
+Teddy feels alone again              VERSE 1
+It happens every night
+There inside his room again
+He listens as they fight
+
+Tonight it will be different         VERSE 2
+Leaving while they sleep
+He sneaks into the closed garage
+Tonight he'll find peace
+
+Crying "Mama won't you listen!       TRANS BR 1
+Daddy can't you see!"
+He slides the seat back
+Turns the key
+
+It's a short ride to the dark side   CHORUS
+All the love he might have known
+Lost forever, left alone
+No one in the world could hear
+The closing of the door
+TEDDY DOESN'T LIVE HERE ANYMORE
+```
 
 ```text
 verse:  clear Common Meter opening
@@ -354,6 +625,9 @@ verse 2 strategy: slight rhythmic unbalance at a tense idea
 transitional bridge: longest phrase so far, then shorter phrases
 chorus: title/hook delivers the prepared stress shape
 ```
+
+The song's third system is bridge → chorus: it drops the verse block
+entirely rather than running a third verse and transitional bridge.
 
 Use this form when verse and chorus share a strong groove or when the chorus
 needs a small lift, ramp, or release before arrival.
@@ -376,6 +650,26 @@ verse: long phrases, imperfect rhymes, distance between rhyme sounds
 transitional bridge: short phrases, quick rhymes
 refrain: title closes the system
 ```
+
+Chapter 6's example is "You Never Let Me Down," song system 1:
+
+```text
+Turned loose in a company of strangers        VERSE 1
+Getting nowhere, we had nowhere to go
+Bad blues hit you harder when you're aching
+They never leave you, they'll never leave you alone
+They get you crawlin'
+
+I might've fallen                             TRANS BR 1
+But you were always around
+
+YOU NEVER LET ME DOWN                         REFRAIN
+YOU NEVER LET ME DOWN
+```
+
+Pat pairs "They get you crawlin' / I might've fallen" as the contrasting
+move — short phrases, quick rhymes — and then "But you were always around" is
+the set-up: a 3-stress line supplying a sound for the hook to attach to.
 
 Use this when the title should remain part of the verse system, but the lyric
 still needs a short ramp into the title.
@@ -406,6 +700,21 @@ verse 2: final phrase adds rhythmic irregularity at a tense idea
 effect: section still closes, but tips forward into transitional bridge
 ```
 
+"Teddy Doesn't Live Here Anymore," verse 2:
+
+```text
+Tonight it will be different
+Leaving while they sleep
+He sneaks into the closed garage
+Tonight he'll find peace
+```
+
+The last phrase puts two stressed syllables in a row, forcing an irregular
+rhythm — and a regular one would have been easy to write. The irregularity
+lands at a point of strong tension in the ideas, so it is prosody as well as
+motion; the imperfect rhyme "sleep/peace" defines the section while still
+letting you feel the pull forward into the transitional bridge.
+
 Use second-verse strategy when the story or emotion has intensified but the
 song still needs the same formal identity.
 
@@ -420,8 +729,20 @@ shorten or lengthen phrases toward pressure
 deliver title/hook in the prepared position
 ```
 
-In one example, a long phrase before the hook acts like a slingshot: stretching
-time gives power to the release into the title.
+In "Teddy Doesn't Live Here Anymore," the longest phrase in the song system
+sits immediately before the hook:
+
+```text
+No one in the world could hear
+The closing of the door
+TEDDY DOESN'T LIVE HERE ANYMORE
+```
+
+Pat: "I think of the longer phrase as the rubber of a slingshot, stretching to
+give power to the release. It seems to me that it should be longer than the
+Hook, especially since there are no 5-stress lines to set up expectations for
+a 5-stress close." Exercise 37 asks the writer to try the opposite — set up
+the hook with shorter phrases instead — and compare the sense of arrival.
 
 ## Parallel sections
 
@@ -434,6 +755,23 @@ parallel: same strong-stress positions, changed content
 variation: extra weak syllables between strong positions
 effect: faster surface motion without losing structure
 ```
+
+"Teddy Doesn't Live Here Anymore" changes the content of its second
+transitional bridge but keeps it in close parallel with the first:
+
+```text
+He cries, "Baby, it's so cold here
+Won't you take me home?"
+She shivers as she turns away
+Leaves alone
+```
+
+The third line, "She shivers as she turns away," carries the same three strong
+stresses as its counterpart "He slides the seat back" — the additional
+unstressed syllables "shiver quickly past and leave with her," forcing the
+music to accelerate by stuffing syllables between the strong positions. Pat
+calls the effect startling here, then adds the general rule: "Normally,
+though, keep your sections parallel."
 
 ## Exercises to preserve
 
@@ -501,13 +839,25 @@ effect: faster surface motion without losing structure
 
 *Essential Guide to Lyric Form and Structure* (1991), Chapter 6 names the principle behind A-A-B-A and similar forms:
 
-> "Statement, restatement, variation, return to original." — Pat
-> (*Essential Guide to Lyric Form and Structure* (1991), Chapter 6, paraphrased)
+> "Repeating the structure of the first statement defines 'home base.' Moving
+> away from home base at the third phrase creates tension — a move to
+> unfamiliar territory. Coming back to familiar territory at phrase four is a
+> resolution, a welcome home party." — Pat (*Essential Guide to Lyric Form and
+> Structure* (1991), Chapter 6)
 
-The limerick is the small-scale model. Lines 1-2 state, line 3 varies
-(often with shorter length or different rhyme), lines 4-5 return.
-A song's AABA form runs the same principle at section level: A states,
-A restates, B varies (the bridge), A returns.
+The limerick is the small-scale model, and Chapter 6 prints it in four
+phrases:
+
+```text
+There once was a student named Esser
+Whose knowledge grew lesser and lesser
+It at last grew so small, he knew nothing at all
+And now he's a college professor
+```
+
+Phrases 1-2 state and restate, phrase 3 varies (shorter units, different
+rhyme), phrase 4 returns. A song's AABA form runs the same principle at
+section level: A states, A restates, B varies (the bridge), A returns.
 
 Use the home-base principle to:
 
@@ -574,7 +924,16 @@ draft, so it is a revision procedure too.
 
 The companion failure mode to four-times-verses: a verse-chorus form
 that runs three full systems with no contrast risks flatness on the
-third arrival.
+third arrival. Chapter 23 works it on "Love Her or Leave Her to Me,"
+whose chorus is:
+
+```text
+Love her or leave her to me
+Keep her or let her go free
+Don't go two-timing her
+'Less you're resigning her
+Love her or leave her to me
+```
 
 Three named alternatives:
 
@@ -614,8 +973,8 @@ compressed.
 ## *Essential Guide to Lyric Form and Structure* (1991) worked examples
 
 Pat's *Essential Guide to Lyric Form and Structure* (1991), Chapter 6 has four canonical worked examples demonstrating each
-form's mechanics on real songs. See [song-forms-examples](song-forms-examples.md)
-for paraphrased mechanism analyses (NOT lyric reproduction) of:
+form's mechanics on a full lyric. See [song-forms-examples](song-forms-examples.md)
+for the lyrics as Chapter 6 prints them plus his mechanism analyses of:
 
 - **"This Bottle and Me"** — verse/refrain with Common Meter ×2, xaxaxbxb,
   fragmentation after line 4; bridge variant demonstrates all three *Essential
@@ -630,7 +989,8 @@ for paraphrased mechanism analyses (NOT lyric reproduction) of:
   unstressed-syllable trick implying a fifth stress; hook delivers 5-stress
   for the first time
 - **"You Never Let Me Down"** — verse/trans-bridge/refrain with deliberate
-  long-distance-imperfect → short-close-perfect contrast mechanism
+  contrast: long phrases and distant imperfect rhyme in the verse, then
+  "short phrases, quick rhymes" in the transitional bridge
 
 Load song-forms-examples when a writer asks "how is this form actually
 built?" or "how does a deceptive verse hand off to a resolving chorus?"

--- a/plugins/songwriting/context/pat-pattison/research/title-game.md
+++ b/plugins/songwriting/context/pat-pattison/research/title-game.md
@@ -3,8 +3,19 @@
 Pat Pattison's documented Title Game exercise, used as a co-write warmup
 and as a solo title-generation drill. Source: Songwriter Trysts podcast
 episode 40 (verified web research 2026-05-10) — the most detailed public
-documentation of the mechanics. Also referenced briefly in *Writing
-Better Lyrics* (2009) appendix.
+documentation of the mechanics.
+
+> **Sourcing note.** The Title Game does **not** appear in *Writing
+> Better Lyrics* (2009) or *Songwriting Without Boundaries* (2011). An
+> earlier version of this file claimed it was "referenced briefly in
+> *Writing Better Lyrics* (2009) appendix" — that is false. The appendix
+> ("Co-Writing: The 'No'-Free Zone") mentions Pat arriving at a Nashville
+> session "with my notes and titles" and contains no title exercise of
+> any kind. This file's cascade mechanics are podcast-sourced and cannot
+> be made verbatim-from-book. The two things this file borrows that
+> **are** in the books are the No-Free Zone protocol (2009 appendix) and
+> the stressed-vowel targeting method (2009, Chapter 19), both restored
+> below with citations.
 
 ## Core idea
 
@@ -45,8 +56,26 @@ For two writers:
 2. **Read titles aloud, trade off** — Writer A reads a title; Writer B
    takes the stressed vowel of A's title and generates a new title from
    it; passes to A; A generates from B's title; repeat
-3. **No rejection.** Per No-Free Zone (per `co-writing.md`): silence =
-   request for more; do not say "no" mid-cascade
+3. **No rejection.** Per the No-Free Zone. Pat learned it from Stan Webb,
+   his first professional co-writer, in a SESAC writers' room in
+   Nashville; the appendix to *Writing Better Lyrics* (2009) prints
+   Stan's rules in his own words:
+
+   > "Say everything that comes into your head. Say it out loud, no
+   > matter how dumb it is. Don't censor anything. If you say something
+   > really dumb, you might give me an idea that's not quite as dumb."
+
+   > "So that means that we'll never say 'no' to each other. A co-writing
+   > room is a 'no'-free zone. If you suggest a line and I don't like it,
+   > I just won't say anything. Silence is a request for more, more,
+   > more. It says 'just keep throwing stuff out there.' When either one
+   > of us likes something, we'll say 'yes.' Otherwise, just keep going."
+
+   Pat's own addition, same appendix: "Never talk about writing in a
+   co-writing room, especially about technique. Telling what you know
+   about writing isn't writing." And the closing line: "Don't be afraid
+   to write crap — it makes the best fertilizer. The more of it you
+   write, the better your chances are of growing something wonderful."
 4. **Cascade for 5-10 minutes** without stopping to judge
 5. **Mine together** — both writers underline the 3-5 titles in the chain
    that pulled hardest
@@ -81,9 +110,37 @@ the writers can let any of them go.
 Tighter constraints surface tighter clusters but reduce surprise. Looser
 constraints surface variety but make mining harder.
 
+### The vowel constraint's book source
+
+The cascade's stressed-vowel machinery is not invented — it is Pat's
+**targeting** technique from *Writing Better Lyrics* (2009), Chapter 19
+("Understanding Motion"), applied to titles. His instruction, Exercise
+28:
+
+> "Make up your own title, and, using it as the first line of an oncoming
+> chorus, write an AAB structure leading up to it, with the third line
+> targeting a vowel sound in the title. Try not to target the end rhyme.
+> Instead, give the words inside the title a sonic boost."
+
+The point Pat is making — that a title's **inner** vowels, not its end
+rhyme, are the sonic handles — is what makes a stressed-vowel cascade
+productive rather than a rhyme-list. His worked illustration uses the
+title "For One Smile in a Million": an unrhymed `while` in line three of
+the preceding section emphasizes `smile` in the chorus. Exercise 41
+generalizes it: "Construct a title that matches the unmatched line in
+both rhythm and rhyme. Target an inner vowel of the title line rather
+than the end rhyme."
+
+Chapter 4 adds the worksheet-side guideline: "If you are working with a
+title, be sure to put its key vowel sounds in the list."
+
 ## Title types to feed the cascade
 
-Per `hook.md` "Title generation", the seven title types are:
+Per `hook.md` "Title generation". **Unverified against the books:** the
+seven-type taxonomy below appears in neither *Writing Better Lyrics*
+(2009) nor *Songwriting Without Boundaries* (2011). It is owned by
+`hook.md` and left as-is here; whoever owns `hook.md` should confirm its
+source.
 
 1. One-word
 2. Place-name
@@ -96,9 +153,13 @@ Per `hook.md` "Title generation", the seven title types are:
 Mixing types within a cascade adds variety (One-word → Place-name →
 Word-play on the same vowel). Sticking to one type tightens focus.
 
-## Stressed-vowel cascade example (structure only)
+## Stressed-vowel cascade example (synthesized)
 
-(No specific song titles reproduced — describing the cascade SHAPE only.)
+The chain below is **synthesized, not Pat's**. No cascade transcript
+exists in either book — the exercise is podcast-sourced, and the podcast
+does not print a title chain. Nothing is being withheld here; there is no
+source text to restore. Treat the shape as a template and generate real
+titles into it.
 
 Seed: 3-stress title with long-A vowel
 ↓ (next: same vowel, different content)

--- a/plugins/songwriting/context/pat-pattison/research/verse-development.md
+++ b/plugins/songwriting/context/pat-pattison/research/verse-development.md
@@ -22,11 +22,92 @@ chorus or refrain that follows. If two verses shine the same color, the chorus
 will feel the same. If each verse changes the angle, the repeated material
 gains weight.
 
+> Think of your verses as colored spotlights. They shine their lights on their
+> chorus or refrain. If two verses project exactly the same color, their
+> choruses will look the same. If they project different or deeper colors, the
+> choruses will look different.
+
 > Boxes only show how the ideas evolve.
 
-The box model is form-neutral. It can describe verse/chorus, verse/refrain,
-AABA, verse/prechorus/chorus, or any other formal design. What matters is how
-the ideas develop.
+The box model is form-neutral. Chapter 7 opens by listing the formal movements
+one three-box series can describe:
+
+```text
+verse / chorus / verse / chorus / bridge / chorus
+verse / refrain / verse / refrain / bridge / verse / refrain (AABA)
+verse / pre-chorus / chorus / verse / pre-chorus / chorus / bridge / chorus
+verse / chorus / verse / chorus / verse / chorus
+```
+
+What matters is how the ideas develop. And Pat's first note about method is that
+the formulas are not the primary tool:
+
+> When you keep your verses interesting and keep your idea moving forward,
+> you'll have little trouble lighting up your chorus or refrain in different
+> ways. You don't have to use formulas. You don't have to introduce a whole new
+> cast of characters. You just have to pay attention.
+
+## The chapter's worked lyric — "Child Again"
+
+Everything below is demonstrated on Beth Nielsen Chapman's "Child Again."
+
+```text
+Verse 1
+
+She's wheeled into the hallway
+Till the sun moves down the floor
+Little squares of daylight
+Like a hundred times before
+She's taken to the garden
+For the later afternoon
+Just before her dinner
+They return her to her room
+
+Chorus
+
+And inside her mind
+She is running in the summer wind
+Inside her mind
+She is running in the summer wind
+Like a child again
+
+Verse 2
+
+The family comes on Sunday
+And they hover for a while
+They fill her room with chatter
+And they form a line of smiles
+Children of her children
+Bringing babies of their own
+Sometimes she remembers
+Then her mama calls her home
+```
+
+The bridge is an overlay of old-fashioned children's songs, sung as a duet —
+"It's raining it's pouring" against "Come out and play with me," "The old man is
+snoring" against "And bring your dollies three," and so on, closing on "Some
+more / Forever more."
+
+**How the color changes.** Verse 1 contains three scenes, each showing the old
+woman being taken somewhere; her physical helplessness is established in the
+first line and reiterated twice. So the first chorus is entered from
+helplessness, and *running* reads as contrast.
+
+Verse 2 "turns the color of her relatives." Four generations crowd her room, and
+her mind wanders off — *Sometimes she remembers / Then her mama calls her home*.
+Pat's reading of the second chorus:
+
+> The emphasis is no longer on her running, but on the family (her mama) that
+> she runs to, surrounded as she is by strangers. The second chorus lights up
+> brilliantly, a new and different color made possible by strong verse
+> development.
+
+The bridge is "the coup de grâce" — it shows the colors of childhood, and the
+third chorus is heard with new eyes: she is back with her mama, able to run
+home, and the listener now knows she is destined to follow her own mother as
+inevitably as the generations in her room will follow her.
+
+Same five lines of chorus, three sizes. That is the whole demonstration.
 
 ## Travelogue warning
 
@@ -36,10 +117,60 @@ not naturally connect to each other. The chorus is the only glue.
 
 > Verse development should mean verse relationship.
 
+The name comes from the travel film: "Ah, fabulous Hawaii — majestic mountains,
+pipeline surfing, luxury hotels, exotic cuisine." Interesting places, dull film,
+because "their only links are accidents of geography."
+
+Pat's two lyric-summary demonstrations. First:
+
+```text
+Verse 1: Police brutality is a common problem in large cities.
+Refrain: Streets are turning deadly in the dark.
+
+Verse 2: Car bombs are becoming more common as a terrorist weapon.
+Refrain: Streets are turning deadly in the dark.
+
+Verse 3: More prostitutes carry the AIDS virus every year.
+Refrain: Streets are turning deadly in the dark.
+```
+
+> What does police brutality have to do with car bombs or prostitutes with AIDS?
+> Nothing, except that they are all part of fabulous *Streets are turning deadly
+> in the dark*.
+
+Pat then heads off the objection that nobody actually writes that — "Wrong. In
+fact, it happens all the time — all too often in songs with serious political,
+ethical, or religious messages":
+
+```text
+Verse 1: We're screwing up our planet.
+Refrain: We're losing the human race.
+
+Verse 2: We're killing each other in stupid wars.
+Refrain: We're losing the human race.
+
+Verse 3: We ignore our poor and homeless.
+Refrain: We're losing the human race.
+```
+
+> No matter how well written and interesting these verses get, the basic defect
+> remains: The verses don't work together to accumulate power — they are simply
+> a travelogue of human ineptitude. Important ideas deserve the most powerful
+> presentation you can muster.
+
 Travelogues often appear in message songs because the writer tours several
 important issues instead of developing one accumulating situation. Each verse
 may be vivid, serious, and well-written on its own, but the boxes remain the
 same size because no verse lends weight to the next.
+
+The chapter's image for the cost:
+
+> If you go a third of the way up the mountain and start three separate
+> avalanches from different spots, you'll cause some damage to the town below,
+> but not nearly as much as if you'd gone to the top and rolled one snowball all
+> the way down.
+
+> In a travelogue, all the boxes are the same size.
 
 ## Travelogue test
 
@@ -60,8 +191,83 @@ Ask:
 
 ## Chain reaction model
 
-Chapter 8 contrasts a scattered topic tour with one continuous fabric. The stronger
-strategy lets each verse roll down the same mountain:
+Chapter 8 builds a travelogue on purpose and then repairs it, using a title of
+its own: "Chain Reaction," on cycles of violence. The chorus stays put
+throughout:
+
+```text
+One more link in a chain reaction
+Spinning round and round and round
+A tiny step, a small subtraction
+One more link in a chain reaction
+```
+
+**The travelogue version.** Verse 1 is a gang shooting:
+
+```text
+Louis ducks behind the door
+Patient as a stone
+Listens, braces, hears the footsteps
+Crip for sure and all alone
+Steel barking, flashing, biting
+Sinking to its home
+Flesh to blood to heart to bone
+```
+
+Verse 2 then makes "the easy move" and randomly relocates — to "some place like
+fabulous West Beirut":
+
+```text
+Camille slips along the wall
+Muslims stand their posts
+Pulls the pin and lobs the metal
+Perfect hook shot, crowd explodes
+Spilling colors red and khaki
+Gargles in their throats
+Infidels and pagan hosts
+```
+
+Verse 3 relocates again, to "fabulous old South Africa" (*White boys rock the
+ancient Ford / Teeter-totter swing …*). Pat's verdict on verse 2 is the precise
+statement of the failure:
+
+> However compelling the scene is, it is isolated; a single snowball a third of
+> the way up the mountain. … Its only power comes from what it is, not what it
+> connects to. Verse one was a separate avalanche. It lent no power to verse
+> two.
+
+**The repaired version.** Same verse 1. Verse 2 now stays with Louis, walking
+away from his own shooting:
+
+```text
+Straightens up now cool and thin
+Checking out his score
+That's for Iggy, dirty bastard
+Gargled blood in memory's roar
+Circle turf in hasty exit
+One more hero born
+Mamas screaming dark and torn
+```
+
+Verse 3 is the retaliation the first two made inevitable:
+
+```text
+Gathered hands in rings of steel
+They weld a sacred vow
+Swing down low, chariot wheeling
+Rolling dark across the town
+Mad archangel's scabbard flashing
+Cut another down
+Driving by on bloody ground
+```
+
+Note what carried: *gargled blood* in verse 2 answers *gargles in their throats*
+from the discarded verse, *that's for Iggy* supplies the prior cause verse 1
+withheld, and *one more hero born* seeds the vow verse 3 collects. The chorus's
+third line also shifts, *A tiny step, a small subtraction* → *Another turn,
+another fraction*, once the chain is actually turning.
+
+The abstract shape underneath:
 
 ```text
 Verse 1: event
@@ -69,8 +275,8 @@ Verse 2: consequence / memory / retaliation / changed state
 Verse 3: next consequence / vow / escalation / payoff
 ```
 
-The chorus can then gain force because every return carries the whole previous
-chain. The title becomes more than a label; it becomes a mechanism.
+The chorus gains force because every return carries the whole previous chain.
+The title becomes more than a label; it becomes a mechanism.
 
 ## Natural continuity
 
@@ -108,7 +314,13 @@ Too far apart:
 - momentum resets at every verse.
 
 Strong verse development keeps the ideas close enough to belong together and
-far enough apart to make the repeated material gain weight.
+far enough apart to make the repeated material gain weight. Pat states both
+poles in one breath at the close of Chapter 8:
+
+> Verse development is probably a lyricist's trickiest job. Verse ideas must
+> advance enough, but can't move too much. If the ideas are too close, the
+> repetition of the chorus will become static and boring. If the verses' ideas
+> are too far apart, you might end up in fabulous Hawaii.
 
 ## Verse responsibility
 
@@ -130,6 +342,14 @@ If the answer is no, the verse is not doing enough development work.
 Power positions are naturally spotlighted locations inside a lyric section.
 Put important material there.
 
+> The opening and closing lines of any lyric section are naturally strong. They
+> are bathed in spotlights. If you want people to notice an important idea, put
+> it in the lights of a power position, and you will communicate the idea more
+> forcefully.
+
+Chapter 7 points at *Songwriting: Essential Guide to Lyric Form and Structure*
+for the full treatment; here it demonstrates on "Child Again."
+
 The most common power positions are:
 
 - opening line,
@@ -150,6 +370,28 @@ The closing line before a chorus or refrain is a trigger position. It releases
 the listener into the repeated material while carrying its image or idea
 forward.
 
+> I call it a trigger position, because it releases us into the chorus, carrying
+> whatever the line says with us, and therefore we see the chorus in the light
+> of the idea, *They return her to her room*.
+
+Verse 1's opening and closing read together, then the chorus they aim at:
+
+```text
+She's wheeled into the hallway
+They return her to her room
+
+And inside her mind
+She is running in the summer wind …
+Like a child again
+```
+
+Verse 2's pair does the same job in a different color:
+
+```text
+The family comes on Sunday
+Then her mama calls her home
+```
+
 Use trigger lines to:
 
 - color the chorus,
@@ -167,6 +409,35 @@ Balanced phrases can create new internal starts and endings. For example, an
 eight-line verse may behave like two four-line units. That creates four major
 power points: opening and closing of part one, opening and closing of part two.
 
+"Child Again" verse 1 is Pat's case. Its first four lines are basic common meter
+("like *Mary had a little lamb*"), alternating long and short phrases:
+
+```text
+                                      rhyme   stresses
+She's whéeled ínto the hállway          x       3+
+While the sún moves dówn the flóor      a       3
+Líttle squáres of dáylight              x       3+
+Like a húndred tímes befóre             a       3
+```
+
+> After these four lines, things are balanced. The structure has resolved. This
+> creates a new beginning at line five — another power position.
+
+And line five is used for it — *Taken* is the first stressed syllable:
+
+```text
+She's taken to the garden
+For the later afternoon
+Just before her dinner
+They return her to her room
+```
+
+So of the verse's eight lines, "two are opening positions, and two are closing
+positions." All four carry the same message: she is moved, taken, returned.
+
+> Chapman makes sure we enter the first chorus from the angle of physical
+> helplessness. … forcing us to see the first chorus the color she wants us to.
+
 Use this scan:
 
 1. Mark the section's phrase groups.
@@ -177,10 +448,47 @@ Use this scan:
 
 ## Placement changes meaning
 
-Chapter 7 demonstrates that the same information can produce a different chorus if
-placed in different power positions. Moving images away from openings,
-closings, and trigger lines can shift the listener's focus even when the raw
-content stays similar.
+Chapter 7 proves this by rewriting "Child Again" verse 1 with the *same
+information* redistributed. Pat titles the section "Not So Powerful Power
+Positions":
+
+```text
+While the sun moves down the hallway
+She's wheeled out from her room
+So many times she's been there
+As the squares of daylight move
+Then later in the garden
+She's taken out of doors
+They return her for her dinner
+Down the hallway's polished floors
+
+Chorus
+
+And inside her mind
+She is running in the summer wind…
+Like a child again
+```
+
+Nothing has been added or removed. What now sits in the four power positions:
+
+```text
+While the sun moves down the hallway      (opening)
+As the squares of daylight move           (close of part one)
+Then later in the garden                  (open of part two)
+Down the hallway's polished floors        (trigger)
+```
+
+Sunlight, daylight, garden, floors — scenery. The wheelchair, the being *taken*,
+the being *returned* have all slid into weak interior positions. Pat's verdict:
+
+> Even though the beauty of the original verse has suffered, the ideas haven't
+> really changed, only their placement has changed.
+
+> Because the power positions focus us elsewhere, the chorus seems to stress her
+> escape from routine rather than her physical disability.
+
+The chorus text is untouched and it means something else. That is the whole
+claim: placement, not wording, decides what the repeated section is about.
 
 When a verse has good material but the chorus feels wrong, ask:
 
@@ -236,6 +544,50 @@ Any structural surprise creates power:
 When using a surprise, place a meaningful idea there. A surprise that carries
 filler wastes focus.
 
+> Wherever you create a special effect with your structure, you call attention
+> to what you are saying. This extra focus gives the position its power.
+
+Pat's first demonstration extends a nursery rhyme past its expected close:
+
+```text
+Mary had a little lamb
+Its fleece was white as snow
+And everywhere that Mary went
+The lamb would go, indeed
+He goes wherever Mary leads
+He follows with devoted speed
+```
+
+Reading of it: phrase 1 is the usual opening power position. Phrase 4 is a power
+position because we expect it to close the section — and it gains extra punch by
+rhyming *early*, at the second stress rather than the third. Phrase 5 is
+unexpected, "adding special interest." The final phrase is "the most powerful of
+the bunch."
+
+His second is Jim Rushing's "Slow Healing Heart," a nine-phrase structure:
+
+```text
+                                                rhyme
+When I left I left walking wounded                x
+I made my escape from the rain                    a
+Still a prisoner of hurt                          b
+I had months worth of work                        b
+Freeing my mind of the pain                       a
+I had hours of sitting alone in the dark          c
+Listening to sad songs and coming apart           c
+Lord knows I made crying an art                   c
+Woe is a slow healing heart                       c
+```
+
+> When the third phrase ends short, the acceleration gets our attention. Then
+> the fourth phrase chimes in, and the fifth phrase closes with a rhyme. Six is
+> another opening and calls extra attention to its length.
+
+Five of nine positions are doing work. Pat's closing instruction for the whole
+chapter: "First be aware of where your power positions are: opening positions,
+closing positions, and surprises, like shorter, longer, or extra lines. Pay
+attention as you create them, then put something important there."
+
 ## Verse-development diagnosis
 
 When reviewing a draft:
@@ -256,11 +608,12 @@ When reviewing a draft:
 
 Exercise 12 - Repair a travelogue:
 
-- Start from one isolated verse in a scattered topic lyric.
-- Keep the chorus.
-- Write two more verses that grow from that verse.
-- Preserve the established rhyme scheme and rhythm.
-- Make the verse sequence accumulate into one strategy.
+- Start with either verse two (Camille, West Beirut) or verse three (the ancient
+  Ford, South Africa) of the original "Chain Reaction" travelogue above.
+- Keep the same chorus.
+- Write two more verses that grow from that verse into a story.
+- Follow the current verse rhyme scheme and rhythm.
+- Make the verse sequence accumulate into one full-blown strategy.
 - Check that the verses still make sense when the chorus is removed.
 
 ## Skill workflow
@@ -298,14 +651,18 @@ different perspectives; a Past-Present-Future sequence colors it with
 three different time positions. The chorus surface text doesn't change;
 the listener's interpretation does.
 
-## Ibsen's gun principle (*Writing Better Lyrics* (2009), Chapter 7)
+## Ibsen's gun principle (*Writing Better Lyrics* (2009), Chapter 10)
 
-Pat invokes Anton Chekhov / Henrik Ibsen's principle for dramatic
-construction: every element in a song needs a function.
+Pat invokes Henrik Ibsen's principle for dramatic construction, quoting him
+directly:
 
-The shorthand: if a gun appears in Act I, it should fire in Act III.
-Applied to lyric: every detail, image, character, line should do work
-for the song. Decoration without function is waste.
+> If you put a gun in Act I, it damn well better go off by the end of the play!
+
+And draws the consequence for lyric:
+
+> This is more than a principle about effective use of props. It says that you
+> should have a reason for each element in your work. Nothing without its
+> purpose. No duplication of function.
 
 The diagnostic: for each element in the lyric, ask "what does this do?"
 If the answer is "it's there because I like it / it sounded good / it
@@ -313,17 +670,44 @@ filled the line," the element fails Ibsen's gun test.
 
 ### Duplication of function
 
-A sharper version of the same principle (*Writing Better Lyrics* (2009), Chapter 7): no two elements
-should serve the same function. If the speaker and a secondary character
-do the same job, cut one. If two images establish the same emotional
+No two elements should serve the same function. If the speaker and a secondary
+character do the same job, cut one. If two images establish the same emotional
 tone, pick the stronger.
 
-Pat's "Digging for the Line" case study (*Writing Better Lyrics* (2009)): the speaker's daughter
-was cut from the lyric because she had no job that the speaker himself
-couldn't do — duplication of function.
+Pat's case is "Digging for the Line," written as first-person narrative — a
+narrator recalling a father who loved watching greyhounds run, and quoting what
+the father taught. Translating it into third person creates two problems. First,
+pronouns: the child has to become *she* to keep the *he*s from jumbling, which
+is why the line reads *Her daddy loved the greyhounds / Oh he lived to watch 'em
+run*. Second, and worse:
 
-The cut wasn't an emotional decision (the daughter was fine as a
-character); it was a structural decision (her function was redundant).
+> Even with that problem solved, you end up with a story about a father telling
+> a story to his daughter. Seems a little complicated.
+
+> *Daddy told me this story* is an acceptable premise for a song, but *here's a
+> story about someone telling a story* seems more remote.
+
+So Pat applies Ibsen: "Maybe the daughter is a gun that isn't going off." He
+removes her, giving the father a name and letting him learn the lesson himself:
+
+```text
+Edwin loved the greyhounds
+He lived to watch 'em run
+…
+It hurt to see them run
+A race they'd never win
+But as he grew old he learned to see
+What it really means
+```
+
+> Much cleaner than with two characters. Simplify, simplify, simplify.
+
+The cut is not an emotional judgment on the character; it is structural — with
+the story in third person, her function was redundant. Note the limit Pat sets
+on his own conclusion: he does *not* declare third person the winner. The choice
+between "listening in a more intimate situation to the singer telling us what he
+learned from daddy" and "observing Edwin from a distance as he discovers the
+meaning of running" is left open — "Your call."
 
 ## Cross-references (continued)
 

--- a/plugins/songwriting/context/pat-pattison/research/worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/worksheets.md
@@ -1,6 +1,7 @@
 # Lyric Worksheets
 
-Pat Pattison - *Writing Better Lyrics* (2009), Chapter 4.
+Pat Pattison - *Writing Better Lyrics* (2009), Chapter 4, with the show-before-you-tell
+rule from Chapter 2 and the cliché no-list from Chapter 5.
 
 Use this when a user asks how to brainstorm a lyric, create options before
 drafting, escape forced rhymes, organize title/idea material, or build a
@@ -8,8 +9,12 @@ worksheet that combines object writing, thesaurus work, and rhyme search.
 
 Source images inspected:
 
-- Chapter 4: `image_rsrcATS.jpg`, `image_rsrcATT.jpg`, `image_rsrcATU.jpg`,
-  `image_rsrcATV.jpg`, `image_rsrcATW.jpg`, `image_rsrcATX.jpg`.
+- Chapter 4: `image_rsrcATS.jpg` (the three consonant-family boxes),
+  `image_rsrcATT.jpg` (t's plosive relatives), `image_rsrcATU.jpg` (f's fricative
+  relatives), `image_rsrcATV.jpg` (Rhyme Types: Scale of Resolution Strengths),
+  `image_rsrcATW.jpg` and `image_rsrcATX.jpg` (WORKSHEET: RISKY BUSINESS, core
+  words 1-5 and 6-10).
+- Chapter 5: `image_rsrcATY.jpg` (the cliché-images list).
 
 Related files: [object writing](object-writing.md),
 [metaphor](metaphor.md), [rhyme types](rhyme-types.md), and
@@ -17,9 +22,18 @@ Related files: [object writing](object-writing.md),
 
 ## Core idea
 
-A worksheet is a pre-drafting tool that gives the writer enough idea and rhyme
-options to reject weak choices. Its job is to prevent helpless gratitude for
-the first idea or rhyme that appears.
+The chapter opens on the gig analogy that gives it its title:
+
+> Writing a lyric is like getting a gig: If you're grateful for any idea that
+> comes along, you're probably not getting the best stuff. But if you have lots of
+> legitimate choices, you won't end up playing six hours in Bangor, Maine, for
+> twenty bucks. Look at it this way: The more often you can say no, the better
+> your gigs get.
+
+So a worksheet is a specialized brainstorming tool that produces bathtubs full of
+ideas and, at the same time, tailors those ideas specifically for one lyric.
+Simply, it contains two things: a list of key ideas and a list of rhymes for each
+one.
 
 > A worksheet externalizes the inward process of lyric writing.
 
@@ -40,15 +54,30 @@ sensory world, not by whatever the rhyming dictionary happens to offer first.
 
 ## Stage 1: focus the idea
 
-Start from one of three entry points:
+Chapter 4 runs the whole build on one topic — homelessness — and names three ways
+a writer arrives at it. Pat phrases each as something the writer actually says:
 
-- emotion: a person, event, image, or memory touches the writer,
-- concept: the writer wants a subject or stance,
-- title: a phrase suggests an angle.
+- **From an emotion.** "That old homeless woman with everything she owns in a
+  shopping cart really touches me. I want to write a song about her."
+- **From a cold, calculated idea.** "I'm tired of writing love songs. I want to
+  do one on a serious subject, maybe homelessness."
+- **From a title you like** — say, "Risky Business."
 
-Then find the lyric's specific angle. Use object writing to dive into the idea
-before collecting abstract keywords. The best focus usually arrives as an
-object, scene, situation, or pressure that can carry feeling.
+The title entry needs one extra move: find an interesting angle on it. Pat's is a
+scrap of dialogue.
+
+```text
+"What do you do for a living?"
+"I survive on the streets."
+"That's a pretty risky business."
+```
+
+In each case it is on you to find the angle, brainstorm the idea, and create the
+world the idea will live in. You always bring your unique perspective, so you
+will have something interesting to offer — but you will have to look at enough
+ideas to find the best perspective. Object writing is the key to developing
+choices: you must dive into your vaults of sense material, those unique and
+secret places, to find out what images you have stored away around the idea.
 
 Use [object writing](object-writing.md) to ask:
 
@@ -59,34 +88,102 @@ Use [object writing](object-writing.md) to ask:
 
 ## Objective correlatives
 
-Pattison invokes T. S. Eliot's "objective correlative": an object or situation
-that correlates with an emotion. In skill use, treat it as the worksheet's
-anchor image.
+Pat's definition, and it is worth using verbatim because it sets the bar at
+touchability rather than at cleverness:
 
-An objective correlative should be:
+> These expressive objects or situations are what T.S. Eliot calls "objective
+> correlatives" — objects anyone can touch, smell, and see that correlate with
+> the emotion you want to express.
 
-- concrete enough to see, touch, smell, or hear,
-- specific enough to avoid generic emotion,
-- emotionally aligned with the lyric's pressure,
-- available for metaphor, title development, or section imagery.
+His two examples for the homelessness lyric are a broken wheel on a homeless
+woman's shopping cart (an object that can serve as a metaphor, a vehicle to carry
+your feelings) and your parents fighting (a situation from your own life that
+connects you to hers). Note that one is an object and one is a situation — both
+qualify.
 
-If the user gives an abstract topic, first hunt for an objective correlative
-before building rhyme lists.
+*Writing Better Lyrics* (2009), Chapter 2 supplies the test for whether the
+correlative is actually doing work. Pat forgot his puppy's collar on the kitchen
+table on Show-and-Tell day, and Sister Mary Elizabeth told him: "You can't tell
+unless you show first." He calls it the Sister Mary Elizabeth Rule of
+Songwriting — show before you tell — and his demonstration is a four-line section
+with the collar swapped in and out:
+
+```text
+Without:   All the things we used to do
+           Those dreamy teenage nights
+           Nothing matters like it did
+           Back when you were mine
+
+With:      Hot rod hearts and high school rings
+           Those dreamy teenage nights
+           Nothing matters like it did
+           Back when you were mine
+```
+
+"Hot rod hearts and high school rings" is a bag of dye. Hang it at the top of the
+section and let it drip its colors downward onto the other lines. Move it to line
+three and the first two lines get nothing, because colors drip down, not up.
+
+That is what a good objective correlative buys you, and it is why the hunt
+happens before the rhyme lists: the correlative is the thing whose vocabulary
+Stage 2 will harvest. If the user gives an abstract topic, find the collar first.
+See [object writing](object-writing.md) for the diving technique that surfaces
+one.
 
 ## Stage 2: idea-word list
 
-Use a Roget-style thesaurus or concept map to expand the lyric's world. Prefer
-a thesaurus organized by ideas over a simple alphabetical synonym finder when
-brainstorming, because nearby concept groups can reveal unexpected angles.
+Use a thesaurus set up according to Roget's original plan — organized by the flow
+of ideas, not alphabetically. Dictionary-style versions are useful only for
+finding synonyms and antonyms; they turn brainstorming into a cumbersome exercise
+in cross-referencing.
 
-Process:
+> Your thesaurus is better than a good booking agent.
 
-1. Choose a general keyword for the lyric idea.
-2. Find the closest conceptual neighborhood.
-3. Browse nearby categories, opposites, dangers, remedies, and adjacent ideas.
-4. Take quick sensory dives into promising words.
-5. Save words that create image, pressure, motion, or title potential.
-6. Trim the list to roughly ten or twelve high-value words.
+Pat walks the chain in full for "Risky Business." Look up the general idea in the
+index (the back half of the book) and read the notations:
+
+```text
+risk    gambling 618n; possibility 469n; danger 661n; speculate 791vb
+```
+
+Read `danger 661n` as: you will find *risk* in the noun group of section 661
+under the key word *danger*. Key words are always in italics; they set a general
+meaning for the section the way a key signature sets the tone center in a piece
+of music. For homelessness under the title "Risky Business," `danger 661n` is the
+closest fit.
+
+Now turn to section 661 in the text (front half) and read the *neighborhood*, not
+just the entry. Pat lists the surrounding section headings in his own thesaurus:
+
+```text
+Ill health, disease      Escape
+Insalubrity              Salubrity (well-being)
+Deterioration            Improvement
+Relapse                  Restoration
+Bane                     Remedy
+Danger                   Safety
+Pitfall                  Refuge. Safeguard
+Danger signal            Warning
+                         Preservation
+                         Deliverance
+```
+
+Sixteen pages of double-column entries, with *risk* totally surrounded by its
+relatives — the diseases on one side, the remedies on the other. The first few
+entries under *danger* read:
+
+```text
+N. danger, peril; ... shadow of death, jaws of d., dragon's mouth,
+dangerous situation, unhealthy s., desperate s., forlorn hope 700n.
+predicament; emergency 137n. crisis; insecurity, jeopardy, risk,
+hazard, ticklishness...
+```
+
+Look actively. Take each entry for a quick dive through your sense memories, the
+way you would object-write. Jot down the best words and keep at it until you are
+into serious overload. Only then start saying no, trimming to about ten or twelve
+words with different vowel sounds in their stressed syllables. Put the survivors
+in the middle of a blank sheet, number them, and box them for easy reference.
 
 Selection rules:
 
@@ -98,18 +195,84 @@ Selection rules:
 
 ## Stage 3: rhyme search
 
-For each surviving idea-word, look up rhyme options and keep only words that
-connect to the lyric's world. The worksheet should expand meaning and sound at
-the same time.
+For each surviving idea-word, look it up in a rhyming dictionary, extend the
+search to the imperfect rhyme types, and select only words that connect with your
+ideas. Don't bother with cliché rhymes or other typical rhymes.
 
-Use:
+Chapter 4 demonstrates the search three times, once per consonant family, and the
+shape is always the same: exhaust perfect rhyme first, notice how thin it is,
+then walk the family.
 
-- perfect rhyme,
-- family rhyme,
-- additive rhyme,
-- subtractive rhyme,
-- assonance rhyme,
-- consonance rhyme when useful.
+Plosives — `I'm stuck in a rut`. Perfect rhymes for *rut*: `cut, glut, gut, hut,
+shut`. Now meet t's relatives:
+
+```text
+ud       uk       ub       up        ug
+blood    buck     club     hard up   bug
+flood    duck     hub      makeup    jug
+mud      luck     pub      cup       unplug
+stud     muck     scrub              plug
+thud     stuck    tub                shrug
+         truck                       snug
+                                     tug
+```
+
+Fricatives — `There's nowhere I can feel safe`. Perfect rhymes for *safe*: `waif`.
+That is the entire list. Now f's family:
+
+```text
+as                av        az           aj      ath     aTH
+case              behave    blaze        age     faith   bathe
+ace               brave     craze        cage
+breathing-space   cave      daze         page
+chase             grave     haze         rage
+face              shave     phrase       stage
+disgrace          slave     paraphrase
+embrace           wave      praise
+grace
+lace
+resting-place
+space
+```
+
+Nasals — `My head is pounding like a drum`. Perfect rhymes for *drum*: `hum,
+pendulum, numb, slum, strum`. Then m's relatives:
+
+```text
+un                ung
+fun               hung
+gun               flung
+overrun           wrung
+won               sung
+jettison
+skeleton
+```
+
+Additive rhyme has its own ordering rule, and it is the one worksheet-builders
+most often skip: the less sound you add, the closer you stay to perfect rhyme.
+Work outward in that order — voiced plosives (b, d, g) first, then unvoiced
+plosives, then voiced fricatives, then unvoiced fricatives, then the nasals. For
+*free* that produces a ladder running closest-to-furthest:
+
+```text
+speed, cheap, sweet, grieve, belief, dream, clean, deal
+```
+
+You can add consonants even when consonants are already there
+(`street/sweets`, `alive/drives`, `dream/screamed`, `trick/risk`), and you can
+combine the technique with family rhyme (`dream/cleaned`,
+`club/floods/shove/stuffed`). Subtractive is the same operation seen from the
+other end: starting from `fast`, `class` is subtractive; starting from `class`,
+`fast` is additive. For *fast* the chapter also offers `glass, flat, mashed`
+(family), `laughed` (family), `crash` (family subtractive).
+
+Assonance is as far from perfect rhyme as you can get without changing the vowel.
+For `I hope you're satisfied`, *satisfied* yields `life, trial, crime, sign, rise,
+survive, surprise`.
+
+Look actively at every candidate. Use each one to dive through your senses, as
+though you were object writing — that is what keeps the rhyme search inside the
+lyric's world instead of inside the dictionary's.
 
 For definitions and fuller rhyme workflows, route to
 [rhyme types](rhyme-types.md) and [rhyme worksheets](rhyme-worksheets.md).
@@ -129,22 +292,101 @@ That abundance lets the writer reject:
 Do not treat a worksheet as a mandatory word bank. Treat it as a controlled
 overload system. Its value is the ability to choose.
 
-## Rhyme as emotional stability
-
-Chapter 4 introduces a scale from most resolved to least resolved:
+*Writing Better Lyrics* (2009), Chapter 5 supplies the concrete no-list. These are
+the rhyme pairs Pat says put puppies to sleep — when you hear one, there is no
+need to lose sleep wondering what's coming next:
 
 ```text
-perfect rhyme
-family rhyme
-additive / subtractive rhyme
-assonance rhyme
-consonance rhyme
+hand / understand / command      light / night / sight / tight
+eyes / realize / sighs / lies    love / above / dove
+walk / talk                      heart / start / apart / part
+fire / desire / higher           hide / inside / denied
+kiss / miss                      wrong / strong / song / long
+burn / yearn / learn             touch / much
+dance / chance / romance         word / heard
+forever / together / never       begun / done
+friend / end                     arms / charms / harm / warm
+ache / break                     blues / lose
+cry / die / try / lie /          true / blue / through
+  good-bye / deny                lover / discover / cover
+tears / fears                    pain / rain / same
+best / rest / test               stronger / longer
+door / before / more             fight / right
+knees / please                   take it / make it / fake it / shake it
+change / rearrange               maybe / baby
 ```
 
-The point is not just more options. Each rhyme type changes emotional
-resolution. Perfect rhyme lands firmly. Family rhyme stays close to home.
-Additive and subtractive rhyme loosen the landing. Assonance and consonance
-can leave curiosity, longing, or instability.
+Pat's own diagnosis of why this list matters to worksheet-building: most cliché
+rhymes are perfect rhymes. That is a good reason to stretch into the other types
+— family, additive, subtractive, and even assonance — which are guaranteed fresh
+and which most listeners won't register as imperfect. If a column comes back full
+of the pairs above, the search stopped at Stage 3's first step.
+
+The full cliché taxonomy — phrases, images, metaphors, and the friendly-cliché
+setups that redeem them — is in [cliche](cliche.md).
+
+## Rhyme as emotional stability
+
+Chapter 4 gets at this through the piano. Play F (F in the bass), G7 (G in the
+bass), then C with C-E-G in the right hand and C in the bass, singing a C. That
+feels like arriving home. Now run it again with G in the bass — still home, less
+solidly. Again with E in the bass — a version of home with some discomfort in it,
+a very expressive chord. Again with E in the bass and the C taken out of the
+right hand — less comfortable still. Last time, add a B and leave the C out: you
+are now playing E minor, the three minor in the key of C, still singing the C.
+Only a suggestion of home rather than sitting down to the supper table.
+
+All of those voicings are tonic functions. Some land solidly and bring motion to
+a complete halt; others have a foot at home but their minds are looking for the
+next place to go. Rhyme works the same way. Chapter 4 prints the types on a
+single horizontal axis:
+
+```text
+Most Resolved                                              Least Resolved
+|                                                                       |
+|             |              |               |                          |
+|        Family Rhyme        |        Assonance Rhyme                    |
+|                            |                                          |
+Perfect Rhyme          Additive/                              Consonance
+                       Subtractive Rhyme                           Rhyme
+```
+
+The worked ladder holds the couplet's structure fixed — a stable four-stress
+couplet — and changes only the rhyme type:
+
+```text
+Perfect:      A lovely day to have some fun / Hit the beach, get some sun
+Family:       A lovely day to have some fun / Hit the beach, bring the rum
+              (a lot like C with G in the bass)
+Additive:     A lovely day to have some fun / Hit the beach, get some lunch
+              (a lot like C with E in the bass)
+Subtractive:  Hit the beach and get some lunch / A lovely day, have some fun
+              (a lot like C with E in the bass)
+Assonance:    A lovely day to have some fun / Hit the beach, fall in love
+              (a lot like C with E in the bass, no C in the right hand)
+Consonance:   A lovely day to have some fun / Hit the beach, bring it on
+              (a lot like the E minor in the key of C)
+```
+
+The second ladder shows the same control changing *meaning*, not just landing.
+The cliché setup telegraphs its own answer — `Baby baby take my hand / Let me know
+you ... understand`. Say something else and you get both messages at once, because
+the expected word is still audible underneath:
+
+```text
+take a stand     perfect rhyme; full resolution supports the idea
+like to dance    n in common, d against c — a tinge of longing from the
+                 difference at the end
+making plans     the same tinge of instability
+want to laugh    assonance; the chances of hooking up now seem about as remote
+on your mind     consonance; curiosity and uncertainty, expressed completely
+                 and only by the rhyme type
+```
+
+Expanding rhyme possibilities does three things: it multiplies the chance of
+saying what you mean and still rhyming, it guarantees the rhymes will not be
+predictable or cliché, and — most important — it lets you control how stable or
+unstable the rhyme feels, so the rhyme can support or even create emotion.
 
 Use [rhyme strategy](rhyme-strategy.md) when deciding where stable or unstable
 rhymes belong inside a section.
@@ -152,18 +394,69 @@ rhymes belong inside a section.
 ## Worksheet layout
 
 Chapter 4's own worksheet is ten numbered core words, each heading a single
-undifferentiated column of rhymes:
+undifferentiated column of rhymes. There is no title header, no angle field, and
+no objective-correlative field on the page — those live in the writer's head and
+in the object writing that preceded it. The page is the boxed core-word list plus
+ten columns.
+
+The chapter's worked example is a lyric on homelessness under the working title
+"Risky Business." Here is Pat's own trimmed core-word list, the Stage 2 output he
+boxed in the middle of a blank sheet:
 
 ```text
-Title / working idea:
-Angle:
-Objective correlative:
-
-1. <core word>     2. <core word>     3. <core word>
-   <rhyme>            <rhyme>            <rhyme>
-   <rhyme>            (<alternate>)      <rhyme>
-   ...                ...                ...
+1.  risk
+2.  business
+3.  left out
+4.  freeze (wheel, shield)
+5.  storm
+6.  dull (numb)
+7.  night (child)
+8.  change
+9.  defense
+10. home (hope, broken, coat)
 ```
+
+And here is the worksheet those ten words produced, reproduced as Pat prints it
+under the heading WORKSHEET: RISKY BUSINESS:
+
+```text
+1. risk      2. business     3. left out   4. freeze         5. storm
+   cliff        collisions      proud         grieve            reform
+   fist         visions         bound         leave             (re)born
+   kissed       frigid          count         peace             court
+   stiff        forgiveness     vowed         appeased          cord
+   itch         submissive      aloud         street            scorn
+   pitch        delicious       renowned      debris            divorce
+   drift        riches          aroused       diseased          reward
+   switch       suspicious      crowned       guarantee(s)      warm
+   shift        kisses                        wheel             torn
+   pinched      finish                        shield            ignored
+   chips        wind
+
+6. dull      7. night        8. change     9. defense       10. home
+   sulk         flight          cage          expense           disowned
+   annulled     spite           slave         bench             blown
+   cult         bride           grave         trench            bone
+   pale         strike          safe          drenched          unknown
+   brawl        prize           faith         friend            stoned
+   numb         despised        castaway      revenge           dethroned
+   opium        deprived        ricochet      content           zone
+   martyrdom    child           haste         condemned         hope
+   crumbs       fault                         contempt          coat
+   gun          crawl                                           throat
+   young                                                        remote
+                                                                ghost
+                                                                Job
+                                                                load
+                                                                broken
+```
+
+Read the columns and the mixing is obvious: `risk` collects perfect rhymes
+(`fist`, `kissed`), family rhymes (`cliff`, `stiff`, `chips`), and assonance
+(`itch`, `pitch`, `switch`) in one run. `freeze` runs from perfect (`peace`,
+`street`) through consonance (`wheel`, `shield`). `home` runs fifteen deep and
+ends on `broken`, which is barely a rhyme at all and is exactly the kind of
+option the worksheet exists to make available.
 
 Parentheses are the chapter's only annotation, and they do two jobs:
 
@@ -195,16 +488,29 @@ Keep the page flexible. Add, remove, and swap core words as the lyric clarifies.
 
 ## Chapter 4 exercise as coaching prompt
 
-Exercise 9 - Focus and worksheet seed:
+Exercise 9 is four sentences long, and its shape is worth copying exactly:
 
-- Pick the lyric idea or topic.
-- Object-write on it for ten minutes.
-- Stay sense-bound and personal.
-- Identify one expressive image or situation that can carry the emotion.
-- Save strong idea-words on a separate list.
-- Expand those words with a thesaurus or concept map.
-- Trim to ten or twelve core words with useful stressed vowels.
-- Build one mixed rhyme column under each core word.
+> Stop reading, get out a pen, and dive into homelessness for ten minutes. Stay
+> sense-bound and very specific. How do you connect to the idea? Did you ever get
+> lost in the woods as a child? Run away from home? Sleep in a car in New York?
+
+The three questions at the end are the whole coaching move. They do not ask the
+writer to think about homelessness; they hand over three specific personal
+memories that might already contain it. When adapting this to a user's topic,
+supply the same thing: a ten-minute timer, the sense-bound rule, and two or three
+concrete "did you ever" questions aimed at their own experience.
+
+Then the follow-up question, which is where the objective correlative arrives:
+
+> Now, did you find an expressive image, like a broken wheel on a homeless
+> woman's shopping cart, that can serve as a metaphor — a vehicle to carry your
+> feelings? Did you see some situation, like your parents fighting, that seems to
+> connect you with her situation?
+
+And the instruction not to stop at the first one: even if you find ideas that
+work well, keep looking a while longer, because when you find a good idea there
+is usually a bunch more behind it. Jot the good ones on a separate sheet — that
+separate sheet becomes the raw material for Stage 2.
 
 ## Skill workflow
 
@@ -222,3 +528,14 @@ When applying this file:
 8. Parenthesise alternates and optional morphemes; drop everything else by
    leaving it off the page.
 9. Draft only after the worksheet contains enough options to say no.
+
+Chapter 4 closes on a commitment, and it is the right thing to hand a user who
+asks how to get good at this:
+
+> Decide now that you will do a complete worksheet for each of your next ten
+> lyrics, then stick to it.
+
+Pat's own forecast for that run: the first one will be slow and painful, but full
+of new and interesting options. By the third, ideas will come fast and furious —
+too much to say, too many choices, too many rhymes. Reading a worksheet is
+stimulating; doing your own is what sets you on fire.

--- a/plugins/songwriting/context/pat-pattison/templates/audit-checklist-prompt.md
+++ b/plugins/songwriting/context/pat-pattison/templates/audit-checklist-prompt.md
@@ -34,7 +34,7 @@ For the chosen line, walk through each cluster aloud with the writer:
 ```
 **Line:** "<the line>"
 
-**Stress & meter** (Books 1 Chapter 3, 3 Chapter 4)
+**Stress & meter** (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3; *Songwriting Without Boundaries* (2011), Challenge 4)
 - [ ] Every stressed syllable on a strong beat?
 - [ ] No greedy spots? (unstressed forced to strong beat, or stressed to weak)
 - [ ] "into" handled per ínto rule (*Songwriting Without Boundaries* (2011), Challenge 4)?
@@ -42,7 +42,7 @@ For the chosen line, walk through each cluster aloud with the writer:
 - [ ] Grey-area stress flagged, not silently resolved?
 - [ ] Sing-check passed?
 
-**Rhyme stability** (Books 1 Chapter 4, 2 Chapter 4, 4 Chapters 4-6) — if rhyme position
+**Rhyme stability** (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4; *Writing Better Lyrics* (2009), Chapter 4; *Essential Guide to Rhyming* (2014), Chapters 4-6) — if rhyme position
 - [ ] Identity check: pre-vowel consonants DIFFER?
 - [ ] Stability tier chosen by emotional intent?
 - [ ] No automatic cliche pair?


### PR DESCRIPTION
## Summary

Two things, and the first is the important one.

**1. Reverses the "paraphrase only" rule.** Every prior release of this plugin
was built under a rule that said never reproduce Pat Pattison's text — no
example lyrics, no exercise wording, no worked answers. That rule entered
through a session handoff and propagated through eight of them without ever
being checked with the repo owner, who owns all four books. It was actively
destroying the value of the reference: a summarized exercise is not an
exercise, and a described worked example is not an example. `exercises.md`
literally advertised that none of its numbered exercises were Pat's.

Pat's real text, examples, exercise wording, worksheet layouts and printed
answer keys are restored across 29 research files — roughly 9,000 lines.
Web-sourced passages (Berklee Online, patpattison.com, American Songwriter,
Coursera) stay paraphrased and stay marked unaudited, because those sources
are not in the corpus and nothing was invented to fill them.

**2. A source-fidelity pass over *Essential Guide to Lyric Form and Structure*
(1991) Chapter 4 (Rhyme)**, read in full with all 40 of its figures at 3x
upscale, against `rhyme-fundamentals.md` and `rhyme-strategy.md`.

## Defects found in Chapter 4

Two came only from the figures — they do not exist in the text layer at all.

- **The identity test asserted the opposite of the rule it was stating.**
  `rhyme-fundamentals.md` said identity "matches conditions 1 and 2 and **also**
  matches 3" where condition 3 is *"different consonant sound before the
  vowel."* Identity fails condition 3 — that failure is the entire distinction.
  As written, the test passed every identity as a rhyme. Every other file in the
  plugin states the check correctly; this was the sole outlier.
- **`abba` was listed as a balanced pattern.** The chapter uses `abba` as its
  explicit counterexample, and its printed exercise answer key marks `abba`
  **open**. A balanced system is closed by definition, so both sources agree it
  is neither. `rhyme-strategy.md` also contradicted itself, calling it
  "encloses" in one table and listing it under floating instability in another.
- **The balance-paradigm list was missing half the set** — Pat prints six.
- **A feminine-rhyme example was mislabeled an identity.**
- **Both files' image inventories omitted this chapter entirely.** Fourth
  consecutive Book 1 chapter whose inventory concealed a defect.

## Verified, no change needed

- `prosody.md`'s "1991 Chapter 3-4 (Structural Pentad)" citation holds; its
  standing "Chapter 4 unaudited" flag is cleared.
- `exercises.md`'s Chapter 4 block is complete, Ex 18-28, no numbering gap.
- `rhyme-types.md`'s page-scan inventory is genuine — every cited filename
  resolves against a fresh extraction.

## Tooling

`_typos.toml` gains `DUM` as a case-sensitive identifier. "da DUM da DUM" is
standard scansion notation, now verbatim in four files, and the spell-checker
was rewriting it to "DUMB". Added at the canonical root per that file's own
policy note rather than as scattered inline suppressions.

## Verification

All local gates green: `typos`, `markdownlint-cli2` (103 files), `lychee`
(728 links), `validate-plugins.sh`, `check-changelog-parity.sh --check-bump`.

Version bumped to 0.8.5 with a per-fix CHANGELOG entry.

## Related

No linked issue
