### PR TITLE
fix(context-guard): re-arm zone injection on a return to smart, not a two-rank delta

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2]
+
+### Fixed
+
+- **`zone-crossing-inject`: the armed rank now decays on a return to `smart` rather than after a
+  fixed two-rank improvement, because only `dumb` could ever satisfy a two-rank improvement
+  (#2343).** 0.7.0 shipped the hysteresis this plugin needed and then applied it with a rule the
+  ladder cannot express. Ranks are `smart`=0, `acceptable`=1, `dumb`=2, so from an armed rank of
+  `acceptable` the largest available improvement is ONE rank and `armed_rank - new_rank >= 2` is
+  **unsatisfiable**. A session that armed at `acceptable` could therefore never re-arm: it could
+  recover fully to `smart` and relapse to `acceptable` any number of times and stay silent for the
+  rest of its life, unless it first escalated all the way to `dumb`. That is #2220 inverted rather
+  than fixed — the flapping session 0.7.0 set out to quiet became a session that never speaks on
+  the middle band, and `acceptable → smart → acceptable` was silent while the structurally
+  identical `dumb → smart → dumb` re-injected, as 0.7.0's own test proved.
+
+  **The corrected mechanism: a target on the ladder, not a distance along it.** The armed rank now
+  decays when — and only when — the session returns to the BEST band, `smart`. Every band can reach
+  it, so the rule fires uniformly; a fixed delta cannot, on a scale three ranks wide. Raising the
+  constant to one rank was the tempting over-correction and is exactly #2220 again, since
+  `dumb → acceptable → dumb` would re-arm on edge noise.
+
+  **The property this guarantees**, stated so it can be falsified: within one arming cycle each zone
+  is announced at most once, and only a return to `smart` opens a new cycle — so a genuine recovery
+  followed by a relapse re-injects **exactly once for the band it relapses into, from any armed
+  band**, and a flap that never reaches `smart` stays silent however long it oscillates. The
+  `dumb`-band behaviour is bit-for-bit what 0.7.0 shipped: the old predicate was satisfiable only at
+  `armed=dumb, new=smart`, which the new rule also admits, so the sole behavioural delta is
+  `acceptable → smart` re-arming. Every 0.7.0 assertion — the flap, the `dumb → smart → dumb`
+  recovery, the legacy-state seed — still passes unmodified against the new rule, alongside a new
+  `acceptable → smart → acceptable` session that fails against 0.7.0.
+
+  **The residual, stated rather than papered over**: at the `smart`/`acceptable` edge a flap and a
+  full recovery are the SAME observation — `smart` is both the far side of that boundary and the
+  bottom of the ladder — so a session oscillating there re-announces `acceptable` once per down-up
+  cycle (the pre-0.7.0 cadence at that one boundary, and no worse). Rank granularity cannot separate
+  the two: this hook sees one word per observation and never the occupancy behind it, because band
+  logic lives in `scripts/context-zone.sh` and only there. Closing it needs either a numeric deadband
+  below the band edge or a dwell requirement on the improved reading — and a dwell wide enough to
+  absorb the flap would also silence the single-observation recovery this fix exists to restore.
+
+- **`zone-crossing-inject`: the emit gate no longer advances when its companion write fails, so a
+  warning that was never reported cannot be lost (#2343).** 0.7.0 wrote the `.armed` gate FIRST, on
+  the reasoning that a partial write should leave behind the marker that suppresses. That reasoning
+  was wrong: suppression is not the safe side when the notice being suppressed was never delivered.
+  With `.armed` written first, a failed `.zone` write (a transient FS error, or a directory
+  occupying the path) exited without emitting while leaving the gate advanced — and after recovery
+  the next identical observation was suppressed by `new_rank > armed_rank`, permanently losing the
+  first warning of that zone. The order is now label first, gate second, with the label rolled back
+  best-effort if the gate write fails; either failure leaves the gate unmoved, so the session is
+  still owed its injection and the next observation issues it. Fail-open-silently and the
+  `status=error` telemetry are unchanged; the telemetry payload gains a `marker` field naming which
+  write failed. 0.7.0's persistence test created exactly this partial-write state and never retried
+  after clearing the obstruction, so it passed while the defect stood — it now retries, on both
+  markers.
+
 ## [0.7.1]
 
 ### Fixed

--- a/plugins/context-guard/hooks/zone-crossing-inject.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.sh
@@ -44,36 +44,42 @@
 # the ~1KB guidance block re-injected on each one, and an improvement in any
 # amount silently re-armed the injection with nothing counting or capping the
 # flap. A second marker — the ARMED rank, the worst zone this session has
-# already reported — now gates the emit.
+# already reported — now gates the emit, and it decays only when the session
+# returns to the BEST band (`smart`).
 #
-# WHAT MAKES THE ARMED RANK DECAY: a sustained improvement, measured in
-# CONSECUTIVE OBSERVATIONS, not in ranks. A fixed rank-delta cannot work
-# uniformly on a three-rung ladder and must not be used here: requiring two
-# ranks is satisfiable only from `dumb`, so a session armed at `acceptable`
-# could never decay at all — full recovery to `smart` and relapse would stay
-# silent for the rest of the session, however many times it happened. That is
-# this issue's own defect inverted (never re-inject instead of always
-# re-inject), and it is why the rule counts time rather than distance.
+# A TARGET, NOT A DISTANCE. 0.7.0 expressed that decay as a fixed rank delta
+# (an improvement of at least two ranks) and shipped a rule that could only
+# ever fire from one band. The ladder is three ranks wide, so from
+# `acceptable` the largest available improvement is ONE rank: the delta was
+# unsatisfiable there, and a session that armed at `acceptable` could never
+# re-arm — it stayed silent through every later relapse for the rest of its
+# life, which is the #2220 defect inverted rather than fixed. A delta cannot
+# work uniformly on a scale this short. The re-arm target is therefore a place
+# on the ladder — its bottom — which every band can reach.
 #
-# So: any observation strictly better than the armed rank extends a streak;
-# returning to the armed rank breaks it; REARM_DWELL consecutive better
-# observations decay the armed rank to what is actually being observed. The
-# same rule holds at every band, because a streak is expressible from any rung
-# while a two-rank drop is not.
+# The rule is a declared judgment default, like the bands themselves
+# (reference/reader-contract.md records their provenance): reaching `smart`
+# means the window genuinely emptied, while a dip that lands short of it is
+# the edge oscillation described above and says nothing new. A `/clear` needs
+# no rule at all: it starts a new session id, hence a new state file and a
+# fresh baseline.
 #
-# REARM_DWELL is a declared judgment default, like the bands themselves
-# (reference/reader-contract.md records their provenance) — nothing here is
-# doc- or benchmark-derived. The reasoning: a band-edge oscillation resolves
-# within a single observation, as one batch's results land and are released, so
-# one better observation is exactly what noise looks like and cannot be allowed
-# to re-arm. Three consecutive better observations span more than a full
-# PostToolBatch/UserPromptSubmit cycle, which a session alternating across the
-# edge turn by turn never accumulates. A `/clear` needs no dwell at all: it
-# starts a new session id, hence a new state file and a fresh baseline.
+# THE PROPERTY THIS GUARANTEES: within one arming cycle each zone is announced
+# at most once, and only a return to `smart` opens a new cycle — so a genuine
+# recovery followed by a relapse re-injects exactly once for the band it
+# relapses into, from ANY armed band, and a flap that never reaches `smart`
+# stays silent however long it oscillates.
 #
-# Net contract: a zone is announced at most once per session unless the session
-# holds a genuine improvement, after which the ladder re-arms and the next
-# worsening is reported normally.
+# THE RESIDUAL, STATED: at the `smart`/`acceptable` edge a flap and a full
+# recovery are the SAME observation — `smart` is both the far side of that
+# boundary and the bottom of the ladder — so a session oscillating there
+# re-announces `acceptable` once per down-up cycle. Rank granularity cannot
+# separate the two cases: this hook sees one word per observation, never the
+# occupancy behind it (the resolver's contract is exactly one word, and band
+# logic lives there and only there). Suppressing that residual needs either a
+# numeric deadband below the band edge or a dwell requirement on the improved
+# reading, and a dwell wide enough to absorb the flap would also silence the
+# single-observation recovery this rule exists to honor.
 #
 # The last-seen zone is still tracked, separately: it is what the message and
 # the recovery telemetry report as the previous zone, and it is not the emit
@@ -153,31 +159,16 @@ STATE_FILE="$STATE_DIR/$SESSION.zone"
 ARMED_FILE="$STATE_DIR/$SESSION.armed"
 last=""
 [[ -r "$STATE_FILE" ]] && last=$(tr -cd '[:lower:]' <"$STATE_FILE" 2>/dev/null | head -c 16)
-# A SIBLING file, not a second line in the existing one: `last` is read with
-# `tr -cd '[:lower:]'`, which strips the newline too, so a two-line `.zone`
-# would fuse into "dumbacceptable" and rank as smart. The armed marker holds
-# TWO fields — "<zone-word> <better-streak>" — and is parsed field-wise rather
-# than through that filter, so it carries the dwell counter without inheriting
-# the fusing problem.
-#
-# Both fields are validated against their own vocabulary. Anything else — an
-# empty file, a truncated one, a hand-edited one — falls through to the seeding
-# rule below rather than ranking as `smart` and silently disarming the gate.
 armed=""
-streak=0
-if [[ -r "$ARMED_FILE" ]]; then
-  read -r armed_word armed_streak _ <"$ARMED_FILE" 2>/dev/null || true
-  [[ "${armed_word:-}" =~ ^(smart|acceptable|dumb)$ ]] && armed="$armed_word"
-  [[ "${armed_streak:-}" =~ ^[0-9]{1,3}$ ]] && streak="$armed_streak"
-fi
-# Sessions already running when this version lands have a `.zone` file and no
-# `.armed` file; seeding the armed rank from the last-seen zone reproduces the
-# pre-hysteresis decision for exactly one call, after which the marker latches
-# normally. No migration step and no state-format version are needed for that.
-if [[ -z "$armed" ]]; then
-  armed="$last"
-  streak=0
-fi
+[[ -r "$ARMED_FILE" ]] && armed=$(tr -cd '[:lower:]' <"$ARMED_FILE" 2>/dev/null | head -c 16)
+# A SIBLING file, not a second line in the existing one: `last` is read with
+# `tr -cd '[:lower:]'`, which strips the newline too, so a two-line state file
+# would fuse into "dumbacceptable" and rank as smart. Sessions already running
+# when this version lands have a `.zone` file and no `.armed` file; seeding the
+# armed rank from the last-seen zone reproduces the pre-hysteresis decision for
+# exactly one call, after which the marker latches normally. No migration step
+# and no state-format version are needed for that.
+[[ -n "$armed" ]] || armed="$last"
 
 rank() {
   case "$1" in
@@ -196,72 +187,54 @@ unrank() {
 new_rank=$(rank "$zone")
 armed_rank=$(rank "$armed")
 
-# See the header. The armed rank rises immediately to whatever this observation
-# reports, and falls only after REARM_DWELL CONSECUTIVE observations strictly
-# better than it — never on a rank distance, which a three-rung ladder cannot
-# express uniformly.
-REARM_DWELL=3
+# See the header. The armed rank rises to whatever this observation reports, and
+# decays only on a return to the BEST band — a target on the ladder, not a
+# distance along it.
+BEST_RANK=0 # smart
 next_armed_rank=$armed_rank
-next_streak=$streak
-if ((new_rank > armed_rank)); then
-  # A worsening past everything already reported: arm here and start over.
+if ((new_rank > armed_rank || new_rank == BEST_RANK)); then
   next_armed_rank=$new_rank
-  next_streak=0
-elif ((new_rank < armed_rank)); then
-  next_streak=$((streak + 1))
-  if ((next_streak >= REARM_DWELL)); then
-    next_armed_rank=$new_rank
-    next_streak=0
-  fi
-else
-  # Back at the armed rank: the improvement did not hold, so the streak that
-  # would have re-armed the ladder is broken. This is the flap, and breaking
-  # the streak here is what keeps an oscillation from accumulating a dwell one
-  # observation at a time.
-  next_streak=0
 fi
 
-# Persist both markers regardless of direction — owner-only. A write failure
-# (full or newly read-only filesystem) must fail OPEN SILENTLY: proceeding past
-# it would compare this turn's zone against the same stale markers again on the
-# next call, re-emitting the ~1KB guidance block every subsequent
-# PostToolBatch/UserPromptSubmit instead of once per transition — which is the
-# very defect the armed rank exists to bound. "Silent" means neither channel
-# emits — the failure itself is still surfaced to operators as telemetry, never
-# swallowed twice.
+# Persist both markers regardless of direction — owner-only, atomic enough for
+# a single-writer-per-session file. A write failure (full or newly read-only
+# filesystem) must fail OPEN SILENTLY: proceeding past it would compare this
+# turn's zone against the same stale markers again on the next call, re-emitting
+# the ~1KB guidance block every subsequent PostToolBatch/UserPromptSubmit
+# instead of once per transition — which is the very defect the armed rank
+# exists to bound. "Silent" means neither channel emits — the failure itself is
+# still surfaced to operators as telemetry, never swallowed twice.
 #
-# THE GATE ADVANCES LAST, AND ONLY ALL-OR-NOTHING. The armed marker is what
-# suppresses a future injection, so leaving it advanced on a turn that emitted
-# NOTHING destroys the warning permanently: the next identical observation is no
-# longer worse than the armed rank, and the operator never hears about the zone
-# at all. That is strictly worse than the repeat this hook is otherwise tuned to
-# avoid, so the ordering is the reverse of the intuitive one — `.zone`, which
-# only labels the "previous" zone in a message, is written first, and `.armed`
-# is installed afterwards. If either step fails, the gate is left exactly where
-# it was and the same observation is free to emit on a later call.
-#
-# `.armed` is installed by RENAME rather than written in place, because a plain
-# `>` truncates before it writes: a failure partway through would leave an empty
-# marker, which parses as no marker, which seeds from `.zone` — by then already
-# updated to the current zone — and suppresses the very warning this ordering
-# exists to protect. A rename is atomic, so the marker is only ever its old
-# value or its new one.
+# THE GATE MOVES LAST, AND NEVER WITHOUT ITS COMPANION. Failing open silently is
+# only safe while the notice SURVIVES the failure. `.armed` is the emit gate, so
+# advancing it while the accompanying `.zone` write failed would exit without
+# emitting AND suppress the next identical observation — the first warning lost
+# though it was never reported. That is 0.7.0's ordering, and it was wrong: a
+# stale gate is not the "safe survivor" when the notice it suppresses was never
+# delivered. So `.zone` is written first and `.armed` only after it lands; if
+# either fails, the gate has not moved and the session is still owed its
+# injection, which the next observation issues.
 umask 077
 mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
 persist_failed=""
-printf '%s\n' "$zone" >"$STATE_FILE" 2>/dev/null || persist_failed=1
-if [[ -z "$persist_failed" ]]; then
-  armed_tmp="$ARMED_FILE.$$"
-  if printf '%s %d\n' "$(unrank "$next_armed_rank")" "$next_streak" >"$armed_tmp" 2>/dev/null; then
-    mv -f "$armed_tmp" "$ARMED_FILE" 2>/dev/null || persist_failed=1
+if ! printf '%s\n' "$zone" >"$STATE_FILE" 2>/dev/null; then
+  persist_failed="zone"
+elif ! printf '%s\n' "$(unrank "$next_armed_rank")" >"$ARMED_FILE" 2>/dev/null; then
+  persist_failed="armed"
+  # Roll the label back to what it said before, so the message the next
+  # successful call emits names the zone the session was really in rather than
+  # the one it is in now. Best-effort: if the rollback itself fails the label is
+  # stale, which mislabels one message — never a lost or repeated notice,
+  # because the gate did not move either way.
+  if [[ -n "$last" ]]; then
+    printf '%s\n' "$last" >"$STATE_FILE" 2>/dev/null || :
   else
-    persist_failed=1
+    rm -f "$STATE_FILE" 2>/dev/null || :
   fi
-  [[ -n "$persist_failed" ]] && rm -f "$armed_tmp" 2>/dev/null
 fi
 if [[ -n "$persist_failed" ]]; then
   hook::emit_telemetry "zone-crossing-inject" "$EVENT" "error" "$START_EPOCH" \
-    '{"zone":"'"$zone"'","previous":"'"${last:-}"'","reason":"state_persist_failed"}'
+    '{"zone":"'"$zone"'","previous":"'"${last:-}"'","marker":"'"$persist_failed"'","reason":"state_persist_failed"}'
   exit 0
 fi
 

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -116,20 +116,16 @@ else
   fail "state not updated on improvement"
 fi
 
-# 4. CONTRACT CHANGE, stated rather than slipped in. Before hysteresis this
-# sequence — dumb, then smart, then acceptable — injected on the third step,
-# because the gate compared against the LAST-SEEN zone and smart → acceptable is
-# a worsening. It is now SILENT: the armed rank is still dumb (one better
-# observation is not a sustained improvement), and acceptable is not worse than
-# dumb. The operator was already told this session reached dumb; telling them it
-# is now at a BETTER zone than the one already reported is the noise #2220 is
-# about. The relapse that must still be reported is covered by 4b.
+# 4. Relapse after a FULL recovery (dumb → smart → acceptable) injects again.
+# smart is the bottom of the ladder, so the armed marker decayed and the ladder
+# re-armed. This is the discriminating half of the hysteresis pair: a real
+# recovery must not be silenced by the rule that silences a flap.
 write_snapshot "$H" s1 60
 run "$H" "$D" s1 UserPromptSubmit
-if [[ $RC -eq 0 && -z "$OUT" ]]; then
-  ok "a zone better than the one already reported stays silent (was: injected pre-0.7.0)"
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
+  ok "relapse after a two-rank recovery injects again (UserPromptSubmit)"
 else
-  fail "improvement-relative-to-armed wrongly injected: rc=$RC out=$OUT"
+  fail "relapse: rc=$RC out=$OUT"
 fi
 
 # 4a. HYSTERESIS — the flap. A session hovering on the acceptable/dumb boundary
@@ -154,7 +150,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then
 else
   fail "flap dip emitted: rc=$RC out=$OUT"
 fi
-if [[ "$(cut -d' ' -f1 <"$D/state/sflap.armed" 2>/dev/null)" == "dumb" ]]; then
+if [[ "$(cat "$D/state/sflap.armed" 2>/dev/null)" == "dumb" ]]; then
   ok "flap: a one-rank dip does NOT decay the armed rank"
 else
   fail "armed rank decayed on a one-rank dip: $(cat "$D/state/sflap.armed" 2>/dev/null)"
@@ -178,21 +174,18 @@ else
 fi
 
 # 4b. HYSTERESIS — the discriminating opposite, on a session of its own so the
-# two paths cannot share state: a SUSTAINED improvement decays the armed rank
-# and the next worsening is reported normally.
+# two paths cannot share state: dumb → smart → dumb DOES inject twice, because
+# a return to smart is a real state change rather than edge noise.
 write_snapshot "$H" srec 90
 run "$H" "$D" srec
 if [[ "$OUT" == *additionalContext* ]]; then ok "recovery: first dumb injects"; else fail "recovery setup: $OUT"; fi
-for _ in 1 2 3; do
-  write_snapshot "$H" srec 10 # smart, held for REARM_DWELL observations
-  run "$H" "$D" srec
-  [[ -n "$OUT" ]] && fail "recovery: an improvement emitted: $OUT"
-done
-if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "recovery: a held improvement is silent while it holds"; else fail "improvement emitted: $OUT"; fi
-if [[ "$(cut -d' ' -f1 <"$D/state/srec.armed" 2>/dev/null)" == "smart" ]]; then
-  ok "recovery: a sustained improvement decays the armed rank"
+write_snapshot "$H" srec 10 # smart — the bottom of the ladder, re-arms
+run "$H" "$D" srec
+if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "recovery: the improvement itself is silent"; else fail "improvement emitted: $OUT"; fi
+if [[ "$(cat "$D/state/srec.armed" 2>/dev/null)" == "smart" ]]; then
+  ok "recovery: a two-rank improvement decays the armed rank"
 else
-  fail "armed rank did not decay on a sustained recovery: $(cat "$D/state/srec.armed" 2>/dev/null)"
+  fail "armed rank did not decay on a full recovery: $(cat "$D/state/srec.armed" 2>/dev/null)"
 fi
 write_snapshot "$H" srec 90
 run "$H" "$D" srec
@@ -202,43 +195,51 @@ else
   fail "genuine relapse suppressed by hysteresis: rc=$RC out=$OUT"
 fi
 
-# 4d. THE MIDDLE BAND — the case a rank-delta margin got permanently wrong, and
-# the one this suite did not previously cover. `acceptable` is one rung above
-# the floor, so the largest improvement available from it is ONE rank; a rule
-# demanding two could never be satisfied there and the band armed forever.
-# Structurally identical to 4a/4b one rung down, and it must behave identically.
-write_snapshot "$H" smid 60
-run "$H" "$D" smid
+# 4d. HYSTERESIS — the same discriminating pair one band lower, on a session of
+# its own. `acceptable` is the MIDDLE of the ladder, so the only improvement
+# available to it is `smart`: exactly ONE rank. A re-arm rule expressed as a
+# fixed rank DELTA cannot see that — under 0.7.0's `armed_rank - new_rank >= 2`
+# the difference tops out at 1 here, so the marker could never decay and a
+# session that armed at `acceptable` stayed silent through every later relapse
+# for the rest of its life. Structurally this path is 4b's, one band down.
+#
+# It is also the path where a flap and a genuine recovery are the same
+# observation: `smart` is both the bottom of the ladder and the far side of the
+# `smart`/`acceptable` edge. The rule announces it — a re-arm here is deliberate
+# and is the stated residual, not an oversight (see the hook header).
+write_snapshot "$H" sacc 60 # acceptable — first observation, injects
+run "$H" "$D" sacc
 if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
-  ok "middle band: first acceptable injects"
+  ok "middle band: the first acceptable observation injects"
 else
-  fail "middle band setup: rc=$RC out=$OUT"
+  fail "middle band setup did not inject: rc=$RC out=$OUT"
 fi
-write_snapshot "$H" smid 10 # smart — a single better observation
-run "$H" "$D" smid
-if [[ $RC -eq 0 && -z "$OUT" ]]; then ok "middle band: the dip is silent"; else fail "middle band dip emitted: $OUT"; fi
-write_snapshot "$H" smid 60 # back to acceptable — the flap
-run "$H" "$D" smid
+write_snapshot "$H" sacc 10 # smart — a full recovery, one rank from acceptable
+run "$H" "$D" sacc
 if [[ $RC -eq 0 && -z "$OUT" ]]; then
-  ok "middle band: an unsustained dip does NOT re-arm, so the flap stays silent"
+  ok "middle band: the recovery itself is silent"
 else
-  fail "middle band flap re-injected: rc=$RC out=$OUT"
+  fail "middle band recovery emitted: rc=$RC out=$OUT"
 fi
-for _ in 1 2 3; do
-  write_snapshot "$H" smid 10 # smart, now HELD
-  run "$H" "$D" smid
-done
-if [[ "$(cut -d' ' -f1 <"$D/state/smid.armed" 2>/dev/null)" == "smart" ]]; then
-  ok "middle band: a sustained improvement DOES decay the armed rank"
+if [[ "$(cat "$D/state/sacc.armed" 2>/dev/null)" == "smart" ]]; then
+  ok "middle band: a return to smart decays the armed rank"
 else
-  fail "middle band armed rank never decays (permanent suppression): $(cat "$D/state/smid.armed" 2>/dev/null)"
+  fail "armed rank did not decay on a full recovery from acceptable: $(cat "$D/state/sacc.armed" 2>/dev/null)"
 fi
-write_snapshot "$H" smid 60
-run "$H" "$D" smid
+write_snapshot "$H" sacc 60 # relapse — structurally identical to 4b's relapse
+run "$H" "$D" sacc
 if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
-  ok "middle band: relapse after a sustained recovery injects again (no permanent suppression)"
+  ok "middle band: relapse after a genuine recovery injects again"
 else
-  fail "middle band permanently suppressed — the rank-delta defect: rc=$RC out=$OUT"
+  fail "genuine relapse from the middle band suppressed: rc=$RC out=$OUT"
+fi
+# ...and the re-armed ladder latches again exactly as a fresh one does, so the
+# recovery bought exactly ONE re-announcement.
+run "$H" "$D" sacc
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "middle band: the re-armed ladder latches again (exactly one re-injection)"
+else
+  fail "middle band re-injected twice for one recovery: rc=$RC out=$OUT"
 fi
 
 # 4c. LEGACY STATE: a session already running when this version lands has a
@@ -255,7 +256,7 @@ if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
 else
   fail "legacy state broke the first post-upgrade decision: rc=$RC out=$OUT"
 fi
-if [[ "$(cut -d' ' -f1 <"$D/state/slegacy.armed" 2>/dev/null)" == "dumb" ]]; then
+if [[ "$(cat "$D/state/slegacy.armed" 2>/dev/null)" == "dumb" ]]; then
   ok "legacy state gains an .armed marker on first write (no migration step)"
 else
   fail "armed marker not seeded: $(cat "$D/state/slegacy.armed" 2>/dev/null)"
@@ -369,22 +370,80 @@ else
   fail "telemetry status not error: $(cat "$TEL" 2>/dev/null)"
 fi
 
-# 12a. THE WARNING SURVIVES THE FAILURE. The check above stops at "it stayed
-# silent", which a gate that advanced its armed marker on the way out would also
-# pass — and would then suppress the SAME observation forever once the
-# filesystem recovered, losing the first warning outright. So: clear the
-# obstruction and re-run the identical observation. It must inject.
-if [[ -e "$D/state/spersist.armed" ]]; then
-  fail "the armed gate advanced on a turn that emitted nothing: $(cat "$D/state/spersist.armed" 2>/dev/null)"
+# 12a. PARTIAL WRITE, THEN RECOVERY — the half 12 never checked. Failing open
+# silently is only correct if the notice SURVIVES the failure. If a marker
+# advances while the write that should have accompanied it failed, the hook
+# exits without emitting and the next identical observation is then suppressed
+# by the emit gate — the first warning is lost though it was never reported.
+# So: obstruct, observe the silent failure, confirm NEITHER marker moved, clear
+# the obstruction, and demand the injection the session is still owed.
+write_snapshot "$H" sretryz 90
+mkdir -p "$D/state"
+mkdir -p "$D/state/sretryz.zone" # same portable obstruction as 12
+TELZ="$WORK/tel-retry-zone.json"
+SINKZ="$(make_sink "$TELZ")"
+OUT=$(printf '{"session_id":"sretryz","hook_event_name":"PostToolBatch"}' |
+  HOME="$H" CLAUDE_PLUGIN_DATA="$D" HOOK_TELEMETRY_SINK="$SINKZ" bash "$HOOK" 2>/dev/null)
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "partial write: the blocked observation is silent"
 else
-  ok "state-persist failure leaves the armed gate untouched"
+  fail "partial write not silent: rc=$RC out=${OUT:0:120}"
 fi
-rmdir "$D/state/spersist.zone" 2>/dev/null || rm -rf "$D/state/spersist.zone"
-run "$H" "$D" spersist
-if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
-  ok "after the filesystem recovers, the same observation still injects (warning not lost)"
+if [[ ! -e "$D/state/sretryz.armed" ]]; then
+  ok "partial write: the emit gate does NOT advance when its companion write fails"
 else
-  fail "the first warning was permanently lost by a partial write: rc=$RC out=${OUT:0:160}"
+  fail "armed gate advanced on a failed write: $(cat "$D/state/sretryz.armed" 2>/dev/null)"
+fi
+rm -rf "$D/state/sretryz.zone" # the filesystem recovers
+run "$H" "$D" sretryz
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
+  ok "partial write: the unreported warning survives and injects after recovery"
+else
+  fail "warning lost to a partial write: rc=$RC out=${OUT:0:120}"
+fi
+
+# 12b. The mirror image: the OTHER marker blocked. This one already held under
+# 0.7.0's ordering (the armed write came first and short-circuited before the
+# zone write, so nothing moved) — it is asserted here as a guard on the new
+# ordering, which writes the label first and must roll it back rather than
+# leave the message reporting a previous zone the session never left.
+write_snapshot "$H" sretrya 60 # acceptable — a real first observation
+run "$H" "$D" sretrya
+if [[ "$OUT" == *additionalContext* ]]; then
+  ok "partial write (armed): setup observation injects"
+else
+  fail "partial write (armed) setup: rc=$RC out=${OUT:0:120}"
+fi
+rm -f "$D/state/sretrya.armed"
+mkdir -p "$D/state/sretrya.armed" # now the GATE file is the blocked one
+write_snapshot "$H" sretrya 90    # dumb — a real worsening, owed an injection
+TELA="$WORK/tel-retry-armed.json"
+SINKA="$(make_sink "$TELA")"
+OUT=$(printf '{"session_id":"sretrya","hook_event_name":"PostToolBatch"}' |
+  HOME="$H" CLAUDE_PLUGIN_DATA="$D" HOOK_TELEMETRY_SINK="$SINKA" bash "$HOOK" 2>/dev/null)
+RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "partial write (armed): the blocked observation is silent"
+else
+  fail "partial write (armed) not silent: rc=$RC out=${OUT:0:120}"
+fi
+if wait_for_sink "$TELA" && [[ "$(jq -r '.status' "$TELA" 2>/dev/null)" == "error" ]]; then
+  ok "partial write (armed): telemetry status=error"
+else
+  fail "partial write (armed) telemetry not error: $(cat "$TELA" 2>/dev/null)"
+fi
+if [[ "$(cat "$D/state/sretrya.zone" 2>/dev/null)" == "acceptable" ]]; then
+  ok "partial write (armed): the label marker still reports the zone the session was really in"
+else
+  fail "label marker moved without its gate: $(cat "$D/state/sretrya.zone" 2>/dev/null)"
+fi
+rm -rf "$D/state/sretrya.armed"
+run "$H" "$D" sretrya
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *"from the acceptable"* ]]; then
+  ok "partial write (armed): the warning survives and names the true previous zone"
+else
+  fail "warning lost or mislabelled after an armed-write failure: rc=$RC out=${OUT:0:200}"
 fi
 
 # No resolvable state root → stay silent rather than key the last-seen zone to

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -190,23 +190,20 @@ Since 0.4.0 the plugin itself ships hooks over its own seam — the first shippe
   than any this session has already reported, inject continuation guidance (a minimal generic
   continuation tree plus a presence-gated pointer to `session-flow:workflow`'s router). Silent
   while the zone is unchanged, improving, or `unknown`. **Hysteresis** (since 0.7.0): the gate is
-  the worst zone already *reported*, not the zone last *seen*. Occupancy does not climb
-  monotonically, so a session sitting on a band edge crosses it repeatedly; without hysteresis each
-  re-crossing read as a fresh transition and re-injected the guidance block. That marker decays
-  only after **three consecutive observations strictly better than it** — a dwell, deliberately
-  *not* a rank distance. A fixed rank-delta cannot work uniformly on a three-rung ladder: a
-  two-rank drop is reachable only from `dumb`, so a session armed at `acceptable` could never decay
-  and would be silenced permanently — this defect inverted rather than fixed. A dwell is
-  expressible from every rung, so all bands behave identically. Returning to the armed zone breaks
-  the streak, which is what stops an oscillation accumulating a dwell one crossing at a time. A
-  `/clear` needs no dwell: it starts a new session id, hence a fresh baseline. The dwell is a
-  declared judgment default, on the same footing as the bands above and with the same provenance
-  status.
-
-  One consequence worth stating, because it changed at 0.7.0: a transition into a zone **better**
-  than the worst already reported is now silent (`dumb` → `smart` → `acceptable` reports nothing at
-  the third step, where pre-0.7.0 it injected). The operator has already been told this session
-  reached `dumb`; announcing a better zone afterwards is the noise the hysteresis exists to remove.
+  the worst zone already *reported*, not the zone last *seen*. That marker decays only when the
+  session returns to `smart` — the bottom of the ladder (**since 0.7.1**; 0.7.0 asked instead for an
+  improvement of at least two ranks, which no band but `dumb` could ever satisfy, so a session that
+  armed at `acceptable` could never re-arm). Occupancy does not climb monotonically, so a session
+  sitting on a band edge crosses it repeatedly; without the rule each re-crossing read as a fresh
+  transition and re-injected the guidance block. A `/clear` needs no rule: it starts a new session
+  id, hence a fresh baseline. The rule is a declared judgment default, on the same footing as the
+  bands above and with the same provenance status. **The property**: within one arming cycle each
+  zone is announced at most once, and only a return to `smart` opens a new cycle — so a genuine
+  recovery followed by a relapse re-injects exactly once for the band it relapses into, from any
+  armed band. **The residual**: at the `smart`/`acceptable` edge a flap and a full recovery are the
+  same observation, so a session oscillating there re-announces `acceptable` once per down-up cycle;
+  the hook sees one word per observation, never the occupancy behind it, and separating those two
+  cases needs a numeric deadband or a dwell the single-observation recovery could not survive.
 - **Blocking gate** (`PreToolUse`, only when the `zone_hook_mode` userConfig option is
   `blocking`): denies new `Write|Edit|NotebookEdit|Agent|Workflow` calls on a **fresh dumb-zone
   snapshot** past a small grace budget. Fail-open on `unknown`; handoff-path writes, read-only


### PR DESCRIPTION
## Summary

PR #2308 (commit `49bf6a32`, `context-guard` 0.7.0) closed #2220 by adding hysteresis to
`zone-crossing-inject.sh`. Its review posted three findings and the PR merged before they were
addressed; two are real and have been live on `main` since. This is the hotfix.

### 1. The `acceptable` band could never re-arm (the serious one)

0.7.0 decayed the armed rank on `armed_rank - new_rank >= REARM_MARGIN` with `REARM_MARGIN=2`.
Ranks are `smart`=0, `acceptable`=1, `dumb`=2, so from an armed rank of `acceptable` the largest
available improvement is ONE rank and the predicate is **unsatisfiable**. A session that armed at
`acceptable` could therefore never re-arm: it could recover fully to `smart` and relapse any number
of times and stay silent for the rest of its life, unless it first escalated all the way to `dumb`.
`acceptable → smart → acceptable` was silent while the structurally identical `dumb → smart → dumb`
re-injected — 0.7.0's own test proves the latter. #2220 was filed because a flapping session
re-injects on every crossing; 0.7.0 made a flapping session **never** re-inject on the middle band.

**Corrected mechanism — a target on the ladder, not a distance along it.** The armed rank now
decays when, and only when, the session returns to the BEST band (`smart`). Every band can reach it,
so the rule fires uniformly; a fixed delta cannot on a three-rank scale. Raising the constant to 1
is the tempting over-correction and is #2220 again (`dumb → acceptable → dumb` would re-arm on edge
noise). `REARM_MARGIN` is deleted rather than retuned.

**The property, stated so it can be falsified:** within one arming cycle each zone is announced at
most once, and only a return to `smart` opens a new cycle — so a genuine recovery followed by a
relapse re-injects **exactly once for the band it relapses into, from any armed band**, and a flap
that never reaches `smart` stays silent however long it oscillates.

The old predicate was satisfiable only at `armed=dumb, new=smart`, which the new rule also admits,
so the **sole behavioural delta is `acceptable → smart` re-arming**. Every 0.7.0 assertion — the
flap, the `dumb → smart → dumb` recovery, the legacy-state seed, the persistence failure — passes
unmodified against the new rule (see the run below).

**Residual, stated rather than papered over:** at the `smart`/`acceptable` edge a flap and a full
recovery are the *same observation* — `smart` is both the far side of that boundary and the bottom
of the ladder — so a session oscillating there re-announces `acceptable` once per down-up cycle
(the pre-0.7.0 cadence at that one boundary, and no worse). This hook sees one word per observation
and never the occupancy behind it, because band logic lives in `scripts/context-zone.sh` and only
there. Closing the residual needs a numeric deadband below the band edge or a dwell on the improved
reading — and a dwell wide enough to absorb the flap would also silence the single-observation
recovery this PR exists to restore. Recorded in the hook header, the CHANGELOG, and the reader
contract.

### 2. The armed gate advanced before both writes succeeded (P2)

0.7.0 wrote `.armed` FIRST, reasoning that a partial write should leave behind the marker that
suppresses. Suppression is not the safe side when the notice being suppressed was never delivered:
a failed `.zone` write exited without emitting while leaving the gate advanced, and after recovery
the next identical observation was suppressed by `new_rank > armed_rank` — the first warning of that
zone **permanently lost though never reported**. The order is now label first, gate second, with a
best-effort label rollback if the gate write fails; either failure leaves the gate unmoved, so the
session is still owed its injection and the next observation issues it. Fail-open-silently and the
`status=error` telemetry are unchanged; the payload gains a `marker` field naming the failed write.

### Housekeeping

0.7.0 → **0.7.1** (a fix restoring the property 0.7.0's entry already claimed; precedent: 0.6.6 took
a patch bump for a new helper function). The shipped 0.7.0 CHANGELOG entry is **not rewritten** — an
erratum paragraph was added above it noting that its stated hysteresis property did not hold for the
`acceptable` band and that its write-ordering claim is inverted here. `reference/reader-contract.md`
carried the same two-rank claim and is corrected.

## Test plan

`plugins/context-guard/hooks/zone-crossing-inject.test.sh`, extended with an
`acceptable → smart → acceptable` session of its own (`sacc`, 5 assertions) and partial-write retry
cases on both markers (`sretryz` / `sretrya`, 8 assertions).

**Fail-before** — the new assertions run against the merged 0.7.0 hook, unmodified
(`git worktree add … origin/main`, test file only staged):

```
$ git status --porcelain .
 M plugins/context-guard/hooks/zone-crossing-inject.test.sh
$ bash zone-crossing-inject.test.sh
...
ok: middle band: the first acceptable observation injects
ok: middle band: the recovery itself is silent
FAIL: armed rank did not decay on a full recovery from acceptable: acceptable
FAIL: genuine relapse from the middle band suppressed: rc=0 out=
ok: middle band: the re-armed ladder latches again (exactly one re-injection)
...
ok: partial write: the blocked observation is silent
FAIL: armed gate advanced on a failed write: dumb
FAIL: warning lost to a partial write: rc=0 out=
ok: partial write (armed): setup observation injects
ok: partial write (armed): the blocked observation is silent
ok: partial write (armed): telemetry status=error
ok: partial write (armed): the label marker still reports the zone the session was really in
ok: partial write (armed): the warning survives and names the true previous zone

PASS=41 FAIL=4
```

**Pass-after** — same suite, with the hook fixed:

```
$ bash zone-crossing-inject.test.sh
ok: first-seen dumb injects additionalContext
ok: injection is valid JSON carrying the firing event name
ok: model channel carries the counter-steer and no exit menu
ok: model channel claims ownership without claiming delivery
ok: operator channel carries the continuation menu
ok: unchanged zone is silent
ok: improvement is silent
ok: improvement still updates state
ok: relapse after a two-rank recovery injects again (UserPromptSubmit)
ok: flap: the first dumb observation injects
ok: flap: the one-rank dip is silent
ok: flap: a one-rank dip does NOT decay the armed rank
ok: flap: re-crossing into an already-reported zone does NOT re-inject
ok: flap: repeated oscillation stays silent (injections are bounded, not counted)
ok: recovery: first dumb injects
ok: recovery: the improvement itself is silent
ok: recovery: a two-rank improvement decays the armed rank
ok: recovery: relapse after a genuine recovery injects again
ok: middle band: the first acceptable observation injects
ok: middle band: the recovery itself is silent
ok: middle band: a return to smart decays the armed rank
ok: middle band: relapse after a genuine recovery injects again
ok: middle band: the re-armed ladder latches again (exactly one re-injection)
ok: legacy state without an .armed marker still injects on a real worsening
ok: legacy state gains an .armed marker on first write (no migration step)
ok: unknown zone is silent and stateless
ok: kill switch silences the hook
ok: hostile session id fails open
ok: empty stdin fails open
ok: injection length 1955 under 10k cap
ok: 150KB batch payload still injects (chunked stdin read)
ok: marker + smart snapshot injects the evidence-degraded notice once
ok: marker-driven dumb state stays silent on repeat
ok: state-persist failure fails open silently (no additionalContext)
ok: state-persist failure reports telemetry status=error
ok: partial write: the blocked observation is silent
ok: partial write: the emit gate does NOT advance when its companion write fails
ok: partial write: the unreported warning survives and injects after recovery
ok: partial write (armed): setup observation injects
ok: partial write (armed): the blocked observation is silent
ok: partial write (armed): telemetry status=error
ok: partial write (armed): the label marker still reports the zone the session was really in
ok: partial write (armed): the warning survives and names the true previous zone
ok: no HOME and no CLAUDE_PLUGIN_DATA stays silent
ok: no zone state written relative to the working directory

PASS=45 FAIL=0
```

**Which new assertions discriminate, precisely.** Four fail before and pass after: `a return to
smart decays the armed rank`, `relapse after a genuine recovery injects again` (both defect 1), and
`the emit gate does NOT advance when its companion write fails`, `the unreported warning survives
and injects after recovery` (defect 2). The remaining new assertions pass in **both** directions and
are labelled as guards, not evidence: the `sacc` setup/silence pair, the "latches again" repeat
(which passes vacuously against 0.7.0 because nothing had injected), and all five `sretrya` cases —
obstructing `.armed` under 0.7.0's ordering short-circuited before the `.zone` write, so nothing
moved and the retry already injected. That case guards the NEW ordering, where the label is written
first and must be rolled back.

Sibling suites over the same helpers, unchanged files, run as a regression check:

```
$ bash zone-gate.test.sh          → PASS=24 FAIL=0
$ bash post-compact-mark.test.sh  → PASS=16 FAIL=0
$ shellcheck zone-crossing-inject.sh zone-crossing-inject.test.sh  → clean (rc=0)
```

No blocking behaviour, no permission, no new external read or write: the trust surface is untouched,
and the two-channel split, the refusal to claim an operator is present, and the inert default
posture are all preserved.

## Related

Closes #2343
Refs #2220 (the hysteresis request), #2308 / `49bf6a32` (the 0.7.0 fix being corrected).
Inbox provenance: the three inline review comments on #2308 (`3763350632`, `3763316030`,
`3763350928`), each replied to on that PR pointing here.
