### PR TITLE
fix(autonomy): name the field the deterministic/model slot split turns on

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
 Versions 0.1.0–0.7.0 predate this file (introduced with 0.7.1); their history lives in the
 merged work-package PRs (#333, #343, #356, #372, #377, #600, #676).
 
+## [0.16.2]
+
+### Fixed
+
+- **The verification-topology leaf now names `scanner_class`, the field that decides whether a slot
+  is deterministic or model-adjudicated.** The schema and the checker both key the whole
+  deterministic/model split on it — which constraints are legal, which floor a slot counts toward,
+  how distinctness is judged — while the normative leaf described the split only in prose. A binding
+  author reading the contract could not tell how to declare a deterministic slot, and the contract
+  is the surface that is supposed to answer that.
+
 ## [0.16.1]
 
 ### Fixed

--- a/plugins/autonomy/reference/guardrails/verification-topology.md
+++ b/plugins/autonomy/reference/guardrails/verification-topology.md
@@ -21,13 +21,15 @@ policy — only the binding that resolves a role to an instance.
 ## Checker slots
 
 A class's topology declares a list of checker SLOTS, and a slot is filled by either a DETERMINISTIC
-layer or a MODEL-ADJUDICATED role. The distinction is load-bearing: a deterministic layer has no
-model or vendor identity, so the relational constraints and predicates below bind only
-model-adjudicated slots and are never required of a deterministic one.
+layer or a MODEL-ADJUDICATED role. A slot declares which it is: a `scanner_class` naming the
+deterministic layer that fills it marks the slot deterministic, and a slot without one is
+model-adjudicated. The distinction is load-bearing: a deterministic layer has no model or vendor
+identity, so the relational constraints and predicates below bind only model-adjudicated slots and
+are rejected on a deterministic one rather than ignored.
 
 **Distinctness is REQUIRED on every slot and cannot be opted out of.** Two slots are distinct only
-where they cannot share a failure mode: deterministic slots are distinguished by scanner class,
-model-adjudicated slots by resolved model identity. **Two slots that resolve identically declare ONE
+where they cannot share a failure mode: deterministic slots are distinguished by their
+`scanner_class`, model-adjudicated slots by resolved model identity. **Two slots that resolve identically declare ONE
 checker**, and a binding whose distinct-slot count falls below its class floor is invalid.
 
 A slot NAME tells a validator nothing about what the slot resolves to, so distinctness that is only


### PR DESCRIPTION
## Summary

Post-merge sweep of #2326 found the verification-topology leaf never names `scanner_class`, the field the schema and checker key the entire deterministic/model slot split on.

The field decides which relational constraints and predicates are legal on a slot, which floor it counts toward, and whether distinctness is judged by scanner class or by resolved model identity. The leaf described the split in prose — "a slot is filled by either a DETERMINISTIC layer or a MODEL-ADJUDICATED role" — and left the reader no way to write one.

A binding author reading the normative contract could not declare a deterministic slot without reading the validator source. That inverts the arrangement the leaf exists to establish.

## Test plan

- `node scripts/validate-plugin-contracts.mjs` — 45 setup skills, 2398 files.
- `bash scripts/check-changelog-parity.sh --check` — passes.
- `python scripts/sync-plugin-options-docs.py --check` — passes.
- `grep -rniE "frontier|flagship|daily driver" plugins/autonomy/reference/` — empty.
- `grep -c blocking` over the narration lane's section — 0.
- Docs-only change to contract prose; no schema, checker, or fixture change, so the 540-check binding suite is unaffected.

## Related

No linked issue — found by a post-merge consistency sweep of #2326's contract surface against its own implementation, and small enough to fix directly rather than file and queue.