### PR TITLE
docs: update claude-security-paths header for gitignore semantics

### DIFF
--- a/.github/claude-security-paths
+++ b/.github/claude-security-paths
@@ -1,8 +1,9 @@
 # Repo-owned security-review scope: this repo's security-sensitive surfaces,
 # read by the ci-workflows claude-security-review reusable workflow via its
 # `paths-file` input from the PR's BASE branch. An absent file FAILS OPEN
-# (every PR reviewed). Format: GitHub Actions `paths:` patterns, one per line;
-# `#` comments and blank lines are ignored.
+# (every PR reviewed). Format: root-anchored gitignore patterns (one per line),
+# matched via `git check-ignore`; `!`, `?`, and `+` are forbidden and fail the
+# security lane closed. `#` comments and blank lines are ignored.
 .github/**
 .claude/**
 scripts/**

--- a/.github/claude-security-paths
+++ b/.github/claude-security-paths
@@ -1,8 +1,8 @@
 # Repo-owned security-review scope: this repo's security-sensitive surfaces,
 # read by the ci-workflows claude-security-review reusable workflow via its
 # `paths-file` input from the PR's BASE branch. An absent file FAILS OPEN
-# (every PR reviewed). Format: root-anchored gitignore patterns (one per line),
-# matched via `git check-ignore`; `!`, `?`, and `+` are forbidden and fail the
+# (every PR reviewed). Format: gitignore patterns (one per line), matched via
+# `git check-ignore` from the repo root; `!`, `?`, and `+` are forbidden and fail the
 # security lane closed. `#` comments and blank lines are ignored.
 .github/**
 .claude/**


### PR DESCRIPTION
Fixes #1995

Since the ci-workflows v0.10.2 repin (#1990), `.github/claude-security-paths` is matched as root-anchored gitignore patterns via `git check-ignore`, not GitHub Actions `paths:` syntax. The header now states gitignore semantics and that `!`, `?`, and `+` are forbidden.

## Related

- #1990