### PR TITLE
docs: reconcile headless marketplace registration with CLOUD-SESSIONS

### DIFF
--- a/docs/MIGRATION-PLAYBOOK.md
+++ b/docs/MIGRATION-PLAYBOOK.md
@@ -587,9 +587,16 @@ Catalog these per migration; they are the usual failures when an in-repo skill b
   update them.
 - **Agent shadowing.** Project/user `.claude/agents/` override same-named plugin agents. A leftover
   in-repo copy masks the plugin version until removed from the source repo.
-- **Headless registration.** `extraKnownMarketplaces` auto-registration requires the interactive trust
-  dialog; CI/headless/cloud must run `claude plugin marketplace add` explicitly or pre-seed via
-  `CLAUDE_CODE_PLUGIN_SEED_DIR`.
+- **Headless registration.** Distinguish the marketplace **source** from the session shape:
+  - **Remote or git-sourced catalogs** (GitHub repo, URL, npm, …) in CI or other non-interactive
+    runs: no interactive trust dialog — run `claude plugin marketplace add` explicitly or pre-seed via
+    `CLAUDE_CODE_PLUGIN_SEED_DIR` ([Plugin marketplaces — Pre-populate plugins for containers](https://code.claude.com/docs/en/plugin-marketplaces#pre-populate-plugins-for-containers),
+    fetched 2026-08-12).
+  - **`directory` / `file` source with a relative path in checked-in project `.claude/settings.json`:**
+    the path [resolves against the repository checkout](https://code.claude.com/docs/en/plugin-marketplaces#relative-paths),
+    including cloud sessions that install from the clone at session start — no separate
+    `marketplace add` step. Local collaborators still see the interactive trust prompt once they
+    trust the folder. See [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md) "Plugins in sessions on this repo".
 
 ## Per-plugin migration gate
 
@@ -1279,13 +1286,16 @@ surface to a published plugin for a single consumer's low-value nicety.
 
 1. Register the marketplace in the consumer's `extraKnownMarketplaces` and enable the plugin in
    `enabledPlugins` (project `settings.json`, so clones inherit it on trust — the interactive trust prompt
-   both registers and installs the enabled plugin). Headless/CI has no such prompt, and registering a
+   both registers and installs the enabled plugin for **local** collaborators). **Headless CI** and other
+   non-interactive runs with **remote/git-sourced** catalogs have no such prompt, and registering a
    marketplace does not install its plugins, so do both explicitly at project scope: `claude plugin
    marketplace add <repo> --scope project` then `claude plugin install <plugin>@<marketplace> --scope
    project --config KEY=VALUE …`, seeding every
    non-default `userConfig` toggle on that install command — `--config` applies only on a fresh install and
    is ignored once the plugin is already installed (smoke-test C), so a headless reconfiguration later
-   means uninstall/reinstall. Otherwise the marketplace is known but the plugin is absent, and step 3's
+   means uninstall/reinstall. **Exception:** a `directory`/`file` relative-path entry in checked-in
+   project settings resolves against the repo checkout (cloud sessions included) — see
+   [`docs/CLOUD-SESSIONS.md`](CLOUD-SESSIONS.md). Otherwise the marketplace is known but the plugin is absent, and step 3's
    verify edit would run with no plugin hook.
 2. Interactively, `/plugin configure` adjusts `userConfig` toggles at any time; keep the
    `HOOK_TELEMETRY_SINK` wiring and the sink script (the bridge), adapting the sink for any


### PR DESCRIPTION
Fixes #2053

## What

`MIGRATION-PLAYBOOK.md` previously stated that **all** `extraKnownMarketplaces` auto-registration requires the interactive trust dialog and that CI/headless/cloud must run `claude plugin marketplace add` — contradicting `docs/CLOUD-SESSIONS.md`, which documents that a `directory` relative-path entry in checked-in `.claude/settings.json` resolves against the repository checkout and cloud sessions install from the clone at session start.

This PR splits the guidance by **source shape** (remote/git vs directory/file relative path), cites the official relative-path and seed-dir docs (fetched 2026-08-12), and cross-links `CLOUD-SESSIONS.md`.

## Note on acceptance criteria

The issue asked for an empirical `claude plugin list` probe in a cloud session. This PR resolves the written contradiction from sourced docs; a live probe remains useful confirmation but is no longer blocked on choosing which page to trust.

## Related

- #2053