### PR TITLE
feat(songwriting): finish Wave A verbatim cleanup and fix the <br> extraction bug

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -68,6 +68,10 @@ plus an extractor bug that had been silently corrupting every quoted stanza.**
   "Digging for the Line" and "As Each Year Ends", none of which the file named.
   Pat prints exactly **four** direct-address listener positions; the file's
   count is now his.
+- **`point-of-view.md`'s own header over-claimed.** It said the file names "the
+  song and writers"; "Sentimental Lady", "Digging for the Line" and "As Each
+  Year Ends" carry **no writer credit** in Pat's text or the permissions page,
+  so it now says "the song, and the writers where Pat names them."
 - **`repetition.md` had silently truncated a quote** (a dropped opening clause,
   then recapitalized) and **softened a categorical rule** — Pat writes that the
   device *only* works in first and second person. Both restored.

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -68,6 +68,14 @@ plus an extractor bug that had been silently corrupting every quoted stanza.**
   "Digging for the Line" and "As Each Year Ends", none of which the file named.
   Pat prints exactly **four** direct-address listener positions; the file's
   count is now his.
+- **`stable-unstable-meta.md` debunked "central emotion" at the top and then
+  kept using it as a diagnostic key.** The fabricated quote was replaced, but
+  the worked diagnostic, the coaching prompts and the anti-patterns still keyed
+  off the invented phrase. All three now use Pat's actual wording from
+  *Writing Better Lyrics* (2009) Chapter 18 — **"central intent, idea, and
+  emotion"**. A provenance section was added naming the two things in the file
+  that are **not** Pat's: the tone-of-voice axis (non-book, 0 corpus hits) and
+  the worked diagnostic (this file's own applied example).
 - **Two restored quotes lost their italics and so looked like transcription
   errors.** "you already knows all this stuff" and "a kind of universal feeling
   that you seems to add" both read as subject-verb slips. They are not: the raw

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -92,6 +92,49 @@ plus an extractor bug that had been silently corrupting every quoted stanza.**
   then recapitalized) and **softened a categorical rule** — Pat writes that the
   device *only* works in first and second person. Both restored.
 
+### Fixed — a second sweep, and the scaffolding thesis measured
+
+- **`audit-checklist.md` was nearly half wrong, box by box.** 192 lines carrying
+  26 chapter citations and **zero reproduced text** — pure `- [ ]` scaffolding
+  attributed to specific chapters. All 83 checkboxes were tallied against the
+  cited chapters: **42 traceable, 15 distorted, 26 invented.** Traceable boxes
+  now quote Pat's actual sentence; distorted ones are corrected; invented ones
+  are relabelled as this file's own synthesis rather than deleted, so the owner
+  can see what is his tooling's invention and what is Pat's. **11 false section
+  attributions** were fixed.
+- **`bridge.md` opened on a six-word quote.** `"A bridge isn't a verse."` was
+  bare and uncited. The sentence is real but was **truncated** — Pat's full
+  passage in *Writing Better Lyrics* (2009) Chapter 23 goes on to contrast the
+  bridge against verse and chorus. Restored in full and cited, along with
+  Exercises 49 and 50 (entirely absent), the 1991 Chapter 5 five-point bridge
+  definition, and the transitional-bridge list — each restored as Pat's printed
+  numbered list rather than a flattened paraphrase.
+- **A fabricated alias pair in `bridge.md`.** The file listed "channel" and
+  "runway" as names for the pre-chorus. Zooming the actual figure shows Pat
+  lists only Pre-Chorus, Climb or Lift, Vest, Verse Extension, Ramp and Prime.
+  Removed. **This one was only catchable by reading the image.**
+- **A fabricated quote in `response-filter.md`**, plus a quote misattributed to
+  *Writing Better Lyrics* (2009) Chapter 1 that is really Chapter 5. Several
+  Berklee-sourced blockquotes elsewhere were de-quoted rather than left
+  masquerading as Pat's printed words.
+- **`cliche.md` presented two couplets as displayed stanzas.** Pat quotes both
+  inline in running prose, slash-separated. Corrected to match.
+
+### Verified — the line-break damage is narrower than feared
+
+The `<br>` bug was reported as potentially affecting all ~9,000 restored lines.
+**Measured, it does not.** Every quoted block in all 49 research files was
+checked mechanically — **1,109 consecutive line-pairs** — for the specific
+corruption signature, a file splitting a line the corrected source keeps whole.
+
+27 candidates surfaced and nearly all were legitimate: 14 in `phrasing.md` are
+Pat's own deliberate split into **eight short phrases**, and the rest are
+dialogue split per speaker, contrasted variant lines, and a wrapped thesaurus
+entry. **Only `cliche.md` needed correcting.** A proposed "fix" to `hook.md` was
+checked against the raw XHTML and **rejected** — there is a `<br>` between every
+line there, so those are genuinely separate printed lines and joining them would
+have introduced the very corruption being hunted.
+
 **The shape of the defect, now that five files have been done at once:** the
 paraphrase rule did not merely omit Pat's text, it **replaced it with invented
 scaffolding** — "Use when" lists, bullet "tests", checklists, named axes and

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -68,6 +68,14 @@ plus an extractor bug that had been silently corrupting every quoted stanza.**
   "Digging for the Line" and "As Each Year Ends", none of which the file named.
   Pat prints exactly **four** direct-address listener positions; the file's
   count is now his.
+- **Two restored quotes lost their italics and so looked like transcription
+  errors.** "you already knows all this stuff" and "a kind of universal feeling
+  that you seems to add" both read as subject-verb slips. They are not: the raw
+  XHTML italicises **`you`** in each, because Pat means the *word* `you` as a
+  mentioned term, which takes a singular verb. **Both sentences are correct as
+  printed**; the italics are now restored. This is a second, subtler failure
+  mode of the extractor — stripped italics can make correct verbatim text look
+  broken and invite a "correction" that would corrupt Pat's actual words.
 - **`point-of-view.md`'s own header over-claimed.** It said the file names "the
   song and writers"; "Sentimental Lady", "Digging for the Line" and "As Each
   Year Ends" carry **no writer credit** in Pat's text or the permissions page,

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,129 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.8.6]
+
+**Wave A cleanup — the five research files the previous pass left unfinished,
+plus an extractor bug that had been silently corrupting every quoted stanza.**
+
+### Fixed — the extraction bug, which reaches back into 0.8.5
+
+- **`<br>` carries attributes in these EPUBs and the extractor was missing
+  them.** The sources are Calibre-produced and write line breaks as
+  `<br class="calibre2"/>`, which a `<br\s*/?>` pattern does not match; the
+  tag-stripper then removed them, so **every lyric stanza arrived as a single
+  run-together line**. Agents restoring those stanzas were **inferring the line
+  breaks**. Corrected to `<br\b[^>]*>` and the corpus re-extracted.
+- **This is a correctness bug, not a cosmetic one** — line count is what
+  balance, stability and scansion claims are *about*. Re-verifying against the
+  corrected source immediately caught a real error: the stagnant sheriff Box 3
+  in *Writing Better Lyrics* (2009) Chapter 6 is **two printed lines, not one**.
+- **The spine/image invariants do not detect it** — all four passed cleanly
+  before and after. A stanza spot-check has been added to the extractor gate.
+- **The ~9,000 lines restored in 0.8.5 were built with the buggy pattern** and
+  have not been re-verified. Recorded for the verification pass.
+
+### Fixed — fabricated material removed
+
+- **`rhyme-types.md` carried an invented Pat quote.** A pull-quote reading
+  "Craft prepares you to be creative." appears **nowhere in any of the four
+  books**. Replaced with the real sentence from *Essential Guide to Rhyming*
+  (2014), Chapter 9.
+- **`stable-unstable-meta.md`, a 201-line file, held seven separate
+  fabrications** — an unsourced "central emotion" `— Pat` quote (zero corpus
+  hits), an epigraph falsely attributed to Berklee Online, an entirely invented
+  "five motion controllers" table (`melodic rhythm` and `harmonic rhythm` return
+  zero hits corpus-wide), invented stability-lever rows, a fake tone-of-voice
+  quote, an invented "Pat's stance" paragraph with invented examples, and an
+  invented table column plus a phantom pre-chorus row. All replaced with Pat's
+  actual five elements of structure from *Writing Better Lyrics* (2009)
+  Chapter 18, or relabelled unaudited where no book source exists.
+- **`repetition.md`'s hidden-question and hidden-command matrices were
+  invented**, including a fabricated "Effect" column. Replaced with Pat's
+  printed `do` / `did` / `will` blocks and the real
+  *You tell me / Tell me / Want me* sequence.
+- **`box-model.md` was largely invented above the citation line.** Removed: the
+  three-tier box-weight scheme, an entire fabricated **"Other named division
+  axes"** table (Time of day / Season / Location / Sense / Speaker stance /
+  Distance — no such list exists in either chapter), an invented three-bullet
+  "travelogue test", an invented three-bullet "same-color test", invented
+  You-I-We and Past-Present-Future bullet glosses, invented failure-mode rows,
+  and editorializing Pat never wrote ("if Box 3 is lighter than Box 2, the song
+  sags"). Each replaced with Pat's actual passage — the stack-of-boxes
+  paragraph, his Hawaii travelogue definition, his colored-spotlights paragraph
+  and his real worked diagnoses. **"Same-color" is this file's shorthand, not
+  Pat's term, and is now labelled as such.**
+- **`box-model.md`'s "One More Dollar" section was a prose plot summary.**
+  Replaced with Pat's printed lyric and the real box diagram
+  (Working / Gambling / Panhandling to get home), read off the figure.
+- **`point-of-view.md` was scaffolded with invented apparatus.** Removed five
+  separate invented "Use when" lists, an invented four-question direct-address
+  "fact test", invented translation "tests", and a fabricated
+  *One walks into the room / You walk into the room* example. Replaced with
+  Pat's actual one→you substitution on the Seger couplet, his real one-sentence
+  test, his printed narrative rewrites, and the songs he actually names —
+  "The Great Pretender", "Sentimental Lady", "Dress Rehearsal Rag",
+  "Digging for the Line" and "As Each Year Ends", none of which the file named.
+  Pat prints exactly **four** direct-address listener positions; the file's
+  count is now his.
+- **`repetition.md` had silently truncated a quote** (a dropped opening clause,
+  then recapitalized) and **softened a categorical rule** — Pat writes that the
+  device *only* works in first and second person. Both restored.
+
+**The shape of the defect, now that five files have been done at once:** the
+paraphrase rule did not merely omit Pat's text, it **replaced it with invented
+scaffolding** — "Use when" lists, bullet "tests", checklists, named axes and
+failure-mode tables that read like craft guidance and cite nothing. This
+apparatus is the single most common fabrication form found, it is present in
+every file examined, and it is more dangerous than a wrong quote because it
+looks like the useful part.
+
+### Fixed — citations and claims narrowed
+
+- **`box-model.md` was cited to *Writing Better Lyrics* (2009) Chapters 6-9,
+  22-23.** Chapters 22 and 23 contain **zero** occurrences of "box". Narrowed to
+  Chapters 6-9.
+- **`five-compositional-elements.md` claimed the 1991 book has "no family,
+  additive, assonance, or consonance vocabulary".** Narrowed rather than
+  deleted: family, additive and assonance are genuinely absent, but
+  *Essential Guide to Lyric Form and Structure* (1991) Chapter 4 names
+  **Consonance Rhyme** in the Shelley analysis.
+- **`rhyme-types.md`'s "six rhyme types" count was checked and left unchanged** —
+  the reported count/list disagreement was not real.
+- **Exercise 8.7 is genuinely absent from the printed book.** *Essential Guide
+  to Rhyming* (2014) Chapter 8 runs 8.1-8.6 and 8.8-8.10, confirmed against the
+  page scans rather than the text layer alone, because a numbering gap is
+  normally an omission detector. `rhyme-sonic-bonding.md` already said so.
+
+### Restored — Pat's verbatim text
+
+- **`box-model.md`** — the form-neutral box definition, the progressive-weight
+  passage, the division-of-labor principle and the "Between Fathers and Sons"
+  analysis, from *Writing Better Lyrics* (2009) Chapters 6-9.
+- **`point-of-view.md`** — the perspectives, the Hangman material and the
+  Chapter 13 dialogue, from *Writing Better Lyrics* (2009) Chapters 10-13. Its
+  Berklee Online material was deliberately left untouched and marked unaudited;
+  **no quote was invented for a source that cannot be read.**
+- **`stable-unstable-meta.md`** — Pat's actual stability wording, the film-score
+  passage, the high-wire opening and the "Can't Be Really Gone" reading.
+- **`repetition.md`** — the sheriff summaries and box sets, the
+  "I'd just like to know" three-box demo, the neutral chorus, and the
+  "Strawberry Wine" and "Unanswered Prayers" analyses with their songwriter
+  credits.
+- **`song-forms-examples.md`** — Pat's worked form analyses from *Essential
+  Guide to Lyric Form and Structure* (1991) Chapter 6: the missing verses of
+  "This Bottle and Me", his three-purposes bridge passage, the Ballad Stanza
+  introduction with the "Western Wind" and "The Unquiet Grave" quotes, and
+  Exercises 35 and 38. The file's header also claimed these were "canonical
+  songs"; they are **Pat's own demo lyrics**, and now say so.
+- **Figure-only content recovered.** Several passages in 1991 Chapter 6 exist
+  **only as images**, following a dangling colon in the text — including the
+  AABA **statement / restatement / variation / return** table, the S1/S2/S3
+  bridge diagrams, the ABAB ballad-stanza principle and the verse scansion
+  strips. The chorus walk-through phrase attributions were also corrected
+  against the figures, so each of Pat's sentences now sits beside the printed
+  phrase it describes.
+
 ## [0.8.5]
 
 **A reversal of standing policy, plus a source-fidelity pass.**

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -92,6 +92,25 @@ plus an extractor bug that had been silently corrupting every quoted stanza.**
   then recapitalized) and **softened a categorical rule** — Pat writes that the
   device *only* works in first and second person. Both restored.
 
+### Changed — the License section now describes what is actually here
+
+- **`README.md`'s License paragraph was factually false.** It claimed the plugin
+  "contains distilled craft guidance and short verified anchor quotes, not book
+  text." It has not been true since 0.8.5. Rewritten: MIT covers the plugin's
+  own code, skills and prompts and does not extend to quoted material; the
+  research files reproduce Pat's text and the lyrics he analyses verbatim, as a
+  deliberate decision by the owner, who owns all four books and is the only user;
+  Pat's writing remains his and the lyrics remain their writers'; readers who are
+  not the owner get no rights to any of it from the MIT header, and are pointed
+  at the four books.
+- **`point-of-view.md` had invented its own no-full-lyrics rule** — "Complete
+  third-party song lyrics are not reproduced" — and cut lyrics to fragments,
+  leaving it inconsistent with `box-model.md`, which reproduces them in full.
+  The rule was never the owner's; it is revoked and the header now says so. The
+  "As Each Year Ends" stanza is restored to Pat's full six lines. **Some
+  excerpts in that file are still short; this is recorded there as a known gap
+  rather than a policy.**
+
 ### Fixed — a second sweep, and the scaffolding thesis measured
 
 - **`audit-checklist.md` was nearly half wrong, box by box.** 192 lines carrying

--- a/plugins/songwriting/README.md
+++ b/plugins/songwriting/README.md
@@ -74,6 +74,32 @@ internal rhyme generation.
 
 ## License
 
-MIT (SPDX-License-Identifier: MIT). Pat Pattison's books are cited as methodology
-sources; the plugin contains distilled craft guidance and short verified anchor quotes, not book
-text.
+MIT (SPDX-License-Identifier: MIT) covers **this plugin's own code, skills and
+prompts**. It does not extend to material quoted from other authors.
+
+**This wording changed in 0.8.6 because the previous version was inaccurate.** It
+said the plugin "contains distilled craft guidance and short verified anchor
+quotes, not book text." Since 0.8.5 that has not been true. The research files
+under `context/pat-pattison/research/` reproduce Pat Pattison's examples, worked
+analyses, exercise wording and printed answer keys **verbatim**, along with the
+song lyrics he analyses — because a summarized exercise is not an exercise, and
+a described worked example is not an example.
+
+That is a deliberate decision by the repository owner, who owns all four books
+and maintains this as a **personal craft reference for his own use**. It is
+recorded on [#2183](https://github.com/melodic-software/claude-code-plugins/pull/2183)
+and [#2189](https://github.com/melodic-software/claude-code-plugins/pull/2189).
+
+**Pat Pattison's writing remains his, and the song lyrics remain their writers'.**
+Where Pat quotes a lyric, his publisher licensed it; that license is theirs, not
+this repository's. Nothing here is relicensed, and the MIT header above grants
+you no rights to any of it.
+
+**If you are not the owner, do not treat the reproduced book text or lyrics as
+MIT-licensed material.** Buy the books — they are the source, and they are worth
+it:
+
+- *Songwriting: Essential Guide to Lyric Form and Structure* (1991)
+- *Writing Better Lyrics* (2009)
+- *Songwriting Without Boundaries* (2011)
+- *Essential Guide to Rhyming* (2014)

--- a/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
+++ b/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
@@ -4,12 +4,41 @@
 or refusing a box is valid — but skipping silently is not. Name the skip
 reason out loud so the writer keeps craft conscious, not accidental.
 
-Source: synthesized across *Essential Guide to Lyric Form and Structure* (1991), Chapter 5/Chapter 7 (section identification, hot
-spots), *Writing Better Lyrics* (2009), Chapter 4/Chapter 18-21 (rhyme stability, structural elements), *Songwriting Without Boundaries* (2011)
-Chapter 4 (stress / "into" rule), *Essential Guide to Rhyming* (2014), Chapters 4-6 (rhyme type identity check), and
-Pat's recurring critique vocabulary in writer-sample commentary.
+**What this file is.** The checklist form is this repo's, not Pat's — he never
+publishes a pre-lock audit. What is his is the material each box invokes, and
+this file now quotes it rather than paraphrasing it. Boxes that turned out to
+have no source are still here, but relabelled as this file's own synthesis so
+you can tell the tooling from the books.
+
+Sources, corrected:
+
+- *Essential Guide to Lyric Form and Structure* (1991) — Ch 3 (rhythm, the
+  too-hot/too-cold test), Ch 4 (the conditions for rhyme, identity), Ch 5
+  (section types, song systems), Ch 6 (song forms, what a bridge accomplishes),
+  Ch 7 (hot spots, hook placement)
+- *Writing Better Lyrics* (2009) — Ch 1-2 (senses, show before tell), Ch 4
+  (rhyme types incl. subtractive), Ch 5 (clichés), Ch 6 (boxes, You-I-We),
+  Ch 7 (power positions), Ch 8 (travelogues), Ch 9 (recoloring), Ch 10-13
+  (point of view), Ch 19 (the five basic structural elements, motion and
+  emotion), Ch 22 (song forms, "four times is a lot")
+- *Songwriting Without Boundaries* (2011) — Challenge #1 and #2 (verbs),
+  Challenge #4 (stress, the *ínto* rule). This book has **Challenges and Days,
+  not chapters**; the old header's "Chapter 4" was a citation-form error.
+- *Essential Guide to Rhyming* (2014) — Ch 4 "Family Friends" (partners and
+  companions), Ch 9 "Craft and Rhyme Types" (rhyme type by position)
+
+<!-- The old header also claimed a fourth source: "Pat's recurring critique
+     vocabulary in writer-sample commentary." That names no book, chapter, or
+     page and cannot be checked. Dropped. -->
+<!-- Other corrections to the old header: it cited Writing Better Lyrics (2009)
+     Ch 18-21 for "structural elements" (Ch 20-21 are Form Follows Function and
+     The Great Balancing Act), and Essential Guide to Rhyming (2014) Ch 4-6 for
+     the "rhyme type identity check" (Ch 4-6 are Family Friends / Friendly
+     Relatives / Kissin' Cousins — rhyme types; identity is a 1991 Ch 4 idea). -->
 
 ## When to run
+
+*This list is this file's own workflow — no book source.*
 
 - **Pre-lock a line** — before committing a line to the canonical `LYRIC.md`
 - **Pre-lock a section** — verse, chorus, bridge, refrain, transitional bridge
@@ -22,157 +51,506 @@ Pat's recurring critique vocabulary in writer-sample commentary.
 Before reviewing a section, name its type. Different section types have
 different jobs — auditing a refrain like a chorus is the wrong test.
 
-**Verse?**
+**Verse?** Pat's list of the verse's jobs, verbatim:
+
+> "The Verse is the basic worker of the lyric. Its jobs are
+>
+> 1. To introduce ideas
+> 2. To set up the CENTRAL IDEA
+> 3. To develop or continue ideas
+> 4. To set structural standards for the lyric,
+>
+> thus, 5. Verses should close down."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5
 
 - [ ] introduces ideas
-- [ ] sets structural standards (line count, length, rhyme scheme, rhythm)
-- [ ] closes down — does not leak into the next section
-- [ ] develops, not restates (verse 2 vs verse 1)
+- [ ] sets up the central idea
+- [ ] develops or continues ideas
+- [ ] sets structural standards — and note *which* standards Pat names:
+      "Verses establish BALANCE, PACE, FLOW, CLOSURE, AND CLOSURE TYPE for the
+      lyric, setting a point of comparison for other structures in the lyric."
+      (same chapter)
+- [ ] closes down
+<!-- SYNTHESIS, not a Ch 5 claim: "develops, not restates (verse 2 vs verse 1)"
+     was listed here as a verse-identification test. It is really the travelogue
+     test from Writing Better Lyrics (2009) Ch 8, and it belongs in the
+     per-section pass, where it already appears. Removed from the diagnosis. -->
 
-**Chorus?**
+**Chorus?** Pat's list, verbatim:
 
-- [ ] most balanced section in the lyric
-- [ ] acts as the central section — central idea lives here
-- [ ] stops forward motion (a landing place)
-- [ ] color-resistant — same words repaint across visits
+> "1. Completes, comments on, or summarizes ideas.
+> 2. Contains the CENTRAL IDEA.
+> 3. Is the lyric's CENTRAL SECTION.
+> 4. Is typically the lyric's most balanced section.
+>
+> thus, 5. Stops forward motion."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5
 
-**Bridge?**
+- [ ] completes, comments on, or summarizes ideas
+- [ ] contains the central idea
+- [ ] is the lyric's central section
+- [ ] is *typically* the most balanced section — his hedge is load-bearing:
+      "Being most balanced doesn't necessarily mean perfectly balanced."
+- [ ] stops forward motion — "This creates the feeling of 'starting over
+      again' in the next section."
+- [ ] repaintable — same words take new color on each visit
+      (*Writing Better Lyrics* (2009), Chapter 9, not Chapter 5; see
+      `repetition.md`)
 
-- [ ] developmental — moves away from established structures
-- [ ] new perspective or contrasting angle
-- [ ] most unbalanced section in the lyric
-- [ ] does NOT restate verse material
+**Bridge?** Pat's list, verbatim:
 
-**Transitional bridge (pre-chorus / climb / lift / ramp / vest)?**
+> "This section is often called a 'release,' or boredom breaker: the place
+> where you try to get away from the ideas and structures the lyric has
+> already established. But it is also much more:
+>
+> 1. It is a DEVELOPMENTAL section.
+> 2. It develops a new perspective or contrasting idea.
+> 3. It unbalances the section by moving away from established structures,
+> creating structural tension.
+> 4. It is resolved by a return to previously established structures,
+>
+> thus, 5. It is frequently the lyric's most unbalanced section."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5
 
-- [ ] enclosed inside a song system (between verse and chorus)
-- [ ] shortest and most unbalanced section in its system
-- [ ] does NOT close the song system — that belongs to the chorus
-- [ ] sets up the chorus rhythmically and emotionally
+- [ ] developmental section
+- [ ] develops a new perspective or contrasting idea
+- [ ] unbalances by moving away from established structures
+- [ ] **resolved by a return to previously established structures** — the box
+      this file was missing; a bridge that never comes home is not finished
+- [ ] *frequently* the most unbalanced section (his hedge, not "always")
+
+**Transitional bridge?** Pat's own name for it, and his list, verbatim:
+
+> "This is as close as I can come to an accurate name for this elusive little
+> section. I have heard it called by many names:"
+> — then a figure listing: Pre-Chorus · Vest · Ramp · Climb or Lift ·
+> Verse Extension · Prime
+> "This section is used for so many jobs, none of these descriptive names
+> quite fit all of them:
+>
+> 1. It is a DEVELOPMENTAL section.
+> 2. It introduces a pivotal idea as a transition between Verse and Chorus.
+> 3. It is always enclosed in a Song System, almost always between a verse and
+> a chorus.
+> 4. It unbalances the Song System by contrasting with the established verse
+> structure. It makes you want to get to a balanced or CENTRAL section.
+>
+> Thus, 5. It is usually the lyric's shortest and most unbalanced section."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5
+
+- [ ] developmental section
+- [ ] introduces a pivotal idea as a transition between verse and chorus
+- [ ] always enclosed in a song system, almost always between verse and chorus
+- [ ] unbalances the song system by contrasting with the established verse
+      structure
+- [ ] *usually* the shortest and most unbalanced section
+- [ ] placement test: "a Transitional Bridge comes before the Song System has
+      closed down, between a Verse and a Chorus. The more typical Bridge always
+      comes after a song system has closed down." (same chapter)
 
 **Refrain?**
 
-- [ ] part of the verse — NOT a separate section
+> "This is not a section at all. It is just a name for the part of a Verse
+> that contains the CENTRAL IDEA and gets repeated in the other Verses. A
+> Refrain is different from a Chorus, since a Chorus is contained in its own
+> separate section. 'Refrain' is a handy term when you talk about lyrics that
+> have only Verses, or Verses and a Bridge."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5
+
+- [ ] part of a verse — not a section at all
 - [ ] contains the central idea
-- [ ] repeated at end of every verse
-- [ ] same length/position each visit
+- [ ] gets repeated in the other verses
+<!-- CORRECTED: this file previously required the refrain to be "repeated at
+     end of every verse" with "same length/position each visit." Pat says only
+     that it is repeated in the other verses. His own first example, Buck Ram's
+     "The Great Pretender," carries its refrain at the TOP of each verse, so the
+     end-of-verse requirement contradicts the chapter it was cited to. -->
 
 ## Per-line checklist
 
 Run for any line under consideration for locking.
 
-**Stress & meter (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3, *Songwriting Without Boundaries* (2011), Challenge 4)**
+**Stress & meter (*Essential Guide to Lyric Form and Structure* (1991),
+Chapter 3 "Rhythm: Setting Up, Shutting Down"; *Songwriting Without Boundaries*
+(2011), Challenge #4 "Writing in Rhythm & Rhyme" — that book is organized in
+Challenges and Days, never chapters)**
 
-- [ ] every stressed syllable lands on a strong beat
-- [ ] no stressed syllable forced into a position the pattern or the bar leaves weak — this is "greed" in the 1991 sense
-- [ ] no unstressed syllable riding a strong beat — the reverse alignment error, equally a distortion of natural speech
-- [ ] the strong positions carry the line's *important* words, not filler — a line can pass both checks above and still be too cold
-- [ ] "into" handled per the ínto rule (*Songwriting Without Boundaries* (2011), Challenge 4) — not intó
-- [ ] compound words primary-stressed on first syllable
-- [ ] grey-area stress flagged, not silently resolved
-- [ ] sing-check passed (read aloud / sing against melody if known)
+Pat frames this as Goldilocks — too hot, too cold, just right:
 
-**Rhyme stability (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4; *Writing Better Lyrics* (2009), Chapter 4; *Essential Guide to Rhyming* (2014), Chapters 4-6)**
+> "It is important not to be greedy: do not put stressed syllables in the
+> unstressed positions. This one is too hot. […] The 'greedy' spots would
+> surely get buried or at the very least sound hurried (and lose their
+> emotion) when you set them to the music of the original verse. It is equally
+> important to match the original's important words with equally important
+> words. This one is too cold […] You must resist greed. But you must put your
+> important words in the important positions. This one is just right."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 3
 
-- [ ] if line ends in a rhyme position: identity check — pre-vowel consonants DIFFER
-- [ ] stability tier chosen by emotional intent, not convenience (perfect / family / additive / assonance / consonance)
-- [ ] no automatic cliche pair (moon/June, fire/desire, heart/apart unless reframed)
-- [ ] family-rhyme partners/companions inversion respected (plosive partners closer; fricative companions closer)
-- [ ] for partial rhyme: chosen for forward motion, not by accident
-- [ ] sing-check on rhyme position (vowel coloring varies by register)
+- [ ] too hot? — no stressed syllables sitting in the pattern's unstressed
+      positions (this is "greed")
+- [ ] too cold? — the important positions carry important words, not filler.
+      A line can resist greed perfectly and still be too cold.
+<!-- REMOVED as unsupported: "no unstressed syllable riding a strong beat — the
+     reverse alignment error." Pat's second failure mode is not unstressed
+     syllables on strong beats; it is UNIMPORTANT WORDS in important positions.
+     The inversion was this file's invention, not the chapter's. -->
+- [ ] "into" handled as ínto, not intó:
+      > "Take a second to notice into, another two-syllable preposition. It is
+      > stressed ínto, not intó. It is probably the most badly handled word in
+      > songwriting—perhaps since it usually follows a stressed syllable […]
+      > The proper handling is / She walked (pause) ínto the room."
+      > — *Songwriting Without Boundaries* (2011), Challenge #4
+- [ ] compound words: "In English, the primary stress in compound words is
+      almost always on the first syllable." (same challenge)
+- [ ] prepositions kept in secondary rhythmic positions — "when you set lyric
+      to melody, you will remember to relegate prepositions to secondary
+      rhythmic positions in the bar." (same challenge)
 
-**Hot spots (*Essential Guide to Lyric Form and Structure* (1991), Chapter 7, phrase-level extension)**
+*This file's own additions, not book claims:* flag grey-area stress rather than
+silently resolving it; read the line aloud (or sing it against the melody if
+one exists) before locking.
 
-- [ ] line 1 of section: strong content word at start
-- [ ] last line of section: title or punchline-grade content
-- [ ] within a phrase: second-most-important word at beginning, most-important at end
-- [ ] no important content in unimportant grammatical positions (between hot spots)
+**Rhyme stability (*Essential Guide to Lyric Form and Structure* (1991),
+Chapter 4 "Rhyme: Taking Total Control"; *Writing Better Lyrics* (2009),
+Chapter 4 "Learning to Say No: Building Worksheets"; *Essential Guide to
+Rhyming* (2014), Chapters 4-6 "Family Friends" / "Friendly Relatives" /
+"Kissin' Cousins")**
+
+- [ ] if line ends in a rhyme position: identity check. Pat's third condition
+      for rhyme is "Their beginnings are different," and he explains why:
+      > "'IDENTITY' means that syllables start the same way. 'Fuse/confuse' is
+      > not a rhyme, it is an IDENTITY. Your ear does not pay attention to the
+      > sounds of the syllables. There is no tension, no 'difference' to be
+      > resolved by sameness. 'Peace/piece' and 'lease/police' are also
+      > Identities. The same sounds are repeated, just like a cheerleader's
+      > yell."
+      > — *Essential Guide to Lyric Form and Structure* (1991), Chapter 4
+- [ ] rhyme type chosen deliberately. Pat's own roster — note **subtractive**,
+      which this checklist had been omitting: "family rhymes, additive and
+      subtractive rhymes, assonance and even consonance rhymes (especially for
+      l and r)" (*Writing Better Lyrics* (2009), Chapter 4). Additive ordering
+      runs closest-to-perfect outward: "The less sound you add, the closer you
+      stay to perfect rhyme."
+- [ ] no automatic cliche pair. Check against Pat's own printed CLICHÉ RHYMES
+      list, not a remembered one: "fire / desire / higher" and "heart / start /
+      apart / part" are on it; **moon/June, which this checklist used to cite,
+      is not.** The list opens: "When you hear one of these, no need to lose
+      sleep wondering what's coming next. Plop. Naptime."
+      (*Writing Better Lyrics* (2009), Chapter 5)
+- [ ] if a cliche rhyme is hard to avoid, take his exit: "Most cliché rhymes
+      are perfect rhymes, a good reason to stretch into other rhyme types —
+      family rhyme, additive and subtractive rhyme, and even assonance rhyme.
+      These imperfect rhyme types are guaranteed fresh, and most listeners
+      won't notice the difference." (same chapter)
+- [ ] family-rhyme partners/companions inversion respected — the box is right,
+      and here is the sentence behind it:
+      > "When using fricatives, companions (in the same horizontal row) are
+      > closer than partners (set vertically). […] The opposite was true for
+      > plosives. Fricatives take longer to say than plosives, so you hear the
+      > unvoiced or voiced sound more clearly."
+      > — *Essential Guide to Rhyming* (2014), Chapter 4
+      His definitions: "Partners use the same physical positions, as well as
+      handling the air column in the same way," while "Companions have the same
+      voicing characteristic." (same chapter)
+*This file's own additions, not book claims:* "for partial rhyme: chosen for
+forward motion, not by accident"; "sing-check on rhyme position (vowel coloring
+varies by register)." Neither phrasing appears in the corpus.
+
+**Hot spots / power positions (*Essential Guide to Lyric Form and Structure*
+(1991), Chapter 7; *Writing Better Lyrics* (2009), Chapter 7)**
+
+Pat's hot spots are **beginnings and endings of sections** — not positions
+inside a phrase:
+
+> "Beginnings and endings. Two HOT SPOTS. […] Find your most important ideas
+> and put them in the HOT SPOTS. […] Whatever ideas you put in HOT SPOTS
+> become your most important ideas. You make them important by putting them
+> there."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 7
+
+> "The opening and closing lines of any lyric section are naturally strong.
+> They are bathed in spotlights. If you want people to notice an important
+> idea, put it in the lights of a power position, and you will communicate the
+> idea more forcefully. […] Closing lines are also power positions, another
+> place to light up an important idea. […] I call it a trigger position,
+> because it releases us into the chorus, carrying whatever the line says with
+> us."
+> — *Writing Better Lyrics* (2009), Chapter 7
+
+- [ ] the section's opening line carries an idea worth the spotlight
+- [ ] the section's closing line — the trigger position — carries the idea you
+      want the next section read in the light of
+<!-- SYNTHESIS, not a Chapter 7 claim: "within a phrase: second-most-important
+     word at beginning, most-important at end" and "no important content in
+     unimportant grammatical positions." Pat's hot spots operate at section
+     beginnings and endings. The old heading half-admitted this by calling
+     itself a "phrase-level extension"; that hedge was doing the work of a
+     citation. Keep the habit if it helps you, but it is this file's, not his. -->
 
 **POV / address (*Writing Better Lyrics* (2009), Chapters 10-13)**
 
-- [ ] who is speaking? to whom? consistent with section?
-- [ ] no pronoun bouncing between unrelated 1st/2nd/3rd within section
-- [ ] hangman test: does direct-address material avoid telling "you" facts "you" already know?
-- [ ] camera distance (close-up / middle / hybrid / long-shot) matches section role
+- [ ] who is speaking? Pat's opening questions: "Who is doing the talking? Is
+      it you personally? Is it a character you're creating? What should that
+      character's relationship to the audience be? A storyteller? A confessor?
+      Something else?" (*Writing Better Lyrics* (2009), Chapter 10)
+- [ ] one of his **four** points of view chosen on purpose — "third-person
+      narrative, second-person narrative, first-person narrative, and direct
+      address" (same chapter)
+- [ ] camera distance matches the section's job: "Point of view controls our
+      distance from the world of the song. Think of it as a movie camera,
+      allowing the audience to look at the song's world from various distances,
+      from long shots to close-ups." His printed scale runs
+      **Most Intimate (Close-up: Feelings)** — Direct Address · Second Person
+      Narrative · First Person Narrative · Third Person Narrative —
+      **Most Objective (Long Range: Facts)**. It is a continuum of the four
+      POVs, not the free-standing four-name distance set this checklist used to
+      list. Three of those names are his, each attached to a specific POV:
+      third person is "the long-distance, panoramic view," first person is "the
+      middle-distance shot," and direct address is "the camera close-up […] the
+      most intimate of the points of view." **"Hybrid" is not his** — the word
+      returns zero hits across all four books.
+- [ ] hangman test (*Writing Better Lyrics* (2009), Chapter 11): "Sometimes,
+      lyrics sound like Mom. They seem to be talking directly to you, but are
+      really telling someone else what you already know. […] Don't give the
+      facts to someone who already should know them!"
+<!-- SYNTHESIS: "no pronoun bouncing between unrelated 1st/2nd/3rd within
+     section" is this file's rule of thumb. Pat's Chapters 10-13 treat POV shift
+     as a deliberate, usable move (see `point-of-view.md`), not as a blanket
+     within-section prohibition. -->
 
-**Image specificity (*Writing Better Lyrics* (2009), Chapters 1-2)**
+**Image specificity (*Writing Better Lyrics* (2009), Chapters 1-2;
+*Songwriting Without Boundaries* (2011), Challenges #1-2 for the verb box)**
 
-- [ ] if line tells (names emotion / lesson / topic): is there a Rusty's-collar image placed before it?
-- [ ] no generic label substituting for a concrete image ("the place" → which place; "the love" → whose love)
-- [ ] sense-bound: at least one sense in play (sight / hearing / smell / taste / touch / organic / kinesthetic)
-- [ ] verb does work (strong verb > adjective)
+- [ ] if the line tells (names an emotion, lesson, or topic), is there an image
+      shown before it? Pat's name for the rule and his statement of it:
+      > "To this day, I call that the 'Sister Mary Elizabeth Rule of
+      > Song-writing.' Show before you tell. Showing makes the telling more
+      > powerful because your senses and your mind are both engaged. […] The
+      > Sister Mary Elizabeth Rule of Songwriting says: First, hold up Rusty's
+      > collar, and then say what you will."
+      > — *Writing Better Lyrics* (2009), Chapter 2
+<!-- SYNTHESIS: "no generic label substituting for a concrete image ('the place'
+     → which place; 'the love' → whose love)" is this file's phrasing and its
+     invented example pair. The underlying show-before-tell principle is Pat's
+     (above); this particular test is not. -->
+- [ ] sense-bound, using his seven: "Anything goes, as long as it is
+      sense-bound. […] Use all seven senses: sight, hearing, smell, taste,
+      touch, organic, and kinesthetic." (*Writing Better Lyrics* (2009),
+      Chapter 1)
+- [ ] the verb does the work:
+      > "Verbs. You've already learned something about them. They're the most
+      > potent force in language. Nouns are inert. They sit there. Adjectives
+      > pile on top of them and sit there. Verbs electrify them, propel them,
+      > launch them into action. The difference between average and great
+      > writing: verbs."
+      > — *Songwriting Without Boundaries* (2011), Challenge #2
+      And his audition test: "Strong verbs are the key to strong writing.
+      Audition your verbs. Let them prance and somersault for you. Verbs based
+      in metaphor or steeped in the senses usually get the gig."
+      (*Songwriting Without Boundaries* (2011), Challenge #1)
 
 **Cliche scan (*Writing Better Lyrics* (2009), Chapter 5)**
 
-- [ ] no stale phrase (broken heart, fire of love, lonely night)
-- [ ] no predictable rhyme pair
-- [ ] no cliche metaphor family used unreframed (storm-anger, fire-passion, darkness-sadness, prison-love, drown-in-love)
-- [ ] if cliche is used: is it "friendly" — reframed by context so it earns its place?
+- [ ] no cliche image. His cure, verbatim: "The best cure for cliché images is
+      to dive into your own sense pool and discover images that communicate
+      your feelings. What did your lover say? Where were you? What kind of car?
+      What was the texture of the upholstery in the backseat? You get the idea."
+- [ ] no predictable rhyme pair (his CLICHÉ RHYMES list, quoted above)
+- [ ] no cliche metaphor used unreframed. Pat's CLICHÉ METAPHORS list is longer
+      than the five this checklist named — his full set is: storm for anger ·
+      darkness for ignorance, sadness, and loneliness · fire for love or
+      passion · rain for tears · seasons for stages of life or relationships ·
+      prison/prisoner especially for love · cold for emotional indifference ·
+      light for knowledge or happiness · walls for protection from harm,
+      especially from love · broken heart · drown in love. He introduces them:
+      "Review chapter three, 'Making Metaphors.' There's no reason to keep
+      sleepwalking in these yellow fogs."
+- [ ] if a cliche stays, is it *friendly*? "In some cases, you can use a cliché
+      to your advantage. Put it in a context that brings out its original
+      meaning or makes us see it in a new way." His examples are Sammy Fain and
+      Irving Kahal's "I'll be seeing you" and David Wilcox slanting "it's all
+      downhill from here" in "Top of the Roller Coaster."
 
-**Prosody (*Writing Better Lyrics* (2009), Chapter 18-21)**
+**Prosody (*Writing Better Lyrics* (2009), Chapters 18-19)**
 
-- [ ] motion (stable / unstable) supports emotion at this moment
-- [ ] structure at line boundary aligns with content tension (closure / forward push)
-- [ ] tone-of-voice stable: same speaker, same emotional register
+> "Motion creates emotion. Or, maybe better: Motion creates and supports
+> emotion."
+> — *Writing Better Lyrics* (2009), Chapter 19
+
+- [ ] motion supports emotion here. His two sources of motion: "1) the words
+      and ideas themselves, and 2) the overall lyric structure, which consists
+      of: a. groupings of lines, and b. line structure, a combination of three
+      things: rhythm of the line, length of the line (line length is determined
+      by the number of stresses in a line), and rhyme scheme used in the
+      combinations of lines." (same chapter)
+- [ ] payoff check: "When you control the way a lyric moves, you're able to
+      affect your audience on two levels simultaneously, rather than just on
+      the level of meaning." (same chapter)
+<!-- SYNTHESIS: "tone-of-voice stable: same speaker, same emotional register."
+     The phrase "tone of voice" returns ZERO hits across all four books; a
+     sibling audit of `stable-unstable-meta.md` found the same and removed it
+     there. Keep it as a habit if useful, but it is not Pat's. -->
+<!-- SYNTHESIS: "structure at line boundary aligns with content tension
+     (closure / forward push)" restates his stable/unstable material in this
+     file's own vocabulary; see `stable-unstable-meta.md` for the sourced
+     version. -->
 
 ## Per-section checklist
 
 After the per-line pass, zoom out.
 
-**Five Compositional Elements (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3-4 + *Essential Guide to Rhyming* (2014), Chapter 9)**
+**The five basic structural elements (*Writing Better Lyrics* (2009),
+Chapter 19)**
+
+Pat's phrase is "the five basic structural elements," and it is a 2009 idea,
+not a 1991 one. *Essential Guide to Lyric Form and Structure* (1991) counts
+**four**, not five — its Introduction is the juggling act: "As a lyricist, you
+must learn to juggle four balls," and the four questions are "How many phrases
+will I have? · How long will each phrase be? · What rhythms will I use in each
+phrase? · How should I arrange the rhymes?" The fifth element, **rhyme types**,
+is the one 2009 adds — he names it while setting it aside: "four of the five
+basic structural elements (we'll leave out rhyme types) — an even number of
+lines, matched line length, stable rhythm, and stable rhyme scheme."
 
 - [ ] number of lines counted (even? odd? deliberate?)
-- [ ] line lengths counted (stress count, not syllable count)
-- [ ] rhyme scheme (capital letters per *Writing Better Lyrics* (2009), Chapter 19: lines sharing rhyme + stress + rhythm get the same letter)
-- [ ] rhyme types per position (which stability tier where)
-- [ ] rhythm — duple / triple / mixed; consistent across like sections
+- [ ] line lengths counted — "line length is determined by the number of
+      stressed syllables in a line" (Chapter 19)
+- [ ] rhyme scheme notated. His convention, verbatim: "To notate the way a
+      structure moves, let's use capital letters (e.g., A, B, C) to stand for
+      lines that have both the same line lengths and the same rhyme scheme.
+      Each line labeled with the same letter will: (1) rhyme with, (2) have the
+      same number of stressed syllables as, and (3) have the same basic rhythm
+      as every other line in the section with the same letter." (Chapter 19)
+- [ ] rhyme types per position — which type sits in the dominant position and
+      which in the tonic (*Essential Guide to Rhyming* (2014), Chapter 9,
+      "Craft and Rhyme Types")
+- [ ] rhythm of each line
+<!-- CORRECTED HEADING: this section was titled "Five Compositional Elements"
+     and cited to Essential Guide to Lyric Form and Structure (1991) Ch 3-4 plus
+     Essential Guide to Rhyming (2014) Ch 9. Neither source names five elements.
+     "Five compositional elements" as a phrase returns no corpus hits at all. -->
+<!-- SYNTHESIS: "duple / triple / mixed; consistent across like sections" is
+     this file's gloss on the rhythm element, not Chapter 19's wording. -->
 
-**Stable / unstable signature**
+**Stable / unstable signature (*Essential Guide to Lyric Form and Structure*
+(1991), Chapter 5)**
 
-- [ ] section's lyric stability matches its melodic stability (or pushes against it deliberately)
-- [ ] central section more balanced than outer sections
-- [ ] bridge more unbalanced than verses
-- [ ] transitional bridge most unbalanced of its system
+This block previously carried no citation at all while sitting between two
+cited blocks, which made it read as inherited attribution. Three of its four
+boxes are Pat's, and the sentences are the ones already quoted above: the
+chorus "Is typically the lyric's most balanced section," the bridge "is
+frequently the lyric's most unbalanced section," and the transitional bridge
+"is usually the lyric's shortest and most unbalanced section."
 
-**Repetition (*Writing Better Lyrics* (2009), Chapter 9)**
+- [ ] central section is the most balanced (*typically*)
+- [ ] bridge is more unbalanced than the verses (*frequently*)
+- [ ] transitional bridge is the shortest and most unbalanced of its system
+      (*usually*)
+<!-- SYNTHESIS: "section's lyric stability matches its melodic stability (or
+     pushes against it deliberately)" is this file's own box. The 1991 book
+     treats structure without a melody in hand; see `stable-unstable-meta.md`
+     and `prosody.md` for what Pat does say about lyric/music alignment. -->
 
-- [ ] chorus / refrain repaintable across visits
-- [ ] verse 2 develops, not travelogues
-- [ ] box-model weight rule respected: heaviest box last
+**Repetition (*Writing Better Lyrics* (2009), Chapters 6, 8, and 9 — one
+chapter per box, not Chapter 9 for all three)**
+
+- [ ] chorus / refrain can actually be recolored — "Strong verse development is
+      crucial to deepening the colors of your refrain or chorus. Just as
+      important, however, is making sure your refrain chorus can be recolored.
+      Sometimes it can resist recoloring, no matter how well your verses
+      develop." (Chapter 9)
+- [ ] verses develop rather than tour. His travelogue test, verbatim: "Verse
+      development should mean verse relationship. Your verses should have a
+      good reason to hang out together. When verses are in the same lyric only
+      because you're taking a tour of the title, you likely have a travelogue
+      on your hands." (Chapter 8)
+- [ ] box weight increases: "think about a song as a stack of boxes that are
+      connected to each other, each one getting progressively larger. Think of
+      each one gaining more weight, the last being the heaviest of the lot."
+      (Chapter 6; see `box-model.md`)
 
 ## Pre-lock-title checklist
 
-**Sound (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4; *Essential Guide to Rhyming* (2014), Chapters 3-4)**
+**Sound — this file's own title workflow, built on Pat's material**
+
+Pat has no "pre-lock the title" checklist. These boxes are this repo's routine;
+what is his are the underlying tools they invoke: the rhyme conditions and
+identity (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4),
+family rhyme (*Essential Guide to Rhyming* (2014), Chapter 4, "Family
+Friends"), and the CLICHÉ RHYMES list (*Writing Better Lyrics* (2009),
+Chapter 5). The previous heading also cited *Essential Guide to Rhyming*
+(2014), Chapter 3, which is "Getting References" — about rhyming dictionaries
+and worksheets, not title sound.
 
 - [ ] stressed vowel identified
 - [ ] family rhymes plausible (run `datamuse.sh family <title>` per `ai-tools.md`)
-- [ ] no automatic cliche partners
+- [ ] no automatic cliche partners (check Pat's list, above)
 - [ ] front-heavy or back-heavy noted (phrasing.md)
 - [ ] stress pattern named (per `meter.md` paradigms)
 
-**Meaning**
+**Meaning — this file's own, no book source**
 
-- [ ] central idea named in one sentence
+- [ ] central idea named in one sentence — the one box with a book anchor:
+      "The CENTRAL IDEA is the main message of the lyric."
+      (*Essential Guide to Lyric Form and Structure* (1991), Chapter 5)
 - [ ] emotional shape implied
 - [ ] POV implied (who says this, to whom)
 - [ ] one paragraph of "what the song is about" written before drafting
 
-**Form fit (*Essential Guide to Lyric Form and Structure* (1991), Chapter 6)**
+**Form fit — this file's synthesis; the underlying distinctions are Pat's**
+
+<!-- The "does the title repeat well? → chorus form / does it live once? →
+     verse/refrain or AABA" decision procedure is not in Essential Guide to
+     Lyric Form and Structure (1991) Chapter 6. The word "title" appears once in
+     that whole chapter. What IS his is the chorus/refrain distinction it rests
+     on (Chapter 5, quoted at the top of this file) and the hook-placement
+     strategies of Chapter 7. -->
 
 - [ ] does title repeat well? → chorus form
 - [ ] does title live once? → verse/refrain or AABA
-- [ ] hot-spot position chosen (chorus first / chorus last / refrain at verse end / bridge target)
+- [ ] hook position chosen. Pat's constraint on the verse/refrain case: "most
+      of the time when you write a Verse/Refrain, you will use your HOOK either
+      at the beginning or at the end, usually not both. If you use it both
+      places, you will have to use it twice in every verse. In most cases, that
+      would be too much." (*Essential Guide to Lyric Form and Structure*
+      (1991), Chapter 7)
 
 ## Pre-lock-form checklist
 
 - [ ] central section chosen (chorus or refrain — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5)
-- [ ] title position decided
+- [ ] title position decided <!-- this file's box, no book source -->
 - [ ] repetition strategy: chorus repaints? refrain stays exact?
-- [ ] bridge present? — bridge fulfills at least one of the three *Essential Guide to Lyric Form and Structure* (1991), Chapter 6 functions (break monotony / different-size song system / new perspective)
-- [ ] "four times is a lot" check (*Writing Better Lyrics* (2009), Chapter 22) — V/V/Ch/V/V/Ch risk
-- [ ] verse-job division clear (You-I-We? Past-Present-Future? per box-model.md)
+      <!-- The repaint half is Pat's (Writing Better Lyrics (2009) Ch 9,
+           quoted above). "Refrain stays exact" is this file's addition —
+           Essential Guide to Lyric Form and Structure (1991) Ch 5 says only
+           that the refrain "gets repeated in the other Verses." -->
+- [ ] bridge present? Pat's three things a bridge accomplishes, verbatim:
+      > "1. It would break up the monotony of the same pattern. This will also
+      > set up the last verse with a contrasting section.
+      > 2. It would give different size Song Systems […]
+      > 3. A Bridge would also give the verse ideas a chance to 'breathe' by
+      > moving to a new angle or perspective."
+      > — *Essential Guide to Lyric Form and Structure* (1991), Chapter 6
+      Note he presents these as three things one bridge does together, not a
+      menu to satisfy one of.
+- [ ] "four times is a lot" check: "v / v / ch / v / v / ch repeats the same
+      melody, chords, phrase lengths, and rhyme schemes four times. Four times
+      is a lot. You risk boring your listeners when you make four trips through
+      the same structure. Your verses, especially the crucial fourth verse, had
+      better be very interesting to risk all that repetition."
+      (*Writing Better Lyrics* (2009), Chapter 22)
+- [ ] verse-job division clear. Pat's You-I-We move comes from his Development
+      Tips: "It's difficult to see where to go next. It feels like everything's
+      been covered. Perhaps it might help to separate the perspectives,
+      dividing the idea into the three different perspectives: (1) you, (2) I
+      (me), and (3) we." (*Writing Better Lyrics* (2009), Chapter 6; the
+      Past-Present-Future variant follows in the same chapter — see
+      `box-model.md`)
 
 ## Coach posture when running an audit
+
+*This section is this file's own — no book source. Kept because it is how the
+repo wants an audit conducted, not because Pat says it.*
 
 - Do not list every miss. Surface the dominant problem first.
 - If the dominant problem is upstream (title doesn't fit form, form doesn't fit emotion), fixing downstream lines won't help.
@@ -181,7 +559,10 @@ After the per-line pass, zoom out.
 
 ## Cross-references
 
-- `five-compositional-elements.md` — pentad diagnostic worksheet
+- `five-compositional-elements.md` — pentad diagnostic worksheet. Pat's own
+  phrase for these is "the five basic structural elements" (*Writing Better
+  Lyrics* (2009), Chapter 19); "compositional elements" is this repo's coinage
+  and returns no hits in any of the four books.
 - `stable-unstable-meta.md` — section-level prosody scan
 - `rhyme-fundamentals.md` — identity-vs-rhyme check origin
 - `cliche.md` — cliche taxonomy

--- a/plugins/songwriting/context/pat-pattison/research/beyond-books.md
+++ b/plugins/songwriting/context/pat-pattison/research/beyond-books.md
@@ -95,8 +95,9 @@ the recurring framing for Pat's craft stance.
 > "Tools, not rules." — recurring column framing, also the column title in
 > *American Songwriter*
 
-> "Sense-bound is universal. Generic is not." — recurring teaching across
-> books + columns
+> "Songs should be universal, but don't mistake universal for generic.
+> Sense-bound is universal." — Pat Pattison, *Writing Better Lyrics*
+> (2009), Chapter 5; the point recurs in the columns
 
 Columns are short; not all are dated or archived consistently. For
 canonical Pat material, the books are primary; columns extend rather than

--- a/plugins/songwriting/context/pat-pattison/research/box-model.md
+++ b/plugins/songwriting/context/pat-pattison/research/box-model.md
@@ -1,34 +1,45 @@
 # Box Model — Verse Development Across Time
 
-Pat Pattison - *Writing Better Lyrics* (2009), Chapters 6-9, 22-23. The box model
-is the most cross-cutting structural framework in *Writing Better Lyrics* (2009). It governs verse
-development, repetition strategy, second-verse rescue, and form-potency
-analysis.
+Pat Pattison - *Writing Better Lyrics* (2009), Chapters 6-9. Boxes are
+introduced in Chapter 6 (Productive Repetition) and carried through Chapters
+7-9. The model governs verse development, repetition strategy, second-verse
+rescue, and chorus repainting.
 
 ## Core idea
 
-A song's verses are a stack of connected boxes. Each box carries content;
-each box has a weight (its emotional / informational density); each
-subsequent box must be heavier than the last, OR have a new angle the prior
-boxes lacked.
+A box is a unit of idea-movement, not a unit of form
+(*Writing Better Lyrics* (2009), Chapter 7):
 
-> Put separate ideas in separate boxes.
+> Boxes represent the movement of ideas. They are form neutral. A series of
+> three boxes can represent almost any formal movement:
+>
+> verse / chorus / verse / chorus / bridge / chorus
+>
+> verse / refrain / verse / refrain / bridge / verse / refrain (AABA)
+>
+> verse / pre-chorus / chorus / verse / pre-chorus / chorus / bridge / chorus
+>
+> verse / chorus / verse / chorus / verse / chorus
+>
+> Boxes only show how the ideas evolve, regardless of the specific form you use.
 
-This is Pat's division-of-labor principle: every verse system has its own
-exclusive job. Two verses doing the same job is a **same-color** failure
-(*Writing Better Lyrics* (2009), Chapter 7) — NOT a travelogue. The two are
-opposite poles; see [Travelogue vs same-color](#travelogue-vs-same-color).
+The governing principle, stated at the end of the "Between Fathers and Sons"
+demonstration in Chapter 6:
+
+> Here is a simple principle for division of labor: Put separate ideas in
+> separate boxes.
+
+Two verses doing the same job leave the boxes the same size — see
+[Travelogue vs same-color](#travelogue-vs-same-color) for how that differs
+from a travelogue.
 
 ## Box weight rule
 
-- **Box 1 (verse 1):** introduces. Lightest content allowed — sensory entry,
-  POV setup, time/place anchor.
-- **Box 2 (verse 2):** advances. Adds new angle, new tension, new
-  consequence, new perspective shift. NOT a restatement.
-- **Box 3 (verse 3 / bridge / final verse):** heaviest. The "why" of the
-  song. The emotional landing.
+Pat's own statement of the stack, opening Chapter 6's box discussion:
 
-Pat's own statement of the stack:
+> It might be helpful to think about a song as a stack of boxes that are
+> connected to each other, each one getting progressively larger. Think of each
+> one gaining more weight, the last being the heaviest of the lot.
 
 > The first box begins the flow of ideas, introducing us to the song's world. The
 > second box continues the idea, but from a different angle, combining the weight
@@ -36,46 +47,176 @@ Pat's own statement of the stack:
 > first two, introducing its own angle and combining its idea with the first two,
 > resulting in the heaviest box.
 
+Pat's diagram for this is three stacked boxes, each one wider, taller and
+darker than the one above it — box 1 smallest and palest on top, box 3 largest
+and blackest at the bottom.
+
+His worked sketch, on the title idea *I'd just like to know* — "Assume you're
+working with the idea 'I'd just like to know.'":
+
+> Box 1: "Hi, it's nice to see you. You're looking good, and you're looking
+> really happy. Are you? I hope you don't mind my asking. I'd just like to know."
+
+> Let's try to advance the idea and make the second box gain weight.
+
+> Box 2: "When you left, did you already know you were moving in with him? When
+> I was out of town, did he come over to your place? Did you hide that picture
+> of us you kept on your dresser? I suppose it doesn't matter now, but I'd just
+> like to know."
+
+> See how the idea gains weight with the new information? It combines the first
+> box, the meeting, with some history, giving the second box more weight and
+> giving more impact to the title.
+
+> Box 3: "For me, a relationship is all about honesty. I want to be able to say
+> everything to you, and for you to say everything to me. I don't want any
+> secrets, no matter what. You could have told me about him. I wouldn't have
+> tried to stop you. I'd just like to know."
+
+Each box gets its own drawn box in the print edition, labeled with the angle
+plus the unchanging title line:
+
+```text
+┌────────────────────────┐
+│ 'Sup                   │              Box 1
+│ I'd just like to know  │
+└────────────────────────┘
+┌──────────────────────────────────┐
+│ D'ja cheat?                      │    Box 2
+│                                  │
+│ I'd just like to know            │
+│                                  │
+└──────────────────────────────────┘
+┌────────────────────────────────────────────┐
+│ Honesty                                    │  Box 3
+│                                            │
+│                                            │
+│ I'd just like to know                      │
+│                                            │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
 > Box 3 combines or resolves all the information, and delivers the point of the
 > song. It's often the "why" of the song — why I'm saying all this to you. It
 > weighs the most.
 
-His worked sketch, on the title idea *I'd just like to know*, shows the same
-five words carrying three different sentences:
+> Now, it's simply a matter of actually writing the song, but writing it knowing
+> where you're going. You have an outline, a scaffold to hang your song on. You
+> can bang around inside each box without being afraid of getting lost.
+
+## Put separate ideas in separate boxes
+
+Chapter 6's section of that name opens on "Strawberry Wine" (Matraca Berg and
+Gary Harrison):
 
 ```text
-Box 1  A greeting. "You're looking good, and you're looking really happy.
-       Are you? I hope you don't mind my asking. I'd just like to know."
-Box 2  An accusation. "When you left, did you already know you were moving in
-       with him? … I suppose it doesn't matter now, but I'd just like to know."
-Box 3  The why. "For me, a relationship is all about honesty. … You could have
-       told me about him. I wouldn't have tried to stop you.
-       I'd just like to know."
+He was working through college on my grandpa's farm
+I was thirsting for knowledge and he had a car
+I was caught somewhere between a woman and a child
+One restless summer we found love growing wild
+On the banks of the river on a well beaten path
+It's funny how those memories they last
+
+Like strawberry wine and seventeen
+The hot July moon saw everything
+My first taste of love oh bittersweet
+Green on the vine
+Like strawberry wine
+
+I still remember when thirty was old
+And my biggest fear was September when he had to go
+A few cards and letters and one long distance call
+We drifted away like the leaves in the fall
+But year after year I come back to this place
+Just to remember the taste
+
+Of strawberry wine and seventeen
+The hot July moon saw everything
+My first taste of love oh bittersweet
+Green on the vine
+Like strawberry wine
+
+The fields have grown over now
+Years since they've seen a plow
+There's nothing time hasn't touched
+Is it really him or the loss of my innocence
+I've been missing so much
+
+Strawberry wine and seventeen
+The hot July moon saw everything
+My first taste of love oh bittersweet
+Green on the vine
+Like strawberry wine
 ```
 
-If Box 3 is lighter than Box 2, the song sags. If Box 2 repeats Box 1, the
-chorus picks up the entire emotional load — usually too much load.
+> What a nice lyric. The specific images really take you there, involve your own
+> sense memories, involve you in the song. And I love the bridge, using the
+> grandpa's fields as a metaphor for life and experience. And the chorus, from
+> the title right on through until the end, grows each time we hear it.
+
+> Who drinks strawberry wine? Kids. Strawberry wine has both the taste of soda
+> pop (childhood) and the danger of alcohol (adulthood). Besides which, it's
+> cheap. It's the perfect vehicle for a song about coming of age, moving from
+> childhood to adulthood.
+
+> Watch the boxes develop:
+
+```text
+┌────────────────────────┐
+│ First love             │              Box 1
+│ Strawberry wine        │
+└────────────────────────┘
+┌──────────────────────────────────┐
+│ Wouldn't last                    │    Box 2
+│                                  │
+│ Strawberry wine                  │
+│                                  │
+└──────────────────────────────────┘
+┌────────────────────────────────────────────┐
+│ Love will never be like that again         │  Box 3
+│                                            │
+│                                            │
+│ Strawberry wine                            │
+│                                            │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+> Each new verse idea builds on the last and adds weight to the song, enlarging
+> the boxes. Each line gains weight each time we see it. The last chorus is the
+> most powerful.
+
+He then tracks a single chorus line through the three boxes:
+
+> If we simply look at the line the hot July moon saw everything, we'll see the
+> weight gain clearly:
+
+> Box 1: The hot July moon saw us down by the river having our first experience.
+
+> Box 2: The hot July moon knew that our love, like so many before ("well-beaten
+> path"), wouldn't last.
+
+> Box 3: The hot July moon knew that, over time, we'd become unable to experience
+> the innocence and power of first love — accumulated experiences would create
+> too much awareness — "the fields have grown over now."
+
+> The moon grows from an observer to a prophet and predictor of the future. It
+> becomes a bigger and bigger moon, needing bigger and bigger boxes. When you
+> write a chorus, each line you include has the same responsibility: to be able
+> to gain weight.
 
 ## Division-of-labor strategies
 
-Pat names two repeatable formulas for distributing verse jobs across boxes.
+Chapter 6's "Development Tips" section names exactly two formulas — perspective
+and tense. It opens:
+
+> The principle of division of labor has practical applications for your song.
+> Say you've written a verse whose summary is:
 
 ### You-I-We formula
 
-Each verse takes a different relational POV.
-
-- **Box 1: You** — verse 1 focuses on the other person. Their action, their
-  presence, their absence, their gesture.
-- **Box 2: I** — verse 2 shifts to the speaker. The speaker's response,
-  state, history.
-- **Box 3: We** — final verse shifts to the shared frame. What we are now,
-  what we were, what we could be.
-
-Or any reordering: I → You → We, We → I → You, etc. The formula is the
-distribution, not the order.
-
-Pat's demonstration starts from a stuck verse summary — one where "it feels like
-everything's been covered":
+Pat's demonstration starts from that stuck verse summary:
 
 ```text
 You are really wonderful
@@ -86,28 +227,29 @@ Love Love Love
 Love Love Love
 ```
 
+> It's difficult to see where to go next. It feels like everything's been
+> covered. Perhaps it might help to separate the perspectives, dividing the idea
+> into the three different perspectives: (1) you, (2) I (me), and (3) we.
+
 All three perspectives are crammed into box 1. Split out, with the same refrain
 under each, they become (Pat's own illustration, deliberately ridiculous —
 he signs off "Okay, just kidding"):
 
 ```text
-Box 1: You are amazing. And beautiful. Your blonde hair flows over your
-       milky-white complexion like chicken gravy over mashed potatoes…
+Box 1: You are amazing. And beautiful. Your blonde hair flows over your milky-white complexion like chicken gravy over mashed potatoes…
 
-       Love Love Love
-       Love Love Love
+Love Love Love
+Love Love Love
 
-Box 2: I've been looking for a codependent relationship for a long time.
-       Someone who'll mother me and let me do whatever I want to…
+Box 2: I've been looking for a codependent relationship for a long time. Someone who'll mother me and let me do whatever I want to…
 
-       Love Love Love
-       Love Love Love
+Love Love Love
+Love Love Love
 
-Box 3: We'll always be together. Everyone I've ever loved is still with
-       me…in the downstairs freezer…
+Box 3: We'll always be together. Everyone I've ever loved is still with me…in the downstairs freezer…
 
-       Love Love Love
-       Love Love Love
+Love Love Love
+Love Love Love
 ```
 
 > But you can see how the boxes gain weight by separating the perspectives. Call
@@ -115,17 +257,11 @@ Box 3: We'll always be together. Everyone I've ever loved is still with
 > different perspective. It's a nice guideline for dividing your verses' jobs.
 
 The joke is doing real work: the boxes gain weight because each one is *about*
-something the others are not, and Pat's third box is heaviest because it turns.
+something the others are not.
 
 ### Past-Present-Future formula
 
-Each verse takes a different tense.
-
-- **Box 1: Past** — what happened. The story's seed event.
-- **Box 2: Present** — what is now. The current state.
-- **Box 3: Future** — what will be / could be. The projection or fear.
-
-Pat's starting verse for this one:
+> Or this — you write a verse that says:
 
 ```text
 We were so good together
@@ -137,60 +273,88 @@ Love Love Love
 ```
 
 > This idea contains three tenses: past, present, and future. Try separating them
-> into separate boxes.
+> into separate boxes:
 
 ```text
 Box 1: We used to smile and laugh together, etc., so much in…
+
+Love Love Love
+Love Love Love
+
 Box 2: Everything's turned sour. What happened to…
-Box 3: Can we work to stay together, or drift away, only remembering how it
-       felt to be in…
+
+Love Love Love
+Love Love Love
+
+Box 3: Can we work to stay together, or drift away, only remembering how it felt to be in…
+
+Love Love Love
+Love Love Love
 ```
 
-> So tense can also provide access to verse development, just like perspective
-> can.
+Pat closes both demonstrations in one paragraph, technique and warning together:
 
-Like You-I-We, the order is interchangeable. Reverse chronology is a strong
-play (Future → Present → Past) — letting the listener reconstruct the
-sequence backwards.
+> So tense can also provide access to verse development, just like perspective
+> can. Sometimes one or the other will be just what you need; other times, like
+> any formula, they could take the freshness out of your writing. Be aware of
+> these techniques, just beware of letting them become a habit in your writing.
 
 **Both demonstrations share one diagnostic.** The stuck verse already contained
 every box. Neither formula invented material; each unpacked what the writer had
 compressed into box 1. When a writer says "everything's been covered," check
 first whether the covering happened all in one box.
 
-Pat's warning, attached in the same breath: "Sometimes one or the other will be
-just what you need; other times, like any formula, they could take the freshness
-out of your writing. Be aware of these techniques, just beware of letting them
-become a habit in your writing."
+Perspective and tense are the only two division formulas Pat names. Chapter 7
+adds that you should not lean on formulas at all when the verses are already
+working:
 
-### Other named division axes
+> When you keep your verses interesting and keep your idea moving forward,
+> you'll have little trouble lighting up your chorus or refrain in different
+> ways. You don't have to use formulas. You don't have to introduce a whole new
+> cast of characters. You just have to pay attention.
 
-| Axis | Box 1 / Box 2 / Box 3 candidates |
-|---|---|
-| Time of day | morning / day / night |
-| Season | spring / summer / autumn / winter |
-| Location | here / there / nowhere |
-| Sense | what I saw / what I heard / what I felt |
-| Speaker stance | hopeful / doubting / resolved |
-| Distance | close-up / middle / long-shot (*Writing Better Lyrics* (2009), Chapter 10 camera distances) |
+### Better than any formula: an idea that develops itself
 
-Pick the axis that supports the song's central emotional shape, not the
-axis that's most clever.
-
-### Better than any axis: an idea that develops itself
-
-Pat's stated preference is to need no axis at all:
+Pat's stated preference is to need no formula at all:
 
 > It's better when you find an idea that contains the DNA of its own
 > development, or when plot does the development work.
 
 His case is Gillian Welch's "One More Dollar," where plot alone drives the
-boxes: a man leaves home for orchard work and sends his wages back, promising to
-come home when the next crop pays his way; then a freeze kills the work and he
-gambles at the bar downtown; then he is on the street asking strangers for "a
-coin and a Christian prayer." The refrain never changes:
+boxes. The chorus never changes; the verses move underneath it:
 
 ```text
+A long time ago I left my home
+For a job in the fruit trees
+But I missed those hills with the windy pines
+For their song seemed to suit me
+So I sent my wages to my home
+Said we'd soon be together
+For the next good crop would pay my way
+And I would come home forever
+
+One more dime to show for my day
+One more dollar and I'm on my way
+When I reach those hills, boys
+I'll never roam
+One more dollar and I'm going home
+
+No work said the boss at the bunk house door
+There's a freeze on the branches
+So when the dice came out at the bar downtown
+I rolled and I took my chances
+
+One more dime to show for my day
+One more dollar and I'm on my way
+When I reach those hills, boys
+I'll never roam
+One more dollar and I'm going home
+
+A long time ago I left my home
+Just a boy passing twenty
+Could you spare a coin and a Christian prayer
+For my luck has turned against me
+
 One more dime to show for my day
 One more dollar and I'm on my way
 When I reach those hills, boys
@@ -198,23 +362,92 @@ I'll never roam
 One more dollar and I'm going home
 ```
 
-> Each verse moves the story forward, making chances of getting home more and
-> more remote.
+> Wonderful stuff. See how the lyric pulls us in with its sense-bound imagery,
+> turning us into participants rather than observers? Her words are full of our
+> stuff. And look at the lyrics using the box structure. Watch how the chorus
+> gains weight, transforming the meaning of the chorus each time:
 
-Reach for a division axis when the idea does *not* carry its own development.
-That ordering matters — the axes are a repair, not a starting move.
+```text
+┌────────────────────────┐
+│ Working to get home    │              Box 1
+│ One more dollar        │
+└────────────────────────┘
+┌──────────────────────────────────┐
+│ Gambling to get home             │    Box 2
+│                                  │
+│ One more dollar                  │
+│                                  │
+└──────────────────────────────────┘
+┌────────────────────────────────────────────┐
+│ Panhandling to get home                    │  Box 3
+│                                            │
+│                                            │
+│ One more dollar                            │
+│                                            │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+> Each verse moves the story forward, making chances of getting home more and
+> more remote. Great stuff!
+
+## A sagging middle box: "Unanswered Prayers"
+
+Chapter 6's last worked example — "one last example, this one with a challenge
+in it" — is "Unanswered Prayers" (Pat Alger, Garth Brooks, Larry B. Bastian).
+Verse three plus the second chorus:
+
+<!-- spellchecker:off -->
+
+> Is there anything gained? Not much. The boxes are roughly the same size. We
+> already knew, from the combination of the first two verses and the chorus, how
+> thankful he was not to be with his old girlfriend. This verse just elaborates
+> on the same theme, giving us a few more details, including the old girlfriend's
+> attitude. And the final line, I guess the Lord knows what he's doin' after all,
+> just repeats the idea just because he doesn't answer doesn't mean he don't care.
+
+<!-- spellchecker:on -->
+
+> In short, the second chorus is destined to die an ignominious death right there
+> in front of everybody.
+
+The bridge rescues the third chorus:
+
+> Much better. I had forgotten about the wife. The third chorus is interesting
+> again; it gains weight by adding the wife. … The wife becomes God's greatest
+> gift. A lovely payoff.
+
+> Two out of three choruses work great, but the song sags at the second chorus.
+> There isn't enough new information in verse three to make the chorus
+> interesting. Other than leaving it alone as good enough (two out of three ain't
+> bad …), what would you do?
+
+Pat's own answer — reintroduce the wife in verse three and skip the bridge:
+
+```text
+She wasn't quite the angel that I remembered in my dreams
+And I could tell that time had changed me in her eyes too it seemed
+As she turned and walked away I looked at my wife
+And recognized the gift I'd been given in my life
+```
+
+> Now the song is a simple three verse, two chorus layout with both choruses
+> doing their work.
 
 ## The "what came before?" diagnostic
 
 When a writer is stuck on verse 2, the question is rarely "what's the next
 event?" Pat states the move twice in Chapter 6:
 
-> Just because you wrote a verse first doesn't mean it's your first verse. Give
-> yourself two chances. Don't just ask "Where do I go next?" Try asking "What
-> happened before this?"
+> One more tip: Just because you wrote a verse first doesn't mean it's your
+> first verse. Give yourself two chances. Don't just ask "Where do I go next?"
+> Try asking "What happened before this?"
 
-> Instead of asking "Where do I go now?" it may help to ask "Where did I get here
-> from?"
+> Of course, there are no rules. The solution to the question "Where do I go
+> now?" changes with every song. Sometimes it's even the wrong question. Just
+> because you wrote a verse first doesn't mean it's the first verse. Instead of
+> asking "Where do I go now?" it may help to ask "Where did I get here from?"
+> Get used to juggling and trying new things.
 
 What he claims is the reordering itself — the verse you wrote first may not be
 box 1 — not any particular destination for it. Try the material in each slot
@@ -224,87 +457,173 @@ And the stronger version of the same advice runs upstream of the stuck point
 entirely:
 
 > Thinking about boxes from the outset, the minute an idea comes, is by far the
-> best remedy for "second-verse hell."
+> best remedy for "second-verse hell" (songwriters' term for "Where do I go
+> next?").
 
 ## Travelogue vs same-color
 
-Two verse failures sit at OPPOSITE ends of one axis, and Chapter 8 closes by
-naming both poles: verse ideas that sit too close together make the repeated
-chorus static and boring, and verse ideas that sit too far apart become a
-travelogue. Diagnosing one as the other prescribes the wrong fix.
+Two verse failures sit at OPPOSITE ends of one axis. Chapter 8 names both poles
+in its closing exercise:
 
-| | **Travelogue** (Chapter 8) | **Same-color** (Chapter 7) |
+> Verse development is probably a lyricist's trickiest job. Verse ideas must
+> advance enough, but can't move too much. If the ideas are too close, the
+> repetition of the chorus will become static and boring. If the verses' ideas
+> are too far apart, you might end up in fabulous Hawaii. Hawaii is a nice place,
+> but songwriters beware how you get there. The best trip is paid for by royalty
+> checks from great songs.
+
+Diagnosing one as the other prescribes the wrong fix. ("Same-color" below is
+this file's shorthand for the too-close pole; Pat's own term for the symptom is
+that the boxes come out the same size. The colored-spotlight framing is his —
+Chapter 7 — and the worked case is in Chapter 6.) The table below is this
+file's construction, not a table Pat prints; the chapter labels say where each
+pole's material comes from.
+
+| | **Travelogue** (Chapter 8) | **Same-color** (Chapters 6-7) |
 |---|---|---|
 | Verse ideas are | too far apart | too close together |
 | What links the verses | nothing but the title / refrain / chorus | they say the same thing twice |
 | What breaks | accumulation — each box starts a separate avalanche instead of one rolling downhill | repainting — each verse shines the same colored light, so the chorus never looks new |
 | Box symptom | boxes gain no weight; all the same size | Box 2 = Box 1 |
-| Fix | find the chain — what in verse 1 CAUSES verse 2, what verse 2 makes inevitable | shift the job via You-I-We, Past-Present-Future, or another division axis |
+| Fix | find the chain — use each verse to prepare what comes next | shift the job via You-I-We or Past-Present-Future |
 
-Chapter 8's own image for the difference: three avalanches started separately
-a third of the way up a mountain do less damage than one snowball rolled from
-the top. Travelogue is three separate avalanches.
+Chapter 8's own image for the difference:
 
-### Travelogue test (*Writing Better Lyrics* (2009), Chapter 8)
+> Your lyric accumulates power when your verses work together — using each verse
+> to prepare what comes next. It's like starting avalanches. If you go a third of
+> the way up the mountain and start three separate avalanches from different
+> spots, you'll cause some damage to the town below, but not nearly as much as if
+> you'd gone to the top and rolled one snowball all the way down. Speed and power
+> accumulate and sweep everything away. The town is devastated. The boxes gain
+> weight and power as the snow plummets down the mountain.
 
-Remove the chorus and read only the verses in sequence.
+> In a travelogue, all the boxes are the same size.
 
-- Without the title's glue, would a listener know what is going on?
-- Does each verse carry information forward into the next, or does each one
-  start over?
-- Does verse 2 gain any weight from verse 1 having happened?
+### What a travelogue is (*Writing Better Lyrics* (2009), Chapter 8)
 
-If the verses are independent observations linked only by the title /
-refrain / chorus, the song is a **travelogue**. Pat's diagnosis: "Verse
-development should mean verse relationship. Your verses should have a good
-reason to hang out together."
+Pat's definition, in his words:
 
-His canonical summary sets — both message songs, both well-intentioned:
+> We've all seen travelogues. Ah, fabulous Hawaii — majestic mountains, pipeline
+> surfing, luxury hotels, exotic cuisine. The places may be interesting, but as
+> a film, a travelogue is dull, dull, dull. Its elements have no natural
+> continuity. What do majestic mountains have to do with twenty-foot waves
+> featuring pipeline surfing? What have either of these to do with elegant hotels
+> and Oriental cuisine? Their only links are accidents of geography: They are all
+> part of fabulous Hawaii!
+
+His first lyric summary, printed with the refrain repeated after every verse:
 
 ```text
 Verse 1: Police brutality is a common problem in large cities.
-Verse 2: Car bombs are becoming more common as a terrorist weapon.
-Verse 3: More prostitutes carry the AIDS virus every year.
 Refrain: Streets are turning deadly in the dark.
 
+Verse 2: Car bombs are becoming more common as a terrorist weapon.
+Refrain: Streets are turning deadly in the dark.
+
+Verse 3: More prostitutes carry the AIDS virus every year.
+Refrain: Streets are turning deadly in the dark.
+```
+
+> What's going on here? What does police brutality have to do with car bombs or
+> prostitutes with AIDS? Nothing, except that they are all part of fabulous
+> Streets are turning deadly in the dark. Aside from their connection to the
+> refrain, the elements have no natural relationship — they don't belong together.
+
+> Verse development should mean verse relationship. Your verses should have a
+> good reason to hang out together. When verses are in the same lyric only
+> because you're taking a tour of the title, you likely have a travelogue on
+> your hands.
+
+The second summary set, same defect on a bigger subject:
+
+```text
 Verse 1: We're screwing up our planet.
+Refrain: We're losing the human race.
+
 Verse 2: We're killing each other in stupid wars.
+Refrain: We're losing the human race.
+
 Verse 3: We ignore our poor and homeless.
 Refrain: We're losing the human race.
 ```
 
-Nothing links the verses except the refrain. The full worked travelogue and its
-repair ("Chain Reaction") are in
+> No matter how well written and interesting these verses get, the basic defect
+> remains: The verses don't work together to accumulate power — they are simply
+> a travelogue of human ineptitude. Important ideas deserve the most powerful
+> presentation you can muster.
+
+The full worked travelogue and its repair ("Chain Reaction") are in
 [verse-development](verse-development.md#chain-reaction-model).
 
-### Same-color test (*Writing Better Lyrics* (2009), Chapter 7)
+### Same-color: boxes the same size (*Writing Better Lyrics* (2009), Chapter 6)
 
-Read each verse, then read the chorus that follows it, and name the color the
-verse just cast on it.
+The test Pat actually applies is to read each verse and then the chorus that
+follows it, and see whether the second chorus can say anything the first didn't.
+Chapter 7 supplies the image:
 
-- Does each verse have its own job the others don't share?
-- Do two verses project the same color in different words?
-- Say the chorus's meaning after verse 1 and again after verse 2 — if the two
-  statements match, the verses are the same color.
+> Think of your verses as colored spotlights. They shine their lights on their
+> chorus or refrain. If two verses project exactly the same color, their choruses
+> will look the same. If they project different or deeper colors, the choruses
+> will look different.
 
 Verses connected but same-colored is NOT a travelogue; the chain is intact and
 the repainting is missing.
 
-Pat's case is "Between Fathers and Sons" (John Jarvis and Gary Nicholson). Its
-two perspectives — the son looking at his father, and the son now a father — are
-both spent inside box 1, so box 2 restates. On verse four:
+Pat's case is "Between Fathers and Sons" (John Jarvis and Gary Nicholson), in
+Chapter 6. He counts **two** boxes, not three:
 
-> Oops. I know I've been here before. It's verse two with *I* changed to *you*.
-> … The second chorus is a goner. It can't help but say exactly the same thing
-> as the first chorus.
+> "Between Fathers and Sons" is made up of two boxes. Verses one and two plus
+> the first chorus make up box one. Verses three and four plus the second chorus
+> make the second box.
+
+On verse three:
+
+> This sounds familiar. Not that I've seen things from the mother's perspective
+> yet, but I have seen the father — in fact, both fathers — trying to protect the
+> child. I've also seen the child trying to go beyond the parents. Not that this
+> information isn't interesting, it's just not new. The ideas (if not the exact
+> perspectives — she and you) have been covered. This doesn't bode well for the
+> second chorus. We'll need development rather than restatement to keep
+> repetition interesting.
+
+On verse four:
+
+> Oops. I know I've been here before. It's verse two with I changed to you. No
+> need to try to universalize verse four with you. The idea was already
+> universal. The second chorus is a goner. It can't help but say exactly the
+> same thing as the first chorus.
 
 > It isn't so much that there is no advancement of the idea in verses three and
 > four, there just isn't enough to give us a new look at the chorus when we get
-> there. … Both boxes are the same size.
+> there. The power of this lovely chorus is diminished rather than enlarged the
+> second time around, and we leave the song less interested than we were in the
+> middle. Both boxes are the same size. Let's see if we can make the second box
+> grow.
 
-The fix is redistribution, not rewriting: move *Now when I look at my own son*
-down into box 2 and let box 1 keep only the son's view of his father. Same
-chorus, two colors. The verses were always connected — the split was missing.
+The fix is redistribution, not rewriting:
+
+> The song contains two perspectives: a son looking at his father, and the son
+> as father. If the first box could focus only on the son looking at his father
+
+— box 1 keeps *My father had so much to tell me*, and its verse two becomes a
+new prose idea:
+
+```text
+I kept him at arm's length.
+I didn't want him interfering with my life.
+He kept trying, but I wouldn't let him.
+That's how it always has been between fathers and sons
+```
+
+Box 2 then opens with the verse that used to sit in box 1,
+*Now when I look at my own son*.
+
+> The father's perspective colors the second chorus. It becomes — for me, at
+> least — more interesting than the first chorus.
+
+> The problem in "Between Fathers and Sons" is that both ideas are in the first
+> box, leaving the lyric no place new to go. Separating the ideas into separate
+> boxes makes both choruses fresh.
 
 Contrast the sheriff demonstration in
 [repetition](repetition.md#stagnant-repetition), where Pat repairs stagnation
@@ -313,32 +632,82 @@ distribution problem in both cases.
 
 ## Box weight failure modes
 
+This table is a summary of the diagnoses Pat works through above, not a list he
+prints.
+
 | Failure | Symptom | Fix |
 |---|---|---|
-| Box 2 = Box 1 | second verse feels redundant; chorus never repaints | same-color (Chapter 7) — apply You-I-We or Past-Present-Future shift |
-| Box 3 ≤ Box 2 | song sags at the end | promote bridge or final verse to carry "why" |
-| All boxes same weight | song feels flat / no destination | redistribute via division-of-labor axis |
-| Box 1 too heavy | listener lost in detail before chorus | move heavy material to Box 2 or Box 3 |
-| Boxes unconnected | travelogue (Chapter 8) — verses share only the title | find the chain — what causes / what consequences link them |
+| Both ideas crammed into box 1 | box 2 restates; "the second chorus is a goner" | split the ideas across boxes — the "Between Fathers and Sons" repair (Ch 6) |
+| Boxes the same size | chorus repetition goes "static and boring" (Ch 8) | separate the perspectives (you-I-we) or the tenses (past-present-future) (Ch 6) |
+| Stagnation — verses say the same thing in different words | the sheriff summaries; "the only real fix is to take the idea new places" (Ch 6) | develop the idea, not the language |
+| Boxes unconnected, linked only by the title | travelogue — "you might end up in fabulous Hawaii" (Ch 8) | use each verse to prepare what comes next; one snowball from the top |
+| Refrain resists the new color | you can't change the verse's tense or POV without breaking the refrain (Ch 9) | neutralize the refrain's tense and POV |
 
-Equal box weight is a symptom of travelogue, not a synonym for it: a
-travelogue always leaves the boxes the same size, but boxes can also flatten
-inside a properly chained lyric. Diagnose the connection first, the weight
-second.
+Equal box weight is a symptom of travelogue, not a synonym for it: Pat says "in
+a travelogue, all the boxes are the same size," but boxes can also come out the
+same size inside a properly chained lyric — "Between Fathers and Sons" is
+connected throughout and still ends up with two same-size boxes. Diagnose the
+connection first, the weight second.
 
 ## Repaintable chorus across boxes
 
-The chorus repeats across all three boxes. Its words stay the same; its
-**color** changes because the surrounding verses color it differently.
+Strong boxes are only half the job. Chapter 9 opens:
 
-Pat: "If two verses project the same color, their choruses will look the
-same." This is the verses-as-colored-spotlights frame (*Writing Better Lyrics* (2009), Chapter 7).
+> Strong verse development is crucial to deepening the colors of your refrain or
+> chorus. Just as important, however, is making sure your refrain chorus can be
+> recolored. Sometimes it can resist recoloring, no matter how well your verses
+> develop.
 
-For repaintable choruses (*Writing Better Lyrics* (2009), Chapter 9):
+> You can often solve the problem by neutralizing the refrain's tense and POV —
+> stripping away protective coatings so your refrain can accept the colors the
+> verses try to paint.
 
-- Strip tense from chorus (use -ing forms, infinitives, no verb)
-- Strip POV from chorus (remove pronouns when possible)
-- Productive ambiguity: chorus line should support two readings, both true
+**Neutralizing tenses.** "Verbs determine tenses":
+
+```text
+Past: He lost the human race.
+
+Present: He loses the human race.
+
+Future: He'll lose the human race.
+```
+
+> Controlling verbs is the key to controlling tense. Here are three ways:
+
+> Use the -ing form of the verb (e.g., losing). Omit any helping verbs (losing
+> instead of is losing, was losing, will be losing). Don't mistake the -ing verb
+> form for verbal adjectives (participles), e.g., a losing strategy, or for
+> verbal nouns (gerunds), e.g., losing builds character.
+
+> Use the to form of the verb (infinitive) and omit the main verb, e.g., to lose
+> rather than I hate to lose.
+
+> Omit verbs altogether.
+
+> A tense-neutral refrain will accept whatever tense the verse throws at it.
+
+Worked on the refrain, the three give *Losing the human race*, *To lose the
+human race*, and *A loss in the human race*.
+
+**Neutralizing point of view** — "Pronouns determine POV":
+
+> To strip your refrain's POV, omit pronouns. Sometimes you'll have to neutralize
+> verb tenses, too.
+
+**Stripping your chorus:**
+
+> Neutralize a chorus the same way you neutralize a refrain: Don't use a tense
+> or POV.
+
+> Like a refrain, a neutral chorus will accept the verse's tense and POV, no
+> matter how many times you change them in the lyric. Remember as a rule of thumb
+> that verses show, chorus tells. Keep your verses specific and interesting.
+
+Pat's real-world case is Paul Simon's "Still Crazy After All These Years" — a
+refrain with no pronouns and no verb, so each verse can set its own POV:
+
+> All three work fine. The result is a productive ambiguity that adds to the
+> spell of the lyric.
 
 ## Cross-references
 

--- a/plugins/songwriting/context/pat-pattison/research/bridge.md
+++ b/plugins/songwriting/context/pat-pattison/research/bridge.md
@@ -1,73 +1,127 @@
 # Bridge Writing
 
-Pat Pattison - *Songwriting: Essential Guide to Lyric Form and Structure*
-(1991), Chapters 5-6; *Writing Better Lyrics* (2009), Chapters 22-23. Bridge as
-a developmental section: most unbalanced, structurally distinct, content-new.
+Pat Pattison — *Essential Guide to Lyric Form and Structure* (1991), Chapters
+5-6; *Writing Better Lyrics* (2009), Chapters 22-23. The source passages below
+preserve Pattison's printed wording for bridge definitions, functions,
+diagnostics, examples, and exercises.
 
 ## Core idea
 
-A bridge is the only fully developmental section. Verses introduce and
-restate; choruses repaint the central idea; refrains close systems. The
-bridge moves **away** from established structures and brings new perspective.
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 5, establishes
+the larger distinction first:
 
-> A bridge isn't a verse.
+> Start by thinking of each lyric section as either a CENTRAL SECTION or a
+> DEVELOPMENTAL SECTION. Everything within the lyric moves toward or departs
+> from a CENTRAL SECTION.
 
-If a writer adds a "bridge" that uses the verse's phrase count, line length,
-rhyme scheme, and content angle, that isn't a bridge — that's another
-verse with different words.
+> DEVELOPMENTAL SECTIONS contain DEVELOPMENTAL IDEAS: ideas that lead up to or
+> develop the CENTRAL IDEA. They should move forward until they get to a
+> CENTRAL SECTION.
+
+*Writing Better Lyrics* (2009), Chapter 23, on adding a bridge to a
+verse/chorus lyric (the "Love Her or Leave Her to Me" worksheet):
+
+> Again, be careful. A bridge isn't a verse — it doesn't do the same job or
+> use the same structure. It is a contrasting section. Verses usually develop
+> plot. A chorus usually steps away from, comments on, or summarizes the
+> verses. In our lyric, the verses develop the situation, the chorus gives a
+> warning. A bridge will have to take a different angle.
+
+The same warning, stated as a timing test — *Essential Guide to Lyric Form and
+Structure* (1991), Chapter 5, testing whether a candidate section (#1A) could
+serve as a bridge:
+
+> Could #1A be a Bridge? Maybe, but be careful. A Bridge should sound
+> completely different right from its very first phrase. If you used #1A as a
+> Bridge after the Verse/Chorus Song System above, it would sound like a verse
+> for the first three phrases. There would be no contrast, no "release" until
+> too late.
+
+> EXERCISE 29: REWRITE THE "CANDY BAR" SECTION ABOVE AS A BRIDGE SO IT WILL
+> CONTRAST WITH THE SONG SYSTEM IT FOLLOWS. YOU MIGHT START BY SHORTENING THE
+> FIRST PHRASE TO MAKE IT SOUND DIFFERENT RIGHT AWAY.
 
 ## Three bridge functions (*Essential Guide to Lyric Form and Structure* (1991), Chapter 6)
 
-A bridge must serve **at least one**, often all three:
+Chapter 6 prints a form-specific three-item list for a verse/refrain lyric:
 
-1. **Break monotony** — the song has been in established structure too long;
-   the bridge contrasts to reset the ear, and sets up the section after it as
-   a contrasting arrival
-2. **Different-size song system** — the different size belongs to the *system*,
-   not to the bridge's own dimensions. Pat's word is **different**, and the
-   direction depends on the form:
-   - *Verse/chorus.* Systems 1 and 2 each run verse → chorus. A bridge that is
-     shorter than a verse (most are) makes system 3 **shorter**, so the final
-     chorus arrives "early" and gains interest from the change of pace.
-   - *Verse/refrain or AABA.* Every system was one verse long. The bridge does
-     not shorten anything — it creates a system that starts at the bridge and
-     ends when the last verse closes, which is **longer** than the ones before
-     it. Chapter 6 claims only the size change here, not an early arrival; the
-     "early" language belongs to the verse/chorus case above.
+> Because of all the repetition of structure, this lyric gets boring fast. It
+> needs a release from all the repetition. You could consider a Bridge in this
+> situation. It would accomplish three things:
+>
+> 1. It would break up the monotony of the same pattern. This will also set up
+>    the last verse with a contrasting section.
+>
+> 2. It would give different size Song Systems:
+>
+>    This breaks the repetition of the same size pattern. With only verses, each
+>    Song System is the length of each verse. Adding a Bridge creates another
+>    Song System that starts at the Bridge and ends when the last verse closes.
+>
+> 3. A Bridge would also give the verse ideas a chance to “breathe” by moving to
+>    a new angle or perspective.
 
-   Diagnose by asking what the bridge is grouped with, not by assuming the last
-   system shrinks
-3. **New perspective** — bridge says something the verses haven't said.
-   Often the "why" — the underlying cause or stakes the song has only
-   implied so far. Chapter 6 frames it as letting the established ideas
-   "breathe" by moving to a new angle
+For a verse/chorus lyric, Chapter 6 prints a second three-item list:
 
-Diagnose a draft bridge: which of these three does it do? If none, it isn't
-bridging — it's restating. Rewrite or remove.
+> If you wanted to add more to the A B A B system above, you should probably
+> think about a Bridge instead of another verse. As you saw in the A A B A song
+> form, too much repetition gets boring fast. A Bridge would accomplish three
+> things:
+>
+> 1. It would break up the monotony of the same pattern. This will also move
+>    into the last chorus from a new angle, a contrasting section.
+>
+> 2. Assuming that the Bridge is shorter than the Verses (most of the time it
+>    is), it would give you different sizes of Song Systems:
+>
+>    This breaks the repetition of the same pattern. S1 and S2 are the same
+>    size. S3 will be shorter, giving the Chorus a boost in interest when you
+>    get to it “early.”
+>
+> 3. A Bridge would also give the idea a chance to “breathe” by releasing to a
+>    new angle or perspective.
 
-**Do not confuse this list with Chapter 5's.** *Essential Guide to Lyric Form
-and Structure* (1991) carries two bridge lists
-and they answer different questions. Chapter 6's three purposes above are what
-*adding* a bridge accomplishes for a form. Chapter 5 gives a separate
-**five-point characterization of what a bridge is**: it is a developmental
-section; it develops a new perspective or contrasting idea; it unbalances by
-moving away from established structures, creating structural tension; it is
-resolved by the return to established structures; and it is therefore
-frequently the lyric's most unbalanced section. Chapter 5 also notes the
-section is often called a "release" or boredom breaker — and that it is much
-more than that. Cite Chapter 6 for the purposes, Chapter 5 for the definition.
+These are Chapter 6's two three-item lists. Chapter 5 gives a separate
+five-point characterization of what a bridge is:
+
+> This section is often called a “release,” or boredom breaker: the place where
+> you try to get away from the ideas and structures the lyric has already
+> established. But it is also much more:
+>
+> 1. It is a DEVELOPMENTAL section.
+> 2. It develops a new perspective or contrasting idea.
+> 3. It unbalances the section by moving away from established structures,
+>    creating structural tension.
+> 4. It is resolved by a return to previously established structures,
+>
+> thus, 5. It is frequently the lyric’s most unbalanced section.
+
+Cite Chapter 6 for the form-specific purposes and Chapter 5 for the definition.
 
 ## When a song needs a bridge
 
-| Song shape | Bridge needed? |
-|---|---|
-| V/Refrain × 3-4 | optional; bridge before final V or as alt-final-verse |
-| V/V/Ch/V/V/Ch | strong candidate — "four times is a lot" (see below) |
-| V/Ch/V/Ch | not strict; this is already one of the fixes for the form above |
-| V/Ch/V/Ch/V/Ch | almost always — the third system "seems to fall a little flat, not so much for what it says, but because we've seen its structure twice before" |
-| V/Ch/V/Ch/Br/Ch | the canonical pop form |
-| AABA | yes — B section IS the bridge; A returns feel like homecoming |
-| Through-written | usually no — but a contrasting section may earn the label |
+For a verse/refrain lyric, use Chapter 6's first three-item list above.
+
+For a verse/chorus lyric that has completed two systems, *Essential Guide to
+Lyric Form and Structure* (1991), Chapter 6, says:
+
+> You have been through two Song Systems. The lyric ends here nicely. A B A B
+> delivers a very effective punch.
+
+For verse / chorus / verse / chorus / verse / chorus, *Writing Better Lyrics*
+(2009), Chapter 23, says:
+
+> Not a bad lyric. It chugs along nicely for two verse / chorus systems,
+> developing its ideas with light, cute structure. The third system, however,
+> seems to fall a little flat, not so much for what it says, but because we've
+> seen its structure twice before. There's nothing wrong with the form — the
+> form just doesn't help add interest.
+
+<!-- unaudited: No matching statement about through-written songs was found in
+the four specified chapters. -->
+
+Through-written songs usually do not need a bridge, though a contrasting
+section may earn the label.
 
 ### The four-times risk (*Writing Better Lyrics* (2009), Chapter 22)
 
@@ -79,116 +133,235 @@ The "four times is a lot" warning belongs to **v/v/ch/v/v/ch**, not to v/ch/v/ch
 > verses, especially the crucial fourth verse, had better be very interesting
 > to risk all that repetition.
 
-Chapter 22 gives three risk-avoidance techniques, only one of which is a bridge:
+Chapter 22 prints three risk-avoidance techniques.
 
-1. **Dump a verse.** Distill two verses into one on a "best of" principle. The
-   resulting v/v/ch/v/ch "gives the second chorus a boost by seeming to get to
-   it early — a distinct advantage."
-2. **Turn one of the verses into a bridge**, giving v/v/ch/v/ch/br/ch.
-3. **Restructure both verses into a single unit**, so the form stops repeating
-   itself rather than adding a section.
+#### First Risk-Avoidance Technique
 
-So v/ch/v/ch is not a form carrying the four-times risk — it is what technique
-1 produces. Diagnose the risk by counting trips through the *same* structure.
+> Try dumping a verse. This is not as easy as it sounds, because unless you've
+> written a real dead dog for one of your verses, you probably need at least
+> some of the material in each one. So try to select the most important stuff,
+> on a sort of “best of” principle, and distill one verse from two.
+
+> This resulting verse / verse / chorus / verse / chorus song form is more
+> streamlined. It gives the second chorus a boost by seeming to get to it early
+> — a distinct advantage. And the distilled verse is often stronger than the
+> two separate verses it came from.
+
+> EXERCISE 47
+>
+> What do you think of my distilled verses? Did I lose too much, or did I keep
+> the necessary stuff? You try it. Distill the original third and fourth verses
+> into one verse of the same structure. Remember to end the verse with the
+> refrain: Weak is a slow healing heart.
+
+#### Second Risk-Avoidance Technique
+
+> Turn one of the verses into a bridge, making the overall form fit the
+> following structure:
+>
+> v / v / ch / v / ch / br / ch.
+
+> Be careful with this option. A bridge is a contrasting element, both in
+> structure and in content. You'll have to change both the structure and the
+> kind of information you give.
+
+Chapter 22's worked bridge is:
+
+> Bridge
+>
+> I pray that someday
+> I won't be afraid
+> But some hurts take longer to fade
+
+> The move to future tense in the bridge helps shift away from the verse
+> material. Shorter lines and a three-line unbalanced section (rhyming AAA)
+> change the structure.
+
+> EXERCISE 48
+>
+> Now come up with your own bridge to fit “Slow Healing Heart.”
+
+#### Third Risk-Avoidance Technique
+
+> Keep all the lines, but restructure both verses into a single unit. Of course,
+> this means more than not skipping a space between verses on your lyric sheet.
+> It means changing the form of the verses so they don't repeat each other.
+
+> Any of these three risk-avoidance techniques solve the problem created by the
+> verse / verse / chorus / verse / verse / chorus form. They will help structure
+> work for you, rather than risking songs that seem too long. Even if every line
+> of all four verses is to die for, you can reorganize them into a form that
+> delivers power rather than sags. All it takes is time, energy, and — most
+> importantly — focus on the importance of potent song form. It's worth the
+> work.
 
 ## Bridge sourcing — the missing angle
 
-Pat's strongest bridge-finding move (*Writing Better Lyrics* (2009), Chapter 23): look at what the song
-has **not** said.
+Pat's bridge-finding move, *Writing Better Lyrics* (2009), Chapter 23:
 
-- If verses are about loss, what about the moment before loss?
-- If verses are second-person address, what about the speaker's interior?
-- If verses are concrete and specific, what about the abstract why?
-- If verses are present-tense, what about a memory or a fear?
+> When you're writing a bridge, start by looking at what you've already said,
+> then look for a missing piece. In this case, we know the speaker wants the
+> wife, and that the husband is fooling around. We know the wife calls the
+> speaker and that the speaker has plans. But we don't know what makes her so
+> desirable. This might be an interesting angle, especially since the third
+> verse starts:
 
-The bridge takes the angle the song needs but doesn't have yet. This is the
-"new perspective" function (Function 3) operationalized.
+> Well, I guess some men got no appreciation
+> They never see the finer things in life …
+
+He sets the contrast requirement first (Chapter 23, Option 1):
+
+> The most obvious boredom quencher is to insert a contrasting section — a
+> bridge — between the second and third system. As usual, the contrast should
+> be significant. The structure of the bridge should be different from the
+> verse and chorus structures, including a different rhyme scheme, a different
+> number of lines, and different line lengths. It should also say something
+> different.
+
+### EXERCISE 49 (*Writing Better Lyrics* (2009), Chapter 23)
+
+> A bridge focusing on her qualities would lead smoothly into the third verse.
+> Start by making a list of her qualities — things she is, things she does.
+> Draw the list from your own experiences. Do a little object writing. For
+> example:
+
+Pat's own object-writing sample for this exercise is printed verbatim in
+`song-forms.md` ("Kicking through the fallen leaves…") — not duplicated here.
+
+> Your object writing will create a mood and character for you to respond to.
+> Then try a few bridges. Be sure your bridge is a contrasting section. Keep it
+> short and effective.
+
+Pat's caution on Option 1: "Simply inserting a bridge is always an option when
+you need a boredom breaker. The risk here, though, is that the lyric may get
+(or seem) a little long because it returns to a verse again before the chorus."
+
+**EXERCISE 50** (Option 2, after his own bridge): "Try substituting the bridge
+you wrote for the one I wrote. Do you like how it works?"
 
 ## Bridge mechanics — structure
 
-A bridge contrasts the verses on multiple axes. Pick at least two:
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 5, supplies this
+structural checklist:
 
-- **Phrase length** — verses 4-stress → bridge 5-stress, or verses tetrameter → bridge pentameter
-- **Line count** — different number of lines per system
-- **Rhyme scheme** — verses xaxa → bridge aabb, or verses tight → bridge loose
-- **Rhyme type** — verses perfect → bridge consonance (or reverse)
-- **Tempo/rhythm** — verses duple → bridge triple, or steady → syncopated
-- **POV** — verses third-person → bridge first-person (per `point-of-view.md` camera distances)
-- **Tense** — verses present → bridge past or future
-- **Tone of voice** — verses controlled → bridge raw (or vice versa)
+> Remember these?
+>
+> 1. Number of phrases
+> 2. Length of phrases
+> 3. Rhythm of phrases
+> 4. Rhyme scheme
+>
+> We will use each one to juggle the candy bar verse. Our goal is to make
+> different kinds of lyric sections.
 
-The bridge should NOT contrast on every axis — that overshoots into chaos.
-Pick the axes that match the perspective shift.
+The exact bridge-specific contrast requirement from *Writing Better Lyrics*
+(2009), Chapter 23, appears once under “Bridge sourcing — the missing angle.”
+The tense, line-length, line-count, and rhyme demonstration from Chapter 22
+appears once under “Second Risk-Avoidance Technique.”
 
 ## AABA homecoming principle (*Writing Better Lyrics* (2009), Chapter 23)
 
-In AABA form, the bridge (B) creates tension; the final A creates
-homecoming.
+Pat reaches AABA as **Option 3** for the three-verse lyric: "If you can't
+translate your third verse into a bridge — say that you really need that third
+idea as a verse — try a verse form that thrives on three-idea development: the
+AABA verse / refrain form."
 
-- A1 — establishes
-- A2 — develops within the same structure (box-model Box 2)
-- B (bridge) — contrasts; takes the listener somewhere unfamiliar
-- A3 — returns to A's structure; **feels like arrival** because of B's
-  departure
+> An AABA song form is effective because it creates a strong sense of
+> resolution when it moves back to the third verse. The first two verses
+> define "home base," then the bridge takes you away from home — away from the
+> familiar structure. When you come back to the third verse, you come back
+> home to familiar territory. It's a real homecoming, seeing the old
+> neighborhood again after a long trip. The tension created by moving away has
+> been resolved.
 
-The B section's job is to make A's return feel earned. A bridge that's too
-similar to A robs the return of its homecoming weight.
+> An AABA's last system is actually bridge / verse, providing a nice contrast
+> to the opening verses, as well as sponsoring the homecoming parade.
+
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 6, states the
+return directly:
+
+> The move into the last verse returns to home base, resolving the tension
+> created by moving away.
 
 ## Transitional bridge vs full bridge
 
 These are different sections. Do not conflate.
 
-**Transitional bridge (pre-chorus / climb / lift / ramp / vest / prime /
-channel / runway / verse extension):**
+**Transitional bridge** — *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 5. Pat: "This is as close as I can come to an accurate name for this
+elusive little section. I have heard it called by many names" — the figure
+lists exactly six: **Pre-Chorus · Climb or Lift · Vest · Verse Extension ·
+Ramp · Prime**. (Earlier drafts of this file added "channel" and "runway";
+they are not in Pat's list.) Then: "This section is used for so many jobs,
+none of these descriptive names quite fit all of them:"
 
-- Enclosed inside a song system (between verse and chorus)
-- Short, unbalanced
-- Sets up the chorus
-- Does NOT close a system
-- Same in every system (or close to it)
+> 1. It is a DEVELOPMENTAL section.
+> 2. It introduces a pivotal idea as a transition between Verse and Chorus.
+> 3. It is always enclosed in a Song System, almost always between a verse and
+>    a chorus.
+> 4. It unbalances the Song System by contrasting with the established verse
+>    structure. It makes you want to get to a balanced or CENTRAL section.
+>
+> Thus, 5. It is usually the lyric's shortest and most unbalanced section.
 
-**Bridge (full bridge):**
+**Bridge (full bridge)** — *Essential Guide to Lyric Form and Structure*
+(1991), Chapter 5:
 
-- Stands between systems, not inside one
-- Longest unbalanced section in the song
-- New perspective (the "why")
-- Appears once, late in the song (typically between systems 2 and 3)
+> You won't use Transitional Bridges too often unless you write dance songs, in
+> R&B and more Pop-oriented rock, where songs rely on a strong dance groove.
+> Both verse and chorus usually have the same groove, so a Transitional Bridge
+> is inserted between them as a “release” — to break the monotony and build
+> tension for a return to the groove. In this way, a Transitional Bridge works
+> just like a typical Bridge. But remember, a Transitional Bridge comes before
+> the Song System has closed down, between a Verse and a Chorus. The more
+> typical Bridge always comes after a song system has closed down.
 
-The transitional bridge is a setup tool inside a verse-chorus pair. The
-bridge is a structural break between pairs. Different jobs.
+**Why the full bridge sits between systems** — Chapter 5 makes the equivalence
+explicit, working from the AABA case ("The Great Pretender") outward:
+
+> A bridge works exactly the same way when it is inserted AFTER TWO COMPLETE
+> SONG SYSTEMS IN A VERSE/CHORUS LYRIC. In this case each verse/chorus system,
+> because it functions as a complete unit, works like a verse section in an
+> A A B A form.
+
+His worked case is Donald Fagen and Walter Becker's "Babylon Sisters" (Steely
+Dan) — the bridge "makes a clear move away from the structures of the Verse and
+Chorus," and:
+
+> In this lyric, the Bridge leads to another verse. As long as the bridge takes
+> you back to familiar territory, the sense of return or resolution will be
+> there.
+
+> All these new ideas, plus the new phrase lengths and a new rhyme scheme are a
+> real trip away from home base, making the return to the verse a homecoming …
 
 ## Bridge length
 
-There's no fixed length. Common patterns:
+Chapter 23's exact length instruction appears once in EXERCISE 49 above.
+Chapter 6's relative-length statement appears once in the verse/chorus
+three-item list above.
 
-- **2 lines** — minimal; works in tight forms (AABA folk songs)
-- **4-6 lines** — most common in modern pop
-- **8 lines** — when the bridge does heavy lifting (full perspective shift)
-- **Variable line lengths** — different from anywhere else in the song
-
-If the bridge is the same length as a verse, it's probably a verse.
+<!-- removed unsupported taxonomy: The prior 2-line, 4-6-line, and 8-line
+categories do not appear in the four specified chapters. -->
 
 ## Bridge writing workflow
 
-1. **Diagnose** — does the song need a bridge? Check the table above.
-2. **Find the missing angle** — what has the song not said? Object-write
-   that angle (per `object-writing.md`) for 10 minutes.
-3. **Choose contrast axes** — pick 2-3 from the mechanics list. Match
-   contrast intensity to perspective intensity.
-4. **Draft** — write the bridge from the new angle, in the new structure.
-   Do not import verse rhyme scheme, phrase length, or rhythm.
-5. **Test** — does B → final-chorus or B → final-A feel like homecoming?
-   If not, the bridge didn't depart far enough.
-6. **Sing the transition out** — bridge into chorus must connect rhythmically
-   and tonally. If the bridge ends on a structural cliff, the chorus return
-   feels jarring; if the bridge resolves too completely, the chorus feels
-   redundant.
+Use the source passages already preserved once in this file:
+
+1. “Bridge sourcing — the missing angle” for Chapter 23's missing-piece move.
+2. EXERCISE 49 for the object-writing prompt and short-effective instruction.
+3. “Bridge mechanics — structure” for the printed structural checklist and
+   the two worked contrast references.
+4. “AABA homecoming principle” for the return test.
 
 ## Failure modes
 
+<!-- unaudited: This table is editorial synthesis. No matching table or complete
+set of diagnostic claims was found in the four specified chapters. -->
+
 | Failure | Diagnosis | Fix |
 |---|---|---|
-| "Bridge that's another verse" | uses verse structure + verse angle | rewrite for new angle (Function 3) + structural contrast (Function 2) |
+| "Bridge that's another verse" | uses verse structure + verse angle | rewrite for the new angle + contrasting structure |
 | "Bridge that's a chorus restatement" | repeats chorus content with different words | replace with the song's missing angle |
 | "Bridge that doesn't connect" | contrasts on every axis, chorus return feels jarring | reduce contrast to 2-3 axes |
 | "Bridge that's too long" | takes over the song's emotional weight | trim; the bridge serves the chorus, not the other way around |

--- a/plugins/songwriting/context/pat-pattison/research/cliche.md
+++ b/plugins/songwriting/context/pat-pattison/research/cliche.md
@@ -39,17 +39,12 @@ Chapter 5 opens on a PBS documentary about a narcoleptic puppy who keeps
 toppling over mid-romp. The narrator blames the disorder; Pat blames the radio
 playing in the background. The puppy drops at these lines:
 
-```text
-You gotta take a chance
-If you want a true romance
-```
+"You gotta take a chance / If you want a true romance." She sleeps until the
+song finishes, then gets up chasing her tail until she hears "Take my hand /
+Let me know you understand." Plop.
 
-and then again at:
-
-```text
-Take my hand
-Let me know you understand
-```
+(Pat quotes both couplets inline, slash-separated, inside the running prose —
+not as displayed stanzas.)
 
 > I may not be *The New England Journal of Medicine*, but I know why the puppy
 > is falling asleep: clichés. Cliché phrases. Cliché rhymes. Cliché images.

--- a/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
+++ b/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
@@ -306,7 +306,12 @@ balls (not five) are introduced sequentially:
 The **fifth element (rhyme type)** was added in *Essential Guide to Rhyming*
 (2014). *Essential Guide to Lyric Form and Structure* (1991)
 intentionally uses only **perfect rhyme and identity** for all 44
-exercises — no family, additive, assonance, or consonance vocabulary.
+exercises. Family, additive, and assonance vocabulary is absent from the
+book entirely. **Consonance is the one exception**: Chapter 4 names the
+type once, in passing, analysing Shelley's "Ozymandias" — "'Appear' is
+an imperfect rhyme (technically, a Consonance Rhyme) with 'despair' and
+'bare.'" — but never defines it, never lists it among the working types,
+and never asks for it in an exercise.
 
 This pedagogical bounding matters: *Essential Guide to Lyric Form and Structure* (1991) exercises should be coached
 WITHOUT rhyme-type substitutions because the bounding is intentional.

--- a/plugins/songwriting/context/pat-pattison/research/metaphor.md
+++ b/plugins/songwriting/context/pat-pattison/research/metaphor.md
@@ -67,7 +67,7 @@ the metaphor feels random. The craft move is to create enough conflict to
 spark imagination while leaving enough hidden relationship for the listener to
 feel the connection.
 
-> "Productive ambiguity lies at the heart of metaphor."
+> "You'll find that productive ambiguity lies at the heart of metaphor."
 > — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 2
 > Day 1
 
@@ -1061,10 +1061,10 @@ The mechanical consequence: **simile keeps the listener at distance**
 
 ### Coleridge's imagination-vs-fancy distinction
 
-Pat cites Samuel Taylor Coleridge in Challenge 2 Day 14:
+Pat cites Coleridge in Challenge 2 Day 14:
 
-> "Coleridge called metaphor 'an act of the imagination,' whereas he
-> relegated simile to 'an act of fancy.'"
+> "Samuel Taylor Coleridge called metaphor 'an act of the imagination,'
+> whereas he relegated simile to 'an act of fancy.'"
 > — Pat Pattison (citing Coleridge),
 > *Songwriting Without Boundaries* (2011), Challenge 2 Day 14
 

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -401,7 +401,8 @@ Pat's second documented demonstration is Cathy Brettell's ten-minute write on
 > jellies to my toes like an anchor hoisted over ship" took Cathy from an
 > elevator ride to an ocean storm, no permission asked.
 >
-> — Pat Pattison, same
+> — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 1
+> opener
 
 Note the ending: "(time!)" and then "soft crystal knob pulls shut" cut off. That
 is the buzzer, printed.
@@ -761,8 +762,10 @@ The single most-emphasized object-writing discipline across Books
 
 Not after finishing the word. Not after closing the thought. Stop.
 
-> "Stop immediately when the timer ends." — Pat (*Writing Better Lyrics* (2009), Chapter 1;
-> *Songwriting Without Boundaries* (2011), Challenges 1-4, paraphrased)
+> "Stop IMMEDIATELY when the timer goes off. Do not even finish the word
+> you are on."
+> — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 1
+> Day 1 (the instruction repeats at the head of the later days)
 
 Reasons:
 

--- a/plugins/songwriting/context/pat-pattison/research/point-of-view.md
+++ b/plugins/songwriting/context/pat-pattison/research/point-of-view.md
@@ -9,7 +9,7 @@ to rewrite the same lyric from another camera distance.
 Quoted material is Pat's printed text, reproduced verbatim from *Writing Better
 Lyrics* (2009). Complete third-party song lyrics are not reproduced; where Pat
 prints a full lyric, this file keeps the excerpt his point turns on and names
-the song and writers.
+the song, and the writers where Pat names them.
 
 Source images inspected:
 

--- a/plugins/songwriting/context/pat-pattison/research/point-of-view.md
+++ b/plugins/songwriting/context/pat-pattison/research/point-of-view.md
@@ -130,7 +130,7 @@ He runs both translations on "The Fire Inside" and reports what each one does.
 First person — *"There's a reckless feeling in my heart as I head out tonight"*:
 
 > The result is a clear first-person narrative. But something gets lost: a kind
-> of universal feeling that you seems to add.
+> of universal feeling that *you* seems to add.
 
 Third person — *"There's a reckless feeling in her heart as she heads out
 tonight"*:
@@ -396,7 +396,7 @@ And the transfer to lyrics:
 > You walked up and you said hello
 > And then you asked my name
 
-> This sounds unnatural because you already knows all this stuff. The verse is
+> This sounds unnatural because *you* already knows all this stuff. The verse is
 > trying to do two things at once: Tell the audience the facts, while pretending
 > to carry on a conversation with you. Technically, we have a point of view
 > problem: second person trying to do first or third person's job. Don't give

--- a/plugins/songwriting/context/pat-pattison/research/point-of-view.md
+++ b/plugins/songwriting/context/pat-pattison/research/point-of-view.md
@@ -1,17 +1,29 @@
 # Point of View
 
-Pat Pattison - *Writing Better Lyrics* (2009), Chapter 10-13.
+Pat Pattison - *Writing Better Lyrics* (2009), Chapters 10-13.
 
 Use this when a user asks who should be speaking in a lyric, whether a song
 should use I/you/he/she/they, why a draft feels distant or too exposed, or how
 to rewrite the same lyric from another camera distance.
 
+Quoted material is Pat's printed text, reproduced verbatim from *Writing Better
+Lyrics* (2009). Complete third-party song lyrics are not reproduced; where Pat
+prints a full lyric, this file keeps the excerpt his point turns on and names
+the song and writers.
+
 Source images inspected:
 
-- Chapter 10: `image_rsrcAU6.jpg`.
-- Chapter 11: no linked page-scan images.
-- Chapter 12: no linked page-scan images.
-- Chapter 13: no linked page-scan images.
+- Chapter 10: `image_rsrcAU6.jpg` (the POINT OF VIEW: CAMERA ANGLES scale —
+  transcribed below).
+- Chapters 11-13: no linked page-scan images; text layer only.
+
+Three sections near the end rest on **non-book sources** (Berklee Online /
+patpattison.com) that could not be read for this pass — audience-centering,
+direct-address-plus-present-tense, and the pronoun-consistency anti-pattern.
+They are marked inline with `<!-- unaudited -->` comments and their paraphrases
+are retained as paraphrase. A fourth section, the cinematic metaphor, was
+sourced the same way but made a claim the book contradicts; it has been
+corrected against Chapter 10 and carries a note saying so.
 
 Related files: [verse development](verse-development.md),
 [repetition](repetition.md), [object writing](object-writing.md), and
@@ -19,449 +31,842 @@ Related files: [verse development](verse-development.md),
 
 ## Core idea
 
-Point of view controls the relationship among singer, audience, and the song's
-world. Pattison treats POV like a movie camera: the choice determines distance,
-intimacy, objectivity, and what kind of information sounds natural.
+Pat opens Chapter 10 with the questions every lyric has to answer:
 
-> Point of view controls our distance.
+> Whenever you put pen to paper, you must answer a few fundamental questions:
+> Who is doing the talking? Is it you personally? Is it a character you're
+> creating? What should that character's relationship to the audience be? A
+> storyteller? A confessor? Something else?
+>
+> You write for an instrument — a singer (maybe you) who faces the audience and
+> delivers your words. The point of view you choose controls the relationship
+> between the singer and the audience. It sets the context for your ideas.
+>
+> You control this choice. You control the singer's role (and, therefore, your
+> audience's relationship to the singer) by choosing between the four possible
+> points of view: third-person narrative, second-person narrative, first-person
+> narrative, and direct address.
+>
+> Point of view controls our distance from the world of the song. Think of it as
+> a movie camera, allowing the audience to look at the song's world from various
+> distances, from long shots to close-ups.
+>
+> — *Writing Better Lyrics* (2009), Chapter 10
 
-The main choices in Chapter 10:
+The figure Pat prints is headed **POINT OF VIEW: CAMERA ANGLES**
+(`image_rsrcAU6.jpg`). Its axis labels and its four tick marks, transcribed
+exactly:
 
 ```text
-most intimate                                             most objective
-direct address -> second-person narrative -> first-person -> third-person
+Most Intimate (Close-up: Feelings)          Most Objective (Long Range: Facts)
+|-------------------|-------------------|-------------------|----------------
+   Direct Address      Second Person        First Person        Third Person
+                         Narrative            Narrative           Narrative
 ```
 
-Chapter 10 focuses on third-person narrative, first-person narrative, and direct
-address. Later chapters handle second-person narrative in detail.
+> Let's look at the three main points of view: third-person narrative,
+> first-person narrative, and direct address. We'll deal with second-person
+> narrative separately in chapter twelve.
+
+(Chapter 11 intervenes with the hangman problem before that promise is kept.)
 
 ## Second-person narrative
 
-Second-person narrative uses `you` as the grammatical subject of a story, but
-without an active `I` speaking to `you`. It feels like a hybrid of third-person
-narrative and direct address.
+Chapter 12's main specimen is **Bob Seger's "The Fire Inside"**, which Pat says
+*"took me by surprise, because it has all the qualities of a narrative, but it
+uses second person (you)."* Its opening couplet is the line whose pronouns he
+keeps swapping through the chapter:
 
-It is not the same as direct address:
+> There's a hard moon risin' on the streets tonight
+> There's a reckless feeling in your heart as you head out tonight
 
-- Direct address: an `I` speaks to a `you`.
-- Second-person narrative: the song tells a story about `you`.
+Pat's definition:
 
-Second-person narrative borrows intimacy from direct address because the
-listener feels the `you` could be them. It also borrows objectivity from
-narrative because the singer can still guide a story from outside.
+> Second-person narrative serves up a tricky combination of third-person
+> narrative (where we watch the character) and direct address (talking right to
+> the character).
+
+And on where the intimacy comes from:
+
+> Think back to our point of view scale. The intimacy of second-person narrative
+> comes from its suggestion of direct address. We expect I to appear from behind
+> the curtain at any moment. It just never happens.
+>
+> Second-person narrative actively forces us to say, "This character could
+> easily be me."
 
 ## How second-person narrative works
 
-Second-person narrative often behaves like the general pronoun `one`, but with
-the illusion of direct contact:
+Pat builds it in two moves. First the impersonal pronoun:
 
-```text
-One walks into the room.
-You walk into the room.
-```
+> Part of it works like using you as a substitute for one (e.g., "You get what
+> you pay for" is the same as "One gets what one pays for").
 
-The second version feels more immediate. It asks the listener to inhabit the
-character rather than merely observe.
+Run the Seger couplet that way:
 
-Use second-person narrative when:
+> There's a hard moon risin' on the streets tonight
+> There's a reckless feeling in one's heart as one heads out tonight
 
-- the character could easily be the listener,
-- the lyric wants universality without losing immediacy,
-- the singer should not appear as an `I`,
-- the song needs narrative motion but also close-up pressure,
-- the lyric can avoid telling `you` obvious facts.
+Then the second move:
+
+> Now stir in the illusion of direct address by using you instead of one:
+>
+> There's a hard moon risin' on the streets tonight
+> There's a reckless feeling in your heart as you head out tonight
+
+Pat rules out the other candidate reading before he gets here. He reads the
+whole first verse in first person and concludes: *"Clearly, Seger is not using
+you as a disguise for I."*
 
 ## Translation tests
 
-Test second-person narrative by translating it into third person and first
-person.
+Pat states the test in one sentence:
 
-Third-person test:
+> One test for second-person narrative: Does it translate easily into third
+> person?
 
-- Replace `you` with `he`, `she`, or `they`.
-- If the story becomes a clean narrative, the second-person version is probably
-  narrative, not direct address.
+He runs both translations on "The Fire Inside" and reports what each one does.
 
-First-person test:
+First person — *"There's a reckless feeling in my heart as I head out tonight"*:
 
-- Replace `you` with `I`.
-- If the lyric becomes confession and loses its universal force, second person
-  may be doing useful work.
+> The result is a clear first-person narrative. But something gets lost: a kind
+> of universal feeling that you seems to add.
 
-Keep the version that best matches the lyric's emotional distance.
+Third person — *"There's a reckless feeling in her heart as she heads out
+tonight"*:
+
+> Continue reading the whole lyric in third person. Take your time. Now it's a
+> clear third-person narrative, landing squarely in storytelling mode.
+
+His verdict after both passes: *"Each narrative mode makes you look at the lyric
+differently."*
 
 ## The we turn
 
-Chapter 12 notes how a late move from `you` to `we` can pull the listener fully into
-the lyric's universal emotion. This works when the song has made `you` feel
-representative rather than merely individual.
+> The universal theme set up in the lovely third verse helps, too. One key to
+> the lyric's success is the move to first-person plural at the end
 
-Use the move carefully:
+The tail of Seger's third verse, where the move happens:
 
-- `you` lets the listener inhabit the character,
-- `we` confirms shared human condition,
-- the shift should feel earned by the lyric's theme.
+> Dreams die hard
+> And we watch them erode
+> But we cannot be denied
+> The fire inside
 
-If `we` arrives before the listener has accepted the `you`, it can sound
-generic.
+Pat's one-line gloss:
+
+> We forces the listener into the emotion.
 
 ## Internal second person
 
-Second person can also be an internal voice: a person talking to self as `you`.
-That is not narrative in the same sense. It behaves like internal monologue or
-internal dialogue.
+Pat first raises this as the reading he has to eliminate for Seger:
 
-Use internal second person when:
+> Sometimes you can be used as a substitute for first person. That's the way I
+> sometimes talk to myself: "Come on, Pat, can't you be clear for once?" instead
+> of "I wish I could be clear for once."
 
-- the character is confronting themselves,
-- the line feels like a command from inside the mind,
-- a mirror, ritual, addiction, fear, or shame creates divided self-talk.
+Then, at the end of Chapter 12, he comes back to it with a model:
 
-Do not confuse this with direct address to another person or with second-person
-narrative.
+> You can also leave the narrative mode, using second person as a substitute for
+> I, as in, "C'mon, can't you be clear for once?" Or as an internal command:
+> "C'mon, be clear for once!" Leonard Cohen's "Dress Rehearsal Rag" is a good
+> example. In it, the character is standing in front of a mirror getting ready
+> to shave
+
+Two lines from Pat's excerpt of the Cohen lyric:
+
+> … Look at your body now, there's nothing much to save
+> And a bitter voice in the mirror cries "Hey, Prince, you need a shave"
+
+His verdict, and the reason this belongs in a separate bin from the Seger case:
+
+> I suppose we could call it an internal monologue or dialogue. One thing is
+> clear: Narrative it ain't.
 
 ## Third-person narrative
 
-Third-person narrative is the long shot. The singer and audience stand outside
-the song's world and look together at a character, event, or scene.
+> In third-person narrative, the singer acts as a storyteller who simply directs
+> the audience's attention to an objective world neither the singer nor the
+> audience is a part of. They look together at a third thing, an objective,
+> independent world. If you think in terms of film, this is the long-distance,
+> panoramic view. We, the audience, are simply observing the song's world. We
+> are not participants.
 
-Pronouns:
+Pat's pronoun table, as printed — all four rows, both columns:
 
-- he, she, it, they,
-- him, her, them,
-- his, her, its, their,
-- his, hers, theirs.
+| | Singular | Plural |
+|---|---|---|
+| Subject | he, she, it | they |
+| Direct object | him, her, it | them |
+| Possessive adjective | his, her, its | their |
+| Possessive predicate | his, hers, its | theirs |
 
-Use third person when:
+> e.g. Possessive adjective: "That is her responsibility."
+>
+> Possessive predicate: "The responsibility is hers."
 
-- the lyric needs objectivity,
-- the singer should act as storyteller,
-- the audience should observe rather than participate,
-- external behavior matters more than confession,
-- the song needs panoramic distance,
-- gender or singer identity should remain flexible.
+> In third-person narrative, both the singer and the audience turn together to
+> look at the song's world. The singer functions as storyteller or narrator, and
+> the audience observes.
 
-Watch for pronoun clutter. If several same-gender characters appear, third
-person can become confusing unless the lyric simplifies or names carefully.
+Pat's first specimen is **Buck Ram's "The Great Pretender"** — he prints it whole
+here and then twice more with the pronouns changed, so it is the control case
+for the whole comparison. Its opening quatrain:
+
+> Yes, she's the great pretender
+> Pretending that she's doing well
+> Her need is such, she pretends too much
+> She's lonely but no one can tell
+
+> Imagine watching a singer perform the song. Either gender could sing it, no
+> problem. As an audience, we would look at the pretender along with the singer.
+> Neither we nor the singer participates in the world.
+
+His second third-person specimen is **"Sentimental Lady"**, whose chorus is the
+thing the rest of the chapter keeps rewriting:
+
+> Sentimental lady
+> Doesn't mind it when it's raining
+> Doesn't seem to matter when it ends
+> Sentimental lady
+> Sips her tea in perfect safety
+> Smiles her secret smile and pretends
 
 ## First-person narrative
 
-First-person narrative is a middle-distance shot. The singer participates in
-the story and reveals something about self, but still speaks to the audience
-about other people or events.
+> A first-person narrative is also a storytelling mode, but instead of being
+> separate from the action, the singer participates. There is some intimacy
+> here. The audience knows something about the singer, who speaks directly to
+> the audience about other people and events. The other people and events are
+> still at a distance from the audience.
 
-Pronouns:
+| | Singular | Plural |
+|---|---|---|
+| Subject | I | We |
+| Direct object | me | us |
+| Possessive adjective | my | our |
+| Possessive predicate | mine | ours |
 
-- I, me, my, mine,
-- we, us, our, ours.
+The membership rule, in Pat's words — the second sentence is the one that
+actually does diagnostic work:
 
-First-person narrative usually mixes first- and third-person pronouns. It does
-not include a direct `you` as the addressed listener inside the song world.
+> In a first-person narrative, the first-person pronouns mix with third-person
+> pronouns. There is no you.
 
-Use first person when:
+And the camera position, stated flatly:
 
-- the audience should know the singer's stake,
-- memory or confession matters,
-- the singer learned or witnessed something,
-- the story needs intimacy without direct confrontation,
-- the lyric benefits from a character telling the audience what happened.
+> We, the audience, have some level of intimacy with the singer, but we are
+> still observers to the rest of the song's world. The singer is a participant,
+> revealing something about himself or herself, so the gender of the singer and
+> the pronouns will now make a difference. In film terms, this is the
+> middle-distance shot.
 
-First person should sound like the speaker's lived perception. External
-observer phrases often become awkward when placed in the singer's mouth.
+Pat's first-person specimen is **"Digging for the Line"**, which opens *"My daddy
+loved the greyhounds / Oh he lived to watch 'em run."* His gloss:
+
+> The narrator tells the story, but includes him/herself in it. In the last
+> verse, daddy is quoted by the narrator while we are allowed to eavesdrop.
+
+He then demonstrates the failure mode by converting "Sentimental Lady" to first
+person and letting it fall over. On *"I hardly seem to notice as I step across
+the street"*:
+
+> This sounds odd. She's saying external or descriptive things about herself,
+> like "I hardly seem to notice as I step across the street." Observations like
+> this are best left to a third-person narrator.
+
+On *"Lost in thought I read his letters"*:
+
+> Again it sounds unnatural for her to say, "Lost in thought I read his letters."
+> The language is more appropriate from the mouth of an observer than from the
+> mouth of a participant.
+
+The one section that survives the conversion is the bridge — and Pat says why:
+
+> The bridge sounds natural in first person, since she's telling us something
+> about herself we couldn't know from simply looking. Of course, looking into a
+> character's mind is also perfectly appropriate in third-person narrative.
+
+So the repair is not pronoun swapping — Pat rewrites the lines from inside her
+head, and then allows: *"Okay, so the rewrite could be more elegant. The point is
+that it works better."* Which lines he changed, and why, is under
+[rewrite is not pronoun replacement](#rewrite-is-not-pronoun-replacement) below.
 
 ## Direct address
 
-Direct address is the close-up. The singer, an implied `I`, speaks to a `you`.
-Pattison notes that this is often inaccurately called second person, but it is
-really contact between first and second person.
+> In direct address (sometimes inaccurately called second person), the singer
+> (the first person, I) is talking to some second person (you), or maybe even
+> right to the audience.
+>
+> This is the close-up, the most intimate a song can be. You can see the lip
+> quivering and the jaw muscles tightening with emotion. This is about feelings,
+> not facts.
 
-Pronouns:
+That last sentence is where the figure's axis labels come from — Close-up:
+Feelings at one end, Long Range: Facts at the other.
 
-- you, your, yours,
-- often mixed with I, me, my, mine, we, us, our.
+| | Singular | Plural |
+|---|---|---|
+| Subject | you | you |
+| Direct object | you | you |
+| Possessive adjective | your | your |
+| Possessive predicate | yours | yours |
 
-Use direct address when:
+> Second-person pronouns are mixed with first-person pronouns to produce direct
+> address — contact between I and you.
 
-- the lyric needs immediate emotional pressure,
-- the singer is confronting, seducing, apologizing, accusing, blessing, or
-  pleading,
-- the audience should feel included or implicated,
-- the song's power depends on the singer speaking to someone.
+Pat prints **four** listener positions, not "several" — and states them from
+inside the listener's head, first person:
 
-Direct address can create several listener positions:
+> This is the camera close-up. The singer sings directly to another person or
+> people. (In English, there is no difference between singular and plural you,
+> unless we resort to y'all or youse as plural forms, both forms intended as
+> sophistications in a barren language that forgot to make the distinction.)
+> Because of the direct contact, second person is the most intimate of the
+> points of view. As a listener:
+>
+> I imagine the singer is singing to me, or
+>
+> I watch the singer singing directly to someone else, real or imagined by the
+> singer, or
+>
+> I can imagine that the singer is someone I know singing to me, or
+>
+> I can identify with the singer and sing to someone I know.
+>
+> However I do it, it's pretty intimate.
 
-- the listener imagines being addressed,
-- the listener watches the singer address someone else,
-- the listener identifies with the singer,
-- the listener imagines singing the song to someone from their own life.
+His direct-address specimen is **"As Each Year Ends"**, in which *"the singer
+speaks to the image of someone in his past"*:
 
-That flexibility is powerful, but it can get complicated quickly.
+> Becky Rose, you stole the night
+> Body dark, a sash of light
+> Soft you slippered from my bed
+
+> Even though Becky Rose is not in the singer's presence, it's still pretty
+> intimate stuff.
+
+He then reruns the same song as first-person narrative (*"Becky Rose stole the
+night / Her body dark, a sash of light"*) and as third person, and asks *"What do
+you lose? Are there any gains?"* His own answer names exactly one change:
+
+> One thing changes: The chorus can be in present rather than future tense. A
+> third-person narrative can have a larger overview of time, stating simply, He
+> tastes them once again as each year ends.
+>
+> From the first person, the singer promises to continue raising his glass: I'll
+> taste them once again as each year ends.
+>
+> I don't have a problem making a choice here. I prefer the intimacy of direct
+> address. Does that mean we should always go for intimacy?
 
 ## The hangman problem
 
-Chapter 11 warns against using direct address as a fake conversation that exists only
-to tell the audience facts. If the singer says `you` but then recounts facts
-the addressed person already knows, the lyric sounds like a parent reciting
-charges in front of someone else.
+Chapter 11 opens on a scene, not a rule. Eleven-year-old Pat has shot out a
+neighbor's window with a BB gun, and dinner is the gallows:
 
-> Make second person conversational.
+> "Just wait till your father gets home, young man!" said Mom, rolling her eyes
+> in exasperation.
+>
+> I was really going to get it. She'd tell Dad and I'd be lucky to see anything
+> but my bedroom walls for weeks. More likely, this time I'd probably swing,
+> twisting slowly in the wind.
 
-The problem is not the use of `you`. The problem is making `you` listen to a
-history lesson about their own life.
+The prosecution opens, and Pat marks the tell:
+
+> "Well, young man, you've had quite a day today, haven't you?" […]
+>
+> "You're eleven years old, and should know better, shouldn't you?"
+>
+> They always start by telling you how old you are.
+
+Then the sentence that is the whole chapter:
+
+> She knew the facts, and I knew the facts. The girls knew the facts. Dad was
+> the only one who didn't know, so why was she telling me instead of him? More
+> pleasure in the execution?
+
+And the transfer to lyrics:
+
+> Sometimes, lyrics sound like Mom. They seem to be talking directly to you, but
+> are really telling someone else what you already know. Like this:
+>
+> I met you on a Saturday
+> Your hair was wound in braids
+> You walked up and you said hello
+> And then you asked my name
+
+> This sounds unnatural because you already knows all this stuff. The verse is
+> trying to do two things at once: Tell the audience the facts, while pretending
+> to carry on a conversation with you. Technically, we have a point of view
+> problem: second person trying to do first or third person's job. Don't give
+> the facts to someone who already should know them!
 
 ## Direct-address fact test
 
-When a direct-address line contains backstory, ask:
+Pat's first two repairs are pure pronoun moves, printed side by side with the
+broken verse. First-person narrative — *"would sound closer to what's really
+happening"*:
 
-- Would the addressed person already know this?
-- Is the singer really talking to `you`, or using `you` to inform the audience?
-- Does the line include the singer's reaction, memory, confession, accusation,
-  or present emotional reason for saying it?
-- Could first-person or third-person narrative deliver the facts more
-  naturally?
+> I met her on a Saturday
+> Her hair was wound in braids
+> She walked up and she said hello
+> And then she asked my name
 
-If `you` already knows the facts, add the singer's angle or change POV.
+> Third-person narrative is better, too:
+>
+> He met her on a Saturday
+> Her hair was wound in braids
+> She walked up and she said hello
+> And then she asked his name
+
+But he does not stop at the pronoun swap. The real question he asks is whether
+the facts deserve to be in the song at all:
+
+> Moving into first- or third-person narrative is one way to solve the problem.
+> But sometimes you may be committed to second person. In that case, you have to
+> find a way to make the conversation sound more natural. Do you really want the
+> audience to know that it was Saturday and she had braids and she made the
+> first move? If not, just drop the unnatural verse and write a better, more
+> natural one. If the facts are important, you have to say them naturally, like
+> you would in a real conversation.
 
 ## Natural ways to include shared history
 
-Direct address can include shared facts when the singer's purpose is clear.
-Useful frames:
+Pat prints **two** rewrites of the braids verse, not a list of frames. First:
 
-- I still remember...
-- I never felt...
-- I did not know then...
-- You may not have noticed...
-- I should have told you...
-- I keep coming back to...
-- Do you remember...
+> I never felt anything quite as strong
+> As I did that Saturday night we met
+> You looked so fresh with your hair in braids
+> And I felt like singing
+> When you walked right up and asked my name
 
-These frames make the fact part of the singer's present emotional action rather
-than a report.
+> Including personal information that you couldn't have known makes the
+> conversation more natural. Or this:
+>
+> I still remember the Saturday night we met
+> Your hair so pretty, up in braids
+> You blew me away when you said hello
+> And asked me, "What's your name?"
+
+His verdict on both, including the honest disclaimer:
+
+> Both of these versions work because they include the singer's reactions to the
+> facts. Okay, so it's not great writing. Even so, it still sounds more natural,
+> and once you know what approach to take, you can always polish up the
+> language. The second version also includes the old "do you remember" ploy for
+> introducing information. Put it in your own bag of tricks.
+
+So the mechanism has a name in Pat's text and it is exactly one thing: **the
+singer's reactions to the facts**. "Do you remember" is the one *ploy* he names
+on top of it.
 
 ## Hangman repair workflow
 
-When direct address sounds stiff:
+Chapter 11 ends with the rule and the habit, in Pat's words. The rule:
 
-1. Mark every fact addressed to `you`.
-2. Decide whether `you` already knows each fact.
-3. If yes, add why the singer is saying it now.
-4. If the fact is only for the audience, test first-person narrative.
-5. If the song wants objectivity, test third-person narrative.
-6. Keep direct address only when the line behaves like real speech.
-7. Read aloud with the imagined listener in the room.
+> No matter what the point of view is, mothers will always have their modes of
+> torment. This natural use of second person is maddeningly effective. Any
+> mother would be proud to use it.
+>
+> The point is simple: Make second person conversational. If you want to give
+> the audience a history lesson, either put it in third person or find a natural
+> way to list your facts. If you've gotta swing, make it quick and natural.
 
-Do not keep second person just because it feels intimate. Forced intimacy is
-less convincing than a clean narrative POV.
+The habit — note that Pat asks for **all three** points of view on **every**
+lyric, and that the method is reading aloud, not silent editing:
+
+> As a matter of habit, you should try out all three points of view — first,
+> second, and third person — for each lyric you write from now until you die,
+> just to make sure you are using the best possible one for each song. Read your
+> lyric aloud, each time substituting the different pronouns to see which you
+> like best. Sometimes, a change in point of view will raise a bland lyric from
+> the dead.
 
 ## Natural information test
 
-Every POV has information it can say naturally and information it strains to
-say.
+Pat never prints a checklist for this. He states it as a mouth test, twice, in
+the "Sentimental Lady" conversion, and once as a rule for direct address. The
+three sentences that carry it — all restored in full above — are:
 
-Third person can describe external action, setting, gesture, and body language
-cleanly. First person can reveal internal motive, memory, and self-knowledge.
-Direct address can deliver emotional pressure to a target.
+- external or descriptive detail about the speaker — *best left to a
+  third-person narrator* ([first person](#first-person-narrative))
+- language that belongs to an observer rather than a participant
+  ([first person](#first-person-narrative))
+- facts the addressee already holds ([the hangman problem](#the-hangman-problem))
 
-When a line sounds unnatural, ask:
-
-- Who would know this?
-- Who would say this out loud?
-- Is the speaker describing self from the outside?
-- Is the narrator explaining what only a participant would know?
-- Is a direct-address singer saying factual background better suited to
-  narrative?
-
-Rewrite from the POV's natural access instead of only swapping pronouns.
+Against those sits the counter-case in the same chapter: the "Sentimental Lady"
+bridge survives first person because she is telling us something about herself
+we could not get by looking — and Pat immediately grants third person the same
+access. So the constraint is asymmetric. Interior access is available to both
+narratives; **outside-looking-in description of the speaker is the thing first
+person cannot say naturally.**
 
 ## Rewrite is not pronoun replacement
 
-Changing POV requires changing perspective, not just changing pronouns. A third
-person image may need to become first-person sensation. A first-person memory
-may need to become third-person action. Direct address may need a target,
-pressure, and implied relationship.
+Pat demonstrates this rather than stating it. He first converts "Sentimental
+Lady" to first person by swapping pronouns only, shows it failing, and then
+says:
 
-Use this workflow:
+> If we really were to make sense of "Sentimental Lady" as a first-person
+> narrative, the perspective would have to shift in several places
 
-1. Identify the current POV.
-2. Identify the singer's role.
-3. Identify the audience's role.
-4. Decide what information is natural from that role.
-5. Rewrite images and verbs from inside the chosen camera distance.
-6. Recheck pronouns only after the perspective works.
+The lines he actually changes are the tell. *"She hardly seems to notice as she
+steps across the street"* does not become *"I hardly seem to notice…"*; it
+becomes:
+
+> Splashed by cooling raindrops as I step across the street
+
+An outside observation becomes a sensation on the skin. Likewise *"Knows where
+she's headed for / She goes inside / Shuts the door"* becomes *"I know what I'm
+headed for / Slip inside / Shut the door"* — intention replacing observed
+behavior. His summary of the whole operation:
+
+> The trick is to put yourself in her mind — look from her perspective, and say
+> what comes naturally.
 
 ## Duplication of function
 
-Chapter 10 uses the "gun in Act I" idea to stress purpose: every element should have
-a job. POV choices can expose redundant characters. If a story becomes "someone
-telling a story about someone telling a story," test whether one character can
-be removed.
+This comes out of Pat's second conversion exercise:
 
-Ask:
+> As a further exercise, go back and try changing "Digging for the Line" into a
+> third-person narrative. It's an interesting problem, isn't it? First there's
+> the pronoun problem: you have to make daddy's child she to keep the hes from
+> getting all jumbled together. Instead of:
+>
+> His daddy loved the greyhounds
+> Oh he(?) lived to watch 'em run
+>
+> You have to say:
+>
+> Her daddy loved the greyhounds
+> Oh he lived to watch 'em run
+>
+> Even with that problem solved, you end up with a story about a father telling
+> a story to his daughter. Seems a little complicated
 
-- Does this narrator add a necessary relationship?
-- Could the main character carry the story directly?
-- Does a character exist only to explain another character?
-- Would third person become cleaner if the intermediary vanished?
-- Would first person become stronger if the singer's stake were central?
+Then the principle, with Pat's attribution intact:
 
-Simplify when a POV layer adds distance without adding meaning.
+> Daddy told me this story is an acceptable premise for a song, but here's a
+> story about someone telling a story seems more remote. The playwright Henrik
+> Ibsen said, "If you put a gun in Act I, it damn well better go off by the end
+> of the play!" This is more than a principle about effective use of props. It
+> says that you should have a reason for each element in your work. Nothing
+> without its purpose. No duplication of function.
+
+He then applies it by deletion:
+
+> Maybe the daughter is a gun that isn't going off. Let's see what happens if we
+> eliminate her altogether
+
+The narrator disappears and the character is named — *"Edwin loved the greyhounds
+/ He lived to watch 'em run"* — and:
+
+> Much cleaner than with two characters. Simplify, simplify, simplify.
+
+Pat then prints the first- and third-person versions in facing columns and says
+the decision lives in one place:
+
+> The key will be in the third verse. We will choose between listening in a more
+> intimate situation to the singer telling us what he/she learned from daddy, or
+> observing Edwin from a distance as he discovers the meaning of running
+
+The pivot lines, side by side:
+
+| First-person narrative | Third-person narrative |
+|---|---|
+| But daddy smiled and made me see | But as he grew old he learned to see |
+| This is what he said to me | What it really means |
+| Son, a greyhound lives for running | A greyhound lives for running |
+
+And he refuses to make it a rule:
+
+> In first person, the singer as character/storyteller is right in front of us.
+> We feel like we know him/her. But third person is cleaner and more focused in
+> this case, because it eliminates a character. Your call.
 
 ## Dialogue and POV
 
-Chapter 13 applies POV choice to songs built from dialogue. Dialogue in a lyric is
-not automatically a duet. A duet needs equal characters who can share or answer
-the repeated material. If only one character owns the chorus, one singer can
-tell the conversation with quoted speech.
+Chapter 13 opens with the raw material as a transcript, before it is a lyric at
+all — Pat's framing is *"Conversation overheard in a country home, using a
+surveillance microphone"*:
 
-**The duet test is the chorus, not the conversation.** Ask who can sing the
-repeated section. If the chorus is one character's request, plea, or claim, the
-other character cannot sing it and the song is not a duet however evenly the
-dialogue is distributed. Sung dialogue with two genuinely equal speakers is
-opera; a lyric hands the whole conversation to one singer, in quotes.
+> **Alphonse:** What gifts can I bring you to prove that my love for you is
+> true? I want to make you mine forever. There's nothing on this Earth I would
+> not do.
+>
+> **Emma Rae:** Anything I have wanted, you have given willingly. So now there's
+> only one more thing I need: If you love me, give me wings. Don't be afraid if
+> I fly. A bird in a cage will forget how to sing; if you love me, give me
+> wings.
+>
+> **Alphonse** (walking over to the window, staring into space)**:** I just want
+> to protect you, because this world is a dangerous place.
+>
+> **Emma Rae** (putting her arms around him)**:** I know you mean well, but
+> there's lessons I must learn for myself. […]
 
-Test dialogue through three POV setups:
+> Gosh, what a nice conversation. It even rhymes. How would you turn this
+> dialogue into a song? Think about it for a minute. Go back, read it again, and
+> try it.
 
-- First-person narrative: `I asked her...` or `He asked me...`
-- Direct address: `I asked you...` or `You asked me...`
-- Third-person narrative: `He asked her...`
+His answer to the obvious first guess:
 
-The best choice depends on whose story it really is and why the singer is
-telling it.
+> No, it probably isn't a duet. Duets need equal characters, both of whom can
+> say the same chorus. Emma Rae is the only one here who can say "Give me
+> wings." Unless you're writing opera (sung dialogue), you're better off having
+> one singer tell us about the conversation, complete with quotes. The real
+> trick is selecting a point of view to set the whole thing up.
+
+Pat prints three numbered options, each as the same opening couplet re-pointed,
+each with a one-paragraph gloss.
+
+> **1. FIRST-PERSON NARRATIVE**
+>
+> I asked her, "What gifts can I bring you / To prove that my love for you is
+> true?"
+>
+> Or:
+>
+> He asked me, "What gifts can I bring you / To prove that my love for you is
+> true?"
+>
+> In first-person narrative, the singer tells us about a conversation he/she
+> actually had with some third party. Like someone coming in to work and saying,
+> "Guess who I talked to yesterday. You'll never believe who he was with!" And
+> then telling you the story.
+
+> **2. DIRECT ADDRESS**
+>
+> I asked you, "What gifts can I bring you / To prove that my love for you is
+> true?"
+>
+> In direct address, the singer is talking either directly to us, or to some
+> unseen you. We're watching him/her have a conversation with a second person.
+
+> **3. THIRD-PERSON NARRATIVE**
+>
+> He asked her, "What gifts can I bring you / To prove that my love for you is
+> true?"
+>
+> Now our singer is a storyteller, pointing to a scene in the distance. The
+> singer isn't in the story, and neither are we.
+
+> Let's try all three.
 
 ## First-person dialogue
 
-First-person dialogue works when the singer has a clear reason to tell the
-story. If the real emotional center belongs to the other character, first
-person may put the spotlight on the wrong person.
+Pat writes the male-narrator version out in full and then reports the symptom
+before he names the cause:
 
-Use first-person dialogue when:
+> The point of view works okay, but something is askew. The emotion feels off
+> balance, a little forced. Why is this guy standing up there with his
+> microphone telling us the story, anyway? What's his point?
 
-- the singer changes because of the conversation,
-- the singer has a final insight,
-- the singer is confessing, explaining, or remembering,
-- the quoted other person reveals something the singer now understands.
+The diagnosis, the named model, and Pat's own draft repair — all in one
+paragraph:
 
-If the singer merely reports what someone else said, ask why the microphone is
-in that singer's hand.
+> Maybe the source of the problem is that the lyric is about her, not I. Our
+> first version of first-person narrative shines the spotlight on the wrong
+> person. In order for the male character to sing the song, he'd have to have
+> something important to say about the story at the end, like in the final line
+> of Don Schlitz's "The Gambler": But in his final words I found an ace that I
+> could keep. Maybe something like: I gave her her freedom, and we've been great
+> ever since / Soaring together, lovers and friends.
 
-**The repair when the answer is "no reason": give the singer a final insight.**
-Chapter 13 does not treat first-person dialogue as unusable when the story
-belongs to the other character — it adds a closing line in which the narrator
-says what the conversation cost or taught them, which retroactively earns the
-whole retelling. Pat's cited model is a well-known gambler song whose narrator
-spends the entire lyric quoting someone else and then, in the final line, names
-what he took from it.
+Swapping the narrator to the woman does not by itself fix it:
 
-So the diagnostic has two exits, not one:
+> This point of view is better, but not terrific. Again, why is she raising the
+> microphone and telling us these facts? We'd still need something like: He gave
+> me my freedom, and we've been great ever since / Soaring together, lovers and
+> friends.
 
-- Move to third person, letting the scene speak without a narrator, **or**
-- keep first person and write the narrator an ending that justifies the telling.
-
-Choose the second when the narrator genuinely changed; the first when they did
-not.
+> Moral: If the singer is the I in the story, you've got to give him/her a good
+> reason for telling it.
 
 ## Direct-address dialogue
 
-Direct-address dialogue often triggers the hangman problem. If `you` was there
-for the conversation, retelling it to `you` can sound like a history lesson.
+Pat's verdict on this one is flat, and he offers **no** conditions under which it
+works — the paraphrase's list of four "use it only when" exceptions had no source
+in the chapter. He sets it up (*"Next, let's get up close and personal"*), writes
+it out, and then:
 
-Use direct-address dialogue only when:
+> Total disaster — the worst of history lessons. The you of the song was already
+> there during the conversation, so what's the point of telling her about it
+> again? The same is true if the woman sings the song:
+>
+> You asked me, "What gifts can I bring you / To prove that my love for you is
+> true?"
 
-- the singer is re-opening the wound,
-- the quoted moment is being reinterpreted now,
-- the present conversation matters more than the past facts,
-- the addressed person could plausibly need to hear the memory again.
-
-Otherwise, test first-person or third-person narrative.
+> As we saw in chapter eleven, "Second Person and the Hangman," simply telling
+> people what they already know doesn't make for credible dialogue.
 
 ## Third-person dialogue
 
-Third-person narrative can make dialogue clean because the singer becomes a
-storyteller, and the audience watches both characters at a distance. It avoids
-the question "Why are you telling me what I already know?" and can work for any
-singer gender if the character pronouns remain clear.
+Third person is where the real song landed. Pat introduces it as fact, not
+preference:
 
-Use third-person dialogue when:
+> Finally, look at the point of view of the actual lyric of this song, "Give Me
+> Wings," by Don Schlitz and Rhonda Kye Fleming
 
-- the scene matters more than the singer's confession,
-- both characters need to be visible,
-- the chorus belongs clearly to one character,
-- quoted speech is the most natural way to reveal conflict.
+Its opening quatrain and the transitional bridge that follows:
+
+> He asked her, "What gifts can I bring you
+> To prove that my love for you is true?
+> I want to make you mine forever
+> There's nothing on this Earth I would not do"
+>
+> She said, "Anything I have wanted
+> You have given willingly
+> So now there's only one more thing I need
+
+His verdict — and, immediately, the refusal to generalize it into a rule:
+
+> Nifty. It doesn't matter if the singer is male or female, the dialogue seems
+> complete and natural. This doesn't mean that third-person narrative is always
+> the right answer for every lyric that uses dialogue. You should read every
+> lyric you write in each point of view. See how each one feels, then decide
+> which one works best.
 
 ## Dialogue structure note
 
-Chapter 13 also shows how dialogue sections use structure to support emotion,
-in a deliberate three-stage sequence:
+Pat tacks a structural reading onto the end of the chapter — *"Something on
+structure while we're here"* — because *"there's more to like about this little
+gem of a lyric… a really nice display of technical savvy."*
 
-1. **A balanced verse lulls the listener** — four lines of common meter, `xaxa`.
-   The stability is a setup, not the point.
-2. **A three-line transitional bridge topples that balance** — an odd line count
-   after an even one leaves the ear reaching for a landing, which is exactly
-   what a transitional bridge is for.
-3. **The chorus withholds the rhyme the ear was promised**, repeating the title
-   in the fourth position instead. See
-   [deceptive cadence](hook.md#deceptive-cadence--spotlight-the-title-by-withholding-the-rhyme).
+**The verse.** *"The verses are fairly balanced — four lines in common meter,
+rhyming xaxa"* — with the stress counts exactly as printed in his table:
 
-This belongs primarily to [form](form.md), [meter](meter.md), and
-[prosody](prosody.md), but it matters for POV because the structural surprise
-spotlights the line the speaking character most needs to say — and in quoted
-dialogue, that line is inside quotation marks. The structure decides which
-character's words the section is actually about.
+| Line | Rhyme | Stresses |
+|---|---|---|
+| He asked her, "What gifts can I bring you | x | 3+ |
+| To prove that my love for you is true? | a | 3 |
+| Want to make you mine forever | x | 3+ |
+| There's nothing on this Earth I would not do" | a | 3 |
 
-When dialogue has a quoted chorus, check whether the structure makes that
-quote feel inevitable.
+> Pretty standard stuff. But beware, it's a setup to lull you into a false sense
+> of security.
+
+**The transitional bridge.** Pat gives the section its whole roster of names
+before choosing one:
+
+> The section between the verse and chorus (call it whatever you want to — vest,
+> pre-chorus, prime, lift, channel, runway, climb — I call it a transitional
+> bridge) throws us off balance with its three lines […]
+>
+> Or, if you like, two lines of wickedly unequal length […]
+>
+> We are toppled into the chorus, praying to find a secure landing. Perfect.
+> That's what a transitional bridge is supposed to do.
+
+**The chorus.** Pat walks the ear's expectation line by line — *"The first two
+lines feel sturdy, balancing each other with three stresses"*, then *"a
+four-stress line sets up a little more tension"* on *"A bird in a cage will
+forget how to sing"*:
+
+> Boy, do we ever want a three-stress line rhyming with fly. How come? The aba
+> rhyme scheme, wings/fly/sing, begs for a pairing with the unrhymed word.
+
+He writes the resolved version the ear is asking for — *"I must soar beyond the
+sky"* — calls it *"pretty cheesy"*, and then rejects it on prosody grounds:
+
+> The rhyme structure, wings/fly/sing/sky, feels much more resolved than the
+> situation of the song intends. She's asking for, not getting, wings. That's
+> why the real chorus's rhyme scheme, abaa, is so perfect
+
+The payoff accomplishes exactly **three** things, numbered in the text:
+
+> The last line fools you (I call it a deceptive cadence), and in doing so, it
+> accomplishes three things: (1) it repeats the title — a good commercial move;
+> (2) the structural surprise spotlights the title; and (3) it resolves the
+> chorus, though not as solidly as a rhyme for fly would have. The surprise
+> rhyme is emotionally better suited to the intent of the chorus since it's a
+> little less secure.
+
+See [deceptive cadence](hook.md#deceptive-cadence--spotlight-the-title-by-withholding-the-rhyme).
+
+Pat files this under structure, and it belongs primarily to [form](form.md),
+[meter](meter.md), and [prosody](prosody.md). The POV consequence is ours, not
+his printed claim: the line the deceptive cadence spotlights is inside quotation
+marks, so the structural surprise lands on one character's words. When dialogue
+has a quoted chorus, check which character the structure is actually pointing
+at.
 
 ## POV check
 
-Run a POV check during drafting and again after a complete draft:
+Pat gives no numbered procedure. He gives a frequency and a refusal, and
+Chapter 10 ends on them:
 
-1. Mark every pronoun.
-2. Name the POV and camera distance.
-3. Name the singer's role.
-4. Name the audience's role.
-5. Test third person, first person, and direct address.
-6. Rewrite a sample verse and chorus in each viable POV.
-7. Compare intimacy, clarity, natural information, and singer fit.
-8. Keep the POV that best supports the song's emotional job.
+> It's impossible to make a rule about when to use each point of view. The only
+> way to make sure your point of view is working the most effectively it can is
+> to do a point of view check on every lyric you write. Check once during the
+> process, and then also at the end of the process. Every lyric. You'll find
+> that a different point of view works better often enough to make checking
+> every time worth it. It only takes a little practice and not much time, and
+> sometimes it will turn a good lyric into a killer one.
 
-## Chapter 10 exercise as coaching prompt
+Chapter 12 closes the same way, with one addition about where the odds sit:
 
-Exercise 14 - POV rewrite:
+> Practice with points of view. Get in the habit of checking every lyric you
+> write from each point of view. Sometimes a change will make all the
+> difference. Mostly, you'll get your best results with direct address and with
+> standard first- and third-person narratives. But don't let that keep you from
+> checking out second-person narrative. When it works, it works big time.
 
-- Take one lyric section.
-- Rewrite it in direct address.
-- Then compare it with first-person and third-person versions.
-- Track what each POV gains and loses.
-- Choose the POV that best fits the singer's relationship to the audience.
+## Exercises as coaching prompts
 
-Chapter 11 - Hangman rewrite:
+Chapters 10-13 contain exactly **two** numbered exercises — 14 and 15. Chapters
+11 and 13 have none. (An earlier draft of this file listed a "Chapter 11 —
+Hangman rewrite" and a "Chapter 13 — Dialogue POV test"; neither exists in the
+book. What those chapters give instead is un-numbered, and is quoted in place
+above.)
 
-- Take a direct-address verse that tells `you` shared facts.
-- Rewrite it in first-person narrative.
-- Rewrite it in third-person narrative.
-- Return to direct address and include the singer's reaction to each fact.
-- Keep the version that sounds most natural aloud.
+**EXERCISE 14** (Chapter 10) — it names the two songs, and Pat's own phrasing
+depends on the question he asks immediately before it, *"Does that mean we should
+always go for intimacy?"*:
 
-Exercise 15 - Second-person narrative translation:
+> Try rewriting "Sentimental Lady" and "Digging for the Line" in direct address
+> before you answer the question above. Go on, do it.
 
-- Take a second-person narrative passage.
-- Translate it into third person.
-- Translate it into first person.
-- Compare objectivity, intimacy, singer role, and universality.
-- Keep second person only if it does work the other versions cannot.
+The chapter also sets an un-numbered companion task under the heading "Back to
+Third-Person Narrative": *"As a further exercise, go back and try changing
+'Digging for the Line' into a third-person narrative."*
 
-Chapter 13 - Dialogue POV test:
+**EXERCISE 15** (Chapter 12) — the passage is Steely Dan's "Kid Charlemagne", and
+Pat supplies the first line of each translation:
 
-- Write a dialogue lyric seed in first-person narrative.
-- Rewrite it in direct address.
-- Rewrite it in third-person narrative.
-- Ask whose story it is.
-- Ask why the singer is telling it.
-- Keep the POV that makes the quoted lines feel most natural.
+> While the music played
+> You worked by candlelight
+> Those San Francisco nights
+> You were the best in town
+
+> Go ahead and translate it into third person:
+> While the music played
+> He worked by candlelight …
+> Finish it.
+> And now, translate it into first-person narrative:
+> While the music played
+> I worked by candlelight …
+> Finish it.
+
+Pat answers his own exercise, and then warns about the exit:
+
+> Which do you like better for "Kid Charlemagne"? Yup. I like second-person
+> narrative best here too. But a cautionary note: Don't dash out and turn all
+> your third-person narratives into second person. Beware of the hangman: Don't
+> tell facts to someone who should already know them!
+
+Chapter 13's two un-numbered tasks are quoted where they occur: the
+turn-this-dialogue-into-a-song prompt under
+[dialogue and POV](#dialogue-and-pov), and — after Pat swaps the narrator to the
+woman — *"Go back to the first version and make the rest of the changes."*
 
 ## Skill workflow
 
-When applying this file:
+Operational steps for this plugin, derived from the material above rather than
+printed by Pat. His own instruction is simpler and appears under
+[POV check](#pov-check): run the check once during the process and once at the
+end, on every lyric, reading aloud with the pronouns substituted.
 
 1. Ask who is singing, who is being addressed, and who the audience watches.
 2. Mark the pronouns in the user's draft.
@@ -477,48 +882,66 @@ When applying this file:
 
 ## Close-up vs middle distance — the cinematic metaphor
 
-Pat reframes POV as camera distance — a metaphor working songwriters
-remember faster than the technical taxonomy.
+<!-- corrected against the book: an earlier draft of this section (sourced to
+     patpattison.com / Berklee Online) assigned second-person narrative the
+     middle-distance shot and first-person narrative a "close-up on the
+     interior". Writing Better Lyrics (2009), Chapter 10 assigns the
+     middle-distance shot to FIRST-person narrative, and the printed camera-angle
+     figure places First Person Narrative on the objective side of Second Person
+     Narrative. The book wins. -->
 
-- **Direct address** is a close-up. Singer is inches from listener;
-  the song is intimate, urgent, present.
-- **Second-person narrative** is a middle-distance shot. Singer
-  watches a person they address as `you`; listener watches both.
-- **First-person narrative** is a close-up on the singer's interior.
-  Listener overhears.
-- **Third-person narrative** is a wide shot. Singer watches a scene;
-  listener watches with them.
+The camera metaphor is Pat's own, from Chapter 10, and every rung of it is
+printed in the book. In his words, not a summary:
 
-> "Direct Address is a close-up." — Pat (patpattison.com "POV")
+- **Direct address** — *"This is the close-up, the most intimate a song can be…
+  This is about feelings, not facts."*
+- **Second-person narrative** — no film term assigned; the printed scale puts it
+  one tick out from direct address, and Pat explains the position in Chapter 12:
+  its intimacy *"comes from its suggestion of direct address"* while we still
+  watch the character.
+- **First-person narrative** — *"In film terms, this is the middle-distance
+  shot."*
+- **Third-person narrative** — *"this is the long-distance, panoramic view. We,
+  the audience, are simply observing the song's world. We are not
+  participants."*
 
-Three load-bearing questions Pat returns to:
-
-> "Who is talking? To whom? Why?" — Pat
-
-Answer all three before drafting. A song that does not know its
-camera distance drifts between intimacy and observation and loses
-both.
+The questions to answer before drafting are the four Pat actually opens the
+chapter with, restored under [core idea](#core-idea): who is doing the talking,
+is it you personally, is it a character you're creating, and what should that
+character's relationship to the audience be.
 
 ## Audience-centering — the song is about them
 
-A counter-intuitive principle from Pat's interviews: the song is
-about the listener as much as the singer or addressee. The closer
-the camera, the more the listener participates.
+<!-- unaudited: non-book source (Berklee Online / interviews); paraphrase
+     retained. The blockquote that stood here was a paraphrase formatted as a
+     direct quotation and has been de-quoted; do not restore quotation marks
+     around it without the primary source. -->
 
-> "The song should, somehow, always be about them." — Pat
+Paraphrase, unverified against the four books: the song is about the listener as
+much as the singer or addressee, and the closer the camera, the more the
+listener participates. The reported gist is that a song should somehow always be
+about *them*.
 
-This is the why behind close-up preference for love songs: the
-listener becomes `you`. Middle distance keeps the listener
-watching; close-up puts the listener inside.
+The book does support the mechanism, in Chapter 10, where Pat lists the four
+things a listener does with a direct-address lyric — three of the four put the
+listener inside the song ("I imagine the singer is singing to me", "I can
+imagine that the singer is someone I know singing to me", "I can identify with
+the singer and sing to someone I know"). See
+[direct address](#direct-address) above for the passage in full.
 
 ## Direct address + present tense = maximum intimacy
 
-The single strongest intimacy combination Pat names:
+<!-- unaudited: non-book source (Berklee Online); paraphrase retained. The
+     blockquote that stood here was already labelled "paraphrased" inside
+     quotation marks — a fabricated quote — and has been de-quoted. -->
 
-> "Most intimacy lives in Direct Address and Present Tense." — Pat
-> (Berklee Online, paraphrased)
+Paraphrase, unverified: Pat is reported to name direct address plus present
+tense as the strongest intimacy combination. The tense half of that claim is
+**not** in Chapters 10-13; the closest the book comes is his "As Each Year Ends"
+comparison, where moving to third person lets the chorus sit in present rather
+than future tense — a point about overview of time, not about intimacy.
 
-Mechanism:
+Mechanism (derived, not Pat's printed words):
 
 - Direct address removes narrative distance.
 - Present tense removes temporal distance.
@@ -532,14 +955,22 @@ tense) loosens intimacy. Pull deliberately, not by accident.
 
 ## Pronoun-consistency anti-pattern
 
-Most common POV failure in love and address songs: singer switches
-between `you` (direct address) and `she`/`he`/`they` (narrative
-reference to addressee) mid-song. Each switch breaks intimacy.
+<!-- unaudited: non-book source (Berklee Online); paraphrase retained. The
+     blockquote here was explicitly labelled a paraphrase inside quotation marks
+     and has been de-quoted. The two named reference songs are from the same
+     unread article and are NOT verified. -->
 
-> "Talking to me and about me at the same time feels odd." — Pat
-> (paraphrase, Berklee Online)
+Paraphrase, unverified: the most common POV failure in love and address songs is
+a singer switching between `you` (direct address) and `she`/`he`/`they`
+(narrative reference to the same addressee) mid-song, on the reported grounds
+that being talked to and talked about at once feels odd.
 
-Diagnosis:
+Note the book's adjacent, verified rule, which is about pronoun *clarity* rather
+than consistency: converting "Digging for the Line" to third person forces the
+child to become *she*, because otherwise you *"have to make daddy's child she to
+keep the hes from getting all jumbled together."*
+
+Diagnosis (derived):
 
 1. Mark every pronoun in the lyric.
 2. For each, ask: does this `you` refer to the addressee, or has
@@ -557,26 +988,33 @@ Fixes:
   thinking out loud and the chorus as the singer turning to face
   the addressee.
 
-Reference cases (per Pat's Berklee article, not reproduced here):
-"I Only Have Eyes For You" preserves consistent direct address
-throughout (single mode, single intimacy plane). A widely-cited
-modern love hit was Pat's named negative example for pronoun
-bouncing across the same song.
+Reference cases, unverified and attributed to the same unread Berklee article:
+"I Only Have Eyes For You" is cited as preserving consistent direct address
+throughout, and an unnamed modern love hit as the negative example for pronoun
+bouncing. Neither song appears in Chapters 10-13 of *Writing Better Lyrics*
+(2009). Do not present either as Pat's example without checking the article.
 
 ## You as flexible English pronoun
 
-English `you` is singular and plural, formal and intimate, and can
-substitute for `one` or for `I`. Second-person narrative trades on
-the flexibility — listener hears the address as personal, universal,
-or singer-to-self.
+This one is book-grounded and needs no outside source. Pat establishes each job
+of `you` in the text; all three passages are quoted in full earlier in this
+file:
 
-> "You is plural, singular, can stand in for one or I." — Pat
-> (paraphrase, patpattison.com)
+1. **Singular and plural at once** — *"In English, there is no difference between
+   singular and plural you, unless we resort to y'all or youse as plural forms,
+   both forms intended as sophistications in a barren language that forgot to
+   make the distinction."* (Chapter 10 — see [direct address](#direct-address))
+2. **A stand-in for `one`** — *"Part of it works like using you as a substitute
+   for one."* (Chapter 12 — see
+   [how second-person narrative works](#how-second-person-narrative-works))
+3. **A stand-in for `I`, or an internal command** — *"C'mon, can't you be clear
+   for once?"* / *"C'mon, be clear for once!"* (Chapter 12 — see
+   [internal second person](#internal-second-person))
 
-This is why a second-person narrative song often produces multiple
-legitimate readings: listener picks the one that fits their
-situation. Use the ambiguity deliberately; do not flatten unless
-the song needs a single reading to land.
+The earlier claim that `you` is also *formal and intimate* is not something Pat
+says; his printed distinction is number, not register. What he does say is that
+the intimacy comes from the *suggestion* of direct address, and that the payoff
+of the ambiguity is the listener saying *"This character could easily be me."*
 
 ## Cross-references
 

--- a/plugins/songwriting/context/pat-pattison/research/point-of-view.md
+++ b/plugins/songwriting/context/pat-pattison/research/point-of-view.md
@@ -7,9 +7,17 @@ should use I/you/he/she/they, why a draft feels distant or too exposed, or how
 to rewrite the same lyric from another camera distance.
 
 Quoted material is Pat's printed text, reproduced verbatim from *Writing Better
-Lyrics* (2009). Complete third-party song lyrics are not reproduced; where Pat
-prints a full lyric, this file keeps the excerpt his point turns on and names
-the song, and the writers where Pat names them.
+Lyrics* (2009), including the lyrics he analyses, as he prints them. Songs are
+named, with their writers where Pat names them — several carry no writer credit
+in his text or on the permissions page, and none is invented here.
+
+An earlier pass imposed a "complete third-party song lyrics are not reproduced"
+rule and cut the lyrics down to fragments. **That rule was never the repo
+owner's and has been revoked** — he owns all four books and keeps this as a
+personal reference. Sibling files such as `box-model.md` already reproduce the
+lyrics Pat works with in full; this file is being brought into line with them.
+**Some excerpts here are still short and are a known remaining gap, not a
+policy.**
 
 Source images inspected:
 
@@ -342,6 +350,9 @@ speaks to the image of someone in his past"*:
 > Becky Rose, you stole the night
 > Body dark, a sash of light
 > Soft you slippered from my bed
+> Not to wake me, dressing slow
+> How I watched I still don't know
+> I should have knelt and bowed to you instead
 
 > Even though Becky Rose is not in the singer's presence, it's still pretty
 > intimate stuff.

--- a/plugins/songwriting/context/pat-pattison/research/repetition.md
+++ b/plugins/songwriting/context/pat-pattison/research/repetition.md
@@ -62,26 +62,61 @@ Chapter 9's worked refrain is *He lost the human race* — a good line, double
 meaning and all, which then refuses to sit under a future-tense verse (*He'll
 tilt his head one final night*). The three strategies applied to it:
 
-| Strategy | Chapter 9's version | Effect |
+| Strategy | Chapter 9's version | What Pat says it does |
 | --- | --- | --- |
-| `-ing` form | Losing the human race | Accepts past, present, or future context. |
-| Infinitive | To lose the human race | Points toward action without committing to time. |
-| No verb | A loss in the human race | Turns the repeat into a commentary or image. |
+| `-ing` form | Losing the human race | "the neutralized refrain accepts any tense" |
+| Infinitive | To lose the human race | Same — Pat gives the infinitive **no distinct effect**; he says only "whichever results you like better, the `-ing` form or the infinitive, it's nice to have the option" |
+| No verb | A loss in the human race | "it makes the refrain sound like a commentary" |
+
+Pat's closing instruction on the three: **"Always try all three options. Use
+whichever feels best."**
 
 Pat's rules for each: with `-ing`, omit any helping verbs (*losing*, not *is
 losing* / *was losing* / *will be losing*), and don't confuse the verb form with
 a participle (*a losing strategy*) or a gerund (*losing builds character*). With
 the infinitive, omit the main verb — *to lose*, not *I hate to lose*.
 
-The verse it has to survive, in all three tenses:
+The original, tense-locked:
 
 ```text
 Exploding from the starting blocks
-Again he set / sets / he'll set the pace
+Again he set the pace
+Though he was crowned by laurel wreaths
+As thousands cheered he came to grief
+He lost the human race
+```
+
+The `-ing` refrain under Pat's three printed tense settings — same last line
+every time:
+
+```text
+Past tense
+
+Exploding from the starting blocks
+Again he set the pace
 Though he was crowned by laurel wreaths
 As thousands cheered he came to grief
 Losing the human race
+
+Present tense
+
+Exploding from the starting blocks
+Again he sets the pace
+Although he's crowned by laurel wreaths
+As thousands cheer he comes to grief
+Losing the human race
+
+Future tense
+
+Exploding from the starting blocks
+Again he'll set the pace
+Though he'll be crowned by laurel wreaths
+As thousands cheer he'll come to grief
+Losing the human race
 ```
+
+Pat then runs the same three tenses again with *To lose the human race* and
+again with *A loss in the human race*.
 
 > Always try all three options. Use whichever feels best.
 
@@ -110,13 +145,45 @@ race* does the same double duty — no verb tense, no pronoun — and the chapte
 proves it by running the identical refrain under five different verse POVs:
 
 ```text
-Again I set the pace     … As thousands cheer I'll come to grief
-Again we set the pace    … As thousands cheer we'll come to grief
-Again you set the pace   … As thousands cheer you'll come to grief
-Again she sets the pace  … As thousands cheer she'll come to grief
-Again they set the pace  … As thousands cheer they'll come to grief
+First person (singular)
 
-                         Losing the human race
+Exploding from the starting blocks
+Again I set the pace
+Although I'm crowned by laurel wreaths
+As thousands cheer I'll come to grief
+Losing the human race
+
+First person (plural)
+
+Exploding from the starting blocks
+Again we set the pace
+Although we're crowned by laurel wreaths
+As thousands cheer we'll come to grief
+Losing the human race
+
+Second person
+
+Exploding from the starting blocks
+Again you set the pace
+Although you're crowned by laurel wreaths
+As thousands cheer you'll come to grief
+Losing the human race
+
+Third person (singular)
+
+Exploding from the starting blocks
+Again she sets the pace
+Although she's crowned by laurel wreaths
+As thousands cheer she'll come to grief
+Losing the human race
+
+Third person (plural)
+
+Exploding from the starting blocks
+Again they set the pace
+Although they're crowned by laurel wreaths
+As thousands cheer they'll come to grief
+Losing the human race
 ```
 
 **Watch the third-person `-s`.** Pat's note on when you can skip verb
@@ -129,11 +196,20 @@ neutralization entirely:
 Which is why *And lose the human race* works under I / we / you / they. But it
 is tense-locked, not POV-locked, and breaks the moment a verse goes past:
 
+> Be careful, though. *And lose the human race* works only in present tense. If
+> you change to past, you're in trouble:
+
 ```text
+Third person (plural)
+
+Exploding from the starting blocks
+Again they set the pace
 Though they were crowned by laurel wreaths
 As thousands cheered they came to grief
-And lose the human race        <- wrong; needs "Losing the human race"
+And lose the human race
 ```
+
+> You'd need to neutralize the verb tense, too, back to *losing the human race*.
 
 Diagnose which coat you are stripping. Dropping pronouns fixes POV; only
 changing the verb form fixes tense.
@@ -149,6 +225,18 @@ We were still crazy after all these years
 
 > All three work fine. The result is a productive ambiguity that adds to the
 > spell of the lyric.
+
+Pat carries the same reading through the other two verses:
+
+> Verse two's possible interpretations of the refrain include: *I am still crazy
+> after all these years*, and *you are still crazy after all these years*. We can
+> almost hear the jukebox whispering "Hey fella, you're still crazy about her
+> after all these years." Again, the POV swabs multiple colors on the refrain,
+> creating depth. In the third verse, *my peers wouldn't convict me because I
+> would be still crazy after all these years*, or *they would be still crazy
+> after all these years*. I could cop a plea of insanity. They would understand,
+> being, as my peers, crazy themselves. Again, the neutral refrain contributes
+> productivity to the ambiguity.
 
 ## Verses show, chorus tells
 
@@ -387,10 +475,13 @@ Symptoms:
 Fix stagnant repetition by changing the development, not by changing the
 chorus words first.
 
-**Stagnation does not merely flatten the boxes — it can shrink them.** Chapter 6
-is explicit that stagnant boxes are the same size at best, and more likely lose
-weight, because boredom amplifies across repeats. A second chorus that merely
-repeats does not land neutrally; it lands weaker than the first.
+**Stagnation does not merely flatten the boxes — it can shrink them.**
+
+> The refrain suffers from the same disease as the verses: stagnation. Boredom is
+> amplified. The boxes, at best, are all the same size — they don't gain any
+> weight. More likely, the boxes lose weight. You can feel the letdown when you
+> get to the second and third boxes. You can only fix stagnation by developing
+> the ideas.
 
 **Polished language cannot fix it.** Chapter 6's demonstration is a sheriff
 song, written as bare prose summaries on purpose. Stagnant:
@@ -426,7 +517,8 @@ Box 1  The sheriff is the toughest man in town.
        Beware, beware. All hands beware.
 Box 2  He is very strong and has a fast gun.
        Beware, beware. All hands beware.
-Box 3  Everyone in town knows the sheriff is tough. They are afraid of him.
+Box 3  Everyone in town knows the sheriff is tough.
+       They are afraid of him.
        Beware, beware. All hands beware.
 ```
 
@@ -675,9 +767,11 @@ Will you love me?
 Love me.
 ```
 
-This works best in first or second person with present-tense or infinitive
-verbs. Third person often creates simple repetition rather than command because
-the verb form changes.
+Pat's limit on this is categorical, not a preference: "Remember that this
+technique only works in first person and second person, not third person" —
+third person adds an *s* to the verb, so you get simple repetition and no
+command. With past- or future-tense verbs, isolate the infinitive instead. Full
+matrices below.
 
 ## Repetition diagnosis
 
@@ -839,27 +933,57 @@ isolates the question or command underneath.
 
 ### Hidden questions — full grammatical matrix
 
-**Delete the interrogative pronoun, and KEEP the auxiliary.** The auxiliary is
-what makes the remaining fragment a question; deleting it destroys the effect
-rather than producing it. The deleted word is `who`, `what`, `when`, `where`,
-`why`, or `how`.
+Pat builds it one step at a time:
 
-The change in meaning is the point. The full question presupposes the action
-happens and asks for its object, place, reason, or method. The isolated
-fragment asks whether the action exists at all — a genuinely different and
-usually more exposed question.
+> Look at this question:
+>
+> Who do you love?
+>
+> It starts with one of the interrogative pronouns (who, what, when, where, why,
+> how). It also contains the auxiliary verb *do*. What if you drop *who*? It
+> becomes:
+>
+> Do you love?
+>
+> Now you've got a brand new question. Simply repeat that smaller piece:
+>
+> Who do you love? Do you love?
+>
+> You've isolated a part of the sentence and repeated it, giving a new meaning.
+> You can do it with the other interrogative pronouns, too:
 
-| Original (full question) | Hidden (interrogative pronoun deleted) | Effect |
-|---|---|---|
-| Who do you love? | Do you love? | Asks whether loving happens at all |
-| Where did you go? | Did you go? | Asks whether the leaving happened |
-| What will you try? | Will you try? | Asks whether the attempt will be made |
-| When will I know? | Will I know? | Asks whether knowing ever arrives |
-| Why do you laugh? | Do you laugh? | Asks whether the laughter is real |
-| How did you know? | Did you know? | Asks whether the knowledge existed |
+```text
+What do you love? Do you love?
+When do I love? Do I love?
+Where do you go? Do you go?
+Why do you laugh? Do you laugh?
+How do you know? Do you know?
+```
 
-The technique scales across tenses via the auxiliary — `do` / `did` / `will` —
-and across the subjunctive modals `can` / `could` / `should` / `would`:
+> The auxiliary verb *do* can also introduce a question. That's what makes it
+> work. You can do the same thing with the past and future tense, *did* and
+> *will*:
+
+```text
+Who did you love? Did you love?
+What did you try? Did you try?
+When did I know? Did I know?
+Where did you go? Did you go?
+Why did you laugh? Did you laugh?
+How did you know? Did you know?
+```
+
+```text
+Who will you love? Will you love?
+What will you try? Will you try?
+When will I know? Will I know?
+Where will you go? Will you go?
+Why will you laugh? Will you laugh?
+How will you know? Will you know?
+```
+
+> How about the subjunctive (can, could, should, would) with the interrogative
+> pronouns? Simply delete the pronoun:
 
 | Original | Hidden |
 |---|---|
@@ -867,6 +991,8 @@ and across the subjunctive modals `can` / `could` / `should` / `would`:
 | Who could you love? | Could you love? |
 | Who should you love? | Should you love? |
 | Who would you love? | Would you love? |
+
+> (I'll leave it to you to fill out the other interrogative pronouns.)
 
 The deletion creates a fragment the listener hears as both repetition AND new
 content. Chapter 6's real-world instance is Joni Mitchell's "Roses Blue," where
@@ -880,27 +1006,35 @@ And only with your laughter can you win
 Can you win? Can you win?
 ```
 
-> By simply isolating and repeating a portion of the line, *can you win*, she
-> moves from a declarative sentence into a question, creating new energy and
-> adding a new idea — in this case, the character's uncertainty whether winning
-> (laughter) is possible.
+> In the last two lines, by simply isolating and repeating a portion of the line,
+> *can you win*, she moves from a declarative sentence into a question, creating
+> new energy and adding a new idea — in this case, the character's uncertainty
+> whether winning (laughter) is possible.
 
 Nothing was added. The statement of the terms became a doubt about whether the
 terms can be met.
 
 ### Hidden commands — subject deletion
 
-A declarative with explicit subject can be reduced to a command by deleting
-the subject:
+Pat states the precondition, then runs it:
 
-| Original (declarative) | Hidden command (subject deleted) | Effect |
-|---|---|---|
-| You tell me that you want me. | Tell me that you want me. | Imperative emerges |
-| Tell me that you want me. | Want me. | Second pass; strips to the appeal |
-| You give me everything I need. | Give me everything I need. | Imperative emerges |
-
+> Declarative sentences (or "statements") often can be easy prey for productive
+> repetition. If the subject of the sentence is *you*, and the verb is present
+> tense, there's usually a command (imperative) lurking, waiting to be isolated:
+>
+> You tell me that you want me.
+>
 > Just delete the subject, isolating the verb, and presto, you have yourself a
-> command.
+> command:
+>
+> Tell me that you want me.
+>
+> And even:
+>
+> Want me.
+
+His second: "Try it with: *You give me everything I need.*" It becomes *Give me
+everything I need.*
 
 Note: **third-person cannot generate commands** because English third-
 person verbs take an -s. Pat's counterexample, run through the same two passes:
@@ -917,33 +1051,61 @@ The technique needs the bare verb base, which first and second person supply and
 third person does not.
 
 A second-person question hides a command the same way: `Will you love me?`
-reduces to `Love me.`
+reduces to `Love me.` Pat: "You can isolate commands from questions using
+second-person direct address."
+
+> Whenever you are working with present-tense verbs, look for the opportunity to
+> repeat, starting from the verb, to create a command. Remember that this
+> technique only works in first person and second person, not third person.
 
 ### Infinitive isolation — past and future
 
-Pat's extension: with a past- or future-tense verb, the command hides inside the
-INFINITIVE phrase, not the main verb. Isolate the infinitive and drop its `to`.
+> With past-tense or future-tense verbs, you can use the infinitive (*to*) form
+> of the verb, so the verb can be isolated, creating a present-tense command:
+>
+> Did (past) you want to win my heart? Win my heart.
+>
+> He loved (past) to walk alone. Walk alone.
+>
+> Won't (future) you try to walk alone?
+>
+> Try to walk alone.
+>
+> Walk alone.
+>
+> Neat, huh?
 
-| Original | Infinitive isolation | Tense effect |
-|---|---|---|
-| Did you want to win my heart? | Win my heart. | Past → present command |
-| He loved to walk alone. | Walk alone. | Past → present command |
-| Won't you try to walk alone? | Try to walk alone. → Walk alone. | Future → present, two-stage |
-
-The third row shows the staging the chapter demonstrates: the fragment can be
-isolated once, then isolated again, each pass shedding another layer and landing
-harder.
+The last example shows the staging: the fragment can be isolated once, then
+isolated again, each pass shedding another layer and landing harder.
 
 This is why the main verb's tense stops mattering — the infinitive carries no
 tense of its own, so the same surface fragment works after a past verse and a
 future one alike. That makes it the line-level counterpart of the chorus-level
 tense-neutralization above.
 
-**Moving between sentence types is itself the payoff.** Chapter 6 frames the
-gain as an energy boost: statement → question, or statement → command, lifts the
-emotion to a new level. The repetition is the vehicle; the change of sentence
-type is the cargo. A fragment that repeats without changing sentence type is
-just an echo.
+**Moving between sentence types is itself the payoff.**
+
+> When you move from one type of sentence to another, you create an energy boost
+> that takes the emotion to a new level. … When you're writing a song, stay alert
+> for chances to ask a question or give a command. It'll engage your listeners.
+
+The repetition is the vehicle; the change of sentence type is the cargo. A
+fragment that repeats without changing sentence type is just an echo.
+
+Pat closes the chapter by running the technique on his own prose:
+
+> In general, be alert to the smaller grammatical units in your lines.
+>
+> Sometimes they can do something really special.
+>
+> Do something really special.
+>
+> Would you like to be a better writer?
+>
+> Be a better writer.
+
+Those last four lines are the chapter's final words — Pat demonstrating both moves
+(statement → command, question → command) on himself.
 
 ### When to use
 

--- a/plugins/songwriting/context/pat-pattison/research/response-filter.md
+++ b/plugins/songwriting/context/pat-pattison/research/response-filter.md
@@ -121,8 +121,9 @@ the filter must catch this. See [mosaic-rhyme.md](mosaic-rhyme.md)
 
 **Anchor quote:**
 
-> "When you cheat the rhyme, you cheat the ear. The ear is the boss."
-> — Pat Pattison (recurring teaching, *Essential Guide to Rhyming* (2014))
+> "Never stop listening. If your ear says a sound is wrong, find another
+> rhyme. Trust your ears."
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 5
 
 ## §2 Line-writing filter
 
@@ -211,9 +212,9 @@ the risk live.
 
 **Anchor quote:**
 
-> "Sense-bound is universal. Generic is not."
-> — Pat Pattison (recurring teaching, *Writing Better Lyrics* (2009),
-> Chapter 1)
+> "Songs should be universal, but don't mistake universal for generic.
+> Sense-bound is universal."
+> — Pat Pattison, *Writing Better Lyrics* (2009), Chapter 5
 
 ## §3 Critique filter
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -41,7 +41,6 @@ the Pentad and read both surfaces off it — do not run two separate frameworks.
 > "Rhyme creates a sonic roadmap: it tells those eyeless ears where to
 > go and when to stop."
 > — Pat Pattison, *Essential Guide to Rhyming* (2014), Introduction
-> (paraphrased ≤25w)
 
 The "eyeless ears" framing is load-bearing. The listener cannot SEE the
 lyric. The rhyme structure tells them where the section is heading and

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-sonic-bonding.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-sonic-bonding.md
@@ -898,9 +898,10 @@ start by saying 'I want a word that sounds like the ocean and breaks my voice
 leading expressively.' But the selection process led him there. All you have to
 do is listen for prosody, then choose accordingly."
 
-> "Put yourself in situations where you have several alternatives, and,
-> provided that you understand how and why to pick, your writing will get
-> better." — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 8
+> "Moral: Put yourself in situations where you have several alternatives,
+> and, provided that you understand how and why to pick, your writing will
+> get better." — Pat Pattison, *Essential Guide to Rhyming* (2014),
+> Chapter 8
 
 > "Reasons for choosing. Choosing for reasons." — Pat Pattison,
 > *Essential Guide to Rhyming* (2014), Chapter 8

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
@@ -931,7 +931,9 @@ craft-vs-creativity question. Pat uses a Tiger Woods analogy
 (paraphrased): a golfer who knows every shot in the bag has more
 creative options on the course than one who only knows the driver.
 
-> "Craft prepares you to be creative." — Pat (*Essential Guide to Rhyming* (2014), Chapter 9)
+> "All craft. All technique. Craft prepares him to be immensely creative
+> with his shots." — Pat, on Tiger Woods (*Essential Guide to Rhyming*
+> (2014), Chapter 9)
 
 The lesson for rhyme: knowing all six rhyme types (perfect, family,
 additive/subtractive, assonance, consonance, partial) multiplies a

--- a/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
@@ -1,20 +1,23 @@
 # *Essential Guide to Lyric Form and Structure* (1991) Song-Form Worked Examples
 
 Pat Pattison - *Songwriting: Essential Guide to Lyric Form and Structure*
-(1991), Chapter 6. These are the densest pedagogy in *Essential Guide to Lyric Form and Structure* (1991) — four worked
-mechanism analyses on canonical songs that demonstrate verse/refrain,
-verse/chorus, verse/transitional-bridge/chorus, and verse/transitional-
-bridge/refrain.
+(1991), Chapter 6. These are the densest pedagogy in the book — four worked
+mechanism analyses on Pat's own demonstration lyrics, covering verse/refrain
+(A A B A), verse/chorus, verse/transitional-bridge/chorus, and
+verse/transitional-bridge/refrain.
 
-**What's here.** The four demonstration lyrics as Chapter 6 prints them,
-together with Pat's structural analysis of each. The analysis is about where
-specific stresses, rhymes, and phrase lengths fall, so the lines are quoted
-rather than described — a summary of a scansion argument is not usable.
+**What's here.** The four demonstration lyrics in full as Chapter 6 prints
+them, Pat's structural analysis of each in his own words, the content of the
+chapter's scansion and Song System figures (several of which carry material
+that appears nowhere in the running text), and Exercises 34-38 as printed.
+The analysis is about where specific stresses, rhymes, and phrase lengths
+fall, so the lines are quoted rather than described — a summary of a
+scansion argument is not usable.
 
-Everything under a "Coaching use" heading, the "Why the contrast works" block,
-and the "Common threads across all four" list are this file's own synthesis,
-not claims Chapter 6 makes. Where Pat's own framing is quoted or closely
-followed it is marked as his.
+Everything under a "Coaching use" heading, the "Why the contrast works"
+block, and the "Common threads across all four" list are this file's own
+synthesis, not claims Chapter 6 makes. Everything else is Pat's text as
+printed.
 
 ## Why this file exists
 
@@ -30,6 +33,37 @@ mechanism analyses, not just the form taxonomy.
 **Form:** verse/refrain. Each verse closes with a recurring refrain line
 that carries the title.
 
+Chapter 6 opens the whole discussion on the limerick, then generalizes:
+"In the same way you juggle the phrases of sections, you can learn to
+juggle sections to make Song Systems, or to make full lyrics. The same
+principles apply on each level." "Look at the principle behind the
+limerick":
+
+```text
+There once was a student named Esser
+Whose knowledge grew lesser and lesser
+It at last grew so small, he knew nothing at all
+And now he's a college professor
+```
+
+"The principle is simple" — printed as a four-step figure:
+
+```text
+1. STATEMENT OF STRUCTURE        A
+2. RESTATEMENT OF STRUCTURE      A
+3. VARIATION OF STRUCTURE        B
+4. RETURN TO ORIGINAL STRUCTURE  A
+```
+
+Of it he writes: "Repeating the
+structure of the first statement defines 'home base.' Moving away from home
+base at the third phrase creates tension — a move to unfamiliar territory.
+Coming back to familiar territory at phrase four is a resolution, a welcome
+home party."
+
+"Let's use the principle on a lyric that has only verses. Then we will add
+a Bridge. Here are the Verses":
+
 Verse 1:
 
 ```text
@@ -43,7 +77,33 @@ We got a lot to talk about
 THIS BOTTLE AND ME
 ```
 
-The refrain is the last two phrases; the hook is the last phrase alone:
+Verse 2:
+
+```text
+We started off all full of hope
+That things would work out fine
+But drinking from the loving cup
+We somehow missed the signs
+Sip by sip we used it up
+Now it's empty as can be
+We got a lot to talk about
+THIS BOTTLE AND ME
+```
+
+Verse 3:
+
+```text
+When the sun has set and I need a friend
+And there's no one else around
+I open up the cupboard
+Take this empty bottle down
+It's the last one I was drinking
+When my drinking made her leave
+We got a lot to talk about
+THIS BOTTLE AND ME
+```
+
+"This lyric has a REFRAIN" — and "Part of the Refrain is the HOOK":
 
 ```text
 We got a lot to talk about
@@ -52,16 +112,58 @@ THIS BOTTLE AND ME
 
 **Structural mechanics:**
 
-- Two systems of Common Meter per verse (4/3/4/3 stress, then 4/3/4/3 again)
-- Rhyme scheme: xaxa xbxb across the eight lines per verse
-- Refrain delivered at the verse's structural close, completing the b-rhyme
-- After line 4, the structure fragments — each half-verse becomes its own
-  small AABB-like unit, subdividing the verse into two smaller boxes
-- Forward motion: lines 1-4 build expectation; the refrain payoff lands at
-  the structural close, not at a chorus boundary
+"The Refrain is a part of the verse's phrase and rhyme structure." Pat
+diagrams verse 1 to show it (each 4-line half labeled A, rhyme letters at
+right):
+
+```text
+    We've been sitting here the whole night long   x
+A   Pouring out our hearts                         a
+    About how loving never ends the way            x
+    We felt it at the start                        a
+    ------------------------------------------------
+    And we'll sit right here 'till we decide       x
+A   What the next step ought to be                 b
+    We got a lot to talk about                     x
+    THIS BOTTLE AND ME                             b
+```
+
+"The rhythm of each verse goes twice through the basic Common Meter
+structure. Each verse rhymes xaxaxbxb."
+
+"The structure and the content of each verse fragment the section after
+line 4, making each of the three verses subdivide into two parts (1) A A,
+(2) A A, (3) A A. The Refrain in this lyric appears at the end of each
+verse."
 
 **Bridge variant (same song, Chapter 6 demonstration):**
-Pat keeps all three verses and inserts a bridge between verses 2 and 3:
+
+"Because of all the repetition of structure, this lyric gets boring fast.
+It needs a release from all the repetition. You could consider a Bridge in
+this situation. It would accomplish three things:
+
+1. It would break up the monotony of the same pattern. This will also set
+   up the last verse with a contrasting section.
+
+2. It would give different size Song Systems:
+
+   ```text
+   S1 { A
+   S2 { A
+          B
+   S3 {
+          A
+   ```
+
+   This breaks the repetition of the same size pattern. With only verses,
+   each Song System is the length of each verse. Adding a Bridge creates
+   another Song System that starts at the Bridge and ends when the last
+   verse closes.
+
+3. A Bridge would also give the verse ideas a chance to 'breathe' by moving
+   to a new angle or perspective. Here it is with a Bridge:"
+
+Verses 1 and 2 are unchanged; the Bridge falls between verse 2 and verse 3:
 
 ```text
 THIS BOTTLE AND ME will do all right
@@ -73,36 +175,67 @@ Struggle through another day
 Till another night comes rolling on
 ```
 
-The bridge is asymmetrical — **7 phrases** — and differs from the verses in
-both rhythm and rhyme. Its last four lines are still based on Common Meter;
-what changes is placed exactly where change is needed: the **first** line is
-a clear rhythmic departure, and the **last** line carries an extra stressed
-syllable that works as a rhythmic Deception, moving forward into the last
-verse's return to home base.
+"The Bridge is asymmetrical, containing 7 phrases. It is different from the
+verses in both rhythm and rhyme":
 
-It demonstrates all three *Essential Guide to Lyric Form and
-Structure* (1991), Chapter 6 bridge purposes point-by-point on a real song:
+```text
+This bottle and me will do all right    a
+We'll just stay right here together     x
+Waste away the night                    a
+Waiting 'till the morning comes         x
+And the ache is almost gone             b
+Struggle through another day            x
+'Till another night comes rolling on    b
+```
 
-1. **Break monotony** — bridge contrasts the established verse structure, and
-   sets up the last verse as a contrasting section
-2. **Different-size song system** — with only verses, every song system is one
-   verse long. Adding the bridge creates a system that starts at the bridge and
-   ends when the last verse closes, so the lyric stops running same-size units.
-   The claim is about the *system's* size, not the bridge's own phrase count
-3. **New perspective** — the bridge lets the verse ideas "breathe" by moving to
-   a new angle, rather than restating them
-
-This is the book's clearest demonstration of bridge function as a
-multi-purpose tool, not a structural slot.
+"Though the rhythm of the Bridge is based on Common Meter (especially in
+the last four lines), it is different where a difference needs to be made —
+in its first line where it is clearly a rhythmic departure; and in its last
+line where the extra stressed syllable is a rhythmic Deception. It moves
+forward to form the new Song System" — printed as a bracket enclosing the
+Bridge and Verse 3 together as one system. "The move into the last verse
+returns to home base, resolving the tension created by moving away."
 
 **Coaching use:** writer asking "what makes a refrain land?" — the
-fragmentation at line 4 + the b-rhyme delayed to the refrain are the
-mechanism. The refrain works because the structure withholds the b-rhyme
-across three preceding lines.
+mechanism is the fragmentation after line 4 plus rhyme placement. The
+diagram shows b opening at line 6 ("ought to be") and the refrain's last
+line closing it ("THIS BOTTLE AND ME"), so the refrain is not a withheld
+rhyme arriving late — it is the half-verse's own closure, landing on the
+title every time. The boredom that follows is exactly why Pat then adds
+the Bridge.
 
 ## "Southern Comfort" — Verse/Chorus (Chapter 6)
 
 **Form:** verse/chorus. Verse builds; chorus delivers.
+
+"If the A A B A song form works on the principle of the limerick, the
+simple Verse/Chorus form works on the principle of Common Meter (also
+called the 'Ballad Stanza')." Pat prints two anonymous examples:
+
+```text
+O Western Wind, when will thou blow
+That the small rain down can rain?
+Christ, that my love were in my arms
+And I in my bed again
+                            -- Anonymous
+
+The wind doth blow today my love
+And a few small drops of rain
+I never had but one true love
+In cold grave she was lain
+       -- From "The Unquiet Grave," Anonymous
+```
+
+"Again, the principle is simple":
+
+```text
+1. STATEMENT                       A
+2. NEW STATEMENT                   B
+3. RESTATEMENT OF #1'S STRUCTURE   A
+4. RESTATEMENT OF #2'S STRUCTURE   B
+```
+
+"Now look at a lyric that chains its elements together in the same way."
 
 Verse 1:
 
@@ -130,44 +263,133 @@ But there's no SOUTHERN COMFORT
 Unless you're in my arms
 ```
 
+Verse 2 (the chorus then repeats unchanged):
+
+```text
+Ruby-throated Whipporwills
+Gliding down the sky
+Evenings lonely on the porch
+You slip back on my mind
+SOUTHERN COMFORT after dark
+Helps me face the night
+But there's nothing to look forward to
+'Cept looking back to loving you
+```
+
+> **EXERCISE 34:** SCAN THE SECOND VERSE FOR RHYTHM AND LOOK AT ITS RHYME
+> STRUCTURE TO SEE IF IT IS PARALLEL TO THE FIRST VERSE. DO VERSE 2 AND THE
+> SECOND CHORUS FORM A SECOND SONG SYSTEM?
+
 **Structural mechanics:**
 
-- **Eight phrases in the verse**, rhyming `x a x a x a b b`. The first six lock
-  the ear into Common Meter; the seventh only continues the pattern
-- Nothing is withheld in phrase *count*. The eighth phrase **arrives** — and
-  refuses both the three-stress Common Meter close and the rhyme resolution
-  the first seven have trained the ear to expect. That refusal is the
-  **Deceptive Closure**
-- Pat scopes it precisely: the last phrase, and the last phrase alone,
-  unbalances the section. Any three-stress phrase in that position would have
-  balanced it
-- So the verse's last phrase points forward — it does not close
-- Chorus delivers the withheld three-stress closure AND the title's rhyme
-  payoff
-- Bridge (when present) is derived from a two-stress phrase hint already
-  planted in the song — bridge material has a structural seed, not a free
-  import. The song otherwise runs on 3- and 4-stress phrases; the quick
-  2-stress passes are `Southern evenings, / southern stars` in the verse and
-  `Tried the bedrooms, / tried the bars` in the chorus, both in non-resolving
-  positions. Pat takes the hint and opens the bridge on fast 2-stress
-  phrases, then builds into longer ones:
+"The rhythm of verse one is basically Common Meter for the first six
+phrases... By the time we get through the first six phrases we are locked
+into Common meter. The seventh phrase only continues the pattern... Surely
+everybody on the planet will expect a three-stress Common Meter close. Now
+that you have their attention, it is time for a little surprise... Both the
+rhythm and the rhyme structure unbalance the Verse with a Deceptive
+Closure." The verse's rhyme scheme is printed as:
 
-  ```text
-  Bar to bar
-  Face to face
-  Someone else takes your place
-  But no one's ever new
-  I always turn them into you
-  ```
+```text
+low        x
+trees      a
+magnolia   x
+breeze     a
+stars      x
+peace      a
+cry        b
+realize    b
+```
 
-**Why it works (Pat's framing):**
-Deceptive closure on a verse boundary spotlights forward direction — it
-"calls special attention to the forward direction of the Song System:
-'Makes me realize ... what?'" The ear has been trained to expect
-resolution at the verse's structural close;
-when resolution is withheld, the ear pushes into the next section. The
-chorus arrives carrying the withheld closure plus the title — a double
-spotlight.
+"The DECEPTIVE closure unbalances the Verse. It spotlights the last phrase
+and calls special attention to the forward direction of the Song System:
+'Makes me realize ... what?' The Verse has done its job: it has created a
+clear section, and has also pointed to where it wants to go."
+
+"The last phrase of this verse, and the last phrase alone, unbalances the
+section. It leaves you high and dry with your expectations for a
+three-stress closure unrequited. It is nice that the Verse leaves you
+wanting something, especially when the Chorus delivers it in spades."
+
+On the chorus: "With the exception of line 6, every line has three stresses.
+Line 6 has 2 phrases, accelerating at that point. The final two phrases
+return to three stresses. Any three-stress phrase would have balanced the
+verse! But the verse has refused to deliver. Not until you reach the Chorus
+('home base') do you hear what you wanted to."
+
+"The rhythm is not regular in the HOOK... So you have to wait for a
+repetition of the HOOK to balance the section rhythmically. The rhyme
+structure of the Chorus also gives us what we wanted in the verse but
+didn't get":
+
+```text
+comfort   x
+arms      a
+cure      x
+heart     a
+where     x
+bars      a
+comfort   x
+arms      a
+```
+
+"Both the rhyme and the rhythm deliver what the Verse set up: balance in
+rhyme and a three-stress last phrase. The Song System Closes. Motion is
+stopped." The Song System is bracketed as `Verse { Chorus`.
+**Adding a Bridge to "Southern Comfort":**
+
+"You have been through two Song Systems. The lyric ends here nicely. A B A B
+delivers a very effective punch. If you wanted to add more to the A B A B
+system above, you should probably think about a Bridge instead of another
+verse. As you saw in the A A B A song form, too much repetition gets boring
+fast. A Bridge would accomplish three things:
+
+1. It would break up the monotony of the same pattern. This will also move
+   into the last chorus from a new angle, a contrasting section.
+
+2. Assuming that the Bridge is shorter than the Verses (most of the time it
+   is), it would give you different sizes of Song Systems:
+
+   ```text
+        V              V              B
+   S1 {           S2 {           S3 {
+        CH             CH             CH
+   ```
+
+   This breaks the repetition of the same pattern. S1 and S2 are the same
+   size. S3 will be shorter, giving the Chorus a boost in interest when you
+   get to it 'early.'
+
+3. A Bridge would also give the idea a chance to 'breathe' by releasing to a
+   new angle or perspective."
+
+"How do you approach putting together a Bridge structure? Do you just start
+writing and see what happens? Probably not, since you need to write a
+contrasting section. You at least need to know not to write what you already
+have. So you look at what you have."
+
+"In SOUTHERN COMFORT the phrases are both 3-stress and 4-stress phrases,
+PLUS quick passes at 2-stress phrases in" `Southern evenings, / southern
+stars` "and in" `Tried the bedrooms, / tried the bars`. "Where 2-stress
+phrases have appeared, they have been in non-resolving places. I like the
+idea of taking the hint and developing it for the Bridge, at least to start.
+Here is my result":
+
+```text
+Bar to bar
+Face to face
+Someone else takes your place
+But no one's ever new
+I always turn them into you
+```
+
+"Start with fast 2-stress phrases (as you dive into the singles bar
+lifestyle) for contrast and a push forward. Now build the section into
+longer phrases, slowing it down until you realize (with a sigh at the
+futility of it all), 'But no one's ever new / I always turn them into you.'
+The final realization comes in the restated Chorus."
+
+> **EXERCISE 35:** WRITE A BRIDGE OF YOUR OWN FOR "SOUTHERN COMFORT."
 
 **Coaching use:** writer asking "how does my verse hand off to my chorus
 emotionally?" — the answer is structural, not poetic. Deceptive closure
@@ -178,7 +400,8 @@ withholding.
 ## "Teddy Doesn't Live Here Anymore" — Verse/Trans-Bridge/Chorus (Chapter 6)
 
 **Form:** verse / transitional bridge / chorus, repeated across three
-systems. Most complex worked example in *Essential Guide to Lyric Form and Structure* (1991).
+systems. The most complex worked example in *Essential Guide to Lyric Form
+and Structure* (1991).
 
 Song System 1 — two verse quatrains, transitional bridge, chorus:
 
@@ -206,6 +429,30 @@ The closing of the door
 TEDDY DOESN'T LIVE HERE ANYMORE
 ```
 
+Song System 2:
+
+```text
+Years go by like passing clouds      VERSE 3
+People soon forget
+But at a party in a crowd
+The girl he should have met
+
+She feels a longing, feels a pull
+From somewhere she can't see
+While Teddy from the other side
+Struggles to break free
+
+He cries, "Baby, it's so cold here   TRANS BR 2
+Won't you take me home?"
+She shivers as she turns away
+Leaves alone
+
+[CHORUS repeats unchanged]
+```
+
+(Chapter 6 prints the `VERSE 3` label once, against the first quatrain of
+System 2; the second quatrain carries no printed label of its own.)
+
 Song System 3 replaces the verse block entirely with a bridge:
 
 ```text
@@ -214,46 +461,142 @@ He couldn't see
 Where life ahead of him might lead
 He couldn't see at sweet sixteen
 What could have been
+
+It's a short ride to the dark side   CHORUS
+All the love he might have known
+Lost forever, left alone
+No one in the world could hear
+The closing of the door
+TEDDY DOESN'T LIVE HERE ANYMORE
+TEDDY DOESN'T LIVE HERE ANYMORE
 ```
+
+The final chorus repeats the hook line twice.
 
 **Structural mechanics:**
 
-- Three song systems: `S1 = V1 + V2 → TB1 → Ch`, `S2 = V3 + fourth quatrain
-  → TB2 → Ch`, `S3 = Bridge → Ch`. There is no third transitional bridge and
-  no verse in system 3 — the bridge takes the verse block's place
-- Verse 1 is a clear Common Meter opening that sets the pattern
-- V2 introduces irregular rhythm at the story's tension point — "Tonight
-  he'll find peace" puts two stressed syllables in a row, forcing an
-  irregular rhythm where a regular one was easy to write. The imperfect
-  rhyme "sleep/peace" defines the section but still lets it tip forward
-  into the transitional bridge
-- The transitional bridge runs **long to short**: its opening phrase
-  ("Crying 'Mama won't you listen!") is the longest phrase so far in the
-  lyric, the second is shorter, the third shorter and irregular, then the
-  coup de grâce. Exercise 36 asks the writer to reverse that direction
-- The bridge (system 3) is very unbalanced: three balanced 4-stress rhythms
-  ending two stresses short in the last line, with "just a whiff of rhyme"
-  in see/lead/teen/been. It starts fast, slows on the long second phrase,
-  and the last phrase floats away — like Teddy's chances for love
-- **The slingshot effect** — the longest phrase in the song system sits in
-  the chorus, immediately before the hook ("No one in the world could hear /
-  The closing of the door"). Pat: the long phrase is "the rubber of a
-  slingshot, stretching to give power to the release," and it should be
-  longer than the hook itself, since nothing else in the song sets up a
-  5-stress expectation
-- Hook (the title) lands with five stresses **for the first time in the
-  song**; the entire prior structure has been four-stress territory, so the
-  five-stress hook feels like an arrival the listener has been pulled
-  toward without knowing it
-- Chorus first phrase = a rhythm figure already set up in V2 and TB
+Three song systems: `S1 = V1 + V2 → TB1 → Ch`, `S2 = V3 (two quatrains) →
+TB2 → Ch`, `S3 = Bridge → Ch`. There is no third transitional bridge and no
+verse in system 3 — the bridge takes the verse block's place.
+
+Verse 1: "A clear Common Meter opening, setting the pattern."
+
+Verse 2: "By now you are ready for some 'Second Verse Strategy'" — the scan
+figure elides the first line to `Tonight it will be diff'rent`, which is how
+the 3-stress count works. "This
+verse is slightly unbalanced because of the last phrase. Two stressed
+syllables in a row force an irregular rhythm. Yet it would have been easy to
+write a regular rhythm" — the regular alternative he prints is only in the
+figure: `Tonight he'll find his peace` (adding "his" restores the
+alternation Pat deliberately refused). "The irregular rhythm creates tension
+at a place of strong tension in the ideas. Besides the Prosody, the
+unbalancing moves the section on, even though you know you are at the end
+of a section. The imperfect rhyme of 'sleep/peace' defines the section too,
+but still lets you feel the pull forward. So verse 2 tips forward into the
+Transitional Bridge."
+
+Transitional Bridge 1: "The opening phrase of the Transitional Bridge is the
+longest phrase so far in the lyric. The lyric slows down like it was walking
+through molasses. (Interesting, though: if the composer of the music chooses
+to, the song can actually accelerate here by squeezing this long phrase into
+a short space. The overall result of the squeeze could be a frantic feeling
+that matches Teddy's.)" Then: "The second phrase is shorter, and, with the
+four stresses of the first line, hints at Common Meter... The third phrase
+is even shorter, and, like the third phrase of verse 2, irregular... Finally,
+the coup de grace... You can feel the tension as the lines get shorter and
+Teddy's life closes, too abruptly, too early."
+
+> **EXERCISE 36:** REWRITE THE TRANSITIONAL BRIDGE SO THAT IT MOVES FROM
+> SHORTER PHRASES TO LONGER ONES. TRY TO MOVE IT EVEN FURTHER FROM THE VERSE
+> STRUCTURE BY CHANGING THE RHYME SCHEME. WHAT EFFECT DO YOU THINK THE X A X
+> A RHYME SCHEME HAS? HOW WOULD YOU HAVE DONE IT?
+
+Transitional Bridge 2: "After the two new verses, the second Transitional
+Bridge changes its content, but keeps in close parallel with the first...
+The third line ['She shivers as she turns away'] retains the same number of
+strong stresses as" — the comparison line is printed only in the figure:
+`He slides the seat back`, TB1's third phrase. "The additional unstressed
+syllables shiver quickly past and leave with her. The change forces the
+music to accelerate by stuffing syllables between the strong positions. In
+this case, the effect could be startling. Normally, though, keep your
+sections parallel."
+
+The Bridge (System 3): "This section seems very unbalanced: three balanced
+4-stress rhythms end two stresses short in the last line, with just a whiff
+of rhyme in 'see/lead/teen/been.' Scan it." The scan figure re-lineates the
+five printed lines into four rhythmic ones — the count Pat's "three balanced
+4-stress rhythms" claim depends on:
+
+```text
+Just sixteen. He couldn't see
+Where life ahead of him might lead
+He couldn't see at sweet sixteen
+What could have been
+```
+
+The first phrases "play off against the rhythms, grouping this way":
+
+```text
+Just sixteen
+He couldn't see where life ahead of him might lead
+```
+
+"The Bridge starts fast, then slows with the long second phrase. The last
+phrase sort of floats away. Like Teddy's chances for love."
+
+The Chorus, phrase by phrase: "The Chorus lands on a rhythm figure that has
+been carefully set up in Verse Two and the Transitional Bridge... It feels
+like 'home,' but is too unbalanced to let you rest. The internal rhyme
+accelerates and pushes you ahead into 'all the love he might have known,' a
+balanced 4-stress phrase that moves forward to seek a rhyme ['Lost forever,
+left alone']... Even with the rhyme, the section is still unbalanced here
+because of the odd number of phrases. Keep going... This is the longest
+phrase in the Song System" — 'No one in the world could hear / the closing
+of the door.' "Now we are ready for the release into the 5-stress Hook and a
+rhyme closure" — the hook, `TEDDY DOESN'T LIVE HERE ANYMORE` — "the most
+important and spotlighted phrase in the Song system."
+
+> **EXERCISE 37:** TRY SETTING UP THE HOOK BY USING SHORTER PHRASES INSTEAD
+> OF THE LONG PHRASE:
+>
+> ```text
+> No one in the world could hear
+> the closing of the door
+> ```
+>
+> Try to create a sense of arrival with your shorter phrases; make a couple
+> of tries:
+>
+> ```text
+> 1. (maybe try  / u / u / u ,  / u / u / )
+>    TEDDY DOESN'T LIVE HERE ANYMORE
+>
+> 2. ______________________________
+>    TEDDY DOESN'T LIVE HERE ANYMORE
+> ```
+>
+> The scansion hint on try 1 is printed only inside the figure — the running
+> text gives no template. It sets up two 3-stress trochaic phrases in place
+> of the single long phrase.
+
+**The slingshot:** "I think of the longer phrase as the rubber of a
+slingshot, stretching to give power to the release. It seems to me that it
+should be longer than the Hook, especially since there are no 5-stress lines
+to set up expectations for a 5-stress close."
 
 **The unstressed-syllable trick (Chapter 6):**
-The transitional bridge's opening phrase — `Crying "Mama won't you listen!`
-— is four stresses that **end on an unstressed syllable**, and that trailing
-weak syllable *implies* a fifth stress that never arrives. "Without knowing
-it, your listener is being set up for the only 5-stress phrase in the song:
-the HOOK!" The implication trains the ear; the chorus delivers it on the
-title.
+Of the transitional bridge's opening phrase — `Crying "Mama won't you
+listen!` — Pat writes: "This long phrase has another important effect:
+because it ends on an unstressed syllable, it implies a 5th stressed
+syllable." The figure makes the implied stress audible by writing it in as a
+parenthesized ghost word:
+
+```text
+Crying "Mama won't you listen (now)!
+```
+
+"Without knowing it, your listener is being set up for the only 5-stress
+phrase in the song: the HOOK!"
 
 **Coaching use:** writer asking "how do I set up a hook?" — the answer is
 not louder, not bigger. The answer is structural withholding plus
@@ -262,8 +605,8 @@ bridge imply a fifth stress; deliver the fifth stress on the title.
 
 ## "You Never Let Me Down" — Verse/Trans-Bridge/Refrain (Chapter 6)
 
-**Form:** verse / transitional bridge / refrain. Less common form. The
-contrast between verse and transitional bridge does the lifting.
+**Form:** verse / transitional bridge / refrain. Pat's setup: "Sometimes a
+Transitional Bridge leads, NOT to a separate Chorus, but to a Refrain."
 
 Song system 1:
 
@@ -281,21 +624,94 @@ YOU NEVER LET ME DOWN                         REFRAIN
 YOU NEVER LET ME DOWN
 ```
 
+Song system 2:
+
+<!-- Pat's printed lyric; period spelling is his, not a misspelling --><!-- spellchecker:off -->
+
+```text
+Tough kids growing up like we were brothers   VERSE 2
+Making trouble, barely making it through
+Quick hitch, Viet Nam was tougher
+I didn't worry, I was counting on you
+
+Fightin' dirty                                TRANS BR 2
+Might'a hurt me
+But you were always around
+
+YOU NEVER LET ME DOWN                         REFRAIN
+YOU NEVER LET ME DOWN
+```
+
+<!-- spellchecker:on -->
+
+Song system 3:
+
+```text
+You were so much more than a friend
+Again and again
+
+Those years flood back                        BRIDGE
+As I trace your name
+With those engraved
+On marble black, black and smooth
+Some things will never change
+I still lean on you
+
+No tears for times we shared together         VERSE 3
+Know you'd want it, I know you'd want it that way
+Slow years ticking by as I remember
+Touching you now makes them easy to face
+
+It's like you're still here                   TRANS BR 3
+I feel you so clear
+It's like you're always around
+
+YOU NEVER LET ME DOWN                         REFRAIN
+YOU NEVER LET ME DOWN
+```
+
 **Structural mechanics:**
 
-- Verse: long phrases, imperfect rhymes separated by distance
-  (strangers/aching, go/alone)
-- The contrasting section: "Short phrases. Quick rhymes." Pat groups
-  `They get you crawlin' / I might've fallen` as the pair that does it,
-  reaching back across the printed section break
-- Then the set-up — a 3-stress line, "But you were always around," which
-  supplies a sound for the hook to attach to (around/down)
-- Refrain closes the system down on the title
-- The contrast between verse and TB is the pedagogical point — not
-  similarity, not development, but **deliberate structural opposition**:
-  long phrases with distant imperfect rhyme → short phrases with quick rhyme
+"The difference between the Verse section and the next section is clear.
+The Verse moves in longer phrases, using imperfect rhymes separated by
+distance." The scanned verse is printed rhyming `a b a b`:
+
+```text
+Turned loose in a company of strangers            a
+Getting nowhere, we had nowhere to go             b
+Bad blues hit you harder when you're aching       a
+They won't leave you, they won't leave you alone  b
+```
+
+(The scansion figure prints "They won't leave you, they won't leave you
+alone"; the full lyric a few pages earlier prints "They never leave you,
+they'll never leave you alone." Both readings are as printed.)
+
+"Now, the contrasting section. Short phrases. Quick rhymes."
+
+```text
+They get you crawlin'
+I might've fallen
+```
+
+"and the set-up: 3-stress line and a sound for the HOOK to attach to: 'But
+you were always around' ... Leading to the Refrain: 'YOU NEVER LET ME DOWN'
+... And the Song System closes down on the title."
+
+> **EXERCISE 38:** CHANGE THE TRANSITIONAL BRIDGE OF "YOU NEVER LET ME DOWN"
+> SO IT FORMS AN UNBALANCED SECTION BY ITSELF. THEN DEVELOP THE CHORUS INTO
+> A SEPARATE SYSTEM.
+>
+> ```text
+> Trans Br: ______________________
+>
+> Chorus: ________________________
+> ```
 
 **Why the contrast works:**
+The contrast between verse and TB is the pedagogical point — not
+similarity, not development, but deliberate structural opposition: long
+phrases with distant imperfect rhyme → short phrases with quick rhyme.
 A transitional bridge whose only job is to set up a refrain has more
 freedom than one setting up a chorus. The refrain is short — it doesn't
 need the TB to ramp up massive structural energy. So the TB can be a pure
@@ -308,12 +724,16 @@ feel like two different speakers handing off.
 
 ## Common threads across all four
 
-1. **The form serves the title.** The title's stress count, vowel sound,
-   and phrase length determine the surrounding structure. Pat treats the
-   title as the song's structural seed, not its decoration.
-2. **Withholding is a primary tool.** Deceptive closure, delayed rhyme,
-   absent fifth stress, refrain after structural fragmentation — all four
-   examples deploy withholding as the primary forward-motion mechanism.
+1. **The form serves the title.** In all four, the structure around the
+   hook is built to deliver it — the refrain closes the half-verse on the
+   title, the chorus supplies the three-stress close the verse refused, the
+   5-stress hook lands after a 4-stress world plus a slingshot phrase.
+2. **Withholding drives forward motion — in three of the four.** Deceptive
+   closure in "Southern Comfort," the absent fifth stress in "Teddy," the
+   unresolved short-phrase pair in "You Never Let Me Down." The exception
+   is instructive: "This Bottle and Me" withholds nothing, closes every
+   verse cleanly, and Pat's own verdict is that it "gets boring fast" —
+   which is why the Bridge exists.
 3. **Implication is craft.** The unstressed-syllable trick in "Teddy"
    shows that implying a stress can be more powerful than delivering one.
 4. **Contrast is a tool, not a flaw.** "You Never Let Me Down"'s

--- a/plugins/songwriting/context/pat-pattison/research/stable-unstable-meta.md
+++ b/plugins/songwriting/context/pat-pattison/research/stable-unstable-meta.md
@@ -203,7 +203,7 @@ demonstrates it on Kevin Cronin's "Can't Fight This Feeling," and notes:
 A two-verse / chorus / verse / chorus draft where verse 1 lands fine but
 the chorus feels weak:
 
-- Central emotion: defiant relief after walking out.
+- Central intent, idea, and emotion: defiant relief after walking out.
 - Character: stable (resolved).
 - Verse 1: unstable (image-driven, fragments, family rhyme, suspended
   closure). Matches the "before-the-decision" moment. Verdict: supports.
@@ -222,7 +222,7 @@ The diagnosis names where to push. The fix is craft choices in the
 
 Use these when a writer says "something's off":
 
-- What is the central emotion in one phrase?
+- What is the central intent, idea, and emotion in one phrase?
 - Is that emotion stable or unstable in character?
 - For each section: is the lyric stable or unstable, and how do you know?
 - Where does the rhyme stability fight the lyric stability?
@@ -236,12 +236,30 @@ Use these when a writer says "something's off":
 - **Treating stable/unstable as a property of the writer's style** — it is
   a property of each lever, each section, each line. Reset per song.
 - **Defaulting all verses to unstable and all choruses to stable** without
-  checking the central emotion. Some emotions want a stable verse and an
-  unstable chorus.
+  checking the central intent, idea, and emotion. Some emotions want a stable
+  verse and an unstable chorus.
 - **Picking remote rhyme types because they sound fresh** without asking
   whether the moment wants more or less closure.
 - **Ignoring the tone-of-voice axis** because it cannot be seen on the
   page. Tone overrides typography.
+  <!-- unaudited: "tone of voice" returns 0 hits across all four books; this
+  axis is non-book (attributed to Berklee Online in prosody.md). Retained as
+  paraphrase, not presented as Pat's printed guidance. -->
+
+<!-- The "different tone of voice" coaching prompt above carries the same
+non-book caveat. -->
+
+## Provenance of this file
+
+Pat's printed text is quoted and cited. Two things here are **not** his and are
+marked inline: the **tone-of-voice axis** (non-book, attributed to Berklee
+Online in `prosody.md`; 0 corpus hits), and the **worked diagnostic**, which is
+this file's own applied example rather than a case Pat prints.
+
+A "central emotion" quote attributed to Pat was carried here for eight
+handoffs and is **fabricated** — 0 hits across all four books. It has been
+replaced with his real sentence from *Writing Better Lyrics* (2009), Chapter 18,
+and the phrase is now used in his wording, "central intent, idea, and emotion".
 
 ## Cross-references
 

--- a/plugins/songwriting/context/pat-pattison/research/stable-unstable-meta.md
+++ b/plugins/songwriting/context/pat-pattison/research/stable-unstable-meta.md
@@ -1,45 +1,62 @@
 # Stable / Unstable — the Song-Wide Diagnostic
 
-Pat Pattison — synthesized across *Songwriting: Essential Guide to Lyric Form
-and Structure* (1991, Chapter 3-5), *Pat Pattison's Songwriting: Essential Guide to
-Rhyming* (2014, Chapter 4-9), and Berklee Online "Prosody in Music and Songwriting"
-article. Pat extends stable/unstable from a rhyme tool to a diagnostic that
-covers every motion controller in a song.
+Pat Pattison — primary source *Writing Better Lyrics* (2009), Chapter 18
+"Prosody: Structure as Film Score" and Chapter 21 "The Great Balancing Act",
+with supporting material from *Songwriting: Essential Guide to Lyric Form and
+Structure* (1991), Chapters 1-3, and *Songwriting Without Boundaries* (2011),
+Challenge #4. Stable/unstable is Pat's own umbrella term: it is not a rhyme
+tool he extended, it is the lens he applies to every element of a section.
 
 Use this when a draft is "missing something" but the writer cannot name what.
 Stable/unstable is the meta-question that surfaces prosody mismatches without
 diagnosing rhyme, meter, form, or melody in isolation.
 
-> "Is this verse, stable or unstable? Is this line, stable or unstable?"
-> — Pat (Berklee Online "Prosody in Music and Songwriting")
+> "Looking at your sections through the lens of stability or instability is a
+> practical tool for creating prosody because you'll be able to use it for
+> every aspect of your song: the idea, the melody, the rhythm, the chords, the
+> lyric structure — everything. It governs the choices you make. Ask yourself:
+> Is the emotion in this section stable or unstable? Once you answer that
+> question, you have a standard for making all your other choices."
+> — *Writing Better Lyrics* (2009), Chapter 18
 
 ## Core idea
 
-Every craft element in a song is either creating stability (rest, closure,
-arrival, expectation met) or instability (motion, openness, suspension,
-expectation unmet). Five controllers carry the song's motion. Each can be
-stable or unstable independently. The combinations create prosody.
+Stability and instability are the practical lens Pat puts over prosody. In his
+words:
 
-A song's central emotion has a stability character. Stability of the writing
-should support that character, or push against it deliberately for tension.
+> "Every section of every lyric you write uses five elements — always the same
+> five elements — of structure. These elements conspire to act like a film
+> score and, in and of themselves, create motion. And motion always creates
+> emotion, completely independent of what is being said. Ideally, structure
+> should create prosody — support what is being said — strengthening the
+> message, making it more powerful."
+> — *Writing Better Lyrics* (2009), Chapter 18
 
-> "Everything in your song should be there for the same reason: to express
-> the central emotion." — Pat
+> "The elements all join together to support the central intent, idea, and
+> emotion of the work. Everything fits. Prosody: the appropriate relationship
+> between elements."
+> — *Writing Better Lyrics* (2009), Chapter 18 "Prosody: Structure as Film Score"
 
-## The five motion controllers
+## The five elements of structure
 
-| Controller | Stable when | Unstable when |
+Pat's list, verbatim: "number of lines / length of lines / rhythm of lines /
+rhyme scheme / rhyme type."
+
+<!-- Pat's scansion vocalization; not a misspelling --><!-- spellchecker:off -->
+
+| Element | Stable | Unstable |
 |---|---|---|
-| **Lyric** | Direct telling, fully closed clauses, declarative POV, present-tense statement | Image without telling, sentence fragments, suspended clause, conditional or interrogative |
-| **Melody** | Phrase ends on a tonic-family pitch, downbeat arrival, full cadence | Phrase ends on a non-tonic pitch, upbeat arrival, half cadence |
-| **Harmony** | Tonic chord, root-position triads, expected resolution | Non-tonic chords, inversions, deceptive resolution, suspensions |
-| **Melodic rhythm** | Long notes at line ends, downbeat hits, regular phrase length | Short notes at line ends, syncopation, irregular phrase length |
-| **Harmonic rhythm** | Chord changes at regular intervals (e.g., one per bar) | Variable chord-change spacing, fast harmonic motion under static melody |
+| **Number of lines** | Even — "solid, resolved, balanced, stable" | Odd — "off balance, unresolved, incomplete, unstable" |
+| **Length of lines** | "Two lines of equal length, because they're balanced, tell you to stop." | "Lines of unequal length, because they do not reach a point of balance, tell you to keep moving" |
+| **Rhythm of lines** | Regular — moves along in even groups of two (da DUM) | Variations that throw the pattern off kilter |
+| **Rhyme scheme** | Rhyme close together — "This sounds finished. It stops us. It feels resolved, stable." | Rhyme delayed or absent — "Now we feel the push forward"; no rhyme leaves "our ear ... a little lost" |
+| **Rhyme type** | Perfect rhyme — full resolution | Family, additive, subtractive, assonance, consonance — leaves things hanging |
 
-The lyric controller is the only one this skill works on directly. The other
-four are part of the music. The skill still needs them because the lyric's
-stability character has to fit, push against, or be deliberately mismatched
-with the other four.
+<!-- spellchecker:on -->
+
+Pat's caution on line length: "the length of a line is not determined by the
+number of syllables, but by the number of stressed syllables, because the
+number of stressed syllables helps determine the number of musical bars."
 
 ## Lyric stability levers
 
@@ -47,56 +64,61 @@ Lyric stability is not one thing. It is the sum of several smaller choices.
 
 | Lever | Stable | Unstable |
 |---|---|---|
-| Rhyme stability | Perfect / fully resolved | Family / additive / subtractive / assonance / consonance / partial |
-| Rhyme scheme | Couplets (aabb), full closure each pair | Alternating (abab), enclosed (abba), no rhyme |
-| Phrase count | Even (2, 4) | Odd (3, 5) |
-| Phrase length | Balanced sections (same lengths) | Unbalanced sections (different lengths) |
-| Rhythm | Regular meter, Common Meter, paired feet | Irregular stresses, deliberate variations |
-| Closure | Expected closure | Deceptive or unexpected closure |
-| Line ending | Period, full stop | Comma, dash, suspended |
-| Sentence structure | Complete declarative | Fragment, conditional, question |
-| Verb tense | Present indicative | Conditional, subjunctive, past habitual |
-| POV | Direct address, present tense | Narrative distance, past tense |
-| Tone of voice | Plain, even, settled | Urgent, breathy, broken, sneering |
+| Rhyme type | Perfect rhyme | Family, additive, subtractive, assonance, consonance |
+| Rhyme scheme | Couplets (aabb) — closes each pair | Alternating (abab), enclosed (abba), abbb, no rhyme |
+| Closure | Expected closure | Deceptive closure, unexpected closure |
+| Number of phrases | Even | Odd |
+| Length of phrases | Balanced (equal stress counts) | Unbalanced (unequal stress counts) |
+| Rhythm | Regular, paired feet | Deliberate variations that throw it off kilter |
 
-> "Tone of voice can change stability without changing a single word."
-> — paraphrase of Berklee article
+Pat's rule for the whole table, verbatim from *Songwriting: Essential Guide to
+Lyric Form and Structure* (1991), Chapter 1:
 
-The tone-of-voice lever matters because two recordings of the same lyric can
-have opposite stability. Sing the draft both ways. Stability is what reaches
-the listener, not what's printed.
+> "The answer is that unbalanced sections create a sense of forward movement,
+> while balanced sections stop the motion. Like a juggler, you rely on moving
+> and stopping to create special effects in your act."
+
+<!-- unaudited: tone of voice as a stability lever is not in any of the four
+books; "tone of voice" returns 0 hits across all four. Attributed to Berklee
+Online / Coursera material that has not been read. Source unverified. -->
+
+Unaudited (non-book) lever: tone of voice — two recordings of the same lyric
+can carry opposite stability, so sing the draft both ways.
 
 ## How to diagnose
 
 Ask the meta-question of each section, then of each line:
 
-1. **Name the central emotion** of the song in one phrase.
-2. **Decide whether it is stable or unstable in character.** A resigned lament
-   is stable. An anxious confession is unstable. A defiant breakup line is
-   stable but the moment before it is unstable.
-3. **For each section**, list its stable/unstable choices across the lever
-   table above. If you only have lyric in hand, the lyric levers are enough
-   to start.
-4. **For each line**, ask: is this line stable or unstable, and does that
-   match the emotion at that moment of the song.
-5. **Flag mismatches**. A stable lyric setting against an unstable central
-   emotion mutes the song. The opposite (unstable lyric on a stable emotion)
-   creates tension that may or may not be the point.
+1. **Ask Pat's question first**: "Is the emotion in this section stable or
+   unstable? Once you answer that question, you have a standard for making all
+   your other choices."
+2. **Walk the five elements** of that section — number of lines, length of
+   lines, rhythm of lines, rhyme scheme, rhyme type — and mark each stable or
+   unstable.
+3. **For each line**, ask the same question, and check the moment it sits in.
+4. **Flag the mismatches.** Pat's test case: "Baby, you're the answer to all
+   my prayers. I'll be with you forever. I'm your rock. You can count on me,"
+   said in an odd number of lines — "Do you trust this guy? I don't think so.
+   Something doesn't feel right — there's a mismatch between what is being
+   said and how it's put together, how it moves. Though the message promises
+   stability, the motion creates instability, which pulls the rug out from
+   under the narrator. It creates irony."
 
 Diagnosis output template:
 
 ```text
-Central emotion: <one phrase>
-Character: <stable | unstable | resigned-stable | anxious-unstable | mixed>
-
 Section: <verse 1 | chorus | etc.>
-- Lyric: <stable | unstable> because <levers>
-- Rhyme stability: <type + effect>
-- Phrase count and length: <balance state>
-- Verb tense: <state>
-- Closure: <expected | deceptive | unexpected>
-- POV: <direct | narrative | mixed>
-Verdict: supports / mutes / pushes-against central emotion
+Emotion in this section: <one phrase>  ->  <stable | unstable>
+
+- Number of lines:   <count> <even = stable | odd = unstable>
+- Length of lines:   <stress counts per line> <balanced | unbalanced>
+- Rhythm of lines:   <regular | variations, and where>
+- Rhyme scheme:      <aabb | abab | abbb | none> <stops | pushes forward>
+- Rhyme type:        <perfect | family | additive | subtractive |
+                      assonance | consonance> <resolves | hangs>
+- Closure:           <expected | deceptive | unexpected>
+
+Verdict: structure supports / fights / ironizes the emotion
 ```
 
 Repeat per section.
@@ -107,36 +129,74 @@ Three modes:
 
 1. **Match** — stability of writing aligns with stability of the emotion.
    The lyric "feels right" because nothing fights the meaning.
-2. **Mismatch (accidental)** — stability fights the meaning by accident.
-   A defiant breakup line with weak (unstable) rhyme on the title sounds
-   uncertain. A grieving verse in a bouncy regular meter sounds glib.
-3. **Mismatch (deliberate)** — stability fights the meaning to create
-   irony, distance, or pressure. A cheerful refrain on a despairing verse
-   is the classic case. The writer must be conscious of the choice.
+2. **Mismatch** — the structure contradicts the message, and the structure
+   wins. In "Can't Be Really Gone" the narrator's message is "look at the
+   evidence — it proves she'll be coming back," but Pat's reading of the
+   unstable five-line verse is: "the feeling we get from the unstable
+   structure (which is acting like a film score) is that he's wrong and
+   perhaps a bit hysterical or, at least, in denial."
+3. **Mismatch used on purpose** — the same move, chosen. "It creates irony."
 
-Pat's stance: accidental mismatch is the most common diagnosable problem.
-Most writers do not check stability deliberately, so most mismatches are
-accidents.
+Pat's framing of the whole question: "There are no rules, only tools." And on
+whether the original writer planned it — "So, did Gary Burr think about all
+this stuff as he wrote 'Can't Be Really Gone'? Maybe, maybe not. The important
+issue is: You can."
 
 ## Stability as section design
 
-The five controllers also work at section boundaries. Verses and bridges
-often want to be unstable (move forward). Choruses and refrains often want
-to be stable (arrive, rest, declare). The reverse exists, but the default
-shapes are durable.
+> "Writing lyrics is a high-wire act: The way you keep or lose your balance
+> makes all the difference to your audience. Sometimes a little aerial drama
+> may be just what you need to get and keep your listeners' undivided
+> attention.
+>
+> Here's a very simple balancing (or unbalancing) technique: Control the
+> number of phrases in your sections, and you can learn to keep or lose your
+> balance in just the right places.
+>
+> In general, assuming that phrase lengths are more or less equal, and the
+> rhyme scheme moves more or less evenly, an even number of phrases creates a
+> balanced section; an odd number, an unbalanced section."
+> — *Writing Better Lyrics* (2009), Chapter 21 "The Great Balancing Act"
 
-| Section | Default stability | Why |
+Pat's simplest case is bare repetition. Even number of phrases — stable:
+
+```text
+Your body is a wonderland
+Your body is a wonderland
+```
+
+Odd number — unstable:
+
+```text
+Your body is a wonderland
+Your body is a wonderland
+Your body is a wonderland
+```
+
+"Not a hard concept, but a very useful one." The same effect without
+repetition, in a three-phrase section:
+
+```text
+How am I to reach you
+When am I to touch you
+How am I to hold you
+```
+
+| Section | Default | Pat's reason, from the books |
 |---|---|---|
-| Verse | Unstable | Sets up, moves toward, develops |
-| Chorus | Stable | Arrives, declares, repeats |
-| Refrain | Stable | Anchors and closes |
-| Bridge | Unstable | Breaks pattern, opens for return |
-| Transitional bridge | Unstable | Pushes into chorus |
-| Prechorus | Mixed → leaning unstable | Builds tension into chorus |
+| Verse | Unstable | Developmental sections "move toward or depart from a CENTRAL SECTION" |
+| Chorus | Stable | "Because the Chorus is a CENTRAL SECTION — a place where ideas are completed — the end of the Chorus should stop forward motion. This creates the feeling of 'starting over again' in the next section." |
+| Refrain | Stable | Contains the CENTRAL IDEA; "the most balanced element in the lyric" |
+| Bridge / transitional section | Unstable | "Using an odd number of phrases to unbalance a section works wonders if you want to build up pressure, for example, in a transitional section between verse and chorus." |
 
-A verse that closes too hard (couplets + expected closure + present
-declarative) can flatten a chorus's arrival. A chorus that does not
-declare can sap a song's payoff.
+Quotes above from *Songwriting: Essential Guide to Lyric Form and Structure*
+(1991), Chapters 1 and 5.
+
+Pat's technique for pushing a second verse forward: "Make the first verse
+completely balanced, then unbalance the second verse by adding an extra
+phrase. This unbalancing will make it move forward into the chorus." He
+demonstrates it on Kevin Cronin's "Can't Fight This Feeling," and notes:
+"if you reverse the two verses, the motion stops."
 
 ## Worked diagnostic
 


### PR DESCRIPTION
Wave A of the Pat Pattison chapter audit: finish the five research files the
previous pass left incomplete, settle four unconfirmed leads, and fix an
extractor bug that had been silently corrupting every quoted stanza.

songwriting `0.8.5` → `0.8.6`. No skill bodies changed — this is research
context, the CHANGELOG and the version bump.

## The extractor bug is the headline, and it reaches back into #2183

`<br>` **carries attributes in these EPUBs.** They are Calibre-produced and
write line breaks as `<br class="calibre2"/>`, which a `<br\s*/?>` pattern does
not match. The tag-stripper then removed them, so **every lyric stanza arrived
as one run-together line** — `Losing the human raceFalling from heaven's
grace…`. Agents restoring those stanzas were **inferring the line breaks and
calling the result verbatim.** Fixed to `<br\b[^>]*>`.

This is a correctness bug, not a formatting one: **line count is what balance,
stability and scansion claims are about.** Re-verifying against the corrected
source immediately caught a real error — the stagnant sheriff Box 3 in
*Writing Better Lyrics* (2009) Chapter 6 is **two printed lines, not one**.

**The four spine/image invariants do not detect it.** All four passed cleanly
before and after. Future extractor gates need a stanza spot-check.

**Not fixed here, recorded for the verification wave:** the ~9,000 lines
restored in 0.8.5 were built with the buggy pattern and have not been
re-verified.

## What the sweep found

The paraphrase-only rule that #2183 revoked did not merely omit Pat's text — it
**replaced it with invented scaffolding**: "Use when" lists, bullet "tests",
checklists, named axes and failure-mode tables that read like craft guidance and
cite nothing. This is the most common fabrication form found and the most
dangerous, because it looks like the useful part.

Concretely, in five files:

- **`stable-unstable-meta.md`** — 201 lines, **seven** separate fabrications,
  including an invented "five motion controllers" table (`melodic rhythm` and
  `harmonic rhythm` return zero hits corpus-wide) and an epigraph falsely
  attributed to Berklee Online.
- **`box-model.md`** — a fabricated "Other named division axes" table, invented
  travelogue and same-color "tests", invented POV and tense bullets, and
  editorializing Pat never wrote.
- **`point-of-view.md`** — five invented "Use when" lists, an invented
  four-question "fact test", and a fabricated *One walks into the room* example.
- **`repetition.md`** — invented hidden-question/command matrices, a silently
  truncated quote, and a categorical rule softened into a preference.
- **`rhyme-types.md`** — an invented Pat quote ("Craft prepares you to be
  creative.") with zero corpus hits.

Everything above was replaced with Pat's actual printed text, or relabelled
unaudited where no book source exists. **No quote was invented for a source that
cannot be read** — `point-of-view.md`'s Berklee Online material was deliberately
left paraphrased and is now explicitly marked unaudited.

## The four leads, all settled

1. **`rhyme-types.md` "six rhyme types" — premise false.** The line already read
   "six" against a six-item list. Left unchanged. (The invented quote above was
   found while checking.)
2. **The "central emotion" `— Pat` quote — CONFIRMED FABRICATED**, zero hits
   across all four books.
3. **The 1991 consonance claim — CONFIRMED WRONG, narrowed not deleted.** Family,
   additive and assonance are genuinely absent; *Essential Guide to Lyric Form
   and Structure* (1991) Chapter 4 does name **Consonance Rhyme**.
4. **Exercise 8.7 — genuinely absent from print.** *Essential Guide to Rhyming*
   (2014) Chapter 8 runs 8.1-8.6, 8.8-8.10, verified against the **page scans**
   because a numbering gap is normally an omission detector. No edit needed.

## Figure-only content recovered

Several passages in 1991 Chapter 6 exist **only as images**, after a dangling
colon in the text — the AABA statement/restatement/variation/return table, the
S1/S2/S3 bridge diagrams, the ABAB ballad-stanza principle, and the
Working/Gambling/Panhandling box diagram for "One More Dollar".

## Verification

All green: `typos`, `markdownlint-cli2` (103 files), `lychee --offline`
(770 links), `check-changelog-parity.sh --check-bump`, `validate-plugins.sh`,
and the `Books? [1-4]` citation regression grep. `check-skill.sh` not run — no
skill body changed.

`_typos.toml` was **not** edited; the two new exceptions ("Viet Nam" in a
verbatim lyric, and a scansion strip) use the inline
`spellchecker:off` / `spellchecker:on` block form.

## Related

No linked issue.
