### PR TITLE
fix(guardrails): align stale-path-verify test comment with [Ss] exemption

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -112,7 +112,7 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
 - **`block-dangerous-git` `repo_oid_width` no longer caches a width-0 failure or misdiagnoses it as a movable lease (#2227).** When `git rev-parse --show-object-format` fails, the guard now surfaces the git error, refuses to cache the failure for the rest of the invocation, and blocks with a distinct message from the abbreviation/wrong-width case — so a literal full-width SHA is not blamed on the operator when the repository's hash format could not be read.
 - **`--no-force-with-lease` now clears unknown-width lease state.** A trailing negation that cancels every preceding `--force-with-lease` also resets `lease_width_unknown` and `_lease_oid_width_unknown`, so a pinned lease whose width probe failed is not incorrectly blocked after the negation.
 
-## [0.26.1]
+## [0.26.0]
 
 ### Changed
 

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.27.1]
+
+### Fixed
+
+- **`stale-path-verify.test.sh` comment now matches the shipped `[Ss]` exemption.** The
+  assume-unchanged case comment claimed only uppercase `S` was exempt; the hook and the test
+  nine lines below both treat lowercase `s` as skip-worktree too. (#1555)
+
 ## [0.27.0]
 
 ### Fixed
@@ -104,7 +112,7 @@ All notable changes to the `guardrails` plugin are documented here. Format follo
 - **`block-dangerous-git` `repo_oid_width` no longer caches a width-0 failure or misdiagnoses it as a movable lease (#2227).** When `git rev-parse --show-object-format` fails, the guard now surfaces the git error, refuses to cache the failure for the rest of the invocation, and blocks with a distinct message from the abbreviation/wrong-width case — so a literal full-width SHA is not blamed on the operator when the repository's hash format could not be read.
 - **`--no-force-with-lease` now clears unknown-width lease state.** A trailing negation that cancels every preceding `--force-with-lease` also resets `lease_width_unknown` and `_lease_oid_width_unknown`, so a pinned lease whose width probe failed is not incorrectly blocked after the negation.
 
-## [0.26.0]
+## [0.26.1]
 
 ### Changed
 

--- a/plugins/guardrails/hooks/stale-path-verify.test.sh
+++ b/plugins/guardrails/hooks/stale-path-verify.test.sh
@@ -416,7 +416,8 @@ assert_contains "unstaged deletion is not a sparse exemption → fires" "$OUT" \
 # working-tree disappearance — the same shape as the unstaged deletion above.
 # Exempting `h` would reinstate the suppression this change removes, for a
 # narrower set. #1509's acceptance text names the variant alongside
-# skip-worktree; only `S` earns the exemption, and this case pins that.
+# skip-worktree; only the skip-worktree letter (`S` or `s`) earns the exemption,
+# and this case pins that assume-unchanged alone does not.
 git -C "$SPARSE" update-index --assume-unchanged docs/restored.md >/dev/null 2>&1
 OUT=$(CLAUDE_PROJECT_DIR="$SPARSE" bash "$HOOK" \
   <<<"$(write_json "$SPARSE_TARGET" 'Read `docs/restored.md` first.')" 2>&1)


### PR DESCRIPTION
Fixes #1555

The assume-unchanged test-case comment claimed only uppercase `S` earns the skip-worktree exemption, contradicting the shipped `[[ "$ls_tag" == [Ss] ]]` guard at `stale-path-verify.sh:425` and the lowercase-`s` test nine lines below.

## Related

- Guardrails stale-path-verify [Ss] exemption alignment (#1555)