### PR TITLE
fix(source-control): structured P0/P1 severity markers in resolve guard

### DIFF
--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -7,10 +7,18 @@ All notable changes to the `source-control` plugin are documented here. Format f
 
 ### Fixed
 
+<<<<<<< HEAD
 - **Canonical `gh pr create` now passes `--head` explicitly (#1900).** The §2.4.3 worktree path already
   did; the on-branch canonical path did not. Once dotfiles#375's amended auto-mode grant lands, `gh pr
   create` is covered only when the head branch is named — so the canonical lane must match the
   sibling spelling. Detached HEAD is refused rather than emitting `--head ""`.
+=======
+- **`babysit_resolve_thread` severity guard reads structured P0/P1 markers only (#1939).** The
+  `--autonomous` and `--independent-resolver` paths refused any thread whose body contained a
+  word-bounded `P1` token, so a P2 thread discussing P1 properties in prose became
+  `skipped-severity-marked`. The scan now keys on shields badges and bracketed `[P0]`/`[P1]` only.
+  Vetted `--resolve --thread-id` still applies no severity screen — documented as intentional.
+>>>>>>> f1056a0d (fix(source-control): structured P0/P1 severity markers in resolve guard)
 
 ## [0.53.1]
 

--- a/plugins/source-control/CHANGELOG.md
+++ b/plugins/source-control/CHANGELOG.md
@@ -7,18 +7,16 @@ All notable changes to the `source-control` plugin are documented here. Format f
 
 ### Fixed
 
-<<<<<<< HEAD
 - **Canonical `gh pr create` now passes `--head` explicitly (#1900).** The §2.4.3 worktree path already
   did; the on-branch canonical path did not. Once dotfiles#375's amended auto-mode grant lands, `gh pr
   create` is covered only when the head branch is named — so the canonical lane must match the
   sibling spelling. Detached HEAD is refused rather than emitting `--head ""`.
-=======
 - **`babysit_resolve_thread` severity guard reads structured P0/P1 markers only (#1939).** The
   `--autonomous` and `--independent-resolver` paths refused any thread whose body contained a
   word-bounded `P1` token, so a P2 thread discussing P1 properties in prose became
-  `skipped-severity-marked`. The scan now keys on shields badges and bracketed `[P0]`/`[P1]` only.
-  Vetted `--resolve --thread-id` still applies no severity screen — documented as intentional.
->>>>>>> f1056a0d (fix(source-control): structured P0/P1 severity markers in resolve guard)
+  `skipped-severity-marked`. The scan now keys on shields badges, bracketed `[P0]`/`[P1]`, and
+  explicit `P1:`/`P0:` declaration prefixes — not incidental prose mentions. Vetted
+  `--resolve --thread-id` still applies no severity screen — documented as intentional.
 
 ## [0.53.1]
 

--- a/plugins/source-control/skills/babysit-prs/reference/independent-resolution.md
+++ b/plugins/source-control/skills/babysit-prs/reference/independent-resolution.md
@@ -128,7 +128,10 @@ to self-resolve, and never a reason to reach past the wrapper to raw `resolveRev
 
 - **Security/P1 threads.** `--independent-resolver` retains the severity bright line
   (`skipped-severity-marked`): "never a security or P1 thread" is unconditional on every unattended
-  path, and no evidence buys past it. This is a bound of **the mode**, not of the callers. It is
+  path, and no evidence buys past it. The scan keys on **structured** markers — shields badges and
+  bracketed `[P0]`/`[P1]` — not prose mentions of P1 in a P2 thread's body (#1939). Vetted
+  `--resolve --thread-id` (with TOCTOU pins) applies **no** severity screen; it trusts the calling
+  agent's vetting. That asymmetry is deliberate. This is a bound of **the mode**, not of the callers. It is
   terminal on the `babysit-prs` orchestrator route, whose only resolve form for a current thread is
   this mode — such a thread escalates. `babysit-loop`'s widening carries the one named exception
   (`safety.md`, Security/P1 escalation), and which guarded form that exception uses is its own

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_resolve_thread.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_resolve_thread.py
@@ -199,20 +199,27 @@ from babysit_util import configure_stdio, dig, is_json_object
 # thread to interactive judgment.
 # Structured P0/P1 markers only — shields badge (/badge/P0- or /badge/P1-) or
 # bracketed [P0]/[P1] — not bare prose mentions such as "P1/P4 defect" in a P2
-# thread's body (#1939). Vetted `--resolve --thread-id` mode applies no severity
-# screen; it trusts the calling agent's vetting. That asymmetry is intentional.
-FORBIDDEN_P01_BADGE_RE = re.compile(r"/badge/P[01]-")
-FORBIDDEN_P01_BRACKET_RE = re.compile(r"\[P[01]\]")
+# thread's body (#1939). Line-leading `P1:` / `P0:` declarations and explicit
+# `P1 must fix` forms remain blocking — bots emit them as severity labels.
+# Vetted `--resolve --thread-id` mode applies no severity screen; it trusts the
+# calling agent's vetting. That asymmetry is intentional.
+FORBIDDEN_P01_BADGE_RE = re.compile(r"/badge/P[01]-", re.IGNORECASE)
+FORBIDDEN_P01_BRACKET_RE = re.compile(r"\[P[01]\]", re.IGNORECASE)
+FORBIDDEN_P01_PREFIX_RE = re.compile(r"(?:^|[\s\n])P[01]\s*:", re.IGNORECASE)
+FORBIDDEN_P01_MUST_FIX_RE = re.compile(r"\bP[01]\s+must\s+fix\b", re.IGNORECASE)
 SEVERITY_BLOCK_WORD_RE = re.compile(r"\bCRITICAL\b")
 SECURITY_TEXT_RE = re.compile(r"security", re.IGNORECASE)
 
 
 def _has_severity_marker(body: str) -> bool:
-    """True for the forbidden class only: structured P0/P1 markers (badge or
-    bracket), the word CRITICAL, or the word "security"."""
+    """True for the forbidden class only: structured P0/P1 markers (badge,
+    bracket, or declaration prefix), the word CRITICAL, or the word
+    "security"."""
     return (
         bool(FORBIDDEN_P01_BADGE_RE.search(body))
         or bool(FORBIDDEN_P01_BRACKET_RE.search(body))
+        or bool(FORBIDDEN_P01_PREFIX_RE.search(body))
+        or bool(FORBIDDEN_P01_MUST_FIX_RE.search(body))
         or bool(SEVERITY_BLOCK_WORD_RE.search(body))
         or bool(SECURITY_TEXT_RE.search(body))
     )

--- a/plugins/source-control/skills/babysit-prs/scripts/babysit_resolve_thread.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/babysit_resolve_thread.py
@@ -49,9 +49,11 @@ Deterministic guards encoded here:
   is likewise refused in `--autonomous` mode -- there is no unpinned autonomous
   resolve.
 - `--autonomous` additionally refuses any thread whose fetched comments carry
-  a forbidden-class severity marker: any word-bounded P0/P1 token in any case
-  (shields badge, bracketed marker, or bare prose form such as "P1: ..." /
-  "p1 must fix"), the word CRITICAL, or the word "security" in any case.
+  a forbidden-class severity marker: a structured P0/P1 marker (shields badge
+  `/badge/P0-` or `/badge/P1-`, or bracketed `[P0]` / `[P1]`), the word CRITICAL,
+  or the word "security" in any case. Prose that merely *mentions* P0/P1 does not
+  count — the morning-brief sweep adopted the same structured-marker rule after
+  misclassifying P2 threads whose bodies discussed P1 properties (#1939).
   The permission grants that cover this helper state "never a security or P1
   thread" as an absolute condition; this guard is the code behind that
   sentence for the unattended path, and it is deliberately narrower than the
@@ -195,25 +197,22 @@ from babysit_util import configure_stdio, dig, is_json_object
 # avoid false READINESS counts, but the grant names it); uppercase CRITICAL is
 # the word-form of the same forbidden class. A false positive only routes the
 # thread to interactive judgment.
-# One word-bounded token covers every supported P0/P1 spelling at once --
-# shields badge (/badge/P1-), bracketed marker ([P1]), the bare prose forms
-# bots also emit ("P1: blocking regression", "P1 must fix"), and lowercase
-# variants such as "p1:" or a priority:p1 label fragment -- while the boundary
-# keeps P2/P3 markers and embedded strings like AP1000 out. A thread that
-# merely MENTIONS a p1 token (prose, or a code identifier in a snippet) does
-# flag; that false positive only routes the thread to interactive judgment,
-# which is the safe direction for a resolve guard.
-SEVERITY_BLOCK_P01_RE = re.compile(r"\bP[01]\b", re.IGNORECASE)
+# Structured P0/P1 markers only — shields badge (/badge/P0- or /badge/P1-) or
+# bracketed [P0]/[P1] — not bare prose mentions such as "P1/P4 defect" in a P2
+# thread's body (#1939). Vetted `--resolve --thread-id` mode applies no severity
+# screen; it trusts the calling agent's vetting. That asymmetry is intentional.
+FORBIDDEN_P01_BADGE_RE = re.compile(r"/badge/P[01]-")
+FORBIDDEN_P01_BRACKET_RE = re.compile(r"\[P[01]\]")
 SEVERITY_BLOCK_WORD_RE = re.compile(r"\bCRITICAL\b")
 SECURITY_TEXT_RE = re.compile(r"security", re.IGNORECASE)
 
 
 def _has_severity_marker(body: str) -> bool:
-    """True for the forbidden class only: any word-bounded P0/P1 token
-    (badge, bracket, or bare prose form), the word CRITICAL, or the word
-    "security"."""
+    """True for the forbidden class only: structured P0/P1 markers (badge or
+    bracket), the word CRITICAL, or the word "security"."""
     return (
-        bool(SEVERITY_BLOCK_P01_RE.search(body))
+        bool(FORBIDDEN_P01_BADGE_RE.search(body))
+        or bool(FORBIDDEN_P01_BRACKET_RE.search(body))
         or bool(SEVERITY_BLOCK_WORD_RE.search(body))
         or bool(SECURITY_TEXT_RE.search(body))
     )

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py
@@ -616,17 +616,21 @@ class SeverityProjection(unittest.TestCase):
         record = self._record(["[P1] Unvalidated redirect target"])
         self.assertTrue(rt.project_thread(record)["severityFlagged"])
 
-    def test_bare_p1_prose_forms_flag(self) -> None:
+    def test_bare_p1_prose_does_not_flag(self) -> None:
         for body in (
             "P1: this is a blocking regression",
             "P1 must fix",
             "p1: blocking regression",
-            "[p1] lowercase marker",
+            "Discussing a P1/P4 defect class in prose",
         ):
             record = self._record([body])
-            self.assertTrue(
+            self.assertFalse(
                 rt.project_thread(record)["severityFlagged"], body
             )
+
+    def test_lowercase_bracketed_p1_does_not_flag(self) -> None:
+        record = self._record(["[p1] lowercase marker"])
+        self.assertFalse(rt.project_thread(record)["severityFlagged"])
 
     def test_advisory_p2_marker_does_not_flag(self) -> None:
         # The forbidden class is security/P0/P1 only: advisory P2/P3 threads

--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_babysit_resolve_thread.py
@@ -617,20 +617,23 @@ class SeverityProjection(unittest.TestCase):
         self.assertTrue(rt.project_thread(record)["severityFlagged"])
 
     def test_bare_p1_prose_does_not_flag(self) -> None:
+        record = self._record(["Discussing a P1/P4 defect class in prose"])
+        self.assertFalse(rt.project_thread(record)["severityFlagged"])
+
+    def test_p1_prefix_declarations_flag(self) -> None:
         for body in (
             "P1: this is a blocking regression",
             "P1 must fix",
             "p1: blocking regression",
-            "Discussing a P1/P4 defect class in prose",
         ):
             record = self._record([body])
-            self.assertFalse(
+            self.assertTrue(
                 rt.project_thread(record)["severityFlagged"], body
             )
 
-    def test_lowercase_bracketed_p1_does_not_flag(self) -> None:
+    def test_lowercase_bracketed_p1_flags(self) -> None:
         record = self._record(["[p1] lowercase marker"])
-        self.assertFalse(rt.project_thread(record)["severityFlagged"])
+        self.assertTrue(rt.project_thread(record)["severityFlagged"])
 
     def test_advisory_p2_marker_does_not_flag(self) -> None:
         # The forbidden class is security/P0/P1 only: advisory P2/P3 threads


### PR DESCRIPTION
Fixes #1939

## Summary

- `babysit_resolve_thread` severity scan now keys on structured P0/P1 markers (shields badges and `[P0]`/`[P1]` brackets), not word-bounded prose mentions.
- Document that vetted `--resolve --thread-id` applies no severity screen — intentional asymmetry.

## Test plan

- [x] `python3 -m unittest tests.test_babysit_resolve_thread` (108/0)

## Related

- Fixes #1939
