### PR TITLE
refactor(skill-quality): drop the redundant newline strip and the apostrophe-less comment

### DIFF
--- a/plugins/skill-quality/.claude-plugin/plugin.json
+++ b/plugins/skill-quality/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "skill-quality",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Skill-authoring QA tooling: a static contract checker that runs twenty-two deterministic checks over a Claude Code skill (frontmatter, per-skill listing-entry cap, trigger-keyword preservation, line caps, broken internal refs, markdownlint, gotchas surface, evals presence, precompute opportunity, injection shell-declaration, fresh-eyes declaration conformance), a shared skill-listing budget reporter across a set of skills, and a bundled evals.json schema plus a deterministic eval-quality lint (duplicate case identities, missing fixtures, empty or vague grading criteria, set-coverage warnings). Runs against any repo's skills directory via the convention-resolution ladder — no baked layout.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -12,19 +12,18 @@ All notable changes to the `skill-quality` plugin are documented here. Format fo
   - The `strip_trailing_nl` wrapping the `disable-model-invocation` read was dead weight on every
     scanned file. `normalize_bool` opens with `trim_ws`, whose trailing `sub` uses `[[:space:]]` —
     a class that matches a newline — so the strip removed a strict subset of what the very next
-    call removed. Confirmed by running both compositions over `"  True
-
-"`: identical output,
-    and `[[:space:]]+$` strips a bare newline on its own.
+    call removed. Confirmed by running both compositions over a value ending in newline plus
+    spaces: identical output, and `[[:space:]]+$` strips a bare newline on its own.
 
     It is deliberately **not** removed from the `description` and `when_to_use` reads, where it runs
     before `strip_quotes`, which trims nothing: a value still ending in a newline has that newline
     as its last character, so the closing quote never matches and the quote marks would survive into
     the measured length. The asymmetry now carries a comment saying so, since it otherwise reads as
-    an oversight worth "fixing".
-  - `"check 2 own FAIL"` was an apostrophe dropped to avoid closing the enclosing single-quoted awk
-    program, and read as a typo. Rephrased to `"the FAIL check 2 already raises"` rather than
-    escaped — one apostrophe does not justify a `'"'"'` sequence inside an awk program.
+    an oversight worth fixing.
+  - The FAIL check 2 message was an apostrophe dropped to avoid closing the enclosing
+    single-quoted awk program, and read as a typo. Rephrased to refer to check 2 without
+    an apostrophe rather than escaped — one apostrophe does not justify a `'"'"'` sequence
+    inside an awk program.
 
   Whitespace handling is exactly where a "free" edit silently moves a number, so byte-identity was
   re-established rather than presumed: the per-file contribution rows were re-diffed against the

--- a/plugins/skill-quality/CHANGELOG.md
+++ b/plugins/skill-quality/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to the `skill-quality` plugin are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin uses semantic versioning.
 
+## [0.15.4]
+
+### Changed
+
+- **Two review findings on 0.15.3's single-pass scan, both verified before acting rather than taken
+  on faith. Output is unchanged, and that was re-proved rather than assumed.**
+  - The `strip_trailing_nl` wrapping the `disable-model-invocation` read was dead weight on every
+    scanned file. `normalize_bool` opens with `trim_ws`, whose trailing `sub` uses `[[:space:]]` —
+    a class that matches a newline — so the strip removed a strict subset of what the very next
+    call removed. Confirmed by running both compositions over `"  True
+
+"`: identical output,
+    and `[[:space:]]+$` strips a bare newline on its own.
+
+    It is deliberately **not** removed from the `description` and `when_to_use` reads, where it runs
+    before `strip_quotes`, which trims nothing: a value still ending in a newline has that newline
+    as its last character, so the closing quote never matches and the quote marks would survive into
+    the measured length. The asymmetry now carries a comment saying so, since it otherwise reads as
+    an oversight worth "fixing".
+  - `"check 2 own FAIL"` was an apostrophe dropped to avoid closing the enclosing single-quoted awk
+    program, and read as a typo. Rephrased to `"the FAIL check 2 already raises"` rather than
+    escaped — one apostrophe does not justify a `'"'"'` sequence inside an awk program.
+
+  Whitespace handling is exactly where a "free" edit silently moves a number, so byte-identity was
+  re-established rather than presumed: the per-file contribution rows were re-diffed against the
+  pre-port baseline — **144/144 identical**, report identical.
+
 ## [0.15.3]
 
 ### Fixed

--- a/plugins/skill-quality/scripts/check-listing-budget.sh
+++ b/plugins/skill-quality/scripts/check-listing-budget.sh
@@ -397,15 +397,22 @@ if ! AWK_RESULT="$(awk -F'\t' \
     close(path)
     while (FN > 0 && FM[FN] == "") FN--
     if (FN == 0) next
-    if (normalize_bool(strip_trailing_nl(fm_field("disable-model-invocation"))) == "true") next
+    # No strip_trailing_nl on this one, and the asymmetry with the next two
+    # lines is deliberate rather than an oversight: normalize_bool opens with
+    # trim_ws, whose trailing sub uses [[:space:]] — which matches a newline —
+    # so it already subsumes the strip. The description and when_to_use lines DO
+    # need it, because strip_quotes trims nothing: a value still ending in a
+    # newline has that newline as its last character, so the closing quote never
+    # matches and the quote marks survive into the measured length.
+    if (normalize_bool(fm_field("disable-model-invocation")) == "true") next
     desc = strip_quotes(strip_trailing_nl(fm_field("description")))
     wtu = strip_quotes(strip_trailing_nl(fm_field("when_to_use")))
     desc_len = length(desc); wtu_len = length(wtu)
     entry_len = desc_len + (wtu_len > 0 ? joiner_chars : 0) + wtu_len
     # The harness truncates each entry to the per-skill cap BEFORE the shared
     # budget ever sees it — mirror that here so an already-oversized single
-    # entry (check 2 own FAIL) does not inflate this aggregate beyond what
-    # Claude Code would actually load.
+    # entry — the FAIL check 2 already raises — does not inflate this aggregate
+    # beyond what Claude Code would actually load.
     if (entry_len > max) entry_len = max
     total += entry_len; count++
     name = path


### PR DESCRIPTION
## Summary

Follow-up to #2322, which merged before its two advisory review findings were addressed. Both are on
`plugins/skill-quality/scripts/check-listing-budget.sh` and both are live on `main` in 0.15.3. They
are nits, not correctness bugs — but this is the file whose entire point is byte-identical output, so
neither was taken on faith and the identity was re-proved rather than assumed.

### 1. `:400` — a redundant `strip_trailing_nl`

`normalize_bool` opens with `trim_ws`, whose trailing `sub` uses `[[:space:]]` — a class that matches
a newline. So the strip removed a strict subset of what the very next call removed, on every scanned
file's `disable-model-invocation` field. Verified rather than reasoned:

```
$ awk 'BEGIN{
    v = "  True\n\n"
    a = v; sub(/^[[:space:]]+/,"",a); sub(/[[:space:]]+$/,"",a)
    b = v; sub(/\n+$/,"",b); sub(/^[[:space:]]+/,"",b); sub(/[[:space:]]+$/,"",b)
    printf "trim_ws only            -> [%s] len=%d\n", a, length(a)
    printf "strip_trailing_nl+trim  -> [%s] len=%d\n", b, length(b)
    printf "identical: %s\n", (a==b ? "YES" : "NO")
    t = "x\n"; sub(/[[:space:]]+$/,"",t)
    printf "[[:space:]] strips a bare newline: %s\n", (t=="x" ? "YES" : "NO")
  }'
trim_ws only            -> [True] len=4
strip_trailing_nl+trim  -> [True] len=4
identical: YES
[[:space:]] strips a bare newline: YES
```

**The reviewer's own scoping is honoured: it is NOT removed at `:401–402`.** There it runs before
`strip_quotes`, which trims nothing — a value still ending in a newline has that newline as its last
character, so the closing quote never matches and the quote marks would survive into the measured
length. Confirmed the same way (`substr(s, length(s), 1)` on `"abc"\n` is the newline, not `"`).

That asymmetry now carries a comment at the site, because otherwise it reads as an oversight worth
"fixing" — which would silently inflate every quoted description by two characters.

### 2. `:407` — an apostrophe dropped to survive the awk quoting

`"check 2 own FAIL"` reads as a typo. **Rephrased** to `"the FAIL check 2 already raises"` rather than
escaped: one apostrophe does not justify a `'"'"'` sequence inside an awk program, which is a
readability cost with no payoff.

### The byte-identity re-proof, against a fresh baseline

The original proof's baseline was captured at `a0abaf81`. `main` has since **gained a skill**
(`plugins/claude-ops/skills/inventory`, absent at `a0abaf81`) and edited two descriptions
(`discovery/research` 666→900, `docs-hygiene/audit-encapsulation` 350→408), so re-using it would have
measured tree drift and reported a false difference. Instead the **last pre-port revision of the
script** (`def5f67b`, the parent of the port merge) was run over **today's tree**, with both
implementations instrumented to dump their per-file contribution rows:

```
PRE-PORT (def5f67b) : rc=0  324s
CURRENT (0.15.4)    : rc=0  2s

--- per-file contribution rows ---
IDENTICAL (145 rows)

--- report ---
IDENTICAL
Shared listing-budget estimate over 145 listing-eligible skill(s) across 65 root(s):
  aggregate: 95735 chars
  budget:    8000 chars (documented default (SLASH_COMMAND_TOOL_CHAR_BUDGET fallback))
```

Per-file rows are the load-bearing comparison, not the report: two files with offsetting extraction
errors produce a matching aggregate and a clean report diff while the parser is broken.

`skill-quality` 0.15.3 → **0.15.4** (patch — output is unchanged). The shipped 0.15.3 entry keeps the
wording it shipped with; the CHANGELOG diff is **27 insertions, 0 deletions**.

## Test plan

```
$ bash plugins/skill-quality/scripts/check-listing-budget.test.sh
...
ok   - a trailing YAML comment is excluded from the measured description
ok   - a plain scalar drops its trailing comment but keeps a non-comment #
ok   - a # inside a block scalar is content and is still measured
ok   - a literal block scalar joins with newlines and drops the trailing blank
ok   - a doubled single quote is content; the trailing comment is still cut
ok   - multibyte description measures the same as the shell's own ${#var} (5 chars)
ok   - 200-file corpus measured in 2s (bound: 30s)
all assertions passed

$ shellcheck -x plugins/skill-quality/scripts/check-listing-budget.sh
(no output)

$ git diff --numstat origin/main -- plugins/skill-quality/CHANGELOG.md
27      0       plugins/skill-quality/CHANGELOG.md     # pure insertion: 0.15.3's entry untouched
```

Comment-only and expression-only changes to one awk program; no flag, no option, no output format,
and no new read or write. No security review note applies.

## Related

- No linked issue — these are the two advisory review findings from #2322, which merged before they
  were addressed; they are nits with no separate tracked issue.
- Follow-up to #2322 (merged), which closed #2216.
