### PR TITLE
fix(ci): flag quote-spliced sed command words in portability gate

### DIFF
--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -547,7 +547,7 @@ rm -f "$f"
 # cluster (one token covers both), and --in-place (GNU long form) — #1513
 # =============================================================================
 
-tok="$(one_token_list '(^|[^[:alnum:]_])sed([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]-[bEnrsuz]*i([[:space:]|&;()<>]|$)')"
+tok="$(one_token_list '(^|[^[:alnum:]_])s(\$?['\''"]|\\)*e(\$?['\''"]|\\)*d(\$?['\''"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['\''"]|\\)*-[bEnrsuz]*i([[:space:]|&;()<>]|$)')"
 
 f="$(tmpsh "sed -i 's/foo/bar/' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -787,7 +787,7 @@ sed -Ei; echo done
 CASES
 rm -f "$tok"
 
-tok="$(one_token_list '(^|[^[:alnum:]_])sed([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]--in-place([[:space:]|&;()<>]|=|$)')"
+tok="$(one_token_list '(^|[^[:alnum:]_])s(\$?['\''"]|\\)*e(\$?['\''"]|\\)*d(\$?['\''"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['\''"]|\\)*--(\$?['\''"]|\\)*i(\$?['\''"]|\\)*n(\$?['\''"]|\\)*-(\$?['\''"]|\\)*p(\$?['\''"]|\\)*l(\$?['\''"]|\\)*a(\$?['\''"]|\\)*c(\$?['\''"]|\\)*e(\$?['\''"]|\\)*([[:space:]|&;()<>]|=|$)')"
 
 f="$(tmpsh "sed --in-place 's/foo/bar/' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -2722,6 +2722,26 @@ if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
   fail "a quote-spliced stat command word should fail, got success: $out"
 else
   ok "a quote-spliced stat command word is detected"
+fi
+rm -f "$f"
+# shell quote removal splices sed the same way (#2091): `"sed" -i` and `s"e"d
+# -ni` invoke GNU sed with no backup suffix and must not read clean.
+f="$(tmpsh "$(printf '%s\n' \
+  '"sed" -i '\''s/x/y/'\'' file' \
+  's"e"d -ni p file')")"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "quoted or quote-spliced sed command words should fail, got success: $out"
+elif [[ "$(echo "$out" | grep -c "PORTABILITY: ${f}:")" -eq 2 ]]; then
+  ok "a quoted or quote-spliced sed command word is detected"
+else
+  fail "expected both quoted sed command-word forms flagged, got: $out"
+fi
+rm -f "$f"
+f="$(tmpsh '"sed" --in-place '\''s/x/y/'\'' file')"
+if out="$(scan_paths "$REAL_TOKENS" "$f" 2>&1)"; then
+  fail "a quoted sed command word with --in-place should fail, got success: $out"
+else
+  ok "a quoted sed command word with --in-place is detected"
 fi
 rm -f "$f"
 # the guard must recognize the spliced spelling on BOTH rungs, or a real ladder

--- a/scripts/check-shell-portability.test.sh
+++ b/scripts/check-shell-portability.test.sh
@@ -547,7 +547,7 @@ rm -f "$f"
 # cluster (one token covers both), and --in-place (GNU long form) — #1513
 # =============================================================================
 
-tok="$(one_token_list '(^|[^[:alnum:]_])s(\$?['\''"]|\\)*e(\$?['\''"]|\\)*d(\$?['\''"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['\''"]|\\)*-[bEnrsuz]*i([[:space:]|&;()<>]|$)')"
+tok="$(one_token_list '(^|[^[:alnum:]_"'\'"'"'\\])(\$?['\''"]|\\)*s(\$?['\''"]|\\)*e(\$?['\''"]|\\)*d(\$?['\''"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['\''"]|\\)*-[bEnrsuz]*i([[:space:]|&;()<>]|$)')"
 
 f="$(tmpsh "sed -i 's/foo/bar/' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -787,7 +787,7 @@ sed -Ei; echo done
 CASES
 rm -f "$tok"
 
-tok="$(one_token_list '(^|[^[:alnum:]_])s(\$?['\''"]|\\)*e(\$?['\''"]|\\)*d(\$?['\''"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['\''"]|\\)*--(\$?['\''"]|\\)*i(\$?['\''"]|\\)*n(\$?['\''"]|\\)*-(\$?['\''"]|\\)*p(\$?['\''"]|\\)*l(\$?['\''"]|\\)*a(\$?['\''"]|\\)*c(\$?['\''"]|\\)*e(\$?['\''"]|\\)*([[:space:]|&;()<>]|=|$)')"
+tok="$(one_token_list '(^|[^[:alnum:]_"'\'"'"'\\])(\$?['\''"]|\\)*s(\$?['\''"]|\\)*e(\$?['\''"]|\\)*d(\$?['\''"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['\''"]|\\)*--(\$?['\''"]|\\)*i(\$?['\''"]|\\)*n(\$?['\''"]|\\)*-(\$?['\''"]|\\)*p(\$?['\''"]|\\)*l(\$?['\''"]|\\)*a(\$?['\''"]|\\)*c(\$?['\''"]|\\)*e(\$?['\''"]|\\)*([[:space:]|&;()<>]|=|$)')"
 
 f="$(tmpsh "sed --in-place 's/foo/bar/' \"\$file\"")"
 if out="$(scan_paths "$tok" "$f" 2>&1)"; then
@@ -2762,6 +2762,16 @@ if scan_paths "$REAL_TOKENS" "$f" >/dev/null 2>&1; then
   ok "interleaved quote runs do not span separate words or longer names"
 else
   fail "the spliced-name spelling over-reached: $(scan_paths "$REAL_TOKENS" "$f" 2>&1)"
+fi
+rm -f "$f"
+# a quoted sed suffix inside a longer shell word is not a sed command (#2091).
+f="$(tmpsh "$(printf '%s\n' \
+  'x"sed" -i value' \
+  'u"sed" --in-place x')")"
+if scan_paths "$REAL_TOKENS" "$f" >/dev/null 2>&1; then
+  ok "a quoted sed suffix inside a longer shell word is not flagged"
+else
+  fail "quoted sed suffix inside a longer word must not fire: $(scan_paths "$REAL_TOKENS" "$f" 2>&1)"
 fi
 rm -f "$f"
 

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -253,7 +253,18 @@ sort[^;&|\n]*[[:space:]]['"]?--sort['"]?(=|[[:space:]]+)['"]?version([[:space:]|
 # shape needs real parsing, which this grep-level tripwire does not attempt.
 # It is a false NEGATIVE on a rare shape, the direction this gate already
 # accepts everywhere else.
-(^|[^[:alnum:]_])sed([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]-[bEnrsuz]*i([[:space:]|&;()<>]|$)
+#
+# The command word may carry quote runs between its letters and an optional
+# closing quote after `d`, exactly as the `date -d` / `stat -c` tokens below
+# (#2091): `"sed" -i` and `s"e"d -ni` invoke GNU sed after quote removal and
+# were admitted while the name was spelled as one literal `sed`. Letter-by-letter
+# spelling with `(\$?['"]|\\)*` between letters is what the other command-word
+# tokens use — not a widened `s["'\\]*e["'\\]*d` substring that would flag prose.
+# Attached redirections after the name (`sed&>/dev/null -i`) are not admitted here
+# the way `date -d` / `stat -c` do (#1544): sed's gap already owns the
+# whitespace before the option cluster, and splitting that out broke process-
+# substitution shapes (`sed -f <(gen) -i`) during #2091.
+(^|[^[:alnum:]_])s(\$?['"]|\\)*e(\$?['"]|\\)*d(\$?['"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['"]|\\)*-[bEnrsuz]*i([[:space:]|&;()<>]|$)
 
 # `sed --in-place[=SUFFIX]` (GNU long-form spelling of `-i`) — BSD sed has no
 # long options at all, so this flags suffixed or not (unlike short `-i`, where
@@ -274,7 +285,8 @@ sort[^;&|\n]*[[:space:]]['"]?--sort['"]?(=|[[:space:]]+)['"]?version([[:space:]|
 # tool --in-place x` was reported as a GNU sed call even though the option
 # belongs to `tool` — and at a bare paren, while still admitting a process
 # substitution, so `sed -f <(gen) --in-place "$f"` stays detected.
-(^|[^[:alnum:]_])sed([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]--in-place([[:space:]|&;()<>]|=|$)
+# Same quote-spliced command word as the cluster token above (#2091).
+(^|[^[:alnum:]_])s(\$?['"]|\\)*e(\$?['"]|\\)*d(\$?['"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['"]|\\)*--(\$?['"]|\\)*i(\$?['"]|\\)*n(\$?['"]|\\)*-(\$?['"]|\\)*p(\$?['"]|\\)*l(\$?['"]|\\)*a(\$?['"]|\\)*c(\$?['"]|\\)*e(\$?['"]|\\)*([[:space:]|&;()<>]|=|$)
 
 # `readlink -f` (canonicalize) — a GNU coreutils extension; BSD/macOS readlink
 # has no `-f`/`--canonicalize`. Auto-guarded when a `realpath` attempt is

--- a/scripts/shell-portability-tokens.txt
+++ b/scripts/shell-portability-tokens.txt
@@ -260,11 +260,14 @@ sort[^;&|\n]*[[:space:]]['"]?--sort['"]?(=|[[:space:]]+)['"]?version([[:space:]|
 # were admitted while the name was spelled as one literal `sed`. Letter-by-letter
 # spelling with `(\$?['"]|\\)*` between letters is what the other command-word
 # tokens use — not a widened `s["'\\]*e["'\\]*d` substring that would flag prose.
+# The leading boundary excludes quote/backslash characters so a quoted suffix of a
+# longer shell word (`x"sed" -i` → `xsed`) is not read as a `sed` command; an
+# opening quote run may follow a real boundary only (`"sed" -i`, `;s"e"d -i`).
 # Attached redirections after the name (`sed&>/dev/null -i`) are not admitted here
 # the way `date -d` / `stat -c` do (#1544): sed's gap already owns the
 # whitespace before the option cluster, and splitting that out broke process-
 # substitution shapes (`sed -f <(gen) -i`) during #2091.
-(^|[^[:alnum:]_])s(\$?['"]|\\)*e(\$?['"]|\\)*d(\$?['"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['"]|\\)*-[bEnrsuz]*i([[:space:]|&;()<>]|$)
+(^|[^[:alnum:]_"'\\])(\$?['"]|\\)*s(\$?['"]|\\)*e(\$?['"]|\\)*d(\$?['"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['"]|\\)*-[bEnrsuz]*i([[:space:]|&;()<>]|$)
 
 # `sed --in-place[=SUFFIX]` (GNU long-form spelling of `-i`) — BSD sed has no
 # long options at all, so this flags suffixed or not (unlike short `-i`, where
@@ -285,8 +288,9 @@ sort[^;&|\n]*[[:space:]]['"]?--sort['"]?(=|[[:space:]]+)['"]?version([[:space:]|
 # tool --in-place x` was reported as a GNU sed call even though the option
 # belongs to `tool` — and at a bare paren, while still admitting a process
 # substitution, so `sed -f <(gen) --in-place "$f"` stays detected.
-# Same quote-spliced command word as the cluster token above (#2091).
-(^|[^[:alnum:]_])s(\$?['"]|\\)*e(\$?['"]|\\)*d(\$?['"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['"]|\\)*--(\$?['"]|\\)*i(\$?['"]|\\)*n(\$?['"]|\\)*-(\$?['"]|\\)*p(\$?['"]|\\)*l(\$?['"]|\\)*a(\$?['"]|\\)*c(\$?['"]|\\)*e(\$?['"]|\\)*([[:space:]|&;()<>]|=|$)
+# Same quote-spliced command word as the cluster token above (#2091); same
+# quote-excluding leading boundary so `u"sed" --in-place` is not a false hit.
+(^|[^[:alnum:]_"'\\])(\$?['"]|\\)*s(\$?['"]|\\)*e(\$?['"]|\\)*d(\$?['"]|\\)*([[:space:]]([^;&|()`\n]|[<>]\([^)]*\))*)?[[:space:]]+(\$?['"]|\\)*--(\$?['"]|\\)*i(\$?['"]|\\)*n(\$?['"]|\\)*-(\$?['"]|\\)*p(\$?['"]|\\)*l(\$?['"]|\\)*a(\$?['"]|\\)*c(\$?['"]|\\)*e(\$?['"]|\\)*([[:space:]|&;()<>]|=|$)
 
 # `readlink -f` (canonicalize) — a GNU coreutils extension; BSD/macOS readlink
 # has no `-f`/`--canonicalize`. Auto-guarded when a `realpath` attempt is


### PR DESCRIPTION
Fixes #2091

## Summary

The shell-portability gate's `sed -i` and `sed --in-place` tokens only matched a bare `sed` command word. Quoted and quote-spliced spellings (`"sed" -i`, `s"e"d -ni`) invoke the same GNU-only in-place edit after shell quote removal and were passing unflagged.

## Changes

- Spell the command word letter-by-letter with optional quote runs in `scripts/shell-portability-tokens.txt`, matching the existing `date -d` / `stat -c` tokens.
- Keep the original gap and whitespace-before-option structure so process-substitution shapes (`sed -f <(gen) -i`) continue to match.
- Add unit tests for quoted / quote-spliced `sed` command words against the shipped token list.

## Tests

`bash scripts/check-shell-portability.test.sh` — PASS=325 FAIL=0

## Related

N/A