### PR TITLE
fix(context-guard): gate zone injection on the worst zone already reported, not the last one seen

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0]
+
+### Changed
+
+- **`zone-crossing-inject`: the injection gate is now the worst zone this session has already
+  REPORTED, not the zone it last SAW — zone bands had no hysteresis, so a session flapping across a
+  boundary re-injected on every crossing (#2220).** The bands are hard thresholds and occupancy does
+  not climb monotonically: tool results land and are released, so a session sitting near a boundary
+  crosses it repeatedly. The old latch compared each observation against the last-seen zone and
+  persisted state in both directions, which made every re-crossing a fresh transition — the ~1KB
+  (~250 token) guidance block re-emitted each time, with an *improvement* of any size silently
+  re-arming the injection and nothing counting or capping the flap.
+
+  A second per-session marker (`<session>.armed`) now holds the worst zone already reported, and the
+  emit gate compares against it. It decays only on an improvement of at least **two ranks** — the
+  full width of the `smart`/`acceptable`/`dumb` ladder. The margin is a declared judgment default on
+  exactly the same footing as the bands themselves (`reference/reader-contract.md` records their
+  provenance); nothing here is doc- or benchmark-derived, and the reasoning is stated rather than
+  asserted: a one-rank dip at a band edge is the oscillation described above and says nothing new,
+  while `dumb → smart` cannot be edge noise. A `/clear` needs no margin — it starts a new session
+  id, hence a fresh state file and a fresh baseline.
+
+  Net effect: a zone is announced at most once per session unless the session genuinely recovers,
+  after which the ladder re-arms and the next worsening is reported normally. `dumb → acceptable →
+  dumb` now injects **once**; `dumb → smart → dumb` still injects **twice**. Both are pinned by
+  tests, on separate sessions so the two paths cannot share state.
+
+  A sibling file rather than a second line in the existing one: the state reader is
+  `tr -cd '[:lower:]'`, which strips the newline, so two lines would fuse into `dumbacceptable` and
+  rank as `smart`. Sessions already running when this version lands have a `.zone` file and no
+  `.armed` file; the armed rank seeds from the last-seen zone, so the first call after the upgrade
+  decides exactly as 0.6.6 would have and latches from there — no migration step, no state-format
+  version. The armed marker is written **first** of the two, so a partial write failure can never
+  leave the gate open against a marker that already moved.
+
+  **Not the recurring 10s-timeout defect, and not a duplicate of it.** That one
+  (`20260730-182801-context-guard-zone-crossing-hook-times-out-100-percent`) was four `hooks.json`
+  registrations declaring `timeout: 10` against measured 10.6–21.4s runtimes, so the hook **died
+  rather than ran**; it was fixed in 0.4.8 via PR #2001 by raising all four to 60. This release is
+  about how often the hook injects **when it does run**. A triager reaching for that item should
+  stop here.
+
+  Deliberately preserved, because they are load-bearing and easy to refactor away: the two-channel
+  split with the continuation menu kept out of model context, the hook's refusal to claim an
+  operator is present, the inert default posture, the worsening-only latch itself, and
+  `zone-gate.sh`'s structural no-deadlock exemptions. No blocking behaviour, no permission, and no
+  external read or write changes; the plugin's trust surface is untouched.
+
 ## [0.6.6]
 
 ### Changed

--- a/plugins/context-guard/hooks/zone-crossing-inject.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.sh
@@ -32,10 +32,34 @@
 # own snapshot seam via scripts/context-zone.sh (the single band/combination
 # authority — this hook never re-implements band logic). The last-seen zone
 # is kept per session in a private state file; injection fires only when the
-# rank worsens (smart → acceptable/dumb, acceptable → dumb, or a first
-# observation already past smart). `unknown` is always silent and never
-# updates state — no data is not a transition. Improvements update state
-# silently so a later relapse injects again.
+# rank worsens past the highest rank already REPORTED this session (smart →
+# acceptable/dumb, acceptable → dumb, or a first observation already past
+# smart). `unknown` is always silent and never updates state — no data is not
+# a transition.
+#
+# HYSTERESIS (the armed rank). The bands are hard thresholds, and occupancy
+# does not climb monotonically: tool results land and are released, so a
+# session sitting near a boundary crosses it repeatedly. Comparing only
+# against the LAST-SEEN zone made every re-crossing a fresh transition, so
+# the ~1KB guidance block re-injected on each one, and an improvement in any
+# amount silently re-armed the injection with nothing counting or capping the
+# flap. A second marker — the ARMED rank, the worst zone this session has
+# already reported — now gates the emit, and it decays only on an improvement
+# of at least REARM_MARGIN ranks.
+#
+# The margin is a declared judgment default, like the bands themselves
+# (reference/reader-contract.md records their provenance): a ONE-rank dip at a
+# band edge is the oscillation described above and says nothing new, while a
+# TWO-rank improvement — the full width of the ladder, dumb → smart — cannot
+# be edge noise and means the window genuinely emptied. A `/clear` needs no
+# margin at all: it starts a new session id, hence a new state file and a
+# fresh baseline. So a zone is announced at most once per session unless the
+# session really recovers, after which the ladder re-arms and the next
+# worsening is reported normally.
+#
+# The last-seen zone is still tracked, separately: it is what the message and
+# the recovery telemetry report as the previous zone, and it is not the emit
+# gate.
 #
 # ADVISORY-ONLY: this hook only ever exits 0 and only ever emits context and a
 # user-visible message. The blocking posture lives in the separate PreToolUse
@@ -108,8 +132,19 @@ else
   exit 0
 fi
 STATE_FILE="$STATE_DIR/$SESSION.zone"
+ARMED_FILE="$STATE_DIR/$SESSION.armed"
 last=""
 [[ -r "$STATE_FILE" ]] && last=$(tr -cd '[:lower:]' <"$STATE_FILE" 2>/dev/null | head -c 16)
+armed=""
+[[ -r "$ARMED_FILE" ]] && armed=$(tr -cd '[:lower:]' <"$ARMED_FILE" 2>/dev/null | head -c 16)
+# A SIBLING file, not a second line in the existing one: `last` is read with
+# `tr -cd '[:lower:]'`, which strips the newline too, so a two-line state file
+# would fuse into "dumbacceptable" and rank as smart. Sessions already running
+# when this version lands have a `.zone` file and no `.armed` file; seeding the
+# armed rank from the last-seen zone reproduces the pre-hysteresis decision for
+# exactly one call, after which the marker latches normally. No migration step
+# and no state-format version are needed for that.
+[[ -n "$armed" ]] || armed="$last"
 
 rank() {
   case "$1" in
@@ -118,31 +153,55 @@ rank() {
   *) printf '0' ;; # smart, or no prior observation (baseline)
   esac
 }
+unrank() {
+  case "$1" in
+  2) printf 'dumb' ;;
+  1) printf 'acceptable' ;;
+  *) printf 'smart' ;;
+  esac
+}
 new_rank=$(rank "$zone")
-last_rank=$(rank "$last")
+armed_rank=$(rank "$armed")
 
-# Persist the current zone regardless of direction (improvements update
-# silently) — owner-only, atomic enough for a single-writer-per-session file.
-# A write failure (full or newly read-only filesystem) must fail OPEN
-# SILENTLY: proceeding past it would compare this turn's zone against the
-# same stale `last` again on the next call, re-emitting the ~1KB guidance
-# block every subsequent PostToolBatch/UserPromptSubmit instead of once per
-# transition. "Silent" means neither channel emits — the failure
-# itself is still surfaced to operators as telemetry, never swallowed twice.
+# See the header. The armed rank rises to whatever this observation reports and
+# falls only on an improvement at least this wide.
+REARM_MARGIN=2
+next_armed_rank=$armed_rank
+if ((new_rank > armed_rank || armed_rank - new_rank >= REARM_MARGIN)); then
+  next_armed_rank=$new_rank
+fi
+
+# Persist both markers regardless of direction — owner-only, atomic enough for
+# a single-writer-per-session file. A write failure (full or newly read-only
+# filesystem) must fail OPEN SILENTLY: proceeding past it would compare this
+# turn's zone against the same stale markers again on the next call, re-emitting
+# the ~1KB guidance block every subsequent PostToolBatch/UserPromptSubmit
+# instead of once per transition — which is the very defect the armed rank
+# exists to bound. "Silent" means neither channel emits — the failure itself is
+# still surfaced to operators as telemetry, never swallowed twice.
+#
+# The ARMED file is written FIRST. If only one of the two lands, the safe
+# survivor is the one that suppresses: a stale `.armed` at worst withholds a
+# repeat notice, while a stale `.zone` only mislabels the "previous" zone in a
+# message. Writing the gate first means a partial failure can never leave the
+# gate open against a marker that already moved.
 umask 077
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
-if ! printf '%s\n' "$zone" >"$STATE_FILE" 2>/dev/null; then
+if ! printf '%s\n' "$(unrank "$next_armed_rank")" >"$ARMED_FILE" 2>/dev/null ||
+  ! printf '%s\n' "$zone" >"$STATE_FILE" 2>/dev/null; then
   hook::emit_telemetry "zone-crossing-inject" "$EVENT" "error" "$START_EPOCH" \
     '{"zone":"'"$zone"'","previous":"'"${last:-}"'","reason":"state_persist_failed"}'
   exit 0
 fi
 
-((new_rank > last_rank)) || {
-  # No worsening. A recovery (rank drop) is still a meaningful outcome for
-  # telemetry; an unchanged zone is not.
+((new_rank > armed_rank)) || {
+  # Nothing worse than this session has already reported. Three shapes reach
+  # here and only the first two are worth telemetry: a genuine recovery (rank
+  # drop), a re-crossing the armed rank suppressed (the flap this gate exists
+  # for), and an unchanged zone, which is not an event.
   if [[ -n "$last" && "$zone" != "$last" ]]; then
     hook::emit_telemetry "zone-crossing-inject" "$EVENT" "ok" "$START_EPOCH" \
-      '{"zone":"'"$zone"'","previous":"'"$last"'","injected":false}'
+      '{"zone":"'"$zone"'","previous":"'"$last"'","armed":"'"$armed"'","injected":false}'
   fi
   exit 0
 }
@@ -164,5 +223,5 @@ operator="context-guard: this session crossed from the ${prev_label} into the ${
 
 hook::emit_channels "$EVENT" "$guidance" "$operator"
 hook::emit_telemetry "zone-crossing-inject" "$EVENT" "ok" "$START_EPOCH" \
-  '{"zone":"'"$zone"'","previous":"'"${last:-}"'","injected":true}'
+  '{"zone":"'"$zone"'","previous":"'"${last:-}"'","armed":"'"${armed:-}"'","injected":true}'
 exit 0

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -155,7 +155,7 @@ if [[ "$(cat "$D/state/sflap.armed" 2>/dev/null)" == "dumb" ]]; then
 else
   fail "armed rank decayed on a one-rank dip: $(cat "$D/state/sflap.armed" 2>/dev/null)"
 fi
-write_snapshot "$H" sflap 90 # back to dumb — the re-crossing that used to re-inject
+write_snapshot "$H" sflap 90 # back to dumb — the re-crossing that re-injects without the armed gate
 run "$H" "$D" sflap
 if [[ $RC -eq 0 && -z "$OUT" ]]; then
   ok "flap: re-crossing into an already-reported zone does NOT re-inject"

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -133,9 +133,9 @@ fi
 # a fresh "transition" and re-injected the ~1KB block. Only the FIRST dumb here
 # may emit.
 #
-# NOT the recurring 10s-timeout defect (context-guard 0.4.8 / PR #2001), which
-# was about the hook dying before it ran. This is about how often it injects
-# WHEN it runs.
+# NOT the recurring 10s-timeout defect fixed in context-guard 0.4.8
+# (squash-merged 925c3259), which was about the hook dying before it ran. This
+# is about how often it injects WHEN it runs.
 write_snapshot "$H" sflap 90 # dumb — first observation, injects
 run "$H" "$D" sflap
 if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -116,13 +116,103 @@ else
   fail "state not updated on improvement"
 fi
 
-# 4. Relapse after improvement (smart → acceptable) injects again.
+# 4. Relapse after a FULL recovery (dumb → smart → acceptable) injects again.
+# smart is two ranks below the armed dumb, so the armed marker decayed and the
+# ladder re-armed. This is the discriminating half of the hysteresis pair: a
+# real recovery must not be silenced by the margin that silences a flap.
 write_snapshot "$H" s1 60
 run "$H" "$D" s1 UserPromptSubmit
 if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
-  ok "relapse injects again (UserPromptSubmit)"
+  ok "relapse after a two-rank recovery injects again (UserPromptSubmit)"
 else
   fail "relapse: rc=$RC out=$OUT"
+fi
+
+# 4a. HYSTERESIS — the flap. A session hovering on the acceptable/dumb boundary
+# re-crosses it repeatedly; before the armed rank existed, every re-crossing was
+# a fresh "transition" and re-injected the ~1KB block. Only the FIRST dumb here
+# may emit.
+#
+# NOT the recurring 10s-timeout defect (context-guard 0.4.8 / PR #2001), which
+# was about the hook dying before it ran. This is about how often it injects
+# WHEN it runs.
+write_snapshot "$H" sflap 90 # dumb — first observation, injects
+run "$H" "$D" sflap
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
+  ok "flap: the first dumb observation injects"
+else
+  fail "flap setup did not inject: rc=$RC out=$OUT"
+fi
+write_snapshot "$H" sflap 60 # acceptable — a ONE-rank dip, below the margin
+run "$H" "$D" sflap
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "flap: the one-rank dip is silent"
+else
+  fail "flap dip emitted: rc=$RC out=$OUT"
+fi
+if [[ "$(cat "$D/state/sflap.armed" 2>/dev/null)" == "dumb" ]]; then
+  ok "flap: a one-rank dip does NOT decay the armed rank"
+else
+  fail "armed rank decayed on a one-rank dip: $(cat "$D/state/sflap.armed" 2>/dev/null)"
+fi
+write_snapshot "$H" sflap 90 # back to dumb — the re-crossing that used to re-inject
+run "$H" "$D" sflap
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "flap: re-crossing into an already-reported zone does NOT re-inject"
+else
+  fail "flap re-crossing re-injected (the #2220 defect): rc=$RC out=$OUT"
+fi
+# ...and the same session still reports nothing on further oscillation.
+write_snapshot "$H" sflap 60
+run "$H" "$D" sflap
+write_snapshot "$H" sflap 90
+run "$H" "$D" sflap
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "flap: repeated oscillation stays silent (injections are bounded, not counted)"
+else
+  fail "second flap cycle emitted: rc=$RC out=$OUT"
+fi
+
+# 4b. HYSTERESIS — the discriminating opposite, on a session of its own so the
+# two paths cannot share state: dumb → smart → dumb DOES inject twice, because
+# a two-rank improvement is a real state change rather than edge noise.
+write_snapshot "$H" srec 90
+run "$H" "$D" srec
+if [[ "$OUT" == *additionalContext* ]]; then ok "recovery: first dumb injects"; else fail "recovery setup: $OUT"; fi
+write_snapshot "$H" srec 10 # smart — two ranks, re-arms
+run "$H" "$D" srec
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "recovery: the improvement itself is silent"; else fail "improvement emitted: $OUT"; fi
+if [[ "$(cat "$D/state/srec.armed" 2>/dev/null)" == "smart" ]]; then
+  ok "recovery: a two-rank improvement decays the armed rank"
+else
+  fail "armed rank did not decay on a full recovery: $(cat "$D/state/srec.armed" 2>/dev/null)"
+fi
+write_snapshot "$H" srec 90
+run "$H" "$D" srec
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
+  ok "recovery: relapse after a genuine recovery injects again"
+else
+  fail "genuine relapse suppressed by hysteresis: rc=$RC out=$OUT"
+fi
+
+# 4c. LEGACY STATE: a session already running when this version lands has a
+# `.zone` file and no `.armed` file. The armed rank seeds from the last-seen
+# zone, so the first call after the upgrade decides exactly as the previous
+# version would have, and latches from there.
+mkdir -p "$D/state"
+printf 'acceptable\n' >"$D/state/slegacy.zone"
+rm -f "$D/state/slegacy.armed"
+write_snapshot "$H" slegacy 90 # acceptable → dumb: a worsening under either rule
+run "$H" "$D" slegacy
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
+  ok "legacy state without an .armed marker still injects on a real worsening"
+else
+  fail "legacy state broke the first post-upgrade decision: rc=$RC out=$OUT"
+fi
+if [[ "$(cat "$D/state/slegacy.armed" 2>/dev/null)" == "dumb" ]]; then
+  ok "legacy state gains an .armed marker on first write (no migration step)"
+else
+  fail "armed marker not seeded: $(cat "$D/state/slegacy.armed" 2>/dev/null)"
 fi
 
 # 5. Unknown zone (no snapshot) → silent, state untouched.

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -186,10 +186,16 @@ not validation.
 
 Since 0.4.0 the plugin itself ships hooks over its own seam — the first shipped consumer:
 
-- **Advisory injection** (`PostToolBatch` + `UserPromptSubmit`): once per transition into a worse
-  zone, inject continuation guidance (a minimal generic continuation tree plus a presence-gated
-  pointer to `session-flow:workflow`'s router). Silent while the zone is unchanged, improving, or
-  `unknown`.
+- **Advisory injection** (`PostToolBatch` + `UserPromptSubmit`): on a transition into a zone worse
+  than any this session has already reported, inject continuation guidance (a minimal generic
+  continuation tree plus a presence-gated pointer to `session-flow:workflow`'s router). Silent
+  while the zone is unchanged, improving, or `unknown`. **Hysteresis** (since 0.7.0): the gate is
+  the worst zone already *reported*, not the zone last *seen*, and that marker decays only on an
+  improvement of at least two ranks — the full width of the ladder. Occupancy does not climb
+  monotonically, so a session sitting on a band edge crosses it repeatedly; without the margin each
+  re-crossing read as a fresh transition and re-injected the guidance block. A `/clear` needs no
+  margin: it starts a new session id, hence a fresh baseline. The margin is a declared judgment
+  default, on the same footing as the bands above and with the same provenance status.
 - **Blocking gate** (`PreToolUse`, only when the `zone_hook_mode` userConfig option is
   `blocking`): denies new `Write|Edit|NotebookEdit|Agent|Workflow` calls on a **fresh dumb-zone
   snapshot** past a small grace budget. Fail-open on `unknown`; handoff-path writes, read-only


### PR DESCRIPTION
## Summary

`context-guard`'s zone bands are hard thresholds and the worsening-only latch had no dwell or
cooldown. Because state was persisted regardless of direction, a session hovering across a boundary
re-injected the ~1KB (~250 token) guidance block on **every** re-crossing: an improvement of any
size silently re-armed the injection, and nothing counted or capped the flap.

Occupancy does not climb monotonically — tool results land and are released — so a session sitting
near a band edge crosses it repeatedly. Comparing each observation against the *last-seen* zone made
every one of those a fresh transition.

### The fix

A second per-session marker, `<session>.armed`, holds the worst zone this session has already
**reported**, and that is now the emit gate. It decays only on an improvement of at least
**two ranks** — the full width of the `smart` / `acceptable` / `dumb` ladder.

| Path | Before | After |
|---|---|---|
| `dumb → acceptable → dumb` (the flap) | injects **twice** | injects **once** |
| `dumb → smart → dumb` (real recovery, then relapse) | injects twice | injects **twice** — unchanged |

### Why two ranks

The bands are declared judgment defaults, not doc- or benchmark-derived constants
(`reference/reader-contract.md` records their provenance), and the margin is stated on exactly the
same footing — **no citation is manufactured for it.** The reasoning, stated rather than asserted:
a one-rank dip at a band edge *is* the oscillation that caused the defect and says nothing new,
while `dumb → smart` spans the whole ladder and cannot be edge noise. A `/clear` needs no margin at
all — it starts a new session id, hence a fresh state file and a fresh baseline.

Net contract: a zone is announced at most once per session unless the session genuinely recovers,
after which the ladder re-arms and the next worsening is reported normally.

### This is NOT the recurring 10s-timeout defect

Called out here and in the CHANGELOG so a triager does not close it as a duplicate. Inbox item
`20260730-182801-context-guard-zone-crossing-hook-times-out-100-percent` was four `hooks.json`
registrations declaring `timeout: 10` against measured 10.6–21.4s runtimes, so the hook **died
rather than ran**; it was fixed in `context-guard` 0.4.8 via PR #2001 (squash-merged `925c3259`) by
raising all four to 60. This change is about how often the hook injects **when it does run** —
injection frequency at band edges, not hook completion. That item's still-open residue (profile the
hot path) is also unrelated.

### State-file shape, and the trap avoided

A **sibling file**, not a second line in the existing one. The state reader is
`tr -cd '[:lower:]' <"$STATE_FILE" | head -c 16`, which strips the newline too, so a two-line state
file would fuse into `dumbacceptable` and rank as `smart` — silently disabling the gate.

Live sessions already running when this lands have a `.zone` file and no `.armed` file. The armed
rank seeds from the last-seen zone, so the first call after the upgrade decides exactly as 0.6.6
would have, and latches from there. **No migration step and no state-format version.** Pinned by a
test. The armed marker is written **first** of the two, so a partial write failure can never leave
the gate open against a marker that already moved.

### Deliberately preserved

Named because they are load-bearing and easy to refactor away in passing: the two-channel split with
the continuation menu kept out of model context (the I23 counter-steer reference implementation),
the hook's refusal to claim an operator is present, the inert default posture, the worsening-only
latch itself, and `zone-gate.sh`'s structural no-deadlock exemptions. All untouched.

### Note for the reviewer on an edited test

`zone-crossing-inject.test.sh` case 4 shows in the diff as modified. **Its assertion is byte-for-byte
unchanged** — only the comment and the `ok:` label changed, to say *why* that path still injects
(`smart` is two ranks below the armed `dumb`, so the marker decayed and the ladder re-armed). No
existing assertion was weakened, deleted, or rewritten; the suite grew from 21 to 32 cases.

`context-guard` 0.6.6 → **0.7.0** (minor: injection cadence is observable behaviour). No blocking
behaviour, no permission, no new hook registration, and no external read or write changes — the
plugin's trust surface is untouched, so no security review note applies.

## Test plan

Before/after against the **same new test file**, with only the hook swapped for its merge-base
version:

```
$ git show $(git merge-base origin/main HEAD):plugins/context-guard/hooks/zone-crossing-inject.sh \
    > /tmp/cg-before/context-guard/hooks/zone-crossing-inject.sh
$ bash /tmp/cg-before/context-guard/hooks/zone-crossing-inject.test.sh
...
ok: flap: the first dumb observation injects
ok: flap: the one-rank dip is silent
FAIL: armed rank decayed on a one-rank dip:
FAIL: flap re-crossing re-injected (the #2220 defect): rc=0 out={"hookSpecificOutput":{"hookEventName":"PostToolBatch","additionalContext":"context-guard: this session crossed from the acceptable into the dumb context zone ...
FAIL: second flap cycle emitted: rc=0 out={"hookSpecificOutput":{...}}
ok: recovery: first dumb injects
ok: recovery: the improvement itself is silent
FAIL: armed rank did not decay on a full recovery:
ok: recovery: relapse after a genuine recovery injects again
ok: legacy state without an .armed marker still injects on a real worsening
FAIL: armed marker not seeded:

PASS=27 FAIL=5
```

The second failure is the defect itself, printed verbatim: the re-crossing emits the full guidance
block a second time.

After, on the same fixtures:

```
$ bash plugins/context-guard/hooks/zone-crossing-inject.test.sh
ok: first-seen dumb injects additionalContext
ok: injection is valid JSON carrying the firing event name
ok: model channel carries the counter-steer and no exit menu
ok: model channel claims ownership without claiming delivery
ok: operator channel carries the continuation menu
ok: unchanged zone is silent
ok: improvement is silent
ok: improvement still updates state
ok: relapse after a two-rank recovery injects again (UserPromptSubmit)
ok: flap: the first dumb observation injects
ok: flap: the one-rank dip is silent
ok: flap: a one-rank dip does NOT decay the armed rank
ok: flap: re-crossing into an already-reported zone does NOT re-inject
ok: flap: repeated oscillation stays silent (injections are bounded, not counted)
ok: recovery: first dumb injects
ok: recovery: the improvement itself is silent
ok: recovery: a two-rank improvement decays the armed rank
ok: recovery: relapse after a genuine recovery injects again
ok: legacy state without an .armed marker still injects on a real worsening
ok: legacy state gains an .armed marker on first write (no migration step)
ok: unknown zone is silent and stateless
ok: kill switch silences the hook
ok: hostile session id fails open
ok: empty stdin fails open
ok: injection length 1955 under 10k cap
ok: 150KB batch payload still injects (chunked stdin read)
ok: marker + smart snapshot injects the evidence-degraded notice once
ok: marker-driven dumb state stays silent on repeat
ok: state-persist failure fails open silently (no additionalContext)
ok: state-persist failure reports telemetry status=error
ok: no HOME and no CLAUDE_PLUGIN_DATA stays silent
ok: no zone state written relative to the working directory

PASS=32 FAIL=0
```

Lint:

```
$ shellcheck -x plugins/context-guard/hooks/zone-crossing-inject.sh \
    plugins/context-guard/hooks/zone-crossing-inject.test.sh
(no output)

$ bash scripts/check-silent-skips.sh
No silent prerequisite skips found in hook entry scripts.
```

## Related

- Closes #2220
- Explicitly NOT a duplicate of the 0.4.8 / PR #2001 timeout defect — see above
- Inbox item: `2026-08-10-plugin-quality-audit-four-components`
  (ledger `I7-four-components-023241Z.md` § C-CG-A)
