### PR TITLE
docs(autonomy): name c3-this-run per-invocation merge widening in matrix

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
 Versions 0.1.0–0.7.0 predate this file (introduced with 0.7.1); their history lives in the
 merged work-package PRs (#333, #343, #356, #372, #377, #600, #676).
 
+## [0.16.1]
+
+### Fixed
+
+- **Guardrail matrix names the per-invocation `c3-this-run` widening.** The babysit-loop typed-pair
+  exception is now acknowledged in `reference/guardrails.md` with a route to the
+  `source-control` config-resolution contract. (#2087)
+
 ## [0.16.0]
 
 ### Changed — ACTION REQUIRED for anyone with an existing `L2`/`L3` binding, or auto-merge bound

--- a/plugins/autonomy/reference/guardrails.md
+++ b/plugins/autonomy/reference/guardrails.md
@@ -62,6 +62,22 @@ answered from this document:
 | Which verification layers exist and which block, per class | [security-review](guardrails/security-review.md) |
 | Which roles verify a class, how they must differ, and the shipped checker floors | [verification-topology](guardrails/verification-topology.md) |
 | Which signals may enter the queue autonomously, and under what caps | [admission-policy](guardrails/admission-policy.md) |
+| Per-invocation merge widening (`autopilot` + `--merge c3-this-run`) | [source-control config-resolution](../../source-control/reference/config-resolution.md) (§ typed pair exception) |
+
+## Per-invocation merge widening
+
+The matrix's merge-policy column describes **standing** authority: promotion-gated cells that
+require a recorded, team-tracked adoption before auto-merge is eligible. Separately, the
+`source-control` babysit-loop lane defines **one named per-invocation exception**: an argument
+line that types both the literal `autopilot` tier keyword and `--merge c3-this-run` widens
+*that single invocation's* merge dimension up to and including C3, still bounded by the
+unconditional C4/C5 human-merge floor.
+
+This exception is not a matrix promotion and is never persisted — the next invocation without
+the pair reverts to the tracked `babysit_loop_merge` resolution. No config layer supplies either
+token; both must appear on the invocation line. The full contract (baseline adoption requirement,
+mutual exclusivity with safer `--merge` values, and the C4/C5 ceiling) lives in
+[`source-control/reference/config-resolution.md`](../../source-control/reference/config-resolution.md).
 
 ## Permission posture
 


### PR DESCRIPTION
Fixes #2087.

The guardrail matrix now acknowledges the `autopilot` + `--merge c3-this-run` typed-pair exception and routes to the `source-control` config-resolution contract. Standing merge promotion is unchanged.

## Related

- #2087