### PR TITLE
feat(songwriting): close all four Pat Pattison books at 0.9.0

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -28,10 +28,12 @@ removed and 283 passages restored verbatim.**
 - **Two answer keys existed only as images** and are restored — 2014 Exercise
   8.1 (printed rotated 180°) and Exercise 8.3 item 1, which had been silently
   dropped.
+<!-- spellchecker:off -->
 - **1991 Chapter 7's scansion figures** (12 of them) transcribed from the page
   images. Figure `34C` carries a genuine printing discrepancy — its stress marks
   show three stresses where its DUM-da row shows four — **reproduced as printed,
   not corrected.**
+<!-- spellchecker:on -->
 
 ### Fixed — invented scaffolding, the dominant defect class
 
@@ -84,18 +86,31 @@ removed and 283 passages restored verbatim.**
   names no such principle. The neighbouring quote is genuine and was kept — its
   *form* was fixed (a partial quote stitched mid-sentence, now quoted in full).
 - **Mechanical verification:** every block-quoted sentence in `context/` was
-  tested against the full four-book corpus — **1,558 checked, 1,466 matched
-  verbatim.** The residual were adjudicated individually as artifact,
-  correctly-sourced non-book material, or defect.
+  tested against the full four-book corpus — **1,936 checked, 1,840 matched
+  verbatim.** All 96 residual were adjudicated individually by four fresh
+  agents prompted to *refute*, as artifact, correctly-sourced non-book
+  material, wrong-citation, or fabrication. Roughly half were checker
+  artifacts:
+<!-- spellchecker:off -->
+  hyphenation at a line break (`struc- tural`), a space eaten at a
+  break (`second-personnarrative`), a **drop cap**, U+2003 em-space
+  separators, `[[FIG:]]` splitting a sentence, and the 2014 hard-wrap.
+<!-- spellchecker:on -->
+  **The checker's own limits are recorded with it**, because they bound this
+  claim: it reads only `>` block-quotes, so tables, inline quotes and fenced
+  blocks are not covered — and two of the defects found in the verification
+  pass were bullet lists that could never have appeared on a quote list.
 
 ### Fixed — fabrication-by-correction, a defect class in the opposite direction
 
 - **The plugin had silently corrected Pat's typos.** 1991 Chapter 7 prints "your
   verbs will all already **by** POV neutral"; the file had it as "be". Confirmed
   a book typo in the raw XHTML, and restored with a do-not-correct note.
+<!-- spellchecker:off -->
 - Now marked as printed and protected from future "fixes": `swiftless`,
   `frictatives`, `Famly`, `Percy Bysshe **Shelly**`, `Ozymandius`, and "YOUR
   CHORUS YOU WROTE".
+<!-- spellchecker:on -->
 
 ### Fixed — citations
 
@@ -124,6 +139,35 @@ removed and 283 passages restored verbatim.**
 - **2011 Challenge 1's material**: the Chekhov epigraph, the *writus
   interruptus* passage, Group Writing, and the objectwriting.com contest
   provenance that explains the named sample writers.
+
+### Fixed — verification pass (four fresh agents, prompted to refute)
+
+- **`verse-development.md` claimed a nine-item "power positions" list.**
+  *Writing Better Lyrics* (2009), Chapter 7 prints **no such list** — only a
+  Moral naming **three** families. An eight-bullet "surprise positions" list had
+  four items absent from the chapter, and **Exercise 12 had been inflated from
+  one printed paragraph into six bullets**, two of which Pat never asks for.
+  `EXERCISE` returns zero hits in that chapter, so the file's ten step-lists are
+  now labelled as the file's own rather than Pat's.
+- **`rhyme-fundamentals.md` carried an invented compressed quote** — `"Rhyme is
+  like the accelerator pedal." — Pat`. Pat's printed text (1991 Chapter 4, "II.
+  PACE") is "Rhyme is like the accelerator in a car: the closer the accelerator
+  gets to the floor, the faster the car moves…". Restored in full.
+- **`lyric-melodic-roadmaps.md` hijacked one of Pat's terms** — it claimed "Pat
+  names this state explicitly" while redefining his 1991 term *through-written*,
+  which has 10 corpus hits all meaning something else. Also removed a fabricated
+  "Pat cites Lady Antebellum…" attribution and an invented "misses 80% of
+  mismatches".
+- **`metaphor.md` had an invented four-row Imagination/Fancy table** placed
+  directly beneath a real Coleridge quotation and contradicting the paragraph
+  below it; Pat's whole statement is one sentence about degree.
+- **`cliche.md`'s Exercise 10 was inflated from two steps to five**, and an
+  invented four-bullet "Use this test:" replaced Pat's actual two-part rule.
+- **`meter.md` carried a wrong scansion inside a fenced block** — figure
+  `image_rsrc30K` prints `Knowing no one else can see` as `/ u / u / u /`; the
+  file had `no`/`one` swapped. Caught only by rendering the figure at 12×.
+- **An editorial gloss sat *inside* a block quote in `song-forms-examples.md`**,
+  wearing Pat's voice. Moved out.
 
 ### Changed
 

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,137 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.0]
+
+**All four Pat Pattison books are now formally audited — 44 of 44 units.** This
+release closes the remaining 15: *Essential Guide to Lyric Form and Structure*
+(1991) Chapters 5 and 7, *Essential Guide to Rhyming* (2014) Chapters 1-9, and
+*Songwriting Without Boundaries* (2011) Challenges 1-4. **127 fabrications were
+removed and 283 passages restored verbatim.**
+
+### Fixed — charts and figures the EPUB text layer corrupts
+
+- **Pat's Vowel Triangle was wrong in both legs**, in two files. The figure is
+  printed as a **V with the apex `ä (papa)` at the bottom**; the text layer
+  hoists `ä` to the top and transposes vowels on each leg. Corrected against the
+  page scan to tongue leg `ä → ă (cat) → ĕ (end) → ĭ (it) → ē (me)` and lip leg
+  `ä → ŭ (up) → ŏ (hot) → oo (foot) → ū (too)`. **This is load-bearing:** family
+  assonance is defined as *one step* along a leg, so a transposition changes
+  which pairs count as adjacent. `rhyme-generation.md` had it worse — `ŭ (up)`
+  on the wrong leg entirely and `ă (cat)` missing. Both files now carry an
+  in-file warning against re-deriving it from text.
+- **The consonant chart (2014 Chapter 5) emits column-major as garbage.**
+  Transcribed from the scan. Nasals are a *single* row (all voiced), not a
+  voiced/unvoiced split.
+- **Two answer keys existed only as images** and are restored — 2014 Exercise
+  8.1 (printed rotated 180°) and Exercise 8.3 item 1, which had been silently
+  dropped.
+- **1991 Chapter 7's scansion figures** (12 of them) transcribed from the page
+  images. Figure `34C` carries a genuine printing discrepancy — its stress marks
+  show three stresses where its DUM-da row shows four — **reproduced as printed,
+  not corrected.**
+
+### Fixed — invented scaffolding, the dominant defect class
+
+- **127 fabrications removed across 30 files.** The recurring shapes: `Use when:`
+  lists, bullet "tests", `- [ ]` checklists, named axes, "Revision workflow"
+  step-lists, decision matrices, and round-number thresholds.
+- **Counts and category lists were the most reliable tell.** Corrected: a
+  five-item metaphor taxonomy where **Pat's count is three**; "Pat's four focus
+  questions" where he prints **six**; a seven-name transitional-bridge alias list
+  where the figure prints **six**; a seven-row clause table where he names
+  **five**; a four-bullet hot-spot list where he prints **three** levels; "six
+  rhyme types" under a heading whose printed scale has **five**.
+- **Round-number thresholds were invented without exception** — "3-5
+  candidates", "over 30 minutes", "5-15 per seed word", "removes ~30% of
+  AI-generated rhyme lists". `minutes` appears **zero times** in the entire 2014
+  book.
+- **A table that inverted its chapter's argument.** `rhyme-generation.md`
+  assigned each rhyme tier one fixed use-case; 2014 Chapter 9 argues every
+  effect is **position-conditional** — the same family rhyme lightens a push in
+  the dominant slot and softens a landing in the tonic slot. Replaced with Pat's
+  seven printed dominant×tonic substitutions.
+- **An entire masculine/feminine/mosaic example table** whose every pair
+  (`time/rhyme`, `dreary/weary`, `going/showing`, `silence/find us`) returns zero
+  hits in **both** the 2014 and 1991 books while cited to "2014, Chapter 1".
+- **`metaphor.md`'s self-declared "Restoration blocked" hole is closed** — all
+  six of Pat's printed Day 10 answers restored verbatim.
+- **A misattribution to Pat of someone else's term.** "Destination writing" is
+  **Andrea Stolpe's**; Pat credits her by name and book title. The invented
+  "8-9 minutes / 1-2 minutes" form attached to it is gone.
+
+### Fixed — quotes
+
+- **A fabrication recorded as fixed in 0.8.6 was still live.** `"Craft prepares
+  you to be creative."` was corrected in `rhyme-types.md` and **survived in
+  `exercises.md`** with its citation intact. Pat's real line is "Craft prepares
+  **him** to be immensely creative with his shots". A fix in one file is not
+  proof the invention is gone from the corpus.
+- **A paraphrase was standing in as a verbatim quote.** "Tools, not rules." in
+  that word order appears in **none** of the four books — it is the *column
+  title*. Pat's printed line is "There are no rules, only tools."
+  (*Writing Better Lyrics* (2009), Chapter 18), and again as "there are no
+  rules. Only tools." (*Essential Guide to Rhyming* (2014), Chapter 4).
+- **"One focused finding outweighs ten scattered notes" was invented** (zero
+  corpus hits) and was labelled **"Pat's rule"** in two files. Retained as
+  plugin-authored coaching posture with the attribution removed.
+- **`state / vary / withhold / deliver`** — an invented four-stage scaffold
+  carrying a blockquote falsely attributed to 1991 Chapter 7. Removed from
+  `hook.md` and from its recurrence in `beyond-books.md`.
+- **An invented "Shelley principle"** with a three-item `Use when:` list. Pat
+  names no such principle. The neighbouring quote is genuine and was kept — its
+  *form* was fixed (a partial quote stitched mid-sentence, now quoted in full).
+- **Mechanical verification:** every block-quoted sentence in `context/` was
+  tested against the full four-book corpus — **1,558 checked, 1,466 matched
+  verbatim.** The residual were adjudicated individually as artifact,
+  correctly-sourced non-book material, or defect.
+
+### Fixed — fabrication-by-correction, a defect class in the opposite direction
+
+- **The plugin had silently corrected Pat's typos.** 1991 Chapter 7 prints "your
+  verbs will all already **by** POV neutral"; the file had it as "be". Confirmed
+  a book typo in the raw XHTML, and restored with a do-not-correct note.
+- Now marked as printed and protected from future "fixes": `swiftless`,
+  `frictatives`, `Famly`, `Percy Bysshe **Shelly**`, `Ozymandius`, and "YOUR
+  CHORUS YOU WROTE".
+
+### Fixed — citations
+
+- **Two `Book N` citations were live on `main`**, hidden from the regression grep
+  by line wrapping: `beyond-books.md` ("overlaps Book / 2 Chapter 18-21") and
+  `object-writing.md` ("across Books / 2 and 3"). **The single-line grep in use
+  has a false negative** — the wrap-safe form is
+  `grep -rnPzo "Books?\s+[1-4]\b" | tr '\0' '\n'`.
+- 2014 Chapter 9's boundary corrected from the running heads: spine **120-131**,
+  with 132 being the **Afterword**.
+
+### Added — verbatim restorations
+
+- **1991 Chapter 5 and Chapter 7 in full**, closing the 1991 book: the five hook
+  strategies as printed, the A/B/C forward-motion cases, TARGETING (named in the
+  book, not "in lectures"), the strategic-position passage, Chapter 5's
+  BUILDING SECTIONS material and its four juggling parameters.
+- **1991 Exercises 34-38 and 39-44 restored verbatim**, recovering the song
+  titles and hooks the paraphrases had genericized away — `SOUTHERN COMFORT`,
+  `TEDDY DOESN'T LIVE HERE ANYMORE`, `YOU DON'T HAVE THE BEST OF ME YET`,
+  `I SLIPPED AND FELL IN LOVE`, `LAST NIGHT'S LOVE` and others — plus Pat's
+  printed answer slots.
+- **2014 Chapter 1's secondary-stress pages**, absent entirely, restored.
+- **2014 Chapter 4's central worked example** — Warren Zevon's "Hasten Down the
+  Wind" with all four rhyme-type versions — was missing and is restored.
+- **2011 Challenge 1's material**: the Chekhov epigraph, the *writus
+  interruptus* passage, Group Writing, and the objectwriting.com contest
+  provenance that explains the named sample writers.
+
+### Changed
+
+- Two probes from the audit ledger are resolved with verbatim evidence: the
+  "Can't Fight This Feeling" five-stress claim is **supported** (1991 Chapter 5
+  prose plus Chapter 7's scansion figures — though **Chapter 7 never uses the
+  word "duple"**), and the "Years" composite-balance claim is **supported in its
+  arithmetic** while a trailing paragraph asserting bar counts was **invented**
+  and removed.
+
 ## [0.8.6]
 
 **Wave A cleanup — the five research files the previous pass left unfinished,

--- a/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
+++ b/plugins/songwriting/context/pat-pattison/research/audit-checklist.md
@@ -1,6 +1,9 @@
 # Audit Checklist — Pre-Lock Review Tools
 
-**Tools, not rules.** Every box below is a deliberate choice point. Skipping
+**"There are no rules, only tools."** — *Writing Better Lyrics* (2009),
+Chapter 18. (Pat prints the same stance in *Essential Guide to Rhyming*
+(2014), Chapter 4: "there are no rules. Only tools.") Every box below is a
+deliberate choice point. Skipping
 or refusing a box is valid — but skipping silently is not. Name the skip
 reason out loud so the writer keeps craft conscious, not accidental.
 
@@ -414,7 +417,7 @@ lines, matched line length, stable rhythm, and stable rhyme scheme."
 
 - [ ] number of lines counted (even? odd? deliberate?)
 - [ ] line lengths counted — "line length is determined by the number of
-      stressed syllables in a line" (Chapter 19)
+      stresses in a line" (Chapter 19)
 - [ ] rhyme scheme notated. His convention, verbatim: "To notate the way a
       structure moves, let's use capital letters (e.g., A, B, C) to stand for
       lines that have both the same line lengths and the same rhyme scheme.
@@ -554,7 +557,7 @@ repo wants an audit conducted, not because Pat says it.*
 
 - Do not list every miss. Surface the dominant problem first.
 - If the dominant problem is upstream (title doesn't fit form, form doesn't fit emotion), fixing downstream lines won't help.
-- "Tools, not rules" applies to the audit itself — the writer can refuse any box, but should know they're refusing.
+- "There are no rules, only tools." applies to the audit itself — the writer can refuse any box, but should know they're refusing.
 - After the audit, run one focused revision pass — not a sweep.
 
 ## Cross-references

--- a/plugins/songwriting/context/pat-pattison/research/beyond-books.md
+++ b/plugins/songwriting/context/pat-pattison/research/beyond-books.md
@@ -26,15 +26,19 @@ Online. Available in English, Spanish, and Portuguese.
    forward motion, structural pause
 3. **Sonic GPS — Mapping Your Song with Rhyme** — rhyme types, rhyme
    placement, sonic bonding (overlaps *Essential Guide to Rhyming* (2014), Chapters 4-9)
-4. **Making It Move** — prosody, motion, structural emotion (overlaps Book
-   2 Chapter 18-21)
+4. **Making It Move** — prosody, motion, structural emotion (overlaps
+   *Writing Better Lyrics* (2009), Chapters 18-21)
 
 ### Distinctive material vs the books
 
 - **Title rhythm as motif** — the title's stress pattern is treated as a
-  rhythmic motif developed across the song (state / vary / withhold /
-  deliver). The book material has this in seed form; the course makes the
-  motivic development explicit.
+  rhythmic motif developed across the song. **Unaudited** — course content,
+  not verifiable from the books. (An earlier draft glossed this as a
+  four-stage "state / vary / withhold / deliver" sequence; that phrasing was
+  **invented** and has been removed. Pat's actual treatment of motivic
+  development is in *Essential Guide to Lyric Form and Structure* (1991),
+  Chapter 7 — "Speed it up, slow it down, say it backwards, turn it upside
+  down" — see `hook.md`.)
 - **Stressed-vowel brainstorming from the title** — take the title's
   stressed vowels to the rhyming dictionary FIRST, before drafting lines.
   Generate seed words; build verses from them.
@@ -92,8 +96,13 @@ the recurring framing for Pat's craft stance.
 
 ### Anchor stance (≤25 word column quotes)
 
-> "Tools, not rules." — recurring column framing, also the column title in
-> *American Songwriter*
+> "There are no rules, only tools." — *Writing Better Lyrics* (2009),
+> Chapter 18
+
+"Tools, Not Rules" is the **column title**, not a Pat quotation — the phrase
+in that order appears in none of the four books. Pat's printed wording is the
+line above; he prints it again in *Essential Guide to Rhyming* (2014),
+Chapter 4 as "there are no rules. Only tools."
 
 > "Songs should be universal, but don't mistake universal for generic.
 > Sense-bound is universal." — Pat Pattison, *Writing Better Lyrics*
@@ -363,8 +372,23 @@ informally).
 
 ## Distinctive catchphrases / teaching-moment quotes (≤25 words, attributed)
 
-These verbatim Pat formulations appear across columns / podcasts / talks
-and serve as anchor stance for the skill:
+These Pat formulations appear across columns / podcasts / talks and serve as
+anchor stance for the skill.
+
+**EVERY QUOTE IN THIS SECTION IS UNAUDITED unless it carries a book citation.**
+They are spoken or web sources outside the four books; a mechanical check of the
+corpus cannot confirm them, and their absence from it is *not* evidence against
+them. Two consequences, both binding:
+
+1. **Never re-cite one of these to a book** to make it look checked. If you need
+   a citable version, find Pat's printed sentence and quote that instead.
+2. **Never treat these as verbatim.** Spoken phrasing drifts; several of these
+   are near-variants of printed lines (see `line-brainstorm.md`, which now pairs
+   two of them with their printed counterparts). "Verbatim" was claimed here and
+   cannot be supported for any un-cited item, so the word is gone.
+
+The one exception below is the last entry, which is a real book quote and is
+cited as such.
 
 > "Music means nothing. Music only feels. Words mean."
 > — Pat Pattison, Berklee Alumni Webinar Master Class
@@ -405,9 +429,12 @@ and serve as anchor stance for the skill:
 > "Bring two things to the table: who you are, and what you know."
 > — Pat Pattison, Unpaved interview
 
-> "You can't tell unless you show first." — Sister Mary Elizabeth (cited
-> by Pat as the "Rule of Songwriting"); *Writing Better Lyrics* (2009),
-> Chapter 2
+> "You can't tell unless you show first." — Sister Mary Elizabeth, in
+> *Writing Better Lyrics* (2009), Chapter 2. **This one is from a book and is
+> verbatim.** Pat's name for it is the whole phrase: 'To this day, I call that
+> the "Sister Mary Elizabeth Rule of Song-writing."' (He prints the rule name
+> twice in that chapter, hyphenated as "Song-writing" the first time and
+> "Songwriting" the second; both are as printed.)
 
 ## Cross-references
 

--- a/plugins/songwriting/context/pat-pattison/research/brainstorm.md
+++ b/plugins/songwriting/context/pat-pattison/research/brainstorm.md
@@ -21,33 +21,79 @@ anything", "I want to write but I don't know what", "where do I start",
 Pre-commitment is the point. Do not ask the writer to commit to a title,
 form, or POV. Pull material first. Commitment comes after material exists.
 
-> Object writing is preparation, not a substitute for songwriting.
+Pat's printed words, not a paraphrase of them:
+
+> Object writing prepares you for whatever other writing you do. It is not a
+> substitute.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
+
+And in the 2011 book, the same point with the list attached:
+
+> Object writing is great fun. It prepares you for any creative writing you want
+> to do: lyrics, poetry, short stories, novels.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1
 
 The brainstorm produces raw material. The writer mines it later — often a
 day or two later — to find what's worth pursuing.
 
 ## Path A — Sense-bound entry (10 minutes)
 
-The single highest-yield brainstorm path. Pat's Challenge 1 (*Songwriting Without Boundaries* (2011)) is the
-template.
+The single highest-yield brainstorm path. Pat's Challenge 1 (*Songwriting
+Without Boundaries* (2011)) is the template. He states its shape in one
+sentence at the end of the Challenge 1 introduction:
 
-1. **Pick a seed category** — What / Who / When / Where.
-   - **What** — a thing or event: mirror, arrow, broken cup, bus ticket
-   - **Who** — a person seen or imagined: waitress, priest, exhausted drummer
-   - **When** — a time: first snowfall, late evening, six in the morning
-   - **Where** — a place: hotel bar, parking lot, old church, cliff by the ocean
+> The first five days are devoted to pure object writing. Let's call it "what"
+> writing. Then three days each of "who," "when," and "where" writing. Have fun.
+
+1. **Pick a seed category** — what / who / when / where, in that order. The
+   seeds below are Pat's own printed prompts for those days, not substitutes:
+   - **what** — Sky, Crash, Lily Pad, Bathroom Mirror, Dentist, Screwdriver,
+     Umbrella, Hair, Feather, Curb, Bouquet, Rain Cloud, Movie Theater, Cigar,
+     Arrow (Days 1–5)
+   - **who** — Sailor, Waitress Clearing a Table, Priest, Balloon Man, Homeless
+     Child, Trucker, Cyclist, Ballerina, Puppy (Days 6–8)
+   - **when** — Summer Rainstorm, Graduation, Wedding Rehearsal Dinner, Six in
+     the Morning, First Snowfall, Easter Sunday, Late Evening, Loved One's
+     Funeral, Crossing the Finish Line (Days 9–11)
+   - **where** — A Cliff by the Ocean, Park Bench in the City, Hotel Bar,
+     Suburban Swimming Pool, The Old Fishing Hole, Under an Umbrella, On the
+     City Bus, Wedding in an Old Church, Canoe on the River (Days 12–14)
 2. **Pick ONE seed word** in that category. Don't deliberate. First word
    that arrives.
-3. **Set a 10-minute timer.**
-4. **Object-write** sense-bound (per `object-writing.md`): sight, hearing,
-   smell, taste, touch, organic, kinesthetic. Follow sensory associations
-   even when they leave the seed.
-5. **Stop at the buzzer** — mid-word if that's where the buzzer lands.
+3. **Set a 10-minute timer.** Pat runs three timed pieces per day, not one —
+   *"three timed Object Writing exercises of five minutes, ten minutes and 90
+   seconds"* — and ten minutes is his stated ceiling: *"The ten-minute absolute
+   limit is the key to building both."* One 10-minute piece is the plugin's
+   brainstorm slice of that day.
+4. **Object-write** sense-bound (per `object-writing.md`). Pat's seven senses,
+   in his printed order and his printed names: **Sight Sound Taste Touch Smell
+   Body Motion** — the last two glossed as *"Organic sense (body)"* and
+   *"Kinesthetic sense (motion)"*. Follow sensory associations even when they
+   leave the seed: *"There's no reason to stay loyal to the subject that sets
+   you on your path. Your senses are driving the bus—you can go wherever they
+   take you."*
+5. **Stop at the buzzer** — mid-word if that's where the buzzer lands: *"Be sure
+   you always stop right at the buzzer. Don't finish the sentence. Don't even
+   finish the word you're in the middle of."*
 6. **Mine** the page: underline strongest sensory images, surprising verbs,
    possible title seeds, metaphor seeds. Set aside what isn't useful.
 
 The mined material becomes input for `idea-to-title.md` or
 `fragment-development.md` in a later session.
+
+## Paths B, C and D — plugin scaffolding, not Pat's printed method
+
+<!-- unaudited: Paths B, C and D below are this plugin's own coaching
+     scaffolding. None of them is printed in the four books; Path A is the only
+     path in this file that traces to a page. Do not attribute B, C or D to Pat
+     or cite a book for them. -->
+
+Path A is the only path here that comes from a book. The three below are
+plugin-authored fallbacks for writers who will not start with a timer, and are
+**unaudited** — they are not Pat's printed method and must not be presented as
+his.
 
 ## Path B — Lived-input entry (no timer)
 
@@ -87,10 +133,30 @@ sense-bound:
    emotional shape.
 5. Route to `idea-to-title.md` for the next pass.
 
-This is the Pat Title Game path (cross-ref `title-game.md`) without the
-co-write context — solo title generation.
+This is the "Title Game" path (cross-ref `title-game.md`) without the co-write
+context — solo title generation. **Unaudited.** Neither the phrase "Title Game"
+nor the terms *front-heavy* / *back-heavy* appears anywhere in the four books;
+they come from non-book sources and are not Pat's printed vocabulary. The
+counts (10 candidates, keep 2–3) are this plugin's, not his. *Stressed vowel*
+is genuine Pat vocabulary, from *Essential Guide to Rhyming* (2014).
 
 ## What NOT to do in brainstorm mode
+
+Pat's own prohibitions, verbatim — this is what he actually forbids during a
+timed object write:
+
+> Don't worry about story lines or "how it really happened." No rhyme or rhythm.
+> Not even full sentences. No one needs to understand where you are or how you
+> got there. Save more focused writing for when you need to be focused.
+
+> Guarantee yourself only the time allotted for each prompt. Set a timer, and
+> stop the second it goes off. I mean the second […] Don't finish the sentence.
+> Don't even finish the word you're in the middle of.
+
+> — *Songwriting Without Boundaries* (2011), Challenge 1
+
+The rest of this list is the plugin's, derived from the passages above rather
+than printed by Pat:
 
 - Do not commit to a form. Form decisions belong after material exists.
 - Do not commit to a POV. Same.
@@ -128,8 +194,13 @@ After a brainstorm session:
 ## When brainstorm IS the goal (no song target)
 
 The writer may want pure daily practice (`daily-practice.md`) with no song
-target. That's the 56-day curriculum, not a brainstorm session. Route to
-`/songwriting:practice` instead.
+target. That's the whole of *Songwriting Without Boundaries* (2011) — *"I
+decided to set four 14-day challenges to help you explore your writer's voice
+more fully"* — not a brainstorm session. Route to `/songwriting:practice`
+instead. (56 days is arithmetic on Pat's four × 14; he never prints the number,
+and he explicitly recommends a gap between challenges: *"If you do all these
+challenges, I suggest you take a short time between them to let the swelling
+subside a bit."*)
 
 Brainstorm = intent to develop a song, but no material yet.
 Daily practice = intent to train, no song target required.
@@ -137,6 +208,9 @@ Daily practice = intent to train, no song target required.
 ## Cross-references
 
 - `object-writing.md` — Path A's craft method
+- `metaphor.md` — Challenge 2 and Challenge 3 of *Songwriting Without
+  Boundaries* (2011) turn a mined image into metaphor; that is the pass after
+  this one, not part of it
 - `daily-practice.md` — daily training (different goal)
 - `idea-to-title.md` — develop a seed toward a title
 - `hook.md` — title generation (seven types, Nashville method, stressed-vowel)

--- a/plugins/songwriting/context/pat-pattison/research/bridge.md
+++ b/plugins/songwriting/context/pat-pattison/research/bridge.md
@@ -277,6 +277,30 @@ AABA verse / refrain form."
 > An AABA's last system is actually bridge / verse, providing a nice contrast
 > to the opening verses, as well as sponsoring the homecoming parade.
 
+The 1991 original of that paragraph is *Essential Guide to Lyric Form and
+Structure* (1991), Chapter 5, and it is worth having in Pat's earlier wording
+because it names the mechanism ("away from the verse structure"):
+
+> An A A B A song form is effective partly because it creates this sense of
+> resolution when it moves back to the third verse. The structure of the first
+> two verses defines "home base." Then, the Bridge takes you away from home —
+> away from the verse structure. So when you come back to the third verse, you
+> come back home to familiar territory. It is a real homecoming, like seeing the
+> old neighborhood again after a long trip. The tension created by moving away
+> has been resolved.
+
+Chapter 5 then names what the last system is, in figure `image_rsrc327`:
+
+```text
+( Bridge  ->  Verse ),
+or
+( DEVELOPMENTAL SECTION  ->  CENTRAL SECTION ).
+```
+
+> The sense of arrival when you get to the third verse is the same thing you
+> feel when you move to the Chorus in a Verse/Chorus Song System. A new Song
+> System is formed by the DEVELOPMENTAL SECTION moving into the CENTRAL SECTION.
+
 *Essential Guide to Lyric Form and Structure* (1991), Chapter 6, states the
 return directly:
 
@@ -289,10 +313,19 @@ These are different sections. Do not conflate.
 
 **Transitional bridge** — *Essential Guide to Lyric Form and Structure* (1991),
 Chapter 5. Pat: "This is as close as I can come to an accurate name for this
-elusive little section. I have heard it called by many names" — the figure
-lists exactly six: **Pre-Chorus · Climb or Lift · Vest · Verse Extension ·
-Ramp · Prime**. (Earlier drafts of this file added "channel" and "runway";
-they are not in Pat's list.) Then: "This section is used for so many jobs,
+elusive little section. I have heard it called by many names" — the names live
+only in figure `image_rsrc32E`, which prints exactly **six**, set as a
+three-column, two-row grid (reproduced here in the figure's own layout, because
+row-order and column-order readings disagree and the scan settles nothing
+beyond the grid):
+
+| | | |
+|---|---|---|
+| Pre-Chorus | Vest | Ramp |
+| Climb or Lift | Verse Extension | Prime |
+
+(Earlier drafts of this file added "channel" and "runway"; they are not in
+Pat's list.) Then: "This section is used for so many jobs,
 none of these descriptive names quite fit all of them:"
 
 > 1. It is a DEVELOPMENTAL section.
@@ -324,9 +357,14 @@ explicit, working from the AABA case ("The Great Pretender") outward:
 > because it functions as a complete unit, works like a verse section in an
 > A A B A form.
 
-His worked case is Donald Fagen and Walter Becker's "Babylon Sisters" (Steely
-Dan) — the bridge "makes a clear move away from the structures of the Verse and
-Chorus," and:
+His worked case is **"HAITIAN DIVORCE"** — "Here is a fine example by Donald
+Fagen and Walter Becker of Steely Dan" — printed in full across figures
+`image_rsrc32B` and `image_rsrc32C` as three Song Systems (Verse/Chorus,
+Verse/Chorus, Bridge → Verse/Chorus). An earlier revision of this file named the
+song "Babylon Sisters"; that is wrong, and the figures say so on every line
+("Babs and Clean Willie were in love they said", "This is your HAITIAN
+DIVORCE"). The bridge "makes a clear move away from the structures of the Verse
+and Chorus," and:
 
 > In this lyric, the Bridge leads to another verse. As long as the bridge takes
 > you back to familiar territory, the sense of return or resolution will be

--- a/plugins/songwriting/context/pat-pattison/research/cliche.md
+++ b/plugins/songwriting/context/pat-pattison/research/cliche.md
@@ -1,6 +1,7 @@
 # Cliche
 
-Pat Pattison - *Writing Better Lyrics* (2009), Chapter 5.
+Pat Pattison - *Writing Better Lyrics* (2009), Chapter 5; one ruling from
+*Songwriting Without Boundaries* (2011), Challenge 2, Day 2.
 
 Use this when a user asks why a lyric feels generic, predictable, sleepy,
 familiar, or "AI-ish"; when a line leans on stock phrases, stock rhymes, stock
@@ -268,6 +269,14 @@ anger), not just a banned word. The whole family of associated words comes
 pre-worn with it. Pat's pointer for repair is back to Chapter 3, "Making
 Metaphors" — "There's no reason to keep sleepwalking in these yellow fogs."
 
+A cliche metaphor is still a metaphor. Pat makes the point explicitly in
+*Songwriting Without Boundaries* (2011), Challenge 2 Day 2, while ruling
+on the adjective `dark`: "Remember, dark eyes could be literally true,
+and thus isn't a metaphor. They join together rather than colliding. Dark
+thoughts, though a cliché, is a metaphor. It's literally false." So
+"cliche" and "not a metaphor" are separate verdicts — diagnose staleness
+and literal falsehood separately.
+
 Do not ban these automatically. Ask whether the draft adds a fresh collision or
 specific sensory angle. If it does not, rebuild the metaphor from:
 
@@ -332,14 +341,15 @@ And it's all downhill from here
 The literal roller coaster earns the figurative phrase. Pat's warning attached to
 both cases: "Without a terrific setup, duck whenever you see a cliché."
 
-Use this test:
+Pat's test has **two** parts, not four. He states the first outright, opening the
+section:
 
-- Does the lyric make the familiar phrase mean something newly specific?
-- Is the phrase carrying overtone rather than acting as the main idea?
-- Would the line collapse if the cliche were removed?
-- Has the song earned the phrase through image, situation, or dramatic irony?
+> In some cases, you can use a cliché to your advantage. Put it in a context that
+> brings out its original meaning or makes us see it in a new way.
 
-If the answer is no, cut or rewrite.
+The second is the overtone condition quoted above: the cliche's usual sense must
+ride *under* a primary meaning the song has built, not carry the line itself. If
+neither holds, cut or rewrite.
 
 ## Draft-stage tolerance
 
@@ -389,16 +399,22 @@ Rewrite source: object writing and worksheet words.
 
 ## Chapter 5 exercise as coaching prompt
 
-Exercise 10 - Cliche inventory and parody draft:
+**EXERCISE 10**, verbatim. Pat sets **two** experiments, not five:
 
-- Make a long personal list of cliche phrases, rhymes, images, and metaphors —
-  Pat's instruction is "at least as long as my list above," and he adds "(It
-  won't be difficult.)"
-- String yours and Pat's together into a verse/chorus/verse/chorus lyric,
-  "making sure nothing original sneaks in."
-- Notice how easily it fills space while saying little.
-- Return to a real draft and mark any similar placeholders.
-- Rewrite each one through sensory detail, fresh rhyme, or new metaphor.
+> For fun, try these two experiments. First, come up with your own lists of
+> clichés, at least as long as my list above. (It won't be difficult.) Second,
+> string some of yours and mine together into a verse / chorus / verse / chorus
+> lyric, making sure nothing original sneaks in.
+
+The reason he sets it, stated immediately after:
+
+> Knowledge brings responsibility. Now that you know the fundamental cause of
+> puppy narcolepsy, you have a special responsibility to keep your writing
+> sense-bound and original. No one likes a person who puts puppies to sleep.
+
+Coaching extension — **this plugin's, not Pat's**: after the parody draft, return
+to a real draft, mark any similar placeholders, and rewrite each through sensory
+detail, fresh rhyme, or new metaphor.
 
 ## Skill workflow
 

--- a/plugins/songwriting/context/pat-pattison/research/coaching-protocol.md
+++ b/plugins/songwriting/context/pat-pattison/research/coaching-protocol.md
@@ -5,8 +5,27 @@ skill MUST coach the writer step-by-step, surfacing choice points, applying
 the relevant Pat tool to the writer's answer, and proceeding only when the
 writer has chosen. This file codifies the dialog mechanics.
 
-> "Tools, not rules." — Pat Pattison (recurring column / seminar framing,
-> also the name of his *American Songwriter* magazine column)
+*Provenance: **the protocol is this repo's, not Pat's.** He publishes no dialog
+loop, no phase list, no option quota and no anti-pattern table; the four books
+are written prose, not transcripts of him coaching. Every count in this file
+(≥3 options, 3-15 labeled options, the six sanity-check phases) is a repo
+default. What is genuinely his is the stance the mechanics serve, and the craft
+tools each step applies — those are cited where they appear.*
+
+> "There are no rules, only tools." — *Writing Better Lyrics* (2009),
+> Chapter 18. He prints the same stance in *Essential Guide to Rhyming*
+> (2014), Chapter 4: "there are no rules. Only tools."
+
+<!-- CORRECTED. This block-quoted '"Tools, not rules." — Pat Pattison
+     (recurring column / seminar framing…)'. In that word order the phrase
+     appears in NONE of the four books — 0 hits, wrap-safe, all four. It is the
+     title of his *American Songwriter* column, not something he is recorded
+     saying, so presenting it as a Pat quotation invented a quotation out of a
+     masthead. Replaced with the two sentences he actually prints. Note for the
+     next sweep: the orchestrator's table records this fabrication as "All
+     fixed" after three sites were repaired. It was not — it survived here, and
+     still survives in two other files plus one template (see HANDOFF). -->
+
 
 The protocol exists because generic LLM defaults — long monologues, 14-step
 plans pre-decided, single-pick recommendations — directly contradict Pat's
@@ -148,14 +167,19 @@ When a writer says "you decide", the AI:
 This preserves the writer's agency without forcing the dialog when the
 writer wants a draft.
 
-Example:
+Example — invented illustrative dialogue, not a Pat quotation. It is fenced
+rather than block-quoted precisely so it cannot be mistaken for one (the
+mechanical quote checker flagged all three of its sentences while it was in a
+`>` block):
 
-> Writer: "Just give me a title — I trust you."
-> AI: "Going with 'Last Call at the Moonlight' — image-as-title, front-
-> heavy, sets a specific bar (not 'the bar'), supports a wistful-with-hope
-> feel. The runner-up was 'What's Left' for ambiguity, but it pulls darker
-> than you said you wanted. Want to run with Moonlight or look at What's
-> Left for contrast?"
+```text
+Writer: "Just give me a title — I trust you."
+AI: "Going with 'Last Call at the Moonlight' — image-as-title, front-
+heavy, sets a specific bar (not 'the bar'), supports a wistful-with-hope
+feel. The runner-up was 'What's Left' for ambiguity, but it pulls darker
+than you said you wanted. Want to run with Moonlight or look at What's
+Left for contrast?"
+```
 
 ## Sanity checks per phase
 
@@ -167,7 +191,7 @@ Each coaching phase ends with a sanity check the writer can affirm:
 | Pick the title | Stressed vowel identified, rhyme-stability tested, form-fit named |
 | Draft the central section | Reads aloud naturally, title sits in a hot spot, no greedy spots, ≥1 sense-bound image |
 | Draft verses | Verse 1 sets up, verse 2 develops (not travelogues), POV consistent |
-| Bridge decision | Either no bridge OR bridge does ≥1 of Pat's three jobs |
+| Bridge decision | Either no bridge OR a bridge that does all three of the jobs *Essential Guide to Lyric Form and Structure* (1991), Ch 6 lists — he presents them as three things one bridge does together, not a menu to satisfy one of |
 | Pre-lock | All applicable response-filter sections pass, writer affirms aloud-reading |
 
 When the sanity check passes, the AI says so out loud and offers the next
@@ -201,15 +225,25 @@ specialized action is the right tool.
 
 ## Anchor stance
 
+**All three quotes below are UNAUDITED** — spoken, non-book sources catalogued in
+`beyond-books.md`. Measured wrap-safe across all four books: `Music means
+nothing` = 0 hits, `Verbs are the amplifiers` = 0 hits, `telling people who you
+are` = 0 hits. Absence from the corpus is not evidence against a spoken source,
+so they stay — but do not re-cite any of them to a book, and do not treat them as
+verbatim.
+
 > "Music means nothing. Music only feels. Words mean."
-> — Pat Pattison (Berklee Alumni Webinar Master Class)
+> — Pat Pattison (Berklee Alumni Webinar Master Class) — **unaudited**
 
 > "When you're writing a song, it's not about telling people who you are.
 > It's about telling people who they are."
-> — Pat Pattison (Songwriting Planet interview, 2014)
+> — Pat Pattison (Songwriting Planet interview, 2014) — **unaudited**
 
 > "Verbs are the amplifiers of language."
-> — Pat Pattison (Unpaved interview)
+> — Pat Pattison (Unpaved interview) — **unaudited**. Printed and citable
+> instead: "They're the most potent force in language. […] The difference
+> between average and great writing: verbs." — *Songwriting Without Boundaries*
+> (2011), Challenge #2.
 
 The coaching protocol exists so the AI's process matches Pat's process —
 the writer's voice arrives at the writer's song.

--- a/plugins/songwriting/context/pat-pattison/research/coaching-protocol.md
+++ b/plugins/songwriting/context/pat-pattison/research/coaching-protocol.md
@@ -26,7 +26,6 @@ tools each step applies — those are cited where they appear.*
      fixed" after three sites were repaired. It was not — it survived here, and
      still survives in two other files plus one template (see HANDOFF). -->
 
-
 The protocol exists because generic LLM defaults — long monologues, 14-step
 plans pre-decided, single-pick recommendations — directly contradict Pat's
 coaching practice. The AI must throttle itself into one-question dialog,

--- a/plugins/songwriting/context/pat-pattison/research/daily-practice.md
+++ b/plugins/songwriting/context/pat-pattison/research/daily-practice.md
@@ -108,12 +108,16 @@ generally carries the day's most loaded seed — Crash, Dentist, Homeless Child,
 Loved One's Funeral — while the ninety-second slot stays small and physical.
 When generating a substitute seed, keep that weighting.
 
-Pat's own instruction line for every one of these days, worth reading aloud
-before the timer starts:
+Pat's instruction line, worth reading aloud before the timer starts. The long
+form below is printed **on Day 1 only**. Days 2-14 stop after "Stop IMMEDIATELY
+when the timer goes off." and swap the noun to match the category — "the
+following characters" on the who days, "the following places" on the where days:
 
 > Set a timer and respond to the following prompts for exactly the time allotted.
 > Stop IMMEDIATELY when the timer goes off. Do not even finish the word you are
 > on. Use only your seven senses. No judgments, comments, or quotes allowed.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1, Day 1
 
 He also prints a seven-word strip to let the eye wander over when the writer
 stalls:
@@ -496,9 +500,11 @@ Diagnostic:
 - Do not switch back and forth deliberately — pick whichever the
   page is already doing.
 
-## Anti-patterns Pat names
+## Anti-patterns
 
-Five patterns the timed write should reject:
+Pat states one prohibition, quoted at the end of this section. The five below
+are this skill's expansion of it, not his wording — do not attribute them to
+him. Patterns the timed write should reject:
 
 1. **Explanation mode** — the page narrates what the writer is
    doing, thinking, or feeling rather than what the senses register.
@@ -513,8 +519,8 @@ Five patterns the timed write should reject:
 
 Items 3 and 4 apply to Challenges 1-3 only. Challenge 4 requires both — its whole
 subject is fitting sense-bound material into stress counts and rhyme schemes — so
-do not carry the prohibition into Days 43-56. The rule Pat states without
-qualification, on every day of Challenge 1, is narrower than the list above: "Use
+do not carry the prohibition into Days 43-56. The rule Pat actually states is
+narrower than the list above, and he prints it once, on Challenge 1, Day 1: "Use
 only your seven senses. No judgments, comments, or quotes allowed."
 
 > "No judgments, comments, or quotes allowed." — Pat, *Songwriting Without
@@ -525,9 +531,10 @@ only your seven senses. No judgments, comments, or quotes allowed."
 *Songwriting Without Boundaries* (2011)'s reader-sample sections reveal three recurring critique
 moves Pat applies. Use them when reviewing a writer's daily write:
 
-1. **Spot sense clusters and their leaps.** A passage that moves
-   from one sensory environment to another (elevator to ocean,
-   kitchen to wartime) is doing the work; name the leap.
+1. **Spot sense clusters and their leaps.** A passage that moves from one
+   sensory environment to another is doing the work; name the leap. Pat's own
+   instance is Cathy Brettell's "Elevator," which he says "took Cathy from an
+   elevator ride to an ocean storm, no permission asked."
 2. **Name the productive ambiguity.** When a line could mean two
    things and both work, mark the dual reading — do not flatten.
    See [metaphor](metaphor.md) "Productive ambiguity".
@@ -703,15 +710,16 @@ Pat's own worked recovery, on Day 3's `ghost`: a ghost can plausibly be lazy, so
 `lazy ghost` is "not quite a collision" — try unhuman qualities like `brittle` or
 `wrinkled` instead.
 
-## Pat's critique-move vocabulary (*Songwriting Without Boundaries* (2011) — recurring across all four challenges)
+## Critique-move vocabulary (*Songwriting Without Boundaries* (2011) — recurring across all four challenges)
 
-Throughout writer-sample commentary in all four challenges, Pat applies
-the same recurring diagnostic phrases. These are the coaching vocabulary
-for reviewing object writes and lens writes. Treat as named moves:
+Throughout writer-sample commentary in all four challenges, Pat makes the same
+diagnostic moves. Four of the labels below are his; three are this file's
+shorthand (see the note under the table). Coaching vocabulary for reviewing
+object writes and lens writes:
 
 | Critique move | What it directs |
 |---|---|
-| **Spot sense clusters and their leaps** | Identify where the writing moves from one sensory environment (kitchen) to another (highway); leaps are signals, not failures |
+| **Spot sense clusters and their leaps** | Identify where the writing moves from one sensory environment to another — Pat's instance is Cathy Brettell's elevator ride becoming an ocean storm; leaps are signals, not failures |
 | **Name the productive ambiguity** | When a line could mean two things and both work, mark the dual reading explicitly |
 | **Praise verbs over adjectives** | Verbs carry sensory access; adjectives explain. Underline the verbs first |
 | **Invite family members** | In lens writing, count how many source-family words appear in the target-lens write — the more, the stronger the metaphor |
@@ -719,8 +727,13 @@ for reviewing object writes and lens writes. Treat as named moves:
 | **Rhyming positions are spotlights** | Content of end-line positions tells most of the story; weak words in rhyme positions are wasted spotlights |
 | **Form is a road map** | Structure tells the writer where to go; rhyme shifts signal perspective shifts; line-length shifts signal pace shifts |
 
-Use these phrases verbatim when coaching writer samples. The shorthand
-makes the same critique replicable across sessions.
+Only four of these labels are Pat's own words — "Rhyming positions are
+spotlights" and "Form is a road map" (Challenge 4, Day 11, sourced below),
+"Invite family members" (Challenge 3, Day 2, sourced below), and "Underline the
+verbs," which is Challenge 1, Day 4: "Check out Nick and Linda's verbs. Go
+ahead, underline them. I'll wait." The other three are this file's shorthand for
+moves he makes without naming. Use the shorthand internally; quote only the
+sourced wording back to a writer.
 
 The last two both come from *Songwriting Without Boundaries* (2011), Challenge 4,
 Day 11, in Pat's commentary on six-line sections, and his own wording is shorter

--- a/plugins/songwriting/context/pat-pattison/research/exercises.md
+++ b/plugins/songwriting/context/pat-pattison/research/exercises.md
@@ -11,9 +11,11 @@ conversation. Each entry is a self-contained exercise the writer can
 do alone, given in Pat's own instruction wording with his numbering,
 his word lists and rhyme schemes, and the answer keys the book prints.
 
-Earlier revisions summarized the exercises instead — which meant none of
-them were actually Pat's, the item counts were invented, and Exercises 32
-and 33 had been dropped entirely.
+Earlier revisions summarized the exercises instead, which meant none of
+them were actually Pat's and the item counts were invented. That has since
+been undone: the exercises are given in Pat's printed instruction wording,
+with the titles, hooks, word lists and answer slots he supplies alongside
+them.
 
 ## How to use
 
@@ -24,7 +26,13 @@ and 33 had been dropped entirely.
 3. After the writer finishes, route to the relevant context file for
    the principles the exercise tests.
 
-> "Craft prepares you to be creative." — Pat (*Essential Guide to Rhyming* (2014), Chapter 9)
+> "All craft. All technique. Craft prepares him to be immensely creative
+> with his shots—hitting a high fade over the trees against the wind to
+> land softly near the flag. Creativity indeed, but built on a platform
+> of craft." — *Essential Guide to Rhyming* (2014), Chapter 9, of Tiger
+> Woods. The full passage, with Pat's "Why should songwriting be any
+> different?", is in [rhyme types](rhyme-types.md) under "Craft prepares
+> creativity — Tiger Woods anchor".
 
 The exercises are not assessments. They are repetitions. The
 specific answers do not matter; the writing habit does.
@@ -462,9 +470,12 @@ Routes to: [rhyme strategy](rhyme-strategy.md) "three strategies".
 
 ## *Essential Guide to Lyric Form and Structure* (1991) — Form exercises (Chapter 5)
 
-All five Chapter 5 exercises work the same "candy bar" section. Pat
-uses one verse again and again to show that it is structure, not
-content, that makes a section what it is.
+All five Chapter 5 exercises work the same "candy bar" section. Pat's
+own note on why, verbatim: "By the time you finish this chapter, you
+will have a better sense of how to build the most typical lyric
+sections. You will also be very tired of candy bars. I used the same
+verse again and again to show that it is structure, not content, that
+makes a section what it is."
 
 ```text
 Love me like a candy bar
@@ -494,7 +505,9 @@ SHORTENING THE FIRST PHRASE TO MAKE IT SOUND DIFFERENT RIGHT AWAY.**
 STANDS.** (Rewrite of "Melt me down...":)
 
 Routes to: [form](form.md) "four building levers" and
-[section building](section-building.md).
+[section building](section-building.md) — the "Melt me down like
+butterscotch" Song System that the second half of Ex 29 rewrites is
+printed there.
 
 ### Ex 30 — Verse leading to the candy bar chorus
 
@@ -528,7 +541,7 @@ EFFECT:
 USES:
 ```
 
-Routes to: [form](form.md) "three bridge functions",
+Routes to: [form](form.md) "Bridge — three functions",
 [song forms](song-forms.md).
 
 ### Ex 32 — Two versions juggling rhyme schemes
@@ -552,13 +565,18 @@ Routes to: [form](form.md), [rhyme strategy](rhyme-strategy.md),
 
 ### Ex 33 — Two more transitional bridges
 
-Pat's model for a candy-bar Transitional Bridge — unbalanced, pushing
-forward, but still feeling like a section:
+Writing a Transitional Bridge takes more radical moves. One could
+look more like this:
 
 ```text
 Love me like a candy bar
 Milky Way and Mars
 ```
+
+This is unbalanced. It pushes forward, though it still feels like a
+section. Even a Transitional Bridge should feel like a section. Here
+rhyme takes care of the feeling of section, while the shorter phrase
+length kicks the supports out from under the section.
 
 **EXERCISE 33: WRITE TWO MORE TRANSITIONAL BRIDGES, USING THE "CANDY
 BAR" SECTION. JUGGLE WHATEVER YOU LIKE, BUT MAKE SURE THAT BOTH CAN
@@ -577,100 +595,212 @@ Routes to: [song forms](song-forms.md) "transitional bridge",
 
 ## *Essential Guide to Lyric Form and Structure* (1991) — Song forms exercises (Chapter 6)
 
-### Ex 34 — Second-system analysis
+### Ex 34 — Scan the second verse of "SOUTHERN COMFORT"
 
-Pick a song with two verses and a chorus (V/Ch/V/Ch form). Scan
-verse 2's rhythm. Check verse 2's rhyme. Analyze how the second
-verse develops or restates verse 1.
+**EXERCISE 34: SCAN THE SECOND VERSE FOR RHYTHM AND LOOK AT ITS RHYME
+STRUCTURE TO SEE IF IT IS PARALLEL TO THE FIRST VERSE. DO VERSE 2 AND
+THE SECOND CHORUS FORM A SECOND SONG SYSTEM?**
 
-Routes to: [verse development](verse-development.md),
+Pat prints verse 2 of "SOUTHERN COMFORT" under the instruction, then
+two slots:
+
+```text
+Rhyme structure:__________________________
+
+Comments:
+```
+
+The verse is reproduced verbatim in
+[song forms examples](song-forms-examples.md) under the "Southern
+Comfort" heading; work the exercise against the text there.
+
+Pat's discussion resumes right after the slots: "You have been through
+two Song Systems. The lyric ends here nicely. A B A B delivers a very
+effective punch." That A B A B names the section form
+(Verse/Chorus/Verse/Chorus), not verse 2's rhyme scheme, so it is not
+the answer to the "Rhyme structure:" slot.
+
+Routes to: [song forms examples](song-forms-examples.md),
 [song forms](song-forms.md).
 
-### Ex 35 — Bridge for an existing song
+### Ex 35 — Write a bridge for "SOUTHERN COMFORT"
 
-Pick a song without a bridge. Write a bridge for it. The bridge
-should break monotony, create a different-size song system, and
-provide a new perspective.
+**EXERCISE 35: WRITE A BRIDGE OF YOUR OWN FOR "SOUTHERN COMFORT."**
 
-Routes to: [song forms](song-forms.md), [form](form.md).
+That one sentence is the whole exercise. Pat supplies no slots. He has
+already shown his own bridge for the song a few paragraphs earlier
+("Here is my result:"), and the three things a bridge would accomplish
+are discussion preceding the exercise, not part of it — both are in
+[song forms examples](song-forms-examples.md) under the "Southern
+Comfort" heading.
 
-### Ex 36 — Transitional bridge rewrite
+Routes to: [song forms examples](song-forms-examples.md),
+[song forms](song-forms.md), [form](form.md).
 
-Take an existing transitional bridge. Rewrite it shorter to longer
-phrases. Then rewrite it with a different rhyme scheme. Sing each
-version into the following chorus.
+### Ex 36 — Rewrite the "TEDDY" transitional bridge
 
-Routes to: [song forms](song-forms.md).
+**EXERCISE 36: REWRITE THE TRANSITIONAL BRIDGE SO THAT IT MOVES FROM
+SHORTER PHRASES TO LONGER ONES. TRY TO MOVE IT EVEN FURTHER FROM THE
+VERSE STRUCTURE BY CHANGING THE RHYME SCHEME. WHAT EFFECT DO YOU THINK
+THE X A X A RHYME SCHEME HAS? HOW WOULD YOU HAVE DONE IT?**
 
-### Ex 37 — Hook setup with shorter phrases
+Pat supplies no slots. "The transitional bridge" is the one he has just
+walked through phrase by phrase in "TEDDY DOESN'T LIVE HERE ANYMORE",
+of which he writes: "The opening phrase of the Transitional Bridge is
+the longest phrase so far in the lyric... The second phrase is
+shorter... The third phrase is even shorter... You can feel the tension
+as the lines get shorter and Teddy's life closes, too abruptly, too
+early." That is the direction the exercise asks you to reverse. The
+bridge is quoted in [song forms examples](song-forms-examples.md) under
+the "Teddy Doesn't Live Here Anymore" heading.
 
-Take an existing hook line. Write a new approach to it using
-shorter phrases than the original setup. Does the shorter approach
-arrive better or worse?
+Routes to: [song forms examples](song-forms-examples.md),
+[song forms](song-forms.md).
 
-Routes to: [hook](hook.md), [phrasing](phrasing.md).
+### Ex 37 — Set up the hook with shorter phrases
 
-### Ex 38 — Transitional bridge to chorus development
+**EXERCISE 37: TRY SETTING UP THE HOOK BY USING SHORTER PHRASES INSTEAD
+OF THE LONG PHRASE:**
 
-Take a verse/transitional-bridge/refrain form. Change the
-transitional bridge to an unbalanced section. Develop the chorus as
-a separate song system. Compare to the original.
+```text
+No one in the world could hear
 
-Routes to: [song forms](song-forms.md).
+the closing of the door
+```
+
+Try to create a sense of arrival with your shorter phrases; make a
+couple of tries:
+
+```text
+1.  (maybe try  / u / u / u ,  / u / u / )
+
+TEDDY DOESN'T LIVE HERE ANYMORE
+
+2.
+
+TEDDY DOESN'T LIVE HERE ANYMORE
+```
+
+The scansion hint on try 1 is printed only inside a figure; the running
+text gives no template. Try 2 is left bare, as printed.
+
+Routes to: [hook](hook.md), [phrasing](phrasing.md),
+[song forms examples](song-forms-examples.md).
+
+### Ex 38 — Unbalance the "YOU NEVER LET ME DOWN" bridge
+
+**EXERCISE 38: CHANGE THE TRANSITIONAL BRIDGE OF "YOU NEVER LET ME
+DOWN" SO IT FORMS AN UNBALANCED SECTION BY ITSELF. THEN DEVELOP THE
+CHORUS INTO A SEPARATE SYSTEM.**
+
+```text
+Trans Br:
+
+Chorus:
+```
+
+Last exercise in the chapter. Pat introduces the lyric it names with
+"Sometimes a Transitional Bridge leads, NOT to a separate Chorus, but
+to a Refrain." — worth holding onto while reading the exercise's second
+half. The lyric is quoted in
+[song forms examples](song-forms-examples.md) under the "You Never Let
+Me Down" heading.
+
+Routes to: [song forms examples](song-forms-examples.md),
+[song forms](song-forms.md).
 
 ## *Essential Guide to Lyric Form and Structure* (1991) — Hook exercises (Chapter 7)
 
 ### Ex 39 — Title first then title last
 
-Pick a chorus idea. Write a balanced chorus with the title in line 1.
-Then rewrite with the title as the last line. Compare. Which
-position spotlights the title harder?
+**EXERCISE 39: WRITE A BALANCED CHORUS USING THE FOLLOWING TITLE AT
+THE BEGINNING. THEN, REWRITE IT WITH THE SAME TITLE AT THE END.**
+
+```text
+YOU DON'T HAVE THE BEST OF ME YET
+
+Title First:
+
+Title Last:
+```
 
 Routes to: [hook](hook.md) "five strategies".
 
 ### Ex 40 — Verse setting up that chorus
 
-Take the chorus from Ex 39. Write a verse that sets it up using
-beginning-and-ending positions for important ideas.
+**EXERCISE 40: WRITE A VERSE TO SET UP YOUR CHORUS YOU WROTE FOR THE
+LAST EXERCISE. MAKE SURE YOU USE THE BEGINNING AND END POSITIONS FOR
+IMPORTANT IDEAS.**
+
+("YOUR CHORUS YOU WROTE" is as printed — do not correct it.)
 
 Routes to: [hook](hook.md), [verse development](verse-development.md).
 
 ### Ex 41 — Verse ending with refrain
 
-Write a verse ending with a refrain line. Make the refrain feel
-structurally necessary — use unbalanced rhythm and an odd phrase
-position so the refrain arrival is earned, not arbitrary.
+**EXERCISE 41: WRITE A VERSE THAT ENDS WITH THE REFRAIN:**
+
+```text
+YOU DON'T HAVE THE BEST OF ME YET
+```
+
+Make a repetition necessary by using two strategies:
+
+1. Unbalance the system by making the rhythmic closure at the Refrain
+   awkward, like "SEEING SOMEONE ELSE."
+2. Unbalance the section by making the Refrain an odd numbered phrase
+   (5th phrase or 7th would be ideal).
 
 Routes to: [hook](hook.md), [form](form.md).
 
-### Ex 42 — Title in different chorus positions plus targeting
+### Ex 42 — Chorus opening and closing with the hook, plus targeting
 
-Take an existing title phrase. Write a chorus beginning with it.
-Then write a chorus ending with it. Then write two transitional
-bridges, each targeting a different vowel sound that prepares the
-title's stressed vowel.
+**EXERCISE 42: WRITE A BALANCED CHORUS THAT BEGINS AND ENDS WITH THE
+HOOK,**
+
+```text
+I SLIPPED AND FELL IN LOVE
+```
+
+Now, using "WHY CAN'T I HAVE YOU" as a model,
+
+1. write a Transitional Bridge leading up to it that TARGETS to the
+   vowel sound in "slipped."
+2. Write a Transitional Bridge that targets to "fell."
 
 Routes to: [hook](hook.md) "targeting".
 
 ### Ex 43 — Hook rhythm in strategic position
 
-Pick three existing hook phrases (one duple, one triple, one mixed).
-Write a verse for each that places the hook's rhythm in the
-strategic position (the position that must later be matched at the
-balancing position).
+**EXERCISE 43: FOR EACH HOOK BELOW, WRITE A VERSE THAT USES THE HOOK
+RHYTHM IN A STRATEGIC POSITION.**
+
+```text
+1. LAST NIGHT'S LOVE
+
+2. MY FIRST LOVE WILL BE MY LAST
+
+3. THE LAST OF THE LONELY HEARTS
+```
 
 Routes to: [hook](hook.md) "strategic vs balancing position".
 
 ### Ex 44 — Full song system using all five strategies
 
-Pick a title phrase. Write a full song system that uses all five
-hook strategies:
+**EXERCISE 44: USING ALL FIVE STRATEGIES, WRITE A SONG SYSTEM FOR THE
+HOOK "DON'T GIVE UP."**
 
-1. Hot spots — title in section beginnings or endings.
-2. Point forward — earlier sections lead toward the title.
-3. Repeat — repeat the title for emphasis.
-4. Target sounds — plant the title's stressed vowel earlier.
-5. Hook rhythm in strategic positions.
+That is the whole exercise — one sentence. The five strategies are
+not part of it; Pat prints them separately as the chapter's closing
+summary, verbatim:
+
+```text
+1. Put the HOOK at the beginning or end of its section, maybe both.
+2. Keep your structure moving forward until you get to the HOOK
+3. Repeat the HOOK
+4. Use sound to spotlight your HOOK.
+5. Use the HOOK's rhythm in other strategic places.
+```
 
 Routes to: [hook](hook.md).
 

--- a/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
+++ b/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
@@ -25,7 +25,12 @@ The five elements:
 4. **Rhyme types** (the stability of each rhyme pair)
 5. **Rhythm** (the stress pattern under the line)
 
-> "There will be those five characteristics." — Pat (Coursera companion)
+> **Unaudited.** The "five characteristics" framing comes from Pat's Coursera
+> specialization, which is outside the four books and cannot be checked against
+> the corpus. It is paraphrase, not quotation. Only elements 1–4 are attested in
+> the books as a numbered set (*Essential Guide to Lyric Form and Structure*
+> (1991); see the four-juggling-balls note below); element 5, rhyme type, is the
+> subject of *Essential Guide to Rhyming* (2014).
 
 The five are not a rule; they are the five places where craft choices
 land. A section is "tight" when all five support the central emotion and
@@ -33,10 +38,23 @@ the section's job within the form.
 
 ## Why all five at once
 
-The classic prosody mistake is to fix one element in isolation. Switching
-a rhyme type from family to assonance can change a section's stability,
-but if the line lengths and rhythm still push stable, the new rhyme just
-sounds wrong. Diagnose all five before changing any one.
+The rows are not independent. Pat states the row 4 × row 3 interaction
+directly when he introduces the remote rhyme types
+(*Essential Guide to Rhyming* (2014), Chapter 6):
+
+> Now, let's look at even more remote rhyme types. They have many of the
+> qualities that you value, plus they can do things for you that we can't get
+> from most of our friends so far: they can suppress—or at least diminish—the
+> structural effects of your rhyme schemes.
+>
+> They'll still give you a main rhyming benefit: expressive use of the rhyming
+> position. But they give you something extra: a more subtle control of
+> structure, and new ways to affect the *moving* and *stopping* of structures.
+> These new techniques will be useful tools.
+
+Row 4 can suppress or diminish what row 3 does. So a row read alone can
+report the wrong answer: an `aabb` scheme is not closing anything if the
+types filling it are consonance. Diagnose all five before changing any one.
 
 ## The diagnostic worksheet
 
@@ -48,8 +66,11 @@ Section: <verse 1 | chorus | bridge | etc.>
 1. Number of lines:    <count>
 2. Line lengths:       <stresses per line, e.g., 4/3/4/3 or 4/4/4/4>
 3. Rhyme scheme:       <letters, e.g., abab, aabb, abcb, xaxa, none>
-4. Rhyme types:        <per pair: perfect / family / additive / subtractive
-                        / assonance / consonance / partial / weak-syllable>
+4. Rhyme types:        <per pair, most stable to least: perfect / family
+                        / additive / subtractive / assonance / consonance;
+                        plus partial (off-scale, prevents closure).
+                        "weak-syllable" is named but never defined in the
+                        source — see the caution under element 4 below.>
 5. Rhythm:             <duple / triple / mixed; established pattern;
                         deliberate variations>
 
@@ -99,10 +120,52 @@ pace, flow, and closure.
 
 ### 4. Rhyme types
 
-The stability of each rhyme. Perfect closes hardest; family closes
-nearly as hard; additive / subtractive close meaningfully; assonance
-and consonance suspend; partial opens. A section can have multiple
-rhyme types across its scheme.
+The stability of each rhyme. Pat prints the scale in *Essential Guide to
+Rhyming* (2014), Chapter 6 twice — once to open the chapter (p. 59) and
+again to close it (p. 67, "Look again at our scale") — having introduced
+it in Chapter 4:
+
+```text
+Scale of Rhyme Types: Most Stable to Least Stable
+
+Perfect      Family      Additive/Subtractive     Assonance     Consonance
+Rhyme        Rhyme              Rhyme               Rhyme         Rhyme
+
+Most Stable ─────────────────────────────────────────────────► Least Stable
+```
+
+Five positions, not a two-bucket split: consonance sits strictly below
+assonance. **Partial rhyme is not on the scale.** Pat treats it apart:
+"Partial rhyme is the first rhyme type you have seen that is used only
+for its special effects on structure. Use it to prevent closure in
+otherwise closed structures."
+
+A section can have multiple rhyme types across its scheme.
+
+**A caution on `weak-syllable` as a worksheet answer.** Chapter 6 opens by
+announcing four rhyme types — "1. assonance rhyme / 2. consonance rhyme /
+3. partial rhyme / 4. weak-syllable rhyme" — then delivers sections for only
+the first three. The phrase "weak-syllable rhyme" occurs exactly once in the
+whole of *Essential Guide to Rhyming* (2014), on that list, and the book's own
+index points only back to that page ("weak-syllable rhymes, 59"). It is never
+defined. Treat any weak-syllable answer in row 4 as undefined by the source
+rather than as a recognized type.
+
+Why row 4 is a lever and not just a label — Pat closes the chapter by
+naming what the remote types are *for*:
+
+> These more esoteric rhyme types are useful for two purposes:
+>
+> 1. developing strong content for rhyming positions
+> 2. modifying structural effects.
+>
+> With assonance rhyme, consonance rhyme, and partial rhyme, there is no
+> guesswork involved; they will affect structure. They will create
+> instability. Use them to support unstable ideas. Prosody.
+
+"No guesswork involved" is what makes this row a lever: setting it is a
+prosody decision with a predictable structural result, not a description
+of one.
 
 See [rhyme types](rhyme-types.md) for the full stability scale and
 worked examples per type.
@@ -253,13 +316,46 @@ are all single-row edits, which is why they are legible.
 
 Pat's four named uses of row 1 (phrase count), from the same chapter:
 
-1. spotlighting important ideas,
-2. pushing one section forward into another section,
-3. contrasting one section with another one,
-4. creating a need for a balancing section or phrase.
+1. SPOTLIGHTING IMPORTANT DETAILS
+2. PUSHING ONE SECTION FORWARD INTO ANOTHER SECTION
+3. CONTRASTING ONE SECTION WITH ANOTHER ONE
+4. CREATING A NEED FOR A BALANCING SECTION OR PHRASE
+
+These are Chapter 21's four section headings, printed in caps as shown.
 
 > Unbalanced sections make you want to move to find a stable spot. Balanced
 > sections stop motion; they pause for a rest.
+
+## Worked example — row 4 alone (*Essential Guide to Rhyming* (2014), Chapter 6)
+
+The "Some People's Lives" demonstration above edits one row at a time — row 3
+(rhyme scheme), then row 1 (phrase count). Chapter 6 supplies the matching
+demonstration for **row 4**: the rhyme scheme is left alone and only the rhyme
+*type* in one position changes.
+
+> Consonance rhyme never works like perfect rhyme. Yet, when it is strong
+> enough, it can work for you. You might use it in a case where you have already
+> committed to a rhyme scheme in an earlier verse, and want to keep it, yet relax
+> the motion in a later verse. In verse 3 of Paul Simon's "50 Ways to Leave Your
+> Lover," the end-rhymes are:
+>
+> ```text
+> pain
+> again
+> explain
+> ```
+>
+> His use of the consonance rhyme is pretty. The verses are relaxed, both in
+> attitude and structure. The consonance rhyme in second position dampens the
+> resolving effect of the consecutive rhymes. Try replacing "again" with a
+> perfect rhyme and see what happens! The prosody evaporates.
+
+Rows 1, 2, 3 and 5 are untouched; only the type in second position moves, and the
+section's motion changes. That is the row-4 lever in isolation.
+
+See [rhyme types](rhyme-types.md) for the consonance and partial-rhyme
+treatments in full, and [rhyme strategy](rhyme-strategy.md) for the same example
+read as a scheme-level decision.
 
 ## Coaching prompts
 
@@ -280,8 +376,11 @@ Pat's four named uses of row 1 (phrase count), from the same chapter:
 - **Treating consistency across sections as a virtue.** Verse and
   chorus should differ on at least two rows.
 - **Changing all five rows at once.** One row at a time. Then re-test.
-- **Skipping row 4 (rhyme types).** This is the row most writers leave
-  on autopilot. Naming it forces a stability decision.
+- **Skipping row 4 (rhyme types).** Pat's ground for filling it is that
+  the remote types are predictable, not decorative: "there is no
+  guesswork involved; they will affect structure. They will create
+  instability" (*Essential Guide to Rhyming* (2014), Chapter 6). An
+  unfilled row 4 is a structural effect you did not choose.
 - **Counting syllables instead of stresses for row 2.** Stress count
   is what the ear tracks.
 
@@ -294,8 +393,36 @@ Pat's four named uses of row 1 (phrase count), from the same chapter:
 
 ## Four-juggling-balls origin (*Essential Guide to Lyric Form and Structure* (1991) introduction)
 
-Pat's *Essential Guide to Lyric Form and Structure* (1991) introduction frames lyric craft as juggling balls — the
-writer learns one ball before adding the next. In *Essential Guide to Lyric Form and Structure* (1991), four
+The Introduction is titled "LYRIC ELEMENTS: THE GREAT JUGGLING ACT". After a
+verse of Sting's "BE STILL MY BEATING HEART", Pat writes:
+
+> You will have no trouble learning about lyric structure. It is simple, just
+> like juggling. When a juggler keeps four balls in the air at once it may seem
+> like magic, but there is no magic involved. The juggler learned by throwing
+> one ball up and catching it, throwing and catching, stopping and starting the
+> motion; always gaining greater control over the movement of the ball. Then
+> came two balls, then three, throwing and catching, stopping and starting,
+> with greater and greater control.
+>
+> As a lyricist, you must learn to juggle four balls.
+
+He then prints the four questions twice — first as analysis of Sting's verse,
+then as the writer's own choices:
+
+> 1. How many phrases does it have?
+> 2. How long is each phrase?
+> 3. What is the rhythm of each phrase?
+> 4. How are rhymes arranged?
+
+> Any time you write a verse (or any part of a lyric for that matter) you will
+> have to deal with these four lyric elements.
+>
+> 1. How many phrases will I have?
+> 2. How long will each phrase be?
+> 3. What rhythms will I use in each phrase?
+> 4. How should I arrange the rhymes?
+
+In *Essential Guide to Lyric Form and Structure* (1991), four
 balls (not five) are introduced sequentially:
 
 - Ball 1 (Chapter 1) — phrase count (number of lines)

--- a/plugins/songwriting/context/pat-pattison/research/form.md
+++ b/plugins/songwriting/context/pat-pattison/research/form.md
@@ -59,7 +59,14 @@ Every section has a job:
 
 > DEVELOPMENTAL SECTIONS contain DEVELOPMENTAL IDEAS: ideas that lead up to or
 > develop the CENTRAL IDEA. They should move forward until they get to a CENTRAL
-> SECTION.
+> SECTION. You, of course, have to decide what you want your lyric to say —
+> what your CENTRAL IDEA will be. Once you have decided, construct a CENTRAL
+> SECTION for it. Then construct your DEVELOPMENTAL SECTIONS to serve THE
+> CENTRAL SECTION. Each section in your lyric will have its own job to do. Here
+> are the most typical jobs, so typical that they have names:
+
+That is Pat's build order, stated in his own words: central idea → central
+section → developmental sections that serve it.
 
 The named jobs, from *Essential Guide to Lyric Form and Structure* (1991),
 Chapter 5:
@@ -296,34 +303,68 @@ sections cannot sound like repetition, contrast, departure, or return.
 
 ## Verse-only songs
 
-A song can contain only verses if the verses remain interesting and each verse
-moves to a new place. In that case, the central idea may live inside each
-verse.
+Pat's worked case is Ervin Drake's "IT WAS A VERY GOOD YEAR."
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 5:
 
-Worked example: in "It Was a Very Good Year," the repeated title idea normally
-appears early, so the final verse can delay it until the end. That variation
-spotlights both the new second phrase and the final title return.
+> "IT WAS A VERY GOOD YEAR," like many songs, is made up only of verses. It has
+> no contrasting sections. When you write a lyric that contains only verses,
+> make sure they are interesting.
 
-Principle: repeated verse structures need meaningful variation, not random
-change. Save a changed spotlight position for an idea worth lighting.
+> In the fourth verse there is a wonderful variation. You expect the CENTRAL
+> IDEA to be the second phrase because that's where it was in the other verses.
+> But no.
+
+<!-- LYRIC-HANDOFF pending: Chapter 5 prints four verses of "IT WAS A VERY GOOD
+YEAR" (Ervin Drake) at spine 013 l.87-141 — seventeen / twenty-one /
+thirty-five / "But now the days are short". None is transcribed here yet, so the
+analysis above has no text to point at. -->
+
+> Saving the CENTRAL IDEA till last has two effects:
+>
+> 1. It calls attention to the second phrase, which contains an important idea.
+>
+> 2. It takes you by surprise. Whole flotillas of spotlights turn on to light up
+>    the CENTRAL IDEA.
+
+And on why the verses stay interesting:
+
+> Verses should work like the paragraphs of an essay, moving forward from one
+> idea to the next. Look carefully at "IT WAS A VERY GOOD YEAR." Each verse
+> moves to a new place.
 
 ## Chorus
 
-A chorus completes, comments on, or summarizes ideas. It normally contains the
-central idea, acts as the central section, is the lyric's most balanced
-section, and stops forward motion.
+Chapter 5 prints the Chorus jobs as a five-point list, in the same shape as the
+Verse list above:
 
-Because a chorus usually follows verse material, it is also a contrasting
-section. The verse moves toward it; the chorus lets the listener arrive.
+> Chorus
+>
+> 1. Completes, comments on, or summarizes ideas.
+> 2. Contains the CENTRAL IDEA.
+> 3. Is the lyric's CENTRAL SECTION.
+> 4. Is typically the lyric's most balanced section.
+>
+> thus, 5. Stops forward motion.
 
-```text
-verse:  develops / moves / sets up
-chorus: summarizes / balances / stops
-```
+> Because every song that has a Chorus has one or more verses, a Chorus is
+> usually a contrasting element. The verse ideas move toward or "come home" to
+> the Chorus. Because the Chorus is a CENTRAL SECTION — a place where ideas are
+> completed — the end of the Chorus should stop forward motion. This creates the
+> feeling of "starting over again" in the next section. Here is an excellent
+> Chorus.
 
-"Most balanced" does not mean perfectly symmetrical. A chorus can contain its
-own phrase-length or rhythmic trick while still functioning as the strongest
-arrival point.
+<!-- LYRIC-HANDOFF pending: Pat's colon-equivalent above ("Here is an excellent
+Chorus.") is followed in the chapter by the five-phrase "Years" chorus, spine
+013 l.171-181. Not transcribed here yet. -->
+
+His verdict on that chorus (the "Years" chorus, discussed further under "Chorus
+balance can be composite" below):
+
+> This certainly fits all five of the prescriptions for a Chorus. It summarizes
+> and comments on the verses. It contains the CENTRAL IDEA: "Years are both fast
+> and slow at the same time." It is the lyric's CENTRAL ELEMENT, in terms of
+> structure and meaning, it is the most balanced element in the lyric, and it
+> stops motion.
 
 ## Contrast principle
 
@@ -425,16 +466,43 @@ second group: 3 phrases x 2 stresses = 6
 effect: balanced total, built-in acceleration
 ```
 
-This is form-level juggling: the chorus comments on the long, loose verse
-material by becoming more compact, balanced, and focused.
+Pat's own wording, *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 5 — the arithmetic is his, and the figures `image_rsrc320` and
+`image_rsrc321` carry the scanned phrases:
 
-The musical setting is what completes the prosody, and the stress arithmetic
-alone misses it. The song gives both groups the same four bars — but three
-phrases now have to fit the space two phrases had, and the final phrase gets
-only one bar. The lyric says years go fast; the setting compresses the last
-phrase into the smallest space in the section. When checking a chorus like
-this, ask how much musical time each group occupies, not just how many
-stresses it contains.
+> Beth Nielsen Chapman also does a neat trick with stresses to balance the
+> section. The first two phrases are three stresses (2 x 3 = 6):
+
+> The last three phrases are each two stresses (3 x 2 = 6):
+
+> A balancing act with built in acceleration.
+
+<!-- LYRIC-HANDOFF pending: both of Pat's colons above are dangling — the
+scanned phrases live only in figures `image_rsrc320` and `image_rsrc321` (spine
+013 l.187-191), and the eight-phrase "Years" verse he comments on below is at
+l.206-222. None is transcribed here yet. -->
+
+The chapter frames the same chorus against the five Chorus prescriptions:
+
+> Of course, as you saw earlier, it does its own trick with phrase lengths.
+> Being most balanced doesn't necessarily mean perfectly balanced.
+
+<!-- Chapter 5 gives stress arithmetic only. A prior revision of this file
+added a paragraph about the two groups sharing "the same four bars" and the
+final phrase getting "only one bar"; the chapter never mentions bars, beats or
+musical time for this chorus, and that paragraph has been removed as
+fabrication. -->
+
+This is form-level juggling: the chorus comments on the long, loose verse
+material by becoming more compact, balanced, and focused. That is Pat's point
+about the verse too — Chapter 5, verbatim:
+
+> The verse phrases are long. It takes a long time to get from rhyme to rhyme.
+> It is even a challenge to figure out exactly where some of the phrases start
+> and stop. And the "just-barely-if-at-all" rhyme "there/year" sort of trails
+> off as you watch the singer look around and remember...
+
+> Then into the Chorus. Neat.
 
 ## Phrase-count balance
 
@@ -444,12 +512,13 @@ while an odd number tends to feel unstable.
 
 > The way you keep or lose your balance makes all the difference to your audience.
 
-Use phrase-count balance for four jobs:
+Chapter 21 divides into four numbered sub-sections, one per job. Their headings,
+as printed:
 
-- Spotlighting important ideas.
-- Pushing one section forward into another.
-- Contrasting one section with another.
-- Creating the need for a later balancing phrase or section.
+1. SPOTLIGHTING IMPORTANT DETAILS
+2. PUSHING ONE SECTION FORWARD INTO ANOTHER SECTION
+3. CONTRASTING ONE SECTION WITH ANOTHER ONE
+4. CREATING A NEED FOR A BALANCING SECTION OR PHRASE
 
 Balance and imbalance are not moral categories. A stable section can give an
 important line a resting place. An unstable section can make the listener lean
@@ -546,10 +615,12 @@ For verse-only songs where every section contains the central idea, plain
 
 ## Bridge
 
-A bridge is developmental. It develops a new perspective or contrasting idea,
-moves away from established structures, creates structural tension, and is
-resolved by returning to familiar structures. It is often the lyric's most
-unbalanced section.
+Chapter 5's five-point account of what a bridge *is* ("1. It is a DEVELOPMENTAL
+section… thus, 5. It is frequently the lyric's most unbalanced section.") is
+held verbatim in [bridge](bridge.md). Summarised here only so the section reads:
+a bridge develops a new perspective or contrasting idea, moves away from
+established structures, creates structural tension, and is resolved by a return
+to previously established structures.
 
 ```text
 home base: Verse / Verse
@@ -560,10 +631,29 @@ return:    Verse
 In AABA form, the first two A sections define home. The B section moves away.
 The return to A feels like arrival because the bridge created tension.
 
-Worked example: in "The Great Pretender," the bridge's rhythm feels balanced
-as a section, but its rhyme behavior withholds the expected sound and replaces
-it with a string of related sounds. The bridge is coherent and destabilizing at
-the same time.
+Pat's worked example is Buck Ram's "THE GREAT PRETENDER." Chapter 5, verbatim:
+
+> A very pretty bridge. Though it feels like a section, it still throws you off
+> balance a little, which gets you ready to move into the last verse. Look.
+
+> One ball moves smoothly: the rhythm is balanced and gives you a nice feeling
+> of section. But one ball is unbalanced. You want to hear a rhyme with
+> "believe:"
+
+> But what you get is:
+
+> A slick deception that throws you off balance with five "eel" sounds. Since
+> you are a little off balance, the return to familiar territory is a relief. A
+> new and bigger Song System is formed.
+
+<!-- LYRIC-HANDOFF pending: both of Pat's dangling colons above resolve into
+figures — `image_rsrc324` (the rhyme you expect after "believe") and
+`image_rsrc325` (the rhyme you actually get). Neither is transcribed here yet.
+Spine 013 l.302-308. -->
+
+The AABA homecoming paragraph that follows this passage in the chapter, and the
+`( Bridge -> Verse )` figure `image_rsrc327`, are both quoted in
+[bridge](bridge.md).
 
 ## Bridge in verse-chorus forms
 
@@ -586,8 +676,19 @@ the departure.
 Pattison uses "transitional bridge" for the short developmental section placed
 inside a song system, usually between verse and chorus.
 
-Other names include pre-chorus, climb, lift, vest, verse extension, ramp,
-prime. The name matters less than the job:
+Pat's own preamble: "This is as close as I can come to an accurate name for this
+elusive little section. I have heard it called by many names:" — the colon is
+dangling, and the names live only in figure `image_rsrc32E`. The figure prints
+**six** entries: Pre-Chorus, Vest, Ramp, Climb or Lift, Verse Extension, Prime.
+They are set out with their provenance under "Transitional bridge —
+alternative-name list" below.
+
+<!-- "Climb or Lift" is ONE entry in the figure. A prior revision of this line
+listed seven by splitting climb from lift ("pre-chorus, climb, lift, vest, verse
+extension, ramp, prime"). bridge.md and the alternative-name-list section below
+both already state the six correctly; this line now agrees with them. -->
+
+The name matters less than the job:
 
 - Introduces a pivotal idea between verse and chorus.
 - Is enclosed inside a song system.
@@ -600,36 +701,75 @@ Verse -> Transitional Bridge -> Chorus
 open  -> more unstable        -> central arrival
 ```
 
-Worked example: in The Cars' "Why Can't I Have You," the transitional bridge
-uses repeated rhythmic setup, a shorter third phrase, and an imperfect long-i
-rhyme to trip the listener forward into the title-bearing chorus.
+Pat's worked example is Ric Ocasek's "WHY CAN'T I HAVE YOU" — "This one by Ric
+Ocasek of The Cars is typical." Chapter 5, verbatim:
+
+> The structure of this Transitional Bridge is VERY effective. Its first two
+> lines don't rhyme, but they make a couplet with repeating rhythmic structure:
+
+> The third line is short, unbalancing the section both in length and with an
+> odd number of phrases.
+
+> Added to these unbalancing techniques is the imperfect rhyme "time/mind"
+> positioned to trip you up like a piano wire stretched across the road:
+
+> Not only does this asymmetrical position push you forward, but it sets you up
+> for the long "i" sound of the key words of the HOOK: "WHY CAN'T I HAVE YOU"!
+> The chorus "i" sounds are also positioned asymmetrically, so there is no
+> resolution until the end of the system.
+
+> A Transitional Bridge can change. Here, one phrase makes a difference in
+> meaning, but the structure is preserved. The tripping effect at the long "i"
+> rhyme at "blind" again sets up the sound of the Title.
+
+<!-- LYRIC-HANDOFF pending: each of Pat's colons above is followed in the
+chapter by the transitional-bridge lines being discussed (spine 013 l.404-428),
+and Song Systems 1 and 2 are figures `image_rsrc32F` / `image_rsrc32G`. None is
+transcribed here yet. -->
+
+<!-- unaudited: the summary bullets above ("Introduces a pivotal idea…") are a
+restatement of Chapter 5's five numbered points; those are verbatim in
+bridge.md. -->
+
+<!-- unaudited: elsewhere this file says the "Great Pretender" example uses "an
+extra phrase after an established balanced pattern". Chapter 5 makes no
+phrase-count claim about that bridge — its point is the rhyme deception ("five
+'eel' sounds"). Treat the extra-phrase reading as editorial. -->
 
 ## Refrain
 
-A refrain is not a separate section. It is part of a verse that contains the
-central idea and repeats in other verses.
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 5, verbatim:
 
-Checklist:
+> This is not a section at all. It is just a name for the part of a Verse that
+> contains the CENTRAL IDEA and gets repeated in the other Verses. A Refrain is
+> different from a Chorus, since a Chorus is contained in its own separate
+> section. "Refrain" is a handy term when you talk about lyrics that have only
+> Verses, or Verses and a Bridge.
 
-- Contains the central idea.
-- Lives inside the verse.
-- Repeats in other verses.
-- Is not its own separate section.
+> A Refrain usually comes either at the beginning or the end of a verse. In
+> older "Standards" of the 30's and 40's it usually came at the beginning of the
+> Verse. Recently it comes more often at the end. What is important is:
+>
+> 1. It contains the CENTRAL IDEA
+> 2. It is part of the Verse
+> 3. It is repeated in other Verses
+> 4. It is NOT a separate section
 
-Refrains commonly appear at the beginning or end of a verse. Their placement
-can vary for effect, as in a final verse that delays the refrain until the end.
+> The content of a Refrain should be the CENTRAL IDEA of the Verse. The rest of
+> the Verse develops or leads up to this Central idea. The Refrain contains the
+> TITLE of the song, but can contain other repeated material.
 
 ## Hook
 
-In this chapter, hook means title: the focused statement of the central idea.
-Put it in important structural positions:
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 5, in full — it is
+two sentences and a semicolon-separated list, not a bulleted one:
 
-- balancing position
-- deceptive position
-- unexpected position
-- first and/or last in the chorus
+> In lyrics, "HOOK" means (or should mean) "TITLE." It is the focused statement
+> of the CENTRAL IDEA. You should put it in the most important places in your
+> lyric: in the balancing position; in the deceptive position; in the unexpected
+> position; first and/or last in your Chorus.
 
-Later coverage expands hook placement in [hook](hook.md).
+Chapter 7 expands hook placement — see [hook](hook.md).
 
 ## Section construction
 
@@ -639,40 +779,41 @@ like a verse, chorus, bridge, or transitional bridge. That material is split
 into [section building](section-building.md) so this file can stay focused on
 larger form roles and song systems.
 
-## Exercises to preserve
+## Exercises
 
-- Find the central idea and central section.
-- Label verse, chorus, bridge, refrain, hook, and transitional bridge by job,
-  not by habit or placement alone.
-- Group sections into song systems and mark where each system closes.
-- Test whether bridges and transitional bridges contrast soon enough.
-- Move the central idea or title into a structural spotlight position.
-- Rewrite a fast, active passage as longer phrases with fewer rhymes, then
-  compare how much energy disappears.
-- Rewrite a verse so it contrasts with an existing chorus instead of duplicating
-  the chorus's phrase count, rhyme scheme, or common-meter feel.
-- Add or remove one phrase from a balanced section and listen for the new
-  pressure point.
-- In a lyric with at least three verses, establish a balanced section pattern,
-  then deliberately unbalance a later section and pay it off with a final
-  balancing phrase.
+Chapter 5 prints exactly five exercises — **EXERCISE 29 through EXERCISE 33** —
+and all five are built on the "candy bar" section. They are held verbatim in
+[exercises](exercises.md); do not restate them here.
 
-## Revision workflow
+<!-- A prior revision of this file carried a nine-bullet "Exercises to preserve"
+list ("Find the central idea and central section", "Group sections into song
+systems and mark where each system closes", …). None of those bullets is an
+exercise in Chapter 5; they were invented and have been removed. -->
 
-1. Name the central idea.
-2. Identify the central section.
-3. Label every other section developmental or central.
-4. Mark each section's phrase count, phrase length, rhythm, rhyme scheme, flow,
-   closure, and closure type.
-5. Decide whether each section should move or stop.
-6. Check whether the first phrase of each contrasting section actually
-   contrasts.
-7. Check whether rhyme spacing matches the section's intended speed.
-8. Count phrases locally and across the song system.
-9. Mark stable positions, unstable positions, and delayed balancing phrases.
-10. Put titles and central ideas in structurally important positions.
-11. Build song systems and test whether each system closes before the next
-   begins.
+## What Chapter 5 tells you to do
+
+Chapter 5 closes with its own instruction, verbatim:
+
+> You have looked at typical elements or sections of lyrics. It is important to
+> put them together carefully so they can do their jobs, arranging phrases to
+> make sections move or stop appropriately. Learn the niceties of juggling
+> number of phrases, phrase lengths, rhythms, and rhymes. It helps, especially
+> when you write whole lyrics. The same techniques time after time get less and
+> less effective. Always be on the lookout for new ways to turn on the lights.
+
+The build order is the one quoted under "Central and developmental sections"
+above: decide the CENTRAL IDEA, construct a CENTRAL SECTION for it, then
+construct the DEVELOPMENTAL SECTIONS to serve it.
+
+<!-- A prior revision of this file carried an eleven-step numbered "Revision
+workflow" ("1. Name the central idea. … 11. Build song systems and test whether
+each system closes before the next begins."). Chapter 5 prints no such
+procedure; it was invented and has been removed. -->
+
+<!-- unaudited: the "Common fixes" list below is editorial synthesis. Chapter 5
+prints no if/then fix list. Individual items restate Ch5 claims that are already
+quoted verbatim elsewhere in this file; treat the list as an index, not as
+Pat's wording. -->
 
 ## Common fixes
 
@@ -717,14 +858,19 @@ verse/refrain and AABA the bridge plus the final verse make a system *longer*
 than the verse-only ones before it. Pat's word is **different**, not shorter.
 See [bridge](bridge.md).
 
-A bridge that serves only one function may still work. A bridge that
-serves none should be cut — verse-chorus alone is enough.
+<!-- unaudited: "A bridge that serves only one function may still work. A bridge
+that serves none should be cut" is editorial; neither chapter states it. -->
 
-The bridge MUST differ from verses where it counts. The first line
-matters most: a bridge that opens like a verse signals "another verse"
-instead of "something new."
+On the bridge having to differ from the verses, Pat's actual sentence —
+*Writing Better Lyrics* (2009), Chapter 23, quoted in full rather than clipped
+to a bare "— Pat" tag:
 
-> "A bridge isn't a verse." — Pat (*Writing Better Lyrics* (2009), Chapter 23)
+> Again, be careful. A bridge isn't a verse — it doesn't do the same job or use
+> the same structure. It is a contrasting section.
+
+Chapter 5's test of *when* the contrast has to land is quoted in
+[bridge](bridge.md): "A Bridge should sound completely different right from its
+very first phrase."
 
 ## Four building levers — the candy bar discipline
 
@@ -736,8 +882,21 @@ any section:
 3. Rhythm of phrases (duple, triple, mixed)
 4. Rhyme scheme
 
-A section is the sum of choices across these four. Changing any one
-changes the section's character without changing the idea.
+Pat's own framing of the four, and of why the same verse keeps coming back:
+
+> We will use each one to juggle the candy bar verse. Our goal is to make
+> different kinds of lyric sections.
+
+> By the time you finish this chapter, you will have a better sense of how to
+> build the most typical lyric sections. You will also be very tired of candy
+> bars. I used the same verse again and again to show that it is structure, not
+> content, that makes a section what it is.
+
+> In general, balance or symmetry stop motion, while imbalance or asymmetry push
+> forward.
+
+<!-- unaudited: the four-rewrite template below is editorial scaffolding, not a
+procedure Chapter 5 prints. Pat's actual drills are EXERCISE 29-33. -->
 
 The candy bar discipline: take one verse, rewrite it four times.
 Each rewrite varies only one lever.
@@ -767,42 +926,58 @@ rewrite exposes what the original lever was doing. The version that
 lands becomes the section; the other three become candidate bridges
 or contrast verses.
 
-See [exercises](exercises.md) Ex 29-31 for the full candy bar
+See [exercises](exercises.md) Ex 29-33 for the full candy bar
 exercise series.
 
 ## Refrain is not a separate section
 
-A persistent diagnostic distinction Pat enforces:
+Pat's own statement of the distinction is quoted verbatim under "Refrain"
+above. In his words: "A Refrain is different from a Chorus, since a Chorus is
+contained in its own separate section."
 
-- A **chorus** is a separate section with its own structure.
-- A **refrain** is the last line (or two) of every verse, repeated.
+Two corrections to what this section used to say:
 
-A refrain lives inside the verse. A chorus lives outside the verse.
-Songs can have one, the other, or both. Treating a refrain as a
-"mini-chorus" misroutes structural decisions.
-
-> "Refrain is part of the verse." — Pat (*Essential Guide to Lyric Form and Structure* (1991), Chapter 5, paraphrase)
+- It claimed a refrain is "the last line (or two) of every verse." Chapter 5
+  says the opposite is equally available: "A Refrain usually comes either at the
+  beginning or the end of a verse. In older 'Standards' of the 30's and 40's it
+  usually came at the beginning of the Verse. Recently it comes more often at
+  the end."
+- It carried a blockquote reading `"Refrain is part of the verse." — Pat`,
+  labelled a paraphrase. That is not a sentence Pat writes. His numbered point
+  is "2. It is part of the Verse", and it is restored verbatim above.
 
 ## Transitional bridge — distinct from typical bridge
 
 *Essential Guide to Lyric Form and Structure* (1991), Chapter 5 names a specific kind of bridge that lives **between**
 verse and chorus, not after a closed verse-chorus cycle.
 
-Differences:
+Pat states the difference himself, and it is a difference of *position*, not of
+length:
 
-| Feature | Typical bridge | Transitional bridge |
-|---|---|---|
-| Position | After V/Ch closes a system | Inside V→Ch flow, before chorus |
-| Length | Substantial section (often 4-8 lines) | Short (often 2-4 lines) |
-| Function | New perspective, contrast, release | Push momentum into chorus |
-| Stability | Often unstable, leans into chorus | Always unstable, never closes |
+> But remember, a Transitional Bridge comes before the Song System has closed
+> down, between a Verse and a Chorus. The more typical Bridge always comes after
+> a song system has closed down.
 
-A transitional bridge is sometimes called a "pre-chorus" in
-contemporary terminology. Pat keeps Pat's term because it names
-the structural job rather than the position alone.
+On relative size, all Chapter 5 says is point 5 of its transitional-bridge list:
+"It is usually the lyric's shortest and most unbalanced section."
 
-Use transitional bridges when a verse-chorus boundary feels abrupt;
-the transitional bridge softens the seam while building tension.
+And on when you would reach for one:
+
+> You won't use Transitional Bridges too often unless you write dance songs, in
+> R&B and more Pop-oriented rock, where songs rely on a strong dance groove.
+> Both verse and chorus usually have the same groove, so a Transitional Bridge
+> is inserted between them as a "release" — to break the monotony and build
+> tension for a return to the groove.
+
+<!-- A prior revision carried a four-row comparison table asserting line counts
+("Substantial section (often 4-8 lines)" vs "Short (often 2-4 lines)") and an
+absolute ("Always unstable, never closes"), plus an invented use-rule ("Use
+transitional bridges when a verse-chorus boundary feels abrupt; the transitional
+bridge softens the seam"). Chapter 5 gives no line counts for either section and
+no such rule; all three were invented and have been removed. -->
+
+The full five-point list and the full-bridge contrast are quoted verbatim in
+[bridge](bridge.md).
 
 ## Transitional bridge — alternative-name list (*Essential Guide to Lyric Form and Structure* (1991), Chapter 5)
 
@@ -841,17 +1016,35 @@ The Song System is the verse + (transitional bridge) + chorus unit (or
 verse + refrain unit) — the smallest repeatable structural cycle in a
 song. Multiple song systems stack to form the full song.
 
-The name's origin matters because the concept feels canonical now (Pat
-treats it as established vocabulary across all four books and Berklee
-Online courses), but it was effectively named by Pat + Tom Frazee at
-some point in the mid-1980s. Attribution is honest about its informal
-origin.
+Pat's fuller wording, verbatim:
+
+> Either I made up this name, or my friend Tom Frazee did. I don't remember
+> which. A "Song System" is a group of sections that work together in larger
+> movements, or cycles of motion. The idea is especially helpful when looking at
+> a group of contrasting sections. A Song System always has a CENTRAL SECTION
+> and often has one or more DEVELOPMENTAL SECTIONS.
+
+> Each Song System is a cycle. Each closes down after the CENTRAL SECTION. Once
+> you finish a Song System, you have to start something else: maybe another
+> system just like the one you finished, or maybe something different. But one
+> thing is clear: you have finished something, so you must either be through
+> with the song, or start something up again.
+
+<!-- A prior revision dated the coinage to "some point in the mid-1980s".
+Chapter 5 gives no date — Pat says only that he does not remember which of the
+two of them coined it. Removed. -->
 
 ## Painting / music — forward-movement framing (*Essential Guide to Lyric Form and Structure* (1991), Chapter 5)
 
-Pat's framing for why structural choices matter:
+Pat's framing for why structural choices matter. The passage is quoted verbatim
+under "Core idea" above; the sentence that carries this section is:
 
-> A lyric is like a piece of music: it moves forward one syllable at a time through time. It is not a painting that the listener sees all at once.
+> A lyric is like a piece of music, it moves forward one syllable at a time,
+> through time. It is not like a painting, which you can experience all at once.
+
+<!-- This section previously carried a reworded version of that sentence ("It is
+not a painting that the listener sees all at once") set as a blockquote.
+Corrected against spine 013 l.7. -->
 
 Implication: structural decisions are decisions about MOTION, not about
 arrangement. A line's position in the song affects when the listener
@@ -885,4 +1078,5 @@ helps refocus on the temporal nature of song listening.
 - [phrasing](phrasing.md) — the count and length levers.
 - [meter](meter.md) — the rhythm lever.
 - [rhyme strategy](rhyme-strategy.md) — the rhyme-scheme lever.
-- [exercises](exercises.md) Ex 29-31, 34-38 — form drills.
+- [exercises](exercises.md) Ex 29-33 — Chapter 5's five form drills, all built
+  on the "candy bar" section.

--- a/plugins/songwriting/context/pat-pattison/research/fragment-development.md
+++ b/plugins/songwriting/context/pat-pattison/research/fragment-development.md
@@ -4,6 +4,14 @@ The writer has a partial line, hook fragment, half a verse, or scrap of
 language but doesn't know how to develop it. This file routes fragment →
 draft.
 
+<!-- unaudited: this file is a routing workflow, not a book chapter. Its numbered
+steps, its Step-1/Step-2 inventories, its "structural role" and "Common failure
+modes" tables, and its trigger-phrase list are editorial scaffolding — Pat
+prints no fragment-development procedure in any of the four books. Only the two
+passages carrying an explicit citation (the Chapter 5 build order in Step 5, and
+the refrain reference in the Step 4 table) are traceable to a page. Everything
+else here is house method; do not quote it as Pat's. -->
+
 Distinct from:
 
 - `brainstorm.md` — no material yet
@@ -86,9 +94,17 @@ the surrounding context develops.
 
 ## Step 5 — Build outward (working backwards from strong material)
 
-Pat's principle: build the central section first. If the fragment IS the
-central section's seed, draft outward from it. If the fragment is a verse
-piece, locate the central section first, then draft the fragment's verse.
+Pat states the build order himself, *Essential Guide to Lyric Form and
+Structure* (1991), Chapter 5:
+
+> You, of course, have to decide what you want your lyric to say — what your
+> CENTRAL IDEA will be. Once you have decided, construct a CENTRAL SECTION for
+> it. Then construct your DEVELOPMENTAL SECTIONS to serve THE CENTRAL SECTION.
+> Each section in your lyric will have its own job to do.
+
+So: if the fragment IS the central section's seed, draft outward from it. If the
+fragment is a verse piece, locate the central section first, then draft the
+fragment's verse.
 
 Per `verse-development.md`:
 
@@ -122,7 +138,12 @@ context:
 
 Most fragments survive their original form; some get sharpened during the
 build. A fragment that wants to change as the song develops is a healthy
-fragment — Pat: every revision is an option, not a betrayal.
+fragment.
+
+<!-- FABRICATION REMOVED: this paragraph previously ended "— Pat: every revision
+is an option, not a betrayal." No such sentence appears anywhere in the four
+books; "betray"/"betrayal" occurs in the corpus only inside two object-writing
+samples in *Songwriting Without Boundaries* (2011). Invented quote, deleted. -->
 
 ## When the fragment resists development
 

--- a/plugins/songwriting/context/pat-pattison/research/hook.md
+++ b/plugins/songwriting/context/pat-pattison/research/hook.md
@@ -1,33 +1,48 @@
 # Hook
 
-Pat Pattison - *Songwriting: Essential Guide to Lyric Form and Structure* (1991), Chapter 7.
+Pat Pattison — *Essential Guide to Lyric Form and Structure* (1991), Chapter 7:
+"HOOK PLACEMENT AND FOCUS: TURNING THE LIGHTS ON."
 
 Notation: `/` = stressed syllable, `u` = unstressed syllable.
 
 ## Core idea
 
-The hook is the title or focused statement of the central idea. Structure should
-put it in the spotlight instead of hoping the listener notices it.
+Pat's opening paragraph, verbatim:
 
-> "Your HOOK is the hero of your lyric."
+> "Your HOOK is the hero of your lyric. It belongs in the spotlight, the most
+> important place in your lyric. But putting it there is up to you. You have to
+> put it in focus. You can't just toss your HOOK anywhere and hope the light
+> shines on it — you have to choose where and when to turn the spotlight on.
+> You must refuse to let the light shine anyplace else. Here are five useful
+> strategies for putting your HOOK in lights."
 
-Pattison gives five strategies:
+The five, as printed:
 
-1. Put the hook at the beginning or end of its section, maybe both.
-2. Keep structure moving forward until the hook.
-3. Repeat the hook.
-4. Use sound to spotlight the hook.
-5. Use the hook's rhythm in other strategic places.
+1. Put the HOOK at the beginning or end of its section, maybe both.
+2. Keep your structure moving forward until you get to the HOOK.
+3. Repeat the HOOK.
+4. Use sound to spotlight your HOOK.
+5. Use the HOOK's rhythm in other strategic places.
+
+> "Let's take a quick tour."
 
 ## Strategy 1: hot spots
 
-Beginnings and endings are hot spots. They are high-attention positions at
-several levels:
+> "This one is easy, but it is worth looking at. What it really says is that
+> lights are brighter at the beginnings and ends of sections than in the spaces
+> between."
 
-- Opening and closing section of the whole lyric.
-- Opening and closing phrase of the whole lyric.
-- Opening and closing phrase of each section.
-- Opening and closing idea word inside a phrase.
+Pat then extends it. His three levels, verbatim (italics as printed):
+
+> "The principle of beginnings and endings applies other places.
+>
+> For the lyric as a whole, it says that the opening *section* and the closing
+> *section* must be very strong.
+>
+> *For the lyric as a whole,* it says that the opening *phrase* and the closing
+> *phrase* must be very strong.
+>
+> *For each phrase of your lyric.*"
 
 For a chorus, the hook can appear first, last, or both. Chapter 7's three
 examples:
@@ -74,50 +89,81 @@ most cases would be too much.
 
 ## Hot spots make meaning
 
-Two revision questions are equivalent:
+> "This is important: when you use beginnings and endings for their value as
+> HOT SPOTS, you can think of it this way:
+>
+> Find your most important ideas and put them in the HOT SPOTS.
+>
+> Or, you can think of it this way:
+>
+> Whatever ideas you put in HOT SPOTS become your most important ideas. You
+> make them important by putting them there."
 
-- Which ideas are most important, and are they in hot spots?
-- Which ideas are in hot spots, and have you accidentally made them most
-  important?
-
-If a section opens or closes on a weak line, the structure is spotlighting the
-wrong thing. Move the central idea, title, or best image into the hot spot.
+> "Imagine you have a blinking red LED in your brain set to go off every time
+> you put something at the beginning or end of a section. That will warn you to
+> use the positions well."
 
 ## Strategy 2: point forward to the hook
 
-If the hook ends a central section, keep rhythm and rhyme pushing until the
-hook arrives. The hook should light up, balance, and close.
+Pat's heading for this strategy reads "Keep the structure pointing forward
+until you get to the HOOK"; his opening list of the five reads "Keep your
+structure moving forward until you get to the HOOK." Both are as printed.
 
-```text
-central section:
-setup phrase -> setup phrase -> pressure phrase -> HOOK
-motion       -> motion       -> motion          -> closure
-```
+He gives three cases, A/B/C:
 
-If the hook opens the next section, a developmental section can lean forward
-into it. The developmental section must still feel like a section; it should be
-closed enough to hold together but unbalanced enough to want the hook.
+**A. In CENTRAL SECTIONS, focus your structure on the HOOK** (scanned in fig
+`image_rsrc344`):
 
-```text
-developmental section: coherent but unbalanced
-next section:          HOOK opens / arrival begins
-```
+> "In this case the HOOK is at the end of the section. The structure pushes you
+> forward with both rhythm and rhyme until you finally land on the HOOK. It
+> lights up, balances, and closes."
 
-The same can happen across whole sections: verse or bridge motion points into a
-title-bearing chorus.
+**B. In DEVELOPMENTAL SECTIONS unbalance to push forward when there is a HOOK
+opening the next section.**
+
+> "(Note that your section must still feel like a section, so you can't simply
+> leave it open.)"
+
+His example is the "THE GREAT PRETENDER" bridge. Of it:
+
+> "The rhyme throws you off balance. You expected a rhyme with 'believe.'
+> Instead, 'conceal' works with 'real/feeling/ real/feel,' to keep you off
+> balance."
+
+Then Jim Rushing's verse (fig `image_rsrc345`), leaning into the chorus — see
+"Worked diagnostics" below for Pat's sentence about it.
+
+**C. Most common, simply keep your sections moving into one another.**
+
+His example is the "FATHERS AND SONS" chorus running into the next section:
+
+> "Scan the first part. The phrases are the same length. This is a clear case
+> where the number of phrases unbalances the section and leans ahead."
+
+He closes the case list with Steely Dan:
+
+> "Finally, Fagen and Becker at work:"
+
+> "This one both leans and closes, almost by magic..."
 
 ## Lyric structure can help music
 
-Music can move balanced lyric sections forward, but lyric structure can help.
-Use phrase count, phrase length, rhythm, rhyme, and closure to make the hook's
-arrival feel necessary before the melody carries it.
+Pat closes Strategy 2 with a caution, verbatim:
+
+> "A final caution. It is not necessary that sections not containing a HOOK be
+> unbalanced. There is another obvious way to move one section to the next —
+> musically. If all of your lyric sections were perfectly balanced, the music
+> could still move them forward. But music often appreciates and profits from a
+> helping hand from the lyric."
 
 ## Strategy 3: repeat the hook
 
-The hook should usually appear at least once in each song system. That may be
-enough. Additional repetition should earn its place.
+> "Your HOOK should come at least once in each Song System. That is usually
+> enough. Within reason you can squeeze it in a few more times."
 
-Good repetition types:
+> "Direct repetition is simple, but effective."
+
+Chapter 7's repetition moves, in the order Pat prints them:
 
 - **Direct repetition** — simple but effective:
 
@@ -176,126 +222,155 @@ yourself too much if you repeat yourself too much if you repeat yourself too
 much if you repeat yourself too much if you repeat yourself too much you get
 boring, so be cautious."
 
-Bad repetition is repetition that merely spends attention without structural or
-semantic need.
+The sentence continues straight into the remedy:
+
+> "If you can make your repetition necessary to finish the structure, all the
+> better:"
 
 ## Make repetition necessary
 
-Repetition is stronger when the structure needs it to balance.
+Of the first example (fig `image_rsrc346`) Pat writes only:
 
-```text
-unbalanced first pass:
-3-stress phrase
-3-stress phrase
-long phrase ending on HOOK
+> "The section is balanced by the repetition."
 
-balanced by repetition:
-3-stress phrase
-3-stress phrase
-long phrase ending on HOOK
-long phrase ending on HOOK repeated
-```
+His worked case is the "SEEING SOMEONE ELSE" chorus, scanned across three
+figures (`image_rsrc347`, `348`, `349`):
 
-Another move is to make the refrain the fifth or seventh phrase so the repeated
-hook completes an odd-count pressure.
+> "The first two phrases are each 3-stresses at best. There are certainly some
+> grey areas here"
 
-Exercise pattern: write a verse ending with a refrain, then make the hook
-repeat necessary by using awkward rhythmic closure and an odd-numbered hook
-position.
+> "The next two lines (as written) add up to one 7-stress phrase"
+
+> "You can hear the section close, but it still feels a little off balance. You
+> can feel the general shape of Common Meter, plus the 'self/else' rhyme, but
+> the rhythm is a little irregular and the phrase lengths are uneven, even if
+> you think of the first two phrases as one phrase"
+
+> "It still fails to balance the last phrase. Repeating the last phrase does
+> the trick."
+
+And after the repeat:
+
+> "You have made the repetition a part of the structure."
 
 ## Strategy 4: target hook sounds
 
-Targeting means preparing the ear with a sound that appears in the hook. A
-vowel sound or rhyme color can appear an odd number of times before the hook,
-so the hook feels like the sonic destination.
+Pat's in-chapter heading reads "4. Use sound to spotlight the Hook."; both his
+opening list and his closing recap read "4. Use sound to spotlight your HOOK."
+Headings 2, 3 and 4 all differ slightly from their list entries; all are as
+printed and none is normalised here.
 
-```text
-setup: repeated target vowel or rhyme color
-hook:  key hook word contains that sound
-effect: the title feels sonically lit
-```
-
-Worked example: in "Can't Fight This Feeling," repeated long-i sounds in the
-transitional bridge target an important sound in the coming title. Pattison
-also notes that music can spotlight another hook word at the same time, so
-lyric targeting and harmonic arrival can cooperate.
-
-Use targeting when the hook should feel inevitable but not merely repeated.
+See "TARGETING — the named strategy" below for his naming sentence, his two
+examples, and his analysis of the Kevin Cronin bridge.
 
 ## Strategy 5: use hook rhythm strategically
 
-Know the hook rhythm before writing the lyric. Then place that rhythm in
-strategic positions: positions that must later be matched to balance the
-section.
+> "This is a terrific strategy. It not only helps spotlight your HOOK, but it
+> makes finding line lengths and rhythms for your verses less arbitrary."
 
-In Common Meter, phrase two is strategic because phrase four balances it:
-
-```text
-Phrase 1: / u / u / u /
-Phrase 2: / u / u /       <- strategic position
-Phrase 3: / u / u / u /
-Phrase 4: / u / u /       <- balancing position
-```
-
-If the hook rhythm occupies the strategic position, the listener wants that
-rhythm again. Withhold the match until the hook arrives.
+The Common Meter scansion and the definition of "strategic position" are under
+"Strategic position" below; the composers' analogy Pat draws it
+from is under "Motivic development analogy."
 
 ## Withholding the hook rhythm
 
-Unbalance the system by replacing the expected matching rhythm:
+Pat's two printed ways of unbalancing Common Meter, arrows on the strategic
+second phrase — fig `image_rsrc34B`:
 
+<!-- spellchecker:off -->
 ```text
-Phrase 1: / u / u / u /
-Phrase 2: / u / u /       <- hook rhythm planted
-Phrase 3: / u / u / u /
-Phrase 4: / u / u / u /   <- withheld match
-
-Later:
-HOOK:     / u / u /       <- satisfying match
+    / u / u / u /       DUM da DUM da DUM da DUM
+->  / u / u /     <-    DUM da DUM da DUM
+    / u / u / u /       DUM da DUM da DUM da DUM
+    / u u / u u /       DUM da da DUM da da DUM
 ```
+<!-- spellchecker:on -->
 
-This is motivic development for lyric rhythm: state the hook shape, vary or
-withhold it, then let the title deliver it.
+and fig `image_rsrc34C`:
+
+<!-- spellchecker:off -->
+```text
+    / u / u / u /       DUM da DUM da DUM da DUM
+->  / u / u /     <-    DUM da DUM da DUM
+    / u / u / u /       DUM da DUM da DUM da DUM
+    / u / u /           DUM da DUM da DUM da DUM
+```
+<!-- spellchecker:on -->
+
+<!-- spellchecker:off -->
+(In `34C` the printed stress marks on the fourth line show three stresses while
+the printed DUM-da syllables show four. Reproduced as printed; Pat's argument
+rests on the DUM row.)
+<!-- spellchecker:on -->
 
 ## Irregular hook rhythms
 
-The strategy also works for irregular hooks. Put the irregular hook rhythm in a
-strategic position. Later, write an unmatching phrase that still closes the
-section. When the chorus finally states the irregular hook rhythm, the arrival
-feels like a surprise party.
+> "This strategy works just as well for HOOKS with irregular rhythms. Just put
+> the irregular rhythm in a strategic position so you will have to match it to
+> balance the system. What if your HOOK is"
+
+His worked hook (fig `image_rsrc34U`) is `LAST NIGHT'S LOVE`, scanned `/ / /`.
+
+> "You could do this:"
+
+Fig `image_rsrc34V`, arrows on the second phrase:
 
 ```text
-hook rhythm:       / / /
-strategic setup:   / / / placed where balance will demand a match
-withholding line:  / u u / u /
-hook arrival:      / / /
+    / u / u / u /
+->  / / /            <-
+    / u / u / u / ...
 ```
 
-Do not regularize a distinctive hook just because the verse is easier to write
-that way. Use the irregularity as a structural feature.
+> "Now write an unmatching last phrase to unbalance, YET CLOSE the section.
+> Like"
+
+Fig `image_rsrc34W`: `/ u u / u /`
+
+> "or even the very regular phrase,"
+
+Fig `image_rsrc34X`: `/ u / u /`
+
+> "Because the regular phrase withholds the match with / / / , the section
+> unbalances. When you get to the HOOK in the Chorus,"
+
+Fig `image_rsrc34Y`: `LAST NIGHT'S LOVE` again, scanned `/ / /`.
+
+> "it will be like a surprise party. All the lights come on at once."
 
 ## Deceptive cadence — spotlight the title by withholding the rhyme
 
-Pat's borrowed term (*Writing Better Lyrics* (2009), Chapter 13) for a chorus
-that sets up an expected rhyme and then repeats the title instead.
+Not from Chapter 7 — but **verified**, and it is Pat's own coinage, not a
+borrowed term. *Writing Better Lyrics* (2009), Chapter 13 ("Dialogue and Point
+of View"), analysing the chorus of "Give Me Wings" by Don Schlitz and Rhonda
+Kye Fleming. Pat first writes his own fully-rhyming `abab` alternative fourth
+line, then rejects it:
 
-The setup: an `aba` chorus opening leaves one word unrhymed, and the ear
-actively wants a fourth line rhyming with it — an `abab` close, fully resolved.
-Give the ear that resolution and the chorus lands securely. Repeat the title in
-the fourth position instead (`abaa`) and three things happen at once:
+> Okay, my line is pretty cheesy, but even so, it does the job, resolving the
+> tension nicely, both structurally and emotionally. The rhyme structure,
+> wings/fly/sing/sky, feels much more resolved than the situation of the song
+> intends. She's asking for, not getting, wings. That's why the real chorus's
+> rhyme scheme, abaa, is so perfect:
 
-1. The title repeats — the commercially useful move.
-2. The structural surprise spotlights the title, because the ear was leaning
-   toward a different sound and got the title instead.
-3. The chorus still resolves, but **less securely** than the expected rhyme
-   would have resolved it.
+Then, of the real `abaa` chorus:
 
-That third effect is the craft point, not a side cost. The worked example in
-Chapter 13 is a chorus whose character is asking for something she has not yet
-been given. A fully resolved `abab` close would sound as though she already had
-it; the deceptive cadence leaves the section slightly unsettled, which is what
-the emotional situation actually is. **Match the security of the cadence to
-whether the song's question is answered.**
+> The last line fools you (I call it a deceptive cadence), and in doing so, it
+> accomplishes three things: (1) it repeats the title — a good commercial move;
+> (2) the structural surprise spotlights the title; and (3) it resolves the
+> chorus, though not as solidly as a rhyme for *fly* would have. The surprise
+> rhyme is emotionally better suited to the intent of the chorus since it's a
+> little less secure.
+
+> Neat structure. It lights up the title and supports the emotion of the lines
+> with perfect prosody. I'm glad we looked.
+
+That third effect is the craft point, not a side cost: **match the security of
+the cadence to whether the song's question is answered.**
+
+<!-- EDITORIAL INFERENCE, NOT PRINTED. Everything from here to the end of this
+section is this file's extrapolation from the nine lines Pat actually prints
+(2009 spine 020, "Give Me Wings"). He states the abaa effect and the prosody
+match; he gives no when-to-use list, no when-NOT-to rule, and no diagnostic
+procedure. Do not cite these as Pat's. -->
 
 When to reach for it:
 
@@ -313,29 +388,84 @@ promised and whether the section's emotional state deserves that promise kept.
 
 ## Strategic positions can shift
 
-A phrase may look like the strategic position early in a section and then be
-reinterpreted later. If a later expected match is changed, the earlier phrase
-can become newly important. Use this to make a hook rhythm gather importance
-before the hook arrives.
+> "Here is an interesting rhythm. Its third phrase is the strategic position."
+
+Fig `image_rsrc34K`, arrow on the third phrase:
 
 ```text
-early expectation: phrase 2 seems strategic
-later change:      phrase 5 refuses expected match
-result:            phrase 2 rhythm becomes a stronger setup
+    / u / u / u /
+    / u / u /
+->  / u / u / u / u /
+    / u / u / u /
+    / u / u /
+    / u / u / u / u /
+```
+
+> "What is interesting is that you start through it syllable by syllable, so
+> the second phrase seems like the strategic position all the way until the 4th
+> stress of the third phrase:"
+
+Fig `image_rsrc34M` prints the first three phrases only, the third broken off
+mid-line: `/ u / u / u /`, `/ u / u /`, `/ u / u / u / ...`
+
+> "It feels like Common Meter so far. For a second you think of"
+
+Fig `image_rsrc34N`: `/ u / u /`
+
+> "as the resolving phrase. Although it does not turn out to be the strategic
+> position, the fact that it could have been emphasizes it a little. Plus, if
+> you change the fifth phrase (where you expect to hear it again) you will
+> unbalance the system and make the 3-stress phrase a strategic position:"
+
+Fig `image_rsrc34P`, arrows on the third and fourth phrases — note that
+phrases 4 and 5 now both end unstressed:
+
+```text
+    / u / u / u /
+    / u / u /
+->  / u / u / u / u /
+->  / u / u / u
+    / u / u / u
+    / u / u / u / u /
 ```
 
 ## Worked diagnostics
 
-"Slow Healing Heart" places the title at both ends of a chorus and balances
-the section with stress-group arithmetic: two 3-stress phrases balance three
-2-stress phrases.
+Jim Rushing's "A SLOW HEALING HEART" appears twice in Chapter 7. Its **chorus**
+is the hook-at-both-ends example under Strategy 1. Its **verse** (fig
+`image_rsrc345`) is a Strategy 2 example, and Pat's point there is the opposite
+of balance:
+
+> "Look at this one by Jim Rushing. It is really pretty because it ends on the
+> HOOK, but the HOOK is the shorter, unbalancing phrase, making it lean forward
+> to arrive at — the HOOK:"
 
 "Seeing Someone Else" becomes balanced only when the hook phrase repeats; the
 repetition is part of the structure, not just emphasis.
 
-"Can't Fight This Feeling" uses a hook rhythm in several strategic positions,
-withholds final closure in verse and transitional bridge, and makes the chorus
-arrival satisfying.
+Kevin Cronin's "I CAN'T FIGHT THIS FEELING ANY MORE" is Pat's longest Strategy
+5 case (figs `image_rsrc34H` and `image_rsrc34J` flank the quoted bridge):
+
+> "If you look closer at Kevin Cronin's whole approach to the HOOK, you will
+> see the HOOK rhythm used in several strategic positions."
+
+> "Because the first Verse actually closes the section with the 5-stress
+> phrase, not closing with it at the end of the second verse makes it all the
+> more tantalizing. When you hear it in triplets at the end of the Transitional
+> Bridge, it is maddening. It is so satisfying to finally reach the 5-stress
+> rhythm at the HOOK."
+
+For "SEEING SOMEONE ELSE," Pat scans verse 1 (fig `image_rsrc34R`), then:
+
+> "The 3-stress second phrase becomes more and more important as you get
+> through the two verses."
+
+> "The rhythm of the Transitional Bridge picks up the 3-stress rhythm
+> immediately, although it is not stated smoothly:"
+
+and after fig `image_rsrc34S`:
+
+> "As you saw earlier, it smooths out for the first time at the HOOK."
 
 ## Exercises to preserve
 
@@ -360,6 +490,20 @@ The supplied titles *are* the exercise — keep them.
   MY LAST"; "THE LAST OF THE LONELY HEARTS."
 - **Exercise 44** — Using all five strategies, write a song system for the hook
   "DON'T GIVE UP."
+
+## Pat's chapter close
+
+He restates the five, then:
+
+> "So there they are, five strategies for making your HOOK your hero, basking
+> in the structural spotlight you created for it."
+
+> "Remember these strategies and try them out. They aren't so hard, and they
+> get even easier with practice. Putting your HOOK in the right place at the
+> right time with the right stuff doesn't have to be an accident. You just need
+> to learn to work the switches."
+
+Chapter 7 is the last chapter; the book's AFTERWORD follows it directly.
 
 ## Revision workflow
 
@@ -388,10 +532,12 @@ The supplied titles *are* the exercise — keep them.
 
 ## TARGETING — the named strategy
 
-*Essential Guide to Lyric Form and Structure* (1991), Chapter 7's fourth strategy has a name Pat uses in lectures:
-TARGETING. Plant the title's stressed-vowel sound earlier in the
-section (odd-numbered times), so when the title arrives, its sound
-is already in the listener's ear.
+Pat names the fourth strategy in the book itself, in
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 7:
+
+> "This technique is subtle, but very useful. I call it TARGETING. Here are two
+> examples. Both use a vowel sound that occurs in the HOOK an odd number of
+> times to prepare your ear for the HOOK..."
 
 Mechanism:
 
@@ -402,78 +548,84 @@ Mechanism:
 4. The title arrives prepared; the listener hears familiarity even
    on first listen.
 
-Why odd numbers: an even count would feel paired (one sound calls
-its matching sound). An odd count leaves the ear waiting for the
-balancing sound — which the title supplies.
+Pat gives no reason for the odd count beyond the effect itself — "a vowel sound
+that occurs in the HOOK an odd number of times to prepare your ear for the
+HOOK." Any explanation of *why* odd works is inference, not Chapter 7.
 
-Use TARGETING when:
+Pat's two examples are "WHY CAN'T I HAVE YOU" ("For the first example, see
+'WHY CAN'T I HAVE YOU,' (p. 62).") and a Kevin Cronin transitional bridge into
+the chorus of "I CAN'T FIGHT THIS FEELING ANY MORE." His analysis of the second:
 
-- the title's sound is distinctive enough to be planted,
-- the section is long enough to support 1, 3, or 5 sound-plants,
-- the title's emotional weight benefits from prepared arrival.
+> "This is straightforward. Three 'ite' sounds set up the second most important
+> word in the HOOK. Musically, the tonic chord comes on 'feeling.' Both ideas
+> are supported and spotlighted, one by sound TARGETING in the lyric, the other
+> by the arrival of the tonic. Neat."
 
-Combine with the other four hook strategies; targeting is not a
-substitute for hot-spot placement.
+## Strategic position
 
-## Strategic vs balancing position
+Pat names exactly **one** position in Chapter 7, and this is it. An earlier
+version of this file also gave a "Balancing position" as though it were a
+second Pat term; it is not. He describes the later phrase as the thing that
+*balances*, never as a named position.
 
-Pat names the two structural positions that shape hook expectation:
+> "I thought you'd never ask ... A strategic position is a place you have to
+> match in order to balance a section. In Common Meter, this is a strategic
+> position:"
 
-- **Strategic position** — a position in a section that establishes
-  a pattern the section will need to match later. Often phrase 2 of
-  a Common Meter system.
-- **Balancing position** — the position later in the section that
-  resolves what the strategic position set up. Often phrase 4 of a
-  Common Meter system.
+He then scans Common Meter and says of it:
 
-In Common Meter (4/3/4/3 stress pattern):
+> "The second phrase is the strategic position — when you match it by repeating
+> it in the fourth phrase, the section balances."
 
-| Position | Line | Stress count | Job |
-|---|---|---|---|
-| 1 | line 1 | 4 | First statement |
-| 2 | line 2 | 3 | Strategic — sets up the balancing return |
-| 3 | line 3 | 4 | Restatement or variation |
-| 4 | line 4 | 3 | Balancing — resolves what line 2 set up |
+The Common Meter scansion he prints (fig `image_rsrc34A`), with the arrows
+pointing at the second phrase:
+
+<!-- spellchecker:off -->
+```text
+/ u / u / u /          DUM da DUM da DUM da DUM
+/ u / u /       <-  -> DUM da DUM da DUM  <-
+/ u / u / u /          DUM da DUM da DUM da DUM
+/ u / u /              DUM da DUM da DUM
+```
+<!-- spellchecker:on -->
 
 Place the hook rhythm in the strategic position (line 2) and the
 ear waits for line 4 to match it. Place the hook rhythm only in
 line 4 and the section feels arbitrary.
 
-Two refinements:
+Pat's own next move is to unbalance the system so the match never lands where
+expected:
 
-- A strategic position can be reinterpreted mid-section. A phrase
-  that looked strategic in line 2 can become balancing if a new
-  pattern emerges by line 3. Sing the section to test which
-  interpretation lands.
-- Strategic-balancing relationships work at section level too. A
-  bridge's first line is strategic for the bridge's last line.
+> "If you unbalance the system, [...] or, [...] your listener will still want
+> the rhythm of the strategic position. If the rhythm of the HOOK is in the
+> strategic position, your HOOK will light up when you arrive."
 
 ## Motivic development analogy
 
-Composers state a melodic motif, vary it, withhold it, then deliver
-it. Lyricists do the same with hook rhythm.
+Pat's verbatim framing of Strategy 5:
 
-Four stages:
+> "Think of this strategy in the same way composers think of melodic themes:
+> they state their theme, then use it other places in different ways. Speed it
+> up, slow it down, say it backwards, turn it upside down, keep its shape but
+> change its notes, keep its notes but change its chords, keep its rhythm but
+> change its notes and chords. They call this 'Motivic Development.'"
 
-1. **State** — establish the hook rhythm in a strategic position.
-2. **Vary** — recombine its elements through the section without
-   landing exactly on the hook.
-3. **Withhold** — let the ear expect the hook and delay it.
-4. **Deliver** — land the hook rhythm at the balancing position.
+He gives two reasons composers use it:
 
-> "Motivic development at the lyric level: state, vary, withhold,
-> deliver." — paraphrase, *Essential Guide to Lyric Form and Structure* (1991), Chapter 7
+> "1. It is a subtle way of repeating a theme without getting boring.
+> 2. It makes the theme the focus of the piece."
 
-Use motivic development when the section has time to develop. A
-short refrain may only have room for state-deliver; a longer chorus
-or bridge can run all four stages.
+> "Though you don't need to make it nearly so complicated, you can do the same
+> thing with the rhythm of your HOOK."
 
 ## Know the hook rhythm before writing the lyric
 
-Pat's load-bearing planning rule from *Essential Guide to Lyric Form and Structure* (1991), Chapter 7:
+Pat's load-bearing planning rule, printed in caps on its own line in
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 7:
 
-> "Know the rhythm of your hook before you start writing your
-> lyric." — Pat
+> KNOW THE RHYTHM OF YOUR HOOK BEFORE YOU START WRITING YOUR LYRIC
+
+> "Then use your HOOK'S rhythm in 'strategic positions.'"
 
 Mechanism:
 
@@ -489,12 +641,20 @@ a rhythm that the chorus cannot match, so the chorus's hook arrives
 out of context. Knowing the hook rhythm first ties the whole song
 to the hook.
 
-## Title generation — the seven types
+## Title generation — UNAUDITED, no book source
+
+**UNAUDITED — not from Chapter 7, and no book source is cited.** Chapter 7 of
+*Essential Guide to Lyric Form and Structure* (1991) contains no title
+typology, no "seven types," and no Nashville stressed-vowel method. The two
+quotes below are attributed to Berklee Online and patpattison.com — non-book
+sources that cannot be verified against the corpus, which is exactly where an
+invented quote is hardest to detect. Treat the table, the counts ("5+", "20+"),
+and both quotes as unverified until someone checks the cited web sources.
 
 For situations where the writer has an idea but no title, Pat
 catalogs title types and a Nashville generation method.
 
-### Seven title types
+### Title types (unaudited — the count "seven" is ours, not Pat's)
 
 | Type | Shape | Effect |
 |---|---|---|
@@ -551,39 +711,49 @@ for the full pipeline.
 
 ## Phrase-level hot spots (*Essential Guide to Lyric Form and Structure* (1991), Chapter 7 Strategy 1)
 
-The hot-spot principle does not only apply at the section level — it
-extends to the phrase level. Within a single phrase, the prose-writing
-rule applies:
+Pat's third level, verbatim (italics restored from the raw XHTML):
 
-- The **most important** content word goes at the **end** of the phrase
-- The **second-most important** content word goes at the **beginning**
-- Less important words live in the middle
+> "*For each phrase of your lyric.* Prose writers use the principle of
+> beginnings and endings as a strategy when they write sentences. They insist
+> that the sentence's first 'idea' word (noun, adjective, or verb) should be
+> one of the most important words in the sentence. The same for the end of the
+> sentence. Some writers go so far as to insist that, wherever possible, *the
+> second most important word* in the sentence come at the beginning, and the
+> *most important word* come at the *end.* There is a big difference between
+> the following two sentences. The first puts all its substance at the end."
 
-Two example phrases (Pat-style contrast — describing only):
+```text
+1. When it happens naturally, and no one is wiser, wild sex yanks my chain.
+2. Wild sex, when it happens naturally, and no one is wiser, yanks my chain.
+```
 
-- Phrase A places the strongest noun at the end: ear lands hard there
-- Phrase B places the same noun in the middle: ear coasts past it
+> "Two 'dead' clauses tread water in the first version, waiting for something
+> to happen. The same clauses gather steam in the second version. Starting
+> strong will color what comes afterwards."
 
-Same content, different phrasing — wildly different impact. The phrase
-itself is a small hot-spot system.
+Pat's own summary of the level, one line later:
+
+> "You can apply prose writer's logic to lyric phrases. If you put something
+> important at the beginning of your phrase and something important at the end,
+> your phrase will show off your best ideas where they are most likely to be
+> noticed."
+
+> "Beginnings and endings. HOT SPOTS."
 
 ### LED-in-the-brain metaphor
 
-Pat's kinesthetic training image: imagine a red LED in your brain that
-blinks every time you place a content word at the beginning or end of a
-section, phrase, or line. The LED trains the ear to notice when strong
-material is sitting in a power position — and when it's wasted in the
-middle.
-
-Use the LED metaphor when coaching new writers; it makes the hot-spot
-audit visceral rather than abstract.
+Quoted in full under "Hot spots make meaning" above, where Chapter 7 places it.
+Two things to keep straight when using it: Pat sets the LED to **sections**
+only, not to phrases or lines, and he gives it exactly one job — to *warn* you
+to use the positions well.
 
 ## Conscious craft stance — "you can" (*Essential Guide to Lyric Form and Structure* (1991), Chapter 7 Strategy 5 close)
 
 After analyzing a song's motivic development, Pat closes Chapter 7 Strategy 5
 with a recurring craft stance:
 
-> "Did [the writer] do it on purpose? They could have. Whether or not THEY did is not the point. YOU can."
+> "You can see how well the strategy works. Did Kevin Cronin do it on purpose?
+> He could have. Whether or not HE did is not the point. YOU can."
 
 The principle: identifying a craft tool in another writer's song does NOT
 require proving the other writer used it consciously. The tool exists; you

--- a/plugins/songwriting/context/pat-pattison/research/line-brainstorm.md
+++ b/plugins/songwriting/context/pat-pattison/research/line-brainstorm.md
@@ -285,9 +285,11 @@ Challenge #2.
 Partly corroborated in print, but only the Sondheim half: "Use the worksheet for
 reference. Remember, its main purpose is to get additional ideas and pictures.
 It is a brainstorming device, not a rhyme-finding device. It's a nice reference,
-though. Ask Stephen Sondheim: he uses worksheets all the time." — *Writing
-Better Lyrics* (2009). `Eminem` returns zero hits in all four books, and so does
-the phrase "worksheet process".
+though. Ask Stephen Sondheim: He uses worksheets all the time." — *Writing
+Better Lyrics* (2009), Chapter 24. (Pat's capital `He` is as printed; the
+sentence occurs exactly once in the corpus and `raw/` shows no italics.)
+`Eminem` returns zero hits in all four books, and so does the phrase
+"worksheet process".
 
 The brainstorm IS the worksheet process applied to a single line.
 

--- a/plugins/songwriting/context/pat-pattison/research/line-brainstorm.md
+++ b/plugins/songwriting/context/pat-pattison/research/line-brainstorm.md
@@ -80,6 +80,13 @@ bridge. Run Scope A FOR EACH LINE. Then add:
 
 ## Discipline (filtered through response-filter.md)
 
+*Provenance: the five columns, every target count in this file (~30, ~10, ~5,
+≥5, top-3, 30-50+), and the checkboxes below are **this repo's tool spec**, not
+Pat's. He publishes no line-brainstorm procedure and no candidate quotas. What
+IS his is the craft each box invokes — identity, stability tiers, the seven
+senses, cliché scanning, verb strength — each sourced in the file it links to.
+Do not restate any of these numbers as Pat's.*
+
 The brainstorm is fast and high-volume, but NOT undisciplined. Pre-dump:
 
 - [ ] **Stressed vowel of the end-line word identified** before Column 1
@@ -255,13 +262,32 @@ labels + top-3 suggestions + hand-off route. Volume + curation.
 
 ## Anchor quotes
 
+**Both quotes below are UNAUDITED — spoken interviews, outside the four books,
+unverifiable from the corpus.** Neither is in any book; do not cite either as a
+book quote. Each does, however, have a printed counterpart, and the printed one
+is what to quote when it matters:
+
 > "Verbs are the amplifiers of language. The difference between great
 > writers and average writers is almost always in their verbs."
-> — Pat Pattison (Unpaved interview)
+> — Pat Pattison (Unpaved interview) — **unaudited**
+
+Printed counterpart, and the citable form: "Verbs. You've already learned
+something about them. They're the most potent force in language. Nouns are
+inert. They sit there. Adjectives pile on top of them and sit there. Verbs
+electrify them, propel them, launch them into action. The difference between
+average and great writing: verbs." — *Songwriting Without Boundaries* (2011),
+Challenge #2.
 
 > "Eminem and Stephen Sondheim approach their writing through the same
 > process. It's called a worksheet process."
-> — Pat Pattison (American Blues Scene interview)
+> — Pat Pattison (American Blues Scene interview) — **unaudited**
+
+Partly corroborated in print, but only the Sondheim half: "Use the worksheet for
+reference. Remember, its main purpose is to get additional ideas and pictures.
+It is a brainstorming device, not a rhyme-finding device. It's a nice reference,
+though. Ask Stephen Sondheim: he uses worksheets all the time." — *Writing
+Better Lyrics* (2009). `Eminem` returns zero hits in all four books, and so does
+the phrase "worksheet process".
 
 The brainstorm IS the worksheet process applied to a single line.
 

--- a/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
+++ b/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
@@ -61,7 +61,6 @@ suspension) or a bad one (the listener has to re-parse to catch the meaning).
      word and then claiming he named this state was the fabrication; the
      observation itself is fine, so it is kept, unattributed. -->
 
-
 ## Three ways out — this file's own framing, not Pat's
 
 *No book names an "alignment fix", numbers them, or supplies the `Use when:` and
@@ -124,7 +123,6 @@ Use when:
      Left out rather than demoted, because there is nothing left once the false
      attribution goes. -->
 
-
 Risk: overuse becomes a tic.
 
 ## How to diagnose
@@ -142,7 +140,15 @@ Risk: overuse becomes a tic.
 
 ## Greedy spots and roadmap mismatch
 
-Greed is Pat's word and it points one way only:
+**Frame first — the term covers different ground in two frames**, and this file
+is in the second one. Matching a lyric to a *model lyric* (verse 2 against verse
+1), greed is one-directional: Pat's too-hot failure only. Matching a lyric to a
+*melody* — the frame of this whole file — a mismatch in **either** direction is
+a greedy spot, because either one fights the bar. That two-frame split is the
+plugin's, not Pat's, and it is stated the same way in `prosody.md`, `meter.md`
+and `skills/meter-prosody/SKILL.md`; keep the four consistent.
+
+Pat's printed passage, which is the *model-lyric* frame:
 
 > "It is important not to be greedy: do not put stressed syllables in the
 > unstressed positions. This one is too hot. […] It is equally important to
@@ -151,25 +157,33 @@ Greed is Pat's word and it points one way only:
 > the important positions."
 > — *Essential Guide to Lyric Form and Structure* (1991), Chapter 3
 
-So a greedy spot is a stressed syllable sitting in an unstressed position. His
-*second* failure mode is not the mirror image of it — "too cold" is **weak or
-unimportant words occupying the important positions**, which is a question of
-word choice, not of stress inversion. Greedy spots share a root cause with a
-roadmap mismatch: the lyric's stresses disagree with the music's.
+In that passage greed is the **too-hot** failure only: stressed syllables put in
+unstressed positions. His too-cold failure is **not** its mirror image and is not
+a stress error at all — it is weak or unimportant words occupying the important
+positions, which no stress check finds. Do not scan for it; ask what each strong
+position is *carrying*.
 
-<!-- CORRECTED — DISTORTION. This paragraph defined a greedy spot as "a stressed
-     syllable that lands on a weak musical beat, OR an unstressed syllable
-     riding a strong one", and a following note claimed "both directions belong
-     in this definition", overriding "an earlier revision [that] covered only
-     the stressed-on-weak one". The earlier revision was right. I rendered both
-     1991 Ch 3 figures behind the dangling colons — image_rsrc2ZC ("too hot")
-     and image_rsrc2ZD ("too cold") — and read the printed scansion marks. Too
-     hot puts strong italicised words (deep / hold / heart / born / haunts /
-     God) into unstressed slots. Too cold puts function words (just / now /
-     place / Won't / get / out) into the important slots. Neither figure shows
-     an unstressed syllable riding a strong beat. `audit-checklist.md` had
-     already removed the same inversion; this file had regrown it. -->
+**In this file's melody frame**, a greedy spot is a stressed syllable landing on
+a weak musical beat, **or** an unstressed syllable riding a strong one. Either
+direction steals emphasis from where the music wants it. Greedy spots usually
+share a root cause with a roadmap mismatch: the lyric's stresses disagree with
+the melody's.
 
+<!-- Verified against the two 1991 Ch 3 figures behind the dangling colons.
+     image_rsrc2ZC ("too hot") puts strong italicised words — deep / hold /
+     heart / born / haunts / God — into unstressed slots. image_rsrc2ZD ("too
+     cold") puts function words — just / now / place / Won't / get / out — into
+     the important slots. So too-cold really is a word-choice failure, not a
+     stress inversion, and the model-lyric frame above is right.
+
+     I first read the both-directions definition here as a regrown fabrication
+     and cut it. That was WRONG and it has been restored. The CHANGELOG records
+     a deliberate five-file adjudication splitting the two frames, and it names
+     this file as belonging to the melody frame, where both directions count.
+     What was actually missing was the frame label and Pat's printed text — both
+     now present. Anyone tempted to "fix" this again: read the CHANGELOG entry
+     beginning "Greedy spot was defined inconsistently across five files"
+     first. -->
 
 When you find a greedy spot, check whether the surrounding lyric phrase
 has its boundary in the wrong place. Often fixing the roadmap fixes the
@@ -205,8 +219,8 @@ fine but the chorus feels jerky":
 3. Overlay: the natural lyric pause lands on beat 4 (no melodic rest), and
    the melody's beat-2 rest falls inside a noun phrase that does not want
    to break.
-4. Diagnosis: roadmap mismatch at two points. Greedy spot likely at beat 6,
-   where a stressed syllable is sitting in an unstressed position.
+4. Diagnosis: roadmap mismatch at two points. Greedy spot likely at beat 6
+   where an unstressed syllable rides a strong beat.
 5. Pick a fix:
    - Fix 1: extend the melody's beat-2 rest to beat 4. Risk: changes the
      chorus's hook shape.
@@ -243,7 +257,6 @@ The writer picks one. The skill does not pick for them.
   <!-- The figure "misses 80% of mismatches" was here. Invented. No book states
        any such proportion, and round-number thresholds in this plugin have been
        invented every time one has been checked. -->
-
 
 ## When a roadmap mismatch is good
 

--- a/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
+++ b/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
@@ -5,6 +5,17 @@ Pat Pattison — *patpattison.com* "Lyric and Melodic Phrases" plus
 phrasing. Books bracket the music; this file is the bridge between a lyric's
 natural phrasing and a melody's actual phrasing.
 
+**UNAUDITED — read this before quoting anything below.** The "roadmap" framing
+is not in the four books. Measured wrap-safe across all four: `roadmap` returns
+**one** hit, in *Essential Guide to Rhyming* (2014) and in a different sense
+("Rhyme creates a sonic roadmap"); `compatible roadmaps` and `maximum meaning`
+return **zero**. The two `— Pat (patpattison.com)` quotes below are from a
+non-book source nobody here has been able to open, so they are neither confirmed
+nor refuted — treat them as unverified paraphrase, not as quotable Pat, and
+never build a citation on them. The 1991 Chapter 1-2 citation above is sound
+(those chapters are "Number of Phrases" and "Length of Phrases"); it covers the
+phrase material, not the roadmap vocabulary.
+
 Use this when a writer says "the words don't fit the music", "this line
 breaks weird", "the singer is breathing in the middle of a word", "we set
 the lyric to the melody and it isn't landing", or when a co-writer brings
@@ -21,7 +32,8 @@ listener hears two competing structures and the meaning blurs.
 > getting maximum meaning." — Pat (patpattison.com)
 
 The diagnostic is whether the lyric's phrase boundaries align with the
-melody's phrase boundaries. The fix is one of three named moves below.
+melody's phrase boundaries. Three ways out are set out below; they are this
+file's own organisation of the problem, not a taxonomy Pat publishes.
 
 ## What a roadmap is
 
@@ -34,13 +46,29 @@ breathe, pause, and arrive. Two roadmaps exist in every sung song:
 - **Melodic roadmap** — actual pauses derived from rest durations, phrase
   arcs, breath marks, and harmonic cadences.
 
-A through-written character emerges when the lyric reads as one continuous
-thought even though the melody phrases it in two — that is, lyric roadmap
-disagrees with melodic roadmap. Pat names this state explicitly; it can be
-a good effect (deliberate suspension) or a bad effect (the listener has to
-re-parse to catch the meaning).
+When the lyric reads as one continuous thought even though the melody phrases it
+in two, the two roadmaps disagree. That can be a good effect (deliberate
+suspension) or a bad one (the listener has to re-parse to catch the meaning).
 
-## The three named alignment fixes
+<!-- CORRECTED — TERM HIJACK. This paragraph called that state "a
+     through-written character" and asserted "Pat names this state explicitly."
+     He does not. `through-written` has 10 hits, all in *Essential Guide to
+     Lyric Form and Structure* (1991) Ch 3-4, and it means something else
+     entirely — a property of a rhyme/phrase STRUCTURE, opposed to *fragmented*:
+     "the structure is through-written: that is, there is no place of resolution
+     before the end of the last phrase. The structure keeps pushing you
+     forward." Nothing to do with lyric-vs-melody disagreement. Borrowing his
+     word and then claiming he named this state was the fabrication; the
+     observation itself is fine, so it is kept, unattributed. -->
+
+
+## Three ways out — this file's own framing, not Pat's
+
+*No book names an "alignment fix", numbers them, or supplies the `Use when:` and
+`Risk:` lines below. They are this repo's decision aid. They are still useful;
+they are just not citable to Pat. Do not reintroduce the word "named" here — an
+earlier heading asserted "the three **named** alignment fixes", and a heading
+that keeps claiming a taxonomy is how the claim grows a body back.*
 
 When a roadmap mismatch is breaking the lyric, pick one:
 
@@ -87,8 +115,15 @@ Use when:
   listener to read past as a single thought,
 - a deliberate suspension effect is desired.
 
-Song example: Lady Antebellum "Love Don't Live Here" — Pat cites verses 1-3
-lines 3-4 for this pattern.
+<!-- REMOVED — FABRICATED ATTRIBUTION. This read: 'Song example: Lady Antebellum
+     "Love Don't Live Here" — Pat cites verses 1-3 lines 3-4 for this pattern.'
+     Measured wrap-safe across all four books: `Lady Antebellum` = 0 hits,
+     `Love Don't Live Here` = 0 hits. Pat cites nothing of the kind anywhere in
+     the corpus. The song may well do what the bullet says, but "Pat cites" was
+     invented, and a bare verse-and-line reference reads as a book reference.
+     Left out rather than demoted, because there is nothing left once the false
+     attribution goes. -->
+
 
 Risk: overuse becomes a tic.
 
@@ -107,14 +142,34 @@ Risk: overuse becomes a tic.
 
 ## Greedy spots and roadmap mismatch
 
-A greedy spot is a stressed syllable that lands on a weak musical beat, or an
-unstressed syllable riding a strong one. Either direction steals emphasis from
-where the music wants it. Greedy spots are usually caused by the same root
-problem as a roadmap mismatch: lyric stress disagrees with melodic stress.
+Greed is Pat's word and it points one way only:
 
-Both directions belong in this definition: the worked example below diagnoses
-the unstressed-on-strong case, and an earlier revision covered only the
-stressed-on-weak one, leaving the two at odds.
+> "It is important not to be greedy: do not put stressed syllables in the
+> unstressed positions. This one is too hot. […] It is equally important to
+> match the original's important words with equally important words. This one is
+> too cold […] You must resist greed. But you must put your important words in
+> the important positions."
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 3
+
+So a greedy spot is a stressed syllable sitting in an unstressed position. His
+*second* failure mode is not the mirror image of it — "too cold" is **weak or
+unimportant words occupying the important positions**, which is a question of
+word choice, not of stress inversion. Greedy spots share a root cause with a
+roadmap mismatch: the lyric's stresses disagree with the music's.
+
+<!-- CORRECTED — DISTORTION. This paragraph defined a greedy spot as "a stressed
+     syllable that lands on a weak musical beat, OR an unstressed syllable
+     riding a strong one", and a following note claimed "both directions belong
+     in this definition", overriding "an earlier revision [that] covered only
+     the stressed-on-weak one". The earlier revision was right. I rendered both
+     1991 Ch 3 figures behind the dangling colons — image_rsrc2ZC ("too hot")
+     and image_rsrc2ZD ("too cold") — and read the printed scansion marks. Too
+     hot puts strong italicised words (deep / hold / heart / born / haunts /
+     God) into unstressed slots. Too cold puts function words (just / now /
+     place / Won't / get / out) into the important slots. Neither figure shows
+     an unstressed syllable riding a strong beat. `audit-checklist.md` had
+     already removed the same inversion; this file had regrown it. -->
+
 
 When you find a greedy spot, check whether the surrounding lyric phrase
 has its boundary in the wrong place. Often fixing the roadmap fixes the
@@ -150,8 +205,8 @@ fine but the chorus feels jerky":
 3. Overlay: the natural lyric pause lands on beat 4 (no melodic rest), and
    the melody's beat-2 rest falls inside a noun phrase that does not want
    to break.
-4. Diagnosis: roadmap mismatch at two points. Greedy spot likely at beat 6
-   where an unstressed syllable rides a strong beat.
+4. Diagnosis: roadmap mismatch at two points. Greedy spot likely at beat 6,
+   where a stressed syllable is sitting in an unstressed position.
 5. Pick a fix:
    - Fix 1: extend the melody's beat-2 rest to beat 4. Risk: changes the
      chorus's hook shape.
@@ -183,8 +238,12 @@ The writer picks one. The skill does not pick for them.
 - **Repeating words to bridge gaps that wanted to stay open** — Fix 3 is
   for moments where a single continuous thought needs to span a melodic
   break. Overuse turns it into filler.
-- **Co-writing without speaking-and-singing each line** — silent
-  roadmap planning misses 80% of mismatches.
+- **Co-writing without speaking-and-singing each line** — mismatches are
+  audible and hard to see; planning a roadmap silently misses them.
+  <!-- The figure "misses 80% of mismatches" was here. Invented. No book states
+       any such proportion, and round-number thresholds in this plugin have been
+       invented every time one has been checked. -->
+
 
 ## When a roadmap mismatch is good
 

--- a/plugins/songwriting/context/pat-pattison/research/metaphor.md
+++ b/plugins/songwriting/context/pat-pattison/research/metaphor.md
@@ -99,14 +99,99 @@ else investigates?", "He arrests. What else arrests?" — and named
 writers answer each one, mine the answer's word-family, then apply that
 family back to `policeman` in a sentence.
 
-> **Restoration blocked.** Pat's six printed answers, their family
-> word-lists, and the applied sentences could not be reproduced here;
-> the permission system refused the edit. A previous version of this
-> file filled the space with an invented table (body armor, mother,
-> antibiotic, dam, dental probe, jeweler's loupe, brake pedal, freeze
-> frame, prison gate, cardiac arrest) attributed to Pat. **None of
-> those appear in Day 10.** The fabrication has been deleted rather
-> than replaced — read Challenge 2 Day 10 directly for the real lists.
+**He protects. What else protects?** — Chanelle Davis:
+
+```text
+1. Flu Vaccine
+2. Lifeguard
+
+Flu Vaccine: needle, injections, nurse, doctor, veins, immunize, blood,
+cure, medicine, prick, hospital, cough, sickness, mucus, winter
+
+  The police immunize the public and help fight the symptoms of gangs
+  in New York.
+
+Lifeguard: drowning, waves, rip, sea, beach, swimming, uniform, swift,
+strong, muscly, watchful, on duty
+
+  The police were watchful after the earthquake and rescued many stores
+  from the waves of looters that flooded the city.
+```
+
+**What else does a policeman do? He investigates. What else
+investigates?** — Kristin Cifelli: X-ray
+
+```text
+X-ray: black and white, broken bones, revealing, diagnose
+
+  The police are an x-ray, investigating the broken bones of the
+  neighborhood, revealing every fracture in black and white.
+```
+
+**What else does a policeman do? He arrests. What else arrests?** —
+Chanelle Davis: Heart
+
+```text
+Heart: stop beating, death, hospital, electric shock, blood,
+circulation, ambulance, dying
+
+  More police were pumped into the undercover operation, aiming to stop
+  the circulation of pornography.
+```
+
+Pat's two long answers. In print they follow the short one under the same
+quality: mechanic comes second under *investigates*, the loudest sound
+second under *arrests*. **What else investigates?** — Charlie Worsham:
+mechanic
+
+```text
+Mechanic: engine, oil, sweat, heat, grease, dirty, smudged, pistons,
+wrench, fans, belts, whirring, motor, crank, hood
+```
+
+> Policemen are the mechanics of mystery. They roll up their sleeves,
+> wipe their brow, and pop open the hood of a criminal case, hoping to
+> unlock the mystery. Every piston that misfires, every loose fan belt,
+> every drop of oil is a fingerprint, a smoking gun, a clue as to what
+> went wrong and who's to blame. In the workshop of a downtown office
+> building or crime lab, they take apart and rebuild every piece of the
+> machine. Whatever it takes, they don't stop till they can prosecute
+> the bad guy. And like years of sweat equity beneath the workings of
+> vehicles, years of experience with all makes and models of crimes,
+> train a professional policeman to spot likely suspects quickly and
+> efficiently.
+
+**What else arrests?** — Caroline Harvey: The loudest sound you can
+imagine
+
+```text
+The loudest sound you can imagine: makes everything else disappear,
+stops time, terrifies, echoes, makes your ears numb and ringing, makes
+everything after feel silent and small, makes you flinch
+```
+
+> When I saw him stand up, the rest of the courtroom disappeared. I
+> couldn't feel my legs, my hands were dangling at my side like a shaky
+> mess of Parkinson's. He thundered to the witness chair, his feet
+> thumping loudly with every gait. I cannot remember anything else from
+> that day, but I can recall exactly the way he adjusted first his left
+> shirt sleeve and then his right. How his hair was parted just a few
+> degrees of center and shone under the fluorescent lights like
+> Superman's pompadour. The sound of his voice, as he answered my
+> attorney's questions, echoed the way I imagine a blow horn might sound
+> in the Grand Canyon. All living creatures living miles within distance
+> of the courthouse were silenced when he spoke. When he finished and
+> was excused, I looked down at my hands. I was gripping the fabric of
+> my flowered dress and my left knee, jittery as a mosquito, was
+> helpless.
+
+Those are all six of Pat's printed Day 10 answers. After each quality he
+hands the same task back to the reader — verbatim, under *protects*:
+"Your turn. List two of your own things that protect. Then find related
+nouns, verbs, and adjectives for each one and try to apply them to
+policeman. Write a sentence or a short paragraph for the ones you like."
+Under *investigates* and *arrests* the wording shifts only to "List two
+other things that investigate" / "that arrest."
 
 The three quality-columns generate three different metaphor pools per
 target. The writer picks by emotional intent: an arrest-themed pool
@@ -136,6 +221,17 @@ definitions and examples:
 His extension example for expressed identity: `clouds are sailing ships on
 rivers of wind`.
 
+Pat's one worked close-reading in the Challenge 2 opener is Shelley's
+*Ode to the West Wind*, printed inline exactly as follows — "Look at this
+metaphor from Shelley's *Ode to the West Wind*: 'A heavy weight of hours
+has chained and bowed/One too like thee …'"
+
+His gloss, verbatim: "Hours are links of a chain, accumulating weight and
+bending the old man's back lower and lower as each new hour is added. An
+interesting way to look at old age …" He adds that great metaphors "seem
+to come in a flare of inspiration," but "even if great metaphors come
+from inspiration, you can certainly prepare yourself for their flaring."
+
 Expressed identity is the most explicit and structurally demanding. Qualifying
 metaphor is often compact and local. Verbal metaphor is especially powerful
 because verbs drive language; when the verb surprises the noun, the image
@@ -144,13 +240,18 @@ moves.
 ### Personification — a metaphor sub-type
 
 *Songwriting Without Boundaries* (2011), Challenge 2 Day 1 explicitly
-names **personification** as one form of metaphor: attributing human
-characteristics to nonhuman things. Examples — clouds moping, wind
-yelping, doors complaining, mornings refusing to start.
+names **personification** as one form of metaphor. Pat's verbatim gloss,
+on Jess Meider's weeping handkerchief: "Personification—attributing human
+characteristics to nonhuman things—is just one of the many ways to make a
+metaphor. Just another way to create collisions." His other Day 1 example
+is Susan Cattaneo's "Daylight hurried away, leaving lonely moonlight to
+console the solitary oak tree that wept autumn leaves" — Pat's comment:
+"Personification. Simple. And effective."
 
-Personification is a verbal-metaphor or qualifying-metaphor sub-pattern
-where the borrowed quality is specifically a HUMAN-life one. It is not
-its own fourth type; it is a recipe within the three types. Useful in
+Pat does not assign personification to one of his three types — he calls
+it only "one of the many ways to make a metaphor." It is **not** a fourth
+type; treat it as a recipe that runs inside the three, with the borrowed
+quality being specifically a human one. Useful in
 the eight-recipe table as a quality-source generator.
 
 ## Expressed identity forms
@@ -804,9 +905,14 @@ When applying this file:
 
 ## Eight named metaphor moves (recipe card)
 
-Pat's patpattison.com "Pat's Lyric Tips" plus Berklee teaching catalog
-the metaphor toolkit as eight named generation moves. Use as a recipe
-card when stuck on a single subject and needing options.
+**Plugin-side synthesis — UNAUDITED, not Pat's taxonomy.** These eight
+are a generation checklist assembled here from the material above; they
+are **not** a list of metaphor types, and no book prints them as a set of
+eight. Pat's types number **three** (Expressed Identity, Qualifying,
+Verbal — see above); moves 1-3 below restate those three, and moves 4-8
+are craft procedures, not categories. Do not cite this table as Pat's.
+Use it only as a recipe card when stuck on a single subject and needing
+options.
 
 | # | Move | Form | When to use |
 |---|---|---|---|
@@ -874,17 +980,6 @@ Use participles for:
 Pat's framing for collisions that produce a legible double meaning —
 neither reading is wrong; both are present in the lyric at once.
 
-> "Productive ambiguity — having at least two meanings, both work in
-> context." — Pat (*Songwriting Without Boundaries* (2011), Challenge 2)
-
-A productive-ambiguity test:
-
-1. The line has at least two legitimate readings (literal and
-   metaphoric, or two metaphoric readings).
-2. Each reading reinforces or complicates the other; neither cancels.
-3. The listener does not have to "pick"; both meanings live together
-   under the music.
-
 Pat's actual example is Greg Becker's `lonely handkerchief` sentence in
 Challenge 2 Day 1, where the handkerchief is "crumpling into himself,
 clutching his near empty glass." Pat's comment: "It's hard to tell in
@@ -905,13 +1000,12 @@ subjects nearby in the line.
 
 ### Productive ambiguity vs strained collision
 
-| Test | Productive ambiguity | Strained collision |
-|---|---|---|
-| Both readings legitimate | Yes | No, one is forced |
-| Family distance | Medium | Too far (random) |
-| Listener stops to decode | No, both register | Yes, parse stalls |
-| Literally false test | One reading false, one true; both meaningful | Both readings false; comparison opaque |
-| Cuts on revision? | Never | Often |
+Pat's own criterion for a collision that is *not* working is Day 8's, on
+`the captain is summer`: "When you have very few family members stepping
+into the other living room, simile may work better." He states the
+positive case at Day 8's wineglass/restaurant pair: "This one works well
+both ways. Lots of family members in common—the mark of a productive
+metaphor."
 
 If the collision is too far for the listener to bridge in a single
 hearing, it is strained, not ambiguous. The fix is usually to bring
@@ -986,8 +1080,11 @@ slide together without friction. **A single nondiatonic word collides**
 This is Pat's "playing in keys" workflow at the vocabulary level:
 
 1. Pick a tone center (the song's central concept)
-2. List 10-20 diatonic words (its family)
-3. Combine diatonic words into secondary collisions (winter-bone, cold-letter, frost-prayer)
+2. List its diatonic words — its family. Pat's own worked lists are the
+   three keys above; e.g. diatonic to `tide`: ocean, moon, recede, power,
+   beach.
+3. Combine members of that family into secondary collisions — Pat's own,
+   in the key of power: "An avalanche is an army of snow."
 4. Apply nondiatonic words DELIBERATELY — they make metaphors land
 5. Avoid accidental nondiatonic drift — it makes the lyric feel
    unfocused
@@ -1049,11 +1146,39 @@ mechanical model for why simile works differently than metaphor:
 > — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 2
 > Day 14
 
-In metaphor (`Her smile IS sunlight`), the energy of `sunlight` transfers
-directly to `her smile` — the smile becomes the sunlight. In simile
-(`Her smile is LIKE sunlight`), the word `like` blocks the transfer; the
-energy reflects back to `her smile`, and `sunlight` becomes merely an
-illustrative comparison.
+Pat works this on his own pair, and it is the one to use — his printed
+demonstration, in order:
+
+> Love is a rose.
+>
+> Where do you focus? On the second term?
+>
+> Love = **rose**
+>
+> Or the first term?
+>
+> **Love** = rose
+>
+> If you want the texture, smell, color of the rose in focus, use metaphor.
+>
+> Love is a **rose**.
+>
+> If you want love as the focus, use simile:
+>
+> **Love** is like a rose.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 2, Day 14
+
+The bolding is Pat's own typographic emphasis, recovered from the raw XHTML
+(`<span class="class_s5g3">` wraps the term in focus on each of those four
+lines). The plain text layer strips it, and without it the pairs read as bare
+repetition — the emphasis IS the argument.
+
+<!-- CORRECTED — GENERICIZATION. An invented pair, "Her smile IS sunlight" /
+     "Her smile is LIKE sunlight", stood here doing the job of Pat's own
+     `Love is a rose`, which he prints on the very same page. Substituting a
+     made-up example for one of his is the failure the BRIEF names first. -->
+
 
 The mechanical consequence: **simile keeps the listener at distance**
 (comparing); **metaphor pulls the listener into identification**
@@ -1068,14 +1193,25 @@ Pat cites Coleridge in Challenge 2 Day 14:
 > — Pat Pattison (citing Coleridge),
 > *Songwriting Without Boundaries* (2011), Challenge 2 Day 14
 
-The distinction:
+The distinction, as Pat states it — one sentence, and it is only about degree:
 
-| Imagination (metaphor) | Fancy (simile) |
-|---|---|
-| Creates a NEW understanding by fusing two terms | Compares two terms while keeping them distinct |
-| The shared qualities are deeply submerged | The shared quality is explicit and surface-level |
-| Listener does the work of completing | Writer does the work of pointing |
-| Pressure builds and resolves internally | Pressure resolves at the comparison itself |
+> "He identified the difference between metaphor and simile as a difference of
+> degree, depending on how much the two ideas shared in common. If they shared
+> only a few, simile. More, metaphor."
+> — *Songwriting Without Boundaries* (2011), Challenge 2, Day 14
+
+<!-- REMOVED — INVENTED SCAFFOLDING. A four-row "Imagination (metaphor) / Fancy
+     (simile)" table stood here, directly under the Coleridge quotation, so it
+     read as Pat's or Coleridge's gloss. It is neither. Rows such as "Listener
+     does the work of completing" / "Writer does the work of pointing" and
+     "Pressure builds and resolves internally" / "Pressure resolves at the
+     comparison itself" have no counterpart anywhere in Day 14 or in *Writing
+     Better Lyrics* (2009) Ch 3. Pat's whole statement of the distinction is the
+     single sentence now quoted above — a difference of DEGREE, nothing more.
+     The invented table also contradicted the paragraph immediately following
+     it, which correctly reports that Pat declines the degree test in favour of
+     commitment. Classic named-axes signature: four tidy oppositions where the
+     source has one. -->
 
 Both are valid craft moves. Pat does **not** adopt Coleridge's
 shared-quality test as his own decision rule. His stated criterion is
@@ -1093,13 +1229,28 @@ the first time without help` (focus stays on the concept of freedom).
 *Songwriting Without Boundaries* (2011), Challenge 2 Day 14 names five
 simile targets the writer practices on, with elaboration:
 
-| Target | Pattern |
-|---|---|
-| Trust | "Trust is like \_\_\_because\_\_\_" — pick a thing that shares an attribute, then elaborate why |
-| A bad joke | same pattern |
-| Divorce | same pattern |
-| A waterfall | same pattern |
-| Hope | same pattern |
+**Trust**, **a bad joke**, **divorce**, **a waterfall**, **hope** —
+"Find three similes for each of the following terms. Then write a short
+elaboration on each one."
+
+Pat's own model, printed before the exercise:
+
+```text
+Thirst is like a guest who won't go away.
+  You can bear it for a while, but the longer you wait, the more
+  uncomfortable you feel, until you finally have to head for the
+  bathroom and close the door.
+
+Thirst is like a buffalo hunter on the dry plains of Montana.
+  It stalks everywhere, looking for prey to bring down, peering through
+  tumbleweed at figures moving in the distance toward the waterhole. If
+  it has its way it'll stop them cold before they can get there.
+
+Being thirsty is like being the parent of a teenage daughter.
+  Always wanting another little drop of information and attention, in
+  the dry landscape of texting and sleepovers, after the waterfall of
+  affection from childhood has long since turned to a trickle.
+```
 
 The elaboration is the craft move: a simile without elaboration is a
 naked comparison. A simile WITH elaboration earns its place — the

--- a/plugins/songwriting/context/pat-pattison/research/metaphor.md
+++ b/plugins/songwriting/context/pat-pattison/research/metaphor.md
@@ -746,9 +746,12 @@ Day 14 practice:
 4. Keep the simile only if the elaboration reveals usable sensory or emotional
    material.
 
-## Five-step metaphor practice
+## Five-step metaphor practice (*Writing Better Lyrics* (2009), Chapter 3, Exercise 8)
 
-Chapter 3 ends the exercise sequence with a slower habit-building practice:
+The count is Pat's own, not a rounding: "you will be ready for the final method
+to activate the process: **a five-step exercise** guaranteed to open your
+metaphorical eyes and keep them open." Chapter 3 ends the exercise sequence with
+this slower habit-building practice:
 
 1. List five adjectives; find a noun for each that creates a fresh collision.
 2. List five nouns; find a strong verb for each.
@@ -903,7 +906,12 @@ When applying this file:
 8. Check prosody: the figurative language should support the section's motion,
    rhyme, rhythm, and emotional weight.
 
-## Eight named metaphor moves (recipe card)
+## Eight metaphor moves — this repo's recipe card, not Pat's taxonomy
+
+<!-- The heading read "Eight **named** metaphor moves". The body already
+     debunked the taxonomy claim, but "named" kept asserting it one line above —
+     and a heading that outlives its body is how the claim grows a new body.
+     Nobody names these eight. Word removed. -->
 
 **Plugin-side synthesis — UNAUDITED, not Pat's taxonomy.** These eight
 are a generation checklist assembled here from the material above; they
@@ -1139,9 +1147,9 @@ work is the cost of the image.
 *Songwriting Without Boundaries* (2011), Challenge 2 Day 14 names the
 mechanical model for why simile works differently than metaphor:
 
-> "Simile doesn't transfer focus: like works as an energy blocker — it
+> "Simile doesn't transfer focus: *like* works as an energy blocker — it
 > reflects energy back onto the first term, refusing to let the energy
-> pass to the second term. The is of metaphor allows free passage of
+> pass to the second term. The *is* of metaphor allows free passage of
 > energy to the second term, and lights it up."
 > — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 2
 > Day 14
@@ -1169,16 +1177,21 @@ demonstration, in order:
 >
 > — *Songwriting Without Boundaries* (2011), Challenge 2, Day 14
 
-The bolding is Pat's own typographic emphasis, recovered from the raw XHTML
-(`<span class="class_s5g3">` wraps the term in focus on each of those four
-lines). The plain text layer strips it, and without it the pairs read as bare
-repetition — the emphasis IS the argument.
+The emphasis is Pat's, not ours. The text layer strips it, and without it those
+pairs read as bare repetition — but the emphasis *is* the argument. What the
+source actually shows: in the raw XHTML each of those four lines wraps the term
+in focus in `<span class="class_s5g3">`, and that is a **different** class from
+the `class_s5g` Pat uses for italics (it wraps book titles, and words-as-words
+such as the *like* and *is* in the quotation above). The 2011 stylesheet was not
+extracted, so `class_s5g3` cannot be resolved to a named face here; across the
+book it wraps things like `90 seconds:` prompt labels and prompt words, which
+read as bold. Rendered as bold on that basis. **If a later pass gets the
+stylesheet and it says italic, change the face — do not delete the emphasis.**
 
 <!-- CORRECTED — GENERICIZATION. An invented pair, "Her smile IS sunlight" /
      "Her smile is LIKE sunlight", stood here doing the job of Pat's own
      `Love is a rose`, which he prints on the very same page. Substituting a
      made-up example for one of his is the failure the BRIEF names first. -->
-
 
 The mechanical consequence: **simile keeps the listener at distance**
 (comparing); **metaphor pulls the listener into identification**

--- a/plugins/songwriting/context/pat-pattison/research/meter.md
+++ b/plugins/songwriting/context/pat-pattison/research/meter.md
@@ -433,7 +433,9 @@ section still feels pushed forward by phrase count.
 ## Stress count vs syllable count
 
 This rule reaches the reader as a parenthesis printed inside a page scan, which
-is why it is easy to miss. Pat's words:
+is why it is easy to miss — it is *Essential Guide to Lyric Form and Structure*
+(1991), Chapter 3, figure `image_rsrc2ZU.jpg`, and it appears nowhere in the
+EPUB text layer. Pat's words:
 
 > (Now we can be more precise when we say one phrase is "longer" or "shorter"
 > than another one. When you want to know how long a phrase is, you can figure it
@@ -1157,7 +1159,7 @@ u    /  u   /  u   /  u  //
 Keeping out of sight
 /  u    /   u  /
 Knowing no one else can see
-/  u    u  /   /    u  /
+/  u    /  u   /    u  /
 Knowing something isn't right
 /  u    /  u    /  u  /
 ```
@@ -1594,55 +1596,100 @@ not only louder and longer than unstressed — they're also **higher in
 pitch**. Treating stress as pitch makes the underlying music of speech
 audible.
 
-The model:
+Pat's rule, as printed:
 
-- **Tonic (do)** — unstressed syllable pitch
-- **Sol** (a fifth above) — primary stress
-- **Fa** (a fourth above) — typical strong-stress
-- **Mi** (a third above) — secondary stress
+> Every word with two or more syllables has a melodic shape: One or more
+> syllables have higher pitches than the others. They are called stressed
+> syllables. Stressed syllables are usually a major fourth (fa) above the
+> "tonic" (do) established by the unstressed syllables.
 
-<!-- phonetic stress spelling trips the spell-checker --><!-- spellchecker:off -->
-So a content word like "lonely" carries `sol-do` (loo-uh-LEE-NLY... actually
-`SOL-do`); a two-syllable preposition like "before" carries `mi-do` —
-secondary stress, not full primary. This matters when setting melody: pitch
-contours that mirror natural speech stress feel inevitable; pitch contours
-that fight it feel forced.
+<!-- spellchecker:off -->
+His demonstration word is `release` — "da DUM," with "a melodic leap of a
+fourth on 'lease'—(do fa)." His worked list, with his own solfège:
 <!-- spellchecker:on -->
+
+<!-- Pat's stress-marked spellings trip the spell-checker --><!-- spellchecker:off -->
+```text
+unkínd          do fa
+butcher         fa do
+Uncónscious     do fa do
+Ópposíte        sol do fa
+Cónsequénces    sol do fa do
+Ínterrúpted     fa do sol do
+```
+<!-- spellchecker:on -->
+
+When a word carries two or more stressed syllables, the primary stress is the
+highest in pitch and is "usually a step above the secondary stress." Multi-
+syllable words with more than one stressed syllable will contain a secondary
+stress. One-syllable meaning carriers are "usually raised somewhere between a
+third and fifth above the tonic (do) set by the unstressed syllable" — Pat
+calls those raised pitches "spotlights that shine on these words and draw
+attention to them."
 
 ### Compound word stress rule
 
-<!-- stress-caps compound examples trip the spell-checker --><!-- spellchecker:off -->
-Primary stress on **compound words** in English almost always lands on the
-**first syllable**. Examples: HOMEwork, RAINbow, FOOTball, SUITcase. The
-second syllable carries secondary stress, not primary.
+Pat's frame: some two-syllable words carry **both** a primary and a secondary
+stress. "These are unusual, but easily recognized, since they are usually made
+up of two separate words that would be stressed if they appeared alone, called
+compound words." His examples, in his order:
+
+<!-- Pat's compound-word list trips the spell-checker --><!-- spellchecker:off -->
+```text
+hotdog   sunlight   nighttime   newsstand   pigtail   sandstorm
+```
 <!-- spellchecker:on -->
 
-This rule conflicts with default phrase-stress reading; it must be applied
-word-by-word.
+> In English, the primary stress in compound words is almost always on the
+> first syllable.
 
 ### Two-syllable prepositions — secondary stress
 
-Two-syllable prepositions (`óver`, `befóre`, `accróss`, `aróund`, `intó`)
-carry secondary stress on one syllable — but the pitch rise is `mi` (third
-above tonic), not `sol`/`fa` (fourth/fifth). This is internal stress, not
-full content-word stress.
+Articles, prepositions and conjunctions are usually unstressed, because their
+job is to show relationships between meaning functions — a grammatical (or
+secondary) function. But many prepositions have two or more syllables and so
+contain, within themselves, more and less stressed syllables. Pat's two
+examples: `óver` has a stronger first syllable, `befóre` a stronger second.
+"Generally these stronger syllables rise a major third (mi) above the tonic set
+by the unstressed syllable."
+
+> Because prepositions are not as important as the nouns, verbs, adjectives,
+> and adverbs they serve, their stressed syllables are marked with a secondary
+> stress (//), which also notes their secondary function in the line. Because of
+> this, when you set lyric to melody, you will remember to relegate prepositions
+> to secondary rhythmic positions in the bar.
 
 ### The "into" rule (*Songwriting Without Boundaries* (2011), Challenge 4)
 
-Pat: "into" is probably the most badly handled word in songwriting.
+Pat's own paragraph, and the reason behind it:
 
-The conventional reading is **ínto** (stressed on first syllable). When
-writers set it as **intó** (stressed on second syllable, to fit a melody
-that needs the stress on "to"), the ear knows it's wrong even if the
-listener can't name what's wrong.
+> Take a second to notice into, another two-syllable preposition. It is stressed
+> ínto, not intó. It is probably the most badly handled word in
+> songwriting—perhaps since it usually follows a stressed syllable:
+>
+> She walked into the room.
+>
+> The proper handling is
+>
+> She walked (pause) ínto the room.
+>
+> not
+>
+> She walked intó the room.
+>
+> 'Nuff said.
 
-Fix: rephrase the line so "into" sits in its natural ínto reading, OR
-substitute another preposition that fits the stress pattern.
+The remedy is a **setting** instruction, not a revision one: give "into" its own
+rhythmic space so the first syllable lands where the stress already is. It
+follows directly from the preceding rule — prepositions get relegated to
+secondary rhythmic positions in the bar, and "into" breaks most often because
+the stressed syllable in front of it crowds it off that position.
 
 ## "In Memoriam" quatrain (*Songwriting Without Boundaries* (2011), Challenge 4)
 
-A named variant of the abba quatrain, sourced from Tennyson's *In Memoriam
-A.H.H.*: four equal-length tetrameter lines, abba rhyme scheme.
+A named variant of the abba quatrain, named by Pat after "a poem of that title
+by Alfred, Lord Tennyson": four equal-length tetrameter lines, abba rhyme
+scheme.
 
 Structure:
 
@@ -1653,15 +1700,24 @@ Structure:
 4-stress line  a
 ```
 
-The equal line lengths + the abba pattern (rhyme returning to the
-outermost position after a paired inner rhyme) create suspended-emotion
-texture. The unresolved-then-resolved arc is appropriate for mourning,
-loss, retrospective, dream-state.
+Pat's naming paragraph, verbatim:
 
-Pat lists this form in the Challenge 4 / 14-day rhythm-and-rhyme
-curriculum. Distinct from the looser `abba` Pat uses elsewhere — In
-Memoriam constrains line length to equal tetrameter, where general `abba`
-allows mixed lengths.
+> This is called an "In Memoriam" quatrain, after a poem of that title by
+> Alfred, Lord Tennyson. It was a poem mourning the death of a friend, and
+> because the rhyme scheme's unstable nature was so perfectly appropriate for
+> the subject matter, the name stuck to both the rhyme scheme and the quatrain.
+
+So the effect Pat names is **instability**, not resolution. `abba` is the Day 14
+"unstable structure," and his own statement of what it is for is:
+
+> Today you'll work with an unstable structure, one that will help support lyric
+> ideas in the unstable camp—loss, heartbreak, hope, dreaming, etc.
+
+Distinct from the `abba` Pat drills on that day: Day 14 asks for **tetrameter
+outside lines (1 and 4) and trimeter inside lines (2 and 3)**, and the In
+Memoriam quatrain is what you get when you turn that sequence into equal-length
+tetrameter lines. Pat encourages experimenting with the equal-length version but
+sets the 4/3/3/4 shape for the exercise itself.
 
 ## Pentad cross-domain applicability (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3)
 
@@ -1677,12 +1733,11 @@ surfaces:
 Pat's word for the third surface is *musical*, and it stops there. Earlier
 revisions of this file split it into "melodic structure" and "harmonic
 structure (chord pattern stability per pentad property)"; that split is not in
-the source, and the per-surface criteria it implied were never Pat's. If a
-melody- or harmony-specific stability read is what is wanted, the file that
-actually carries per-domain criteria is
-[stable / unstable](stable-unstable-meta.md), whose five motion controllers
-include melody, harmony, melodic rhythm, and harmonic rhythm as separate rows
-with their own stable/unstable tests.
+the source, and the per-surface criteria it implied were never Pat's. Pat does
+not break the musical surface down here, and no file in this plugin should
+supply per-domain melodic or harmonic stability criteria on his authority. The
+adjacent song-wide frame is [stable / unstable](stable-unstable-meta.md), but it
+works from the five elements of structure, not from a musical-domain table.
 
 The pentad is one analysis frame applied across multiple structural
 surfaces. Do not confuse it with the

--- a/plugins/songwriting/context/pat-pattison/research/mosaic-rhyme.md
+++ b/plugins/songwriting/context/pat-pattison/research/mosaic-rhyme.md
@@ -1,6 +1,6 @@
 # Mosaic Rhyme — Multi-Word Combos Across Parts of Speech
 
-Pat Pattison — *Pat Pattison's Songwriting: Essential Guide to Rhyming*
+Pat Pattison — *Essential Guide to Rhyming*
 (2014), Chapter 1 — where mosaic rhyme is named and defined. Worked examples
 run through Chapter 2 (the "risky business" walkthrough), Chapter 4 (feminine
 family rhymes), and Chapter 6 (feminine assonance rhymes). Extended for
@@ -44,8 +44,8 @@ labeled as such.
 | `commander` / `understand her` | feminine | the unstressed tail is a pronoun, not an identity | Chapter 1 |
 | `expand me` / `strand thee` | feminine | verb + object pronoun on both sides | Chapter 1 |
 | `ap-pre-ci-ate` / `the quiche he ate` | masculine (three-syllable) | article + noun + pronoun + verb | Chapter 1 |
-| `business` / `fizzless` | feminine | noun + adjectival suffix borrowed from `less` | Chapter 2 |
-| `business` / `quizless` | feminine | same construction, different stressed vowel word | Chapter 2 |
+| `business` / `fizzless` | feminine | `fizz` from the masculine short `i` + `z` column, `less` from the masculine short `e` + `s` column | Chapter 2 |
+| `business` / `quizless` | feminine | same construction, `quiz` from the same short `i` + `z` column | Chapter 2 |
 | `travel` / `glass full` | feminine | noun + adjective read as one unit | Chapter 4 |
 | `homely` / `phone me` | feminine | masculine word + pronoun `me` | Chapter 4 |
 | `believer` / `please her` | feminine | verb + object pronoun `her` | Chapter 4 |
@@ -154,10 +154,14 @@ sailin'  /  tail him
 The transferable discipline — and the part that squares with Pat's method — is
 that every word becomes rhyme-able once you decompose its *sound* and
 reassemble a matching unit out of several words. That is exactly the move Pat
-makes in Chapter 2 when `business` has no dictionary partner and he builds
-`fizzless` out of the masculine short `e` + `s` column. The book's route to a
-mosaic is: fail in the obvious section, then rebuild from a different section
-of the dictionary.
+makes in Chapter 2 when `business` has no dictionary partner: the feminine
+<!-- spellchecker:off -->
+section under "IZ ness" is empty, so he rebuilds the word from two *masculine*
+<!-- spellchecker:on -->
+columns — short `i` + `z` for the stressed syllable (`fizz`, `quiz`) and short
+`e` + `s` for the unstressed tail (`less`) — and gets `fizzless` / `quizless`.
+The book's route to a mosaic is: fail in the obvious section, then rebuild from
+a different section of the dictionary.
 
 ## Where mosaic rhyme is generated in the worksheet
 
@@ -174,9 +178,11 @@ When running the three-stage worksheet (per
    - Proper-noun mosaic candidates (if the song's world allows)
    - Slang / contraction / phrase-fragment mosaic candidates
 
-The mosaic column generates 5-15 candidates per seed word in addition to
-the standard tiers. Stressed-vowel anchor identification + identity check
-still apply.
+The mosaic column runs alongside the standard tiers rather than replacing
+them; generate as many candidates per seed word as the search yields.
+Stressed-vowel anchor identification + identity check still apply. (The book
+sets no candidate count — Pat's own `business` search produced seven from the
+short `i` + `z` column and eleven from short `e` + `s`.)
 
 ## Identity check for mosaic rhyme
 
@@ -225,12 +231,17 @@ sound-legal list — `Bess, bless, chess, dress, fess, guess, jess, less, mess,
 press, stress` — and threw nearly all of it out on stress grounds: "Most of
 these are too strong to work as the unstressed syllable in a feminine mosaic.
 You need something with the same stress pattern as `busi-ness`." Try `guess`
-and you get `hís guéss`, two stresses where the target has one. Only `less`
-survives, "since it actually could be unstressed." Sound-legal is not the
-same as scannable.
+and Pat prints two failing scansions: `his guess` marked `/ /` (both stressed,
+where the target has one), "…or, even worse," `his guess` marked `˘ /` — the
+stress on the tail, the exact opposite of `busi-ness`. "Both of these are
+forced and again, self-consciously funny." Only `less` survives, "since it
+actually could be unstressed." Sound-legal is not the same as scannable.
 
 ## Mosaic risk register
 
+**Generated, not Pat's.** No failure-mode table appears in *Essential Guide to
+Rhyming*. The rows below are this plugin's own; the only one traceable to the
+book is the meter-break row, which is Pat's `busi-ness` stress filter above.
 Mosaic rhyme has failure modes:
 
 | Risk | What it looks like | Correction |
@@ -244,6 +255,11 @@ Mosaic rhyme has failure modes:
 | Hot-spot misplacement | Mosaic landed in a verse-middle line, not a hot spot | Place mosaic moves in section-end positions where craft can be seen |
 
 ## When mosaic rhyme is the RIGHT call
+
+**Generated, not Pat's.** These two lists are the plugin's decision aid. Pat
+prints no "use when" criteria for mosaic; in the book, mosaic is simply what
+you reach for when the feminine section comes up empty (Chapter 2) or when a
+feminine target's unstressed syllable rhymes with a pronoun (Chapters 4 and 6).
 
 - Source word has few single-word partners (proper nouns, polysyllabic
   abstractions, words ending in rare consonant clusters)

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -28,6 +28,14 @@ could have found.
 
 > Your senses are driving the bus.
 
+Pat opens Challenge 1 with an epigraph that states the whole discipline in one
+sentence:
+
+> Don't tell me the moon is shining; show me the glint of light on broken glass.
+>
+> —Anton Chekhov, epigraph to *Songwriting Without Boundaries* (2011),
+> Challenge 1
+
 Skill behavior: when a user asks for "more vivid" lyrics, do not start by
 adding adjectives. Start by asking what the speaker sees, hears, smells, tastes,
 touches, feels inside the body, and feels through balance or motion.
@@ -112,7 +120,9 @@ A strong image placed early drips color downward over the lines that follow. If
 the image arrives late, the opening statements remain abstract and
 under-colored.
 
-Use this diagnosis on bland drafts:
+Use this diagnosis on bland drafts. *The four-part breakdown below is this
+file's own tooling — Chapter 2 states the rule and demonstrates it, but prints
+no diagnostic list:*
 
 - Abstract line: names the feeling, lesson, topic, or conclusion.
 - Rusty's collar: the concrete image that lets the listener feel that abstract
@@ -126,7 +136,12 @@ sensory evidence. "I miss home" can work after the listener has felt the hills,
 trees, wages, weather, distance, or body motion of leaving. Without the collar,
 the same claim becomes generic.
 
-## Rusty's collar rewrite pattern
+## Rusty's collar rewrite pattern — this file's own, no book source
+
+*Pat publishes no rewrite sequence for the collar. Chapter 2 is a story, a rule,
+and two demonstrations; the numbered steps and the coaching questions below are
+this repo's routine for applying the rule. The "three possible collars" in step
+3 is a working default, not a number Pat gives.*
 
 When a user brings a flat line, run this sequence:
 
@@ -149,10 +164,25 @@ Useful coaching questions:
 
 ## Cliche substitution warning
 
-Chapter 2 also shows how replacing a specific image with a convenient general phrase
-can weaken a lyric, especially when the substitution exists mainly to make a
-rhyme work. If a draft swaps vivid place, job, weather, object, or body detail
-for broad labels, keep the image and rework the rhyme.
+Chapter 2 closes on this, and it is a real, named case, not a general caution.
+Pat prints Gillian Welch's "One More Dollar" and then a deliberately de-specified
+rewrite of it — see LYRIC-HANDOFF, the lyric itself is not reproduced here —
+and reports the verdict:
+
+> Instant bland. David Rawlings, Welch's partner and an ardent student and
+> practitioner of songwriting, called me with this beige version, remarking how
+> he'd just turned the song into a disaster by trading the specific image for a
+> cliché rhyme, city/pretty. "Look how completely it destroys a perfectly good
+> work," he chuckled.
+>
+> When you're writing, it's fine to just let things flow. But always be on the
+> alert for potential "collars." Don't leave Rusty's collar on the kitchen
+> table, no matter how excited you are to get to school and tell everyone about
+> your new puppy.
+> — *Writing Better Lyrics* (2009), Chapter 2
+
+So: if a draft swaps vivid place, job, weather, object, or body detail for broad
+labels in order to reach a rhyme, keep the image and rework the rhyme.
 
 Use [rhyme strategy](rhyme-strategy.md) and [rhyme types](rhyme-types.md) after
 the collar is protected. The rhyme should serve the image, not erase it.
@@ -165,9 +195,16 @@ Lyrics* (2009), Chapter 1, Exercise 1:
 > Use all seven senses: sight, hearing, smell, taste, touch, organic, and
 > kinesthetic.
 
-*Songwriting Without Boundaries* (2011) prints a shorter list, and prints it
-again at the head of every single day of every challenge as the line the writer
-lets their eye wander to when they do not know where to go next:
+*Songwriting Without Boundaries* (2011) prints a shorter list, and reprints it
+as the line the writer lets their eye wander to when they do not know where to
+go next. It stands at the head of the Challenge 1 opener and of all fourteen
+Challenge 1 days, and again on all fourteen Challenge 4 days; the metaphor
+challenges in between do not carry the strip. Pat's framing on Day 1:
+
+> Use the list below as a place to let your eye wander when you're not sure
+> where to go next.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1, Day 1
 
 ```text
 Sight Sound Taste Touch Smell Body Motion
@@ -326,9 +363,24 @@ The basic practice is strict:
 6. Stop immediately when the timer ends.
 7. Mine the page later for images, phrases, titles, and emotional turns.
 
-Stopping on time matters. The short container trains speed, access, and trust.
-Object writing is a warmup and a source of material, not the whole songwriting
-process.
+Stopping on time matters, and Pat gives the mechanism a name:
+
+> Soon, during your timed writing, something like this will happen: Your writing
+> will start to roll, diving, plunging, heading directly for the soft pink and
+> blue glow below when, beep! The timer goes off. Just stop. Wherever you are.
+> Stop. Writus interruptus. All day your frustrated writer will grumble, "Boy,
+> what I might have said if you hadn't stopped me." Guaranteed, when you sit down
+> the next morning, you will dive deeper faster. You'll reach the bottom in three
+> minutes flat. Next time, one minute. Finally, instantly. That is your goal:
+> immediate access—speed and depth. [...] But, of course, speed doesn't count
+> without depth. The ten-minute absolute limit is the key to building both. And
+> it guarantees a manageable task.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1
+
+The frustration is the point, not a side effect. Object writing is a warmup and
+a source of material, not the whole songwriting process: "It prepares you for
+any creative writing you want to do: lyrics, poetry, short stories, novels."
 
 ## The pivot chain — the mechanism behind "follow the senses"
 
@@ -437,13 +489,23 @@ specific sensory detail.
 
 "Be specific" is uncalibrated advice, and an underweight benchmark produces
 underweight writing. Chapter 1's own demonstration passages set the bar much
-higher than the usual generic-to-slightly-less-generic swap: a single short
-recollection carries the named street, the named city, the speaker's exact age,
-the specific garment, what that garment smelled like, and the sound its
-hardware made when the speaker walked.
+higher than the usual generic-to-slightly-less-generic swap. Pat's benchmark
+passage, two sentences long:
 
-That is the target density — **five or six independent specifics inside one
-sentence, spread across more than one sense channel.**
+> I remember stomping through puddles on Duluth Avenue in St. Paul when I was
+> seven. I had a yellow slicker that smelled like my rubber boots, and my boot
+> buckles jingled when I walked.
+>
+> Where were you? Not on Duluth Avenue, I'll bet.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
+
+Count what is doing the work: the named street, the named city, the speaker's
+exact age, the specific garment, what that garment smelled like, and the sound
+its hardware made when he walked — spread across sight, smell, sound, and body
+motion. That is the density to calibrate against. Pat's point about why it works
+is the second half: "In this way, sense-bound language involves you; my words are
+filled with your experiences."
 
 Calibration check on any line claiming to be specific:
 
@@ -483,15 +545,25 @@ sound, or movement that carries loneliness without naming it.
 ## Group and remote practice
 
 Group object writing can build range because every writer enters the same word
-through different sense memory. Use shorter rounds for larger groups and longer
-rounds for small groups. Read aloud for image and sensory discovery, not
-critique.
+through different sense memory. Pat gives the round lengths as numbers, not as
+a principle:
+
+> In larger groups (five to ten), shorten the time to five minutes so that,
+> during readings, no one gets impatient. Do two or three at a sitting. [...]
+> With smaller groups, write eight to ten minutes each time (never longer).
+> Remember to pick real objects. Butter. Canary. The smell of split pea soup.
+> Hanging ivy. Hot coffee.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1, "Group Writing"
 
 **Same seed, no shared context.** Chapter 1 prints several writers' dives on a
 single common seed word and they are unrecognizable as responses to the same
 prompt. The divergence is the product: each writer enters the word through
-sense memory no one else has. Isolation is what produces it — writers who have
-seen each other's pages converge instead.
+sense memory no one else has. Pat protects it procedurally — his exercises say
+to write your own response *before reading ahead* — but he does not claim
+shared reading flattens a group. He claims the reverse: "Do two or three at a
+sitting. Each one will be better because you feed off each other — each of you
+has something unique to offer."
 
 **The bar escalates between rounds.** In the documented Sunday-group format the
 strongest write of a round sets the standard the next round writes against.
@@ -514,6 +586,23 @@ Object-writing parties can use:
 Remote practice works by sending a daily object prompt and having writers reply
 to the group. The useful part is rhythm and accountability, not performance.
 
+*Songwriting Without Boundaries* (2011) restates the same practice for its
+fourteen-day format, under the heading "Group Writing":
+
+> The fourteen-day challenges in this book work great in a group setting. You
+> can expand your experience by asking friends to join you, either at your
+> favorite coffee shop, someone's home, or even online. It's fascinating to hear
+> other writers dive and roll off the same prompt. Get some people together, set
+> a timer, and start with the object, person, time, or place—depending on the
+> challenge of the day. When time is up, each person reads. Each of you will have
+> something unique to offer. In a good group, the level of writing gets very high
+> (or deep) very quickly.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1
+
+And his closing push, two paragraphs later: "But do form a group, or at least
+find a partner. It'll keep you on track."
+
 ## Expanded object writing
 
 Once the writer has strong sense-bound habits, expand the prompt beyond objects:
@@ -534,6 +623,27 @@ The purpose is not to collect finished lyrics. The purpose is to train the
 writer to enter material through sensory participation instead of observation.
 
 > Sense-bound writing turns observers into participants.
+
+Pat sets out the daily shape and the provenance of the two sample writes printed
+under every prompt:
+
+> Each day of the fourteen-day Object Writing challenge asks the reader to
+> participate in three timed Object Writing exercises of five minutes, ten
+> minutes and 90 seconds for fourteen days. [...] Most of the responses in this
+> first challenge are drawn from an object writing "contest" at
+> objectwriting.com, a site built by Paul Penton in Melbourne, Australia. The
+> contest ran for forty days, each day presenting a new prompt. We chose two,
+> from the 20 to 40 responses we received each day, for inclusion here. This way,
+> you'll have a group writing experience whether you form your own group or not.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1
+
+That is why most samples carry other writers' names: they are contest entries,
+selected two per prompt. Pat's own writes appear only occasionally — on Day 1 he
+supplies the second "Sky" and "Lily Pad" pieces himself. He also closes the
+challenge by
+pointing readers back there — "you might go to www.objectwriting.com for the
+daily prompt there."
 
 Treat every daily prompt as a doorway into sense memory. The seed word may be a
 thing, person, time, or place, but the working rule stays the same: get inside
@@ -597,12 +707,48 @@ Challenge 1 daily seeds:
 Use these as models, not a mandatory canonical list. The category and timer
 matter more than the exact seed word.
 
+## Audition your verbs — Challenge 1, Day 4
+
+Day 4 stops mid-challenge to teach one craft lever, and the lever is verbs.
+Pat's commentary on Nick Miller's and Linda M's curbs:
+
+> Check out Nick and Linda's verbs. Go ahead, underline them. I'll wait.
+>
+> Strong verbs are the key to strong writing. Audition your verbs. Let them
+> prance and somersault for you. Verbs based in metaphor or steeped in the senses
+> usually get the gig.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1, Day 4
+
+He closes the same day with the payoff line: "I hope that paying attention to
+your verbs helped your writing today. It's a surefire way to take your writing
+to another level instantly."
+
+The audition metaphor is the usable part — a verb is a candidate, not a given.
+Pat keeps running the check on later days ("Check out both Linda and Deborah's
+verbs. Yum." — Day 9; "Nice verbs in both pieces." — Day 7). When mining a write,
+underline every verb first and ask which ones got the gig on merit.
+
 ## Place as action organizer
 
-The "where" days make an important adjustment: place is not scenery. A strong
-where creates action, orientation, social pressure, weather, distance, acoustics,
-traffic, smell, and bodily motion. If a lyric claims a general feeling, ask
-where the body is when the feeling happens.
+The "where" days make an important adjustment: place is not scenery. Pat states
+it in four sentences at the end of Day 14:
+
+> "Where" is a wonderful tool. Once you decide the place, the rest of your
+> writing can wrap around it or evolve from it. That's why it's useful to imagine
+> a place when you write, whether or not you actually talk about it. "Where"
+> organizes action.
+>
+> Abstract, generic writing usually lacks the grounding power of "where."
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1, Day 14
+
+And his reason for pairing it with "when", from the Day 12 opener: "'Where' and
+'when' are a powerful combination, working together to create a scene and
+situation—a context for 'who' and 'what' to operate from."
+
+If a lyric claims a general feeling, ask where the body is when the feeling
+happens.
 
 Where-writing repair questions:
 
@@ -645,15 +791,28 @@ distance, and implied want, then invent responsibly.
 
 ### Perspective writes — through the character's senses
 
-Chapter 1 goes further than observing a character: it directs the writer to run
-the object write **inside the character's body**, using that character's senses
-rather than the writer's own. A flight attendant working a short hop, a shelter
-volunteer at closing time — the seven channels stay the same, but every image
-must be one that person could have had.
+*Songwriting Without Boundaries* (2011), Challenge 1, Day 6 and *Writing Better
+Lyrics* (2009), Chapter 1 both go further than observing a character: they
+direct the writer to run the object write **inside the character's body**, using
+that character's senses rather than the writer's own. The seven channels stay
+the same, but every image must be one that person could have had.
 
-Pat cites his own examples from Sting's catalog: songs written from a car
-thief's perspective and from a male prostitute's. Neither is autobiography, and
-both are sense-bound throughout.
+Pat's own examples, verbatim:
+
+> Use other perspectives. Your object writing can be from the perspective of an
+> airline flight attendant, hurrying to serve drinks on a short flight. Or a
+> volunteer at an animal rescue shelter. A car thief, as in Sting's "Stolen Car"
+> or his "Tomorrow We'll See," from the perspective of a male prostitute.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1, Day 6
+
+That last sentence is elliptical as printed; do not smooth it. The 2009 parallel
+spells the same two songs out: "Sting's 'Stolen Car' is told from the
+perspective of a car thief, and his 'Tomorrow We'll See' is from the perspective
+of a male prostitute." Neither is autobiography, and Pat's licence for that is
+explicit: "Try using the character's senses, even if the character is you. And
+remember, your song doesn't have to be an accurate autobiography. Never let
+reality get in the way of truth."
 
 The discipline:
 
@@ -757,15 +916,27 @@ images, verbs, body details, and metaphor seeds.
 
 ## Mid-word stop — non-negotiable
 
-The single most-emphasized object-writing discipline across Books
-2 and 3. When the timer ends, the writer stops where they are.
+The single most-emphasized object-writing discipline across both
+*Writing Better Lyrics* (2009) and *Songwriting Without Boundaries*
+(2011). When the timer ends, the writer stops where they are.
 
 Not after finishing the word. Not after closing the thought. Stop.
 
 > "Stop IMMEDIATELY when the timer goes off. Do not even finish the word
 > you are on."
-> — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 1
-> Day 1 (the instruction repeats at the head of the later days)
+> — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 1,
+> Day 1 (that long form is printed on Day 1 only; Days 2-14 carry
+> "Stop IMMEDIATELY when the timer goes off." alone)
+
+The Challenge 1 opener, under the heading "Timed Writing", says it at length and
+this is the version to read to a writer once:
+
+> Guarantee yourself only the time allotted for each prompt. Set a timer, and
+> stop the second it goes off. I mean the second, as you'll see from some of the
+> examples in this challenge. Be sure you always stop right at the buzzer. Don't
+> finish the sentence. Don't even finish the word you're in the middle of.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1
 
 Reasons:
 
@@ -781,54 +952,88 @@ pen even if you are mid-letter."
 
 ## Destination writing — partial-tell integration
 
-*Writing Better Lyrics* (2009), Chapter 1 names a refinement Pat returns to in lectures. Pure
-object writing is fully sense-bound; destination writing
-deliberately integrates a small amount of telling at the very end
-of a sense-bound passage, so the page produces both raw material
-and a partial direction.
+Destination writing is **not Pat's term** — it is Andrea Stolpe's, and Pat
+credits her for it:
 
-Form:
+> In her book, *Popular Lyric Writing: 10 Steps to Effective Storytelling*,
+> Andrea Stolpe incorporates some commentary, some "telling," into her object
+> writing, calling it "destination writing." She recognizes that good song ideas,
+> especially titles, come just as easily from the "tell" side as the "show" side
+> of your writing.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1, "Expanded Object Writing"
 
-```text
-[ 8-9 minutes of sense-bound writing ]
-[ 1-2 minutes of light interpretive line — a feeling, a turn ]
-```
+Pat prints no minute-split for it — do not invent one. What he prints is a single
+worked instance, and the tell lands as the last line of a sense-bound passage:
 
-The shift happens late, never at the start. Telling at the start
-forecloses sensory access; telling at the end uses the sensory
-material to earn the interpretive line.
+> For example, I was tempted to add one more line to the passage I wrote about
+> the yellow slicker for the "Puddle" exercise:
+>
+> I remember stomping through puddles on Duluth Avenue in St. Paul when I was
+> seven. I had a yellow slicker that smelled like my rubber boots and my boot and
+> buckles jingled when I walked. All the cool guys left their boots open.
+>
+> Even though it isn't sense-bound, I like the last line, especially the tone it
+> takes. It's a comment — a "tell." It might be a line in a song, maybe a comment
+> after a few sense images set it up.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
 
-Use destination writing when:
+He also prints a warning about when to start using tells at all:
 
-- the writer's pure object-writing produces strong material but
-  no usable lyric direction,
-- a song idea exists but the sensory access feels thin,
-- coaching a writer toward connecting raw material to song
-  drafting.
+> You might want to use some tells in your object writing, but you might wait a
+> few weeks before you do — getting really sense-bound is hard work. You need to
+> practice being specific and sense-bound to do it well in the context of
+> building a song.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
 
-Do not use destination writing as a default. Pure object writing
-remains the primary daily practice. Destination writing is the
-bridge from practice into drafting.
+The three-item "Use destination writing when:" list that stood here was
+**invented** — Pat gives no such criteria. What he actually gives is the
+reason it earns its place:
+
+> She recognizes that good song ideas, especially titles, come just as easily
+> from the "tell" side as the "show" side of your writing.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
+
+Pat's own section title for this material is **"Expanded Object Writing"**.
+His one boundary on it is that neither practice is journaling:
+
+> Neither object writing nor destination writing is journaling. In journaling,
+> events, emotions, and "how I really feel" drive the bus. It's usually about
+> self-exploration, not so much about writing. And that's fine. But object
+> writing and destination writing are about writing. They are a preparation
+> for writing songs. They have a specific purpose.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1
 
 ## Airport game — character observation
 
-*Writing Better Lyrics* (2009), Chapter 1 introduces a character-observation drill Pat calls the
-airport game. Useful for Who-category object writing (Days 6-8 of
-*Songwriting Without Boundaries* (2011), Challenge 1).
+Pat names a character-observation drill the airport game. It sits inside the
+"who" material of *Songwriting Without Boundaries* (2011), Challenge 1, Day 6,
+and in *Writing Better Lyrics* (2009), Chapter 1. Use it for the Who-category
+days (Days 6-8 of Challenge 1).
 
-Mechanics:
+It is a **two-person game**, not a solo observation drill. Pat's mechanics,
+verbatim:
 
-1. Sit in a public place — airport, café, train station, park.
-2. Observe one person at a time.
-3. From posture, pace, tension, gesture, objects carried, distance
-   to companions, and clothing, infer:
-   - what they want right now,
-   - why they cannot say it directly,
-   - what just happened to them,
-   - what they are about to do.
-4. Write a 90-second sensory pass on that person.
-5. Keep ethical: invent responsibly; do not surveil; observe only
-   what is visible in public.
+> I also recommend this kind of storytelling when hanging out with other
+> writers. You might even make a special trip to the mall or the airport to
+> exercise your powers of observation. (I call it the "airport game.") As
+> somebody passes you, ask your friend a question: "Who did he take to his
+> junior prom?" "Does she get along with her younger sister?" Take turns asking
+> questions.
+>
+> — *Songwriting Without Boundaries* (2011), Challenge 1, Day 6; printed almost
+> word for word in *Writing Better Lyrics* (2009), Chapter 1
+
+The questions come first and the answers are invented. Pat's framing right
+before it: "People watching is full of interesting possibilities. Ask yourself
+questions: 'Does she play golf? When did she learn?' 'What was his favorite game
+when he was little?' Of course, you'll be drawing on your own experiences as you
+answer your questions. And always stay close to your senses. Specifics. Sense
+images."
 
 Use the airport game when:
 
@@ -857,9 +1062,10 @@ becomes the song's speaker.
 ## Kami-kazi — 90-second speed round (*Writing Better Lyrics* (2009), Chapter 1)
 
 Pat names the 90-second object-writing variant the **Kami-kazi**, crediting
-songwriter Kami Lyle for the technique. The name preserves the oral-history
-texture of how the discipline developed inside Pat's Nashville writing
-group.
+songwriter Kami Lyle, and glosses it in one parenthesis: "a ninety-second piece
+(suggested by Kami Lyle — I call it a Kami-kazi: you really approach it in a
+different way)." *A different way* is the whole gloss he gives it; do not
+elaborate his reasoning for him.
 
 The mechanics:
 
@@ -871,36 +1077,42 @@ The mechanics:
 
 The brevity is the point. With only 90 seconds, the writer has no time to
 deliberate — the seed has to launch into sensory association immediately.
-Pat: the writus interruptus discipline trains depth across sessions; the
-Kami-kazi compresses the discipline into the shortest viable window.
+Writus interruptus trains depth across sessions; the Kami-kazi compresses the
+same discipline into the shortest window Pat uses. That framing is this file's,
+not a quotation.
 
 Use Kami-kazi as warmup before longer 10-minute writes, or as a standalone
 when the writer has only a brief window.
 
 ## Object Writing Parties — Gillian Welch / Nashville Sunday format
 
-Pat documents Gillian Welch's Nashville Sunday writing group as the
-canonical Object Writing Party format. The structure:
+Pat documents Gillian Welch's Nashville Sunday group as the object-writing
+party. Reproduce his account rather than a tidied schedule — the reading after
+every single round is the part a summary drops:
 
-1. **Warm-up** — informal arrival, no writing yet
-2. **5-minute write** — first object write, picked seed read aloud
-3. **10-minute write** — longer object write
-4. **90-second Kami-kazi** — speed round
-5. **Break** — 15-minute pause; no writing
-6. **10-minute write** — second 10-min write
-7. **90-second Kami-kazi** — second speed round
-8. **5-minute write** — closing write, often a recombination of earlier seeds
-9. **Share** — each writer reads ONE page (or part of one) aloud; no critique
+> The best way to do group object writing is face to face. Gillian Welch had a
+> group in Nashville that met for two and a half years, every Sunday afternoon
+> from one to four. They'd warm up with a five-minute exercise and read their
+> results to each other. The best writing of the round would set the bar for the
+> next round. Then another five-minute warm-up. Read. Everyone dives a little
+> deeper. Then ten minutes. Read. One more ten. Read. Then a ninety-second piece
+> (suggested by Kami Lyle — I call it a Kami-kazi: you really approach it in a
+> different way). Read. Then another five minutes to decompress from diving so
+> deep. Read. And a break for munchies and conversation. After the break, they go
+> back for one more ten minutes, then one for ninety seconds, and then one for
+> five minutes before ending their weekly "object writing party." Welch says that
+> object writing was one of the most important keys to her success — and she's had
+> seven Grammy nominations, with three wins.
+>
+> — *Writing Better Lyrics* (2009), Chapter 1, "Object Writing Parties"
 
-The structure alternates timer lengths to keep access fresh — long enough
-for depth, short enough to prevent over-editing.
+Read that as the sequence it is: nine writes — 5, 5, 10, 10, 90s, 5, then the
+break, then 10, 90s, 5 — with Pat marking "Read." after every one of the six
+before the break. The Kami-kazi arrives only after two tens, and a decompression
+five comes before the food break.
 
-The share phase has its own discipline: no critique, no praise that
-qualifies criticism, no questions during reading. Pure listening. Critique,
-if it happens, happens in private conversations after the group breaks.
-
-Adapt for solo practice: drop the share phase, run the timer sequence on
-your own, mine the pages afterward.
+Adapt for solo practice: run the timer sequence on your own, and mine the
+pages afterward.
 
 ## Cross-references
 

--- a/plugins/songwriting/context/pat-pattison/research/phrasing.md
+++ b/plugins/songwriting/context/pat-pattison/research/phrasing.md
@@ -473,30 +473,71 @@ When a section feels wrong, test phrase structure before rewriting every line:
 - Match lyric phrase boundaries to musical phrase boundaries.
 - Contrast verse and chorus phrase lengths when the ideas contrast.
 
-## Clause taxonomy
+## Phrase taxonomy
 
-When slashing a lyric for phrase boundaries, name the kind of clause each
-unit is. Different clause types feel different in song:
+When slashing a lyric for phrase boundaries, name the kind of phrase each unit
+is. Pat's own word for all of them is "phrases," not "clauses."
 
-| Clause type | Example shape | Sonic effect |
-|---|---|---|
-| Prepositional | "in the rain", "under the bridge" | Setting; locates the listener |
-| Verbal | "running home", "having said that" | Action without subject; pushes forward |
-| Adjective | "wearing the same coat", "tired and alone" | Modifier; colors the noun |
-| Adverb | "long after midnight", "without warning" | Modifier; colors the verb |
-| Noun (subject or object) | "the longest day", "what you meant" | The thing itself; stabilizes |
-| Independent clause | "she said goodbye" | Full thought; stops |
-| Dependent clause | "who left the door open" | Hangs; requires anchor |
+> "Phrases are sentences or natural pieces of sentences sometimes called
+> 'clauses.'" — *Essential Guide to Lyric Form and Structure* (1991), Chapter 1
 
-Use the taxonomy to diagnose why a section feels jerky: too many
-independent clauses can feel choppy (every line a stop); too many
-dependent clauses can feel suspended (nothing lands). Mix clause types
-for natural sentence motion in song.
+Pat names **five** phrase types, with his own examples. His preamble: "Any book
+on English Grammar has more than enough to say about phrases, clauses, and
+sentences. It is enough here to look at a few examples. For convenience, call
+them all 'phrases.'"
 
-> "Phrases are sentences or natural pieces of sentences sometimes
-> called 'clauses.'" — Pat (*Essential Guide to Lyric Form and Structure* (1991), Chapter 1)
+Italics are Pat's, and they carry the teaching: in each sentence he italicises
+the span that *is* the phrase.
+
+**Prepositional phrases:**
+
+- *After the rain,* the birds sang madly.
+- Starships exploded *over the shoulder of Orion.*
+
+**Verbal Phrases:**
+
+- *Soaring on paper wings* is risky business. (Gerund)
+- *Barely cracking a smile,* he bowed. (Participle)
+
+**Adjective phrases (modify nouns):**
+
+- She longed for someone *who would serve her forever.*
+
+**Adverb phrases (modify verbs):**
+
+- *When the fog lifted,* she turned for home.
+
+**Noun phrases (used as subject, predicate, or object):**
+
+- *What you* see is a broken man. (Subject) — the italic span closes mid-phrase
+  in the source markup; the noun phrase is "What you see."
+- Sex is not *what it is cracked up to be.* (Predicate)
+- Hit the dealers *where it hurts the most.* (Object)
+
+Pat does **not** list "independent clause" and "dependent clause" as two further
+types. Dependency is a property he points out about the last three, verbatim:
+
+> The next phrases contain both a subject and a verb, but still depend on being
+> part of something bigger. Can you see why?
+
+and, after them:
+
+> Each of the phrases has a word that connects it to a part of the main
+> sentence. (Words like "who, what, when where, why, that.") These words turn
+> the phrases into dependents rather that self-reliant individuals.
+
+(Both oddities in that last sentence — the missing comma in "when where" and
+"rather that" for "rather than" — are in the source XHTML, not extraction
+artifacts; verified against `raw/`. Do not correct them.)
 
 ## Front-heavy and back-heavy phrases
+
+**Unaudited — non-book material.** "Front-heavy," "back-heavy" and "body
+language" return **zero hits across all four books**; the frame comes from
+patpattison.com and seminar material that is not in the corpus. This file
+previously printed two sentences below as block quotations attributed to
+`— Pat`, one of them with no source label at all. Neither can be checked, so
+neither is set as a quotation any more.
 
 Where a lyric phrase begins relative to the bar shapes its emotional
 character. Two states:
@@ -509,10 +550,8 @@ character. Two states:
   late in the bar. The phrase feels in motion, unsettled, leaning
   forward. Body language: walking, falling, reaching.
 
-> "Front-heavy phrases feel solid, stable. They are anchored." — Pat
-> (patpattison.com)
-
-> "Back-heavy phrases are in motion — they feel unstable." — Pat
+The paraphrase stands, unattributed: front-heavy reads as solid and anchored,
+back-heavy reads as in motion and unstable.
 
 Strong vs weak bars amplify the effect. In a 4-bar or 8-bar grouping,
 bars alternate strong (1, 3, 5, 7) and weak (2, 4, 6, 8). Pairings:
@@ -530,14 +569,16 @@ wants back-heavy on a weak bar.
 
 ## Body language
 
-Pat reframes phrasing as the song's body language. Where a phrase sits
-against the bar communicates emotion before the words register.
+**Unaudited — non-book material**, same scope as the section above: "body
+language" appears nowhere in the four books, so do not attribute this framing to
+Pat. Two sentences previously stood here as quotations attributed to
+`— Pat (patpattison.com)` and `— Pat (seminar copy)`; the second was also
+ungrammatical as printed ("Line like body language helps deliver the emotion you
+intend"), which is a fair sign it was never transcribed from anything. Both are
+gone.
 
-> "Phrasing has the power to create emotion. It's the body language."
-> — Pat (patpattison.com)
-
-> "Line like body language helps deliver the emotion you intend."
-> — Pat (seminar copy)
+The framing itself, unattributed: phrasing is the song's body language. Where a
+phrase sits against the bar communicates emotion before the words register.
 
 Three diagnostic questions:
 

--- a/plugins/songwriting/context/pat-pattison/research/point-of-view.md
+++ b/plugins/songwriting/context/pat-pattison/research/point-of-view.md
@@ -126,7 +126,13 @@ Pat rules out the other candidate reading before he gets here. He reads the
 whole first verse in first person and concludes: *"Clearly, Seger is not using
 you as a disguise for I."*
 
-## Translation tests
+## One test for second-person narrative
+
+<!-- This heading previously read "Translation tests" — plural. CHANGELOG line
+     63 records invented translation "tests" as removed from this file, but the
+     plural heading survived the removal. Pat prints ONE test, singular, and the
+     heading is now his own printed phrase (2009 spine 019:167). There is no set
+     of translation tests; do not reintroduce one. -->
 
 Pat states the test in one sentence:
 
@@ -413,11 +419,24 @@ And the transfer to lyrics:
 > problem: second person trying to do first or third person's job. Don't give
 > the facts to someone who already should know them!
 
-## Direct-address fact test
+## Direct address — do the facts belong in the song?
+
+<!-- This heading previously read "Direct-address fact test". Pat never uses the
+     phrase "fact test" — `grep -i "fact test"` returns zero hits in Writing
+     Better Lyrics (2009), Chapter 11 — and the four-question "test" that once
+     sat here was invented and has already been removed. The heading is a
+     PARAPHRASE of Pat's printed question at spine 018:70 — "Do you really want
+     the audience to know that it was Saturday and she had braids and she made
+     the first move?" — not printed text itself. Do not reintroduce a numbered
+     test here. -->
 
 Pat's first two repairs are pure pronoun moves, printed side by side with the
-broken verse. First-person narrative — *"would sound closer to what's really
-happening"*:
+broken verse, and he sets them up with a warning:
+
+> Though it's tempting to try to give the audience facts by letting them
+> eavesdrop on a conversation, be careful. You might end up with something as
+> stilted and unnatural sounding as the little gem above. First-person narrative
+> would sound closer to what's really happening:
 
 > I met her on a Saturday
 > Her hair was wound in braids
@@ -440,7 +459,7 @@ the facts deserve to be in the song at all:
 > audience to know that it was Saturday and she had braids and she made the
 > first move? If not, just drop the unnatural verse and write a better, more
 > natural one. If the facts are important, you have to say them naturally, like
-> you would in a real conversation.
+> you would in a real conversation:
 
 ## Natural ways to include shared history
 

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -309,6 +309,20 @@ Pat's control experiment is the same content rebuilt in four lines:
 Line length is measured by stressed syllables, not raw syllables. Equal stress
 lengths stop the ear; unequal stress lengths push the ear forward.
 
+Pat extends the traffic-cop image in *Songwriting Without Boundaries* (2011),
+Challenge 4, Day 13, and the extension is a **ranking** — line length outranks
+rhyme as a motion controller:
+
+> Both line length and rhyme are traffic cops, but line length has a higher
+> rank—captain, as opposed to sergeant.
+
+He shows the same order of authority twice more in that challenge. Of a
+six-line `xxaxxa` section: "Whatever motion there is comes from line lengths
+matching and unmatching, not from rhyme. These sections feel like they float
+with only rhythm driving the bus, since we don't hear a rhyme until the end."
+And of an `xxaxxa` common-meter/pentameter section: "Even without rhymes in the
+tetrameter and trimeter lines, the line lengths push forward pretty strongly."
+
 Pat demonstrates both inside the "Can't Be Really Gone" verse quoted above.
 Lines one and two, taken as a pair:
 
@@ -1150,12 +1164,24 @@ that together create the song's motion (and therefore its emotion):
 4. **Melodic rhythm** — long notes vs short notes, syncopation, line-end
    note durations.
 
-> "Motion creates e-motion. How you make it move, all by itself, creates
-> a feeling." — Pat
+The bare slogan "motion creates e-motion" is Pat's, but the fuller sentence this
+file used to print inside quotation marks and attribute to `— Pat` traces to no
+readable source and has been removed rather than left to look verbatim.
 
-The lyric controller (this skill's domain) is the rhyme-scheme one. The
-other three live in the music. The lyric's motion choices have to fit the
-musical controllers, push against them deliberately, or expose a mismatch.
+**Challenge 4 contradicts this list on its central point.** The list names the
+rhyme scheme as the one lyric-side controller and puts everything else in the
+music — but *Songwriting Without Boundaries* (2011), Challenge 4, Day 13 ranks
+**line length above rhyme**: "Both line length and rhyme are traffic cops, but
+line length has a higher rank—captain, as opposed to sergeant." Line length is
+a lyric-side controller and it is the stronger one.
+
+Two books say so independently. *Writing Better Lyrics* (2009), Chapter 19 makes
+the same ranking on the two-line ladder in
+[stability reference](#stability-reference): "So line length is a stronger
+motion creator than rhyme, huh? Yup." Treat the four-item list as an unaudited
+web paraphrase that is at minimum incomplete; use
+[length of lines](#length-of-lines) and the stability ladder as the book-sourced
+account.
 
 See [stable / unstable](stable-unstable-meta.md) for the cross-controller
 diagnostic.
@@ -1186,6 +1212,18 @@ apart, because the same word means something narrower in one of them.
 
 The three failures take three different fixes: rescan, re-set against the bar,
 or change which words carry the weight. Name which one you found.
+
+**One case of the melody-side claim is book-sourced**, so it does not rest on
+the web material. *Songwriting Without Boundaries* (2011), Challenge 4, Day 6,
+on rhyming a secondary stress against a primary one:
+
+> Be careful rhyming secondary stress with primary stress: If you place the
+> secondary stress on a stronger musical beat than the primary stress, you'll
+> distort the natural shape of the word.
+
+Pat's worked instances there are the rhyme pairs `breeze/harmonies` and
+`company/memory`, where the rhyming syllable of the longer word is its
+secondary stress.
 
 ### The 1991 source text — too hot, too cold, just right
 
@@ -1334,9 +1372,10 @@ Lyrics* (2009) Chapters 18-19 contain no tone-of-voice material, so there is no
 book text to restore here and none has been invented. The six levers below are
 this file's distillation, not Pat's list.
 
-Pat extends the stable/unstable diagnostic with a non-rhyme, non-meter
-axis: tone of voice. A line printed on the page has one stability
-character; the same line sung in two different voices has two.
+The axis itself: tone of voice sits outside both rhyme and meter. A line printed
+on the page has one stability character; the same line sung in two different
+voices has two. **Do not attribute this axis to Pat** — the phrase "tone of
+voice" returns zero hits across all four books, and no book chapter develops it.
 
 Levers carried by tone:
 
@@ -1357,8 +1396,11 @@ content that the chosen tone can carry without contradiction. A
 declarative chorus delivered breathy from below the beat undermines
 the words, on purpose or by accident.
 
-> "Tone of voice can change stability without changing a single
-> word." — paraphrase of Berklee article
+The claim in one line, **unattributed and unaudited**: tone of voice can change
+a section's stability without a single word changing. This file previously
+printed that sentence inside quotation marks against "paraphrase of Berklee
+article" — quotation marks around an admitted paraphrase of an unreadable
+source. It is not a quotation and is no longer set as one.
 
 If a draft "sounds wrong" but the printed page looks fine, the tone
 of voice may be the lever doing the work. Sing the chorus two ways.
@@ -1411,11 +1453,11 @@ notation — it requires hearing the bar structure clearly. When the melody
 makes the bar boundaries audible, strong/weak bar phrasing creates
 section-internal motion the other two types can't access alone.
 
-Use the third type when:
-
-- a section needs internal motion without rhyme-density change
-- a chorus needs alternating weight without changing line lengths
-- a melody already establishes strong bars and the lyric needs to match
+No "use when" rule for the third type is sourced. An earlier revision of this
+file carried a three-item trigger list here; it was scaffolding invented on top
+of an already-unreadable source, and it has been removed rather than restated.
+If you reach for the strong/weak-bar idea, reach for it descriptively — name
+what the bars are doing — and do not present a selection rule as Pat's.
 
 ## Cross-references
 

--- a/plugins/songwriting/context/pat-pattison/research/repetition.md
+++ b/plugins/songwriting/context/pat-pattison/research/repetition.md
@@ -1,6 +1,8 @@
 # Repetition
 
-Pat Pattison - *Writing Better Lyrics* (2009), Chapter 6 and Chapter 9.
+Pat Pattison - *Writing Better Lyrics* (2009), Chapter 6 and Chapter 9, plus
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 7 for structural
+repetition (the section at the foot of this file).
 
 Use this when a user asks whether a chorus, refrain, hook, title, repeated
 line, or repeated phrase is working; when a song sags on second chorus; when a
@@ -189,9 +191,13 @@ Losing the human race
 **Watch the third-person `-s`.** Pat's note on when you can skip verb
 neutralization entirely:
 
-> If you don't use *he*, *she*, or *it* in your lyric, none of your verbs will
-> add an *s*, so your verbs will all already be POV neutral. You won't need to
-> neutralize the verbs — you just need to drop the pronouns.
+> When you use third person with present tense, the verb adds an *s*: She
+> loses. If you don't use *he*, *she*, or *it* in your lyric, none of your verbs
+> will add an *s*, so your verbs will all already by POV neutral. You won't need
+> to neutralize the verbs — you just need to drop the pronouns:
+
+"all already **by** POV neutral" is as printed — the raw XHTML has `by`, not
+`be`. Do not correct it.
 
 Which is why *And lose the human race* works under I / we / you / they. But it
 is tense-locked, not POV-locked, and breaks the moment a verse goes past:
@@ -881,7 +887,7 @@ Love Love Love
 ```
 
 > This idea contains three tenses: past, present, and future. Try separating
-> them into separate boxes.
+> them into separate boxes:
 
 - **Past** — what happened (the seed event)
 - **Present** — what is now (current state)
@@ -1037,15 +1043,17 @@ His second: "Try it with: *You give me everything I need.*" It becomes *Give me
 everything I need.*
 
 Note: **third-person cannot generate commands** because English third-
-person verbs take an -s. Pat's counterexample, run through the same two passes:
+person verbs take an -s. Pat states it and then runs his counterexample through
+the same two passes:
+
+> Note that this trick doesn't work in third person, since third person adds an
+> *s* to the verb. You create only simple repetition — no command is isolated:
 
 ```text
 She tells me that she wants me.
 Tells me that she wants me.
 Wants me.
 ```
-
-> You create only simple repetition — no command is isolated.
 
 The technique needs the bare verb base, which first and second person supply and
 third person does not.
@@ -1116,6 +1124,91 @@ visit shift what the hidden question / command means in context.
 Cross-ref the chorus-stripping workflow above and the
 [box-model](box-model.md) division-of-labor framework.
 
+## Structural repetition — make the repeat necessary (*Essential Guide to Lyric Form and Structure* (1991), Chapter 7)
+
+Everything above asks whether a repeat *means* more. Chapter 7 of *Essential
+Guide to Lyric Form and Structure* (1991) asks a different, purely structural
+question: whether the repeat is *needed* to finish the section. It is strategy
+3 of that chapter's five hook strategies, and it opens with a frequency rule:
+
+> Your HOOK should come at least once in each Song System. That is usually
+> enough. Within reason you can squeeze it in a few more times.
+
+The warning and the rule arrive in one sentence — Pat demonstrating the vice
+inside the caution against it. It is printed exactly like this; it is not a
+transcription error, and it must not be "fixed":
+
+> Of course, if you repeat yourself too much if you repeat yourself too much if
+> you repeat yourself too much if you repeat yourself too much if you repeat
+> yourself too much you get boring, so be cautious. If you can make your
+> repetition *necessary* to finish the structure, all the better:
+
+Figure `image_rsrc346`, transcribed — a ten-phrase section whose last two
+phrases are the same phrase, with Pat's rhyme letters at the right:
+
+```text
+1.   My kitchen clock's on Phoenix time    a
+2.   That's where you promised you'd be mine    a
+3.   My watch is set for Tennessee    b
+4.   The place where time ran out on me    b
+5.   My bedroom's still in Boston's zone    c
+6.   I wake at dawn, I rise alone,    c
+7.   And though these times all disagree    b
+8.   At least one thing stays true    d
+9.   MY HEART'S STILL SET ON YOU    d
+10.  MY HEART'S STILL SET ON YOU    d
+```
+
+> The section is balanced by the repetition.
+
+### The repeat that finishes the structure — "SEEING SOMEONE ELSE"
+
+Chapter 7's second case is a section that will not balance until its last
+phrase is repeated. As first written it is four phrases:
+
+```text
+Even though you're with me
+Might as well be by myself
+'Cause the way you look at me is like
+You're SEEING SOMEONE ELSE
+```
+
+Pat's diagnosis, in order. Each quote is followed in the book by a scansion
+figure — `image_rsrc347` (the first two phrases), `image_rsrc348` (the last
+two), `image_rsrc349` (the first two run together as one phrase):
+
+> The first two phrases are each 3-stresses at best. There are certainly some
+> grey areas here:
+
+> The next two lines (as written) add up to one 7-stress phrase:
+
+> You can hear the section close, but it still feels a little off balance. You
+> can feel the general shape of Common Meter, plus the "self/else" rhyme, but
+> the rhythm is a little irregular and the phrase lengths are uneven, even if
+> you think of the first two phrases as one phrase:
+
+> It still fails to balance the last phrase. Repeating the last phrase does the
+> trick.
+
+The repaired section — six phrases, the last two a repeat of phrases three and
+four:
+
+```text
+Even though you're with me
+Might as well be by myself
+'Cause the way you look at me is like
+You're SEEING SOMEONE ELSE
+The way you look at me is like
+You're SEEING SOMEONE ELSE
+```
+
+> You have made the repetition a part of the structure.
+
+**The diagnostic this gives you.** Before cutting a repeat, ask the structural
+question as well as the meaning question: if the repeat came out, would the
+section still close? In this case it would not — so the repeat is load-bearing
+and stays. That is the whole of Pat's "all the better" clause.
+
 ## Cross-references
 
 - [box-model](box-model.md) — full division-of-labor framework
@@ -1124,3 +1217,7 @@ Cross-ref the chorus-stripping workflow above and the
 - [verse-development](verse-development.md) — power positions, travelogue
 - [point-of-view](point-of-view.md) — camera distances
 - [stable-unstable-meta](stable-unstable-meta.md) — section prosody scan
+- [hook](hook.md) — the other four hook strategies from *Essential Guide to
+  Lyric Form and Structure* (1991), Chapter 7; "Repeat the HOOK" is strategy 3
+- [song-forms-examples](song-forms-examples.md) — the full "SEEING SOMEONE
+  ELSE" Song System this section's repair belongs to

--- a/plugins/songwriting/context/pat-pattison/research/response-filter.md
+++ b/plugins/songwriting/context/pat-pattison/research/response-filter.md
@@ -12,7 +12,8 @@ captured in the other context files. It is the gate, not new craft.
 
 ## Stance: Tools, Not Rules — applied to the AI itself
 
-> "Tools, not rules." — Pat Pattison (recurring column / seminar framing)
+> "There are no rules, only tools."
+> — Pat Pattison, *Writing Better Lyrics* (2009), Chapter 18
 
 The filter is a tool the AI uses to check its own work. The AI may skip a box
 when justified — but a skip must be NAMED. Silent skips are not OK.
@@ -71,14 +72,27 @@ skip+reason):**
       = identity-in-disguise, REJECTED; `Texas / wrecks us` = rhyme).
 - [ ] **No suffix-driven identity** sneaking through (`-ation`, `-ing`,
       `-tion`, `-ly`, `-ness` chains routinely produce identities)
-- [ ] **≥4 stability tiers surfaced** — perfect / family / additive-
-      subtractive / assonance / consonance — not all perfect
+- [ ] **≥4 stability tiers surfaced** — not all perfect. Pat's printed
+      "Scale of Rhyme Types: Most Stable to Least Stable" runs, in order:
+      Perfect Rhyme → Family Rhyme → Additive/Subtractive Rhyme →
+      Assonance Rhyme → Consonance Rhyme (*Essential Guide to Rhyming*
+      (2014), Chapter 5, chapter-opening scale)
 - [ ] **MOSAIC tier MANDATORY** — ≥3 mosaic candidates surfaced per
       [mosaic-rhyme.md](mosaic-rhyme.md), regardless of source word.
       Cross-part-of-speech (verb+pronoun, adjective+noun, imperative phrase,
       contraction stack) included. Proper-noun mosaic considered when
       the song's world allows. The AI's default is single-word-rhyme; the
       filter forces mosaic onto the table.
+- [ ] **Additive/subtractive search runs in Pat's noticeability order**
+      when the tier is reached — voiced plosives, then unvoiced plosives,
+      then unvoiced fricatives. His worked search on "free" goes
+      +b ("not much there"), +d, +p, +t, +k, then +f, then +s. The
+      governing guideline is printed as: "In general, the more sound you
+      add, the less stable the rhyme becomes. The less sound you add, the
+      more stable the rhyme becomes, and you're closer to a perfect rhyme
+      substitute." Fricatives add more sound than plosives; other than
+      l and r, nasals add the most (*Essential Guide to Rhyming* (2014),
+      Chapter 5)
 - [ ] **Masculine / feminine / mosaic** taxonomy taught (per
       *Essential Guide to Rhyming* (2014), Chapter 1) — at least one
       feminine (2-syllable) candidate AND at least one mosaic candidate
@@ -95,7 +109,13 @@ skip+reason):**
 - [ ] **Syllable match flagged per candidate** when the rhyme position
       demands a specific stress count (mosaic must preserve source meter)
 - [ ] **NO single winner imposed** — writer picks by emotional intent
-- [ ] **Sing-check noted** — the AI cannot sing; the WRITER must sing-check
+- [ ] **Sing-check noted** — the AI cannot sing; the WRITER must sing-check.
+      Not optional politeness: Pat makes singing the test that settles an
+      additive rhyme, twice in Chapter 5 alone (see anchor quotes below).
+      Chapter 4 gives the reason — "Since lyrics are sung, vowel sounds are
+      promoted and consonant sounds are demoted. If you take the time to
+      sing the family rhymes, they will not trouble your sensibilities."
+      (*Essential Guide to Rhyming* (2014), Chapter 4)
 
 **Fail signature 1 — single-word default:** if the AI's about-to-emit
 rhyme list reads like [`rose`, `chose`, `pose`, `nose`, `goes`, `knows`,
@@ -122,7 +142,12 @@ the filter must catch this. See [mosaic-rhyme.md](mosaic-rhyme.md)
 **Anchor quote:**
 
 > "Never stop listening. If your ear says a sound is wrong, find another
-> rhyme. Trust your ears."
+> rhyme. Trust your ears. (But be sure to sing your rhymes when you check.)"
+> — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 5
+
+And again two pages later, closing the l/r additive lists:
+
+> "Again, sing them. Trust your ears."
 > — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 5
 
 ## §2 Line-writing filter
@@ -278,10 +303,14 @@ or a closure call.
 distinction. STOP. Pick the dominant problem and the one revision that
 unlocks the rest.
 
-**Anchor quote:**
+**Posture note (UNAUDITED — not a Pat quote):**
 
-> "One focused finding outweighs ten scattered notes."
-> — synthesized from Pat's recurring critique practice (workshops + columns)
+One focused finding outweighs ten scattered notes. This is plugin-authored
+guidance, not attributable to any of the four books. A prior version of this
+file presented it as a direct quotation credited to "Pat's recurring critique
+practice (workshops + columns)" — an unverifiable non-book label. No such
+sentence appears anywhere in the four-book corpus; the quotation marks and
+the attribution have been removed rather than re-sourced.
 
 ## §4 Coaching posture filter
 
@@ -318,10 +347,13 @@ deliver any step-by-step process.
 all decisions made on the writer's behalf, no questions asked. STOP. The
 writer is the songwriter; AI is the coach.
 
-**Anchor quote:**
+**Posture note (UNAUDITED — not a Pat quote):**
 
-> "Make it sense-bound. Then make it sing. The writer makes both calls."
-> — synthesized from Pat's coaching practice (Berklee + Coursera)
+Make it sense-bound, then make it sing; the writer makes both calls. This is
+plugin-authored guidance. A prior version presented it as a direct quotation
+credited to "Pat's coaching practice (Berklee + Coursera)" — an unverifiable
+non-book label. No such sentence appears anywhere in the four-book corpus; the
+quotation marks and the attribution have been removed rather than re-sourced.
 
 ## §5 Title + hook filter
 
@@ -340,9 +372,9 @@ about to suggest a title or hook position.
 - [ ] **Stressed-vowel analysis** per candidate (vowel sound + stress count
       + front-heavy or back-heavy)
 - [ ] **≥5 title candidates surfaced** — not one pick
-- [ ] **Title types varied** across Pat's seven (per [hook.md](hook.md)):
-      one-word / place-name / person-name / color-or-sensory / comparative /
-      word-play / sonic-bonding
+- [ ] **Title types varied** across the title types catalogued in
+      [hook.md](hook.md) — that file is the single source for their names
+      and count; do not re-assert a count here
 - [ ] **Rhyme stability tested** per finalist — what can rhyme with each
       title's stressed vowel
 - [ ] **Form fit named** — does the title repeat well (chorus form) or
@@ -409,8 +441,10 @@ material.
 - [ ] **Surprising verb** — the verb does more than describe; it judges,
       reveals, contradicts
 - [ ] **Metaphor type named** when offering a metaphor (per
-      [metaphor.md](metaphor.md)): adjective-noun / noun-verb / expressed
-      identity / simile / linking quality
+      [metaphor.md](metaphor.md)). Pat's count is **three**: Expressed
+      Identity, Qualifying Metaphor, Verbal Metaphor. Simile is NOT a
+      fourth type (it is focus control), and neither is personification —
+      it is a recipe within the three. Do not invent extra types
 - [ ] **Productive ambiguity preserved** — the metaphor lets the reader
       complete it; don't over-explain
 - [ ] **Tone center maintained** — the metaphor's emotional pull aligns

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-dictionary-practice.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-dictionary-practice.md
@@ -1,6 +1,8 @@
 # Rhyme Dictionary Practice
 
-Pat Pattison - *Pat Pattison's Songwriting: Essential Guide to Rhyming* (2014), Chapter 1.
+Pat Pattison - *Pat Pattison's Songwriting: Essential Guide to Rhyming* (2014),
+Chapter 1, with the cross-reference lesson from *Essential Guide to Rhyming*
+(2014), Chapter 3.
 
 Use this with `rhyme-fundamentals.md`. *Essential Guide to Lyric Form and Structure* (1991) defines rhyme's structural
 behavior; *Essential Guide to Rhyming* (2014), Chapter 1 turns the definition into a practical search workflow.
@@ -262,6 +264,30 @@ use rhyme creatively." A large candidate set increases creative room.
 
 Practical note: you will be slow at first. "Like anything else, you will get
 better with practice."
+
+## Cross-references: a column can be missing on purpose
+
+*Essential Guide to Rhyming* (2014), Chapter 3 adds the one dictionary skill
+Chapter 1 does not cover: what to do when the word you looked up is not where you
+expected it. Pat's comment 5 on his own search, verbatim:
+
+> "Ignored" didn't appear under "ORD," where I thought it should. But at the end
+> of the column, I saw "adored, etc." which referred me to *OR*. The reference
+> means to look at the *OR* column and add *D* whenever you can. The Wood book
+> uses this shorthand to avoid unnecessary duplication. So, I went to the *OR*
+> column and added *D*. I like the list.
+>
+> — *Essential Guide to Rhyming* (2014), Chapter 3
+
+An absent column is not an absent rhyme family. There is no `ORD` heading because
+every word that would sit under it is an `OR` word with a `D` added, and the Wood
+book declines to print the same list twice. So read to the end of a column before
+concluding the search is over, and follow the `etc.` — Pat's `ignored` column is
+ten words deep only because he did.
+
+Skill behavior: when a lookup comes back empty or thin, try the same stressed
+vowel with the final consonant stripped, then add that consonant back across the
+column you find.
 
 ## Alphabet-search failure
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -692,15 +692,23 @@ order".
 
 ## The accelerator metaphor
 
-Pat's working analogy for rhyme density:
+Pat's working analogy for rhyme density, printed under the heading
+"II. PACE" in *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 4:
 
-> "Rhyme is like the accelerator pedal." — Pat (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4,
-> paraphrased)
+> Rhyme is like the accelerator in a car: the closer the accelerator gets
+> to the floor, the faster the car moves. The closer rhymes are to each
+> other, the faster your lyric moves. And, like the accelerator and the
+> car floor, the further apart they are, the slower you move.
 
-Close rhymes (couplets, internal rhymes) press the accelerator —
-lyric speeds up. Spaced rhymes (`abcb`, every-other-line) ease off —
-lyric decelerates. No rhyme is coasting — section floats forward
-without sonic propulsion.
+An earlier revision of this file printed a compressed invention, "Rhyme is
+like the accelerator pedal," in quotation marks and attributed it to Pat.
+He never wrote that sentence; the paragraph above is what the chapter
+prints. The ceiling is his too:
+
+> As you can see in number two, once you have consecutive rhymes, the
+> pedal is to the metal. You cannot accelerate. The only way to go faster
+> then is to shorten PHRASE LENGTHS.
 
 Use the analogy when coaching a writer who wants a pace change
 without knowing where to start. Density first, types second.

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-fundamentals.md
@@ -14,6 +14,15 @@ types, and the printed answer keys to its exercises exist only as images. The
 `abba` correction below came from a figure and from an exercise key, neither of
 which is in the text layer.
 
+*Essential Guide to Rhyming* (2014), Chapter 1 (printed pages 1–8): **8 linked
+figures, 8 unique** — `image_2-page14.jpg` … `image_2-page20.jpg` and
+`image_4-page1.jpg`. Each is a whole-page scan, and the 2014 EPUB carries a
+complete word-level text layer over it, so nothing in this chapter exists only
+in an image. Two consequences for anyone re-auditing it: Pat's stress marks
+(`/`, `//`) sit on their own collapsed lines in the text layer, and the text
+hard-wraps at every printed line — a single-line grep for a full sentence
+returns zero hits even though the sentence is on the page.
+
 ## The five structural areas
 
 The chapter's organizing claim is that rhyme controls **five** areas of
@@ -61,48 +70,86 @@ behave like the idea.
 
 ## What counts as rhyme
 
-Rhyme connects syllables, not whole printed words. Perfect rhyme needs
-three conditions:
+*Essential Guide to Rhyming* (2014), Chapter 1 opens the definition:
+"Rhyme is a connection between the sounds of syllables, not words." Only the
+last syllables rhyme in `underwear/repair`; the other syllables, `under/re`,
+"…don't figure in at all."
 
-- The vowel sounds are the same.
-- The ending consonants, if present, are the same.
-- The beginnings are different.
+"When two syllables rhyme perfectly, three things happen:"
 
-The ear matters more than the spelling. `love/club` can rhyme because
-their vowel sounds match; two visible `o` letters may not rhyme if the
-vowel sounds differ.
+1. "The syllables' vowel sounds are identical." — `wear/pair`. "Even though
+   they have different letters, they make the same sound in these words. Only
+   your ears count, not your eyes."
+2. "The consonant sounds after the vowels (if any) are identical." — `wear/pair`.
+   "(As you can see by the 'ea' in 'wear' and 'ear,' the same letters can make
+   different sounds in different contexts.)" The "(if any)" matters because
+   syllables don't always end in consonants, as in `disagree/referee`.
+3. "The syllables begin differently." — `wear/pair`.
 
-The different beginning is not optional. Rhyme depends on tension moving
-into resolution: difference first, sameness after.
+"When syllables meet all three of these conditions, call it perfect rhyme."
+
+The third condition is not optional, and Pat says why: "It shows that rhyme
+works by the basic musical principle of tension/resolution: difference moving
+into sameness." When you hear `wear/pair` or `gree/ree`, "your ear notices
+that, in spite of the difference at the beginnings of the syllables, they end
+up sounding alike!"
 
 ## Identity is not rhyme
 
-Identity repeats the same starting sound and ending sound. It is
-repetition, not rhyme, because there is no tension to resolve.
+"When syllables begin the same way, they don't tell the ear to notice sound.
+This is called an identity:"
 
 ```text
-rhyme:     ace / brace / chase / erase
-identity:  place / replace / misplace
+fuse/confuse
 ```
 
-Pat's cheerleader analogy (*Essential Guide to Lyric Form and Structure*
-(1991), Chapter 4 and again in *Essential Guide to Rhyming* (2014),
-Chapter 1, paraphrased ≤25w): a crowd chanting one syllable hears only
-repetition. Nobody in the stadium notices the syllables sound alike.
-Identity is repetition, period.
+"This isn't a rhyme. Your ear doesn't pay attention to the sounds of the
+syllables. Rhyme works with sounds, just like music. Tension/resolution. If
+there is no tension—no 'difference' to be resolved—there can be no
+resolution." (*Essential Guide to Rhyming* (2014), Chapter 1.)
 
-Identity can be useful when deliberate repetition is the effect, but do
-not mistake it for rhyme. If the syllables start the same way, the ear
-hears the repeated unit rather than the rhyming relationship.
+Pat's cheerleader illustration runs in both books (*Essential Guide to Lyric
+Form and Structure* (1991), Chapter 4 and again in *Essential Guide to
+Rhyming* (2014), Chapter 1). The 2014 wording: "The way rhymed syllables begin
+makes a difference: it allows your ear to notice the identical sounds that
+follow. Otherwise, your ear will pick up only repetition, not rhyme. When you
+hear a cheerleader yell:"
 
-**Reordering test** (*Essential Guide to Rhyming* (2014), Chapter 1):
-take a pair you suspect — `peace / piece`. Move one half to a different
-partner: `peace / lease`. The first pairing is identity (same sound start
-to finish); the second is rhyme. The same words; different pairings;
-only one is rhyme.
+```text
+go! go! go! go! go!
+```
 
-Practice move: when using a rhyming dictionary, avoid picking two entries
-from the same identity family unless repetition is the point.
+"…you pay attention to the repetition, not to the sounds of the syllables. No
+one in the stadium thinks, 'Hey, those syllables sound the same!'"
+
+Identity is a property of the *pairing*, not of the word. The same four words
+become rhymes when you re-partner them:
+
+```text
+peace/piece    lease/police
+```
+
+"These words don't call attention to their sounds, because their syllables do
+not resolve difference into sameness. The same sounds are repeated, just like
+a cheerleader's yell. But try:"
+
+```text
+peace/lease    piece/police
+```
+
+"Now you hear the rhymes. Your ear moves to the level of sound."
+
+"There is also a big difference between these two lists:"
+
+```text
+1. birthplace, commonplace, misplace, place, replace
+2. ace, brace, chase, erase, face, disgrace, resting place
+```
+
+"Say them aloud. Your ear doesn't focus on the sounds in the first list, but
+it's drawn like a magnet to the sounds in the second list. In the first list,
+you hear simple repetition. In the second list, you hear the sound of music—or,
+rather, of tension/resolution."
 
 ## Perfect rhyme — Pat prefers "fully resolved"
 
@@ -117,55 +164,127 @@ The terminology preference pervades Pat's later teaching. The skill uses
 both interchangeably; when teaching, prefer "fully resolved" to avoid the
 implied hierarchy.
 
-## Shaking hands — the rhyme metaphor
+## "Shaking Hands" — what the heading actually means
 
-*Essential Guide to Rhyming* (2014), Chapter 1 names rhyme as **"shaking
-hands"** between two syllables. The metaphor:
+"SHAKING HANDS" is the title of the opening section of *Essential Guide to
+Rhyming* (2014), Chapter 1. It is a heading, not a model of rhyme. The
+handshake is between **the reader and Rhyme**, which Pat personifies across the
+book's opening chapters: Chapter 1 introduces you, and Chapter 2 opens "You
+have been introduced. Now find out what Rhyme does for a living." The
+introduction runs on through the chapter titles — "Family Friends," "Friendly
+Relatives," "Kissin' Cousins," "The Fruits of Friendship."
 
-- two people walk toward each other (different beginnings — the pre-vowel
-  consonants differ)
-- they meet (the stressed vowels match)
-- they shake hands (the post-vowel consonants match — or match by family
-  per stability tier)
+The chapter's closing stance under that personification: "Rhyme can be your
+best friend—your biggest help in leading all those eyeless ears through your
+lyrics. Or it can be your enemy. I want to show you how to make rhyme your
+friend." (2014, Introduction, page xii.)
 
-Identity is the same person greeting themselves: no introduction, no
-meeting, no handshake. Just the same word said twice.
-
-The shaking-hands metaphor explains WHY the three-condition test is the
-test. Each condition is one element of the meeting.
+Everything the section itself teaches about rhyme is the three-condition test
+above. Do not tell a writer that rhyme is two people walking toward each other,
+meeting, and shaking hands — Pat never says that, and it invites the error that
+the *vowel* is the meeting and the *ending consonant* is the handshake.
 
 ## Masculine / feminine / mosaic
 
-*Essential Guide to Rhyming* (2014), Chapter 1 names three rhyme shapes
-by syllable count and structure:
+This is **two** categories, not three. *Essential Guide to Rhyming* (2014),
+Chapter 1: "Most rhymes, including perfect rhymes, belong to one of two
+categories. Never to both. Every rhyme is either masculine or feminine. (We
+will conveniently ignore three-syllable rhymes, at least for now.)" Mosaic is
+not a third category — it is a way of *building* either one, out of pieces of
+more than one word.
 
-| Shape | Definition | Example |
-|---|---|---|
-| Masculine | rhyme falls on a single stressed syllable at line end | `time / rhyme` |
-| Feminine | rhyme spans a stressed syllable + one or more unstressed syllables | `only / lonely`, `dreary / weary`, `going / showing` |
-| Mosaic | rhyme is formed across multiple words on one or both sides | `Texas / wrecks us`, `silence / find us` |
-
-Mosaic is covered in depth in [mosaic-rhyme.md](mosaic-rhyme.md) — the
-tier the AI routinely skips, and the tier that unlocks proper-noun
-rhyming + cross-part-of-speech rhyming + the entire rap / hip-hop craft
-tradition.
-
-All three shapes apply within each stability tier. Surface candidates
-across the matrix: tier × shape.
+"Here are some masculine rhymes:"
 
 ```text
-sound: -ace
-rhymes: ace / brace / chase / face / disgrace
-
-sound: -ive
-rhymes: alive / dive / strive / deprive
+command/land/understand/expand/strand
 ```
 
+"Here are some feminine rhymes:"
+
+```text
+commanding/landing/understanding/expanding/stranding
+```
+
+"As you can see, the difference is in the way they end." Masculine rhymes "are
+either one-syllable words, or words that end on a stressed syllable." Feminine
+rhymes "will always end on an unstressed syllable. They are always two-syllable
+rhymes. (Masculine rhymes are one-syllable rhymes.)"
+
+The stressed syllables carry the work. Look at the feminine list above and
+"you'll see that they're all perfect rhymes": `mand-ing`, `land-ing`,
+`stand-ing`, `pand-ing`, `strand-ing` — the stress falls on the first syllable
+of each pair. "Stressed syllables, whether in feminine rhymes or masculine
+rhymes, are the creators of rhyme's tension and resolution."
+
+"The unstressed syllables at the end of the list above are all identities,
+which is normal for feminine rhyme. These identities only continue the
+resolution. Unstressed syllables of feminine rhymes are usually identities, but
+they don't have to be."
+
+```text
+commander/understand her
+expand me/strand thee
+```
+
+"Call these pairs above mosaic rhymes, since they are put together with
+syllables of different words, like stained glass pieces in a church window."
+Mosaic is covered in depth in [mosaic-rhyme.md](mosaic-rhyme.md).
+
 <!-- nonsense drill syllables trip the spell-checker --><!-- spellchecker:off -->
-The source exercise asks for three perfect rhymes for nonsense or partial
-syllables such as `lant`, `ints`, `rutch`, `mose`, and `kate`. Treat that as an
-ear-training drill: find sound matches first, usable words second.
+Exercise 18 of *Essential Guide to Lyric Form and Structure* (1991), Chapter 4
+asks for three perfect rhymes for nonsense or partial syllables such as `lant`,
+`ints`, `rutch`, `mose`, and `kate`. Treat that as an ear-training drill: find
+sound matches first, usable words second.
 <!-- spellchecker:on -->
+
+## Secondary stress — the "appreciate" case
+
+*Essential Guide to Rhyming* (2014), Chapter 1: "Some words end on secondary
+stress—a syllable that, while it is not the primary stress in the word, is
+stronger than the syllables around it. Use '//' to mark secondary stress."
+Pat's notation puts `/` over the primary stress and `//` over the secondary. He
+marks the four-syllable word `ap–pre–ci–ate` with `/` over `pre` and `//` over
+`ate`.
+
+"Listen to it. You can tell by the pitch of the last syllable that it is
+stronger than the syllable before it. You can't treat it as a feminine rhyme,
+since its second last syllable is the unstressed syllable. All feminine rhymes
+have a stressed second-last syllable, or at least their second-last syllable is
+stronger than the last syllable."
+
+"You have two choices when you rhyme 'appreciate.'"
+
+1. "You can treat it as a one-syllable masculine rhyme." — `appreciate/fate/relate`.
+   "Even better, you can use secondary stresses:" `appreciate`, `navigate`,
+   `compensate` (each marked `/` on the primary, `//` on the final syllable).
+   Both sub-cases are masculine; matching secondary stress to secondary stress
+   is a better-sounding masculine rhyme, not a different category.
+2. "You can treat it as a three-syllable rhyme (here, as a mosaic):"
+   `ap-pre-ci-ate/the quiche he ate`.
+
+"These three-syllable rhymes are still masculine, since their last syllable is
+more stressed than the one before it. The somersaults you have to turn for
+these little gems are worth it only if you are writing comedy. They sure do
+dance."
+
+## Finding vs. using — the fundamentals claim
+
+Under "FINDING RHYMES," *Essential Guide to Rhyming* (2014), Chapter 1 draws
+the line the whole rhyme workflow rests on: "Use a rhyming dictionary. This is
+one place where self-reliance and rugged individualism are silly. Finding
+rhymes is almost never a creative act. It's a purely mechanical search. On
+those few occasions where finding a rhyme is creative (finding mosaic rhymes,
+for example), a rhyming dictionary can still stimulate the creative process."
+
+And the payoff: "Finding rhymes is mechanical. Once you have found out what is
+available, the real creative process begins: using rhyme. And the more
+alternatives you have to choose from, the more room you have to be creative.
+Anyone can find a rhyme; not everyone can use rhyme creatively."
+
+The procedure this implies — the alphabet-process critique, the Clement Wood
+walkthrough, Exercises 1.1 and 1.2 — lives in
+[rhyme dictionary practice](rhyme-dictionary-practice.md). Do not duplicate it
+here; this file holds the claim, that file holds the method.
 
 ## Masculine rhyme
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-generation.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-generation.md
@@ -38,7 +38,8 @@ disappoint.
 Pat's worksheet starts with the stressed vowel of the rhyme word. Identify
 it exactly:
 
-- short ä (papa), short ŭ (up), short ĕ (end), short ĭ (it), long ē (me)
+- pure vowels: ä (papa); tongue leg ă (cat), ĕ (end), ĭ (it), ē (me);
+  lip leg ŭ (up), ŏ (hot), oo (foot), ū (too)
 - long ā (play), long ī (cry), long ō (grow), long ū (too)
 - diphthongs: oi (boy), ou (couch), ay, oy
 - r-colored: ēr (ear), ār (air), ōr (door), ūr (tour)
@@ -55,22 +56,109 @@ Before adding any candidate, run the identity check from *Essential Guide to Rhy
 - Suffix words (`-ation`, `-ing`, `-tion`, `-ly`, `-ness`) routinely produce
   identities that look like rhymes. Reject.
 
-This step alone removes ~30% of typical AI-generated rhyme lists.
+This step is where most AI-generated rhyme lists lose members. No measured
+proportion is claimed — Pat gives none, and neither does this plugin.
 
 ### Step 3 — Walk the stability scale (*Essential Guide to Rhyming* (2014))
 
 For each rhyme candidate, classify on Pat's scale:
 
-| Tier | Definition | Strong fit for |
-|---|---|---|
-| Fully resolved / perfect | identical vowel + identical post-vowel consonant + different pre-vowel | full closure, chorus-ending stop, central section landing |
-| Family | identical vowel + RELATED post-vowel consonant + different pre-vowel | almost-closure, expressive softening, verse texture |
-| Additive / subtractive | identical vowel + one consonant added/removed | open-ended forward motion, suspension |
-| Assonance | identical vowel + different post-vowel consonant | high openness, low closure |
-| Consonance | different vowel + similar post-vowel consonant | strategic deceleration, ironic mismatch |
+| Tier | Definition |
+|---|---|
+| Perfect | identical vowel + identical post-vowel consonant + different pre-vowel |
+| Family | identical vowel + post-vowel consonant from the same phonetic family + different pre-vowel |
+| Additive / subtractive | identical vowel + one consonant added/removed |
+| Assonance | identical vowel + different post-vowel consonant |
+| Consonance | different vowel + IDENTICAL post-vowel consonant + different pre-vowel |
+
+That order is Pat's printed chart, *Essential Guide to Rhyming* (2014),
+Chapter 9, p.110 — "Scale of Rhyme Types: Most Stable to Least Stable",
+running Perfect / Family / Additive-Subtractive / Assonance / Consonance
+under a single axis labelled `Most Stable` at the left and `Least Stable`
+at the right. Five types. Partial and weak-syllable rhyme are not on it.
+
+**Do NOT attach a fixed use-case to a tier.** Chapter 9's whole argument is
+that a tier's effect depends on *where you put it* — the same family rhyme
+lightens a push in one position and softens a landing in the other. See
+"Tier effect is position-conditional" below before labelling candidates.
 
 Surface candidates per tier so the writer picks by **emotional intent**, not
 by what came up first.
+
+### Step 3a — Tier effect is position-conditional
+
+*Essential Guide to Rhyming* (2014), Chapter 9. Before labelling a candidate,
+mark which slot it is destined for. Pat's frame, p.108, on `abab`:
+
+> The first three members,
+>
+> blush a / skin b / rush a
+>
+> …push forward. They raise our expectations, creating something akin to a
+> musical dominant function, a V, which asks to be resolved to a tonic
+> function, a resolution. An aba structure creates a sequence: first a, then
+> b, then another a, leading us to expect another b
+
+So the third line is the **dominant (V)** slot and the fourth is the **tonic
+(I)** slot. His baseline, all-perfect, is `blush / skin / rush / sin` — and
+p.109: "That's how perfect rhyme works. It delivers the maximum motion in a
+rhyme scheme. In abab it delivers the hardest push in the dominant position,
+and the strongest resolution in the tonic position."
+
+Reversing which sound holds `a` reverses nothing structurally — `skin / blush
+/ sin / rush` still pushes from V and lands on I: "Rush hits hard, but notice
+it gets its power in part because sin has pushed so hard from its dominant
+position."
+
+Pat then walks the same four-line shape, changing only the rhyme type, keeping
+the scheme stable. His printed readings — one tier, two opposite jobs.
+
+Read the **Scheme** column first — Pat alternates between the two arrangements,
+so the same word appears in V in one row and in I in another. That is his point,
+not an inconsistency.
+
+| Scheme (lines 1-4) | Dominant (V) | Tonic (I) | Pat's reading, Chapter 9 |
+|---|---|---|---|
+| blush / skin / rush / sin | `rush` perfect | `sin` perfect | maximum motion; hardest push, strongest resolution (p.109) |
+| blush / skin / touch / sin | `touch` family | `sin` perfect | "the push at the dominant position is a little lighter (just a touch, if you will), creating a little less intensity when we land on sin. Sin-light, perhaps." The perfect tonic "slams the gates of purgatory rather than the gates of hell." (p.109) |
+| skin / blush / sin / touch | `sin` perfect | `touch` family | "the landing on the family rhyme, touch, is softer and opens the gate a bit… the stable rhyme scheme has been somewhat destabilized by the rhyme type." (p.109) |
+| skin / blush / drift / rush | `drift` assonance | `rush` perfect | "precious little push in dominant position, creating a bit more of an xaxa feeling"; arrival "pretty light. Nothing headlong about it." (p.111) |
+| blush / skin / rush / drift | `rush` perfect | `drift` assonance | "A really hard push from the perfect rhyme blush/rush lands with a splat on the squishy surface of the assonance rhyme… The stable abab rhyme scheme has suddenly lost its ability to close the deal." (p.111) |
+| skin / blush / drift / touch | `drift` assonance | `touch` family | "a pretty light and dreamy flirtation. Abab is getting less and less stable." (p.112) |
+| blush / skin / touch / drift | `touch` family | `drift` assonance | "Now you're really off in dreamland, floating, floating in a misty reverie…" (p.112) |
+
+Family rhyme is the near-substitute: "it delivers most of the power of perfect
+rhyme, but not all. In either the dominant position or tonic position, the
+journey has certainly been affected by changing the rhyme type, but we still
+get a pretty stable feeling." (p.110)
+
+Consonance, p.113, against family in the other slot. In dominant position
+`skin / blush / dawn / touch` "barely nudges forward". In tonic position
+`blush / skin / touch / dawn` — "The gate is wide open. You can feel the
+instability, the desire to lean forward."
+
+**A remote rhyme is not the same as no rhyme.** This is the generation
+constraint most easily missed, and Pat makes it twice on the same page. With
+consonance in the dominant slot "there is more forward pressure than with an
+unrhymed first and third lines" (`skin x / blush a / breathe x / touch a`) —
+"Say them both several times and you'll feel the n in action." And with
+consonance in the tonic slot, against `blush a / skin x / touch a / breathe x`:
+
+> Here, there's no sense of longing to connect back to skin, whereas in
+> [`blush / skin / touch / dawn`] …you can feel dawn trembling, looking back
+> to skin, feeling the pull but tearfully, reluctantly, moving on. Sad.
+
+So never drop a rhyme when what the line wants is an unresolved one — dropping
+it removes the backward pull that the remote rhyme exists to create.
+
+One scheme-level note, p.109, on couplets:
+
+> (In an aabb rhyme scheme, perfect rhyme creates the strongest separation
+> between aa and bb because it slams the door after the first couplet,
+> bringing us to a full stop before starting the motor again at b. Then it
+> slams the door again at bb. That's why a steady diet of perfect rhyme
+> couplets can make a song feel so long: we have to stop every two lines, then
+> start the car again until we hit the next stop sign.)
 
 ### Step 3b — MOSAIC tier (mandatory surface)
 
@@ -130,13 +218,44 @@ Family rhyme search order for post-vowel consonant:
 This generates legitimate family rhymes the model can produce directly from
 its phonetic knowledge — no external lookup needed.
 
+### Step 4b — When family rhyme is not available
+
+Do not silently drop to assonance. Pat names three triggers, verbatim,
+*Essential Guide to Rhyming* (2014), Chapter 5, p.49:
+
+> Sometimes, family rhyme won't help:
+>
+> 1. when words end in vowels
+> 2. when your family rhyme search has not given you acceptable choices
+> 3. when you're looking for a less stable rhyme type
+
+Trigger 1 is structural and the generator must test for it first: "Family
+rhymes depend on consonants after the syllables' stressed vowels. When there
+are no consonants after the vowels, family rhymes aren't an option." Such words
+end in an **open vowel** — every one long except `ä` as in "papa".
+
+In all three cases the next tier is **additive / subtractive**, not assonance.
+Its definitions, the search order through the consonant families, the
+`free / shields` guard against over-generating on the definition alone, and the
+worked `fast` subtraction are all in
+[rhyme-types.md](rhyme-types.md) §"Additive Rhyme" and §"Subtractive Rhyme".
+Generate against those rather than re-deriving the procedure here.
+
 ### Step 5 — Use the vowel triangle for assonance and family vowels
 
 Pat's vowel triangle (*Essential Guide to Rhyming* (2014), Chapter 8):
 
 - Apex: ä (papa) — most open
-- Right leg (lip vowels): ä → ŏ (hot) → ū (too) → oo (foot)
-- Left leg (tongue vowels): ä → ŭ (up) → ĕ (end) → ĭ (it) → ē (me)
+- Right leg (lip vowels): ä → ŭ (up) → ŏ (hot) → oo (foot) → ū (too)
+- Left leg (tongue vowels): ä → ă (cat) → ĕ (end) → ĭ (it) → ē (me)
+
+**Do not re-derive this from the EPUB text layer.** Pat prints the Vowel
+Triangle as a **V with the apex `ä (papa)` at the bottom**; the text layer
+hoists `ä` to the top and transposes vowels on both legs. Verified here
+against the page scan (*Essential Guide to Rhyming* (2014), Chapter 8;
+spine 095, figure repeats at 100/101/103; book index "Vowel Triangle,
+82-83, 87, 88, 90-91"). This is load-bearing: family assonance is one step
+along a leg, so a transposition changes which pairs count as adjacent.
 
 Adjacent vowels on either leg = family assonance (smooth voice leading,
 near-perfect-feel sung).
@@ -145,7 +264,7 @@ Diphthong decomposition (*Essential Guide to Rhyming* (2014), Chapter 8):
 
 - long ā = ĕ + ē (singer holds ĕ)
 - long ī = ä + ē (singer holds ä)
-- long ō = ŏ + ū (singer holds ŏ)
+- long ō = ŏ + ū
 - oi = ŏ + ē
 - ou = ä + ū
 
@@ -200,6 +319,11 @@ Perfect (fully resolved, single-word):
 Family (post-vowel consonant family-related):
 - (limited single-word options for -L-Y ending; mosaic territory)
 
+Additive / subtractive (one consonant added or removed):
+- (this slot is never optional — it sits between Family and Assonance on
+   Pat's printed scale, and it is the tier to reach for when the source
+   ends in an open vowel; see Step 4b)
+
 Assonance (vowel-only match):
 - broken         — long-O, different post-vowel; STRONG for forward motion
 - woven          — long-O, different post-vowel; STRONG
@@ -222,20 +346,96 @@ From the song's world: [if context established]
 - e.g., "the Moonlight" / "the old highway" / "Joplin" if the song goes there
 ```
 
+## Why the tier label carries the emotion — Pat's worked case
+
+*Essential Guide to Rhyming* (2014), Chapter 9, pp. 115-118, on Randy Newman's
+"Feels Like Home". Of the first prechorus: "Essentially, it's common meter with
+a shorter second and fourth line matching." The second prechorus repeats that
+structure exactly; the rhyme type is the only variable.
+
+First prechorus, the pair `long / done` (italics as printed, p.116):
+
+> Does *long/done* rhyme? Well, I don't really care what you call it, but it
+> does have some sonic connection:
+>
+> *Ng* and *n* are members of the same family, the nasals. So *long/done*
+> amounts to a *family/consonance* rhyme, about as far afield as you can go and
+> still give a hint of a sonic resemblance. It probably wouldn't be audible at
+> all without the help of common meter, but it sure opens the gate at the end
+> of the section, creating instability rather than closure.
+>
+> And what's the *emotion* that the rhyme type creates? Something like *longing
+> and uncertainty*, which, of course, is exactly what the lyric itself is
+> saying. Pretty cool.
+
+Second prechorus, the pair `touch / much`: "Perfect rhyme. And, boy, does the
+gate ever slam shut. This is the essence of stability—the same thing, of
+course, that the lyric is addressing." (p.117)
+
+> The rhyme types alone are responsible for the difference in feeling between
+> the first and second prechoruses—the family/consonance rhyme, long/done,
+> supporting (maybe even creating) the unstable feeling in the first prechorus,
+> and the perfect rhyme, touch/much, supporting (maybe even creating) the
+> stable feeling in the second.
+
+Pat then runs the experiment both ways. In the second prechorus he swaps the
+`touch` of the shorter second line for a non-rhyming word, so the closing
+fourth line — unchanged — is left with nothing to resolve against (p.117):
+
+> The last line, which seemed like such an emotional line, has lost a lot of
+> its feeling. It seems less glorious, less heartfelt. What seemed like such a
+> sensational line has turned ordinary. The meaning hasn't really changed. But
+> the motion, and thus the e-motion, has transformed dramatically.
+
+In the first prechorus he goes the other way, rewriting the closing fourth line
+so that `long` is answered by a perfect rhyme instead of by `done` (p.118):
+
+> Again, the meaning is essentially the same, but now we hear a tribute to the
+> power of love, a stable feeling created, again, simply by the rhyme type. It
+> not only transforms the emotion of the section, but the color of the entire
+> first sequence of verse/prechorus/chorus. […] Rather than moving
+> unstable/unstable/stable in the first sequence, we're moving
+> unstable/stable/stable, and the last part of the song feels more like it
+> repeats the same ideas rather than growing.
+
+**The generation lesson.** A rhyme-type choice at one slot is not local. It
+sets the stability of the section, and the section's stability sets whether the
+song's later sequence reads as growth or as repetition. Label candidates with
+that reach in view, not just with how the pair sounds.
+
+The same book's verse pair makes the structural half of the point: verse 1
+"lacks rhyme in the fourth and eighth lines, creating instability and opening
+the gate into the prechorus. The second verse does the opposite" (p.118).
+
 ## Worksheet generation (*Essential Guide to Rhyming* (2014), Chapter 3 + Chapter 7)
 
-For longer rhyme work — title development, theme exploration — generate the
-three-stage worksheet:
+For longer rhyme work — title development, theme exploration — build the
+worksheet. Pat's three steps, verbatim, *Essential Guide to Rhyming* (2014),
+Chapter 3, p.19:
 
-1. **Stage 1 — Focus.** Distill the song's central idea to one paragraph.
-2. **Stage 2 — Idea words.** Extract 8-12 seed words spanning emotion,
-   action, image, relationship, conflict.
-3. **Stage 3 — Rhyme search.** For each seed word, generate all five tiers
-   (perfect / family / additive-subtractive / assonance / consonance) plus
-   world-vocabulary candidates.
+> The trick is to look for rhymes *before* you start to write. It is not as
+> hard as it sounds.
+>
+> 1. Focus your lyric idea as clearly as you can.
+> 2. Make a list of words that fit your idea.
+> 3. Look up those words in your rhyming dictionary, and make lists of rhyme
+>    words that fit your idea.
 
-The worksheet externalizes the inward search and lets the writer choose
-deliberately rather than settling for the first phrase that came to mind.
+Step 2's selection rules are **phonetic, not thematic**. Pat states two, and
+only two (p.20): "Find mostly masculine words. Pick words with different vowel
+sounds." His own running list runs to eleven seeds, not a range. Do not sort
+seeds into emotion / action / relationship / conflict buckets — that is not
+his instruction.
+
+Step 3 in Chapter 3 is a **perfect-rhyme** search only; the rule for keeping a
+rhyme is one sentence, "Write down only rhyme words that fit with your idea."
+(p.21). Expanding the same worksheet across the whole stability scale is
+Chapter 7's job, not Chapter 3's.
+
+Mechanics, seeds, the completed "RISKY BUSINESS" columns and Pat's comments on
+his own search live in [rhyme-worksheets.md](rhyme-worksheets.md); the full
+Chapter 7 expansion search lives in [rhyme-strategy.md](rhyme-strategy.md).
+Generate against those, do not re-derive here.
 
 ## When to fall back to external data
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-sonic-bonding.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-sonic-bonding.md
@@ -111,12 +111,12 @@ Internal rhyme is usually local. "It does not affect phrase structure and,
 unlike end rhymes, does not need to be matched in parallel song sections. Just
 put it in your section, let it do its work, then forget about it."
 
-Use internal rhyme when:
-
-- a passage needs extra motion without changing the rhyme scheme,
-- a line should feel tightly woven,
-- a transition needs sonic continuity,
-- a phrase wants pressure, speed, or play.
+The three effects Pat actually names for it, in order of appearance:
+**acceleration** (symmetrical placement, midline and end line); an
+**off-balance feel** (asymmetrical placement, which he uses prosodically —
+"the house is a bit off-balance here"); and **sonic fabric** (rhymes placed
+internally across several lines). Nothing else in the section claims a use
+for it.
 
 ## Voice leading
 
@@ -169,15 +169,11 @@ That maps onto the three assonance types directly. Simple and hidden assonance
 are the *retained* note (the C you keep). Family assonance is the *moved* note
 (E→F, G→A) — a change, but the smallest one available.
 
-In lyric writing it means choosing vowels and consonants so that the mouth,
-tongue, and ear move with intention. Use it to ask:
-
-- Does this sound glide smoothly into the next sound?
-- Does the line need legato motion or a staccato stop?
-- Are the nearby vowels moving by small steps or making a large expressive
-  jump?
-- Are consonants linking the phrase, or interrupting it?
-- Does the sonic motion match the meaning?
+You can create the effect "both with vowels (assonance) and consonants
+(alliteration)" — which is the chapter's own structure from here on. Its
+audible result, per Pat, is that "these vowel connections can create a
+smoother, more legato line," and that the words' purpose "is to lead you
+through the words smoothly."
 
 Voice leading differs from rhyme. Rhyme can create structure when it appears at
 phrase endings. Voice leading usually works inside phrases, shaping flow,
@@ -242,21 +238,14 @@ Glimmering and vast, out in the tranquil bay.
 (Pat prints these three groups without attribution; the poets are named only
 where he names them.)
 
-Use it to:
+Pat's whole summary of the type is one line: "Simple assonance. The
+repetition of vowel sounds." The purpose he attaches to it is the one he
+attaches to all sonic repetition — to "link ideas sonically as well as
+conceptually."
 
-- bind images or ideas without end-rhyme pressure,
-- make a line more singable,
-- create an undercurrent of smoothness,
-- connect words that are conceptually related.
-
-Coaching test:
-
-1. Mark the stressed vowel sounds in the line.
-2. Circle repeated vowels.
-3. Ask whether those repeated vowels connect meaningful words.
-4. If the connection is accidental but useful, keep it.
-5. If the connection makes the line too sweet, predictable, or mushy, create
-   contrast.
+Chapter 8 sets no test or checklist here; it sets **Exercise 8.1**, which is
+to mark the simple assonance relationships in two passages (both reproduced
+in the exercises section below).
 
 ## Hidden assonance
 
@@ -327,7 +316,20 @@ get the knitting of the short `e` of `pen` picking up the initial short `e`
 sound of the diphthong in `brain`, as well as the long `ee`, the second vowel
 sound in the long `a`. Whew."
 
-Two more diphthongs behave the same way:
+Pat then restates `oi` and `ou` as "other than the diphthongs formed by many
+of the long vowels, there are others" — and note he re-spells them here, and
+adds a parenthesis he does not repeat anywhere else:
+
+```text
+oi (as in boy) = o (as in go) + ee (as in me)   (really a triphthong)
+ou (as in couch) = ah (as in papa) + oo (as in too)
+```
+
+That first line differs from the table on the previous page, where `oi` is
+`ŏ (as in "hot") + ē`. Both spellings are printed; Pat does not reconcile
+them, so do not silently pick one.
+
+These two behave the same way:
 
 ```text
 Boil / roast          Father / grouch
@@ -373,50 +375,56 @@ look inside diphthongs and `l`/`r` colored vowels.
 
 ## The Vowel Triangle (geometry)
 
-Pat's vowel triangle (*Essential Guide to Rhyming* (2014), Chapter 8)
-maps the nine pure English vowels into a triangle whose apex is the most-
-open vowel and whose two legs extend toward tongue-position (left) and
-lip-position (right) closure. Adjacency on either leg = family-assonance
-candidates (small mouth-position changes = smooth voice leading).
+The Vowel Triangle (*Essential Guide to Rhyming* (2014), Chapter 8) "lists
+vowel sounds according to the way they are formed by the mouth." It holds the
+nine pure vowels; everything else is a diphthong. Pat's word for the vertex is
+**the point**, and the most open sound sits there: "At the point is `ä` (as
+in "papa"), the most open sound." The two legs run outward from it, tongue
+vowels left and lip vowels right. Adjacency along a leg is what family
+assonance trades on.
 
-Pat's own layout prints it as two columns flanking the apex — "Tongue Vowels"
-on the left, "Lip Vowels" on the right:
+Pat prints it as a **V** — the point at the *bottom*, "Tongue Vowels" heading
+the left leg, "Lip Vowels" the right, both legs opening upward and outward:
 
 <!-- phonetic vowel markings trip the spell-checker --><!-- spellchecker:off -->
 
 ```text
-                ä (papa)
-        (cat) ă         ŭ (up)
-        (end) ĕ         ŏ (hot)
-         (me) ē         ū (too)
-         (it) ĭ         oo (foot)
-       Tongue Vowels   Lip Vowels
+  Tongue Vowels                          Lip Vowels
+  (me) ē \                                 / ū (too)
+          \                               /
+   (it) ĭ  \                             /  oo (foot)
+            \                           /
+  (end) ĕ    \                         /    ŏ (hot)
+              \                       /
+   (cat) ă     \                     /      ŭ (up)
+                \                   /
+                 \                 /
+                  \               /
+                        ä
+                      (papa)
 ```
 
-Expanded to show the geometry:
+Reading **outward from the point**, which is the order that matters for
+family assonance, the two legs run:
 
-```text
-                      ä   (apex — most open; "papa", "father")
-                     / \
-                    /   \
-   tongue leg ──▶  /     \  ◀── lip leg
-   (raise tongue)  /       \  (round lips)
-                  /         \
-                ă             ŭ   ("cat" tongue; "up" lip)
-                /             \
-               /               \
-              ĕ                 ŏ   ("end" tongue; "hot" lip)
-              /                 \
-             /                   \
-            ē                     ū   ("me" tongue; "too" lip)
-            /                     \
-           /                       \
-          ĭ                         oo   ("it" tongue; "foot" lip)
-```
+- **tongue leg:** ä → ă (cat) → ĕ (end) → ĭ (it) → ē (me)
+- **lip leg:** ä → ŭ (up) → ŏ (hot) → oo (foot) → ū (too)
 
-(The triangle is not strictly drawn; layout is approximate. The
-canonical geometry: apex = ä, left leg = tongue raises progressively
-[ă → ĕ → ē → ĭ], right leg = lips round progressively [ŭ → ŏ → ū → oo].)
+Vowels printed at the same height sit on opposite legs: ē/ū, ĭ/oo, ĕ/ŏ,
+ă/ŭ. (Pat attaches no rule to those pairings; it is just how the figure is
+laid out.)
+
+> **Transcription warning.** The EPUB text layer emits this figure in the
+> wrong order — it hoists `ä` to the top and swaps the outer two vowels on
+> each leg, giving `ă ĕ ē ĭ` and `ŭ ŏ ū oo`. The printed figure (spine 095,
+> reprinted at 100, 101 and 103) shows `ĭ` *between* `ĕ` and `ē`, and `oo`
+> *between* `ŏ` and `ū`. The printed order is also the phonetically correct
+> one — the tongue rises ă → ĕ → ĭ → ē, the lips round ŭ → ŏ → oo → ū.
+> Pat's prose independently fixes which leg is which: the Eliot lines "work
+> with ah (at the point of the vowel triangle) and the first two steps of
+> the lip vowels: short u and short o." So `ŭ` and `ŏ` are *lip* vowels.
+> Verified against the page scan; do not re-derive this figure from the
+> text layer.
 
 <!-- spellchecker:on -->
 
@@ -434,38 +442,34 @@ vowels to extreme tongue vowels." The full triangle is traversed in one
 syllable. The drill teaches what mouth changes accompany which vowel
 transitions — useful when picking family-assonance partners.
 
-### Adjacency rules
+### Counting steps
 
-| Move | Effect |
-|---|---|
-| Stay on same vowel | simple assonance — strongest sonic bond |
-| Step one position on same leg | family assonance — smooth voice leading |
-| Step two positions on same leg | weaker bond; still in the family |
-| Cross from one leg to the apex | family assonance via ä |
-| Jump from leg to leg (skipping apex) | far step; deliberate rupture |
-| End at opposite leg's terminus | maximum vowel contrast |
+Pat does not tabulate the moves; he counts steps in prose while working a
+passage, and only three step-counts actually appear in Chapter 8:
 
-The triangle lets the writer pick by emotional intent: stay close for
-euphony / chant / formality; step further for forward motion / contrast;
-jump across for isolation / rupture / surprise.
+- **same vowel** — simple assonance. `brown` and `dawn` "share the triangle's
+  point, `ah`."
+- **one step** — the working definition of family assonance, and the whole
+  instruction for Exercise 8.6: "supply a word that moves no more than one
+  step from the stressed syllable of the italicized word." Pat's instance:
+  "the double short `u` of `London` is a step away from both `ah` and
+  short `o`."
+- **two steps** — still counted as connection: the initial `ah` of `crowd`
+  "is two steps from `flowed` and `over`'s initial short `o`."
 
-### Diphthong decomposition through the triangle
+For contrast he gives a direction rather than a number: "You can also use it
+to create strong sonic contrast by seeking out words several steps away" —
+the `death` of Exercise 8.5 being the worked case.
 
-Pat's diphthong table (*Essential Guide to Rhyming* (2014), Chapter 8)
-maps each diphthong to two pure-vowel positions on the triangle:
+### What the triangle is for
 
-| Diphthong | Decomposes to | Triangle path |
-|---|---|---|
-| long ā (`play`) | ĕ + ē | tongue-leg sliding inward |
-| long ī (`cry`) | ä + ē | apex → tongue-leg |
-| long ō (`grow`) | ŏ + ū | lip-leg sliding outward |
-| oi (`boy`) | ŏ + ē | lip-leg → tongue-leg |
-| ou (`couch`) | ä + ū | apex → lip-leg |
+Pat's use for it is practical and he states it plainly: "When you use the
+vowel triangle with your rhyming dictionary, you're able to explore not only
+rhymes, but also related vowel sounds. Work on two levels at once: you'll be
+mining ideas and sounds simultaneously."
 
-Singers hold one component of the diphthong depending on register and
-phrasing. The held component is what the ear hears most clearly — useful
-for hidden-assonance matching (the held component bonds with words
-sharing that pure vowel).
+The diphthong decomposition that pairs with it is printed once, in the hidden
+assonance section above — the same five rows. It is not repeated here.
 
 ## Family assonance
 
@@ -512,21 +516,15 @@ of the tool: "When you have a choice between words, this principle of voice
 leading — taking small sonic steps (or large steps, as Eliot did with `death`)
 — could make the difference between a good line and a great one."
 
-Use family assonance when:
+That completes the vowel side of the chapter, and Pat closes it by stacking
+the three levels: "You've now seen all three levels of vowel relationships:
+simple assonance, hidden assonance, and family assonance. Together, they can
+help you knit a strong and euphonious sonic fabric."
 
-- exact vowel repetition is too obvious,
-- the line needs formality, chant, or euphony,
-- a nearby word can keep the sound moving by a small step,
-- the song needs contrast by deliberately jumping several steps away.
-
-Coaching workflow:
-
-1. Identify the stressed vowel in the target word.
-2. Find words with the same vowel for simple assonance.
-3. Find diphthong components for hidden assonance.
-4. Find adjacent vowel sounds for family assonance.
-5. Use a larger vowel jump when the lyric needs isolation, fear, rupture, or
-   emphasis.
+The tool cuts both ways, and Pat says so in the same breath as the euphony:
+small steps for the "sense of formality, as though these lines, echoing
+Dante, are meant to be intoned"; and "strong sonic contrast by seeking out
+words several steps away," which is what isolates `death`.
 
 This is another way to use a rhyme worksheet: not every worksheet word becomes
 an end rhyme. Some words belong inside phrases as sonic motion. "Work on two
@@ -719,22 +717,15 @@ of `b` and `p`, aided by the more remote members of the family, `v` and `w`.
 The dance of the two families, M and N, combined with the several vowel
 connections, creates a musicality that's hard to deny or resist."
 
-Use concealed alliteration to:
+Pat's method for finding it is not analytic but physical, and he states it as
+an instruction: "Read the lines aloud very slowly and listen. Pay special
+attention to your tongue positions. How many times does the tip of your
+tongue rise to touch your hard palate?" That count *is* the diagnostic.
 
-- add a subtle sonic grid under a line,
-- support meter or stress substitutions,
-- connect images through shared mouth movement,
-- make a passage feel musically inevitable,
-- create a pause when consonant movement forces one.
-
-Coaching workflow:
-
-1. Mark the stressed syllables.
-2. Identify repeated exact consonants.
-3. Identify related consonants in `M`, `N`, and `NG` families.
-4. Read the line slowly and count where the mouth repeats a position.
-5. Ask whether that pattern supports the image, emotion, or motion.
-6. If it is too dense, replace one word with a less related sound.
+The stated purpose is the same one that opens the section: "As in family
+rhyme, which uses the horizontal consonant families to expand your rhyming
+palate, you'll use the vertical consonant families to expand your
+alliterative palate."
 
 **Concealed alliteration can separate as well as link.** Pat's example is the
 enjambment in the same passage:
@@ -819,13 +810,9 @@ and how the puppy of the second line runs effortless circles, "each word moving
 smoothly into the next. Say it. Now say it keeping your teeth together. The
 legato junctures illustrate the puppy's former ease of motion."
 
-Useful deliberate juncture can:
-
-- lengthen a space,
-- make distance feel real,
-- make weight or age feel heavy,
-- break a too-smooth motion,
-- reinforce a lyrical stop or turn.
+Pat's own summary of what juncture is for is a single sentence, and it is
+symmetrical: "Juncture can either make words flow one into the other, or it
+can also separate them, providing yet another tool for creating prosody."
 
 Skill behavior: always test lyric lines aloud for accidental collisions. If a
 line is hard to sing or easy to mishear, check juncture before changing the
@@ -906,14 +893,10 @@ do is listen for prosody, then choose accordingly."
 > "Reasons for choosing. Choosing for reasons." — Pat Pattison,
 > *Essential Guide to Rhyming* (2014), Chapter 8
 
-When comparing synonyms, ask:
-
-- Which word keeps the motion going?
-- Which word breaks the motion?
-- Which word sounds like the scene?
-- Which word creates the right mouth-feel for the singer?
-- Which word makes the emotional action easier to hear?
-- Which word gives the best reason for choosing it?
+Pat asks exactly one pair of questions at each comparison, and asks it three
+times unchanged: **"Given these two ways to say the same thing, which word
+works better? Why?"** Keep the wording — the second question is the whole
+lesson, and the chapter supplies no rubric for answering it beyond listening.
 
 ## Exercises as coaching prompts
 
@@ -932,6 +915,28 @@ so keep them distinct. (The book has no Exercise 8.7.)
    By sea-girls wreathed with seaweed red and brown
    Till human voices wake us, and we drown.
 ```
+
+Pat prints an answer key, **rotated 180° at the foot of the page**, which
+marks each assonance group with a different typographic device rather than
+naming it. Reproduced with the devices intact:
+
+> *Under* the <u>brown</u> **fog** of a **win**ter **dawn**,
+> A <u>crowd</u> FLOWED OVER *London* **Bridge**, SO many,
+> I had ***not thought*** death had *undone* SO many.
+
+> We have lin*gered* in the <u>cham</u>*bers* of the sea
+> By **sea**-*girls* **wreathed** with **seaweed** red and brown
+> Till human voices <u>wake</u> us, and **we** drown.
+
+Reading the devices — **this gloss is inference, not Pat's; he prints the
+marks and names nothing**: italic = short `ŭ` (*Under*, *London*, *undone*);
+underline = the `ou` diphthong (<u>brown</u>, <u>crowd</u>); capitals =
+long `ō` (FLOWED, OVER, SO); bold-italic = short `ŏ` (***not thought***).
+In the second passage bold = long `ē` (**sea**, **wreathed**, **seaweed**,
+**we**), italic = `ər` (lin*gered*, cham*bers*, *girls*), underline = long
+`ā` (<u>cham</u>bers, <u>wake</u>). Bold in the *first* passage covers two
+sets at once — `fog`/`dawn` and `win`ter/`Bridge` — so do not read a single
+vowel off it.
 
 **Exercise 8.2. Simple Assonance Practice.** Using your rhyming dictionary,
 supply a word that creates simple assonance with the stressed syllable of the
@@ -959,8 +964,27 @@ italicized word:
 2. After the torchlight red on sweaty faces
 ```
 
-For 2, Pat gives the answer: `light` and `faces` share the `ee`; `red` and
-`faces` share `ĕ`.
+Pat answers **both**, again by marking rather than naming (the marks are
+stripped from the text layer; recovered from the page scan):
+
+<!-- Pat italicises part-words to isolate a sound; verbatim as printed --><!-- spellchecker:off -->
+
+> (Answer)
+> Listen! you hear the *grat*ing roar
+> Of *peb*bles…
+
+<!-- spellchecker:on -->
+
+The italics fall on the short `ĕ` — overt in `pebbles`, hidden inside the
+long `ā` of `grating` (`ĕ`+`ē`). Same mechanism as `play head games`.
+
+> (Answer)
+> After the torch<u>light</u> *red* on *sweaty* <u>fa</u>ces
+> (*Light and faces share the ee. Red and faces share `ĕ`.*)
+
+The parenthesis is Pat's own gloss, so item 2 is the one place in the chapter
+where he names the shared sounds outright. Note `sweaty` is marked too,
+joining `red` on the `ĕ`.
 
 **Exercise 8.4. Hidden Assonance.** The same ten prompts as 8.2, but now
 worked with the diphthong table, the rhyming dictionary, and the vowel triangle
@@ -1038,12 +1062,16 @@ best matches the meaning.
 
 ## Chapter 8 skill workflow
 
-When applying Chapter 8 directly:
+**This ordering is this file's, not Pat's.** Chapter 8 sets exercises, not a
+procedure; the steps below simply walk its five topics in the order it
+introduces them (internal rhyme → assonance → alliteration → voice leading
+and prosody → juncture). Step 1 is Pat's, and he repeats it throughout:
+"Read the lines aloud very slowly and listen."
 
 1. Read the line or section aloud.
 2. Mark end rhymes separately from interior sound links.
-3. Identify local internal rhymes and decide whether they accelerate,
-   stabilize, or unbalance the phrase.
+3. Identify local internal rhymes and decide whether they accelerate or
+   unbalance the phrase.
 4. Mark vowel connections: simple, hidden, family, and contrast.
 5. Mark consonant connections: exact alliteration, medial/terminal repetition,
    and vertical-family concealed alliteration.
@@ -1086,8 +1114,8 @@ Juncture section above — rough (staccato) versus smooth (legato), given a full
 treatment in *Essential Guide to Rhyming* (2014), Chapter 8 with the
 `She can't take your rent`, "Ozymandias," and Frost demonstrations. The
 three-state table below is a linguistics import layered on top of Pat's two
-states for diction and genre work. It is **not** Pat's terminology and should
-not be attributed to him.
+states for diction and genre work. It is **not** Pat's terminology, is
+**unaudited** (no book source), and must not be attributed to him.
 
 | State | Mechanism | Sonic effect |
 |---|---|---|
@@ -1120,8 +1148,9 @@ juncture.
 
 ## Sonic fabric — the section-wide texture
 
-**Sonic fabric is Pat's own term**, used throughout Chapter 8 (and indexed to
-its first appearance there). He introduces it for interior rhyme placement:
+**Sonic fabric is Pat's own term**, used four times in Chapter 8 and carried
+in the book's index at its first appearance ("sonic fabric, 78"). He
+introduces it for interior rhyme placement:
 
 > "Call it sonic fabric, created by placing rhymes internally. Great stuff."
 > — Pat Pattison, *Essential Guide to Rhyming* (2014), Chapter 8
@@ -1131,8 +1160,8 @@ together" — and again after the three assonance levels: "Together, they can
 help you knit a strong and euphonious sonic fabric."
 
 The section-wide diagnostic below extends that idea from the line to the
-section. The extension is this knowledge base's; the term and the weaving
-metaphor are Pat's.
+section. That extension is this knowledge base's and is **unaudited** — only
+the term and the weaving metaphor are Pat's.
 
 Sonic fabric:
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-spotlight-connection.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-spotlight-connection.md
@@ -1,21 +1,27 @@
 # Rhyme Spotlight And Connection
 
-Pat Pattison - *Pat Pattison's Songwriting: Essential Guide to Rhyming* (2014), Chapter 2.
+Pat Pattison — *Essential Guide to Rhyming* (2014), Chapter 2, "Exchanging
+Business Cards" (printed pp. 9–17).
 
 Use this with [rhyme fundamentals](rhyme-fundamentals.md),
 [rhyme strategy](rhyme-strategy.md), and
 [rhyme dictionary practice](rhyme-dictionary-practice.md). This chapter turns
 rhyme from a sound match into a lyric-thinking tool.
 
-Source images inspected for this chapter span: `image_4-page2.jpg`,
-`image_4-page3.jpg`, `image_4-page4.jpg`, `image_4-page5.jpg`,
-`image_4-page6.jpg`, `image_4-page7.jpg`, `image_4-page8.jpg`,
-`image_4-page9.jpg`, `image_4-page10.jpg`, `image_4-page11.jpg`.
+**Reading this file.** Pat's own words appear *only* inside quotation marks,
+blockquotes, and fenced blocks — that is the whole of the verbatim layer, and
+it is printed as printed. Every other sentence here, headed or not, is this
+plugin's operational framing: it is not in the chapter and must never be quoted
+back as Pat's.
+
+Source page scans for this chapter: `image_4-page2.jpg` through
+`image_4-page10.jpg` (printed pp. 9–17). `image_4-page11.jpg` (printed p. 18)
+is blank; Chapter 3, "Getting References," opens on printed p. 19.
 
 ## Core idea
 
-The chapter is titled "Exchanging Business Cards." You have been introduced to
-rhyme; now find out what it does for a living. Its business card reads:
+"You have been introduced. Now find out what Rhyme does for a living. Its
+business card reads:"
 
 ```text
 RHYME
@@ -26,7 +32,8 @@ RHYME
 ```
 
 This file covers the first two jobs. Pat sends the third to a different book:
-motion is the subject of *Essential Guide to Lyric Form and Structure* (1991).
+"We will look at the first two. My book, *The Essential Guide to Lyric Form and
+Structure* (Berklee Press, 2nd edition 2014), deals with creating motion."
 In this knowledge base, motion is developed in
 [rhyme strategy](rhyme-strategy.md), especially rhyme spacing, pace, and
 closure.
@@ -35,7 +42,7 @@ closure.
 
 The rhyming positions are at the ends of phrases. Because they control
 structure, end-phrase positions are always important. When the ends of phrases
-rhyme, the position takes on extra importance. Pat's four reasons:
+rhyme, the phrase-end position takes on extra importance. Here's why.
 
 1. It is followed by a grammatical pause. This lets the lyric's idea "ring on"
    during the silence.
@@ -44,8 +51,8 @@ rhyme, the position takes on extra importance. Pat's four reasons:
 3. Since it is the end of a musical phrase, a melodic or harmonic signal
    usually will tell you what to expect next. This special musical function
    calls even more attention to the spot.
-4. When there is rhyme in the phrase-end position, it will sound like other
-   words, again focusing attention on the position.
+4. When there is rhyme in the phrase-end position, it has a special feature: it
+   will sound like other words, again focusing attention on the position.
 
 "You can see that the rhyme position at phrase-end attracts a lot of attention.
 It's a spotlight."
@@ -70,8 +77,21 @@ Pat's demonstration is two rhyme-word lists with the *same rhyme scheme*:
 suggests a story all by itself. Imagine what might happen if you had whole
 phrases."
 
+Pat's next move is to run this on your own back catalogue:
+
+> "Try something. Pick out two of your old lyrics, and list your rhyme words on
+> a sheet of paper. It is revealing (and too often depressing) to see how
+> little attention you pay to the most powerful positions you have to work
+> with. If your lists are dull rather than interesting, you are not getting the
+> most out of your rhyming position. Get into the habit of noticing what you
+> put there."
+
+And his pass/fail line: "If you can get a good idea of a lyric's meaning just
+from spotlight information, you are using your rhyming positions effectively."
+
 His worked example of spotlights doing the job is Erwin Drake's "It Was a Very
-Good Year," where "the rhymes carry the ideas almost by themselves":
+Good Year": "Look carefully at these rhymes ... The rhymes carry the ideas
+almost by themselves."
 
 ```text
 nights / lights / green / seventeen
@@ -80,21 +100,10 @@ means / limousines / drive / thirty-five
 kegs / dregs / clear / year
 ```
 
-Read only that list and you already have the song: four ages of a man's life,
-each with its women and its social altitude, told through the rhyme positions
-alone.
-
-Diagnostic:
-
-1. List only the end-rhyme words from the section.
-2. Hide the rest of the lyric.
-3. Ask what subject, relationship, plot, or emotional pressure the list implies.
-4. If the answer is "almost nothing," revise the rhyme positions before merely
-   polishing the lines around them.
-
-Pat's own framing of the test: "If you can get a good idea of a lyric's meaning
-just from spotlight information, you are using your rhyming positions
-effectively."
+Pat then sends the reader to the record: "Now, take a minute to hop online and
+take a look at the full lyric. I'll wait." And on the reader's return:
+"Welcome back. Yup, the rhymes really communicate the lyric's meaning. By the
+time you add in the other phrase-end words, the story is practically complete."
 
 This does not mean every rhyme word must be a title, thesis, or dramatic
 reveal. It means rhyme positions should carry meaningful content rather than
@@ -102,8 +111,9 @@ being filled by whatever word was easiest to rhyme.
 
 ## Empty rhymes
 
-"Your worst enemies are empty rhymes and cliché rhymes." Pat's empty-rhyme
-list is the first column above:
+"Since your rhyme position has spotlights shining on it, you had better put
+interesting ideas there. Your worst enemies are empty rhymes and cliché
+rhymes." Pat's empty-rhyme list is the first column above:
 
 ```text
 me / do / be / you / know / so
@@ -123,18 +133,14 @@ there only because they were available.
 lyrics, one that uses spotlights effectively and one that does not. List the
 rhymes in two columns, one under each title, and compare.
 
-Pat's warning about doing this to your own work: "It is revealing (and too
-often depressing) to see how little attention you pay to the most powerful
-positions you have to work with."
+The printed exercise gives two title slots and two `SPOTLIGHT WORDS:` columns,
+one under each title. Pat's warning about turning the same exercise on your own
+work is quoted above, under *Important words belong in rhyme positions*.
 
-In skill use, this can become a rewrite prompt:
-
-```text
-List your end-rhyme words only.
-Circle the words that carry image, action, conflict, relationship, or title
-pressure.
-Replace two uncircled words before rewriting the full lines.
-```
+In skill use, this can become a rewrite prompt (the plugin's wording, not
+Pat's): list your end-rhyme words only; circle the ones that carry image,
+action, conflict, relationship, or title pressure; replace two uncircled words
+before rewriting the full lines.
 
 ## Cliche rhymes
 
@@ -155,7 +161,11 @@ above ____    met   ____
 burn ____     true  ____
 ```
 
-Pat reports the answers he got — paired back to their prompts:
+Pat reports his own answers as one running parenthetical: "(I got as answers:
+'understand, desire, there, real, die, talk, love, learn, apart, telephone,
+charms, realize, all or wall, lonely, regret or forget,
+you/do/blue/through/new.')" Paired back to their prompts, reading the printed
+columns down:
 
 ```text
 hand  → understand      heart → apart
@@ -172,8 +182,9 @@ His diagnosis is precise: "None of these words are empty. They mean something.
 But when you pair them with their predictable mates, they bland off to nowhere
 ... These pairs all cause sleeping sickness."
 
-The cure is the second half of the exercise: look the same words up in the
-rhyming dictionary and see if you can do better. Preserve the principle — the
+And his cure: "Your goal is to find a cure for the infection. Start by looking
+up the words from exercise 2.2 in your rhyming dictionary and see if you can do
+better." Preserve the principle — the
 first rhyme that arrives is the cultural reflex, not the best craft choice.
 
 Skill behavior for cliche targets:
@@ -195,7 +206,9 @@ burn
 
 "These two ideas connect, at least as metaphors. Other ideas rush in:
 'consume, torment, hot....' But besides having four letters, the syllables have
-no sonic connection at all." Attention stays on the meanings.
+no sonic connection at all. Rather, your attention stays focused on their
+meanings, their metaphorical connection. The connection could be strengthened
+if the syllables had something in common: if they sounded alike."
 
 ```text
 desire
@@ -224,25 +237,6 @@ but vivid connection, weigh the whole song's tone. A comic, formal, or highly
 structured section may want more audible resolution. A conversational or
 emotionally raw section may benefit from a less tidy but more surprising bond.
 
-## Double connection
-
-The strongest rhyme pairs often connect on two levels:
-
-- The ear hears the relationship.
-- The mind understands why the ideas belong together.
-
-This is different from merely finding two words with the same sound ending. A
-good rhyme can make the listener feel that the second idea was waiting inside
-the first one.
-
-Revision questions:
-
-- Does the rhyme pair create a story relationship?
-- Does it create a metaphor relationship?
-- Does it reveal contrast, irony, cause, or consequence?
-- Does it sharpen the speaker's attitude?
-- Would the pair still feel connected if spoken without music?
-
 ## Common-idea exercise
 
 **Exercise 2.3. Common Ideas.** For each word below, find a rhyme word that
@@ -259,7 +253,8 @@ affair   alarm    school   past
 "When you use your rhyming dictionary in such a focused way — looking for words
 that connect ideas — it is a real help."
 
-Pat then shows the pairs generating plot on their own: "'Scold/hold' could
+Pat then shows the pairs generating plot on their own: "Some of your rhyming
+pairs above might suggest other ideas. 'Scold/hold' could
 suggest an argument, complete with making up afterwards. (Or it might have been
 a phone call.) 'Break/mistake' could be Mom's favorite lamp, perhaps followed
 by 'scold/hold.' A rhyme often suggests some further idea. That is one of its
@@ -271,9 +266,12 @@ metaphor, and emotional direction.
 
 ## Rhyme as idea generator
 
-Ordinarily a writer waits until a phrase exists and only then hunts a rhyme to
-match it. Pat inverts it — search first, and let the sound hand you the idea.
-His demonstration starts from `desperado`:
+> "Before, when you have written lyrics, you've waited until you already have a
+> phrase to match before you looked for a rhyme. As you looked at each
+> possibility, you tried to find ways to match them with your original word.
+> Some pretty strange ideas can come from this process, some more workable than
+> others. Looking for a rhyme for 'desperado' could lead you to something like
+> this:"
 
 ```text
 Slicker than a desperado
@@ -282,10 +280,8 @@ Steals your heart and runs for cover
 Leaves a trail of broken lovers
 ```
 
-Nothing in the search asked for a con man; `staccato` produced him, and
-`cover/lovers` produced the wreckage he leaves. "What this process shows is the
-power of rhyme to make you think of new ideas. A rhyming dictionary can
-actually stimulate the creative process."
+"What this process shows is the power of rhyme to make you think of new ideas.
+A rhyming dictionary can actually stimulate the creative process."
 
 Use this workflow:
 
@@ -296,9 +292,8 @@ Use this workflow:
 5. Choose the group that makes the song more specific.
 6. Draft lines after the relationship is clear.
 
-Bad use of a dictionary asks, "What word rhymes?"
-
-Good use asks, "Which available sound opens the most useful idea?"
+Bad use of a dictionary asks *what word rhymes*. Good use asks *which
+available sound opens the most useful idea*.
 
 ## Mismatch can become comedy
 
@@ -328,10 +323,10 @@ Skill behavior:
 
 ## Going deeper than the first dictionary page
 
-Sometimes the dictionary does not give a useful perfect rhyme. "Connections
-sound silly or far-fetched. You feel like you have to force ideas to rhyme,
-when the opposite should be happening. It makes you want to go into your
-'I-don't-want-to-rhyme' stage."
+"Even with your rhyming dictionary in hand, too often, no good rhymes are
+available. Connections sound silly or far-fetched. You feel like you have to
+force ideas to rhyme, when the opposite should be happening. It makes you want
+to go into your 'I-don't-want-to-rhyme' stage. Try working with this:"
 
 Pat's worked "Going Deeper" case starts here:
 
@@ -342,9 +337,12 @@ I want to play it safe
 
 <!-- phonetic vowel markings trip the spell-checker --><!-- spellchecker:off -->
 
-**Step 1 — try the obvious section.** `business` is feminine, so look under
-`ĬZ ness`. Nothing rhymes with it. Two choices remain: find a mosaic rhyme, or
-don't rhyme it.
+**Step 1 — try the obvious section.** "To get a third line, you might try to
+rhyme 'business.' Look in your rhyming dictionary in the feminine section under
+`IZ ness`. Oops. No words rhyme with it. Now you have two choices."
+
+> 1. "Since it is feminine, find a *mosaic rhyme*, or…"
+> 2. "Don't rhyme it."
 
 **Step 2 — build the mosaic from the masculine section.** Look under short
 `ĭ` + `z`. Best of a short list: `fizz`, `friz`, `his`, `is`, `quiz`, `'tis`,
@@ -353,9 +351,10 @@ Tisness? Whizness? "There are some faint sparks, but all seem to smack of
 forced comedy that promise only self-consciously 'look-at-me-I-can't-find-a-
 rhyme' humor."
 
-**Step 3 — remember the tail need not be an identity.** Feminine rhymes do not
-have to repeat the unstressed syllable, so look under short `ĕ` + `s`, one-
-syllable words only:
+**Step 3 — remember the tail need not be an identity.** "Remember, feminine
+rhymes do not necessarily have identities in their unstressed syllables. Look
+in the masculine section under short `ĕ` + `s`. Of course, only one-syllable
+words will do."
 
 ```text
 Bess    bless   chess   dress   fess
@@ -369,9 +368,9 @@ press   stress
 
 **Step 5 — check the *fourth* line before committing the third.** "The key to
 what will happen in the third phrase is often what happens in the fourth."
-Rhymes for `safe`: `chafe`, `strafe`, `waif`. `strafe` is a transitive verb
-needing a direct object, so it inverts the sentence at the phrase end. That
-leaves `chafe`:
+Rhymes for `safe`: `chafe`, `strafe`, `waif`. "Ick. Even if you wanted
+'strafe,' it is a transitive verb needing a direct object to complete it.
+(Remember 'besiege'?)" That leaves `chafe` and `waif`. "Try 'chafe' first."
 
 ```text
 I'm sick of all this risky business
@@ -380,9 +379,10 @@ I'll learn to drink my tonic fizzless
 Where no one makes me chafe (?)
 ```
 
-"Ugh! This is downright gruesome, like an underwear commercial." `waif` is no
-better, though it can at least be placed honestly by dropping to two lines and
-writing an unrhymed third:
+"Ugh! This is downright gruesome, like an underwear commercial. You could keep
+trying to use 'chafe' in a more imaginative way, or to lead up to it with a
+better idea. I don't see much hope. I don't see much hope for 'waif' either.
+You might try something like:"
 
 ```text
 I'm sick of all this risky business
@@ -390,13 +390,18 @@ I want to play it safe
 Or die a helpless waif
 ```
 
+"Then, try to write a different (unrhymed) third phrase."
+
 **The real diagnosis.** "The problem is not the approach to 'chafe,' nor is it
 that 'waif' needs to fit more naturally. Neither word has much promise. Yet
 lyricists often spend valuable energy and creativity trying to create silk
 purses with words like these. The problem, as usual, is in picking 'business'
 and 'safe' without much forethought."
 
-Options when you are already stuck there:
+Pat's own fix is a planning instruction, not a rescue — see *Do not pick weak
+friends* at the foot of this file, which is where the chapter ends.
+
+Derived options when you are already stuck there anyway (not Pat's list):
 
 - Find a mosaic rhyme.
 - Use a less exact rhyme type if the style permits it.
@@ -415,24 +420,33 @@ of a feminine rhyme.
 
 Pat's filter on the `business` list: "Most of these are too strong to work as
 the unstressed syllable in a feminine mosaic. You need something with the same
-stress pattern as `busi-ness`." Take `guess`:
+stress pattern as `busi-ness`." He then prints the scansion twice — "With most
+of the choices, for example, `his guess`. You will end up with":
 
 ```text
+ /    /
 his guess
 ```
 
-You end up either with two stresses (`hís guéss`) "or, even worse," a stressed
-second unit that outranks the first. "Both of these are forced and again,
-self-consciously funny."
+"…or, even worse,"
 
-`less` survives the filter "since it actually could be unstressed":
+```text
+ ˘    /
+his guess.
+```
+
+"Both of these are forced and again, self-consciously funny." Neither scans
+like `busi-ness` (stressed–unstressed): the first stresses both units, the
+second throws the stress onto the tail.
+
+"But 'less' could work, since it actually could be unstressed."
 
 ```text
 quizless
 fizzless
 ```
 
-Which yields the third line, with a caveat Pat states himself:
+"Try."
 
 ```text
 I'm sick of all this risky business
@@ -457,9 +471,11 @@ Skill behavior:
 
 ## Do not pick weak friends
 
-The chapter's practical warning is simple:
+The chapter's last words, and its practical warning:
 
-> "Look hard before you pick your friends."
+> "Here is part of the solution:
+>
+> Look hard before you pick your friends."
 
 Once a word occupies a rhyme position, it becomes a friend that later lines
 must answer. If the word has poor rhyme potential or weak idea potential, the

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
@@ -2,7 +2,7 @@
 
 Pat Pattison - *Songwriting: Essential Guide to Lyric Form and Structure*
 (1991), Chapter 4. Extended with *Pat Pattison's Songwriting: Essential Guide to
-Rhyming* (2014), Chapter 9, and *Songwriting Without Boundaries* (2011),
+Rhyming* (2014), Chapters 7 and 9, and *Songwriting Without Boundaries* (2011),
 Challenge 4.
 
 Source images inspected:
@@ -14,6 +14,12 @@ Source images inspected:
   inventory listed only the *Essential Guide to Rhyming* (2014) and
   *Songwriting Without Boundaries* (2011) images and omitted this chapter
   entirely, which is how the `abba` error below survived.
+- *Essential Guide to Rhyming* (2014), Chapter 7 (printed pp. 69-75, spine
+  082-088; p. 76 is a blank verso): text layer complete and used verbatim.
+  Scans consulted for layout only — `image_A-page2.jpg` (the two-column
+  `safe`/`business` worksheet and the `swiftless` spelling) and
+  `image_A-page8.jpg` (Exercise 7.1's three-column fill-in grid, which the text
+  layer flattens into an unreadable order, and its bordered keyword box).
 - *Essential Guide to Rhyming* (2014), Chapter 9: `image_C-page20.jpg`, `image_E-page1.jpg`, `image_E-page2.jpg`,
   `image_E-page3.jpg`, `image_E-page4.jpg`, `image_E-page5.jpg`,
   `image_E-page6.jpg`, `image_E-page7.jpg`, `image_E-page8.jpg`,
@@ -707,24 +713,30 @@ The matrix is read top-down per slot:
 ## Shelley anchor — through-written without internal fragmentation
 
 *Essential Guide to Lyric Form and Structure* (1991), Chapter 4 uses Shelley's "Ozymandias" as a teaching anchor (the
-poem itself is public domain). The sonnet's rhyme scheme deliberately
-avoids `aabb` adjacency. Each pair is separated, so no internal
-couplet closes early and fragments the sonnet's single argument.
+poem itself is public domain). Pat's scansion is scoped to **"these last
+six lines"**, not the whole poem — do not restate it as a claim about the
+sonnet entire. Across those six lines each rhyme pair is separated, so no
+internal couplet closes early and fragments the single argument.
+
+(Two spellings are as printed and are not ours to correct: Pat sets the
+attribution "Percy Bysshe Shelly", and the title appears as "Ozymandius"
+in his running text and again in the *Essential Guide to Rhyming* (2014)
+index.)
 
 The lesson: rhyme adjacency forces structural decisions even before
 the words are chosen. A long single thought benefits from spread
 rhymes; a section made of short paired thoughts benefits from
 couplet adjacency.
 
-Use the Shelley principle when:
+**"The Shelley principle" is not Pat's term** — he names no such principle,
+and the three-item "use when" list that stood here was invented. The
+preceding paragraph is the actual lesson the chapter draws. Pat's own words
+for what rhyme is doing here:
 
-- a verse needs to read as one continuous thought,
-- a section's argument depends on the listener following from line
-  1 to line N without internal stops,
-- the writer is tempted to use couplets out of habit rather than
-  intent.
-
-> "Nothing can match rhyme's power" to control flow. — Pat (*Essential Guide to Lyric Form and Structure* (1991), Chapter 4)
+> "Rhyme is the best way to control a lyric's FLOW. Nothing can match
+> rhyme's power in this area. Not phrase length. Not rhythm."
+>
+> — *Essential Guide to Lyric Form and Structure* (1991), Chapter 4
 
 ## Sound vs order — the two forces
 
@@ -779,12 +791,187 @@ Match stability to weight; pick deliberately.
 
 Cross-ref the decision matrix above and `rhyme-types.md` stability scale.
 
+## The full rhyme search (*Essential Guide to Rhyming* (2014), Chapter 7)
+
+Chapter 7, "The Fruits of Friendship," is where the rhyme-type layer above stops
+being theory and becomes a search procedure. Pat opens it:
+
+> Now it's time to go back to worksheets. This time, we'll launch a full rhyme
+> search.
+>
+> Our goal is to find better words than we did with perfect rhyme. Look again:
+
+The lyric he looks again at is his own two-line seed:
+
+```text
+I'm sick of all this risky business
+I want to play it safe
+```
+
+> For starters, "business" and "safe" can go on the worksheet. Now, you can find
+> rhymes for them.
+
+His worksheet, exactly as printed (`swiftless` is as printed — do not correct
+it):
+
+<!-- spellchecker:off -->
+```text
+safe            business
+faith           collisions
+chase           decisions
+race            visions
+space           forgiveness
+brave           frigid
+grave           religious
+slave           gifted
+cage            shiftless
+stage           swiftless
+castaway        kisses
+ricochet        ambitious
+runaway         delicious
+haste           suspicious
+braced          submissive
+                riches
+                finish
+                whiz
+                stiff
+```
+<!-- spellchecker:on -->
+
+> Better. There are some real possibilities here.
+
+### The search is run against every keyword, not just the rhyme slot
+
+`safe` and `business` have now been searched. Pat then prints the same search
+for the other eleven worksheet keywords, numbered 1-11, each split into a
+Perfect Rhymes column and an Imperfect Rhymes column:
+
+> Here is a complete rhyme search for each of the words on the worksheet. Figure
+> out what kind of rhymes they are and how I found them. They are all related to
+> the general idea of "RISKY BUSINESS." The list will have to be trimmed down
+> later.
+
+Three things in that instruction are the strategy, and all three are easy to
+skip past:
+
+1. **Every keyword gets searched**, not only the words that happen to sit in
+   rhyme position. Only `business` and `safe` end lines in the printed couplet;
+   the other eleven do not appear in it at all. The keyword list is the song's
+   vocabulary, not its rhyme scheme.
+2. **The reader has to reverse-engineer the type** ("figure out what kind of
+   rhymes they are and how I found them") rather than being handed labels.
+3. **Over-generate first, trim later.** The list "will have to be trimmed down
+   later" — needing a trim is the expected outcome, not a sign of a bad search.
+
+The thirteen keywords, as printed in the bordered box on p. 75 (note `scared`
+here; the numbered search columns and the Exercise 7.1 grid both print `scare`):
+
+<!-- spellchecker:off -->
+```text
+1. scared     6. risk       11. gone
+2. afraid     7. chance     12. safe
+3. flirt      8. dull       13. business
+4. attention  9. leave
+5. left out  10. ignored
+```
+<!-- spellchecker:on -->
+
+**One worked specimen — keyword 9, `leave`.** This is an excerpt, not the whole
+search; the other ten numbered columns run across pp. 70-74 (spine 083-087) and
+belong under [rhyme worksheets](rhyme-worksheets.md).
+
+<!-- spellchecker:off -->
+```text
+Perfect Rhymes        Imperfect Rhymes
+
+9. leave              9. leave
+believe               breathe          peace
+deceive               seethe           police (Identity)
+grieve                appeased         beach
+ho-heave              please           c.o.d.
+                      diseased         debris
+                      freeze           guarantee(s)
+                      squeeze(d)       knees
+                      tease(d)         degrees
+                      prestige         refugee(s)
+                      relief           amenities
+                      grief            apologies
+                      thief            dignity
+                      teeth            fantasies
+                      caprice          hostilities
+```
+<!-- spellchecker:on -->
+
+Note what the columns carry besides words. Pat flags `police` as an **Identity**
+inside the imperfect column — the same separation this file's diagnostic
+workflow asks for ("mark identities separately from rhymes"). His other
+annotations across the search work the same way: `dance (cliché?)`,
+`knockout (id.)`, `lookout (id.)`, `(oops!)` printed under `disc` in the perfect
+column for `risk`, and `mend on, etc.` / `stretchin', etc.` closing the
+imperfect column for `attention`. The parenthesised
+`(s)`, `(d)`, `(ed)` are inflection options he leaves open on the page rather
+than resolving early.
+
+The sharpest single piece of evidence for the chapter's premise is the entry for
+keyword 6, `risk`. Its **entire** Perfect Rhymes column, as printed, is two
+lines:
+
+```text
+6. risk
+disc
+(oops!)
+```
+
+The Imperfect column beside it runs thirty-four entries in two sub-columns —
+`fist, kissed, mist, resist, tryst, wisp, abyss, avarice, bliss, dismissed,
+wished, dish, drift, gift, hints, shift, swift` alongside
+`cliff, stiff, tiff, quick, kicks,
+lick(s), sick, trick, transfixed, ditch, itch, pitch, switch, bridge, crypt,
+chips, apocalypse`. When a keyword's perfect rhymes amount to `disc`, the full
+search is not a refinement on perfect rhyme — it is the only way that keyword
+gets usable options at all.
+
+### Why the search is worth the labour
+
+The chapter closes on a single claim, and it is the argument for worksheets:
+
+> Rhymes are suggestive. As you look through them, they create associations that
+> can lead you in directions you might not have seen otherwise. A good reason to
+> use worksheets.
+
+The strategic point: the search is not a hunt for the one word that fits the
+slot you already have. It is a way of generating directions for the lyric. That
+is why the search runs wide enough to need trimming afterwards, and why every
+keyword gets searched rather than only the rhyme positions.
+
+### Chapter 7 exercises
+
+**EXERCISE 7.1. Perfect and Imperfect Rhyme Practice**
+
+> From the columns of perfect and imperfect rhymes above, choose your ten
+> favorite rhymes for each of the keywords and write them down below.
+
+Printed as a three-column fill-in grid over the thirteen keywords, with writing
+space under each. (In the grid, keyword 1 is printed `scare`; in the boxed
+keyword list on the same page it is `scared`. Both are as printed — do not
+normalise either.)
+
+**EXERCISE 7.2. "Risky Business" Practice**
+
+> Rewrite your lyric "Risky Business" using some of your new ideas and rhyme
+> words.
+
+As a coaching pair these are one move, not two: trim the over-long search down
+to ten per keyword, then rewrite the lyric from what survived. The trim is the
+craft step Chapter 7 exists to force.
+
 ## Cross-references
 
 - [rhyme types](rhyme-types.md) — the stability scale that fills
   the decision matrix.
 - [rhyme worksheets](rhyme-worksheets.md) — full search algorithm
-  per slot.
+  per slot, and the twelve "RISKY BUSINESS" perfect/imperfect columns this
+  file excerpts only `leave` from.
 - [rhyme generation](rhyme-generation.md) — internal generation discipline.
 - [Five Compositional Elements](five-compositional-elements.md) —
   rhyme scheme (row 3) and rhyme types (row 4) per section.

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
@@ -6,7 +6,12 @@ This file covers the rhyme-type scale from full resolution through the most remo
 
 ## Image inventory
 
-Chapter 4 was read as a full page span and these page scans were inspected: `image_4-page18.jpg`, `image_4-page19.jpg`, `image_4-page20.jpg`, `image_6-page1.jpg`, `image_6-page2.jpg`, `image_6-page3.jpg`, `image_6-page4.jpg`, `image_6-page5.jpg`, `image_6-page6.jpg`, `image_6-page7.jpg`, `image_6-page8.jpg`, `image_6-page9.jpg`, `image_6-page10.jpg`, `image_6-page11.jpg`, `image_6-page12.jpg`, `image_6-page13.jpg`, `image_6-page14.jpg`, `image_6-page15.jpg`, `image_6-page16.jpg`, `image_6-page17.jpg`, `image_6-page18.jpg`, `image_6-page19.jpg`, `image_6-page20.jpg`, and `image_8-page1.jpg` (blank trailing page).
+Chapter 4 spans pages 25-47 — `image_4-page18.jpg` through `image_6-page20.jpg`,
+plus the blank trailing page `image_8-page1.jpg`. On the most recent audit pass
+the chapter was confirmed against the complete text layer (spine items 038-060),
+and **one** page scan was rendered and read directly: `image_6-page13.jpg` (p. 40),
+to settle the column order of the final family-rhyme table, which the plain-text
+extraction interleaves. The remaining scans were not re-inspected on that pass.
 
 Chapter 5 was read as a full page span and these page scans were inspected: `image_8-page2.jpg`, `image_8-page3.jpg`, `image_8-page4.jpg`, `image_8-page5.jpg`, `image_8-page6.jpg`, `image_8-page7.jpg`, `image_8-page8.jpg`, `image_8-page9.jpg`, `image_8-page10.jpg`, and `image_8-page11.jpg`.
 
@@ -14,32 +19,172 @@ Chapter 6 was read as a full page span and these page scans were inspected: `ima
 
 ## Why Rhyme Type Matters
 
-Rhyme is not only decoration. It organizes lyric structure, makes structure audible, controls forward motion, tells the listener when a section is complete, and colors how resolved or unresolved a moment feels.
+*Essential Guide to Rhyming* (2014), Chapter 4 opens under the heading
+"EXPANDING RHYME POSSIBILITIES":
 
-Pattison prefers the term "fully resolved rhyme" over "perfect rhyme" because "perfect" implies "better." The real question is not whether a rhyme is morally perfect; it is how much closure it creates.
-
-> "a description, not an accolade"
+> "I don't particularly like the name 'perfect rhyme,' since 'perfect' also
+> seems to imply 'better.' I prefer something like 'fully resolved rhyme,'
+> because it's a description, not an accolade. Rhyme in a lyric:
+>
+> 1. organizes lyric structure, making it visible to the ear
+> 2. creates and controls movement through the structure:
+>    a. tells us when to move forward
+>    b. tells us when a section is finished
+>    c. tells us how resolved/stable the section is
+> 3. can support ideas by varying the strength of resolution."
 
 Think of rhyme stability like harmonic stability:
 
-- A fully resolved rhyme can feel like a tonic chord.
-- A less resolved rhyme can suspend, soften, or destabilize closure.
-- A lyric can resolve while the music stays open, stay open while the music resolves, or have both music and rhyme slam shut.
-- Rhyme choice is prosody when it supports the emotion and meaning of the lyric.
+> "Like chords in a song, rhymes can have varying degrees of stability. What if
+> someone were to make a musical rule that every section has to end on the tonic
+> chord (in root position) with the melody also on the tonic? With a rule like
+> that, a great deal of the wonderful subtlety and expressiveness, longing, and
+> moments of ambivalence that the ending of a section can create, would suddenly
+> be gone. All the heartbreaking longing at the end of Samuel Barber's 'Adagio
+> for Strings' would evaporate with the appearance of the tonic chord. That's why
+> there is no rule like that."
+
+Pat answers the "my ear wants perfect rhyme" objection the same way: "The ear
+'wants to hear' the tonic chord too. It looks for resolution, and that's why
+withholding resolution to some degree creates such wonderful musical effects.
+Some wonderful effects can be gotten with rhyme too, if those ears would only
+listen."
+
+The chapter's thesis, against forcing full resolution:
+
+> "Forcing a rhyme does not uphold a tradition, nor does making rhyme woefully
+> predictable. And though it may be a proof of verbal skill to manage to say
+> something nifty despite using rhymes that have been heard ten thousand times,
+> it happens all too infrequently. It's also impressive to watch someone contort,
+> struggle, and wriggle out of a straight jacket, but our interest lies in the
+> difficulty, not the beauty, of the act.
+>
+> Say something wonderful, and let your rhyme support the emotion you want to
+> create, not limit it."
+
+Music can color a word — minor against major, subdominant against sus4 — so
+"perfect rhyme could just sit there and wait for the music to lend it a color—to
+fill loud/proud with sadness or longing. Yup. It could. Or, rhyme could step up
+to the plate and join the emotion game too, giving the songwriter a whole new
+shiny set of tools to play with. Why should the music have all the fun?"
+
+The three settings Pat lists: "let the music resolve, but let the rhyme feel a
+little incomplete, like tide/life or friend/wind"; "let both the music and the
+rhyme feel incomplete"; or "let them both slam the door shut. It's all about
+prosody: creating musical and lyrical structures that support (indeed, create)
+your emotional intent."
 
 ## Stability Scale
 
-From most stable to least stable:
+The printed table on the Chapter 4 opening pages, headed "Scale of Rhyme Types:
+Most Stable to Least Stable":
 
-1. Fully resolved / perfect rhyme
-2. Family rhyme
-3. Additive / subtractive rhyme
-4. Assonance rhyme
-5. Consonance rhyme
+```text
+Perfect     Family      Additive/Subtractive    Assonance   Consonance
+Rhyme       Rhyme       Rhyme                   Rhyme       Rhyme
+
+Most Stable ------------------------------------------> Least Stable
+```
+
+Chapter 4 names the types only: "We'll save definitions and discussions for the
+next several chapters. The only point here is to introduce the concept of a scale
+of rhyme types moving in degrees from more to less stable."
 
 Family rhyme is close to full resolution. It usually feels like a legitimate rhyme in song because sung vowels are promoted and consonants are softened.
 
 Assonance and consonance are the "kissin' cousins" end of the scale: they still use the rhyme position expressively, but they weaken or suppress the normal structural closure of a rhyme scheme. Partial rhyme is related, but functions more as a structure-opening technique than as another ordinary end-rhyme stop.
+
+## Song anchor: Warren Zevon, "Hasten Down the Wind"
+
+Chapter 4's demonstration that rhyme type alone changes the emotion of a section.
+Pat calls it "an interesting, real-life example of the least stable rhyme type on
+the rhyme scale, consonance rhyme. The rhymed syllables have only their final
+consonants in common. Even the vowel sounds are different."
+
+<!-- spellchecker:off -->
+```text
+She's so many women
+He can't find the one who was his friend
+He's hanging on to half a heart
+But he can't have the restless part
+So he tells her to HASTEN DOWN THE WIND
+```
+<!-- spellchecker:on -->
+
+"The consonance rhyme 'friend/wind' leaves us hanging, suspended, unsure. It
+conveys its own feeling that overlays the ideas; he feels unsure of his
+decision—it hurts, but, alas (back of the hand swooning to the forehead), he must
+let her go, sadly. 'I'll always remember you.'"
+
+**Version 2 — perfect rhyme.** "Look at the difference if we use perfect rhyme:"
+
+<!-- spellchecker:off -->
+```text
+She's so many women
+He can't find the one who was his friend
+He's hanging on to half a heart
+But he can't have the restless part
+So he tells her to hasten 'round the bend
+```
+<!-- spellchecker:on -->
+
+"Oops. Now, he just wants her gone, and good riddance. The perfect rhyme is
+resolved, and the feeling carries over to him. The contrast with the feeling of
+the first version is remarkable."
+
+**The control question.** "Is it the rhyme type that does it? Couldn't it be the
+more poetic language? Sure, the second version is less 'poetic.' Maybe it was the
+words, 'hasten down the wind,' that made it feel softer—while the more direct and
+commonplace 'hasten 'round the bend' carries no such suggestion. Maybe. But try
+this:"
+
+**Version 3 — family rhyme** (`him / wind`):
+
+<!-- spellchecker:off -->
+```text
+She's so many women
+He can't believe she once belonged to him
+He's hanging on to half a heart
+But he can't have the restless part
+So he tells her to HASTEN DOWN THE WIND
+```
+<!-- spellchecker:on -->
+
+"The closer rhyme here makes the section feel much more resolved, and this
+feeling of resolution clearly carries over to the poetic last line. It makes it
+feel so much more matter-of-fact than the original. He's letting her go—what else
+would anyone do?"
+
+Pat's caveat: even though it feels resolved like the perfect rhyme, "it's perhaps
+a bit sadder than the more direct friend/bend. This could be a function of the
+poetic language, or perhaps the effect is mitigated a tad by the family rhyme,
+which is muddied slightly by the addition of 'd' in him/wind."
+
+**Version 4 — "an even more perfect rhyme … as a test case"** (`been / wind`):
+
+<!-- spellchecker:off -->
+```text
+She's so many women
+But she won't be what she had always been
+He's hanging on to half a heart
+But he can't have the restless part
+So he tells her to HASTEN DOWN THE WIND
+```
+<!-- spellchecker:on -->
+
+"Now all the longing is gone. The emotional difference you get between
+friend/wind and been/wind is undeniable."
+
+Pat's verdict on the whole demonstration: "It's an interesting interplay between
+language and rhyme type, with rhyme type stepping up and clearly demonstrating
+its ability to influence feeling. Though the style of language may exert a small
+influence, rhyme type is top dog here. Neat example. Thanks Warren, we'll miss
+you."
+
+**The back of the hand rule.** "I call it the 'back of the hand rule.' Whenever
+you are saying something that would allow you to cry 'Alas!' (with the back of
+your hand to your forehead), you can use a consonance rhyme. Except, of course,
+that there are no rules. Only tools."
 
 ## Fully Resolved Rhyme
 
@@ -49,43 +194,73 @@ A fully resolved rhyme has:
 - identical consonant sound after that vowel,
 - different consonant sound before the vowel.
 
-Example pattern:
+Chapter 4's own printed perfect-rhyme pair (the one the music is asked to "lend
+a color" to):
 
 ```text
-time / rhyme
+loud / proud
 ```
 
-The shared vowel-plus-after-sound creates strong closure. Overusing only full resolution can also make obvious pairs and cliche connections easier to fall into.
+Chapter 4 states the trade-off directly, under the heading "PERFECT RHYME
+SUBSTITUTES": "Perfect rhyme is stable and ought to be used to support stable
+ideas: facts, certainty, commitment. But because perfect rhyme limits your
+opportunities and often results in predictable or cliché rhymes, is there some
+way to create stability with imperfect rhymes? Yup."
+
+Pat's framing of the whole substitute scale: "there are different kinds of
+imperfect rhymes. Some are very close to perfect rhyme, so it will be easy for
+you to use them to substitute for perfect rhyme. Others are not very close and
+will not work as well as substitutes. You can use them too, but it's important to
+understand what you are doing and why."
 
 ## Family Rhyme Definition
 
-A family rhyme has:
+Pat's definition, verbatim — "In family rhyme:
 
-- the same vowel sound in the stressed rhyming syllable,
-- related consonant sounds after the vowel,
-- different consonant sounds before the vowel.
+1. the rhyming syllables' vowel sounds are the same,
+2. the consonant sounds after the vowels are phonetic relatives, and
+3. the rhyming syllables begin differently."
 
-It is the same logic as fully resolved rhyme, except the post-vowel consonants are phonetic relatives instead of identical.
+"Family rhymes are the same as perfect rhymes except for one thing: the
+consonants after the vowel are not the same, but they belong to the same phonetic
+family. They are phonetic relatives—that's why I call them 'family' rhymes."
 
-Family rhyme gives three immediate benefits:
+"When two consonants are phonetically related, we can trade one in for the other
+and get a family rhyme."
 
-1. More choices for rhyme-position words.
-2. Fewer automatic cliches from predictable perfect-rhyme pairs.
-3. More control over structural closure.
+The chapter's closing statement of the three benefits, verbatim:
+
+> "1. They give you more choices, helping you to use your rhyming
+> positions more effectively.
+> 2. They help you avoid the cliché rhymes so common in perfect rhyme.
+> 3. And, as you will see soon, they help you control structure."
+
+"Since lyrics are sung, vowel sounds are promoted and consonant sounds are
+demoted. If you take the time to sing the family rhymes, they will not trouble
+your sensibilities. They will sound like 'real rhymes!'"
 
 ## Phonetic Relationship Tests
 
-Consonants are family-related when they share one or more physical properties:
+"Vowels are tone generators. Consonants are like filter systems: they cluster
+around the vowels. Consonants can relate to each other because they produce
+sounds either by:
 
-- Technique: how the air is handled.
-- Position: where the mouth forms the sound.
-- Voicing: whether the vocal cords vibrate.
+1. using the same technique
+2. using the same physical positions
+3. using (or not using) the vocal cords
 
-The practical families in this chapter are:
+When two consonants share any of these relationships, they are phonetically
+related. When two consonants are phonetically related, we can substitute one for
+the other after the vowel and get a family rhyme. That's how you find family
+rhymes."
 
-- plosives,
-- fricatives,
-- nasals.
+Under the heading "PHONETIC RELATIONSHIPS": "The most general phonetic
+relationship is between consonants that use the same technique to produce sound.
+Consonants divide into three groups according to how you use the air column:
+
+1. plosives
+2. fricatives
+3. nasals"
 
 ## Family Rhyme Table
 
@@ -101,25 +276,38 @@ The table is a search tool, not a pronunciation theory lesson. Use it to find su
 
 ## Plosives
 
-Plosives explode air pressure:
+"The word 'plosive' means just what you think: a little explosion of air. As you
+talk (or sing), the air column coming out of your mouth is stopped. Pressure
+builds up and then explodes to make the consonant sound."
 
 ```text
 Voiced:     b   d   g
 Unvoiced:   p   t   k
 ```
 
-For plosives, partners are closest, then companions, then other same-technique plosives.
+"All six plosives use the same exploding technique. They fit the first criterion.
 
-Partners share mouth position:
+1\. using the same technique — b, d, g, p, t, k
 
-- `b` / `p`
-- `d` / `t`
-- `g` / `k`
+Within the plosive family, there are further relationships.
 
-Companions share voicing:
+2\. using the same physical positions — b = p, d = t, g = k
 
-- voiced companions: `b`, `d`, `g`
-- unvoiced companions: `p`, `t`, `k`
+Call this extra relationship 'partners.' Partners use the same physical
+positions, as well as handling the air column in the same way. They have two
+relationships in common.
+
+3\. using (or not using) the vocal cords — b = d = g, p = t = k
+
+Call this extra relationship 'companions.' Companions have the same voicing
+characteristic. When two consonants belong to the same family, plus have an extra
+relationship (either partners or companions), they are better perfect rhyme
+substitutes. In the plosive family chart, companions are on the horizontal and
+partners are on the vertical."
+
+"Here are the practical results: if a syllable ends in a plosive, there are five
+more places to look for rhymes in addition to perfect rhyme. There is even an
+order to look in."
 
 Search order for a plosive target:
 
@@ -178,34 +366,50 @@ The key coaching move is not to accept everything. The point is to multiply choi
 
 ## Persnickety G
 
-`G` is made near the back of the mouth. Some short vowels shift while preparing for `g`, so `g` is not always a useful substitute.
+"Be careful with g. You make the sound near the back of your mouth by touching
+the middle of your tongue to your soft palate. Your mouth changes the sounds of
+some of the short vowels as you prepare to make the g sound. G will not give you
+a perfect rhyme substitute in some cases. Look:
 
-Be careful with short vowels: `hag` does not sound like `hat`; `egg` does not sound like `ebb`; `big` does not sound like `bid`; `log` does not sound like `lob`.
+- short a as in 'hag.' It does not sound like 'hat.'
+- short e as in 'egg.' It does not sound like 'ebb.'
+- short i as in 'big.' It does not sound like 'bid.'
+- short o as in 'log.' It does not sound like 'lob.'
 
-Useful rule of thumb: long vowels usually work, short vowels usually do not, and short `u` often works.
+(But you may use o as in 'fraud,' 'hawk,' 'fought' to extend your options when
+you start with 'log.')"
 
-Do not memorize the list as dogma. Listen and sing.
+"You can use g with these vowels:
+
+- long a as in 'vague.' Long e as in 'league.'
+- long o as in 'vogue.' Long u as in 'fugue' (the only one).
+- short u as in 'rug'
+
+As a rule of thumb: 'Long—yes. Short—no.' You do not have to memorize this list.
+Your ear will tell you fast enough. Never stop listening."
 
 ## Fricatives
 
-Fricatives slow the airflow enough to create friction:
+"You make fricatives by slowing the airflow out of your mouth enough to cause
+friction—a little like a leaking air hose."
 
 ```text
 Voiced:     v   TH   z   zh   j
 Unvoiced:   f   th   s   sh   ch
 ```
 
-For fricatives, companions are closer than partners. This is the reverse of plosives because fricatives last longer, making voicing more audible, and the mouth positions are closer together.
+"When using fricatives, companions (in the same horizontal row) are closer than
+partners (set vertically)... The opposite was true for plosives. Fricatives take
+longer to say than plosives, so you hear the unvoiced or voiced sound more
+clearly. Also, fricatives are closer together in your mouth than plosives. All
+the fricatives come from the area in your mouth between b and d."
 
-Search order for a fricative target:
+"For fricative family rhymes, go to all the companions before you cross over.
+Then to the partner, then all its companions."
 
-1. Start with perfect rhymes.
-2. Search companions in the same horizontal row, moving from closest to farther.
-3. Cross to the partner.
-4. Search that partner's companions.
-5. Filter for grammar, image value, cliche risk, and singability.
-
-Example: if the target ends in `sh`, move first through unvoiced companions such as `ch`, `s`, `th`, and `f`, then cross to voiced `zh` and its companions.
+"Whether you are looking up fricatives or plosives, companions start closest and
+move outward. If you are working with sh, you would go from ch to s, th and
+finally, f."
 
 Worked example: `safe` (*Essential Guide to Rhyming* (2014), Chapter 4)
 
@@ -218,7 +422,14 @@ as:   case   ace   breathing space   chase   commonplace
       resting place   space   trace (as a noun)
 ```
 
-Nothing worthwhile under `ash` or `ach`, so cross the line to `f`'s partner `v`, then that partner's companions:
+Pat's selection note on that column: "I didn't pick 'erase' because it is a
+transitive verb, needing to be completed by a direct object." — `erase my heart`
+— "It would be awkward in the rhyming position. Words like 'chase,' 'trace,' and
+'embrace,' even though as verbs they are transitive, can be nouns, so there is no
+problem picking them."
+
+"There is nothing worthwhile under 'ash' or 'ach.'" Time to cross the line to
+`f`'s partner `v`, then that partner's companions:
 
 ```text
 av:   behave   brave   cave   grave   shave   slave   wave
@@ -227,7 +438,18 @@ az:   blaze   craze   daze   haze   maze   phrase   paraphrase   praise
 aj:   age   cage   page   rage   stage
 ```
 
-Pat's comment on the `az` column: "The nice thing about a cliche word like 'daze' is that it may sound fresh again away from its usual connection to 'haze.' That is another strength of family rhyme. They surprise you. They do not make the usual connections."
+On the `av` column: "Again, I left out 'crave' and 'forgave' because they are
+transitive verbs. I left out 'gave' because it is bland."
+
+On the `az` column: "The nice thing about a cliché word like 'daze' is that it may
+sound fresh again away from its usual connection to 'haze.' That is another
+strength of family rhyme. They surprise you. They do not make the usual
+connections."
+
+On the `aj` column, a warning about secondary stress: "Words like 'lineage' are
+interesting. The secondary stress on the last syllable is a different sound.
+'Lineage' will not work as a family rhyme for 'safe.' But then, it won't work
+with 'age' either."
 
 A parallel feminine search on `travel` yields:
 
@@ -235,83 +457,165 @@ A parallel feminine search on `travel` yields:
 bashful   dazzle   wrathful   glass full (mosaic)   satchel   fragile
 ```
 
-Some columns offer few results; with others, "results come cascading in." Fricative rhymes usually at least quadruple your choices.
-
-Selection matters:
-
-- Avoid transitive verbs in rhyme position when they demand a direct object after the line break.
-- A noun use can rescue a word that would be awkward as a verb.
-- A cliche word can feel fresher when removed from its usual perfect-rhyme partner.
-- Words with secondary stress may not use the sound you expect; test the actual stressed vowel.
+"Some offer few results, while with others, results come cascading in. Usually,
+you at least quadruple your choices with fricative rhymes."
 
 ## Nasals
 
-Nasals send sound through the nose:
+"When you say a nasal, you make all the sound come out of your nose."
 
 ```text
 m   n   ng
 ```
 
-Nasals are voiced and only have companions. Mouth positions echo plosives:
+"Nasal mouth positions are like the plosive mouth positions, except that when you
+block the air, you send sound out of your nose rather than letting the pressure
+build to an explosion." Pat's plugged-nose demonstration:
 
-- plugged-nose `m` can become `b`,
-- plugged-nose `n` can become `d`,
-- plugged-nose `ng` can become `g`.
+<!-- spellchecker:off -->
+```text
+"My mommy misses me."          M turns into b.
+"No one notices Nanna."        N becomes d.
+"I sing songs that ring wrong."  Ng turns into g.
+```
+<!-- spellchecker:on -->
 
-Those plosive substitutions are not family-rhyme substitutes here; they become useful later.
+"Too bad you can't use these related plosives as rhyme substitutes. We will,
+however, see a use for this substitution in later chapters."
+
+"Nasals are voiced. They only have companions."
 
 Worked example: `home`
 
-- Perfect options include `catacomb`, `comb`, `hippodrome`, `honeycomb`, `Nome`.
-- Pattison resists predictable `roam`.
-- Nasal companion `n` opens `blown`, `bone`, `chaperone`, `cornerstone`, `gramophone`, `grown`, `throne`, `undertone`, `zone`.
-- Avoid commonplaces like `alone`, `phone`, and `own` unless the line earns them.
+```text
+home
+catacomb   comb   hippodrome   honeycomb   Nome
+```
 
-`Ng` has limited usefulness: it does not work with long vowels, works with short `o` as in `gone / wrong`, and works with short `u` as in `fun / rung`. When it helps, it helps a lot; most of the time it is no help.
+"I resisted 'roam' because it is an expected cliché (though it might sound fresh
+rhymed with 'alone')." Now the nasal companion `n`:
+
+```text
+on
+blown   bone   chaperone   cornerstone   Gramophone
+grown   throne   undertone   zone
+```
+
+"There is plenty to choose from here, depending on what you are writing about. No
+need for commonplaces like 'alone' 'phone' or 'own' with all this interesting
+material. Oddly, 'alone' is a cliché rhyme with 'home.' Even some sticklers for
+perfect rhyme use it, maybe without noticing."
+
+"You saw that ng does not work with long o. In fact, ng never works with long
+vowels and works with only two of the short ones:
+
+- short o as in 'gone/wrong'
+- short u as in 'fun/rung'
+
+Mostly, ng is no help. But when it does help, it helps a lot."
 
 ## Feminine Family Rhymes
 
-For feminine rhymes, work with the stressed syllable as if it were the only syllable, then search in the feminine section of the rhyming dictionary.
+"So far, we have worked with mostly masculine rhymes. But family rhymes are just
+as easy to find for feminine rhymes, and just as valuable. Remember, work with
+the stressed syllables in feminine rhymes. Treat them as if they were the only
+syllable there."
 
-Examples:
+`lonely` — "just look at the stressed syllable: `lone`. The consonant after the
+vowel, n, is a nasal. The substitute for n is m. So look under 'OM-li' in the
+feminine section. You will find: `homely`. Not a bad connection either."
 
-- `lonely` -> stressed `lone`; substitute `n` with nasal companion `m`; search for `O...M-li`; result: `homely`.
-- `table` -> stressed `tab`; substitute `b` with partner `p`; result: `maple`.
-- `table` -> substitute `b` with companion `d`; result: `ladle`.
+"You can find feminine family rhymes any time the stressed syllable ends in a
+plosive, fricative, or nasal. Just use the table as usual, then look in section
+two (the feminine section) of the rhyming dictionary."
 
-Feminine sections are often slim, so every additional possibility is valuable.
+`table` — "work with the accented syllable, 'tab.' B is a voiced plosive. First,
+use b's partner, p. Under 'AP'l' in the feminine section of the rhyming
+dictionary, you find `maple`. Move next to d, and under 'AD'l' you can find
+`ladle`. And so on."
 
-Mosaic options can also work:
+"The pickings are pretty slim in the feminine section, so any additional
+possibilities are like gold."
 
-- `homely / phone me`
-- `believer / please her`
+"Sometimes, you will be able to work with the feminine word's stressed syllable
+in the masculine section (especially when the unstressed syllable rhymes with a
+pronoun). You might get
 
-In informal tones, especially country and hip-hop, dropping final `g` from `-ing` can create mosaic possibilities:
+```text
+homely/phone me
+believer/please her
+```
 
-- `sailin' / tail him`
+As you can see, mosaic rhymes work just as well as family rhymes."
 
-Use the device only when the lyric's diction supports it.
+"A neat trick: If the tone of your lyric is informal, you might try dropping the
+g on feminine 'ing' words, like 'sailing.' Then you can create a mosaic rhyme
+with 'him.'
 
-Feminine family rhymes are strong substitutes for perfect rhymes because the unstressed syllable after the rhyme adds a whole extra syllable of identity.
+```text
+sailin'
+tail him
+```
+
+This trick works especially well in country and hip-hop, where g is dropped
+almost as a matter of principle."
+
+"Since there is so much identity after the rhyme at the stressed vowel (another
+whole syllable in fact), feminine family rhymes are strong substitutes for
+perfect rhymes."
 
 ## Multiple Final Consonants
 
-When a syllable ends in more than one consonant, search each consonant in turn or substitute both.
+Printed heading: "SYLLABLES ENDING IN MORE THAN ONE CONSONANT".
 
-Example target: `fast`
+"You can also use family rhyme techniques when a syllable ends in more than one
+consonant. Just look up family rhymes for each consonant in turn. Or, find
+substitutes for both. Try: `fast`"
 
-- Treat `-ed` after an unvoiced consonant as a `t` sound.
-- First replace the first consonant in the cluster: `ashed`, `bashed`, `cashed`, `clashed`, `crashed`, `dashed`, `flashed`, `lashed`, `splashed`, `thrashed`, `unlashed`.
-- Try `f + t`: `craft`, `draft`, `raft`, `shaft`, `autographed`, `gaffed`, `laughed`, `photographed`.
-- Try `ch + t`: `attached`, `dispatched`, `matched`, `scratched`, `snatched`.
-- Keep `s` and vary final `t`: `clasp`, `gasp`, `grasp`, `rasp`, `flask`, `mask`, `task`.
-- Voiced fricatives can voice the final `t` to `d`: `jazzed`, `razzed`.
+"If the first consonant is unvoiced, the following one will be unvoiced too. In:
+`ashed` ...the 'ed' sounds like t. Just look under 'ash + t.'"
 
-Choices stack quickly when there are two or more consonants after the vowel.
+```text
+ashed   bashed   cashed   clashed   crashed   dashed
+flashed   lashed   splashed   thrashed   unlashed
+```
+
+"A pretty amazing list." Now "f + t." (printed as `aft` / `af + ed`):
+
+```text
+craft   draft   raft   shaft
+autographed   gaffed   laughed   photographed
+```
+
+"Good results." Now "ch + t" (printed as `ach + ed`):
+
+```text
+attached   dispatched   matched   scratched   snatched
+```
+
+"Now look for family relations of t in 'fast,' keeping s."
+
+```text
+asp:  clasp   gasp   grasp   rasp
+ask:  flask   mask   task
+```
+
+"When you move to the voiced fricatives, the t sound becomes voiced as d."
+
+```text
+azd:    jazzed   razzed
+```
+
+"For 'fast,' the voiced fricatives turn out to be little help. Not that you
+needed any. Whenever a syllable has two or more consonants after the vowel, the
+choices stack up pretty fast."
 
 ## L And R
 
-`L` and `r` do not have useful family substitutes. Family rhyme still helps when `l` or `r` appears with another consonant that can be substituted.
+"You will find the preceding techniques especially useful when one of the
+consonants after the vowel is 'l' or 'r.' Neither 'l' nor 'r' has a useful family
+substitute. But when either one appears with a consonant that has family
+relationships, your rhyme search is easier."
 
 Example: `hurt` (*Essential Guide to Rhyming* (2014), Chapter 4)
 
@@ -324,7 +628,9 @@ urb:      curb   suburb
 urg:      iceberg
 ```
 
-Many perfect rhymes for `hurt` are transitive verbs, which limits options. Pat flags the payoff of the `d` substitution: "Good news! You can use the past-tense verbs of 'ur.'"
+"Many perfect rhymes for 'hurt' are transitive verbs. That limits your options."
+Pat flags the payoff of the `d` substitution: "(Good news! You can use the
+past-tense verbs of 'ur.')"
 
 Example: `help` (*Essential Guide to Rhyming* (2014), Chapter 4)
 
@@ -336,9 +642,9 @@ eld:  unparalleled   weld
 elt:  felt   heartfelt   melt
 ```
 
-The same "past-tense verbs of 'el'" bonus applies. Nothing turns up anywhere else.
-
-Even when the expansion is modest, it may rescue a word that has no usable perfect rhyme.
+The same bonus applies — "(Good news! You can use the past-tense verbs of 'el.')"
+— and then: "Nothing anywhere else. But the expansion is not bad, considering you
+had nothing at all for 'help.'"
 
 ## Friendly Relatives - Additive / Subtractive
 
@@ -748,6 +1054,9 @@ Pat's summary of the remote types: assonance, consonance, and partial rhyme are 
 
 ### Coaching Prompts For Remote Rhyme
 
+Synthesis, not a printed list — Chapter 6 prints no such sequence. Use as
+coaching scaffolding only; do not attribute to Pat.
+
 When coaching a writer through kissin' cousins:
 
 1. Ask whether the spot should close, stay open, or partly close.
@@ -763,13 +1072,15 @@ When coaching a writer through kissin' cousins:
 
 Use these as future coaching prompts:
 
-- Exercise 4.1: Find related perfect rhymes for `league`, then family rhymes from closer phonetic relationships to farther away.
-- Exercise 4.2: Find related perfect rhymes for `touch`, then family rhymes from closer to farther.
-- Exercise 4.3: Find related rhymes for `won`, then family rhymes from closer to farther.
-- Exercise 4.4: Find perfect rhymes for `taking`, then family rhymes from closest to farther away.
-- Exercise 4.5: Find related perfect rhymes for `drunk`, then family rhymes from closer to farther.
-- Exercise 4.6: Find related perfect rhymes for `heart`, then family rhymes by substituting for `t`.
-- Exercise 4.7: Find related perfect rhymes for `yourself`, then family rhymes by substituting for `f`.
+Chapter 4's seven exercises, with their printed titles and wording:
+
+- **EXERCISE 4.1. Family Rhyme** — "Using your rhyming dictionary, find related perfect rhymes for 'league.' Then find family rhymes, working from closer phonetic relationships to further away."
+- **EXERCISE 4.2. Perfect Rhymes and Family Rhymes** — "Using your rhyming dictionary, find related perfect rhymes for 'touch.' Then find family rhymes, working from closer phonetic relationships to further away."
+- **EXERCISE 4.3. Rhymes for "Won"** — "Using your dictionary, find related rhymes for 'won.' Then find family rhymes, working from closer phonetic relationships to those further away."
+- **EXERCISE 4.4. Rhyming "Taking"** — "Using your rhyming dictionary, find perfect rhymes for 'taking.' Then find family rhymes, working from the closest relationship to those further away."
+- **EXERCISE 4.5 Rhyming "Drunk"** — "Using your rhyming dictionary, find related perfect rhymes for 'drunk.' Then find family rhymes, working from closer phonetic relationships to those further away." (printed with no period after "4.5")
+- **EXERCISE 4.6. Rhyming "Heart"** — "Find related perfect rhymes for 'heart.' Then find family rhymes, substituting for 't,' working from closer phonetic relationships to those further away."
+- **EXERCISE 4.7. Rhyming "Yourself"** — "Find related perfect rhymes for 'yourself.' Then find family rhymes, substituting 'f,' working from closer phonetic relationships to those further away."
 - Exercise 5.1: Find related perfect rhymes for `goodbye`, then additive rhymes from voiced plosives to unvoiced plosives to unvoiced fricatives.
 - Exercise 5.2: Find related perfect rhymes for `stone`, then additive rhymes from unvoiced plosives to voiced plosives to unvoiced fricatives.
 - Exercise 5.3: Find related perfect rhymes and family rhymes for `hush`; watch for family additive rhymes, especially plosive additions and inside-the-word additions.
@@ -780,6 +1091,14 @@ Use these as future coaching prompts:
 - Exercise 6.4: For `love`, `serving`, `return`, `play`, `hinting`, `farthing`, `fetch`, `pullet`, `ring`, and `fortune`, find three related partial rhymes using any rhyme type.
 
 ## Coaching Workflow
+
+Chapter 4's own closing instruction: "Family rhyme will help you use your rhyming
+positions effectively. By combining it with perfect rhyme on your worksheet, you
+can make rhyme your friend forever."
+
+The steps below are a synthesis across Chapters 4-6, not a printed list. Steps
+1-5 and 14 restate Chapter 4's search order and worksheet advice; the rest
+generalizes the later chapters' techniques into one sequence.
 
 When coaching family, additive, subtractive, assonance, consonance, and partial rhyme:
 
@@ -871,58 +1190,54 @@ and a perfect rhyme would over-close, partial rhyme. If only the
 stressed half matters, use family or additive rhyme on the
 masculine half alone.
 
-## Stopping rules — when to end a rhyme search
+## Generate wide, then shortlist
 
-A pragmatic discipline. A rhyme worksheet can grow indefinitely if
-the writer keeps adding candidates. Stopping rules:
+Chapter 4's own discipline is not a stopping rule but a two-pass one: run the
+whole family search, then cut. After the `rut` search Pat writes, of the roughly
+five-times-larger field, "Not all great, but then the five choices offered by
+perfect rhyme could be better too. Here are the ones I would actually consider
+using" — and prints a shortlist roughly half the size of the full search. Counted
+off his own summary table on that page: 25 family words (`ud` 4, `uk` 6, `up` 3,
+`ub` 5, `ug` 7) plus 6 perfect rhymes, cut to 13 family words plus `rut` and
+`shut`.
 
-1. **Sufficient candidates per slot.** Stop searching when 3-5
-   usable candidates exist for the rhyme position (more for hook
-   positions, fewer for incidental).
-2. **Diminishing image quality.** Stop when the next candidate is
-   visibly weaker than the candidates already in hand. The next
-   weaker family or cousin rhyme will not rescue the section.
-3. **Family-to-cousin transition.** When family-rhyme candidates
-   stop appearing and only assonance/consonance candidates remain,
-   pause to check whether the line wants that much instability.
-   If yes, continue; if no, stop.
-4. **The line's idea has narrowed.** When the candidate list
-   reveals that only one or two words actually fit the idea, stop.
-   The worksheet has done its job.
-5. **The clock.** Worksheet sessions over 30 minutes for a single
-   slot usually start producing worse candidates, not better.
-   Save the worksheet, take a break, return fresh.
+The filters he applies by name in Chapter 4, each shown at work in the `safe`
+and `home` searches:
 
-> "Never stop listening." — Pat (*Essential Guide to Rhyming* (2014), Chapter 5)
+- **transitive verbs** that need a direct object after the line break ("erase,"
+  "crave," "forgave") are skipped; the same word kept as a noun is fine ("chase,"
+  "trace," "embrace");
+- **bland** words are skipped ("I left out 'gave' because it is bland");
+- **expected clichés** are resisted ("I resisted 'roam'"; "No need for
+  commonplaces like 'alone' 'phone' or 'own'");
+- **secondary stress** disqualifies words whose stressed vowel is not the one you
+  think ("lineage");
+- and everything survives or dies by ear: "Sing them."
 
-The listening rule applies inside the search, not as a license to
-search forever. Sing every candidate; stop when the song's needs
-are met.
+> "Your ear will tell you fast enough. Never stop listening." —
+> *Essential Guide to Rhyming* (2014), Chapter 4
 
 ## Stability is a design tool — Barber anchor
 
-*Essential Guide to Rhyming* (2014), Chapter 4's argument against forced full resolution. Pat cites
-Samuel Barber's *Adagio for Strings* as a case where resolution is
-withheld; the piece succeeds *because* it does not close. The
-musical example is not Pat's invention — it is a teaching anchor
-for the principle that resolution is a craft choice, not a virtue.
+*Essential Guide to Rhyming* (2014), Chapter 4's argument against forced full
+resolution. The Barber sentence is quoted verbatim in "Why Rhyme Type Matters"
+above; the point Pat makes with it is narrow and exact — the *ending of a
+section* is where subtlety lives, and a rule forcing the tonic there would
+evaporate "all the heartbreaking longing at the end of Samuel Barber's 'Adagio
+for Strings.'"
 
 The lesson:
 
 - Treat full resolution as one option among the stability scale,
   not as the default.
 - Withhold closure when the emotion is incomplete.
-- Use family, additive/subtractive, assonance, consonance, partial,
+- Use family, additive/subtractive, assonance, consonance, and partial
   rhymes as deliberate stability moves.
 
-The phrase Pat returns to:
-
-> "A description, not an accolade." — Pat (*Essential Guide to Rhyming* (2014), Chapter 4 on "perfect"
-> as a rhyme label)
-
-Calling a rhyme "perfect" describes its full-resolution character.
-It does not declare the rhyme good or bad. Imperfect rhymes are
-good when the line wants instability.
+Calling a rhyme "perfect" describes its full-resolution character. It does not
+declare the rhyme good or bad — Pat's whole reason for preferring "fully resolved
+rhyme" is that the label should be "a description, not an accolade." Imperfect
+rhymes are good when the line wants instability.
 
 ## Craft prepares creativity — Tiger Woods anchor
 
@@ -948,60 +1263,48 @@ The discipline:
 
 Pat's three-step paraphrase: isolate, understand, compose.
 
-## The piano walk-through (*Writing Better Lyrics* (2009), Chapter 4)
+## The chord analogy — two sources, no slot-by-slot mapping
 
-Pat's distinctive teaching demonstration for the stability scale: the same
-chord, played with different bass notes, mapping each voicing to a rhyme
-type. The demonstration is instrumental — the writer hears the resolution
-decrease in real time.
+*Essential Guide to Rhyming* (2014), Chapter 4 makes the analogy in the negative:
+"Like chords in a song, rhymes can have varying degrees of stability." A rule
+forcing every section onto a root-position tonic with the melody on the tonic
+would cost the music "wonderful subtlety and expressiveness, longing, and moments
+of ambivalence" — see the Barber passage in "Why Rhyme Type Matters" above.
 
-The walk:
+*Writing Better Lyrics* (2009), Chapter 4 runs a piano demonstration under the
+heading "Rhymes and Chords": a IV–V7–I cadence played five times, singing a C
+each time, with the tonic chord revoiced further from root position on each pass
+(C in the bass; then G in the bass; then E in the bass; then E in the bass with
+the C removed from the right hand; then E minor, adding a B and still leaving the
+C out — "only a suggestion of home, rather than sitting down to the supper
+table"). Pat's conclusion there: "All of these voicings are useful, and all of
+these voicings are tonic (home) functions... Rhymes work the same way."
 
-1. **C major in root position** — C in the bass, full closure. This is
-   **perfect / fully resolved rhyme** — the strongest possible landing.
-2. **C/G** (G in bass, C major chord) — the chord is still C major but
-   the bass shift opens it. The resolution feels slightly less complete.
-   This is **family rhyme** — same chord identity, softened landing.
-3. **C/E** (E in bass) — the bass note destabilizes further. The chord
-   is C major but the ear questions home. This is **additive /
-   subtractive rhyme** — the rhyme position is preserved but post-vowel
-   territory shifts.
-4. **C major chord without C in the melody at all** — the chord is
-   suggested, not declared. This is **assonance rhyme** — vowel match,
-   consonant openness.
-5. **Arriving at E minor as "only a suggestion of home"** — the chord
-   identity has slipped. The ear knows where home is but the music
-   refuses to land there. This is **consonance rhyme** — consonants
-   match while vowels diverge.
-
-The walk teaches that rhyme-type choice IS an emotional / compositional
-decision, equivalent to a chord voicing decision. Listeners feel the
-stability differential even if they cannot name it.
-
-Use when coaching a writer who picks rhyme type by convenience rather
-than by emotional intent. The piano walk makes the differential visceral.
+**Caution.** Neither book maps a specific voicing onto a specific rhyme type. The
+analogy is a graded-stability one: voicings run from landing solidly to
+"wanderlust," and rhyme types run from most to least stable. Do not present a
+one-to-one voicing → rhyme-type correspondence as Pat's.
 
 ## Partners and companions — why the inversion
 
 Pat's family-rhyme rule has an inversion that confuses new readers: for
 plosives, partners (same mouth position) are closer than companions (same
-voicing); for fricatives, companions are closer than partners. The
-physiological reason:
+voicing); for fricatives, companions are closer than partners.
 
-- **Plosives** (b/d/g/p/t/k) are **momentary** sounds. The lips and
-  tongue hit a position and release. With such short duration, voicing
-  is **hard to hear**; the mouth position is what the ear catches.
-  Therefore: same mouth position = closer relationship.
-- **Fricatives** (v/f/TH/th/z/s/zh/sh/j/ch) have **duration** — the
-  sound sustains while air flows. Voicing is **clearly audible** over
-  the sustained airflow. The mouth positions are also already close
-  together within each family. Therefore: same voicing = closer
-  relationship.
-- **Nasals** (m/n/ng) are all voiced — no voicing distinction; companions
-  only.
+Pat gives the reason only on the fricative side, and it is the whole explanation:
 
-This inversion isn't arbitrary — it falls out of how the sounds physically
-exist in the mouth + ear.
+> "The opposite was true for plosives. Fricatives take longer to say than
+> plosives, so you hear the unvoiced or voiced sound more clearly. Also,
+> fricatives are closer together in your mouth than plosives. All the fricatives
+> come from the area in your mouth between b and d."
+
+So for plosives — which the chapter describes as "Just a little explosion. It
+happens very fast" — the shared *position* is the audible relationship, and
+partners come first. For fricatives the sound sustains, so shared *voicing*
+becomes audible and companions come first.
+
+Nasals (m/n/ng) are all voiced, so there is no voicing distinction: "Nasals are
+voiced. They only have companions."
 
 ## Weak-syllable rhyme — source citation
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-types.md
@@ -1241,27 +1241,55 @@ rhymes are good when the line wants instability.
 
 ## Craft prepares creativity — Tiger Woods anchor
 
-*Essential Guide to Rhyming* (2014), Chapter 9 frames the entire rhyme-stability scale through the
-craft-vs-creativity question. Pat uses a Tiger Woods analogy
-(paraphrased): a golfer who knows every shot in the bag has more
-creative options on the course than one who only knows the driver.
+*Essential Guide to Rhyming* (2014), Chapter 9 ("Craft and Rhyme Types")
+frames the entire rhyme-stability scale through the craft-vs-creativity
+question. It opens on Tiger Woods, verbatim:
 
-> "All craft. All technique. Craft prepares him to be immensely creative
-> with his shots." — Pat, on Tiger Woods (*Essential Guide to Rhyming*
-> (2014), Chapter 9)
+> Why bother learning craft? Why do we have to pay attention to all this
+> stuff on rhyme types and sonics? Shouldn't the writing process just be
+> simple and organic—just letting things flow naturally? Ask Tiger Woods,
+> who works daily on his craft: focusing on the technical aspects of his
+> swing, learning different kinds of grasses and how they affect the
+> clubhead at impact, how to read the treetops for wind direction, how to
+> fade or draw a ball using modified grips and stances. All craft. All
+> technique. Craft prepares him to be immensely creative with his
+> shots—hitting a high fade over the trees against the wind to land
+> softly near the flag. Creativity indeed, but built on a platform of
+> craft.
+>
+> Why should songwriting be any different?
 
-The lesson for rhyme: knowing all six rhyme types (perfect, family,
-additive/subtractive, assonance, consonance, partial) multiplies a
-writer's options at every rhyme position. Creativity without craft
-tries to wing it from one tool; creativity with craft chooses from six.
+Pat's own next move is the "bag" image again — the rhyme types are the
+clubs:
 
-The discipline:
+> Let's look at rhyme types and the emotion they can create when you bring
+> them (along with your brain) to the writing table, where your heart has
+> been struggling, all by itself, to get over the trees against the wind
+> to the green. We'll look, as usual, through the lens of prosody: mutual
+> support of your intention with all the elements in your bag, your craft.
 
-1. Isolate one rhyme type.
-2. Practice it until the search runs without thought.
-3. Compose with all types available.
+And the working method he states for the chapter, ending in the three
+words this section used to paraphrase as a numbered drill:
 
-Pat's three-step paraphrase: isolate, understand, compose.
+> Here, however, we'll look only at the rhymes themselves so we can
+> isolate their motion; understand what they do within the more
+> complicated motions created in combination with the other elements.
+> Isolate, understand, compose.
+
+An earlier revision of this file glossed that as a three-step practice
+drill — "Isolate one rhyme type / Practice it until the search runs
+without thought / Compose with all types available" — which is not what
+Pat says. His "understand" is not *drill one type until it is automatic*;
+it is understanding what the rhymes do **in combination with the other
+elements**, which is the sentence's whole point. The three words are his;
+the drill was not.
+
+On counting: Pat never prints a number here. The printed scale heads five
+columns (see "Stability Scale" above), Chapter 6 adds partial rhyme and
+weak-syllable rhyme, and weak-syllable gets nothing but its name — so the
+six fully documented tiers are the ones this file works with, for the
+reasons set out under "Weak-syllable rhyme — source citation" below. Cite
+that reasoning rather than presenting "six" as Pat's count.
 
 ## The chord analogy — two sources, no slot-by-slot mapping
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
@@ -38,7 +38,7 @@ Chapter 3 opens with the friend-finding analogy in Pat's own words:
 
 The whole method is three steps:
 
-> The trick is to look for rhymes before you start to write. It is not as hard
+> The trick is to look for rhymes *before* you start to write. It is not as hard
 > as it sounds.
 >
 > 1. Focus your lyric idea as clearly as you can.
@@ -48,7 +48,9 @@ The whole method is three steps:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 3
 
-The chapter's running example is the couplet Pat returns to in Chapter 7:
+Pat does not introduce a fresh example to run the method on. He writes, verbatim,
+"Start with our old idea." — the couplet already in play from earlier in the book,
+and the one he returns to in Chapter 7:
 
 ```text
 I'm sick of all this risky business
@@ -61,13 +63,12 @@ A rhyme worksheet is not a finished lyric, a rhyme dump, or a display of clever
 language. It is a map of possible spotlight words and idea-connected rhyme
 families.
 
-It helps the writer:
-
-- Find words that fit the lyric idea before line endings are locked.
-- Avoid choosing target words with weak rhyme potential.
-- Discover new story, metaphor, or emotional directions from rhyme families.
-- Keep cliches, identities, and awkward grammar out of important positions.
-- Enter drafting with more than one route through the lyric.
+Pat's page 24 summary makes four claims for it, and he ranks them: no dead ends
+("keep from boxing yourself into a corner"), net time saved despite the up-front
+cost, higher quality, and — "more importantly" — rhyme positions that
+"communicate ideas effectively." The last is the one the whole procedure exists
+for. The summary is quoted in full under
+[English is rhyme-poor](#english-is-rhyme-poor).
 
 Skill behavior: when a user asks for rhymes, first decide whether they need a
 single rhyme answer or a worksheet. If they are drafting a song section, a
@@ -97,7 +98,10 @@ And Pat's own idea sketch for "Risky Business," verbatim:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 3
 
-Useful focus questions (expanded from Pat's four for skill use):
+Pat prints six questions, in that order: "What does your lyric say? What could it
+say? Is it a lyric about the dangers of dating good-looking men/women? The risk I
+take being with you? Why? Is 'you' a flirt?" Further focus questions, not in the
+book, added here for skill use:
 
 - Who is speaking?
 - Who is being addressed?
@@ -154,16 +158,15 @@ And the selection rule, verbatim:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 3
 
-Seed-word categories (skill expansion of Pat's rule):
+Note what the two selection constraints are and are not. They are phonetic —
+mostly masculine, different vowel sounds — not thematic. The theme is already
+handled by where the words come from: "Let the list come from your idea sketch."
+Every one of Pat's eleven is lifted from his own sketch on page 20.
 
-- Title words.
-- Emotional words.
-- Action words.
-- Relationship words.
-- Conflict words.
-- Concrete images.
-- Words that imply the section's turn.
-- Words with promising vowel variety.
+"Mostly masculine" is exact rather than loose: ten of the eleven are masculine,
+and `attention` is the one feminine word on the sheet. For the second rule Pat
+gives the instruction and no rationale — "Pick words with different vowel
+sounds." — so take it as stated.
 
 Do not treat the seed list as final. It is only a list of words to test.
 
@@ -172,13 +175,14 @@ Do not treat the seed list as final. It is only a list of words to test.
 Exercise 3.2 makes the title part of the worksheet habit. Pat's instruction:
 "Make it a habit to include each important word from the title in your list."
 
-Why:
+He does not say why. Two things elsewhere in the chapter do. Comment 6 records
+what happens when the running example's own keywords are tested: "business" —
+half the title "risky business" — and "safe" both get eliminated "because they
+don't yield many rhymes." And Exercise 3.3 adds the parenthetical "(If you use my
+title, be sure not to put it in a rhyming position.)"
 
-- Title words are likely to become spotlight words.
-- They may need to be protected from weak rhyme positions.
-- Their rhyme families can suggest better title placement.
-- A title word may have poor rhyme potential, warning the writer not to force
-  it into an end rhyme.
+So testing a title word is not a way of guaranteeing it a line-ending. It is a
+way of finding out early whether it can hold one at all.
 
 Skill behavior: when a user gives a title, split it into important words and
 test each one as a seed.
@@ -193,7 +197,9 @@ Pat's step 3, verbatim:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 3
 
-Active search means:
+"Look actively" is Pat's phrase from step 2. Each of the following is a move he
+either instructs on page 20 or performs in his seven comments on page 23,
+generalised into an instruction:
 
 - Add a better seed word if the search reveals one.
 - Remove a seed word that has poor promise.
@@ -211,22 +217,22 @@ worksheet is a thinking tool, not a compliance form.
 
 After the raw search, filter the list by function. Reject or mark:
 
-- Transitive verbs that need an object and therefore land awkwardly at the end
-  of a line.
-- Cliche pairs that make the listener predict the next word.
-- Identities that repeat too much of the target sound.
-- Words that technically rhyme but do not fit the song's relationship,
-  setting, or tone.
-- Words that produce comic energy in a serious section.
-- Words whose grammar would force the line into an unnatural syntax.
+Chapter 3 rejects on three grounds, each of which Pat performs rather than states:
 
-Keep:
+- Transitive verbs, which "are awkward in the rhyming position" — comment 1,
+  where he drops "desert."
+- Clichés — comment 2, where he drops "romance" and "trance," and the
+  `(Cliché?)` mark he leaves on `dance`.
+- Identities — not discussed in this chapter, only marked, six times, on the
+  sheet itself.
 
-- Words that fit the idea.
-- Words that deepen the emotional situation.
-- Words that open a new but related story path.
-- Words with useful stress and phrase-end behavior.
-- Words that can carry spotlight attention.
+Two further grounds are worth applying but come from elsewhere in the corpus, not
+from Chapter 3: words that technically rhyme but do not fit the song's
+relationship, setting, or tone, and words whose grammar would force the line into
+an unnatural syntax.
+
+The keep-rule is one sentence, and it is the whole test: "Write down only rhyme
+words that fit with your idea." Pat states no second criterion.
 
 ## Change the seed if needed
 
@@ -235,14 +241,15 @@ because the new form generates more useful rhymes. This is not cheating. It is
 craft. Pat does it on the page: seed 1 enters the box as `scared` and leaves the
 search as `scare`.
 
-Examples of acceptable changes:
+His reasoning, verbatim, is comment 3: "I changed 'scared' to 'scare' because it
+had better rhymes. 'Scare' is usually a transitive verb, though it could be used
+as a noun. It might not be much use itself, but I like the rhyme list it
+generates."
 
-- Change tense.
-- Change noun to verb or verb to noun.
-- Replace an adjective with a noun from the same field.
-- Replace a weak title-adjacent word with a stronger synonym.
-- Move a poor-rhyming word out of the rhyme position and let a related word
-  carry the end.
+Two things there are worth copying. The swap is licensed purely by yield — better
+rhymes — not by the new word being a better lyric word. And Pat keeps the seed
+even after admitting it "might not be much use itself," because the seed's job is
+to generate a column, not to appear in the song.
 
 Skill behavior: when the target word has poor rhyme potential, offer a
 "nearby seed" option rather than only giving weak rhymes.
@@ -252,13 +259,9 @@ Skill behavior: when the target word has poor rhyme potential, offer a
 Some words should not be put into rhyme positions even if they matter to the
 song. A word can be central to the idea and still be a poor end-rhyme target.
 
-Drop or protect a seed when:
-
-- It yields too few useful rhymes.
-- Its best rhymes are off-tone.
-- Its rhymes are all cliches.
-- Its sound family forces the section toward comedy.
-- It tempts the writer toward awkward grammar.
+Chapter 3 gives exactly one criterion for dropping a seed, and it is quantitative:
+the word doesn't yield many rhymes. Nothing about tone, register, or comedy enters
+into it at this stage.
 
 Pat's own case: `risk` produces almost nothing ("disc… (oops!)"), and he leaves
 `safe` and `business` off the Chapter 3 list entirely because they "don't yield
@@ -294,11 +297,41 @@ Exercise wording, verbatim:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 3
 
+"The sheet below" is a printed blank form filling the rest of page 21: the eleven
+seeds spread as headings across three columns with room to write under each, and
+the ruled seed box reproduced again in the middle of the page so the writer can
+see the whole list while filling in any one column.
+
+```text
+1. scared           5. left out             8. dull
+
+                    ┌──────────────┐
+2. afraid           │  1. scared   │        9. leave
+                    │  2. afraid   │
+                    │  3. flirt    │
+                    │  4. attention│
+                    │  5. left out │
+                    │  6. risk     │
+                    │  7. chance   │
+                    │  8. dull     │
+                    │  9. leave    │
+                    │ 10. ignored  │
+                    │ 11. gone     │
+                    └──────────────┘
+
+3. flirt            6. risk                 10. ignored
+
+
+4. attention        7. chance               11. gone
+```
+
 ### Pattison's completed Chapter 3 worksheet
 
 "Here is my result:" — Pat's own filled-in sheet, verbatim, three columns across
 the page with the boxed seed list sitting in the middle. Marks in parentheses are
-his.
+his. One typographic detail the plain-text block cannot carry: in `look out
+(Identity)` the printed page sets `out` alone in italic. `knockout (Identity)` on
+the line above it is entirely roman. Pat gives no reason for the difference.
 
 <!-- book worksheet word lists trip the spell-checker --><!-- spellchecker:off -->
 
@@ -361,10 +394,10 @@ Verbatim, numbered as printed:
 > 4. The only chance "risk" has is to "slip a disc." I can't think of a good use
 >    for "compact disc."
 > 5. "Ignored" didn't appear under "ORD," where I thought it should. But at the
->    end of the column, I saw "adored, etc." which referred me to OR. The
->    reference means to look at the OR column and add D whenever you can. The
+>    end of the column, I saw "adored, etc." which referred me to *OR*. The
+>    reference means to look at the *OR* column and add *D* whenever you can. The
 >    Wood book uses this shorthand to avoid unnecessary duplication. So, I went
->    to the OR column and added D. I like the list.
+>    to the *OR* column and added *D*. I like the list.
 > 6. I left "safe" and "business" out of the list. If I had been starting from
 >    scratch, I would have tried them, but then eliminated them because they
 >    don't yield many rhymes.
@@ -380,12 +413,16 @@ the reason for the whole procedure (7).
 
 For skill use, the output should show both candidates and labels:
 
-```text
-seed: ignored
-useful: adored, bored, restored
-watch: identity risk with same ending family
-idea paths: neglect, craving attention, repair after neglect
-```
+Pat labels candidates on the sheet itself rather than in a separate note, and he
+uses exactly two marks in Chapter 3. Copy those two rather than inventing a
+vocabulary:
+
+- `(Identity)` on `left out / knockout`, `left out / look out`, and on
+  `attention / detention`, `intention`, `pretention`, `tension`.
+- `(Cliché?)` — with the question mark — on `chance / dance`.
+
+He also writes a dead seed down instead of deleting it: `risk` gets `disc…`
+followed by `(oops!)`.
 
 The label is as important as the candidate. It teaches the writer to judge the
 word, not just collect it.

--- a/plugins/songwriting/context/pat-pattison/research/section-building.md
+++ b/plugins/songwriting/context/pat-pattison/research/section-building.md
@@ -1,168 +1,428 @@
 # Section Building
 
-Pat Pattison - *Songwriting: Essential Guide to Lyric Form and Structure* (1991), Chapter 5.
+Pat Pattison — *Essential Guide to Lyric Form and Structure* (1991), Chapter 5,
+the "BUILDING SECTIONS" half of the chapter. Everything below is Pat's printed
+text and his figures, transcribed.
 
 ## Core idea
 
-Section function comes from structure, not topic. A verse, chorus, bridge, or
-transitional bridge is created by how phrase count, phrase length, rhythm, and
-rhyme behave in context.
-
-> "Juggle juggle."
+Section function comes from structure, not topic — which is why Pat runs one
+verse, "Love me like a candy bar," through five structural variants instead of
+five different lyrics. His two governing sentences are quoted in place below.
 
 Use this file with [form](form.md), [phrasing](phrasing.md),
 [meter](meter.md), and [rhyme strategy](rhyme-strategy.md).
 
-## The starting section
+## The starting section — BUILDING SECTIONS
 
-Pattison reworks a deliberately simple section to show that one piece of
-content can become different section types when its structure changes.
+> By the time you finish this chapter, you will have a better sense of how to
+> build the most typical lyric sections. You will also be very tired of candy
+> bars. I used the same verse again and again to show that it is structure, not
+> content, that makes a section what it is.
 
-Neutral balanced base:
-
-```text
-4 phrases
-balanced phrase count
-constant pace
-through-written flow
-closed
-expected closure
-```
-
-That base could work as a verse or chorus depending on its relation to the
-surrounding sections. To change the job, change one structural variable at a
-time.
-
-## Juggle phrase count
-
-Adding a phrase without a rhyme creates a five-phrase variant:
+> In general, balance or symmetry stop motion, while imbalance or asymmetry push
+> forward. This is balanced:
 
 ```text
-base:     4 phrases, balanced
-variant: 5 phrases, added unrhymed phrase before closure
-effect:  asymmetrical, decelerated, still closed
-use:     verse variation, especially a second verse
+Love me like a candy bar
+Sugar, try my flavor
+Let me be your chocolate star
+Layer after layer
 ```
 
-This might be a bridge only if it contrasts immediately. If the first phrases
-sound too much like the verse, the listener will not feel release until too
-late.
+> Here is its description:
 
-Adding rhymed phrases creates a different effect:
+Figure `image_rsrc32H`, transcribed:
 
 ```text
-effect: accelerated by rhyme, fragmented near the end,
-        unexpected rhyme closure
-use:    verse or possible bridge; probably too unbalanced for a chorus
+BALANCE:   _x_ SYMMETRICAL      ___ ASYMMETRICAL
+PACE:      _x_ CONSTANT         ___ ACCELERATED     ___ DECELERATED
+FLOW:      _x_ THROUGH-WRITTEN  ___ FRAGMENTED
+CLOSURE:   _x_ CLOSED           ___ OPEN
+C. TYPE:   _x_ EXPECTED         ___ UNEXPECTED      ___ DECEPTIVE
 ```
 
-The structure may force an abnormal bar count unless phrase lengths are also
-shortened.
+> This structure would work well as either a Verse or a Chorus, though as a
+> verse it could also be a little more unbalanced. Time to get practical.
+> Remember these?
+>
+> 1. Number of phrases
+> 2. Length of phrases
+> 3. Rhythm of phrases
+> 4. Rhyme scheme
+>
+> We will use each one to juggle the candy bar verse. Our goal is to make
+> different kinds of lyric sections.
 
-## Juggle phrase length
+## 1. Number of phrases
 
-Lengthening the last phrase creates deceptive closure and spotlights the end.
-That can work as a verse, bridge, or chorus if the spotlighted phrase carries
-the central idea.
-
-For chorus use, repeating the title phrase can create both rhythmic deception
-and rhyme deception:
+> First, number of phrases. We can unbalance the structure by adding a phrase
+> without a rhyme:
 
 ```text
-opening title phrase
-supporting phrases
-closing title phrase
-effect: strong central-idea spotlight
+#1A. Love me like a candy bar
+     Sugar, try my flavor
+     Let me be your chocolate star
+     Smooth and rich and sweet
+     Layer after layer
 ```
 
-Rule: do not spotlight filler. Structural surprise magnifies whatever sits in
-the surprise position.
-
-## Juggle rhythm
-
-Rhythmic change can close and still push forward. In the chapter's rhythm
-variant, the last phrase moves toward triples and withholds the expected duple
-resolution.
+Figure `image_rsrc32J`, transcribed:
 
 ```text
-verse ending: withhold expected duple resolution
-next section: title arrives in resolving duple figure
+BALANCE:   ___ SYMMETRICAL      _x_ ASYMMETRICAL
+PACE:      ___ CONSTANT         ___ ACCELERATED     _x_ DECELERATED
+FLOW:      _x_ THROUGH-WRITTEN  ___ FRAGMENTED
+CLOSURE:   _x_ CLOSED           ___ OPEN
+C. TYPE:   _x_ EXPECTED         ___ UNEXPECTED      ___ DECEPTIVE
 ```
 
-Worked example: Pattison points to "Can't Fight This Feeling." Verse 2 and the
-transitional bridge delay the expected five-stress duple phrase; the chorus
-finally delivers it with the title.
-
-Use rhythmic withholding when the next section should feel like the place where
-the missing pattern arrives.
-
-## Juggle rhyme scheme
-
-Changing rhyme can create deceptive closure even when phrase count and rhythm
-remain comparatively balanced.
+> Now use added phrases that rhyme:
 
 ```text
-expected closing sound: earlier rhyme group
-actual closing sound:   different repeated or title-bearing sound
-effect: spotlight on last stress
+#1B Love me like a candy bar
+    Sugar, try my flavor
+    Let me be your chocolate crunch
+    Let me be your honey brunch
+    Layer after layer
 ```
 
-As with phrase length, a chorus version works better when the final spotlight
-lands on the title or central idea.
+Figure `image_rsrc32K`, transcribed:
+
+```text
+BALANCE:   ___ SYMMETRICAL      _x_ ASYMMETRICAL
+PACE:      ___ CONSTANT         _x_ ACCELERATED     ___ DECELERATED
+FLOW:      ___ THROUGH-WRITTEN  _x_ FRAGMENTED
+CLOSURE:   _x_ CLOSED           ___ OPEN
+C. TYPE:   ___ EXPECTED         _x_ UNEXPECTED      ___ DECEPTIVE
+```
+
+Pat's judgment on the altered sections as a group:
+
+> Each of these altered sections keeps its identity as an independent section,
+> but the unbalancing also leaves them hanging a little. It creates a tension
+> that could be resolved by reaching a more balanced section.
+
+Then, on #1A:
+
+> #1A might be a Verse. It closes the way you expect it to, but the added phrase
+> puts space between rhymes, slowing the section down. It delays closure like
+> Verse 2 of "CAN'T FIGHT THIS FEELING," so 1A might also a be good verse 2.
+
+(That sentence is as printed. Do not "fix" it.)
+
+Figure `image_rsrc32P` sets #1A inside a Song System, transcribed:
+
+```text
+     Melt me down like butterscotch          VERSE
+     Sweet as golden honey
+     Cherries dipped in creamy fudge
+     Chocolate Easter Bunny
+
+#1A  Love me like a candy bar                VERSE
+     Sugar, try my flavor
+     Let me be your chocolate star
+     Smooth and rich and sweet
+     Layer after layer
+
+        OH HENRY, I'll be Forever Yours,     CHORUS
+        'Till Mars deserts the Milky Way
+        and kids desert the candy stores
+        OH HENRY, I've lost my self control
+        Get ready for a Marathon
+        Make your Tootsie Roll
+```
+
+Pat then asks whether #1A could be a Bridge and answers no — the quote and
+EXERCISE 29 are preserved once, in [bridge](bridge.md). Figure `image_rsrc32R`
+is the Song System he means, with #1A moved to the bridge slot:
+
+```text
+Song System   Melt me down like butterscotch          VERSE
+              Sweet as golden honey
+              Cherries dipped in creamy fudge
+              Chocolate Easter Bunny
+
+                 OH HENRY, I'll be Forever Yours,     CHORUS
+                 Till Mars deserts the Milky Way
+                 and kids desert the candy stores
+                 OH HENRY, I've lost my self control
+                 Get ready for a Marathon
+                 Make your Tootsie Roll
+
+                    Love me like a candy bar
+                    Sugar, try my flavor
+                    Let me be your chocolate star
+                    Smooth and rich and sweet
+                    Layer after layer
+```
+
+On #1B:
+
+> #1B is accelerated by its rhymes, but not its phrase lengths. Its rhythm
+> closes DECEPTIVELY after the fourth phrase; the rhyme scheme closes
+> UNEXPECTEDLY. Spotlights blaze on.
+
+> The section fragments between phrases four and five, making the last phrase
+> UNEXPECTED. It will probably force the music of the section into an abnormal
+> number of bars, probably either 5 or 10.
+
+> If the accelerating phrases were shorter it would fit into 4 or 8 bars
+> smoothly:
+
+```text
+Love me like a candy bar
+Sugar, try my flavor
+A chocolate crunch
+A honey brunch
+Layer after layer
+```
+
+> With its longer third and fourth phrases, it is probably too unbalanced for a
+> Chorus, though stranger things have happened.
+
+> I like it best as a Verse, especially in an A A B A form. It might work as a
+> Bridge, as long as the other sections were different enough.
+
+## 2. Length of phrases
+
+> Next, length of phrases:
+
+```text
+#2. Love me like a candy bar
+    Sugar, try my flavors
+    Let me be your chocolate star
+    Layer after milky layer
+```
+
+Figure `image_rsrc32M`, transcribed:
+
+```text
+BALANCE:   ___ SYMMETRICAL      _x_ ASYMMETRICAL
+PACE:      _x_ CONSTANT         ___ ACCELERATED     ___ DECELERATED
+FLOW:      _x_ THROUGH-WRITTEN  ___ FRAGMENTED
+CLOSURE:   _x_ CLOSED           ___ OPEN
+C. TYPE:   ___ EXPECTED         ___ UNEXPECTED      _x_ DECEPTIVE
+```
+
+> The lengthening of the last phrase in #2 … creates a Deceptive Closure,
+> unbalancing the section and turning spotlights on its last phrase, especially
+> the third stress where the section should have closed, and the last stress
+> where it actually does close. #2 could serve as a Bridge, as long as it works
+> as a contrast to the other sections in its lyric.
+
+> It could easily work as a Verse, perhaps best as a slightly unbalanced second
+> verse. In either case, whether you use it as a Bridge or a Verse, be careful.
+> What you turn spotlights on should be worthy of attention. Be sure to put
+> important ideas in spotlighted positions.
+
+> Finally, #2 could be used as a Chorus. Here the spotlighting is important. It
+> should spotlight the CENTRAL IDEA, perhaps like this:
+
+```text
+LOVE ME LIKE A CANDY BAR
+Sugar, try my flavors
+Let me be your chocolate star
+LOVE ME LIKE A CANDY BAR
+```
+
+> As you can see, repeating the first phrase gives you a rhythmic Deception plus
+> a rhyme Deception for very strong spotlighting.
+
+EXERCISE 30 follows from this chorus; it is preserved in
+[exercises](exercises.md).
+
+## 3. Rhythm of phrases
+
+> Now, rhythm of phrases:
+
+```text
+#3. Love me like a candy bar
+    Layer after layer
+    Let me be your chocolate star
+    Sugar I'm bursting with flavor
+```
+
+> (The phrase length here doesn't change, practically speaking, since the number
+> of stressed syllables is the same.)
+
+> Rhythm accelerates in the last phrase of #3 … This has two effects:
+>
+> 1. Though it closes, it pushes forward. So you could use it as a last move
+>    before you get to a CENTRAL SECTION.
+>
+> 2. By moving to triple meter, the last phrase withholds the expected
+>    three-stress duple resolution.
+
+Figure `image_rsrc32S` is that withheld duple figure:
+
+```text
+( / u / u / )
+```
+
+> This makes the duple figure available to you later as a resolving figure, say
+> as a Title opening its following section:
+
+```text
+Love me like a candy bar                   VERSE
+Layer after layer
+Let me be your chocolate star
+Sugar I'm bursting with flavor             (withholding)
+
+    /       u  /  u   /
+   YOURS, FOREVER YOURS                    (delivering)   [image_rsrc32T]
+
+You won't need any more                    CHORUS
+With all I've got in store
+I'M YOURS, FOREVER YOURS
+```
+
+### The same trick in "Can't Fight This Feeling"
+
+> Watch how this triplet trick is used in "CAN'T FIGHT THIS FEELING" at the end
+> of the TRANSITIONAL BRIDGE.
+
+> Verse 2 sets up a 5-stress duple phrase, then shortens the phrases at the end
+> of the Verse to avoid closing on a five-stress phrase:
+
+```text
+I tell myself that I can't hold out forever      VERSE 2
+I say there is no reason for my fear             [image_rsrc32U, scanned]
+'Cause I feel so secure when we're together
+You give my life direction                       (withholding)   [image_rsrc32V]
+You make everything so clear                     (withholding)   [image_rsrc32V]
+```
+
+> Phrase Length and Number of Phrases conspire to unbalance the section. It is
+> closed because of the rhyme, but without the benefit of the five-stress phrase
+> you expected.
+
+> Then, the final tease. The three-stress phrases of the Transitional Bridge
+> finally give way to a five-stress phrase, this time in triples:
+
+```text
+And I'm getting closer than I ever thought that I might   [image_rsrc32W]
+```
+
+> (All the grey areas in the last phrase give the music a chance to yank it into
+> even triples. I scanned it deferring to the musical yanking.)
+
+> The delay is maddening. The long last phrase accelerates its rhythm but slows
+> down because of its length. It still refuses to state the resolving 5-stress
+> duple phrase. Then, at last, Ta Da, the Chorus and the Title:
+
+```text
+ /    u    /    u   /    u  /  u   /
+I can't fight this feeling any more. . .       CHORUS   [image_rsrc32X]
+```
+
+> Two neat delaying tactics set up the Title. Nice juggling.
+
+Then, on #3 itself:
+
+> You could use [`Sugar I'm bursting with flavor`, scanned in triple meter,
+> `image_rsrc32Y`] the same way, though not as the end of a Transitional Bridge.
+> It is too balanced for a Transitional Bridge, and it pushes forward too hard at
+> the wrong place to be a Chorus. It might be a Bridge. I would use the section
+> as a Verse.
+
+## 4. Rhyme scheme
+
+> Finally, rhyme scheme:
+
+```text
+#4. Love me like a candy bar
+    Sugar, try my flavors
+    Let me be your chocolate star
+    Your Milky Way and Mars
+```
+
+Figure `image_rsrc32N`, transcribed:
+
+```text
+BALANCE:   ___ SYMMETRICAL      _x_ ASYMMETRICAL
+PACE:      ___ CONSTANT         _x_ ACCELERATED     ___ DECELERATED
+FLOW:      _x_ THROUGH-WRITTEN  ___ FRAGMENTED
+CLOSURE:   _x_ CLOSED           ___ OPEN
+C. TYPE:   ___ EXPECTED         ___ UNEXPECTED      _x_ DECEPTIVE
+```
+
+> The rhyme Deception spotlights the last stress of the last phrase. Make sure
+> you put something important there.
+
+> The section is pretty well balanced. It would be useful as a verse, perhaps as
+> a second verse in a Verse/Verse/Chorus Song System. It might be a good Chorus
+> Structure, but again, I'd like to see the spotlighted last phrase used as a
+> title spot:
+
+```text
+Sugar I'm your CANDY BAR
+Come on, try my flavors
+Love me like a chocolate star
+I'm your CANDY BAR
+```
+
+> But the closing phrase loses some punch, since its 3-stress phrase rhymes with
+> a four-stress phrase. I'd extend the phrase too. Our earlier try at a Chorus
+> was better:
+
+```text
+LOVE ME LIKE A CANDY BAR
+Sugar, try my flavors
+Let me be your chocolate star
+LOVE ME LIKE A CANDY BAR
+```
+
+> Juggle juggle.
 
 ## Transitional bridge construction
 
-A transitional bridge needs a stronger departure than a normal verse variation.
-It can be very short if it still feels like a section.
+> Writing a Transitional Bridge takes more radical moves. One could look more
+> like this:
 
 ```text
-two short phrases
-rhyme supplies section identity
-short length removes support
-effect: coherent but unstable
+Love me like a candy bar
+Milky Way and Mars
 ```
 
-The trick is balance at the minimum required for identity plus enough
-instability to demand the next section.
+> This is unbalanced. It pushes forward, though it still feels like a section.
+> Even a Transitional Bridge should feel like a section. Here rhyme takes care
+> of the feeling of section, while the shorter phrase length kicks the supports
+> out from under the section.
 
-## Section-use decisions
+EXERCISE 33 follows from this two-phrase model; it is preserved in
+[exercises](exercises.md).
 
-Use the altered section as a verse when it closes but still leaves room for the
-song to continue. This is especially useful for second verses that need more
-motion than first verses.
+## Section-use decisions — Pat's own verdicts
 
-Use it as a chorus when the strongest spotlight lands on the central idea or
-title and the section feels like arrival.
+The chapter never prints a "use it as X when …" rule set. It prints Pat's
+judgment on each variant, and those judgments are the guidance:
 
-Use it as a bridge when it contrasts immediately with the previous song system
-and resolves by returning to familiar structure.
+| Variant | Pat's verdict, verbatim |
+|---|---|
+| #1A | "#1A might be a Verse. It closes the way you expect it to, but the added phrase puts space between rhymes, slowing the section down." / "Could #1A be a Bridge? Maybe, but be careful." |
+| #1B | "With its longer third and fourth phrases, it is probably too unbalanced for a Chorus, though stranger things have happened." / "I like it best as a Verse, especially in an A A B A form. It might work as a Bridge, as long as the other sections were different enough." |
+| #2 | "#2 could serve as a Bridge, as long as it works as a contrast to the other sections in its lyric." / "It could easily work as a Verse, perhaps best as a slightly unbalanced second verse." / "Finally, #2 could be used as a Chorus." |
+| #3 | "It is too balanced for a Transitional Bridge, and it pushes forward too hard at the wrong place to be a Chorus. It might be a Bridge. I would use the section as a Verse." |
+| #4 | "The section is pretty well balanced. It would be useful as a verse, perhaps as a second verse in a Verse/Verse/Chorus Song System. It might be a good Chorus Structure …" |
 
-Use it as a transitional bridge when it appears before the central section,
-inside the same song system, and feels short, unstable, and pointed toward the
-chorus.
+An earlier revision of this file replaced these with four invented "Use it as X
+when …" rules. None of them are Pat's.
 
-## Exercises to preserve
+## Exercises
 
-- Rewrite a section as a bridge that contrasts immediately with the preceding
-  song system.
-- Rewrite the preceding verse instead so the proposed bridge can work as-is.
-- Write a verse that leads into a chorus version of a structurally altered
-  section; contrast phrase length and rhyme scheme.
-- Create two versions by changing phrase rhythms; label the effects and likely
-  uses.
-- Create two versions by changing rhyme schemes; ensure both close.
-- Create transitional bridges that remain identifiable as sections while
-  pushing hard toward the next section.
+Chapter 5's exercises are EXERCISE 29–33, all working the candy bar section.
+They are preserved verbatim in [exercises](exercises.md); do not restate them in
+paraphrase here.
 
-## Revision workflow
+## How the chapter closes
 
-1. Start with a stable section description: phrase count, length, rhythm,
-   rhyme, flow, closure, closure type.
-2. Decide the new section job.
-3. Change one variable first.
-4. Re-label the structural effect.
-5. Check whether the spotlighted words deserve attention.
-6. Check whether the section still feels like a section.
-7. Check whether it contrasts soon enough.
-8. Fit the surrounding verse, chorus, bridge, or transitional bridge to the new
-   structural role.
+> You have looked at typical elements or sections of lyrics. It is important to
+> put them together carefully so they can do their jobs, arranging phrases to
+> make sections move or stop appropriately. Learn the niceties of juggling
+> number of phrases, phrase lengths, rhythms, and rhymes. It helps, especially
+> when you write whole lyrics. The same techniques time after time get less and
+> less effective. Always be on the lookout for new ways to turn on the lights.
+
+An earlier revision of this file ended with an eight-step "revision workflow"
+that is not in Chapter 5. It has been removed.

--- a/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
@@ -577,10 +577,12 @@ important and spotlighted phrase in the Song system."
 > 2. ______________________________
 >    TEDDY DOESN'T LIVE HERE ANYMORE
 > ```
->
-> The scansion hint on try 1 is printed only inside the figure — the running
-> text gives no template. It sets up two 3-stress trochaic phrases in place
-> of the single long phrase.
+
+The scansion hint on try 1 is printed only inside figure `image_rsrc33Y` —
+the running text gives no template. Read off the scan, it is
+`(maybe try  / u / u / u ,  / u / u / )`: two 3-stress trochaic phrases in
+place of the single long phrase. (That gloss is this file's, not Pat's; the
+exercise itself is quoted verbatim above.)
 
 **The slingshot:** "I think of the longer phrase as the rubber of a
 slingshot, stretching to give power to the release. It seems to me that it

--- a/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
@@ -10,6 +10,9 @@ verse/transitional-bridge/refrain.
 them, Pat's structural analysis of each in his own words, the content of the
 chapter's scansion and Song System figures (several of which carry material
 that appears nowhere in the running text), and Exercises 34-38 as printed.
+Chapter 7's own fifth demonstration lyric, "SEEING SOMEONE ELSE," is kept
+separate in the addendum at the foot of the file so the four Chapter 6
+analyses stay a set.
 The analysis is about where specific stresses, rhymes, and phrase lengths
 fall, so the lines are quoted rather than described — a summary of a
 scansion argument is not usable.
@@ -740,12 +743,73 @@ feel like two different speakers handing off.
    verse-vs-TB opposition demonstrates that section difference is
    structural payoff, not structural weakness.
 
+## Addendum — "SEEING SOMEONE ELSE" (Chapter 7, not Chapter 6)
+
+The four analyses above are Chapter 6's. Chapter 7 adds a fifth complete
+demonstration lyric of its own, introduced with one line — "Look at this Song
+System." — and printed with no section labels, as three stanzas under the
+title. Reproduced as printed:
+
+<!-- spellchecker:off -->
+
+```text
+SEEING SOMEONE ELSE
+
+I feel some changes in the air
+You haven't been yourself
+You been lookin' kinda dreamy off in space
+Could it be the smell of perfume
+That's starting up this aching
+Or the secrets I see lighting up your face
+
+When we talk you never meet my eyes
+You're looking right on past
+I've been trying not to notice up till now
+But I can't escape the feeling
+That something's going down now
+It's almost like there's someone else around
+
+Even though you're with me
+Might as well be by myself
+'cause the way you look at me is like
+You're SEEING SOMEONE ELSE
+The way you look at me is like
+You're SEEING SOMEONE ELSE
+```
+
+<!-- spellchecker:on -->
+
+Pat's analysis of it, complete, in order. The stanzas are unlabelled in print,
+but this prose names them: stanzas one and two are the Verses, "Even though
+you're with me / Might as well be by myself" is the Transitional Bridge, and
+the HOOK is the repeated last pair.
+
+> You can see the same rhythmic strategy in both Verses. I will scan the first
+> Verse.
+
+Figure `image_rsrc34R` is that scan — the six lines of stanza one with stress
+and unstress marks over every syllable.
+
+> The 3-stress second phrase becomes more and more important as you get through
+> the two verses.
+
+> The rhythm of the Transitional Bridge picks up the 3-stress rhythm
+> immediately, although it is not stated smoothly:
+
+Figure `image_rsrc34S`, the Transitional Bridge scanned.
+
+> As you saw earlier, it smooths out for the first time at the HOOK.
+
+Figure `image_rsrc34T`, the HOOK pair scanned: `The way you look at me is like /
+YOU'RE SEEING SOMEONE ELSE`.
+
 ## Cross-references
 
 - `song-forms.md` — form taxonomy + four-times-a-lot warnings
 - `form.md` — section identification, candy bar discipline, bridge functions
-- `hook.md` — five strategies, hot spots, targeting (slingshot principle
-  origin)
+- `hook.md` — five strategies, hot spots, targeting (*Essential Guide to Lyric
+  Form and Structure* (1991), Chapter 7). The slingshot is **not** from that
+  chapter: it is Chapter 6's, quoted in full under "Teddy" above.
 - `meter.md` — Common Meter, paradigms, Structural Pentad
 - `phrasing.md` — phrase length / count balance
 - `rhyme-strategy.md` — three rhyme strategies (Pat's named decision matrix)

--- a/plugins/songwriting/context/pat-pattison/research/song-forms.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms.md
@@ -953,22 +953,37 @@ Three named alternatives:
 Diagnose at form-planning: count the systems, name what each is
 supposed to add, choose the alternative if needed.
 
-## Song system sizing
+## Song system
 
-Sections are grouped into song systems. A song system is a complete
-cycle that the listener experiences as a single unit. Sizing the
-system shapes the form's pace.
+Pat's own definition, and the origin of the term, *Essential Guide to Lyric
+Form and Structure* (1991), Chapter 5:
 
-| System size | Components | Effect |
-|---|---|---|
-| Small | Single section (verse only, refrain only) | Stark; intimate; static |
-| Medium | Verse + chorus | Standard pop arc |
-| Large | Verse + prechorus + chorus | Builds tension before arrival |
-| Extended | Verse + bridge + chorus | Slower pace; literary feel |
+> Either I made up this name, or my friend Tom Frazee did. I don't remember
+> which. A "Song System" is a group of sections that work together in larger
+> movements, or cycles of motion. The idea is especially helpful when looking at
+> a group of contrasting sections. A Song System always has a CENTRAL SECTION
+> and often has one or more DEVELOPMENTAL SECTIONS.
 
-Mixing sizes within a song creates motion: a medium first system
-followed by a large second system feels expansive; the reverse feels
-compressed.
+> Each Song System is a cycle. Each closes down after the CENTRAL SECTION. Once
+> you finish a Song System, you have to start something else: maybe another
+> system just like the one you finished, or maybe something different. But one
+> thing is clear: you have finished something, so you must either be through
+> with the song, or start something up again.
+
+> Talking about Song Systems is the most useful in lyrics that have different
+> kinds of sections: Verse + Chorus, Verse + Bridge + Chorus, Bridge + Chorus.
+> Song Systems give you a way to describe how larger units (groups or sections)
+> work together. It comes in handy.
+
+> In a lyric where all the sections are the same, and each section contains the
+> CENTRAL IDEA ("IT WAS A VERY GOOD YEAR," for example), the concept of Song
+> System doesn't help much. You could talk about "sections" just as easily.
+
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 7 adds the one
+rule that ties the hook to the Song System:
+
+> Your HOOK should come at least once in each Song System. That is usually
+> enough. Within reason you can squeeze it in a few more times.
 
 ## *Essential Guide to Lyric Form and Structure* (1991) worked examples
 

--- a/plugins/songwriting/context/pat-pattison/research/stable-unstable-meta.md
+++ b/plugins/songwriting/context/pat-pattison/research/stable-unstable-meta.md
@@ -184,19 +184,36 @@ How am I to hold you
 
 | Section | Default | Pat's reason, from the books |
 |---|---|---|
-| Verse | Unstable | Developmental sections "move toward or depart from a CENTRAL SECTION" |
-| Chorus | Stable | "Because the Chorus is a CENTRAL SECTION — a place where ideas are completed — the end of the Chorus should stop forward motion. This creates the feeling of 'starting over again' in the next section." |
-| Refrain | Stable | Contains the CENTRAL IDEA; "the most balanced element in the lyric" |
-| Bridge / transitional section | Unstable | "Using an odd number of phrases to unbalance a section works wonders if you want to build up pressure, for example, in a transitional section between verse and chorus." |
+| Verse | **Closes down** — it sets the standard | Ch 5's verse job list ends "4. To set structural standards for the lyric, / thus, 5. Verses should close down." A verse is the point of comparison, not automatically the unstable section: "Verses establish BALANCE, PACE, FLOW, CLOSURE, AND CLOSURE TYPE for the lyric, setting a point of comparison for other structures in the lyric." |
+| Chorus | Stable | "Because the Chorus is a CENTRAL SECTION — a place where ideas are completed — the end of the Chorus should stop forward motion. This creates the feeling of 'starting over again' in the next section." Ch 5's chorus list: "4. Is typically the lyric's most balanced section. / thus, 5. Stops forward motion." |
+| Refrain | Not a section — no stability of its own | "This is not a section at all. It is just a name for the part of a Verse that contains the CENTRAL IDEA and gets repeated in the other Verses." Scan the verse it lives in, not the refrain. |
+| Bridge | Unstable | "3. It unbalances the section by moving away from established structures, creating structural tension. … thus, 5. It is frequently the lyric's most unbalanced section." |
+| Transitional bridge | Unstable, and shortest | "Thus, 5. It is usually the lyric's shortest and most unbalanced section." And from Chapter 1: "Using an odd number of phrases to unbalance a section works wonders if you want to build up pressure, for example, in a transitional section between verse and chorus." |
 
-Quotes above from *Songwriting: Essential Guide to Lyric Form and Structure*
-(1991), Chapters 1 and 5.
+Quotes above from *Essential Guide to Lyric Form and Structure* (1991),
+Chapter 5, except the "works wonders" sentence, which is Chapter 1.
 
-Pat's technique for pushing a second verse forward: "Make the first verse
-completely balanced, then unbalance the second verse by adding an extra
-phrase. This unbalancing will make it move forward into the chorus." He
-demonstrates it on Kevin Cronin's "Can't Fight This Feeling," and notes:
-"if you reverse the two verses, the motion stops."
+Two corrections to an earlier revision of this table: the Verse row read
+"Unstable", which contradicts Chapter 5's own verse list; and the Refrain row
+carried "the most balanced element in the lyric", which Chapter 5 says about the
+**chorus** of "Years", not about a refrain.
+
+Pat's technique for pushing a second verse forward — *Essential Guide to Lyric
+Form and Structure* (1991), **Chapter 1**, not 2009:
+
+> This unbalancing strategy is also useful when you have two verses that lead
+> into a chorus. Make the first verse completely balanced, then unbalance the
+> second verse by adding an extra phrase. This unbalancing will make it move
+> forward into the chorus. The first and second verses of Kevin Cronin's "CAN'T
+> FIGHT THIS FEELING" provide a good example.
+
+> Unbalancing the second verse makes it move forward. It throws it into the air,
+> just like juggling. Notice that if you reverse the two verses, the motion
+> stops.
+
+Chapter 5 returns to the same verse 2 to make a rhythm point instead — see
+[section building](section-building.md), "The same trick in 'Can't Fight This
+Feeling'".
 
 ## Worked diagnostic
 

--- a/plugins/songwriting/context/pat-pattison/research/title-game.md
+++ b/plugins/songwriting/context/pat-pattison/research/title-game.md
@@ -120,7 +120,9 @@ The cascade's stressed-vowel machinery is not invented — it is Pat's
 > "Make up your own title, and, using it as the first line of an oncoming
 > chorus, write an AAB structure leading up to it, with the third line
 > targeting a vowel sound in the title. Try not to target the end rhyme.
-> Instead, give the words inside the title a sonic boost."
+> Instead, give the words inside the title a sonic boost. Then rewrite the
+> third line (B line) to target a different vowel sound in the title. As in
+> the sample that follows."
 
 The point Pat is making — that a title's **inner** vowels, not its end
 rhyme, are the sonic handles — is what makes a stressed-vowel cascade

--- a/plugins/songwriting/context/pat-pattison/research/verse-development.md
+++ b/plugins/songwriting/context/pat-pattison/research/verse-development.md
@@ -15,6 +15,19 @@ Related files: [repetition](repetition.md), [form](form.md),
 [phrasing](phrasing.md), [meter](meter.md), and
 [object writing](object-writing.md).
 
+**What in this file is Pat's.** Chapters 7 and 8 print running prose, worked
+readings of specific lyrics, one Moral, and — in Chapter 8 only — one
+exercise. (Chapter 7 contains no exercise at all: `EXERCISE` returns zero
+hits in it.) They print **no procedures, no checklists and no taxonomies.**
+So the numbered
+and bulleted lists under "Travelogue test", "Natural continuity", "Verse
+responsibility", "Use this scan", "Opening position", "Closing position",
+"Use trigger lines to", "Verse-development diagnosis" and "Skill workflow"
+are this file's own operational scaffolding, useful for coaching but **not
+Pat's text and not attributable to him.** The surrounding prose and block
+quotes in those sections are sourced; it is the lists themselves that are
+not. Everything in a `>` block quote is verbatim.
+
 ## Core idea
 
 Verses are colored spotlights. Each verse shines a particular color on the
@@ -27,7 +40,9 @@ gains weight.
 > choruses will look the same. If they project different or deeper colors, the
 > choruses will look different.
 
-> Boxes only show how the ideas evolve.
+> Boxes only show how the ideas evolve, regardless of the specific form you
+> use. In this chapter, we'll look a little closer at the responsibility your
+> verses have in making your boxes gain weight.
 
 The box model is form-neutral. Chapter 7 opens by listing the formal movements
 one three-box series can describe:
@@ -320,7 +335,9 @@ poles in one breath at the close of Chapter 8:
 > Verse development is probably a lyricist's trickiest job. Verse ideas must
 > advance enough, but can't move too much. If the ideas are too close, the
 > repetition of the chorus will become static and boring. If the verses' ideas
-> are too far apart, you might end up in fabulous Hawaii.
+> are too far apart, you might end up in fabulous Hawaii. Hawaii is a nice
+> place, but songwriters beware how you get there. The best trip is paid for
+> by royalty checks from great songs.
 
 ## Verse responsibility
 
@@ -350,17 +367,24 @@ Put important material there.
 Chapter 7 points at *Songwriting: Essential Guide to Lyric Form and Structure*
 for the full treatment; here it demonstrates on "Child Again."
 
-The most common power positions are:
+Chapter 7 never prints a list of power positions. It prints one Moral, and
+that is the whole taxonomy — **three** families, not nine:
 
-- opening line,
-- closing line,
-- beginning of a balanced subsection,
-- end of a balanced subsection,
-- trigger line immediately before a chorus or refrain,
-- shorter or longer line that breaks a pattern,
-- extra line,
-- early or delayed rhyme,
-- any structural surprise.
+> Moral: First be aware of where your power positions are: opening
+> positions, closing positions, and surprises, like shorter, longer, or
+> extra lines. Pay attention as you create them, then put something
+> important there. Everything will come up rosy, seafoam green, Tangiers
+> blue, sun yellow …
+
+The extra cases this file used to list as peers of those three — subsection
+openings and closings, the trigger line, an early rhyme — are not a fourth
+and fifth family. They are instances Pat derives inside the chapter's two
+readings: the "Child Again" subsections ("She uses her power positions — the
+first and last positions of the verse, plus the ending and beginning of its
+subsections") and the nursery-rhyme reading ("it gains extra punch by
+rhyming early, at the second rather than the third stress"). Both appear in
+full below. An earlier revision of this file flattened them into a
+nine-bullet "most common power positions" list that Pat does not print.
 
 Power positions are not decoration. They steer the listener's focus.
 
@@ -530,22 +554,21 @@ Use the closing to:
 
 ## Surprise positions
 
-Any structural surprise creates power:
+Pat opens the surprise case like this:
 
-- a shorter line,
-- a longer line,
-- an extra line,
-- an early rhyme,
-- a delayed rhyme,
-- a pattern break,
-- a repeated fragment,
-- a sudden change in syntax.
+> Opening and closing phrases are not the only way to create power positions.
+> Wherever you create a special effect with your structure, you call attention
+> to what you are saying. This extra focus gives the position its power.
+
+The surprises he actually names are **shorter, longer, or extra lines** (the
+Moral) and, in the nursery-rhyme reading below, **rhyming early**. An earlier
+revision of this file expanded that into an eight-item list adding "a delayed
+rhyme", "a pattern break", "a repeated fragment" and "a sudden change in
+syntax"; none of those are Chapter 7's. The test the chapter does give is the
+generalisation above: any special effect you create with structure.
 
 When using a surprise, place a meaningful idea there. A surprise that carries
 filler wastes focus.
-
-> Wherever you create a special effect with your structure, you call attention
-> to what you are saying. This extra focus gives the position its power.
 
 Pat's first demonstration extends a nursery rhyme past its expected close:
 
@@ -583,10 +606,13 @@ Woe is a slow healing heart                       c
 > the fourth phrase chimes in, and the fifth phrase closes with a rhyme. Six is
 > another opening and calls extra attention to its length.
 
-Five of nine positions are doing work. Pat's closing instruction for the whole
-chapter: "First be aware of where your power positions are: opening positions,
-closing positions, and surprises, like shorter, longer, or extra lines. Pay
-attention as you create them, then put something important there."
+Pat's own count and his refusal to pad it:
+
+> I could argue that seven is a power position as well, but I won't. Five out
+> of nine is plenty of action, a tribute to interesting structures.
+
+His closing Moral for the whole chapter is quoted under "Power positions"
+above.
 
 ## Verse-development diagnosis
 
@@ -604,17 +630,26 @@ When reviewing a draft:
 9. Use [object writing](object-writing.md) when the verse needs sharper
    sensory material.
 
-## Chapter 8 exercise as coaching prompt
+## Chapter 8's exercise
 
-Exercise 12 - Repair a travelogue:
+Chapter 8 prints one exercise, as a single paragraph. Verbatim:
 
-- Start with either verse two (Camille, West Beirut) or verse three (the ancient
-  Ford, South Africa) of the original "Chain Reaction" travelogue above.
-- Keep the same chorus.
-- Write two more verses that grow from that verse into a story.
-- Follow the current verse rhyme scheme and rhythm.
-- Make the verse sequence accumulate into one full-blown strategy.
-- Check that the verses still make sense when the chorus is removed.
+> **EXERCISE 12**
+>
+> Start with either verse two or verse three of the original and write two
+> more verses to make a story. (Keep the same chorus, and be sure to follow
+> the current verse rhyme scheme and rhythm.) You'll notice the power and
+> momentum your lyric develops as the verses accumulate into one full-blown
+> strategy.
+
+("The original" is the "Chain Reaction" travelogue above — verse two is
+Camille in West Beirut, verse three the ancient Ford in South Africa.) The
+paragraph runs straight on into "Verse development is probably a lyricist's
+trickiest job …", quoted under "Distance control" above. An earlier revision
+of this file inflated the exercise into six bullets, two of which — "make the
+verse sequence accumulate into one full-blown strategy" as an instruction,
+and "check that the verses still make sense when the chorus is removed" — are
+not part of what Pat asks for.
 
 ## Skill workflow
 

--- a/plugins/songwriting/context/pat-pattison/research/workflows.md
+++ b/plugins/songwriting/context/pat-pattison/research/workflows.md
@@ -14,7 +14,14 @@ Pat's craft tools are concept-organized; a songwriter at a desk works
 scenario-first. This file collapses the right sequence of passes per scenario,
 naming which `context/*.md` files to load and in what order.
 
-> "Tools, not rules." — Pat (column title; recurring stance)
+> "There are no rules, only tools."
+>
+> — *Writing Better Lyrics* (2009), Chapter 18
+
+("Tools, Not Rules" is the *American Songwriter* column title, **not** a Pat
+quotation — that word order appears in none of the four books. Pat prints the
+stance again in *Essential Guide to Rhyming* (2014), Chapter 4: "there are no
+rules. Only tools.")
 
 Every chain below is a default sequence, not a mandate. Skip steps the writer
 has already done. Jump back when a later pass exposes an earlier weakness

--- a/plugins/songwriting/context/pat-pattison/research/workflows.md
+++ b/plugins/songwriting/context/pat-pattison/research/workflows.md
@@ -358,8 +358,9 @@ Default chain:
    hook / align-melody / cliche / form / object-writing / bridge / rhyme /
    audit-checklist).
 
-Coach posture: Pat's rule — one focused finding, not ten scattered notes.
-Surface secondaries briefly, do not fix them.
+Coach posture: one focused finding, not ten scattered notes. Surface
+secondaries briefly, do not fix them. (Plugin-authored coaching posture —
+**not** a Pat rule. The phrase returns zero hits across all four books.)
 
 ## Routing notes
 

--- a/plugins/songwriting/context/pat-pattison/research/worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/worksheets.md
@@ -37,9 +37,14 @@ one.
 
 > A worksheet externalizes the inward process of lyric writing.
 
-*Essential Guide to Rhyming* (2014)'s rhyme worksheet focuses on rhyme expansion. *Writing Better Lyrics* (2009), Chapter 4 is broader:
-focus the lyric idea, generate idea-language, then build rhyme options around
-the words that matter.
+The same three stages run *Essential Guide to Rhyming* (2014), Chapter 3, in
+almost the same words — focus the idea, list words that fit it, look them up —
+but that chapter builds the sheet out of perfect rhyme only, and reaches its idea
+words straight from a prose idea sketch. *Writing Better Lyrics* (2009), Chapter
+4 is broader on both counts: it routes the idea-word stage through object writing
+and a Roget's thesaurus, and it searches every rhyme type from the start. See
+[rhyme worksheets](rhyme-worksheets.md) for the Chapter 3 version and for
+Chapter 7, where the rhyming book widens its own search.
 
 ## Three-stage worksheet
 

--- a/plugins/songwriting/context/pat-pattison/templates/audit-checklist-prompt.md
+++ b/plugins/songwriting/context/pat-pattison/templates/audit-checklist-prompt.md
@@ -1,8 +1,9 @@
 # Audit Checklist Prompt Template
 
 Use when writer asks to pre-lock a line, a section, the title, or the
-form. "Tools, not rules" — each box is a deliberate choice point, not a
-gate. Naming a skip is fine; silent skips are not.
+form. "There are no rules, only tools." (*Writing Better Lyrics* (2009),
+Chapter 18) — each box is a deliberate choice point, not a gate. Naming a
+skip is fine; silent skips are not.
 
 ## Coach posture
 

--- a/plugins/songwriting/context/pat-pattison/templates/demo-review-prompt.md
+++ b/plugins/songwriting/context/pat-pattison/templates/demo-review-prompt.md
@@ -135,7 +135,8 @@ Route the dominant move to the right action:
 
 ## Coach posture
 
-- Pat's rule: one focused finding. Not ten scattered notes.
+- One focused finding. Not ten scattered notes. (Plugin-authored coaching
+  posture — **not** a Pat rule; zero hits across all four books.)
 - Surface secondaries briefly, do not fix them.
 - Read aloud is non-negotiable (Step 2).
 - If dominant problem is upstream (title doesn't fit form, form doesn't

--- a/plugins/songwriting/context/pat-pattison/templates/line-brainstorm-prompt.md
+++ b/plugins/songwriting/context/pat-pattison/templates/line-brainstorm-prompt.md
@@ -253,7 +253,14 @@ The brainstorm is volume; the curation is dialog.
 
 > "Eminem and Stephen Sondheim approach their writing through the same
 > process. It's called a worksheet process."
-> — Pat Pattison (American Blues Scene interview)
+> — Pat Pattison (American Blues Scene interview) — **unaudited**
+
+Non-book source, so it cannot be checked against the four books. Only the
+Sondheim half is corroborated in print — *Writing Better Lyrics* (2009),
+Chapter 24: "Ask Stephen Sondheim: He uses worksheets all the time."
+`Eminem` and the phrase "worksheet process" both return zero hits in all
+four books. Full audit note in
+[line-brainstorm.md](../research/line-brainstorm.md).
 
 The line-brainstorm IS the worksheet process applied to a single line.
 


### PR DESCRIPTION
**All four Pat Pattison books are now formally audited — 44 of 44 units.** This
closes the remaining 15: *Essential Guide to Lyric Form and Structure* (1991)
Chapters 5 and 7, *Essential Guide to Rhyming* (2014) Chapters 1–9, and
*Songwriting Without Boundaries* (2011) Challenges 1–4.

**127 fabrications removed, 283 passages restored verbatim**, across 19 audit
agents and 4 verification agents.

## Both denominators

- **Axis 1 — formally audited: 44 of 44 units (100%).**
- **Axis 2 — fine-grained: 205 of 226 (91%)** — computed, not estimated:
  `24 (2009 chapters) + 7 (1991 chapters) + 56 (2011 days) + 118 (2014 pages)`.

The 2014 figure is **118, not 139**, because Chapter 1 opens at spine 014 and
Chapter 9 closes at spine 131 — a boundary corrected from the running heads this
run, where the old map said 132 (that is the Afterword). The 21 fine-grained
units outstanding are therefore Book 4's front matter (14 pages) and back matter
(7 pages): TOC, preface, afterword, index. **No craft chapter in any of the four
books remains unaudited.**

## The biggest single fix

**Pat's Vowel Triangle was wrong in both legs, in two files.** The EPUB text
layer hoists the apex to the top and transposes vowels on each side. The printed
figure is a V with `ä (papa)` at the bottom — tongue leg `ä → ă → ĕ → ĭ → ē`,
lip leg `ä → ŭ → ŏ → oo → ū`. This is load-bearing: family assonance is defined
as *one step* along a leg, so a transposition changes which pairs count as
adjacent. Verified against the page scan before applying.

## What the defect actually looked like

Invented scaffolding, not omission — and **counts were the most reliable tell**:
a five-item metaphor taxonomy where Pat's count is three; "four focus questions"
where he prints six; seven transitional-bridge alias names where the figure
prints six; a nine-item "power positions" list where the chapter prints no list
at all; an exercise inflated from one paragraph into six bullets. Every
round-number threshold checked was invented — `minutes` appears **zero times** in
the entire 2014 book.

Also fixed a defect class running the **other** way: the plugin had silently
**corrected Pat's typos**. 1991 Chapter 7 prints "your verbs will all already
**by** POV neutral"; the file had "be". `swiftless`, `frictatives`, `Famly`,
`Shelly` and `Ozymandius` are likewise now marked as printed.

## Verification

Every block-quoted sentence in `context/` was machine-checked against the full
four-book corpus: **1,936 checked, 1,840 matched verbatim**, and all 96 residual
adjudicated individually by four fresh agents prompted to *refute*.

**Two honest caveats on that number.** The checker reads only `>` block-quotes —
tables, inline quotes and fenced blocks are not covered, and several real
defects found were bullet lists that could never have appeared on a quote list.
And the checker itself had three bugs, found by an agent rather than by me,
including a `UnicodeEncodeError` that silently truncated its report and hid
seven files from verification until a fourth agent was dispatched to cover them.

**Five confident corrections were refused on evidence** — including a `— Pat`
quote that turned out genuine, a table column order only the page scan could
settle, a lost `ff` ligature (`topped of`), and a line the book prints two
different ways. Deleting on suspicion would have destroyed Pat's actual words.

## What "44 of 44" does not mean

Closing the units is not the same as clearing every file. Several files are
built from chapters audited in *earlier* sessions and were never verbatim
checked — `object-writing.md` is roughly half 2009 material with ~120 unaudited
lines, `meter.md`'s Paradigm/Pentad sections rest on 1991 Chapter 3 whose figures
are unrendered, and `cliche.md` is entirely 2009 Chapter 5. Fabrications turned
up in the 2009 regions agents happened to check. **The next unit of work should
be file-level, not chapter-level.**

## Verification suite

`typos` clean · `markdownlint` 0 errors across 103 files · changelog parity
passes · `validate-plugins.sh` passes · `lychee` 804 links, 0 errors · wrap-safe
`Book N` regression clean.

Note the standard `Book N` grep has a **false negative**: two violations were
live on `main`, hidden by line wrapping. The wrap-safe form is
`grep -rnPzo "Books?\s+[1-4]\b" | tr '\0' '\n'`.

## Related

No linked issue.
