### PR TITLE
fix(docs-hygiene): audit-encapsulation detects plugin skill paths in monorepos

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Documentation-hygiene toolkit of six skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — docs-hygiene plugin
 
+## [0.11.1]
+
+### Fixed
+
+- **`audit-encapsulation/detect.sh` scanned vacuously in marketplace monorepos (#1889).** The
+  private-surface pattern anchored only on `.claude/skills/`; this repository authors skills under
+  `plugins/<plugin>/skills/`. The detector now matches both layouts, includes `plugins/` in the scan
+  scope, applies the scripts/ carve-out and self-citation filter to plugin paths, and ships a
+  positive-control fixture test so a future pattern regression cannot return a silent empty again.
+
 ## [0.11.0]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Audit and remediate skill-encapsulation violations — external citations reaching into private surfaces inside `.claude/skills/<X>/` beyond the slash invocation. Use when: 'audit encapsulation', 'find skill leaks', 'skill boundary violation', 'who is reaching into <skill>', 'check skill boundaries', 'public API drift', or before refactoring a skill."
+description: "Audit and remediate skill-encapsulation violations — external citations reaching into private surfaces inside `.claude/skills/<X>/` or `plugins/<plugin>/skills/<X>/` (marketplace monorepos) beyond the slash invocation. Use when: 'audit encapsulation', 'find skill leaks', 'skill boundary violation', 'who is reaching into <skill>', 'check skill boundaries', 'public API drift', or before refactoring a skill."
 argument-hint: "[detect|fix|file-issues]"
 user-invocable: true
 disable-model-invocation: false
@@ -18,7 +18,7 @@ This skill provides the detection + classification + remediation discipline that
 
 ## Public surface matrix
 
-The **Skill** surface — public = frontmatter + documented actions + args/flags + `/skill-name` slash invocation + the `scripts/` entry surface; private = everything else inside `.claude/skills/<X>/` (any OTHER subdirectory, all `*.schema.json` at any depth, all heading anchors) — is defined by `context/public-surface-contract.md`, including the data-file and scripts/ entry-surface carve-outs and the rip-and-paste-portability rationale. This skill audits cites against two more authoring surfaces the contract file does not enumerate:
+The **Skill** surface — public = frontmatter + documented actions + args/flags + `/skill-name` slash invocation + the `scripts/` entry surface; private = everything else inside `.claude/skills/<X>/` or `plugins/<plugin>/skills/<X>/` (any OTHER subdirectory, all `*.schema.json` at any depth, all heading anchors) — is defined by `context/public-surface-contract.md`, including the data-file and scripts/ entry-surface carve-outs and the rip-and-paste-portability rationale. This skill audits cites against two more authoring surfaces the contract file does not enumerate:
 
 | Surface | Public (cite externally) | Private |
 |---------|--------------------------|---------|

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Find external citations into private skill internals (.claude/skills/<X>/...).
+# Find external citations into private skill internals (.claude/skills/<X>/... and
+# plugins/<plugin>/skills/<X>/... in marketplace monorepos).
 #
 # Contract this detector encodes: ../context/public-surface-contract.md
 # (bundled with this skill).
@@ -59,7 +60,7 @@ for d in .claude/*/; do
   fi
   SCOPE_DIRS+=("$d")
 done
-for d in .github docs .lefthook; do
+for d in .github docs .lefthook plugins; do
   [[ -d "$d" ]] && SCOPE_DIRS+=("$d")
 done
 
@@ -85,7 +86,10 @@ fi
 # excludes `SKILL.md` (uppercase) so bare `<skill>/SKILL.md` path cites
 # pass (discouraged-but-legal). Does NOT match plain-JSON data files at
 # skill root (`<skill>/catalog.json`) per the data-file carve-out.
-PATTERN='\.claude/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|\.claude/skills/[a-z][a-z0-9-]\+/SKILL\.md#\|\.claude/skills/[a-z][a-z0-9-]\+/[^/]\+\.schema\.json'
+# Two skill-root layouts share one detector:
+#   - consumer-installed: `.claude/skills/<skill>/...`
+#   - marketplace monorepo: `plugins/<plugin>/skills/<skill>/...`
+PATTERN='\.claude/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|\.claude/skills/[a-z][a-z0-9-]\+/SKILL\.md#\|\.claude/skills/[a-z][a-z0-9-]\+/[^/]\+\.schema\.json\|plugins/[a-z][a-z0-9-]\+/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|plugins/[a-z][a-z0-9-]\+/skills/[a-z][a-z0-9-]\+/SKILL\.md#\|plugins/[a-z][a-z0-9-]\+/skills/[a-z][a-z0-9-]\+/[^/]\+\.schema\.json'
 
 # scripts/ entry-surface carve-out: a skill's `scripts/` is its declared ENTRY
 # surface — harness / CI / hooks / workflow registries MAY path-cite it. Like
@@ -99,7 +103,7 @@ PATTERN='\.claude/skills/[a-z][a-z0-9-]\+/[a-z][a-z0-9_-]\+/\|\.claude/skills/[a
 # line. The skill-to-skill half of the asymmetry (a sibling SKILL.md citing
 # another skill's scripts/ stays slash-only) is out of this inbound audit's
 # scope — see the contract file.
-SCRIPTS_RE='\.claude/skills/[a-z][a-z0-9-]+/scripts/'
+SCRIPTS_RE='(\.claude/skills/[a-z][a-z0-9-]+/scripts/|plugins/[a-z][a-z0-9-]+/skills/[a-z][a-z0-9-]+/scripts/)'
 
 HITS_FILE="$(mktemp)"
 trap 'rm -f "$HITS_FILE"' EXIT
@@ -144,6 +148,9 @@ while IFS= read -r line; do
     legal=0
     if [[ "$file" =~ ^\.claude/skills/([^/]+)/ ]] &&
       [[ "$text" == *".claude/skills/${BASH_REMATCH[1]}/"* ]]; then
+      legal=1
+    elif [[ "$file" =~ ^plugins/[^/]+/skills/([^/]+)/ ]] &&
+      [[ "$text" == *"/skills/${BASH_REMATCH[1]}/"* ]]; then
       legal=1
     elif [[ "$text" == *"plugins/cache/"* ]]; then
       legal=1

--- a/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
+++ b/plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh
@@ -190,6 +190,22 @@ code=$?
 assert_exit "self-citation filtered legal → exit 0" 0 "$code"
 assert_contains "summary counts self-citation as legal" "$err" "raw=1 legal=1 illegal=0"
 
+plugin_skill_root="plugins/my-plugin/skills"
+
+# Positive control: marketplace monorepo layout must not scan vacuously (#1889).
+plugin_repo="$(fixture_repo "docs/guide.md" \
+  "see ${plugin_skill_root}/foo/context/notes.md for detail")"
+out="$(cd "$plugin_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "plugin private-subdir cite → exit 1" 1 "$?"
+expected_plugin_row="$(printf 'docs/guide.md\t1\t%s/foo/context/' "$plugin_skill_root")"
+assert_contains "plugin violation row emitted" "$out" "$expected_plugin_row"
+
+plugin_scripts_repo="$(fixture_repo "docs/guide.md" \
+  "run ${plugin_skill_root}/alpha/scripts/foo.sh")"
+out="$(cd "$plugin_scripts_repo" && bash "$SCRIPT" 2>/dev/null)"
+assert_exit "plugin scripts/ entry cite → exit 0 (carve-out)" 0 "$?"
+assert_silent "plugin scripts/ cite emits nothing" "$out"
+
 if [[ "$FAILED" -ne 0 ]]; then
   exit 1
 fi


### PR DESCRIPTION
Fixes #1889

## What

`detect.sh` anchored every private-surface match on `.claude/skills/`, so running it at this marketplace repo's root returned vacuously clean. The detector now also matches `plugins/<plugin>/skills/<skill>/` private paths, includes `plugins/` in scan scope, and applies the scripts/ carve-out and self-citation filter to both layouts.

## Tests

`plugins/docs-hygiene/skills/audit-encapsulation/scripts/detect.test.sh` — new positive-control cases for plugin private-subdir cites (must fail) and plugin `scripts/` cites (must pass carve-out). All 36 checks pass locally.

## Related

- #1889