### PR TITLE
fix(repo-hygiene): widen AskUserQuestion fallback for dontAsk denial

### DIFF
--- a/plugins/repo-hygiene/.claude-plugin/plugin.json
+++ b/plugins/repo-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "repo-hygiene",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Repo hygiene action-router: /repo-hygiene:clean sweeps reclaimable caches, build artifacts, and stale git metadata, and can realign the working tree to a fresh-pull state — dry-run-first, with destructive tiers gated behind explicit confirmation and a session-scoped destructive-command guard. Ecosystem targets are detected at runtime; secrets, runtime dependencies, and skill data are preserved by default.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/repo-hygiene/CHANGELOG.md
+++ b/plugins/repo-hygiene/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to the `repo-hygiene` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.10.1]
+
+### Fixed
+
+- **The confirmation gate fell back to an inline question only when `AskUserQuestion` was
+  *absent*.** Permission mode `dontAsk` "auto-denies tools unless pre-approved … `AskUserQuestion` …
+  denied even if you've allowed them"
+  ([permissions](https://code.claude.com/docs/en/permissions)), which leaves the tool visible in the
+  pool while every call fails; only a bare-name deny rule removes it from context entirely. Keying
+  the fallback on absence let a `dontAsk` session pick a tool it cannot use and leave the destructive
+  confirmation gate unsatisfied rather than asking inline. The fallback now triggers on absent,
+  denied, **or otherwise unusable** — including a denial discovered only by calling it — mirroring
+  the sibling fix in `disk-hygiene` (#2016).
+
 ## [0.10.0]
 
 ### Fixed

--- a/plugins/repo-hygiene/skills/clean/SKILL.md
+++ b/plugins/repo-hygiene/skills/clean/SKILL.md
@@ -90,7 +90,7 @@ Protected-path enforcement gates `scan`, `caches`, `build`, `git`, AND `tree` (`
 
 ## Confirmation gate
 
-**Question surface — every question this skill asks.** Prefer `AskUserQuestion`: its answer is the user's own and cannot be fabricated. It is not always in the pool — permission mode `dontAsk` denies it unconditionally, and a bare-name `permissions.deny` rule or a `disallowed-tools` entry removes it — so when it is absent, ask the same question inline as a numbered choice and wait for the reply. The surface varies; nothing below it does.
+**Question surface — every question this skill asks.** Prefer `AskUserQuestion`: its answer is the user's own and cannot be fabricated. It is not always usable, in two distinct ways — a bare-name `permissions.deny` rule or a `disallowed-tools` entry removes it from context entirely, while permission mode `dontAsk` denies it even when an allow rule names it, leaving it visible and every call failing. Fall back to the same question asked inline as a numbered choice whenever the tool is absent, denied, **or otherwise unusable** — including a denial discovered only by calling it; a denied call is an unanswered question, never an answer. Then wait for the reply. The surface varies; nothing below it does.
 
 **Destructive confirmation — every `--apply`, branch deletion, and stash drop.** Show the dry-run first, then take the user's own affirmative answer, given in this interactive session, naming exactly the set just shown. A prior general request, an alias, a flag, "clean everything", approval of a different set, or silence is not confirmation — never supply or infer the answer yourself. Autonomous sessions abort here rather than ask.
 


### PR DESCRIPTION
## Summary

Mirror the #2016 `disk-hygiene` confirmation-gate prose fix in `repo-hygiene`: the inline-question fallback must trigger when `AskUserQuestion` is absent, denied, or otherwise unusable — not only when it is absent.

## Fix

- Update `plugins/repo-hygiene/skills/clean/SKILL.md` confirmation gate question-surface rule to match the corrected `dontAsk` / deny / disallowed-tools wording.
- Bump plugin to 0.10.1 with CHANGELOG entry.

## Verification

Prose-only change; no shell/python suites map to this file. Reviewed against the live permissions docs claim cited in #2088 and the merged `disk-hygiene` sibling wording.

## Related

Fixes #2088 (completes the three-item sweep alongside #2252 and #2254).