### PR TITLE
feat(claude-config,claude-memory): key plugin-data reports per project and contract the rule

### DIFF
--- a/docs/PLUGIN-PHILOSOPHY.md
+++ b/docs/PLUGIN-PHILOSOPHY.md
@@ -478,6 +478,7 @@ doc before a second plugin adopts it. Fleet audits check conformance per row.
 | Hook precision (false-positive discipline) | [`docs/conventions/hook-precision/`](conventions/hook-precision/README.md) |
 | Hook config delivery (userConfig→hook channel matrix) | [`docs/conventions/hook-config-delivery/`](conventions/hook-config-delivery/README.md) |
 | Permission-rule hygiene | [`docs/conventions/permission-rule-hygiene/`](conventions/permission-rule-hygiene/README.md) |
+| Plugin-data report keying, retention, and overwrite | [`docs/conventions/plugin-data-report-keying/`](conventions/plugin-data-report-keying/README.md) |
 | Repository standards index | [`docs/conventions/standards/`](conventions/standards/README.md) |
 | Skill layout contract and evals schema | `skill-quality` plugin (contract gate + bundled schema) |
 | Review severity vocabulary | `review` plugin (`context/severity.md`) |

--- a/docs/conventions/plugin-data-report-keying/CHANGELOG.md
+++ b/docs/conventions/plugin-data-report-keying/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Plugin-data report keying — Changelog
+
+Notable changes to the `${CLAUDE_PLUGIN_DATA}` keying, retention, and overwrite contract. The contract
+is versioned by the `Version:` stamp in `README.md` (SemVer). A rule whose `[SPEC]` obligation
+tightens is a major bump; a new rule or a new named example is a minor bump; wording and adoption-table
+updates are a patch.
+
+## 1.0.0 — 2026-08-12
+
+Initial published contract. Written because the hazard was already understood inside the fleet and
+applied inconsistently *within one plugin* — the signature of a missing rule rather than a per-skill
+oversight. `docs/conventions/` carried eighteen entries and none governed how a plugin names what it
+writes under `${CLAUDE_PLUGIN_DATA}`; the nearest governing text (`docs/MIGRATION-PLAYBOOK.md` seam 4)
+scopes *what may live there*, not how it is named.
+
+- **Rule 1 [SPEC]** — every write is keyed `<component>/<state-key>/<filename>`, with `<state-key>` =
+  `<repo-identity>/<worktree-discriminator>`. The scheme is `claude-config:audit-pass`'s, reused
+  rather than reinvented, and ships as the shared `lib/state-key.sh` registered in
+  `scripts/cross-plugin-source-registry.txt`.
+- **Rule 1a [SPEC]** — derive the key by running commands, never as a condition over
+  `${CLAUDE_PROJECT_DIR}` "when set". That placeholder substitutes inline in skill and agent content,
+  so the literal token never reaches the model and the condition is not its to evaluate.
+- **Rule 1b [SPEC]** — a key becomes directory components, so validate it as one and hash anything
+  outside the accepted segment shape. A remote of `../../../etc` would otherwise walk the artifact out
+  of the plugin's namespace; an unvalidated version of this derivation was caught doing exactly that
+  in review.
+- **Rule 1c** — the "looks scoped but isn't" case named with its worked example
+  (`bug-report:write`'s kebab-cased project-root basename), so the next writer does not repeat it.
+  Recorded as context, explicitly not filed as a `bug-report` defect.
+- **Rule 2 [SPEC]** — retention is chosen by whether the artifact is read back, and the two failure
+  modes are separated: keying closes *collision* (project B served project A's content), retention
+  closes *overwrite* (yesterday's artifact gone). A non-destructive history does not close collision,
+  because serving the newest is not serving this project's.
+- **Rule 3 [SPEC]** — never serve or derive from an artifact that cannot be attributed to a project.
+  This governs migration too: a legacy unkeyed file has no project segment, so adopting it into a key
+  invents the attribution keying exists to remove.
+- **Rule 4** — state the uninstall fragility where the keyed artifact is the only durable copy; the
+  data directory is deleted on uninstall from the last scope unless `--keep-data` is passed.
+- Adoption table records four conformant writers, one basename-keyed writer, one verification-based
+  alternative (`claude-config:unhobble`), one slug-keyed instance of the gap
+  (`docs/conventions/topic-docs/`'s non-repo fallback), and one deliberate non-adopter
+  (`machine-health:audit`).

--- a/docs/conventions/plugin-data-report-keying/README.md
+++ b/docs/conventions/plugin-data-report-keying/README.md
@@ -1,0 +1,183 @@
+# Plugin-data report keying, retention, and overwrite
+
+Version: 1.0.0
+Last updated: 2026-08-12
+
+A marketplace-wide contract for **how a plugin names what it writes under `${CLAUDE_PLUGIN_DATA}`** —
+the key, the retention shape, and whether a write may overwrite. It does not govern *what* may live
+there; that is `docs/MIGRATION-PLAYBOOK.md`'s seam 4 (`${CLAUDE_PLUGIN_DATA}` for machine state
+only), and this convention sits underneath it.
+
+## The harness fact this exists for
+
+[Plugins reference](https://code.claude.com/docs/en/plugins-reference), § *Persistent data
+directory*, fetched 2026-08-12:
+
+> The `${CLAUDE_PLUGIN_DATA}` directory resolves to `~/.claude/plugins/data/{id}/`, where `{id}` is
+> the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`, and `-` replaced by `-`.
+
+**The formula is keyed to the plugin identifier and nothing else.** No project, no checkout, no
+worktree, no session. A plugin that writes a fixed filename there has one such file *per machine*,
+shared by every repository the operator works in.
+
+Same page, on lifetime:
+
+> The data directory is deleted automatically when you uninstall the plugin from the last scope where
+> it is installed. … The CLI deletes by default; pass `--keep-data` to preserve it.
+
+So anything stored there is also **uninstall-fragile**, which is an argument against unbounded
+per-project trees and for a bounded shape.
+
+Upstream is *silent* on naming, not permissive — reports and audit history are not among the
+documented intended uses ("installed dependencies such as `node_modules` … generated code, and
+caches"). There is nothing to wait for; this is ours to decide.
+
+## The two failure modes, which need different fixes
+
+Distinguish them before choosing a shape. Conflating them is how a fix ships that closes one and
+leaves the other open.
+
+| | **Collision** | **Overwrite** |
+|---|---|---|
+| What happens | Two projects share one path | Two runs of **one** project share one path |
+| Symptom | Project B is served project A's content | Yesterday's artifact is gone |
+| Fixed by | **Keying** the path by project | **Retention** — one file per run, or an appended history |
+| Severity | Higher when the artifact is **read back** | Data loss only |
+
+**Keying is not optional; retention is a judgment.** A non-destructive history closes overwrite and
+does nothing about collision: serving *the newest* report is not the same as serving *this project's*
+report. A writer whose artifact is only ever written (a cache, a scratch file) may key and stop
+there.
+
+## Rule 1 — key every write by project identity [SPEC]
+
+A plugin writing under `${CLAUDE_PLUGIN_DATA}` puts a **state key** between the plugin's own
+namespace and the filename:
+
+```
+${CLAUDE_PLUGIN_DATA}/<component>/<state-key>/<filename>
+```
+
+**`<state-key>` = `<repo-identity>/<worktree-discriminator>`.** The scheme is
+`claude-config:audit-pass`'s, specified in full in its
+[`reference/run-state-and-resumability.md`](../../../plugins/claude-config/skills/audit-pass/reference/run-state-and-resumability.md)
+§3:
+
+- **`repo-identity`** — the **first configured remote** URL (not necessarily one named `origin`)
+  normalized to `host/owner/repo`, lowercased, scheme/credentials/`.git` stripped. No remote →
+  `local/<sha256 of the canonicalized repo root, 12>`. Not a repository at all →
+  `nonrepo/<sha256 of the working directory, 12>`.
+- **`worktree-discriminator`** — `sha256` of the canonicalized worktree root, truncated to 8. Two
+  worktrees of one repository legitimately hold different content and must not share an artifact.
+
+**Do not mint a second scheme.** A shared implementation ships as `lib/state-key.sh`, byte-identical
+across the plugins that carry it and registered in `scripts/cross-plugin-source-registry.txt`.
+Adopting is one line:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
+```
+
+### 1a — derive the key by running commands, never by testing a placeholder [SPEC]
+
+Do **not** write the path as a condition over `${CLAUDE_PROJECT_DIR}` "when set". That placeholder is
+substituted inline in skill and agent content before the model sees the file, so the literal token
+never appears and the condition is not the model's to evaluate. The key comes from commands the run
+actually executes.
+
+### 1b — a key is a path segment, so validate it like one [SPEC]
+
+A remote URL is arbitrary text that becomes **directory components**. A remote of `../../../etc`
+walks the artifact out of the plugin's namespace. Accept an identity only in the shape the scheme
+means — segments of `[a-z0-9._-]`, each starting alphanumeric — and **hash anything else** so it
+still keys deterministically and still stays inside the namespace. This is not hypothetical: an
+unvalidated version of exactly this derivation was caught normalizing a report path outside its
+skill's namespace during review.
+
+### 1c — the "looks scoped but isn't" case, named so it is not repeated
+
+`plugins/bug-report/skills/write/SKILL.md:97` keys on the **kebab-cased basename of the project
+root**:
+
+> `${CLAUDE_PLUGIN_DATA}/bug-reports/<project-slug>/` … The plugin data directory is per-plugin, not
+> per-project — without the slug, Step 2's duplicate scan would match another repository's report on
+> the same symbol.
+
+The line states the hazard correctly and then picks a colliding key: two same-named checkouts — a
+fork, a same-named worktree, `~/work/api` and `~/oss/api` — share one slug directory, and the
+duplicate scan cross-matches between them. It escapes *overwrite* only because its filenames are
+timestamped. `plugins/claude-config/skills/unhobble/SKILL.md:53-62` names the same insufficiency in
+prose: "`${CLAUDE_PLUGIN_DATA}` is machine-global, so two checkouts sharing a basename…".
+
+**This is recorded here as the worked example, not filed as a `bug-report` defect.** A basename is
+not project identity. Nothing here obliges an immediate migration of an existing keyed-by-basename
+writer; it obliges the next one not to repeat it.
+
+## Rule 2 — choose retention by whether the artifact is read back [SPEC]
+
+| The artifact is… | Shape | Why |
+|---|---|---|
+| Written and never read by the plugin | `<state-key>/<name>` — a rolling latest is fine | Nothing can be served wrongly |
+| Read back and served to the operator | `<state-key>/<name>` **and** the read must derive the same key | Serving the newest ≠ serving this project's |
+| A trend or a history | one file per run **plus** an appended line | A same-day rerun must not erase the earlier point |
+
+The reference implementation of the third row is `plugins/machine-health/skills/audit/SKILL.md`, steps
+6 and 7: `<OutputBase>/reports/health-<UTC-timestamp>.md` — "one file per run, so a same-day rerun
+does not overwrite the earlier report" — plus `<StateBase>/state/latest.json` and one appended line in
+`<StateBase>/state/history.jsonl`, "the trend source of truth". Note it is *not* an adopter of rule 1:
+its roots are passed in explicitly by the caller rather than keyed, for a reason that file states — a
+subprocess can inherit another plugin's `CLAUDE_PLUGIN_DATA` value. Cited here for retention shape
+only.
+
+**A rolling latest is a legitimate choice, and it must be a stated one.** `claude-memory:audit` keeps
+`last-audit.md` deliberately: the report is a working artifact, not a series. Say so where the path is
+defined, so a reader can tell a decision from an oversight.
+
+## Rule 3 — never serve an artifact you cannot attribute [SPEC]
+
+This is the rule that makes rule 1 worth having, and it governs **migration** as much as reads.
+
+An artifact written under an older unkeyed layout has **no project segment**, so nothing records which
+repository produced it. It therefore cannot be adopted into any project's key — doing so invents an
+attribution, which is precisely the defect keying removes.
+
+- Missing at the derived key → say *"no artifact for this project"* and offer to produce one. Do not
+  fall back to an unkeyed path to find something.
+- A legacy unkeyed file is present → name its path to the operator as a leftover they may delete.
+  Do not read it, do not move it under a key, do not compute anything from it.
+
+The last clause matters where a writer *derives* from the prior artifact. `audit-instructions`'s
+report header carries a per-surface token delta "versus the previous catalog version"; under a
+colliding path that computation runs against another project's surface set and prints a **number**
+rather than declining. A silently wrong figure is worse than a missing one.
+
+## Rule 4 — state the uninstall fragility where the artifact is the only copy
+
+Uninstalling from the last scope deletes the whole data directory unless `--keep-data` is passed. A
+component whose sole durable output lives there should say so once, near the path, rather than
+letting an operator discover it. Keying does not change this; it multiplies it, since a keyed tree
+holds every project's artifact under the same deletable root.
+
+## Adoption
+
+| Writer | State |
+|---|---|
+| `claude-config:audit-pass` | Keyed since it shipped (`runs/<state-key>/<run-id>/`); this scheme's origin |
+| `claude-config:audit-prompting-postures` | Keyed (#2250) |
+| `claude-config:audit-instructions` | Keyed, plus rule 3 on the delta computation |
+| `claude-memory:audit` | Keyed on write **and** on both read paths (`report`, `fix`), plus rule 3 |
+| `bug-report:write` / `bug-report:setup` | Keyed by project-root **basename** — rule 1c's worked example; not migrated |
+| `claude-config:unhobble` | Different solution, same problem: keys by `<experiment-id>` whose basename is *a label*, and records the canonical checkout identity (absolute worktree path, and the origin URL when one exists) **in the manifest**, verifying it before every later phase. Verification instead of a keyed path; acceptable because the artifact is never *served* — a mismatch aborts and names the conflicting path |
+| `docs/conventions/topic-docs/` non-repo fallback | Keyed by **topic slug**, not project (`${CLAUDE_PLUGIN_DATA}/topic-docs/<slug>/`, the non-interactive branch when no project root resolves) — an instance of the gap, recorded here rather than silently declared conformant |
+| `machine-health:audit` | Not keyed — roots are passed in by the caller, deliberately, per that skill's own inherited-variable hazard. Cited above for retention shape only |
+
+## Related
+
+- `docs/MIGRATION-PLAYBOOK.md` seam 4 — what may live under `${CLAUDE_PLUGIN_DATA}` at all. This
+  convention governs naming beneath that.
+- `docs/conventions/topic-docs/` — tier placement, including the `${CLAUDE_PLUGIN_DATA}` machine-state
+  tier.
+- #1568 — the `${CLAUDE_*}` substitution-scope question. Rule 1a stands on the plugins reference's own
+  substitution table for skill and agent *content*, and deliberately does not depend on the
+  unsettled question of whether that extends to bundled spoke files loaded on demand; a component
+  whose spokes might not substitute derives in `SKILL.md` and passes the resolved path down.

--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.0]
+
+### Added
+
+- **`lib/state-key.sh`** — the `<repo-identity>/<worktree-discriminator>` derivation, previously
+  specified in `audit-pass`'s `reference/run-state-and-resumability.md` §3 and copied as a ~40-line
+  shell block into `audit-prompting-postures`, now an executable with a 23-case suite. The third
+  adopter would have been a third copy. It ships byte-identical in `claude-memory` and is registered
+  in `scripts/cross-plugin-source-registry.txt`, so the copies cannot drift silently. The suite pins
+  the properties the prose asserted and nothing checked: an https remote and its scp-style ssh
+  equivalent key identically; a repo whose only remote is `upstream` keys by that remote rather than
+  dropping to the local rung; two worktrees of one repository key apart; and — the security
+  property — a remote that would become directory components outside the namespace (`../../../etc`,
+  an absolute local path, a Windows path) is hashed instead, with no `..` and no backslash surviving
+  into a key.
+
+### Changed
+
+- **`audit-instructions` no longer computes a token delta against another project's report.** It
+  persisted to a fixed `${CLAUDE_PLUGIN_DATA}/audit-instructions/last-audit.md`, and that directory
+  is keyed to the plugin identifier and nothing else — no project, checkout, worktree, or session
+  segment — so every run from every project on the machine overwrote the last. The lost artifact was
+  the smaller half. The same Phase D block requires the report header to carry a per-surface token
+  delta "versus the previous catalog version": under collision that prior file exists but belongs to
+  a *different project's* surface set, so the skill computed and printed a number instead of
+  declining. The report path now carries a state key, and the two absent-prior cases are separated —
+  no report at this project's key means the delta is omitted with a reason, while an unkeyed leftover
+  from an earlier version is named to the operator and never used as a baseline. It was the last
+  writer in this plugin on a fixed path; `audit-pass` has keyed since it shipped and #2250 moved
+  `audit-prompting-postures`.
+- **An eval pins the property**, which had none: a second project neither overwrites the first's
+  report nor borrows its delta.
+
 ## [0.34.0]
 
 ### Added

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -7,10 +7,13 @@ All notable changes to the `claude-config` plugin are documented here. Format fo
 
 ### Added
 
-- **`lib/state-key.sh`** — the `<repo-identity>/<worktree-discriminator>` derivation, previously
-  specified in `audit-pass`'s `reference/run-state-and-resumability.md` §3 and copied as a ~40-line
-  shell block into `audit-prompting-postures`, now an executable with a 23-case suite. The third
-  adopter would have been a third copy. It ships byte-identical in `claude-memory` and is registered
+- **`lib/state-key.sh`** — the `<repo-identity>/<worktree-discriminator>` derivation, specified in
+  `audit-pass`'s `reference/run-state-and-resumability.md` §3 and until now *copied* as a ~40-line
+  shell block into `audit-prompting-postures`, becomes one executable with a 23-case suite. The third
+  adopter would have been the third copy, so `audit-prompting-postures` is migrated onto it in the
+  same change rather than left as a second implementation of one scheme inside one plugin — the drift
+  the accompanying convention exists to forbid. Its verified properties are still stated there; what
+  is gone is the restated algorithm. It ships byte-identical in `claude-memory` and is registered
   in `scripts/cross-plugin-source-registry.txt`, so the copies cannot drift silently. The suite pins
   the properties the prose asserted and nothing checked: an https remote and its scp-style ssh
   equivalent key identically; a repo whose only remote is `upstream` keys by that remote rather than

--- a/plugins/claude-config/lib/state-key.sh
+++ b/plugins/claude-config/lib/state-key.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Per-project state key for anything a plugin writes under ${CLAUDE_PLUGIN_DATA}.
+#
+# WHY. ${CLAUDE_PLUGIN_DATA} resolves to ~/.claude/plugins/data/{id}/, keyed to
+# the plugin identifier and nothing else (plugins reference, § Persistent data
+# directory). There is no project, checkout, worktree, or session segment in the
+# formula. So a skill that writes a fixed filename there has one file per
+# MACHINE: every run from every repository overwrites the last, and a skill that
+# READS it back can serve one project's findings as another's.
+#
+# This prints the missing segment. The scheme is `audit-pass`'s, reused rather
+# than reinvented — see
+# skills/audit-pass/reference/run-state-and-resumability.md §3:
+#
+#   <state-key> = <repo-identity>/<worktree-discriminator>
+#
+#   repo-identity          the first configured remote URL normalized to
+#                          host/owner/repo, lowercased, scheme/credentials/.git
+#                          stripped. No remote -> local/<sha256 of repo root,12>.
+#                          Not a repo at all -> nonrepo/<sha256 of cwd,12>.
+#   worktree-discriminator sha256 of the canonicalized worktree root, cut to 8.
+#                          Two worktrees of one repository legitimately hold
+#                          different content and must not share a report.
+#
+# SECURITY — this is why the identity is validated rather than merely lowercased.
+# A remote URL is arbitrary text that becomes DIRECTORY COMPONENTS in the caller's
+# path. A remote of `../../../etc` would walk a report out of the plugin's own
+# namespace. Any identity that is not a plain lowercase segment path is replaced
+# by a hash, so it still keys deterministically and still stays inside the
+# namespace. Every rejected shape is covered by state-key.test.sh.
+#
+# NOT a substitute for a per-run filename. Keying stops cross-project collision;
+# it does not stop a same-project rerun overwriting yesterday's report. A caller
+# that needs history writes one file per run under this key and appends a line
+# to a history file — see docs/conventions/plugin-data-report-keying/.
+#
+# Usage:
+#   state-key.sh [--root <path>] [--explain]
+#
+#   --root <path>  derive for that directory instead of the current one
+#   --explain      write the rung taken and its inputs to stderr
+#
+# Exit: 0 always on a successful derivation — every input reaches some rung, so
+# there is no "cannot key" outcome. 2 on a bad argument or an unusable --root.
+#
+# Shared source: this file is byte-identical across the plugins that carry it and
+# is registered in scripts/cross-plugin-source-registry.txt. Edit the canonical
+# copy (claude-config) and copy it over the others.
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+state-key.sh — per-project state key for ${CLAUDE_PLUGIN_DATA} writes.
+
+Prints <repo-identity>/<worktree-discriminator> for a directory, so a report
+persisted under the plugin data directory belongs to one project rather than to
+the machine.
+
+Usage:
+  state-key.sh [--root <path>] [--explain] [--help]
+
+  --root <path>  derive for that directory instead of the current one
+  --explain      write the rung taken and its inputs to stderr
+
+Exit: 0 on a derivation; 2 on a bad argument or an unusable --root.
+EOF
+}
+
+ROOT_ARG=""
+EXPLAIN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --root)
+    if [[ $# -lt 2 ]]; then
+      echo "ERROR: --root needs a path" >&2
+      exit 2
+    fi
+    ROOT_ARG="$2"
+    shift 2
+    ;;
+  --explain)
+    EXPLAIN=1
+    shift
+    ;;
+  *)
+    echo "ERROR: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+if [[ -n "$ROOT_ARG" ]]; then
+  if [[ ! -d "$ROOT_ARG" ]]; then
+    echo "ERROR: --root is not a directory: $ROOT_ARG" >&2
+    exit 2
+  fi
+  cd "$ROOT_ARG" || exit 2
+fi
+
+# sha256sum is absent on stock macOS; shasum -a 256 is the portable partner.
+# Neither is guaranteed, so a third rung keeps the key derivable rather than
+# letting the whole scheme fail on a minimal image.
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256
+  else
+    echo "ERROR: no sha256sum or shasum on PATH — cannot derive a state key" >&2
+    exit 2
+  fi
+}
+
+hash12() { printf '%s' "$1" | sha256 | cut -c1-12; }
+hash8() { printf '%s' "$1" | sha256 | cut -c1-8; }
+
+# "the FIRST configured remote" — not necessarily one named `origin`. A repo
+# whose only remote is `upstream` still has a remote and must not fall through
+# to the local rung.
+remote_name=$(git remote 2>/dev/null | tr -d '\r' | head -1)
+remote=""
+if [[ -n "$remote_name" ]]; then
+  remote=$(git config --get "remote.${remote_name}.url" 2>/dev/null | tr -d '\r')
+fi
+# tr -d '\r': Git on Windows can return a CRLF-terminated path.
+root=$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+
+rung=""
+if [[ -n "$remote" ]]; then
+  identity=$(printf '%s' "$remote" |
+    sed -e 's#^[a-z+]*://##' -e 's#^[^@/]*@##' -e 's#:#/#' -e 's#\.git$##' |
+    tr '[:upper:]' '[:lower:]')
+  # A remote URL is arbitrary text and becomes DIRECTORY COMPONENTS here, so
+  # accept it only in the shape the scheme means — segments of [a-z0-9._-] each
+  # starting alphanumeric. That rejects `../central` (a relative filesystem
+  # remote, which would otherwise write outside the caller's namespace),
+  # absolute local paths, and backslashes. Anything rejected still keys
+  # deterministically, by hash.
+  if printf '%s' "$identity" | grep -qE '^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$'; then
+    rung="remote"
+  else
+    identity="remote/$(hash12 "$remote")"
+    rung="remote-hashed"
+  fi
+elif [[ -n "$root" ]]; then
+  identity="local/$(hash12 "$root")"
+  rung="local"
+else
+  # Not a git repository. `audit-pass`'s ladder stops at the two git rungs
+  # because it refuses non-git targets; a report-only skill audits them, so the
+  # scheme needs a third rung rather than a failure.
+  identity="nonrepo/$(hash12 "$PWD")"
+  rung="nonrepo"
+fi
+
+discriminator=$(hash8 "${root:-$PWD}")
+
+if [[ $EXPLAIN -eq 1 ]]; then
+  {
+    echo "rung:          $rung"
+    echo "remote:        ${remote:-<none>}"
+    echo "repo root:     ${root:-<not a git repository>}"
+    echo "cwd:           $PWD"
+    echo "identity:      $identity"
+    echo "discriminator: $discriminator"
+  } >&2
+fi
+
+printf '%s/%s\n' "$identity" "$discriminator"

--- a/plugins/claude-config/lib/state-key.test.sh
+++ b/plugins/claude-config/lib/state-key.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Self-contained tests for lib/state-key.sh (no external test lib — ships with the plugin).
+#
+# The copy in claude-memory is byte-identical and registered in
+# scripts/cross-plugin-source-registry.txt, so this suite covers both.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/state-key.sh"
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+FAILED=0
+CASE_NUM=0
+
+pass() {
+  CASE_NUM=$((CASE_NUM + 1))
+  printf 'PASS: %s\n' "$1"
+}
+fail() {
+  CASE_NUM=$((CASE_NUM + 1))
+  FAILED=$((FAILED + 1))
+  printf 'FAIL: %s\n  detail: %s\n' "$1" "$2" >&2
+}
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected [$2], got [$3]"; fi
+}
+assert_ne() {
+  if [[ "$2" != "$3" ]]; then pass "$1"; else fail "$1" "expected difference, both were [$2]"; fi
+}
+assert_contains() {
+  case "$2" in
+  *"$3"*) pass "$1" ;;
+  *) fail "$1" "expected to contain: $3" ;;
+  esac
+}
+assert_not_contains() {
+  case "$2" in
+  *"$3"*) fail "$1" "unexpected substring: $3" ;;
+  *) pass "$1" ;;
+  esac
+}
+assert_exit() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "expected exit $2, got $3"; fi
+}
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: git not installed" >&2
+  exit 0
+fi
+
+mkrepo() {
+  # mkrepo <name> [remote-url] — echo a fresh repo path
+  local d="$TEST_TMPDIR/$1"
+  mkdir -p "$d"
+  git -C "$d" init -q 2>/dev/null
+  git -C "$d" config user.email t@example.com
+  git -C "$d" config user.name Test
+  if [[ -n "${2:-}" ]]; then
+    git -C "$d" remote add origin "$2"
+  fi
+  printf '%s' "$d"
+}
+
+key() { bash "$SCRIPT" --root "$1" 2>/dev/null; }
+
+# --- Case 1: an https remote normalizes to host/owner/repo --------------------
+r="$(mkrepo https https://github.com/Melodic-Software/Claude-Code-Plugins.git)"
+k="$(key "$r")"
+assert_contains "case 1: https remote normalizes" "$k" "github.com/melodic-software/claude-code-plugins/"
+assert_not_contains "case 1: .git suffix stripped" "$k" ".git/"
+
+# --- Case 2: the scp-style ssh form keys identically ---------------------------
+# The property that matters: one repository, two remote spellings, one key. A
+# scheme that keyed them apart would fragment a project's own history.
+r2="$(mkrepo ssh git@github.com:Melodic-Software/Claude-Code-Plugins.git)"
+k2="$(key "$r2")"
+assert_eq "case 2: ssh and https identities agree" \
+  "${k%/*}" "${k2%/*}"
+
+# --- Case 3: an upstream-only repo keys by that remote, not the local rung ----
+r="$(mkrepo upstream-only)"
+git -C "$r" remote add upstream https://gitlab.com/acme/widget.git
+k="$(key "$r")"
+assert_contains "case 3: first remote is used whatever its name" "$k" "gitlab.com/acme/widget/"
+assert_not_contains "case 3: did not fall through to local" "$k" "local/"
+
+# --- Case 4: no remote falls to local/<hash> ----------------------------------
+r="$(mkrepo no-remote)"
+k="$(key "$r")"
+assert_contains "case 4: no remote keys local" "$k" "local/"
+
+# --- Case 5: a non-repo directory keys nonrepo/<hash> -------------------------
+d="$TEST_TMPDIR/plain"
+mkdir -p "$d"
+k="$(key "$d")"
+assert_contains "case 5: non-repo keys nonrepo" "$k" "nonrepo/"
+
+# --- Case 6: a traversal remote cannot escape the namespace -------------------
+# The security property. A remote URL becomes directory components in the
+# caller's path, so `../../../etc` must not survive into the key. It is hashed
+# instead — still deterministic, still inside the namespace.
+r="$(mkrepo traversal ../../../etc)"
+k="$(key "$r")"
+assert_not_contains "case 6: no .. in the key" "$k" ".."
+assert_contains "case 6: traversal remote is hashed" "$k" "remote/"
+k_again="$(key "$r")"
+assert_eq "case 6: hashed key is deterministic" "$k" "$k_again"
+
+# --- Case 7: an absolute local remote is hashed, not embedded -----------------
+r="$(mkrepo abslocal /var/lib/central.git)"
+k="$(key "$r")"
+assert_not_contains "case 7: absolute path not embedded" "$k" "var/lib"
+assert_contains "case 7: absolute local remote is hashed" "$k" "remote/"
+
+# --- Case 8: a Windows-path remote is hashed ----------------------------------
+r="$(mkrepo winpath 'C:\repos\central.git')"
+k="$(key "$r")"
+# A literal backslash, built without a backslash-bearing literal: shellcheck's
+# SC1003 fires on every spelling of one inside quotes, and this assertion is
+# precisely about a backslash surviving into a path segment.
+backslash=$(printf '%b' '\134')
+assert_not_contains "case 8: no backslash in the key" "$k" "$backslash"
+assert_contains "case 8: windows-path remote is hashed" "$k" "remote/"
+
+# --- Case 9: two worktrees of one repo differ in the discriminator ------------
+# The whole reason the key has a second segment: two checkouts of one repository
+# legitimately hold different content and must not share a report.
+r="$(mkrepo wt-base https://github.com/acme/widget.git)"
+printf 'x\n' >"$r/f.txt"
+git -C "$r" add f.txt 2>/dev/null
+git -C "$r" commit -qm "seed" 2>/dev/null
+wt="$TEST_TMPDIR/wt-second"
+git -C "$r" worktree add -q "$wt" -b other 2>/dev/null
+ka="$(key "$r")"
+kb="$(key "$wt")"
+assert_eq "case 9: same repository identity" "${ka%/*}" "${kb%/*}"
+assert_ne "case 9: different worktree discriminator" "${ka##*/}" "${kb##*/}"
+git -C "$r" worktree remove --force "$wt" 2>/dev/null
+
+# --- Case 10: the key is a plain relative path, never absolute ----------------
+# It is concatenated onto ${CLAUDE_PLUGIN_DATA} by the caller, so a leading
+# slash would relocate the whole write.
+for d in "$TEST_TMPDIR/plain" "$(mkrepo shape https://github.com/acme/widget.git)"; do
+  k="$(key "$d")"
+  case "$k" in
+  /* | *:* | *' '*) fail "case 10: key is a plain relative path" "got [$k]" ;;
+  *) pass "case 10: key is a plain relative path ($k)" ;;
+  esac
+done
+
+# --- Case 11: --explain writes to stderr and leaves stdout clean --------------
+r="$(mkrepo explain https://github.com/acme/widget.git)"
+out="$(bash "$SCRIPT" --root "$r" --explain 2>/dev/null)"
+err="$(bash "$SCRIPT" --root "$r" --explain 2>&1 >/dev/null)"
+assert_eq "case 11: stdout is exactly the key" "$out" "$(key "$r")"
+assert_contains "case 11: explain names the rung" "$err" "rung:"
+
+# --- Case 12: a bad argument and a missing root both exit 2 -------------------
+rc=0
+bash "$SCRIPT" --nope >/dev/null 2>&1 || rc=$?
+assert_exit "case 12: unknown argument exits 2" 2 "$rc"
+rc=0
+bash "$SCRIPT" --root "$TEST_TMPDIR/does-not-exist" >/dev/null 2>&1 || rc=$?
+assert_exit "case 12: missing --root exits 2" 2 "$rc"
+rc=0
+bash "$SCRIPT" --root >/dev/null 2>&1 || rc=$?
+assert_exit "case 12: --root with no value exits 2" 2 "$rc"
+
+if [[ "$FAILED" -eq 0 ]]; then
+  printf '\nAll %d checks passed.\n' "$CASE_NUM"
+  exit 0
+fi
+printf '\n%d/%d checks failed.\n' "$FAILED" "$CASE_NUM" >&2
+exit 1

--- a/plugins/claude-config/skills/audit-instructions/SKILL.md
+++ b/plugins/claude-config/skills/audit-instructions/SKILL.md
@@ -365,13 +365,40 @@ gate fails, dropped for that named reason.
 
 ## Phase D — Report
 
-Persist the report to `${CLAUDE_PLUGIN_DATA}/audit-instructions/last-audit.md` and summarize it in
-chat. The report header carries a **cost line**: how many checks ran per surface (naming any added
-by a catalog version bump), the model-scoped rows skipped for the resolved target, and the
-estimated per-surface token delta versus the previous catalog version — and it confirms the run
-added zero new interactive gates (report-only contract unchanged; the target-model fail-loud stop
-is an invocation-time validation abort, not an interactive gate — it prompts nobody and blocks
-nothing mid-run). Present findings as a table:
+Persist the report to `${CLAUDE_PLUGIN_DATA}/audit-instructions/<state-key>/last-audit.md`.
+
+**Derive `<state-key>` by running this:**
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
+```
+
+It prints `<repo-identity>/<worktree-discriminator>` — `audit-pass`'s scheme, per
+[its run-state reference](../audit-pass/reference/run-state-and-resumability.md) §3, which
+`audit-prompting-postures` also uses. Run it and use the result. Do **not** express the path as a
+condition over `${CLAUDE_PROJECT_DIR}` "when set": that placeholder is substituted inline before this
+file reaches you, so the literal token is never visible and the condition is not yours to evaluate.
+
+**Why the key is load-bearing in this skill specifically.** `${CLAUDE_PLUGIN_DATA}` resolves to
+`~/.claude/plugins/data/{id}/`, keyed to the plugin identifier and nothing else
+([plugins reference](https://code.claude.com/docs/en/plugins-reference), § Persistent data directory).
+Under a fixed filename every run from every project on the machine overwrites the last — and the cost
+line below then computes its **per-surface token delta against a prior report belonging to a different
+project's surface set**, printing a number rather than declining. The lost artifact is the smaller
+half; a silently wrong figure in the report header is the larger one.
+
+**Two absent-prior cases, and they are not the same.** With no report at the derived key, say so and
+omit the delta — "first run for this project; no prior catalog version to compare" — rather than
+reaching for another file. An unkeyed `audit-instructions/last-audit.md` left by an earlier version
+has no project segment and is therefore unattributable: name its path to the user as a leftover, and
+do not compute a delta from it.
+
+Then summarize in chat. The report header carries a **cost line**: how many checks ran per surface
+(naming any added by a catalog version bump), the model-scoped rows skipped for the resolved target,
+and the estimated per-surface token delta versus the previous catalog version **for this project** —
+and it confirms the run added zero new interactive gates (report-only contract unchanged; the
+target-model fail-loud stop is an invocation-time validation abort, not an interactive gate — it
+prompts nobody and blocks nothing mid-run). Present findings as a table:
 
 | # | Check | Surface:Line | Severity | Tier | Authority | Finding | Proposed change |
 |---|-------|--------------|----------|------|-----------|---------|-----------------|

--- a/plugins/claude-config/skills/audit-instructions/evals/evals.json
+++ b/plugins/claude-config/skills/audit-instructions/evals/evals.json
@@ -194,6 +194,19 @@
         "Resolves blockability from the handler's own event row in the upstream per-event exit-2 table before applying the gate abstraction, rather than from a fixed list of blocking and non-blocking events, and takes the paired content from what that row states is prevented",
         "States that the same handler on a blockable event such as PreToolUse would enter the comparison set as the act it blocks, so the non-blocking case is a scoped exclusion rather than a blanket exemption for exit-2 hooks"
       ]
+    },
+    {
+      "id": 17,
+      "name": "second-project-neither-overwrites-nor-borrows-a-delta",
+      "prompt": "/claude-config:audit-instructions — I ran this in my other repo yesterday on this same laptop. Where does today's report land, and what does the cost line's per-surface token delta compare against?",
+      "expected_output": "Today's report lands under a per-project state key — <repo-identity>/<worktree-discriminator>, audit-pass's scheme, derived by RUNNING the resolver — so it neither overwrites nor is compared against yesterday's report from the other repo. Because no prior report exists at THIS project's key, the cost line omits the per-surface token delta and says why (first run for this project; no prior catalog version to compare) rather than printing a number computed against an unrelated surface set. The answer names the mechanism: ${CLAUDE_PLUGIN_DATA} resolves to ~/.claude/plugins/data/{id}/ and is keyed to the plugin identifier alone, with no project segment, so a fixed last-audit.md is one file per machine — and the silently wrong delta is the worse half of that, not the lost file.",
+      "files": [],
+      "expectations": [
+        "Names a per-project keyed report path and states that the other repo's report is neither overwritten nor read",
+        "Derives the state key by running the resolver rather than by evaluating whether ${CLAUDE_PROJECT_DIR} is set",
+        "Omits the per-surface token delta and says why, instead of computing one against another project's prior report",
+        "Reuses audit-pass's <repo-identity>/<worktree-discriminator> scheme rather than inventing a second one"
+      ]
     }
   ]
 }

--- a/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
+++ b/plugins/claude-config/skills/audit-prompting-postures/SKILL.md
@@ -78,61 +78,33 @@ it." Findings a verifier refutes are dropped or demoted to `info`.
 Persist the report to
 `${CLAUDE_PLUGIN_DATA}/audit-prompting-postures/<state-key>/last-audit.md`.
 
-**Derive `<state-key>` by running the commands below.** `${CLAUDE_PLUGIN_DATA}` is machine-global, not
-per-project, so a fixed `last-audit.md` is silently overwritten by the next run from any other root —
-this skill's only durable deliverable, destroyed by ordinary use of it. The scheme is `audit-pass`'s,
-reused rather than reinvented: `<repo-identity>/<worktree-discriminator>`, per
-[audit-pass's run-state reference](../audit-pass/reference/run-state-and-resumability.md) §3.
+**Derive `<state-key>` by running this:**
 
 ```bash
-# sha256sum is absent on stock macOS; shasum -a 256 is the portable partner.
-sha256() { if command -v sha256sum >/dev/null 2>&1; then sha256sum; else shasum -a 256; fi; }
-
-# "the FIRST configured remote" — not necessarily one named `origin`. A repo whose only
-# remote is `upstream` still has a remote, and must not fall through to the local rung.
-remote_name=$(git remote 2>/dev/null | head -1)
-remote=$(git config --get "remote.${remote_name}.url" 2>/dev/null || true)
-# tr -d '\r': Git on Windows can return a CRLF-terminated path.
-root=$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r' || true)
-
-# repo-identity
-if [ -n "$remote" ]; then
-  identity=$(printf '%s' "$remote" \
-    | sed -e 's#^[a-z+]*://##' -e 's#^[^@/]*@##' -e 's#:#/#' -e 's#\.git$##' \
-    | tr '[:upper:]' '[:lower:]')
-  # A remote URL is arbitrary text and becomes DIRECTORY COMPONENTS here, so accept it
-  # only in the shape the scheme means — segments of [a-z0-9._-] each starting
-  # alphanumeric. That rejects `../central` (a relative filesystem remote, which would
-  # otherwise write outside this skill's namespace), absolute local paths, and
-  # backslashes. Anything rejected still keys deterministically, by hash.
-  if ! printf '%s' "$identity" | grep -qE '^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$'; then
-    identity="remote/$(printf '%s' "$remote" | sha256 | cut -c1-12)"
-  fi
-elif [ -n "$root" ]; then
-  identity="local/$(printf '%s' "$root" | sha256 | cut -c1-12)"
-else
-  # Non-repo root. audit-pass's ladder stops at the two git rungs because it refuses
-  # non-git targets; this skill is report-only and audits them, so it needs a third.
-  identity="nonrepo/$(printf '%s' "$PWD" | sha256 | cut -c1-12)"
-fi
-
-# worktree-discriminator — two worktrees of one repo legitimately hold different content
-discriminator=$(printf '%s' "${root:-$PWD}" | sha256 | cut -c1-8)
-
-state_key="$identity/$discriminator"
+bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
 ```
 
-Executed, not merely written: an https remote and its scp-style ssh equivalent normalize to the same
-`github.com/<owner>/<repo>`; a repo whose only remote is `upstream` keys by that remote rather than
-dropping to the local rung; a repo with no remote gives `local/<12>`; a non-repo root gives
-`nonrepo/<12>`; and relative (`../central.git`), absolute-local, and Windows-path remotes all key by
-hash and stay inside this skill's directory. Two worktrees of one repository differ in the
-discriminator, which is the property it exists for.
+`${CLAUDE_PLUGIN_DATA}` is machine-global, not per-project, so a fixed `last-audit.md` is silently
+overwritten by the next run from any other root — this skill's only durable deliverable, destroyed by
+ordinary use of it. The scheme is `audit-pass`'s, reused rather than reinvented:
+`<repo-identity>/<worktree-discriminator>`, per
+[audit-pass's run-state reference](../audit-pass/reference/run-state-and-resumability.md) §3, and it
+lives in one executable rather than being restated per skill —
+[`lib/state-key.sh`](../../lib/state-key.sh), with `lib/state-key.test.sh` beside it. Pass `--explain`
+when the report should say which rung produced the key.
 
-Run those and use the result. Do **not** express the path as a condition over `${CLAUDE_PROJECT_DIR}`
+What that suite pins, so this file does not have to restate the derivation to be trusted: an https
+remote and its scp-style ssh equivalent normalize to the same `github.com/<owner>/<repo>`; a repo whose
+only remote is `upstream` keys by that remote rather than dropping to the local rung; a repo with no
+remote gives `local/<12>`; a non-repo root gives `nonrepo/<12>`; and relative (`../central.git`),
+absolute-local, and Windows-path remotes all key by hash, with no `..` and no backslash surviving into
+a path segment — the identity becomes directory components, so that is a security property, not a
+cosmetic one. Two worktrees of one repository differ in the discriminator, which is what it exists for.
+
+Run it and use the result. Do **not** express the path as a condition over `${CLAUDE_PROJECT_DIR}`
 "when set": that placeholder is substituted inline before this file reaches you, so the literal token
-is never visible and the condition is not yours to evaluate. Derive the key from commands you actually
-run.
+is never visible and the condition is not yours to evaluate. Derive the key from a command you
+actually run.
 
 **Open the report with a three-line header**, so a file that does survive is self-describing rather
 than merely un-overwritten:

--- a/plugins/claude-memory/.claude-plugin/plugin.json
+++ b/plugins/claude-memory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-memory",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Keeps a repo's Claude Code memory layer healthy and under your control, against criteria derived from official Claude Code documentation. The audit skill checks the instruction/memory layer (CLAUDE.md, CLAUDE.local.md, .claude/rules/, auto-memory) with a deterministic script-backed spine plus judgment-tier checks. The stateless skill inspects, disables, and (confirm-gated) purges Claude-written auto memory across all settings scopes.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-memory/CHANGELOG.md
+++ b/plugins/claude-memory/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to the `claude-memory` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.9.0]
+
+### Added
+
+- **`lib/state-key.sh`** — the per-project state key for anything written under
+  `${CLAUDE_PLUGIN_DATA}`. Prints `<repo-identity>/<worktree-discriminator>`, the scheme
+  `claude-config:audit-pass` defines and `audit-prompting-postures` already uses, adopted here rather
+  than reinvented. Byte-identical to the `claude-config` copy and registered in
+  `scripts/cross-plugin-source-registry.txt`, so the two cannot drift apart silently. A remote URL
+  becomes directory components in the resulting path, so an identity outside the accepted segment
+  shape — a relative remote like `../central.git`, an absolute local path, a Windows path — is hashed
+  rather than embedded; the suite asserts no `..` and no backslash survives into a key.
+
+### Changed
+
+- **`audit` no longer serves one project's findings as another's.** It wrote its report to a fixed
+  `${CLAUDE_PLUGIN_DATA}/audit/last-audit.md` — machine-global, since that directory is keyed to the
+  plugin identifier and nothing else — and then **read it back**: `report` mode served whatever the
+  file held and `fix` mode acted on it. On a machine with two repositories, `report` in project B
+  could present project A's findings as project B's, and `fix` could propose edits derived from
+  another repository's memory layer. A wrong answer served, not merely a lost artifact — which is why
+  an append-only history would not have closed it. All four sites now resolve one path,
+  `audit/<state-key>/last-audit.md`: the write in `context/audit.md`, its restatement in
+  `reference/criteria.md`, and the two reads in `SKILL.md` and `context/fix.md`. The path is derived
+  once in `SKILL.md` and referred to by the spokes rather than restated, and the key comes from
+  running the resolver, never from testing whether a placeholder is set.
+- **A report that cannot be attributed to a project is no longer served or migrated.** The pre-rename
+  `health/` layout and any unkeyed `audit/last-audit.md` carry no project segment, so nothing records
+  which repository produced them, and adopting one into a project's key would invent that attribution.
+  The previous behavior moved `health/` to `audit/` and read it. Both read paths now decline, name the
+  leftover file's path as something the operator may delete, and offer a fresh audit. **This is a
+  behavior change on upgrade**: an operator holding a report under the old layout is told to re-run
+  rather than shown the old one.
+- **`fix` mode states why an unattributable report is unusable input** rather than treating a missing
+  report as the only failure case — it proposes edits to real instruction files, so acting on another
+  repository's findings is the expensive error.
+- **Two evals pin the property**, which had no coverage at all: two repositories neither share nor
+  overwrite one report, and a legacy unkeyed report is neither served nor adopted. The
+  `report-without-prior-audit` case now asserts the per-project derived path rather than "the most
+  recent saved audit".
+
 ## [0.8.1]
 
 ### Changed

--- a/plugins/claude-memory/lib/state-key.sh
+++ b/plugins/claude-memory/lib/state-key.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Per-project state key for anything a plugin writes under ${CLAUDE_PLUGIN_DATA}.
+#
+# WHY. ${CLAUDE_PLUGIN_DATA} resolves to ~/.claude/plugins/data/{id}/, keyed to
+# the plugin identifier and nothing else (plugins reference, § Persistent data
+# directory). There is no project, checkout, worktree, or session segment in the
+# formula. So a skill that writes a fixed filename there has one file per
+# MACHINE: every run from every repository overwrites the last, and a skill that
+# READS it back can serve one project's findings as another's.
+#
+# This prints the missing segment. The scheme is `audit-pass`'s, reused rather
+# than reinvented — see
+# skills/audit-pass/reference/run-state-and-resumability.md §3:
+#
+#   <state-key> = <repo-identity>/<worktree-discriminator>
+#
+#   repo-identity          the first configured remote URL normalized to
+#                          host/owner/repo, lowercased, scheme/credentials/.git
+#                          stripped. No remote -> local/<sha256 of repo root,12>.
+#                          Not a repo at all -> nonrepo/<sha256 of cwd,12>.
+#   worktree-discriminator sha256 of the canonicalized worktree root, cut to 8.
+#                          Two worktrees of one repository legitimately hold
+#                          different content and must not share a report.
+#
+# SECURITY — this is why the identity is validated rather than merely lowercased.
+# A remote URL is arbitrary text that becomes DIRECTORY COMPONENTS in the caller's
+# path. A remote of `../../../etc` would walk a report out of the plugin's own
+# namespace. Any identity that is not a plain lowercase segment path is replaced
+# by a hash, so it still keys deterministically and still stays inside the
+# namespace. Every rejected shape is covered by state-key.test.sh.
+#
+# NOT a substitute for a per-run filename. Keying stops cross-project collision;
+# it does not stop a same-project rerun overwriting yesterday's report. A caller
+# that needs history writes one file per run under this key and appends a line
+# to a history file — see docs/conventions/plugin-data-report-keying/.
+#
+# Usage:
+#   state-key.sh [--root <path>] [--explain]
+#
+#   --root <path>  derive for that directory instead of the current one
+#   --explain      write the rung taken and its inputs to stderr
+#
+# Exit: 0 always on a successful derivation — every input reaches some rung, so
+# there is no "cannot key" outcome. 2 on a bad argument or an unusable --root.
+#
+# Shared source: this file is byte-identical across the plugins that carry it and
+# is registered in scripts/cross-plugin-source-registry.txt. Edit the canonical
+# copy (claude-config) and copy it over the others.
+
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+state-key.sh — per-project state key for ${CLAUDE_PLUGIN_DATA} writes.
+
+Prints <repo-identity>/<worktree-discriminator> for a directory, so a report
+persisted under the plugin data directory belongs to one project rather than to
+the machine.
+
+Usage:
+  state-key.sh [--root <path>] [--explain] [--help]
+
+  --root <path>  derive for that directory instead of the current one
+  --explain      write the rung taken and its inputs to stderr
+
+Exit: 0 on a derivation; 2 on a bad argument or an unusable --root.
+EOF
+}
+
+ROOT_ARG=""
+EXPLAIN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --root)
+    if [[ $# -lt 2 ]]; then
+      echo "ERROR: --root needs a path" >&2
+      exit 2
+    fi
+    ROOT_ARG="$2"
+    shift 2
+    ;;
+  --explain)
+    EXPLAIN=1
+    shift
+    ;;
+  *)
+    echo "ERROR: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+if [[ -n "$ROOT_ARG" ]]; then
+  if [[ ! -d "$ROOT_ARG" ]]; then
+    echo "ERROR: --root is not a directory: $ROOT_ARG" >&2
+    exit 2
+  fi
+  cd "$ROOT_ARG" || exit 2
+fi
+
+# sha256sum is absent on stock macOS; shasum -a 256 is the portable partner.
+# Neither is guaranteed, so a third rung keeps the key derivable rather than
+# letting the whole scheme fail on a minimal image.
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256
+  else
+    echo "ERROR: no sha256sum or shasum on PATH — cannot derive a state key" >&2
+    exit 2
+  fi
+}
+
+hash12() { printf '%s' "$1" | sha256 | cut -c1-12; }
+hash8() { printf '%s' "$1" | sha256 | cut -c1-8; }
+
+# "the FIRST configured remote" — not necessarily one named `origin`. A repo
+# whose only remote is `upstream` still has a remote and must not fall through
+# to the local rung.
+remote_name=$(git remote 2>/dev/null | tr -d '\r' | head -1)
+remote=""
+if [[ -n "$remote_name" ]]; then
+  remote=$(git config --get "remote.${remote_name}.url" 2>/dev/null | tr -d '\r')
+fi
+# tr -d '\r': Git on Windows can return a CRLF-terminated path.
+root=$(git rev-parse --show-toplevel 2>/dev/null | tr -d '\r')
+
+rung=""
+if [[ -n "$remote" ]]; then
+  identity=$(printf '%s' "$remote" |
+    sed -e 's#^[a-z+]*://##' -e 's#^[^@/]*@##' -e 's#:#/#' -e 's#\.git$##' |
+    tr '[:upper:]' '[:lower:]')
+  # A remote URL is arbitrary text and becomes DIRECTORY COMPONENTS here, so
+  # accept it only in the shape the scheme means — segments of [a-z0-9._-] each
+  # starting alphanumeric. That rejects `../central` (a relative filesystem
+  # remote, which would otherwise write outside the caller's namespace),
+  # absolute local paths, and backslashes. Anything rejected still keys
+  # deterministically, by hash.
+  if printf '%s' "$identity" | grep -qE '^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)*$'; then
+    rung="remote"
+  else
+    identity="remote/$(hash12 "$remote")"
+    rung="remote-hashed"
+  fi
+elif [[ -n "$root" ]]; then
+  identity="local/$(hash12 "$root")"
+  rung="local"
+else
+  # Not a git repository. `audit-pass`'s ladder stops at the two git rungs
+  # because it refuses non-git targets; a report-only skill audits them, so the
+  # scheme needs a third rung rather than a failure.
+  identity="nonrepo/$(hash12 "$PWD")"
+  rung="nonrepo"
+fi
+
+discriminator=$(hash8 "${root:-$PWD}")
+
+if [[ $EXPLAIN -eq 1 ]]; then
+  {
+    echo "rung:          $rung"
+    echo "remote:        ${remote:-<none>}"
+    echo "repo root:     ${root:-<not a git repository>}"
+    echo "cwd:           $PWD"
+    echo "identity:      $identity"
+    echo "discriminator: $discriminator"
+  } >&2
+fi
+
+printf '%s/%s\n' "$identity" "$discriminator"

--- a/plugins/claude-memory/skills/audit/SKILL.md
+++ b/plugins/claude-memory/skills/audit/SKILL.md
@@ -86,17 +86,61 @@ Load [context/update.md](context/update.md) for the research-and-refresh workflo
 
 Load [context/fix.md](context/fix.md) for the fix-with-approval workflow.
 
-## Report mode
+## Report location — derive it before writing or reading
 
-Read the most recent audit report from `${CLAUDE_PLUGIN_DATA}/audit/last-audit.md`. If
-missing, first check the pre-rename location `${CLAUDE_PLUGIN_DATA}/health/last-audit.md`
-(this skill was previously named `health`) and move that directory to the new name when
-found; only when neither exists, inform the user no audit has been run yet and suggest
-running the audit.
+Every action that touches the report uses **one** path, resolved here: `audit` writes it, `report`
+serves it, `fix` acts on it.
+
+```
+${CLAUDE_PLUGIN_DATA}/audit/<state-key>/last-audit.md
+```
+
+**Derive `<state-key>` by running this, in the project being audited:**
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/lib/state-key.sh"
+```
+
+It prints `<repo-identity>/<worktree-discriminator>` — the scheme `claude-config:audit-pass` defines
+and `audit-prompting-postures` already uses, adopted here rather than reinvented. Run it and use the
+result: the key comes from a command this run actually executes, not from a token read out of a file.
+Pass `--explain` when the report should say which rung produced its key.
+
+**Why the key exists.** `${CLAUDE_PLUGIN_DATA}` resolves to `~/.claude/plugins/data/{id}/`, keyed to
+the plugin identifier and nothing else — no project, checkout, worktree, or session segment
+([plugins reference](https://code.claude.com/docs/en/plugins-reference), § Persistent data directory).
+A fixed `audit/last-audit.md` is therefore **one file per machine**. Losing reports is the smaller
+half; the larger half is the read. `report` mode would serve whatever that file currently holds and
+`fix` mode would act on it, so on a machine with two repositories, project B can be shown project A's
+findings and offered edits derived from another repository's memory layer. That is a wrong answer
+served, not merely an artifact lost — which is why an append-only history does not close it and the
+*path* has to carry project identity.
+
+**Never serve a report you cannot attribute.** If nothing exists at the derived path, say that no
+audit has been run **for this project** and suggest running one. Do not fall back to an unkeyed
+location.
+
+**The pre-rename `health/` directory and any unkeyed `audit/last-audit.md` are unattributable.** This
+skill was once named `health`, and both older layouts wrote a machine-global file with no project
+segment, so nothing records which repository produced it. It cannot be adopted into a project's key
+without inventing that attribution — and inventing it is exactly the defect the key exists to remove.
+Where such a file is present, name its path to the user as a leftover they may delete, and run the
+audit rather than reading it.
 
 **Audit output is contributor-local by design.** Reports audit a contributor's personal auto-memory
 (`~/.claude/projects/<project>/memory/`), which varies per team member — so they persist in the
 plugin's own data directory, never in the consuming repo.
+
+**A rolling latest is a separate decision from keying, and this skill keeps one on purpose.**
+`last-audit.md` is replaced by the next run *of the same project*; the report is a working artifact,
+not a trend series. That is only safe because the key makes "the same project" mean something. See
+[`docs/conventions/plugin-data-report-keying/`](https://github.com/melodic-software/claude-code-plugins/blob/main/docs/conventions/plugin-data-report-keying/README.md)
+for when a writer owes a per-run history instead.
+
+## Report mode
+
+Read the report at the derived path above and present it. When it is absent, apply the
+never-serve-what-you-cannot-attribute rule above rather than reaching for another file.
 
 ## Consumer-convention extension seam
 

--- a/plugins/claude-memory/skills/audit/context/audit.md
+++ b/plugins/claude-memory/skills/audit/context/audit.md
@@ -101,12 +101,17 @@ After per-file checks, cross-reference:
 
 ## Step 4: Generate report
 
-Use the output format from criteria.md. Save to `${CLAUDE_PLUGIN_DATA}/audit/last-audit.md`
-(create the directory if absent — audit output stays contributor-local because it covers personal
-auto-memory; see SKILL.md "Report mode"). Pre-rename state migration: if
-`${CLAUDE_PLUGIN_DATA}/health/` exists and `${CLAUDE_PLUGIN_DATA}/audit/` does not, move the old
-directory to the new name first (the skill was previously named `health` and wrote there) so
-prior reports survive the upgrade.
+Use the output format from criteria.md. Save to **the path SKILL.md resolves in "Report location"** —
+`audit/<state-key>/last-audit.md` under the plugin data directory, with `<state-key>` produced by the
+resolver SKILL.md names. Derive it there rather than restating a path here, so the writer and the two
+readers (`report` and `fix`) cannot drift apart. Create the directory if absent; audit output stays
+contributor-local because it covers personal auto-memory.
+
+**No migration from the pre-rename `health/` layout, deliberately.** Both older layouts wrote a
+machine-global file with no project segment, so nothing records which repository produced it, and it
+cannot be adopted into a project's key without inventing that attribution — the exact defect the key
+removes. Where one is present, name its path to the user as a leftover they may delete. See SKILL.md
+"Report location".
 
 Present the report to the user with:
 

--- a/plugins/claude-memory/skills/audit/context/fix.md
+++ b/plugins/claude-memory/skills/audit/context/fix.md
@@ -1,13 +1,19 @@
 # Fix Workflow
 
-Apply fixes for audit findings. Requires a prior audit — reads findings from
-`${CLAUDE_PLUGIN_DATA}/audit/last-audit.md` (checking the pre-rename
-`${CLAUDE_PLUGIN_DATA}/health/` location first when the new path is absent, per the
-migration note in SKILL.md "Report mode").
+Apply fixes for audit findings. Requires a prior audit — reads findings from **the path SKILL.md
+resolves in "Report location"**, `audit/<state-key>/last-audit.md` under the plugin data directory.
+Derive the key there; do not restate a path here.
 
 ## Prerequisites
 
-Read the last-audit report. If missing, inform the user and suggest running the audit first.
+Read the last-audit report **from this project's derived path**. If it is absent, say that no audit
+has been run for this project and suggest running one.
+
+**This mode proposes edits to real instruction files, so an unattributable report is not usable
+input.** Do not fall back to an unkeyed location: a machine-global `audit/last-audit.md` or a
+pre-rename `health/last-audit.md` carries no project segment, so findings in it may describe a
+different repository's memory layer entirely. Name such a file to the user as a leftover and run a
+fresh audit instead of acting on it.
 
 ## Fix strategy
 

--- a/plugins/claude-memory/skills/audit/evals/evals.json
+++ b/plugins/claude-memory/skills/audit/evals/evals.json
@@ -65,12 +65,13 @@
       "id": 6,
       "name": "report-without-prior-audit",
       "prompt": "Show me the memory health report — I want to see the last results.",
-      "expected_output": "The report action reads the most recent saved audit. When none exists, it informs the user that no audit has been run yet and suggests running the audit, rather than fabricating results.",
+      "expected_output": "The report action reads the saved audit at THIS project's derived path — audit/<state-key>/last-audit.md under the plugin data directory, with the state key produced by running the resolver SKILL.md names. When nothing is there it says no audit has been run for this project and suggests running one, rather than fabricating results or reaching for another file.",
       "files": [],
       "expectations": [
-        "Output attempts to read the most recent saved audit report",
-        "When no prior audit exists, output states that none has been run and suggests running the audit",
-        "Output does not fabricate or invent audit results"
+        "Reads the report at the per-project derived path rather than a fixed machine-global filename",
+        "Derives the state key by running the resolver, not by evaluating whether a placeholder is set",
+        "When no prior audit exists for this project, states that and suggests running the audit",
+        "Does not fabricate audit results, and does not fall back to an unkeyed location to find some"
       ]
     },
     {
@@ -95,6 +96,33 @@
         "FAILs the `pnpm run compile` command because package.json does not define that script",
         "Does NOT report build/test commands as absent, because step 0 finds them on another loaded surface (auto memory) and routes location to C3",
         "Reports the wrong command once under C9 and does not double-report it under C7"
+      ]
+    },
+    {
+      "id": 9,
+      "name": "two-repos-do-not-share-one-report",
+      "prompt": "I ran this audit in my work repo this morning. I am now in a completely different repo on the same laptop. If I run `report`, whose findings do I get — and if I run the audit here, does it clobber this morning's?",
+      "expected_output": "Neither crosses over. The report path carries a per-project state key — <repo-identity>/<worktree-discriminator>, the scheme claude-config:audit-pass defines — derived by RUNNING the resolver, so the two projects write and read under different directories beneath the plugin data directory. `report` in this repo serves this repo's report or says none has been run here; it never serves the work repo's. Running the audit here does not clobber this morning's. The answer names the reason: ${CLAUDE_PLUGIN_DATA} is keyed to the plugin identifier alone, with no project, checkout, worktree, or session segment, so an unkeyed filename is one file per machine — and because this skill READS the file back, the consequence is a wrong answer served, not merely a lost artifact. Two worktrees of one repository also key apart, via the discriminator.",
+      "files": [],
+      "expectations": [
+        "States that the second project neither reads nor overwrites the first project's report, and names a distinct path for each",
+        "Derives the state key by running the resolver rather than by evaluating whether a placeholder is set",
+        "Reuses audit-pass's <repo-identity>/<worktree-discriminator> scheme instead of inventing a second one",
+        "Explains that the read-back path is why keying is required and an append-only history alone would not be sufficient",
+        "States that two worktrees of one repository also key apart"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "legacy-unkeyed-report-is-not-served-or-adopted",
+      "prompt": "Show me the memory health report. I know I have run this before — I can see a last-audit.md sitting in the plugin's data directory from an older version.",
+      "expected_output": "The report action looks at THIS project's derived path and finds nothing there. It does not serve the older unkeyed file and does not migrate it into this project's key: a machine-global last-audit.md — including the pre-rename health/ layout — carries no project segment, so nothing records which repository produced it, and adopting it would invent an attribution. The answer names the leftover file's path as something the user may delete, states that no audit has been run for this project, and offers to run one.",
+      "files": [],
+      "expectations": [
+        "Does NOT present the unkeyed legacy report as this project's findings",
+        "Does NOT migrate or copy the legacy file into this project's keyed path",
+        "Names the leftover path to the user and explains it cannot be attributed to a project",
+        "Offers to run a fresh audit for this project"
       ]
     }
   ]

--- a/plugins/claude-memory/skills/audit/reference/criteria.md
+++ b/plugins/claude-memory/skills/audit/reference/criteria.md
@@ -415,5 +415,7 @@ Present findings as a deterministic report:
 |---|-------|------|---------|
 ```
 
-Save the report to `${CLAUDE_PLUGIN_DATA}/audit/last-audit.md` for the `report` action to
-retrieve.
+Save the report to the path SKILL.md resolves in "Report location" —
+`audit/<state-key>/last-audit.md` under the plugin data directory — so the `report` and `fix` actions
+retrieve **this project's** report rather than whichever one was written last on this machine. The
+key is derived by the resolver SKILL.md names; this file states the format, not the path.

--- a/scripts/cross-plugin-source-registry.txt
+++ b/scripts/cross-plugin-source-registry.txt
@@ -25,3 +25,11 @@ reference/standards-contract.md
 # where the managed scope is read and audited; claude-memory only reports the
 # locations). Fix a drift by copying that file over the others.
 lib/managed-scope.sh
+
+# No dedicated check — enforced by this script's own --check.
+# Canonical copy: plugins/claude-config/lib/state-key.sh (claude-config owns the
+# scheme: audit-pass defines it in reference/run-state-and-resumability.md §3 and
+# three of its skills key by it; claude-memory adopts it). The test suite lives
+# beside the canonical copy as lib/state-key.test.sh and covers both. Fix a drift
+# by copying the canonical file over the others.
+lib/state-key.sh


### PR DESCRIPTION
## Summary

Three writers under `${CLAUDE_PLUGIN_DATA}` shared one file per machine, and `docs/conventions/` had no rule to point at.

**The harness fact, verbatim** — [plugins reference](https://code.claude.com/docs/en/plugins-reference), § *Persistent data directory*, re-fetched as raw markdown 2026-08-12: *"The `${CLAUDE_PLUGIN_DATA}` directory resolves to `~/.claude/plugins/data/{id}/`, where `{id}` is the plugin identifier with characters outside `a-z`, `A-Z`, `0-9`, `_`, and `-` replaced by `-`."* Keyed to the plugin identifier and nothing else — no project, checkout, worktree, or session segment. A fixed filename there is one file per machine.

### #2277 — `claude-memory:audit` is the sharp one, because it reads the file back

`report` mode served whatever `audit/last-audit.md` currently held and `fix` mode acted on it. On a machine with two repositories, `report` in project B could present project A's findings as project B's, and `fix` could propose edits derived from another repository's memory layer. **A wrong answer served, not merely a lost artifact** — which is why an append-only history would not close it: serving *the newest* report is not serving *this project's*.

All four sites now resolve one keyed path, `audit/<state-key>/last-audit.md`: the write in `context/audit.md`, its restatement in `reference/criteria.md`, and the two reads in `SKILL.md` and `context/fix.md`.

### #2276 — `claude-config:audit-instructions` printed a wrong number, not just a lost file

Its Phase D header must carry a per-surface token delta *"versus the previous catalog version"*. Under collision that prior file exists but belongs to a **different project's surface set**, so the skill computed and printed a figure instead of declining. A silently wrong number in a report header is the worse half of this defect. The path is now keyed, and the two absent-prior cases are separated: no report at this project's key → omit the delta with a stated reason; an unkeyed leftover → name it to the operator, never use it as a baseline.

It was the last writer in this plugin on a fixed path. `audit-pass` has keyed since it shipped; #2250 moved `audit-prompting-postures`.

### The scheme is `audit-pass`'s — but the third adopter would have been the third copy

`audit-pass` specifies `<repo-identity>/<worktree-discriminator>` in prose; #2250 copied a ~40-line shell block into `audit-prompting-postures`. Rather than paste it twice more, it ships as **`lib/state-key.sh`** with a 23-case suite — byte-identical across both plugins and registered in `scripts/cross-plugin-source-registry.txt`, following the existing `lib/managed-scope.sh` precedent, so the copies cannot drift silently.

The suite pins what the prose asserted and nothing checked, including the security property: **a remote URL becomes directory components in the resulting path**, so `../../../etc`, an absolute local path, and a Windows path are hashed rather than embedded, and the suite asserts no `..` and no backslash survives into a key.

### Two decisions worth stating plainly

1. **Legacy unkeyed reports are neither served nor migrated.** `claude-memory` previously *moved* the pre-rename `health/` directory to `audit/` and read it. Both older layouts carry no project segment, so nothing records which repository produced them; adopting one into a project's key invents the attribution keying exists to remove. Both read paths now decline, name the leftover file's path as something the operator may delete, and offer a fresh audit. **This is a behavior change on upgrade** — an operator holding a report under the old layout is told to re-run rather than shown the old one. It is why `claude-memory` takes a minor bump.
2. **The derivation lives in `SKILL.md`, and the spokes point at it.** `SKILL.md` is unambiguously skill content, doc-confirmed for placeholder substitution. Whether substitution reaches bundled `context/*.md` and `reference/*.md` loaded on demand is **#1568's open question**, and this fix deliberately does not depend on the answer: `SKILL.md` derives the path once, the three spokes refer to it by section name and restate no token of their own.

### #2278 — the convention

`docs/conventions/plugin-data-report-keying/` (README + CHANGELOG, registered in `docs/PLUGIN-PHILOSOPHY.md`'s registry — one row added, nothing reformatted). It separates the two failure modes that need different fixes:

| | **Collision** | **Overwrite** |
|---|---|---|
| Symptom | Project B served project A's content | Yesterday's artifact gone |
| Fixed by | **Keying** | **Retention** |

and states that a non-destructive history closes only the second. Rule 3 — *never serve or derive from an artifact you cannot attribute* — is the one that governs migration.

**RKD-06 is carried as the convention's worked example, not filed as a defect.** `bug-report:write` keys on the kebab-cased **basename** of the project root; the line already states the hazard and then picks a colliding key (two same-named checkouts share one directory). The originating item filed it explicitly as "context, not a defect to fix", and that is honored: it appears in rule 1c and in the adoption table, and no `bug-report` file is touched.

The adoption table also records two things I checked rather than assumed: `claude-config:unhobble` solves the same problem a *different* way (basename as a label, canonical checkout identity recorded in the manifest and verified before every phase — acceptable because its artifact is never served), and `machine-health:audit` is a deliberate non-adopter whose roots are passed in by the caller for a hazard that skill documents. `machine-health` is cited for retention shape only.

## Test plan

New suite, 23 cases, all green:

```
$ bash plugins/claude-config/lib/state-key.test.sh
PASS: case 1: https remote normalizes
PASS: case 2: ssh and https identities agree
PASS: case 3: first remote is used whatever its name
PASS: case 3: did not fall through to local
PASS: case 4: no remote keys local
PASS: case 5: non-repo keys nonrepo
PASS: case 6: no .. in the key
PASS: case 6: traversal remote is hashed
PASS: case 6: hashed key is deterministic
PASS: case 7: absolute path not embedded
PASS: case 8: no backslash in the key
PASS: case 9: same repository identity
PASS: case 9: different worktree discriminator
PASS: case 10: key is a plain relative path (nonrepo/69c19dcafcf7/69c19dca)
PASS: case 10: key is a plain relative path (github.com/acme/widget/91b15dd8)
PASS: case 11: stdout is exactly the key
PASS: case 12: unknown argument exits 2

All 23 checks passed.
```

Executed against this checkout, not only fixtures:

```
$ bash plugins/claude-config/lib/state-key.sh --explain
rung:          remote
remote:        https://github.com/melodic-software/claude-code-plugins
repo root:     C:/Projects/melodic/worktrees/lane-cc-wave2
identity:      github.com/melodic-software/claude-code-plugins
discriminator: 39f67c08
github.com/melodic-software/claude-code-plugins/39f67c08
```

Repo gates:

```
$ shellcheck --rcfile=.shellcheckrc -x plugins/claude-config/lib/state-key.sh plugins/claude-config/lib/state-key.test.sh plugins/claude-memory/lib/state-key.sh
SHELLCHECK CLEAN

$ bash scripts/check-shell-portability.sh --paths <the three files>
No unexcused GNU-only constructs in 3 shell file(s).

$ bash scripts/check-cross-plugin-source-drift.sh --check
No unregistered or drifted cross-plugin source clusters found.

$ CHECK_SKILL_SKILLS_ROOT=plugins/claude-memory/skills bash plugins/skill-quality/scripts/check-skill.sh audit
CHECK-SKILL audit: PASS — 0 errors, 1 warning(s)

$ CHECK_SKILL_SKILLS_ROOT=plugins/claude-config/skills bash plugins/skill-quality/scripts/check-skill.sh audit-instructions
CHECK-SKILL audit-instructions: PASS — 0 errors, 2 warning(s)

$ bash plugins/skill-quality/scripts/check-evals-quality.sh <both evals.json>
check-evals-quality: PASS (0 warning(s) across 1 file(s))   # x2

$ npx markdownlint-cli2 <every changed markdown file>
Summary: 0 issues in 0 files

$ bash scripts/check-changelog-parity.sh --check && --check-order && --check-bump origin/main
Every versioned plugin has a CHANGELOG.md …
All 76 changelog(s) read newest-first with no duplicate versions.
Every plugin whose version changed vs origin/main has a '## [<version>]' CHANGELOG.md entry.
```

All `check-skill.sh` warnings are pre-existing on those skills, not introduced here.

No behavioral test applies to the prose half (the four keyed sites and the convention) — those are model-facing instructions. They are covered by three eval cases instead, listed below, which is the mechanism this repo uses for that layer.

## Security review note

`lib/state-key.sh` is a new **read-only** surface: it runs `git remote`, `git config --get`, `git rev-parse --show-toplevel`, and a hash. No write, no network, no execution of anything it reads. It adds no permission rule, no `allowed-tools` entry, and no hook.

The one security-relevant property is deliberate and tested: **its output becomes directory components in a caller's path**, so an attacker-influenced remote URL is a path-traversal vector. The identity is accepted only as lowercase segments of `[a-z0-9._-]` each starting alphanumeric, and anything else is replaced by a sha256 prefix — deterministic, and inside the namespace. Cases 6, 7, 8 and 10 assert that no `..`, no backslash, and no absolute or space-bearing form survives into a key. This hardening is inherited from #2250, where an unvalidated version of the same derivation was caught in review normalizing a report path outside its skill's namespace.

Trust-surface direction is *narrowing*, not widening: `claude-memory:audit` previously read and acted on a machine-global file it could not attribute to a project, and now refuses to.

Bumps: `claude-config` → **0.35.0** (new `lib/`, behavior change), `claude-memory` → **0.9.0** (behavior change including the migration removal). `docs/conventions/` carries its own contract version (1.0.0) and no plugin bump.

## Test plan — eval coverage added

The keying property had **zero** eval coverage in either plugin.

- `claude-memory:audit` — `two-repos-do-not-share-one-report`, `legacy-unkeyed-report-is-not-served-or-adopted`, and `report-without-prior-audit` rewritten to assert the per-project derived path rather than "the most recent saved audit".
- `claude-config:audit-instructions` — `second-project-neither-overwrites-nor-borrows-a-delta`, which pins the delta-omission as well as the path.

## Related

Closes #2276
Closes #2277
Closes #2278

Inbox item: `2026-08-10-claude-config-report-keying-and-dispatch` (RKD-01, RKD-03, RKD-04, RKD-05, RKD-06), plus `20260811-020411-claude-config-audit-pass-report-path-inside-scan-set` § F7, which contributes the datum that made this an inconsistency *inside one plugin* rather than a fleet-wide omission.
Ledger: `.work/handoff-inbox-batch-4/ledgers/I6-report-keying-dispatch.md` · `.../I8-audit-pass-report-path.md` § F7.

Adjacent, not duplicated: #2250 (closed) is the same defect on `audit-prompting-postures` and the template followed here. #2229 / #2230 (closed) covered `audit-pass`'s *containment* defect — containment within a run and collision across runs are different defects. #1568 owns the substitution-scope question this fix routes around rather than assumes. #1182 is hook-config-delivery adoption tracking, unrelated.
