### PR TITLE
docs(repo-hygiene): record CLAUDE_SKILL_DIR scope residual for clean context files

### DIFF
--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+<<<<<<< HEAD
 ## [0.10.1]
 
 ### Fixed
@@ -16,6 +17,20 @@ All notable changes to the `repo-hygiene` plugin are documented here. Format fol
   confirmation gate unsatisfied rather than asking inline. The fallback now triggers on absent,
   denied, **or otherwise unusable** — including a denial discovered only by calling it — mirroring
   the sibling fix in `disk-hygiene` (#2016).
+=======
+## [Unreleased]
+
+### Documentation
+
+- **Record the accepted two-form invocation split for `/repo-hygiene:clean` (#2237).** decide-lane
+  verdict: **DEFER** converting bundled `context/*.md` files from
+  `bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/…` to `${CLAUDE_SKILL_DIR}/scripts/…`.
+  `${CLAUDE_SKILL_DIR}` substitutes in SKILL.md content and `allowed-tools` only (skills docs,
+  changelog v2.1.69); context files are Read raw and whether substitution reaches them is
+  unverified — a wrong conversion expands to `/scripts/…` and fails silently. New spoke
+  `skills/clean/reference/invocation-forms.md`; `allowed-tools-pairing.test.sh` now guards that
+  `context/*.md` never adopt the direct `${CLAUDE_SKILL_DIR}/scripts/…` form.
+>>>>>>> 9a829ef6 (docs(repo-hygiene): record CLAUDE_SKILL_DIR scope residual for clean context files)
 
 ## [0.10.0]
 

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,7 +3,19 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
-<<<<<<< HEAD
+## [Unreleased]
+
+### Documentation
+
+- **Record the accepted two-form invocation split for `/repo-hygiene:clean` (#2237).** decide-lane
+  verdict: **DEFER** converting bundled `context/*.md` files from
+  `bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/…` to `${CLAUDE_SKILL_DIR}/scripts/…`.
+  `${CLAUDE_SKILL_DIR}` substitutes in SKILL.md content and `allowed-tools` only (skills docs,
+  changelog v2.1.69); context files are Read raw and whether substitution reaches them is
+  unverified — a wrong conversion expands to `/scripts/…` and fails silently. New spoke
+  `skills/clean/reference/invocation-forms.md`; `allowed-tools-pairing.test.sh` now guards that
+  `context/*.md` never adopt the direct `${CLAUDE_SKILL_DIR}/scripts/…` form.
+
 ## [0.10.1]
 
 ### Fixed
@@ -17,20 +29,6 @@ All notable changes to the `repo-hygiene` plugin are documented here. Format fol
   confirmation gate unsatisfied rather than asking inline. The fallback now triggers on absent,
   denied, **or otherwise unusable** — including a denial discovered only by calling it — mirroring
   the sibling fix in `disk-hygiene` (#2016).
-=======
-## [Unreleased]
-
-### Documentation
-
-- **Record the accepted two-form invocation split for `/repo-hygiene:clean` (#2237).** decide-lane
-  verdict: **DEFER** converting bundled `context/*.md` files from
-  `bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/…` to `${CLAUDE_SKILL_DIR}/scripts/…`.
-  `${CLAUDE_SKILL_DIR}` substitutes in SKILL.md content and `allowed-tools` only (skills docs,
-  changelog v2.1.69); context files are Read raw and whether substitution reaches them is
-  unverified — a wrong conversion expands to `/scripts/…` and fails silently. New spoke
-  `skills/clean/reference/invocation-forms.md`; `allowed-tools-pairing.test.sh` now guards that
-  `context/*.md` never adopt the direct `${CLAUDE_SKILL_DIR}/scripts/…` form.
->>>>>>> 9a829ef6 (docs(repo-hygiene): record CLAUDE_SKILL_DIR scope residual for clean context files)
 
 ## [0.10.0]
 

--- a/plugins/repo-hygiene/scripts/allowed-tools-pairing.test.sh
+++ b/plugins/repo-hygiene/scripts/allowed-tools-pairing.test.sh
@@ -15,6 +15,14 @@
 # `allowed-tools`; `${CLAUDE_PLUGIN_ROOT}` stays a literal string there and the
 # grant is inert.
 #
+# Two-form split (decide-lane #2237, DEFER): `SKILL.md` uses the paired
+# `${CLAUDE_SKILL_DIR}/scripts/…` form that matches its grants; bundled
+# `context/*.md` files keep the interpreter-led
+# `bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/…` form because substitution
+# of `${CLAUDE_SKILL_DIR}` into on-demand context files is unverified — a wrong
+# conversion expands to `/scripts/…` and fails silently. See
+# `skills/clean/reference/invocation-forms.md`.
+#
 # SC2016 is disabled file-wide on purpose. Every single-quoted `${…}` here is a
 # fixed string searched for VERBATIM in markdown and frontmatter, where those
 # placeholders are substituted by Claude Code at load time. Letting the shell
@@ -83,6 +91,17 @@ for skill in "${SKILLS[@]}"; do
     fi
     if grep -qF '"${CLAUDE_SKILL_DIR}/scripts/' "$f"; then
       fail "$f: body quotes the bundled-script path — an unquoted rule will not match it"
+    fi
+    # Bundled context files must stay on `${CLAUDE_PLUGIN_ROOT}` until substitution
+    # scope for on-demand context is verified (#2237). Direct
+    # `${CLAUDE_SKILL_DIR}/scripts/…` there would look paired but expand to
+    # `/scripts/…` if the placeholder is not substituted.
+    if [[ "$f" == skills/*/context/* ]]; then
+      if grep -qF '${CLAUDE_SKILL_DIR}/scripts/' "$f"; then
+        fail "$f: context file must not use \${CLAUDE_SKILL_DIR}/scripts/ — keep \${CLAUDE_PLUGIN_ROOT} form (#2237)"
+      else
+        pass "$f: context file free of direct \${CLAUDE_SKILL_DIR}/scripts/ invocations"
+      fi
     fi
   done
 

--- a/plugins/repo-hygiene/scripts/allowed-tools-pairing.test.sh
+++ b/plugins/repo-hygiene/scripts/allowed-tools-pairing.test.sh
@@ -99,8 +99,20 @@ for skill in "${SKILLS[@]}"; do
     if [[ "$f" == skills/*/context/* ]]; then
       if grep -qF '${CLAUDE_SKILL_DIR}/scripts/' "$f"; then
         fail "$f: context file must not use \${CLAUDE_SKILL_DIR}/scripts/ — keep \${CLAUDE_PLUGIN_ROOT} form (#2237)"
+      fi
+      # Every bundled-script reference must retain the interpreter-led PLUGIN_ROOT
+      # prefix — banning SKILL_DIR alone still passes if a command is rerouted to
+      # another invalid path such as bash /wrong/preflight.sh.
+      required='bash ${CLAUDE_PLUGIN_ROOT}/skills/'"$skill"'/scripts/'
+      while IFS= read -r line; do
+        if [[ "$line" != *"$required"* ]]; then
+          fail "$f: context script invocation must use bash \${CLAUDE_PLUGIN_ROOT}/skills/$skill/scripts/… — got: ${line%%$'\n'}"
+        fi
+      done < <(grep -F 'skills/'"$skill"'/scripts/' "$f" || true)
+      if grep -qF 'skills/'"$skill"'/scripts/' "$f"; then
+        pass "$f: context script invocations use interpreter-led \${CLAUDE_PLUGIN_ROOT} form"
       else
-        pass "$f: context file free of direct \${CLAUDE_SKILL_DIR}/scripts/ invocations"
+        pass "$f: context file has no bundled-script invocations to pin"
       fi
     fi
   done

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -41,6 +41,8 @@ Return the repo toward a known-good state. **Selective tiers** (`scan`, `caches`
 
 Bare invocation never mutates silently: resolve intent → dry-run → user confirmation → `--apply`. Full menu, aliases, and confirmation matrix: [context/action-router.md](context/action-router.md).
 
+Bundled-script invocation uses two deliberate forms — paired `${CLAUDE_SKILL_DIR}` in this file (matches `allowed-tools`) and interpreter-led `${CLAUDE_PLUGIN_ROOT}` in routed `context/*.md` detail files. Rationale and decide-lane verdict: [reference/invocation-forms.md](reference/invocation-forms.md).
+
 ## Arguments
 
 `$ARGUMENTS` — cleanup action or alias. Resolve first:

--- a/plugins/repo-hygiene/skills/clean/reference/invocation-forms.md
+++ b/plugins/repo-hygiene/skills/clean/reference/invocation-forms.md
@@ -34,7 +34,7 @@ skill's markdown content" without saying bundled context files loaded later coun
 already leans toward the broader reading: `docs/conventions/permission-rule-hygiene/README.md`
 states the same substitution scope for `${CLAUDE_SKILL_DIR}` in "the skill's markdown content"
 without carving out bundled files loaded on demand, so the two repo docs are in tension until
-#2237 settles it empirically. `${CLAUDE_PLUGIN_ROOT}` is documented more broadly
+issue #2237 settles it empirically. `${CLAUDE_PLUGIN_ROOT}` is documented more broadly
 (plugins-reference: "Skill and agent content | Anywhere the placeholder appears"), so it is the
 safe token for copy-paste examples the model may run from a context file.
 

--- a/plugins/repo-hygiene/skills/clean/reference/invocation-forms.md
+++ b/plugins/repo-hygiene/skills/clean/reference/invocation-forms.md
@@ -1,0 +1,58 @@
+# clean invocation forms — accepted two-form split
+
+`/repo-hygiene:clean` deliberately carries **two** bundled-script invocation forms. This is an
+accepted residual, not a pairing defect to "fix" by converting every `context/*.md` file to
+`${CLAUDE_SKILL_DIR}`.
+
+## Paired form — `SKILL.md` + `allowed-tools`
+
+`SKILL.md` and its `allowed-tools` frontmatter use the **paired** form from #2225:
+
+- Body: direct, unquoted `${CLAUDE_SKILL_DIR}/scripts/<name>.sh`
+- Rule: `Bash(${CLAUDE_SKILL_DIR}/scripts/<name>.sh:*)`
+
+Per the [skills](https://code.claude.com/docs/en/skills#available-string-substitutions) docs
+(changelog v2.1.69), Claude Code substitutes `${CLAUDE_SKILL_DIR}` in **two** places only: the
+skill's markdown content, and Bash rules in `allowed-tools`. The five read-only grants
+(`resolve-clean-action.sh`, `scan.sh`, `preflight.sh`, `git-branch-audit.sh`, `git-stash-audit.sh`)
+are fully paired through this surface.
+
+## Interpreter-led form — bundled `context/*.md`
+
+The six routed detail files still invoke through the **interpreter-led** form:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/skills/clean/scripts/<name>.sh
+```
+
+Files: `context/action-router.md`, `context/clean-batch.md`, `context/git-branch-cleanup.md`,
+`context/git-tree-reset.md`, `context/git-tree-reset-batch.md`, `context/preflight.md`.
+
+They are loaded on demand when `SKILL.md` routes into a step. Whether `${CLAUDE_SKILL_DIR}`
+substitution reaches those files is **unverified** — the skills page scopes substitution to "the
+skill's markdown content" without saying bundled context files loaded later count. `${CLAUDE_PLUGIN_ROOT}`
+is documented more broadly (plugins-reference: "Skill and agent content | Anywhere the placeholder
+appears"), so it is the safe token for copy-paste examples the model may run from a context file.
+
+**Failure mode if converted on the wrong assumption:** an unsubstituted body emits a literal
+`${CLAUDE_SKILL_DIR}/scripts/x.sh`, which the Bash tool expands from an unset environment variable
+(that variable is not exported into the tool's shell) to `/scripts/x.sh`. It fails safe — a prompt or
+a not-found error, never a wrong action — but **silently**, which is the defect class #2225 exists
+to remove.
+
+## decide-lane verdict (#2237)
+
+**DEFER** converting `context/*.md` to `${CLAUDE_SKILL_DIR}`. Keep the `${CLAUDE_PLUGIN_ROOT}`
+form until substitution scope for bundled context files is settled empirically (see #2237). Commands
+the model takes from a `context/*.md` will not match the paired `allowed-tools` rules and will
+prompt or fall to the classifier — that is expected and does not weaken #2225's fix, because every
+granted script is also invoked from `SKILL.md`.
+
+`scripts/allowed-tools-pairing.test.sh` pins both halves: the paired contract on `SKILL.md`, and a
+guard that `context/*.md` never adopt the direct `${CLAUDE_SKILL_DIR}/scripts/…` form.
+
+## Related
+
+- #2225 — paired body+rule rewrite this defers finishing
+- #1824 — neighbouring open question on `${CLAUDE_SKILL_DIR}` in pre-compute blocks
+- `docs/conventions/permission-rule-hygiene/README.md` — which variables substitute in `allowed-tools`

--- a/plugins/repo-hygiene/skills/clean/reference/invocation-forms.md
+++ b/plugins/repo-hygiene/skills/clean/reference/invocation-forms.md
@@ -30,9 +30,13 @@ Files: `context/action-router.md`, `context/clean-batch.md`, `context/git-branch
 
 They are loaded on demand when `SKILL.md` routes into a step. Whether `${CLAUDE_SKILL_DIR}`
 substitution reaches those files is **unverified** — the skills page scopes substitution to "the
-skill's markdown content" without saying bundled context files loaded later count. `${CLAUDE_PLUGIN_ROOT}`
-is documented more broadly (plugins-reference: "Skill and agent content | Anywhere the placeholder
-appears"), so it is the safe token for copy-paste examples the model may run from a context file.
+skill's markdown content" without saying bundled context files loaded later count. That phrasing
+already leans toward the broader reading: `docs/conventions/permission-rule-hygiene/README.md`
+states the same substitution scope for `${CLAUDE_SKILL_DIR}` in "the skill's markdown content"
+without carving out bundled files loaded on demand, so the two repo docs are in tension until
+#2237 settles it empirically. `${CLAUDE_PLUGIN_ROOT}` is documented more broadly
+(plugins-reference: "Skill and agent content | Anywhere the placeholder appears"), so it is the
+safe token for copy-paste examples the model may run from a context file.
 
 **Failure mode if converted on the wrong assumption:** an unsubstituted body emits a literal
 `${CLAUDE_SKILL_DIR}/scripts/x.sh`, which the Bash tool expands from an unset environment variable


### PR DESCRIPTION
No linked issue

## Summary

Records the decide-lane **DEFER** verdict for #2237: keep `/repo-hygiene:clean`'s six bundled `context/*.md` files on the interpreter-led `${CLAUDE_PLUGIN_ROOT}` form; do not convert them to `${CLAUDE_SKILL_DIR}` until substitution scope for on-demand context files is verified empirically.

- Adds `skills/clean/reference/invocation-forms.md` documenting the accepted two-form split (`SKILL.md` paired on `${CLAUDE_SKILL_DIR}` + `allowed-tools`; `context/*.md` deferred on `${CLAUDE_PLUGIN_ROOT}`).
- Points from `SKILL.md` to the new reference spoke.
- Extends `allowed-tools-pairing.test.sh` with a comment and guard asserting `context/*.md` never adopt direct `${CLAUDE_SKILL_DIR}/scripts/…` invocations.
- CHANGELOG entry under `[Unreleased]`.

`docs/conventions/permission-rule-hygiene` is **not** standards-managed (no sync manifest entry); the residual is recorded skill-locally per convention.

No changes to the six `context/*.md` invocation forms.

## Test plan

- [x] `bash plugins/repo-hygiene/scripts/allowed-tools-pairing.test.sh` — all checks pass, including six new context-file guards

## Related

Refs #2237
