### PR TITLE
docs(autonomy): record the topology obligations on the seam that receives them

### DIFF
--- a/plugins/autonomy/.claude-plugin/plugin.json
+++ b/plugins/autonomy/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "autonomy",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Governed autonomous agent operation: role-topology, binding-seam, wiring-vs-advisor, telemetry, return-accounting, trigger-dispatch, per-work-class guardrail-matrix, standing-routine-catalog, and design-only runner-charter contracts for climbing the AI-adoption ladder, plus a guided-setup skill that discovers an adopting org's state, writes its schema-versioned binding, wires standards-pinned OTLP emission with a zero-cost file-artifact default, wires human-attested return capture at the task boundary, wires signal adapters with one governed dispatch entrypoint, binds the five-class guardrail matrix to an org's isolation substrates with an in-boundary live-validation probe before recording each fail-closed binding, and stands up standing-routine-catalog classes as scheduled temporal signal adapters behind the one governed queue with free scheduling defaults wired as reviewable changes and each routine's work-class mapping homed on the security surface.",
   "author": {
     "name": "Melodic Software",

--- a/plugins/autonomy/CHANGELOG.md
+++ b/plugins/autonomy/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the `autonomy` plugin are documented here. Format follows
 Versions 0.1.0–0.7.0 predate this file (introduced with 0.7.1); their history lives in the
 merged work-package PRs (#333, #343, #356, #372, #377, #600, #676).
 
+## [0.16.3]
+
+### Fixed
+
+- **The runner charter now records the three obligations the verification-topology work deferred
+  to it.** That work states plainly that per-run verdict aggregation and resolved-instance
+  distinctness ship unverified because no runner exists to carry them — but it recorded the
+  deferral only on the leaf making it, and a deferral the receiving seam does not name is
+  indistinguishable from an obligation nobody owns. The runner's inherited-constraints section
+  now carries all three (verdict aggregation under the unanimity invariant including the
+  timeout and no-verdict cases, refusing to count two checkers that resolve to one instance, and
+  lens drawing), each stated as a hole until the build trigger fires.
+
 ## [0.16.2]
 
 ### Fixed

--- a/plugins/autonomy/reference/runner.md
+++ b/plugins/autonomy/reference/runner.md
@@ -69,6 +69,15 @@ All imported unchanged; each is enforced by its owning contract, cited never res
   autonomous/human-gated classes. The runner is a claiming surface, so the
   [one-entrypoint invariant](trigger-dispatch.md#dispatch) and its scope boundary bind it
   directly; the audit trail that funnelling produces is the trust loop.
+- Checker verdicts are aggregated per the
+  [verification-topology leaf](guardrails/verification-topology.md), which enforces at
+  binding-validity time what no static check can reach at run time. **Three obligations land on
+  this seam when the build trigger fires**, and each is a hole until it does: aggregating verdicts
+  under the unanimity invariant, including the checker-timeout and no-verdict cases a static check
+  never sees; refusing to count two checkers the binding held distinct that RESOLVE to one
+  instance; and drawing lenses per that leaf's draw rule. A binding cannot express a topology that
+  auto-proceeds with no force behind its checkers — the runner is what makes the same true of a
+  RUN.
 
 ## Anti-goals
 


### PR DESCRIPTION
## Summary

#2326 states plainly that per-run verdict aggregation and resolved-instance distinctness ship unverified, because no runner exists to carry them. It recorded that deferral only on the leaf making it. The runner charter — the seam receiving the work — said nothing.

A deferral the receiving seam does not name is indistinguishable from an obligation nobody owns. Whoever builds the runner reads its charter, not the leaf that quietly assigned them three requirements.

All three land in `## Inherited constraints`, where the charter already cites its owning contracts rather than restating them:

- aggregating verdicts under the unanimity invariant, including the checker-timeout and no-verdict cases no static check reaches;
- refusing to count two checkers the binding held distinct that RESOLVE to one instance;
- drawing lenses per the leaf's draw rule.

Each is stated as a hole until the build trigger fires — the charter's own idiom, and consistent with its trigger-gated build.

## Test plan

- `node scripts/validate-plugin-contracts.mjs` — 45 setup skills, 2412 files.
- `bash scripts/check-changelog-parity.sh --check` — passes.
- `grep -rniE "frontier|flagship|daily driver" plugins/autonomy/reference/` — empty.
- Docs-only; no schema, checker, or fixture change.

## Related

No linked issue — found by a post-merge sweep checking whether #2326's stated deferrals were recorded anywhere they would actually be read.