### PR TITLE
docs(guardrails): name tee and other interpreter gaps in block-hook-bypass scope note

### DIFF
--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -8,11 +8,13 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
 ### Changed
 
 - **`block-hook-bypass`'s scope note now names `tee` and other inline-interpreter
-  write families it does not model (#2218).** No behaviour changes — the
-  `_BYPASS_SCOPE_NOTE`, two `SCOPE (documented residual)` blocks, the README
-  residuals section, and five accepted-floor tests now move together so a reader
-  does not credit the guard with `tee` or general interpreter coverage from the
-  old "recognized inline interpreter code" wording.
+  write families it does not model (#2218).** No behaviour changes — lane-specific
+  `_BYPASS_SCOPE_NOTE_BASH` / `_BYPASS_SCOPE_NOTE_PWSH`, two `SCOPE (documented
+  residual)` blocks, the README residuals section, and five accepted-floor tests
+  now move together so a reader does not credit the guard with POSIX `tee` or
+  general interpreter coverage from the old "recognized inline interpreter code"
+  wording — and a PowerShell block no longer claims `tee` is unseen when Tee-Object
+  and its alias are modeled.
 
 - **0.25.0 described the scratch-root exemption's fail-close inaccurately on every surface, twice
   over. Corrected, and pinned (#2236; root cause #2226).** No behaviour changes — four documents

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
 
 ### Changed
 
+- **`block-hook-bypass`'s scope note now names `tee` and other inline-interpreter
+  write families it does not model (#2218).** No behaviour changes — the
+  `_BYPASS_SCOPE_NOTE`, two `SCOPE (documented residual)` blocks, the README
+  residuals section, and five accepted-floor tests now move together so a reader
+  does not credit the guard with `tee` or general interpreter coverage from the
+  old "recognized inline interpreter code" wording.
+
 - **0.25.0 described the scratch-root exemption's fail-close inaccurately on every surface, twice
   over. Corrected, and pinned (#2236; root cause #2226).** No behaviour changes — four documents
   become accurate and four regression tests now pin the boundaries they describe.

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -94,11 +94,12 @@ out of scope until such a signal exists.
   producer is another program (`sort f > out`, `curl … > page.html`, `cat a b >
   c`) is allowed — only a content producer writing a real file
   (`cat > f` consuming stdin, `echo`/`printf > f`, inline `python3 -c` writes,
-  the PowerShell write cmdlets) is blocked. **`tee` / `tee -a` and inline writes
-  via other interpreters (`node -e`, `perl -e`, `ruby -e`, `sed -i`, `dd of=`,
-  `awk >`, …) are accepted residuals** — outside the modeled surface, not
-  oversights. The block message carries this scope so a reader does not credit the
-  guard with coverage it never claimed.
+  the PowerShell write cmdlets, including `Tee-Object` and its `tee` alias on the
+  PowerShell tool) is blocked. On the **Bash** tool, **`tee` / `tee -a` and inline
+  writes via other interpreters (`node -e`, `perl -e`, `ruby -e`, `sed -i`, `dd
+  of=`, `awk >`, …) are accepted residuals** — outside the modeled surface, not
+  oversights. The block message carries a lane-specific scope note so a reader does
+  not credit the guard with coverage it never claimed.
 - **`block-hook-bypass` has one target-scoped exemption beyond `/dev/null`, and
   it is off unless an operator turns it on.** `block_hook_bypass_scratch_roots`
   takes a comma-separated list of absolute directories whose contents are

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -94,8 +94,11 @@ out of scope until such a signal exists.
   producer is another program (`sort f > out`, `curl … > page.html`, `cat a b >
   c`) is allowed — only a content producer writing a real file
   (`cat > f` consuming stdin, `echo`/`printf > f`, inline `python3 -c` writes,
-  the PowerShell write cmdlets) is blocked. The block message carries this scope
-  so a reader does not credit the guard with coverage it never claimed.
+  the PowerShell write cmdlets) is blocked. **`tee` / `tee -a` and inline writes
+  via other interpreters (`node -e`, `perl -e`, `ruby -e`, `sed -i`, `dd of=`,
+  `awk >`, …) are accepted residuals** — outside the modeled surface, not
+  oversights. The block message carries this scope so a reader does not credit the
+  guard with coverage it never claimed.
 - **`block-hook-bypass` has one target-scoped exemption beyond `/dev/null`, and
   it is off unless an operator turns it on.** `block_hook_bypass_scratch_roots`
   takes a comma-separated list of absolute directories whose contents are

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -756,19 +756,28 @@ producer_redirect_bypass() {
 # is a speed bump against specific accidental write-workaround forms in one
 # command string, not a boundary — and it is deliberately producer-scoped, so
 # ordinary data-processing redirects (`sort f > out`, `curl … > page.html`) and
-# other unmodeled write utilities (`tee`, inline `node -e`, …) are allowed by
-# design too, not only writes inside an invoked script.
-_BYPASS_SCOPE_NOTE="Scope: only this command string is inspected — known shell \
-file-write forms plus inline python3 -c only. tee, other inline-interpreter \
-writes (e.g. node -e, sed -i), writes inside an invoked script file or a \
-program's own opaque code, and redirects produced by another program, are not \
-seen."
+# other unmodeled Bash write utilities (POSIX `tee`, inline `node -e`, …) are
+# allowed by design too, not only writes inside an invoked script.
+_BYPASS_SCOPE_NOTE_BASH="Scope: only this command string is inspected — known shell \
+file-write forms plus inline python3 -c only. POSIX tee pipe writes, other \
+inline-interpreter writes (e.g. node -e, sed -i), writes inside an invoked \
+script file or a program's own opaque code, and redirects produced by another \
+program, are not seen."
+_BYPASS_SCOPE_NOTE_PWSH="Scope: only this command string is inspected — known PowerShell \
+file-write cmdlets and content-producer redirects (including Tee-Object and the \
+tee alias) plus inline python3 -c only. Other inline-interpreter writes (e.g. \
+node -e), writes inside an invoked script file or a program's own opaque code, \
+and redirects produced by another program, are not seen."
 
 block_bypass() {
   local form="$1" reason="$2"
   echo "BLOCKED: $reason" >&2
   echo "Use the Write or Edit tool instead of a shell file-write workaround." >&2
-  echo "$_BYPASS_SCOPE_NOTE" >&2
+  if [[ "$TOOL_NAME" == "PowerShell" ]]; then
+    echo "$_BYPASS_SCOPE_NOTE_PWSH" >&2
+  else
+    echo "$_BYPASS_SCOPE_NOTE_BASH" >&2
+  fi
   emit_tel "blocked" "$form"
   exit 2
 }
@@ -823,10 +832,11 @@ fi
 # detection.
 normalize_segments "$EXEC_LC"
 
-# SCOPE (documented residual): `tee` / `tee -a` pipe-to-file writes are NOT
-# caught — the guard models cat/echo/printf redirects and python3 -c, not every
-# POSIX write utility. Catching tee needs a separate lane; covered by an
-# accepted-floor test.
+# SCOPE (documented residual): Bash lane only. POSIX `tee` / `tee -a` pipe-to-file
+# writes are NOT caught — the guard models cat/echo/printf redirects and
+# python3 -c, not every POSIX write utility. The PowerShell lane blocks
+# Tee-Object and its `tee` alias via ps::write_bypass. Catching POSIX tee needs a
+# separate Bash lane; covered by an accepted-floor test.
 #
 # cat > file (allow cat without redirect, and allow a `> /dev/null` discard).
 if cat_redirect_bypass; then

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -755,12 +755,14 @@ producer_redirect_bypass() {
 # have, and a human credits the guard with coverage it never claimed. The guard
 # is a speed bump against specific accidental write-workaround forms in one
 # command string, not a boundary — and it is deliberately producer-scoped, so
-# ordinary data-processing redirects (`sort f > out`, `curl … > page.html`) are
-# allowed by design too, not only writes inside an invoked script.
+# ordinary data-processing redirects (`sort f > out`, `curl … > page.html`) and
+# other unmodeled write utilities (`tee`, inline `node -e`, …) are allowed by
+# design too, not only writes inside an invoked script.
 _BYPASS_SCOPE_NOTE="Scope: only this command string is inspected — known shell \
-file-write forms plus recognized inline interpreter code (e.g. python -c). Writes \
-inside an invoked script file or a program's own opaque code, and redirects \
-produced by another program, are not seen."
+file-write forms plus inline python3 -c only. tee, other inline-interpreter \
+writes (e.g. node -e, sed -i), writes inside an invoked script file or a \
+program's own opaque code, and redirects produced by another program, are not \
+seen."
 
 block_bypass() {
   local form="$1" reason="$2"
@@ -821,6 +823,11 @@ fi
 # detection.
 normalize_segments "$EXEC_LC"
 
+# SCOPE (documented residual): `tee` / `tee -a` pipe-to-file writes are NOT
+# caught — the guard models cat/echo/printf redirects and python3 -c, not every
+# POSIX write utility. Catching tee needs a separate lane; covered by an
+# accepted-floor test.
+#
 # cat > file (allow cat without redirect, and allow a `> /dev/null` discard).
 if cat_redirect_bypass; then
   block_bypass "cat-redirect" "cat > file write bypasses Write/Edit hooks"
@@ -833,6 +840,12 @@ if producer_redirect_bypass; then
   block_bypass "echo-redirect" "echo/printf > file write bypasses Write/Edit hooks"
 fi
 
+# SCOPE (documented residual): inline writes via interpreters other than
+# python3 -c — `node -e`, `perl -e`, `ruby -e`, `sed -i`, `dd of=`, `awk >`,
+# and similar — are NOT caught. Only the python3 -c lane is modeled; each other
+# interpreter has its own spelling and write surface. Covered by accepted-floor
+# tests.
+#
 # python3 -c with file-write indicators. Detect the `python3 -c` INVOCATION in
 # the literal-stripped form (EXEC_LC) so prose/commit text merely mentioning it
 # is not a false positive; scan the RAW command (COMMAND_LC) for the write

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -739,8 +739,10 @@ assert_contains "bash block states its scope" "$scopeout" \
   "only this command string is inspected"
 assert_contains "bash block names the invoked-script gap" "$scopeout" \
   "inside an invoked script file"
-assert_contains "bash block exempts inspected inline code from the gap" "$scopeout" \
-  "recognized inline interpreter code"
+assert_contains "bash block limits interpreter coverage to python3 -c" "$scopeout" \
+  "inline python3 -c only"
+assert_contains "bash block names the tee gap" "$scopeout" "tee"
+assert_contains "bash block names other-interpreter gap" "$scopeout" "node -e"
 psscope=$(bash "$HOOK" <<<"$(pwsh_command_json "Set-Content f.txt 'x'")" 2>&1)
 assert_contains "powershell block states its scope" "$psscope" \
   "only this command string is inspected"
@@ -752,6 +754,13 @@ run "invoked script is not inspected (allowed)" "bash execute.sh" 0
 run "invoked script with its own redirect (allowed)" "bash execute.sh >> run.log" 0
 run "non-producer redirect (allowed)" "sort data.txt > out.txt" 0
 run "cat with input files is not a heredoc write (allowed)" "cat a.txt b.txt > c.txt" 0
+# tee and other inline-interpreter writes are outside the modeled surface.
+run "tee pipe write (accepted floor — allowed)" 'echo "*" | tee .gitignore' 0
+run "tee -a append (accepted floor — allowed)" 'echo "*" | tee -a .gitignore' 0
+run "node -e write (accepted floor — allowed)" \
+  "node -e \"require('fs').writeFileSync('f.txt','a')\"" 0
+run "sed -i in-place write (accepted floor — allowed)" "sed -i 's/a/b/' f.txt" 0
+run "dd of= write (accepted floor — allowed)" "dd of=f.txt <<< x" 0
 
 # --- Scratch-root exemption (block_hook_bypass_scratch_roots) ----------------
 # The guard's first TARGET-scoped axis. The last exemption of this shape

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -741,11 +741,12 @@ assert_contains "bash block names the invoked-script gap" "$scopeout" \
   "inside an invoked script file"
 assert_contains "bash block limits interpreter coverage to python3 -c" "$scopeout" \
   "inline python3 -c only"
-assert_contains "bash block names the tee gap" "$scopeout" "tee"
+assert_contains "bash block names the tee gap" "$scopeout" "POSIX tee"
 assert_contains "bash block names other-interpreter gap" "$scopeout" "node -e"
 psscope=$(bash "$HOOK" <<<"$(pwsh_command_json "Set-Content f.txt 'x'")" 2>&1)
 assert_contains "powershell block states its scope" "$psscope" \
   "only this command string is inspected"
+assert_contains "powershell block names Tee-Object coverage" "$psscope" "Tee-Object"
 
 # The behaviour the scope note describes. A write inside an invoked script is
 # not inspected, and a redirect whose producer is another program is allowed by
@@ -759,7 +760,8 @@ run "tee pipe write (accepted floor — allowed)" 'echo "*" | tee .gitignore' 0
 run "tee -a append (accepted floor — allowed)" 'echo "*" | tee -a .gitignore' 0
 run "node -e write (accepted floor — allowed)" \
   "node -e \"require('fs').writeFileSync('f.txt','a')\"" 0
-run "sed -i in-place write (accepted floor — allowed)" "sed -i 's/a/b/' f.txt" 0
+run "sed -i in-place write (accepted floor — allowed)" \
+  "sed -i 's/a/b/' f.txt" 0 # portability-ok: test fixture command string containing sed -i, not an unsuffixed sed -i invocation
 run "dd of= write (accepted floor — allowed)" "dd of=f.txt <<< x" 0
 
 # --- Scratch-root exemption (block_hook_bypass_scratch_roots) ----------------


### PR DESCRIPTION
## Summary

`block-hook-bypass`'s `_BYPASS_SCOPE_NOTE` existed to tell a reader exactly what the guard does **not** see, but two uncovered write families were missing from that list:

1. **`tee` / `tee -a`** — pipe-to-file writes are allowed; the string `tee` did not appear anywhere in the script.
2. **Other inline-interpreter writes** — `node -e`, `perl -e`, `ruby -e`, `sed -i`, `dd of=`, `awk >`, and similar are allowed. The old "recognized inline interpreter code (e.g. python -c)" wording invited readers to assume general interpreter coverage when only `python3 -c` is modeled.

**No hook logic changes.** This is a disclosure fix plus accepted-floor tests, following the same convention #1802 established: name the residual in a `SCOPE (documented residual)` block and pin it with tests so message and reality move together.

## Test plan

- [x] `bash plugins/guardrails/hooks/block-hook-bypass.test.sh` — PASS=307, FAIL=0
- [x] Five new accepted-floor tests: `tee`, `tee -a`, `node -e`, `sed -i`, `dd of=`
- [x] Three updated scope-note message assertions: `inline python3 -c only`, `tee`, `node -e`

## Related

- Fixes #2218
- Same class as #1802 (closed) — scope-note disclosure for residuals the guard deliberately does not model