### PR TITLE
feat(songwriting): release 1.0.0 — file-level audit, web sources read, and the first output test

### DIFF
--- a/plugins/songwriting/.claude-plugin/plugin.json
+++ b/plugins/songwriting/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "songwriting",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Songwriting craft companion — nine concern-scoped lyric-craft skills (workflow router, rhyme, object-writing, metaphor, meter-prosody, song-form, co-write, diagnose, practice) applying Pat Pattison's methods, with an object-writing agent that performs the sensory exercise itself and per-skill emission boundaries that route generation to the skill that owns it, plus Suno v5.5 prompt engineering (style prompts, tagged lyrics, genre templates, troubleshooting).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `songwriting` plugin are documented here. Format foll
 
 **Chapter coverage was complete at 0.9.0; file coverage was not.** This release
 audits the five files built from chapters closed in earlier sessions, reads the
-two non-book web sources that eight sessions had treated as unopenable, and —
+three non-book web sources that eight sessions had treated as unopenable, and —
 for the first time in ten sessions — **tests whether the plugin's output is any
 good.**
 

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -126,8 +126,9 @@ Scansion was read off rendered figures rather than re-derived, and **Pat's own
 The two first-party-contradicted tier rows are corrected: **Free has no stem
 separation at all** (the "2-track stems: Free ✓" row was false), and Split from
 Mix / Auto Split / Advanced Split are three **modes**, not track counts. Voices
-reached free plans on 7 August 2026, with an unresolved web-versus-mobile caveat
-recorded rather than guessed. **The remaining Suno remediation items are not
+stays Pro / Premier; free plans got a **trial** on 7 August 2026, with an
+unresolved web-versus-mobile caveat recorded rather than guessed — a trial is
+not all-tier entitlement, and the plugin no longer describes it as one. **The remaining Suno remediation items are not
 done** — see the audit's own ordering in `.work/songwriting-plugin-pilot/`.
 
 ## [0.9.0]

--- a/plugins/songwriting/CHANGELOG.md
+++ b/plugins/songwriting/CHANGELOG.md
@@ -3,6 +3,133 @@
 All notable changes to the `songwriting` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [1.0.0]
+
+**Chapter coverage was complete at 0.9.0; file coverage was not.** This release
+audits the five files built from chapters closed in earlier sessions, reads the
+two non-book web sources that eight sessions had treated as unopenable, and —
+for the first time in ten sessions — **tests whether the plugin's output is any
+good.**
+
+Scoreboard, computed from the ledger and unchanged by this release because the
+work was file-level, not chapter-level: **Axis 1 — formally audited, 44 of 44
+units (100%). Axis 2 — fine-grained, 205 of 226 (91%).** The 21 outstanding
+fine-grained units remain *Essential Guide to Rhyming* (2014) front matter
+(spine 0-13) and back matter (spine 132-138) — TOC, preface, afterword, index.
+No craft chapter is unaudited in any of the four books.
+
+### Added — the output test, and what it found
+
+- **The lines are good, and the reason matters.** Running the craft skills on a
+  real brief produced usable verses in common meter and a chorus using Paradigm
+  Three's deceptive closure to spotlight the title. The `object-writer` agent is
+  the strongest component: dispatched blind on the seed "an extension cord",
+  knowing nothing of the brief, it returned "seven turns, always seven, he
+  counted them out loud" for a song about a dead father. The blind dispatch is
+  what produced that, and both writers graded a thin sense channel honestly
+  rather than padding it.
+- **The quality is contingent on the response filter actually running.** Every
+  good line survived because a specific §2 box rejected a worse one; drafting
+  without naming boxes produced the generic default the filter exists to catch.
+  **`response-filter.md` is therefore the highest-leverage file in the plugin**,
+  and the filter is self-administered with no enforcement.
+- Caveat recorded rather than glossed: the installed plugin was 0.8.3 while this
+  branch was 0.9.0, so the *content* was tested by executing the skill bodies
+  directly. **The shipped invocation path is still untested end to end.**
+
+### Fixed — two "duplications" that were not, and one that was
+
+- **`phrasing.md` and `meter.md` were FALSE POSITIVES.** Pat prints the Steely
+  Dan verse at eight phrases, then pulls one out to show seven, then cuts to
+  four — that is his pedagogy. `meter.md`'s two "Mary Had a Little Lamb" blocks
+  differ in line four: a three-stress close for Paradigm One against a
+  four-stress overshoot for Paradigm Three. **Folding either would have
+  destroyed correct Pat text.** Both left alone.
+- **`song-forms.md` was the only genuine one** — a whole "Third-system risk"
+  section restating Chapter 23's worked lyric and Pat's three numbered Options.
+  Folded to a cross-reference; the surviving section verified to lose nothing.
+
+### Fixed — the 1991 figure trap, caught live again
+
+`"She sold the fleece to pay the rent"` returns **zero hits** in the 1991 text
+layer, wrap-safe and by fragment. It is **genuinely printed** in figure
+`image_rsrc30F` with "the rent" in italics. That book argues in figures and its
+text layer under-reports; every cut in `meter.md` was checked against a rendered
+scan first. A verification pass rendered **all 45 Chapter 3 figures** and
+confirmed none prints a mood, a section label, or a "best for" line — so the
+three unsourced comparison rows and the "Teaching move" line were cut correctly.
+
+### Fixed — file-level audits
+
+- **`cliche.md`** — the cliché-phrase list shipped as "a representative slice,
+  in his grouping" and was neither: **43 of Pat's 101 printed cells were
+  missing, and surviving rows were stitched together from different printed
+  rows.** The complete 34-row table is restored from the raw XHTML and verified
+  cell-for-cell, including the duplicate `losing sleep` that Pat really prints
+  twice.
+- **`rhyme-strategy.md`** — the two "Decision matrix" sections were **not**
+  duplicates but different subjects; one had Pat's family/assonance pairing
+  **inverted**. Nine Chapter 9 pairings re-verified in the chapter's own order.
+  The two Strategy 1/2/3 treatments *were* genuine duplication and are merged.
+- **`rhyme-worksheets.md`** — a thirteen-slot seed box was attributed to
+  Exercise 7.2; the page-75 scan shows it inside the Exercise 7.1 grid, between
+  `6. risk` and `7. chance`. A column-order extraction artifact. Also fixed:
+  `flirt / church` mislabelled consonance when Pat's own definition requires
+  differing vowels, and a claim that all eleven seeds came from his page-20
+  sketch when only three do.
+- **`object-writing.md`** — 2009 Chapter 2 prints no exercise at all; an
+  invented count was presented under its provenance. Rusty's collar moves down
+  **two** lines, not one.
+
+### Fixed — non-book sources, all three READ for the first time
+
+- **patpattison.com "Lyric and Melodic Phrases"** — the "maximum meaning" quote
+  is real and had been truncated. Its taxonomy of fixes is **Pat's own and has
+  four options**, not three; a prior pass had demoted it as plugin-authored, and
+  dropping his fourth ("Keep it the way it is, since no one listens to lyrics
+  anyway") is what made the list look invented.
+- **patpattison.com "The Art of Phrasing"** — **`front-heavy` / `back-heavy` are
+  Pat's own coinage**, defined on that page, not plugin shorthand. So is
+  "Phrasing has the power to create emotion. It's the body language of your
+  song." Both had been wrongly marked. **"Not in the four books" and "not Pat's" are
+  different claims** — cite the column, never a chapter.
+- **American Songwriter "Motion Creates E-Motion"** — carries no four-controller
+  framework and never mentions line length, so the "live unresolved conflict"
+  with *Songwriting Without Boundaries* (2011) Challenge 4, Day 13 **does not
+  exist.** Recorded as incomplete, not contradicted.
+
+### Fixed — third-party lyric restorations (all Class A defects cleared)
+
+All five `LYRIC-HANDOFF` markers in `form.md` are resolved — every dangling
+set-up now has its text under it: the four "IT WAS A VERY GOOD YEAR" verses in
+Pat's order, the "Years" chorus and its nine-line verse, both Song Systems from
+figures `image_rsrc32F` / `32G`, and the deceptive-closure rhyme figures.
+Scansion was read off rendered figures rather than re-derived, and **Pat's own
+"thirty-five" / "thirty five" inconsistency is preserved as printed.**
+
+### Fixed — vocabulary and the agent contract
+
+- **`central emotion` (0 corpus hits) replaced with Pat's real phrase**, "the
+  central intent, idea, and emotion of the work" (*Writing Better Lyrics*
+  (2009), Chapter 18), across nine files. It truncated a real three-part phrase,
+  which is why quote sweeps kept missing it.
+- `tone of voice` (0 hits, and not located in any Pat column either) registered
+  as plugin shorthand in `book-references.md`.
+- **The `object-writer` agent's frontmatter promised a return shape its own
+  output contract forbids.** Corrected to match: path, seven graded channels,
+  one sentence.
+- Audit-process vocabulary had leaked into shipped content — a reader hitting
+  "see LYRIC-HANDOFF" had no way to know what that meant. Removed.
+
+### Fixed — Suno platform drift (partial)
+
+The two first-party-contradicted tier rows are corrected: **Free has no stem
+separation at all** (the "2-track stems: Free ✓" row was false), and Split from
+Mix / Auto Split / Advanced Split are three **modes**, not track counts. Voices
+reached free plans on 7 August 2026, with an unresolved web-versus-mobile caveat
+recorded rather than guessed. **The remaining Suno remediation items are not
+done** — see the audit's own ordering in `.work/songwriting-plugin-pilot/`.
+
 ## [0.9.0]
 
 **All four Pat Pattison books are now formally audited — 44 of 44 units.** This

--- a/plugins/songwriting/agents/object-writer.md
+++ b/plugins/songwriting/agents/object-writer.md
@@ -1,6 +1,6 @@
 ---
 name: object-writer
-description: "Performs one timed Pat Pattison object write itself — sense-bound, pivoting through the seven senses, stopping mid-word at the buzzer — then writes the result to a file and returns the path plus a seven-channel sense inventory quoting its own phrases. Dispatched blind, one per seed, by /songwriting:object-writing generate; deliberately given no access to the song, the draft, or the other writers. Not intended for direct ad-hoc use."
+description: "Performs one timed Pat Pattison object write itself — sense-bound, pivoting through the seven senses, stopping mid-word at the buzzer — then writes the write AND its phrase-quoting sense inventory to a file, returning only the file path, the seven channels each graded strong/thin/absent, and one sentence on where the pivot chain landed. Dispatched blind, one per seed, by /songwriting:object-writing generate; deliberately given no access to the song, the draft, or the other writers. Not intended for direct ad-hoc use."
 tools: "Write"
 model: inherit
 effort: high

--- a/plugins/songwriting/context/pat-pattison/research/book-references.md
+++ b/plugins/songwriting/context/pat-pattison/research/book-references.md
@@ -91,17 +91,31 @@ Pat Pattison — *What's in a Song* podcast, "Creating Metaphors" episode
 Date when relevant. Citation includes the publication / platform first,
 then the title.
 
-## Plugin-authored vocabulary — terms that are NOT Pat's
+## Vocabulary that is NOT in the four books
 
-These terms are used throughout this plugin as working shorthand. **None of them
-appears anywhere in the four-book corpus.** Each count below was measured against
-the extracted text of all four books, wrap-safe:
+**"Not in the books" and "not Pat's" are different claims. Do not collapse
+them** — an earlier version of this table did, and was wrong. Pat teaches
+outside the books too, and terms he coins in a column are still his.
+
+Each corpus count below was measured wrap-safe against the extracted text of all
+four books:
 
 | Term | Corpus hits | Status |
 | --- | --- | --- |
-| `tone of voice` | 0 | Plugin-authored shorthand. Keep, but never attribute to Pat. |
-| `front-heavy` / `back-heavy` | 0 | Plugin-authored shorthand for phrase weighting. Same rule. |
+| `front-heavy` / `back-heavy` | 0 | **Pat's own coinage**, outside the books — see below. Citable to the column, never to a book. |
+| `tone of voice` | 0 | Not located in any Pat source, book or column. Treat as plugin shorthand; never attribute to Pat. |
 | `central emotion` | 0 | **Do not use.** It truncates a real three-part phrase — see below. |
+
+`front-heavy` / `back-heavy` are Pat's, coined in his patpattison.com column
+"The Art of Phrasing" (fetched and read 2026-08-11,
+<https://www.patpattison.com/art-of-phrasing>), which defines both:
+
+> "We'll call phrases that start on the downbeat of a bar, or pick up to the
+> downbeat, front-heavy."
+> "We'll call phrases that start after the downbeat back-heavy."
+
+So the correct caveat on these two is **"not in the four books, cite the
+column"** — not "not Pat's". `phrasing.md` had this right before this table did.
 
 `central emotion` is a distortion rather than an invention, which is why sweeps
 for fabricated quotes kept missing it. Pat's actual sentence is:

--- a/plugins/songwriting/context/pat-pattison/research/book-references.md
+++ b/plugins/songwriting/context/pat-pattison/research/book-references.md
@@ -91,6 +91,33 @@ Pat Pattison — *What's in a Song* podcast, "Creating Metaphors" episode
 Date when relevant. Citation includes the publication / platform first,
 then the title.
 
+## Plugin-authored vocabulary — terms that are NOT Pat's
+
+These terms are used throughout this plugin as working shorthand. **None of them
+appears anywhere in the four-book corpus.** Each count below was measured against
+the extracted text of all four books, wrap-safe:
+
+| Term | Corpus hits | Status |
+| --- | --- | --- |
+| `tone of voice` | 0 | Plugin-authored shorthand. Keep, but never attribute to Pat. |
+| `front-heavy` / `back-heavy` | 0 | Plugin-authored shorthand for phrase weighting. Same rule. |
+| `central emotion` | 0 | **Do not use.** It truncates a real three-part phrase — see below. |
+
+`central emotion` is a distortion rather than an invention, which is why sweeps
+for fabricated quotes kept missing it. Pat's actual sentence is:
+
+> The elements all join together to support the central intent, idea, and emotion
+> of the work. Everything fits. Prosody: the appropriate relationship between
+> elements.
+> — Pat Pattison, *Writing Better Lyrics* (2009), Chapter 18
+
+When the three-part idea is meant, write it in Pat's wording — "the central
+intent, idea, and emotion" — not the shortened "central emotion."
+
+A term being plugin-authored is not a defect and does not have to be removed.
+Presenting one **as Pat's** is the defect. `stable-unstable-meta.md` carries the
+worked example of the correction.
+
 ## Why this convention matters
 
 - Book numbers are unstable references — readers (human or AI) re-order them

--- a/plugins/songwriting/context/pat-pattison/research/cliche.md
+++ b/plugins/songwriting/context/pat-pattison/research/cliche.md
@@ -94,7 +94,9 @@ fine; the next step is finding your own way of saying it.
 
 ## Four cliche families
 
-Diagnose cliches by family:
+The four family names and the four headed lists below them are Pat's. The
+Symptom and Cure columns of this table are **this plugin's, not Pat's** — a
+routing aid, not something he prints:
 
 | Family | Symptom | Cure |
 | --- | --- | --- |
@@ -112,7 +114,9 @@ Cliche phrases usually tell instead of show. They name a familiar emotion,
 gesture, or relational situation without giving the listener a body, object,
 room, weather, texture, or action to enter.
 
-Diagnosis questions:
+Diagnosis questions — these and the rewrite pattern below are **this plugin's,
+not Pat's**; Chapter 5 prints the phrase list and the two draft verses, and
+prescribes no procedure:
 
 - Does this phrase appear in hundreds of songs?
 - Could another singer in another story use it unchanged?
@@ -120,30 +124,44 @@ Diagnosis questions:
 - Does it explain emotion before showing Rusty's collar?
 - Does it arrive because the writer is trying to fill meter or rhyme?
 
-Pat's own list runs to roughly a hundred entries. A representative slice, in his
-grouping:
+Pat prints his own list under the heading CLICHÉ PHRASES as a three-column
+table. Here it is complete, in printed order:
 
 ```text
-(way down) deep inside      touch my (very) soul       take my hand
-heart-to-heart              eye to eye                 hand-in-hand
-side by side                face-to-face               by my side
-we've just begun            hurts so bad               walk out (that) door
-can't stand the pain        feel the pain              give me half a chance
-gotta take a chance         such a long time           night and day
-all night long              the test of time           rest of my life
-someone like you            no one can take your place lonely nights
-say you'll be mine          how it used to be          made up my mind
-calling out your name       it's gonna be all right    get down on my knees
-more than friends           set me free                heaven above
-done you wrong              break these chains         kiss your lips
-falling apart               can't live without you     taken for granted
-lost without you            break my heart             safe and warm
-give you my heart           broken heart               can't go on
-want you / need you / love you                         keep holding on
-end of the line             now or never               pay the price
-never let you (me) go       hold me tight              worth fighting for
-nothing to lose             see the light              forget my foolish pride
-oh baby                     drive me crazy             going insane
+(way down) deep inside      touch my (very) soul     take my hand
+heart-to-heart              eye to eye               hand-in-hand
+side by side                in and out               face-to-face
+up and down                 by my side               back and forth
+we've just begun            hurts so bad             walk out (that) door
+can't stand the pain        can't take it            feel the pain
+give me half a chance       last chance              gotta take a chance
+such a long time            night and day            take your time
+all night long              the test of time         the rest of time
+rest of my life             someone like you         end of time
+no one can take your place  all my love              no one like you
+lonely nights               say you'll be mine       losing sleep
+I'll get along              how it used to be        made up my mind
+calling out your name       it's gonna be all right  get down on my knees
+more than friends           set me free              end it all
+fooling around              work it out              had your fun
+heaven above                true to you              done you wrong
+break these chains          kiss your lips           back to me
+take it easy                falling apart            make you stay
+can't live without you      taken for granted        asking too much
+somebody else               lost without you         no tomorrow
+break my heart              safe and warm            give you my heart
+try one more time           broken heart             aching heart
+can't go on                 all we've been through   want you / need you / love you
+keep holding on             end of the line          now or never
+always be true              hold on                  over the hill
+pay the price               never let you (me) go    know for sure
+right or wrong              rise above               hold me tight
+what we're fighting for     all we've done           tear me apart
+you know it's true          worth fighting for       play the game
+hold me close               nothing to lose          see the light
+forget my foolish pride     losing sleep             oh baby
+drive me crazy              treat me like a fool     all my dreams come true
+going insane                rhyme or reason
 ```
 
 Rewrite pattern:
@@ -193,7 +211,9 @@ Pat's diagnosis of why the list looks like that, and the cure it implies:
 > won't notice the difference.
 
 Use [worksheets](worksheets.md) to build options, then use
-[rhyme types](rhyme-types.md) to widen the field:
+[rhyme types](rhyme-types.md) to widen the field. The assignments below are
+**this plugin's, not Pat's** — Chapter 5 names the imperfect types but assigns
+none of them a job, and consonance is not in his list here at all:
 
 - family rhyme for close-but-fresh resolution,
 - additive or subtractive rhyme for loosened resolution,
@@ -232,7 +252,8 @@ own memory:
 > What did your lover say? Where were you? What kind of car? What was the
 > texture of the upholstery in the backseat?
 
-Ask:
+Ask — extending Pat's four questions; the list below is **this plugin's, not
+Pat's**:
 
 - Whose lips, eyes, hands, door, room, or car?
 - What did the object actually look, smell, sound, or feel like?
@@ -278,7 +299,8 @@ thoughts, though a cliché, is a metaphor. It's literally false." So
 and literal falsehood separately.
 
 Do not ban these automatically. Ask whether the draft adds a fresh collision or
-specific sensory angle. If it does not, rebuild the metaphor from:
+specific sensory angle. If it does not, rebuild the metaphor from the following
+— **this plugin's** routing into Chapter 3, not a list Pat prints here:
 
 - object-writing details,
 - a less expected key of related words,
@@ -341,15 +363,15 @@ And it's all downhill from here
 The literal roller coaster earns the figurative phrase. Pat's warning attached to
 both cases: "Without a terrific setup, duck whenever you see a cliché."
 
-Pat's test has **two** parts, not four. He states the first outright, opening the
-section:
+Pat states the test outright, opening the section — one instruction with two
+alternatives:
 
 > In some cases, you can use a cliché to your advantage. Put it in a context that
 > brings out its original meaning or makes us see it in a new way.
 
-The second is the overtone condition quoted above: the cliche's usual sense must
-ride *under* a primary meaning the song has built, not carry the line itself. If
-neither holds, cut or rewrite.
+The overtone sentence quoted above is Pat's reading of the Fain/Kahal case, not a
+second general criterion: there, the cliche's usual sense rides *under* a primary
+meaning the song has built. Where a setup does neither job, cut or rewrite.
 
 ## Draft-stage tolerance
 

--- a/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
+++ b/plugins/songwriting/context/pat-pattison/research/five-compositional-elements.md
@@ -33,8 +33,8 @@ The five elements:
 > subject of *Essential Guide to Rhyming* (2014).
 
 The five are not a rule; they are the five places where craft choices
-land. A section is "tight" when all five support the central emotion and
-the section's job within the form.
+land. A section is "tight" when all five support the central intent, idea,
+and emotion of the work, and the section's job within the form.
 
 ## Why all five at once
 
@@ -75,7 +75,7 @@ Section: <verse 1 | chorus | bridge | etc.>
                         deliberate variations>
 
 Verdict:
-- Supports central emotion? <yes | partially | no>
+- Supports the central intent, idea, and emotion? <yes | partially | no>
 - Supports section job in form? <yes | partially | no>
 - Strongest element: <which>
 - Weakest element: <which>

--- a/plugins/songwriting/context/pat-pattison/research/form.md
+++ b/plugins/songwriting/context/pat-pattison/research/form.md
@@ -310,14 +310,56 @@ Pat's worked case is Ervin Drake's "IT WAS A VERY GOOD YEAR."
 > no contrasting sections. When you write a lyric that contains only verses,
 > make sure they are interesting.
 
+```text
+When I was thirty-five IT WAS A VERY GOOD YEAR
+IT WAS A VERY GOOD YEAR for blue-blooded girls
+Of independent means
+We'd ride in limousines
+Their chauffeurs would drive
+When I was thirty five
+```
+
+<!-- Pat prints "thirty-five" in the first line and "thirty five" in the last,
+     within the same verse. Both are as printed at spine 013. Do NOT normalize
+     the hyphen — the plugin has been caught silently correcting Pat before. -->
+
 > In the fourth verse there is a wonderful variation. You expect the CENTRAL
 > IDEA to be the second phrase because that's where it was in the other verses.
 > But no.
 
-<!-- LYRIC-HANDOFF pending: Chapter 5 prints four verses of "IT WAS A VERY GOOD
-YEAR" (Ervin Drake) at spine 013 l.87-141 — seventeen / twenty-one /
-thirty-five / "But now the days are short". None is transcribed here yet, so the
-analysis above has no text to point at. -->
+```text
+But now the days are short, I'm in the autumn of the year
+And now I think of my life as a vintage wine
+From fine old kegs
+From the brim to the dregs
+It poured sweet and clear
+IT WAS A VERY GOOD YEAR
+```
+
+The four verses Pat prints, in his order. Verse one sets the standard:
+
+```text
+When I was seventeen IT WAS A VERY GOOD YEAR
+IT WAS A VERY GOOD YEAR for small town girls
+On soft summer nights
+We'd hide from the lights
+On the village green
+When I was seventeen
+```
+
+— Ervin Drake, "IT WAS A VERY GOOD YEAR"
+
+> Again, the verse sets the standard. Again, it is easy to recognize a
+> repetition:
+
+```text
+When I was twenty-one IT WAS A VERY GOOD YEAR
+IT WAS A VERY GOOD YEAR for city girls
+Who lived up the stair
+With perfumed hair
+That came undone
+When I was twenty-one
+```
 
 > Saving the CENTRAL IDEA till last has two effects:
 >
@@ -353,9 +395,15 @@ Verse list above:
 > feeling of "starting over again" in the next section. Here is an excellent
 > Chorus.
 
-<!-- LYRIC-HANDOFF pending: Pat's colon-equivalent above ("Here is an excellent
-Chorus.") is followed in the chapter by the five-phrase "Years" chorus, spine
-013 l.171-181. Not transcribed here yet. -->
+```text
+And I let time go by so slow
+And I made every moment last
+And I thought about YEARS
+How they take so long
+And they go so fast
+```
+
+— Beth Nielsen Chapman, "Years"
 
 His verdict on that chorus (the "Years" chorus, discussed further under "Chorus
 balance can be composite" below):
@@ -473,14 +521,35 @@ Chapter 5 — the arithmetic is his, and the figures `image_rsrc320` and
 > Beth Nielsen Chapman also does a neat trick with stresses to balance the
 > section. The first two phrases are three stresses (2 x 3 = 6):
 
+Transcribed from figure `image_rsrc320`, rendered and read (`u` = Pat's breve,
+`/` = his acute):
+
+```text
+And I let time go by so slow
+ u  u  u   /  u  /  u   /
+And I made every moment last
+ u  u  u    /u   /u    /
+```
+
 > The last three phrases are each two stresses (3 x 2 = 6):
 
-> A balancing act with built in acceleration.
+Transcribed from figure `image_rsrc321`:
 
-<!-- LYRIC-HANDOFF pending: both of Pat's colons above are dangling — the
-scanned phrases live only in figures `image_rsrc320` and `image_rsrc321` (spine
-013 l.187-191), and the eight-phrase "Years" verse he comments on below is at
-l.206-222. None is transcribed here yet. -->
+```text
+And I thought about Years
+ u  u    /     u u   /
+How they take so long
+ u   u    /   u   /
+And they go so fast
+ u   u   /  u   /
+```
+
+Two markings worth not "correcting": **"made" carries a breve, not a stress**,
+and in "thought about" the stress sits on **"thought"** while both syllables of
+"about" are unstressed. Do not re-scan these from intuition — the marks are
+Pat's, read off the printed figures.
+
+> A balancing act with built in acceleration.
 
 The chapter frames the same chorus against the five Chorus prescriptions:
 
@@ -640,16 +709,37 @@ Pat's worked example is Buck Ram's "THE GREAT PRETENDER." Chapter 5, verbatim:
 > of section. But one ball is unbalanced. You want to hear a rhyme with
 > "believe:"
 
+Figure `image_rsrc324`, rendered and read — the couplet as the ear predicts it,
+with the rhyme-scheme letters Pat prints in the right margin:
+
+```text
+Too real is this feeling of make believe           a
+Too real when I feel what my heart can't conceive  a
+```
+
+In that figure Pat italicizes only the closing rhyme syllable of "believe" and
+of "conceive", showing the two lines landing on the same sound.
+
 > But what you get is:
+
+Figure `image_rsrc325` — what is actually printed. The rhyme letter changes to
+`b`:
+
+```text
+Too real is this feeling of make believe           a
+Too real when I feel what my heart can't conceal   b
+```
+
+Here the italics move: Pat sets "real", "feel", "real", "feel" and the "ceal"
+of "conceal" in italics — five marked sounds, not two.
 
 > A slick deception that throws you off balance with five "eel" sounds. Since
 > you are a little off balance, the return to familiar territory is a relief. A
 > new and bigger Song System is formed.
 
-<!-- LYRIC-HANDOFF pending: both of Pat's dangling colons above resolve into
-figures — `image_rsrc324` (the rhyme you expect after "believe") and
-`image_rsrc325` (the rhyme you actually get). Neither is transcribed here yet.
-Spine 013 l.302-308. -->
+The five "eel" sounds Pat counts are exactly the five he italicizes in figure
+`image_rsrc325`. The first figure is a hypothetical — "conceive" is the rhyme
+the ear wants and does not get — so do not quote that line as part of the song.
 
 The AABA homecoming paragraph that follows this passage in the chapter, and the
 `( Bridge -> Verse )` figure `image_rsrc327`, are both quoted in
@@ -722,10 +812,51 @@ Ocasek of The Cars is typical." Chapter 5, verbatim:
 > meaning, but the structure is preserved. The tripping effect at the long "i"
 > rhyme at "blind" again sets up the sound of the Title.
 
-<!-- LYRIC-HANDOFF pending: each of Pat's colons above is followed in the
-chapter by the transitional-bridge lines being discussed (spine 013 l.404-428),
-and Song Systems 1 and 2 are figures `image_rsrc32F` / `image_rsrc32G`. None is
-transcribed here yet. -->
+The lines each of those colons points at, in Pat's order. He builds the bridge
+up a phrase at a time. First the couplet whose two lines do not rhyme:
+
+```text
+Just one more time to touch you
+Just one more time to tell you
+```
+
+Then the short third line that unbalances it:
+
+```text
+Just one more time to touch you
+Just one more time to tell you
+You're on my mind
+```
+
+Then the same bridge running into the Chorus, where the imperfect "time/mind"
+rhyme trips the ear and sets up the long "i" of the title:
+
+```text
+Just one more time to touch you
+Just one more time to tell you
+You're on my mind
+WHY CAN'T I HAVE YOU
+```
+
+Song System 2, read from figure `image_rsrc32G` — the same transitional bridge
+with only its third phrase changed, which is the point Pat is making:
+
+```text
+Candy smile, all the while, glinting                 VERSE
+Your eyes like mica, lethal pout, hinting
+Felt the pressure tight and warm, softly striking
+I tripped and stumbled, I cling forever
+I go all night
+
+    Just one more time to touch you                  TR. BR.
+    Just one more time to tell you
+    I'm not so blind
+
+WHY CAN'T I HAVE YOU . . .                           CHORUS
+```
+
+The section labels in the right margin (`VERSE`, `TR. BR.`, `CHORUS`) and the
+indentation of the bridge are Pat's, as printed in the figure.
 
 <!-- unaudited: the summary bullets above ("Introduces a pivotal idea…") are a
 restatement of Chapter 5's five numbered points; those are verbatim in

--- a/plugins/songwriting/context/pat-pattison/research/form.md
+++ b/plugins/songwriting/context/pat-pattison/research/form.md
@@ -306,6 +306,32 @@ sections cannot sound like repetition, contrast, departure, or return.
 Pat's worked case is Ervin Drake's "IT WAS A VERY GOOD YEAR."
 *Essential Guide to Lyric Form and Structure* (1991), Chapter 5:
 
+All four verses, in the order Chapter 5 prints them, each with the prose Pat
+sets against it. Verse one:
+
+```text
+When I was seventeen IT WAS A VERY GOOD YEAR
+IT WAS A VERY GOOD YEAR for small town girls
+On soft summer nights
+We'd hide from the lights
+On the village green
+When I was seventeen
+```
+
+> — Ervin Drake, "IT WAS A VERY GOOD YEAR"
+
+> Again, the verse sets the standard. Again, it is easy to recognize a
+> repetition:
+
+```text
+When I was twenty-one IT WAS A VERY GOOD YEAR
+IT WAS A VERY GOOD YEAR for city girls
+Who lived up the stair
+With perfumed hair
+That came undone
+When I was twenty-one
+```
+
 > "IT WAS A VERY GOOD YEAR," like many songs, is made up only of verses. It has
 > no contrasting sections. When you write a lyric that contains only verses,
 > make sure they are interesting.
@@ -334,31 +360,6 @@ From fine old kegs
 From the brim to the dregs
 It poured sweet and clear
 IT WAS A VERY GOOD YEAR
-```
-
-The four verses Pat prints, in his order. Verse one sets the standard:
-
-```text
-When I was seventeen IT WAS A VERY GOOD YEAR
-IT WAS A VERY GOOD YEAR for small town girls
-On soft summer nights
-We'd hide from the lights
-On the village green
-When I was seventeen
-```
-
-— Ervin Drake, "IT WAS A VERY GOOD YEAR"
-
-> Again, the verse sets the standard. Again, it is easy to recognize a
-> repetition:
-
-```text
-When I was twenty-one IT WAS A VERY GOOD YEAR
-IT WAS A VERY GOOD YEAR for city girls
-Who lived up the stair
-With perfumed hair
-That came undone
-When I was twenty-one
 ```
 
 > Saving the CENTRAL IDEA till last has two effects:
@@ -403,7 +404,13 @@ How they take so long
 And they go so fast
 ```
 
-— Beth Nielsen Chapman, "Years"
+<!-- No attribution line is printed under this chorus in Chapter 5 — Pat runs it
+     straight into "This certainly fits all five…". Do NOT add one: an earlier
+     pass added "— Beth Nielsen Chapman, 'Years'" here in the same em-dash form
+     as Pat's one real attribution (the Ervin Drake line above, spine 013 raw
+     l.57), which made fabricated typography look like printed text. The song is
+     "Years" and Pat names Beth Nielsen Chapman in his own prose below; that is
+     where the credit lives. -->
 
 His verdict on that chorus (the "Years" chorus, discussed further under "Chorus
 balance can be composite" below):
@@ -467,6 +474,26 @@ and "3+" is an ordinary variant of its four-stress line, so the section still
 leans toward the meter the verse has already established at length. Where a
 chorus is meant to contrast with a common-meter verse, check what its
 balancing phrases are doing, not only whether the numbers differ.
+
+The verse itself, as Chapter 5 prints it — nine typographic lines, each its own
+paragraph in the source:
+
+```text
+Across the street
+the Randall's oldest daughter must have come home
+Her two boys built a snowman by the backyard swings
+I thought of Old Man Randall and his Christmas decorations
+And how he used to leave them up till early spring
+And I thought of all the summers
+I paced that porch and swore I'd die of boredom there
+And I thought of what I'd give
+to feel another summer linger when a day feels like a year
+```
+
+**Nine printed lines, eight phrases — and the mismatch is Pat's point, not an
+error.** He introduces this verse by saying the phrases are long and that "It is
+even a challenge to figure out exactly where some of the phrases start and
+stop." Do not count the printed lines and call that a phrase count.
 
 On how many verse phrases that is: **the two books agree at eight, and the
 apparent standoff was our error, not Pat's.** *Writing Better Lyrics* (2009),
@@ -835,6 +862,37 @@ rhyme trips the ear and sets up the long "i" of the title:
 Just one more time to touch you
 Just one more time to tell you
 You're on my mind
+WHY CAN'T I HAVE YOU
+You're breaking my heart in two
+You know what I'm going through
+WHY CAN'T I HAVE YOU
+```
+
+All seven lines are printed at this stage — three bridge phrases and the full
+four-line Chorus. Keep the Chorus complete here: the paragraph above turns on
+the chorus "i" sounds being "positioned asymmetrically, so there is no
+resolution until the end of the system", and the evidence for that is the last
+three lines. Quoting only the first Chorus line leaves that claim with nothing
+under it.
+
+Song System 1, read from figure `image_rsrc32F` — the whole system Pat brackets
+on the page, so the transitional bridge can be seen in its place between verse
+and chorus:
+
+```text
+Dreamy lips, set in motion, flashing                 VERSE
+Breathless hush, pounding soft, lasting
+Glossy mouth, taste untamed, moving
+Carousel, up and down
+Just like you
+
+    Just one more time to touch you                  TR. BR.
+    Just one more time to tell you
+    You're on my mind
+
+WHY CAN'T I HAVE YOU                                 CHORUS
+You're breaking my heart in two
+You know what I'm going through
 WHY CAN'T I HAVE YOU
 ```
 

--- a/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
+++ b/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
@@ -5,16 +5,28 @@ Pat Pattison — *patpattison.com* "Lyric and Melodic Phrases" plus
 phrasing. Books bracket the music; this file is the bridge between a lyric's
 natural phrasing and a melody's actual phrasing.
 
-**UNAUDITED — read this before quoting anything below.** The "roadmap" framing
+**Source status — the non-book source has now been READ.** The "roadmap" framing
 is not in the four books. Measured wrap-safe across all four: `roadmap` returns
 **one** hit, in *Essential Guide to Rhyming* (2014) and in a different sense
 ("Rhyme creates a sonic roadmap"); `compatible roadmaps` and `maximum meaning`
-return **zero**. The two `— Pat (patpattison.com)` quotes below are from a
-non-book source nobody here has been able to open, so they are neither confirmed
-nor refuted — treat them as unverified paraphrase, not as quotable Pat, and
-never build a citation on them. The 1991 Chapter 1-2 citation above is sound
-(those chapters are "Number of Phrases" and "Length of Phrases"); it covers the
-phrase material, not the roadmap vocabulary.
+return **zero**.
+
+It is, however, genuinely Pat's, from outside the books. The article
+"Lyric and Melodic Phrases" was fetched and read on 2026-08-11 at
+<https://www.patpattison.com/lyric-and-melodic-phrases>, and it uses "roadmap"
+throughout as its governing metaphor. The "maximum meaning" quote below is
+**confirmed verbatim** against that page, and the three fixes below are **Pat's
+own numbered options**, not this file's invention — see that section.
+
+Still unconfirmed: the `"Phrasing has the power to create emotion. It's the body
+language."` quote further down. It is **not** in the "Lyric and Melodic Phrases"
+article — the phrase "body language" does not appear there at all — and no other
+patpattison.com page carrying it has been located. It is marked unaudited in
+place and must not be quoted as Pat.
+
+The 1991 Chapter 1-2 citation above is sound (those chapters are "Number of
+Phrases" and "Length of Phrases"); it covers the phrase material, not the
+roadmap vocabulary.
 
 Use this when a writer says "the words don't fit the music", "this line
 breaks weird", "the singer is breathing in the middle of a word", "we set
@@ -29,11 +41,13 @@ and end based on breath, cadence, and rest. When the two disagree, the
 listener hears two competing structures and the meaning blurs.
 
 > "Creating compatible roadmaps melodically and lyrically is essential to
-> getting maximum meaning." — Pat (patpattison.com)
+> getting maximum meaning and impact from your song."
+> — Pat Pattison, patpattison.com, "Lyric and Melodic Phrases"
+> (fetched and verified 2026-08-11)
 
 The diagnostic is whether the lyric's phrase boundaries align with the
-melody's phrase boundaries. Three ways out are set out below; they are this
-file's own organisation of the problem, not a taxonomy Pat publishes.
+melody's phrase boundaries. The fixes set out below are **Pat's own numbered
+options** from that article, not this file's organisation of the problem.
 
 ## What a roadmap is
 
@@ -61,13 +75,24 @@ suspension) or a bad one (the listener has to re-parse to catch the meaning).
      word and then claiming he named this state was the fabrication; the
      observation itself is fine, so it is kept, unattributed. -->
 
-## Three ways out — this file's own framing, not Pat's
+## Ways out — Pat's options, with this file's decision aid layered on
 
-*No book names an "alignment fix", numbers them, or supplies the `Use when:` and
-`Risk:` lines below. They are this repo's decision aid. They are still useful;
-they are just not citable to Pat. Do not reintroduce the word "named" here — an
-earlier heading asserted "the three **named** alignment fixes", and a heading
-that keeps claiming a taxonomy is how the claim grows a body back.*
+*Corrected 2026-08-11 after the source article was fetched and read.* Split the
+two things carefully, because an earlier pass got this backwards in both
+directions:
+
+- **Pat's, and citable.** The options themselves are his. "Lyric and Melodic
+  Phrases" lists **four**, and the first three are what this file calls Fix 1,
+  Fix 2 and Fix 3 — change the music to match the lyric's roadmap; change the
+  lyric to match the melodic roadmap; repeat a word from the first line at the
+  beginning of the next line. An earlier pass demoted these as "this file's own
+  framing, not Pat's." That demotion was wrong.
+- **Still this repo's, and NOT citable.** No book or article supplies the
+  `Use when:` and `Risk:` lines below, or the "Fix N" titles. Those are the
+  decision aid and stay unattributed.
+- **Do not write "the three named alignment fixes."** Pat lists his options; he
+  does not name them, and there are four of them, not three. That phrasing was
+  the original fabrication and it is still wrong.
 
 When a roadmap mismatch is breaking the lyric, pick one:
 
@@ -124,6 +149,20 @@ Use when:
      attribution goes. -->
 
 Risk: overuse becomes a tic.
+
+### Pat's fourth option — recorded because leaving it out is what caused the error
+
+The article's list does not stop at three. Its fourth option is:
+
+> "Keep it the way it is, since no one listens to lyrics anyway."
+> — Pat Pattison, patpattison.com, "Lyric and Melodic Phrases"
+> (fetched and verified 2026-08-11)
+
+It is a joke, and it is doing real work: it names the thing a writer is
+actually tempted to do, so that declining to fix a mismatch is a visible
+choice rather than a silent default. Do not present it as a craft
+recommendation — and do not drop it again. Counting his four options as three
+is precisely what made an earlier pass conclude the taxonomy was invented.
 
 ## How to diagnose
 
@@ -198,8 +237,18 @@ Where the lyric phrase begins relative to the bar shapes the roadmap.
 - **Back-heavy** — phrase starts after the downbeat. Feels in motion,
   unstable.
 
-> "Phrasing has the power to create emotion. It's the body language."
-> — Pat (patpattison.com)
+<!-- DEMOTED 2026-08-11 — attribution not confirmed. This was carried as a
+     direct quotation credited to patpattison.com. The "Lyric and Melodic
+     Phrases" article was fetched and read on 2026-08-11 and does NOT contain
+     it: the phrase "body language" does not appear in that article at all, and
+     no other patpattison.com page carrying it has been located. The quotation
+     marks and the attribution are removed rather than re-sourced. The
+     observation itself is retained below, unattributed, because it is useful
+     and the craft point does not depend on who said it. Do NOT re-add a
+     citation without reading a page that actually prints the sentence. -->
+
+Phrasing carries emotion — it is a section's body language. (Unattributed;
+plugin-authored phrasing of the point. See the demotion note above.)
 
 A back-heavy lyric phrase against a front-heavy melodic phrase fights the
 section's body language. The fix is usually to shift the lyric's leading

--- a/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
+++ b/plugins/songwriting/context/pat-pattison/research/lyric-melodic-roadmaps.md
@@ -18,11 +18,12 @@ throughout as its governing metaphor. The "maximum meaning" quote below is
 **confirmed verbatim** against that page, and the three fixes below are **Pat's
 own numbered options**, not this file's invention — see that section.
 
-Still unconfirmed: the `"Phrasing has the power to create emotion. It's the body
-language."` quote further down. It is **not** in the "Lyric and Melodic Phrases"
-article — the phrase "body language" does not appear there at all — and no other
-patpattison.com page carrying it has been located. It is marked unaudited in
-place and must not be quoted as Pat.
+The `"body language"` quote further down is **also confirmed**, but to a
+different column — "The Art of Phrasing"
+(<https://www.patpattison.com/art-of-phrasing>), not this one. It was briefly
+demoted this session on the mistaken grounds that no source carried it; a
+refuting pass found the page immediately. Its tail "of your song" had been
+truncated and is restored.
 
 The 1991 Chapter 1-2 citation above is sound (those chapters are "Number of
 Phrases" and "Length of Phrases"); it covers the phrase material, not the
@@ -237,18 +238,24 @@ Where the lyric phrase begins relative to the bar shapes the roadmap.
 - **Back-heavy** — phrase starts after the downbeat. Feels in motion,
   unstable.
 
-<!-- DEMOTED 2026-08-11 — attribution not confirmed. This was carried as a
-     direct quotation credited to patpattison.com. The "Lyric and Melodic
-     Phrases" article was fetched and read on 2026-08-11 and does NOT contain
-     it: the phrase "body language" does not appear in that article at all, and
-     no other patpattison.com page carrying it has been located. The quotation
-     marks and the attribution are removed rather than re-sourced. The
-     observation itself is retained below, unattributed, because it is useful
-     and the craft point does not depend on who said it. Do NOT re-add a
-     citation without reading a page that actually prints the sentence. -->
+<!-- DEMOTED, THEN RESTORED, both on 2026-08-11. The demotion was WRONG and is
+     recorded here so it is not repeated. This quote was demoted on the grounds
+     that the "Lyric and Melodic Phrases" article does not contain it (true —
+     "body language" does not appear in THAT article) and that no other
+     patpattison.com page carrying it had been located (FALSE). A refuting
+     verification pass found the source on the first search: it is a DIFFERENT
+     column, "The Art of Phrasing". The lesson is that failing to find a source
+     is not evidence it does not exist — search again before demoting. -->
 
-Phrasing carries emotion — it is a section's body language. (Unattributed;
-plugin-authored phrasing of the point. See the demotion note above.)
+> "Phrasing has the power to create emotion. It's the body language of your
+> song."
+> — Pat Pattison, patpattison.com, "The Art of Phrasing"
+> (<https://www.patpattison.com/art-of-phrasing>, fetched 2026-08-11)
+
+Note the tail: the plugin previously printed this as "It's the body language."
+and stopped. The article reads "the body language **of your song**" — the same
+truncation this file made to the "maximum meaning" quote above. Both are now
+restored in full.
 
 A back-heavy lyric phrase against a front-heavy melodic phrase fights the
 section's body language. The fix is usually to shift the lyric's leading

--- a/plugins/songwriting/context/pat-pattison/research/meter.md
+++ b/plugins/songwriting/context/pat-pattison/research/meter.md
@@ -546,7 +546,7 @@ four-stress second phrase produces once it is carried across all four lines.
 
 ## Common meter as map
 
-In *Writing Better Lyrics* Chapter 14, common meter becomes a drafting map, not only
+In *Writing Better Lyrics* (2009), Chapter 14, common meter becomes a drafting map, not only
 a scansion label. Pat's image for the eight-bar section is a sea voyage — "the
 sea captain of Western popular music" — and the two- and four-bar subdivisions
 are landmarks along it. The end of bar two rests, bars three and four tack into
@@ -629,7 +629,7 @@ content. Do not turn on a spotlight for decoration.
 
 ## Common-meter spotlighting
 
-In *Writing Better Lyrics* Chapter 15, Pattison turns common meter into a controlled
+In *Writing Better Lyrics* (2009), Chapter 15, Pattison turns common meter into a controlled
 spotlight machine. Begin with a stable abab / 4-3-4-3 pattern, let the listener
 expect the fourth line to rhyme with line two and carry three stresses, then
 alter one variable at a time. His demonstration stanza, which the whole chapter
@@ -761,7 +761,7 @@ without the tighter nursery-rhyme pull of abab.
 
 ## Two-by-two meter
 
-In *Writing Better Lyrics* Chapter 16, Pattison contrasts common meter's eight-bar
+In *Writing Better Lyrics* (2009), Chapter 16, Pattison contrasts common meter's eight-bar
 journey with four-stress couplets that organize two bars plus two bars. The
 basic pattern is four stresses matched by four stresses. Because the line
 lengths match, the listener can stop comfortably after line two.
@@ -923,7 +923,7 @@ one that closes cleanly.
 
 ## Managing lockstep couplets
 
-In *Writing Better Lyrics* Chapter 17, Pattison treats repeated four-stress rhymed
+In *Writing Better Lyrics* (2009), Chapter 17, Pattison treats repeated four-stress rhymed
 couplets as useful raw material that can become deadly if every two lines stop
 and start the song again. The danger pattern is aa bb cc dd ee: matched lengths
 plus paired rhymes make the lyric march in small units, so every weak line
@@ -1252,7 +1252,7 @@ As with deceptive closure, use the surprise position for important content.
 
 ## Challenge 4 rhythm practice
 
-*Songwriting Without Boundaries* Challenge 4 links object writing to lyric
+*Songwriting Without Boundaries* (2011), Challenge 4 links object writing to lyric
 practice by putting timed sensory writing inside stress-counted forms. The
 writer still looks for sensory detail and metaphor, but now every line has a
 metrical job.
@@ -1508,21 +1508,34 @@ u   /    u   /     u  /   u   /
 Use Paradigm Three when the last idea must spotlight or unsettle. The
 expectation of a 3-stress close makes the longer line audible.
 
-## Paradigm comparison — One vs Two
+## Paradigm comparison — One vs Two (*Essential Guide to Lyric Form and Structure* (1991), Chapter 3)
 
-Teaching move: write the same idea in Paradigm One and Paradigm Two.
-The words feel different because the flow shape differs.
+Pat prints the two paradigms in immediate succession and states why:
+
+> Comparing PARADIGM 1 and PARADIGM 2 is the best way to understand FLOW. It
+> shows when and why a structure pushes forward, and when and why it doesn't.
+
+The comparison is drawn in arrows, not described. Paradigm 1's figure carries
+`-> motion` against phrases two and three and `<- closure` against phrase four;
+Paradigm 2's carries `<- closure` twice, against phrases two and four. The
+differences Chapter 3 names behind those arrows:
 
 | Aspect | Paradigm One | Paradigm Two |
 |---|---|---|
-| Stresses | 4/3/4/3 | 4/4/4/4 |
-| Flow | through-written | fragmented |
-| Length perception | Long arc | Two paired chunks |
-| Default mood | Expansive, narrative | Even, declarative |
-| Best for | Verses that develop | Choruses that declare |
+| Stress counts | 4/3/4/3 | 4/4/4/4 |
+| Repetition scheme | SAME / DIFFERENT / SAME ... | SAME / SAME / SAME / SAME |
+| Flow | through-written | fragmented — closes internally after phrase two |
 
-When unsure, draft both and sing each. The ear picks faster than
-the page.
+One consequence follows once the structure is set in bars: Paradigm Two
+"defines a four-bar unit as the primary unit of the structure rather than, like
+Common Meter, showing the four-bar unit as a subdivision of an eight-bar unit."
+
+Chapter 3 assigns neither paradigm a mood, a section type, or a "best for" use;
+the paradigms are characterized only by the Pentad. Earlier revisions of this
+file carried "Length perception," "Default mood," and "Best for" rows here,
+plus a "Teaching move" directing a writer to set the same idea in both — none
+of that is in the chapter, and Exercises 14 and 15 in fact ask for three systems
+of *different* content in each paradigm. Removed rather than re-sourced.
 
 ## Duple-to-triple and triple-to-duple physics
 

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -97,7 +97,8 @@ The mechanism is not "color" in the abstract. It is a bag of dye:
 > bag of dye. Hang the dye on top of the section and let it drip its colors
 > downward onto the other lines, giving them more interest and depth.
 
-Placement is load-bearing, and Pat proves it by moving the collar down one line:
+Placement is load-bearing, and Pat proves it by moving the collar down two lines,
+from the top of the section to line three:
 
 ```text
 Nothing matters like it did
@@ -197,9 +198,9 @@ Lyrics* (2009), Chapter 1, Exercise 1:
 
 *Songwriting Without Boundaries* (2011) prints a shorter list, and reprints it
 as the line the writer lets their eye wander to when they do not know where to
-go next. It stands at the head of the Challenge 1 opener and of all fourteen
-Challenge 1 days, and again on all fourteen Challenge 4 days; the metaphor
-challenges in between do not carry the strip. Pat's framing on Day 1:
+go next. It appears once in the Challenge 1 opener, once on each of the fourteen
+Challenge 1 days, and once again on each of the fourteen Challenge 4 days; the
+metaphor challenges in between do not carry the strip. Pat's framing on Day 1:
 
 > Use the list below as a place to let your eye wander when you're not sure
 > where to go next.
@@ -456,8 +457,8 @@ Pat's second documented demonstration is Cathy Brettell's ten-minute write on
 > — Pat Pattison, *Songwriting Without Boundaries* (2011), Challenge 1
 > opener
 
-Note the ending: "(time!)" and then "soft crystal knob pulls shut" cut off. That
-is the buzzer, printed.
+Note the ending as printed: the write trails off into an ellipsis after "soft
+crystal knob pulls shut", and "(time!)" follows it. That is the buzzer, printed.
 
 Diagnostic when a write reads flat: number the images and name the sense
 carrying each handoff. Handoffs carried by topic ("and also in the elevator
@@ -600,8 +601,8 @@ fourteen-day format, under the heading "Group Writing":
 >
 > — *Songwriting Without Boundaries* (2011), Challenge 1
 
-And his closing push, two paragraphs later: "But do form a group, or at least
-find a partner. It'll keep you on track."
+And his closing push, a little further down the same opener: "But do form a
+group, or at least find a partner. It'll keep you on track."
 
 ## Expanded object writing
 
@@ -732,7 +733,7 @@ underline every verb first and ask which ones got the gig on merit.
 ## Place as action organizer
 
 The "where" days make an important adjustment: place is not scenery. Pat states
-it in four sentences at the end of Day 14:
+it in four sentences on Day 14:
 
 > "Where" is a wonderful tool. Once you decide the place, the rest of your
 > writing can wrap around it or evolve from it. That's why it's useful to imagine
@@ -867,10 +868,10 @@ Exercise 3 - Timed "pepper" session:
 - Push beyond sight into taste, smell, touch, organic, and kinesthetic detail.
 - Stop at the buzzer, then mine the page.
 
-Chapter 2 - Rusty's collar rewrite:
+Rusty's collar rewrite — *this file's own drill; Chapter 2 prints no exercise*:
 
 - Choose one telling line from a lyric draft.
-- List five sensory images that could prove or color the line.
+- List sensory images that could prove or color the line.
 - Put the strongest image before the telling line.
 - Read the pair aloud and decide whether the telling now carries more weight.
 - If the telling is redundant, cut it and let the image do the work.

--- a/plugins/songwriting/context/pat-pattison/research/object-writing.md
+++ b/plugins/songwriting/context/pat-pattison/research/object-writing.md
@@ -167,8 +167,8 @@ Useful coaching questions:
 
 Chapter 2 closes on this, and it is a real, named case, not a general caution.
 Pat prints Gillian Welch's "One More Dollar" and then a deliberately de-specified
-rewrite of it — see LYRIC-HANDOFF, the lyric itself is not reproduced here —
-and reports the verdict:
+rewrite of it. The two lyrics are not reproduced here; the verdict he draws from
+the comparison is:
 
 > Instant bland. David Rawlings, Welch's partner and an ardent student and
 > practitioner of songwriting, called me with this beige version, remarking how

--- a/plugins/songwriting/context/pat-pattison/research/phrasing.md
+++ b/plugins/songwriting/context/pat-pattison/research/phrasing.md
@@ -532,12 +532,19 @@ artifacts; verified against `raw/`. Do not correct them.)
 
 ## Front-heavy and back-heavy phrases
 
-**Unaudited — non-book material.** "Front-heavy," "back-heavy" and "body
-language" return **zero hits across all four books**; the frame comes from
-patpattison.com and seminar material that is not in the corpus. This file
-previously printed two sentences below as block quotations attributed to
-`— Pat`, one of them with no source label at all. Neither can be checked, so
-neither is set as a quotation any more.
+**Non-book material — and the source has now been READ (2026-08-11).**
+"Front-heavy," "back-heavy" and "body language" return **zero hits across all
+four books**. That is because the frame is from Pat's patpattison.com column
+"The Art of Phrasing" (<https://www.patpattison.com/art-of-phrasing>), which
+coins both terms outright:
+
+> "We'll call phrases that start on the downbeat of a bar, or pick up to the
+> downbeat, front-heavy."
+> "We'll call phrases that start after the downbeat back-heavy."
+
+**These are Pat's terms, not this plugin's.** Cite the column; never cite a
+chapter for them. This file was right to keep them and right not to claim a
+book — it was the only file that had this correct.
 
 Where a lyric phrase begins relative to the bar shapes its emotional
 character. Two states:

--- a/plugins/songwriting/context/pat-pattison/research/prosody.md
+++ b/plugins/songwriting/context/pat-pattison/research/prosody.md
@@ -27,13 +27,20 @@ and the phrase "preserving the natural shape of the language" are stated
 outright in *Writing Better Lyrics* (2009) Chapter 18, and that section is
 cited to the book below.
 
-**Still unaudited:** the Berklee Online article, patpattison.com, the American
-Songwriter column, and OSONG-525 — which remain distillations nobody has
-checked against their originals. Three passages here rest on those sources
-alone and stay paraphrased: the four-controller framework, tone of voice as a
-stability lever, and the third phrasing type. Where this file's wording and the
-1991 chapter's wording diverge, the divergence is marked in place rather than
-silently reconciled.
+**Web-source status, updated 2026-08-11.** The **American Songwriter column
+"Motion Creates E-Motion In Songwriting" (17 October 2012) has now been fetched
+and read** — see [motion creates e-motion](#motion-creates-e-motion--the-motion-controllers).
+Result: it does **not** carry a four-controller framework, and it never mentions
+line length, which dissolves a conflict this file previously recorded as live.
+
+**Still unaudited:** the Berklee Online article, patpattison.com, and OSONG-525
+— distillations nobody has checked against their originals. Two passages rest on
+those sources alone and stay paraphrased: tone of voice as a stability lever,
+and the third phrasing type. (`tone of voice` is also plugin-authored shorthand
+with 0 corpus hits — see
+[book-references](book-references.md) "Plugin-authored vocabulary".) Where this
+file's wording and the 1991 chapter's wording diverge, the divergence is marked
+in place rather than silently reconciled.
 
 ## Image inventory
 
@@ -1148,15 +1155,27 @@ verbatim wording for the two title-targeting drills is given below because the
 - Let line length, rhyme scheme, and line count disagree only when the emotional
   effect is worth the instability.
 
-## Motion creates e-motion — four controllers
+## Motion creates e-motion — the motion controllers
 
-**Unaudited — web source, paraphrase retained deliberately.** The American
-Songwriter column is not in the corpus, so nothing here has been checked against
-Pat's actual wording and none of it is restored to verbatim. Chapters 18-19 do
-not contain a four-controller list.
+**The column has now been READ — corrected 2026-08-11.** Fetched at
+<https://americansongwriter.com/motion-creates-e-motion-in-songwriting/>
+(Pat Pattison, 17 October 2012). Chapters 18-19 do not contain a
+four-controller list, and **neither does the column.** What the column actually
+prints is one sentence naming rhyme as *one* controller among others:
 
-Pat's American Songwriter column condenses the engine into four controllers
-that together create the song's motion (and therefore its emotion):
+> "Rhyme is one of the controllers of motion in a song."
+
+and one sentence naming the others in passing:
+
+> "Sure, the musical groove, the harmonic and melodic rhythms make things move.
+> But rhyme overlays these and adds yet another layer of motion in the song."
+
+The four items below are a fair distillation of what those two sentences name,
+and they are kept on that basis — but **Pat does not enumerate four
+controllers**, and this list must never be presented as his numbered framework.
+That is the "counts are the tell" failure this project keeps hitting.
+
+Distilled from the column, not enumerated by it:
 
 1. **Rhyme scheme** — pace, flow, closure.
 2. **Musical groove** — the rhythmic feel under the lyric.
@@ -1168,20 +1187,25 @@ The bare slogan "motion creates e-motion" is Pat's, but the fuller sentence this
 file used to print inside quotation marks and attribute to `— Pat` traces to no
 readable source and has been removed rather than left to look verbatim.
 
-**Challenge 4 contradicts this list on its central point.** The list names the
-rhyme scheme as the one lyric-side controller and puts everything else in the
-music — but *Songwriting Without Boundaries* (2011), Challenge 4, Day 13 ranks
-**line length above rhyme**: "Both line length and rhyme are traffic cops, but
-line length has a higher rank—captain, as opposed to sergeant." Line length is
-a lyric-side controller and it is the stronger one.
+**The list is INCOMPLETE, not contradicted — corrected 2026-08-11.** An earlier
+pass recorded a live conflict here between this list and Challenge 4. Having
+read the column, there is no conflict to resolve: **the phrase "line length"
+does not appear in the column at all**, and the column makes no comparative
+claim about line length against rhyme. It is silent on the question, not
+opposed to the books.
 
-Two books say so independently. *Writing Better Lyrics* (2009), Chapter 19 makes
-the same ranking on the two-line ladder in
+What remains true is that the list is not a complete inventory of lyric-side
+motion controllers, because line length is the strongest one and it is missing.
+*Songwriting Without Boundaries* (2011), Challenge 4, Day 13 ranks **line length
+above rhyme**: "Both line length and rhyme are traffic cops, but line length has
+a higher rank—captain, as opposed to sergeant." *Writing Better Lyrics* (2009),
+Chapter 19 makes the same ranking independently on the two-line ladder in
 [stability reference](#stability-reference): "So line length is a stronger
-motion creator than rhyme, huh? Yup." Treat the four-item list as an unaudited
-web paraphrase that is at minimum incomplete; use
+motion creator than rhyme, huh? Yup."
+
+So: use the column for the music-side controllers it names, and use
 [length of lines](#length-of-lines) and the stability ladder as the book-sourced
-account.
+account of the lyric side. Do not re-file this as a contradiction.
 
 See [stable / unstable](stable-unstable-meta.md) for the cross-controller
 diagnostic.

--- a/plugins/songwriting/context/pat-pattison/research/response-filter.md
+++ b/plugins/songwriting/context/pat-pattison/research/response-filter.md
@@ -174,7 +174,9 @@ any prose lyric line.
       section, last word before a rhyme position)
 - [ ] **Hot-spot phrase rule** — within a phrase: 2nd-most-important word at
       the beginning, most-important word at the end (or first/last per
-      front-heavy/back-heavy choice)
+      front-heavy/back-heavy choice — `front-heavy` / `back-heavy` are
+      plugin-authored shorthand, 0 corpus hits; see
+      [book-references.md](book-references.md) "Plugin-authored vocabulary")
 - [ ] **Stress map** — every stressed syllable lands on a strong beat (no
       greedy spots — unstressed forced to a downbeat, or stressed forced
       to a weak beat)
@@ -198,7 +200,9 @@ any prose lyric line.
       middle for narrative, long-shot for chorus universality — or
       deliberate hybrid)
 - [ ] **Tone-of-voice** stable — same speaker, same emotional register as
-      the section's other lines
+      the section's other lines (`tone of voice` is plugin-authored shorthand,
+      0 corpus hits; see [book-references.md](book-references.md)
+      "Plugin-authored vocabulary")
 - [ ] **Vowel awareness** — the line's stressed vowels chosen, not
       defaulted; bright vowels (long-ē, long-ā) feel sharp; dark vowels
       (long-ō, long-ū) feel weighted
@@ -417,7 +421,8 @@ AABA", "do I need a bridge", or AI is about to recommend a song form.
 - [ ] **Transitional bridge (pre-chorus)** — only if a climb to chorus
       needs explicit lift; not by default
 - [ ] **Form fits melody** if a melody exists — see §2 phrasing checklist
-- [ ] **Stable/unstable signature** matches central emotion
+- [ ] **Stable/unstable signature** matches the central intent, idea, and
+      emotion of the work
 
 ## §7 Image filter (object writing + metaphor)
 

--- a/plugins/songwriting/context/pat-pattison/research/response-filter.md
+++ b/plugins/songwriting/context/pat-pattison/research/response-filter.md
@@ -174,9 +174,10 @@ any prose lyric line.
       section, last word before a rhyme position)
 - [ ] **Hot-spot phrase rule** — within a phrase: 2nd-most-important word at
       the beginning, most-important word at the end (or first/last per
-      front-heavy/back-heavy choice — `front-heavy` / `back-heavy` are
-      plugin-authored shorthand, 0 corpus hits; see
-      [book-references.md](book-references.md) "Plugin-authored vocabulary")
+      front-heavy/back-heavy choice — `front-heavy` / `back-heavy` are **Pat's
+      own terms**, coined in his patpattison.com "The Art of Phrasing" column
+      rather than in any of the four books, so cite the column and never a
+      chapter; see [book-references.md](book-references.md))
 - [ ] **Stress map** — every stressed syllable lands on a strong beat (no
       greedy spots — unstressed forced to a downbeat, or stressed forced
       to a weak beat)
@@ -200,9 +201,9 @@ any prose lyric line.
       middle for narrative, long-shot for chorus universality — or
       deliberate hybrid)
 - [ ] **Tone-of-voice** stable — same speaker, same emotional register as
-      the section's other lines (`tone of voice` is plugin-authored shorthand,
-      0 corpus hits; see [book-references.md](book-references.md)
-      "Plugin-authored vocabulary")
+      the section's other lines (`tone of voice` is 0 hits across the four books
+      and has not been located in a Pat column either — treat as plugin
+      shorthand; see [book-references.md](book-references.md))
 - [ ] **Vowel awareness** — the line's stressed vowels chosen, not
       defaulted; bright vowels (long-ē, long-ā) feel sharp; dark vowels
       (long-ō, long-ū) feel weighted

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
@@ -8,12 +8,16 @@ Challenge 4.
 Source images inspected:
 
 - *Essential Guide to Lyric Form and Structure* (1991), Chapter 4: **40 linked
-  page-scan figures**, all 40 unique, read at 3x upscale. This file's primary
-  source argues in scans — the balance paradigms, every closure type, and all
-  three strategy examples are figures, not prose. Earlier revisions of this
-  inventory listed only the *Essential Guide to Rhyming* (2014) and
-  *Songwriting Without Boundaries* (2011) images and omitted this chapter
-  entirely, which is how the `abba` error below survived.
+  page-scan figures**, all 40 distinct files, read at 3x-4x upscale. This
+  file's primary source argues in scans — the balance paradigms, every closure
+  type, the exercise answer keys, and all three strategy examples are figures,
+  not prose. Earlier revisions of this inventory listed only the *Essential
+  Guide to Rhyming* (2014) and *Songwriting Without Boundaries* (2011) images
+  and omitted this chapter entirely, which is how the `abba` error below
+  survived. Distinct files are not distinct content: `image_rsrc31U` and
+  `image_rsrc31X` print the same six-line lyric, because Pat reprints example
+  c) when he comes back to it. Reprints in this chapter are pedagogy — do not
+  fold them.
 - *Essential Guide to Rhyming* (2014), Chapter 7 (printed pp. 69-75, spine
   082-088; p. 76 is a blank verso): text layer complete and used verbatim.
   Scans consulted for layout only — `image_A-page2.jpg` (the two-column
@@ -40,20 +44,52 @@ sections.
 This file focuses on decision-making. For definitions and mechanics, see
 [rhyme fundamentals](rhyme-fundamentals.md).
 
-## The four control questions
+## The five areas rhyme controls
 
-Before changing words, diagnose what the rhyme scheme is doing:
+Chapter 4 names five, not four. Pat's list as printed:
+
+> Rhyme controls or helps to control each structural area:
+>
+> I. Rhyme helps create BALANCE (symmetry), or lack of BALANCE (asymmetry) in
+> a structure.
+>
+> II. Rhyme controls the PACE of structures. (Acceleration, Deceleration,
+> Constant Motion)
+>
+> III. Rhyme controls the FLOW of phrases by stopping motion, or by keeping
+> motion going.
+>
+> IV. Rhyme controls the CLOSURE (or resolution).
+>
+> V. Rhyme helps control TYPE OF CLOSURE. (EXPECTED CLOSURE, DECEPTIVE
+> CLOSURE, UNEXPECTED CLOSURE.)
+
+Before changing words, diagnose the section against those five, plus the
+scheme itself:
 
 - Scheme: which sounds repeat, which lines are unrhymed, and where identities
   are masquerading as rhymes?
-- Structure: does the scheme balance, unbalance, fragment, or through-write the
-  section?
-- Pace: are rhymes close enough to accelerate, far enough apart to decelerate,
-  or regular enough to stay constant?
-- Closure: does the section close expectedly, deceptively, unexpectedly, or
-  remain open?
+- Balance: is the system symmetrical or asymmetrical?
+- Pace: do the rhymes accelerate, decelerate, or hold constant motion?
+- Flow: does the scheme fragment the section or through-write it?
+- Closure: is the system closed or open?
+- Type of closure: expected, deceptive, or unexpected?
 
-These questions turn rhyme into a craft lever instead of a word-hunt.
+## The three rhyme strategies
+
+Having covered the "What," Chapter 4 turns to the "Why" and names three:
+
+> Once you understand the effect that rhyme structure has on a system, you can
+> start to develop strategies for choosing them. There are three basic rhyme
+> strategies:
+>
+> 1. Outlining the way ideas move.
+>
+> 2. Supporting meaning. (Prosody)
+>
+> 3. Creating relationships between sections.
+
+The three sections below take them in that order.
 
 ## Strategy 1: outline idea movement
 
@@ -161,9 +197,16 @@ more active.
 
 ## Accelerate strategically
 
-Acceleration comes from bringing rhymes closer together. Pat's example — the
-consecutive rhymes in lines 3, 4 and 5 accelerate the section and build
-pressure, working in sync with the idea:
+Acceleration comes from bringing rhymes closer together. Chapter 4's image for
+it:
+
+> Rhyme is like the accelerator in a car: the closer the accelerator gets to
+> the floor, the faster the car moves. The closer rhymes are to each other, the
+> faster your lyric moves. And, like the accelerator and the car floor, the
+> further apart they are, the slower you move.
+
+Pat's example — the consecutive rhymes in lines 3, 4 and 5 accelerate the
+section and build pressure, working in sync with the idea:
 
 ```text
 I saw her once and that was it        a
@@ -190,13 +233,18 @@ the consecutive `c c c` cluster increases pressure before a
 later return. Feminine rhymes can heighten comedy because the two-syllable tail
 adds bounce while the cluster speeds up.
 
-Use acceleration for:
+Acceleration and deceleration are relative terms; the chapter insists on a
+reference point. Alternating rhyme (`bring / search / sing`) sets a pace, and
+adding consecutive rhymes to it (`last / fast`) accelerates the system.
+Starting consecutive and moving to alternating decelerates it. Keeping either
+pattern going leaves the PACE CONSTANT.
 
-- Rising attraction.
-- Panic or comic escalation.
-- Physical action.
-- A thought narrowing toward obsession.
-- A title or hook that needs pressure behind it.
+There is a ceiling, and Pat states it plainly:
+
+> ... once you have consecutive rhymes, the pedal is to the metal. You cannot
+> accelerate. The only way to go faster then is to shorten PHRASE LENGTHS. In
+> juggling, when the balls are going at top speed, the only way to juggle
+> faster is to decrease the distance the balls have to go.
 
 Do not accelerate just because the rhyme words are available. If the next verse
 must reuse the scheme, the next verse needs an idea that can carry the same
@@ -207,13 +255,9 @@ late pressure.
 Deceleration comes from moving rhymes farther apart or returning from
 consecutive rhyme to alternating rhyme.
 
-Use deceleration for:
-
-- Reflection.
-- Regret.
-- Explanatory or narrative space.
-- A section that should relax before contrast.
-- A bridge idea that should not inherit a high-pressure verse scheme.
+Exercise 22 drills both directions on the same material: it gives three short
+rhyme lists and asks the writer to accelerate each by adding or subtracting
+words, then start over and decelerate them.
 
 If a repeated section has one verse about excitement and another about calm,
 the same rhyme acceleration may betray the calmer content. Solve by changing
@@ -241,19 +285,20 @@ in the closing spotlight.
 
 ## Strategy 3: relate sections
 
-Use rhyme to decide how sections speak to each other.
+Use rhyme to decide how sections speak to each other. Chapter 4 asks three
+questions and then hands the strategy forward:
 
-Ask:
+> Should a particular section move forward or should it stop? How strong should
+> the push forward or the stop be? How strong should the contrast be between
+> sections? This third strategy will be easier to deal with after the next
+> chapter on FORMAL ELEMENTS.
 
-- Should the verse move forward or stop?
-- Should the chorus answer with stronger closure?
-- Should the bridge relax, interrupt, or reframe the rhyme behavior?
-- How strong should the contrast be between sections?
-
-If two sections use different rhyme strategies, make the difference audible and
-meaningful. A through-written verse into a fragmented chorus can feel like
-motion resolving into a hook. A fragmented verse into a through-written chorus
-can feel like the hook opens the song outward.
+That deferral matters. Chapter 4 supplies Strategy 3's questions, not its
+answers, and prints no verse-scheme-to-chorus-scheme recommendations at all —
+so treat any such pairing as a reading of a particular draft, never as a menu
+the chapter offers. A through-written verse into a fragmented chorus can feel
+like motion resolving into a hook; a fragmented verse into a through-written
+chorus can feel like the hook opens the song outward.
 
 ## Working from idea to scheme
 
@@ -488,21 +533,33 @@ consonance rhyme in the fourth line can feel connected-but-unresolved.
 
 ## Decision matrix
 
-Use this matrix after labeling the scheme:
+"Decision matrix" is this file's scaffolding, not Pat's term — the word appears
+nowhere in any of the four books. Chapter 9 prints no table. It walks one `abab`
+frame (`blush / skin / rush / sin`) through nine type substitutions and says
+what each one does. Those nine, in the chapter's own order, are the matrix:
 
-| Section need | Dominant position | Tonic position |
+| Dominant (a) | Tonic (b) | What Chapter 9 says it does |
 | --- | --- | --- |
-| Strong declaration | Perfect | Perfect |
-| Stable but not slammed | Family | Perfect or family |
-| Gentle lean into closure | Family | Family |
-| Dreamy or floating | Assonance | Family or assonance |
-| Longing, uncertainty | Family or consonance | Consonance |
-| Almost no closure | Assonance or consonance | Assonance or consonance |
-| Contrast inside repeated sections | Weaker type in unstable section | Stronger type in stable section |
+| Perfect | Perfect | Maximum motion: the hardest push, the strongest resolution |
+| Family | Perfect | Push "a little lighter"; still resolves, but "slams the gates of purgatory rather than the gates of hell" |
+| Perfect | Family | Strong push; the landing "is softer and opens the gate a bit" |
+| Assonance | Perfect | "Precious little push," closer to an `xaxa` feeling; the arrival is "pretty light" |
+| Perfect | Assonance | The push "lands with a splat on the squishy surface"; `abab` "has suddenly lost its ability to close the deal" |
+| Assonance | Family | "A pretty light and dreamy flirtation" |
+| Family | Assonance | "Really off in dreamland, floating, floating in a misty reverie" |
+| Consonance | Family | "Barely nudges forward," yet more forward pressure than leaving lines 1 and 3 unrhymed |
+| Family | Consonance | "The gate is wide open" — longing and uncertainty; the Randy Newman case below |
 
-If the section already has strong meter, syntax, melody, or line-length
-pressure, the rhyme type can be weaker and still read as connected. If the
-section has little other pressure, weak rhyme types may feel like no structure.
+Family/family, assonance/assonance and consonance/consonance are not among
+them. The chapter never demonstrates those pairings, so this file does not
+recommend them.
+
+If the section already has strong meter or line-length pressure, the rhyme type
+can be weaker and still read as connected. Chapter 9 makes exactly that point:
+where an assonance rhyme leaves "precious little push" in dominant position, the
+push "would have to come from somewhere else, like e.g., line lengths (something
+like common meter ... which creates the same dominant push as an abab rhyme
+scheme)."
 
 ## Repeated-section problem
 
@@ -622,93 +679,66 @@ and any line-length pressure. Revise one line so the rhyme strategy better
 matches the emotional motion.
 ```
 
-## The three rhyme strategies (named)
+## Why `abba` does not close
 
-*Essential Guide to Lyric Form and Structure* (1991), Chapter 4 names three rhyme strategies. The skill applies each
-separately or in combination per section.
+An earlier revision of this file described `abba` as "enclosing," which reads as
+a closure claim and contradicted the Challenge 4 table above, where `abba` is
+listed under floating instability. *Essential Guide to Lyric Form and Structure*
+(1991), Chapter 4 settles it twice over, both times in figures rather than
+prose:
 
-### Strategy 1 — Outline how ideas move
+- The balance argument prints `trim / alive / dive` (`abb`, `image_rsrc30U`) and
+  says it "is not balanced by" `trim / live / dive / swim` — which is `abba`
+  (`image_rsrc30V`). What does balance it is `abbabb` (`image_rsrc30W`) or
+  `abbacc` (`image_rsrc30X`). `abba` is the chapter's counter-example to
+  balance, not an instance of it. `abba` is likewise absent from the chapter's
+  printed paradigms of BALANCE (`image_rsrc30Y`), which are `abab`, `xaxa`,
+  `aa`, `aabb`, `abcabc`, and `xxaxxa`.
+- Exercise 24 asks the reader to mark each scheme closed or open, and its answer
+  key — printed upside down at the foot of the page — gives item 6, `a b b a`,
+  as **O** for open (`image_rsrc31B`).
 
-Rhyme scheme as map of idea movement. Different schemes fragment or
-join ideas across the section.
+The other two books agree from the other direction. *Essential Guide to Rhyming*
+(2014), Chapter 9 reaches for `abba` as its example of "an unstable rhyme
+scheme," and *Songwriting Without Boundaries* (2011), Challenge 4 devotes a day
+to it as "Unstable Structure: abba," noting that it "creates an interesting
+feeling of floating."
 
-| Scheme | Effect on idea movement |
-|---|---|
-| `aabb` | Fragments each pair; each couplet closes a thought |
-| `abab` | Through-writes; idea spans the four-line arc |
-| `abba` | Frames the inner pair — but stays **open**, not closed (see below) |
-| `xaxa` | Through-writes with relaxed structure |
-| `aaba` | Points forward toward a fourth `b` that does not arrive |
-| `abcb` | Closes the rhymed pair; leaves first and third open |
+Use `abba` when a section should frame an idea without resolving it — loss,
+hope, suspension — not when it needs to land.
 
-**`abba` does not close.** Earlier revisions of this table said `abba`
-"encloses," which reads as a closure claim and contradicted this file's own
-Challenge 4 table below, where `abba` is listed under floating instability. The
-1991 chapter settles it twice over: it presents `abba` as the scheme that
-*fails* to balance an opening `abb`, and its printed exercise key marks `abba`
-**open**. Use `abba` when a section should frame an idea without resolving it —
-loss, hope, suspension — not when it needs to land.
+## Choosing the rhyme type for a slot
 
-Use Strategy 1 to decide which idea-shape the section wants:
-fragmented declarations, single arcs, framed center, or unresolved push.
+This index is the skill's own routing aid. An earlier revision claimed
+*Essential Guide to Rhyming* (2014), Chapter 9 "synthesizes a decision matrix
+for rhyme type by emotional intent"; it does not. Chapter 9 never sorts rhyme
+types by intent, and the rows below for partial and weak-syllable rhyme come
+from Chapter 6, not Chapter 9. The rhyme types are Pat's; the intent column is
+this file's gloss, and every definition lives in
+[rhyme types](rhyme-types.md).
 
-### Strategy 2 — Support meaning (prosody)
-
-Pick rhyme density to match the section's emotional pace. Close
-rhymes accelerate; spaced rhymes decelerate; missing rhymes float.
-
-| Pace need | Rhyme density |
-|---|---|
-| Contemplative verse | Spaced (every other line, or every 4) |
-| Active chorus | Close (couplets, internal rhymes) |
-| Drifting prechorus | Missing or weak (no rhyme on most lines) |
-| Settled refrain | Strong final pair |
-
-Strategy 2 is what Pat calls the accelerator-pedal use of rhyme:
-the closer the rhymes, the faster the lyric.
-
-### Strategy 3 — Relate sections
-
-Rhyme in one section sets up contrast or echo in the next. A verse
-with sparse rhyme makes a chorus with dense rhyme feel arrival.
-A chorus that echoes the verse's scheme creates continuity.
-
-| Relationship | Verse scheme | Chorus scheme |
+| Intent at the slot | Rhyme type | Where Pat defines it |
 |---|---|---|
-| Strong contrast | abab | aabbcc (couplet flood) |
-| Subtle contrast | xaxa | abab |
-| Continuity | abab | abab (with stronger rhyme types) |
-| Disruption | abab | xxxx (no rhyme; spoken-word feel) |
+| Confident arrival, declarative closure | Perfect | Chapter 1 |
+| Resolved but fresh; cliche-avoidance | Family | Chapter 4 |
+| Vowel ending; more options via consonant addition | Additive | Chapter 5 |
+| Cluster ending; more options via consonant removal | Subtractive | Chapter 5 |
+| Connection without closure; the vowel carrying | Assonance | Chapter 6 |
+| The shape of resolution without its certainty | Consonance | Chapter 6 |
+| Two-syllable word, no full close | Partial | Chapter 6 |
+| Connection only at the unstressed final syllable | Weak-syllable | Chapter 6 |
 
-Strategy 3 is the section-to-section move. It governs how the song's
-rhyme architecture composes, not just how a single section behaves.
+Working order at a slot:
 
-## Decision matrix — which rhyme type when
-
-*Essential Guide to Rhyming* (2014), Chapter 9 synthesizes a decision matrix for rhyme type by
-emotional intent. Pat's stance: rhyme type is not a default, it is
-a choice per slot.
-
-| Emotional intent | Rhyme type |
-|---|---|
-| Confident arrival, declarative closure | Perfect (fully resolved) |
-| Resolved but fresh; cliche-avoidance | Family |
-| Open-vowel start; cliche-avoidance via consonant addition | Additive |
-| Cluster-ending; declutter via consonant removal | Subtractive |
-| Connection without closure; held vowel carrying | Assonance |
-| Shape of resolution without certainty; consonant carrying | Consonance |
-| Feminine word but no full close | Partial |
-| Connection only at unstressed final syllable | Weak-syllable |
-| Spotlight without overclose | Deceptive closure (any type) |
-| Surprise after expected close | Unexpected closure |
-
-The matrix is read top-down per slot:
-
-1. Name the emotional intent at the slot.
-2. Identify the candidate rhyme type from the matrix.
+1. Name what the slot has to do emotionally.
+2. Take a candidate type from the index.
 3. Run the worksheet for that type.
-4. If candidates fail the line, drop to the next less-stable type.
-5. Sing the result.
+4. If nothing fits the line, move one step down the stability scale.
+
+Closure type is a separate lever, not a rhyme type. Deceptive and unexpected
+closure are structural moves from *Essential Guide to Lyric Form and Structure*
+(1991), Chapter 4, and they are covered under "Closure as spotlight" above; do
+not read them off this index.
 
 ## Shelley anchor — through-written without internal fragmentation
 
@@ -768,19 +798,25 @@ defaults.
 A named example for using consonance rhyme to relax verse motion
 strategically — not by accident.
 
-Pat cites Verse 3 of Paul Simon's "50 Ways to Leave Your Lover" as
-demonstrating consonance rhyme as a deceleration tool:
+Pat cites verse 3 of Paul Simon's "50 Ways to Leave Your Lover" as the case for
+consonance rhyme when a scheme is already committed and a later verse needs its
+motion relaxed:
 
-<!-- phonetic ending fragment trips the spell-checker --><!-- spellchecker:off -->
-- The verse's three rhyme-position words share consonant endings (pain /
-  again / explain) — all -ane ending consonance, technically a partial
-  rhyme since the stressed vowels differ
-- The consonance creates structural continuation without the harder
-  closure of perfect rhyme
-- The verse keeps the song "lighter" than the verses that use perfect rhyme
-- The placement is intentional — verse 3 is meant to feel less weighted
-  than verses 1-2, and the rhyme stability shift carries that intent
-<!-- spellchecker:on -->
+> Consonance rhyme never works like perfect rhyme. Yet, when it is strong
+> enough, it can work for you. You might use it in a case where you have already
+> committed to a rhyme scheme in an earlier verse, and want to keep it, yet
+> relax the motion in a later verse.
+
+The three end-rhymes he lists are `pain`, `again`, `explain`. Read what he
+actually says about them: it is `again`, in **second position**, that is the
+consonance rhyme — its stressed vowel differs, while `pain` and `explain` rhyme
+perfectly with each other. Sitting between them, the odd one out "dampens the
+resolving effect of the consecutive rhymes."
+
+- Pat's verdict: "His use of the consonance rhyme is pretty. The verses are
+  relaxed, both in attitude and structure."
+- His test: "Try replacing 'again' with a perfect rhyme and see what happens!
+  The prosody evaporates."
 
 ### What this teaches
 

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-strategy.md
@@ -554,12 +554,20 @@ Family/family, assonance/assonance and consonance/consonance are not among
 them. The chapter never demonstrates those pairings, so this file does not
 recommend them.
 
-If the section already has strong meter or line-length pressure, the rhyme type
-can be weaker and still read as connected. Chapter 9 makes exactly that point:
-where an assonance rhyme leaves "precious little push" in dominant position, the
-push "would have to come from somewhere else, like e.g., line lengths (something
-like common meter ... which creates the same dominant push as an abab rhyme
-scheme)."
+If the section already has pressure from somewhere else, the rhyme type can be
+weaker and still read as connected. Chapter 9 makes exactly that point: where an
+assonance rhyme leaves "precious little push" in dominant position, the push
+"would have to come from somewhere else, like e.g., line lengths (something like
+common meter ... which creates the same dominant push as an abab rhyme scheme)."
+
+Do not narrow "somewhere else" to meter and line length. Chapter 9's own list of
+what else can carry a section is wider — "melody, harmony, message, line lengths,
+and line rhythms."
+
+The converse holds too, and Chapter 9 states it directly: **if the section has
+little other pressure, a weak rhyme type can read as no structure at all.** Of
+the same assonance-dominant case — "But without a push from somewhere else, our
+arrival at rush is pretty light."
 
 ## Repeated-section problem
 
@@ -734,6 +742,9 @@ Working order at a slot:
 2. Take a candidate type from the index.
 3. Run the worksheet for that type.
 4. If nothing fits the line, move one step down the stability scale.
+5. Sing the result. (This step is this plugin's phrasing, but the discipline is
+   Pat's and he repeats it — "Again, sing them. Trust your ears."
+   *Essential Guide to Rhyming* (2014), Chapter 5.)
 
 Closure type is a separate lever, not a rhyme type. Deceptive and unexpected
 closure are structural moves from *Essential Guide to Lyric Form and Structure*

--- a/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
+++ b/plugins/songwriting/context/pat-pattison/research/rhyme-worksheets.md
@@ -63,11 +63,12 @@ A rhyme worksheet is not a finished lyric, a rhyme dump, or a display of clever
 language. It is a map of possible spotlight words and idea-connected rhyme
 families.
 
-Pat's page 24 summary makes four claims for it, and he ranks them: no dead ends
-("keep from boxing yourself into a corner"), net time saved despite the up-front
-cost, higher quality, and — "more importantly" — rhyme positions that
-"communicate ideas effectively." The last is the one the whole procedure exists
-for. The summary is quoted in full under
+Pat's page 24 summary makes four claims for it, and he ranks them in two tiers:
+no dead ends ("keep from boxing yourself into a corner") and net time saved
+despite the up-front cost, then — "More importantly" — that "it raises quality
+and guarantees that your rhyming position will communicate ideas effectively."
+The second tier covers both quality and communication, not communication alone.
+The summary is quoted in full under
 [English is rhyme-poor](#english-is-rhyme-poor).
 
 Skill behavior: when a user asks for rhymes, first decide whether they need a
@@ -161,7 +162,12 @@ And the selection rule, verbatim:
 Note what the two selection constraints are and are not. They are phonetic —
 mostly masculine, different vowel sounds — not thematic. The theme is already
 handled by where the words come from: "Let the list come from your idea sketch."
-Every one of Pat's eleven is lifted from his own sketch on page 20.
+That is about content, not about copying words across. Only three of Pat's
+eleven — `afraid`, `attention`, `left out` — appear as words in the page 20
+sketch; `risk` and `flirt` appear only in the focus questions above it; and
+`scared`, `chance`, `dull`, `leave`, `ignored`, `gone` are not printed anywhere
+on page 20. Pat's instruction leaves room for both routes: the list comes from
+the sketch, "adding any extra inspiration you have."
 
 "Mostly masculine" is exact rather than loose: ten of the eleven are masculine,
 and `attention` is the one feminine word on the sheet. For the second rule Pat
@@ -568,14 +574,14 @@ sub-column when it overflows. Marks in parentheses are Pat's.
 Perfect Rhymes          Imperfect Rhymes
 
 1. scare                1. scare
-   affair                  compare        stairs
-   unaware                 ensnare        unfair
+   affair                  compare
+   unaware                 ensnare
    care                    repair
    dare                    snared
    despair                 unprepared
    fair                    scarce
-   glare
-   prayer
+   glare                   stairs
+   prayer                  unfair
 
 2. afraid               2. afraid
    charade                 bait           wait
@@ -736,11 +742,14 @@ worksheet focused on application:
   or less finality.
 
 Reading the list against the scale answers Pat's "figure out how I found them"
-challenge. `scare / snared` is additive. `flirt / absurd` is family (`t` to its
-partner `d`). `flirt / church` is consonance. `chance / mask` keeps `s` and
-subtracts. `leave / police` is marked `(Identity)` because the `-lease` sound
-repeats too much of the target. `attention / mend on, etc.` and
-`attention / stretchin', etc.` are mosaics.
+challenge. `scare / snared` is additive — same vowel, an extra consonant on the
+second syllable. `flirt / absurd` is family (`t` traded for its phonetic partner
+`d`). `flirt / church` is assonance, not consonance: the vowel is the same in
+both, and Pat's consonance rhyme requires the vowel sounds to differ.
+`leave / police` is marked `(Identity)` for the reason Pat gives in Chapter 1 —
+the rhyming syllables begin the same way, so the ear hears repetition instead of
+sound; `lease/police` is his own printed example of exactly that.
+`attention / mend on, etc.` and `attention / stretchin', etc.` are mosaics.
 
 Skill behavior: label imperfect candidates by likely relationship where useful,
 but do not overburden the user with a taxonomy lecture. The practical question
@@ -813,20 +822,40 @@ Exercise wording, verbatim:
 > — *Essential Guide to Rhyming* (2014), Chapter 7
 
 Chapter 7 keyword set (the Chapter 3 eleven, plus the two seeds Chapter 3 had
-dropped):
+dropped), laid out exactly like the Chapter 3 sheet: thirteen seeds spread as
+headings across three columns with room to write under each, and the ruled seed
+box reproduced in the middle of the page, now thirteen slots deep.
 
 ```text
-1. scare      6. risk     9. leave
-2. afraid                10. ignored
-3. flirt                 11. gone
-4. attention  7. chance  12. safe
-5. left out   8. dull    13. business
+1. scare       6. risk                  9. leave
+
+               ┌───────────────┐
+2. afraid      │  1. scared    │       10. ignored
+               │  2. afraid    │
+               │  3. flirt     │
+               │  4. attention │
+               │  5. left out  │
+               │  6. risk      │
+3. flirt       │  7. chance    │       11. gone
+               │  8. dull      │
+               │  9. leave     │
+               │ 10. ignored   │
+               │ 11. gone      │
+               │ 12. safe      │
+               │ 13. business  │
+               └───────────────┘
+
+4. attention   7. chance                12. safe
+
+
+5. left out    8. dull                  13. business
 ```
 
 Note the drift between the two printings: the ruled seed box in Chapter 3 and the
-blank sheet in Exercise 7.2 both say `scared`, while the search results and the
-Exercise 7.1 grid say `scare`. That is comment 3 in Chapter 3 taking effect — the
-seed changed mid-search and the printed sheets were never re-synced.
+ruled box on this Exercise 7.1 sheet both say `scared`, while the search-result
+headings and the Exercise 7.1 column headings say `scare`. That is comment 3 in
+Chapter 3 taking effect — the seed changed mid-search and the printed boxes were
+never re-synced.
 
 Skill behavior: when a user asks to continue from a worksheet, ask them to pick
 or approve a short favorite set before drafting. If they do not want to choose,
@@ -843,24 +872,11 @@ Exercise wording, verbatim:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 7
 
-The exercise then reprints the numbered seed list as a blank worksheet, thirteen
-slots deep:
-
-```text
- 1. scared
- 2. afraid
- 3. flirt
- 4. attention
- 5. left out
- 6. risk
- 7. chance
- 8. dull
- 9. leave
-10. ignored
-11. gone
-12. safe
-13. business
-```
+That single sentence is the whole of Exercise 7.2 on the printed page — an
+instruction and then blank space. The thirteen-slot ruled seed box on the same
+page (page 75) belongs to the Exercise 7.1 sheet above it, not to this exercise;
+the text layer runs the two together because it reads the box out of column
+order.
 
 Exercise pattern to preserve:
 
@@ -899,16 +915,20 @@ Compact output example, using Pat's own `safe` and `business` results:
 
 ```text
 seed: safe
-perfect: faith, chase, race, space
-imperfect: brave, grave, slave, cage, stage, castaway, ricochet, runaway,
-           haste, braced
+perfect: too few to build on — Chapter 3 dropped this seed because it and
+           "business" "don't yield many rhymes" (comment 6)
+imperfect: Pat's page 69 list, printed undifferentiated — faith, chase, race,
+           space, brave, grave, slave, cage, stage, castaway, ricochet,
+           runaway, haste, braced
 watch: over-familiar safety/risk pairs
 idea paths: caution, escape, public performance, locked-in fear
 
 seed: business
-perfect: none strong enough for default closure
-imperfect: collisions, decisions, visions, forgiveness, religious, gifted,
-           shiftless, kisses, ambitious, delicious, suspicious, submissive
+perfect: dropped in Chapter 3 for the same reason as "safe"
+imperfect: Pat's page 69 list, printed undifferentiated — collisions,
+           decisions, visions, forgiveness, frigid, religious, gifted,
+           shiftless, swiftless, kisses, ambitious, delicious, suspicious,
+           submissive, riches, finish, whiz, stiff
 watch: comic corporate tone unless wanted
 idea paths: bad choices, imagined betrayal, forgiveness after risk
 ```
@@ -927,22 +947,26 @@ Exercise wording, verbatim:
 >
 > — *Essential Guide to Rhyming* (2014), Chapter 3
 
-The printed sheet seeds the first three slots from the title and leaves seven
-open:
+The printed sheet has the same two parts as the Chapter 3 and Exercise 7.1
+sheets: title-seeded headings down the left with room to write under each, and a
+ruled seed box beside them whose first three slots are filled from the title and
+whose remaining seven are left open.
 
 ```text
 Idea sketch:
 
- 1. last
- 2. night
- 3. love
- 4.
- 5.
- 6.
- 7.
- 8.
- 9.
-10.
+1. last                 ┌──────────────┐
+                        │  1. last     │
+                        │  2. night    │
+                        │  3. love     │
+                        │  4.          │
+2. night                │  5.          │
+                        │  6.          │
+                        │  7.          │
+                        │  8.          │
+                        │  9.          │
+3. love                 │ 10.          │
+                        └──────────────┘
 ```
 
 This exercise makes the title a generator instead of a fixed burden. If a title

--- a/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms-examples.md
@@ -814,7 +814,8 @@ YOU'RE SEEING SOMEONE ELSE`.
   chapter: it is Chapter 6's, quoted in full under "Teddy" above.
 - `meter.md` — Common Meter, paradigms, Structural Pentad
 - `phrasing.md` — phrase length / count balance
-- `rhyme-strategy.md` — three rhyme strategies (Pat's named decision matrix)
+- `rhyme-strategy.md` — three rhyme strategies. (Its decision matrices are this
+  plugin's, not Pat's — `matrix` returns 0 hits across all four books.)
 - `prosody.md` — motion creates emotion
 
 ## When to load this file

--- a/plugins/songwriting/context/pat-pattison/research/song-forms.md
+++ b/plugins/songwriting/context/pat-pattison/research/song-forms.md
@@ -837,23 +837,13 @@ though, keep your sections parallel."
 
 ## Limerick principle — home base at section level
 
-*Essential Guide to Lyric Form and Structure* (1991), Chapter 6 names the principle behind A-A-B-A and similar forms:
+*Essential Guide to Lyric Form and Structure* (1991), Chapter 6 names the principle behind A-A-B-A and similar forms. The limerick, the A-A-B-A structure block, and Pat's "home base" quote are printed once above under [Home base principle](#home-base-principle) — this section applies them at section level rather than reprinting them.
 
-> "Repeating the structure of the first statement defines 'home base.' Moving
-> away from home base at the third phrase creates tension — a move to
-> unfamiliar territory. Coming back to familiar territory at phrase four is a
-> resolution, a welcome home party." — Pat (*Essential Guide to Lyric Form and
-> Structure* (1991), Chapter 6)
-
-The limerick is the small-scale model, and Chapter 6 prints it in four
-phrases:
-
-```text
-There once was a student named Esser
-Whose knowledge grew lesser and lesser
-It at last grew so small, he knew nothing at all
-And now he's a college professor
-```
+One detail worth holding, because it looks like an error and is not: Chapter 6
+prints the limerick in **four** phrases, running "It at last grew so small, he
+knew nothing at all" as a single phrase. Chapter 2 prints the *same* limerick in
+**five**, splitting that line in two, because there the point is that the shorter
+third and fourth phrases accelerate into the punchline. Both printings are Pat's.
 
 Phrases 1-2 state and restate, phrase 3 varies (shorter units, different
 rhyme), phrase 4 returns. A song's AABA form runs the same principle at
@@ -924,34 +914,15 @@ draft, so it is a revision procedure too.
 
 The companion failure mode to four-times-verses: a verse-chorus form
 that runs three full systems with no contrast risks flatness on the
-third arrival. Chapter 23 works it on "Love Her or Leave Her to Me,"
-whose chorus is:
+third arrival.
 
-```text
-Love her or leave her to me
-Keep her or let her go free
-Don't go two-timing her
-'Less you're resigning her
-Love her or leave her to me
-```
-
-Three named alternatives:
-
-1. **Bridge before the third verse.** Inserts contrast before the
-   final V/Ch arrival: `v / ch / v / ch / br / v / ch`. Carries its
-   own risk — the song returns to a full verse before the last
-   chorus, so it can still read as long.
-2. **Bridge replacing the third verse.** The bridge carries the turn
-   the third verse would have carried, and the final chorus follows
-   directly: `v / ch / v / ch / br / ch`. There is no third verse.
-3. **AABA verse/refrain conversion.** For the opposite case — when
-   the third idea genuinely needs to stay a verse. AABA thrives on
-   three-idea development, so all three verse ideas survive; the
-   title becomes a refrain inside each verse rather than a separate
-   chorus.
+Chapter 23's worked lyric ("Love Her or Leave Her to Me"), Pat's three
+numbered Options, and his bridge material are all above under
+[Three-System Verse/Chorus Risk](#three-system-versechorus-risk) — that
+section is the canonical treatment and this one no longer restates it.
 
 Diagnose at form-planning: count the systems, name what each is
-supposed to add, choose the alternative if needed.
+supposed to add, choose the Option if needed.
 
 ## Song system
 

--- a/plugins/songwriting/context/pat-pattison/research/variations.md
+++ b/plugins/songwriting/context/pat-pattison/research/variations.md
@@ -164,7 +164,7 @@ The writer chooses by trade-off, not by what reads best in isolation.
 Surface the labeled list with trade-offs. Let the writer choose.
 
 If the writer asks which is best, push back gently: "the choice depends on
-[the song's central emotion / the melody's pitch contour / the verse's POV
+[the song's central intent, idea, and emotion / the melody's pitch contour / the verse's POV
 discipline]. Which matters most for this song?"
 
 ## Artifact pattern

--- a/plugins/songwriting/context/pat-pattison/research/workflows.md
+++ b/plugins/songwriting/context/pat-pattison/research/workflows.md
@@ -230,7 +230,8 @@ Default chain:
    lengths, rhyme scheme, rhyme types, rhythm. See
    [Five Compositional Elements](five-compositional-elements.md).
 3. **Stable / unstable scan** — lyric, melody (if known), harmony,
-   melodic rhythm, harmonic rhythm — flag mismatches with central emotion.
+   melodic rhythm, harmonic rhythm — flag mismatches with the central
+   intent, idea, and emotion.
    See [stable / unstable](stable-unstable-meta.md).
 4. **Hot-spot audit** — what is in line 1 of each section? What is in the
    last line? Does the title sit in a hot spot? See [hook](hook.md).

--- a/plugins/songwriting/context/pat-pattison/templates/co-write-session-opener.md
+++ b/plugins/songwriting/context/pat-pattison/templates/co-write-session-opener.md
@@ -74,7 +74,8 @@ E. Cliche check at every section boundary (5 minutes per boundary)
 
 F. Stability check (10 minutes)
    - One pass through the draft asking "does the song's motion
-     match its central emotion?" See [stable / unstable](../research/stable-unstable-meta.md).
+     match its central intent, idea, and emotion?" See
+     [stable / unstable](../research/stable-unstable-meta.md).
 
 G. Wrap (10 minutes)
    - Record the demo (rough phone capture is fine).

--- a/plugins/songwriting/context/pat-pattison/templates/diagnose-section-prompt.md
+++ b/plugins/songwriting/context/pat-pattison/templates/diagnose-section-prompt.md
@@ -54,7 +54,7 @@ Five Compositional Elements:
 Stable/unstable verdict:
 - Section lyric character: ...
 - Levers carrying that character: ...
-- Match with central emotion: supports | mutes | pushes-against
+- Match with central intent, idea, and emotion: supports | mutes | pushes-against
 - Match with section job: yes | partially | no
 
 Dominant problem (one):

--- a/plugins/songwriting/context/pat-pattison/templates/variations-prompt.md
+++ b/plugins/songwriting/context/pat-pattison/templates/variations-prompt.md
@@ -74,7 +74,7 @@ If the writer asks which is best, push back:
 
 ```
 The choice depends on:
-- the song's central emotion
+- the song's central intent, idea, and emotion
 - the surrounding section's prosodic shape
 - the melody's pitch contour (if known)
 - the rhyme scheme commitments already made

--- a/plugins/songwriting/skills/object-writing/SKILL.md
+++ b/plugins/songwriting/skills/object-writing/SKILL.md
@@ -61,8 +61,10 @@ Dispatch rules:
    isolation is the mechanism; briefing an agent on the song destroys the divergence it exists to
    produce. This is a hard boundary, not a default.
 3. **Each agent writes to its own file** under the song's `ideation/` (per
-   [artifact-persistence](../../context/pat-pattison/research/artifact-persistence.md)) and returns
-   a path plus a sense-inventory summary. Never ask an agent to return the write in a message.
+   [artifact-persistence](../../context/pat-pattison/research/artifact-persistence.md)). It returns
+   only three things: the path, the seven channels each graded `strong` / `thin` / `absent`, and
+   one sentence on where the pivot chain landed. The write itself and the phrase-quoting sense
+   inventory live in the file — never ask an agent to return either in a message.
 4. **Grade coverage on return**, then mine. Read each file, honor thin-channel reports rather than
    overruling them, and pull individual images forward. Mining stays here because you hold the song
    context the writers deliberately lack.

--- a/plugins/songwriting/skills/suno/context/advanced.md
+++ b/plugins/songwriting/skills/suno/context/advanced.md
@@ -15,7 +15,7 @@ Suno v5.5 has multiple generation modes, post-generation tools, and personalizat
 
 | Feature | Where to find it | Tier |
 |---------|------------------|------|
-| **Voices** (clone YOUR singing identity) | [voices.md](voices.md) — full guide | Pro / Premier |
+| **Voices** (clone YOUR singing identity) | [voices.md](voices.md) — full guide | All tiers since Aug 7 2026 (free-plan access may be mobile-only — see [voices.md](voices.md)) |
 | **Custom Models** (fine-tune on your catalog) | [v55-features.md](v55-features.md#2-custom-models-fine-tune-on-your-catalog) | Pro / Premier |
 | **My Taste** (passive preference learning) | [v55-features.md](v55-features.md#3-my-taste-passive-preference-learning) | All tiers |
 | **Personas** (vibe templates from existing songs) | this file, below | All tiers |
@@ -23,7 +23,7 @@ Suno v5.5 has multiple generation modes, post-generation tools, and personalizat
 | **Extend** (lengthen songs) | this file | All tiers |
 | **Replace Section** (inpainting) | this file | Pro / Premier |
 | **Upload Audio** (demo as seed) | [workflow-recipes.md](workflow-recipes.md#recipe-1-demo-upload--finished-track) | All tiers (size varies) |
-| **Stems** (2-track / 12-track export) | [studio.md](studio.md#stem-isolation--export) | 2-track all / 12-track Pro+ |
+| **Stems** (Split from Mix / Auto Split / Advanced Split) | [studio.md](studio.md#stem-isolation--export) | No stem separation on Free; Split from Mix + Auto Split on Pro+; Advanced Split Premier-only |
 | **Suno Studio (GAW)** (multitrack DAW) | [studio.md](studio.md) — full guide | Premier |
 | **Creative Sliders** (Weirdness, Style Influence, Audio Influence) | this file, below | Custom mode |
 | **ReMi** (lyric-generation model) | this file, below | All tiers |

--- a/plugins/songwriting/skills/suno/context/advanced.md
+++ b/plugins/songwriting/skills/suno/context/advanced.md
@@ -15,7 +15,7 @@ Suno v5.5 has multiple generation modes, post-generation tools, and personalizat
 
 | Feature | Where to find it | Tier |
 |---------|------------------|------|
-| **Voices** (clone YOUR singing identity) | [voices.md](voices.md) — full guide | All tiers since Aug 7 2026 (free-plan access may be mobile-only — see [voices.md](voices.md)) |
+| **Voices** (clone YOUR singing identity) | [voices.md](voices.md) — full guide | Pro / Premier; free plans got a **trial** on Aug 7 2026, possibly mobile-only — see [voices.md](voices.md) |
 | **Custom Models** (fine-tune on your catalog) | [v55-features.md](v55-features.md#2-custom-models-fine-tune-on-your-catalog) | Pro / Premier |
 | **My Taste** (passive preference learning) | [v55-features.md](v55-features.md#3-my-taste-passive-preference-learning) | All tiers |
 | **Personas** (vibe templates from existing songs) | this file, below | All tiers |

--- a/plugins/songwriting/skills/suno/context/power-tips.md
+++ b/plugins/songwriting/skills/suno/context/power-tips.md
@@ -35,7 +35,7 @@ These produce **different outputs**. Order encodes priority.
 Surgical refinement of a single instrument layer without losing the rest:
 
 1. Generate full song
-2. **12-track stem export**
+2. **Auto Split stem export** (up to 12 stems; Pro / Premier)
 3. Upload ONE stem back as Audio Influence at 80%
 4. Prompt narrowly for that element only (`punchy 808 trap drums, no other elements`)
 5. Regenerate
@@ -257,7 +257,7 @@ Enables **album-vocal continuity across genre-diverse tracks** — same vocal ch
 
 ### Studio "Remove Effects" per-stem (v5.5)
 
-In Suno Studio with 12-track stems: right-click an individual stem → `Remove Effects`. Strips processing from JUST that stem (e.g., strip reverb from vocals only) before DAW export.
+In Suno Studio with Auto Split stems: right-click an individual stem → `Remove Effects`. Strips processing from JUST that stem (e.g., strip reverb from vocals only) before DAW export.
 
 Cleaner external mixing; you keep the production on stems you like and dry the ones you'll re-process.
 

--- a/plugins/songwriting/skills/suno/context/studio.md
+++ b/plugins/songwriting/skills/suno/context/studio.md
@@ -74,14 +74,22 @@ Studio's export menu has **3 scopes**:
 
 **Tempo-Locked WAV** is the key one for DAW workflows — embeds tempo + grid info so the stem snaps cleanly when imported into Logic / Ableton / Pro Tools.
 
-### 2-track vs 12-track stems (v5.5)
+### Stem separation modes (v5.5)
 
-| Tier | Stem split |
-|------|-----------|
-| Free / lower | 2-track: vocals + instrumental |
-| Pro / Premier | 12-track: drums, bass, vocals, harmony, lead synth, pads, sax/lead, percussion, FX, etc. |
+**Corrected 2026-08-11** against <https://suno.com/pricing>. The old table here
+read "Free: 2-track stems", which is **false** — Free reads "No stem
+separation". The naming was wrong too: these are three **modes**, not track
+counts.
 
-12-track is what you want for serious external mixing — replace any single instrument, automate per-stem, master each lane independently.
+| Mode | What it yields | Tier |
+|------|----------------|------|
+| Split from Mix | 2 stems (vocals + instrumental) | Pro / Premier |
+| Auto Split | up to 12 stems (drums, bass, vocals, harmony, synth, pads, percussion, FX, etc.) | Pro / Premier |
+| Advanced Split | ~100 instruments | Premier only |
+
+Free has no stem separation at all. Auto Split is what you want for serious
+external mixing — replace any single instrument, automate per-stem, master each
+lane independently.
 
 ## Demo / file upload into Studio
 

--- a/plugins/songwriting/skills/suno/context/tips.md
+++ b/plugins/songwriting/skills/suno/context/tips.md
@@ -164,7 +164,7 @@ Don't change three things at once. Change mood OR instrumentation OR BPM, regene
 
 ### 3. Stem-first workflow for production
 
-Generate full track → export 12-track stems → polish in Logic / Ableton / Pro Tools. Suno is great at the rough mix; external DAW is great at the final 10%.
+Generate full track → Auto Split stem export (up to 12 stems; Pro / Premier) → polish in Logic / Ableton / Pro Tools. Suno is great at the rough mix; external DAW is great at the final 10%.
 
 ### 4. Persona library for cross-project consistency
 

--- a/plugins/songwriting/skills/suno/context/v55-features.md
+++ b/plugins/songwriting/skills/suno/context/v55-features.md
@@ -6,7 +6,7 @@
 
 ### 1. Voices (clone your singing identity)
 
-**Pro / Premier only.** Clone your own vocals so generated songs sound like YOU singing.
+**Free plans included since Aug 7 2026 — with an unresolved platform caveat (see below).** Clone your own vocals so generated songs sound like YOU singing.
 
 | Detail | Spec |
 |--------|------|
@@ -19,7 +19,11 @@
 | Privacy | Private by default, account-locked, non-shareable |
 | Activation | Select voice from dropdown in Custom mode + raise Audio Influence |
 
-Clip length, 2-minute auto-selection, verification, and privacy rows verified 2026-07-18 against <https://help.suno.com/en/articles/11362369>; Pro/Premier tier per <https://suno.com/blog/v5-5>.
+Clip length, 2-minute auto-selection, verification, and privacy rows verified 2026-07-18 against <https://help.suno.com/en/articles/11362369>.
+
+**Tier corrected 2026-08-08.** The March 2026 Pro/Premier gate (per <https://suno.com/blog/v5-5>) has been superseded. <https://suno.com/release-notes>, Aug 7 2026: "We brought Voices to both iOS and Android. Record your voice once and use it on any song. Now available to try on free plans."
+
+**Unresolved platform caveat — do not assume free Voices on web.** That release-note entry is tagged *Improvement, iOS, Android, Create* with **no `Web` tag**, while every other web-touching entry in the same window carries one. <https://suno.com/pricing> shows no Voices bullet under Free, and both Voices help articles are silent on plan gating. Free-plan Voices may therefore be mobile-only. Unresolved as of 2026-08-08 — verify in-app before relying on it.
 
 **Critical prompting rule when a Voice is active:**
 
@@ -97,9 +101,10 @@ Char-limit rows verified 2026-07-18 against third-party testers ([hookgenius cha
 | Cover | ✓ | ✓ | ✓ |
 | Extend | ✓ | ✓ | ✓ |
 | Audio upload | up to 8 min | up to 30 min | up to 30 min |
-| 2-track stems | ✓ | ✓ | ✓ |
-| 12-track stems | — | ✓ | ✓ |
-| Voices | — | ✓ | ✓ |
+| Stem separation — Split from Mix (2 stems) | — | ✓ | ✓ |
+| Stem separation — Auto Split (up to 12 stems) | — | ✓ | ✓ |
+| Stem separation — Advanced Split (~100 instruments) | — | — | ✓ |
+| Voices | see platform caveat above | ✓ | ✓ |
 | Custom Models (up to 3) | — | ✓ | ✓ |
 | Replace Section | — | ✓ | ✓ |
 | Suno Studio | — | — | ✓ |
@@ -108,6 +113,7 @@ Char-limit rows verified 2026-07-18 against third-party testers ([hookgenius cha
 
 - Studio row corrected 2026-07-18: **Premier-exclusive** per <https://suno.com/pricing> — Pro has no Studio access.
 - Audio-upload row verified 2026-07-18 against <https://suno.com/pricing>: Free up to 8 minutes, Pro/Premier up to 30 minutes (the earlier 60s/120s figures were stale).
+- **Stem rows corrected 2026-08-08** against <https://suno.com/pricing>. Free reads "No stem separation" — the previous "2-track stems: Free ✓" row was false. Pro carries "2 stem separation types (Auto; Split from mix)"; Premier carries "3 stem separation types (… and Advanced split)". Naming correction too: Auto Split / Split from Mix / Advanced Split are three **modes**, not track counts — "12-track stems" was a misnomer for Auto Split, which yields up to 12 stems.
 - Free-tier generation runs on **v4.5-all**, not v5.5 (third-party report: TechRadar).
 
 ## Sources

--- a/plugins/songwriting/skills/suno/context/v55-features.md
+++ b/plugins/songwriting/skills/suno/context/v55-features.md
@@ -6,7 +6,7 @@
 
 ### 1. Voices (clone your singing identity)
 
-**Free plans included since Aug 7 2026 — with an unresolved platform caveat (see below).** Clone your own vocals so generated songs sound like YOU singing.
+**Pro / Premier. Free plans got a *trial* on Aug 7 2026 — with an unresolved platform caveat (see below).** Clone your own vocals so generated songs sound like YOU singing.
 
 | Detail | Spec |
 |--------|------|
@@ -104,7 +104,7 @@ Char-limit rows verified 2026-07-18 against third-party testers ([hookgenius cha
 | Stem separation — Split from Mix (2 stems) | — | ✓ | ✓ |
 | Stem separation — Auto Split (up to 12 stems) | — | ✓ | ✓ |
 | Stem separation — Advanced Split (~100 instruments) | — | — | ✓ |
-| Voices | see platform caveat above | ✓ | ✓ |
+| Voices | trial only (see caveat above) | ✓ | ✓ |
 | Custom Models (up to 3) | — | ✓ | ✓ |
 | Replace Section | — | ✓ | ✓ |
 | Suno Studio | — | — | ✓ |

--- a/plugins/songwriting/skills/suno/context/voices.md
+++ b/plugins/songwriting/skills/suno/context/voices.md
@@ -2,7 +2,7 @@
 
 Voices clones YOUR singing identity. v5.5 only. 18+, geographically gated.
 
-**Tier corrected 2026-08-08 — no longer Pro/Premier-only.** <https://suno.com/release-notes>, Aug 7 2026: "We brought Voices to both iOS and Android. Record your voice once and use it on any song. Now available to try on free plans." **Caveat:** that entry carries no `Web` tag (unlike other web-touching entries in the same window), `suno.com/pricing` lists no Voices bullet under Free, and both Voices help articles are silent on plan gating — so free-plan Voices may be mobile-only. Unresolved; verify in-app.
+**Tier updated 2026-08-08 — Pro / Premier, plus a free-plan TRIAL.** The release note says free plans can "try" Voices; **a trial is not all-tier entitlement, and this file must not describe it as one.** <https://suno.com/release-notes>, Aug 7 2026: "We brought Voices to both iOS and Android. Record your voice once and use it on any song. Now available to try on free plans." **Caveat:** that entry carries no `Web` tag (unlike other web-touching entries in the same window), `suno.com/pricing` lists no Voices bullet under Free, and both Voices help articles are silent on plan gating — so free-plan Voices may be mobile-only. Unresolved; verify in-app.
 
 ## What Voices does
 

--- a/plugins/songwriting/skills/suno/context/voices.md
+++ b/plugins/songwriting/skills/suno/context/voices.md
@@ -1,6 +1,8 @@
 # Voices — full guide
 
-Voices clones YOUR singing identity. v5.5 only. **Pro / Premier tier.** 18+, geographically gated.
+Voices clones YOUR singing identity. v5.5 only. 18+, geographically gated.
+
+**Tier corrected 2026-08-08 — no longer Pro/Premier-only.** <https://suno.com/release-notes>, Aug 7 2026: "We brought Voices to both iOS and Android. Record your voice once and use it on any song. Now available to try on free plans." **Caveat:** that entry carries no `Web` tag (unlike other web-touching entries in the same window), `suno.com/pricing` lists no Voices bullet under Free, and both Voices help articles are silent on plan gating — so free-plan Voices may be mobile-only. Unresolved; verify in-app.
 
 ## What Voices does
 


### PR DESCRIPTION
## What

Takes `songwriting` to **1.0.0**. Chapter coverage was complete at 0.9.0; **file** coverage was not. This audits the five files built from chapters closed in earlier sessions, reads the three non-book web sources that eight sessions had treated as unopenable, and — for the first time in ten sessions — tests whether the plugin's output is any good.

**Scoreboard, computed from the ledger, deliberately unchanged:** Axis 1 — formally audited, **44 of 44 units (100%)**. Axis 2 — fine-grained, **205 of 226 (91%)**. This was file-level work, so neither denominator moves. The 21 outstanding fine-grained units are *Essential Guide to Rhyming* (2014) front matter (spine 0-13) and back matter (spine 132-138). No craft chapter is unaudited in any of the four books.

## The output test — the question nothing had asked in ten sessions

**The lines are good.** Running the craft skills on a real brief produced usable verses in common meter and a chorus using Paradigm Three's deceptive closure to land the title in the spotlighted position.

The `object-writer` agent is the strongest component. Dispatched blind on the seed "an extension cord" — knowing nothing of the brief — it returned *"seven turns, always seven, he counted them out loud"* for a song about a dead father. The blind dispatch is what produced that. Both writers ended mid-word and graded a thin sense channel honestly instead of padding it.

**The finding that matters: quality is entirely contingent on the response filter actually running.** Every good line survived because a specific §2 box rejected a worse one. Drafting without naming boxes produced exactly the generic default the filter exists to catch. `response-filter.md` is the highest-leverage file in the plugin, and the filter is self-administered with no enforcement.

Caveat recorded rather than glossed: the installed plugin was 0.8.3 while this branch was 0.9.0, and installing was out of scope, so the *content* was tested by executing the skill bodies directly. **The shipped invocation path is still untested end to end.**

## Two near-misses avoided

- **Two of three queued "duplicated blocks" were FALSE POSITIVES.** Pat prints the Steely Dan verse at eight phrases, then pulls one out to show seven, then cuts to four — his pedagogy, not duplication. `meter.md`'s two "Mary Had a Little Lamb" blocks differ in line four (three-stress Paradigm One vs four-stress Paradigm Three). Folding either would have destroyed correct Pat text. Only `song-forms.md` was genuine.
- **The 1991 figure trap, live again.** `"She sold the fleece to pay the rent"` is **zero hits** in the 1991 text layer even wrap-safe, and is genuinely printed in figure `image_rsrc30F` with "the rent" in italics. Every cut in `meter.md` was checked against a rendered scan first.

## The refuting pass found real errors — in my own work

Three fresh agents were prompted to refute. They earned it:

- **I demoted a real Pat quote.** I checked one article for `"It's the body language"`, didn't find it, and concluded no page carried it. A refuter found it on the first search, in a *different* column ("The Art of Phrasing"). Restored, with the tail `of your song` the plugin had truncated — the same truncation I'd fixed 130 lines earlier in the same file.
- **I asserted something false.** My new vocabulary register said `front-heavy`/`back-heavy` are plugin-authored. That column coins them outright. I had collapsed **"not in the four books"** into **"not Pat's"** — different claims. `phrasing.md` had it right and I overrode it.
- **I fabricated an attribution line** — `— Beth Nielsen Chapman, "Years"` under a chorus, in the same em-dash form as Pat's one genuine attribution 56 lines above. Chapter 5 prints none there. Also: four verses printed 3,4,1,2 under a sentence claiming "in his order", and three chorus lines silently cut from a block whose adjacent paragraph reasons about exactly those lines.

All reversed, with the reasoning recorded in place so it is not repeated.

The Wave G audits themselves came back **0 REFUTED / 23 CONFIRMED** — verified by rendering all 45 Chapter 3 figures and diffing the cliché table programmatically against the parsed HTML.

## Other fixes

- **`cliche.md`** — the cliché-phrase list shipped as "a representative slice, in his grouping" and was neither: **43 of Pat's 101 printed cells missing**, surviving rows stitched from different printed rows. Complete 34-row table restored, verified cell-for-cell.
- **`rhyme-strategy.md`** — the two "Decision matrix" sections were different subjects, not duplicates; one had Pat's family/assonance pairing **inverted**.
- **`rhyme-worksheets.md`** — a seed box attributed to Exercise 7.2 actually sits inside the 7.1 grid (column-order extraction artifact); `flirt / church` mislabelled consonance when Pat's definition requires differing vowels.
- **All five `LYRIC-HANDOFF` markers in `form.md` resolved.** Scansion read off rendered figures rather than re-derived, and Pat's own `thirty-five` / `thirty five` inconsistency preserved as printed.
- **`central emotion` (0 corpus hits) replaced with Pat's real phrase** across nine files — it truncated "the central intent, idea, and emotion of the work".
- The `object-writer` agent's frontmatter promised a return shape its own contract forbids. Corrected.
- Suno drift, **partial**: the two first-party-contradicted tier rows are fixed. Remaining items are not done.

## Not done — stated plainly

- **Suno remediation items 2-9** (confidence re-tiering, bad first-party citations, the Jul 9/20 coverage gaps). The agent applying them died mid-run; its partial work was coherent and I finished the consistency pass, but the rest is outstanding.
- **Class B lyric enrichment** — ~15 items where the file is thinner than the book but nothing dangles. The receipts themselves classify these as enrichment, not defect.
- **The 21 fine-grained units** of Book 4 front/back matter.
- **An end-to-end test of the shipped invocation path.**

## Verification

`typos` · `markdownlint-cli2` (103 files, 0 errors) · `lychee --offline --include-fragments` (824 links, 0 errors) · `check-changelog-parity.sh --check-bump` · `validate-plugins.sh` · `check-skill.sh object-writing` (skill body changed) — all pass.

Extractor gated on both the four invariants and a stanza spot-check through the `<br>` bug, plus the end-to-end figure gate rendering `answers: 1. T; 2. F; 3. F; 4. T; 5. F; 6. F; 7. T; 8. T; 9. F; 10. F`.

## Related

No linked issue.
