### PR TITLE
fix(review): add per_page=100 to ci-log-auditor jobs API call

### DIFF
--- a/plugins/review/agents/ci-log-auditor.md
+++ b/plugins/review/agents/ci-log-auditor.md
@@ -19,7 +19,7 @@ You are a read-only CI run auditor for GitHub Actions. Your job: catch issues `#
 2. **Get run facts without raw logs first** — jobs, conclusions, step states, timing:
 
    ```bash
-   gh api --paginate "repos/<owner>/<repo>/actions/runs/<run-id>/jobs" --jq '.jobs[] | {name, conclusion, steps: [.steps[] | {name, conclusion, number}]}'
+   gh api --paginate "repos/<owner>/<repo>/actions/runs/<run-id>/jobs?per_page=100" --jq '.jobs[] | {name, conclusion, steps: [.steps[] | {name, conclusion, number}]}'
    gh api "repos/<owner>/<repo>/actions/runs/<run-id>/timing"
    ```
 


### PR DESCRIPTION
## Summary

The `ci-log-auditor` agent's jobs fetch uses `gh api --paginate` but omitted `per_page=100`. The GitHub REST API defaults to 30 items per page; without an explicit page size, pagination still works but requires more round trips and is inconsistent with the check-runs and annotations calls documented later in the same file.

This adds `?per_page=100` to the jobs endpoint URL on line 22.

## Test plan

- [x] `./scripts/affected-tests.sh --allow-unmapped` (docs-only change; no mapped suites)

## Related

Fixes #2238