### PR TITLE
docs(guardrails): block-dangerous-git contract names Bash and PowerShell

### DIFF
--- a/plugins/guardrails/hooks/block-dangerous-git.sh
+++ b/plugins/guardrails/hooks/block-dangerous-git.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse hook: block irreversible git operations on Bash tool calls.
+# PreToolUse hook: block irreversible git operations on Bash and PowerShell tool calls.
 #
 # Default block-list is irreversible-only (form tokens):
 #   push-force     — git push --force / -f / +refspec / --mirror


### PR DESCRIPTION
## Summary

Reword the opening contract comment in `block-dangerous-git.sh` so it names both
tool surfaces the hook is registered for. The `hooks.json` matcher is
`Bash|PowerShell`, and the file already documents the bundled PowerShell grammar
classifier a few lines below — only the first sentence still said Bash-only.

Docs accuracy only; no behavior change.

Fixes #2145

## Test plan

- [x] `scripts/affected-tests.sh --run plugins/guardrails/hooks/block-dangerous-git.sh`
  — PASS=381 FAIL=0

## Related

- #2124 — live bypass in the same guard (unrelated; filed separately)
- #1938 — stranded post-merge review-findings sweep