### PR TITLE
fix(scripts): gate changelog sections a change set deletes (#2264)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,9 +500,10 @@ jobs:
         run: scripts/check-orphaned-fixtures.sh --check
 
   # CHANGELOG parity: a versioned plugin must keep a CHANGELOG.md whose newest
-  # version heading does not outrun the manifest (static --check), and a PR that
+  # version heading does not outrun the manifest (static --check), a PR that
   # changes a plugin's manifest version must update that plugin's CHANGELOG.md in
-  # the same diff (--check-bump, PR-only). Existing
+  # the same diff (--check-bump, PR-only), and no PR may DROP a version heading a
+  # changelog already carried (--check-preserved, PR-only). Existing
   # "versioned but changelog-less" debt is grandfathered by name in
   # scripts/changelog-parity-baseline.txt with a stale guard; the bump gate is
   # never relaxed by the baseline. The self-test runs unconditionally so a broken
@@ -526,6 +527,15 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: scripts/check-changelog-parity.sh --check-bump "origin/$BASE_REF"
+      # The other half of the same PR discipline: the bump gate polices what a
+      # change set ADDS and never what it REMOVES, so a merge-forward that writes
+      # the new release under the PREVIOUS release's heading deletes a released
+      # section with no conflict marker and no gate to catch it (#2264).
+      - name: Verify no changed changelog drops a version heading it carried at the fork point
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: scripts/check-changelog-parity.sh --check-preserved "origin/$BASE_REF"
       # Whole-file, not per-diff: the other two modes reason about one version at
       # a time, so neither can see that two branches staged the same number or
       # that a stale-based entry landed below one already on main.

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -19,8 +19,14 @@
 #                                                         or the new version is
 #                                                         not strictly greater
 #                                                         than the one at <ref>
+#   scripts/check-changelog-parity.sh --check-preserved <ref>
+#                                                         fail if a changelog
+#                                                         this change set touched
+#                                                         DROPS a `## [<v>]`
+#                                                         entry it carried at the
+#                                                         fork point
 #
-# Two complementary gaps the same audit surfaced:
+# Three complementary gaps the same audit surfaced:
 #   * --check is the static repo-wide invariant: a plugins/<name>/.claude-plugin/
 #     plugin.json carrying a `version` must ship a plugins/<name>/CHANGELOG.md.
 #     It catches a plugin that has bumped versions but never kept a changelog at
@@ -50,6 +56,23 @@
 #     regress a version main has already moved past nor collide on a number
 #     another change set claimed first (see the VERSION REGRESSION / VERSION
 #     COLLISION checks below).
+#   * --check-preserved is the other half of that PR discipline: the bump gate
+#     polices what a change set ADDS and never what it REMOVES, so a released
+#     section could be deleted — its notes absorbed into the new release — with
+#     all three other modes green (claude-code-plugins#2264). --check-bump asks
+#     only about the bumped version, --check-order reads a gap in the sequence as
+#     correctly ordered, and --check compares the manifest against the changelog
+#     MAXIMUM. The live producer is a concurrent bump: when two change sets bump
+#     one plugin, git's conflict region tends to open BELOW the newest heading,
+#     so a plausible merge-forward resolution writes both releases under a single
+#     heading — or RELABELS the older heading to the new version — and leaves no
+#     conflict marker behind to catch it. Deletion is never the correct treatment
+#     of a yanked release either: Keep a Changelog keeps the heading and marks it
+#     `## [0.0.5] - 2014-12-13 [YANKED]`, which this gate reads as preserved.
+#     There is deliberately no exemption list — the two removals an author might
+#     reach for both have a legal non-deleting form (mark it [YANKED]; bump the
+#     manifest up to a premature entry rather than folding it away), so a hatch
+#     would only ever silence the defect it exists to catch.
 #
 # Existing "versioned but changelog-less" debt is grandfathered by plugin NAME in
 # scripts/changelog-parity-baseline.txt (same stale-guarded idiom as
@@ -68,9 +91,9 @@ BASELINE="${CHANGELOG_PARITY_BASELINE:-scripts/changelog-parity-baseline.txt}"
 
 mode="${1:-}"
 case "$mode" in
---check | --check-bump | --check-order) ;;
+--check | --check-bump | --check-order | --check-preserved) ;;
 *)
-  echo "usage: $(basename "$0") [--check | --check-bump <base-ref> | --check-order]" >&2
+  echo "usage: $(basename "$0") [--check | --check-bump <base-ref> | --check-order | --check-preserved <base-ref>]" >&2
   exit 2
   ;;
 esac
@@ -305,9 +328,13 @@ if [[ "$mode" == "--check" ]]; then
   exit 0
 fi
 
-# --check-bump mode
+# ===================== the two diff modes: shared prologue ==================
+# --check-bump and --check-preserved both reason about what THIS change set did
+# to a file, so both need the same three things resolved the same way: the base
+# ref, the fork point, and the change set's own touched paths. Resolved once so
+# the two modes cannot drift into reading the diff differently.
 if [[ -z "${2:-}" ]]; then
-  echo "usage: $(basename "$0") --check-bump <base-ref>" >&2
+  echo "usage: $(basename "$0") $mode <base-ref>" >&2
   exit 2
 fi
 base="$2"
@@ -329,6 +356,10 @@ fi
 # plugin-root scoping) a cosmetic touch elsewhere under the plugin dir cannot pull
 # a main-only advance back into scope.
 declare -A bumped_candidate
+# The changelogs this change set touched, in `git diff` order, for
+# --check-preserved. Same two roots --check-order sweeps.
+touched_changelogs=()
+declare -A seen_changelog
 # Read the change set's touched paths via COMMAND substitution, not process
 # substitution: this gate is a required CI merge check, and a git failure here
 # must fail loud, never silently pass. Process substitution swallows git's exit
@@ -364,10 +395,105 @@ while IFS= read -r path; do
     rest="${path#plugins/}"
     bumped_candidate["${rest%%/*}"]=1
     ;;
+  plugins/*/CHANGELOG.md | docs/conventions/*/CHANGELOG.md)
+    # A `case` glob's `*` spans `/`, so the depth is re-checked explicitly: only
+    # a changelog exactly one directory below a root is in scope, never one
+    # nested deeper inside a plugin.
+    rest="${path#plugins/}"
+    rest="${rest#docs/conventions/}"
+    if [[ "$rest" == "${rest%%/*}/CHANGELOG.md" && -z "${seen_changelog[$path]:-}" ]]; then
+      seen_changelog["$path"]=1
+      touched_changelogs+=("$path")
+    fi
+    ;;
   *) ;;
   esac
 done <<<"$diff_paths"
 
+# ============================ --check-preserved =============================
+# Every version heading a touched changelog carried at the FORK POINT must still
+# be there at head. Compared against the fork point, never the base TIP: a branch
+# that has not integrated main would read every heading main added after the fork
+# as "deleted" — a false positive on a required gate. The two semantics coincide
+# in the scenario this catches, because absorbing a section requires having
+# merged main forward in the first place (that is what opens the conflict
+# region), and once the base is an ancestor of head the fork point IS the base
+# tip.
+#
+# Matching is on the VERSION the heading names, via the shared extractor, so a
+# heading reformatted between the `## [1.2.3]` and `## 1.2.3 — date` forms still
+# reads as preserved (that is --check-bump's FORMAT concern, not a deletion), and
+# a yanked release marked `## [0.0.5] - 2014-12-13 [YANKED]` keeps its version in
+# the list exactly as Keep a Changelog intends.
+#
+# Reading discipline: a git read is COMMAND substitution with its status checked
+# (a failed git read must never read as "nothing to preserve" and pass), while
+# the heading extraction's status is deliberately ignored — `grep -oE` exits 1 on
+# a changelog with no version headings at all, which is not an error. No reader
+# in this path exits early on its input, so no writer can take SIGPIPE under
+# pipefail (see the has_heading note in --check-bump).
+if [[ "$mode" == "--check-preserved" ]]; then
+  deleted=0
+  compared=0
+  declare -A head_seen
+  for changelog in "${touched_changelogs[@]}"; do
+    # Absent at the fork point => added by this change set; nothing to preserve.
+    # `git ls-tree` is the probe that separates that from a git invocation which
+    # genuinely FAILED: a path missing from the tree is exit 0 with EMPTY output,
+    # an unusable rev is a non-zero exit. (`git cat-file -e` cannot make that
+    # distinction — it exits 128 for both, so a change set ADDING a changelog
+    # would fail the gate.) A failure must never read as "nothing to preserve".
+    if ! base_listing="$(git ls-tree -r --name-only "$merge_base" -- "$changelog")"; then
+      echo "check-changelog-parity: 'git ls-tree -r --name-only $merge_base -- $changelog' failed; refusing to pass without checking." >&2
+      exit 2
+    fi
+    [[ -n "$base_listing" ]] || continue
+    if ! base_body="$(git show "$merge_base:$changelog")"; then
+      echo "check-changelog-parity: 'git show $merge_base:$changelog' failed; refusing to pass without checking." >&2
+      exit 2
+    fi
+    mapfile -t base_versions < <(printf '%s\n' "$base_body" | changelog_versions -)
+    ((${#base_versions[@]} > 0)) || continue
+
+    head_versions=()
+    if [[ -f "$changelog" ]]; then
+      mapfile -t head_versions < <(changelog_versions "$changelog")
+    elif [[ ! -d "${changelog%/CHANGELOG.md}" ]]; then
+      # The whole plugin/convention directory went with it — a removal, not an
+      # absorbed section. A rename lands here too: the old path's directory is
+      # gone, and the new path is new at the fork point (skipped above).
+      continue
+    fi
+
+    head_seen=()
+    if ((${#head_versions[@]} > 0)); then
+      for v in "${head_versions[@]}"; do head_seen["$v"]=1; done
+    fi
+    missing=""
+    for v in "${base_versions[@]}"; do
+      [[ -n "${head_seen[$v]:-}" ]] && continue
+      head_seen["$v"]=1 # a version repeated at base is reported once
+      missing="${missing}${missing:+ }$v"
+    done
+    compared=$((compared + ${#base_versions[@]}))
+
+    if [[ -n "$missing" ]]; then
+      echo "DELETED CHANGELOG ENTRY: $changelog documented $missing at the fork point but no longer does." >&2
+      echo "  A released section's heading vanished. The usual cause is a CHANGELOG merge-forward resolved by writing the new release under the PREVIOUS release's heading — absorbing it — or by RELABELLING that heading to the new version; git leaves no conflict marker behind for either. Restore the heading with its own notes above the entry that replaced it." >&2
+      echo "  Neither removal an author might intend needs a deletion: a yanked release keeps its heading and is marked '## [<version>] - <date> [YANKED]' (Keep a Changelog), and a release note written ahead of its bump is fixed by bumping the manifest up to it, not by folding it away." >&2
+      deleted=$((deleted + 1))
+    fi
+  done
+
+  if ((deleted > 0)); then
+    echo "A released '## [<version>]' entry may never be dropped by a change set; every heading present at the fork point must still be present at head." >&2
+    exit 1
+  fi
+  echo "All ${#touched_changelogs[@]} changed changelog(s) preserve every version heading they carried at $merge_base ($compared heading(s) compared)."
+  exit 0
+fi
+
+# ============================== --check-bump ================================
 undocumented=0
 malformed=0
 preexisting=0

--- a/scripts/check-changelog-parity.test.sh
+++ b/scripts/check-changelog-parity.test.sh
@@ -821,5 +821,280 @@ write_changelog "$repo/docs/conventions/demo/CHANGELOG.md" '## 1.10 — 2026-02-
 if out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-order 2>&1)"; then ok "two- and three-component versions compare correctly together"; else fail "mixed-width comparison wrong: $out"; fi
 rm -rf "$repo"
 
+# ===================== --check-preserved (#2264) =========================
+# The gap: every other mode polices what a change set ADDS. A merge-forward that
+# writes the new release under the PREVIOUS release's heading — absorbing it —
+# deletes a released section with no conflict marker left behind, and all three
+# pass. The first case below asserts that gap explicitly (the other three modes
+# green on the very tree --check-preserved red-lines) so a future edit cannot
+# quietly make this mode redundant without the suite noticing.
+
+# ABSORBED PREDECESSOR: base carries 0.51.8 and 0.51.7; head bumps to 0.51.9 and
+# folds 0.51.8's note into the new section, deleting its heading.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 0.51.8 yes
+printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [0.51.9]\n\n- nine\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'absorb 0.51.8 into 0.51.9'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"DELETED CHANGELOG ENTRY"*"plugins/alpha/CHANGELOG.md"* && "$out" == *"0.51.8"* ]]; then ok "an absorbed predecessor section fails --check-preserved, naming the vanished version"; else fail "absorbed section not caught: rc=$rc out='$out'"; fi
+for other in "--check-bump $base" "--check-order" "--check"; do
+  # shellcheck disable=SC2086  # deliberate split: the mode and its optional base ref
+  if (cd "$repo" && bash scripts/check-changelog-parity.sh $other >/dev/null 2>&1); then ok "the absorbed-section tree still passes '$other' (the gap --check-preserved exists to close)"; else fail "'$other' unexpectedly fired on the absorbed-section tree — the gap assertion is stale"; fi
+done
+rm -rf "$repo"
+
+# RELABELLED PREDECESSOR: the same bad resolution renames 0.51.8's heading to
+# 0.51.9 instead of adding one. That IS a deletion of 0.51.8, and the failure
+# message must say so, so the author recognises what their resolve did.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 0.51.8 yes
+printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [0.51.9]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'relabel 0.51.8 as 0.51.9'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"0.51.8"* && "$out" == *"RELABELLING"* ]]; then ok "a relabelled heading fails --check-preserved and the message names relabelling as a cause"; else fail "relabelled heading not caught or not explained: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# LEGITIMATE BUMP: adds a heading, preserves every predecessor -> passes. The
+# discriminating half of the pair above; a check that never passes is as useless
+# as one that never fires.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 0.51.8 yes
+printf '# Changelog\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "0.51.9" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [0.51.9]\n\n- nine\n\n## [0.51.8]\n\n- eight\n\n## [0.51.7]\n\n- seven\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a bump that adds a heading and preserves its predecessors passes --check-preserved"; else fail "legitimate bump wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# STALE BRANCH THAT NEVER INTEGRATED: main adds `## [1.1.0]` after the fork; the
+# branch edits its OWN changelog and never merges main forward. Compared against
+# the base TIP, every heading main added would read as deleted — a false positive
+# on a required gate. The fork point is the only correct comparison.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+fork="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.1.0]\n\n- main note\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'main bumps alpha'
+main="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q -b pr "$fork"
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n- a wording fix\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'pr edits its changelog, never integrates main'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$main" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a stale branch that never integrated main is not flagged (fork-point comparison, no false positive)"; else fail "stale branch wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# CHANGELOG NEW IN THIS CHANGE SET: absent at the fork point, so there is nothing
+# to preserve. (`git cat-file -e` cannot express this — it exits 128 for a
+# missing path exactly as it does for an unusable rev — so this case is the guard
+# on the existence probe.)
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 no
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'add a changelog'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a changelog added by this change set passes --check-preserved (nothing to preserve)"; else fail "newly added changelog wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# PLUGIN REMOVED: the changelog goes with its whole directory. That is a removal,
+# not an absorbed section.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+mk_plugin "$repo" beta 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+rm -rf "$repo/plugins/alpha"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'remove the alpha plugin'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "removing a plugin outright passes --check-preserved (its whole directory went with it)"; else fail "plugin removal wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# CHANGELOG DELETED, PLUGIN KEPT: the extreme form of the same defect — every
+# released heading vanishes at once, and the plugin is still there.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+rm -f "$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'delete the changelog, keep the plugin'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"DELETED CHANGELOG ENTRY"*"1.0.0"* ]]; then ok "deleting a changelog while its plugin survives fails --check-preserved"; else fail "whole-file deletion not caught: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# YANKED RELEASE: Keep a Changelog keeps the heading and marks it `[YANKED]`
+# rather than deleting it, so the correct treatment of a pulled release must
+# PASS. This is why the mode ships no exemption list.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.0.1" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+printf '# Changelog\n\n## [1.0.1]\n\n- revert\n\n## [1.0.0] - 2026-01-01 [YANKED]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'yank 1.0.0'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "marking a release '[YANKED]' preserves its heading and passes --check-preserved"; else fail "yanked-release marking wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# REFORMATTED HEADING: bracketed -> unbracketed names the same version. Matching
+# is on the VERSION, so a format change is not a deletion (--check-bump owns the
+# format concern).
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## 1.0.0 — 2026-01-01\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'reformat the heading'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "reformatting a heading to another accepted form is not a deletion"; else fail "heading reformat wrongly flagged: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# HEADINGLESS CHANGELOG: the shared extractor's `grep -oE` exits 1 when a file
+# declares no version heading at all. Under pipefail that status must NOT be read
+# as a failed check — a false positive on every prose-only changelog.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\nNothing released yet.\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'edit a headingless changelog'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "a changelog with no version headings passes --check-preserved (grep's no-match status is not an error)"; else fail "headingless changelog wrongly failed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# FENCED EXAMPLE HEADING: what looks like a heading inside a code fence is not
+# one, so removing it is not a deletion. The shared extractor owns this.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+printf '# Changelog\n\n## [1.0.0]\n\n~~~\n## [9.9.9]\n~~~\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## [1.0.0]\n\n- one\n' >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'drop the fenced example'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 0 ]]; then ok "removing a fenced example heading is not a deletion"; else fail "fenced example wrongly counted as a released heading: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# CONVENTION CHANGELOG: unversioned by any manifest, so --check and --check-bump
+# never look at it. Absorption is just as possible there, and --check-preserved
+# sweeps the same two roots --check-order does.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+mkdir -p "$repo/docs/conventions/demo"
+printf '# Changelog\n\n## 2.0.0 — 2026-01-02\n\n- two\n\n## 1.0.0 — 2026-01-01\n\n- one\n' >"$repo/docs/conventions/demo/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '# Changelog\n\n## 3.0.0 — 2026-01-03\n\n- three\n- two\n\n## 1.0.0 — 2026-01-01\n\n- one\n' >"$repo/docs/conventions/demo/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'absorb 2.0.0 into 3.0.0'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 1 && "$out" == *"docs/conventions/demo/CHANGELOG.md"* && "$out" == *"2.0.0"* ]]; then ok "convention changelogs are in --check-preserved scope"; else fail "convention changelog absorption missed: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# LARGE CHANGELOG under gawk (the #2130 shape, applied to this mode): the heading
+# lists are read through the same rendered_lines writer, so no reader in this
+# path may exit before EOF. Forced gawk for the same reason as the --check-bump
+# fixture above — mawk survives a closed pipe and would prove nothing.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+{
+  printf '# Changelog\n\n## [1.0.0]\n\n'
+  for ((i = 0; i < 4000; i++)); do
+    printf '%s\n' '- a release note line padding the file well past any pipe or stdio buffer'
+  done
+  printf '\n## [0.9.0]\n'
+} >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+printf '{ "name": "alpha", "version": "1.1.0" }\n' >"$repo/plugins/alpha/.claude-plugin/plugin.json"
+{
+  printf '# Changelog\n\n## [1.1.0]\n\n- one one\n\n## [1.0.0]\n\n'
+  for ((i = 0; i < 4000; i++)); do
+    printf '%s\n' '- a release note line padding the file well past any pipe or stdio buffer'
+  done
+  printf '\n## [0.9.0]\n'
+} >"$repo/plugins/alpha/CHANGELOG.md"
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm bump
+if command -v gawk >/dev/null 2>&1; then
+  mkdir -p "$repo/bin"
+  printf '#!/bin/sh\nexec gawk "$@"\n' >"$repo/bin/awk"
+  chmod +x "$repo/bin/awk"
+  out="$(cd "$repo" && PATH="$repo/bin:$PATH" bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+  rc=$?
+  if [[ $rc -eq 0 ]]; then ok "a large changelog passes --check-preserved under gawk (no early-exiting reader, no SIGPIPE misread)"; else fail "large-changelog preservation wrongly failed under gawk: rc=$rc out='$out'"; fi
+else
+  echo "SKIP: the SIGPIPE fixture requires gawk; under mawk a closed pipe is survivable, so this case cannot distinguish fixed from unfixed." >&2
+fi
+rm -rf "$repo"
+
+# NO COMMON ANCESTOR: same fail-loud discipline as --check-bump — a git read that
+# could not be computed must never read as "nothing was deleted" and pass.
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+base="$(git -C "$repo" rev-parse HEAD)"
+git -C "$repo" checkout -q --orphan orphan
+git -C "$repo" rm -rq --cached . >/dev/null 2>&1 || true
+mk_plugin "$repo" alpha 1.1.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm 'orphan root'
+out="$(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved "$base" 2>&1)"
+rc=$?
+if [[ $rc -eq 2 && "$out" == *"failed"* ]]; then ok "--check-preserved fails loud (exit 2) when the diff cannot be computed"; else fail "--check-preserved did not fail loud on a missing common ancestor: rc=$rc out='$out'"; fi
+rm -rf "$repo"
+
+# usage errors mirror --check-bump's
+repo="$(mk_repo)"
+git_init "$repo"
+mk_plugin "$repo" alpha 1.0.0 yes
+git -C "$repo" add -A >/dev/null && git -C "$repo" commit -qm base
+(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved >/dev/null 2>&1)
+if [[ $? -eq 2 ]]; then ok "--check-preserved without a base ref -> exit 2"; else fail "--check-preserved missing base ref did not exit 2"; fi
+(cd "$repo" && bash scripts/check-changelog-parity.sh --check-preserved does-not-exist >/dev/null 2>&1)
+if [[ $? -eq 2 ]]; then ok "--check-preserved with an unresolvable base ref -> exit 2"; else fail "--check-preserved bad base ref did not exit 2"; fi
+rm -rf "$repo"
+
 printf '\nPASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 ((FAIL == 0))


### PR DESCRIPTION
## Summary

`scripts/check-changelog-parity.sh` policed the **bump** and never the **preservation**. A change set could delete an already-released section's heading — absorbing its notes into the new release — and all three modes passed. Reproduced verbatim from #2264, now a test fixture:

| tree | `--check-bump` | `--check-order` | `--check` | `--check-preserved` |
|---|---|---|---|---|
| base `## [0.51.8]`, `## [0.51.7]` → head `## [0.51.9]`, `## [0.51.7]` | PASS | PASS | PASS | **FAIL** |

Why each of the three missed it: `--check-bump` asks only about the *bumped* version and never enumerates the base's other headings; `--check-order` reads `0.51.9, 0.51.7` as correctly ordered with no duplicates, and a *gap* is not an ordering violation; `--check` compares the manifest against the changelog **maximum**. Git leaves no conflict marker behind for that resolution either — when two change sets bump one plugin, the conflict region tends to open *below* the newest heading, so a plausible merge-forward writes two releases under one heading silently. It happened on this repo during the #2163/#2171 drain and was caught only because a human ran a heading-list diff by hand.

This adds a fourth mode, **`--check-preserved <base-ref>`**: every `## [<version>]` heading a touched changelog carried at the **fork point** must still be there at head. Wired as a PR-only step in the existing `changelog-parity-gate` job, so no required-context name changes.

### Three design decisions

**1. Its own mode, not an addition to `--check-bump`.** `--check-bump` already resolves the base and the plugin scope, so folding it in is cheaper — but its scope is *plugins whose manifest version changed*, which is exactly where an absorbed heading would **not** be looked for. A section can be absorbed by a change set that never touches a manifest, and the convention changelogs under `docs/conventions/*/` are unversioned by any manifest so `--check` and `--check-bump` never read them at all. The new mode sweeps every **changed** changelog under both roots `--check-order` reads. The two modes share one prologue for the base ref, the fork point, and the touched-path scan, so they cannot drift into reading the diff differently.

**2. Fork point, never the base tip.** The issue suggested `git show "$base:$changelog"`. Compared against the base **tip**, a branch that has not integrated `main` reads every heading `main` added after the fork as "deleted" — a false positive on a required gate that would block every in-flight PR. The two semantics coincide in the scenario this catches, because absorbing a section *requires* having merged `main` forward (that is what opens the conflict region), and once the base is an ancestor of head the fork point **is** the base tip. Merge-base loses nothing and cannot produce that false-positive class at all. Guarded by its own test (`a stale branch that never integrated main is not flagged`), which fails under base-tip semantics.

**3. No exemption list — decided against real evidence, not in the abstract.** Two removals an author might reach for, and neither needs a deletion:

- A **yanked release**: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) keeps the heading and marks it `## [0.0.5] - 2014-12-13 [YANKED]` — *"The `[YANKED]` tag is loud for a reason"* — so the canonical "legitimate deletion" is not a deletion at all under the convention these changelogs follow. A `[YANKED]`-marked heading keeps its version in the extractor's list and passes; there is a test for it.
- A **note written against a version the manifest then skipped**: keep the heading and say so in the section body. The remedy `--check` suggests first — bump the manifest onto that number — is often unavailable, because by the time the mismatch is noticed the manifest has already moved past it and bumping back down is a `VERSION REGRESSION` under `--check-bump`.

The sweep below found exactly one deletion in this repo's recent history — **04822fc4**, which closed #2131 by folding `docs-hygiene`'s never-released `## [0.9.7]` into `## [0.10.0]` — and it is the second shape. That is the strongest available argument *for* a hatch, and it is also the argument against one: **in the diff, that fold is indistinguishable from the absorption this gate exists to catch**. A structural exemption would therefore have to exempt both. An allowlist file (the repo's `changelog-parity-baseline.txt` / `contract-slice-baseline.txt` idiom) was the alternative considered and declined: it cannot be stale-guarded meaningfully here (post-merge the removal is in the base, so an entry never expires without red-lining `main` for someone else), and a required gate whose whole purpose is catching a hurried merge resolution should not ship the off switch a hurried resolver will reach for. The failure message states the annotate-in-place remedy instead.

**Renames.** The same bad resolution can *relabel* `## [0.51.8]` to `## [0.51.9]` rather than delete it. That is a deletion of `0.51.8` and the check reports it as one — correctly — and the failure message names relabelling explicitly so the author recognises what their resolve did. Separately, a plugin **directory** rename can carry an absorption past the gate (default rename detection makes `git diff --name-only` report only the new path); that is recorded in the code as a known boundary, not an oversight — `--check-bump`'s manifest scoping has the same property, and `--no-renames` would not close it.

### Constraints of the file that were preserved

- **SIGPIPE (#2154 / #2159).** No reader in the new path exits before EOF — the heading lists go through the same `rendered_lines` writer into `grep -oE` and `mapfile`, none of which stop early — so no writer can take SIGPIPE under `pipefail` on any awk. Covered by a large-changelog fixture under a forced-`gawk` PATH shim, the same idiom the `--check-bump` SIGPIPE fixture uses. CI confirms it ran rather than skipped (no `SKIP:` line in the job log).
- **Fixed-string, column-one heading matching** and SemVer metacharacter escaping are untouched; the new mode reuses the shared `changelog_versions` extractor rather than adding a second reader, so a fenced or HTML-commented example heading is invisible to it too.
- **Fail-closed git reads.** Existence at the fork point is probed with `git ls-tree` (missing path → exit 0, empty output; unusable rev → non-zero), **not** `git cat-file -e`, which exits 128 for both and would have failed every change set that *adds* a changelog. Verified empirically before relying on it. The heading extraction's status is deliberately ignored — `grep -oE` exits 1 on a changelog with no version headings, which is not an error, and treating it as one would false-positive on every prose-only changelog (covered by a test).
- Not a single file under `plugins/**` is touched.

## Test plan

**Suite: `PASS=76 FAIL=0`** (55 pre-existing + 21 new), `bash scripts/check-changelog-parity.test.sh`, and green on CI (`ubuntu-24.04`).

New cases prove the check **discriminates**, not merely that it exists:

- FAILS on the issue's absorption shape, naming the vanished version — and the same test asserts all three *other* modes stay **green** on that very tree, so a future edit cannot quietly make this mode redundant without the suite noticing.
- FAILS on a relabelled heading, and the message names relabelling as a cause.
- PASSES on a legitimate bump that adds a heading and preserves its predecessors.
- PASSES on: a stale branch that never integrated main (the false-positive guard), a changelog *added* by the change set, a plugin removed outright, a `[YANKED]`-marked heading, a heading reformatted between the two accepted forms, a headingless changelog, a removed fenced example.
- FAILS on a changelog deleted while its plugin survives — and gets the restore-the-file remediation rather than the absorbed-heading one.
- Convention changelogs (`docs/conventions/*/CHANGELOG.md`) are in scope, proven by an absorption there.
- Large-changelog SIGPIPE fixture under forced gawk; fail-loud (exit 2) on a diff that cannot be computed; usage errors → exit 2.

### Zero false positives on the live tree

Corpus: **65** plugin changelogs + **10** convention changelogs = **75** in scope, carrying **1530** version headings today. A separate scan confirms **0 of the 1487** headings in the *plugin* changelogs currently name a version above their manifest (the remaining 43 headings are in the 10 convention changelogs, which no manifest versions, so there is nothing to compare them against).

**Sweep B — the load-bearing one.** `main` is **squash-merged** (`git rev-list --merges origin/main` → 0 results), so each commit on `main` *is* a merged PR. Every one of the **60** most recent commits touching a changelog was replayed as its own PR (tree at `C`, base `C^1`) in a throwaway local clone:

| | |
|---|---|
| commits replayed | **60** |
| changelogs entering scope (summed) | **243** |
| headings compared (summed) | **7789** |
| clean | **59** |
| fired | **1** |

The single fire is **04822fc4** — `plugins/docs-hygiene/CHANGELOG.md documented 0.9.7 at the fork point but no longer does` — and it is a **true positive**: that commit really did delete `## [0.9.7]` and move its bullet up under `## [0.10.0]` ([diff](https://github.com/melodic-software/claude-code-plugins/commit/04822fc4082965b394a1148537de7dbc4dd52244#diff-plugins/docs-hygiene/CHANGELOG.md)). It was a legitimate fold of a never-released entry, which is why design decision 3 above is written the way it is. A sweep that never fires across 60 real commits would be *weaker* evidence than one that fires exactly on the commit that deleted a heading.

**Sweep A — whole-corpus, older bases.** The real mode run from a tree at `main` with progressively older bases, so every heading present at that base must survive at head:

| base | changelogs in scope | headings compared | result |
|---|---|---|---|
| `origin/main~10` | 19 | 671 | rc=0 |
| `origin/main~50` | 44 | **1252** | rc=0 |
| `origin/main~200` | 67 | 1108 | rc=0 |
| `origin/main~600` | 74 | 609 | rc=0 |

(A root-commit base was also run; it compares **0** headings because no changelog existed then, so it is not evidence and is excluded from the table.)

**Conflict-marker sweep.** `<<<<<<<`: 0. `|||||||`: 0. `>>>>>>>`: 0. `=======`: 8 matches, every one inside a `# ===== <section> =====` banner comment matching the file's existing section-header style — none a conflict marker.

**Other gates, locally:** `shellcheck --rcfile=.shellcheckrc -x` on both files → clean; `scripts/check-shell-portability.sh --paths` on both files → `No unexcused GNU-only constructs in 2 shell file(s)`; `scripts/check-silent-skips.sh --check` → clean; `actionlint .github/workflows/ci.yml` → clean.

**Independent verification.** A fresh-context verifier reads the diff at the pinned head SHA, builds its **own** sweep (not the author's scripts), reverts the fix to prove the new tests fail without it, and confirms the SIGPIPE-safe reading discipline. Its verdict is posted to this PR as a comment.

## Related

Closes #2264.

Same file, different failure: #2154 / #2159 (the SIGPIPE regression that made a *present* heading read as missing; this one made a *missing* heading read as fine). #2131 is the reverse-parity gap whose remediation commit is the single true-positive fire in Sweep B. The incident that produced the live absorption: #2163 / #2171.
