### PR TITLE
fix(docs-hygiene): Form 14 matches title-cased ATX headings

### DIFF
--- a/plugins/docs-hygiene/.claude-plugin/plugin.json
+++ b/plugins/docs-hygiene/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "docs-hygiene",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Documentation-hygiene toolkit of six skills: compress (flavor-trim markdown with a semantic-diff safety net), audit-noise (classify markdown noise), extract-ssot (deduplicate repeated content into a single source of truth), audit-encapsulation (detect citations into skill-private surfaces), rename-references (sweep stale references after renames), and audit-derivability (classify whether a whole document earns its existence — could a fresh agent re-derive it from the code?).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/docs-hygiene/CHANGELOG.md
+++ b/plugins/docs-hygiene/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog — docs-hygiene plugin
 
+## [0.11.2]
+
+### Fixed
+
+- **`rename-references` Form 14 missed title-cased ATX headings (#1394).** The ATX and Setext
+  title alternatives now carry `(?i)` so `# Re-Anchor` matches a container named `re-anchor`
+  instead of falling through to bare Form 2. Declaration alternatives stay case-sensitive;
+  `audit.md` warns against global `-i`.
+
 ## [0.11.1]
 
 ### Fixed

--- a/plugins/docs-hygiene/skills/rename-references/context/audit.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/audit.md
@@ -47,6 +47,8 @@ Run all patterns from [patterns.md](patterns.md) in parallel via Grep tool. For 
   REJECTS outright (`the literal "\n" is not allowed in a regex`). Without it the Setext pattern
   errors rather than under-matching, so the survey silently loses the form and a container's
   landing-page title survives as Form-2 residue that container mode excludes
+- Form 14's ATX and Setext alternatives embed `(?i)` so title-case headings match; do **not** add
+  `-i` globally — declaration alternatives must stay case-sensitive (#1394)
 - Apply auto-exclusions per `../SKILL.md` "Auto-exclusions" via `glob` filter or post-filter
 
 **Collect per-OCCURRENCE records, not per-line ones.** `output_mode: "content"` returns matching

--- a/plugins/docs-hygiene/skills/rename-references/context/patterns.md
+++ b/plugins/docs-hygiene/skills/rename-references/context/patterns.md
@@ -293,8 +293,8 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
 ## Form 14: Document title / declared name
 
 ```regex
-^#{1,6}\s+`?<old>`?\s*(#+\s*)?$
-^`?<old>`?\s*$\n^(=+|-+)\s*$
+(?i)^#{1,6}\s+`?<old>`?\s*(#+\s*)?$
+(?i)^`?<old>`?\s*$\n^(=+|-+)\s*$
 ^\s*(name|title|id):\s*("<old>"|'<old>'|<old>)(\s+#.*)?\s*$
 (^|[{,])\s*"(name|title|id)"\s*:\s*"<old>"\s*(,|}|$)
 ^\s*"?(name|title|id)"?\s*=\s*("<old>"|'<old>')\s*(#.*)?$
@@ -302,6 +302,10 @@ existing "Frozen historical records" rule already excludes. See `triage.md`
 ```
 
 - **Triage default:** Certain
+- **Case on title shapes only:** the ATX and Setext alternatives carry a `(?i)` flag — a
+  title-cased heading (`# Re-Anchor` for a container named `re-anchor`) is the same reference as
+  a lowercase one and keeps Form 14's scope rule. Declaration alternatives stay case-sensitive:
+  manifest and catalog registrations are exact identifiers (#1394).
 - **Catches:** an ATX heading whose ENTIRE content is the renamed token — the README H1 that
   names the thing — a `name` / `title` / `id` declaration in YAML frontmatter, a JSON manifest or
   catalog, or a TOML manifest — and a catalog entry KEYED by the container rather than declaring


### PR DESCRIPTION
Fixes #1394

## What

Form 14's ATX and Setext title alternatives now embed `(?i)` so `# Re-Anchor` matches a container named `re-anchor` instead of missing Form 14 and falling through to bare Form 2 (which defaulted to Certain for non-verb tokens). Manifest/catalog declaration alternatives stay case-sensitive; `audit.md` warns against global `-i`.

## Related

- #1394