### PR TITLE
fix(discovery): use install-root paths in dispatch spokes

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — discovery plugin
 
+## [0.14.1]
+
+### Fixed
+
+- **Dispatch spokes now cite agent definitions with `${CLAUDE_PLUGIN_ROOT}` paths.** The explore and
+  research dispatch contracts pointed at `plugins/discovery/agents/<name>.md`, which does not resolve
+  from an installed plugin root. (#2269)
+
 ## [0.14.0]
 
 ### Fixed

--- a/plugins/discovery/skills/explore/reference/dispatch.md
+++ b/plugins/discovery/skills/explore/reference/dispatch.md
@@ -2,7 +2,7 @@
 
 `SKILL.md` carries the routing mandate and the acceptance gate's three steps. This file carries why
 each step is shaped the way it is, and what the parent does when one fails. The agent's own side is
-`plugins/discovery/agents/explorer.md`.
+`${CLAUDE_PLUGIN_ROOT}/agents/explorer.md`.
 
 ## Why the gate reads the slice path, not the payload
 

--- a/plugins/discovery/skills/research/context/dispatch.md
+++ b/plugins/discovery/skills/research/context/dispatch.md
@@ -2,7 +2,7 @@
 
 `SKILL.md` carries the routing mandate. This file carries what the **parent** owes around a
 dispatched run, and why each obligation exists. The agent's own side is
-`plugins/discovery/agents/researcher.md`.
+`${CLAUDE_PLUGIN_ROOT}/agents/researcher.md`.
 
 ## The orchestration boundary
 


### PR DESCRIPTION
Fixes #2269 (B-F12 row only)

`skills/explore/reference/dispatch.md` and `skills/research/context/dispatch.md` cited `plugins/discovery/agents/<name>.md`, which does not resolve from an installed plugin root. Both now use `${CLAUDE_PLUGIN_ROOT}/agents/<name>.md`, matching the rest of the plugin.

The POSIX-only `mkdir -p && touch` baseline command (F9/B-F7) is left for a follow-up.