### PR TITLE
fix(context-guard): re-arm the zone gate on a dwell, not a rank distance, and never advance it on a silent turn

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,90 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1]
+
+### Fixed
+
+- **The 0.7.0 re-arm rule permanently silenced the middle band; it now decays on a DWELL rather than
+  a rank distance (#2220).** `REARM_MARGIN=2` is satisfiable only from `dumb`: the largest
+  improvement available from `acceptable` is one rank, so `armed_rank - new_rank >= 2` could never
+  hold there. A session that armed at `acceptable` could never decay again — a full recovery to
+  `smart` followed by a relapse stayed silent for the rest of the session, however many times it
+  happened, unless the session first escalated all the way to `dumb`. Reproduced against the shipped
+  hook side by side with the structurally identical `dumb` sequence, which did re-inject:
+
+  ```
+  acceptable -> INJECTED   armed=acceptable        dumb  -> INJECTED   armed=dumb
+  smart      -> silent     armed=acceptable        smart -> silent     armed=smart
+  acceptable -> silent     armed=acceptable        dumb  -> INJECTED   armed=dumb
+  smart      -> silent     armed=acceptable
+  acceptable -> silent     armed=acceptable
+  ```
+
+  This was **0.7.0's own defect inverted** — never re-inject instead of always re-inject — so the
+  fix is not a smaller constant: a delta of 1 simply restores the flap 0.7.0 set out to remove. The
+  rule now counts **time instead of distance**. Any observation strictly better than the armed rank
+  extends a streak, returning to the armed rank breaks it, and **three consecutive better
+  observations** decay the armed rank. A streak is expressible from every rung of a three-rung
+  ladder while a two-rank drop is not, so every band now behaves identically: an unsustained dip
+  never re-arms, and a sustained one always does — from `acceptable` exactly as from `dumb`.
+
+  The dwell is a declared judgment default on the same footing as the bands themselves
+  (`reference/reader-contract.md` records their provenance); nothing here is doc- or
+  benchmark-derived. A band-edge oscillation resolves within a single observation as one batch's
+  results land and are released, so one better observation is precisely what noise looks like; three
+  span more than a full PostToolBatch/UserPromptSubmit cycle, which a session alternating across the
+  edge turn by turn never accumulates.
+
+- **The armed gate no longer advances on a turn that emitted nothing, which could lose a warning
+  permanently.** 0.7.0 wrote the markers gate-first, on the reasoning that a stale gate merely
+  withholds a repeat. That was backwards. If `.armed` landed and the companion `.zone` write then
+  failed (a transient full or read-only filesystem, or a directory occupying the path), the hook
+  exited without emitting while leaving the gate advanced — so once the filesystem recovered, the
+  next identical observation was no longer worse than the armed rank and the **first** warning was
+  never delivered at all. Losing the first warning is strictly worse than the repeat the ordering
+  was protecting against.
+
+  `.zone` is now written first and `.armed` installed afterwards, all-or-nothing: if either step
+  fails the gate is left exactly where it was and the same observation is free to emit on a later
+  call. `.armed` is installed by **rename** rather than written in place, because `>` truncates
+  before it writes — a failure partway through would otherwise leave an empty marker, which parses
+  as no marker, which seeds from a `.zone` already updated to the current zone, suppressing the very
+  warning the ordering exists to protect.
+
+### Changed
+
+- **A transition into a zone BETTER than the worst already reported is now silent.** 0.7.0 still
+  injected on `dumb` → `smart` → `acceptable`, because a single `smart` observation re-armed the
+  ladder outright and `acceptable` was then worse than the armed `smart`. Under the dwell it is
+  silent: one observation is not a sustained improvement, so the armed rank is still `dumb` and
+  `acceptable` is not worse than `dumb`. The operator has already been told this session reached
+  `dumb`; announcing a better zone afterwards is the noise #2220 is about. The pre-existing test
+  that asserted the old behaviour was updated rather than deleted, and says so at its site.
+
+### Notes
+
+- **Erratum, not a rewrite — the 0.7.0 entry below keeps the wording it shipped with.** Its
+  description of the re-arm rule ("an improvement of at least **two ranks**") is accurate about what
+  0.7.0 did; what it does not say is that the rule was unsatisfiable from `acceptable`. The claim it
+  makes about `dumb → acceptable → dumb` injecting once remains true. Read it as superseded by this
+  entry rather than as wrong (`docs/conventions/upstream-drift/README.md` §Adopters: history is
+  never rewritten).
+- **The test gap that allowed this is closed at the same time.** 0.7.0's suite exercised only
+  `dumb → smart → dumb`, which the rank-delta rule happened to get right; the
+  `acceptable → smart → acceptable` path — the one it got permanently wrong — had no case. Case 4d
+  now covers that band's flap and its sustained-recovery half on a session of its own. The
+  persistence test likewise now clears the obstruction and re-runs the identical observation, which
+  is what makes it discriminating; previously it stopped at "it stayed silent", a state a gate that
+  had advanced would also have passed.
+- `.armed` now holds `"<zone-word> <streak>"` and is parsed field-wise, with both fields validated
+  against their own vocabulary so a truncated or hand-edited marker falls back to seeding rather
+  than silently disarming the gate. A 0.7.0 marker holds a bare zone word: the streak parses as 0,
+  which is exactly the right starting point, so no migration step and no state-format version are
+  needed.
+- No blocking behaviour, no permission, no new hook registration, and no external read or write
+  changes; the plugin's trust surface is untouched.
+
 ## [0.7.0]
 
 ### Changed

--- a/plugins/context-guard/hooks/zone-crossing-inject.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.sh
@@ -44,17 +44,35 @@
 # the ~1KB guidance block re-injected on each one, and an improvement in any
 # amount silently re-armed the injection with nothing counting or capping the
 # flap. A second marker — the ARMED rank, the worst zone this session has
-# already reported — now gates the emit, and it decays only on an improvement
-# of at least REARM_MARGIN ranks.
+# already reported — now gates the emit.
 #
-# The margin is a declared judgment default, like the bands themselves
-# (reference/reader-contract.md records their provenance): a ONE-rank dip at a
-# band edge is the oscillation described above and says nothing new, while a
-# TWO-rank improvement — the full width of the ladder, dumb → smart — cannot
-# be edge noise and means the window genuinely emptied. A `/clear` needs no
-# margin at all: it starts a new session id, hence a new state file and a
-# fresh baseline. So a zone is announced at most once per session unless the
-# session really recovers, after which the ladder re-arms and the next
+# WHAT MAKES THE ARMED RANK DECAY: a sustained improvement, measured in
+# CONSECUTIVE OBSERVATIONS, not in ranks. A fixed rank-delta cannot work
+# uniformly on a three-rung ladder and must not be used here: requiring two
+# ranks is satisfiable only from `dumb`, so a session armed at `acceptable`
+# could never decay at all — full recovery to `smart` and relapse would stay
+# silent for the rest of the session, however many times it happened. That is
+# this issue's own defect inverted (never re-inject instead of always
+# re-inject), and it is why the rule counts time rather than distance.
+#
+# So: any observation strictly better than the armed rank extends a streak;
+# returning to the armed rank breaks it; REARM_DWELL consecutive better
+# observations decay the armed rank to what is actually being observed. The
+# same rule holds at every band, because a streak is expressible from any rung
+# while a two-rank drop is not.
+#
+# REARM_DWELL is a declared judgment default, like the bands themselves
+# (reference/reader-contract.md records their provenance) — nothing here is
+# doc- or benchmark-derived. The reasoning: a band-edge oscillation resolves
+# within a single observation, as one batch's results land and are released, so
+# one better observation is exactly what noise looks like and cannot be allowed
+# to re-arm. Three consecutive better observations span more than a full
+# PostToolBatch/UserPromptSubmit cycle, which a session alternating across the
+# edge turn by turn never accumulates. A `/clear` needs no dwell at all: it
+# starts a new session id, hence a new state file and a fresh baseline.
+#
+# Net contract: a zone is announced at most once per session unless the session
+# holds a genuine improvement, after which the ladder re-arms and the next
 # worsening is reported normally.
 #
 # The last-seen zone is still tracked, separately: it is what the message and
@@ -135,16 +153,31 @@ STATE_FILE="$STATE_DIR/$SESSION.zone"
 ARMED_FILE="$STATE_DIR/$SESSION.armed"
 last=""
 [[ -r "$STATE_FILE" ]] && last=$(tr -cd '[:lower:]' <"$STATE_FILE" 2>/dev/null | head -c 16)
-armed=""
-[[ -r "$ARMED_FILE" ]] && armed=$(tr -cd '[:lower:]' <"$ARMED_FILE" 2>/dev/null | head -c 16)
 # A SIBLING file, not a second line in the existing one: `last` is read with
-# `tr -cd '[:lower:]'`, which strips the newline too, so a two-line state file
-# would fuse into "dumbacceptable" and rank as smart. Sessions already running
-# when this version lands have a `.zone` file and no `.armed` file; seeding the
-# armed rank from the last-seen zone reproduces the pre-hysteresis decision for
-# exactly one call, after which the marker latches normally. No migration step
-# and no state-format version are needed for that.
-[[ -n "$armed" ]] || armed="$last"
+# `tr -cd '[:lower:]'`, which strips the newline too, so a two-line `.zone`
+# would fuse into "dumbacceptable" and rank as smart. The armed marker holds
+# TWO fields — "<zone-word> <better-streak>" — and is parsed field-wise rather
+# than through that filter, so it carries the dwell counter without inheriting
+# the fusing problem.
+#
+# Both fields are validated against their own vocabulary. Anything else — an
+# empty file, a truncated one, a hand-edited one — falls through to the seeding
+# rule below rather than ranking as `smart` and silently disarming the gate.
+armed=""
+streak=0
+if [[ -r "$ARMED_FILE" ]]; then
+  read -r armed_word armed_streak _ <"$ARMED_FILE" 2>/dev/null || true
+  [[ "${armed_word:-}" =~ ^(smart|acceptable|dumb)$ ]] && armed="$armed_word"
+  [[ "${armed_streak:-}" =~ ^[0-9]{1,3}$ ]] && streak="$armed_streak"
+fi
+# Sessions already running when this version lands have a `.zone` file and no
+# `.armed` file; seeding the armed rank from the last-seen zone reproduces the
+# pre-hysteresis decision for exactly one call, after which the marker latches
+# normally. No migration step and no state-format version are needed for that.
+if [[ -z "$armed" ]]; then
+  armed="$last"
+  streak=0
+fi
 
 rank() {
   case "$1" in
@@ -163,32 +196,70 @@ unrank() {
 new_rank=$(rank "$zone")
 armed_rank=$(rank "$armed")
 
-# See the header. The armed rank rises to whatever this observation reports and
-# falls only on an improvement at least this wide.
-REARM_MARGIN=2
+# See the header. The armed rank rises immediately to whatever this observation
+# reports, and falls only after REARM_DWELL CONSECUTIVE observations strictly
+# better than it — never on a rank distance, which a three-rung ladder cannot
+# express uniformly.
+REARM_DWELL=3
 next_armed_rank=$armed_rank
-if ((new_rank > armed_rank || armed_rank - new_rank >= REARM_MARGIN)); then
+next_streak=$streak
+if ((new_rank > armed_rank)); then
+  # A worsening past everything already reported: arm here and start over.
   next_armed_rank=$new_rank
+  next_streak=0
+elif ((new_rank < armed_rank)); then
+  next_streak=$((streak + 1))
+  if ((next_streak >= REARM_DWELL)); then
+    next_armed_rank=$new_rank
+    next_streak=0
+  fi
+else
+  # Back at the armed rank: the improvement did not hold, so the streak that
+  # would have re-armed the ladder is broken. This is the flap, and breaking
+  # the streak here is what keeps an oscillation from accumulating a dwell one
+  # observation at a time.
+  next_streak=0
 fi
 
-# Persist both markers regardless of direction — owner-only, atomic enough for
-# a single-writer-per-session file. A write failure (full or newly read-only
-# filesystem) must fail OPEN SILENTLY: proceeding past it would compare this
-# turn's zone against the same stale markers again on the next call, re-emitting
-# the ~1KB guidance block every subsequent PostToolBatch/UserPromptSubmit
-# instead of once per transition — which is the very defect the armed rank
-# exists to bound. "Silent" means neither channel emits — the failure itself is
-# still surfaced to operators as telemetry, never swallowed twice.
+# Persist both markers regardless of direction — owner-only. A write failure
+# (full or newly read-only filesystem) must fail OPEN SILENTLY: proceeding past
+# it would compare this turn's zone against the same stale markers again on the
+# next call, re-emitting the ~1KB guidance block every subsequent
+# PostToolBatch/UserPromptSubmit instead of once per transition — which is the
+# very defect the armed rank exists to bound. "Silent" means neither channel
+# emits — the failure itself is still surfaced to operators as telemetry, never
+# swallowed twice.
 #
-# The ARMED file is written FIRST. If only one of the two lands, the safe
-# survivor is the one that suppresses: a stale `.armed` at worst withholds a
-# repeat notice, while a stale `.zone` only mislabels the "previous" zone in a
-# message. Writing the gate first means a partial failure can never leave the
-# gate open against a marker that already moved.
+# THE GATE ADVANCES LAST, AND ONLY ALL-OR-NOTHING. The armed marker is what
+# suppresses a future injection, so leaving it advanced on a turn that emitted
+# NOTHING destroys the warning permanently: the next identical observation is no
+# longer worse than the armed rank, and the operator never hears about the zone
+# at all. That is strictly worse than the repeat this hook is otherwise tuned to
+# avoid, so the ordering is the reverse of the intuitive one — `.zone`, which
+# only labels the "previous" zone in a message, is written first, and `.armed`
+# is installed afterwards. If either step fails, the gate is left exactly where
+# it was and the same observation is free to emit on a later call.
+#
+# `.armed` is installed by RENAME rather than written in place, because a plain
+# `>` truncates before it writes: a failure partway through would leave an empty
+# marker, which parses as no marker, which seeds from `.zone` — by then already
+# updated to the current zone — and suppresses the very warning this ordering
+# exists to protect. A rename is atomic, so the marker is only ever its old
+# value or its new one.
 umask 077
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
-if ! printf '%s\n' "$(unrank "$next_armed_rank")" >"$ARMED_FILE" 2>/dev/null ||
-  ! printf '%s\n' "$zone" >"$STATE_FILE" 2>/dev/null; then
+persist_failed=""
+printf '%s\n' "$zone" >"$STATE_FILE" 2>/dev/null || persist_failed=1
+if [[ -z "$persist_failed" ]]; then
+  armed_tmp="$ARMED_FILE.$$"
+  if printf '%s %d\n' "$(unrank "$next_armed_rank")" "$next_streak" >"$armed_tmp" 2>/dev/null; then
+    mv -f "$armed_tmp" "$ARMED_FILE" 2>/dev/null || persist_failed=1
+  else
+    persist_failed=1
+  fi
+  [[ -n "$persist_failed" ]] && rm -f "$armed_tmp" 2>/dev/null
+fi
+if [[ -n "$persist_failed" ]]; then
   hook::emit_telemetry "zone-crossing-inject" "$EVENT" "error" "$START_EPOCH" \
     '{"zone":"'"$zone"'","previous":"'"${last:-}"'","reason":"state_persist_failed"}'
   exit 0

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -116,16 +116,20 @@ else
   fail "state not updated on improvement"
 fi
 
-# 4. Relapse after a FULL recovery (dumb → smart → acceptable) injects again.
-# smart is two ranks below the armed dumb, so the armed marker decayed and the
-# ladder re-armed. This is the discriminating half of the hysteresis pair: a
-# real recovery must not be silenced by the margin that silences a flap.
+# 4. CONTRACT CHANGE, stated rather than slipped in. Before hysteresis this
+# sequence — dumb, then smart, then acceptable — injected on the third step,
+# because the gate compared against the LAST-SEEN zone and smart → acceptable is
+# a worsening. It is now SILENT: the armed rank is still dumb (one better
+# observation is not a sustained improvement), and acceptable is not worse than
+# dumb. The operator was already told this session reached dumb; telling them it
+# is now at a BETTER zone than the one already reported is the noise #2220 is
+# about. The relapse that must still be reported is covered by 4b.
 write_snapshot "$H" s1 60
 run "$H" "$D" s1 UserPromptSubmit
-if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
-  ok "relapse after a two-rank recovery injects again (UserPromptSubmit)"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "a zone better than the one already reported stays silent (was: injected pre-0.7.0)"
 else
-  fail "relapse: rc=$RC out=$OUT"
+  fail "improvement-relative-to-armed wrongly injected: rc=$RC out=$OUT"
 fi
 
 # 4a. HYSTERESIS — the flap. A session hovering on the acceptable/dumb boundary
@@ -150,7 +154,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then
 else
   fail "flap dip emitted: rc=$RC out=$OUT"
 fi
-if [[ "$(cat "$D/state/sflap.armed" 2>/dev/null)" == "dumb" ]]; then
+if [[ "$(cut -d' ' -f1 <"$D/state/sflap.armed" 2>/dev/null)" == "dumb" ]]; then
   ok "flap: a one-rank dip does NOT decay the armed rank"
 else
   fail "armed rank decayed on a one-rank dip: $(cat "$D/state/sflap.armed" 2>/dev/null)"
@@ -174,18 +178,21 @@ else
 fi
 
 # 4b. HYSTERESIS — the discriminating opposite, on a session of its own so the
-# two paths cannot share state: dumb → smart → dumb DOES inject twice, because
-# a two-rank improvement is a real state change rather than edge noise.
+# two paths cannot share state: a SUSTAINED improvement decays the armed rank
+# and the next worsening is reported normally.
 write_snapshot "$H" srec 90
 run "$H" "$D" srec
 if [[ "$OUT" == *additionalContext* ]]; then ok "recovery: first dumb injects"; else fail "recovery setup: $OUT"; fi
-write_snapshot "$H" srec 10 # smart — two ranks, re-arms
-run "$H" "$D" srec
-if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "recovery: the improvement itself is silent"; else fail "improvement emitted: $OUT"; fi
-if [[ "$(cat "$D/state/srec.armed" 2>/dev/null)" == "smart" ]]; then
-  ok "recovery: a two-rank improvement decays the armed rank"
+for _ in 1 2 3; do
+  write_snapshot "$H" srec 10 # smart, held for REARM_DWELL observations
+  run "$H" "$D" srec
+  [[ -n "$OUT" ]] && fail "recovery: an improvement emitted: $OUT"
+done
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "recovery: a held improvement is silent while it holds"; else fail "improvement emitted: $OUT"; fi
+if [[ "$(cut -d' ' -f1 <"$D/state/srec.armed" 2>/dev/null)" == "smart" ]]; then
+  ok "recovery: a sustained improvement decays the armed rank"
 else
-  fail "armed rank did not decay on a full recovery: $(cat "$D/state/srec.armed" 2>/dev/null)"
+  fail "armed rank did not decay on a sustained recovery: $(cat "$D/state/srec.armed" 2>/dev/null)"
 fi
 write_snapshot "$H" srec 90
 run "$H" "$D" srec
@@ -193,6 +200,45 @@ if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
   ok "recovery: relapse after a genuine recovery injects again"
 else
   fail "genuine relapse suppressed by hysteresis: rc=$RC out=$OUT"
+fi
+
+# 4d. THE MIDDLE BAND — the case a rank-delta margin got permanently wrong, and
+# the one this suite did not previously cover. `acceptable` is one rung above
+# the floor, so the largest improvement available from it is ONE rank; a rule
+# demanding two could never be satisfied there and the band armed forever.
+# Structurally identical to 4a/4b one rung down, and it must behave identically.
+write_snapshot "$H" smid 60
+run "$H" "$D" smid
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
+  ok "middle band: first acceptable injects"
+else
+  fail "middle band setup: rc=$RC out=$OUT"
+fi
+write_snapshot "$H" smid 10 # smart — a single better observation
+run "$H" "$D" smid
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "middle band: the dip is silent"; else fail "middle band dip emitted: $OUT"; fi
+write_snapshot "$H" smid 60 # back to acceptable — the flap
+run "$H" "$D" smid
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "middle band: an unsustained dip does NOT re-arm, so the flap stays silent"
+else
+  fail "middle band flap re-injected: rc=$RC out=$OUT"
+fi
+for _ in 1 2 3; do
+  write_snapshot "$H" smid 10 # smart, now HELD
+  run "$H" "$D" smid
+done
+if [[ "$(cut -d' ' -f1 <"$D/state/smid.armed" 2>/dev/null)" == "smart" ]]; then
+  ok "middle band: a sustained improvement DOES decay the armed rank"
+else
+  fail "middle band armed rank never decays (permanent suppression): $(cat "$D/state/smid.armed" 2>/dev/null)"
+fi
+write_snapshot "$H" smid 60
+run "$H" "$D" smid
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
+  ok "middle band: relapse after a sustained recovery injects again (no permanent suppression)"
+else
+  fail "middle band permanently suppressed — the rank-delta defect: rc=$RC out=$OUT"
 fi
 
 # 4c. LEGACY STATE: a session already running when this version lands has a
@@ -209,7 +255,7 @@ if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
 else
   fail "legacy state broke the first post-upgrade decision: rc=$RC out=$OUT"
 fi
-if [[ "$(cat "$D/state/slegacy.armed" 2>/dev/null)" == "dumb" ]]; then
+if [[ "$(cut -d' ' -f1 <"$D/state/slegacy.armed" 2>/dev/null)" == "dumb" ]]; then
   ok "legacy state gains an .armed marker on first write (no migration step)"
 else
   fail "armed marker not seeded: $(cat "$D/state/slegacy.armed" 2>/dev/null)"
@@ -321,6 +367,24 @@ if wait_for_sink "$TEL" && [[ "$(jq -r '.status' "$TEL" 2>/dev/null)" == "error"
   ok "state-persist failure reports telemetry status=error"
 else
   fail "telemetry status not error: $(cat "$TEL" 2>/dev/null)"
+fi
+
+# 12a. THE WARNING SURVIVES THE FAILURE. The check above stops at "it stayed
+# silent", which a gate that advanced its armed marker on the way out would also
+# pass — and would then suppress the SAME observation forever once the
+# filesystem recovered, losing the first warning outright. So: clear the
+# obstruction and re-run the identical observation. It must inject.
+if [[ -e "$D/state/spersist.armed" ]]; then
+  fail "the armed gate advanced on a turn that emitted nothing: $(cat "$D/state/spersist.armed" 2>/dev/null)"
+else
+  ok "state-persist failure leaves the armed gate untouched"
+fi
+rmdir "$D/state/spersist.zone" 2>/dev/null || rm -rf "$D/state/spersist.zone"
+run "$H" "$D" spersist
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
+  ok "after the filesystem recovers, the same observation still injects (warning not lost)"
+else
+  fail "the first warning was permanently lost by a partial write: rc=$RC out=${OUT:0:160}"
 fi
 
 # No resolvable state root → stay silent rather than key the last-seen zone to

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -190,12 +190,23 @@ Since 0.4.0 the plugin itself ships hooks over its own seam — the first shippe
   than any this session has already reported, inject continuation guidance (a minimal generic
   continuation tree plus a presence-gated pointer to `session-flow:workflow`'s router). Silent
   while the zone is unchanged, improving, or `unknown`. **Hysteresis** (since 0.7.0): the gate is
-  the worst zone already *reported*, not the zone last *seen*, and that marker decays only on an
-  improvement of at least two ranks — the full width of the ladder. Occupancy does not climb
-  monotonically, so a session sitting on a band edge crosses it repeatedly; without the margin each
-  re-crossing read as a fresh transition and re-injected the guidance block. A `/clear` needs no
-  margin: it starts a new session id, hence a fresh baseline. The margin is a declared judgment
-  default, on the same footing as the bands above and with the same provenance status.
+  the worst zone already *reported*, not the zone last *seen*. Occupancy does not climb
+  monotonically, so a session sitting on a band edge crosses it repeatedly; without hysteresis each
+  re-crossing read as a fresh transition and re-injected the guidance block. That marker decays
+  only after **three consecutive observations strictly better than it** — a dwell, deliberately
+  *not* a rank distance. A fixed rank-delta cannot work uniformly on a three-rung ladder: a
+  two-rank drop is reachable only from `dumb`, so a session armed at `acceptable` could never decay
+  and would be silenced permanently — this defect inverted rather than fixed. A dwell is
+  expressible from every rung, so all bands behave identically. Returning to the armed zone breaks
+  the streak, which is what stops an oscillation accumulating a dwell one crossing at a time. A
+  `/clear` needs no dwell: it starts a new session id, hence a fresh baseline. The dwell is a
+  declared judgment default, on the same footing as the bands above and with the same provenance
+  status.
+
+  One consequence worth stating, because it changed at 0.7.0: a transition into a zone **better**
+  than the worst already reported is now silent (`dumb` → `smart` → `acceptable` reports nothing at
+  the third step, where pre-0.7.0 it injected). The operator has already been told this session
+  reached `dumb`; announcing a better zone afterwards is the noise the hysteresis exists to remove.
 - **Blocking gate** (`PreToolUse`, only when the `zone_hook_mode` userConfig option is
   `blocking`): denies new `Write|Edit|NotebookEdit|Agent|Workflow` calls on a **fresh dumb-zone
   snapshot** past a small grace budget. Fail-open on `unknown`; handoff-path writes, read-only


### PR DESCRIPTION
## Summary

Follow-up to #2308, which merged before its review findings were addressed. **All three findings are
live on `main` in `context-guard` 0.7.0**, and the first is a shipped behaviour bug. Each was
reproduced against the shipped hook before anything was changed.

### 🔴 1. 0.7.0 permanently silences the middle band

`REARM_MARGIN=2` is satisfiable **only** from `dumb`. The largest improvement available from
`acceptable` (rank 1) is one rank, so `armed_rank - new_rank >= 2` can never hold there. A session
that arms at `acceptable` never decays again: full recovery to `smart` followed by relapse stays
silent for the rest of the session, however many times it happens, unless it first escalates all the
way to `dumb`.

Reproduced against the hook as shipped, beside the structurally identical `dumb` sequence:

```
=== acceptable -> smart -> acceptable ===        === dumb -> smart -> dumb (control) ===
1. acceptable  -> INJECTED  armed=acceptable     1. dumb   -> INJECTED  armed=dumb
2. smart       -> silent    armed=acceptable     2. smart  -> silent    armed=smart
3. acceptable  -> silent    armed=acceptable     3. dumb   -> INJECTED  armed=dumb
4. smart       -> silent    armed=acceptable
5. acceptable  -> silent    armed=acceptable
```

Same shape, one rung apart, opposite outcomes. **This is #2220's own defect inverted** — never
re-inject instead of always re-inject — which is why the fix is not a smaller constant. A delta of 1
simply restores the flap 0.7.0 set out to remove.

**The rule now counts time, not distance.** An observation strictly better than the armed rank
extends a streak; returning to the armed rank breaks it; **three consecutive better observations**
decay the armed rank. A streak is expressible from every rung of a three-rung ladder while a
two-rank drop is not, so every band behaves identically. Verified side by side after the change:

```
=== dumb: unsustained dip (flap) ===          === acceptable: unsustained dip (flap) ===
1. dumb     -> INJECTED  armed=[dumb 0]       1. acceptable -> INJECTED  armed=[acceptable 0]
2. smart    -> silent    armed=[dumb 1]       2. smart      -> silent    armed=[acceptable 1]
3. dumb     -> silent    armed=[dumb 0]       3. acceptable -> silent    armed=[acceptable 0]

=== dumb: sustained dip (recovery) ===        === acceptable: sustained dip (recovery) ===
1. dumb     -> INJECTED  armed=[dumb 0]       1. acceptable -> INJECTED  armed=[acceptable 0]
2. smart    -> silent    armed=[dumb 1]       2. smart      -> silent    armed=[acceptable 1]
3. smart    -> silent    armed=[dumb 2]       3. smart      -> silent    armed=[acceptable 2]
4. smart    -> silent    armed=[smart 0]      4. smart      -> silent    armed=[smart 0]
5. dumb     -> INJECTED  armed=[dumb 0]       5. acceptable -> INJECTED  armed=[acceptable 0]
```

The dwell is a **declared judgment default** on the same footing as the bands themselves
(`reference/reader-contract.md` records their provenance) — nothing here is doc- or
benchmark-derived, and no citation is manufactured for it. The reasoning: a band-edge oscillation
resolves within a single observation as one batch's results land and are released, so one better
observation is precisely what noise looks like; three span more than a full
PostToolBatch/UserPromptSubmit cycle, which a session alternating across the edge turn by turn never
accumulates.

### 🟡 2. The test gap that allowed it

0.7.0's suite exercised only `dumb → smart → dumb`, the one path a rank-delta rule happens to get
right. Case **4d** adds `acceptable → smart → acceptable` on its own session, covering both the flap
half and the sustained-recovery half. It fails against the shipped implementation.

### 3. The armed gate advanced on a turn that emitted nothing

0.7.0 wrote the markers gate-first, reasoning that a stale gate merely withholds a repeat. That was
backwards. If `.armed` landed and the companion `.zone` write then failed, the hook exited without
emitting **while leaving the gate advanced** — so once the filesystem recovered, the next identical
observation was no longer worse than the armed rank and the **first** warning was never delivered at
all. Losing the first warning is strictly worse than the repeat the ordering was protecting against.

`.zone` is now written first and `.armed` installed afterwards, all-or-nothing. `.armed` is installed
by **rename**, not written in place: `>` truncates before it writes, so a partial failure would
leave an empty marker, which parses as no marker, which seeds from a `.zone` already updated to the
current zone — the same loss by another route.

The persistence test previously stopped at "it stayed silent", a state an advanced gate would also
pass. It now asserts the gate is untouched **and** clears the obstruction and re-runs the identical
observation, which must inject.

### Behaviour change, stated rather than slipped in

`dumb → smart → acceptable` is now **silent** (0.7.0 injected at the third step, because one `smart`
observation re-armed the ladder outright). Under the dwell the armed rank is still `dumb`, and
`acceptable` is not worse than `dumb`. The operator has already been told this session reached
`dumb`; announcing a *better* zone afterwards is the noise #2220 is about. The pre-existing test that
asserted the old behaviour was **updated rather than deleted**, and says so at its site.

### Erratum, not a rewrite

`context-guard` 0.7.0 → **0.7.1**. The shipped 0.7.0 entry keeps the wording it shipped with — the
CHANGELOG diff is **84 insertions, 0 deletions** — and a 0.7.1 erratum points forward instead
(`docs/conventions/upstream-drift/README.md` §Adopters: history is never rewritten). A 0.7.0 `.armed`
marker holds a bare zone word; the streak field parses as 0, which is the correct starting point, so
there is no migration step and no state-format version.

## Test plan

The reviewer on #2308 noted it **could not execute** the suites and reasoned by hand. These were run.

```
$ bash plugins/context-guard/hooks/zone-crossing-inject.test.sh
ok: first-seen dumb injects additionalContext
ok: injection is valid JSON carrying the firing event name
ok: model channel carries the counter-steer and no exit menu
ok: model channel claims ownership without claiming delivery
ok: operator channel carries the continuation menu
ok: unchanged zone is silent
ok: improvement is silent
ok: improvement still updates state
ok: a zone better than the one already reported stays silent (was: injected pre-0.7.0)
ok: flap: the first dumb observation injects
ok: flap: the one-rank dip is silent
ok: flap: a one-rank dip does NOT decay the armed rank
ok: flap: re-crossing into an already-reported zone does NOT re-inject
ok: flap: repeated oscillation stays silent (injections are bounded, not counted)
ok: recovery: first dumb injects
ok: recovery: a held improvement is silent while it holds
ok: recovery: a sustained improvement decays the armed rank
ok: recovery: relapse after a genuine recovery injects again
ok: middle band: first acceptable injects
ok: middle band: the dip is silent
ok: middle band: an unsustained dip does NOT re-arm, so the flap stays silent
ok: middle band: a sustained improvement DOES decay the armed rank
ok: middle band: relapse after a sustained recovery injects again (no permanent suppression)
ok: legacy state without an .armed marker still injects on a real worsening
ok: legacy state gains an .armed marker on first write (no migration step)
ok: unknown zone is silent and stateless
ok: kill switch silences the hook
ok: hostile session id fails open
ok: empty stdin fails open
ok: injection length 1955 under 10k cap
ok: 150KB batch payload still injects (chunked stdin read)
ok: marker + smart snapshot injects the evidence-degraded notice once
ok: marker-driven dumb state stays silent on repeat
ok: state-persist failure fails open silently (no additionalContext)
ok: state-persist failure reports telemetry status=error
ok: state-persist failure leaves the armed gate untouched
ok: after the filesystem recovers, the same observation still injects (warning not lost)
ok: no HOME and no CLAUDE_PLUGIN_DATA stays silent
ok: no zone state written relative to the working directory

PASS=39 FAIL=0
```

Every other suite in the plugin — none of their files changed, so this is the regression guard on the
shared state directory and the resolver contract:

```
hooks/zone-gate           PASS=24 FAIL=0
hooks/post-compact-mark   PASS=16 FAIL=0
scripts/context-zone      PASS=73 FAIL=0
scripts/statusline-tee    PASS=47 FAIL=0
scripts/statusline-shim   passed: 36  failed: 0
```

Gates:

```
$ shellcheck -x plugins/context-guard/hooks/zone-crossing-inject.sh \
    plugins/context-guard/hooks/zone-crossing-inject.test.sh
(no output)

$ npx markdownlint-cli2 plugins/context-guard/CHANGELOG.md plugins/context-guard/reference/reader-contract.md
Summary: 0 issues in 0 files

$ bash scripts/check-changelog-parity.sh --check-order
All 76 changelog(s) read newest-first with no duplicate versions.

$ bash scripts/check-changelog-parity.sh --check-bump $(git merge-base origin/main HEAD)
Every plugin whose version changed vs 5a3930082ce7f4c6a53e3fd760036790e342c637 has a '## [<version>]' CHANGELOG.md entry.

$ git diff --numstat origin/main -- plugins/context-guard/CHANGELOG.md
84      0       plugins/context-guard/CHANGELOG.md     # pure insertion: 0.7.0's entry untouched

$ grep -rnE '(^|[^[:alnum:]_])PR[[:space:]]*#[0-9]+' plugins/context-guard/hooks/*.sh plugins/context-guard/scripts/*.sh
(no matches — comment-hygiene clean)
```

Nothing else in the plugin enumerates the state directory: `zone-gate.sh` and `post-compact-mark.sh`
each address `$SESSION.gate-count` by exact path and no glob over `state/*` exists, so the marker
cannot be picked up by a pruner or a session count. No blocking behaviour, no permission, no new hook
registration, and no external read or write changes — the trust surface is untouched, so no security
review note applies.

## Related

- Closes #2347
- Follow-up to #2308 (merged), which shipped `context-guard` 0.7.0 while its advisory review lane was
  still running; all three of that lane's findings are addressed here
- Completes the intent of #2220, whose fix shipped with the inverted defect described above
- Not the 0.4.8 timeout defect — see the 0.7.0 entry, which already says so
