### PR TITLE
docs(context-guard): record the 0.7.1/0.7.2 re-arm collision and withdraw an unrun claim

### DIFF
--- a/plugins/context-guard/.claude-plugin/plugin.json
+++ b/plugins/context-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "context-guard",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Per-session context-window observability plus the first shipped consumer: a statusline wrapper tees each session's context_window fields to a per-session snapshot file, a zone resolver classifies usage into smart/acceptable/dumb bands (percentage bands plus window-class token bands, conservative-min combination, zones.json SSOT with shipped defaults), a reader contract fixes how consuming sessions interpret the snapshots, and zone-crossing hooks report once per transition into a worse zone across two channels \u2014 the continuation menu to the operator, who owns that choice, and to the model only the zone determination plus the counter-steer that a zone word is not a decay signal (advisory by default; an optional blocking mode gates new mutating work on a fresh dumb-zone snapshot with handoff-writing exempt), with a PostCompact hook persisting an evidence-degraded marker.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -5,7 +5,54 @@ All notable changes to the `context-guard` plugin.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3]
+
+### Fixed
+
+- **The 0.7.1/0.7.2 collision is now on the record, and one claim that was never executed is
+  withdrawn (#2355).** Two PRs fixed the same defect in parallel and both landed: #2344 shipped
+  **0.7.1**, re-arming on a **dwell** (three consecutive strictly-better observations), and #2345
+  shipped **0.7.2**, re-arming on a **return to `smart`**, replacing the dwell implementation
+  wholesale. The behaviour on `main` is 0.7.2's and it is tested — but the record of the swap was
+  lost in the collision, so this release repairs the record. Documentation and tests only: **no
+  behaviour change**, and nothing here alters what the suite demands of the hook's logic.
+
+  - **`reference/reader-contract.md` credited the wrong version.** It read "the marker decays only
+    when the session returns to `smart` (**since 0.7.1**)". The return-to-`smart` rule is **0.7.2**;
+    0.7.1 is the dwell. The sentence was written while the change was still numbered 0.7.1 and the
+    reference did not move with the bump. Corrected, and it now names the dwell it replaced.
+
+  - **0.7.2's entry argued only against 0.7.0 and never against the 0.7.1 it superseded.** Read
+    top-down, the file installed a dwell in 0.7.1 and then described a different mechanism one
+    version later as though the dwell had never existed. The difference is load-bearing, not
+    stylistic: under a three-observation dwell, `acceptable → smart → acceptable` — a genuine
+    recovery observed **once** — does not re-inject, which is the exact sequence 0.7.2 exists to
+    make re-inject. A dwell wide enough to absorb a band-edge flap cannot also honour a
+    single-observation recovery; 0.7.2 chose the recovery and accepted the residual flap at the
+    `smart`/`acceptable` edge. That trade is now stated where the two versions meet.
+
+  - **An unverified comparative is withdrawn.** 0.7.2's residual paragraph said the edge cadence was
+    "the pre-0.7.0 cadence at that one boundary, and no worse". 0.6.6's hook was never run to
+    measure that, so the comparative was reasoned rather than executed, and it is retracted here
+    rather than left standing. What replaces it is measured: the cadence is **one announcement per
+    down-up cycle**, now pinned by assertions (a second recovery buys a second announcement and no
+    more), so "bounded rather than runaway" no longer rests on reading the code.
+
+  - **Cross-version state compatibility is pinned.** 0.7.1 wrote `.armed` with TWO fields
+    (`<zone> <streak>`, e.g. `dumb 0`); 0.7.2 writes one word and reads with `tr -cd '[:lower:]'`,
+    which strips the digit and the separator. A session that started under 0.7.1 and continued under
+    0.7.2 therefore reads back correctly and stays suppressed rather than re-announcing a zone it
+    has already reported. That held by construction and now holds by assertion — no migration step,
+    exactly as with the 0.6.6 → 0.7.0 legacy-state seed.
+
 ## [0.7.2]
+
+**Erratum (0.7.3):** two claims below need correction. The residual paragraph's "(the pre-0.7.0
+cadence at that one boundary, and no worse)" was never executed against 0.6.6 and is **withdrawn**;
+the measured statement is one announcement per down-up cycle, now pinned by tests. And this entry
+argues only against 0.7.0's two-rank delta, while the version it actually replaced in the working
+tree was **0.7.1's dwell** — that trade is recorded in 0.7.3 above. Everything else here, including
+the property, the residual itself, and the write-ordering fix, stands as written and is tested.
 
 ### Fixed
 

--- a/plugins/context-guard/CHANGELOG.md
+++ b/plugins/context-guard/CHANGELOG.md
@@ -22,9 +22,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     0.7.1 is the dwell. The sentence was written while the change was still numbered 0.7.1 and the
     reference did not move with the bump. Corrected, and it now names the dwell it replaced.
 
-  - **0.7.2's entry argued only against 0.7.0 and never against the 0.7.1 it superseded.** Read
-    top-down, the file installed a dwell in 0.7.1 and then described a different mechanism one
-    version later as though the dwell had never existed. The difference is load-bearing, not
+  - **0.7.2's entry argued only against 0.7.0 and never against the 0.7.1 it superseded — and two
+    of its claims are false relative to the version it actually followed.** It was written with
+    0.7.0 as the parent, so "the sole behavioural delta is `acceptable → smart` re-arming" and
+    "every 0.7.0 assertion still passes unmodified" were verified against 0.7.0 and quietly became
+    misleading when 0.7.1 landed first: against 0.7.1's dwell the delta is the whole re-arm rule and
+    **13 assertions of this suite differ**, measured against `f57fb788`. Both are scoped in an
+    erratum on that entry rather than rewritten. The underlying difference is load-bearing, not
     stylistic: under a three-observation dwell, `acceptable → smart → acceptable` — a genuine
     recovery observed **once** — does not re-inject, which is the exact sequence 0.7.2 exists to
     make re-inject. A dwell wide enough to absorb a band-edge flap cannot also honour a
@@ -47,12 +51,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.7.2]
 
-**Erratum (0.7.3):** two claims below need correction. The residual paragraph's "(the pre-0.7.0
-cadence at that one boundary, and no worse)" was never executed against 0.6.6 and is **withdrawn**;
-the measured statement is one announcement per down-up cycle, now pinned by tests. And this entry
-argues only against 0.7.0's two-rank delta, while the version it actually replaced in the working
-tree was **0.7.1's dwell** — that trade is recorded in 0.7.3 above. Everything else here, including
-the property, the residual itself, and the write-ordering fix, stands as written and is tested.
+**Erratum (0.7.3):** three corrections, and the first two turn on *which version this entry was
+written against*. It was authored with **0.7.0** as the parent; by the time it merged the parent was
+**0.7.1's dwell**, and two of its sentences are true only of the former:
+
+- "the sole behavioural delta is `acceptable → smart` re-arming" — true against 0.7.0. Against
+  0.7.1 the delta is the entire re-arm rule.
+- "Every 0.7.0 assertion … still passes unmodified against the new rule" — true, and still true, of
+  0.7.0's assertions. It is not a statement about 0.7.1: this suite reports **13 failures** against
+  0.7.1's hook (measured against `f57fb788`; the run is in #2364).
+
+Third, the residual paragraph's "(the pre-0.7.0 cadence at that one boundary, and no worse)" was
+never executed against 0.6.6 and is **withdrawn**; the measured statement is one announcement per
+down-up cycle, now pinned by tests. The rest of this entry — the property, the residual itself, the
+corrected mechanism, and the write-ordering fix — stands as written and is tested against the code
+on `main`.
 
 ### Fixed
 

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -241,6 +241,33 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then
 else
   fail "middle band re-injected twice for one recovery: rc=$RC out=$OUT"
 fi
+# A second down-up cycle buys a second announcement and no more. This is the
+# stated residual at the `smart`/`acceptable` edge — where a flap and a full
+# recovery are the same observation — pinned as an assertion rather than left as
+# prose: the cadence is ONE announcement per down-up cycle, bounded rather than
+# runaway. 0.7.2's entry additionally called that "the pre-0.7.0 cadence, and no
+# worse"; that comparative was never executed against 0.6.6 and is withdrawn in
+# 0.7.3. What is asserted here is only what this suite runs.
+write_snapshot "$H" sacc 10 # smart — a second full recovery
+run "$H" "$D" sacc
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "middle band: the second recovery is silent too"
+else
+  fail "middle band second recovery emitted: rc=$RC out=$OUT"
+fi
+write_snapshot "$H" sacc 60
+run "$H" "$D" sacc
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *acceptable* ]]; then
+  ok "middle band: the second down-up cycle announces exactly once more"
+else
+  fail "second cycle suppressed: rc=$RC out=$OUT"
+fi
+run "$H" "$D" sacc
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "middle band: one announcement per down-up cycle, bounded not runaway"
+else
+  fail "middle band announced twice in one cycle: rc=$RC out=$OUT"
+fi
 
 # 4c. LEGACY STATE: a session already running when this version lands has a
 # `.zone` file and no `.armed` file. The armed rank seeds from the last-seen
@@ -260,6 +287,31 @@ if [[ "$(cat "$D/state/slegacy.armed" 2>/dev/null)" == "dumb" ]]; then
   ok "legacy state gains an .armed marker on first write (no migration step)"
 else
   fail "armed marker not seeded: $(cat "$D/state/slegacy.armed" 2>/dev/null)"
+fi
+
+# 4e. CROSS-VERSION STATE: 0.7.1 shipped a dwell whose `.armed` marker carried
+# TWO fields — "<zone> <streak>", e.g. "dumb 0" — for one version before 0.7.2
+# replaced the rule with a return-to-`smart` target and went back to one word. A
+# session that started under 0.7.1 and continued under 0.7.2 still has the
+# two-field marker on disk, and the reader must resolve it to the zone rather
+# than to a fresh baseline: `tr -cd '[:lower:]'` strips the digit and the
+# separator, so the armed rank survives and an already-reported zone stays
+# suppressed instead of being announced twice. Held by construction; pinned here
+# so the next edit to the reader cannot quietly break it.
+mkdir -p "$D/state"
+printf 'dumb 0\n' >"$D/state/sdwell.armed"
+printf 'dumb\n' >"$D/state/sdwell.zone"
+write_snapshot "$H" sdwell 90 # dumb again — already reported under 0.7.1
+run "$H" "$D" sdwell
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "a 0.7.1 two-field .armed marker still suppresses an already-reported zone"
+else
+  fail "0.7.1-format marker misread as a fresh baseline: rc=$RC out=${OUT:0:120}"
+fi
+if [[ "$(cat "$D/state/sdwell.armed" 2>/dev/null)" == "dumb" ]]; then
+  ok "a 0.7.1 two-field .armed marker is rewritten in the one-word format"
+else
+  fail "0.7.1-format marker not normalized: $(cat "$D/state/sdwell.armed" 2>/dev/null)"
 fi
 
 # 5. Unknown zone (no snapshot) → silent, state untouched.

--- a/plugins/context-guard/hooks/zone-crossing-inject.test.sh
+++ b/plugins/context-guard/hooks/zone-crossing-inject.test.sh
@@ -293,11 +293,11 @@ fi
 # TWO fields — "<zone> <streak>", e.g. "dumb 0" — for one version before 0.7.2
 # replaced the rule with a return-to-`smart` target and went back to one word. A
 # session that started under 0.7.1 and continued under 0.7.2 still has the
-# two-field marker on disk, and the reader must resolve it to the zone rather
-# than to a fresh baseline: `tr -cd '[:lower:]'` strips the digit and the
-# separator, so the armed rank survives and an already-reported zone stays
-# suppressed instead of being announced twice. Held by construction; pinned here
-# so the next edit to the reader cannot quietly break it.
+# two-field marker on disk, and the reader must resolve it to the ZONE rather
+# than to a fresh baseline, so an already-reported zone stays suppressed instead
+# of being announced a second time. Asserted as an outcome on both marker
+# shapes; the reader's internals are its own business, and this case pins what
+# the next edit to them may not break.
 mkdir -p "$D/state"
 printf 'dumb 0\n' >"$D/state/sdwell.armed"
 printf 'dumb\n' >"$D/state/sdwell.zone"
@@ -312,6 +312,25 @@ if [[ "$(cat "$D/state/sdwell.armed" 2>/dev/null)" == "dumb" ]]; then
   ok "a 0.7.1 two-field .armed marker is rewritten in the one-word format"
 else
   fail "0.7.1-format marker not normalized: $(cat "$D/state/sdwell.armed" 2>/dev/null)"
+fi
+# Second shape, so the case rests on more than one string: a mid-ladder marker
+# with a non-zero streak. `acceptable` armed, `acceptable` observed → silent,
+# and a worsening to `dumb` from that same marker must still be announced.
+printf 'acceptable 1\n' >"$D/state/sdwell2.armed"
+printf 'acceptable\n' >"$D/state/sdwell2.zone"
+write_snapshot "$H" sdwell2 60
+run "$H" "$D" sdwell2
+if [[ $RC -eq 0 && -z "$OUT" ]]; then
+  ok "a 0.7.1 marker with a non-zero streak resolves to its zone, not a baseline"
+else
+  fail "streak-bearing marker misread as a fresh baseline: rc=$RC out=${OUT:0:120}"
+fi
+write_snapshot "$H" sdwell2 90
+run "$H" "$D" sdwell2
+if [[ $RC -eq 0 && "$OUT" == *additionalContext* && "$OUT" == *dumb* ]]; then
+  ok "a worsening past a 0.7.1-format marker is still announced"
+else
+  fail "worsening suppressed by a 0.7.1-format marker: rc=$RC out=${OUT:0:120}"
 fi
 
 # 5. Unknown zone (no snapshot) → silent, state untouched.

--- a/plugins/context-guard/reference/reader-contract.md
+++ b/plugins/context-guard/reference/reader-contract.md
@@ -191,9 +191,11 @@ Since 0.4.0 the plugin itself ships hooks over its own seam — the first shippe
   continuation tree plus a presence-gated pointer to `session-flow:workflow`'s router). Silent
   while the zone is unchanged, improving, or `unknown`. **Hysteresis** (since 0.7.0): the gate is
   the worst zone already *reported*, not the zone last *seen*. That marker decays only when the
-  session returns to `smart` — the bottom of the ladder (**since 0.7.1**; 0.7.0 asked instead for an
+  session returns to `smart` — the bottom of the ladder (**since 0.7.2**; 0.7.0 asked instead for an
   improvement of at least two ranks, which no band but `dumb` could ever satisfy, so a session that
-  armed at `acceptable` could never re-arm). Occupancy does not climb monotonically, so a session
+  armed at `acceptable` could never re-arm, and 0.7.1 replaced that delta with a three-observation
+  dwell for one version — see the CHANGELOG for why the dwell did not survive). Occupancy does not
+  climb monotonically, so a session
   sitting on a band edge crosses it repeatedly; without the rule each re-crossing read as a fresh
   transition and re-injected the guidance block. A `/clear` needs no rule: it starts a new session
   id, hence a fresh baseline. The rule is a declared judgment default, on the same footing as the


### PR DESCRIPTION
## Summary

Two PRs fixed the same defect in parallel and both landed within minutes of each other:

| PR | Version | Re-arm rule | Fate |
|---|---|---|---|
| #2344 | `context-guard` 0.7.1 | **dwell** — three consecutive strictly-better observations | superseded one version later |
| #2345 | `context-guard` 0.7.2 | **return to `smart`** — a target on the ladder | live on `main` |

`main`'s behaviour is 0.7.2's and it is tested (`zone-crossing-inject.test.sh` PASS=45 FAIL=0 at
`dba84918`, verified before this branch). What did not survive the collision is the **record** of it,
plus one claim in the 0.7.2 entry that was never executed. This PR is documentation and tests only —
**no behaviour change**, and nothing here alters what the suite demands of the hook's logic.

### 1. `reference/reader-contract.md:194` credited the wrong version

It read "the marker decays only when the session returns to `smart` (**since 0.7.1**)". The
return-to-`smart` rule is **0.7.2**; 0.7.1 is the dwell. The sentence was written while the change
was still numbered 0.7.1 and the version reference did not move with the bump. Corrected, and it now
names the dwell it replaced.

### 2. The 0.7.2 entry argued only against 0.7.0 — and two of its claims are false against the 0.7.1 it actually followed

This is not only an omission. The entry was written with **0.7.0 as the parent** and merged with
**0.7.1** as the parent, which makes two of its sentences misleading where they now sit:

- "the sole behavioural delta is `acceptable → smart` re-arming" — true against 0.7.0; against
  0.7.1's dwell the delta is the **entire re-arm rule**.
- "Every 0.7.0 assertion … still passes unmodified against the new rule" — a true statement about
  0.7.0's assertions, and not a statement about 0.7.1: this suite reports **13 failures** against
  `f57fb788`'s hook (run below).

Both are named and scoped in the erratum rather than rewritten. The underlying difference is
load-bearing, not stylistic: **under a three-observation dwell, `acceptable → smart → acceptable` — a
genuine recovery observed once — does not re-inject**, which is the exact sequence 0.7.2 exists to
make re-inject. A dwell wide enough to absorb a band-edge flap cannot also honour a
single-observation recovery; 0.7.2 chose the recovery and accepted the residual flap at the
`smart`/`acceptable` edge. That trade is now stated where the two versions meet — measured, not
reasoned.

### 3. An unverified comparative is withdrawn

0.7.2's residual paragraph said the edge cadence was "the pre-0.7.0 cadence at that one boundary,
and no worse". **0.6.6's hook was never run to measure that.** The comparative was reasoned rather
than executed, so it is retracted rather than left standing — it is probably true, which is exactly
what makes an unexecuted mechanism claim worth removing. What replaces it is measured: one
announcement per down-up cycle, now pinned by assertions.

Per the repo's convention the shipped 0.7.2 entry is **not rewritten** — an erratum paragraph is
added above it and the substance lives in the new 0.7.3 entry.

### 4. Two behaviours that were prose are now assertions

- **The residual cadence.** A second down-up cycle on the `sacc` session buys a second announcement
  and no more, so "bounded rather than runaway" no longer rests on reading the code.
- **Cross-version state.** 0.7.1 wrote `.armed` with TWO fields (`<zone> <streak>`, e.g. `dumb 0`);
  0.7.2 writes one word. A session that started under 0.7.1 and continued under 0.7.2 must resolve
  that marker to its **zone** rather than to a fresh baseline, or it gets re-announced a zone it
  already reported. New case 4e asserts the outcome on two marker shapes — `dumb 0` (suppressed,
  then normalized to one word) and `acceptable 1`, a mid-ladder marker with a non-zero streak
  (suppressed at the same zone, and a worsening past it still announced). Outcomes only: the
  reader's internals are not asserted, because they were not measured.

## Test plan

**These seven new assertions are guards, not fail-before evidence, and this PR does not claim
otherwise.** They pin behaviour that already shipped in 0.7.2, so they pass against `main`'s hook in
both directions. Their discriminating power is shown against the *other* design that was live one
version earlier.

```
$ shellcheck zone-crossing-inject.test.sh
(clean)

$ bash zone-crossing-inject.test.sh
...
ok: middle band: the second recovery is silent too
ok: middle band: the second down-up cycle announces exactly once more
ok: middle band: one announcement per down-up cycle, bounded not runaway
ok: a 0.7.1 two-field .armed marker still suppresses an already-reported zone
ok: a 0.7.1 two-field .armed marker is rewritten in the one-word format
ok: a 0.7.1 marker with a non-zero streak resolves to its zone, not a baseline
ok: a worsening past a 0.7.1-format marker is still announced

PASS=52 FAIL=0
```

The same suite against **0.7.1's hook** (`git checkout f57fb788 -- plugins/context-guard/hooks/zone-crossing-inject.sh`),
which is the collision measured rather than asserted — the two designs are not interchangeable:

```
FAIL: relapse: rc=0 out=
FAIL: armed rank decayed on a one-rank dip: dumb 1
FAIL: armed rank did not decay on a full recovery: dumb 1
FAIL: genuine relapse suppressed by hysteresis: rc=0 out=
FAIL: armed rank did not decay on a full recovery from acceptable: acceptable 1
FAIL: genuine relapse from the middle band suppressed: rc=0 out=
FAIL: second cycle suppressed: rc=0 out=
FAIL: armed marker not seeded: dumb 0
FAIL: 0.7.1-format marker not normalized: dumb 0
FAIL: partial write (armed) not silent: rc=0 out={"hookSpecificOutput":...
FAIL: partial write (armed) telemetry not error: {
FAIL: label marker moved without its gate: dumb
FAIL: warning lost or mislabelled after an armed-write failure: rc=0 out=

PASS=37 FAIL=13
```

Note `FAIL: second cycle suppressed` in that run: it is the dwell refusing the single-observation
recovery, which is precisely the trade this PR writes into the record. The hook was restored to
`HEAD` afterwards; the diff touches no `.sh` file other than the test.

Baseline before branching, at `dba84918`:

```
$ bash zone-crossing-inject.test.sh   → PASS=45 FAIL=0
$ bash zone-gate.test.sh              → PASS=24 FAIL=0
$ bash post-compact-mark.test.sh      → PASS=16 FAIL=0
```

`context-guard` 0.7.2 → **0.7.3** (patch — documentation and test guards only; no hook logic
changes). Diffed against merge-base `dba84918`.

## Related

Closes #2355
Refs #2220 (the original hysteresis request), #2343 (the re-arm defect), #2344 / `f57fb788`
(0.7.1, the dwell), #2345 / `3d69448c` (0.7.2, the rule on `main`).
