### PR TITLE
fix(guardrails): name kill switch and isolated Write/Edit refusal in block-hook-bypass message

### DIFF
--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -774,7 +774,7 @@ block_bypass() {
   echo "BLOCKED: $reason" >&2
   echo "Use the Write or Edit tool instead of a shell file-write workaround." >&2
   echo "In an isolated session, Write or Edit may be refused for paths in the main checkout — that remedy is then unavailable." >&2
-  echo "An operator can set the guardrails block_hook_bypass_enabled option to false (/plugin configure) to bypass; that switch is not actionable by the blocked agent." >&2
+  echo "An operator can set the guardrails block_hook_bypass_enabled option to false (/plugin configure) to bypass; that option is user-scoped and persists in every repository where guardrails is enabled — re-enable it when the bypass is no longer needed. The switch is not actionable by the blocked agent." >&2
   if [[ "$TOOL_NAME" == "PowerShell" ]]; then
     echo "$_BYPASS_SCOPE_NOTE_PWSH" >&2
   else

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -773,6 +773,8 @@ block_bypass() {
   local form="$1" reason="$2"
   echo "BLOCKED: $reason" >&2
   echo "Use the Write or Edit tool instead of a shell file-write workaround." >&2
+  echo "In an isolated session, Write or Edit may be refused for paths in the main checkout — that remedy is then unavailable." >&2
+  echo "An operator can set the guardrails block_hook_bypass_enabled option to false (/plugin configure) to bypass; that switch is not actionable by the blocked agent." >&2
   if [[ "$TOOL_NAME" == "PowerShell" ]]; then
     echo "$_BYPASS_SCOPE_NOTE_PWSH" >&2
   else

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -728,6 +728,9 @@ run_pwsh "PS: module-qualified Write-Error 2> file (blocked)" \
 psout=$(bash "$HOOK" <<<"$(pwsh_command_json "Set-Content f.txt 'x'")" 2>&1)
 assert_contains "PS write block names Write/Edit" "$psout" "Write or Edit tool"
 assert_absent "PS write block message is shell-agnostic" "$psout" "Bash file-write"
+assert_contains "PS write block names kill switch" "$psout" "block_hook_bypass_enabled"
+assert_contains "PS write block names isolated Write/Edit refusal" "$psout" "main checkout"
+assert_contains "PS write block marks kill switch operator-only" "$psout" "not actionable by the blocked agent"
 
 # --- Enforcement-scope disclosure -------------------------------------------
 # The message asserted "use Write or Edit instead" with no scope, so it read as
@@ -735,6 +738,10 @@ assert_absent "PS write block message is shell-agnostic" "$psout" "Bash file-wri
 # over one command string. Both lanes must carry the scope, and the behaviour
 # the scope describes is pinned below it so message and reality move together.
 scopeout=$(bash "$HOOK" <<<"$(command_json "printf 'x' > out.log")" 2>&1)
+assert_contains "bash block names kill switch" "$scopeout" "block_hook_bypass_enabled"
+assert_contains "bash block names isolated Write/Edit refusal" "$scopeout" "main checkout"
+assert_contains "bash block marks kill switch operator-only" "$scopeout" \
+  "not actionable by the blocked agent"
 assert_contains "bash block states its scope" "$scopeout" \
   "only this command string is inspected"
 assert_contains "bash block names the invoked-script gap" "$scopeout" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -731,6 +731,9 @@ assert_absent "PS write block message is shell-agnostic" "$psout" "Bash file-wri
 assert_contains "PS write block names kill switch" "$psout" "block_hook_bypass_enabled"
 assert_contains "PS write block names isolated Write/Edit refusal" "$psout" "main checkout"
 assert_contains "PS write block marks kill switch operator-only" "$psout" "not actionable by the blocked agent"
+assert_contains "PS write block warns kill switch is user-scoped" "$psout" "user-scoped"
+assert_contains "PS write block warns kill switch persists across repositories" "$psout" "every repository"
+assert_contains "PS write block tells operator to re-enable kill switch" "$psout" "re-enable it"
 
 # --- Enforcement-scope disclosure -------------------------------------------
 # The message asserted "use Write or Edit instead" with no scope, so it read as
@@ -742,6 +745,10 @@ assert_contains "bash block names kill switch" "$scopeout" "block_hook_bypass_en
 assert_contains "bash block names isolated Write/Edit refusal" "$scopeout" "main checkout"
 assert_contains "bash block marks kill switch operator-only" "$scopeout" \
   "not actionable by the blocked agent"
+assert_contains "bash block warns kill switch is user-scoped" "$scopeout" "user-scoped"
+assert_contains "bash block warns kill switch persists across repositories" "$scopeout" \
+  "every repository"
+assert_contains "bash block tells operator to re-enable kill switch" "$scopeout" "re-enable it"
 assert_contains "bash block states its scope" "$scopeout" \
   "only this command string is inspected"
 assert_contains "bash block names the invoked-script gap" "$scopeout" \


### PR DESCRIPTION
Fixes #2219

## Summary

`block_bypass()` is the only surface an agent meets when this guard fires. The block message now:

1. **Names the kill switch** — `block_hook_bypass_enabled` (operator-only, via `/plugin configure`).
2. **States the isolated-session collision** — Write or Edit may be refused for paths in the main checkout, so the prescribed remedy is not always available.

No hook logic changes; blocking behavior is unchanged.

## Test plan

- [x] `bash plugins/guardrails/hooks/block-hook-bypass.test.sh` — PASS=314, FAIL=0
- [x] Five new message assertions (Bash + PowerShell): kill switch name, main-checkout refusal clause, operator-only wording

## Related

- Adjacent to #2243 (scope-note disclosure for #2218) — this PR only touches the remediation lines in `block_bypass()`, not `_BYPASS_SCOPE_NOTE`
