### PR TITLE
fix(guardrails): decide block-hook-bypass's exemptions on the whole redirect operand

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",
@@ -125,7 +125,7 @@
     "block_hook_bypass_scratch_roots": {
       "type": "string",
       "title": "block-hook-bypass scratch roots",
-      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary \u2014 a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. Any quote or backslash after the first `>` CHARACTER in the command (operator or not) cancels the exemption for the whole command \u2014 so a quote in a later segment, or a `>` inside quoted content, also cancels it. Symlinks are not followed",
+      "description": "Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary — a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed",
       "default": ""
     },
     "stdin_read_timeout": {

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,86 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.27.0]
+
+### Fixed
+
+- **`block-hook-bypass` exempted a quoted redirect target on its first word, so a write whose real
+  destination was somewhere else entirely was waved through as a `/dev/null` discard (#2226).**
+  A quoted redirect operand is ONE pathname to bash. This guard decided its target-based exemptions
+  on the operand's first whitespace- or separator-delimited fragment, because the machinery either
+  side of that decision disagreed about what a kept operand is: `strip_literals` **keeps** a quoted
+  write target as literal content — dropping the quotes so a quoted target still reads as a write —
+  while `normalize_segments` then read a `;`, `|`, `&`, `(`, `)` or newline *inside* it as a segment
+  boundary and `_redir_scan`'s target class ended at whitespace.
+
+  Measured at `56f5cd21` (0.25.3), hook invoked as a decision function on a `PreToolUse` Bash
+  payload — `rc=2` blocked, `rc=0` allowed:
+
+  ```
+  rc=0 :: echo x > "/dev/null ../../etc/pw"        # exempted on the word /dev/null
+  rc=0 :: echo x > "/dev/null;/../../etc/passwd"
+  rc=0 :: echo x > '/dev/null ../../etc/pw'
+  rc=0 :: echo x > /dev/"null ../../etc/pw"
+  rc=0 :: echo x > /dev/null\;/../../etc/passwd    # the unquoted escaped spelling
+  rc=0 :: cat > "/dev/null ../../etc/pw"           # and the cat lane
+  ```
+
+  Nothing named `/dev/null` is the destination in any of them. Reaching a *chosen* file this way
+  needs a directory whose name ends in the whitespace-bearing fragment to already exist, so this is
+  correctness and defence-in-depth rather than a demonstrated escape — but it is the exact assumption
+  every target-based exemption rests on, and this guard now has two.
+
+  `strip_literals` marks a kept operand's literal content with two sentinels. `\x03` **OPAQUE**
+  stands in for one character whose literal value would read as syntax downstream, or for a backslash
+  escape this strip cannot reproduce faithfully (inside double quotes bash *retains* the backslash
+  unless it escapes `$`, `` ` ``, `"`, `\` or a newline). It is inert to every scan, so the operand
+  survives as one token, and its presence means the pathname is not recoverable here — no exemption
+  of any kind may be granted. `\x04` **QUOTED** is emitted where a kept span opens; the discard
+  compare strips it, so `> "/dev/null"` is still a discard, while the scratch-root axis keeps its
+  shipped floor of never exempting a quoted operand. A raw `\x01`-`\x04` byte arriving in the command
+  text is mapped to OPAQUE, so a forged sentinel can only ever *cost* an exemption.
+
+  Every mark is gated on "this word began right after a `>`" — the same test the quoted-operand keep
+  already used, now factored out and applied to the unquoted backslash branch too. **That gating is
+  load-bearing, not tidiness:** `normalize_segments`, `_producer_head`, `_cat_redir` and every
+  whitespace trim in the file are byte-for-byte as shipped, so an escaped separator *between*
+  commands (`echo x \; > f`) still travels the unchanged `\x02`-to-space path, and a backslash in a
+  command word (`/c/Python313/python3.exe -c`) is untouched. #1680 and #1667 read this same
+  normalization; their shapes (`echo x >&2`, `printf … >&2`, `echo x &>file`, `1>&2`, `2>&1`,
+  `>&2>file`, `cat 1>&2`, `cat 1>&-`) carry no quotes and no backslashes, emit no mark, and were
+  measured before and after with **no delta**. Neither issue moves.
+
+### Changed
+
+- **The scratch-root exemption's fail-close is keyed on the redirect operand instead of the whole
+  raw command, retiring both blunt edges 0.25.1 documented (#2236).** With the operand/quote
+  association restored above, `scratch_target_exempt` no longer has to infer it from
+  `${COMMAND#*>}`. It reads the operand's own marks, so the two frictions 0.25.1 recorded as
+  unfixable-without-#2226 are gone:
+
+  | command, root `/tmp/scratch` | 0.25.3 | 0.27.0 |
+  | --- | --- | --- |
+  | `echo x > /tmp/scratch/f && grep foo "notes.txt"` | blocked | **allowed** |
+  | `echo x > /tmp/scratch/f; cat "notes.txt"` | blocked | **allowed** |
+  | `echo "a > b" > /tmp/scratch/f` | blocked | **allowed** |
+  | `echo 'x > y' > /tmp/scratch/f` | blocked | **allowed** |
+  | `echo x > "/tmp/scratch/f"` — a merely quoted operand | blocked | blocked |
+  | `echo x > "/tmp/scratch/a;/../../etc/passwd"` | blocked | blocked |
+
+  **Grade every verdict this release moves on the direction that matters:** refusing an exemption is
+  friction, granting one is a bypass. Nineteen shapes move from GRANTED to REFUSED — the whole
+  `/dev/null` family above, plus a multi-line quoted operand, an operand continued by a
+  backslash-newline, an empty quoted target, and a forged sentinel byte. **Three move the other
+  way** — the first three rows of that table — and each lands on a target the marks prove was bare:
+  no quote mark, no opaque mark, no backslash. That is the entire grant surface of this release.
+  The scratch axis's own floor is deliberately *not* widened even though the operand is now known
+  precisely: a quoted operand stays non-exempt, and 0.25.0's assertion saying so is untouched.
+
+  0.25.1's entry below says the breadth "stays" and that narrowing it needs #2226. Both were true
+  when written; #2226 is now fixed and this entry is that entry's erratum. Per Keep a Changelog the
+  0.25.x entries are left as they shipped.
+
 ## [0.26.1]
 
 ### Fixed
@@ -148,6 +228,11 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
 ## [0.25.1]
 
 ### Changed
+
+> **Erratum:** the second bullet below states that the fail-close's breadth stays, because narrowing
+> it needs #2226. #2226 is fixed in 0.26.0 and the breadth is gone — the check is keyed on the
+> redirect operand now. The mechanism this entry corrects for 0.25.0 was accurate for 0.25.x; see
+> 0.26.0 above for what replaced it. Everything else in this entry is unchanged.
 
 - **`block-hook-bypass`'s scope note now names `tee` and other inline-interpreter
   write families it does not model (#2218).** No behaviour changes — lane-specific

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -71,17 +71,31 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
   | `echo x > "/tmp/scratch/a;/../../etc/passwd"` | blocked | blocked |
 
   **Grade every verdict this release moves on the direction that matters:** refusing an exemption is
-  friction, granting one is a bypass. Nineteen shapes move from GRANTED to REFUSED — the whole
-  `/dev/null` family above, plus a multi-line quoted operand, an operand continued by a
-  backslash-newline, an empty quoted target, and a forged sentinel byte. **Three move the other
-  way** — the first three rows of that table — and each lands on a target the marks prove was bare:
-  no quote mark, no opaque mark, no backslash. That is the entire grant surface of this release.
-  The scratch axis's own floor is deliberately *not* widened even though the operand is now known
-  precisely: a quoted operand stays non-exempt, and 0.25.0's assertion saying so is untouched.
+  friction, granting one is a bypass. Counted from the new suite run against 0.25.3's hook, which
+  reports 19 failures split 15/4 by direction:
+
+  - **15 move from GRANTED to REFUSED.** The `/dev/null` family above in its quoted, single-quoted,
+    partially-quoted, escaped, fd-numbered (`1>`), `cat`-lane and real-file-then-operand spellings,
+    plus a multi-line quoted operand, an operand continued by a backslash-newline, and an empty
+    quoted target (`> ""`).
+  - **4 move from REFUSED to GRANTED** — the first four rows of the table above. That is the entire
+    grant surface of this release, and each one lands on a target the marks *prove* was bare: no
+    quote mark, no opaque mark, no backslash.
+
+  A forged sentinel byte and an escaped-space operand are **not** in either set: both already blocked
+  at 0.25.3 and are pinned here as regression guards, not flips. The scratch axis's own floor is
+  deliberately *not* widened even though the operand is now known precisely: a quoted operand stays
+  non-exempt, and 0.25.0's assertion saying so is untouched.
 
   0.25.1's entry below says the breadth "stays" and that narrowing it needs #2226. Both were true
   when written; #2226 is now fixed and this entry is that entry's erratum. Per Keep a Changelog the
   0.25.x entries are left as they shipped.
+
+  One assertion 0.25.0 shipped is **retired** rather than kept: `control: /dev/null still shows the
+  inherited truncation (#2226, allowed)`, which 0.25.0's own PR wrote so that it "flips visibly when
+  this issue is fixed". It is replaced by six `/dev/null` assertions covering the whole family, not
+  just its `;` spelling. Every other 0.25.0 and 0.25.1 assertion still passes unmodified except the
+  four graded above.
 
 ## [0.26.1]
 

--- a/plugins/guardrails/README.md
+++ b/plugins/guardrails/README.md
@@ -113,23 +113,22 @@ out of scope until such a signal exists.
   blocks, and a relative, unexpanded (`$VAR`, `~`) or glob target is never
   exempt. A **quoted or escaped** operand is never exempt either, and that one
   fails closed rather than being documented: the quote strip drops a kept
-  target's quotes and the segment split then reads a `;`, `|`, `&` or space
+  target's quotes, and the segment split would then read a `;`, `|`, `&` or space
   *inside* the operand as syntax, so `> "/tmp/scratch/a;/../../etc/passwd"` —
-  one pathname to bash — would otherwise be judged on `/tmp/scratch/a`. The rule
-  is therefore blunt, and blunt in two directions worth stating exactly: **any
-  quote or backslash after the first `>` character in the command — operator or
-  not — cancels the exemption.** It is not scoped to the segment being evaluated,
-  so a quote in an unrelated later segment cancels it too
-  (`echo x > /tmp/scratch/f && grep foo "notes.txt"` blocks; the same compound
-  without quotes does not). And it is not keyed on the redirect *operator*, so a
-  `>` inside quoted content starts the scan early and that content's own closing
-  quote falls inside it — `echo "hi there" > /tmp/scratch/f` is exempt, but
-  `echo "a > b" > /tmp/scratch/f` is **not**. Both are the safe direction: the
-  check can only ever refuse an exemption, never grant one. Making it precise
-  needs the same thing in both cases — knowing which `>` and which quotes are
-  syntax rather than content — which is exactly what the quote strip destroys
-  before this code runs. The same root cause reaches the `/dev/null` exemption and
-  predates this option — filed as #2226 and pinned by a control test. Two residuals remain, both
+  one pathname to bash — would be judged on `/tmp/scratch/a`. Since **0.26.0**
+  the operand is **marked** wherever that would happen, so it reaches the compare
+  as one word and the decision is made on the whole thing: an operand carrying
+  whitespace, `;`, `|`, `&`, `(`, `)`, a newline or a backslash escape exempts
+  nothing, and a merely quoted operand is refused by this axis on its shipped
+  floor. **Quotes and backslashes elsewhere in the command no longer matter.**
+  Before 0.26.0 this test read the whole raw command tail after the first `>`
+  *character*, so a quote in an unrelated later segment, or a `>` inside quoted
+  content, cancelled the exemption for an earlier plain write. Both were friction
+  rather than protection and both are gone — `echo x > /tmp/scratch/f && grep foo
+  "notes.txt"` and `echo "a > b" > /tmp/scratch/f` are exempt again. The same
+  truncation reached the `/dev/null` discard and predated this option (#2226);
+  the same marking closes it, so a quoted `/dev/null` operand carrying a second
+  fragment now **blocks** where it was allowed. Two residuals remain, both
   deliberate and both pinned: normalization is lexical, so symlinks out of a
   root are not followed, and the compare is case-insensitive because the segment
   scan runs over the lowercased command. Naming a root is accepting that root's
@@ -317,7 +316,7 @@ reads it from.
 | `block_dangerous_git_allow` | string | *(none)* | `CLAUDE_PLUGIN_OPTION_BLOCK_DANGEROUS_GIT_ALLOW` | Comma-separated forms block-dangerous-git permits: push-force, push-lease-unsafe, reset-hard, clean-force, checkout-dot, restore-dot, checkout-force; empty blocks all |
 | `block_noncanonical_commit_allow` | string | *(none)* | `CLAUDE_PLUGIN_OPTION_BLOCK_NONCANONICAL_COMMIT_ALLOW` | Comma-separated form tokens to allow (currently: message-flag, which permits `-m` even when the message contains a newline) |
 | `block_no_verify_hook_manager_prefixes` | string | *(none)* | `CLAUDE_PLUGIN_OPTION_BLOCK_NO_VERIFY_HOOK_MANAGER_PREFIXES` | Comma-separated hook-manager env-var name prefixes block-no-verify treats as a bypass when set to 0/false (e.g. lefthook,husky); empty uses the built-in default set (lefthook, husky, pre_commit, simple_git_hooks) |
-| `block_hook_bypass_scratch_roots` | string | *(none)* | `CLAUDE_PLUGIN_OPTION_BLOCK_HOOK_BYPASS_SCRATCH_ROOTS` | Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary — a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. Any quote or backslash after the first `>` CHARACTER in the command (operator or not) cancels the exemption for the whole command — so a quote in a later segment, or a `>` inside quoted content, also cancels it. Symlinks are not followed |
+| `block_hook_bypass_scratch_roots` | string | *(none)* | `CLAUDE_PLUGIN_OPTION_BLOCK_HOOK_BYPASS_SCRATCH_ROOTS` | Comma-separated ABSOLUTE directories block-hook-bypass exempts as scratch/temp write targets (e.g. /tmp/scratch,/d/jobtmp/session); empty (the default) exempts nothing and leaves the guard's shipped behaviour unchanged. Matching is on the effective stdout target after lexical normalization, at a path-component boundary — a sibling merely sharing the name prefix, a `..` escape out of a root, and a discard-then-real-file redirect all still block. A quoted or escaped OPERAND is never exempt: the operand is marked so it survives the quote strip and the segment split as one word, and an operand carrying whitespace, `;`, `\|`, `&`, `(`, `)`, a newline or a backslash escape exempts nothing. Quotes elsewhere in the command no longer matter. Symlinks are not followed |
 | `stdin_read_timeout` | number<br>*min 1* | `2` | `CLAUDE_PLUGIN_OPTION_STDIN_READ_TIMEOUT` | Idle bound on reading the hook payload from stdin — how long a silent pipe is tolerated before a blocking guard fails closed |
 
 ### How to set these

--- a/plugins/guardrails/hooks/block-hook-bypass.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.sh
@@ -115,6 +115,67 @@ emit_tel() {
   hook::emit_telemetry "block-hook-bypass" "PreToolUse" "$1" "$start" "$data" "${CLAUDE_PROJECT_DIR:-}"
 }
 
+# --- Redirect-operand literal marking (#2226) --------------------------------
+#
+# Both exemptions below are decided on the redirect TARGET, so the target must be
+# the whole operand bash would use — not a prefix of it. strip_literals KEEPS a
+# quoted write target (dropping its quotes) so the write still reads as a write,
+# but the kept text then flows into machinery that reads shell SYNTAX: the
+# segment split treats `;`, `|`, `&`, `(`, `)` and a newline as boundaries, and
+# _redir_scan's target class ends at whitespace, `>` and `|`. A quoted operand
+# carrying any of those therefore reached the exemption tests as its first
+# fragment — `echo x > "/dev/null ../../etc/pw"` was judged on the word
+# `/dev/null` and exempted, while nothing named `/dev/null` is the destination.
+#
+# Two sentinel bytes carry the association the strip would otherwise destroy:
+#
+#   \x03 OPAQUE — stands in for one character of operand LITERAL content whose
+#        own value would read as syntax downstream, or whose text this strip
+#        cannot reproduce faithfully (a backslash escape). It is inert to every
+#        scan in this file, so the operand survives as ONE token; its presence
+#        means the operand's exact pathname is NOT recoverable here, and NO
+#        exemption of any kind may be granted.
+#   \x04 QUOTED — emitted once where a kept quoted span opens. It records that
+#        the operand was quoted at all without hiding the text: the `/dev/null`
+#        discard compare strips it (a quoted `> "/dev/null"` is still a discard),
+#        while the scratch-root axis keeps its shipped floor of never exempting a
+#        quoted operand.
+#
+# A raw \x01-\x04 byte arriving in the command text is mapped to OPAQUE as well,
+# so a forged sentinel can only ever COST an exemption, never manufacture one.
+_MARK_OPAQUE=$'\x03'
+_MARK_QUOTE=$'\x04'
+
+# True when the character about to be consumed belongs to a REDIRECT OPERAND —
+# the word being emitted began right after a `>`. Strip the current trailing
+# operand word (back to the last whitespace or shell metachar), then the
+# whitespace before it, and test for `>`.
+#
+# Gating every mark on this is what keeps normalize_segments, _producer_head,
+# _cat_redir and every whitespace trim in this file byte-for-byte as shipped:
+# nothing outside an operand is marked, so an escaped separator between commands
+# (`echo x \; > f`) still travels the unchanged `\x02`-to-space path, and a
+# backslash in a command WORD (`/c/Python313/python3.exe -c`) is untouched.
+_in_redirect_operand() {
+  local tail="$1"
+  tail="${tail%"${tail##*[[:space:]<>|&\;()]}"}"
+  tail="${tail%"${tail##*[![:space:]]}"}"
+  [[ "${tail: -1}" == ">" ]]
+}
+
+# One character of KEPT operand content, into _KEEP_CHAR: itself, or the opaque
+# marker when its literal value would read as syntax downstream. Single-sourced
+# so the two kept-span emit sites cannot drift apart.
+_KEEP_CHAR=""
+_keep_char() {
+  case "$1" in
+  [[:space:]] | ';' | '|' | '&' | '(' | ')' | '<' | '>' | $'\x01' | $'\x02' | $'\x03' | $'\x04')
+    _KEEP_CHAR="$_MARK_OPAQUE"
+    ;;
+  *) _KEEP_CHAR="$1" ;;
+  esac
+}
+
 # Strip single- and double-quoted literal spans so the executable-token scan
 # sees only shell syntax, not payload text. Heredoc bodies are dropped wholesale
 # (their content is data, not a command). The quote strip carries an OPEN quote
@@ -130,7 +191,10 @@ strip_literals() {
   # carries, alongside it, whether that span is a REDIRECT OPERAND (a quoted
   # target: the char before the opening quote is `>`) — those are kept as literal
   # content instead of dropped, so a quoted write target survives the strip.
-  local open_quote="" open_keep="" out i n c prev tail
+  # `op_cont` is set when a line ends with a backslash INSIDE a redirect operand:
+  # bash removes the backslash-newline entirely, so the operand continues on the
+  # next line with no separator and the joining newline must not be emitted.
+  local open_quote="" open_keep="" out i n c prev nxt op_cont
   # `(^|[^<])` before `<<` excludes a here-string `<<<` — matching `<<` inside
   # `<<<` would capture a bogus delimiter and strand the stripper in-heredoc,
   # swallowing every later line (a here-string bypass). The delimiter body
@@ -178,6 +242,7 @@ strip_literals() {
     out=""
     i=0
     n=${#line}
+    op_cont=0
     while ((i < n)); do
       c="${line:i:1}"
       if [[ "$open_quote" == "'" ]]; then
@@ -185,21 +250,26 @@ strip_literals() {
           open_quote=""
           open_keep=""
         elif [[ -n "$open_keep" ]]; then
-          out+="$c"
+          _keep_char "$c"
+          out+="$_KEEP_CHAR"
         fi
         ((i += 1))
       elif [[ "$open_quote" == '"' ]]; then
         if [[ "$c" == $'\\' ]]; then
-          # Inside double quotes a backslash escapes the next char; when this span
-          # is a kept redirect operand, keep that escaped char literally.
-          [[ -n "$open_keep" ]] && out+="${line:i+1:1}"
+          # Inside double quotes a backslash escapes the next char. In a kept
+          # redirect operand this strip cannot reproduce the result faithfully —
+          # bash RETAINS the backslash unless the escaped char is one of
+          # `$` `` ` `` `"` `\` or a newline — so the pair is marked OPAQUE
+          # rather than guessed at, and the operand loses its exemption.
+          [[ -n "$open_keep" ]] && out+="$_MARK_OPAQUE"
           ((i += 2))
         else
           if [[ "$c" == '"' ]]; then
             open_quote=""
             open_keep=""
           elif [[ -n "$open_keep" ]]; then
-            out+="$c"
+            _keep_char "$c"
+            out+="$_KEEP_CHAR"
           fi
           ((i += 1))
         fi
@@ -212,13 +282,17 @@ strip_literals() {
           # target (`echo x > "$out"` -> `echo x > $out`, still a detectable write;
           # partial `echo x > /dev/"null"` -> `echo x > /dev/null`, still exempt),
           # while a quoted span anywhere else (prose, `--body "..."`, a quoted echo
-          # argument) is dropped as before so its tokens stay inert. Boundary: strip
-          # the current trailing operand word (chars up to the last whitespace or
-          # shell metachar), then the whitespace before it, and test for `>`.
+          # argument) is dropped as before so its tokens stay inert. Boundary:
+          # _in_redirect_operand. A kept span also emits the QUOTED marker, so the
+          # exemptions downstream can tell a quoted operand from a bare one
+          # instead of inferring it from quotes anywhere in the raw command.
           open_quote="$c"
-          tail="${out%"${out##*[[:space:]<>|&\;()]}"}"
-          tail="${tail%"${tail##*[![:space:]]}"}"
-          [[ "${tail: -1}" == ">" ]] && open_keep=1 || open_keep=""
+          if _in_redirect_operand "$out"; then
+            open_keep=1
+            out+="$_MARK_QUOTE"
+          else
+            open_keep=""
+          fi
           ((i += 1))
           ;;
         '#')
@@ -244,17 +318,53 @@ strip_literals() {
           ((i += 1))
           ;;
         $'\\')
-          out+="${line:i:2}"
-          ((i += 2))
+          nxt="${line:i+1:1}"
+          if ! _in_redirect_operand "$out"; then
+            # Outside an operand the pair is left exactly as it was:
+            # normalize_segments still needs `\<sep>` to reach its escaped-
+            # separator sentinel, and a backslash in a command word is path text.
+            out+="${line:i:2}"
+            ((i += 2))
+          elif [[ -z "$nxt" ]]; then
+            # Backslash at end of line INSIDE an operand: bash removes the
+            # backslash-newline outright, so the operand continues on the next
+            # line. Mark it and suppress the joining newline below.
+            out+="$_MARK_OPAQUE"
+            op_cont=1
+            ((i += 1))
+          else
+            # An escaped character in an operand is LITERAL content. Its own value
+            # is dropped when it would read as syntax; otherwise it is kept behind
+            # the marker, because the escape means the written text is not the
+            # pathname (`D:\jobtmp\scratch\f` is `D:jobtmpscratchf` to bash).
+            _keep_char "$nxt"
+            [[ "$_KEEP_CHAR" == "$_MARK_OPAQUE" ]] && out+="$_MARK_OPAQUE" ||
+              out+="$_MARK_OPAQUE$nxt"
+            ((i += 2))
+          fi
           ;;
         *)
-          out+="$c"
+          # A raw sentinel byte in the command text is treated as opaque literal
+          # content, so it can never be mistaken for a mark this strip emitted.
+          case "$c" in
+          $'\x01' | $'\x02' | $'\x03' | $'\x04') out+="$_MARK_OPAQUE" ;;
+          *) out+="$c" ;;
+          esac
           ((i += 1))
           ;;
         esac
       fi
     done
-    result+="${out}"$'\n'
+    # A newline INSIDE a kept operand is literal content, not a separator — a
+    # quoted target may span physical lines, and a backslash-newline inside one
+    # is removed by bash outright. Either way the operand must stay one token.
+    if [[ -n "$open_quote" && -n "$open_keep" ]]; then
+      result+="${out}${_MARK_OPAQUE}"
+    elif ((op_cont)); then
+      result+="$out"
+    else
+      result+="${out}"$'\n'
+    fi
   done < <(printf '%s\n' "$cmd") # not <<<: a >=64KiB here-string deadlocks (see hardcoded-path-patterns.sh)
   printf '%s' "${result%$'\n'}"
 }
@@ -295,6 +405,10 @@ _cat_redir='(^|[[:space:];|&()]+)cat([[:space:]]*>|[[:space:]]+1>)'
 # target class excludes `&`, so an fd dup (`>&1`) is not mistaken for a file.
 # Used by set_last_stdout_target, never matched alone: the PRESENCE of a
 # `/dev/null` redirect proves nothing (see below).
+# The operand marks `\x03`/`\x04` are deliberately ADMITTED by the target class
+# where the normalization sentinels `\x01`/`\x02` are excluded: their whole point
+# is that a marked operand reaches this scan as ONE word (see the marking block
+# above strip_literals). resolve_target_marks reads them off the captured target.
 _redir_scan=$'(^|[^0-9&])1?>>?[[:space:]]*([^|&>[:space:]\x01\x02]+)'
 # A simple-command segment whose command token is `echo` or `printf` — the
 # content producers a `> file` redirect turns into a Write/Edit bypass. Anchored
@@ -487,6 +601,31 @@ set_last_stdout_target() {
   done
 }
 
+# Resolve the operand marks strip_literals attached to the effective target (see
+# the marking block above it) into the three things the exemptions need: whether
+# the operand's pathname is recoverable at all (TARGET_OPAQUE), whether it was
+# quoted (TARGET_QUOTED), and the text itself with the quote marks removed.
+# Globals, not an echo, for the same no-fork reason as set_last_stdout_target.
+TARGET_TEXT=""
+TARGET_OPAQUE=0
+TARGET_QUOTED=0
+resolve_target_marks() {
+  local t="$1"
+  TARGET_OPAQUE=0
+  TARGET_QUOTED=0
+  [[ "$t" == *"$_MARK_OPAQUE"* ]] && TARGET_OPAQUE=1
+  [[ "$t" == *"$_MARK_QUOTE"* ]] && TARGET_QUOTED=1
+  TARGET_TEXT="${t//"$_MARK_QUOTE"/}"
+}
+
+# 0 when the effective target is the stdout DISCARD. Quoting is transparent here
+# — `> "/dev/null"` and `> /dev/"null"` are the same discard — but an OPAQUE
+# operand is not: `> "/dev/null ../../etc/pw"` is one pathname to bash and it is
+# not `/dev/null`, which is exactly the bypass #2226 reported.
+devnull_target_exempt() {
+  ((TARGET_OPAQUE == 0)) && [[ "$TARGET_TEXT" == "/dev/null" ]]
+}
+
 # --- Scratch-root exemption (opt-in; TARGET-PATH axis) ------------------------
 #
 # This guard is PRODUCER-scoped: it fires on echo/printf/cat/python3 -c as the
@@ -535,15 +674,14 @@ set_last_stdout_target() {
 # root only in case is therefore also exempt.
 #
 # A QUOTED OR ESCAPED redirect operand is never exempt — see the fail-closed
-# test at the top of scratch_target_exempt. A quoted operand can carry
-# whitespace, `;`, `|`, `&` or a newline that strip_literals and
-# normalize_segments have already resolved away as syntax, leaving only a
-# safe-looking prefix of the real pathname to compare. The same truncation
-# reaches the `/dev/null` exemption and PREDATES this axis (measured at
-# `685dd381`: `echo x > "/dev/null;/../../etc/passwd"` is allowed there); that
-# half is filed as #2226 and pinned here by a control test, because fixing it
-# means teaching strip_literals to mark a kept operand's internal separators —
-# shared machinery this row does not touch.
+# tests at the top of scratch_target_exempt. Since 0.26.0 that decision is made
+# on the OPERAND, from the marks strip_literals attaches to it, not on the raw
+# command: an operand carrying whitespace, `;`, `|`, `&`, `(`, `)`, a newline or
+# a backslash escape is OPAQUE and exempts nothing, and a merely quoted one is
+# refused by this axis on its shipped floor. The truncation that made those
+# operands compare as a safe-looking prefix of themselves also reached the
+# `/dev/null` exemption and predated this axis (#2226); both are closed by the
+# same marking, and devnull_target_exempt is where the discard half decides.
 #
 # SCOPE: Bash lane only. The PowerShell lane classifies on cmdlet/redirect
 # CO-OCCURRENCE and never resolves a single effective target, so there is no
@@ -595,44 +733,38 @@ _norm_path() {
 scratch_target_exempt() {
   local target="$1" norm_target root roots
   [[ -n "$_SCRATCH_ROOTS" ]] || return 1
-  # FAIL CLOSED on a QUOTED or ESCAPED redirect operand, before anything else.
-  # By the time LAST_STDOUT_TARGET exists the evidence is gone: strip_literals
-  # KEEPS a quoted write target but drops its quotes, and normalize_segments then
-  # turns a `;`, `|`, `&` or newline inside that operand into a segment boundary
-  # and whitespace into a word boundary — so the operand
-  # `"/tmp/scratch/a;/../../etc/passwd"`, which bash treats as ONE pathname,
-  # reaches the compare as the safe-looking prefix `/tmp/scratch/a`. Exempting
-  # that is precisely the one-token bypass the `/dev/null` precedent warns about.
-  # The only surviving evidence is the RAW command, so refuse the exemption when
-  # any quote or backslash appears after the first `>` in it.
+  # FAIL CLOSED on an operand whose pathname is not dependably what reaches the
+  # compare, before anything else. All three tests are keyed on the OPERAND, via
+  # the marks strip_literals attached to it (see the marking block above
+  # strip_literals) — not on the raw command.
   #
-  # STATE THE TRUE SCOPE — it is broader than "the operand" in TWO ways, and both
-  # are easy to describe more precisely than they behave:
+  #   OPAQUE  — the operand carries literal content whose value would read as
+  #             syntax, or a backslash escape this strip cannot reproduce. The
+  #             pathname is not recoverable, so no exemption may be granted:
+  #             `> "/tmp/scratch/a;/../../etc/passwd"` is ONE pathname to bash and
+  #             exempting its `/tmp/scratch/a` prefix is precisely the one-token
+  #             bypass the `/dev/null` precedent warns about.
+  #   QUOTED  — the operand was quoted at all. Its text IS recoverable here, and
+  #             this axis still refuses it: the shipped floor since 0.25.0 is that
+  #             a quoted operand is never scratch-exempt, and keeping it holds the
+  #             grant surface of this change to targets proven bare.
+  #   `\`     — a residual belt. Nothing reaching here should still carry a raw
+  #             backslash (an in-operand escape is marked OPAQUE, a single-quoted
+  #             one is marked QUOTED), and _norm_path folds `\` to `/`, so refuse
+  #             rather than compare a path that folding invented.
   #
-  #   1. NOT segment-scoped. This reads the WHOLE raw tail, not the segment being
-  #      evaluated and not the target word, so a quote anywhere later in a compound
-  #      command costs an EARLIER, unambiguous write its exemption:
-  #      `echo x > /tmp/scratch/f && grep foo "notes.txt"` blocks, even though
-  #      segment 1's target is a plain path.
-  #   2. NOT keyed on the redirect OPERATOR. `${COMMAND#*>}` splits at the first
-  #      literal `>` CHARACTER and never decides whether it is an operator, so a
-  #      `>` inside quoted CONTENT starts the tail early and that content's own
-  #      closing quote lands inside it: `echo "a > b" > /tmp/scratch/f` blocks.
-  #      Quotes before the redirect are otherwise fine — `echo "hi there" > …` is
-  #      exempt — but only while the quoted content holds no `>`.
-  #
-  # Both are deliberate and both are the safe direction: this test can only ever
-  # REFUSE an exemption, never grant one, so the failure mode is lost convenience,
-  # never a bypass. Fixing either one needs the same thing — knowing which `>` and
-  # which quotes are SYNTAX rather than CONTENT — and that is exactly the
-  # association strip_literals destroys before this code runs. Same root cause as
-  # #2226; not attempted here. Four regression tests pin these boundaries so the
-  # breadth cannot silently widen or narrow. An operator who wants the exemption
-  # keeps quotes, backslashes and `>` out of the command after the target.
-  #
-  # The same truncation reaches the `/dev/null` exemption and predates this axis;
-  # it is filed as #2226 and pinned by a control test.
-  [[ "${COMMAND#*>}" == *[\"\'\\]* ]] && return 1
+  # 0.25.0 could do none of this and read `${COMMAND#*>}` instead — any quote or
+  # backslash after the first `>` CHARACTER, anywhere in the command. That was
+  # blunt in two directions (#2236): it was not segment-scoped, so a quote in an
+  # unrelated later segment cost an earlier unambiguous write its exemption, and
+  # it was not keyed on the redirect OPERATOR, so a `>` inside quoted content
+  # started the scanned tail early. Both are gone; both narrowings GRANT the
+  # exemption where it was refused, and both land only on a target the marks prove
+  # was bare — `echo x > /tmp/scratch/f && grep foo "notes.txt"` and
+  # `echo "a > b" > /tmp/scratch/f` are exempt again.
+  ((TARGET_OPAQUE)) && return 1
+  ((TARGET_QUOTED)) && return 1
+  [[ "$target" == *\\* ]] && return 1
   _norm_path "$target" || return 1
   [[ -n "$_NORM_PATH" ]] || return 1
   norm_target="$_NORM_PATH"
@@ -668,10 +800,11 @@ cat_redirect_bypass() {
     # write. Checked before the /dev/null test so an empty value cannot fall
     # through to `return 0`.
     [[ -n "$LAST_STDOUT_TARGET" ]] || continue
-    [[ "$LAST_STDOUT_TARGET" == "/dev/null" ]] && continue
+    resolve_target_marks "$LAST_STDOUT_TARGET"
+    devnull_target_exempt && continue
     # Same left-to-right rule as the discard above: the exemption is decided on
     # the EFFECTIVE target, so `cat > /allowed/tmp/f > real.txt` still blocks.
-    scratch_target_exempt "$LAST_STDOUT_TARGET" && continue
+    scratch_target_exempt "$TARGET_TEXT" && continue
     return 0
   done < <(printf '%s\n' "$NORMALIZED_SEGMENTS") # not <<<: a >=64KiB here-string deadlocks (see hardcoded-path-patterns.sh)
   return 1
@@ -740,10 +873,11 @@ producer_redirect_bypass() {
     # file operand, nothing to block" rather than re-blocking a dup if the two
     # target classes ever drift apart again.
     [[ -n "$LAST_STDOUT_TARGET" ]] || continue
-    [[ "$LAST_STDOUT_TARGET" == "/dev/null" ]] && continue
+    resolve_target_marks "$LAST_STDOUT_TARGET"
+    devnull_target_exempt && continue
     # Mirror of the cat lane, and for the same reason: decided on the EFFECTIVE
     # target, so `echo x > /allowed/tmp/f > real.txt` still blocks.
-    scratch_target_exempt "$LAST_STDOUT_TARGET" && continue
+    scratch_target_exempt "$TARGET_TEXT" && continue
     return 0
   done < <(printf '%s\n' "$NORMALIZED_SEGMENTS") # not <<<: a >=64KiB here-string deadlocks (see hardcoded-path-patterns.sh)
   return 1

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -873,12 +873,13 @@ run "scratch: case-insensitive compare (documented residual, allowed)" \
   "echo hello > /tmp/SCRATCH/f" 0 "$SCRATCH_ENV=/tmp/scratch"
 
 # TRUNCATED-OPERAND FAIL-CLOSED. strip_literals keeps a quoted write target but
-# drops its quotes, and normalize_segments then resolves a `;`, `|`, `&`,
-# newline or space inside that operand as SYNTAX — so a quoted pathname reaches
-# the compare as a safe-looking prefix of itself. bash treats the whole
+# drops its quotes, and before 0.26.0 normalize_segments then resolved a `;`,
+# `|`, `&`, newline or space inside that operand as SYNTAX — so a quoted pathname
+# reached the compare as a safe-looking prefix of itself. bash treats the whole
 # quoted word as one pathname, so exempting the prefix would be a one-token
-# bypass. The scratch axis therefore refuses to exempt any quoted or escaped
-# operand.
+# bypass. The operand now carries an OPAQUE mark over each such character and
+# survives as one token (#2226); this axis refuses any operand that is opaque,
+# and — its shipped floor, unchanged — any operand that was quoted at all.
 run "scratch: quoted operand with ; is not exempted (blocked)" \
   "echo x > \"/tmp/scratch/a;/../../etc/passwd\"" 2 "$SCRATCH_ENV=/tmp/scratch"
 run "scratch: quoted operand with | is not exempted (blocked)" \
@@ -895,27 +896,31 @@ run "scratch: even a benign quoted target is not exempted (blocked)" \
 # exemption — as long as the quoted content holds no `>`; see the pair below.
 run "scratch: quoted content, unquoted target (allowed)" \
   "echo \"hello world\" > /tmp/scratch/f" 0 "$SCRATCH_ENV=/tmp/scratch"
-# THE BREADTH, pinned rather than left to drift. It is blunt in TWO directions
-# and both sides of each boundary are asserted, so a later change cannot quietly
-# widen or narrow either. Both are one-directional — the check can only refuse an
-# exemption, never grant one — and making either precise needs to know which `>`
-# and which quotes are syntax rather than content, which is exactly what
-# strip_literals destroys before this runs (#2226).
+# THE BREADTH THAT WAS, still pinned on both sides — but the verdicts moved in
+# 0.26.0 and these four assertions are where that is visible. 0.25.x could not
+# tell operand quotes from content quotes, so it read `${COMMAND#*>}` and refused
+# the exemption on ANY quote or backslash after the first `>` CHARACTER anywhere
+# in the command (#2236). The operand marks supply that association, so the test
+# is keyed on the target word instead and both shapes below are exempt again.
+# Each is a GRANT, and each lands only on a target the marks prove was bare — no
+# quote mark, no opaque mark, no backslash.
 #
-# (1) NOT segment-scoped: a quote in an unrelated LATER segment cancels the
-#     exemption for an earlier, unambiguous write.
-run "scratch: quote in an unrelated later segment cancels it (blocked)" \
-  "echo x > /tmp/scratch/f && grep foo \"notes.txt\"" 2 "$SCRATCH_ENV=/tmp/scratch"
+# (1) Segment-scoped now: a quote in an unrelated LATER segment is that segment's
+#     business. Segment 1's target is a plain path strictly under the root.
+run "scratch: quote in an unrelated later segment keeps it (allowed)" \
+  "echo x > /tmp/scratch/f && grep foo \"notes.txt\"" 0 "$SCRATCH_ENV=/tmp/scratch"
 run "scratch: the same compound with no quotes keeps it (allowed)" \
   "echo x > /tmp/scratch/f && grep foo notes.txt" 0 "$SCRATCH_ENV=/tmp/scratch"
-# (2) NOT keyed on the redirect OPERATOR: `${COMMAND#*>}` splits at the first `>`
-#     CHARACTER, so a `>` inside quoted CONTENT starts the tail early and that
-#     content's own closing quote lands inside it. This is the case the 0.25.0
-#     text got backwards by promising that quotes before the redirect are safe.
-run "scratch: > inside double-quoted content cancels it (blocked)" \
-  "echo \"a > b\" > /tmp/scratch/f" 2 "$SCRATCH_ENV=/tmp/scratch"
-run "scratch: > inside single-quoted content cancels it (blocked)" \
-  "echo 'x > y' > /tmp/scratch/f" 2 "$SCRATCH_ENV=/tmp/scratch"
+run "scratch: quote in a later ;-segment keeps it (allowed)" \
+  "echo x > /tmp/scratch/f; cat \"notes.txt\"" 0 "$SCRATCH_ENV=/tmp/scratch"
+# (2) Keyed on the redirect OPERAND now: a `>` inside quoted CONTENT is content,
+#     and that content's quotes are the content's own. strip_literals drops the
+#     whole span — the same quote tracking every other lane of this guard already
+#     relies on to keep quoted prose inert.
+run "scratch: > inside double-quoted content keeps it (allowed)" \
+  "echo \"a > b\" > /tmp/scratch/f" 0 "$SCRATCH_ENV=/tmp/scratch"
+run "scratch: > inside single-quoted content keeps it (allowed)" \
+  "echo 'x > y' > /tmp/scratch/f" 0 "$SCRATCH_ENV=/tmp/scratch"
 # --- Redirect-operand marking (#2226) ---------------------------------------
 # THE REPORTED BYPASS AND ITS FAMILY. A quoted redirect operand is one pathname
 # to bash. Until 0.26.0 the exemptions were decided on its first whitespace- or

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -875,9 +875,10 @@ run "scratch: case-insensitive compare (documented residual, allowed)" \
 # TRUNCATED-OPERAND FAIL-CLOSED. strip_literals keeps a quoted write target but
 # drops its quotes, and normalize_segments then resolves a `;`, `|`, `&`,
 # newline or space inside that operand as SYNTAX — so a quoted pathname reaches
-# the compare as a safe-looking prefix of itself. bash treats the whole quoted
-# word as one pathname, so exempting the prefix would be a one-token bypass.
-# The scratch axis therefore refuses to exempt any quoted or escaped operand.
+# the compare as a safe-looking prefix of itself. bash treats the whole
+# quoted word as one pathname, so exempting the prefix would be a one-token
+# bypass. The scratch axis therefore refuses to exempt any quoted or escaped
+# operand.
 run "scratch: quoted operand with ; is not exempted (blocked)" \
   "echo x > \"/tmp/scratch/a;/../../etc/passwd\"" 2 "$SCRATCH_ENV=/tmp/scratch"
 run "scratch: quoted operand with | is not exempted (blocked)" \
@@ -915,11 +916,87 @@ run "scratch: > inside double-quoted content cancels it (blocked)" \
   "echo \"a > b\" > /tmp/scratch/f" 2 "$SCRATCH_ENV=/tmp/scratch"
 run "scratch: > inside single-quoted content cancels it (blocked)" \
   "echo 'x > y' > /tmp/scratch/f" 2 "$SCRATCH_ENV=/tmp/scratch"
-# Control: the SAME truncation reaches the /dev/null exemption and predates this
-# axis, which is why it is filed as #2226 rather than fixed here. Pinned so a
-# future strip_literals fix flips it visibly.
-run "control: /dev/null still shows the inherited truncation (#2226, allowed)" \
-  "echo x > \"/dev/null;/../../etc/passwd\"" 0
+# --- Redirect-operand marking (#2226) ---------------------------------------
+# THE REPORTED BYPASS AND ITS FAMILY. A quoted redirect operand is one pathname
+# to bash. Until 0.26.0 the exemptions were decided on its first whitespace- or
+# separator-delimited fragment, so `> "/dev/null ../../etc/pw"` was exempted on
+# the word `/dev/null` while nothing named `/dev/null` was the destination. The
+# operand now carries an opaque mark over every character whose literal value
+# would read as syntax, and survives the strip and the segment split as ONE
+# token, so no fragment of it can stand in for the whole.
+#
+# The DISCARD lane. Every one of these is allowed at 0.25.3 unless noted.
+run "#2226: quoted /dev/null + space fragment (blocked)" \
+  "echo x > \"/dev/null ../../etc/pw\"" 2
+run "#2226: quoted /dev/null + ; fragment (blocked)" \
+  "echo x > \"/dev/null;/../../etc/passwd\"" 2
+run "#2226: quoted /dev/null + | fragment (blocked)" \
+  "echo x > \"/dev/null|/../../etc/passwd\"" 2
+run "#2226: quoted /dev/null + & fragment (blocked)" \
+  "echo x > \"/dev/null&/../../etc/passwd\"" 2
+run "#2226: quoted /dev/null + parens (blocked)" \
+  "echo x > \"/dev/null(a)/../../etc/pw\"" 2
+# A backslash inside a DOUBLE-quoted operand: bash keeps the backslash here, this
+# strip cannot, so the pair is opaque rather than guessed at.
+run "#2226: double-quoted /dev/null + backslash escape (blocked)" \
+  "echo x > \"/dev/null\\ ../../etc/pw\"" 2
+run "#2226: single-quoted /dev/null + space fragment (blocked)" \
+  "echo x > '/dev/null ../../etc/pw'" 2
+run "#2226: partially-quoted /dev/null + space fragment (blocked)" \
+  "echo x > /dev/\"null ../../etc/pw\"" 2
+# The same truncation via an UNQUOTED escape. `\;` reached normalize_segments'
+# escaped-separator sentinel and was restored to a space, cutting the operand.
+run "#2226: unquoted escaped ; in a /dev/null operand (blocked)" \
+  "echo x > /dev/null\\;/../../etc/passwd" 2
+run "#2226: unquoted escaped space in a /dev/null operand (blocked)" \
+  "echo x > /dev/null\\ ../../etc/pw" 2
+# fd-numbered stdout spelling, the cat lane, and redirect ordering all reach the
+# same decision, so all three carry the shape.
+run "#2226: 1> fd-numbered quoted operand (blocked)" \
+  "echo x 1>\"/dev/null ../../etc/pw\"" 2
+run "#2226: cat lane, quoted operand (blocked)" \
+  "cat > \"/dev/null ../../etc/pw\"" 2
+run "#2226: quoted operand then real file (blocked)" \
+  "echo x > \"/dev/null ../x\" > real.txt" 2
+run "#2226: real file then quoted operand (blocked)" \
+  "echo x > real.txt > \"/dev/null ../x\"" 2
+# A quoted operand spanning physical lines, and an operand continued by a
+# backslash-newline: bash keeps both as one word, so the mark must too.
+DEVNULL_MULTILINE=$(printf 'echo x > "/dev/null\n../../etc/pw"')
+run "#2226: multi-line quoted operand (blocked)" "$DEVNULL_MULTILINE" 2
+DEVNULL_CONTINUED=$(printf 'echo x > /dev/null\\\n../../etc/pw')
+run "#2226: operand continued by backslash-newline (blocked)" "$DEVNULL_CONTINUED" 2
+# A raw sentinel byte in the command text must never pass for a mark this strip
+# emitted — the quote mark is stripped before the discard compare, so a forged
+# one would otherwise make `/dev/<EOT>null` compare equal to `/dev/null`.
+DEVNULL_FORGED=$(printf 'echo x > /dev/\x04null')
+run "#2226: forged quote-mark byte in the target (blocked)" "$DEVNULL_FORGED" 2
+DEVNULL_FORGED_OPAQUE=$(printf 'echo x > /dev/\x03null')
+run "#2226: forged opaque-mark byte in the target (blocked)" "$DEVNULL_FORGED_OPAQUE" 2
+# An empty quoted operand is not a discard and is not a path; it blocks.
+run "#2226: empty quoted target (blocked)" "echo x > \"\"" 2
+# THE FRICTION FLOOR. An unambiguous quoted or partially-quoted discard is still
+# a discard — the quote mark is transparent to this compare, deliberately, so
+# the fix costs no ordinary /dev/null usage. (Also pinned above, kept adjacent
+# here because it is the boundary the marking must not cross.)
+run "#2226: unambiguous quoted /dev/null stays a discard (allowed)" \
+  "echo x > \"/dev/null\"" 0
+run "#2226: unambiguous partially-quoted /dev/null stays a discard (allowed)" \
+  "cat > /dev/\"null\"" 0
+# The stderr/fd lanes never resolved a stdout target and must not start now.
+run "#2226: 2> quoted operand is not a stdout write (allowed)" \
+  "echo x 2>\"/dev/null a\"" 0
+
+# THE SCRATCH LANE, same shapes. These already blocked at 0.25.3 via the
+# whole-command fail-close; they must keep blocking on the operand-keyed rule
+# that replaced it, otherwise the narrowing below traded a bypass for a fix.
+run "#2226: scratch, quoted operand with > inside (blocked)" \
+  "echo x > \"/tmp/scratch/a>real.txt\"" 2 "$SCRATCH_ENV=/tmp/scratch"
+run "#2226: scratch, unquoted escaped ; in the operand (blocked)" \
+  "echo x > /tmp/scratch/a\\;/../../etc/passwd" 2 "$SCRATCH_ENV=/tmp/scratch"
+SCRATCH_CONTINUED=$(printf 'echo x > /tmp/scratch/a\\\n../../etc/passwd')
+run "#2226: scratch, operand continued by backslash-newline (blocked)" \
+  "$SCRATCH_CONTINUED" 2 "$SCRATCH_ENV=/tmp/scratch"
 
 # The exemption is target-scoped only — it must not relax the producer axis.
 run "scratch: python3 -c write into an exempt root still blocks" \

--- a/plugins/guardrails/hooks/block-hook-bypass.test.sh
+++ b/plugins/guardrails/hooks/block-hook-bypass.test.sh
@@ -897,13 +897,15 @@ run "scratch: even a benign quoted target is not exempted (blocked)" \
 run "scratch: quoted content, unquoted target (allowed)" \
   "echo \"hello world\" > /tmp/scratch/f" 0 "$SCRATCH_ENV=/tmp/scratch"
 # THE BREADTH THAT WAS, still pinned on both sides — but the verdicts moved in
-# 0.26.0 and these four assertions are where that is visible. 0.25.x could not
-# tell operand quotes from content quotes, so it read `${COMMAND#*>}` and refused
-# the exemption on ANY quote or backslash after the first `>` CHARACTER anywhere
-# in the command (#2236). The operand marks supply that association, so the test
-# is keyed on the target word instead and both shapes below are exempt again.
-# Each is a GRANT, and each lands only on a target the marks prove was bare — no
-# quote mark, no opaque mark, no backslash.
+# 0.26.0 and these four cases are where that is visible. 0.25.x could not tell
+# operand quotes from content quotes, so it read `${COMMAND#*>}` and refused the
+# exemption on ANY quote or backslash after the first `>` CHARACTER anywhere in
+# the command (#2236). The operand marks supply that association, so the test is
+# keyed on the target word instead and both shapes below are exempt again.
+# FOUR of the five assertions here are GRANTS — blocked at 0.25.3, allowed now —
+# and they are the ENTIRE grant surface of the #2226 fix. Each lands only on a
+# target the marks prove was bare: no quote mark, no opaque mark, no backslash.
+# The fifth (the unquoted compound) was already allowed and is the control.
 #
 # (1) Segment-scoped now: a quote in an unrelated LATER segment is that segment's
 #     business. Segment 1's target is a plain path strictly under the root.


### PR DESCRIPTION
## Summary

A quoted redirect operand is **one pathname** to bash. `block-hook-bypass` decided its target-based
exemptions on that operand's first whitespace- or separator-delimited **fragment**, because the two
pieces of machinery either side of the decision disagree about what a kept operand is:
`strip_literals` **keeps** a quoted write target as literal content (dropping the quotes, so a quoted
target still reads as a write) while `normalize_segments` then reads a `;`, `|`, `&`, `(`, `)` or
newline *inside* it as a segment boundary, and `_redir_scan`'s target class ends at whitespace.

So the `/dev/null` discard — the only target exemption that is on by default — fired for writes whose
destination was not `/dev/null`. Measured at `56f5cd21` (0.25.3), hook invoked as a decision function
on a `PreToolUse` Bash payload:

```
rc=0 :: echo x > "/dev/null ../../etc/pw"        # the reported bypass — exempted on the word /dev/null
rc=0 :: echo x > "/dev/null;/../../etc/passwd"
rc=0 :: echo x > "/dev/null|/../../etc/passwd"
rc=0 :: echo x > '/dev/null ../../etc/pw'
rc=0 :: echo x > /dev/"null ../../etc/pw"
rc=0 :: echo x > /dev/null\;/../../etc/passwd    # the UNQUOTED escaped spelling, via \x02 to space
rc=0 :: cat > "/dev/null ../../etc/pw"           # the cat lane
rc=2 :: echo x > "/tmp/scratch/a ../../etc/pw"   # control: the scratch axis already fails closed
```

Reaching a *chosen* file this way needs a directory whose name ends in the whitespace-bearing
fragment to already exist, so this is correctness and defence-in-depth rather than a demonstrated
escape. It matters because it is the exact assumption every target-based exemption rests on, and this
guard now has two.

### The mechanism

`strip_literals` marks a kept operand's literal content with two sentinels:

- `\x03` **OPAQUE** — one character whose literal value would read as syntax downstream, or a
  backslash escape this strip cannot reproduce faithfully (inside double quotes bash *retains* the
  backslash unless it escapes `$`, a backtick, `"`, `\` or a newline — the old code dropped it and
  kept the escaped char, which is wrong). Inert to every scan, so the operand survives as **one
  token**; its presence means the pathname is not recoverable here, so **no exemption of any kind may
  be granted**.
- `\x04` **QUOTED** — emitted where a kept span opens. The discard compare strips it, so
  `> "/dev/null"` is still a discard; the scratch axis keeps its shipped floor of never exempting a
  quoted operand.

A raw `\x01`–`\x04` byte arriving in the command text is mapped to OPAQUE, so a forged sentinel can
only ever *cost* an exemption, never manufacture one.

**Every mark is gated on `_in_redirect_operand`** — the same "this word began right after a `>`" test
the quoted-operand keep already used, now factored out and also applied to the unquoted backslash
branch. That gating is load-bearing, not tidiness: `normalize_segments`, `_producer_head`,
`_cat_redir` and every whitespace trim in the file are **byte-for-byte as shipped**, so an escaped
separator *between* commands (`echo x \; > f`) still travels the unchanged `\x02`-to-space path and a
backslash in a command word (`/c/Python313/python3.exe -c`) is untouched.

### Both consumers, as the issue asks

With the association restored, `scratch_target_exempt` no longer has to infer it from
`${COMMAND#*>}`. The fail-close is keyed on the operand's own marks, which **retires both blunt edges
#2236 documented and #2235 pinned** — it is segment-scoped now, and it is keyed on the operand rather
than on the first literal `>` character. All four surfaces #2235 corrected move together again: the
hook comment, the CHANGELOG, the README caveat paragraph, and the manifest's option description
(README options table regenerated by `sync-plugin-options-docs.py`).

### Constraint 5 — direction of every moved verdict

Refusing an exemption is friction; granting one is a bypass. Counted mechanically from the new suite
run against `origin/main`'s hook below, which reports 19 failures splitting **15 / 4** by direction:

```
$ … | grep '^FAIL' | awk -F'expected exit ' '{print $2}' | sort | uniq -c
      4 0, got 2      <- moves to GRANTED
     15 2, got 0      <- moves to REFUSED
```

- **REFUSES (security-positive), 15 shapes.** The `/dev/null` family above in its quoted,
  single-quoted, partially-quoted, escaped, fd-numbered (`1>`), `cat`-lane and
  real-file-then-operand spellings; a multi-line quoted operand; an operand continued by a
  backslash-newline; an empty quoted target (`> ""`, previously allowed, now blocks).
- **GRANTS (the entire grant surface), 4 shapes.** `echo x > /tmp/scratch/f && grep foo "notes.txt"`,
  `echo x > /tmp/scratch/f; cat "notes.txt"`, `echo "a > b" > /tmp/scratch/f`, and
  `echo 'x > y' > /tmp/scratch/f`. Each lands only on a target the marks **prove** was bare — no
  quote mark, no opaque mark, no backslash — using the same quote tracking every other lane of this
  guard already relies on to keep quoted prose inert. These are exactly the frictions #2235
  documented as lost convenience.
- **In neither set:** a forged sentinel byte and an escaped-space operand
  (`> /dev/null\ ../../etc/pw`) already blocked at 0.25.3. They are pinned here as regression guards,
  not flips — the marking must not *stop* them blocking.
- **Deliberately NOT widened.** The scratch axis still refuses a merely quoted operand
  (`> "/tmp/scratch/f"`) even though the pathname is now known precisely. Widening it would be a
  grant with no reported need, and keeping it leaves #2224's "even a benign quoted target is not
  exempted" assertion untouched.

Two commit messages on this branch (`eba2ee6f`, `f775974b`) state these as 19/3 and describe the
`;`-compound as "added rather than flipped". Both were miscounted against the run above and are
corrected here and in the CHANGELOG; the numbers in this section are the ones that hold.

### Shared machinery — #1680 and #1667 (constraint 3)

Both read this file's normalization. **Measured, not reasoned:** their shapes carry no quotes and no
backslashes, so no mark is ever emitted for them, and the code they concern (`normalize_segments`'s
`>&` / `<&` / `&>` sentinel and its `\&` restore, `_echo_file_out`'s leading class) is unchanged.
Before and after on this branch, identical in both columns:

```
rc=0 :: echo x >&2              rc=0 :: echo x 2>&1
rc=0 :: printf '%s' x >&2       rc=0 :: echo x >&2>file
rc=0 :: echo x &>realfile.txt   rc=0 :: cat 1>&2
rc=0 :: echo x 1>&2             rc=0 :: cat 1>&-
```

Neither issue moves in either direction; neither is fixed by this PR.

`guardrails` 0.25.3 → **0.26.0** (minor: what is exempted changes in both directions). The 0.25.0 and
0.25.1 entries are left as they shipped; 0.25.1 gains an erratum pointer inside it, mirroring the one
0.25.0 already carries.

## Test plan

**Adversarial-first: the tests were written and committed before the fix** (`bb937fec`), then the
deliberate assertion flips in their own commit (`f775974b`), then the fix (`eba2ee6f`).

The new suite run against **`origin/main`'s hook at `56f5cd21`** (same test file, main's
`plugins/guardrails` extracted with `git archive`) — 19 real failures:

```
FAIL: scratch: quote in an unrelated later segment keeps it (allowed): expected exit 0, got 2
FAIL: scratch: quote in a later ;-segment keeps it (allowed): expected exit 0, got 2
FAIL: scratch: > inside double-quoted content keeps it (allowed): expected exit 0, got 2
FAIL: scratch: > inside single-quoted content keeps it (allowed): expected exit 0, got 2
FAIL: #2226: quoted /dev/null + space fragment (blocked): expected exit 2, got 0
FAIL: #2226: quoted /dev/null + ; fragment (blocked): expected exit 2, got 0
FAIL: #2226: quoted /dev/null + | fragment (blocked): expected exit 2, got 0
FAIL: #2226: quoted /dev/null + & fragment (blocked): expected exit 2, got 0
FAIL: #2226: quoted /dev/null + parens (blocked): expected exit 2, got 0
FAIL: #2226: double-quoted /dev/null + backslash escape (blocked): expected exit 2, got 0
FAIL: #2226: single-quoted /dev/null + space fragment (blocked): expected exit 2, got 0
FAIL: #2226: partially-quoted /dev/null + space fragment (blocked): expected exit 2, got 0
FAIL: #2226: unquoted escaped ; in a /dev/null operand (blocked): expected exit 2, got 0
FAIL: #2226: 1> fd-numbered quoted operand (blocked): expected exit 2, got 0
FAIL: #2226: cat lane, quoted operand (blocked): expected exit 2, got 0
FAIL: #2226: real file then quoted operand (blocked): expected exit 2, got 0
FAIL: #2226: multi-line quoted operand (blocked): expected exit 2, got 0
FAIL: #2226: operand continued by backslash-newline (blocked): expected exit 2, got 0
FAIL: #2226: empty quoted target (blocked): expected exit 2, got 0
PASS=314 FAIL=19
```

The same suite on this branch:

```
$ bash plugins/guardrails/hooks/block-hook-bypass.test.sh
PASS=333 FAIL=0
```

**What moved in the inherited assertions, stated exactly.** #2224's 36 scratch-axis assertions and
#2235's boundary tests all still pass unmodified, with two exceptions:

- **Three of #2235's four boundary tests flipped** 2 → 0 (the two quote-in-a-later-segment shapes and
  the two `>`-inside-quoted-content shapes; the unquoted compound is unchanged and stays as the
  control). They are re-pinned in `f775974b`, on their own, with the reasoning in the message — a
  fourth grant, the `;`-separated compound #2236 reported and nothing covered, is added there too.
- **One of #2224's 36 is RETIRED, not flipped:**
  `control: /dev/null still shows the inherited truncation (#2226, allowed)`. #2224 wrote that
  assertion for exactly this moment — its PR body says it is "pinned here by a control test that
  flips visibly when it is fixed" — so retiring it is that PR's own instruction, not a silent
  loosening. It is replaced by six `/dev/null` assertions covering the whole family rather than just
  its `;` spelling. It went out in `bb937fec` alongside the new tests rather than in its own commit;
  that is a process miss on my part and is called out here so a reviewer does not have to find it.

Gates, run locally in the worktree:

```
$ shellcheck --rcfile=.shellcheckrc -x plugins/guardrails/hooks/block-hook-bypass.sh \
    plugins/guardrails/hooks/block-hook-bypass.test.sh
shellcheck CLEAN

$ bash scripts/check-shell-portability.sh --paths \
    plugins/guardrails/hooks/block-hook-bypass.sh plugins/guardrails/hooks/block-hook-bypass.test.sh
No unexcused GNU-only constructs in 2 shell file(s).

$ python3 scripts/sync-plugin-options-docs.py --check
plugin options docs: up to date

$ bash scripts/check-changelog-parity.sh --check
Every versioned plugin has a CHANGELOG.md (or a stale-guarded baseline entry), and none documents a version above its manifest.

$ bash scripts/check-changelog-parity.sh --check-order
All 75 changelog(s) read newest-first with no duplicate versions.

$ bash scripts/check-changelog-parity.sh --check-bump origin/main
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.

$ npx markdownlint-cli2 plugins/guardrails/CHANGELOG.md plugins/guardrails/README.md
Summary: 0 issues in 0 files
```

Security-review note: this change **narrows** the guard's trust surface on net. It adds no hook, no
grant, and no external read or write. Its grant direction is four shapes, each on a target proven
bare, listed above.

Cost note, since this file deliberately refuses forks and calls out a quadratic term 0.21.0 removed:
`_in_redirect_operand` is the same `${out%…}` pair the quoted-operand keep already ran per quote
character, but it now also runs per **unquoted backslash**, and it scans all of `out`. A
Windows-path-heavy command has more backslashes than quotes, so that is a real (small, string-op,
fork-free) addition to the per-call cost rather than a pure refactor.

## Related

Closes #2226 — `block-hook-bypass` exempts a quoted redirect target on its first word only.

Follows up #2224 (merged, 0.25.0 — the scratch-root axis that surfaced this and pinned the
`/dev/null` half with a control test that this PR flips) and #2235 / #2236 (merged, 0.25.1 — the
scope-accuracy correction whose two documented blunt edges this PR retires).

Related, and deliberately **not** moved: **#1680** and **#1667**, the other defects in this file's
normalization machinery. Measured before and after with no delta, evidence above.
Adjacent, not addressed: **#547** (the guard-precision class issue).

Origin: handoff-inbox batch 4, lane owning `guardrails`. #2226 was filed from implementation work on
#2210 / #2224, not from a ledger row.