### PR TITLE
fix(claude-ops): fail closed when lane config validation jq queries error

### DIFF
--- a/plugins/claude-ops/CHANGELOG.md
+++ b/plugins/claude-ops/CHANGELOG.md
@@ -19,6 +19,15 @@ All notable changes to the `claude-ops` plugin are documented here. Format follo
   functions, which is what #2146 asked for: previously each call site asserted a posture in a
   comment and nothing where the decision is made explained it. Synced from `lib/hook-utils.sh`.
 
+### Fixed
+
+- **`lane-launcher` preflight validation jq queries now fail closed on query errors.** The duplicate-name,
+  path-safety, and field-typing checks in `resolve_config` ran their jq filters in command
+  substitutions and treated empty output as "no problem" without checking whether jq succeeded. A
+  malformed config that slipped past the sibling type gate could make a query error vacuously pass.
+  Each substitution now checks jq's exit status and rejects the config when the validation query
+  itself fails.
+
 ## [0.29.0]
 
 ### Added

--- a/plugins/claude-ops/skills/lanes/scripts/lane-launcher.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/lane-launcher.sh
@@ -328,7 +328,10 @@ resolve_config() {
   # same-named sessions while stop reaches only the most-recent one. Reject it at
   # config time rather than silently acting on an ambiguous set.
   local dupes
-  dupes="$(jq -r '[.lanes[].name | select(. != null)] | group_by(.) | map(select(length > 1) | .[0]) | join(", ")' "$CONFIG")"
+  dupes="$(jq -r '[.lanes[].name | select(. != null)] | group_by(.) | map(select(length > 1) | .[0]) | join(", ")' "$CONFIG")" || {
+    err "lane config validation query failed (duplicate lane names): $CONFIG"
+    exit 3
+  }
   [[ -z "$dupes" ]] || {
     err "lane config has duplicate lane names: $dupes (names must be unique): $CONFIG"
     exit 3
@@ -344,7 +347,11 @@ resolve_config() {
   traversal="$(jq -r '
     [ .lanes[].name
       | select(. != null)
-      | select(test("[/\\\\]") or . == "." or . == "..") ] | join(", ")' "$CONFIG")"
+      | select(type == "string")
+      | select(test("[/\\\\]") or . == "." or . == "..") ] | join(", ")' "$CONFIG")" || {
+    err "lane config validation query failed (lane name path safety): $CONFIG"
+    exit 3
+  }
   [[ -z "$traversal" ]] || {
     err "lane config has lane names that are not usable as a path component: $traversal"
     err "  (a name must not contain '/' or '\\', or be '.' or '..'): $CONFIG"
@@ -369,7 +376,10 @@ resolve_config() {
       | select(.key == "name" or .key == "model" or .key == "effort" or .key == "prompt")
       | select(.value != null and (.value | type) != "string")
       | "lane #\($i) .\(.key) is \(.value | type)" ]
-    | join(", ")' "$CONFIG")"
+    | join(", ")' "$CONFIG")" || {
+    err "lane config validation query failed (lane field typing): $CONFIG"
+    exit 3
+  }
   [[ -z "$mistyped" ]] || {
     err "lane config has non-string values for string fields: $mistyped"
     err "  (name/model/effort/prompt must be JSON strings): $CONFIG"

--- a/plugins/claude-ops/skills/lanes/scripts/lane-launcher.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/lane-launcher.test.sh
@@ -244,25 +244,44 @@ for mistyped_field in name model effort prompt; do
 done
 
 # Defence-in-depth: a failed validation jq query must reject the config, not
-# pass vacuously on empty output when jq errors (#2088).
+# pass vacuously on empty output when jq errors (#2088). Each resolve_config
+# validation query gets its own stub match so copy-pasted guards cannot regress
+# independently.
 REAL_JQ="$(command -v jq)"
 mkdir -p "$TMP/jqbin"
-cat >"$TMP/jqbin/jq" <<EOF
-#!/usr/bin/env bash
-if [[ "\$*" == *group_by* ]]; then
-  echo 'jq: error: simulated validation query failure' >&2
-  exit 1
-fi
-exec "$REAL_JQ" "\$@"
-EOF
-chmod +x "$TMP/jqbin/jq"
 cat >"$TMP/valid-for-jq-fail.json" <<'JSON'
 { "lanes": [ { "name": "work", "prompt": "work.md" } ] }
 JSON
+install_jq_fail_stub() {
+  local needle="$1"
+  cat >"$TMP/jqbin/jq" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *$(printf '%q' "$needle")* ]]; then
+  echo 'jq: error: simulated validation query failure' >&2
+  exit 1
+fi
+exec $(printf '%q' "$REAL_JQ") "\$@"
+EOF
+  chmod +x "$TMP/jqbin/jq"
+}
+
+install_jq_fail_stub 'group_by'
 out="$(PATH="$TMP/jqbin:$PATH" run_launcher status --repo "$REPO" --config "$TMP/valid-for-jq-fail.json" --agents-json "$AGENTS_EMPTY" 2>&1)"
 rc=$?
 assert_eq "a failed duplicate-names validation query exits 3" 3 "$rc"
 assert_contains "a failed duplicate-names validation query is named in the message" "$out" "validation query failed (duplicate lane names)"
+
+install_jq_fail_stub 'test("[/'
+out="$(PATH="$TMP/jqbin:$PATH" run_launcher status --repo "$REPO" --config "$TMP/valid-for-jq-fail.json" --agents-json "$AGENTS_EMPTY" 2>&1)"
+rc=$?
+assert_eq "a failed lane-name path-safety validation query exits 3" 3 "$rc"
+assert_contains "a failed lane-name path-safety validation query is named in the message" "$out" "validation query failed (lane name path safety)"
+
+install_jq_fail_stub '.key == "effort"'
+out="$(PATH="$TMP/jqbin:$PATH" run_launcher status --repo "$REPO" --config "$TMP/valid-for-jq-fail.json" --agents-json "$AGENTS_EMPTY" 2>&1)"
+rc=$?
+assert_eq "a failed lane field typing validation query exits 3" 3 "$rc"
+assert_contains "a failed lane field typing validation query is named in the message" "$out" "validation query failed (lane field typing)"
 
 # `null` remains the JSON spelling of "no value" and stays equivalent to absent.
 jq -n '{lanes: [{name: "work", prompt: "work.md", model: null}]}' >"$TMP/nullmodel.json"

--- a/plugins/claude-ops/skills/lanes/scripts/lane-launcher.test.sh
+++ b/plugins/claude-ops/skills/lanes/scripts/lane-launcher.test.sh
@@ -243,6 +243,27 @@ for mistyped_field in name model effort prompt; do
   assert_contains "a boolean .$mistyped_field is named in the message" "$out" ".$mistyped_field is boolean"
 done
 
+# Defence-in-depth: a failed validation jq query must reject the config, not
+# pass vacuously on empty output when jq errors (#2088).
+REAL_JQ="$(command -v jq)"
+mkdir -p "$TMP/jqbin"
+cat >"$TMP/jqbin/jq" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *group_by* ]]; then
+  echo 'jq: error: simulated validation query failure' >&2
+  exit 1
+fi
+exec "$REAL_JQ" "\$@"
+EOF
+chmod +x "$TMP/jqbin/jq"
+cat >"$TMP/valid-for-jq-fail.json" <<'JSON'
+{ "lanes": [ { "name": "work", "prompt": "work.md" } ] }
+JSON
+out="$(PATH="$TMP/jqbin:$PATH" run_launcher status --repo "$REPO" --config "$TMP/valid-for-jq-fail.json" --agents-json "$AGENTS_EMPTY" 2>&1)"
+rc=$?
+assert_eq "a failed duplicate-names validation query exits 3" 3 "$rc"
+assert_contains "a failed duplicate-names validation query is named in the message" "$out" "validation query failed (duplicate lane names)"
+
 # `null` remains the JSON spelling of "no value" and stays equivalent to absent.
 jq -n '{lanes: [{name: "work", prompt: "work.md", model: null}]}' >"$TMP/nullmodel.json"
 out="$(run_launcher start --repo "$REPO" --config "$TMP/nullmodel.json" --agents-json "$AGENTS_EMPTY" --dry-run 2>&1)"


### PR DESCRIPTION
No linked issue

## Summary

Check jq exit status for the three preflight validation queries in `lane-launcher.sh` `resolve_config` (duplicate lane names, path-safety, field typing) so a query error rejects the config instead of passing vacuously on empty output.

## Fix

- Add `|| { err ...; exit 3 }` after each validation jq command substitution.
- Restrict the path-safety filter to string lane names so non-string names still reach the typing check with the existing error message.
- Add a regression test that simulates a jq validation failure via a PATH wrapper.

## Verification

```shell
bash plugins/claude-ops/skills/lanes/scripts/lane-launcher.test.sh
```

195 cases pass (includes new jq-failure case).

## Related

Refs #2088
