### PR TITLE
fix(claude-config): tighten check-structure unreadable note

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.33.1]
+
+### Fixed
+
+- **`check-structure.sh` unreadable note no longer overstates a bare Read deny.** The note now
+  matches `context/procedures.md` and `SKILL.md`: a `Read(...)` deny alone cannot make `open()`
+  fail inside this script; sandbox `denyRead` — including a Read deny merged into the sandbox
+  boundary — or filesystem permissions can. (#1607)
+
 ## [0.33.0]
 
 ### Changed

--- a/plugins/claude-config/skills/audit/scripts/check-structure.sh
+++ b/plugins/claude-config/skills/audit/scripts/check-structure.sh
@@ -94,10 +94,10 @@ emit_file_facts() {
     return 0
   fi
   printf 'Present: yes\n'
-  # A read that fails is NOT invalid JSON. A Read deny rule, a sandbox denyRead
-  # path, or plain filesystem permissions all make open() fail here, and
-  # reporting that as malformed config would be a false finding. Distinguish it
-  # and report the file as not inspectable instead.
+  # A read that fails is NOT invalid JSON. Sandbox denyRead — including a Read
+  # deny merged into the sandbox boundary — or plain filesystem permissions all
+  # make open() fail here, and reporting that as malformed config would be a
+  # false finding. Distinguish it and report the file as not inspectable instead.
   #
   # `: <"$path"` opens the file and discards it — an open() probe that never
   # reads a byte. Deliberately not `content=$(…)`: holding the file in a shell
@@ -107,7 +107,7 @@ emit_file_facts() {
     printf 'Readable: no\n'
     printf 'Valid JSON: n/a\n'
     printf 'Top-level keys: n/a\n'
-    printf 'Note: present but unreadable — not inspectable (deny rule, sandbox denyRead, or filesystem permissions). Not a malformed-config finding.\n'
+    printf 'Note: present but unreadable — not inspectable (sandbox denyRead — including a Read deny merged into the sandbox boundary — or filesystem permissions). Not a malformed-config finding.\n'
     return 0
   fi
   if ! tr -d '\r' <"$path" | jq empty 2>/dev/null; then


### PR DESCRIPTION
Fixes #1607

The `check-structure.sh` unreadable-file note no longer lists a bare `Read(...)` deny as a cause. A Read deny alone cannot make `open()` fail inside this script (the arbitrary-subprocess carve-out from #1599); sandbox `denyRead` — including a Read deny merged into the sandbox boundary — or filesystem permissions can.

## Related

- #1599