### PR TITLE
fix(claude-config): sync audit-permission-grants criteria to convention 1.2

### DIFF
--- a/plugins/claude-config/.claude-plugin/plugin.json
+++ b/plugins/claude-config/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-config",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Eight configuration-health skills (plus setup) for a repo's Claude Code configuration: audit (settings.json / .mcp.json / hooks / plugins / permissions drift), audit-automation-gaps (evidence-gated verdicts on automation gaps), audit-permission-grants (allow-rule / allowed-tools grants for auto-mode durability and portability), audit-permission-state (which settings scopes exist and what rules each one holds — managed policy, user-global, project, local, and the pre-v2.1.211 start-directory copy), audit-instructions (locally-owned instruction surfaces vs current model capability — proposes removals/rewrites of instructions the model no longer needs, and detects cross-surface instruction conflicts), audit-prompting-postures (the additive lane — posture guidance the prompting guide says a component's purpose needs but the component does not carry), audit-pass (one coordinated, ordered, resumable pass over a named target — three-scope inventory, run-time-derived exclusion set, stable finding identity, suppression memory, resume, one human gate — delegating every check to the plugin that owns it), and unhobble (the empirical bare-baseline experiment: reversibly strip a repo's standing instructions, log real stumbles against the current model, re-add only what evidence earns).",
   "author": {
     "name": "Melodic Software",

--- a/plugins/claude-config/CHANGELOG.md
+++ b/plugins/claude-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the `claude-config` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.35.2]
+
+### Fixed
+
+- **`audit-permission-grants` criteria synced to permission-rule-hygiene 1.2.** Bumped the pinned
+  version stamp, added a convention commit handshake, and disclosed the bare package-manager wildcard
+  extension in P1. (#2284, A14 and A18)
+
 ## [0.35.1]
 
 ### Fixed

--- a/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
+++ b/plugins/claude-config/skills/audit-permission-grants/reference/criteria.md
@@ -1,12 +1,14 @@
 # Permission Hygiene Criteria
 
-Version: 1.0.0
-Last updated: 2026-07-14
+Version: 1.2.0
+Last updated: 2026-08-12
+Synced from: permission-rule-hygiene convention 1.2 (`2a481e9d`)
 
 This file defines the checks the `audit-permission-grants` audit runs. The **principle, the three
 anti-patterns, and the prescribed correct pattern — with official-doc citations — live in the
 marketplace's permission-rule-hygiene convention** and are not restated here, published at
-<https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/permission-rule-hygiene/README.md>.
+<https://raw.githubusercontent.com/melodic-software/claude-code-plugins/main/docs/conventions/permission-rule-hygiene/README.md>
+(pinned at the commit named in **Synced from** above).
 This file is the mechanical check layer: what the detector flags, at what severity, and how to read a
 finding. Each check's **Recommend** line below carries the fix in the form the report needs, so a run
 never depends on fetching the convention.
@@ -43,6 +45,8 @@ wildcarded interpreter (`Bash(python*)`, `Bash(node *)`, `Bash(bash <path>*)`, `
 package-manager grant — a runner subcommand (`Bash(npx *)`, `Bash(uvx *)`, `Bash(pipx run *)`,
 `Bash(pnpm dlx *)`, …) or a bare package-manager wildcard (`Bash(npm:*)`, `Bash(npm *)`,
 `Bash(pnpm:*)`, `Bash(yarn:*)`), which grants arbitrary execution via `npm exec` / lifecycle scripts —
+**this bare form reaches past the documented "package-manager run commands" category** (broader, not
+narrower; same authoring anti-pattern and fix) —
 a script-glob command (`Bash(*.py:*)`), or an `Agent` allow rule (bare `Agent` or scoped `Agent(...)` —
 both dropped categorically, with no narrow carry-over form).
 


### PR DESCRIPTION
Fixes #2284 (A14 and A18).

- Bump `criteria.md` to convention 1.2 with a commit handshake line.
- Disclose the bare package-manager wildcard extension in P1 (matching the convention asymmetry marker).

Remaining rows (A6, A9, A10, A13, A17, script changes) left for follow-up.

## Related

- #2284