### PR TITLE
test(source-control): disable commit signing in prune_babysit_worktrees fixtures

### DIFF
--- a/plugins/source-control/skills/babysit-prs/scripts/tests/test_prune_babysit_worktrees.py
+++ b/plugins/source-control/skills/babysit-prs/scripts/tests/test_prune_babysit_worktrees.py
@@ -46,12 +46,15 @@ def git(*args: str) -> str:
 
 
 def make_repo(tmp: pathlib.Path) -> pathlib.Path:
-    """A one-commit repository with committer identity set locally."""
+    """A one-commit repository with committer identity and signing set locally."""
     main = tmp / "mainrepo"
     main.mkdir()
     git("init", "-q", str(main))
     git("-C", str(main), "config", "user.email", "t@t")
     git("-C", str(main), "config", "user.name", "t")
+    # Repo-local only: machines with commit.gpgsign=true globally have no key for
+    # the fixture identity and every setup commit errors out (#2358).
+    git("-C", str(main), "config", "commit.gpgsign", "false")
     git("-C", str(main), "commit", "-q", "--allow-empty", "-m", "init")
     return main
 


### PR DESCRIPTION
Fixes #2358

## Summary

- Set `commit.gpgsign false` repo-locally in `make_repo` so fixture setup does not attempt GPG signing on machines with global `commit.gpgsign=true`.
- Matches the pattern already used in `worktree-create-gate.test.sh` and `scripts/test-git-helpers.sh`.

## Test plan

- [x] `python3 -m unittest tests.test_prune_babysit_worktrees` (45/0)

## Related

- #2309 — same class of defect fixed in shell suites
- #2333 — shared `test-git-helpers.sh` contract this mirrors