### PR TITLE
fix(guardrails): validate replace_all extraction in advisory verify hooks

### DIFF
--- a/plugins/guardrails/.claude-plugin/plugin.json
+++ b/plugins/guardrails/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "guardrails",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "Twelve safety guards that block secret/credential writes, hardcoded machine-specific paths, git hook-bypass attempts, irreversible git operations (force-push, reset --hard, worktree-wide checkout/restore discards), Bash file-write workarounds that circumvent Write/Edit hooks, multi-line `git commit -m` messages (an actual-newline `-m` mangles across shells; single-line `-m` passes), commit subjects and gh pr create titles that violate the repo's tracked team convention (when one is declared in .claude/source-control.md), (advisory) hallucinated CLI flags, (advisory) /plugin:skill references that do not resolve, (advisory) markdown citing a repo path the repo's own history shows was removed, (advisory, opt-in) un-throttled Workflow fan-out that risks burst 529s, and (advisory, opt-in) direct gh pr create calls bypassing this marketplace's own pull-request skill — each independently toggleable.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/guardrails/CHANGELOG.md
+++ b/plugins/guardrails/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `guardrails` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.27.2]
+
+### Fixed
+
+- **`skill-reference-verify` and `stale-path-verify` treated a malformed `replace_all`
+  extraction like a legitimate `false` (#2126).** Both hooks now accept only the
+  stringified `"true"` / `"false"` values the jq filter produces; any other shape skips
+  verification rather than proceeding on the permissive branch.
+
 ## [0.27.1]
 
 ### Fixed

--- a/plugins/guardrails/hooks/skill-reference-verify.sh
+++ b/plugins/guardrails/hooks/skill-reference-verify.sh
@@ -137,6 +137,15 @@ case "$TOOL" in
 Edit)
   SCAN_CONTENT="${HOOK_JQ_FIELDS[1]}"
   REPLACE_ALL="${HOOK_JQ_FIELDS[3]}"
+  case "$REPLACE_ALL" in
+  true | false) ;;
+  *)
+    # Advisory guard: a malformed replace_all extraction must not wear the permissive
+    # "false" branch. Well-formed payloads always stringify to true/false; anything
+    # else is an unreadable field — skip verification rather than guess.
+    exit 0
+    ;;
+  esac
   EDIT_WROTE_LINES="${HOOK_JQ_FIELDS[4]}"
   ;;
 Write) SCAN_CONTENT="${HOOK_JQ_FIELDS[2]}" ;;

--- a/plugins/guardrails/hooks/stale-path-verify.sh
+++ b/plugins/guardrails/hooks/stale-path-verify.sh
@@ -96,6 +96,15 @@ case "$TOOL" in
 Edit)
   SCAN_CONTENT="${HOOK_JQ_FIELDS[1]}"
   REPLACE_ALL="${HOOK_JQ_FIELDS[3]}"
+  case "$REPLACE_ALL" in
+  true | false) ;;
+  *)
+    # Advisory guard: a malformed replace_all extraction must not wear the permissive
+    # "false" branch. Well-formed payloads always stringify to true/false; anything
+    # else is an unreadable field — skip verification rather than guess.
+    exit 0
+    ;;
+  esac
   ;;
 Write) SCAN_CONTENT="${HOOK_JQ_FIELDS[2]}" ;;
 *) exit 0 ;;


### PR DESCRIPTION
Fixes #2126

## What

`skill-reference-verify` and `stale-path-verify` consumed `replace_all` with a `== "true"` test, so an empty or otherwise malformed extraction was indistinguishable from a legitimate `false` and proceeded on the permissive branch. Both hooks now accept only `"true"` or `"false"`; anything else skips verification.

## Tests

Existing `skill-reference-verify.test.sh` (110) and `stale-path-verify.test.sh` (87) pass locally.

## Related

- #2126