### PR TITLE
fix(claude-config): drop P2's unsupported no-expansion claim, refuse an unresolvable scan root, and key the postures report per project

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Seven configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -70,6 +70,15 @@ project-keyed path instead of one fixed name.
   cannot evaluate "when set" — the originally filed fix sketch would have introduced that defect while
   removing this one.
 
+  **A remote URL is arbitrary text that becomes directory components here, so it is validated before
+  use.** Only the shape the scheme means is accepted — path segments of `[a-z0-9._-]` each starting
+  alphanumeric. Everything else keys by hash instead, still deterministically. Without that check a
+  relative filesystem remote (`git remote add origin ../central.git`) yields the identity `../central`
+  and the report lands *outside* this skill's directory; absolute-local and Windows-path remotes fail
+  the same way. And the remote is read from **the first configured remote** — `git remote | head -1` —
+  not from one named `origin`, because a repo whose only remote is `upstream` has a remote and must not
+  drop to the local rung. Both were found in review against the first draft, which did exactly that.
+
 ### Added
 
 - Evals 4 and 5 for `audit-prompting-postures`: two roots must produce two surviving reports keyed by

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -23,11 +23,12 @@ project-keyed path instead of one fixed name.
   variables is stripped, so `Bash(npm test *)` matches `NODE_ENV=test npm test`. The skill was telling
   authors to remove the documented zero-prompt pattern.
 - **And the same sentence was emitted on `Read` and `Edit` findings, where it is false twice over.**
-  Probing the shipped detector confirms P2 fires on `Read(/c/Users/kyle/notes.md)` and
-  `Edit(/Users/alice/src/**)` carrying the Bash-scoped message — but those classes use gitignore
-  pattern syntax and **do** resolve `~/`: `Read(~/Documents/*.pdf)` matches
-  `/Users/alice/Documents/*.pdf`. One message string serves every class, so it now carries only what is
-  true of all of them — the portability break — and names the portable form per class. The mechanism
+  Probing the shipped detector confirms P2 fires on a `Read(<home>/notes.md)` or
+  `Edit(<home>/src/**)` rule carrying the Bash-scoped message — but those classes use gitignore
+  pattern syntax and **do** resolve `~/`: the permissions page's own example has
+  `Read(~/Documents/*.pdf)` matching `<home>/Documents/*.pdf`. One message string serves every class,
+  so it now carries only what is true of all of them — the portability break — and names the portable
+  form per class. The mechanism
   detail moves into `criteria.md` as a per-rule-class table, syncing down from the
   `permission-rule-hygiene` convention, which already held the corrected doctrine including the
   `${CLAUDE_PROJECT_DIR}` v2.1.196 substitution floor and the fact that `${CLAUDE_PLUGIN_ROOT}` is not

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,77 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.32.0]
+
+Two behavior changes, hence the minor: `permission-rule-check.sh` refuses an unresolvable scan root
+instead of sweeping the user profile, and `audit-prompting-postures` writes its report to a
+project-keyed path instead of one fixed name.
+
+### Fixed
+
+- **`audit-permission-grants` P2 stated a rule the docs do not contain, and emitted it on rule classes
+  it is false for.** The check's **Why** read "Bash rules match literally with no `~`/`$HOME`/env
+  expansion". Grepping the complete raw markdown of both
+  [permissions](https://code.claude.com/docs/en/permissions) and
+  [skills](https://code.claude.com/docs/en/skills) (fetched with `curl` to a file, 2026-08-11) finds no
+  such sentence on either page — the claim is **unsupported**, not merely over-broad — and two
+  documented behaviors contradict it. Claude Code substitutes `${CLAUDE_SKILL_DIR}` and
+  `${CLAUDE_PROJECT_DIR}` in Bash rules in `allowed-tools`, which the skills page presents as *the* way
+  to run a bundled script without a prompt; and a leading assignment of certain known-safe environment
+  variables is stripped, so `Bash(npm test *)` matches `NODE_ENV=test npm test`. The skill was telling
+  authors to remove the documented zero-prompt pattern.
+- **And the same sentence was emitted on `Read` and `Edit` findings, where it is false twice over.**
+  Probing the shipped detector confirms P2 fires on `Read(/c/Users/kyle/notes.md)` and
+  `Edit(/Users/alice/src/**)` carrying the Bash-scoped message — but those classes use gitignore
+  pattern syntax and **do** resolve `~/`: `Read(~/Documents/*.pdf)` matches
+  `/Users/alice/Documents/*.pdf`. One message string serves every class, so it now carries only what is
+  true of all of them — the portability break — and names the portable form per class. The mechanism
+  detail moves into `criteria.md` as a per-rule-class table, syncing down from the
+  `permission-rule-hygiene` convention, which already held the corrected doctrine including the
+  `${CLAUDE_PROJECT_DIR}` v2.1.196 substitution floor and the fact that `${CLAUDE_PLUGIN_ROOT}` is not
+  substituted at all. The wrong text was pinned by a passing assertion, so the test moved with it.
+
+### Changed
+
+- **`permission-rule-check.sh` refuses an unresolvable scan root instead of falling through to `$PWD`.**
+  Outside a git repository `$PWD` is whatever directory the session happens to stand in — on a
+  developer machine, usually the user profile — and both scans walk the root with `find` with no depth
+  bound and stderr discarded, then exit 0. A timeout or a swallowed permission error was
+  indistinguishable from a clean bill, on a skill that is model-invocable
+  (`disable-model-invocation: false`). The ladder is now fixture dir → git toplevel →
+  `${CLAUDE_PROJECT_DIR}` and nothing after it; an unresolvable root exits **2**, reusing the
+  environment-gap channel the contract already documents for a missing `jq` rather than minting a new
+  code, so the advisory exit-0-for-findings contract is untouched. **`--count` refuses too** — a `0`
+  printed by a scan that never resolved a root reads exactly like a clean bill. The refusal names what
+  it tried and how to fix it.
+- All five "always exits 0" statements moved together — `reference/criteria.md`, and the script's
+  header comment, usage block, and `--help` text — since a refusal branch contradicts each. `SKILL.md`
+  carried no such claim to update: `grep` finds none there, and its exit-related line documents the jq
+  exit 2.
+- **`audit-prompting-postures` keys its report per project.** It persisted to a single
+  `${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/last-audit.md`, and `${CLAUDE_PLUGIN_DATA}` resolves
+  to `~/.claude/plugins/data/{id}/` where `{id}` is the *plugin* identifier, never the project. The
+  skill's only durable deliverable was therefore overwritten by the next run from any other root — the
+  audit artifact destroyed by ordinary use of the skill. The path now carries a `<state-key>`, and the
+  report opens with a three-line header (resolved root, scope filter, UTC timestamp) so a surviving file
+  is self-describing rather than merely un-overwritten.
+
+  **The scheme is `audit-pass`'s, reused rather than reinvented** —
+  `<repo-identity>/<worktree-discriminator>` from its run-state reference — because a second scheme for
+  one concern is the drift this batch exists to remove. One rung is added: that ladder has
+  git-with-remote and git-without-remote and no non-repo rung, which `audit-pass` does not need because
+  it refuses non-git targets, while this skill is report-only and audits them.
+
+  **The derivation is written as commands to run, never as a condition over `${CLAUDE_PROJECT_DIR}`.**
+  That placeholder substitutes inline in skill content, so the model never sees the literal token and
+  cannot evaluate "when set" — the originally filed fix sketch would have introduced that defect while
+  removing this one.
+
+### Added
+
+- Evals 4 and 5 for `audit-prompting-postures`: two roots must produce two surviving reports keyed by
+  the reused scheme, and a non-repo root must still key and still self-describe.
+
 ## [0.31.0]
 
 `audit-pass` changes what it does on two target classes, which is why this is a minor: a target that is

--- a/plugins/claude-config/skills/audit-permission-grants/SKILL.md
+++ b/plugins/claude-config/skills/audit-permission-grants/SKILL.md
@@ -53,7 +53,11 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/audit-permission-grants/scripts/permission-ru
 
 It scans frontmatter `allowed-tools` and settings `permissions.allow` across the consuming repo and
 prints one finding per fragile grant (`<severity> [<check>] <source>: <detail>`). `--count` prints the
-count. It requires `jq`; a missing `jq` exits 2 (report the environment gap rather than a clean bill).
+count. **Exit 2 is the environment-gap channel — report the gap rather than a clean bill.** Two things
+raise it: a missing `jq`, and a scan root that resolves to neither a git toplevel nor
+`$CLAUDE_PROJECT_DIR`. On the second, say the scan did not run and give the fix — run from inside the
+repository you mean to scan, or set `$PERMISSION_HYGIENE_FIXTURE_DIR` explicitly. Never report "no
+fragile permission grants found" on an exit 2.
 `settings.local.json` is parsed for its `permissions.allow` array only — never echoed wholesale.
 
 If a scope filter was given, run the full detector and present only the matching checks (P1/P2 map to

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -17,8 +17,12 @@ skill/command/agent frontmatter `allowed-tools` and the `permissions.allow` arra
 `.claude/settings.json` and `.claude/settings.local.json`, plus any plugin `settings.json`, and emits
 one finding per fragile grant. Frontmatter files under a `vendor/` path segment are skipped: they are
 vendored upstream references, not loadable skills/agents/commands, so their `allowed-tools` never take
-effect and a finding on them would be a false positive. It is advisory (always exits 0); `--count`
-prints the finding count.
+effect and a finding on them would be a false positive. Findings are advisory and never fail the run,
+so a completed scan exits 0 in either mode; `--count` prints the finding count. **An environment gap
+exits 2 instead of reporting a clean bill** — a missing `jq`, or a scan root that resolves to neither a
+git toplevel nor `$CLAUDE_PROJECT_DIR`. There is no fallback to the current directory, because outside
+a repository that is usually the user profile and scanning it would walk the whole home tree and still
+exit 0.
 `settings.local.json` is parsed for its `permissions.allow` array only — never read or echoed wholesale
 (it may hold tokens).
 
@@ -60,10 +64,40 @@ Windows), `/home/<name>/…`, `/Users/<name>/…`, or `C:\Users\<name>\…`.
 **How to check**: run the detector. `${CLAUDE_PROJECT_DIR}/…`, `~/…`, and `//…` forms are not flagged
 (they expand or are portable anchors); only concrete usernames match.
 
-**Why**: Bash rules match literally with no `~`/`$HOME`/env expansion, so the rule breaks on other
-machines/usernames and leaks a username into version control. See convention anti-pattern 2.
+**Why**: the rule names a concrete user home, so it breaks on any other machine or username — and after
+a skill migrates into a plugin, since the install path changes — and it leaks a username into version
+control. That portability break is the whole of the finding, and it holds for every rule class this
+check fires on.
 
-**Recommend**: replace with a machine-independent bare-name rule.
+**Do not state it as "no expansion".** No such rule is documented on the permissions page, and the
+blanket form is false for the file tools. Match the mechanism to the rule class:
+
+| Rule class | What actually happens |
+| --- | --- |
+| `Bash(...)` | A glob over the literal command string ([permissions](https://code.claude.com/docs/en/permissions#bash)) — with the two documented exceptions below. |
+| `Read(...)` / `Edit(...)` | gitignore pattern syntax, which **does** resolve anchors: `~/path` from the home directory, `//path` from the filesystem root, `/path` from the settings source ([permissions](https://code.claude.com/docs/en/permissions#read-and-edit)). `Read(~/Documents/*.pdf)` matches `/Users/alice/Documents/*.pdf`. |
+
+The two exceptions on Bash rules:
+
+1. **Token substitution in `allowed-tools`.** Claude Code substitutes `${CLAUDE_SKILL_DIR}` and
+   `${CLAUDE_PROJECT_DIR}` in both a skill's markdown content and Bash rules in `allowed-tools`
+   ([skills](https://code.claude.com/docs/en/skills#available-string-substitutions)) — the documented
+   way to run a bundled script without a prompt, e.g.
+   `allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/render.sh *)`. Two limits the convention records:
+   `${CLAUDE_PROJECT_DIR}` substitution requires Claude Code **v2.1.196 or later** (below that floor the
+   rule stays a literal string and never matches), and `${CLAUDE_PLUGIN_ROOT}` is **not** substituted at
+   all, so a rule written with it is inert.
+2. **Leading env-assignment stripping**, and it is scoped: an assignment of certain known-safe variables
+   is stripped, so `Bash(npm test *)` matches `NODE_ENV=test npm test`. An **allow** rule will not match
+   past an assignment of any other variable; a **deny** or **ask** rule matches past any leading
+   assignment ([permissions](https://code.claude.com/docs/en/permissions#process-wrappers)).
+
+Full doctrine, and the source this row syncs from: the
+[permission-rule-hygiene convention](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/permission-rule-hygiene/README.md)
+anti-pattern 2.
+
+**Recommend**: replace with a portable form — `${CLAUDE_SKILL_DIR}` for a skill's own bundled script, a
+bare-name command on PATH, or for `Read`/`Edit` rules the `~/` home anchor.
 
 ## P3: Plugin self-granted permissions [warning]
 

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -75,7 +75,7 @@ blanket form is false for the file tools. Match the mechanism to the rule class:
 | Rule class | What actually happens |
 | --- | --- |
 | `Bash(...)` | A glob over the literal command string ([permissions](https://code.claude.com/docs/en/permissions#bash)) — with the two documented exceptions below. |
-| `Read(...)` / `Edit(...)` | gitignore pattern syntax, which **does** resolve anchors: `~/path` from the home directory, `//path` from the filesystem root, `/path` from the settings source ([permissions](https://code.claude.com/docs/en/permissions#read-and-edit)). `Read(~/Documents/*.pdf)` matches `/Users/alice/Documents/*.pdf`. |
+| `Read(...)` / `Edit(...)` | gitignore pattern syntax, which **does** resolve anchors: `~/path` from the home directory, `//path` from the filesystem root, `/path` from the settings source ([permissions](https://code.claude.com/docs/en/permissions#read-and-edit)). The page's own example: `Read(~/Documents/*.pdf)` matches `<home>/Documents/*.pdf`. |
 
 The two exceptions on Bash rules:
 

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.sh
@@ -21,11 +21,20 @@
 #       so a self-granted permission rule is silently ignored; the operative
 #       allow-rule has to be added by the operator to ~/.claude/settings.json.
 #
-# Advisory: prints findings, ALWAYS exits 0 (findings never fail the run).
-# Requires jq for the settings-file half; exits 2 when jq is absent.
+# Advisory about FINDINGS: they never fail the run, so a scan that completes exits 0
+# whether or not it found anything. Environment gaps are the exception and exit 2 —
+# missing jq, and an unresolvable scan root (below).
 #
-# Root resolution: $PERMISSION_HYGIENE_FIXTURE_DIR, else the cwd's git
-# toplevel, else $CLAUDE_PROJECT_DIR, else $PWD. Never the plugin's own dir.
+# Root resolution: $PERMISSION_HYGIENE_FIXTURE_DIR, else the cwd's git toplevel, else
+# $CLAUDE_PROJECT_DIR. Never the plugin's own dir, and NEVER $PWD.
+#
+# Why there is no $PWD fallback: outside a git repository $PWD is whatever directory
+# the session happens to stand in, which on a developer machine is typically the user
+# profile. Both scans below walk the root with `find` with no depth bound and stderr
+# discarded, so that fallback turned an unresolved root into an unbounded sweep of the
+# user's home that still exited 0 — a timeout or a swallowed permission error was
+# indistinguishable from a clean bill. An unresolvable root is an environment gap, so
+# it is reported as one (exit 2) rather than scanned on a guess.
 #
 # Usage:
 #   permission-rule-check.sh            # human-readable findings, one per line
@@ -47,8 +56,12 @@ Usage: permission-rule-check.sh [--count|--help]
 Scans skill/command/agent frontmatter `allowed-tools` and the `permissions.allow`
 arrays of .claude/settings.json and .claude/settings.local.json for P1 (auto-mode
 -dropped interpreter/blanket rules), P2 (hardcoded machine paths), and plugin
-settings.json for P3 (unsupported self-granted `permissions`). Advisory — exit 0.
-Requires jq (exit 2 when absent).
+settings.json for P3 (unsupported self-granted `permissions`).
+
+Findings are advisory and never fail the run, so a completed scan exits 0 in both
+modes. Environment gaps exit 2 instead of reporting a clean bill: missing jq, and a
+scan root that resolves to neither a git toplevel nor $CLAUDE_PROJECT_DIR. Set
+$PERMISSION_HYGIENE_FIXTURE_DIR to scan an explicit directory.
 EOF
 }
 
@@ -72,7 +85,30 @@ if [[ -n "${PERMISSION_HYGIENE_FIXTURE_DIR:-}" ]]; then
   ROOT="$PERMISSION_HYGIENE_FIXTURE_DIR"
 else
   ROOT="$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')"
-  [[ -n "$ROOT" ]] || ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"
+  [[ -n "$ROOT" ]] || ROOT="${CLAUDE_PROJECT_DIR:-}"
+fi
+
+# No $PWD fallback — see the header. Refuse rather than sweep an unknown tree, and
+# refuse in BOTH modes: a `--count` of 0 from a scan that never resolved a root reads
+# exactly like a clean bill, which is the confusion this refusal exists to remove.
+if [[ -z "$ROOT" ]]; then
+  cat >&2 <<'EOF'
+ERROR: no scan root resolved — refusing to scan.
+
+Tried, in order: $PERMISSION_HYGIENE_FIXTURE_DIR, the current directory's git
+toplevel, then $CLAUDE_PROJECT_DIR. None resolved, and there is deliberately no
+fallback to the current directory: outside a repository that is usually the user
+profile, and scanning it would walk the whole home tree and still report success.
+
+Fix by running from inside the repository you mean to scan, or set
+$PERMISSION_HYGIENE_FIXTURE_DIR to the directory to scan explicitly.
+EOF
+  exit 2
+fi
+
+if [[ ! -d "$ROOT" ]]; then
+  printf 'ERROR: scan root does not exist or is not a directory: %s\n' "$ROOT" >&2
+  exit 2
 fi
 
 # --- Detection patterns -------------------------------------------------------
@@ -136,7 +172,7 @@ scan_rule() {
     [[ -n "$m" ]] && emit warning P1 "$src" "'$m' is an interpreter/runner-led grant, not the portable bare-name pattern; Claude Code drops the broad forms of this shape (blanket, package-manager runners, and wildcarded/globbed-target interpreters) on entering auto mode. Expose the guarded script as a bare PATH command and allow that, e.g. Bash(babysit_merge.sh:*)."
   done < <(printf '%s\n' "$text" | grep -oE "$P1_ERE" 2>/dev/null | sort -u)
   while IFS= read -r m; do
-    [[ -n "$m" ]] && emit error P2 "$src" "hardcoded machine path in '$m' — Bash rules match literally (no ~/\$HOME/env expansion), so this breaks on other machines/usernames and leaks a username into source control. Use a machine-independent bare-name rule."
+    [[ -n "$m" ]] && emit error P2 "$src" "hardcoded machine path in '$m' — the rule names a concrete user home, so it breaks on other machines and usernames and leaks a username into source control. Portable forms: \${CLAUDE_SKILL_DIR} for a skill's own bundled script (substituted in allowed-tools Bash rules), a bare-name command on PATH, or the ~/ home anchor for Read/Edit rules."
   done < <(printf '%s\n' "$text" | grep -oE "$P2_ERE" 2>/dev/null | sort -u)
 }
 

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -56,6 +56,8 @@ SL='/'
 BS='\'
 POSIX_MP="${SL}c${SL}Users${SL}alice${SL}.agents${SL}skills${SL}merge${SL}x.sh"
 WIN_MP="C:${BS}Users${BS}bob${BS}x.sh"
+READ_MP="${SL}c${SL}Users${SL}carol${SL}notes.md"
+EDIT_MP="${SL}Users${SL}dave${SL}src${SL}**"
 
 # --- Case 1: --help ----------------------------------------------------------
 rc=0
@@ -143,8 +145,8 @@ assert_eq "two machine-path findings" "2" "$(run "$D4" --count)"
 # claim on a true finding.
 D4B="$TEST_TMPDIR/p2-file-tools"
 mkdir -p "$D4B/.claude"
-jq -n '{permissions:{allow:["Read(/c/Users/kyle/notes.md)","Edit(/Users/alice/src/**)"]}}' \
-  >"$D4B/.claude/settings.json"
+jq -n --arg r "Read(${READ_MP})" --arg e "Edit(${EDIT_MP})" \
+  '{permissions:{allow:[$r,$e]}}' >"$D4B/.claude/settings.json"
 OUT_FT=$(run "$D4B")
 assert_contains "flags a machine path in a Read rule" "$OUT_FT" "[P2]"
 assert_not_contains "Read-rule finding does not claim Bash semantics" "$OUT_FT" "Bash rules match literally"

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -288,6 +288,26 @@ assert_not_contains "--count prints no count on a refusal" "$count_err" "0
 # A resolvable root still works, so the refusal did not break the normal path.
 assert_eq "explicit fixture root still scans" "0" "$(run "$TEST_TMPDIR/p2-exempt" --count)"
 
+# A root that resolved but does not exist — or is not a directory — is the same class
+# of environment gap and takes the same channel. Without this, `find` would print
+# nothing to a discarded stderr and the run would still report a clean bill.
+rc=0
+missing_err=$(PERMISSION_HYGIENE_FIXTURE_DIR="$TEST_TMPDIR/does-not-exist" bash "$SCRIPT" 2>&1) || rc=$?
+assert_exit "fixture root that does not exist refuses" 2 "$rc"
+assert_contains "refusal names the bad path" "$missing_err" "does not exist or is not a directory"
+assert_not_contains "missing root is not a clean bill" "$missing_err" "No fragile permission grants found."
+
+not_a_dir="$TEST_TMPDIR/regular-file"
+: >"$not_a_dir"
+rc=0
+notdir_err=$(PERMISSION_HYGIENE_FIXTURE_DIR="$not_a_dir" bash "$SCRIPT" 2>&1) || rc=$?
+assert_exit "fixture root that is a regular file refuses" 2 "$rc"
+assert_contains "regular-file refusal names the same reason" "$notdir_err" "not a directory"
+
+rc=0
+PERMISSION_HYGIENE_FIXTURE_DIR="$TEST_TMPDIR/does-not-exist" bash "$SCRIPT" --count >/dev/null 2>&1 || rc=$?
+assert_exit "--count refuses a nonexistent root too" 2 "$rc"
+
 # --- Case 9: missing jq exits 2 ---------------------------------------------
 real_bash=$(command -v bash)
 empty_path_dir="$TEST_TMPDIR/empty-path"

--- a/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
+++ b/plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
@@ -132,8 +132,24 @@ jq -n --arg posix "Bash(${POSIX_MP}:*)" --arg win "Bash(${WIN_MP}:*)" \
   '{permissions:{allow:[$posix,$win]}}' >"$D4/.claude/settings.json"
 OUT=$(run "$D4")
 assert_contains "flags POSIX-normalized machine path" "$OUT" "[P2]"
-assert_contains "P2 detail mentions literal matching" "$OUT" "no ~/\$HOME"
+assert_contains "P2 detail names the portability break" "$OUT" "breaks on other machines"
+assert_not_contains "P2 detail does not assert a blanket no-expansion rule" "$OUT" "no ~/\$HOME"
+assert_not_contains "P2 detail does not scope its rationale to Bash rules" "$OUT" "Bash rules match literally"
 assert_eq "two machine-path findings" "2" "$(run "$D4" --count)"
+
+# P2 fires on Read/Edit rules too, and those rule classes DO resolve `~/`
+# (permissions.md: "`~/path` | Path from home directory"). One message string serves
+# every class, so it must not carry a Bash-only mechanism — that would be a false
+# claim on a true finding.
+D4B="$TEST_TMPDIR/p2-file-tools"
+mkdir -p "$D4B/.claude"
+jq -n '{permissions:{allow:["Read(/c/Users/kyle/notes.md)","Edit(/Users/alice/src/**)"]}}' \
+  >"$D4B/.claude/settings.json"
+OUT_FT=$(run "$D4B")
+assert_contains "flags a machine path in a Read rule" "$OUT_FT" "[P2]"
+assert_not_contains "Read-rule finding does not claim Bash semantics" "$OUT_FT" "Bash rules match literally"
+assert_not_contains "Read-rule finding does not deny ~ expansion" "$OUT_FT" "no ~/\$HOME"
+assert_eq "both file-tool machine paths flagged" "2" "$(run "$D4B" --count)"
 
 # --- Case 5: P2 exemptions — PROJECT_DIR / home-relative not flagged ---------
 D5="$TEST_TMPDIR/p2-exempt"
@@ -241,6 +257,34 @@ jq -n '{permissions:{allow:["Bash(python*)"]}}' >"$D8B/.claude/settings.local.js
 OUT=$(run "$D8B")
 assert_contains "flags P1 grant in settings.local.json" "$OUT" "Bash(python*)"
 assert_contains "finding names the local settings file" "$OUT" "settings.local.json"
+
+# --- Case 9b: unresolvable scan root refuses instead of sweeping -------------
+# The root ladder is $PERMISSION_HYGIENE_FIXTURE_DIR -> git toplevel ->
+# $CLAUDE_PROJECT_DIR, with NO fallback to the cwd. Run from a non-repo directory
+# with every rung unset: the scan must refuse (exit 2, the environment-gap channel)
+# rather than walk whatever the cwd happens to be and report a clean bill.
+#
+# CLAUDE_PROJECT_DIR is unset explicitly as well as the fixture var — an outer
+# session that exports it would otherwise resolve the root and hide the regression.
+nonrepo="$TEST_TMPDIR/not-a-repo"
+mkdir -p "$nonrepo"
+
+rc=0
+root_err=$(cd "$nonrepo" && env -u PERMISSION_HYGIENE_FIXTURE_DIR -u CLAUDE_PROJECT_DIR \
+  GIT_CEILING_DIRECTORIES="$TEST_TMPDIR" bash "$SCRIPT" 2>&1) || rc=$?
+assert_exit "unresolvable root exits 2, not 0" 2 "$rc"
+assert_contains "refusal names the failure" "$root_err" "no scan root resolved"
+assert_not_contains "refusal is not a clean bill" "$root_err" "No fragile permission grants found."
+
+rc=0
+count_err=$(cd "$nonrepo" && env -u PERMISSION_HYGIENE_FIXTURE_DIR -u CLAUDE_PROJECT_DIR \
+  GIT_CEILING_DIRECTORIES="$TEST_TMPDIR" bash "$SCRIPT" --count 2>&1) || rc=$?
+assert_exit "--count also refuses rather than printing 0" 2 "$rc"
+assert_not_contains "--count prints no count on a refusal" "$count_err" "0
+"
+
+# A resolvable root still works, so the refusal did not break the normal path.
+assert_eq "explicit fixture root still scans" "0" "$(run "$TEST_TMPDIR/p2-exempt" --count)"
 
 # --- Case 9: missing jq exits 2 ---------------------------------------------
 real_bash=$(command -v bash)

--- a/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
@@ -88,14 +88,26 @@ reused rather than reinvented: `<repo-identity>/<worktree-discriminator>`, per
 # sha256sum is absent on stock macOS; shasum -a 256 is the portable partner.
 sha256() { if command -v sha256sum >/dev/null 2>&1; then sha256sum; else shasum -a 256; fi; }
 
-remote=$(git config --get remote.origin.url 2>/dev/null || true)
-root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+# "the FIRST configured remote" — not necessarily one named `origin`. A repo whose only
+# remote is `upstream` still has a remote, and must not fall through to the local rung.
+remote_name=$(git remote 2>/dev/null | head -1)
+remote=$(git config --get "remote.${remote_name}.url" 2>/dev/null || true)
+# tr -d '\r': Git on Windows can return a CRLF-terminated path.
+root=$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r' || true)
 
 # repo-identity
 if [ -n "$remote" ]; then
   identity=$(printf '%s' "$remote" \
     | sed -e 's#^[a-z+]*://##' -e 's#^[^@/]*@##' -e 's#:#/#' -e 's#\.git$##' \
     | tr '[:upper:]' '[:lower:]')
+  # A remote URL is arbitrary text and becomes DIRECTORY COMPONENTS here, so accept it
+  # only in the shape the scheme means — segments of [a-z0-9._-] each starting
+  # alphanumeric. That rejects `../central` (a relative filesystem remote, which would
+  # otherwise write outside this skill's namespace), absolute local paths, and
+  # backslashes. Anything rejected still keys deterministically, by hash.
+  if ! printf '%s' "$identity" | grep -qE '^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$'; then
+    identity="remote/$(printf '%s' "$remote" | sha256 | cut -c1-12)"
+  fi
 elif [ -n "$root" ]; then
   identity="local/$(printf '%s' "$root" | sha256 | cut -c1-12)"
 else
@@ -110,10 +122,12 @@ discriminator=$(printf '%s' "${root:-$PWD}" | sha256 | cut -c1-8)
 state_key="$identity/$discriminator"
 ```
 
-Executed against this repository the three rungs give, respectively,
-`github.com/melodic-software/claude-code-plugins/8163d6b9`, `local/<12>/<8>`, and `nonrepo/<12>/<8>`;
-two worktrees of one repository differ in the discriminator (`8163d6b9` vs `009628cd`), which is the
-property it exists for.
+Executed, not merely written: an https remote and its scp-style ssh equivalent normalize to the same
+`github.com/<owner>/<repo>`; a repo whose only remote is `upstream` keys by that remote rather than
+dropping to the local rung; a repo with no remote gives `local/<12>`; a non-repo root gives
+`nonrepo/<12>`; and relative (`../central.git`), absolute-local, and Windows-path remotes all key by
+hash and stay inside this skill's directory. Two worktrees of one repository differ in the
+discriminator, which is the property it exists for.
 
 Run those and use the result. Do **not** express the path as a condition over `${CLAUDE_PROJECT_DIR}`
 "when set": that placeholder is substituted inline before this file reaches you, so the literal token

--- a/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
@@ -75,8 +75,61 @@ Dispatch one fresh-context, non-fork verifier per surface batch, prompted to ref
 addition: "argue this component's purpose does not need this posture, or that it already carries
 it." Findings a verifier refutes are dropped or demoted to `info`.
 
-Persist the report to `${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/last-audit.md` and summarize
-in chat:
+Persist the report to
+`${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/<state-key>/last-audit.md`.
+
+**Derive `<state-key>` by running the commands below.** `${CLAUDE_PLUGIN_DATA}` is machine-global, not
+per-project, so a fixed `last-audit.md` is silently overwritten by the next run from any other root —
+this skill's only durable deliverable, destroyed by ordinary use of it. The scheme is `audit-pass`'s,
+reused rather than reinvented: `<repo-identity>/<worktree-discriminator>`, per
+[audit-pass's run-state reference](../audit-pass/reference/run-state-and-resumability.md) §3.
+
+```bash
+# sha256sum is absent on stock macOS; shasum -a 256 is the portable partner.
+sha256() { if command -v sha256sum >/dev/null 2>&1; then sha256sum; else shasum -a 256; fi; }
+
+remote=$(git config --get remote.origin.url 2>/dev/null || true)
+root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+
+# repo-identity
+if [ -n "$remote" ]; then
+  identity=$(printf '%s' "$remote" \
+    | sed -e 's#^[a-z+]*://##' -e 's#^[^@/]*@##' -e 's#:#/#' -e 's#\.git$##' \
+    | tr '[:upper:]' '[:lower:]')
+elif [ -n "$root" ]; then
+  identity="local/$(printf '%s' "$root" | sha256 | cut -c1-12)"
+else
+  # Non-repo root. audit-pass's ladder stops at the two git rungs because it refuses
+  # non-git targets; this skill is report-only and audits them, so it needs a third.
+  identity="nonrepo/$(printf '%s' "$PWD" | sha256 | cut -c1-12)"
+fi
+
+# worktree-discriminator — two worktrees of one repo legitimately hold different content
+discriminator=$(printf '%s' "${root:-$PWD}" | sha256 | cut -c1-8)
+
+state_key="$identity/$discriminator"
+```
+
+Executed against this repository the three rungs give, respectively,
+`github.com/melodic-software/claude-code-plugins/8163d6b9`, `local/<12>/<8>`, and `nonrepo/<12>/<8>`;
+two worktrees of one repository differ in the discriminator (`8163d6b9` vs `009628cd`), which is the
+property it exists for.
+
+Run those and use the result. Do **not** express the path as a condition over `${CLAUDE_PROJECT_DIR}`
+"when set": that placeholder is substituted inline before this file reaches you, so the literal token
+is never visible and the condition is not yours to evaluate. Derive the key from commands you actually
+run.
+
+**Open the report with a three-line header**, so a file that does survive is self-describing rather
+than merely un-overwritten:
+
+```
+Resolved root: <absolute path audited>
+Scope filter:  <the scope argument this run used, or "all">
+Run (UTC):     <ISO-8601 timestamp>
+```
+
+Then summarize in chat:
 
 | # | Posture | Component | Verdict | Proposed addition |
 |---|---------|-----------|---------|-------------------|

--- a/plugins/claude-config/skills/audit-prompting-postures/evals/evals.json
+++ b/plugins/claude-config/skills/audit-prompting-postures/evals/evals.json
@@ -34,6 +34,31 @@
         "Judges P6 NOT-APPLICABLE for a report-only, human-gated component",
         "Names the failed predicate in the verdict instead of manufacturing a finding"
       ]
+    },
+    {
+      "id": 4,
+      "name": "two-roots-produce-two-reports",
+      "prompt": "/claude-config:audit-prompting-postures — I ran this in my work repo yesterday and I am running it in a different repo now. Will today's run overwrite yesterday's report, and where does each land?",
+      "expected_output": "No. The report path carries a state key derived per project — <repo-identity>/<worktree-discriminator>, the scheme audit-pass already uses — so the two runs write to different directories under ${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/ and both survive. The skill derives the key by RUNNING the documented commands (git remote, git toplevel, sha256 of the canonicalized root), not by testing whether a placeholder is set. It names a distinct resolved path for each run, and notes that two worktrees of the SAME repository also key apart because the discriminator hashes the worktree root.",
+      "files": [],
+      "expectations": [
+        "Answers that the second run does NOT overwrite the first, and names a distinct path for each",
+        "Derives the state key by running the documented git and sha256 commands rather than by evaluating whether a placeholder is set",
+        "Reuses audit-pass's <repo-identity>/<worktree-discriminator> scheme rather than inventing a second keying scheme",
+        "States that two worktrees of one repository also key apart, via the worktree discriminator"
+      ]
+    },
+    {
+      "id": 5,
+      "name": "non-repo-root-still-keys-and-self-describes",
+      "prompt": "/claude-config:audit-prompting-postures — I am running this from my home directory, which is not a git repository at all. Does it still work, and can I tell later which root a saved report came from?",
+      "expected_output": "Yes to both. The identity ladder carries a third rung for a non-repo root — nonrepo/<hash of the working directory> — because this skill is report-only and legitimately audits such roots, unlike audit-pass which refuses non-git targets outright. And the report opens with a mandated three-line header giving the resolved root, the scope filter, and a UTC timestamp, so a surviving file is self-describing rather than merely un-overwritten.",
+      "files": [],
+      "expectations": [
+        "Runs rather than refusing, and keys the report under a non-repo rung instead of falling back to one fixed shared path",
+        "Does NOT invent a git-only derivation that cannot resolve without a repository",
+        "States that the report opens with a header naming the resolved root, the scope filter, and a UTC timestamp"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three findings, one plugin. Every claim below was **executed or grepped this pass**, not derived from a
model of the code — the standard this batch adopted after PR 2's review found three defects of the shape
"a comment asserting something the code does not do".

### P2's rationale is unsupported by the docs, and false on rule classes it fires on (#2248)

`reference/criteria.md:63` read *"Bash rules match literally with no `~`/`$HOME`/env expansion"*.

**Grepped, not assumed.** Both pages pulled with `curl` to a file (`skills.md` 87,211 bytes;
`permissions.md` 61,351 bytes) and searched:
`grep -in "no ~/\$HOME|match literally|literally with no|no expansion|does not expand"` returns **zero
hits across both**. The Bash section (`permissions.md:162-176`) specifies wildcard glob matching and
states no no-expansion rule. So the claim is **unsupported**, not merely over-broad.

Two documented behaviors contradict it:

- `skills.md:333` — *"Claude Code substitutes `${CLAUDE_SKILL_DIR}` and `${CLAUDE_PROJECT_DIR}` in two
  places: the skill's markdown content, and Bash rules in the `allowed-tools` frontmatter."* The
  canonical example at `:339` is `allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/render.sh *)`. The
  skill was telling authors to remove the documented zero-prompt pattern.
- `permissions.md:190` — known-safe leading env-assignment stripping, and **scoped**: an allow rule
  won't match past an assignment of any other variable, while deny/ask match past any. Stated flatly it
  would over-generalize, so the new text carries the scoping.

**And the message is emitted on rule classes where it is false twice over.** The single string at
`permission-rule-check.sh:139` serves every class. Probed against the shipped script:

| Rule | Result |
|---|---|
| `Bash(/c/Users/kyle/x.sh:*)` | flagged P2 |
| `Read(/c/Users/kyle/notes.md)` | **flagged, with the "Bash rules match literally" message** |
| `Edit(/Users/alice/src/**)` | **flagged, same message** |
| `Read(~/Documents/notes.md)` | not flagged (correct) |
| `Bash(${CLAUDE_SKILL_DIR}/scripts/x.sh *)` | not flagged (correct) |
| `Bash(${CLAUDE_PROJECT_DIR}/scripts/lint.sh *)` | not flagged (correct) |

`Read`/`Edit` rules use gitignore pattern syntax and **do** resolve `~/` (`permissions.md:280`:
`Read(~/Documents/*.pdf)` → `/Users/alice/Documents/*.pdf`). So on a `Read` finding the old message named
the wrong rule class *and* asserted a mechanism false for that class.

The emitted message now carries only what is true of every class — the portability break — and names the
portable form per class. The mechanism detail moves into `criteria.md` as a per-rule-class table, syncing
**down** from `docs/conventions/permission-rule-hygiene/README.md:106-134`, which already held the
corrected doctrine and two limits the ledger's sketch omitted: `${CLAUDE_PROJECT_DIR}` substitution
requires **v2.1.196+**, and `${CLAUDE_PLUGIN_ROOT}` is **not** substituted at all, so a rule using it is
inert. No convention edit needed — this is the sync direction.

### The scan fell through to `$PWD` and swept the user profile, exiting 0 (#2249)

`permission-rule-check.sh:71-76` ended `ROOT="${CLAUDE_PROJECT_DIR:-$PWD}"`. Outside a repository `$PWD`
is whatever directory the session stands in — on a developer machine, usually the user profile — and
both scans walk it with `find`, no `-maxdepth`, no `-prune`, stderr discarded, then `exit 0`. A timeout
or a swallowed permission error was indistinguishable from a clean bill, on a skill that is
model-invocable (`disable-model-invocation: false` at `SKILL.md:5`).

The ladder now ends at `${CLAUDE_PROJECT_DIR}`; an unresolvable root **exits 2**, reusing the
environment-gap channel the contract already documents for a missing `jq` rather than minting a code, so
the advisory exit-0-for-findings contract is untouched. **`--count` refuses too** — a `0` from a scan
that never resolved a root reads exactly like a clean bill, and that path exited 0 separately at `:264`.

**Ledger correction, verified:** the ledger lists `SKILL.md:56` as a third "always exits 0" site to
update. `grep -n "exits 0\|exit 0"` over `SKILL.md` returns **no match**; `:56` is the jq-exits-2 line.
`SKILL.md` carries no always-exits-0 claim. The real count is **five**, in two files:
`reference/criteria.md:20` plus the script's header, usage block, and `--help` text. All moved together.

### The postures report had no project dimension (#2250)

`audit-prompting-postures/SKILL.md:78` persisted to one fixed
`${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/last-audit.md`. `${CLAUDE_PLUGIN_DATA}` resolves to
`~/.claude/plugins/data/{id}/` where `{id}` is the **plugin** identifier, never the project — so the
skill's only durable deliverable was silently overwritten by the next run from any other root.

**The filed fix sketch is not what shipped, deliberately.** It proposed `${CLAUDE_PROJECT_DIR}` with a
"when set, else" fallback. That placeholder substitutes **inline in skill content**, so the model never
sees the literal token and cannot evaluate "when set" — the defect filed separately against `audit-pass`
as `F9`. Implementing it as sketched would have introduced that defect while removing this one. The
derivation is therefore written as **commands to run**.

**The scheme is `audit-pass`'s, reused rather than reinvented** —
`<repo-identity>/<worktree-discriminator>` from `run-state-and-resumability.md` §3 — because a second
scheme for one concern is the drift this batch exists to remove. **One rung added:** that ladder has
git-with-remote and git-without-remote and no non-repo rung. `audit-pass` does not need one (PR #2234
made it refuse non-git targets); this skill is report-only and legitimately audits them — the run that
produced the finding was rooted at a non-repo home directory.

Plus the mandated three-line header (resolved root, scope filter, UTC timestamp), so a surviving report
is self-describing rather than merely un-overwritten.

### What review caught — including the same defect class, in my own work

Five threads, all resolved, four follow-up commits. Two of the findings were the exact shape this batch
keeps hitting, and both were mine:

- **The snippet read `remote.origin.url` while the sentence above it claimed verbatim reuse of a scheme
  that says "the first configured remote URL".** Reproduced: a repo whose only remote is `upstream`
  returns empty and fell to the `local/` rung *despite having a remote*, so one repository keyed
  differently depending on what someone named their remote. Now `git remote | head -1`.
- **A remote URL is arbitrary text that becomes directory components, and I did not validate it.**
  Reproduced with `git remote add origin ../central.git`: state key `../central/2a8fd283`, and the
  report path normalizes to `/…/central/…` — **outside this skill's namespace entirely**. Absolute-local
  and Windows-path remotes break the same way. The identity is now accepted only in the shape the scheme
  means, and anything else keys by hash, still deterministically.

Plus three smaller ones: `root` now strips CRLF to match the sibling script this same PR touches; the
new `-d "$ROOT"` guard shipped untested next to four assertions for its sibling branch, and now has five
cases; and CI's machine-path detector caught four literals I added, where the test file already had a
runtime-assembly idiom I had failed to follow.

Verified after the remote fix across seven shapes — relative, absolute-local, Windows, https, scp-style
ssh, no-remote, non-repo:

```
  CONTAINED  remote/feb98d0c6fe2/5bdf8482       relative filesystem remote
  CONTAINED  remote/9025af3e59ae/72f53c5b       absolute local remote
  CONTAINED  remote/ee5e188160e5/f80a5d9b       windows local remote
  CONTAINED  github.com/acme/widget/5fb34de0    normal https remote
  CONTAINED  github.com/acme/widget/31e38d12    scp-style ssh remote
  CONTAINED  local/aa0eeb6c3f8f/aa0eeb6c        no remote at all
  CONTAINED  nonrepo/862f1fe5638e/862f1fe5      not a repo

  remote name: upstream   key: github.com/acme/widget/51e207e2   (was local/… before the fix)
  stable across runs; with several remotes the first wins
```

### Trust surface

Narrows. The scan refuses an unresolved root instead of walking the user's home, and the report path can
no longer escape the skill's own directory via a crafted remote. Nothing widens. No new grant, hook, or
network read.

## Test plan

**Fail-before / pass-after, both rows.** The new assertions run against the **pre-fix** script
(`git checkout origin/main -- permission-rule-check.sh`, test file kept):

```
$ bash plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
FAIL: P2 detail does not assert a blanket no-expansion rule
FAIL: P2 detail does not scope its rationale to Bash rules
FAIL: Read-rule finding does not claim Bash semantics
FAIL: Read-rule finding does not deny ~ expansion
FAIL: unresolvable root exits 2, not 0
FAIL: refusal names the failure
FAIL: refusal is not a clean bill
FAIL: --count also refuses rather than printing 0
14/68 checks failed.
```

Restored, and after the fix:

```
$ bash plugins/claude-config/skills/audit-permission-grants/scripts/permission-rule-check.test.sh
All 68 checks passed.
```

Baseline for reference was `All 50 checks passed.` at the merge-base.

Two of the new assertions are **guards, not failing tests**, and are presented as such: the
`${CLAUDE_SKILL_DIR}` positive case and "explicit fixture root still scans" both pass before the change
too. The A4 refusal test unsets `CLAUDE_PROJECT_DIR` as well as `PERMISSION_HYGIENE_FIXTURE_DIR` and sets
`GIT_CEILING_DIRECTORIES`, so it fails for the intended reason rather than inheriting a root from the
outer session.

**The CC-F1 derivation was executed, not just written.** All three identity rungs, in real contexts:

```
--- context 1: this repo (has a remote)
github.com/melodic-software/claude-code-plugins/8163d6b9
--- context 2: git repo with NO remote
local/c508785eede5/c508785e
--- context 3: not a repo at all
nonrepo/fa5107130e4e/fa510713
```

And the worktree discriminator does what it exists for — two worktrees of this repository:

```
C:/Projects/melodic/worktrees/batch4-laneA-audit -> 8163d6b9
C:/Projects/melodic/claude-code-plugins         -> 009628cd
```

Portability caught by executing rather than assuming: `sha256sum` is absent on stock macOS, so the
snippet carries a `shasum -a 256` fallback (both verified present here).

**Static gates:**

```
$ shellcheck permission-rule-check.sh permission-rule-check.test.sh     (clean)
$ jq empty audit-prompting-postures/evals/evals.json plugin.json        (clean)
$ bash check-evals-quality.sh audit-prompting-postures/evals/evals.json
check-evals-quality: PASS (0 warning(s) across 1 file(s))
$ CHECK_SKILL_SKILLS_ROOT=... check-skill.sh audit-permission-grants
CHECK-SKILL audit-permission-grants: PASS — 0 errors, 1 warning(s)   (pre-existing: no Gotchas surface)
$ CHECK_SKILL_SKILLS_ROOT=... check-skill.sh audit-prompting-postures
CHECK-SKILL audit-prompting-postures: PASS — 0 errors, 0 warning(s)
$ npx markdownlint-cli2 <5 changed md files>                            Summary: 0 issues in 0 files
```

CHANGELOG verified as additions only: `git diff --cached CHANGELOG.md | grep -c '^-[^-]'` = **0**, so the
shipped `0.30.0` and `0.31.0` entries are untouched.

## Related

Closes #2248
Closes #2249
Closes #2250

Inbox items: batch-4 ledger `I10` rows `A1` and `A4`; ledger `I9` row `CC-F1`, whose mechanism was
replaced per reconciliation `OR-3` (`rationale_falsified` in effect, caught cross-ledger).

Bump: `claude-config` 0.31.0 → **0.32.0** — minor, because two graded behaviors move (an unresolvable
root now refuses; the report path changes).

**Reproduced but deliberately not fixed:** `criteria.md:60-61` claims `//…` forms are not flagged, and
`Read(//Users/alice/secrets/**)` — the docs' own literal example at `permissions.md:278` — **is** flagged.
That is ledger row `A2` (MED, `implement_now: false`), a different hunk in the same file. The
reproduction is recorded on #2248 as corroborating evidence for it; the new text asserts nothing about
`//` exemption. Also left: `A3` (P2 prints an 8-char fragment), `A11`, `A14`, and `CC-F2`–`CC-F11`.
Filing for those is held pending the operator's call on batch-4 volume (`OR-4`).
