### PR TITLE
fix(docs): a 200 is not the page you asked for, and an absence has a scope

### DIFF
--- a/docs/conventions/upstream-drift/CHANGELOG.md
+++ b/docs/conventions/upstream-drift/CHANGELOG.md
@@ -26,6 +26,9 @@ canonical name, or enforceability verdict changed.
   down.** 1.2.0 said a truncated read supports no absence claim; it never said a *complete* read of
   one page supports no claim about the product. Two moves break it: widening the subject (searching
   `hooks`, concluding "Claude Code has no X"), and searching a phrase rather than the capability.
+  It joins the binding list at the top of the section, which now states **three** rules rather than
+  two — the count is part of the normative text, so a reader can tell a binding rule from an
+  explanatory aside.
   Worked instance, verified on `hooks.md`: "verbose hooks" appears **zero** times while the same
   page documents enabling verbose mode with `Ctrl+O` or `--verbose` for async hook notifications,
   and `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` for matcher counts — so a phrase search licenses a

--- a/docs/conventions/upstream-drift/CHANGELOG.md
+++ b/docs/conventions/upstream-drift/CHANGELOG.md
@@ -4,6 +4,43 @@ Notable changes to the upstream-drift contract (SemVer). Changing a required par
 name, or an enforceability verdict is a major bump; additive guidance is a minor bump; docs-only
 clarification is a patch.
 
+## 1.3.0 — 2026-08-11
+
+Closes two holes in [§Reading the basis — the fetch route](README.md#reading-the-basis--the-fetch-route)
+that 1.2.0 left open, both found by the fleet using it. Additive guidance; no required part,
+canonical name, or enforceability verdict changed.
+
+- **A `200` does not mean you got the page you asked for, and 1.2.0's rung 1 implied it did.** The
+  rung guarded against truncation and against a channel that 404s, but not against a channel that
+  succeeds with the wrong page. A retired slug is silently aliased to its successor — no redirect,
+  no `Location`, no notice in the body: `slash-commands.md` returns `200` with 82,668 bytes titled
+  "Extend Claude with skills", **byte-identical to `skills.md`** (both SHA-256 `a833dd5c…`), with
+  `0` redirects reported (verified 2026-08-11). An invented slug still `404`s, so the aliasing is
+  specific to slugs that once existed. This failure outranks truncation: a term the *requested*
+  page owns comes back missing from a full, healthy-looking body, so the false absence carries
+  every outward sign of a good read. Identity is now part of rung 1, with two cheap checks —
+  confirm the slug against `llms.txt` (across ten slugs, the nine live ones appear as
+  `docs/en/<slug>.md` and only the aliased one does not), and read the body's first heading before
+  quoting it. A missing slug is a prompt to find the successor in the index and cite **that** slug.
+- **An absence claim now carries its scope, because the rung ladder only ever bounded one scope
+  down.** 1.2.0 said a truncated read supports no absence claim; it never said a *complete* read of
+  one page supports no claim about the product. Two moves break it: widening the subject (searching
+  `hooks`, concluding "Claude Code has no X"), and searching a phrase rather than the capability.
+  Worked instance, verified on `hooks.md`: "verbose hooks" appears **zero** times while the same
+  page documents enabling verbose mode with `Ctrl+O` or `--verbose` for async hook notifications,
+  and `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` for matcher counts — so a phrase search licenses a
+  false nonexistence claim from a complete read of the right page. An absence claim states the
+  corpus and the terms tried.
+- **Stated as its own rule because it is the reason to care: a sound conclusion on a false premise
+  is fragile, not safe.** The instance above kept its conclusion on a corrected premise
+  ([#2190](https://github.com/melodic-software/claude-code-plugins/pull/2190)); the next reader who
+  checks a false premise discards the conclusion with it.
+
+Both holes were found by the 2026-08-11 stamp re-verification
+([#2187](https://github.com/melodic-software/claude-code-plugins/pull/2187)) applying 1.2.0 at
+scale — the convention's own recheck discipline surfacing gaps in the convention, one release after
+it shipped.
+
 ## 1.2.0 — 2026-08-10
 
 Adds [§Reading the basis — the fetch route](README.md#reading-the-basis--the-fetch-route): a rung

--- a/docs/conventions/upstream-drift/README.md
+++ b/docs/conventions/upstream-drift/README.md
@@ -127,6 +127,10 @@ Two rules bind every read, whichever rung it comes from:
 - **A truncated read supports no absence claim, ever.** If the fetch stops short, say so and mark
   the item unverified. "Not in the response" is never "not on the page" — the reader cannot tell
   those apart, which is the entire failure this rung ladder exists to prevent.
+- **An absence claim names the page it was checked against, and reaches no further.** A term missing
+  from one page is missing from *that page*; the product may document it elsewhere, under other
+  wording. Searching one page and stating the result about Claude Code is the same false negative
+  one scope up — see [the scope of an absence](#the-scope-of-an-absence).
 
 ### The rungs
 
@@ -156,6 +160,74 @@ the general form belongs in this doc and those surfaces keep their page-specific
 **The `.md` channel is per-page, not universal.** `docpage-digest`'s profile records that a
 raw-markdown channel working for one doc can 404 for another, so a run verifies the channel for the
 page it is reading and drops a rung when it does not resolve.
+
+### A 200 does not mean you got the page you asked for
+
+A rung-1 fetch can return `200`, `text/markdown`, and a complete untruncated body that is
+**someone else's page**. A retired slug is silently aliased to its successor: no redirect, no
+`Location` header, no notice in the body. Verified 2026-08-11 —
+`https://code.claude.com/docs/en/slash-commands.md` returns `200` with 82,668 bytes whose first
+heading is `# Extend Claude with skills`, **byte-identical to `skills.md`** (both SHA-256
+`a833dd5c96b9b111de0daec5fc6436e210c8cdc009e51306d32438746db0b5a5`), while the rendered URL reports
+`0` redirects. This is not a catch-all: an invented slug (`nonexistent-page-xyz.md`) returns a clean
+`404`, so the alias is specific to slugs that once existed.
+
+The failure this produces is worse than truncation, because truncation at least yields text you can
+see is short. Here a search for a term the *requested* page owns comes back empty against a full,
+healthy-looking body — a false absence carrying every outward sign of a good read. **Absence is only
+ever assertable against a page whose identity was checked**, which makes identity part of rung 1
+rather than a nicety.
+
+Two checks, both cheap, and a run does them before it trusts a body:
+
+- **Confirm the slug is canonical against `https://code.claude.com/docs/llms.txt`.** It lists the
+  live pages, so a slug the index does not carry is retired or renamed — that alone flags the
+  alias. Verified across ten slugs on 2026-08-11: the nine live ones each appear as
+  `docs/en/<slug>.md`; `slash-commands` appears in no such entry (only an unrelated
+  `agent-sdk/slash-commands`), which is exactly the one that aliased.
+- **Read the body's own first heading before quoting it.** `skills.md` and a live `<slug>.md` both
+  say what they are on line 5. A heading that does not match the page you asked for ends the read;
+  a title that merely differs in wording from the slug does not (`sub-agents.md` is titled "Create
+  custom subagents", `costs.md` "Manage costs effectively" — both correct).
+
+A slug missing from `llms.txt` is not automatically a dead end: it may have been renamed, and the
+index is the place to find the successor. Fetch the successor and cite **that** slug, rather than
+the retired one that happens to still serve bytes. Because the alias is silent, an unchecked
+citation of a retired slug keeps working indefinitely while pointing somewhere its author never
+read — and the day the alias is dropped it becomes a `404` on a claim nobody re-derived.
+
+Credit where the fleet found it: this surfaced in the 2026-08-11 stamp re-verification
+([#2187](https://github.com/melodic-software/claude-code-plugins/pull/2187)), where a per-page
+channel check noticed `slash-commands.md` serving `skills` content and recorded that a `200` is not
+proof the page is the one you wanted.
+
+### The scope of an absence
+
+A verified absence is a fact about **the text searched**, never about the product. Two moves break
+it, and both produce a claim that reads as researched:
+
+- **Widening the subject.** Searching `hooks` and concluding "Claude Code has no X" asserts
+  something about every page not searched. The honest form names the corpus: "not documented on
+  `hooks`", or — if the sweep really covered the index — "not documented on any page listed in
+  `llms.txt` as of `<date>`", which is a much larger and much more expensive claim.
+- **Searching the phrase instead of the capability.** A literal string can be absent while the
+  thing it names is documented in other words on the same page. Worked instance, verified
+  2026-08-11 on `hooks.md`: the phrase "verbose hooks" appears **zero** times, yet the page itself
+  documents "Async hook completion notifications are suppressed by default. To see them, enable
+  verbose mode with `Ctrl+O` or start Claude Code with `--verbose`", and separately
+  "set `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` to see additional log lines such as hook matcher
+  counts and query matching". A phrase search would have returned nothing and licensed "no verbose
+  hooks toggle exists" — false, from a complete, untruncated read of the right page.
+
+So an absence claim states the corpus and the terms tried, and a claim that a *capability* is
+missing searches the capability's plausible vocabulary, not one phrasing of it. This bit the fleet
+for real: the same 2026-08-11 sweep advertised a nonexistence claim of exactly this shape and
+withdrew it on re-check ([#2190](https://github.com/melodic-software/claude-code-plugins/pull/2190)).
+The conclusion it supported survived on a different premise — worth stating as its own rule, since
+it is the reason to care: **a sound conclusion resting on a false premise is not safe, it is
+fragile**, because the next reader who checks the premise discards the conclusion with it. Fix the
+premise and keep the conclusion; never keep a premise because the conclusion it props up is
+convenient.
 
 ### The mirror rung and its freshness step
 

--- a/docs/conventions/upstream-drift/README.md
+++ b/docs/conventions/upstream-drift/README.md
@@ -120,7 +120,7 @@ manufactures drift that is not there. `env-vars` produced exactly that false neg
 independent fetches, each stopping before the `CLAUDE_CODE_MAX_*` range and each reporting those
 rows missing ([#2182](https://github.com/melodic-software/claude-code-plugins/pull/2182)).
 
-Two rules bind every read, whichever rung it comes from:
+Three rules bind every read, whichever rung it comes from:
 
 - **No verbatim quote, no claim.** A record's basis is the text, not a paraphrase of it. A verdict
   of "current" states the quoted span it matched.


### PR DESCRIPTION
No linked issue

## Summary

`upstream-drift` 1.2.0 shipped the fetch route yesterday ([#2185](https://github.com/melodic-software/claude-code-plugins/pull/2185)).
[#2187](https://github.com/melodic-software/claude-code-plugins/pull/2187) applied it across 327
stamps today and surfaced **two holes in it**. Both are the route's own failure mode — a false
absence carrying every outward sign of a good read — one scope up from where 1.2.0 drew the line.

This is the convention's recheck discipline finding gaps in the convention, one release after it
shipped. `upstream-drift` 1.2.0 → 1.3.0, additive; no required part, canonical name, or
enforceability verdict changed. Pure `docs/`, so no plugin bump.

## Fix

### Hole 1 — a `200` does not mean you got the page you asked for

1.2.0's rung 1 guarded against truncation and against a channel that 404s. It did not guard against
a channel that **succeeds with the wrong page**. A retired slug is silently aliased to its
successor — no redirect, no `Location`, no notice in the body:

| Probe | Result |
|---|---|
| `slash-commands.md` | `200`, `text/markdown`, 82,668 bytes, first heading `# Extend Claude with skills` |
| `skills.md` | `200`, `text/markdown`, 82,668 bytes, same heading |
| SHA-256 of both | `a833dd5c96b9b111de0daec5fc6436e210c8cdc009e51306d32438746db0b5a5` — **byte-identical** |
| Rendered `slash-commands` | `200`, `num_redirects: 0` |
| `nonexistent-page-xyz.md` | `404` — so this is **not** a catch-all; aliasing is specific to slugs that once existed |

**This outranks truncation as a failure.** Truncation at least yields text you can see is short.
Here a search for a term the *requested* page owns comes back empty against a full, healthy-looking
body. Identity is therefore now part of rung 1, with two cheap checks:

- **Confirm the slug against `llms.txt`.** Verified across ten slugs: the nine live ones each
  appear as `docs/en/<slug>.md`; `slash-commands` appears in no such entry (only an unrelated
  `agent-sdk/slash-commands`) — exactly the one that aliased. A mechanical detector, not a judgment
  call.
- **Read the body's first heading before quoting it.** A heading that does not match the page you
  asked for ends the read. A title merely *worded* differently from the slug does not —
  `sub-agents.md` is titled "Create custom subagents", `costs.md` "Manage costs effectively"; both
  are correct pages.

A missing slug is not a dead end — it is a prompt to find the successor in the index and cite
**that** slug. Left unchecked, a citation of a retired slug keeps working indefinitely while
pointing somewhere its author never read, then becomes a `404` on a claim nobody re-derived the day
the alias is dropped.

### Hole 2 — an absence claim now carries its scope

1.2.0 said a truncated read supports no absence claim. It never said a **complete** read of one page
supports no claim about the product. Two moves break it:

- **Widening the subject.** Searching `hooks` and concluding "Claude Code has no X" asserts
  something about every page not searched. The honest form names the corpus: "not documented on
  `hooks`" — or, if the sweep genuinely covered the index, "not documented on any page listed in
  `llms.txt` as of `<date>`", a far larger and more expensive claim.
- **Searching the phrase instead of the capability.** Verified on `hooks.md`: the phrase
  "verbose hooks" appears **zero** times, while the same page documents

  > Async hook completion notifications are suppressed by default. To see them, enable verbose mode
  > with `Ctrl+O` or start Claude Code with `--verbose`.

  and separately

  > set `CLAUDE_CODE_DEBUG_LOG_LEVEL=verbose` to see additional log lines such as hook matcher
  > counts and query matching

  A phrase search returns nothing here and licenses "no verbose hooks toggle exists" — false, from a
  complete, untruncated read of the *right* page.

Stated as its own rule because it is the reason to care: **a sound conclusion resting on a false
premise is fragile, not safe.** The instance above kept its conclusion on a corrected premise
([#2190](https://github.com/melodic-software/claude-code-plugins/pull/2190)); the next reader who
checks a false premise discards the conclusion with it. Fix the premise and keep the conclusion —
never keep a premise because the conclusion it props up is convenient.

## Verification

Every claim above was re-derived here directly rather than taken on report, per the rule this
section states — a report of an absence is exactly the thing the convention says not to accept
second-hand:

- Both `.md` bodies fetched and hashed locally; `slash-commands`/`skills` identity confirmed by
  matching SHA-256, byte count, and first heading
- Redirect behavior probed with `curl -L -w '%{num_redirects}'` on the rendered URL
- `404` control run against an invented slug, establishing the alias is not a catch-all
- `llms.txt` fetched (187 `docs/en/` entries) and checked slug-by-slug across all ten
- `hooks.md` fetched in full; `grep -ic "verbose hooks"` → `0`, and all four `verbose` mentions read
  verbatim
- Nine live pages fetched to confirm the title-vs-slug check does not produce false positives

**Gates (committed tree, CI form):** `check-contract-slice-prune.sh --check-diff origin/main`,
`check-changelog-parity.sh --check-bump origin/main`, `check-skill-portability.sh`,
`check-shell-portability.sh` — all pass; `markdownlint-cli2` over both changed files — 0 errors.
Remaining gates: CI is the authority.

## Related

- [#2185](https://github.com/melodic-software/claude-code-plugins/pull/2185) — shipped the fetch
  route this patches
- [#2187](https://github.com/melodic-software/claude-code-plugins/pull/2187) — applied it at scale
  and found both holes
- [#2190](https://github.com/melodic-software/claude-code-plugins/pull/2190) — withdrew the
  over-scoped nonexistence claim that hole 2 generalizes
