### PR TITLE
docs(discovery): erratum for backwards 0.14.1 routing CHANGELOG

### DIFF
--- a/plugins/discovery/.claude-plugin/plugin.json
+++ b/plugins/discovery/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "discovery",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Structured discovery before changes: explore the local codebase and run disciplined multi-source external research, both dispatching a purpose-built subagent by default so the reading stays out of the main conversation — with source tiers, falsification, recency gates, and a corpus-coverage ledger — persisting EXPLORE.md / RESEARCH.md index-plus-sidecar handoff artifacts.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/discovery/CHANGELOG.md
+++ b/plugins/discovery/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — discovery plugin
 
+## [0.15.1]
+
+### Fixed
+
+- **Erratum for the 0.14.1 CHANGELOG entry (#2339).** That entry stated the routing gap backwards —
+  it described deep work landing in the lighter skill, while #2271 (`D-F9`) filed the opposite
+  (small lookups routed into `research-deep`). The clause 0.14.1 shipped was a positive pointer toward
+  the heavier sibling, not a negative boundary claiming small work for `research`; 0.15.0 replaced it
+  with the correct direction. The 0.14.1 text stands as written; this records the correction. The
+  contract test now keys on that direction, not merely on naming `research-deep`.
+
 ## [0.15.0]
 
 ### Fixed

--- a/plugins/discovery/scripts/contract.test.sh
+++ b/plugins/discovery/scripts/contract.test.sh
@@ -200,10 +200,8 @@ fi
 # ---------------------------------------------------------------------------
 assert_present 'the research description carries a boundary against research-deep' \
   'skills/research/SKILL.md' '^description:.*research-deep'
-assert_present 'the research description claims single-topic work for research' \
-  'skills/research/SKILL.md' '^description:.*single topic'
-assert_present 'the research description routes multi-topic work to research-deep' \
-  'skills/research/SKILL.md' '^description:.*multi-topic'
+assert_present 'the research description orders single-topic (this skill) before multi-topic routing to research-deep' \
+  'skills/research/SKILL.md' '^description:.*right skill for a single topic.*multi-topic.*research-deep'
 
 # ---------------------------------------------------------------------------
 # 10. The write boundary is stated once and pointed at (#2270 F6)

--- a/plugins/discovery/scripts/contract.test.sh
+++ b/plugins/discovery/scripts/contract.test.sh
@@ -200,6 +200,10 @@ fi
 # ---------------------------------------------------------------------------
 assert_present 'the research description carries a boundary against research-deep' \
   'skills/research/SKILL.md' '^description:.*research-deep'
+assert_present 'the research description claims single-topic work for research' \
+  'skills/research/SKILL.md' '^description:.*single topic'
+assert_present 'the research description routes multi-topic work to research-deep' \
+  'skills/research/SKILL.md' '^description:.*multi-topic'
 
 # ---------------------------------------------------------------------------
 # 10. The write boundary is stated once and pointed at (#2270 F6)


### PR DESCRIPTION
Fixes #2339

## Summary

- Add a 0.15.1 CHANGELOG erratum recording that the 0.14.1 entry described the #2271 routing gap backwards and that 0.15.0 already shipped the correct negative boundary.
- Tighten `contract.test.sh` to assert the description claims single-topic work for `research` and routes multi-topic work to `research-deep`, not merely that the sibling is named.

Docs and contract assertions only.

## Test plan

- [x] `plugins/discovery/scripts/contract.test.sh`

## Related

- Fixes #2339
- #2311 (discovery 0.15.0, whose wording closes the routing direction 0.14.1 stated backwards)
- #2271 (the hub-inversion and routing row this erratum corrects the record for)
