### PR TITLE
docs(hook-observability): scope a nonexistence claim to the surfaces searched

### DIFF
--- a/docs/conventions/hook-observability/README.md
+++ b/docs/conventions/hook-observability/README.md
@@ -170,13 +170,20 @@ melodic-software/claude-code-plugins#930.
   the `--verbose` flag, `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` for hook matcher counts, and
   `--include-hook-events` for the stream-json event feed.
 
-  What none of them is, is a **consumer-facing toggle that makes an ordinary hook's routine work
-  visible**. Each is either operator-driven debugging (`--debug`, the debug log level), a
-  transcript view the consumer must already have switched on, or a machine feed for a `-p` harness.
-  A plugin cannot assume any of them is active, and none changes where a hook must *put* its
-  message. So the rule stands unchanged — `statusMessage` and `systemMessage` are the surfaces a
-  fleet hook writes to — but it rests on "a plugin cannot depend on an operator's debug posture",
-  not on a nonexistence claim.
+  The rule this doc needs does not depend on what those surfaces are, only on what an author may
+  assume: **every one of them is off unless the consumer turned it on, and none of them changes
+  where a hook must put its message.** `Ctrl+O` is a keystroke the user presses; `--verbose` and
+  `--include-hook-events` are launch flags; `verbose` and `viewMode` are settings; the debug log
+  level is an environment variable. A plugin authored today cannot know which, if any, is active in
+  the session its hook runs in, and a hook whose output lands only in a channel the consumer may
+  never have enabled is not observable. So the rule stands unchanged — `statusMessage` and
+  `systemMessage` are the surfaces a fleet hook writes to — resting on **a plugin cannot assume the
+  consumer's view state**, not on any claim about which surfaces exist.
+
+  Recheck trigger: a Claude Code release that surfaces hook output on a channel active by default,
+  or that adds a hook-output field to the JSON output schema beyond the three in
+  [the three surfaces](#the-three-surfaces) — either would make the assumption above false and
+  reopen this bullet.
 
   > **Correction, 2026-08-11.** This bullet previously read "No native 'verbose hooks' toggle
   > exists in Claude Code," verified against a `hooks`-page fetch. The literal phrase "verbose
@@ -185,6 +192,14 @@ melodic-software/claude-code-plugins#930.
   > absence — the negative was scoped to the page searched and stated about the product. See
   > [upstream-drift, "Reading the basis"](../upstream-drift/README.md#reading-the-basis--the-fetch-route):
   > a claim of the form "X does not exist" has to name the surfaces searched.
+  >
+  > The counts above are illustrative of that error, not load-bearing: nothing in this doc's rules
+  > depends on how many pages carry the word. They are deliberately floored ("at least 13") and
+  > need no recheck — a count that only ever grows cannot falsify the point it illustrates. The
+  > one claim here that *is* load-bearing is the quoted `Ctrl+O` / `--verbose` sentence
+  > (basis: <https://code.claude.com/docs/en/hooks>, rung-1 raw-markdown read, 2026-08-11), and it
+  > argues **for** the rule rather than against it, so its recheck trigger is the one on the
+  > paragraph above.
 
 ## Conformance
 

--- a/docs/conventions/hook-observability/README.md
+++ b/docs/conventions/hook-observability/README.md
@@ -60,13 +60,17 @@ giving the whole scheme a documented home is a separate follow-up, tracked outsi
 **Also required — a hook that CHANGED the user's file content without being asked.** An autofix hook
 edits a file the user is working in, on the strength of an unrelated tool call, with no prompt and no
 diff. The harness's own signal for it is a generic "PostToolUse hook modified `<file>` after your
-edit (likely a formatter)" line that names no hook and shows no change — an observed harness string,
-not a documented one: it appears on no Claude Code docs page (checked across the corpus 2026-08-11).
-What the docs do settle, verified against
-<https://code.claude.com/docs/en/hooks> (fetched 2026-08-10), is the negative this rule needs: the three documented output channels
+edit (likely a formatter)" line that names no hook and shows no change — quoted from an observed
+session, not from a docs page, and load-bearing here only as an illustration of the shape such a
+notice takes. What the docs settle is the negative this rule actually rests on, verified against
+<https://code.claude.com/docs/en/hooks> (fetched 2026-08-10): the three documented output channels
 carry no file-change or diff surface, so a benign reflow and a wrong dictionary rewrite arrive
-identically. The person whose file was changed is the only one who can judge whether the change was
-correct, so **the hook must name what it changed on the user channel**, not only the agent one: what
+identically. Recheck trigger: a Claude Code release that adds a file-change or diff surface to the
+hook output schema — a fourth output field, or such a payload on one of
+[the three](#the-three-surfaces) — which would make this rule's disclosure requirement redundant.
+
+The person whose file was changed is the only one who can judge whether the change was correct, so
+**the hook must name what it changed on the user channel**, not only the agent one: what
 was rewritten, to what, where, and how to prevent it. This is a *narrow* addition to the scope above,
 and its boundary is content the user did not request — a hook that only *reports* (a lint finding, a
 suggested fix, a diagnostic) still belongs on `additionalContext` alone. The same cap discipline as

--- a/docs/conventions/hook-observability/README.md
+++ b/docs/conventions/hook-observability/README.md
@@ -60,8 +60,10 @@ giving the whole scheme a documented home is a separate follow-up, tracked outsi
 **Also required — a hook that CHANGED the user's file content without being asked.** An autofix hook
 edits a file the user is working in, on the strength of an unrelated tool call, with no prompt and no
 diff. The harness's own signal for it is a generic "PostToolUse hook modified `<file>` after your
-edit (likely a formatter)" line that names no hook and shows no change — verified against
-<https://code.claude.com/docs/en/hooks> (fetched 2026-08-10): the three documented output channels
+edit (likely a formatter)" line that names no hook and shows no change — an observed harness string,
+not a documented one: it appears on no Claude Code docs page (checked across the corpus 2026-08-11).
+What the docs do settle, verified against
+<https://code.claude.com/docs/en/hooks> (fetched 2026-08-10), is the negative this rule needs: the three documented output channels
 carry no file-change or diff surface, so a benign reflow and a wrong dictionary rewrite arrive
 identically. The person whose file was changed is the only one who can judge whether the change was
 correct, so **the hook must name what it changed on the user channel**, not only the agent one: what
@@ -161,10 +163,28 @@ melodic-software/claude-code-plugins#930.
   human-only-choice carve-out above; over-applying it to blocking paths or to advisory findings the
   model can act on is itself a conformance defect (redundant user noise, or misrouting
   agent-actionable content to the user channel).
-- **Not a UI feature.** No native "verbose hooks" toggle exists in Claude Code as of 2026-08-10
-  (confirmed against the same fresh fetch this doc cites) — `statusMessage` and `systemMessage`
-  are the sanctioned surfaces available today. An upstream feature request for a native
-  verbose-hooks UI toggle is tracked separately, outside this repo.
+- **Not a UI feature — but "no verbose surface exists" is the wrong reason.** Verbose surfaces do
+  exist and one of them carries hook output: "Async hook completion notifications are suppressed by
+  default. To see them, enable verbose mode with `Ctrl+O` or start Claude Code with `--verbose`"
+  (hooks reference, verified 2026-08-11). Alongside it are the `verbose` and `viewMode` settings,
+  the `--verbose` flag, `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` for hook matcher counts, and
+  `--include-hook-events` for the stream-json event feed.
+
+  What none of them is, is a **consumer-facing toggle that makes an ordinary hook's routine work
+  visible**. Each is either operator-driven debugging (`--debug`, the debug log level), a
+  transcript view the consumer must already have switched on, or a machine feed for a `-p` harness.
+  A plugin cannot assume any of them is active, and none changes where a hook must *put* its
+  message. So the rule stands unchanged — `statusMessage` and `systemMessage` are the surfaces a
+  fleet hook writes to — but it rests on "a plugin cannot depend on an operator's debug posture",
+  not on a nonexistence claim.
+
+  > **Correction, 2026-08-11.** This bullet previously read "No native 'verbose hooks' toggle
+  > exists in Claude Code," verified against a `hooks`-page fetch. The literal phrase "verbose
+  > hooks" appears on no page, but the word `verbose` appears across at least 13 Claude Code
+  > pages including four hook-related mentions on `hooks` itself. Absence from one page is not
+  > absence — the negative was scoped to the page searched and stated about the product. See
+  > [upstream-drift, "Reading the basis"](../upstream-drift/README.md#reading-the-basis--the-fetch-route):
+  > a claim of the form "X does not exist" has to name the surfaces searched.
 
 ## Conformance
 


### PR DESCRIPTION
No linked issue

## Summary

PR #2187 claimed, as a headline result, that reading complete raw pages made two negative claims assertable "for the first time". **One of them was wrong**, and wrong in the way negative claims usually are: I searched one page and stated the result about the product.

This corrects it. The rule it supports does not change; its justification does.

## Fix

### The claim that was wrong

`docs/conventions/hook-observability/README.md` read:

> **Not a UI feature.** No native "verbose hooks" toggle exists in Claude Code as of 2026-08-10 (confirmed against the same fresh fetch this doc cites)

The literal phrase "verbose hooks" does appear on no page. But `verbose` appears across **at least 13 Claude Code docs pages**, four of those mentions on `hooks` itself — and one is squarely on point:

> Async hook completion notifications are suppressed by default. To see them, enable verbose mode with `Ctrl+O` or start Claude Code with `--verbose`.

A verbose mode that reveals hook output is precisely what the bullet denied. Also present, none of it acknowledged:

| Surface | What it is |
| :-- | :-- |
| `verbose` setting | "Show full tool output instead of truncated summaries" |
| `viewMode` setting | `"default"` / `"verbose"` / `"focus"` |
| `--verbose` flag | Full turn-by-turn output; overrides `viewMode` |
| `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` | Hook matcher counts and query matching |
| `--include-hook-events` | Hook lifecycle events in the stream-json feed |

### Why the rule still stands

None of those is a **consumer-facing toggle that makes an ordinary hook's routine work visible**. Each is operator-driven debugging, a transcript view the consumer must already have switched on, or a machine feed for a `-p` harness. A plugin cannot depend on an operator's debug posture, and none of them changes where a hook must *put* its message.

So `statusMessage` and `systemMessage` remain the surfaces a fleet hook writes to, and no hook in the fleet changes. What changes is that the rule now rests on "a plugin cannot assume an operator's debug posture" instead of on a nonexistence claim that was false. A correct conclusion resting on a false premise is fragile — the next person to check the premise has reason to discard the conclusion with it.

### Second fix, same class

The same file attributed this to the hooks page:

> The harness's own signal for it is a generic "PostToolUse hook modified `<file>` after your edit (likely a formatter)" line

That string appears on **no** Claude Code docs page. It is an observed harness string, and the sentence read as though it had been verified against the page cited beside it. It is now labelled as observed, and the documented negative it sits next to — that the three output channels carry no file-change or diff surface — is kept and separately attributed, since that is the part the rule actually needs and it does hold.

## Verification

- `verbose` occurrence counts taken across the full raw-markdown corpus fetched via the rung-1 route in [`upstream-drift`, "Reading the basis"](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/upstream-drift/README.md#reading-the-basis--the-fetch-route): 13 pages carry it, `hooks.md` four times.
- The `Ctrl+O` / `--verbose` sentence quoted verbatim from `hooks.md`.
- "PostToolUse hook modified" and "likely a formatter" both return zero matches across every page in the corpus.

Gates: `check-contract-slice-prune` pass · `check-changelog-parity --check-bump` pass · `check-skill-portability` pass (no skill files in scope) · `markdownlint-cli2` 0 errors. Pure `docs/` change — no plugin version bump required.

## Related

- PR #2187 — introduced the claim this corrects, as one of its two advertised negatives
- PR #2185 — established the rung-1 fetch route; its gotcha "absence from one page is not absence" is what prompted re-checking my own merged work, and is what caught this
