### PR TITLE
chore(conventions): route unstamped upstream-fact carriers into upstream-drift, and record the gate deferral

### DIFF
--- a/docs/conventions/upstream-drift/CHANGELOG.md
+++ b/docs/conventions/upstream-drift/CHANGELOG.md
@@ -4,6 +4,40 @@ Notable changes to the upstream-drift contract (SemVer). Changing a required par
 name, or an enforceability verdict is a major bump; additive guidance is a minor bump; docs-only
 clarification is a patch.
 
+## 1.4.0 — 2026-08-12
+
+Closes the **adoption** gap rather than a design one: the contract already owned verification
+stamps, recheck triggers, and the rule that the name binds on touch, but plugins restating upstream
+harness facts in bare prose had no route into the Adopters table and nothing made a stale claim
+surface ([#2273](https://github.com/melodic-software/claude-code-plugins/issues/2273)). Additive
+guidance; no required part, canonical name, or enforceability verdict changed.
+
+- **The Adopters table now says how a post-1.0.0 row gets there, and what disqualifies one.** The
+  preamble read "Migrated at this contract's 1.0.0", which any appended row would have quietly
+  falsified. It now separates the migrated rows from later on-touch adoptions and requires each
+  later row to name the release that added it. It also states the bar the third column already
+  implied but never wrote down: **a surface is tabled only once it conforms**, so a carrier known to
+  be unstamped is a tracked issue rather than a row. That column is a promise to a reader, and
+  tabling an unstamped surface would assert exactly what the reader would then not get.
+- **The fleet's open carriers are recorded where that rule sends them.** A sweep of `plugins/**` for
+  surfaces stating an upstream harness behaviour with no source, date, or trigger found 12 carriers
+  across 11 plugins, filed with quoted lines at
+  [#2297](https://github.com/melodic-software/claude-code-plugins/issues/2297) — along with the
+  files checked and found *conforming*, and the sweep's own limitation (a file-level citation gate
+  under-represents mixed files, so the list is a lower bound and says so). None is tabled here.
+- **An adoption CI gate is deferred, recorded as a decision with its own trigger.** The
+  load-bearing finding is that the check §Enforceability already names — flag a `Verified <date>`
+  with no trigger — **would not have caught the case that prompted the question**
+  ([#2207](https://github.com/melodic-software/claude-code-plugins/issues/2207)): that surface
+  carried no stamp at all, so a stamp-anchored grep had nothing to match. The named check is shaped
+  for a half-conforming record; the failure that ships is the zero-part one, and separating an
+  upstream restatement from an in-repo fact is a judgment about meaning — reasoning-only under the
+  tiers doc. A harness-vocabulary grep fires on every correct citation too, and a gate that forces
+  routine suppression trains authors to bypass it. Recorded with a basis and an event trigger — a
+  third unstamped carrier reaching `main`, or a demonstrated detector needing no suppression list —
+  so the deferral expires on evidence rather than on a date. The existing named-not-built check and
+  its own build trigger are unchanged.
+
 ## 1.3.0 — 2026-08-11
 
 Closes two holes in [§Reading the basis — the fetch route](README.md#reading-the-basis--the-fetch-route)

--- a/docs/conventions/upstream-drift/README.md
+++ b/docs/conventions/upstream-drift/README.md
@@ -277,9 +277,50 @@ Classified per `melodic-software/standards` `conventions/engineering/enforceabil
 | The trigger clears the observability bar | **Reasoning-only** — whether an event is decidable from evidence is a judgment about meaning. |
 | A trigger has fired | **Reasoning-only** today; **detect-then-judge** if a hash store lands — the hash mismatch flags, and judgment decides whether the page change touches the claim, because a changed page is not a changed fact. |
 
+### Recorded decision — an adoption gate is deferred, and the check named above would have missed the case that prompted it
+
+**Decided 2026-08-12 UTC: no CI gate is built for adoption of this convention, in either candidate
+shape.** Recorded as a decision rather than left implicit, because this repo's `*-gate` CI pattern
+is the standing precedent for promoting a convention to a check and the question was asked directly
+([#2273](https://github.com/melodic-software/claude-code-plugins/issues/2273)).
+
+The premise that settles it: the candidate check named in the table above — *flag any
+`Verified <date>` line or row whose surface states no trigger* — **would not have caught
+[#2207](https://github.com/melodic-software/claude-code-plugins/issues/2207)**, the finding that
+prompted the question. That surface carried no stamp at all, so a stamp-anchored grep had nothing to
+match on. The named check is shaped for a *half-conforming* record; the failure that actually ships
+is the *zero-part* one. It therefore stays named-not-built on its own build trigger, unchanged, and
+is not evidence that mechanization covers this class.
+
+The zero-part shape has no deterministic check available. Deciding whether a sentence restates an
+upstream-owned specific — as against an in-repo fact, a description of the surface's own behaviour,
+or ordinary prose — is a judgment about meaning, which is **reasoning-only** under the tiers doc. A
+grep for harness vocabulary (`PostToolUse`, `${CLAUDE_*}`, `settings.json`, and so on) fires on
+every correct citation and every in-repo mention alike, and a gate whose false-positive rate forces
+routine suppression trains authors to bypass it — worse than no gate, because it converts a real
+signal into noise with an approved silencer.
+
+- **Basis** — `melodic-software/standards` `conventions/engineering/enforceability-tiers.md` (the
+  reasoning-only tier and the worth-mechanizing routing rule), plus the worked instance above.
+- **Recheck trigger** — a third unstamped upstream-fact carrier reaches `main` after this decision
+  (two are already on the record: `plugin-quality`, corrected in its 0.4.0, and `architecture`,
+  whose false claim was removed in its 0.5.1), **or** a detector is demonstrated that separates an
+  upstream restatement from an in-repo one without a suppression list. Either event reopens the
+  shape question; neither is a date.
+
 ## Adopters
 
-Migrated at this contract's 1.0.0 to the single name, each citing this doc with content intact.
+The rows below were migrated at this contract's 1.0.0 to the single name, each citing this doc with
+content intact. **A row added after 1.0.0 is a surface that adopted on touch** — the mechanism the
+note under the table already requires — and names the release that added it, so the table never
+implies a surface was migrated at 1.0.0 when it was not.
+
+**A surface is tabled only once it actually conforms.** The third column is a promise to a reader
+about what they can rely on, so a carrier *known* to be unstamped belongs in a tracked issue, never
+in a row: tabling it would assert the very thing the reader would then not get. The fleet's open
+carriers are recorded that way in
+[#2297](https://github.com/melodic-software/claude-code-plugins/issues/2297).
+
 The rows are not all the same thing, and the table says which is which. A **conforming record**
 carries the four required parts for an upstream-derived claim or decision. A **named trigger**
 shares the canonical name, the observability bar, and


### PR DESCRIPTION
## Summary

Plugins restate upstream harness facts in bare prose — no source URL, no as-of date, no recheck
trigger — so when the upstream behaviour changes, nothing makes the stale claim surface.
`docs/conventions/upstream-drift/` already owns exactly this concern and already says the name
**binds on touch**. The gap was **adoption, not design**, so nothing new is invented here.

Docs-only. No plugin, script, hook, or CI behaviour changes.

### 1. The Adopters table now says how a post-1.0.0 row gets there — and what disqualifies one

The preamble read *"Migrated at this contract's 1.0.0"*, which any appended row would have quietly
falsified. It now separates the eight migrated rows from later on-touch adoptions and requires each
later row to name the release that added it.

It also writes down the bar the third column already implied but never stated: **a surface is tabled
only once it actually conforms.** That column is a promise to a reader about what they can rely on,
so a carrier *known* to be unstamped belongs in a tracked issue, never in a row — tabling it would
assert the very thing the reader would then not get, which is this batch's own recurring defect
class pointed at the convention meant to prevent it.

### 2. The fleet sweep — 12 carriers, filed rather than tabled

A sweep of `plugins/**` for surfaces stating an upstream harness behaviour with no source, date, or
trigger found **12 carriers across 11 plugins**, filed at #2297 with quoted lines and a per-plugin
tally. The issue also records the files checked and found **conforming** (so the sweep is not
one-sided) and states its own limitation plainly: the citation gate was **file-level**, so any file
containing a docs URL anywhere was dropped from the carrier pass, which structurally
under-represents mixed files — roughly 300 files were dropped that way. It is a **lower bound, not a
census**, and it says so.

None is tabled here, which is change 1 applied to its own findings.

### 3. `architecture` is deliberately NOT added to the table

Row 1 of #2273 asks for exactly that row. It is not being added, and the reason is the point:

#2286 (merged while this was in flight) removed the false substitution claim, closing #2207. But the
surviving bullet on `main` still reads:

> **The durable candidate artifact is a per-project memory-tier file, never `${CLAUDE_PLUGIN_DATA}`.**
> **Even resolved it points at a plugin-global dir that collides candidates across projects.** …

"Even resolved it points at a plugin-global dir" **is** an upstream-owned specific —
`plugins-reference` §Environment variables → §Persistent data directory, which resolves the token to
`~/.claude/plugins/data/{id}/`. It carries no URL, no date, and no trigger. So A-F4 (the unstamped-
prose row of #2207) is untouched and `architecture` is still a carrier. Per change 1 it is recorded
in #2297, not tabled.

### 4. Enforcement decided: deferred, as a recorded decision with its own trigger

Row 3 asks whether this repo's `*-gate` CI pattern should enforce adoption. **No gate is built**,
and the reason is a finding rather than a preference:

The candidate check §Enforceability **already names** — *flag any `Verified <date>` line or row whose
surface states no trigger* — **would not have caught #2207**, the case that prompted the question.
That surface carried no stamp at all, so a stamp-anchored grep had nothing to match on. The named
check is shaped for a **half-conforming** record; the failure that actually ships is the
**zero-part** one. The existing named-not-built check and its own build trigger are left unchanged.

The zero-part shape has no deterministic check available: deciding whether a sentence restates an
upstream-owned specific — as against an in-repo fact or ordinary prose — is a judgment about
meaning, **reasoning-only** under the tiers doc. A harness-vocabulary grep (`PostToolUse`,
`${CLAUDE_*}`, `settings.json`) fires on every correct citation and in-repo mention alike, and a gate
whose false-positive rate forces routine suppression trains authors to bypass it — worse than no
gate, because it converts a real signal into noise with an approved silencer.

Recorded as the doc's own **second record kind** with a basis and an event trigger — a third
unstamped carrier reaching `main`, or a demonstrated detector needing no suppression list — so the
deferral expires on evidence rather than on a date.

### Disposition of all three rows of #2273

| Row | Disposition |
|---|---|
| Add `architecture` to Adopters | **Not added, deliberately** — #2286 left an unstamped upstream specific in the same bullet, so the plugin does not conform. Recorded in #2297 instead, per the tabling rule this PR adds. |
| Sweep fleet-wide, add each carrier | **Swept.** 12 carriers / 11 plugins filed at #2297 with evidence, conforming counter-examples, and the sweep's stated limits. Not tabled, same rule. |
| Decide enforce vs document | **Decided: deferred**, recorded with basis and trigger, on the finding that the named candidate check would have missed the motivating case. |

`upstream-drift` 1.3.0 → **1.4.0** (minor: additive guidance, per the contract's own versioning
rule — no required part, canonical name, or enforceability verdict changed).

## Test plan

```
$ npx markdownlint-cli2 docs/conventions/upstream-drift/README.md \
    docs/conventions/upstream-drift/CHANGELOG.md
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Linting: 2 files
Summary: 0 issues in 0 files

$ bash scripts/check-changelog-parity.sh --check-order
All 75 changelog(s) read newest-first with no duplicate versions.

$ bash scripts/check-changelog-parity.sh --check-bump $(git merge-base origin/main HEAD)
Every plugin whose version changed vs c722271c723e1b0dd1196697a0100e961b06dd94 has a '## [<version>]' CHANGELOG.md entry.
```

`--check-order` and `--check-bump` both read `docs/conventions/*/CHANGELOG.md`, so the convention
changelog's `## 1.4.0 — 2026-08-12` heading form and its ordering are exercised by the run above,
not assumed.

The claim in §3 is quoted from `main` rather than recalled:

```
$ git show origin/main:plugins/architecture/skills/improve/SKILL.md | sed -n '71p'
- **The durable candidate artifact is a per-project memory-tier file, never `${CLAUDE_PLUGIN_DATA}`.** Even resolved it points at a plugin-global dir that collides candidates across projects. ...
```

The upstream basis for calling that an upstream-owned specific was re-fetched at rung 1 during this
work — `https://code.claude.com/docs/en/plugins-reference.md`, 2026-08-12 UTC, `200`,
`text/markdown`, 95,338 bytes / 1,314 lines, first heading `# Plugins reference`, slug confirmed
canonical against `llms.txt`, SHA-256
`f6627de35a3f285d18cf22494843bb328d65e3b867fbc1856865caa47ea3ea64` — line 709: "The
`${CLAUDE_PLUGIN_DATA}` directory resolves to `~/.claude/plugins/data/{id}/` …".

## Related

- Closes #2273
- Filed by this work: #2297 (the 12 fleet carriers, plus `architecture` per §3)
- #2207 / #2286 — the per-plugin half; #2286 closed the false claim, this closes the fleet half
- #1568, #1824 — the recurring false-claim family
- #1638 — closed; established `docs/conventions/upstream-drift/`
- Inbox item: `20260811-021645-plugin-audit-four-components-and-guard-deadlock-ownership`
  (ledger `I9-021645-four-components.md` § Lane E end)
