### PR TITLE
docs(playbook): scope marketplace add in reintegration cutover checklist

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -1280,8 +1280,9 @@ surface to a published plugin for a single consumer's low-value nicety.
 1. Register the marketplace in the consumer's `extraKnownMarketplaces` and enable the plugin in
    `enabledPlugins` (project `settings.json`, so clones inherit it on trust — the interactive trust prompt
    both registers and installs the enabled plugin). Headless/CI has no such prompt, and registering a
-   marketplace does not install its plugins, so do both explicitly: `claude plugin marketplace add <repo>`
-   then `claude plugin install <plugin>@<marketplace> --scope project --config KEY=VALUE …`, seeding every
+   marketplace does not install its plugins, so do both explicitly at project scope: `claude plugin
+   marketplace add <repo> --scope project` then `claude plugin install <plugin>@<marketplace> --scope
+   project --config KEY=VALUE …`, seeding every
    non-default `userConfig` toggle on that install command — `--config` applies only on a fresh install and
    is ignored once the plugin is already installed (smoke-test C), so a headless reconfiguration later
    means uninstall/reinstall. Otherwise the marketplace is known but the plugin is absent, and step 3's


### PR DESCRIPTION
Fixes #2096

## Summary

The Reintegration cutover checklist step 1 paired an unscoped `claude plugin marketplace add <repo>` with `claude plugin install … --scope project`. The bare `marketplace add` writes to **user** settings, so a fresh clone or CI agent on another machine would carry the enabled plugin but have no registered marketplace to resolve it from — the same defect Fresh-consumer onboarding §1 already documents.

- Add `--scope project` to the headless `marketplace add` command in the cutover checklist.
- Clarify that both headless commands run at project scope so registration and install land in checked-in project settings.

Grep of `docs/MIGRATION-PLAYBOOK.md` found no other unscoped `marketplace add <repo>` instances; the remaining mention (line ~591) is generic headless guidance without a concrete command form.

## Test plan

- [x] Grep `docs/MIGRATION-PLAYBOOK.md` for unscoped `marketplace add` — only the fixed instance and the generic § mention remain.
- [x] Cutover checklist `marketplace add` now matches Fresh-consumer onboarding §1 (`--scope project`).
- [x] Adjacent `install` command unchanged (`--scope project`).

## Related

- #2094 — dometrain setup skill fix (same defect, scoped out of playbook sweep)
- Precedent: `plugins/miro`, `plugins/claude-ops`, `plugins/session-flow`, `plugins/rate-limit-guard`, `plugins/dometrain` setup skills