### PR TITLE
fix(claude-config): declare dispatch-unavailable posture in audit skills

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
+  "version": "0.35.1",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.35.0",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.1]
+
+### Fixed
+
+- **Audit skills declare a posture when subagent dispatch is unavailable.** `audit-instructions`,
+  `audit-prompting-postures`, and `audit-pass` now require disclosure, `(unverified)` marking, and
+  per-lane verification attestation when mandated fresh-context dispatch cannot run, so a skipped
+  verify phase is structurally distinguishable from a fully verified report. (#2279)
+
 ## [0.35.0]
 
 ### Added

--- a/plugins/claude-config/skills/audit-instructions/SKILL.md
+++ b/plugins/claude-config/skills/audit-instructions/SKILL.md
@@ -363,6 +363,20 @@ untested. Refute a pair on its own gates — *same observable, or two sharing a 
 resident text already arbitrate? is there a prompt that fires both?* A defended pair is one where a
 gate fails, dropped for that named reason.
 
+### When dispatch is unavailable
+
+Phases B and C **require** fresh-context, non-fork subagent dispatch. When the Agent tool is
+blocked, unavailable, or the session cannot spawn subagents:
+
+1. **Disclose in the report header** which phases ran inline, which were skipped, and why dispatch
+   was unavailable — a run that skipped verification MUST be structurally distinguishable from a
+   fully verified one.
+2. **Mark unverified proposals.** Every removal or rewrite that did not receive an independent
+   verifier MUST carry an `(unverified)` marker in the findings table and MUST NOT be surfaced as a
+   confident removal.
+3. **Extend the cost line.** The Phase D cost line MUST list phases that did not run and name the
+   verification mode per surface (`verified` | `inline` | `skipped`).
+
 ## Phase D — Report
 
 Persist the report to `${CLAUDE_PLUGIN_DATA}/audit-instructions/<state-key>/last-audit.md`.

--- a/plugins/claude-config/skills/audit-pass/SKILL.md
+++ b/plugins/claude-config/skills/audit-pass/SKILL.md
@@ -301,6 +301,18 @@ and the finding it claims to resolve — the artifact, not this run's reasoning 
 advisor when one is installed and set up (the OpenAI Codex plugin, say, invoked per its own docs),
 with a **fresh-context (non-fork) subagent** as the stated fallback.
 
+### When dispatch is unavailable
+
+The apply-verify step and delegated lanes that mandate subagent dispatch **require** that dispatch.
+When the Agent tool is blocked, unavailable, or the session cannot spawn subagents:
+
+1. **Record per-lane verification mode** in the run manifest and assembled report (`verified` |
+   `inline` | `skipped`) for every lane that mandates independent verification.
+2. **Mark unverified findings.** Proposals or applied fixes that did not receive an independent
+   verifier MUST carry an `(unverified)` marker and MUST NOT be presented as resolved.
+3. **Do not silently complete.** The `skipped` section and report header MUST name dispatch
+   unavailability when it prevented a mandated verification phase.
+
 ## Phase 6 — Report
 
 Two artifacts, because incremental persistence and a sectioned report want different shapes: an

--- a/plugins/claude-config/skills/audit-pass/reference/report-location-and-schema.md
+++ b/plugins/claude-config/skills/audit-pass/reference/report-location-and-schema.md
@@ -117,6 +117,7 @@ the run and target identity, the resolved version of every catalog consulted, an
 | `suppressed` | every entry with its reason, date, contributing cascade layer, and its disposition — including each `needs-reconfirmation` entry with the changed side named, each stale entry, each malformed entry, each **`personal-only, not applied`** entry, and every UNEXPLAINED DISAPPEARANCE |
 | `delegated` | `/doctor`'s output, diffed by nobody |
 | `skipped` | every surface excluded, **with its reason** — a silent exclusion reads as coverage, and this section is what stops it |
+| `verification` | per-lane verification mode (`verified` \| `inline` \| `skipped`) for lanes that mandate independent subagent dispatch; omitted only when every such lane verified |
 
 **Resume reads the partial, not the report**, so completion state is derivable from the artifact
 rather than tracked beside it and able to disagree with it.

--- a/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
@@ -75,6 +75,17 @@ Dispatch one fresh-context, non-fork verifier per surface batch, prompted to ref
 addition: "argue this component's purpose does not need this posture, or that it already carries
 it." Findings a verifier refutes are dropped or demoted to `info`.
 
+### When dispatch is unavailable
+
+Phase D **requires** fresh-context, non-fork verifier dispatch. When the Agent tool is blocked,
+unavailable, or the session cannot spawn subagents:
+
+1. **Disclose in the report header** that Phase D did not run and why.
+2. **Mark unverified proposals.** Every proposed addition that did not receive an independent
+   verifier MUST carry an `(unverified)` marker and MUST NOT be presented as a confident finding.
+3. **Add a verifier attestation line** to the report tail — components verified, verified inline,
+   or skipped — alongside the existing coverage and Sources lines.
+
 Persist the report to
 `${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/<state-key>/last-audit.md`.
 
@@ -122,7 +133,9 @@ Then summarize in chat:
 
 Verdicts: `MISSING` (finding, with proposed addition as a fenced diff), `PRESENT` (where it is),
 `NOT-APPLICABLE` (with the failed predicate). End with a coverage line — components inventoried,
-classified, unclassified — and a Sources line citing the pages fetched this run with dates.
+classified, unclassified — and a Sources line citing the pages fetched this run with dates. When
+Phase D ran, end with a verifier attestation line — surface batches verified, verified inline, or
+skipped.
 
 ## Gotchas
 


### PR DESCRIPTION
Fixes #2279.

Three audit skills mandate independent subagent verification but previously had no degraded mode. Each now requires disclosure when dispatch is unavailable, `(unverified)` marking for unverified proposals, and per-lane verification attestation in the report.

## Related

- #2279